### PR TITLE
Ansible: Install minimum version of Go (1.15.5)

### DIFF
--- a/scripts/ansible/roles/avalanche_base/tasks/main.yml
+++ b/scripts/ansible/roles/avalanche_base/tasks/main.yml
@@ -3,5 +3,6 @@
   with_first_found:
     - "{{ ansible_facts.distribution | lower }}-{{ ansible_facts.distribution_major_version }}.yml"
     - "{{ ansible_facts.distribution | lower }}.yml"
+    - "not_supported.yml"
   tags:
-    - golang_base
+    - avalanche_base

--- a/scripts/ansible/roles/avalanche_base/tasks/not_supported.yml
+++ b/scripts/ansible/roles/avalanche_base/tasks/not_supported.yml
@@ -1,0 +1,10 @@
+- name: Not supported
+  fail:
+    msg:
+      This operating system is not supported by this role
+      (system={{ ansible_facts.system }},
+      os_family={{ ansible_facts.os_family }},
+      distribution={{ ansible_facts.distribution }},
+      distribution_version={{ ansible_facts.distribution_version }}).
+  tags:
+    - avalanche_base

--- a/scripts/ansible/roles/avalanche_build/tasks/main.yml
+++ b/scripts/ansible/roles/avalanche_build/tasks/main.yml
@@ -10,4 +10,4 @@
   args:
     chdir: "{{ repo_folder }}"
   environment:
-    PATH: /sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/snap/bin
+    PATH: /usr/lib/go-{{ golang_version_min_major }}.{{ golang_version_min_minor }}/bin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/snap/bin

--- a/scripts/ansible/roles/golang_base/defaults/main.yml
+++ b/scripts/ansible/roles/golang_base/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Changes to this minimum version should be coordinated with changes the
+# documented minimum in README.md
+golang_version_min: 1.15.5
+golang_version_min_info: "{{ golang_version_min.split('.') | map('int') | list }}"
+golang_version_min_major: "{{ golang_version_min_info[0] }}"
+golang_version_min_minor: "{{ golang_version_min_info[1] }}"

--- a/scripts/ansible/roles/golang_base/tasks/centos-7.yml
+++ b/scripts/ansible/roles/golang_base/tasks/centos-7.yml
@@ -1,12 +1,17 @@
+# CentOS 7.x does not include golang.
+# The EPEL repository includes it, and tracks golang packages from Fedora.
+
 - name: Install Go repo
   yum:
     name:
       - epel-release
+  tags:
+    - golang_base
 
 - name: Install Go
   become: true
   yum:
     name:
-      - golang  # 1.13.11 in July 2020
+      - "golang >= {{ golang_version_min }}"
   tags:
     - golang_base

--- a/scripts/ansible/roles/golang_base/tasks/centos-8.yml
+++ b/scripts/ansible/roles/golang_base/tasks/centos-8.yml
@@ -1,7 +1,28 @@
+# CentOS Linux 8.x has periodic minor releases, each one has a Go release.
+# CentOS Stream 8 is a rolling release, Go is updated on a continuous basis.
+
+- name: Add Go repository
+  # Typically the version of Go in CentOS Linux will be too old. So use the
+  # CentOS Stream AppStream repository, but but only for Go packages.
+  yum_repository:
+    name: centos-stream-appstream
+    description: CentOS Stream $releasever - AppStream
+    mirrorlist: http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=AppStream&infra=$infra
+    gpgcheck: true
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+    file: CentOS-Stream-AppStream  # .repo extension is added by Ansible
+    includepkgs: golang*
+  # Only run on CentOS Linux. CentOS Stream already has this repo configured.
+  # On CentOS Linux distribution_version is "<major>.<minor>".
+  # On CentOS Stream distribution_version is just "<major>".
+  when: (ansible_facts.distribution_version | length) >= 3
+  tags:
+    - golang_base
+
 - name: Install Go
   become: true
   yum:
     name:
-      - golang  # 1.13.4 in July 2020
+      - "golang >= {{ golang_version_min }}"
   tags:
     - golang_base

--- a/scripts/ansible/roles/golang_base/tasks/debian-10.yml
+++ b/scripts/ansible/roles/golang_base/tasks/debian-10.yml
@@ -1,12 +1,23 @@
 # Debian 10.x (buster) includes golang 1.11.x.
 # The testing repository tracks https://golang.org releases more closely.
 
-- name: Configure default release
+- name: Configure Apt
   become: true
   copy:
-    content: |
-      APT::Default-Release "stable";
-    dest: /etc/apt/apt.conf.d/99defaultrelease
+    content: "{{ golang_base_apt_conf.content }}"
+    dest: "{{ golang_base_apt_conf.dest }}"
+  loop:
+    - content: |
+        APT::Default-Release "stable";
+      dest: /etc/apt/apt.conf.d/99defaultrelease
+    - content: |
+        Package: *
+        Pin: release o=Debian,a=testing,n=bullseye
+        Pin-Priority: 400
+      dest: /etc/apt/preferences.d/99pin-bullseye
+  loop_control:
+    label: "{{ golang_base_apt_conf.dest }}"
+    loop_var: golang_base_apt_conf
   tags:
     - golang_base
 

--- a/scripts/ansible/roles/golang_base/tasks/debian-10.yml
+++ b/scripts/ansible/roles/golang_base/tasks/debian-10.yml
@@ -1,15 +1,44 @@
+# Debian 10.x (buster) includes golang 1.11.x.
+# The testing repository tracks https://golang.org releases more closely.
+
+- name: Configure default release
+  become: true
+  copy:
+    content: |
+      APT::Default-Release "stable";
+    dest: /etc/apt/apt.conf.d/99defaultrelease
+  tags:
+    - golang_base
+
 - name: Add Go repository
   become: true
   apt_repository:
-    repo: deb http://deb.debian.org/debian buster-backports main
+    repo: deb http://deb.debian.org/debian testing main
   tags:
     - golang_base
 
 - name: Install Go
   become: true
+  # Apt doesn't support specifying a minimum version (e.g. foo >= 1.0)
+  # https://github.com/ansible/ansible/issues/69034
   apt:
     name:
-      - golang-go
-    default_release: buster-backports
+      - "golang-{{ golang_version_min_major }}.{{ golang_version_min_minor }}-go"
+    default_release: testing
+  tags:
+    - golang_base
+
+- name: Query installed packages
+  package_facts:
+  tags:
+    - golang_base
+
+- name: Check minimum Go version
+  vars:
+    pkg_name: golang-{{ golang_version_min_major }}.{{ golang_version_min_minor }}-go
+  assert:
+    that:
+      - pkg_name in ansible_facts.packages
+      - ansible_facts.packages[pkg_name][0].version is version(golang_version_min, '>=')
   tags:
     - golang_base

--- a/scripts/ansible/roles/golang_base/tasks/main.yml
+++ b/scripts/ansible/roles/golang_base/tasks/main.yml
@@ -3,5 +3,6 @@
   with_first_found:
     - "{{ ansible_facts.distribution | lower }}-{{ ansible_facts.distribution_version }}.yml"
     - "{{ ansible_facts.distribution | lower }}-{{ ansible_facts.distribution_major_version }}.yml"
+    - "not_supported.yml"
   tags:
     - golang_base

--- a/scripts/ansible/roles/golang_base/tasks/not_supported.yml
+++ b/scripts/ansible/roles/golang_base/tasks/not_supported.yml
@@ -1,0 +1,10 @@
+- name: Not supported
+  fail:
+    msg:
+      This operating system is not supported by this role
+      (system={{ ansible_facts.system }},
+      os_family={{ ansible_facts.os_family }},
+      distribution={{ ansible_facts.distribution }},
+      distribution_version={{ ansible_facts.distribution_version }}).
+  tags:
+    - golang_base

--- a/scripts/ansible/roles/golang_base/tasks/ubuntu-18.04.yml
+++ b/scripts/ansible/roles/golang_base/tasks/ubuntu-18.04.yml
@@ -8,8 +8,25 @@
 
 - name: Install Go
   become: true
+  # Apt doesn't support specifying a minimum version (e.g. foo >= 1.0)
+  # https://github.com/ansible/ansible/issues/69034
   apt:
     name:
-      - golang-go
+      - "golang-{{ golang_version_min_major }}.{{ golang_version_min_minor }}-go"
+  tags:
+    - golang_base
+
+- name: Query installed packages
+  package_facts:
+  tags:
+    - golang_base
+
+- name: Check minimum Go version
+  vars:
+    pkg_name: golang-{{ golang_version_min_major }}.{{ golang_version_min_minor }}-go
+  assert:
+    that:
+      - pkg_name in ansible_facts.packages
+      - ansible_facts.packages[pkg_name][0].version is version(golang_version_min, '>=')
   tags:
     - golang_base

--- a/scripts/ansible/roles/golang_base/tasks/ubuntu-20.04.yml
+++ b/scripts/ansible/roles/golang_base/tasks/ubuntu-20.04.yml
@@ -1,7 +1,1 @@
-- name: Install Go
-  become: true
-  apt:
-    name:
-      - golang-go
-  tags:
-    - golang_base
+ubuntu-18.04.yml


### PR DESCRIPTION
This PR updates the Ansible role that installs Go for avalanchego. It now installs at least the minimum version of Go required by avalanchego.

As before, all my Ansible PRs are collected into the  branch https://github.com/moreati/avalanchego/tree/ansible-rollup, for those that wish to use them.