### PR TITLE
percolate db error when not found

### DIFF
--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ava-labs/avalanchego/database"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network"
 	"github.com/ava-labs/avalanchego/snow/choices"
@@ -585,6 +587,9 @@ func (t *Transitive) deliver(blk snowman.Block) error {
 
 	// Make sure this block is valid
 	if err := blk.Verify(); err != nil {
+		if err == database.ErrNotFound {
+			t.errs.Add(err)
+		}
 		t.Ctx.Log.Debug("block failed verification due to %s, dropping block", err)
 
 		// if verify fails, then all descendants are also invalid


### PR DESCRIPTION
A potential catch for the reported High cpu..
When the Verify fails with [ErrNotFound](https://github.com/ava-labs/avalanchego/blob/038ae3550859b7920530c437d88332df575778c4/database/errors.go#L11)

DEBUG[10-02|00:08:36] <P Chain> .../snow/engine/snowman/transitive.go#588: block failed verification due to **not found**, dropping block

I do however think it could be related to [PR](https://github.com/ava-labs/avalanchego/pull/482) 

