### PR TITLE
Use constant stop/start db syntax for current/pending validators

### DIFF
--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -2042,7 +2042,7 @@ func (service *Service) GetStake(_ *http.Request, args *api.JSONAddresses, respo
 	startIter := startDB.NewIterator()
 	defer startIter.Release()
 
-	for startIter.Next() { // Iterates over current stakers
+	for startIter.Next() { // Iterates over pending stakers
 		stakerBytes := startIter.Value()
 
 		tx := Tx{}

--- a/vms/platformvm/state.go
+++ b/vms/platformvm/state.go
@@ -264,17 +264,17 @@ func (vm *VM) removeStaker(db database.Database, subnetID ids.ID, tx *rewardTx) 
 
 // Returns the pending staker that will start staking next
 func (vm *VM) nextStakerStart(db database.Database, subnetID ids.ID) (*Tx, error) {
-	iter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix)), db).NewIterator()
-	defer iter.Release()
+	startIter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix)), db).NewIterator()
+	defer startIter.Release()
 
-	if !iter.Next() {
+	if !startIter.Next() {
 		return nil, errNoValidators
 	}
 	// Key: [Staker start time] | [Tx ID]
 	// Value: Byte repr. of tx that added this validator
 
 	tx := Tx{}
-	if _, err := Codec.Unmarshal(iter.Value(), &tx); err != nil {
+	if _, err := Codec.Unmarshal(startIter.Value(), &tx); err != nil {
 		return nil, err
 	}
 	return &tx, tx.Sign(vm.codec, nil)
@@ -282,17 +282,17 @@ func (vm *VM) nextStakerStart(db database.Database, subnetID ids.ID) (*Tx, error
 
 // Returns the current staker that will stop staking next
 func (vm *VM) nextStakerStop(db database.Database, subnetID ids.ID) (*rewardTx, error) {
-	iter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix)), db).NewIterator()
-	defer iter.Release()
+	stopIter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix)), db).NewIterator()
+	defer stopIter.Release()
 
-	if !iter.Next() {
+	if !stopIter.Next() {
 		return nil, errNoValidators
 	}
 	// Key: [Staker stop time] | [Tx ID]
 	// Value: Byte repr. of tx that added this validator
 
 	tx := rewardTx{}
-	if _, err := Codec.Unmarshal(iter.Value(), &tx); err != nil {
+	if _, err := Codec.Unmarshal(stopIter.Value(), &tx); err != nil {
 		return nil, err
 	}
 	return &tx, tx.Tx.Sign(vm.codec, nil)
@@ -300,11 +300,11 @@ func (vm *VM) nextStakerStop(db database.Database, subnetID ids.ID) (*rewardTx, 
 
 // Returns true if [nodeID] is a validator (not a delegator) of subnet [subnetID]
 func (vm *VM) isValidator(db database.Database, subnetID ids.ID, nodeID ids.ShortID) (TimedTx, bool, error) {
-	iter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix)), db).NewIterator()
-	defer iter.Release()
+	stopIter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix)), db).NewIterator()
+	defer stopIter.Release()
 
-	for iter.Next() {
-		txBytes := iter.Value()
+	for stopIter.Next() {
+		txBytes := stopIter.Value()
 		tx := rewardTx{}
 		if _, err := Codec.Unmarshal(txBytes, &tx); err != nil {
 			return nil, false, err
@@ -333,11 +333,11 @@ func (vm *VM) isValidator(db database.Database, subnetID ids.ID, nodeID ids.Shor
 // Returns true if [nodeID] will be a validator (not a delegator) of subnet
 // [subnetID]
 func (vm *VM) willBeValidator(db database.Database, subnetID ids.ID, nodeID ids.ShortID) (TimedTx, bool, error) {
-	iter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix)), db).NewIterator()
-	defer iter.Release()
+	startIter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix)), db).NewIterator()
+	defer startIter.Release()
 
-	for iter.Next() {
-		txBytes := iter.Value()
+	for startIter.Next() {
+		txBytes := startIter.Value()
 		tx := Tx{}
 		if _, err := Codec.Unmarshal(txBytes, &tx); err != nil {
 			return nil, false, err

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -417,7 +417,7 @@ func (vm *VM) Bootstrapped() error {
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
 
-	for stopIter.Next() { // Iterates in order of increasing start time
+	for stopIter.Next() { // Iterates in order of increasing stop time
 		txBytes := stopIter.Value()
 
 		tx := rewardTx{}
@@ -485,7 +485,7 @@ func (vm *VM) Shutdown() error {
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
 
-	for stopIter.Next() { // Iterates in order of increasing start time
+	for stopIter.Next() { // Iterates in order of increasing stop time
 		txBytes := stopIter.Value()
 
 		tx := rewardTx{}
@@ -878,7 +878,7 @@ pendingStakerLoop:
 	defer stopIter.Release()
 
 currentStakerLoop:
-	for stopIter.Next() { // Iterates in order of increasing start time
+	for stopIter.Next() { // Iterates in order of increasing stop time
 		txBytes := stopIter.Value()
 
 		tx := rewardTx{}
@@ -964,7 +964,7 @@ func (vm *VM) updateVdrSet(subnetID ids.ID) error {
 	stopIter := stopDB.NewIterator()
 	defer stopIter.Release()
 
-	for stopIter.Next() { // Iterates in order of increasing start time
+	for stopIter.Next() { // Iterates in order of increasing stop time
 		txBytes := stopIter.Value()
 
 		tx := rewardTx{}
@@ -1165,12 +1165,12 @@ func (vm *VM) getStakers() ([]validators.Validator, error) {
 	stopPrefix := []byte(fmt.Sprintf("%s%s", constants.PrimaryNetworkID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, vm.DB)
 	defer stopDB.Close()
-	iter := stopDB.NewIterator()
-	defer iter.Release()
+	stopIter := stopDB.NewIterator()
+	defer stopIter.Release()
 
 	stakers := []validators.Validator{}
-	for iter.Next() { // Iterates in order of increasing start time
-		txBytes := iter.Value()
+	for stopIter.Next() { // Iterates in order of increasing stop time
+		txBytes := stopIter.Value()
 		tx := rewardTx{}
 		if _, err := vm.codec.Unmarshal(txBytes, &tx); err != nil {
 			return nil, fmt.Errorf("couldn't unmarshal validator tx: %w", err)
@@ -1188,7 +1188,7 @@ func (vm *VM) getStakers() ([]validators.Validator, error) {
 
 	errs := wrappers.Errs{}
 	errs.Add(
-		iter.Error(),
+		stopIter.Error(),
 		stopDB.Close(),
 	)
 	return stakers, errs.Err
@@ -1202,12 +1202,12 @@ func (vm *VM) getPendingStakers() ([]validators.Validator, error) {
 	startDBPrefix := []byte(fmt.Sprintf("%s%s", constants.PrimaryNetworkID, startDBPrefix))
 	startDB := prefixdb.NewNested(startDBPrefix, vm.DB)
 	defer startDB.Close()
-	iter := startDB.NewIterator()
-	defer iter.Release()
+	startIter := startDB.NewIterator()
+	defer startIter.Release()
 
 	stakers := []validators.Validator{}
-	for iter.Next() { // Iterates in order of increasing start time
-		txBytes := iter.Value()
+	for startIter.Next() { // Iterates in order of increasing start time
+		txBytes := startIter.Value()
 		tx := rewardTx{}
 		if _, err := vm.codec.Unmarshal(txBytes, &tx); err != nil {
 			return nil, fmt.Errorf("couldn't unmarshal validator tx: %w", err)
@@ -1225,7 +1225,7 @@ func (vm *VM) getPendingStakers() ([]validators.Validator, error) {
 
 	errs := wrappers.Errs{}
 	errs.Add(
-		iter.Error(),
+		startIter.Error(),
 		startDB.Close(),
 	)
 	return stakers, errs.Err


### PR DESCRIPTION
This PR fixes some comments describing the iterators over the current/pending validator sets. Additionally, it uses the same syntax throughout when creating these iterators of `startIter`/`stopIter`.