### PR TITLE
Skip AMI generation with Fuji tags

### DIFF
--- a/.github/workflows/update-ami.py
+++ b/.github/workflows/update-ami.py
@@ -22,7 +22,7 @@ for var in variables:
     print("A Variable is not set correctly or this is not the right repo.  Only validating packer.")
     update_marketplace = False
 
-if 'rc' in tag:
+if 'rc' in tag or 'fuji' in tag:
   print("This is a release candidate.  Only validating packer.")
   update_marketplace = False
 


### PR DESCRIPTION
## Why this should be merged

AMI generation produces the latest tag, we don't want to do this for pre-releases.

## How this works

Skip AMI generation when `fuji` is in the tag.

## How this was tested

N/A