### PR TITLE
Test abandon vertex because of trDep in future epoch

### DIFF
--- a/snow/engine/avalanche/issuer.go
+++ b/snow/engine/avalanche/issuer.go
@@ -25,7 +25,7 @@ type issuer struct {
 
 	// Note:
 	// [trIssuer] must return all unfulfilled dependencies (including those
-	// that have been issued into the epoch of [vtx] in order to be notified
+	// that have been issued into the epoch of [vtx]) in order to be notified
 	// if any of these unfulfilled dependencies are accepted in a future epoch
 	// such that we can abandon [vtx].
 	// [trDeps] and [unfulfilledDeps] are kept as two separate
@@ -209,12 +209,12 @@ type vtxIssuer struct{ i *issuer }
 
 func (vi *vtxIssuer) Dependencies() ids.Set { return vi.i.vtxDeps }
 func (vi *vtxIssuer) Fulfill(id ids.ID)     { vi.i.FulfillVtx(id) }
-func (vi *vtxIssuer) Abandon(id ids.ID)     { vi.i.Abandon() }
+func (vi *vtxIssuer) Abandon(ids.ID)        { vi.i.Abandon() }
 func (vi *vtxIssuer) Update()               { vi.i.Update() }
 
 type trIssuer struct{ i *issuer }
 
 func (ti *trIssuer) Dependencies() ids.Set { return ti.i.trDeps }
 func (ti *trIssuer) Fulfill(id ids.ID)     { ti.i.FulfillTr(id) }
-func (ti *trIssuer) Abandon(id ids.ID)     { ti.i.Abandon() }
+func (ti *trIssuer) Abandon(ids.ID)        { ti.i.Abandon() }
 func (ti *trIssuer) Update()               { ti.i.Update() }

--- a/snow/engine/avalanche/transitive.go
+++ b/snow/engine/avalanche/transitive.go
@@ -511,6 +511,10 @@ func (t *Transitive) issue(vtx avalanche.Vertex, updatedEpoch bool) error {
 				// Mark that depenency [depID] is not accepted in an earlier
 				// epoch and is not processing in the current epoch
 				i.trDeps.Add(depID)
+			} else {
+				// If the dependency has already been issued, then we add the
+				// dependency to processingDeps
+				i.processingDeps.Add(depID)
 			}
 		}
 	}

--- a/snow/engine/avalanche/transitive.go
+++ b/snow/engine/avalanche/transitive.go
@@ -490,6 +490,10 @@ func (t *Transitive) issue(vtx avalanche.Vertex, updatedEpoch bool) error {
 				continue
 			}
 
+			// Add [depID] to the set of transitions that this issuer
+			// is blocking on.
+			i.trDeps.Add(depID)
+
 			// [processingDepTxs] is a list of processing txs that contain
 			// dependency [depID].
 			processingDepTxs := t.Consensus.ProcessingTxs(depID)
@@ -510,11 +514,7 @@ func (t *Transitive) issue(vtx avalanche.Vertex, updatedEpoch bool) error {
 				t.missingTransitions[epoch] = missing
 				// Mark that depenency [depID] is not accepted in an earlier
 				// epoch and is not processing in the current epoch
-				i.trDeps.Add(depID)
-			} else {
-				// If the dependency has already been issued, then we add the
-				// dependency to processingDeps
-				i.processingDeps.Add(depID)
+				i.unfulfilledDeps.Add(depID)
 			}
 		}
 	}

--- a/snow/engine/avalanche/transitive_test.go
+++ b/snow/engine/avalanche/transitive_test.go
@@ -5012,7 +5012,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 		},
 	}
 	txA1 := &conflicts.TestTx{
-		BytesV: []byte{0},
+		BytesV: utils.RandomBytes(32),
 		EpochV: priorEpoch,
 		TestDecidable: choices.TestDecidable{
 			IDV:     ids.GenerateTestID(),
@@ -5021,7 +5021,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 		TransitionV: trA,
 	}
 	txA2 := &conflicts.TestTx{
-		BytesV: []byte{1},
+		BytesV: utils.RandomBytes(32),
 		EpochV: currentEpoch,
 		TestDecidable: choices.TestDecidable{
 			IDV:     ids.GenerateTestID(),
@@ -5030,7 +5030,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 		TransitionV: trA,
 	}
 	txB := &conflicts.TestTx{
-		BytesV: []byte{2},
+		BytesV: utils.RandomBytes(32),
 		EpochV: priorEpoch,
 		TestDecidable: choices.TestDecidable{
 			IDV:     ids.GenerateTestID(),
@@ -5039,7 +5039,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 		TransitionV: trB,
 	}
 	txC := &conflicts.TestTx{
-		BytesV: []byte{2},
+		BytesV: utils.RandomBytes(32),
 		EpochV: priorEpoch,
 		TestDecidable: choices.TestDecidable{
 			IDV:     ids.GenerateTestID(),
@@ -5102,7 +5102,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 	}
 	manager.GetF = func(id ids.ID) (avalanche.Vertex, error) {
 		if id != vtxA2.ID() {
-			t.Fatalf("Called Get for unexpected vtxID: %s", id)
+			assert.FailNow(t, "Called Get for unexpected vtxID: %s", id)
 		}
 		return vtxA2, nil
 	}
@@ -5120,7 +5120,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 	}
 	manager.GetF = func(id ids.ID) (avalanche.Vertex, error) {
 		if id != vtxA1.ID() {
-			t.Fatalf("Called Get for unexpected vtxID: %s", id)
+			assert.FailNow(t, "Called Get for unexpected vtxID: %s", id)
 		}
 		return vtxA1, nil
 	}
@@ -5139,7 +5139,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 	}
 	manager.GetF = func(id ids.ID) (avalanche.Vertex, error) {
 		if id != vtxC.ID() {
-			t.Fatalf("Unexpectedly called Get for vtxID: %s", id)
+			assert.FailNow(t, "Unexpectedly called Get for vtxID: %s", id)
 		}
 		return vtxC, nil
 	}
@@ -5150,7 +5150,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 
 	manager.GetF = func(id ids.ID) (avalanche.Vertex, error) {
 		if id != vtxA2.ID() {
-			t.Fatalf("Unexpectedly called Get for vtxID: %s", id)
+			assert.FailNow(t, "Unexpectedly called Get for vtxID: %s", id)
 		}
 		return vtxA2, nil
 	}

--- a/snow/engine/avalanche/transitive_test.go
+++ b/snow/engine/avalanche/transitive_test.go
@@ -5146,6 +5146,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 	err = te.PushQuery(vdr, 2, vtxC.ID(), vtxC.Bytes())
 	assert.NoError(t, err)
 	assert.False(t, te.Consensus.VertexIssued(vtxC), "should not have issued vtxC")
+	assert.True(t, te.pending.Contains(vtxC.ID()), "vtxC should have been in pending")
 
 	manager.GetF = func(id ids.ID) (avalanche.Vertex, error) {
 		if id != vtxA2.ID() {
@@ -5162,8 +5163,7 @@ func TestEngineAbandonDependencyFulfilledInFutureEpoch(t *testing.T) {
 	assert.NoError(t, err, "unexpected error calling Chits with vtxA2")
 	assert.Equal(t, choices.Accepted, vtxA2.Status(), "expected vtxA2 to be Processing")
 
-	// Since trA was accepted into epoch 2, vtxC (epoch 1) should be abandoned because its
-	// transaction txC has a dependency that will be fulfilled in epoch 2.
-	trToDependentsEpoch1 := te.trBlocked[priorEpoch]
-	assert.Len(t, trToDependentsEpoch1, 0)
+	// // Since trA was accepted into epoch 2, vtxC (epoch 1) should be abandoned because its
+	// // transaction txC has a dependency that will be fulfilled in epoch 2.
+	assert.False(t, te.pending.Contains(vtxC.ID()), "vtxC should have been abandoned")
 }


### PR DESCRIPTION
This PR adds a regression test for the following case:

vtxC contains trC that depends on trA and trB.

trA is issued into epochs 1 and 2, such that vtxC thinks it doesn't need to wait for trA to be fulfilled in its epoch. However, if trA is then accepted into epoch 2, vtxC should be abandoned because its dependencies can no longer be fulfilled in epoch 1.