### PR TITLE
Switch to use graceful stop on grpc server closer to prevent panic

### DIFF
--- a/snow/engine/avalanche/transitive_test.go
+++ b/snow/engine/avalanche/transitive_test.go
@@ -31,6 +31,7 @@ func TestEngineShutdown(t *testing.T) {
 	config := DefaultConfig()
 	vmShutdownCalled := false
 	vm := &vertex.TestVM{}
+	vm.T = t
 	vm.ShutdownF = func() error { vmShutdownCalled = true; return nil }
 	config.VM = vm
 

--- a/utils/atomic_bool.go
+++ b/utils/atomic_bool.go
@@ -1,3 +1,6 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package utils
 
 import "sync/atomic"

--- a/vms/rpcchainvm/factory.go
+++ b/vms/rpcchainvm/factory.go
@@ -74,5 +74,6 @@ func (f *Factory) New(ctx *snow.Context) (interface{}, error) {
 	}
 
 	vm.SetProcess(client)
+	vm.ctx = ctx
 	return vm, nil
 }

--- a/vms/rpcchainvm/ghttp/gconn/conn_server.go
+++ b/vms/rpcchainvm/ghttp/gconn/conn_server.go
@@ -54,7 +54,7 @@ func (s *Server) Write(ctx context.Context, req *gconnproto.WriteRequest) (*gcon
 // Close ...
 func (s *Server) Close(ctx context.Context, req *gconnproto.CloseRequest) (*gconnproto.CloseResponse, error) {
 	err := s.conn.Close()
-	s.closer.Stop()
+	s.closer.GracefulStop()
 	return &gconnproto.CloseResponse{}, err
 }
 

--- a/vms/rpcchainvm/ghttp/http_client.go
+++ b/vms/rpcchainvm/ghttp/http_client.go
@@ -35,7 +35,7 @@ func NewClient(client ghttpproto.HTTPClient, broker *plugin.GRPCBroker) *Client 
 // Handle ...
 func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	closer := grpcutils.ServerCloser{}
-	defer closer.Stop()
+	defer closer.GracefulStop()
 
 	readerID := c.broker.NextId()
 	go c.broker.AcceptAndServe(readerID, func(opts []grpc.ServerOption) *grpc.Server {

--- a/vms/rpcchainvm/gkeystore/keystore_server.go
+++ b/vms/rpcchainvm/gkeystore/keystore_server.go
@@ -39,7 +39,7 @@ type dbCloser struct {
 
 func (db *dbCloser) Close() error {
 	err := db.Database.Close()
-	db.closer.Stop()
+	db.closer.GracefulStop()
 	return err
 }
 

--- a/vms/rpcchainvm/grpcutils/server_closer.go
+++ b/vms/rpcchainvm/grpcutils/server_closer.go
@@ -22,7 +22,7 @@ func (s *ServerCloser) Add(server *grpc.Server) {
 	defer s.lock.Unlock()
 
 	if s.closed {
-		server.Stop()
+		server.GracefulStop()
 	} else {
 		s.servers = append(s.servers, server)
 	}
@@ -35,6 +35,18 @@ func (s *ServerCloser) Stop() {
 
 	for _, server := range s.servers {
 		server.Stop()
+	}
+	s.closed = true
+	s.servers = nil
+}
+
+// GracefulStop ...
+func (s *ServerCloser) GracefulStop() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	for _, server := range s.servers {
+		server.GracefulStop()
 	}
 	s.closed = true
 	s.servers = nil

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -217,7 +217,7 @@ func (vm *VMClient) Shutdown() error {
 	_, err := vm.client.Shutdown(context.Background(), &vmproto.ShutdownRequest{})
 	errs.Add(err)
 
-	vm.serverCloser.Stop()
+	vm.serverCloser.GracefulStop()
 	for _, conn := range vm.conns {
 		errs.Add(conn.Close())
 	}

--- a/vms/rpcchainvm/vm_server.go
+++ b/vms/rpcchainvm/vm_server.go
@@ -204,7 +204,7 @@ func (vm *VMServer) Shutdown(context.Context, *vmproto.ShutdownRequest) (*vmprot
 	errs.Add(vm.vm.Shutdown())
 	close(vm.toEngine)
 
-	vm.serverCloser.Stop()
+	vm.serverCloser.GracefulStop()
 	for _, conn := range vm.conns {
 		errs.Add(conn.Close())
 	}


### PR DESCRIPTION
Fixes ava-labs/coreth#84 

This issue occurred under a high load of RPC calls, which caused some connections to be pruned before they could finish resulting in an attempt to write to a closed http response writer.