### PR TITLE
Bump coreth to v0.3.21

### DIFF
--- a/scripts/build_coreth.sh
+++ b/scripts/build_coreth.sh
@@ -13,7 +13,7 @@ BUILD_DIR="$AVALANCHE_PATH/build" # Where binaries go
 PLUGIN_DIR="$BUILD_DIR/plugins" # Where plugin binaries (namely coreth) go
 BINARY_PATH="$PLUGIN_DIR/evm"
 
-CORETH_VER="v0.3.20"
+CORETH_VER="v0.3.21"
 
 CORETH_PATH="$GOPATH/pkg/mod/github.com/ava-labs/coreth@$CORETH_VER"
 


### PR DESCRIPTION
- adds a repair script that fixes a database corruption bug in the canonical chain that may cause API calls to return inconsistent results (note: this may cause the C-Chain to pause approximately one minute during initialization)
- fixes bug in EVM tracer where a contract with no code could cause custom tracers attempting to access the database to panic