### PR TITLE
add check for breaking go version to build_avalanche script

### DIFF
--- a/scripts/build_avalanche.sh
+++ b/scripts/build_avalanche.sh
@@ -12,7 +12,7 @@ set -o pipefail
 # README.md
 # go.mod
 go_version_minimum="1.15.5"
-go_version_breaking="1.17"
+go_version_breaking="1.17.1"
 
 go_version() {
     go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'
@@ -35,7 +35,7 @@ version_br() {
     local ver1=$1
     local ver2=$2
     # Sort the versions, if the 1st item != ver1 then ver1 < ver2
-    if  [[ $(echo -e -n "$ver1\n$ver2\n" | sort -V | head -n1) != "$ver1" ]]; then
+    if  [[ $(echo -e -n "$ver1\n$ver2\n" | sort -rV | head -n1) == "$ver1" ]]; then
         return 0
     else
         return 1

--- a/scripts/build_avalanche.sh
+++ b/scripts/build_avalanche.sh
@@ -12,13 +12,14 @@ set -o pipefail
 # README.md
 # go.mod
 go_version_minimum="1.15.5"
+go_version_breaking="1.17"
 
 go_version() {
     go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'
 }
 
 version_lt() {
-    # Return true if $1 is a lower version than than $2,
+    # Return true if $1 is a lower version than $2,
     local ver1=$1
     local ver2=$2
     # Reverse sort the versions, if the 1st item != ver1 then ver1 < ver2
@@ -29,8 +30,25 @@ version_lt() {
     fi
 }
 
+version_br() {
+    # Return true if $1 is a higher version than $2,
+    local ver1=$1
+    local ver2=$2
+    # Sort the versions, if the 1st item != ver1 then ver1 < ver2
+    if  [[ $(echo -e -n "$ver1\n$ver2\n" | sort -V | head -n1) != "$ver1" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 if version_lt "$(go_version)" "$go_version_minimum"; then
     echo "AvalancheGo requires Go >= $go_version_minimum, Go $(go_version) found." >&2
+    exit 1
+fi
+
+if version_br "$(go_version)" "$go_version_breaking"; then
+    echo "AvalancheGo requires Go < $go_version_breaking, Go $(go_version) found." >&2
     exit 1
 fi
 


### PR DESCRIPTION
Version 1.5.3 can not be build with go > 1.17 and gets stuck during compiling.
The `build_avalanche.sh` script already checks for a minimum go version.
To address the mentioned problem I introduced a check for a breaking or untested go version and set it to 1.17

Now when one tries to build with a version of 1.17.0 upwards the following message comes up

`AvalancheGo requires Go < 1.17, Go 1.17.1 found.`

 
* [X] Is this change backward compatible with the previous version of AvalancheGo?


