### PR TITLE
Update ansible lint to latest commit

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Lint Ansible playbooks
         # Lastest commit, as of February 22, 2021
-        uses: ansible/ansible-lint-action@c37fb7b
+        uses: ansible/ansible-lint-action@c37fb7b4bda2c8cb18f4942716bae9f11b0dc9bc
         with:
           targets: |
             scripts/ansible/kill_playbook.yml

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,8 +11,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint Ansible playbooks
-        # Lastest commit, as of 30 Apr 2020
-        uses: ansible/ansible-lint-action@6c8c14186662e43effbe39a678950896a46799ad
+        # Lastest commit, as of February 22, 2021
+        uses: ansible/ansible-lint-action@c37fb7b
         with:
           targets: |
             scripts/ansible/kill_playbook.yml


### PR DESCRIPTION
This PR is intended to fix the ansible lint CI by updating to the latest commit for the github action.