### PR TITLE
socket refactor

### DIFF
--- a/ipcs/socket/socket.go
+++ b/ipcs/socket/socket.go
@@ -106,15 +106,12 @@ func (s *Socket) Send(msg []byte) error {
 	// Prefix the message with an 8 byte length
 	lenBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(lenBytes, uint64(len(msg)))
-	// msg = append(lenBytes, msg...)
 	for _, conn := range conns {
-		if _, err = conn.Write(lenBytes); err != nil {
-			s.removeConn(conn)
-			errs.Add(fmt.Errorf("failed to write message to %s: %w", conn.RemoteAddr(), err))
-		} else {
-			if _, err = conn.Write(msg); err != nil {
+		for _, byteSlice := range [][]byte{lenBytes, msg} {
+			if _, err = conn.Write(byteSlice); err != nil {
 				s.removeConn(conn)
 				errs.Add(fmt.Errorf("failed to write message to %s: %w", conn.RemoteAddr(), err))
+				break
 			}
 		}
 	}

--- a/ipcs/socket/socket.go
+++ b/ipcs/socket/socket.go
@@ -104,10 +104,10 @@ func (s *Socket) Send(msg []byte) error {
 	var err error
 	errs := wrappers.Errs{}
 	// Prefix the message with an 8 byte length
-	lenBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(lenBytes, uint64(len(msg)))
+	lenBytes := [8]byte{}
+	binary.BigEndian.PutUint64(lenBytes[:], uint64(len(msg)))
 	for _, conn := range conns {
-		for _, byteSlice := range [][]byte{lenBytes, msg} {
+		for _, byteSlice := range [][]byte{lenBytes[:], msg} {
 			if _, err = conn.Write(byteSlice); err != nil {
 				s.removeConn(conn)
 				errs.Add(fmt.Errorf("failed to write message to %s: %w", conn.RemoteAddr(), err))


### PR DESCRIPTION
Calculate the msg size only if we have active connections.
Send the length followed by the msg to avoid a byte copy.
Set the receiver to fetch a uint64, which is what was used for the send.