### PR TITLE
Add getNodeIP to info api

### DIFF
--- a/api/info/service.go
+++ b/api/info/service.go
@@ -189,3 +189,16 @@ func (service *Info) GetTxFee(_ *http.Request, args *struct{}, reply *GetTxFeeRe
 	reply.TxFee = json.Uint64(service.txFee)
 	return nil
 }
+
+// GetNodeIPReply are the results from calling GetNodeVersion
+type GetNodeIPReply struct {
+	IP string `json:"ip"`
+}
+
+// GetNodeVersion returns the version this node is running
+func (service *Info) GetNodeIP(_ *http.Request, _ *struct{}, reply *GetNodeIPReply) error {
+	service.log.Info("Info: GetNodeIP called")
+
+	reply.IP = service.networking.IP().String()
+	return nil
+}

--- a/main/main.go
+++ b/main/main.go
@@ -130,7 +130,7 @@ func main() {
 	)
 	defer externalIPUpdater.Stop()
 
-	log.Info("IP: %s", Config.StakingIP.IP().String())
+	log.Info("IP: %s", Config.StakingIP.IP())
 
 	log.Debug("initializing node state")
 	node := node.Node{}

--- a/main/main.go
+++ b/main/main.go
@@ -130,7 +130,7 @@ func main() {
 	)
 	defer externalIPUpdater.Stop()
 
-	log.Info("Node started with IP: %s", Config.StakingIP.IP().String())
+	log.Info("IP: %s", Config.StakingIP.IP().String())
 
 	log.Debug("initializing node state")
 	node := node.Node{}

--- a/main/main.go
+++ b/main/main.go
@@ -130,6 +130,8 @@ func main() {
 	)
 	defer externalIPUpdater.Stop()
 
+	log.Info("Node started with IP: %s", Config.StakingIP.IP().String())
+
 	log.Debug("initializing node state")
 	node := node.Node{}
 	if err := node.Initialize(&Config, log, factory); err != nil {

--- a/network/network.go
+++ b/network/network.go
@@ -90,6 +90,9 @@ type Network interface {
 	// must be managed internally to the network. Calling close multiple times
 	// will return a nil error.
 	Close() error
+
+	// Return the IP of the node
+	IP() utils.IPDesc
 }
 
 type network struct {
@@ -726,6 +729,10 @@ func (n *network) Track(ip utils.IPDesc) {
 	defer n.stateLock.Unlock()
 
 	n.track(ip)
+}
+
+func (n *network) IP() utils.IPDesc {
+	return n.ip.IP()
 }
 
 // assumes the stateLock is not held.


### PR DESCRIPTION
Add info.getNodeIP()..  Returns the node's IP.

curl -X POST --data '{
    "jsonrpc":"2.0",
    "id"     :1,
    "method" :"info.getNodeIP"
}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/info

{"jsonrpc":"2.0","result":{"ip":"x.x.x.x:9651"},"id":1}
