### PR TITLE
Suppress banner when output is not a terminal

### DIFF
--- a/app/runner/runner.go
+++ b/app/runner/runner.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
+	"golang.org/x/term"
 
 	"github.com/ava-labs/avalanchego/app"
 	"github.com/ava-labs/avalanchego/app/process"
@@ -37,7 +38,9 @@ func Run(config Config, nodeConfig node.Config) {
 		return
 	}
 
-	fmt.Println(process.Header)
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Println(process.Header)
+	}
 
 	exitCode := app.Run(nodeApp)
 	os.Exit(exitCode)

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	gonum.org/v1/gonum v0.9.1
 	google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8
@@ -110,7 +111,6 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/sys v0.0.0-20220405052023-b1e9470b6e64 // indirect
-	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect


### PR DESCRIPTION
This makes logs more uniform and easier to filter, while still preserving the full ASCII art glory for people running interactively.

Successor to #1013