### PR TITLE
reduce sample size of the accepted frontier

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -412,10 +412,9 @@ func (m *manager) createAvalancheChain(
 	sender := sender.Sender{}
 	sender.Initialize(ctx, m.Net, m.ManagerConfig.Router, m.TimeoutManager)
 
-	alpha := bootstrapWeight/2 + 1
 	sampleK := consensusParams.K
-	if uint64(sampleK) > alpha {
-		sampleK = int(alpha)
+	if uint64(sampleK) > bootstrapWeight {
+		sampleK = int(bootstrapWeight)
 	}
 
 	// The engine handles consensus
@@ -428,7 +427,7 @@ func (m *manager) createAvalancheChain(
 				Beacons:      beacons,
 				SampleK:      sampleK,
 				StartupAlpha: (3*bootstrapWeight + 3) / 4,
-				Alpha:        alpha, // must be > 50%
+				Alpha:        bootstrapWeight/2 + 1, // must be > 50%
 				Sender:       &sender,
 			},
 			VtxBlocked: vtxBlocker,
@@ -500,10 +499,9 @@ func (m *manager) createSnowmanChain(
 	sender := sender.Sender{}
 	sender.Initialize(ctx, m.Net, m.ManagerConfig.Router, m.TimeoutManager)
 
-	alpha := bootstrapWeight/2 + 1
 	sampleK := consensusParams.K
-	if uint64(sampleK) > alpha {
-		sampleK = int(alpha)
+	if uint64(sampleK) > bootstrapWeight {
+		sampleK = int(bootstrapWeight)
 	}
 
 	// The engine handles consensus
@@ -516,7 +514,7 @@ func (m *manager) createSnowmanChain(
 				Beacons:      beacons,
 				SampleK:      sampleK,
 				StartupAlpha: (3*bootstrapWeight + 3) / 4,
-				Alpha:        alpha, // must be > 50%
+				Alpha:        bootstrapWeight/2 + 1, // must be > 50%
 				Sender:       &sender,
 			},
 			Blocked:      blocked,

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -412,6 +412,12 @@ func (m *manager) createAvalancheChain(
 	sender := sender.Sender{}
 	sender.Initialize(ctx, m.Net, m.ManagerConfig.Router, m.TimeoutManager)
 
+	alpha := bootstrapWeight/2 + 1
+	sampleK := consensusParams.K
+	if uint64(sampleK) > alpha {
+		sampleK = int(alpha)
+	}
+
 	// The engine handles consensus
 	engine := &aveng.Transitive{}
 	if err := engine.Initialize(aveng.Config{
@@ -420,8 +426,9 @@ func (m *manager) createAvalancheChain(
 				Ctx:          ctx,
 				Validators:   validators,
 				Beacons:      beacons,
+				SampleK:      sampleK,
 				StartupAlpha: (3*bootstrapWeight + 3) / 4,
-				Alpha:        bootstrapWeight/2 + 1, // must be > 50%
+				Alpha:        alpha, // must be > 50%
 				Sender:       &sender,
 			},
 			VtxBlocked: vtxBlocker,
@@ -493,6 +500,12 @@ func (m *manager) createSnowmanChain(
 	sender := sender.Sender{}
 	sender.Initialize(ctx, m.Net, m.ManagerConfig.Router, m.TimeoutManager)
 
+	alpha := bootstrapWeight/2 + 1
+	sampleK := consensusParams.K
+	if uint64(sampleK) > alpha {
+		sampleK = int(alpha)
+	}
+
 	// The engine handles consensus
 	engine := &smeng.Transitive{}
 	if err := engine.Initialize(smeng.Config{
@@ -501,8 +514,9 @@ func (m *manager) createSnowmanChain(
 				Ctx:          ctx,
 				Validators:   validators,
 				Beacons:      beacons,
+				SampleK:      sampleK,
 				StartupAlpha: (3*bootstrapWeight + 3) / 4,
-				Alpha:        bootstrapWeight/2 + 1, // must be > 50%
+				Alpha:        alpha, // must be > 50%
 				Sender:       &sender,
 			},
 			Blocked:      blocked,

--- a/snow/engine/avalanche/bootstrap/bootstrapper_test.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper_test.go
@@ -59,6 +59,7 @@ func newConfig(t *testing.T) (Config, ids.ShortID, *common.SenderTest, *vertex.T
 		Ctx:        ctx,
 		Validators: peers,
 		Beacons:    peers,
+		SampleK:    int(peers.Weight()),
 		Alpha:      uint64(peers.Len()/2 + 1),
 		Sender:     sender,
 	}

--- a/snow/engine/avalanche/transitive_test.go
+++ b/snow/engine/avalanche/transitive_test.go
@@ -2251,6 +2251,8 @@ func TestEngineBootstrappingIntoConsensus(t *testing.T) {
 	vdr := ids.GenerateTestShortID()
 	vals.AddWeight(vdr, 1)
 
+	config.SampleK = int(vals.Weight())
+
 	sender := &common.SenderTest{}
 	sender.T = t
 	config.Sender = sender

--- a/snow/engine/common/bootstrapper.go
+++ b/snow/engine/common/bootstrapper.go
@@ -53,9 +53,18 @@ type Bootstrapper struct {
 func (b *Bootstrapper) Initialize(config Config) error {
 	b.Config = config
 
-	for _, vdr := range b.Beacons.List() {
+	beacons, err := b.Beacons.Sample(config.SampleK)
+	if err != nil {
+		return err
+	}
+
+	for _, vdr := range beacons {
 		vdrID := vdr.ID()
 		b.pendingAcceptedFrontier.Add(vdrID)
+	}
+
+	for _, vdr := range b.Beacons.List() {
+		vdrID := vdr.ID()
 		b.pendingAccepted.Add(vdrID)
 	}
 

--- a/snow/engine/common/config.go
+++ b/snow/engine/common/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Validators validators.Set
 	Beacons    validators.Set
 
+	SampleK       int
 	StartupAlpha  uint64
 	Alpha         uint64
 	Sender        Sender

--- a/snow/engine/snowman/bootstrap/bootstrapper_test.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper_test.go
@@ -52,6 +52,7 @@ func newConfig(t *testing.T) (Config, ids.ShortID, *common.SenderTest, *block.Te
 		Ctx:        ctx,
 		Validators: peers,
 		Beacons:    peers,
+		SampleK:    int(peers.Weight()),
 		Alpha:      uint64(peers.Len()/2 + 1),
 		Sender:     sender,
 	}

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1716,6 +1716,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 				Ctx:        ctx,
 				Validators: vdrs,
 				Beacons:    beacons,
+				SampleK:    int(beacons.Weight()),
 				Alpha:      uint64(beacons.Len()/2 + 1),
 				Sender:     &sender,
 			},


### PR DESCRIPTION
Reduce the number of beacons sampled for the accepted frontier as the safety requirement is only to have 1 correct node, so sampling the full validator set is needlessly expensive.