### PR TITLE
cleaned up staking of locked tokens

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -165,6 +165,9 @@ func (n *Node) initNetworking() error {
 
 	consensusRouter := n.Config.ConsensusRouter
 	if !n.Config.EnableStaking {
+		if err := primaryNetworkValidators.AddWeight(n.ID, n.Config.DisabledStakingWeight); err != nil {
+			return err
+		}
 		consensusRouter = &insecureValidatorManager{
 			Router: consensusRouter,
 			vdrs:   primaryNetworkValidators,

--- a/vms/platformvm/add_validator_tx.go
+++ b/vms/platformvm/add_validator_tx.go
@@ -129,9 +129,9 @@ func (tx *UnsignedAddValidatorTx) SemanticVerify(
 	if currentTime, err := vm.getTimestamp(db); err != nil {
 		return nil, nil, nil, nil, tempError{err}
 	} else if startTime := tx.StartTime(); !currentTime.Before(startTime) {
-		return nil, nil, nil, nil, permError{fmt.Errorf("validator's start time (%s) at or after current timestamp (%s)",
-			currentTime,
-			startTime)}
+		return nil, nil, nil, nil, permError{fmt.Errorf("validator's start time (%s) at or before current timestamp (%s)",
+			startTime,
+			currentTime)}
 	}
 
 	_, isValidator, err := vm.isValidator(db, constants.PrimaryNetworkID, tx.Validator.NodeID)

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -192,7 +192,7 @@ func (service *Service) GetBalance(_ *http.Request, args *GetBalanceArgs, respon
 	for _, utxo := range utxos {
 		out, ok := utxo.Out.(*secp256k1fx.TransferOutput)
 		if !ok {
-			service.vm.Ctx.Log.Warn("expected UTXO output to be type *secp256k1fx.TransferOutput but is type %T", utxo.Out)
+			// TODO: support looking up tokens that are locked.
 			continue
 		}
 		balance, err = math.Add64(balance, out.Amount())

--- a/vms/platformvm/spend.go
+++ b/vms/platformvm/spend.go
@@ -142,7 +142,7 @@ func (vm *VM) stake(
 			Out: &StakeableLockOut{
 				Locktime: out.Locktime,
 				TransferableOut: &secp256k1fx.TransferOutput{
-					Amt:          remainingValue,
+					Amt:          amountToStake,
 					OutputOwners: inner.OutputOwners,
 				},
 			},

--- a/vms/platformvm/stakeable_lock.go
+++ b/vms/platformvm/stakeable_lock.go
@@ -16,6 +16,14 @@ type StakeableLockOut struct {
 	avax.TransferableOut `serialize:"true"`
 }
 
+// Addresses ...
+func (s *StakeableLockOut) Addresses() [][]byte {
+	if addressable, ok := s.TransferableOut.(avax.Addressable); ok {
+		return addressable.Addresses()
+	}
+	return nil
+}
+
 // Verify ...
 func (s *StakeableLockOut) Verify() error {
 	if s.Locktime == 0 {


### PR DESCRIPTION
- Fixed `stake` function from producing invalid transactions.
- Added indexing of locked funds that can be staked.