### PR TITLE
replace "whitelisted" with "allowed"

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -150,7 +150,7 @@ type ManagerConfig struct {
 	AVAXAssetID                 ids.ID
 	XChainID                    ids.ID
 	CriticalChains              ids.Set          // Chains that can't exit gracefully
-	WhitelistedSubnets          ids.Set          // Subnets to validate
+	AllowedSubnets              ids.Set          // Subnets to validate
 	TimeoutManager              *timeout.Manager // Manages request timeouts when sending messages to other validators
 	HealthService               health.Service
 	RetryBootstrap              bool                   // Should Bootstrap be retried
@@ -224,8 +224,8 @@ func (m *manager) CreateChain(chain ChainParameters) {
 // Create a chain, this is only called from the P-chain thread, except for
 // creating the P-chain.
 func (m *manager) ForceCreateChain(chainParams ChainParameters) {
-	if chainParams.SubnetID != constants.PrimaryNetworkID && !m.WhitelistedSubnets.Contains(chainParams.SubnetID) {
-		m.Log.Debug("Skipped creating non-whitelisted chain:\n"+
+	if chainParams.SubnetID != constants.PrimaryNetworkID && !m.AllowedSubnets.Contains(chainParams.SubnetID) {
+		m.Log.Debug("Skipped creating non-allowed chain:\n"+
 			"    ID: %s\n"+
 			"    VMID:%s",
 			chainParams.ID,

--- a/config/config.go
+++ b/config/config.go
@@ -556,9 +556,9 @@ func getEpochConfig(v *viper.Viper, networkID uint32) (genesis.EpochConfig, erro
 	return genesis.GetEpochConfig(networkID), nil
 }
 
-func getWhitelistedSubnets(v *viper.Viper) (ids.Set, error) {
-	whitelistedSubnetIDs := ids.Set{}
-	for _, subnet := range strings.Split(v.GetString(WhitelistedSubnetsKey), ",") {
+func getAllowedSubnets(v *viper.Viper) (ids.Set, error) {
+	allowedSubnetIDs := ids.Set{}
+	for _, subnet := range strings.Split(v.GetString(AllowedSubnetsKey), ",") {
 		if subnet == "" {
 			continue
 		}
@@ -566,9 +566,9 @@ func getWhitelistedSubnets(v *viper.Viper) (ids.Set, error) {
 		if err != nil {
 			return nil, fmt.Errorf("couldn't parse subnetID %q: %w", subnet, err)
 		}
-		whitelistedSubnetIDs.Add(subnetID)
+		allowedSubnetIDs.Add(subnetID)
 	}
-	return whitelistedSubnetIDs, nil
+	return allowedSubnetIDs, nil
 }
 
 func getDatabaseConfig(v *viper.Viper, networkID uint32) node.DatabaseConfig {
@@ -792,8 +792,8 @@ func GetNodeConfig(v *viper.Viper, buildDir string) (node.Config, error) {
 		return node.Config{}, err
 	}
 
-	// Whitelisted Subnets
-	nodeConfig.WhitelistedSubnets, err = getWhitelistedSubnets(v)
+	// Allowed Subnets
+	nodeConfig.AllowedSubnets, err = getAllowedSubnets(v)
 	if err != nil {
 		return node.Config{}, err
 	}

--- a/config/flags.go
+++ b/config/flags.go
@@ -221,7 +221,7 @@ func addNodeFlags(fs *flag.FlagSet) {
 	// Stake Minting Period
 	fs.Duration(StakeMintingPeriodKey, genesis.LocalParams.StakeMintingPeriod, "Consumption period of the staking function")
 	// Subnets
-	fs.String(WhitelistedSubnetsKey, "", "Whitelist of subnets to validate.")
+	fs.String(AllowedSubnetsKey, "", "Allowlist of subnets to validate.")
 
 	// Bootstrapping
 	fs.String(BootstrapIPsKey, "", "Comma separated list of bootstrap peer ips to connect to. Example: 127.0.0.1:9630,127.0.0.1:9631")

--- a/config/keys.go
+++ b/config/keys.go
@@ -84,7 +84,7 @@ const (
 	SnowMaxTimeProcessingKey                  = "snow-max-time-processing"
 	SnowEpochFirstTransitionKey               = "snow-epoch-first-transition"
 	SnowEpochDurationKey                      = "snow-epoch-duration"
-	WhitelistedSubnetsKey                     = "whitelisted-subnets"
+	AllowedSubnetsKey                         = "allowed-subnets"
 	AdminAPIEnabledKey                        = "api-admin-enabled"
 	InfoAPIEnabledKey                         = "api-info-enabled"
 	KeystoreAPIEnabledKey                     = "api-keystore-enabled"

--- a/network/network.go
+++ b/network/network.go
@@ -233,8 +233,8 @@ type network struct {
 	// Rate-limits outgoing messages
 	outboundMsgThrottler throttling.OutboundMsgThrottler
 
-	// WhitelistedSubnets of the node
-	whitelistedSubnets ids.Set
+	// AllowedSubnets of the node
+	allowedSubnets ids.Set
 }
 
 type Config struct {
@@ -284,7 +284,7 @@ func NewDefaultNetwork(
 	compressionEnabled bool,
 	inboundMsgThrottler throttling.InboundMsgThrottler,
 	outboundMsgThrottler throttling.OutboundMsgThrottler,
-	whitelistedSubnets ids.Set,
+	allowedSubnets ids.Set,
 ) (Network, error) {
 	return NewNetwork(
 		namespace,
@@ -327,7 +327,7 @@ func NewDefaultNetwork(
 		compressionEnabled,
 		inboundMsgThrottler,
 		outboundMsgThrottler,
-		whitelistedSubnets,
+		allowedSubnets,
 	)
 }
 
@@ -373,7 +373,7 @@ func NewNetwork(
 	compressionEnabled bool,
 	inboundMsgThrottler throttling.InboundMsgThrottler,
 	outboundMsgThrottler throttling.OutboundMsgThrottler,
-	whitelistedSubnets ids.Set,
+	allowedSubnets ids.Set,
 ) (Network, error) {
 	// #nosec G404
 	netw := &network{
@@ -430,7 +430,7 @@ func NewNetwork(
 		compressionEnabled:   compressionEnabled,
 		inboundMsgThrottler:  inboundMsgThrottler,
 		outboundMsgThrottler: outboundMsgThrottler,
-		whitelistedSubnets:   whitelistedSubnets,
+		allowedSubnets:       allowedSubnets,
 	}
 	codec, err := message.NewCodecWithAllocator(
 		fmt.Sprintf("%s_codec", namespace),

--- a/network/peer.go
+++ b/network/peer.go
@@ -601,7 +601,7 @@ func (p *peer) sendVersionWithSubnets() {
 		p.net.stateLock.RUnlock()
 		return
 	}
-	whitelistedSubnets := p.net.whitelistedSubnets
+	allowedSubnets := p.net.allowedSubnets
 	msg, err := p.net.b.VersionWithSubnets(
 		p.net.networkID,
 		p.net.nodeID,
@@ -610,7 +610,7 @@ func (p *peer) sendVersionWithSubnets() {
 		p.net.versionCompatibility.Version().String(),
 		myVersionTime,
 		myVersionSig,
-		whitelistedSubnets.List(),
+		allowedSubnets.List(),
 	)
 	p.net.stateLock.RUnlock()
 	p.net.log.AssertNoError(err)
@@ -841,14 +841,14 @@ func (p *peer) versionCheck(msg message.Message, isVersionWithSubnets bool) {
 				return
 			}
 			// add only if we also track this subnet
-			if p.net.whitelistedSubnets.Contains(subnetID) {
+			if p.net.allowedSubnets.Contains(subnetID) {
 				p.trackedSubnets.Add(subnetID)
 			}
 		}
 	} else {
 		// this peer has old Version, we don't know what its interested in.
 		// so assume that it tracks all available subnets
-		p.trackedSubnets.Add(p.net.whitelistedSubnets.List()...)
+		p.trackedSubnets.Add(p.net.allowedSubnets.List()...)
 	}
 
 	sig := msg.Get(message.SigBytes).([]byte)

--- a/node/config.go
+++ b/node/config.go
@@ -195,8 +195,8 @@ type Config struct {
 	RouterHealthConfig       router.HealthConfig `json:"routerHealthConfig"`
 	ConsensusShutdownTimeout time.Duration       `json:"consensusShutdownTimeout"`
 
-	// Subnet Whitelist
-	WhitelistedSubnets ids.Set `json:"whitelistedSubnets"`
+	// Subnet Allowlist
+	AllowedSubnets ids.Set `json:"allowedSubnets"`
 
 	// ChainConfigs
 	ChainConfigs map[string]chains.ChainConfig `json:"-"`

--- a/node/node.go
+++ b/node/node.go
@@ -291,7 +291,7 @@ func (n *Node) initNetworking() error {
 		n.Config.NetworkConfig.CompressionEnabled,
 		inboundMsgThrottler,
 		outboundMsgThrottler,
-		n.Config.WhitelistedSubnets,
+		n.Config.AllowedSubnets,
 	)
 	return err
 }
@@ -669,7 +669,7 @@ func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 		CriticalChains:                         criticalChains,
 		TimeoutManager:                         timeoutManager,
 		HealthService:                          n.healthService,
-		WhitelistedSubnets:                     n.Config.WhitelistedSubnets,
+		AllowedSubnets:                         n.Config.AllowedSubnets,
 		RetryBootstrap:                         n.Config.RetryBootstrap,
 		RetryBootstrapWarnFrequency:            n.Config.RetryBootstrapWarnFrequency,
 		ShutdownNodeFunc:                       n.Shutdown,
@@ -698,7 +698,7 @@ func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 			Chains:                n.chainManager,
 			Validators:            vdrs,
 			StakingEnabled:        n.Config.EnableStaking,
-			WhitelistedSubnets:    n.Config.WhitelistedSubnets,
+			AllowedSubnets:        n.Config.AllowedSubnets,
 			TxFee:                 n.Config.TxFee,
 			CreateAssetTxFee:      n.Config.CreateAssetTxFee,
 			CreateSubnetTxFee:     n.Config.CreateSubnetTxFee,

--- a/vms/platformvm/factory.go
+++ b/vms/platformvm/factory.go
@@ -29,7 +29,7 @@ type Factory struct {
 	StakingEnabled bool
 
 	// Set of subnets that this node is validating
-	WhitelistedSubnets ids.Set
+	AllowedSubnets ids.Set
 
 	// Fee that must be burned by every create staker transaction
 	AddStakerTxFee uint64

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -217,7 +217,7 @@ func (vm *VM) initBlockchains() error {
 		}
 	}
 
-	for subnetID := range vm.WhitelistedSubnets {
+	for subnetID := range vm.AllowedSubnets {
 		chains, err := vm.internalState.GetChains(subnetID)
 		if err != nil {
 			return err
@@ -241,7 +241,7 @@ func (vm *VM) createChain(tx *Tx) error {
 
 	if vm.StakingEnabled && // Staking is enabled, so nodes might not validate all chains
 		constants.PrimaryNetworkID != unsignedTx.SubnetID && // All nodes must validate the primary network
-		!vm.WhitelistedSubnets.Contains(unsignedTx.SubnetID) { // This node doesn't validate this blockchain
+		!vm.AllowedSubnets.Contains(unsignedTx.SubnetID) { // This node doesn't validate this blockchain
 		return nil
 	}
 
@@ -536,7 +536,7 @@ func (vm *VM) updateValidators(force bool) error {
 	vm.localStake.Set(float64(weight))
 	vm.totalStake.Set(float64(primaryValidators.Weight()))
 
-	for subnetID := range vm.WhitelistedSubnets {
+	for subnetID := range vm.AllowedSubnets {
 		subnetValidators, err := currentValidators.ValidatorSet(subnetID)
 		if err != nil {
 			return err


### PR DESCRIPTION
This pull changes the `--whitelisted-subnets` parameter to `--allowed-subnets`. 

As you may know this terminology has a racist background. So this simple change would make the Avalanche a good example for the community. See more about the problem:
https://twitter.com/andrestaltz/status/1030200563802230786
https://en.wikipedia.org/wiki/Whitelisting#Controversy

* [x] Does this PR change a config flag? Yes.
* [x] Is this change backward compatible with the previous version of AvalancheGo? Yes.

