### PR TITLE
BUILD: Docker cleanup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*.md
+*.yml
+.ci
+.git
+.github
+.idea
+.travis
+build
+db
+Dockerfile*
+keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
-# syntax=docker/dockerfile:experimental
-
+# Create build stage and build the binaries
 FROM golang:1.13.4-buster
 
-RUN mkdir -p /go/src/github.com/ava-labs
-
-WORKDIR $GOPATH/src/github.com/ava-labs/
-COPY . gecko
-
 WORKDIR $GOPATH/src/github.com/ava-labs/gecko
+COPY . .
 RUN ./scripts/build.sh
 
-RUN ln -sv $GOPATH/src/github.com/ava-labs/gecko/ /gecko
+# Create final image with binaries and no build dependencies
+FROM debian:buster
+
+EXPOSE 9650
+EXPOSE 9651
+WORKDIR /gecko
+VOLUME /var/lib/avalanche
+ENTRYPOINT ["./build/avalanche", "-db-dir", "/var/lib/avalanche"]
+
+# Copy binaries from build stage
+COPY --from=0 /go/src/github.com/ava-labs/gecko /gecko


### PR DESCRIPTION
- Add ENTRYPOINT so image is useful by default
- Simplify Dockerfile
- Document ports via EXPOSE
- Add basic .dockerignore

The only functional difference is that you do not need to give it a command to be useful, making the following work:

`docker run avaplatform/gecko` will start the Gecko node with no flags.

`docker run avaplatform/gecko -log-level=verbo -api-ipcs-enabled=true` will start the Gecko node with the given flags.

Note: I did not touch scripts/build_image.sh or the scripts/Docker.deploy that it uses. I'm not sure exactly what these are for but afaict they're obsoleted by the removal of Salticidae and the addition of go modules.