### PR TITLE
Add staged timer

### DIFF
--- a/utils/timer/staged_timer.go
+++ b/utils/timer/staged_timer.go
@@ -1,0 +1,17 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package timer
+
+import "time"
+
+func NewStagedTimer(f func() (time.Duration, bool)) *Timer {
+	t := NewTimer(nil)
+	t.handler = func() {
+		delay, repeat := f()
+		if repeat {
+			t.SetTimeoutIn(delay)
+		}
+	}
+	return t
+}

--- a/utils/timer/staged_timer_test.go
+++ b/utils/timer/staged_timer_test.go
@@ -1,0 +1,112 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package timer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestSingleStagedTimer(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ticks := 1
+	i := 0
+	timer := NewStagedTimer(func() (time.Duration, bool) {
+		defer wg.Done()
+		i++
+		return 0, false
+	})
+	go timer.Dispatch()
+
+	timer.SetTimeoutIn(time.Millisecond)
+	wg.Wait()
+	assert.Equal(t, i, ticks)
+}
+
+func TestMultiStageTimer(t *testing.T) {
+	wg := sync.WaitGroup{}
+	ticks := 3
+	wg.Add(ticks)
+
+	i := 0
+	timer := NewStagedTimer(func() (time.Duration, bool) {
+		defer wg.Done()
+		i++
+		return time.Millisecond, i < ticks
+	})
+	go timer.Dispatch()
+
+	timer.SetTimeoutIn(time.Millisecond)
+	wg.Wait()
+	assert.Equal(t, i, ticks)
+}
+
+func TestCancelSimpleStagedStimer(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	msTimer := NewStagedTimer(func() (time.Duration, bool) {
+		defer wg.Done()
+		t.Fatal("Timer should have been canceled before being called")
+		return 0, false
+	})
+	cancelTimer := NewTimer(func() {
+		defer wg.Done()
+		msTimer.Cancel()
+	})
+
+	go msTimer.Dispatch()
+	go cancelTimer.Dispatch()
+
+	// Set [msTimer] with a larger timeout than [cancelTimer]. This should cause
+	// [msTimer] to be cancelled before being called.
+	msTimer.SetTimeoutIn(5 * time.Millisecond)
+	cancelTimer.SetTimeoutIn(time.Millisecond)
+
+	wg.Wait()
+	// Sleep for 10 milliseconds, so that if cancellation was not successful
+	// the timeout will fire and cause the test to fail.
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestCancelStagedTimer(t *testing.T) {
+	wg := sync.WaitGroup{}
+	// Add 2 to waitgroup, as we expect one tick from the [msTimer] and
+	// a second tick from [cancelTimer].
+	wg.Add(2)
+
+	i := 0
+
+	// Set [msTimer] to go off successfully once, and fail on the second
+	// callback.
+	msTimer := NewStagedTimer(func() (time.Duration, bool) {
+		if i > 0 {
+			t.Fatal("Timer should have been cancelled before second callback")
+		}
+		i++
+		wg.Done()
+		return 10 * time.Millisecond, true
+	})
+	cancelTimer := NewTimer(func() {
+		defer wg.Done()
+		msTimer.Cancel()
+	})
+
+	go msTimer.Dispatch()
+	go cancelTimer.Dispatch()
+
+	// Set [msTimer] with a shorter timeout, so it fires once and then [cancelTimer]
+	// should stop the second callback.
+	msTimer.SetTimeoutIn(time.Millisecond)
+	cancelTimer.SetTimeoutIn(5 * time.Millisecond)
+
+	wg.Wait()
+	// Sleep for 10 milliseconds, so that if cancellation was not successful
+	// the timeout will fire and cause the test to fail.
+	time.Sleep(10 * time.Millisecond)
+}

--- a/utils/timer/staged_timer_test.go
+++ b/utils/timer/staged_timer_test.go
@@ -51,7 +51,6 @@ func TestCancelSimpleStagedStimer(t *testing.T) {
 	wg.Add(1)
 
 	msTimer := NewStagedTimer(func() (time.Duration, bool) {
-		defer wg.Done()
 		t.Fatal("Timer should have been canceled before being called")
 		return 0, false
 	})
@@ -88,8 +87,8 @@ func TestCancelStagedTimer(t *testing.T) {
 		if i > 0 {
 			t.Fatal("Timer should have been cancelled before second callback")
 		}
+		defer wg.Done()
 		i++
-		wg.Done()
 		return 10 * time.Millisecond, true
 	})
 	cancelTimer := NewTimer(func() {

--- a/utils/timer/timer_test.go
+++ b/utils/timer/timer_test.go
@@ -23,7 +23,6 @@ func TestTimer(t *testing.T) {
 func TestTimerCancel(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	defer wg.Wait()
 
 	failTimer := NewTimer(func() {
 		wg.Done()
@@ -37,6 +36,11 @@ func TestTimerCancel(t *testing.T) {
 	go failTimer.Dispatch()
 	go cancelTimer.Dispatch()
 
-	failTimer.SetTimeoutIn(time.Second)
+	failTimer.SetTimeoutIn(10 * time.Millisecond)
 	cancelTimer.SetTimeoutIn(time.Millisecond)
+
+	wg.Wait()
+	// Sleep for 10ms, so that if cancellation does not work the timer will
+	// go off and cause the test to fail.
+	time.Sleep(10 * time.Millisecond)
 }


### PR DESCRIPTION
This PR adds a staged timer which allows the timer's callback function to specify an additional timeout if it should repeat. This is intended to allow a very simple implementation of a two stage timer.