### PR TITLE
Add current validators index

### DIFF
--- a/.ci/run_e2e_tests.sh
+++ b/.ci/run_e2e_tests.sh
@@ -17,7 +17,7 @@ echo "Using Avalanche Image: $AVALANCHE_IMAGE"
 
 DOCKER_REPO="avaplatform"
 BYZANTINE_IMAGE="$DOCKER_REPO/avalanche-byzantine:v0.1.5-rc.1"
-TEST_SUITE_IMAGE="$DOCKER_REPO/avalanche-testing:v0.10.5-rc.1"
+TEST_SUITE_IMAGE="$DOCKER_REPO/avalanche-testing:v0.10.5-rc.2"
 
 # If Docker Credentials are not available skip the Byzantine Tests
 if [[ -z ${DOCKER_USERNAME} ]]; then

--- a/vms/platformvm/state.go
+++ b/vms/platformvm/state.go
@@ -115,6 +115,7 @@ func (vm *VM) enqueueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 		prefixStartDB.Close(),
 	)
 
+	// If the staker being added is a validator, add it to the pending validators index
 	if priority != 1 {
 		prefixPendingValidators := []byte(fmt.Sprintf("%s%s", subnetID, pendingValidatorsPrefix))
 		pendingValidatorsDB := prefixdb.NewNested(prefixPendingValidators, db)
@@ -171,6 +172,7 @@ func (vm *VM) dequeueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 		prefixStartDB.Close(),
 	)
 
+	// If the staker being removed is a validator, remove it from the pending validators index
 	if priority != 1 {
 		prefixPendingValidators := []byte(fmt.Sprintf("%s%s", subnetID, pendingValidatorsPrefix))
 		pendingValidatorsDB := prefixdb.NewNested(prefixPendingValidators, db)
@@ -232,6 +234,7 @@ func (vm *VM) addStaker(db database.Database, subnetID ids.ID, tx *rewardTx) err
 		prefixStopDB.Close(),
 	)
 
+	// If the staker being added is a validator, add it to the current validators index
 	if priority > 0 {
 		prefixCurrentValidators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
 		currentValidatorsDB := prefixdb.NewNested(prefixCurrentValidators, db)
@@ -289,6 +292,7 @@ func (vm *VM) removeStaker(db database.Database, subnetID ids.ID, tx *rewardTx) 
 		prefixStopDB.Close(),
 	)
 
+	// If the staker being removed is a validator, remove it from the current validators index
 	if priority > 0 {
 		prefixCurrentValidators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
 		currentValidatorsDB := prefixdb.NewNested(prefixCurrentValidators, db)

--- a/vms/platformvm/state.go
+++ b/vms/platformvm/state.go
@@ -27,9 +27,10 @@ import (
 
 // TODO: Cache prefixed IDs or use different way of keying into database
 const (
-	startDBPrefix  = "start"
-	stopDBPrefix   = "stop"
-	uptimeDBPrefix = "uptime"
+	startDBPrefix           = "start"
+	stopDBPrefix            = "stop"
+	uptimeDBPrefix          = "uptime"
+	currentValidatorsPrefix = "currentVdrs"
 )
 
 var (
@@ -97,17 +98,13 @@ func (vm *VM) enqueueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 	prefixStart := []byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix))
 	prefixStartDB := prefixdb.NewNested(prefixStart, db)
 
-	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
-	p.PackLong(uint64(staker.StartTime().Unix()))
-	p.PackByte(priority)
-	p.PackFixedBytes(stakerID[:])
-	if p.Err != nil {
+	startKey, err := timedTxKey(staker.StartTime(), priority, stakerID)
+	if err != nil {
 		// Close the DB, but ignore the error, as the parent error needs to be
 		// returned.
 		_ = prefixStartDB.Close()
-		return fmt.Errorf("couldn't serialize validator key: %w", p.Err)
+		return err
 	}
-	startKey := p.Bytes
 
 	errs := wrappers.Errs{}
 	errs.Add(
@@ -143,17 +140,13 @@ func (vm *VM) dequeueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 	prefixStart := []byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix))
 	prefixStartDB := prefixdb.NewNested(prefixStart, db)
 
-	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
-	p.PackLong(uint64(staker.StartTime().Unix()))
-	p.PackByte(priority)
-	p.PackFixedBytes(stakerID[:])
-	if p.Err != nil {
+	startKey, err := timedTxKey(staker.StartTime(), priority, stakerID)
+	if err != nil {
 		// Close the DB, but ignore the error, as the parent error needs to be
 		// returned.
 		_ = prefixStartDB.Close()
-		return fmt.Errorf("couldn't serialize validator key: %w", p.Err)
+		return fmt.Errorf("couldn't serialize validator key: %w", err)
 	}
-	startKey := p.Bytes
 
 	errs := wrappers.Errs{}
 	errs.Add(
@@ -169,6 +162,7 @@ func (vm *VM) addStaker(db database.Database, subnetID ids.ID, tx *rewardTx) err
 	var (
 		staker   TimedTx
 		priority byte
+		nodeID   ids.ShortID
 	)
 	switch unsignedTx := tx.Tx.UnsignedTx.(type) {
 	case *UnsignedAddDelegatorTx:
@@ -177,9 +171,11 @@ func (vm *VM) addStaker(db database.Database, subnetID ids.ID, tx *rewardTx) err
 	case *UnsignedAddSubnetValidatorTx:
 		staker = unsignedTx
 		priority = 1
+		nodeID = unsignedTx.Validator.NodeID
 	case *UnsignedAddValidatorTx:
 		staker = unsignedTx
 		priority = 2
+		nodeID = unsignedTx.Validator.NodeID
 	default:
 		return fmt.Errorf("staker is unexpected type %T", tx.Tx.UnsignedTx)
 	}
@@ -195,23 +191,30 @@ func (vm *VM) addStaker(db database.Database, subnetID ids.ID, tx *rewardTx) err
 	prefixStop := []byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix))
 	prefixStopDB := prefixdb.NewNested(prefixStop, db)
 
-	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
-	p.PackLong(uint64(staker.EndTime().Unix()))
-	p.PackByte(priority)
-	p.PackFixedBytes(txID[:])
-	if p.Err != nil {
+	stopKey, err := timedTxKey(staker.EndTime(), priority, txID)
+	if err != nil {
 		// Close the DB, but ignore the error, as the parent error needs to be
 		// returned.
 		_ = prefixStopDB.Close()
-		return fmt.Errorf("couldn't serialize validator key: %w", p.Err)
+		return fmt.Errorf("couldn't serialize validator key: %w", err)
 	}
-	stopKey := p.Bytes
 
 	errs := wrappers.Errs{}
 	errs.Add(
 		prefixStopDB.Put(stopKey, txBytes),
 		prefixStopDB.Close(),
 	)
+
+	if priority > 0 {
+		prefixCurrentValdiators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
+		prefixCurrentValdiatorsDB := prefixdb.NewNested(prefixCurrentValdiators, db)
+
+		errs.Add(
+			prefixCurrentValdiatorsDB.Put(nodeID.Bytes(), txBytes),
+			prefixCurrentValdiatorsDB.Close(),
+		)
+	}
+
 	return errs.Err
 }
 
@@ -221,6 +224,7 @@ func (vm *VM) removeStaker(db database.Database, subnetID ids.ID, tx *rewardTx) 
 	var (
 		staker   TimedTx
 		priority byte
+		nodeID   ids.ShortID
 	)
 	switch unsignedTx := tx.Tx.UnsignedTx.(type) {
 	case *UnsignedAddDelegatorTx:
@@ -229,9 +233,11 @@ func (vm *VM) removeStaker(db database.Database, subnetID ids.ID, tx *rewardTx) 
 	case *UnsignedAddSubnetValidatorTx:
 		staker = unsignedTx
 		priority = 1
+		nodeID = unsignedTx.Validator.NodeID
 	case *UnsignedAddValidatorTx:
 		staker = unsignedTx
 		priority = 2
+		nodeID = unsignedTx.Validator.NodeID
 	default:
 		return fmt.Errorf("staker is unexpected type %T", tx.Tx.UnsignedTx)
 	}
@@ -242,23 +248,30 @@ func (vm *VM) removeStaker(db database.Database, subnetID ids.ID, tx *rewardTx) 
 	prefixStop := []byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix))
 	prefixStopDB := prefixdb.NewNested(prefixStop, db)
 
-	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
-	p.PackLong(uint64(staker.EndTime().Unix()))
-	p.PackByte(priority)
-	p.PackFixedBytes(txID[:])
-	if p.Err != nil {
+	stopKey, err := timedTxKey(staker.EndTime(), priority, txID)
+	if err != nil {
 		// Close the DB, but ignore the error, as the parent error needs to be
 		// returned.
 		_ = prefixStopDB.Close()
-		return fmt.Errorf("couldn't serialize validator key: %w", p.Err)
+		return fmt.Errorf("couldn't serialize validator key: %w", err)
 	}
-	stopKey := p.Bytes
 
 	errs := wrappers.Errs{}
 	errs.Add(
 		prefixStopDB.Delete(stopKey),
 		prefixStopDB.Close(),
 	)
+
+	if priority > 0 {
+		prefixCurrentValdiators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
+		prefixCurrentValdiatorsDB := prefixdb.NewNested(prefixCurrentValdiators, db)
+
+		errs.Add(
+			prefixCurrentValdiatorsDB.Delete(nodeID.Bytes()),
+			prefixCurrentValdiatorsDB.Close(),
+		)
+	}
+
 	return errs.Err
 }
 
@@ -300,34 +313,24 @@ func (vm *VM) nextStakerStop(db database.Database, subnetID ids.ID) (*rewardTx, 
 
 // Returns true if [nodeID] is a validator (not a delegator) of subnet [subnetID]
 func (vm *VM) isValidator(db database.Database, subnetID ids.ID, nodeID ids.ShortID) (TimedTx, bool, error) {
-	iter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, stopDBPrefix)), db).NewIterator()
-	defer iter.Release()
+	prefixCurrentValdiators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
+	prefixCurrentValdiatorsDB := prefixdb.NewNested(prefixCurrentValdiators, db)
+	defer prefixCurrentValdiatorsDB.Close()
 
-	for iter.Next() {
-		txBytes := iter.Value()
-		tx := rewardTx{}
-		if _, err := Codec.Unmarshal(txBytes, &tx); err != nil {
-			return nil, false, err
-		}
-
-		switch vdr := tx.Tx.UnsignedTx.(type) {
-		case *UnsignedAddValidatorTx:
-			if subnetID == constants.PrimaryNetworkID && vdr.Validator.NodeID == nodeID {
-				if err := tx.Tx.Sign(vm.codec, nil); err != nil {
-					return nil, false, err
-				}
-				return vdr, true, nil
-			}
-		case *UnsignedAddSubnetValidatorTx:
-			if subnetID == vdr.Validator.SubnetID() && vdr.Validator.NodeID == nodeID {
-				if err := tx.Tx.Sign(vm.codec, nil); err != nil {
-					return nil, false, err
-				}
-				return vdr, true, nil
-			}
-		}
+	txBytes, err := prefixCurrentValdiatorsDB.Get(nodeID.Bytes())
+	if err != nil {
+		return nil, false, nil
 	}
-	return nil, false, nil
+
+	tx := rewardTx{}
+	if _, err := Codec.Unmarshal(txBytes, &tx); err != nil {
+		return nil, false, err
+	}
+
+	if err := tx.Tx.Sign(vm.codec, nil); err != nil {
+		return nil, false, err
+	}
+	return tx.Tx.UnsignedTx.(TimedTx), true, nil
 }
 
 // Returns true if [nodeID] will be a validator (not a delegator) of subnet
@@ -930,4 +933,16 @@ func (vm *VM) unmarshalBlockFunc(bytes []byte) (snowman.Block, error) {
 	}
 	// Populate the un-serialized fields of the block
 	return block, block.initialize(vm, bytes)
+}
+
+// timedTxKey constructs the key to use for [txID] in stop and start prefix DBs
+func timedTxKey(time time.Time, priority byte, txID ids.ID) ([]byte, error) {
+	p := wrappers.Packer{MaxSize: wrappers.LongLen + wrappers.ByteLen + hashing.HashLen}
+	p.PackLong(uint64(time.Unix()))
+	p.PackByte(priority)
+	p.PackFixedBytes(txID[:])
+	if p.Err != nil {
+		return nil, fmt.Errorf("couldn't serialize validator key: %w", p.Err)
+	}
+	return p.Bytes, nil
 }

--- a/vms/platformvm/state.go
+++ b/vms/platformvm/state.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
-	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
@@ -31,6 +30,7 @@ const (
 	stopDBPrefix            = "stop"
 	uptimeDBPrefix          = "uptime"
 	currentValidatorsPrefix = "currentVdrs"
+	pendingValidatorsPrefix = "pendingVdrs"
 )
 
 var (
@@ -77,6 +77,7 @@ func (vm *VM) enqueueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 	var (
 		staker   TimedTx
 		priority byte
+		nodeID   ids.ShortID
 	)
 	switch unsignedTx := stakerTx.UnsignedTx.(type) {
 	case *UnsignedAddDelegatorTx:
@@ -85,9 +86,11 @@ func (vm *VM) enqueueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 	case *UnsignedAddSubnetValidatorTx:
 		staker = unsignedTx
 		priority = 0
+		nodeID = unsignedTx.Validator.NodeID
 	case *UnsignedAddValidatorTx:
 		staker = unsignedTx
 		priority = 2
+		nodeID = unsignedTx.Validator.NodeID
 	default:
 		return fmt.Errorf("staker is unexpected type %T", stakerTx)
 	}
@@ -111,6 +114,17 @@ func (vm *VM) enqueueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 		prefixStartDB.Put(startKey, txBytes),
 		prefixStartDB.Close(),
 	)
+
+	if priority != 1 {
+		prefixPendingValidators := []byte(fmt.Sprintf("%s%s", subnetID, pendingValidatorsPrefix))
+		pendingValidatorsDB := prefixdb.NewNested(prefixPendingValidators, db)
+
+		errs.Add(
+			pendingValidatorsDB.Put(nodeID.Bytes(), txBytes),
+			pendingValidatorsDB.Close(),
+		)
+	}
+
 	return errs.Err
 }
 
@@ -120,6 +134,7 @@ func (vm *VM) dequeueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 	var (
 		staker   TimedTx
 		priority byte
+		nodeID   ids.ShortID
 	)
 	switch unsignedTx := stakerTx.UnsignedTx.(type) {
 	case *UnsignedAddDelegatorTx:
@@ -128,9 +143,11 @@ func (vm *VM) dequeueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 	case *UnsignedAddSubnetValidatorTx:
 		staker = unsignedTx
 		priority = 0
+		nodeID = unsignedTx.Validator.NodeID
 	case *UnsignedAddValidatorTx:
 		staker = unsignedTx
 		priority = 2
+		nodeID = unsignedTx.Validator.NodeID
 	default:
 		return fmt.Errorf("staker is unexpected type %T", stakerTx)
 	}
@@ -153,6 +170,16 @@ func (vm *VM) dequeueStaker(db database.Database, subnetID ids.ID, stakerTx *Tx)
 		prefixStartDB.Delete(startKey),
 		prefixStartDB.Close(),
 	)
+
+	if priority != 1 {
+		prefixPendingValidators := []byte(fmt.Sprintf("%s%s", subnetID, pendingValidatorsPrefix))
+		pendingValidatorsDB := prefixdb.NewNested(prefixPendingValidators, db)
+
+		errs.Add(
+			pendingValidatorsDB.Delete(nodeID.Bytes()),
+			pendingValidatorsDB.Close(),
+		)
+	}
 	return errs.Err
 }
 
@@ -206,12 +233,12 @@ func (vm *VM) addStaker(db database.Database, subnetID ids.ID, tx *rewardTx) err
 	)
 
 	if priority > 0 {
-		prefixCurrentValdiators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
-		prefixCurrentValdiatorsDB := prefixdb.NewNested(prefixCurrentValdiators, db)
+		prefixCurrentValidators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
+		currentValidatorsDB := prefixdb.NewNested(prefixCurrentValidators, db)
 
 		errs.Add(
-			prefixCurrentValdiatorsDB.Put(nodeID.Bytes(), txBytes),
-			prefixCurrentValdiatorsDB.Close(),
+			currentValidatorsDB.Put(nodeID.Bytes(), txBytes),
+			currentValidatorsDB.Close(),
 		)
 	}
 
@@ -263,12 +290,12 @@ func (vm *VM) removeStaker(db database.Database, subnetID ids.ID, tx *rewardTx) 
 	)
 
 	if priority > 0 {
-		prefixCurrentValdiators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
-		prefixCurrentValdiatorsDB := prefixdb.NewNested(prefixCurrentValdiators, db)
+		prefixCurrentValidators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
+		currentValidatorsDB := prefixdb.NewNested(prefixCurrentValidators, db)
 
 		errs.Add(
-			prefixCurrentValdiatorsDB.Delete(nodeID.Bytes()),
-			prefixCurrentValdiatorsDB.Close(),
+			currentValidatorsDB.Delete(nodeID.Bytes()),
+			currentValidatorsDB.Close(),
 		)
 	}
 
@@ -313,11 +340,11 @@ func (vm *VM) nextStakerStop(db database.Database, subnetID ids.ID) (*rewardTx, 
 
 // Returns true if [nodeID] is a validator (not a delegator) of subnet [subnetID]
 func (vm *VM) isValidator(db database.Database, subnetID ids.ID, nodeID ids.ShortID) (TimedTx, bool, error) {
-	prefixCurrentValdiators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
-	prefixCurrentValdiatorsDB := prefixdb.NewNested(prefixCurrentValdiators, db)
-	defer prefixCurrentValdiatorsDB.Close()
+	prefixCurrentValidators := []byte(fmt.Sprintf("%s%s", subnetID, currentValidatorsPrefix))
+	currentValidatorsDB := prefixdb.NewNested(prefixCurrentValidators, db)
+	defer currentValidatorsDB.Close()
 
-	txBytes, err := prefixCurrentValdiatorsDB.Get(nodeID.Bytes())
+	txBytes, err := currentValidatorsDB.Get(nodeID.Bytes())
 	if err != nil {
 		return nil, false, nil
 	}
@@ -336,34 +363,25 @@ func (vm *VM) isValidator(db database.Database, subnetID ids.ID, nodeID ids.Shor
 // Returns true if [nodeID] will be a validator (not a delegator) of subnet
 // [subnetID]
 func (vm *VM) willBeValidator(db database.Database, subnetID ids.ID, nodeID ids.ShortID) (TimedTx, bool, error) {
-	iter := prefixdb.NewNested([]byte(fmt.Sprintf("%s%s", subnetID, startDBPrefix)), db).NewIterator()
-	defer iter.Release()
+	prefixPendingValidators := []byte(fmt.Sprintf("%s%s", subnetID, pendingValidatorsPrefix))
+	pendingValidatorsDB := prefixdb.NewNested(prefixPendingValidators, db)
+	defer pendingValidatorsDB.Close()
 
-	for iter.Next() {
-		txBytes := iter.Value()
-		tx := Tx{}
-		if _, err := Codec.Unmarshal(txBytes, &tx); err != nil {
-			return nil, false, err
-		}
-
-		switch vdr := tx.UnsignedTx.(type) {
-		case *UnsignedAddValidatorTx:
-			if subnetID == constants.PrimaryNetworkID && vdr.Validator.NodeID == nodeID {
-				if err := tx.Sign(vm.codec, nil); err != nil {
-					return nil, false, err
-				}
-				return vdr, true, nil
-			}
-		case *UnsignedAddSubnetValidatorTx:
-			if subnetID == vdr.Validator.SubnetID() && vdr.Validator.NodeID == nodeID {
-				if err := tx.Sign(vm.codec, nil); err != nil {
-					return nil, false, err
-				}
-				return vdr, true, nil
-			}
-		}
+	txBytes, err := pendingValidatorsDB.Get(nodeID.Bytes())
+	if err != nil {
+		return nil, false, nil
 	}
-	return nil, false, nil
+
+	tx := Tx{}
+	if _, err := Codec.Unmarshal(txBytes, &tx); err != nil {
+		return nil, false, err
+	}
+
+	if err := tx.Sign(vm.codec, nil); err != nil {
+		return nil, false, err
+	}
+
+	return tx.UnsignedTx.(TimedTx), true, nil
 }
 
 // getUTXO returns the UTXO with the specified ID


### PR DESCRIPTION
This PR adds an index of the current validator set in order to reduce an O(n) search for a current validator to an O(1) lookup. This drastically reduces the execution time for reward transactions during bootstrapping, which previously spent the majority of CPU time in the `isValidator` call.