### PR TITLE
Fix bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,4 +31,4 @@ Which OS you used to reveal the bug.
 **Additional context**
 Add any other context about the problem here.
 
-**To best protect the Avalanche community security bugs should be reported in accordance to our [Security Policy](/SECURITY.md)**
+**To best protect the Avalanche community security bugs should be reported in accordance to our [Security Policy](../security/policy)**


### PR DESCRIPTION
## Why this should be merged

The current security policy links to https://github.com/SECURITY.md. Which is a 404. Closes #996 

## How this works

Links to the security policy page.

## How this was tested

Clicking the link.