### PR TITLE
utils/rpc - strip password from url when logging

### DIFF
--- a/utils/rpc/requester.go
+++ b/utils/rpc/requester.go
@@ -62,9 +62,11 @@ func (requester jsonRPCRequester) SendJSONRPCRequest(
 	}
 
 	url := fmt.Sprintf("%s/%s%s", requester.uri, endpoint, queryParamsStr)
+	logSafeUrl := stripPassword(url)
+
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(requestBodyBytes))
 	if err != nil {
-		return fmt.Errorf("problem while creating JSON RPC POST request to %s: %s", url, err)
+		return fmt.Errorf("problem while creating JSON RPC POST request to %s: %s", logSafeUrl, err)
 	}
 
 	req.Header = headers
@@ -72,7 +74,7 @@ func (requester jsonRPCRequester) SendJSONRPCRequest(
 
 	resp, err := requester.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("problem while making JSON RPC POST request to %s: %w", url, err)
+		return fmt.Errorf("problem while making JSON RPC POST request to %s: %w", logSafeUrl, err)
 	}
 	statusCode := resp.StatusCode
 

--- a/utils/rpc/utils.go
+++ b/utils/rpc/utils.go
@@ -1,0 +1,20 @@
+package rpc
+
+import (
+	"net/url"
+	"strings"
+)
+
+func stripPassword(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return uri
+	}
+
+	_, passSet := u.User.Password()
+	if passSet {
+		return strings.Replace(u.String(), u.User.String()+"@", u.User.Username()+":***@", 1)
+	}
+
+	return u.String()
+}

--- a/utils/rpc/utils_test.go
+++ b/utils/rpc/utils_test.go
@@ -1,0 +1,13 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPasswordStripped(t *testing.T) {
+	url := "https://user:password@my.avalanche.api.com/ext/P"
+	stipped := stripPassword(url)
+	assert.Equal(t, "https://user:***@my.avalanche.api.com/ext/P", stipped)
+}


### PR DESCRIPTION
This is a small fix to strip password from the URL that gets logged when there's an RPC error
I encountered it when I was using https://github.com/ava-labs/avalanchego/blob/master/indexer/client.go to query the index API.

The code to strip the password is copied from https://go-review.googlesource.com/c/go/+/175018/

Example log before fix

```
problem while making JSON RPC POST request to https://username:actualpassword@myapiaddress/ext/index/P/block: Post "https://username:***@myapiaddress/ext/index/P/block": read tcp someipaddress:65509->someipaddress:443: read: connection reset by peer
```

Example log after fix

```
problem while making JSON RPC POST request to https://username:***@myapiaddress/ext/index/P/block: Post "https://username:***@myapiaddress/ext/index/P/block": read tcp someipaddress:65509->someipaddress:443: read: connection reset by peer
```