### PR TITLE
docs: Increase minimum disk for increased chain size

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a blockchains platform with high throughput, and blazing fast transactions.
 
 Avalanche is an incredibly lightweight protocol, so the minimum computer requirements are quite modest.
 
-- Hardware: 2 GHz or faster CPU, 4 GB RAM, 20 GB hard disk.
+- Hardware: 2 GHz or faster CPU, 4 GB RAM, 40 GB available disk.
 - OS: Ubuntu >= 18.04 or Mac OS X >= Catalina.
 - Software: [Go](https://golang.org/doc/install) version >= 1.15.5 and set up [`$GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH).
 - Network: IPv4 or IPv6 network connection, with an open public port.


### PR DESCRIPTION
The main chain now consumes 20 GB of disk. This spec leaves some head
room, until pruning arrives. I also changed the wording to align it with
avalanche-docs.

Twinned with https://github.com/ava-labs/avalanche-docs/pull/138