### PR TITLE
TWEAK: socket performance

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -47,6 +47,8 @@ const (
 	defaultGossipSize                                = 50
 	defaultPingPongTimeout                           = time.Minute
 	defaultPingFrequency                             = 3 * defaultPingPongTimeout / 4
+	defaultReadBufferSize                            = 16 * 1024
+	defaultReadHandshakeTimeout                      = 15 * time.Second
 )
 
 var (
@@ -128,6 +130,8 @@ type network struct {
 	gossipSize                         int
 	pingPongTimeout                    time.Duration
 	pingFrequency                      time.Duration
+	readBufferSize                     uint32
+	readHandshakeTimeout               time.Duration
 
 	executor timer.Executor
 
@@ -192,6 +196,8 @@ func NewDefaultNetwork(
 		defaultGossipSize,
 		defaultPingPongTimeout,
 		defaultPingFrequency,
+		defaultReadBufferSize,
+		defaultReadHandshakeTimeout,
 	)
 }
 
@@ -226,6 +232,8 @@ func NewNetwork(
 	gossipSize int,
 	pingPongTimeout time.Duration,
 	pingFrequency time.Duration,
+	readBufferSize uint32,
+	readHandshakeTimeout time.Duration,
 ) Network {
 	// #nosec G404
 	netw := &network{
@@ -266,6 +274,8 @@ func NewNetwork(
 		retryDelay:                         make(map[string]time.Duration),
 		myIPs:                              map[string]struct{}{ip.String(): {}},
 		peers:                              make(map[[20]byte]*peer),
+		readBufferSize:                     readBufferSize,
+		readHandshakeTimeout:               readHandshakeTimeout,
 	}
 	if err := netw.initialize(registerer); err != nil {
 		log.Warn("initializing network metrics failed with: %s", err)
@@ -626,6 +636,15 @@ func (n *network) Dispatch() error {
 			n.log.Debug("error during server accept: %s", err)
 			return err
 		}
+		switch conn := conn.(type) {
+		case *net.TCPConn:
+			if err := conn.SetLinger(0); err != nil {
+				n.log.Warn("failed to set no linger due to: %s", err)
+			}
+			if err := conn.SetNoDelay(true); err != nil {
+				n.log.Warn("failed to set socket nodelay due to: %s", err)
+			}
+		}
 		go n.upgrade(&peer{
 			net:          n,
 			conn:         conn,
@@ -918,11 +937,14 @@ func (n *network) attemptConnect(ip utils.IPDesc) error {
 // assumes the stateLock is not held. Returns an error if the peer's connection
 // wasn't able to be upgraded.
 func (n *network) upgrade(p *peer, upgrader Upgrader) error {
+	p.conn.SetReadDeadline(time.Now().Add(n.readHandshakeTimeout))
 	id, conn, err := upgrader.Upgrade(p.conn)
 	if err != nil {
+		_ = p.conn.Close()
 		n.log.Verbo("failed to upgrade connection with %s", err)
 		return err
 	}
+	conn.SetReadDeadline(time.Time{})
 	p.sender = make(chan []byte, n.sendQueueSize)
 	p.id = id
 	p.conn = conn


### PR DESCRIPTION
Add no delay/linger on accepted socket connections.

Put a 5 second release deadline on the upgrade.  Without this you can sit on a connection forever and lock FD's.

Increase the read buffer to 16k.  Allot of the messages are > 1024, so you end up polling many times to complete a message.

Set peer.close = true as soon as we close, in order to allow the reader/writer/requestFinishHandshake/pings to exit their threads as soon as we close the socket.