### PR TITLE
RLock on Validators set retrieval

### DIFF
--- a/snow/validators/state.go
+++ b/snow/validators/state.go
@@ -35,11 +35,11 @@ type State interface {
 }
 
 type lockedState struct {
-	lock sync.Locker
+	lock *sync.RWMutex // ctx.Lock of the vm providing validators sets
 	s    State
 }
 
-func NewLockedState(lock sync.Locker, s State) State {
+func NewLockedState(lock *sync.RWMutex, s State) State {
 	return &lockedState{
 		lock: lock,
 		s:    s,
@@ -47,15 +47,15 @@ func NewLockedState(lock sync.Locker, s State) State {
 }
 
 func (s *lockedState) GetMinimumHeight(ctx context.Context) (uint64, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
 	return s.s.GetMinimumHeight(ctx)
 }
 
 func (s *lockedState) GetCurrentHeight(ctx context.Context) (uint64, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
 	return s.s.GetCurrentHeight(ctx)
 }
@@ -72,8 +72,8 @@ func (s *lockedState) GetValidatorSet(
 	height uint64,
 	subnetID ids.ID,
 ) (map[ids.NodeID]*GetValidatorOutput, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
 	return s.s.GetValidatorSet(ctx, height, subnetID)
 }


### PR DESCRIPTION
## Why this should be merged
ProposerVm requires that P-chain exposes the validator set at a bunch of heights.
In this PR we relax the locking needed to pull validator sets, using just a read lock.

## How this works
this PR is built on top of https://github.com/ava-labs/avalanchego-internal/pull/2109, a refactoring of validators state .

## How this was tested
CI
