### PR TITLE
ansible: Don't set GOPATH

### DIFF
--- a/scripts/ansible/roles/gopath/tasks/main.yml
+++ b/scripts/ansible/roles/gopath/tasks/main.yml
@@ -1,5 +1,0 @@
-- name: Set GOPATH
-  lineinfile:
-    path: ~/.bashrc
-    line: GOPATH=$HOME/go
-    mode: preserve

--- a/scripts/ansible/service_playbook.yml
+++ b/scripts/ansible/service_playbook.yml
@@ -4,7 +4,6 @@
   hosts: avalanche_nodes
   roles:
     - name: golang_base
-    - name: gopath
     - name: avalanche_base
     - name: avalanche_build
     - name: avalanche_user


### PR DESCRIPTION
Gecko is now composed of go modules, there is no need to set $GOPATH
environment variable.