### PR TITLE
vms: skip hidden files in plugin dir

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -739,6 +739,10 @@ func (n *Node) registerRPCVMs() error {
 		// Strip any extension from the file. This is to support windows .exe
 		// files.
 		name = name[:len(name)-len(filepath.Ext(name))]
+		// Skip hidden files.
+		if len(name) == 0 {
+			continue
+		}
 
 		vmID, err := n.vmManager.Lookup(name)
 		if err != nil {


### PR DESCRIPTION
Hidden files in the plugin directory will cause the node to not start:

```
FATAL[09-04|09:23:56] avalanchego/app/process/process.go#169: error initializing node: couldn't initialize chain manager: invalid vmID
```

I ran into this when starting a node with a `.DS_Store` file in the plugins directory.

* [x] Is this change backward compatible with the previous version of AvalancheGo?
