### PR TITLE
Support Custom Genesis Config for Non-Standard NetworkIDs

### DIFF
--- a/genesis/config.go
+++ b/genesis/config.go
@@ -214,7 +214,7 @@ func GetConfig(networkID uint32) *Config {
 func GetConfigFile(filePath string) (*Config, error) {
 	b, err := ioutil.ReadFile(path.Clean(filePath))
 	if err != nil {
-		return nil, fmt.Errorf("%w: unable to load file %s", err, filePath)
+		return nil, fmt.Errorf("unable to load file %s: %w", filePath, err)
 	}
 
 	var unparsedConfig UnparsedConfig

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -205,3 +205,8 @@ func GetConfig(networkID uint32) *Config {
 		return &tempConfig
 	}
 }
+
+// GetConfigFile ...
+func GetConfigFile(filepath string) (*Config, error) {
+	return nil, nil
+}

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -6,6 +6,9 @@ package genesis
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -206,7 +209,23 @@ func GetConfig(networkID uint32) *Config {
 	}
 }
 
-// GetConfigFile ...
-func GetConfigFile(filepath string) (*Config, error) {
-	return nil, nil
+// GetConfigFile loads a *Config from a provided
+// filePath.
+func GetConfigFile(filePath string) (*Config, error) {
+	b, err := ioutil.ReadFile(path.Clean(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("%w: unable to load file %s", err, filePath)
+	}
+
+	var unparsedConfig UnparsedConfig
+	if err := json.Unmarshal(b, &unparsedConfig); err != nil {
+		return nil, fmt.Errorf("could not unmarshal JSON: %w", err)
+	}
+
+	config, err := unparsedConfig.Parse()
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse config: %w", err)
+	}
+
+	return &config, nil
 }

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -210,11 +210,11 @@ func GetConfig(networkID uint32) *Config {
 }
 
 // GetConfigFile loads a *Config from a provided
-// filePath.
-func GetConfigFile(filePath string) (*Config, error) {
-	b, err := ioutil.ReadFile(path.Clean(filePath))
+// filepath.
+func GetConfigFile(filepath string) (*Config, error) {
+	b, err := ioutil.ReadFile(path.Clean(filepath))
 	if err != nil {
-		return nil, fmt.Errorf("unable to load file %s: %w", filePath, err)
+		return nil, fmt.Errorf("unable to load file %s: %w", filepath, err)
 	}
 
 	var unparsedConfig UnparsedConfig

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -78,7 +78,7 @@ type Config struct {
 	StartTime                  uint64        `json:"startTime"`
 	InitialStakeDuration       uint64        `json:"initialStakeDuration"`
 	InitialStakeDurationOffset uint64        `json:"initialStakeDurationOffset"`
-	InitialStakedFunds         []ids.ShortID `json:"unitialStakedFunds"`
+	InitialStakedFunds         []ids.ShortID `json:"initialStakedFunds"`
 	InitialStakers             []Staker      `json:"initialStakers"`
 
 	CChainGenesis string `json:"cChainGenesis"`

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -75,10 +75,10 @@ func validateConfig(networkID uint32, config *Config) error {
 	offsetTimeRequired := config.InitialStakeDurationOffset * uint64(len(config.InitialStakers)-1)
 	if offsetTimeRequired > config.InitialStakeDuration {
 		errs.Add(fmt.Errorf(
-			"initial stake duration is %s but need at least %s with offset of %s",
-			time.Duration(config.InitialStakeDuration)*time.Second,
-			time.Duration(offsetTimeRequired)*time.Second,
-			time.Duration(config.InitialStakeDurationOffset)*time.Second,
+			"initial stake duration is %d but need at least %d with offset of %d",
+			config.InitialStakeDuration,
+			offsetTimeRequired,
+			config.InitialStakeDurationOffset,
 		))
 	}
 

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -113,15 +113,14 @@ func validateConfig(networkID uint32, config *Config) error {
 //    (ie the genesis state of the network)
 // 2) The asset ID of AVAX
 func Genesis(networkID uint32, filepath string) ([]byte, ids.ID, error) {
-	var config *Config
+	config := GetConfig(networkID)
 	if len(filepath) > 0 && networkID != constants.MainnetID && networkID != constants.TestnetID {
 		customConfig, err := GetConfigFile(filepath)
 		if err != nil {
 			return nil, ids.ID{}, fmt.Errorf("unable to load provided genesis config at %s: %w", filepath, err)
 		}
+
 		config = customConfig
-	} else {
-		config = GetConfig(networkID)
 	}
 
 	if err := validateConfig(networkID, config); err != nil {

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -41,6 +41,17 @@ const (
 //
 // The ID of the new network is [networkID].
 
+// Genesis returns:
+// 1) The byte representation of the genesis state of the platform chain
+//    (ie the genesis state of the network)
+// 2) The asset ID of AVAX
+func Genesis(networkID uint32) ([]byte, ids.ID, error) {
+	// TODO: change to FromNetwork
+	return FromConfig(GetConfig(networkID))
+}
+
+// TODO: FromFile (load file config and then attempt to call FromConfig
+
 // FromConfig returns:
 // 1) The byte representation of the genesis state of the platform chain
 //    (ie the genesis state of the network)
@@ -313,17 +324,9 @@ func splitAllocations(allocations []Allocation, numSplits int) [][]Allocation {
 	return append(allNodeAllocations, currentNodeAllocation)
 }
 
-// Genesis returns:
-// 1) The byte representation of the genesis state of the platform chain
-//    (ie the genesis state of the network)
-// 2) The asset ID of AVAX
-func Genesis(networkID uint32) ([]byte, ids.ID, error) {
-	return FromConfig(GetConfig(networkID))
-}
-
 // VMGenesis ...
-func VMGenesis(networkID uint32, vmID ids.ID) (*platformvm.Tx, error) {
-	genesisBytes, _, err := Genesis(networkID)
+func VMGenesis(config *Config, vmID ids.ID) (*platformvm.Tx, error) {
+	genesisBytes, _, err := FromConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -57,7 +57,7 @@ func Genesis(networkID uint32, filePath string) ([]byte, ids.ID, error) {
 
 	if customConfig.NetworkID != networkID {
 		return nil, ids.ID{}, fmt.Errorf(
-			"networkID %d loaded but genesis config contains networkID %d",
+			"networkID %d specified but genesis config contains networkID %d",
 			networkID,
 			customConfig.NetworkID,
 		)

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -171,9 +171,9 @@ func validateConfig(networkID uint32, config *Config) error {
 // 1) The ID of the new network. [networkID]
 // 2) The location of a custom genesis config to load. [filepath]
 //
-// If [filepath] is empty or the given network ID is Mainnet or Testnet, loads the
+// If [filepath] is empty or the given network ID is Mainnet, Testnet, or Local, loads the
 // network genesis state from predefined configs. If [filepath] is non-empty and networkID
-// isn't Mainnet or Testnet, loads the network genesis data from the config at [filepath].
+// isn't Mainnet, Testnet, or Local, loads the network genesis data from the config at [filepath].
 //
 // Genesis returns:
 // 1) The byte representation of the genesis state of the platform chain
@@ -181,7 +181,16 @@ func validateConfig(networkID uint32, config *Config) error {
 // 2) The asset ID of AVAX
 func Genesis(networkID uint32, filepath string) ([]byte, ids.ID, error) {
 	config := GetConfig(networkID)
-	if len(filepath) > 0 && networkID != constants.MainnetID && networkID != constants.TestnetID {
+	if len(filepath) > 0 {
+		switch networkID {
+		case constants.MainnetID, constants.TestnetID, constants.LocalID:
+			return nil, ids.ID{}, fmt.Errorf(
+				"cannot override genesis config for standard network %s (%d)",
+				constants.NetworkName(networkID),
+				networkID,
+			)
+		}
+
 		customConfig, err := GetConfigFile(filepath)
 		if err != nil {
 			return nil, ids.ID{}, fmt.Errorf("unable to load provided genesis config at %s: %w", filepath, err)

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -153,10 +153,6 @@ func validateConfig(networkID uint32, config *Config) error {
 		return errors.New("C-Chain genesis cannot be empty")
 	}
 
-	if len(config.Message) == 0 {
-		return errors.New("genesis message cannot be empty")
-	}
-
 	return nil
 }
 
@@ -167,7 +163,7 @@ func validateConfig(networkID uint32, config *Config) error {
 // exist, etc.), defining the genesis state of the Platform Chain is the same as
 // defining the genesis state of the network.
 //
-// Geneses accepts:
+// Genesis accepts:
 // 1) The ID of the new network. [networkID]
 // 2) The location of a custom genesis config to load. [filepath]
 //

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -55,7 +55,7 @@ func Genesis(networkID uint32, filePath string) ([]byte, ids.ID, error) {
 		return nil, ids.ID{}, fmt.Errorf("unable to load provided genesis config at %s: %w", filePath, err)
 	}
 
-	// Confirm loaded genesis config matches expected networkID
+	// Confirm loaded Config.NetworkID matches expected networkID
 	if customConfig.NetworkID != networkID {
 		return nil, ids.ID{}, fmt.Errorf(
 			"networkID %d loaded but genesis file contains networkID %d",

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -57,7 +57,7 @@ func Genesis(networkID uint32, filePath string) ([]byte, ids.ID, error) {
 
 	if customConfig.NetworkID != networkID {
 		return nil, ids.ID{}, fmt.Errorf(
-			"networkID %d loaded but genesis file contains networkID %d",
+			"networkID %d loaded but genesis config contains networkID %d",
 			networkID,
 			customConfig.NetworkID,
 		)

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -55,7 +55,6 @@ func Genesis(networkID uint32, filePath string) ([]byte, ids.ID, error) {
 		return nil, ids.ID{}, fmt.Errorf("unable to load provided genesis config at %s: %w", filePath, err)
 	}
 
-	// Confirm loaded Config.NetworkID matches expected networkID
 	if customConfig.NetworkID != networkID {
 		return nil, ids.ID{}, fmt.Errorf(
 			"networkID %d loaded but genesis file contains networkID %d",

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -147,7 +147,6 @@ func TestValidateConfig(t *testing.T) {
 				thisConfig.Message = ""
 				return &thisConfig
 			}(),
-			err: "genesis message cannot be empty",
 		},
 	}
 

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -256,7 +256,7 @@ func TestGenesis(t *testing.T) {
 	tests := map[string]struct {
 		networkID       uint32
 		customConfig    string
-		missingFilePath string
+		missingFilepath string
 		err             string
 		expected        string
 	}{
@@ -290,7 +290,7 @@ func TestGenesis(t *testing.T) {
 		},
 		"local with custom (missing filepath)": {
 			networkID:       9999,
-			missingFilePath: "missing.json",
+			missingFilepath: "missing.json",
 			err:             "unable to load provided genesis config",
 		},
 	}
@@ -306,8 +306,8 @@ func TestGenesis(t *testing.T) {
 				}
 			}
 
-			if len(test.missingFilePath) > 0 {
-				customFile = test.missingFilePath
+			if len(test.missingFilepath) > 0 {
+				customFile = test.missingFilepath
 			}
 
 			genesisBytes, _, err := Genesis(test.networkID, customFile)

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -400,7 +400,8 @@ func TestVMGenesis(t *testing.T) {
 				assert.Equal(
 					vmTest.expectedID,
 					genesisTx.ID().String(),
-					"genesisID with networkID %d mismatch",
+					"%s genesisID with networkID %d mismatch",
+					vmTest.vmID,
 					test.networkID,
 				)
 			})

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -265,30 +265,39 @@ func TestGenesis(t *testing.T) {
 			expected:  "3e6662fdbd88bcf4c7dd82cb4699c0807f1d7315d493bc38532697e11b226276",
 		},
 		"fuji": {
+			networkID: constants.FujiID,
+			expected:  "2e6b699298a664793bff42dae9c1af8d9c54645d8b376fd331e0b67475578e0a",
+		},
+		"fuji (with custom specified)": {
 			networkID:    constants.FujiID,
 			customConfig: localGenesisConfigJSON, // won't load
-			expected:     "2e6b699298a664793bff42dae9c1af8d9c54645d8b376fd331e0b67475578e0a",
+			err:          "cannot override genesis config for standard network fuji (5)",
 		},
-		"local without custom": {
+		"local": {
 			networkID: constants.LocalID,
 			expected:  "d036edc78cee38f003c529fa2ca3f95da47c7b87f5f3c0e126c9bf34e7f2285a",
 		},
-		"local with custom": {
+		"local (with custom specified)": {
+			networkID:    constants.LocalID,
+			customConfig: customGenesisConfigJSON,
+			err:          "cannot override genesis config for standard network local (12345)",
+		},
+		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
 			expected:     "a1d1838586db85fe94ab1143560c3356df9ba2445794b796bba050be89f4fcb4",
 		},
-		"local with custom (networkID mismatch)": {
+		"custom (networkID mismatch)": {
 			networkID:    9999,
 			customConfig: localGenesisConfigJSON,
 			err:          "networkID 9999 specified but genesis config contains networkID 12345",
 		},
-		"local with custom (invalid format)": {
+		"custom (invalid format)": {
 			networkID:    9999,
 			customConfig: invalidGenesisConfigJSON,
 			err:          "unable to load provided genesis config",
 		},
-		"local with custom (missing filepath)": {
+		"custom (missing filepath)": {
 			networkID:       9999,
 			missingFilepath: "missing.json",
 			err:             "unable to load provided genesis config",

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -146,7 +146,7 @@ func TestGenesis(t *testing.T) {
 		"local with custom (networkID mismatch)": {
 			networkID:    9999,
 			customConfig: localGenesisConfigJSON,
-			err:          "networkID 9999 loaded but genesis file contains networkID 12345",
+			err:          "networkID 9999 specified but genesis config contains networkID 12345",
 		},
 		"local with custom (invalid format)": {
 			networkID:    9999,
@@ -160,7 +160,7 @@ func TestGenesis(t *testing.T) {
 			var customFile string
 			if len(test.customConfig) > 0 {
 				customFile = path.Join(t.TempDir(), "config.json")
-				err := ioutil.WriteFile(customFile, []byte(test.customConfig), 0644)
+				err := ioutil.WriteFile(customFile, []byte(test.customConfig), 0600)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -169,7 +169,7 @@ func TestGenesis(t *testing.T) {
 			genesisBytes, _, err := Genesis(test.networkID, customFile)
 			if len(test.err) > 0 {
 				if !strings.Contains(err.Error(), test.err) {
-					t.Fatalf("expected error %s but got %s",
+					t.Fatalf(`expected error "%s" but got "%s"`,
 						test.err,
 						err.Error(),
 					)
@@ -182,7 +182,7 @@ func TestGenesis(t *testing.T) {
 
 			genesisHash := fmt.Sprintf("%x", hashing.ComputeHash256(genesisBytes))
 			if genesisHash != test.expected {
-				t.Fatalf("expected genesis hash %s but got %s",
+				t.Fatalf(`expected genesis hash "%s" but got "%s"`,
 					test.expected,
 					genesisHash,
 				)

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -104,6 +104,33 @@ func TestValidateConfig(t *testing.T) {
 			}(),
 			err: "initial stake duration is 31536000 but need at least 400000000 with offset of 100000000",
 		},
+		"empty initial staked funds": {
+			networkID: 12345,
+			config: func() *Config {
+				thisConfig := LocalConfig
+				thisConfig.InitialStakedFunds = []ids.ShortID(nil)
+				return &thisConfig
+			}(),
+			err: "initial staked funds cannot be empty",
+		},
+		"duplicate initial staked funds": {
+			networkID: 12345,
+			config: func() *Config {
+				thisConfig := LocalConfig
+				thisConfig.InitialStakedFunds = append(thisConfig.InitialStakedFunds, thisConfig.InitialStakedFunds[0])
+				return &thisConfig
+			}(),
+			err: "duplicated in initial staked funds",
+		},
+		"initial staked funds not in allocations": {
+			networkID: 5,
+			config: func() *Config {
+				thisConfig := FujiConfig
+				thisConfig.InitialStakedFunds = append(thisConfig.InitialStakedFunds, LocalConfig.InitialStakedFunds[0])
+				return &thisConfig
+			}(),
+			err: "does not have an allocation to stake",
+		},
 		"empty C-Chain genesis": {
 			networkID: 12345,
 			config: func() *Config {

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -120,10 +120,11 @@ var (
 
 func TestGenesis(t *testing.T) {
 	tests := map[string]struct {
-		networkID    uint32
-		customConfig string
-		err          string
-		expected     string
+		networkID       uint32
+		customConfig    string
+		missingFilePath string
+		err             string
+		expected        string
 	}{
 		"mainnet": {
 			networkID: constants.MainnetID,
@@ -153,6 +154,11 @@ func TestGenesis(t *testing.T) {
 			customConfig: invalidGenesisConfigJSON,
 			err:          "unable to load provided genesis config",
 		},
+		"local with custom (missing filepath)": {
+			networkID:       9999,
+			missingFilePath: "missing.json",
+			err:             "unable to load provided genesis config",
+		},
 	}
 
 	for name, test := range tests {
@@ -164,6 +170,10 @@ func TestGenesis(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+			}
+
+			if len(test.missingFilePath) > 0 {
+				customFile = test.missingFilePath
 			}
 
 			genesisBytes, _, err := Genesis(test.networkID, customFile)

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAliases(t *testing.T) {
-	genesisBytes, _, err := Genesis(constants.LocalID)
+	genesisBytes, _, err := Genesis(constants.LocalID, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestAliases(t *testing.T) {
 }
 
 func TestGenesis(t *testing.T) {
-	genesisBytes, _, err := Genesis(constants.MainnetID)
+	genesisBytes, _, err := Genesis(constants.MainnetID, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,12 @@ func TestVMGenesis(t *testing.T) {
 				vmTest.vmID,
 			)
 			t.Run(name, func(t *testing.T) {
-				genesisTx, err := VMGenesis(test.networkID, vmTest.vmID)
+				genesisBytes, _, err := Genesis(test.networkID, "")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				genesisTx, err := VMGenesis(genesisBytes, vmTest.vmID)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -137,7 +142,7 @@ func TestAVAXAssetID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(constants.NetworkIDToNetworkName[test.networkID], func(t *testing.T) {
-			_, avaxAssetID, err := Genesis(test.networkID)
+			_, avaxAssetID, err := Genesis(test.networkID, "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/main/keys.go
+++ b/main/keys.go
@@ -7,6 +7,7 @@ const (
 	defaultString                   = "default"
 	configFileKey                   = "config-file"
 	versionKey                      = "version"
+	genesisConfigFileKey            = "genesis"
 	networkNameKey                  = "network-id"
 	txFeeKey                        = "tx-fee"
 	creationTxFeeKey                = "creation-tx-fee"

--- a/main/params.go
+++ b/main/params.go
@@ -77,6 +77,9 @@ func avalancheFlagSet() *flag.FlagSet {
 	// Config File:
 	fs.String(configFileKey, defaultString, "Specifies a config file")
 
+	// Genesis Config File:
+	fs.String(genesisConfigFileKey, "", "Specifies a genesis config file")
+
 	// NetworkID:
 	fs.String(networkNameKey, defaultNetworkName, "Network ID this node will connect to")
 
@@ -648,6 +651,10 @@ func setNodeConfig(v *viper.Viper) error {
 
 		Config.EpochFirstTransition = time.Unix(v.GetInt64(snowEpochFirstTransition), 0)
 		Config.EpochDuration = v.GetDuration(snowEpochDuration)
+
+		// TODO: attempt to load genesis bytes from file (if defined) into config
+		// TODO: store config as *genesis.Config on node config
+		// TODO: unify coreth config
 	} else {
 		Config.Params = *genesis.GetParams(networkID)
 	}
@@ -659,6 +666,8 @@ func setNodeConfig(v *viper.Viper) error {
 	Config.EnableCrypto = v.GetBool(signatureVerificationEnabledKey)
 
 	// Coreth Plugin
+	// TODO: unify coreth config with genesis file...have coreth flag override
+	// genesis
 	corethConfigString := v.GetString(corethConfigKey)
 	if corethConfigString != defaultString {
 		corethConfigValue := v.Get(corethConfigKey)

--- a/main/params.go
+++ b/main/params.go
@@ -78,7 +78,7 @@ func avalancheFlagSet() *flag.FlagSet {
 	fs.String(configFileKey, defaultString, "Specifies a config file")
 
 	// Genesis Config File:
-	fs.String(genesisConfigFileKey, "", "Specifies a genesis config file")
+	fs.String(genesisConfigFileKey, "", "Specifies a genesis config file (ignored when running standard networks)")
 
 	// NetworkID:
 	fs.String(networkNameKey, defaultNetworkName, "Network ID this node will connect to")

--- a/node/config.go
+++ b/node/config.go
@@ -23,8 +23,9 @@ import (
 type Config struct {
 	genesis.Params
 
-	// Genesis config
-	GenesisConfig *genesis.Config
+	// Genesis information
+	GenesisBytes []byte
+	AvaxAssetID  ids.ID
 
 	// protocol to use for opening the network interface
 	Nat nat.Router

--- a/node/config.go
+++ b/node/config.go
@@ -23,6 +23,9 @@ import (
 type Config struct {
 	genesis.Params
 
+	// Genesis config
+	GenesisConfig *genesis.Config
+
 	// protocol to use for opening the network interface
 	Nat nat.Router
 

--- a/node/node.go
+++ b/node/node.go
@@ -370,7 +370,7 @@ func (n *Node) Dispatch() error {
 func (n *Node) initDatabase() error {
 	n.DB = n.Config.DB
 
-	expectedGenesis, _, err := genesis.Genesis(n.Config.NetworkID)
+	expectedGenesis, _, err := genesis.FromConfig(n.Config.GenesisConfig)
 	if err != nil {
 		return err
 	}
@@ -505,7 +505,7 @@ func (n *Node) initAPIServer() error {
 func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 	n.vmManager = vms.NewManager(&n.APIServer, n.HTTPLog)
 
-	createAVMTx, err := genesis.VMGenesis(n.Config.NetworkID, avm.ID)
+	createAVMTx, err := genesis.VMGenesis(n.Config.GenesisConfig, avm.ID)
 	if err != nil {
 		return err
 	}
@@ -850,7 +850,7 @@ func (n *Node) Initialize(
 		return fmt.Errorf("problem initializing event dispatcher: %w", err)
 	}
 
-	genesisBytes, avaxAssetID, err := genesis.FromConfig(n.Config.Genesis)
+	genesisBytes, avaxAssetID, err := genesis.FromConfig(n.Config.GenesisConfig)
 	if err != nil {
 		return fmt.Errorf("couldn't create genesis bytes: %w", err)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -850,11 +850,11 @@ func (n *Node) Initialize(
 		return fmt.Errorf("problem initializing event dispatcher: %w", err)
 	}
 
-	// TODO: parse from config instead of networkID
-	genesisBytes, avaxAssetID, err := genesis.Genesis(n.Config.NetworkID)
+	genesisBytes, avaxAssetID, err := genesis.FromConfig(n.Config.Genesis)
 	if err != nil {
 		return fmt.Errorf("couldn't create genesis bytes: %w", err)
 	}
+
 	// Start the Health API
 	// Has to be initialized before chain manager
 	if err := n.initHealthAPI(); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -849,6 +849,8 @@ func (n *Node) Initialize(
 	if err = n.initEventDispatcher(); err != nil { // Set up the event dipatcher
 		return fmt.Errorf("problem initializing event dispatcher: %w", err)
 	}
+
+	// TODO: parse from config instead of networkID
 	genesisBytes, avaxAssetID, err := genesis.Genesis(n.Config.NetworkID)
 	if err != nil {
 		return fmt.Errorf("couldn't create genesis bytes: %w", err)


### PR DESCRIPTION
This PR adds a `--genesis` CLI argument that enables the user to specify the [genesis config](https://github.com/ava-labs/avalanchego/blob/master/genesis/config.go) of the custom network their node is going to be running.

### Changes
- [x] Add `--genesis` implementation
- [x] Pass existing tests
- [x] Add genesis validation
- [x] Fix `initialStakedFunds` typo in `genesis/config.go`
- [x] Add new tests

### Follow-Ups
* Update developer documentation: https://github.com/ava-labs/avalanche-docs/blob/master/build/references/command-line-interface.md
* Update `assert.Error; assert.Contains` to `assert.ErrorContains` once [stretchr/testify@v1.8.0](https://github.com/stretchr/testify/pull/1022) released