### PR TITLE
Add REST support.

### DIFF
--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -48,7 +48,8 @@ var mapping map[string]string = map[string]string{
 // NewService returns a new admin API service
 func NewService(version version.Version, nodeID ids.ShortID, networkID uint32, log logging.Logger, chainManager chains.Manager, peers network.Network, httpServer *api.Server) *common.HTTPHandler {
 	newServer := rpc.NewServer()
-	codec := cjson.RestCodec{Mapping: cjson.MappingGenerator(mapping, "admin")}
+	restMap := cjson.MappingGenerator(mapping, "admin")
+	codec := cjson.RestCodec{Mapping: restMap}
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	newServer.RegisterService(&Admin{
@@ -60,7 +61,7 @@ func NewService(version version.Version, nodeID ids.ShortID, networkID uint32, l
 		networking:   peers,
 		httpServer:   httpServer,
 	}, "admin")
-	return &common.HTTPHandler{Handler: newServer}
+	return &common.HTTPHandler{Handler: newServer, RestEndpoints: restMap.GetKeys()}
 }
 
 // GetNodeVersionReply are the results from calling GetNodeVersion

--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -32,10 +32,23 @@ type Admin struct {
 	httpServer   *api.Server
 }
 
+var mapping map[string]string = map[string]string{
+	"/node/id":        "GetNodeID",
+	"/blockchain/id":  "GetBlockchainID",
+	"/network/id":     "GetNetworkID",
+	"/peers":          "Peers",
+	"/profile/start":  "StartCPUProfiler",
+	"/profile/stop":   "StopCPUProfiler",
+	"/profile/memory": "MemoryProfile",
+	"/profile/lock":   "LockProfile",
+	"/stack/trace":    "Stacktrace",
+	"/chain/alias":    "AliasChain",
+}
+
 // NewService returns a new admin API service
 func NewService(version version.Version, nodeID ids.ShortID, networkID uint32, log logging.Logger, chainManager chains.Manager, peers network.Network, httpServer *api.Server) *common.HTTPHandler {
 	newServer := rpc.NewServer()
-	codec := cjson.NewCodec()
+	codec := cjson.RestCodec{Mapping: cjson.MappingGenerator(mapping, "admin")}
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	newServer.RegisterService(&Admin{

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -105,19 +105,19 @@ func (ks *Keystore) Initialize(log logging.Logger, db database.Database) {
 }
 
 var mapping jsoncodec.RPCRestMap = jsoncodec.RPCRestMap{
-	"/api/keystore/user/create": map[string]string{
+	"/keystore/user/create": map[string]string{
 		"post": "keystore.CreateUser",
 	},
-	"/api/keystore/user/delete": map[string]string{
+	"/keystore/user/delete": map[string]string{
 		"post": "keystore.DeleteUser",
 	},
-	"/api/keystore/user/list": map[string]string{
+	"/keystore/user/list": map[string]string{
 		"post": "keystore.ListUsers",
 	},
-	"/api/keystore/user/import": map[string]string{
+	"/keystore/user/import": map[string]string{
 		"post": "keystore.ImportUser",
 	},
-	"/api/keystore/user/export": map[string]string{
+	"/keystore/user/export": map[string]string{
 		"post": "keystore.ExportUser",
 	},
 }

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -115,11 +115,12 @@ var mapping map[string]string = map[string]string{
 // CreateHandler returns a new service object that can send requests to thisAPI.
 func (ks *Keystore) CreateHandler() *common.HTTPHandler {
 	newServer := rpc.NewServer()
-	codec := jsoncodec.RestCodec{Mapping: jsoncodec.MappingGenerator(mapping, "keystore")}
+	restMap := jsoncodec.MappingGenerator(mapping, "keystore")
+	codec := jsoncodec.RestCodec{Mapping: restMap}
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	newServer.RegisterService(ks, "keystore")
-	return &common.HTTPHandler{LockOptions: common.NoLock, Handler: newServer}
+	return &common.HTTPHandler{LockOptions: common.NoLock, Handler: newServer, RestEndpoints: restMap.GetKeys()}
 }
 
 // Get the user whose name is [username]

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -104,28 +104,18 @@ func (ks *Keystore) Initialize(log logging.Logger, db database.Database) {
 	ks.bcDB = prefixdb.New([]byte("bcs"), db)
 }
 
-var mapping jsoncodec.RPCRestMap = jsoncodec.RPCRestMap{
-	"/keystore/user/create": map[string]string{
-		"post": "keystore.CreateUser",
-	},
-	"/keystore/user/delete": map[string]string{
-		"post": "keystore.DeleteUser",
-	},
-	"/keystore/user/list": map[string]string{
-		"post": "keystore.ListUsers",
-	},
-	"/keystore/user/import": map[string]string{
-		"post": "keystore.ImportUser",
-	},
-	"/keystore/user/export": map[string]string{
-		"post": "keystore.ExportUser",
-	},
+var mapping map[string]string = map[string]string{
+	"/user/create": "CreateUser",
+	"/user/delete": "DeleteUser",
+	"/user/list":   "ListUsers",
+	"/user/import": "ImportUser",
+	"/user/export": "ExportUser",
 }
 
 // CreateHandler returns a new service object that can send requests to thisAPI.
 func (ks *Keystore) CreateHandler() *common.HTTPHandler {
 	newServer := rpc.NewServer()
-	codec := jsoncodec.RestCodec{Mapping: mapping}
+	codec := jsoncodec.RestCodec{Mapping: jsoncodec.MappingGenerator(mapping, "keystore")}
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	newServer.RegisterService(ks, "keystore")

--- a/api/keystore/service.go
+++ b/api/keystore/service.go
@@ -104,10 +104,28 @@ func (ks *Keystore) Initialize(log logging.Logger, db database.Database) {
 	ks.bcDB = prefixdb.New([]byte("bcs"), db)
 }
 
+var mapping jsoncodec.RPCRestMap = jsoncodec.RPCRestMap{
+	"/api/keystore/user/create": map[string]string{
+		"post": "keystore.CreateUser",
+	},
+	"/api/keystore/user/delete": map[string]string{
+		"post": "keystore.DeleteUser",
+	},
+	"/api/keystore/user/list": map[string]string{
+		"post": "keystore.ListUsers",
+	},
+	"/api/keystore/user/import": map[string]string{
+		"post": "keystore.ImportUser",
+	},
+	"/api/keystore/user/export": map[string]string{
+		"post": "keystore.ExportUser",
+	},
+}
+
 // CreateHandler returns a new service object that can send requests to thisAPI.
 func (ks *Keystore) CreateHandler() *common.HTTPHandler {
 	newServer := rpc.NewServer()
-	codec := jsoncodec.NewCodec()
+	codec := jsoncodec.RestCodec{Mapping: mapping}
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	newServer.RegisterService(ks, "keystore")

--- a/api/router.go
+++ b/api/router.go
@@ -88,6 +88,8 @@ func (r *router) forceAddRouter(base, endpoint string, handler http.Handler) err
 	endpoints[endpoint] = handler
 	r.routes[base] = endpoints
 	r.router.Handle(url, handler)
+	url = "/api" + endpoint
+	r.router.PathPrefix(url).Handler(handler)
 
 	var err error
 	if aliases, exists := r.aliases[base]; exists {

--- a/api/router.go
+++ b/api/router.go
@@ -7,10 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sync"
 
-	jsoncodec "github.com/ava-labs/gecko/utils/json"
 	"github.com/gorilla/mux"
 )
 
@@ -92,12 +90,6 @@ func (r *router) forceAddRouter(base, endpoint string, handler http.Handler) err
 	endpoints[endpoint] = handler
 	r.routes[base] = endpoints
 	r.router.Handle(url, handler)
-
-	re := regexp.MustCompile(fmt.Sprintf("^%s", baseURL))
-	restBase := re.ReplaceAllString(base, jsoncodec.RestBaseURL)
-	restUrl := restBase + endpoint
-
-	r.router.PathPrefix(restUrl).Handler(handler)
 
 	var err error
 	if aliases, exists := r.aliases[base]; exists {

--- a/snow/engine/common/http_handler.go
+++ b/snow/engine/common/http_handler.go
@@ -19,6 +19,7 @@ const (
 
 // HTTPHandler ...
 type HTTPHandler struct {
-	LockOptions LockOption
-	Handler     http.Handler
+	LockOptions   LockOption
+	Handler       http.Handler
+	RestEndpoints []string
 }

--- a/utils/json/rest_codec.go
+++ b/utils/json/rest_codec.go
@@ -1,0 +1,71 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/rpc/v2"
+)
+
+type RPCRestMap map[string]map[string]string
+type RestCodec struct {
+	Mapping RPCRestMap
+}
+
+type RestCodecRequest struct {
+	*http.Request
+	Mapping RPCRestMap
+}
+
+func (r *RestCodecRequest) Method() (string, error) {
+	req := r.Request
+	uri := strings.ToLower(req.RequestURI)
+	if r.Mapping[uri] == nil {
+		return "", errors.New("Path not found")
+	}
+	method := strings.ToLower(req.Method)
+	if r.Mapping[uri][method] == "" {
+		return "", errors.New("Method not allowed")
+	}
+	return r.Mapping[uri][method], nil
+	// uriSections := strings.SplitN(strings.ToLower(req.RequestURI), "/", 5)
+	// method := fmt.Sprintf("%s.%s%s", uriSections[2], strings.Title(uriSections[4]), strings.Title(uriSections[3]))
+	// return method, nil
+}
+func (r *RestCodecRequest) ReadRequest(args interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(r.Request.Body)
+	if err := json.Unmarshal(buf.Bytes(), args); err != nil {
+		return err
+	}
+	fmt.Println(args)
+	return nil
+}
+func newEncode(w http.ResponseWriter) io.Writer {
+	return w
+}
+func (c *RestCodecRequest) WriteResponse(w http.ResponseWriter, reply interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	encoder := json.NewEncoder(newEncode(w))
+	err := encoder.Encode(reply)
+	fmt.Println(reply)
+	if err != nil {
+		rpc.WriteError(w, http.StatusInternalServerError, err.Error())
+	}
+}
+func (codec RestCodec) NewRequest(req *http.Request) rpc.CodecRequest {
+	fmt.Println(strings.HasPrefix(req.RequestURI, "/api"))
+	if strings.HasPrefix(req.RequestURI, "/api") {
+		r := RestCodecRequest{Request: req, Mapping: codec.Mapping}
+		return &r
+	}
+	return NewCodec().NewRequest(req)
+}
+func (c *RestCodecRequest) WriteError(w http.ResponseWriter, status int, err error) {
+	rpc.WriteError(w, http.StatusInternalServerError, err.Error())
+}

--- a/utils/json/rest_codec.go
+++ b/utils/json/rest_codec.go
@@ -3,11 +3,10 @@ package json
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
+	"path"
 	"strings"
 
 	"github.com/gorilla/rpc/v2"
@@ -20,30 +19,32 @@ type RestCodec struct {
 
 type RestCodecRequest struct {
 	*http.Request
-	Mapping URIMethodMap
+	method string
 }
 
 var (
 	RestBaseURL = "/rest"
 )
 
+func (m *URIMethodMap) GetKeys() []string {
+	var keys []string
+	for k := range map[string]string(*m) {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 //  Checks if the uri is in the mapping of RestCodecRequest
 func (r *RestCodecRequest) Method() (string, error) {
 	//
-	req := r.Request
-	uri := strings.ToLower(req.RequestURI)
-	for k, v := range r.Mapping {
-		if strings.HasSuffix(uri, k) {
-			return v, nil
-		}
-	}
-	return "", errors.New("Path not found")
+	return r.method, nil
 }
 
 // generates mapping of uri to base.method
 func MappingGenerator(m map[string]string, base string) URIMethodMap {
 	r := URIMethodMap{}
 	for k, v := range m {
+		k = path.Join(RestBaseURL, k)
 		r[k] = fmt.Sprintf("%s.%s", base, v)
 	}
 	return r
@@ -57,7 +58,7 @@ func (r *RestCodecRequest) ReadRequest(args interface{}) error {
 	if err := json.Unmarshal(buf.Bytes(), args); err != nil {
 		return err
 	}
-	fmt.Println(args)
+
 	return nil
 }
 func newEncode(w http.ResponseWriter) io.Writer {
@@ -67,18 +68,17 @@ func (c *RestCodecRequest) WriteResponse(w http.ResponseWriter, reply interface{
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	encoder := json.NewEncoder(newEncode(w))
 	err := encoder.Encode(reply)
-	fmt.Println(reply)
+
 	if err != nil {
 		rpc.WriteError(w, http.StatusInternalServerError, err.Error())
 	}
 }
 func (codec RestCodec) NewRequest(req *http.Request) rpc.CodecRequest {
 
-	if strings.HasPrefix(req.RequestURI, RestBaseURL) {
-		re := regexp.MustCompile(fmt.Sprintf("^%s", RestBaseURL))
-		req.RequestURI = re.ReplaceAllString(req.RequestURI, "")
-		r := RestCodecRequest{Request: req, Mapping: codec.Mapping}
-		return &r
+	for endpoint, methodName := range codec.Mapping {
+		if strings.HasSuffix(strings.ToLower(req.RequestURI), endpoint) {
+			return &RestCodecRequest{Request: req, method: methodName}
+		}
 	}
 	return NewCodec().NewRequest(req)
 }

--- a/utils/json/rest_codec.go
+++ b/utils/json/rest_codec.go
@@ -25,7 +25,7 @@ type RestCodecRequest struct {
 var (
 	RestBaseURL = "/rest"
 )
-
+// return list of rest endpoints
 func (m *URIMethodMap) GetKeys() []string {
 	var keys []string
 	for k := range map[string]string(*m) {
@@ -34,9 +34,8 @@ func (m *URIMethodMap) GetKeys() []string {
 	return keys
 }
 
-//  Checks if the uri is in the mapping of RestCodecRequest
+//  Return rpc-method name for the rest api call
 func (r *RestCodecRequest) Method() (string, error) {
-	//
 	return r.method, nil
 }
 

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -239,10 +239,31 @@ func (vm *VM) Shutdown() error {
 	return vm.baseDB.Close()
 }
 
+var mapping map[string]string = map[string]string{
+	"/tx":                        "GetTx",
+	"/tx/issue":                  "IssueTx",
+	"/tx/status":                 "GetTxStatus",
+	"/tx/send":                   "Send",
+	"/tx/mint":                   "CreateMintTx",
+	"/tx/mint/sign":              "SignMintTx",
+	"/utxo":                      "GetUTXOs",
+	"/balance":                   "GetBalance",
+	"/balance/all":               "GetAllBalances",
+	"/asset/description":         "GetAssetDescription",
+	"/asset/cap/fixed/create":    "CreateFixedCapAsset",
+	"/asset/cap/variable/create": "CreateVariableCapAsset",
+	"/address/create":            "CreateAddress",
+	"/address/list":              "ListAddresses",
+	"/key/import":                "ImportKey",
+	"/key/export":                "ExportKey",
+	"/ava/import":                "ImportAVA",
+	"/ava/export":                "ExportAVA",
+}
+
 // CreateHandlers implements the avalanche.DAGVM interface
 func (vm *VM) CreateHandlers() map[string]*common.HTTPHandler {
 	rpcServer := rpc.NewServer()
-	codec := cjson.NewCodec()
+	codec := cjson.RestCodec{Mapping: cjson.MappingGenerator(mapping, "avm")}
 	rpcServer.RegisterCodec(codec, "application/json")
 	rpcServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	rpcServer.RegisterService(&Service{vm: vm}, "avm") // name this service "avm"
@@ -253,10 +274,14 @@ func (vm *VM) CreateHandlers() map[string]*common.HTTPHandler {
 	}
 }
 
+var staticMapping map[string]string = map[string]string{
+	"/genesis/build": "vm.BuildGenesis",
+}
+
 // CreateStaticHandlers implements the avalanche.DAGVM interface
 func (vm *VM) CreateStaticHandlers() map[string]*common.HTTPHandler {
 	newServer := rpc.NewServer()
-	codec := cjson.NewCodec()
+	codec := cjson.RestCodec{Mapping: cjson.MappingGenerator(staticMapping, "avm")}
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	newServer.RegisterService(&StaticService{}, "avm") // name this service "avm"

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -263,13 +263,14 @@ var mapping map[string]string = map[string]string{
 // CreateHandlers implements the avalanche.DAGVM interface
 func (vm *VM) CreateHandlers() map[string]*common.HTTPHandler {
 	rpcServer := rpc.NewServer()
-	codec := cjson.RestCodec{Mapping: cjson.MappingGenerator(mapping, "avm")}
+	restMap := cjson.MappingGenerator(mapping, "avm")
+	codec := cjson.RestCodec{Mapping: restMap}
 	rpcServer.RegisterCodec(codec, "application/json")
 	rpcServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	rpcServer.RegisterService(&Service{vm: vm}, "avm") // name this service "avm"
 
 	return map[string]*common.HTTPHandler{
-		"":        {Handler: rpcServer},
+		"":        {Handler: rpcServer, RestEndpoints: restMap.GetKeys()},
 		"/pubsub": {LockOptions: common.NoLock, Handler: vm.pubsub},
 	}
 }
@@ -281,12 +282,13 @@ var staticMapping map[string]string = map[string]string{
 // CreateStaticHandlers implements the avalanche.DAGVM interface
 func (vm *VM) CreateStaticHandlers() map[string]*common.HTTPHandler {
 	newServer := rpc.NewServer()
-	codec := cjson.RestCodec{Mapping: cjson.MappingGenerator(staticMapping, "avm")}
+	restMap := cjson.MappingGenerator(staticMapping, "avm")
+	codec := cjson.RestCodec{Mapping: restMap}
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 	newServer.RegisterService(&StaticService{}, "avm") // name this service "avm"
 	return map[string]*common.HTTPHandler{
-		"": {LockOptions: common.WriteLock, Handler: newServer},
+		"": {LockOptions: common.WriteLock, Handler: newServer, RestEndpoints: restMap.GetKeys()},
 	}
 }
 

--- a/vms/components/core/snowman_vm.go
+++ b/vms/components/core/snowman_vm.go
@@ -138,10 +138,34 @@ func (svm *SnowmanVM) NotifyBlockReady() {
 //   * The LockOption is the first element of [lockOption]
 //     By default the LockOption is WriteLock
 //     [lockOption] should have either 0 or 1 elements. Elements beside the first are ignored.
+var mapping map[string]string = map[string]string{
+	"/subnet/get":                      "GetSubnets",
+	"/subnet/create":                   "CreateSubnet",
+	"/subnet/blockchain/ids":           "Validates",
+	"/validator/current":               "GetCurrentValidators",
+	"/validator/pending":               "GetPendingValidators",
+	"/validator/sample":                "SampleValidators",
+	"/validator/add/subnet/default":    "AddDefaultSubnetValidator",
+	"/delegator/add/subnet/default":    "AddDefaultSubnetDelegator",
+	"/delegator/add/subnet/nondefault": "AddNonDefaultSubnetValidator",
+	"/account/get":                     "GetAccount",
+	"/account/list":                    "ListAccounts",
+	"/account/create":                  "CreateAccount",
+	"/ava/export":                      "ExportAVA",
+	"/ava/import":                      "ImportAVA",
+	"/sign":                            "Sign",
+	"/tx/issue":                        "IssueTx",
+	"/blockchain/create":               "CreateBlockchain",
+	"/blockchain/status":               "GetBlockchainStatus",
+	"/blockchain/get":                  "GetBlockchains",
+	"/blockchain/validator/ids":        "ValidatedBy",
+}
+
 func (svm *SnowmanVM) NewHandler(name string, service interface{}, lockOption ...common.LockOption) *common.HTTPHandler {
 	server := rpc.NewServer()
-	server.RegisterCodec(json.NewCodec(), "application/json")
-	server.RegisterCodec(json.NewCodec(), "application/json;charset=UTF-8")
+	codec := json.RestCodec{Mapping: json.MappingGenerator(mapping, "platform")}
+	server.RegisterCodec(codec, "application/json")
+	server.RegisterCodec(codec, "application/json;charset=UTF-8")
 	server.RegisterService(service, name)
 
 	var lock common.LockOption = common.WriteLock

--- a/vms/components/core/snowman_vm.go
+++ b/vms/components/core/snowman_vm.go
@@ -163,7 +163,8 @@ var mapping map[string]string = map[string]string{
 
 func (svm *SnowmanVM) NewHandler(name string, service interface{}, lockOption ...common.LockOption) *common.HTTPHandler {
 	server := rpc.NewServer()
-	codec := json.RestCodec{Mapping: json.MappingGenerator(mapping, "platform")}
+	restMap := json.MappingGenerator(mapping, "platform")
+	codec := json.RestCodec{Mapping: restMap}
 	server.RegisterCodec(codec, "application/json")
 	server.RegisterCodec(codec, "application/json;charset=UTF-8")
 	server.RegisterService(service, name)
@@ -172,7 +173,7 @@ func (svm *SnowmanVM) NewHandler(name string, service interface{}, lockOption ..
 	if len(lockOption) != 0 {
 		lock = lockOption[0]
 	}
-	return &common.HTTPHandler{LockOptions: lock, Handler: server}
+	return &common.HTTPHandler{LockOptions: lock, Handler: server, RestEndpoints: restMap.GetKeys()}
 }
 
 // Initialize this vm.


### PR DESCRIPTION
Currently for keystore, avm , platform and admin module. Once you guys approach this, I can very easily add support for health , metric and other endpoints.

Solves https://github.com/ava-labs/gecko/issues/211.

I thought of two methods of solving this.
First splitting the uri and creating keystore.CreateUser from /api/keystore/user/create
```
 uriSections := strings.SplitN(strings.ToLower(req.RequestURI), "/", 5)
	// method := fmt.Sprintf("%s.%s%s", uriSections[2], strings.Title(uriSections[4]), strings.Title(uriSections[3]))
```
But the problem with this is some functions have weird name and can't be defined with above approach. So, i added mapping feature. like.

```
var mapping map[string]string = map[string]string{
	"/user/create": "CreateUser",
	"/user/delete": "DeleteUser",
	"/user/list":   "ListUsers",
	"/user/import": "ImportUser",
	"/user/export": "ExportUser",
}
```

It works with alias too as aliases are added via `AddAlias` in router.go. And it uses addforceRouter to add the handler for the aliased endpoint. 
```
Support for keystore, avm, platform and admin is added.
```
For REST endpoints, baseURL is replaced by restBaseURL. So that for platform module, `/ext/P` for rpc and  `/rest/P` is for REST. For endpoint and corresponding aliases, request will be routed to same handler. If you url is `/rest/P/tx/issue`  is  handled similar to `/rest/platform/tx/issue` or `/rest/bc/P/tx/issue` or `/rest/bc/platform/tx/issue`.