### PR TITLE
Clean up IP tracking

### DIFF
--- a/network/peer.go
+++ b/network/peer.go
@@ -590,8 +590,7 @@ func (p *peer) peerList(msg Msg) {
 		if !ip.Equal(p.net.ip.IP()) &&
 			!ip.IsZero() &&
 			(p.net.allowPrivateIPs || !ip.IsPrivate()) {
-			// TODO: only try to connect once
-			p.net.track(ip)
+			p.net.connectOnce(ip)
 		}
 		p.net.stateLock.Unlock()
 	}


### PR DESCRIPTION
This PR cleans up an outstanding TODO in the network package to ensure that the node only attempts to connect to an IP received in a peer list message once.

Additionally, this PR adds a change to the disconnected logic to ensure that we only track the IPs of recently disconnected IPs if they are validators.