### PR TITLE
Add API getters for peers and current/pending validators

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -403,7 +403,7 @@ func (n *Node) initDatabase() error {
 func (n *Node) initNodeID() error {
 	if !n.Config.EnableP2PTLS {
 		n.ID = ids.ShortID(hashing.ComputeHash160Array([]byte(n.Config.StakingIP.IP().String())))
-		n.Log.Info("Set the node's ID to %s", n.ID)
+		n.Log.Info("Set the node's ID to %s", n.ID.PrefixedString(constants.NodeIDPrefix))
 		return nil
 	}
 
@@ -421,7 +421,7 @@ func (n *Node) initNodeID() error {
 	if err != nil {
 		return fmt.Errorf("problem deriving staker ID from certificate: %w", err)
 	}
-	n.Log.Info("Set node's ID to %s", n.ID)
+	n.Log.Info("Set node's ID to %s", n.ID.PrefixedString(constants.NodeIDPrefix))
 	return nil
 }
 

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -603,6 +603,11 @@ type GetCurrentValidatorsArgs struct {
 	// Subnet we're listing the validators of
 	// If omitted, defaults to primary network
 	SubnetID ids.ID `json:"subnetID"`
+	// NodeIDs of validators to request. If [NodeIDs]
+	// is empty, it fetches all current validators. If
+	// some nodeIDs are not currently validators, they
+	// will be omitted from the response.
+	NodeIDs []string `json:"nodeIDs"`
 }
 
 // GetCurrentValidatorsReply are the results from calling GetCurrentValidators.
@@ -619,6 +624,17 @@ func (service *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentVa
 
 	// Validator's node ID as string --> Delegators to them
 	vdrTodelegators := map[string][]APIPrimaryDelegator{}
+
+	// Create set of nodeIDs
+	nodeIDs := ids.ShortSet{}
+	for _, nodeID := range args.NodeIDs {
+		nID, err := ids.ShortFromPrefixedString(nodeID, constants.NodeIDPrefix)
+		if err != nil {
+			return err
+		}
+		nodeIDs.Add(nID)
+	}
+	includeAllNodes := nodeIDs.Len() == 0
 
 	stopPrefix := []byte(fmt.Sprintf("%s%s", args.SubnetID, stopDBPrefix))
 	stopDB := prefixdb.NewNested(stopPrefix, service.vm.DB)
@@ -640,6 +656,10 @@ func (service *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentVa
 
 		switch staker := tx.Tx.UnsignedTx.(type) {
 		case *UnsignedAddDelegatorTx:
+			if !includeAllNodes && !nodeIDs.Contains(staker.Validator.ID()) {
+				continue
+			}
+
 			weight := json.Uint64(staker.Validator.Weight())
 
 			var rewardOwner *APIOwner
@@ -672,6 +692,10 @@ func (service *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentVa
 			}
 			vdrTodelegators[delegator.NodeID] = append(vdrTodelegators[delegator.NodeID], delegator)
 		case *UnsignedAddValidatorTx:
+			if !includeAllNodes && !nodeIDs.Contains(staker.Validator.ID()) {
+				continue
+			}
+
 			nodeID := staker.Validator.ID()
 			startTime := staker.StartTime()
 			weight := json.Uint64(staker.Validator.Weight())
@@ -716,6 +740,10 @@ func (service *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentVa
 				DelegationFee:   delegationFee,
 			})
 		case *UnsignedAddSubnetValidatorTx:
+			if !includeAllNodes && !nodeIDs.Contains(staker.Validator.ID()) {
+				continue
+			}
+
 			weight := json.Uint64(staker.Validator.Weight())
 			reply.Validators = append(reply.Validators, APIStaker{
 				TxID:      tx.Tx.ID(),
@@ -751,6 +779,11 @@ type GetPendingValidatorsArgs struct {
 	// Subnet we're getting the pending validators of
 	// If omitted, defaults to primary network
 	SubnetID ids.ID `json:"subnetID"`
+	// NodeIDs of validators to request. If [NodeIDs]
+	// is empty, it fetches all pending validators. If
+	// some requested nodeIDs are not pending validators,
+	// they are omitted from the response.
+	NodeIDs []string `json:"nodeIDs"`
 }
 
 // GetPendingValidatorsReply are the results from calling GetPendingValidators.
@@ -766,6 +799,17 @@ func (service *Service) GetPendingValidators(_ *http.Request, args *GetPendingVa
 
 	reply.Validators = []interface{}{}
 	reply.Delegators = []interface{}{}
+
+	// Create set of nodeIDs
+	nodeIDs := ids.ShortSet{}
+	for _, nodeID := range args.NodeIDs {
+		nID, err := ids.ShortFromPrefixedString(nodeID, constants.NodeIDPrefix)
+		if err != nil {
+			return err
+		}
+		nodeIDs.Add(nID)
+	}
+	includeAllNodes := nodeIDs.Len() == 0
 
 	startPrefix := []byte(fmt.Sprintf("%s%s", args.SubnetID, startDBPrefix))
 	startDB := prefixdb.NewNested(startPrefix, service.vm.DB)
@@ -787,6 +831,10 @@ func (service *Service) GetPendingValidators(_ *http.Request, args *GetPendingVa
 
 		switch staker := tx.UnsignedTx.(type) {
 		case *UnsignedAddDelegatorTx:
+			if !includeAllNodes && !nodeIDs.Contains(staker.Validator.ID()) {
+				continue
+			}
+
 			weight := json.Uint64(staker.Validator.Weight())
 			reply.Delegators = append(reply.Delegators, APIStaker{
 				TxID:        tx.ID(),
@@ -796,6 +844,10 @@ func (service *Service) GetPendingValidators(_ *http.Request, args *GetPendingVa
 				StakeAmount: &weight,
 			})
 		case *UnsignedAddValidatorTx:
+			if !includeAllNodes && !nodeIDs.Contains(staker.Validator.ID()) {
+				continue
+			}
+
 			nodeID := staker.Validator.ID()
 			weight := json.Uint64(staker.Validator.Weight())
 			delegationFee := json.Float32(100 * float32(staker.Shares) / float32(PercentDenominator))
@@ -813,6 +865,10 @@ func (service *Service) GetPendingValidators(_ *http.Request, args *GetPendingVa
 				Connected:     &connected,
 			})
 		case *UnsignedAddSubnetValidatorTx:
+			if !includeAllNodes && !nodeIDs.Contains(staker.Validator.ID()) {
+				continue
+			}
+
 			weight := json.Uint64(staker.Validator.Weight())
 			reply.Validators = append(reply.Validators, APIStaker{
 				TxID:      tx.ID(),


### PR DESCRIPTION
This PR adds an optional nodeIDs argument to the API calls: `info.peers`, `platform.getCurrentValidators`, and `platform.getPendingValidators`.

For each of these calls, if the argument is specified as a non-empty list of nodeIDs, then the API call will only include the output for the specified nodeIDs. If a specified nodeID is not found, then it is ignored and omitted from the output instead of causing an error.

Future work: change the way that getCurrentValidators and getPendingValidators retrieves the specific validators when nodeIDs is specified as a non-empty list once the database upgrade has been made to allow validatorTx lookups (both current and pending) to be O(1) instead of O(n) from iterating over the list of validators from the start and stop DBs, to iterating over the specified nodeIDs and doing the O(1) lookup for the current/pending validator transaction. This will make the operation linear in the number of requested validators instead of linear in the size of the current/pending validator sets.