### PR TITLE
return benched chainIDs in peer response

### DIFF
--- a/api/info/service.go
+++ b/api/info/service.go
@@ -143,6 +143,8 @@ type PeersReply struct {
 	NumPeers json.Uint64 `json:"numPeers"`
 	// Each element is a peer
 	Peers []network.PeerID `json:"peers"`
+
+	// TODO: add "benched for all chains"
 }
 
 // Peers returns the list of current validators

--- a/api/info/service.go
+++ b/api/info/service.go
@@ -143,8 +143,6 @@ type PeersReply struct {
 	NumPeers json.Uint64 `json:"numPeers"`
 	// Each element is a peer
 	Peers []network.PeerID `json:"peers"`
-
-	// TODO: add "benched for all chains"
 }
 
 // Peers returns the list of current validators

--- a/network/network.go
+++ b/network/network.go
@@ -747,20 +747,6 @@ func (n *network) Dispatch() error {
 	}
 }
 
-func (n *network) getBenchedStatuses(peerID ids.ShortID) []BenchedStatus {
-	benchStatus := n.benchlistManager.GetBenchedStatuses(peerID)
-
-	benchedStatuses := []BenchedStatus{}
-	for chainID, benched := range benchStatus {
-		benchedStatuses = append(benchedStatuses, BenchedStatus{
-			ChainID: chainID,
-			Benched: benched,
-		})
-	}
-
-	return benchedStatuses
-}
-
 // IPs implements the Network interface
 // assumes the stateLock is not held.
 func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
@@ -774,13 +760,13 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 		for _, peer := range n.peers {
 			if peer.connected.GetValue() {
 				peers = append(peers, PeerID{
-					IP:              peer.conn.RemoteAddr().String(),
-					PublicIP:        peer.getIP().String(),
-					ID:              peer.id.PrefixedString(constants.NodeIDPrefix),
-					Version:         peer.versionStr.GetValue().(string),
-					LastSent:        time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
-					LastReceived:    time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
-					BenchedStatuses: n.getBenchedStatuses(peer.id),
+					IP:           peer.conn.RemoteAddr().String(),
+					PublicIP:     peer.getIP().String(),
+					ID:           peer.id.PrefixedString(constants.NodeIDPrefix),
+					Version:      peer.versionStr.GetValue().(string),
+					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
+					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
+					Benched:      n.benchlistManager.GetBenched(peer.id),
 				})
 			}
 		}
@@ -790,13 +776,13 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 			peer, ok := n.peers[nodeID]
 			if ok && peer.connected.GetValue() {
 				peers = append(peers, PeerID{
-					IP:              peer.conn.RemoteAddr().String(),
-					PublicIP:        peer.getIP().String(),
-					ID:              peer.id.PrefixedString(constants.NodeIDPrefix),
-					Version:         peer.versionStr.GetValue().(string),
-					LastSent:        time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
-					LastReceived:    time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
-					BenchedStatuses: n.getBenchedStatuses(peer.id),
+					IP:           peer.conn.RemoteAddr().String(),
+					PublicIP:     peer.getIP().String(),
+					ID:           peer.id.PrefixedString(constants.NodeIDPrefix),
+					Version:      peer.versionStr.GetValue().(string),
+					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
+					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
+					Benched:      n.benchlistManager.GetBenched(peer.id),
 				})
 			}
 		}

--- a/network/network.go
+++ b/network/network.go
@@ -766,7 +766,7 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 					Version:      peer.versionStr.GetValue().(string),
 					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
 					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
-					// TOOD: add benched boolean for all chains
+					BenchStatus:  n.benchlistManager.BenchStatus(peer.id),
 				})
 			}
 		}
@@ -782,7 +782,7 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 					Version:      peer.versionStr.GetValue().(string),
 					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
 					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
-					// TOOD: add benched boolean for all chains
+					BenchStatus:  n.benchlistManager.BenchStatus(peer.id),
 				})
 			}
 		}

--- a/network/network.go
+++ b/network/network.go
@@ -747,15 +747,18 @@ func (n *network) Dispatch() error {
 	}
 }
 
-func (n *network) wireFriendlyBenchStatus(peerID ids.ShortID) map[string]bool {
-	benchStatus := n.benchlistManager.BenchStatus(peerID)
+func (n *network) getBenchedStatuses(peerID ids.ShortID) []BenchedStatus {
+	benchStatus := n.benchlistManager.GetBenchedStatuses(peerID)
 
-	output := map[string]bool{}
-	for chainID, status := range benchStatus {
-		output[chainID.String()] = status
+	benchedStatuses := []BenchedStatus{}
+	for chainID, benched := range benchStatus {
+		benchedStatuses = append(benchedStatuses, BenchedStatus{
+			ChainID: chainID,
+			Benched: benched,
+		})
 	}
 
-	return output
+	return benchedStatuses
 }
 
 // IPs implements the Network interface
@@ -771,13 +774,13 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 		for _, peer := range n.peers {
 			if peer.connected.GetValue() {
 				peers = append(peers, PeerID{
-					IP:           peer.conn.RemoteAddr().String(),
-					PublicIP:     peer.getIP().String(),
-					ID:           peer.id.PrefixedString(constants.NodeIDPrefix),
-					Version:      peer.versionStr.GetValue().(string),
-					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
-					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
-					BenchStatus:  n.wireFriendlyBenchStatus(peer.id),
+					IP:              peer.conn.RemoteAddr().String(),
+					PublicIP:        peer.getIP().String(),
+					ID:              peer.id.PrefixedString(constants.NodeIDPrefix),
+					Version:         peer.versionStr.GetValue().(string),
+					LastSent:        time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
+					LastReceived:    time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
+					BenchedStatuses: n.getBenchedStatuses(peer.id),
 				})
 			}
 		}
@@ -787,13 +790,13 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 			peer, ok := n.peers[nodeID]
 			if ok && peer.connected.GetValue() {
 				peers = append(peers, PeerID{
-					IP:           peer.conn.RemoteAddr().String(),
-					PublicIP:     peer.getIP().String(),
-					ID:           peer.id.PrefixedString(constants.NodeIDPrefix),
-					Version:      peer.versionStr.GetValue().(string),
-					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
-					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
-					// BenchStatus:  n.wireFriendlyBenchStatus(peer.id),
+					IP:              peer.conn.RemoteAddr().String(),
+					PublicIP:        peer.getIP().String(),
+					ID:              peer.id.PrefixedString(constants.NodeIDPrefix),
+					Version:         peer.versionStr.GetValue().(string),
+					LastSent:        time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
+					LastReceived:    time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
+					BenchedStatuses: n.getBenchedStatuses(peer.id),
 				})
 			}
 		}

--- a/network/network.go
+++ b/network/network.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/api/health"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/networking/benchlist"
 	"github.com/ava-labs/avalanchego/snow/networking/router"
 	"github.com/ava-labs/avalanchego/snow/networking/sender"
 	"github.com/ava-labs/avalanchego/snow/triggers"
@@ -176,6 +177,8 @@ type network struct {
 
 	hasMasked        bool
 	maskedValidators ids.ShortSet
+
+	benchlistManager benchlist.Manager
 }
 
 // NewDefaultNetwork returns a new Network implementation with the provided
@@ -203,6 +206,7 @@ func NewDefaultNetwork(
 	disconnectedRestartTimeout time.Duration,
 	apricotPhase0Time time.Time,
 	sendQueueSize uint32,
+	benchlistManager benchlist.Manager,
 ) Network {
 	return NewNetwork(
 		registerer,
@@ -244,6 +248,7 @@ func NewDefaultNetwork(
 		disconnectedCheckFreq,
 		disconnectedRestartTimeout,
 		apricotPhase0Time,
+		benchlistManager,
 	)
 }
 
@@ -288,6 +293,7 @@ func NewNetwork(
 	disconnectedCheckFreq time.Duration,
 	disconnectedRestartTimeout time.Duration,
 	apricotPhase0Time time.Time,
+	benchlistManager benchlist.Manager,
 ) Network {
 	// #nosec G404
 	netw := &network{
@@ -338,6 +344,7 @@ func NewNetwork(
 		connectedMeter:                     timer.TimedMeter{Duration: disconnectedRestartTimeout},
 		restarter:                          restarter,
 		apricotPhase0Time:                  apricotPhase0Time,
+		benchlistManager:                   benchlistManager,
 	}
 
 	if err := netw.initialize(registerer); err != nil {
@@ -759,6 +766,7 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 					Version:      peer.versionStr.GetValue().(string),
 					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
 					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
+					// TOOD: add benched boolean for all chains
 				})
 			}
 		}
@@ -774,6 +782,7 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 					Version:      peer.versionStr.GetValue().(string),
 					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
 					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
+					// TOOD: add benched boolean for all chains
 				})
 			}
 		}

--- a/network/network.go
+++ b/network/network.go
@@ -747,6 +747,17 @@ func (n *network) Dispatch() error {
 	}
 }
 
+func (n *network) wireFriendlyBenchStatus(peerID ids.ShortID) map[string]bool {
+	benchStatus := n.benchlistManager.BenchStatus(peerID)
+
+	output := map[string]bool{}
+	for chainID, status := range benchStatus {
+		output[chainID.String()] = status
+	}
+
+	return output
+}
+
 // IPs implements the Network interface
 // assumes the stateLock is not held.
 func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
@@ -766,7 +777,7 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 					Version:      peer.versionStr.GetValue().(string),
 					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
 					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
-					BenchStatus:  n.benchlistManager.BenchStatus(peer.id),
+					BenchStatus:  n.wireFriendlyBenchStatus(peer.id),
 				})
 			}
 		}
@@ -782,7 +793,7 @@ func (n *network) Peers(nodeIDs []ids.ShortID) []PeerID {
 					Version:      peer.versionStr.GetValue().(string),
 					LastSent:     time.Unix(atomic.LoadInt64(&peer.lastSent), 0),
 					LastReceived: time.Unix(atomic.LoadInt64(&peer.lastReceived), 0),
-					BenchStatus:  n.benchlistManager.BenchStatus(peer.id),
+					// BenchStatus:  n.wireFriendlyBenchStatus(peer.id),
 				})
 			}
 		}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -216,6 +216,7 @@ func TestNewDefaultNetwork(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net)
 
@@ -330,6 +331,7 @@ func TestEstablishConnection(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net0)
 
@@ -356,6 +358,7 @@ func TestEstablishConnection(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net1)
 
@@ -482,6 +485,7 @@ func TestDoubleTrack(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net0)
 
@@ -508,6 +512,7 @@ func TestDoubleTrack(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net1)
 
@@ -635,6 +640,7 @@ func TestDoubleClose(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net0)
 
@@ -661,6 +667,7 @@ func TestDoubleClose(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net1)
 
@@ -793,6 +800,7 @@ func TestTrackConnected(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net0)
 
@@ -819,6 +827,7 @@ func TestTrackConnected(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net1)
 
@@ -925,6 +934,7 @@ func TestTrackConnectedRace(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net0)
 
@@ -951,6 +961,7 @@ func TestTrackConnectedRace(t *testing.T) {
 		0,
 		time.Now(),
 		defaultSendQueueSize,
+		nil,
 	)
 	assert.NotNil(t, net1)
 

--- a/network/peer_id.go
+++ b/network/peer_id.go
@@ -5,14 +5,17 @@ package network
 
 import (
 	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
 )
 
 // PeerID ...
 type PeerID struct {
-	IP           string    `json:"ip"`
-	PublicIP     string    `json:"publicIP"`
-	ID           string    `json:"nodeID"`
-	Version      string    `json:"version"`
-	LastSent     time.Time `json:"lastSent"`
-	LastReceived time.Time `json:"lastReceived"`
+	IP           string          `json:"ip"`
+	PublicIP     string          `json:"publicIP"`
+	ID           string          `json:"nodeID"`
+	Version      string          `json:"version"`
+	LastSent     time.Time       `json:"lastSent"`
+	LastReceived time.Time       `json:"lastReceived"`
+	BenchStatus  map[ids.ID]bool `json:"benchStatus"`
 }

--- a/network/peer_id.go
+++ b/network/peer_id.go
@@ -9,19 +9,13 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 )
 
-// BenchedStatus ...
-type BenchedStatus struct {
-	ChainID ids.ID `json:"chainID"`
-	Benched bool   `json:"benched"`
-}
-
 // PeerID ...
 type PeerID struct {
-	IP              string          `json:"ip"`
-	PublicIP        string          `json:"publicIP"`
-	ID              string          `json:"nodeID"`
-	Version         string          `json:"version"`
-	LastSent        time.Time       `json:"lastSent"`
-	LastReceived    time.Time       `json:"lastReceived"`
-	BenchedStatuses []BenchedStatus `json:"benchedStatuses"`
+	IP           string    `json:"ip"`
+	PublicIP     string    `json:"publicIP"`
+	ID           string    `json:"nodeID"`
+	Version      string    `json:"version"`
+	LastSent     time.Time `json:"lastSent"`
+	LastReceived time.Time `json:"lastReceived"`
+	Benched      []ids.ID  `json:"benched"`
 }

--- a/network/peer_id.go
+++ b/network/peer_id.go
@@ -5,8 +5,6 @@ package network
 
 import (
 	"time"
-
-	"github.com/ava-labs/avalanchego/ids"
 )
 
 // PeerID ...
@@ -17,5 +15,5 @@ type PeerID struct {
 	Version      string          `json:"version"`
 	LastSent     time.Time       `json:"lastSent"`
 	LastReceived time.Time       `json:"lastReceived"`
-	BenchStatus  map[ids.ID]bool `json:"benchStatus"`
+	BenchStatus  map[string]bool `json:"benchStatus"`
 }

--- a/network/peer_id.go
+++ b/network/peer_id.go
@@ -5,15 +5,23 @@ package network
 
 import (
 	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
 )
+
+// BenchedStatus ...
+type BenchedStatus struct {
+	ChainID ids.ID `json:"chainID"`
+	Benched bool   `json:"benched"`
+}
 
 // PeerID ...
 type PeerID struct {
-	IP           string          `json:"ip"`
-	PublicIP     string          `json:"publicIP"`
-	ID           string          `json:"nodeID"`
-	Version      string          `json:"version"`
-	LastSent     time.Time       `json:"lastSent"`
-	LastReceived time.Time       `json:"lastReceived"`
-	BenchStatus  map[string]bool `json:"benchStatus"`
+	IP              string          `json:"ip"`
+	PublicIP        string          `json:"publicIP"`
+	ID              string          `json:"nodeID"`
+	Version         string          `json:"version"`
+	LastSent        time.Time       `json:"lastSent"`
+	LastReceived    time.Time       `json:"lastReceived"`
+	BenchedStatuses []BenchedStatus `json:"benchedStatuses"`
 }

--- a/node/node.go
+++ b/node/node.go
@@ -518,6 +518,10 @@ func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 	n.Config.NetworkConfig.MetricsNamespace = constants.PlatformName
 	n.Config.NetworkConfig.Registerer = n.Config.ConsensusParams.Metrics
 
+	// Configure benchlist
+	n.Config.BenchlistConfig.Validators = n.vdrs
+	n.benchlistManager = benchlist.NewManager(&n.Config.BenchlistConfig)
+
 	// Manages network timeouts
 	timeoutManager := &timeout.Manager{}
 	if err := timeoutManager.Initialize(&n.Config.NetworkConfig, n.benchlistManager); err != nil {
@@ -818,10 +822,6 @@ func (n *Node) Initialize(
 		return fmt.Errorf("problem initializing HTTP logger: %w", err)
 	}
 	n.HTTPLog = httpLog
-
-	// Configure benchlist
-	n.Config.BenchlistConfig.Validators = n.vdrs
-	n.benchlistManager = benchlist.NewManager(&n.Config.BenchlistConfig)
 
 	if err := n.initDatabase(); err != nil { // Set up the node's database
 		return fmt.Errorf("problem initializing database: %w", err)

--- a/node/node.go
+++ b/node/node.go
@@ -100,6 +100,9 @@ type Node struct {
 	// Manages Virtual Machines
 	vmManager vms.Manager
 
+	// Manages validator benching
+	benchlistManager benchlist.Manager
+
 	// dispatcher for events as they happen in consensus
 	DecisionDispatcher  *triggers.EventDispatcher
 	ConsensusDispatcher *triggers.EventDispatcher
@@ -136,8 +139,6 @@ type Node struct {
 
 	// Restarter can shutdown and restart the node
 	restarter utils.Restarter
-
-	benchlistManager benchlist.Manager
 }
 
 /*

--- a/node/node.go
+++ b/node/node.go
@@ -187,6 +187,10 @@ func (n *Node) initNetworking() error {
 		return err
 	}
 
+	// Configure benchlist
+	n.Config.BenchlistConfig.Validators = n.vdrs
+	n.benchlistManager = benchlist.NewManager(&n.Config.BenchlistConfig)
+
 	consensusRouter := n.Config.ConsensusRouter
 	if !n.Config.EnableStaking {
 		if err := primaryNetworkValidators.AddWeight(n.ID, n.Config.DisabledStakingWeight); err != nil {
@@ -517,10 +521,6 @@ func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 	// Set Prometheus metrics info
 	n.Config.NetworkConfig.MetricsNamespace = constants.PlatformName
 	n.Config.NetworkConfig.Registerer = n.Config.ConsensusParams.Metrics
-
-	// Configure benchlist
-	n.Config.BenchlistConfig.Validators = n.vdrs
-	n.benchlistManager = benchlist.NewManager(&n.Config.BenchlistConfig)
 
 	// Manages network timeouts
 	timeoutManager := &timeout.Manager{}

--- a/snow/networking/benchlist/manager.go
+++ b/snow/networking/benchlist/manager.go
@@ -69,12 +69,18 @@ func NewManager(config *Config) Manager {
 
 func (m *manager) BenchStatus(validatorID ids.ShortID) map[ids.ID]bool {
 	m.lock.RLock()
-	defer m.lock.RUnlock()
+	chains := []ids.ID{}
+	benchLists := []Benchlist{}
+	for chainID, benchlist := range m.chainBenchlists {
+		chains = append(chains, chainID)
+		benchLists = append(benchLists, benchlist)
+	}
+	m.lock.RUnlock()
 
 	// TODO: optimize locking
 	benchStatus := map[ids.ID]bool{}
-	for chainID, benchlist := range m.chainBenchlists {
-		benchStatus[chainID] = benchlist.IsBenched(validatorID)
+	for i, chainID := range chains {
+		benchStatus[chainID] = benchLists[i].IsBenched(validatorID)
 	}
 	return benchStatus
 }


### PR DESCRIPTION
This PR improves the peer response so that it also indicates which chainIDs a given peer is benched on (if any).