### PR TITLE
Add Avalanche liveness health checks

### DIFF
--- a/snow/consensus/avalanche/topological.go
+++ b/snow/consensus/avalanche/topological.go
@@ -298,10 +298,10 @@ func (ta *Topological) HealthCheck(ctx context.Context) (interface{}, error) {
 	}
 
 	// check for long running vertices
-	timeReqRunning := ta.Latency.MeasureAndGetOldestDuration()
-	isProcessingTime := timeReqRunning <= ta.params.MaxItemProcessingTime
-	healthy = healthy && isProcessingTime
-	details["longestRunningVertex"] = timeReqRunning.String()
+	oldestProcessingDuration := ta.Latency.MeasureAndGetOldestDuration()
+	processingTimeOK := oldestProcessingDuration <= ta.params.MaxItemProcessingTime
+	healthy = healthy && processingTimeOK
+	details["longestRunningVertex"] = oldestProcessingDuration.String()
 
 	snowstormReport, err := ta.cg.HealthCheck(ctx)
 	healthy = healthy && err == nil
@@ -312,8 +312,8 @@ func (ta *Topological) HealthCheck(ctx context.Context) (interface{}, error) {
 		if isOutstandingVtx {
 			errorReasons = append(errorReasons, fmt.Sprintf("number outstanding vertexes %d > %d", numOutstandingVtx, ta.params.MaxOutstandingItems))
 		}
-		if !isProcessingTime {
-			errorReasons = append(errorReasons, fmt.Sprintf("vertex processing time %s > %s", timeReqRunning, ta.params.MaxItemProcessingTime))
+		if !processingTimeOK {
+			errorReasons = append(errorReasons, fmt.Sprintf("vertex processing time %s > %s", oldestProcessingDuration, ta.params.MaxItemProcessingTime))
 		}
 		if err != nil {
 			errorReasons = append(errorReasons, err.Error())

--- a/snow/consensus/snowstorm/directed.go
+++ b/snow/consensus/snowstorm/directed.go
@@ -6,6 +6,7 @@ package snowstorm
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -182,12 +183,26 @@ func (dg *Directed) Finalized() bool {
 func (dg *Directed) HealthCheck(context.Context) (interface{}, error) {
 	numOutstandingTxs := dg.Latency.NumProcessing()
 	isOutstandingTxs := numOutstandingTxs <= dg.params.MaxOutstandingItems
+	healthy := isOutstandingTxs
 	details := map[string]interface{}{
 		"outstandingTransactions": numOutstandingTxs,
 	}
-	if !isOutstandingTxs {
-		errorReason := fmt.Sprintf("number of outstanding txs %d > %d", numOutstandingTxs, dg.params.MaxOutstandingItems)
-		return details, fmt.Errorf("snowstorm consensus is not healthy reason: %s", errorReason)
+
+	// check for long running transactions
+	timeReqRunning := dg.Latency.MeasureAndGetOldestDuration()
+	isProcessingTime := timeReqRunning <= dg.params.MaxItemProcessingTime
+	healthy = healthy && isProcessingTime
+	details["longestRunningTransaction"] = timeReqRunning.String()
+
+	if !healthy {
+		var errorReasons []string
+		if !isOutstandingTxs {
+			errorReasons = append(errorReasons, fmt.Sprintf("number outstanding transactions %d > %d", numOutstandingTxs, dg.params.MaxOutstandingItems))
+		}
+		if !isProcessingTime {
+			errorReasons = append(errorReasons, fmt.Sprintf("transaction processing time %s > %s", timeReqRunning, dg.params.MaxItemProcessingTime))
+		}
+		return details, fmt.Errorf("snowstorm consensus is not healthy reason: %s", strings.Join(errorReasons, ", "))
 	}
 	return details, nil
 }


### PR DESCRIPTION
## Why this should be merged

Blocks/vertices/transactions hanging in processing is often the first indication of network instability. We already become unhealthy if blocks are slow to process.

## How this works

Adds alerting if vertices or transactions remain in processing for longer than expected.

## How this was tested

CI