### PR TITLE
Add ProposerRetriever to snow context

### DIFF
--- a/snow/context.go
+++ b/snow/context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/vms/proposervm/proposer"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/teleporter"
@@ -52,6 +53,8 @@ type Context struct {
 	ValidatorState validators.State // interface for P-Chain validators
 	// Chain-specific directory where arbitrary data can be written
 	ChainDataDir string
+
+	ProposerRetriever proposer.Retriever // enables retrieval of current proposers
 }
 
 // Expose gatherer interface for unit testing.

--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -140,6 +140,9 @@ func (p *postForkCommonComponents) Verify(
 
 		childHeight := child.Height()
 		proposerID := child.Proposer()
+
+		p.vm.Retriever.SetChainHeight(childHeight)
+		p.vm.Retriever.SetPChainHeight(parentPChainHeight)
 		minDelay, err := p.vm.Windower.Delay(ctx, childHeight, parentPChainHeight, proposerID)
 		if err != nil {
 			return err
@@ -197,6 +200,8 @@ func (p *postForkCommonComponents) buildChild(
 	if delay < proposer.MaxDelay {
 		parentHeight := p.innerBlk.Height()
 		proposerID := p.vm.ctx.NodeID
+		p.vm.Retriever.SetChainHeight(parentHeight+1)
+		p.vm.Retriever.SetPChainHeight(parentPChainHeight)
 		minDelay, err := p.vm.Windower.Delay(ctx, parentHeight+1, parentPChainHeight, proposerID)
 		if err != nil {
 			return nil, err

--- a/vms/proposervm/proposer/retriever.go
+++ b/vms/proposervm/proposer/retriever.go
@@ -1,0 +1,14 @@
+package proposer
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
+)
+
+const (
+	NumProposers = 6
+)
+
+type Retriever interface {
+	GetCurrentProposers() (set.Set[ids.NodeID], error)
+}

--- a/vms/proposervm/proposer/retriever.go
+++ b/vms/proposervm/proposer/retriever.go
@@ -3,6 +3,9 @@ package proposer
 import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/sampler"
+	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
 
 const (
@@ -11,4 +14,43 @@ const (
 
 type Retriever interface {
 	GetCurrentProposers() (set.Set[ids.NodeID], error)
+}
+
+type retriever struct {
+	state validators.State
+	subnetID ids.ID
+	chainSource uint64
+	sampler sampler.WeightedWithoutReplacement
+
+	// Updated by the VM
+	pChainHeight uint64
+	chainHeight uint64
+}
+
+func NewRetriever(state validators.State, subnetID ids.ID, chainID ids.ID) Retriever {
+	w := wrappers.Packer{Bytes: chainID[:]}
+	return &retriever{
+		state:       state,
+		subnetID:    subnetID,
+		chainSource: w.UnpackLong(),
+		sampler:     sampler.NewDeterministicWeightedWithoutReplacement(),
+		pChainHeight: 0, 
+		chainHeight: 0,
+	}
+}
+
+func (r *retriever) SetPChainHeight(pChainHeight uint64){
+	r.pChainHeight = pChainHeight
+}
+
+func (r *retriever) SetChainHeight(chainHeight uint64){
+	r.chainHeight = chainHeight
+}
+
+func (r *retriever) GetCurrentProposers() (set.Set[ids.NodeID], error) {
+	proposers := set.NewSet[ids.NodeID](NumProposers)
+
+	// compute current proposers
+
+	return proposers, nil
 }

--- a/vms/proposervm/proposer/retriever.go
+++ b/vms/proposervm/proposer/retriever.go
@@ -14,6 +14,8 @@ const (
 
 type Retriever interface {
 	GetCurrentProposers() (set.Set[ids.NodeID], error)
+	SetChainHeight(uint64)
+	SetPChainHeight(uint64)
 }
 
 type retriever struct {

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -300,6 +300,8 @@ func (vm *VM) SetPreference(ctx context.Context, preferred ids.ID) error {
 	}
 
 	// reset scheduler
+	vm.Retriever.SetChainHeight(blk.Height() + 1)
+	vm.Retriever.SetPChainHeight(pChainHeight)
 	minDelay, err := vm.Windower.Delay(ctx, blk.Height()+1, pChainHeight, vm.ctx.NodeID)
 	if err != nil {
 		vm.ctx.Log.Debug("failed to fetch the expected delay",

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -75,6 +75,7 @@ type VM struct {
 	state.State
 	hIndexer indexer.HeightIndexer
 
+	proposer.Retriever
 	proposer.Windower
 	tree.Tree
 	scheduler.Scheduler
@@ -169,6 +170,11 @@ func (vm *VM) Initialize(
 	prefixDB := prefixdb.New(dbPrefix, rawDB)
 	vm.db = versiondb.New(prefixDB)
 	vm.State = state.New(vm.db)
+
+	proposerRetriever := proposer.NewRetriever(vm.ctx.ValidatorState, vm.ctx.SubnetID, vm.ctx.ChainID)
+	vm.Retriever = proposerRetriever
+	vm.ctx.ProposerRetriever = proposerRetriever
+
 	vm.Windower = proposer.New(chainCtx.ValidatorState, chainCtx.SubnetID, chainCtx.ChainID)
 	vm.Tree = tree.New()
 	innerBlkCache, err := metercacher.New(


### PR DESCRIPTION
## Why this should be merged
Allows proposer list to be retrieved by VMs via snow context.

## How this works
- Implements an interface dedicated to providing proposer list (nearly identical to Windower's `Proposers()` function (only differs in that chainHeight and pChainHeight are private)

## How this was tested
