### PR TITLE
Skip e2e tests on untrusted builds

### DIFF
--- a/.ci/run_e2e_tests.sh
+++ b/.ci/run_e2e_tests.sh
@@ -3,7 +3,8 @@ SRC_PATH=$(dirname "${SCRIPTS_PATH}")
 
 # Early auth to avoid limit rating
 if [[ -z ${DOCKER_USERNAME} ]]; then
-    echo "No Auth provided"
+    echo "Skipping E2E Tests for untrusted build"
+    exit 0
 else
     echo "$DOCKER_PASS" | docker login --username "$DOCKER_USERNAME" --password-stdin
 fi
@@ -19,20 +20,13 @@ DOCKER_REPO="avaplatform"
 BYZANTINE_IMAGE="$DOCKER_REPO/avalanche-byzantine:v0.1.5-rc.1"
 TEST_SUITE_IMAGE="$DOCKER_REPO/avalanche-testing:v0.10.5-rc.3"
 
-# If Docker Credentials are not available skip the Byzantine Tests
-if [[ -z ${DOCKER_USERNAME} ]]; then
-    echo "Skipping Byzantine Tests because Docker Credentials were not present."
-    BYZANTINE_IMAGE=""
-else
-    docker pull "${BYZANTINE_IMAGE}"
-fi
-
 # Kurtosis Environment Parameters
 KURTOSIS_CORE_CHANNEL="1.0.3"
 INITIALIZER_IMAGE="kurtosistech/kurtosis-core_initializer:${KURTOSIS_CORE_CHANNEL}"
 API_IMAGE="kurtosistech/kurtosis-core_api:${KURTOSIS_CORE_CHANNEL}"
 PARALLELISM=4
 
+docker pull "${BYZANTINE_IMAGE}"
 docker pull "$TEST_SUITE_IMAGE"
 
 SUITE_EXECUTION_VOLUME="avalanche-test-suite_${AVALANCHE_IMAGE_TAG}_$(date +%s)"


### PR DESCRIPTION
This PR skips E2E tests on untrusted builds.