### PR TITLE
Add build coreth role and corresonding playbooks

### DIFF
--- a/scripts/ansible/ping_playbook.yml
+++ b/scripts/ansible/ping_playbook.yml
@@ -2,6 +2,7 @@
 ---
 - name: Update the network
   connection: ssh
+  gather_facts: false
   hosts: all
   tasks:
     - name: Ping node

--- a/scripts/ansible/restart_with_coreth_playbook.yml
+++ b/scripts/ansible/restart_with_coreth_playbook.yml
@@ -2,7 +2,10 @@
 ---
 - name: Update the network
   connection: ssh
-  gather_facts: false
   hosts: all
   roles:
     - name: avalanche_stop
+    - name: avalanche_build
+    - name: coreth_build
+    - name: avalanche_reset
+    - name: avalanche_start

--- a/scripts/ansible/roles/avalanche_build/defaults/main.yml
+++ b/scripts/ansible/roles/avalanche_build/defaults/main.yml
@@ -1,5 +1,5 @@
 avalanche_binary: "{{ repo_folder }}/build/avalanchego"
 repo_folder: "~{{ ansible_facts.user_id }}/go/src/github.com/ava-labs/avalanchego"
 repo_name: ava-labs/avalanchego
-repo_url: https://github.com/{{ repo_name }}
+repo_url: git@github.com:{{ repo_name }}
 repo_branch: dev

--- a/scripts/ansible/roles/coreth_build/defaults/main.yml
+++ b/scripts/ansible/roles/coreth_build/defaults/main.yml
@@ -1,0 +1,5 @@
+evm_binary: "{{ repo_folder }}/build/plugins/evm"
+repo_folder: "~{{ ansible_facts.user_id }}/go/src/github.com/ava-labs/coreth"
+repo_name: ava-labs/coreth
+repo_url: git@github.com:{{ repo_name }}
+repo_branch: dev

--- a/scripts/ansible/roles/coreth_build/tasks/main.yml
+++ b/scripts/ansible/roles/coreth_build/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Update git clone
+  git:
+    repo: "{{ repo_url }}"
+    dest: "{{ repo_folder }}"
+    version: "{{ repo_branch }}"
+    update: yes
+
+- name: Build project
+  # noqa 301
+  command: ./scripts/build.sh
+  args:
+    chdir: "{{ repo_folder }}"
+  environment:
+    PATH: /usr/lib/go-{{ golang_version_min_major }}.{{ golang_version_min_minor }}/bin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/snap/bin

--- a/scripts/ansible/update_with_coreth_playbook.yml
+++ b/scripts/ansible/update_with_coreth_playbook.yml
@@ -1,8 +1,11 @@
+
 #!/usr/bin/env ansible-playbook
 ---
 - name: Update the network
   connection: ssh
-  gather_facts: false
   hosts: all
   roles:
     - name: avalanche_stop
+    - name: avalanche_build
+    - name: coreth_build
+    - name: avalanche_start


### PR DESCRIPTION
This PR adds an ansible role to build a specific version of coreth as well as new playbooks that use this additional role to deploy a specific version of coreth alongside avalanchego.