### PR TITLE
Increase maximum number of characters in asset symbol to 5

### DIFF
--- a/vms/avm/create_asset_tx.go
+++ b/vms/avm/create_asset_tx.go
@@ -19,7 +19,7 @@ const (
 	minNameLen      = 1
 	maxNameLen      = 128
 	minSymbolLen    = 1
-	maxSymbolLen    = 4
+	maxSymbolLen    = 5
 	maxDenomination = 32
 )
 

--- a/vms/avm/create_asset_tx_test.go
+++ b/vms/avm/create_asset_tx_test.go
@@ -416,8 +416,8 @@ func TestCreateAssetTxSyntacticVerifySymbolTooLong(t *testing.T) {
 			NetworkID:    networkID,
 			BlockchainID: chainID,
 		}},
-		Name:         "TOM",
-		Symbol:       "BRADY",
+		Name:         "MICHAEL",
+		Symbol:       "JORDAN",
 		Denomination: 0,
 		States: []*InitialState{{
 			FxID: 0,

--- a/vms/avm/create_asset_tx_test.go
+++ b/vms/avm/create_asset_tx_test.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	nameTooLong          = "LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL"
-	symbolTooLong        = "LLLLL"
+	symbolTooLong        = "LLLLLL"
 	illegalNameCharacter = "h8*32"
 	invalidASCIIStr      = "ÉÎ"
 	invalidWhitespaceStr = " HAT"


### PR DESCRIPTION
It's not uncommon for tokens/cryptos in other blockchains to have 5-character symbols. Examples are WAVES, OCEAN, SUSHI, CREAM, STORJ. You'll find a handful more if you scan CoinMarketCap. There are token symbols that have more than 5 characters but uncommon. I think increasing the limit to 5 for X-Chain assets is still reasonable.

My motivation for requesting this change is that we have a token project in another blockchain with 5-character symbol we'd like to move it to Avalanche. I can imagine that other projects are (or will be) in the same situation.