### PR TITLE
Add Gun as an equivalent measurement as NanoAVAX.

### DIFF
--- a/utils/units/avax.go
+++ b/utils/units/avax.go
@@ -5,6 +5,7 @@ package units
 
 // Denominations of value
 const (
+	Gun       uint64 = 1
 	NanoAvax  uint64 = 1
 	MicroAvax uint64 = 1000 * NanoAvax
 	Schmeckle uint64 = 49*MicroAvax + 463*NanoAvax

--- a/utils/units/avax.go
+++ b/utils/units/avax.go
@@ -7,8 +7,8 @@ package units
 const (
 	Gun       uint64 = 1
 	NanoAvax  uint64 = 1
-	MicroAvax uint64 = 1000 * NanoAvax
-	Schmeckle uint64 = 49*MicroAvax + 463*NanoAvax
+	MicroAvax uint64 = 1000 * Gun
+	Schmeckle uint64 = 49*MicroAvax + 463*Gun
 	MilliAvax uint64 = 1000 * MicroAvax
 	Avax      uint64 = 1000 * MilliAvax
 	KiloAvax  uint64 = 1000 * Avax


### PR DESCRIPTION
In BTC the smallest unit of measure is a `satoshi`. We should have the smallest unit of AVAX be a `gun`. I realize technically there is an umlaut, but that might be challenging for people to type.