### PR TITLE
Replace containerID with id

### DIFF
--- a/indexer/client.go
+++ b/indexer/client.go
@@ -115,26 +115,26 @@ func (c *client) GetLastAccepted(ctx context.Context, options ...rpc.Option) (Co
 	}, nil
 }
 
-func (c *client) GetIndex(ctx context.Context, ID ids.ID, options ...rpc.Option) (uint64, error) {
+func (c *client) GetIndex(ctx context.Context, id ids.ID, options ...rpc.Option) (uint64, error) {
 	var index GetIndexResponse
 	err := c.requester.SendRequest(ctx, "getIndex", &GetIndexArgs{
-		ID: ID,
+		ID: id,
 	}, &index, options...)
 	return uint64(index.Index), err
 }
 
-func (c *client) IsAccepted(ctx context.Context, ID ids.ID, options ...rpc.Option) (bool, error) {
+func (c *client) IsAccepted(ctx context.Context, id ids.ID, options ...rpc.Option) (bool, error) {
 	var res IsAcceptedResponse
 	err := c.requester.SendRequest(ctx, "isAccepted", &IsAcceptedArgs{
-		ID: ID,
+		ID: id,
 	}, &res, options...)
 	return res.IsAccepted, err
 }
 
-func (c *client) GetContainerByID(ctx context.Context, ID ids.ID, options ...rpc.Option) (Container, error) {
+func (c *client) GetContainerByID(ctx context.Context, id ids.ID, options ...rpc.Option) (Container, error) {
 	var fc FormattedContainer
 	err := c.requester.SendRequest(ctx, "getContainerByID", &GetContainerByIDArgs{
-		ID:       ID,
+		ID:       id,
 		Encoding: formatting.Hex,
 	}, &fc, options...)
 	if err != nil {

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -115,27 +115,27 @@ func (c *client) GetLastAccepted(ctx context.Context, options ...rpc.Option) (Co
 	}, nil
 }
 
-func (c *client) GetIndex(ctx context.Context, containerID ids.ID, options ...rpc.Option) (uint64, error) {
+func (c *client) GetIndex(ctx context.Context, ID ids.ID, options ...rpc.Option) (uint64, error) {
 	var index GetIndexResponse
 	err := c.requester.SendRequest(ctx, "getIndex", &GetIndexArgs{
-		ContainerID: containerID,
+		ID: ID,
 	}, &index, options...)
 	return uint64(index.Index), err
 }
 
-func (c *client) IsAccepted(ctx context.Context, containerID ids.ID, options ...rpc.Option) (bool, error) {
+func (c *client) IsAccepted(ctx context.Context, ID ids.ID, options ...rpc.Option) (bool, error) {
 	var res IsAcceptedResponse
 	err := c.requester.SendRequest(ctx, "isAccepted", &IsAcceptedArgs{
-		ContainerID: containerID,
+		ID: ID,
 	}, &res, options...)
 	return res.IsAccepted, err
 }
 
-func (c *client) GetContainerByID(ctx context.Context, containerID ids.ID, options ...rpc.Option) (Container, error) {
+func (c *client) GetContainerByID(ctx context.Context, ID ids.ID, options ...rpc.Option) (Container, error) {
 	var fc FormattedContainer
 	err := c.requester.SendRequest(ctx, "getContainerByID", &GetContainerByIDArgs{
-		ContainerID: containerID,
-		Encoding:    formatting.Hex,
+		ID:       ID,
+		Encoding: formatting.Hex,
 	}, &fc, options...)
 	if err != nil {
 		return Container{}, err

--- a/indexer/index.go
+++ b/indexer/index.go
@@ -47,8 +47,8 @@ type Index interface {
 	GetContainerByIndex(index uint64) (Container, error)
 	GetContainerRange(startIndex uint64, numToFetch uint64) ([]Container, error)
 	GetLastAccepted() (Container, error)
-	GetIndex(containerID ids.ID) (uint64, error)
-	GetContainerByID(containerID ids.ID) (Container, error)
+	GetIndex(ID ids.ID) (uint64, error)
+	GetContainerByID(ID ids.ID) (Container, error)
 	io.Closer
 }
 
@@ -246,19 +246,19 @@ func (i *index) GetContainerRange(startIndex, numToFetch uint64) ([]Container, e
 }
 
 // Returns database.ErrNotFound if the container is not indexed as accepted
-func (i *index) GetIndex(containerID ids.ID) (uint64, error) {
+func (i *index) GetIndex(ID ids.ID) (uint64, error) {
 	i.lock.RLock()
 	defer i.lock.RUnlock()
 
-	return database.GetUInt64(i.containerToIndex, containerID[:])
+	return database.GetUInt64(i.containerToIndex, ID[:])
 }
 
-func (i *index) GetContainerByID(containerID ids.ID) (Container, error) {
+func (i *index) GetContainerByID(ID ids.ID) (Container, error) {
 	i.lock.RLock()
 	defer i.lock.RUnlock()
 
 	// Read index from database
-	indexBytes, err := i.containerToIndex.Get(containerID[:])
+	indexBytes, err := i.containerToIndex.Get(ID[:])
 	if err != nil {
 		return Container{}, err
 	}

--- a/indexer/index.go
+++ b/indexer/index.go
@@ -246,19 +246,19 @@ func (i *index) GetContainerRange(startIndex, numToFetch uint64) ([]Container, e
 }
 
 // Returns database.ErrNotFound if the container is not indexed as accepted
-func (i *index) GetIndex(ID ids.ID) (uint64, error) {
+func (i *index) GetIndex(id ids.ID) (uint64, error) {
 	i.lock.RLock()
 	defer i.lock.RUnlock()
 
-	return database.GetUInt64(i.containerToIndex, ID[:])
+	return database.GetUInt64(i.containerToIndex, id[:])
 }
 
-func (i *index) GetContainerByID(ID ids.ID) (Container, error) {
+func (i *index) GetContainerByID(id ids.ID) (Container, error) {
 	i.lock.RLock()
 	defer i.lock.RUnlock()
 
 	// Read index from database
-	indexBytes, err := i.containerToIndex.Get(ID[:])
+	indexBytes, err := i.containerToIndex.Get(id[:])
 	if err != nil {
 		return Container{}, err
 	}

--- a/indexer/service.go
+++ b/indexer/service.go
@@ -112,7 +112,7 @@ func (s *service) GetContainerRange(r *http.Request, args *GetContainerRangeArgs
 }
 
 type GetIndexArgs struct {
-	ContainerID ids.ID `json:"containerID"`
+	ID ids.ID `json:"id"`
 }
 
 type GetIndexResponse struct {
@@ -120,13 +120,13 @@ type GetIndexResponse struct {
 }
 
 func (s *service) GetIndex(r *http.Request, args *GetIndexArgs, reply *GetIndexResponse) error {
-	index, err := s.Index.GetIndex(args.ContainerID)
+	index, err := s.Index.GetIndex(args.ID)
 	reply.Index = json.Uint64(index)
 	return err
 }
 
 type IsAcceptedArgs struct {
-	ContainerID ids.ID `json:"containerID"`
+	ID ids.ID `json:"id"`
 }
 
 type IsAcceptedResponse struct {
@@ -134,7 +134,7 @@ type IsAcceptedResponse struct {
 }
 
 func (s *service) IsAccepted(r *http.Request, args *IsAcceptedArgs, reply *IsAcceptedResponse) error {
-	_, err := s.Index.GetIndex(args.ContainerID)
+	_, err := s.Index.GetIndex(args.ID)
 	if err == nil {
 		reply.IsAccepted = true
 		return nil
@@ -147,12 +147,12 @@ func (s *service) IsAccepted(r *http.Request, args *IsAcceptedArgs, reply *IsAcc
 }
 
 type GetContainerByIDArgs struct {
-	ContainerID ids.ID              `json:"containerID"`
-	Encoding    formatting.Encoding `json:"encoding"`
+	ID       ids.ID              `json:"id"`
+	Encoding formatting.Encoding `json:"encoding"`
 }
 
 func (s *service) GetContainerByID(r *http.Request, args *GetContainerByIDArgs, reply *FormattedContainer) error {
-	container, err := s.Index.GetContainerByID(args.ContainerID)
+	container, err := s.Index.GetContainerByID(args.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Breaking changes

`containerID` param will be replaced with `id` for the following [Index APIs](https://docs.avax.network/apis/avalanchego/apis/index-api)
* GetContainerByID()
* GetIndex()
* IsAccepted