### PR TITLE
node: Correctly shutdown when terminated by `systemctl stop`, or `kill`

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/ava-labs/avalanchego/api"
@@ -217,7 +218,7 @@ func (n *Node) initNetworking() error {
 	n.nodeCloser = utils.HandleSignals(func(os.Signal) {
 		// errors are already logged internally if they are meaningful
 		_ = n.Net.Close()
-	}, os.Interrupt, os.Kill)
+	}, syscall.SIGINT, syscall.SIGTERM)
 
 	return nil
 }


### PR DESCRIPTION
This commit fixes the signals intercepted by the node process, in order to
perform a clean shutdown. This may reduce database corruption, observed when
avalanchego is run as a systemd service.

Refs #470

 - SIGINT handler (sent by Ctrl-C) is left unchanged.
 - SIGKILL handler (sent by `kill -9`, cannot be intercepted or handled) is
   removed.
 - SIGTERM handler (sent by `kill <pid>`, `systemctl stop`) is added.

 I believe SIGTERM is what was originally intended, and SIGKILL was specified
 in error. Perhaps because that constant is exposed in the golang os module.

With this change cleanup occurs when `killall avalanchego` is executed (in
another window), just as it would be if Ctrl-C were pressed.

```
:~/src/avalanchego sigterm(+2/-1)± ./build/avalanchego
     _____               .__                       .__
    /  _  \___  _______  |  | _____    ____   ____ |  |__   ____    ,_ o
   /  /_\  \  \/ /\__  \ |  | \__  \  /    \_/ ___\|  |  \_/ __ \   / //\,
  /    |    \   /  / __ \|  |__/ __ \|   |  \  \___|   Y  \  ___/    \>> |
  \____|__  /\_/  (____  /____(____  /___|  /\___  >___|  /\___  >    \\
          \/           \/          \/     \/     \/     \/     \/
WARN [10-03|23:47:04] main/main.go#96: NAT traversal has failed. The node will be able to connect to less nodes.
INFO [10-03|23:47:04] node/node.go#743: Node version is: avalanche/1.0.1
...
INFO [10-03|23:47:14] <P Chain> snow/engine/snowman/bootstrap/bootstrapper.go#211: fetched 5000 blocks
INFO [10-03|23:47:15] <P Chain> snow/engine/snowman/bootstrap/bootstrapper.go#211: fetched 7500 blocks
INFO [10-03|23:47:16] node/node.go#817: shutting down the node
INFO [10-03|23:47:16] <P Chain> snow/engine/snowman/transitive.go#133: shutting down consensus engine
INFO [10-03|23:47:16] <P Chain> snow/networking/router/handler.go#491: finished shutting down chain
INFO [10-03|23:47:16] node/node.go#823: node shut down successfully
INFO [10-03|23:47:16] nat/nat.go#140: Unmapped all ports
```

Without the change no cleanup occurs.

```
:~/src/avalanchego master+± ./build/avalanchego
     _____               .__                       .__
    /  _  \___  _______  |  | _____    ____   ____ |  |__   ____    ,_ o
   /  /_\  \  \/ /\__  \ |  | \__  \  /    \_/ ___\|  |  \_/ __ \   / //\,
  /    |    \   /  / __ \|  |__/ __ \|   |  \  \___|   Y  \  ___/    \>> |
  \____|__  /\_/  (____  /____(____  /___|  /\___  >___|  /\___  >    \\
          \/           \/          \/     \/     \/     \/     \/
WARN [10-03|23:43:23] main/main.go#96: NAT traversal has failed. The node will be able to connect to less nodes.
INFO [10-03|23:43:23] node/node.go#742: Node version is: avalanche/1.0.1
...
INFO [10-03|23:43:32] <P Chain> snow/engine/snowman/bootstrap/bootstrapper.go#211: fetched 2500 blocks
INFO [10-03|23:43:34] <P Chain> snow/engine/snowman/bootstrap/bootstrapper.go#211: fetched 5000 blocks
Terminated
```