### PR TITLE
Backout pending bytes from net.pending on close

### DIFF
--- a/network/peer.go
+++ b/network/peer.go
@@ -437,6 +437,9 @@ func (p *peer) Close() { p.once.Do(p.close) }
 
 // assumes only `peer.Close` calls this
 func (p *peer) close() {
+	peerPending := atomic.LoadInt64(&p.pendingBytes)
+	atomic.AddInt64(&p.net.pendingBytes, -peerPending)
+
 	// If the connection is closing, we can immediately cancel the ticker
 	// goroutines.
 	close(p.tickerCloser)

--- a/network/peer.go
+++ b/network/peer.go
@@ -437,9 +437,6 @@ func (p *peer) Close() { p.once.Do(p.close) }
 
 // assumes only `peer.Close` calls this
 func (p *peer) close() {
-	peerPending := atomic.LoadInt64(&p.pendingBytes)
-	atomic.AddInt64(&p.net.pendingBytes, -peerPending)
-
 	// If the connection is closing, we can immediately cancel the ticker
 	// goroutines.
 	close(p.tickerCloser)
@@ -455,6 +452,9 @@ func (p *peer) close() {
 	// has been closed and will therefore not attempt to write on this channel.
 	close(p.sender)
 	p.senderLock.Unlock()
+
+	peerPending := atomic.LoadInt64(&p.pendingBytes)
+	atomic.AddInt64(&p.net.pendingBytes, -peerPending)
 
 	p.net.disconnected(p)
 }

--- a/network/peer_test.go
+++ b/network/peer_test.go
@@ -17,12 +17,12 @@ import (
 )
 
 type TestMsg struct {
-	op   Op
-	bits []byte
+	op    Op
+	bytes []byte
 }
 
 func newTestMsg(op Op, bits []byte) *TestMsg {
-	return &TestMsg{op: op, bits: bits}
+	return &TestMsg{op: op, bytes: bits}
 }
 
 func (m *TestMsg) Op() Op {
@@ -32,7 +32,7 @@ func (*TestMsg) Get(Field) interface{} {
 	return nil
 }
 func (m *TestMsg) Bytes() []byte {
-	return m.bits
+	return m.bytes
 }
 
 func TestPeer_Close(t *testing.T) {

--- a/network/peer_test.go
+++ b/network/peer_test.go
@@ -1,0 +1,128 @@
+package network
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/networking/benchlist"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/hashing"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestMsg struct {
+	op   Op
+	bits []byte
+}
+
+func newTestMsg(op Op, bits []byte) *TestMsg {
+	return &TestMsg{op: op, bits: bits}
+}
+
+func (m *TestMsg) Op() Op {
+	return m.op
+}
+func (*TestMsg) Get(Field) interface{} {
+	return nil
+}
+func (m *TestMsg) Bytes() []byte {
+	return m.bits
+}
+
+func TestPeer_Close(t *testing.T) {
+	log := logging.NoLog{}
+	ip := utils.NewDynamicIPDesc(
+		net.IPv6loopback,
+		0,
+	)
+	id := ids.ShortID(hashing.ComputeHash160Array([]byte(ip.IP().String())))
+	networkID := uint32(0)
+	appVersion := version.NewDefaultVersion("app", 0, 1, 0)
+	versionParser := version.NewDefaultParser()
+
+	listener := &testListener{
+		addr: &net.TCPAddr{
+			IP:   net.IPv6loopback,
+			Port: 0,
+		},
+		inbound: make(chan net.Conn, 1<<10),
+		closed:  make(chan struct{}),
+	}
+	caller := &testDialer{
+		addr: &net.TCPAddr{
+			IP:   net.IPv6loopback,
+			Port: 0,
+		},
+		outbounds: make(map[string]*testListener),
+	}
+	serverUpgrader := NewIPUpgrader()
+	clientUpgrader := NewIPUpgrader()
+
+	vdrs := validators.NewSet()
+	handler := &testHandler{}
+
+	netwrk := NewDefaultNetwork(
+		prometheus.NewRegistry(),
+		log,
+		id,
+		ip,
+		networkID,
+		appVersion,
+		versionParser,
+		listener,
+		caller,
+		serverUpgrader,
+		clientUpgrader,
+		vdrs,
+		vdrs,
+		handler,
+		time.Duration(0),
+		0,
+		nil,
+		false,
+		0,
+		0,
+		time.Now(),
+		defaultSendQueueSize,
+		HealthConfig{},
+		benchlist.NewManager(&benchlist.Config{}),
+		defaultAliasTimeout,
+	)
+	assert.NotNil(t, netwrk)
+
+	ip1 := utils.NewDynamicIPDesc(
+		net.IPv6loopback,
+		1,
+	)
+	caller.outbounds[ip1.IP().String()] = listener
+	conn, _ := caller.Dial(ip1.IP())
+
+	basenetwork := netwrk.(*network)
+
+	// fake a peer, and write a message
+	peer := newPeer(basenetwork, conn, ip1.IP())
+	peer.sender = make(chan []byte, 10)
+	testMsg := newTestMsg(GetVersion, []byte("hello"))
+	peer.Send(testMsg)
+
+	if basenetwork.pendingBytes != 5 {
+		t.Fatalf("pending bytes invalid")
+	}
+
+	go func() {
+		err := netwrk.Close()
+		assert.NoError(t, err)
+	}()
+
+	peer.close()
+
+	if basenetwork.pendingBytes != 0 {
+		t.Fatalf("pending bytes invalid")
+	}
+}


### PR DESCRIPTION
When a peer is closed clear out remainder peer pending bytes from the net pending bytes.