### PR TITLE
Defer close logs

### DIFF
--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -334,6 +334,15 @@ func (l *Log) SetContextualDisplayingEnabled(enabled bool) {
 	l.config.DisableContextualDisplaying = !enabled
 }
 
+func (l *Log) LogDeferredErrorFunc(f func() error) {
+
+	err := f()
+	if err != nil {
+		l.log(Fatal, "%s", err)
+	}
+	// logs the error but doesn't return it - we might expand this in the future
+}
+
 type fileWriter struct {
 	writer *bufio.Writer
 	file   *os.File

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -62,6 +62,7 @@ type Logger interface {
 
 	// Stop this logger and write back all meta-data.
 	Stop()
+	LogDeferredErrorFunc(f func() error)
 }
 
 // RotatingWriter allows for rotating a stream writer

--- a/utils/logging/test_log.go
+++ b/utils/logging/test_log.go
@@ -77,6 +77,9 @@ func (NoLog) SetDisplayingEnabled(bool) {}
 // SetContextualDisplayingEnabled ...
 func (NoLog) SetContextualDisplayingEnabled(bool) {}
 
+// LogDeferredErrorFunc ...
+func (NoLog) LogDeferredErrorFunc(f func() error) {}
+
 // NoIOWriter is a mock Writer that does not write to any underlying source
 type NoIOWriter struct{}
 

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -828,9 +828,10 @@ func (vm *VM) LoadUser(
 	if err != nil {
 		return nil, nil, fmt.Errorf("problem retrieving user: %w", err)
 	}
+	// TODO check this with Dan
 	// Drop any potential error closing the database to report the original
 	// error
-	defer db.Close()
+	defer vm.ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := userState{vm: vm}
 

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -88,14 +88,12 @@ func (service *Service) ExportKey(r *http.Request, args *ExportKeyArgs, reply *E
 	if err != nil {
 		return fmt.Errorf("problem retrieving user %q: %w", args.Username, err)
 	}
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 
 	sk, err := user.getKey(address)
 	if err != nil {
-		// Drop any potential error closing the database to report the original
-		// error
-		_ = db.Close()
 		return fmt.Errorf("problem retrieving private key: %w", err)
 	}
 
@@ -117,7 +115,7 @@ func (service *Service) ImportKey(r *http.Request, args *ImportKeyArgs, reply *a
 	if err != nil {
 		return fmt.Errorf("problem retrieving data: %w", err)
 	}
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	if addrs, _ := user.getAddresses(); len(addrs) >= maxKeystoreAddresses {
@@ -147,8 +145,6 @@ func (service *Service) ImportKey(r *http.Request, args *ImportKeyArgs, reply *a
 	}
 
 	if err := user.putAddress(sk); err != nil {
-		// Drop any potential error closing the database to report the original
-		// error
 		return fmt.Errorf("problem saving key %w", err)
 	}
 	return db.Close()
@@ -272,7 +268,7 @@ func (service *Service) CreateAddress(_ *http.Request, args *api.UserPass, respo
 	if err != nil {
 		return fmt.Errorf("problem retrieving user %q: %w", args.Username, err)
 	}
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	if addrs, _ := user.getAddresses(); len(addrs) >= maxKeystoreAddresses {
@@ -291,8 +287,6 @@ func (service *Service) CreateAddress(_ *http.Request, args *api.UserPass, respo
 	}
 
 	if err := user.putAddress(key.(*crypto.PrivateKeySECP256K1R)); err != nil {
-		// Drop any potential error closing the database to report the original
-		// error
 		return fmt.Errorf("problem saving key %w", err)
 	}
 	return db.Close()
@@ -307,9 +301,7 @@ func (service *Service) ListAddresses(_ *http.Request, args *api.UserPass, respo
 		return fmt.Errorf("problem retrieving user '%s': %w", args.Username, err)
 	}
 
-	// Drop any potential error closing the database to report the original
-	// error
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	addresses, err := user.getAddresses()
@@ -632,7 +624,7 @@ func (service *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentVa
 
 	stopPrefix := []byte(fmt.Sprintf("%s%s", args.SubnetID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, service.vm.DB)
-	defer stopDB.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(stopDB.Close)
 
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
@@ -780,7 +772,7 @@ func (service *Service) GetPendingValidators(_ *http.Request, args *GetPendingVa
 
 	startPrefix := []byte(fmt.Sprintf("%s%s", args.SubnetID, startDBPrefix))
 	startDB := prefixdb.NewNested(startPrefix, service.vm.DB)
-	defer startDB.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(startDB.Close)
 
 	startIter := startDB.NewIterator()
 	defer startIter.Release()
@@ -957,9 +949,7 @@ func (service *Service) AddValidator(_ *http.Request, args *AddValidatorArgs, re
 	if err != nil {
 		return fmt.Errorf("problem retrieving user %q: %w", args.Username, err)
 	}
-
-	// Drop any potential error closing the database to report the original error
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	// Get the user's keys
 	user := user{db: db}
@@ -1063,10 +1053,7 @@ func (service *Service) AddDelegator(_ *http.Request, args *AddDelegatorArgs, re
 	if err != nil {
 		return fmt.Errorf("problem retrieving user %q: %w", args.Username, err)
 	}
-
-	// Drop any potential error closing the database to report the original
-	// error
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	privKeys, err := user.getKeys()
@@ -1177,10 +1164,7 @@ func (service *Service) AddSubnetValidator(_ *http.Request, args *AddSubnetValid
 	if err != nil {
 		return fmt.Errorf("problem retrieving user %q: %w", args.Username, err)
 	}
-
-	// Drop any potential error closing the database to report the original
-	// error
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	keys, err := user.getKeys()
@@ -1276,10 +1260,7 @@ func (service *Service) CreateSubnet(_ *http.Request, args *CreateSubnetArgs, re
 	if err != nil {
 		return fmt.Errorf("problem retrieving user %q: %w", args.Username, err)
 	}
-
-	// Drop any potential error closing the database to report the original
-	// error
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	privKeys, err := user.getKeys()
@@ -1378,10 +1359,7 @@ func (service *Service) ExportAVAX(_ *http.Request, args *ExportAVAXArgs, respon
 	if err != nil {
 		return fmt.Errorf("problem retrieving user %q: %w", args.Username, err)
 	}
-
-	// Drop any potential error closing the database to report the original
-	// error
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	privKeys, err := user.getKeys()
@@ -1482,10 +1460,7 @@ func (service *Service) ImportAVAX(_ *http.Request, args *ImportAVAXArgs, respon
 	if err != nil {
 		return fmt.Errorf("couldn't get user %q: %w", args.Username, err)
 	}
-
-	// Drop any potential error closing the database to report the original
-	// error
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	privKeys, err := user.getKeys()
@@ -1619,10 +1594,7 @@ func (service *Service) CreateBlockchain(_ *http.Request, args *CreateBlockchain
 	if err != nil {
 		return fmt.Errorf("problem retrieving user %q: %w", args.Username, err)
 	}
-
-	// Drop any potential error closing the database to report the original
-	// error
-	defer db.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(db.Close)
 
 	user := user{db: db}
 	keys, err := user.getKeys()
@@ -2054,7 +2026,7 @@ func (service *Service) GetStake(_ *http.Request, args *api.JSONAddresses, respo
 
 	stopPrefix := []byte(fmt.Sprintf("%s%s", constants.PrimaryNetworkID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, service.vm.DB)
-	defer stopDB.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(stopDB.Close)
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
 
@@ -2085,7 +2057,7 @@ func (service *Service) GetStake(_ *http.Request, args *api.JSONAddresses, respo
 	// Iterate over pending validators
 	startPrefix := []byte(fmt.Sprintf("%s%s", constants.PrimaryNetworkID, startDBPrefix))
 	startDB := prefixdb.NewNested(startPrefix, service.vm.DB)
-	defer startDB.Close()
+	defer service.vm.SnowmanVM.Ctx.Log.LogDeferredErrorFunc(startDB.Close)
 	startIter := startDB.NewIterator()
 	defer startIter.Release()
 

--- a/vms/platformvm/state.go
+++ b/vms/platformvm/state.go
@@ -96,7 +96,7 @@ func (vm *VM) enqueueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 	// Sorted by subnet ID then start time then tx ID
 	prefixStart := []byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix))
 	prefixStartDB := prefixdb.NewNested(prefixStart, db)
-	defer prefixStartDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(prefixStartDB.Close)
 
 	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
 	p.PackLong(uint64(staker.StartTime().Unix()))
@@ -135,7 +135,7 @@ func (vm *VM) dequeueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 	// Sorted by subnet ID then start time then ID
 	prefixStart := []byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix))
 	prefixStartDB := prefixdb.NewNested(prefixStart, db)
-	defer prefixStartDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(prefixStartDB.Close)
 
 	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
 	p.PackLong(uint64(staker.StartTime().Unix()))
@@ -180,7 +180,7 @@ func (vm *VM) addStaker(db database.Database, subnetID ids.ID, tx *rewardTx) err
 	// Sorted by subnet ID then stop time then tx ID
 	prefixStop := []byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix))
 	prefixStopDB := prefixdb.NewNested(prefixStop, db)
-	defer prefixStopDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(prefixStopDB.Close)
 
 	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
 	p.PackLong(uint64(staker.EndTime().Unix()))
@@ -220,7 +220,7 @@ func (vm *VM) removeStaker(db database.Database, subnetID ids.ID, tx *rewardTx) 
 	// Sorted by subnet ID then stop time
 	prefixStop := []byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix))
 	prefixStopDB := prefixdb.NewNested(prefixStop, db)
-	defer prefixStopDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(prefixStopDB.Close)
 
 	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
 	p.PackLong(uint64(staker.EndTime().Unix()))
@@ -412,7 +412,7 @@ func (vm *VM) getReferencingUTXOs(db database.Database, addr []byte, start ids.I
 func (vm *VM) putReferencingUTXO(db database.Database, addrBytes []byte, utxoID ids.ID) error {
 	prefixedDB := prefixdb.NewNested(addrBytes, db)
 
-	defer prefixedDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(prefixedDB.Close)
 	return prefixedDB.Put(utxoID[:], nil)
 }
 
@@ -758,7 +758,7 @@ type validatorUptime struct {
 
 func (vm *VM) uptime(db database.Database, nodeID ids.ShortID) (*validatorUptime, error) {
 	uptimeDB := prefixdb.NewNested([]byte(uptimeDBPrefix), db)
-	defer uptimeDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(uptimeDB.Close)
 
 	uptimeBytes, err := uptimeDB.Get(nodeID.Bytes())
 	if err != nil {
@@ -778,13 +778,13 @@ func (vm *VM) setUptime(db database.Database, nodeID ids.ShortID, uptime *valida
 	}
 
 	uptimeDB := prefixdb.NewNested([]byte(uptimeDBPrefix), db)
-	defer uptimeDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(uptimeDB.Close)
 
 	return uptimeDB.Put(nodeID.Bytes(), uptimeBytes)
 }
 func (vm *VM) deleteUptime(db database.Database, nodeID ids.ShortID) error {
 	uptimeDB := prefixdb.NewNested([]byte(uptimeDBPrefix), db)
-	defer uptimeDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(uptimeDB.Close)
 
 	return uptimeDB.Delete(nodeID.Bytes())
 }

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -468,7 +468,7 @@ func (vm *VM) Bootstrapped() error {
 
 	stopPrefix := []byte(fmt.Sprintf("%s%s", constants.PrimaryNetworkID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, vm.DB)
-	defer stopDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(stopDB.Close)
 
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
@@ -531,7 +531,7 @@ func (vm *VM) Shutdown() error {
 
 	stopPrefix := []byte(fmt.Sprintf("%s%s", constants.PrimaryNetworkID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, vm.DB)
-	defer stopDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(stopDB.Close)
 
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
@@ -814,7 +814,7 @@ func (vm *VM) calculateReward(db database.Database, duration time.Duration, stak
 func (vm *VM) updateSubnetValidators(db database.Database, subnetID ids.ID, timestamp time.Time) error {
 	startPrefix := []byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix))
 	startDB := prefixdb.NewNested(startPrefix, db)
-	defer startDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(startDB.Close)
 
 	startIter := startDB.NewIterator()
 	defer startIter.Release()
@@ -906,7 +906,7 @@ pendingStakerLoop:
 
 	stopPrefix := []byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, db)
-	defer stopDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(stopDB.Close)
 
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
@@ -990,7 +990,7 @@ func (vm *VM) updateVdrSet(subnetID ids.ID) error {
 
 	stopPrefix := []byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, vm.DB)
-	defer stopDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(stopDB.Close)
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
 
@@ -1190,7 +1190,7 @@ func (vm *VM) calculateUptime(db database.Database, nodeID ids.ShortID, startTim
 func (vm *VM) getStakers() ([]validators.Validator, error) {
 	stopPrefix := []byte(fmt.Sprintf("%s%s", constants.PrimaryNetworkID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, vm.DB)
-	defer stopDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(stopDB.Close)
 	iter := stopDB.NewIterator()
 	defer iter.Release()
 
@@ -1226,7 +1226,7 @@ func (vm *VM) getStakers() ([]validators.Validator, error) {
 func (vm *VM) getPendingStakers() ([]validators.Validator, error) {
 	startDBPrefix := []byte(fmt.Sprintf("%s%s", constants.PrimaryNetworkID, startDBPrefix))
 	startDB := prefixdb.NewNested(startDBPrefix, vm.DB)
-	defer startDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(startDB.Close)
 	iter := startDB.NewIterator()
 	defer iter.Release()
 
@@ -1314,7 +1314,7 @@ func (vm *VM) maxStakeAmount(db database.Database, subnetID ids.ID, nodeID ids.S
 
 	stopPrefix := []byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, db)
-	defer stopDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(stopDB.Close)
 
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
@@ -1358,7 +1358,7 @@ func (vm *VM) maxStakeAmount(db database.Database, subnetID ids.ID, nodeID ids.S
 
 	startPrefix := []byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix))
 	startDB := prefixdb.NewNested(startPrefix, db)
-	defer startDB.Close()
+	defer vm.Ctx.Log.LogDeferredErrorFunc(startDB.Close)
 
 	startIter := startDB.NewIterator()
 	defer startIter.Release()


### PR DESCRIPTION
This is part of something I briefly discussed with @StephenButtolph .

We have a lot of `defer db close()`s that we ignore the error.
I think there's what we do when there's an error is a situation-by-situation scenario. 

There are instances where we return `db.Close()` and let upstream handle the error - Which I think it's a good pattern, although calling the close twice might lead to less straight-forward code. But if the need arises, we can always talk a bit about it in the future.

This PR is more to do with adding visibility towards  `defer db close()` errors. Namely, if there is an error we make sure we log it! :)
