### PR TITLE
Change Dockerfile to include VOLUME and not running as root by defaul…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,13 @@ WORKDIR /avalanchego/build
 # Copy the executables into the container
 COPY --from=builder /build/build/ .
 
+RUN addgroup -g 1001 -S ava01 && adduser -u 1001 -S ava01 -G ava01
+RUN chown ava01:ava01 /home/ava01
 
+USER ava01
+
+RUN mkdir /home/ava01/.avalanchego
+
+VOLUME ["/home/ava01/.avalanchego"]
 
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ The image should be tagged as `avaplatform/avalanchego:xxxxxxxx`, where `xxxxxxx
 docker run -ti -p 9650:9650 -p 9651:9651 avaplatform/avalanchego:xxxxxxxx /avalanchego/build/avalanchego
 ```
 
+#### Example how to run fixed Dockerfile on your local machine (non root running inside docker)
+Dockerfile should not run under root - we create user ava01 (uid 1001) in group ava01 (gid 1001). You can easily make external disk  to hold all /home/ava01/.avalanchego files, but remember to change it's owner to 1001 in host machine.
+
+```sh
+docker build . -t ava
+
+mkdir /tmp/data && chown 1001:1001 /tmp/data
+
+docker run -it -p9650:9650 -p9651:9651 -v /tmp/data:/home/ava01/.avalanchego ava --restart unless-stopped avaplatform/avalanchego /avalanchego/build/avalanchego --network-id=fuji  --http-host=
+```
+ 
 ## Running Avalanche
 
 ### Connecting to Mainnet


### PR DESCRIPTION
…t #453

I found out that default Dockerfile did not include any volumes. So apparently it will run out of space after 10 GB.  Avalanchego has multiple directories under ~/.avalanchego.  I did not find any environment variables to be able to change default place. So it needs probably setting db-dir, log-dir and creating own volumes for each other to properly handle disk space.  This is a very simple solution just add one volume.

Also changed so that Dockerfile is not running avalanchego under root access, but created user ava01 to run it.
