### PR TITLE
Optimize log files and logrotation

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -112,7 +112,7 @@ func (s *Server) RegisterChain(chainName string, ctx *snow.Context, vmIntf inter
 		return
 	}
 
-	httpLogger, err := s.factory.MakeChain(chainName, "http")
+	httpLogger, err := s.factory.MakeChainChild(chainName, "http")
 	if err != nil {
 		s.log.Error("Failed to create new http logger: %s", err)
 		return

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -235,7 +235,7 @@ func (m *manager) buildChain(chainParams ChainParameters) (*chain, error) {
 	}
 
 	// Create the log and context of the chain
-	chainLog, err := m.LogFactory.MakeChain(primaryAlias, "")
+	chainLog, err := m.LogFactory.MakeChain(primaryAlias)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating chain's log %w", err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -41,7 +41,7 @@ func main() {
 	logFactory := logging.NewFactory(Config.LoggingConfig)
 	defer logFactory.Close()
 
-	log, err := logFactory.Make()
+	log, err := logFactory.Make("main")
 	if err != nil {
 		fmt.Printf("starting logger failed with: %s\n", err)
 		return

--- a/node/node.go
+++ b/node/node.go
@@ -809,7 +809,7 @@ func (n *Node) Initialize(
 	n.doneShuttingDown.Add(1)
 	n.Log.Info("Node version is: %s", Version)
 
-	httpLog, err := logFactory.MakeSubdir("http")
+	httpLog, err := logFactory.Make("http")
 	if err != nil {
 		return fmt.Errorf("problem initializing HTTP logger: %w", err)
 	}

--- a/utils/logging/config.go
+++ b/utils/logging/config.go
@@ -13,11 +13,11 @@ import (
 )
 
 var (
-	// DefaultLogDirectory ...
+	// DefaultLogDirectory is the default directory where logs are saved
 	DefaultLogDirectory = fmt.Sprintf("~/.%s/logs", constants.AppName)
 )
 
-// Config ...
+// Config defines the configuration of a logger
 type Config struct {
 	RotationInterval                                                                                time.Duration
 	FileSize, RotationSize, FlushSize                                                               int
@@ -27,7 +27,7 @@ type Config struct {
 	Directory, MsgPrefix, LoggerName                                                                string
 }
 
-// DefaultConfig ...
+// DefaultConfig returns a logger configuration with default parameters
 func DefaultConfig() (Config, error) {
 	dir, err := homedir.Expand(DefaultLogDirectory)
 	return Config{

--- a/utils/logging/config.go
+++ b/utils/logging/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	DisableLogging, DisableDisplaying, DisableContextualDisplaying, DisableFlushOnWrite, Assertions bool
 	LogLevel, DisplayLevel                                                                          Level
 	DisplayHighlight                                                                                Highlight
-	Directory, MsgPrefix                                                                            string
+	Directory, MsgPrefix, LoggerName                                                                string
 }
 
 // DefaultConfig ...

--- a/utils/logging/factory.go
+++ b/utils/logging/factory.go
@@ -3,29 +3,34 @@
 
 package logging
 
-// Factory ...
+// Factory creates new instances of different types of Logger
 type Factory interface {
+	// Make creates a new logger with name [name]
 	Make(name string) (Logger, error)
+	// MakeChain creates a new logger to log the events of chain [chainID]
 	MakeChain(chainID string) (Logger, error)
+	// MakeChainChild creates a new sublogger for a [name] module of a chain [chainId]
 	MakeChainChild(chainID string, name string) (Logger, error)
+	// Close stops and clears all of a Factory's instanciated loggers
 	Close()
 }
 
-// factory ...
+// factory implements the Factory interface
 type factory struct {
 	config Config
 
 	loggers []Logger
 }
 
-// NewFactory ...
+// NewFactory returns a new instance of a Factory producing loggers configured with
+// the values set in the [config] parameter
 func NewFactory(config Config) Factory {
 	return &factory{
 		config: config,
 	}
 }
 
-// Make ...
+// Make implements the Factory interface
 func (f *factory) Make(name string) (Logger, error) {
 	config := f.config
 	config.LoggerName = name
@@ -36,7 +41,7 @@ func (f *factory) Make(name string) (Logger, error) {
 	return l, err
 }
 
-// MakeChain ...
+// MakeChain implements the Factory interface
 func (f *factory) MakeChain(chainID string) (Logger, error) {
 	config := f.config
 	config.MsgPrefix = chainID + " Chain"
@@ -48,7 +53,7 @@ func (f *factory) MakeChain(chainID string) (Logger, error) {
 	return log, err
 }
 
-// MakeChainChild ...
+// MakeChainChild implements the Factory interface
 func (f *factory) MakeChainChild(chainID string, name string) (Logger, error) {
 	config := f.config
 	config.MsgPrefix = chainID + " Chain"
@@ -60,7 +65,7 @@ func (f *factory) MakeChainChild(chainID string, name string) (Logger, error) {
 	return log, err
 }
 
-// Close ...
+// Close implements the Factory interface
 func (f *factory) Close() {
 	for _, log := range f.loggers {
 		log.Stop()

--- a/utils/logging/factory.go
+++ b/utils/logging/factory.go
@@ -3,13 +3,11 @@
 
 package logging
 
-import "path/filepath"
-
 // Factory ...
 type Factory interface {
-	Make() (Logger, error)
-	MakeChain(chainID string, subdir string) (Logger, error)
-	MakeSubdir(subdir string) (Logger, error)
+	Make(name string) (Logger, error)
+	MakeChain(chainID string) (Logger, error)
+	MakeChainChild(chainID string, name string) (Logger, error)
 	Close()
 }
 
@@ -28,8 +26,10 @@ func NewFactory(config Config) Factory {
 }
 
 // Make ...
-func (f *factory) Make() (Logger, error) {
-	l, err := New(f.config)
+func (f *factory) Make(name string) (Logger, error) {
+	config := f.config
+	config.LoggerName = name
+	l, err := New(config)
 	if err == nil {
 		f.loggers = append(f.loggers, l)
 	}
@@ -37,11 +37,10 @@ func (f *factory) Make() (Logger, error) {
 }
 
 // MakeChain ...
-func (f *factory) MakeChain(chainID string, subdir string) (Logger, error) {
+func (f *factory) MakeChain(chainID string) (Logger, error) {
 	config := f.config
 	config.MsgPrefix = chainID + " Chain"
-	config.Directory = filepath.Join(config.Directory, "chain", chainID, subdir)
-
+	config.LoggerName = chainID
 	log, err := New(config)
 	if err == nil {
 		f.loggers = append(f.loggers, log)
@@ -49,11 +48,11 @@ func (f *factory) MakeChain(chainID string, subdir string) (Logger, error) {
 	return log, err
 }
 
-// MakeSubdir ...
-func (f *factory) MakeSubdir(subdir string) (Logger, error) {
+// MakeChainChild ...
+func (f *factory) MakeChainChild(chainID string, name string) (Logger, error) {
 	config := f.config
-	config.Directory = filepath.Join(config.Directory, subdir)
-
+	config.MsgPrefix = chainID + " Chain"
+	config.LoggerName = chainID + "." + name
 	log, err := New(config)
 	if err == nil {
 		f.loggers = append(f.loggers, log)

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -5,6 +5,7 @@ package logging
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -368,7 +369,7 @@ func (fw *fileWriter) Rotate() error {
 	for i := fw.config.RotationSize - 1; i > 0; i-- {
 		sourceFilename := filepath.Join(fw.config.Directory, fmt.Sprintf("%s.log.%d", fw.config.LoggerName, i))
 		destFilename := filepath.Join(fw.config.Directory, fmt.Sprintf("%s.log.%d", fw.config.LoggerName, i+1))
-		if _, err := os.Stat(sourceFilename); !os.IsNotExist(err) {
+		if _, err := os.Stat(sourceFilename); !errors.Is(err, os.ErrNotExist) {
 			if err := os.Rename(sourceFilename, destFilename); err != nil {
 				return err
 			}

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -366,7 +366,7 @@ func (fw *fileWriter) Close() error {
 
 // Rotate implements the RotatingWriter interface
 func (fw *fileWriter) Rotate() error {
-	for i := fw.config.RotationSize - 1; i >= 0; i-- {
+	for i := fw.config.RotationSize - 1; i > 0; i-- {
 		sourceFilename := filepath.Join(fw.config.Directory, fmt.Sprintf("%s.log.%d", fw.config.LoggerName, i))
 		destFilename := filepath.Join(fw.config.Directory, fmt.Sprintf("%s.log.%d", fw.config.LoggerName, i+1))
 		if _, err := os.Stat(sourceFilename); !os.IsNotExist(err) {

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -6,7 +6,6 @@ package logging
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -409,9 +408,10 @@ func (fw *fileWriter) Initialize(config Config) (int, error) {
 	}
 	fw.writer = writer
 	fw.file = file
-	fileSize, err := file.Seek(0, io.SeekEnd)
+	fileinfo, err := file.Stat()
 	if err != nil {
 		return 0, err
 	}
+	fileSize := fileinfo.Size()
 	return int(fileSize), nil
 }

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -21,7 +21,7 @@ var (
 	filePrefix = fmt.Sprintf("%s/", constants.AppName)
 )
 
-// Log ...
+// Log implements the Logger interface
 type Log struct {
 	config Config
 
@@ -37,7 +37,7 @@ type Log struct {
 	writer RotatingWriter
 }
 
-// New ...
+// New returns a new logger set up according to [config]
 func New(config Config) (*Log, error) {
 	if err := os.MkdirAll(config.Directory, os.ModePerm); err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func (l *Log) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Stop ...
+// Stop implements the Logger interface
 func (l *Log) Stop() {
 	l.flushLock.Lock()
 	l.closed = true
@@ -200,25 +200,25 @@ func (l *Log) format(level Level, format string, args ...interface{}) string {
 		text)
 }
 
-// Fatal ...
+// Fatal implements the Logger interface
 func (l *Log) Fatal(format string, args ...interface{}) { l.log(Fatal, format, args...) }
 
-// Error ...
+// Error implements the Logger interface
 func (l *Log) Error(format string, args ...interface{}) { l.log(Error, format, args...) }
 
-// Warn ...
+// Warn implements the Logger interface
 func (l *Log) Warn(format string, args ...interface{}) { l.log(Warn, format, args...) }
 
-// Info ...
+// Info implements the Logger interface
 func (l *Log) Info(format string, args ...interface{}) { l.log(Info, format, args...) }
 
-// Debug ...
+// Debug implements the Logger interface
 func (l *Log) Debug(format string, args ...interface{}) { l.log(Debug, format, args...) }
 
-// Verbo ...
+// Verbo implements the Logger interface
 func (l *Log) Verbo(format string, args ...interface{}) { l.log(Verbo, format, args...) }
 
-// AssertNoError ...
+// AssertNoError implements the Logger interface
 func (l *Log) AssertNoError(err error) {
 	if err != nil {
 		l.log(Fatal, "%s", err)
@@ -229,7 +229,7 @@ func (l *Log) AssertNoError(err error) {
 	}
 }
 
-// AssertTrue ...
+// AssertTrue implements the Logger interface
 func (l *Log) AssertTrue(b bool, format string, args ...interface{}) {
 	if !b {
 		l.log(Fatal, format, args...)
@@ -240,7 +240,7 @@ func (l *Log) AssertTrue(b bool, format string, args ...interface{}) {
 	}
 }
 
-// AssertDeferredTrue ...
+// AssertDeferredTrue implements the Logger interface
 func (l *Log) AssertDeferredTrue(f func() bool, format string, args ...interface{}) {
 	// Note, the logger will only be notified here if assertions are enabled
 	if l.config.Assertions && !f() {
@@ -251,7 +251,7 @@ func (l *Log) AssertDeferredTrue(f func() bool, format string, args ...interface
 	}
 }
 
-// AssertDeferredNoError ...
+// AssertDeferredNoError implements the Logger interface
 func (l *Log) AssertDeferredNoError(f func() error) {
 	if l.config.Assertions {
 		err := f()
@@ -265,7 +265,7 @@ func (l *Log) AssertDeferredNoError(f func() error) {
 	}
 }
 
-// StopOnPanic ...
+// StopOnPanic implements the Logger interface
 func (l *Log) StopOnPanic() {
 	if r := recover(); r != nil {
 		l.Fatal("Panicking due to:\n%s\nFrom:\n%s", r, Stacktrace{})
@@ -274,7 +274,7 @@ func (l *Log) StopOnPanic() {
 	}
 }
 
-// RecoverAndPanic ...
+// RecoverAndPanic implements the Logger interface
 func (l *Log) RecoverAndPanic(f func()) { defer l.StopOnPanic(); f() }
 
 func (l *Log) stopAndExit(exit func()) {
@@ -285,7 +285,7 @@ func (l *Log) stopAndExit(exit func()) {
 	}
 }
 
-// RecoverAndExit ...
+// RecoverAndExit implements the Logger interface
 func (l *Log) RecoverAndExit(f, exit func()) { defer l.stopAndExit(exit); f() }
 
 // SetLogLevel ...
@@ -296,7 +296,7 @@ func (l *Log) SetLogLevel(lvl Level) {
 	l.config.LogLevel = lvl
 }
 
-// SetDisplayLevel ...
+// SetDisplayLevel implements the Logger interface
 func (l *Log) SetDisplayLevel(lvl Level) {
 	l.configLock.Lock()
 	defer l.configLock.Unlock()
@@ -304,7 +304,7 @@ func (l *Log) SetDisplayLevel(lvl Level) {
 	l.config.DisplayLevel = lvl
 }
 
-// SetPrefix ...
+// SetPrefix implements the Logger interface
 func (l *Log) SetPrefix(prefix string) {
 	l.configLock.Lock()
 	defer l.configLock.Unlock()
@@ -312,7 +312,7 @@ func (l *Log) SetPrefix(prefix string) {
 	l.config.MsgPrefix = prefix
 }
 
-// SetLoggingEnabled ...
+// SetLoggingEnabled implements the Logger interface
 func (l *Log) SetLoggingEnabled(enabled bool) {
 	l.configLock.Lock()
 	defer l.configLock.Unlock()
@@ -320,7 +320,7 @@ func (l *Log) SetLoggingEnabled(enabled bool) {
 	l.config.DisableLogging = !enabled
 }
 
-// SetDisplayingEnabled ...
+// SetDisplayingEnabled implements the Logger interface
 func (l *Log) SetDisplayingEnabled(enabled bool) {
 	l.configLock.Lock()
 	defer l.configLock.Unlock()
@@ -328,7 +328,7 @@ func (l *Log) SetDisplayingEnabled(enabled bool) {
 	l.config.DisableDisplaying = !enabled
 }
 
-// SetContextualDisplayingEnabled ...
+// SetContextualDisplayingEnabled implements the Logger interface
 func (l *Log) SetContextualDisplayingEnabled(enabled bool) {
 	l.configLock.Lock()
 	defer l.configLock.Unlock()
@@ -336,6 +336,7 @@ func (l *Log) SetContextualDisplayingEnabled(enabled bool) {
 	l.config.DisableContextualDisplaying = !enabled
 }
 
+// fileWriter implements the RotatingWriter interface
 type fileWriter struct {
 	writer *bufio.Writer
 	file   *os.File
@@ -343,22 +344,27 @@ type fileWriter struct {
 	config Config
 }
 
+// Flush implements the RotatingWriter interface
 func (fw *fileWriter) Flush() error {
 	return fw.writer.Flush()
 }
 
+// Write implements the RotatingWriter interface
 func (fw *fileWriter) Write(b []byte) (int, error) {
 	return fw.writer.Write(b)
 }
 
+// WriteString implements the RotatingWriter interface
 func (fw *fileWriter) WriteString(s string) (int, error) {
 	return fw.writer.WriteString(s)
 }
 
+// Close implements the RotatingWriter interface
 func (fw *fileWriter) Close() error {
 	return fw.file.Close()
 }
 
+// Rotate implements the RotatingWriter interface
 func (fw *fileWriter) Rotate() error {
 	for i := fw.config.RotationSize - 1; i >= 0; i-- {
 		sourceFilename := filepath.Join(fw.config.Directory, fmt.Sprintf("%s.log.%d", fw.config.LoggerName, i))
@@ -383,6 +389,7 @@ func (fw *fileWriter) Rotate() error {
 	return nil
 }
 
+// Creates a file if it does not exist or opens it in append mode if it does
 func (fw *fileWriter) create() (*bufio.Writer, *os.File, error) {
 	filename := filepath.Join(fw.config.Directory, fmt.Sprintf("%s.log", fw.config.LoggerName))
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -393,6 +400,7 @@ func (fw *fileWriter) create() (*bufio.Writer, *os.File, error) {
 	return writer, file, nil
 }
 
+// Initialize implements the RotatingWriter interface
 func (fw *fileWriter) Initialize(config Config) (int, error) {
 	fw.config = config
 	writer, file, err := fw.create()

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -370,7 +370,7 @@ func (fw *fileWriter) Rotate() error {
 }
 
 func (fw *fileWriter) create(fileIndex int) (*bufio.Writer, *os.File, error) {
-	filename := filepath.Join(fw.config.Directory, fmt.Sprintf("%d.log", fw.fileIndex))
+	filename := filepath.Join(fw.config.Directory, fmt.Sprintf("%s.%d.log", fw.config.LoggerName, fw.fileIndex))
 	file, err := os.Create(filename)
 	if err != nil {
 		return nil, nil, err

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -268,7 +268,7 @@ func (l *Log) AssertDeferredNoError(f func() error) {
 // StopOnPanic ...
 func (l *Log) StopOnPanic() {
 	if r := recover(); r != nil {
-		l.Fatal("Panicing due to:\n%s\nFrom:\n%s", r, Stacktrace{})
+		l.Fatal("Panicking due to:\n%s\nFrom:\n%s", r, Stacktrace{})
 		l.Stop()
 		panic(r)
 	}
@@ -279,7 +279,7 @@ func (l *Log) RecoverAndPanic(f func()) { defer l.StopOnPanic(); f() }
 
 func (l *Log) stopAndExit(exit func()) {
 	if r := recover(); r != nil {
-		l.Fatal("Panicing due to:\n%s\nFrom:\n%s", r, Stacktrace{})
+		l.Fatal("Panicking due to:\n%s\nFrom:\n%s", r, Stacktrace{})
 		l.Stop()
 		exit()
 	}

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -53,11 +53,17 @@ type Logger interface {
 	// executes the desired exit function
 	RecoverAndExit(f, exit func())
 
+	// Only events above or equal to the level set will be logged
 	SetLogLevel(Level)
+	// Only logged events above or equal to the level set will be logged
 	SetDisplayLevel(Level)
+	// Add a prefix to all logged messages
 	SetPrefix(string)
+	// Enable or disable logging
 	SetLoggingEnabled(bool)
+	// Enable or disable the display of logged events
 	SetDisplayingEnabled(bool)
+	// Enable or disable the display of contextual information for logged events
 	SetContextualDisplayingEnabled(bool)
 
 	// Stop this logger and write back all meta-data.
@@ -66,10 +72,19 @@ type Logger interface {
 
 // RotatingWriter allows for rotating a stream writer
 type RotatingWriter interface {
+	// Creates the log file if it doesn't exist or resume writing to it if it does
 	Initialize(Config) (int, error)
+	// Flushes the writer
 	Flush() error
+	// Writes [b] to the log file
 	Write(b []byte) (int, error)
+	// Writes [s] to the log file
 	WriteString(s string) (int, error)
+	// Closes the log file
 	Close() error
+	// Rotates the log files. Always keeps the current log in the same file.
+	// Rotated log files are stored as by appending an integer to the log file name,
+	// from 1 to the RotationSize defined in the configuration. 1 being the most
+	// recently rotated log file.
 	Rotate() error
 }

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -71,5 +71,5 @@ type RotatingWriter interface {
 	Write(b []byte) (int, error)
 	WriteString(s string) (int, error)
 	Close() error
-	Rotate(RotationSize int) error
+	Rotate() error
 }

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -71,5 +71,5 @@ type RotatingWriter interface {
 	Write(b []byte) (int, error)
 	WriteString(s string) (int, error)
 	Close() error
-	Rotate() error
+	Rotate(RotationSize int) error
 }

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -66,7 +66,7 @@ type Logger interface {
 
 // RotatingWriter allows for rotating a stream writer
 type RotatingWriter interface {
-	Initialize(Config) error
+	Initialize(Config) (int, error)
 	Flush() error
 	Write(b []byte) (int, error)
 	WriteString(s string) (int, error)

--- a/utils/logging/test_factory.go
+++ b/utils/logging/test_factory.go
@@ -7,13 +7,13 @@ package logging
 type NoFactory struct{}
 
 // Make ...
-func (NoFactory) Make() (Logger, error) { return NoLog{}, nil }
+func (NoFactory) Make(string) (Logger, error) { return NoLog{}, nil }
 
 // MakeChain ...
-func (NoFactory) MakeChain(string, string) (Logger, error) { return NoLog{}, nil }
+func (NoFactory) MakeChain(string) (Logger, error) { return NoLog{}, nil }
 
-// MakeSubdir ...
-func (NoFactory) MakeSubdir(string) (Logger, error) { return NoLog{}, nil }
+// MakeChainChild ...
+func (NoFactory) MakeChainChild(string, string) (Logger, error) { return NoLog{}, nil }
 
 // Close ...
 func (NoFactory) Close() {}

--- a/utils/logging/test_log.go
+++ b/utils/logging/test_log.go
@@ -96,7 +96,7 @@ func (nw *NoIOWriter) WriteString(s string) (int, error) { return len(s), nil }
 func (nw *NoIOWriter) Close() error { return nil }
 
 // Rotate ...
-func (nw *NoIOWriter) Rotate(RotationSize int) error { return nil }
+func (nw *NoIOWriter) Rotate() error { return nil }
 
 // NewTestLog ...
 func NewTestLog(config Config) (*Log, error) {

--- a/utils/logging/test_log.go
+++ b/utils/logging/test_log.go
@@ -96,7 +96,7 @@ func (nw *NoIOWriter) WriteString(s string) (int, error) { return len(s), nil }
 func (nw *NoIOWriter) Close() error { return nil }
 
 // Rotate ...
-func (nw *NoIOWriter) Rotate() error { return nil }
+func (nw *NoIOWriter) Rotate(RotationSize int) error { return nil }
 
 // NewTestLog ...
 func NewTestLog(config Config) (*Log, error) {

--- a/utils/logging/test_log.go
+++ b/utils/logging/test_log.go
@@ -81,7 +81,7 @@ func (NoLog) SetContextualDisplayingEnabled(bool) {}
 type NoIOWriter struct{}
 
 // Initialize ...
-func (nw *NoIOWriter) Initialize(Config) error { return nil }
+func (nw *NoIOWriter) Initialize(Config) (int, error) { return 0, nil }
 
 // Flush ...
 func (nw *NoIOWriter) Flush() error { return nil }


### PR DESCRIPTION
- Stores all files in a single directory as specified in #699 
- Always keeps the current log in the same file. Rotated log files are stored as file.log.[1..n] where 1 is the most recently rotated log and n the oldest. (Possibly solves #773 ?)
- Previous logger overwrote the first file on node startup, changed this so that it appends to the previous log instead.