### PR TITLE
scripts: add support for custom image tag

### DIFF
--- a/scripts/build_local_image.sh
+++ b/scripts/build_local_image.sh
@@ -17,6 +17,17 @@ source "$AVALANCHE_PATH"/scripts/constants.sh
 full_commit_hash="$(git --git-dir="$AVALANCHE_PATH/.git" rev-parse HEAD)"
 commit_hash="${full_commit_hash::8}"
 
-echo "Building Docker Image with tags: $avalanchego_dockerhub_repo:$commit_hash , $avalanchego_dockerhub_repo:$current_branch"
-docker build -t "$avalanchego_dockerhub_repo:$commit_hash" \
-        -t "$avalanchego_dockerhub_repo:$current_branch" "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"
+# Populate image tags
+tag_ary=()
+TAG="${TAG:-}"
+if [ ! -z "$TAG" ]; then
+    tag_ary+=( "$TAG" )
+else
+    tag_ary+=( "$avalanchego_dockerhub_repo:$commit_hash" "$avalanchego_dockerhub_repo:$current_branch" )
+fi
+
+tags=$(print_tags "${tag_ary[@]}")
+tag_flags=$(build_tag_flags "${tag_ary[@]}")
+
+echo -e "Building Docker Image with tags: $tags"
+docker build $tag_flags "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -35,3 +35,17 @@ then
     which $CC > /dev/null || ( echo $CC must be available for static compilation && exit 1 )
     static_ld_flags=' -extldflags "-static" -linkmode external '
 fi
+
+# Joins each element in the array with a comma and space
+print_tags() {
+    local ary=("$@")
+    printf -v out "%s, " "${ary[@]}"
+    echo ${out%, }
+}
+
+# Generates docker build tag flags from an array of tags
+build_tag_flags() {
+    local ary=("$@")
+    printf -v out " \055\164 %s" "${ary[@]}"
+    echo "$out"
+}


### PR DESCRIPTION
This PR adds custom tag support for build tooling.

use case:
- As a user/developer exploring avalanche I would like to utilize build scripts for creating my own image tags.

usage:
```
TAG=quay.io/hexfusion/avalanche:latest scripts/build_local_image.sh
```

