### PR TITLE
Utxoids

### DIFF
--- a/vms/components/avax/utxo_address_match.go
+++ b/vms/components/avax/utxo_address_match.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package avax
+
+import reflect "reflect"
+
+func (utxo *UTXO) MatchAddresses(addr []byte) bool {
+	if addresses, ok := utxo.Out.(Addressable); ok {
+		for _, address := range addresses.Addresses() {
+			if reflect.DeepEqual(address, addr) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Why this should be merged
state:UTXOIDs() function currently don't respect modifiedUTXOs, because of this it can miss IDs which are not yet serialized to db

## How this works
Only in case we have a new UTXO in modifiedUTXOs (!= nil) and the filter adress matches addresses() in UTXO, a map is once created and filled with the UTXOIDs from db. After that the new UTXOId is added to the map.

## How this was tested
Not yet tested, if the change makes sense for you, we'll add UnitTest(s) for it
