### PR TITLE
Add CODEOWNERS for the x/ package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,3 +21,4 @@
 /vms/rpcchainvm/ @hexfusion @StephenButtolph
 /vms/registry/ @joshua-kim
 /tests/ @abi87 @gyuho
+/x/ @danlaine @darioush @dboehm-avalabs


### PR DESCRIPTION
## Why this should be merged

People with the most context should be requested for code reviews for the `x/` package.

## How this works

Updates the CODEOWNERS file to add @danlaine  @darioush  and @dboehm-avalabs  as owners of the `x/` package.

## How this was tested

N/A