### PR TITLE
Bump e2e test image to v0.10.5-rc.2

### DIFF
--- a/.ci/run_e2e_tests.sh
+++ b/.ci/run_e2e_tests.sh
@@ -17,7 +17,7 @@ echo "Using Avalanche Image: $AVALANCHE_IMAGE"
 
 DOCKER_REPO="avaplatform"
 BYZANTINE_IMAGE="$DOCKER_REPO/avalanche-byzantine:v0.1.5-rc.1"
-TEST_SUITE_IMAGE="$DOCKER_REPO/avalanche-testing:v0.10.5-rc.1"
+TEST_SUITE_IMAGE="$DOCKER_REPO/avalanche-testing:v0.10.5-rc.2"
 
 # If Docker Credentials are not available skip the Byzantine Tests
 if [[ -z ${DOCKER_USERNAME} ]]; then


### PR DESCRIPTION
Bump the E2E Testing Image to v0.10.5-rc.2. This change bumps the timeout for the coreth e2e test, which should fix some inconsistency in the test passing.