### PR TITLE
update coreth version to correct version

### DIFF
--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -7,4 +7,4 @@
 
 # Set up the versions to be used
 # Don't export them as their used in the context of other calls
-coreth_version=${CORETH_VERSION:-'v0.11.3-rc.1'}
+coreth_version=${CORETH_VERSION:-'v0.11.3'}


### PR DESCRIPTION
I noticed that avalanchego 1.9.3 was being built with coreth 0.11.3-rc.1 which in turn fetches avalanchego 1.9.3-rc.1.

Seems like an oversight.