### PR TITLE
TWEAK: stop tickers if we close

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -627,8 +627,9 @@ func (n *network) Dispatch() error {
 			return err
 		}
 		go n.upgrade(&peer{
-			net:  n,
-			conn: conn,
+			net:          n,
+			conn:         conn,
+			tickerCloser: make(chan struct{}),
 		}, n.serverUpgrader)
 	}
 }
@@ -907,9 +908,10 @@ func (n *network) attemptConnect(ip utils.IPDesc) error {
 		}
 	}
 	return n.upgrade(&peer{
-		net:  n,
-		ip:   ip,
-		conn: conn,
+		net:          n,
+		ip:           ip,
+		conn:         conn,
+		tickerCloser: make(chan struct{}),
 	}, n.clientUpgrader)
 }
 

--- a/network/peer.go
+++ b/network/peer.go
@@ -86,8 +86,6 @@ func (p *peer) Start() {
 	go p.ReadMessages()
 	go p.WriteMessages()
 
-	// Initially send the version to the peer
-	go p.Version()
 	go p.requestFinishHandshake()
 	go p.sendPings()
 }
@@ -217,6 +215,8 @@ func (p *peer) ReadMessages() {
 // attempt to write messages to the peer
 func (p *peer) WriteMessages() {
 	defer p.Close()
+
+	p.Version()
 
 	for msg := range p.sender {
 		p.net.log.Verbo("sending new message to %s:\n%s",


### PR DESCRIPTION
The handshake and pings ticket start up on invocation of 'Start()'..
If however we read and get an EOF (which happens pretty quickly) because the peer closed on us.  Probably because we are a dup connection for the peer.  We can immediately kill off the tickers, which should stop the goroutines and save some resources.
