### PR TITLE
added a continuous time exponential weighted moving average tracker

### DIFF
--- a/utils/math/averager.go
+++ b/utils/math/averager.go
@@ -1,0 +1,18 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package math
+
+import (
+	"time"
+)
+
+// Averager tracks a continuous time exponential moving average of the provided
+// values.
+type Averager interface {
+	// Observe the value at the given time
+	Observe(value float64, currentTime time.Time)
+
+	// Read returns the average of the provided values.
+	Read() float64
+}

--- a/utils/math/continuous_averager.go
+++ b/utils/math/continuous_averager.go
@@ -1,0 +1,51 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package math
+
+import (
+	"math"
+	"time"
+)
+
+type continuousAverager struct {
+	halflife    time.Duration
+	weightedSum float64
+	normalizer  float64
+	lastUpdated time.Time
+}
+
+func NewAverager(
+	initialPrediction float64,
+	halflife time.Duration,
+	currentTime time.Time,
+) Averager {
+	return &continuousAverager{
+		halflife:    halflife,
+		weightedSum: initialPrediction,
+		normalizer:  1,
+		lastUpdated: currentTime,
+	}
+}
+
+func (a *continuousAverager) Observe(value float64, currentTime time.Time) {
+	previousTime := a.lastUpdated
+	if a.lastUpdated.Before(currentTime) {
+		a.lastUpdated = currentTime
+	}
+
+	// negative if this call is out of order, otherwise zero
+	newDelta := currentTime.Sub(a.lastUpdated)
+	// zero if this call is out of order, otherwise negative
+	oldDelta := previousTime.Sub(a.lastUpdated)
+
+	newWeightedDelta := math.Pow(2, float64(newDelta)/float64(a.halflife))
+	oldWeightedDelta := math.Pow(2, float64(oldDelta)/float64(a.halflife))
+
+	a.weightedSum = newWeightedDelta*value + oldWeightedDelta*a.weightedSum
+	a.normalizer = newWeightedDelta + oldWeightedDelta*a.normalizer
+}
+
+func (a *continuousAverager) Read() float64 {
+	return a.weightedSum / a.normalizer
+}

--- a/utils/math/continuous_averager.go
+++ b/utils/math/continuous_averager.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+var (
+	convertEToBase2 = math.Log(2)
+)
+
 type continuousAverager struct {
 	halflife    float64
 	weightedSum float64
@@ -21,7 +25,7 @@ func NewAverager(
 	currentTime time.Time,
 ) Averager {
 	return &continuousAverager{
-		halflife:    float64(halflife) / math.Log(2),
+		halflife:    float64(halflife) / convertEToBase2,
 		weightedSum: initialPrediction,
 		normalizer:  1,
 		lastUpdated: currentTime,

--- a/utils/math/continuous_averager.go
+++ b/utils/math/continuous_averager.go
@@ -9,7 +9,7 @@ import (
 )
 
 type continuousAverager struct {
-	halflife    time.Duration
+	halflife    float64
 	weightedSum float64
 	normalizer  float64
 	lastUpdated time.Time
@@ -21,7 +21,7 @@ func NewAverager(
 	currentTime time.Time,
 ) Averager {
 	return &continuousAverager{
-		halflife:    halflife,
+		halflife:    float64(halflife) / math.Log(2),
 		weightedSum: initialPrediction,
 		normalizer:  1,
 		lastUpdated: currentTime,
@@ -39,8 +39,8 @@ func (a *continuousAverager) Observe(value float64, currentTime time.Time) {
 	// zero if this call is out of order, otherwise negative
 	oldDelta := previousTime.Sub(a.lastUpdated)
 
-	newWeightedDelta := math.Pow(2, float64(newDelta)/float64(a.halflife))
-	oldWeightedDelta := math.Pow(2, float64(oldDelta)/float64(a.halflife))
+	newWeightedDelta := math.Exp(float64(newDelta) / a.halflife)
+	oldWeightedDelta := math.Exp(float64(oldDelta) / a.halflife)
 
 	a.weightedSum = newWeightedDelta*value + oldWeightedDelta*a.weightedSum
 	a.normalizer = newWeightedDelta + oldWeightedDelta*a.normalizer

--- a/utils/math/continuous_averager_benchmark_test.go
+++ b/utils/math/continuous_averager_benchmark_test.go
@@ -1,0 +1,35 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package math
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func BenchmarkAveragers(b *testing.B) {
+	periods := []time.Duration{
+		time.Millisecond,
+		time.Duration(0),
+		-time.Millisecond,
+	}
+	for _, period := range periods {
+		name := fmt.Sprintf("period=%s", period)
+		b.Run(name, func(b *testing.B) {
+			a := NewAverager(0, time.Second, time.Now())
+			AveragerBenchmark(b, a, period)
+		})
+	}
+}
+
+func AveragerBenchmark(b *testing.B, a Averager, period time.Duration) {
+	currentTime := time.Now()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		currentTime = currentTime.Add(period)
+		a.Observe(float64(i), currentTime)
+	}
+}

--- a/utils/math/continuous_averager_test.go
+++ b/utils/math/continuous_averager_test.go
@@ -1,0 +1,41 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package math
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAverager(t *testing.T) {
+	halflife := time.Second
+	currentTime := time.Now()
+
+	a := NewAverager(0, halflife, currentTime)
+	if value := a.Read(); value != 0 {
+		t.Fatalf("wrong value returned. Expected %f ; Returned %f", 0.0, value)
+	}
+
+	currentTime = currentTime.Add(halflife)
+	a.Observe(1, currentTime)
+	if value := a.Read(); value != 1.0/1.5 {
+		t.Fatalf("wrong value returned. Expected %f ; Returned %f", 1.0/1.5, value)
+	}
+}
+
+func TestAveragerTimeTravel(t *testing.T) {
+	halflife := time.Second
+	currentTime := time.Now()
+
+	a := NewAverager(1, halflife, currentTime)
+	if value := a.Read(); value != 1 {
+		t.Fatalf("wrong value returned. Expected %f ; Returned %f", 1.0, value)
+	}
+
+	currentTime = currentTime.Add(-halflife)
+	a.Observe(0, currentTime)
+	if value := a.Read(); value != 1.0/1.5 {
+		t.Fatalf("wrong value returned. Expected %f ; Returned %f", 1.0/1.5, value)
+	}
+}

--- a/utils/uptime/continuous_meter.go
+++ b/utils/uptime/continuous_meter.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	convertEToBase2 = -math.Log(2)
+	convertEToBase2 = math.Log(2)
 )
 
 // ContinuousFactory implements the Factory interface by returning a continuous
@@ -53,8 +53,8 @@ func (a *continuousMeter) update(currentTime time.Time, running bool) {
 }
 
 func (a *continuousMeter) Read(currentTime time.Time) float64 {
-	timeSincePreviousUpdate := currentTime.Sub(a.lastUpdated)
-	if timeSincePreviousUpdate <= 0 {
+	timeSincePreviousUpdate := a.lastUpdated.Sub(currentTime)
+	if timeSincePreviousUpdate >= 0 {
 		return a.value
 	}
 	a.lastUpdated = currentTime

--- a/utils/uptime/continuous_meter.go
+++ b/utils/uptime/continuous_meter.go
@@ -20,14 +20,16 @@ func (ContinuousFactory) New(halflife time.Duration) Meter {
 type continuousMeter struct {
 	running bool
 
-	halflife    time.Duration
+	halflife    float64
 	value       float64
 	lastUpdated time.Time
 }
 
 // NewMeter returns a new Meter with the provided halflife
 func NewMeter(halflife time.Duration) Meter {
-	return &continuousMeter{halflife: halflife}
+	return &continuousMeter{
+		halflife: float64(halflife) / math.Log(2),
+	}
 }
 
 func (a *continuousMeter) Start(currentTime time.Time) {
@@ -53,7 +55,7 @@ func (a *continuousMeter) Read(currentTime time.Time) float64 {
 	}
 	a.lastUpdated = currentTime
 
-	factor := math.Pow(2, -float64(timeSincePreviousUpdate)/float64(a.halflife))
+	factor := math.Exp(-float64(timeSincePreviousUpdate) / a.halflife)
 	a.value *= factor
 	if a.running {
 		a.value += 1 - factor

--- a/utils/uptime/continuous_meter.go
+++ b/utils/uptime/continuous_meter.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+var (
+	convertEToBase2 = -math.Log(2)
+)
+
 // ContinuousFactory implements the Factory interface by returning a continuous
 // time meter.
 type ContinuousFactory struct{}
@@ -28,7 +32,7 @@ type continuousMeter struct {
 // NewMeter returns a new Meter with the provided halflife
 func NewMeter(halflife time.Duration) Meter {
 	return &continuousMeter{
-		halflife: float64(halflife) / math.Log(2),
+		halflife: float64(halflife) / convertEToBase2,
 	}
 }
 
@@ -55,7 +59,7 @@ func (a *continuousMeter) Read(currentTime time.Time) float64 {
 	}
 	a.lastUpdated = currentTime
 
-	factor := math.Exp(-float64(timeSincePreviousUpdate) / a.halflife)
+	factor := math.Exp(float64(timeSincePreviousUpdate) / a.halflife)
 	a.value *= factor
 	if a.running {
 		a.value += 1 - factor


### PR DESCRIPTION
This is intended to be used when replacing the current adaptive network timeout strategy.