### PR TITLE
TWEAK: increase bootup time delay

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -187,7 +187,7 @@ func (n *Node) initNetworking() error {
 		})
 
 		go timer.Dispatch()
-		timer.SetTimeoutIn(15 * time.Second)
+		timer.SetTimeoutIn(1 * time.Minute)
 
 		consensusRouter = &beaconManager{
 			Router:         consensusRouter,


### PR DESCRIPTION
Allow the bootup to take a bit more time.  If you have slower connections it can timeout..

Avoid: "Failed to connect to bootstrap nodes. Node shutting down..."