### PR TITLE
missing job dependency db corruption

### DIFF
--- a/snow/engine/common/queue/jobs.go
+++ b/snow/engine/common/queue/jobs.go
@@ -110,6 +110,9 @@ func (j *Jobs) Execute(job Job) error {
 		if deps.Len() > 0 {
 			continue
 		}
+		// TODO: Calling execute here ensures that double decision blocks are
+		//       always called atomically with their proposal blocks. This is
+		//       only a quick fix and should be handled in a more robust manner.
 		if err := job.Execute(); err != nil {
 			return err
 		}

--- a/snow/engine/common/queue/jobs.go
+++ b/snow/engine/common/queue/jobs.go
@@ -110,6 +110,9 @@ func (j *Jobs) Execute(job Job) error {
 		if deps.Len() > 0 {
 			continue
 		}
+		if err := job.Execute(); err != nil {
+			return err
+		}
 		if err := j.state.DeleteJob(j.db, blockedID); err != nil {
 			return err
 		}


### PR DESCRIPTION
I believe this fixes the DB corruption issue we have been seeing due to running out of open files (or in general just crashing after being killed)...


Steps causing issue.
1) process job that has a dependency.  Verify and accept job.  The item is Accepted, and stored in cache.
2) the job commits and deletes it self as a dependency of child jobs.
3) restart the node.
4) the dependent job starts to process.  It still have a parent block to process b/c of double decisions.  It looks up the parent and finds that it has not yet been accepted.  It cannot find the parent job b/c it was deleted in (2).
5) we get an error missing dependency block, and we never recover.


A double decision block while processing during bootstrap will get half accepted.  Essentially the parent job is processed and commits.  It will set the proposal block to Accepted, but it only persists in cache.
[here](https://github.com/ava-labs/avalanchego/blob/038ae3550859b7920530c437d88332df575778c4/vms/platformvm/proposal_block.go#L156)

It is Accept'd from: [here](https://github.com/ava-labs/avalanchego/blob/038ae3550859b7920530c437d88332df575778c4/vms/platformvm/proposal_block.go#L39)

Called from: [here](https://github.com/ava-labs/avalanchego/blob/038ae3550859b7920530c437d88332df575778c4/snow/engine/snowman/bootstrap/block_job.go#L74)

After the proposal block is accepted it's committed here:
[here](https://github.com/ava-labs/avalanchego/blob/038ae3550859b7920530c437d88332df575778c4/snow/engine/snowman/bootstrap/bootstrapper.go#L274)

Also in the other the bootstrap logic block executions.

If you stop processing before the dependent block, when the node restarts it fails because of a missing dependency.  That missing dependency was previously processed, and accepted and removed from the jobs queue.

So this code [here](https://github.com/ava-labs/avalanchego/blob/038ae3550859b7920530c437d88332df575778c4/snow/engine/snowman/bootstrap/block_job.go#L49)

Essentially blocks bootstrap b/c the parent job is already accepted and the block state is Processing.


-----

Another option is to confirm that Accepted status is persisted to the db 
[here](https://github.com/ava-labs/avalanchego/blob/038ae3550859b7920530c437d88332df575778c4/vms/platformvm/proposal_block.go#L40)
It didn't seem to fix the problem, and it's unclear if a double decision block could be ok if we half persisted the accepted status.
