### PR TITLE
Peer Alias Tracking

### DIFF
--- a/main/keys.go
+++ b/main/keys.go
@@ -89,4 +89,6 @@ const (
 	disconnectedCheckFreqKey        = "disconnected-check-frequency"
 	disconnectedRestartTimeoutKey   = "disconnected-restart-timeout"
 	restartOnDisconnectedKey        = "restart-on-disconnected"
+	peerAliasReleaseFrequency       = "peer-alias-release-frequency"
+	peerAliasReleaseTimeout         = "peer-alias-release-timeout"
 )

--- a/main/keys.go
+++ b/main/keys.go
@@ -89,6 +89,6 @@ const (
 	disconnectedCheckFreqKey        = "disconnected-check-frequency"
 	disconnectedRestartTimeoutKey   = "disconnected-restart-timeout"
 	restartOnDisconnectedKey        = "restart-on-disconnected"
-	peerAliasReleaseFrequency       = "peer-alias-release-frequency"
-	peerAliasReleaseTimeout         = "peer-alias-release-timeout"
+	peerAliasReleaseFreqKey         = "peer-alias-release-frequency"
+	peerAliasTimeoutKey             = "peer-alias-timeout"
 )

--- a/main/params.go
+++ b/main/params.go
@@ -246,6 +246,10 @@ func avalancheFlagSet() *flag.FlagSet {
 	// Coreth Config
 	fs.String(corethConfigKey, defaultString, "Specifies config to pass into coreth")
 
+	// Peer Alias Configuration:
+	fs.Duration(peerAliasReleaseFrequency, 1*time.Minute, "")
+	fs.Duration(peerAliasReleaseTimeout, 10*time.Minute, "")
+
 	return fs
 }
 
@@ -692,6 +696,13 @@ func setNodeConfig(v *viper.Viper) error {
 		}
 	}
 	Config.CorethConfig = corethConfigString
+
+	// Peer alias
+	Config.PeerAliasReleaseFrequency = v.GetDuration(peerAliasReleaseFrequency)
+	Config.PeerAliasReleaseTimeout = v.GetDuration(peerAliasReleaseTimeout)
+	if Config.PeerAliasReleaseFrequency > Config.PeerAliasReleaseTimeout {
+		return fmt.Errorf("[%s] can't be greater than [%s]", peerAliasReleaseFrequency, peerAliasReleaseTimeout)
+	}
 
 	return nil
 }

--- a/main/params.go
+++ b/main/params.go
@@ -246,9 +246,12 @@ func avalancheFlagSet() *flag.FlagSet {
 	// Coreth Config
 	fs.String(corethConfigKey, defaultString, "Specifies config to pass into coreth")
 
-	// Peer Alias Configuration:
-	fs.Duration(peerAliasReleaseFrequency, 1*time.Minute, "")
-	fs.Duration(peerAliasReleaseTimeout, 10*time.Minute, "")
+	// Peer alias configuration
+	fs.Duration(peerAliasReleaseFreqKey, 1*time.Minute, "How often the node attempts to release timed out peer aliases. "+
+		"See [peer-alias-timeout]. If 0, node will not release timed out peer aliases.")
+	fs.Duration(peerAliasTimeoutKey, 10*time.Minute, "How often the node will attempt to connect "+
+		"to an IP address previously associated with a peer (i.e. a peer alias). The node "+
+		"will only attempt to connect to previous aliases if [peer-alias-release-frequency] > 0.")
 
 	return fs
 }
@@ -698,10 +701,10 @@ func setNodeConfig(v *viper.Viper) error {
 	Config.CorethConfig = corethConfigString
 
 	// Peer alias
-	Config.PeerAliasReleaseFrequency = v.GetDuration(peerAliasReleaseFrequency)
-	Config.PeerAliasReleaseTimeout = v.GetDuration(peerAliasReleaseTimeout)
-	if Config.PeerAliasReleaseFrequency > Config.PeerAliasReleaseTimeout {
-		return fmt.Errorf("[%s] can't be greater than [%s]", peerAliasReleaseFrequency, peerAliasReleaseTimeout)
+	Config.PeerAliasReleaseFrequency = v.GetDuration(peerAliasReleaseFreqKey)
+	Config.PeerAliasTimeout = v.GetDuration(peerAliasTimeoutKey)
+	if Config.PeerAliasReleaseFrequency > Config.PeerAliasTimeout {
+		return fmt.Errorf("[%s] can't be greater than [%s]", peerAliasReleaseFreqKey, peerAliasTimeoutKey)
 	}
 
 	return nil

--- a/network/network.go
+++ b/network/network.go
@@ -898,6 +898,7 @@ func (n *network) track(ip utils.IPDesc) {
 		return
 	}
 	if _, ok := n.aliasIPs[str]; ok {
+		fmt.Println("alias", str)
 		return
 	}
 	if _, ok := n.myIPs[str]; ok {

--- a/network/network.go
+++ b/network/network.go
@@ -141,15 +141,15 @@ type network struct {
 	apricotPhase0Time                  time.Time
 
 	// stateLock should never be held when grabbing a peer lock
-	stateLock           sync.RWMutex
-	pendingBytes        int64
-	closed              utils.AtomicBool
-	disconnectedIPs     map[string]struct{}
-	connectedIPs        map[string]struct{}
-	aliasIPs            map[string]struct{}
-	aliasReleaseFreq    time.Duration
-	aliasReleaseTimeout time.Duration
-	retryDelay          map[string]time.Duration
+	stateLock               sync.RWMutex
+	pendingBytes            int64
+	closed                  utils.AtomicBool
+	disconnectedIPs         map[string]struct{}
+	connectedIPs            map[string]struct{}
+	peerAliasIPs            map[string]struct{}
+	peerAliasReleaseFreq    time.Duration
+	peerAliasReleaseTimeout time.Duration
+	retryDelay              map[string]time.Duration
 	// TODO: bound the size of [myIPs] to avoid DoS. LRU caching would be ideal
 	myIPs map[string]struct{} // set of IPs that resulted in my ID.
 	peers map[ids.ShortID]*peer
@@ -207,8 +207,8 @@ func NewDefaultNetwork(
 	disconnectedRestartTimeout time.Duration,
 	apricotPhase0Time time.Time,
 	sendQueueSize uint32,
-	aliasReleaseFreq time.Duration,
-	aliasReleaseTimeout time.Duration,
+	peerAliasReleaseFreq time.Duration,
+	peerAliasReleaseTimeout time.Duration,
 ) Network {
 	return NewNetwork(
 		registerer,
@@ -250,8 +250,8 @@ func NewDefaultNetwork(
 		disconnectedCheckFreq,
 		disconnectedRestartTimeout,
 		apricotPhase0Time,
-		aliasReleaseFreq,
-		aliasReleaseTimeout,
+		peerAliasReleaseFreq,
+		peerAliasReleaseTimeout,
 	)
 }
 
@@ -296,8 +296,8 @@ func NewNetwork(
 	disconnectedCheckFreq time.Duration,
 	disconnectedRestartTimeout time.Duration,
 	apricotPhase0Time time.Time,
-	aliasReleaseFreq time.Duration,
-	aliasReleaseTimeout time.Duration,
+	peerAliasReleaseFreq time.Duration,
+	peerAliasReleaseTimeout time.Duration,
 ) Network {
 	// #nosec G404
 	netw := &network{
@@ -335,9 +335,9 @@ func NewNetwork(
 		pingFrequency:                      pingFrequency,
 		disconnectedIPs:                    make(map[string]struct{}),
 		connectedIPs:                       make(map[string]struct{}),
-		aliasIPs:                           make(map[string]struct{}),
-		aliasReleaseFreq:                   aliasReleaseFreq,
-		aliasReleaseTimeout:                aliasReleaseTimeout,
+		peerAliasIPs:                       make(map[string]struct{}),
+		peerAliasReleaseFreq:               peerAliasReleaseFreq,
+		peerAliasReleaseTimeout:            peerAliasReleaseTimeout,
 		retryDelay:                         make(map[string]time.Duration),
 		myIPs:                              map[string]struct{}{ip.IP().String(): {}},
 		peers:                              make(map[ids.ShortID]*peer),
@@ -897,7 +897,7 @@ func (n *network) track(ip utils.IPDesc) {
 	if _, ok := n.connectedIPs[str]; ok {
 		return
 	}
-	if _, ok := n.aliasIPs[str]; ok {
+	if _, ok := n.peerAliasIPs[str]; ok {
 		return
 	}
 	if _, ok := n.myIPs[str]; ok {
@@ -1151,18 +1151,18 @@ func (n *network) tryAddPeer(p *peer) error {
 
 	// If I am already connected to this peer, then I should close this new
 	// connection.
-	if linkedPeer, ok := n.peers[p.id]; ok {
+	if existing, ok := n.peers[p.id]; ok {
 		if !ip.IsZero() {
 			str := ip.String()
 			delete(n.disconnectedIPs, str)
 			delete(n.retryDelay, str)
-			n.aliasIPs[str] = struct{}{}
-			linkedPeer.ipLock.Lock()
-			linkedPeer.ipAliases = append(linkedPeer.ipAliases, ipAlias{
+			n.peerAliasIPs[str] = struct{}{}
+			existing.ipLock.Lock()
+			existing.aliases = append(existing.aliases, alias{
 				ip:    ip,
 				added: n.clock.Time().Unix(),
 			})
-			linkedPeer.ipLock.Unlock()
+			existing.ipLock.Unlock()
 		}
 		return fmt.Errorf("duplicated connection from %s at %s", p.id.PrefixedString(constants.NodeIDPrefix), ip)
 	}
@@ -1249,13 +1249,7 @@ func (n *network) disconnected(p *peer) {
 	delete(n.peers, p.id)
 	n.numPeers.Set(float64(len(n.peers)))
 
-	p.ipLock.Lock()                     // TODO: need lock?
-	for _, alias := range p.ipAliases { // ip must be non-zero to be added
-		str := alias.ip.String()
-		delete(n.aliasIPs, str)
-	}
-	p.ipAliases = p.ipAliases[:0]
-	p.ipLock.Unlock()
+	p.removeAliases()
 
 	if !ip.IsZero() {
 		str := ip.String()

--- a/network/network.go
+++ b/network/network.go
@@ -1141,6 +1141,9 @@ func (n *network) tryAddPeer(p *peer) error {
 			str := ip.String()
 			delete(n.disconnectedIPs, str)
 			delete(n.retryDelay, str)
+
+			// TODO: add to aliases for peer (create function that acquires a lock)
+			// TODO: have an aliasIP map?
 		}
 		return fmt.Errorf("duplicated connection from %s at %s", p.id.PrefixedString(constants.NodeIDPrefix), ip)
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -898,7 +898,6 @@ func (n *network) track(ip utils.IPDesc) {
 		return
 	}
 	if _, ok := n.aliasIPs[str]; ok {
-		fmt.Println("alias detected", str)
 		return
 	}
 	if _, ok := n.myIPs[str]; ok {
@@ -1163,8 +1162,6 @@ func (n *network) tryAddPeer(p *peer) error {
 				ip:    ip,
 				added: n.clock.Time().Unix(),
 			})
-			fmt.Println(n.id.String(), "added alias", str)
-			fmt.Println("aliases now:", linkedPeer.ipAliases)
 			linkedPeer.ipLock.Unlock()
 		}
 		return fmt.Errorf("duplicated connection from %s at %s", p.id.PrefixedString(constants.NodeIDPrefix), ip)
@@ -1252,12 +1249,10 @@ func (n *network) disconnected(p *peer) {
 	delete(n.peers, p.id)
 	n.numPeers.Set(float64(len(n.peers)))
 
-	p.ipLock.Lock() // TODO: need lock?
-	fmt.Println("total aliases", p.id.String(), len(p.ipAliases))
+	p.ipLock.Lock()                     // TODO: need lock?
 	for _, alias := range p.ipAliases { // ip must be non-zero to be added
 		str := alias.ip.String()
 		delete(n.aliasIPs, str)
-		fmt.Println("deleted alias", str)
 	}
 	p.ipAliases = p.ipAliases[:0]
 	p.ipLock.Unlock()

--- a/network/network.go
+++ b/network/network.go
@@ -898,7 +898,6 @@ func (n *network) track(ip utils.IPDesc) {
 		return
 	}
 	if _, ok := n.aliasIPs[str]; ok {
-		fmt.Println("alias", str)
 		return
 	}
 	if _, ok := n.myIPs[str]; ok {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -971,3 +971,10 @@ func TestTrackConnectedRace(t *testing.T) {
 	err = net1.Close()
 	assert.NoError(t, err)
 }
+
+func TestPeerAliases(testing *testing.T) {
+	// add alias on first duplicate
+	// ensure subsequent calls tracked as aliases
+	// remove an added alias via peer ticker
+	// ensure disconnect removes aliases
+}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1775,6 +1775,12 @@ func TestPeerAliases_Disconnect(t *testing.T) {
 	// Track ip2 on net3
 	wg2.Wait()
 	wg2Done = true
+	assertEqualPeers(t, map[string]ids.ShortID{}, net0.Peers())
+	assertEqualPeers(t, map[string]ids.ShortID{
+		ip0.String(): id0,
+	}, net1.Peers())
+	assert.Len(t, net2.Peers(), 0)
+	assert.Len(t, net3.Peers(), 0)
 	upgrader.m[ip2.String()] = id2
 	caller0.outbounds[ip2.String()] = listener3
 	net0.Track(ip2.IP())

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1382,12 +1382,12 @@ func TestPeerAliases_Ticker(t *testing.T) {
 	wg0.Wait()
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip1.String(): id1,
-	}, net0.Peers())
+	}, net0.Peers([]ids.ShortID{}))
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net1.Peers())
-	assert.Len(t, net2.Peers(), 0)
-	assert.Len(t, net3.Peers(), 0)
+	}, net1.Peers([]ids.ShortID{}))
+	assert.Len(t, net2.Peers([]ids.ShortID{}), 0)
+	assert.Len(t, net3.Peers([]ids.ShortID{}), 0)
 
 	// Attempt to connect to ip2 (same id as ip1)
 	net0.Track(ip2.IP())
@@ -1397,12 +1397,12 @@ func TestPeerAliases_Ticker(t *testing.T) {
 	wg1Done = true
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip1.String(): id1,
-	}, net0.Peers())
+	}, net0.Peers([]ids.ShortID{}))
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net1.Peers())
-	assert.Len(t, net2.Peers(), 0)
-	assert.Len(t, net3.Peers(), 0)
+	}, net1.Peers([]ids.ShortID{}))
+	assert.Len(t, net2.Peers([]ids.ShortID{}), 0)
+	assert.Len(t, net3.Peers([]ids.ShortID{}), 0)
 
 	// Subsequent track call returns immediately with no connection attempts
 	// (would cause fatal error from unauthorized connection if allowed)
@@ -1421,14 +1421,14 @@ func TestPeerAliases_Ticker(t *testing.T) {
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip1.String(): id1,
 		ip2.String(): id2,
-	}, net0.Peers())
+	}, net0.Peers([]ids.ShortID{}))
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net1.Peers())
-	assert.Len(t, net2.Peers(), 0)
+	}, net1.Peers([]ids.ShortID{}))
+	assert.Len(t, net2.Peers([]ids.ShortID{}), 0)
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net3.Peers())
+	}, net3.Peers([]ids.ShortID{}))
 
 	// Cleanup
 	cleanup = true
@@ -1784,12 +1784,12 @@ func TestPeerAliases_Disconnect(t *testing.T) {
 	wg0.Wait()
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip1.String(): id1,
-	}, net0.Peers())
+	}, net0.Peers([]ids.ShortID{}))
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net1.Peers())
-	assert.Len(t, net2.Peers(), 0)
-	assert.Len(t, net3.Peers(), 0)
+	}, net1.Peers([]ids.ShortID{}))
+	assert.Len(t, net2.Peers([]ids.ShortID{}), 0)
+	assert.Len(t, net3.Peers([]ids.ShortID{}), 0)
 
 	// Attempt to connect to ip2 (same id as ip1)
 	net0.Track(ip2.IP())
@@ -1799,12 +1799,12 @@ func TestPeerAliases_Disconnect(t *testing.T) {
 	wg1Done = true
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip1.String(): id1,
-	}, net0.Peers())
+	}, net0.Peers([]ids.ShortID{}))
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net1.Peers())
-	assert.Len(t, net2.Peers(), 0)
-	assert.Len(t, net3.Peers(), 0)
+	}, net1.Peers([]ids.ShortID{}))
+	assert.Len(t, net2.Peers([]ids.ShortID{}), 0)
+	assert.Len(t, net3.Peers([]ids.ShortID{}), 0)
 
 	// Disconnect original peer
 	caller0.clients[ip1.String()].Close()
@@ -1812,12 +1812,12 @@ func TestPeerAliases_Disconnect(t *testing.T) {
 	// Track ip2 on net3
 	wg2.Wait()
 	wg2Done = true
-	assertEqualPeers(t, map[string]ids.ShortID{}, net0.Peers())
+	assertEqualPeers(t, map[string]ids.ShortID{}, net0.Peers([]ids.ShortID{}))
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net1.Peers())
-	assert.Len(t, net2.Peers(), 0)
-	assert.Len(t, net3.Peers(), 0)
+	}, net1.Peers([]ids.ShortID{}))
+	assert.Len(t, net2.Peers([]ids.ShortID{}), 0)
+	assert.Len(t, net3.Peers([]ids.ShortID{}), 0)
 	upgrader.Update(ip2, id2)
 	caller0.Update(ip2, listener3)
 	net0.Track(ip2.IP())
@@ -1826,14 +1826,14 @@ func TestPeerAliases_Disconnect(t *testing.T) {
 	wg3.Wait()
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip2.String(): id2,
-	}, net0.Peers())
+	}, net0.Peers([]ids.ShortID{}))
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net1.Peers())
-	assert.Len(t, net2.Peers(), 0)
+	}, net1.Peers([]ids.ShortID{}))
+	assert.Len(t, net2.Peers([]ids.ShortID{}), 0)
 	assertEqualPeers(t, map[string]ids.ShortID{
 		ip0.String(): id0,
-	}, net3.Peers())
+	}, net3.Peers([]ids.ShortID{}))
 
 	// Cleanup
 	cleanup = true

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1065,7 +1065,7 @@ func assertEqualPeers(t *testing.T, expected map[string]ids.ShortID, actual []Pe
 	}
 }
 
-func TestPeerAliases_Ticker(t *testing.T) {
+func TestPeerAliasesTicker(t *testing.T) {
 	log := logging.NoLog{}
 	networkID := uint32(0)
 	appVersion := version.NewDefaultVersion("app", 0, 1, 0)
@@ -1445,7 +1445,7 @@ func TestPeerAliases_Ticker(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestPeerAliases_Disconnect(t *testing.T) {
+func TestPeerAliasesDisconnect(t *testing.T) {
 	log := logging.NoLog{}
 	networkID := uint32(0)
 	appVersion := version.NewDefaultVersion("app", 0, 1, 0)

--- a/network/peer.go
+++ b/network/peer.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math"
 	"net"
 	"sync"
@@ -144,7 +143,6 @@ func (p *peer) requestFinishHandshake() {
 
 // release ip alieases that have timed out
 func (p *peer) releaseAliases() {
-	fmt.Println("alias release started", p.id.String())
 	releaseTicker := time.NewTicker(p.net.aliasReleaseFreq)
 	defer releaseTicker.Stop()
 
@@ -170,7 +168,6 @@ func (p *peer) releaseAliases() {
 			p.net.stateLock.Lock()
 			delete(p.net.aliasIPs, bestAlias.ip.String())
 			p.net.stateLock.Unlock()
-			fmt.Println("removed alias", bestAlias.ip.String(), p.id.String())
 		case <-p.tickerCloser:
 			return
 		}

--- a/node/config.go
+++ b/node/config.go
@@ -131,5 +131,5 @@ type Config struct {
 
 	// Peer alias configuration
 	PeerAliasReleaseFrequency time.Duration
-	PeerAliasReleaseTimeout   time.Duration
+	PeerAliasTimeout          time.Duration
 }

--- a/node/config.go
+++ b/node/config.go
@@ -128,4 +128,8 @@ type Config struct {
 
 	// Coreth
 	CorethConfig string
+
+	// Peer alias configuration
+	PeerAliasReleaseFrequency time.Duration
+	PeerAliasReleaseTimeout   time.Duration
 }

--- a/node/node.go
+++ b/node/node.go
@@ -246,6 +246,8 @@ func (n *Node) initNetworking() error {
 		n.Config.DisconnectedRestartTimeout,
 		n.Config.ApricotPhase0Time,
 		n.Config.SendQueueSize,
+		n.Config.PeerAliasReleaseFrequency,
+		n.Config.PeerAliasReleaseTimeout,
 	)
 
 	n.nodeCloser = utils.HandleSignals(func(os.Signal) {

--- a/node/node.go
+++ b/node/node.go
@@ -247,7 +247,7 @@ func (n *Node) initNetworking() error {
 		n.Config.ApricotPhase0Time,
 		n.Config.SendQueueSize,
 		n.Config.PeerAliasReleaseFrequency,
-		n.Config.PeerAliasReleaseTimeout,
+		n.Config.PeerAliasTimeout,
 	)
 
 	n.nodeCloser = utils.HandleSignals(func(os.Signal) {


### PR DESCRIPTION
Closes: #544
Closes: #483
Closes: #736

### Issue

Periodically, we receive peerlist gossip from other nodes (which contains a list of IP addresses we should attempt to connect to). We iterate through each one of these IP addresses and [attempt to track it](https://github.com/ava-labs/avalanchego/blob/9c49b71d1b2a93f6a2161abac282c355ede22d3a/network/peer.go#L594). If we’ve seen the IP and are [actively trying to connect, are connected, or it is one of our own](https://github.com/ava-labs/avalanchego/blob/9c49b71d1b2a93f6a2161abac282c355ede22d3a/network/network.go#L856-L874), we do nothing. If we aren’t tracking this IP, we attempt to `connectTo` the IP (backing off on each failure as long as it is still not a duplicate of one we are trying to connect to, we are connected, or it is our own). On our first pass through this loop, let’s just assume that those restrictions are still true so we [`attemptConnect`](https://github.com/ava-labs/avalanchego/blob/9c49b71d1b2a93f6a2161abac282c355ede22d3a/network/network.go#L1018). In `attemptConnect`, we will try to dial the IP and `upgrade` the peer (returning the error of `upgrade`). [There are a few places where we could fail to upgrade the connection or timeout](https://github.com/ava-labs/avalanchego/blob/9c49b71d1b2a93f6a2161abac282c355ede22d3a/network/network.go#L1055-L1072) but let’s assume that doesn’t happen and that we do connect. We will then invoke [`tryAddPeer` (of which we never return the error)](https://github.com/ava-labs/avalanchego/blob/9c49b71d1b2a93f6a2161abac282c355ede22d3a/network/network.go#L1078-L1082). `tryAddPeer` will check if the peer we are attempting to connect to at the IP [is one we already have and if so will exit](https://github.com/ava-labs/avalanchego/blob/9c49b71d1b2a93f6a2161abac282c355ede22d3a/network/network.go#L1119-L1128). Well, this error will go unhandled and we will just stop trying to connect to that IP (after removing it from our `disconnectedIPs` and `retryDelay` map). We don’t want to attempt retrying to connect to a peer we already have, right? Well, this handling causes us to invoke a new `track` / `connectTo` as soon as the next peerlist that is gossiped to us contains this IP we just failed to connect to because it was a duplicate peer (in practice, our backoff then becomes the gap between any 2 peerlist message receives across all peers, which can be very small on mainnet).

So you may be asking, why would there ever be more than 1 IP for a validator gossiped via peerlist? Well, turns out you can indeed have multiple IP addresses that map to your computer behind a single router if you are using IPv6 ([via a mechanism called “privacy extensions”](https://apple.stackexchange.com/a/223056)…[RFC is here](https://tools.ietf.org/html/rfc4941)). I was able to force the public IP address reported by “what is my ip” and “opendns” to change while holding on to previously made peer connections. I’m guessing this can occur much more frequently than intended when someone is encountering network instability (and potentially with IPV4 addresses) inadvertently causing other nodes to DOS you.

### Solution

The simplest fix for this issue is to track "alias IPs" for peers that we are already connected to. We would add to this new set of "alias IPs" when we find a duplicated peer connection. When disconnecting from a peer (in case the IP we are connected to gets stale), we will remove the default IP of the peer and all its aliases so that we can connect again when we are gossiped its new IP. We would also periodically release aliases in the case that an alias is reassigned to a different peer (which would cause us to enter a weird network state).