### PR TITLE
Fixed v version prefix in linux build and missing S3 bucket for macos

### DIFF
--- a/.github/workflows/build-deb-pkg.sh
+++ b/.github/workflows/build-deb-pkg.sh
@@ -26,7 +26,11 @@ fi
 echo "Build debian package..."
 cd $PKG_ROOT
 echo "Tag: $TAG"
-NEW_VERSION_STRING="Version: $TAG"
+VER=$TAG
+if [[ $TAG =~ ^v ]]; then
+  VER=$(echo $TAG | cut -d'v' -f 2)
+fi
+NEW_VERSION_STRING="Version: $VER"
 sed -i "s/Version.*/$NEW_VERSION_STRING/g" debian/DEBIAN/control
 dpkg-deb --build debian avalanchego-linux_$TAG.deb
 aws s3 cp avalanchego-linux_$TAG.deb s3://$BUCKET/linux/

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -42,3 +42,4 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.UPLOAD_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.UPLOAD_KEY }}
+        BUCKET: ${{ secrets.BUCKET }}


### PR DESCRIPTION
This PR should fix the failing linux and macos builds.

Linux build was failing because the debian control file can't deal with a `v` character for the version string.
Macos build was failing due to missing S3 bucket variable