### PR TITLE
Use `maps.Equal` in `set.Equals`

### DIFF
--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -134,17 +134,7 @@ func (s Set[T]) CappedList(size int) []T {
 
 // Equals returns true if the sets contain the same elements
 func (s Set[T]) Equals(other Set[T]) bool {
-	// Using maps.Equals makes the build not work for some reason so do this
-	// manually.
-	if s.Len() != other.Len() {
-		return false
-	}
-	for elt := range other {
-		if _, contains := s[elt]; !contains {
-			return false
-		}
-	}
-	return true
+	return maps.Equal(s, other)
 }
 
 // Removes and returns an element.


### PR DESCRIPTION
This used to not work with an older version of Go but it now works with the minimum go version we require (go 1.19.6)

## Why this should be merged

yay library functions

## How this works

self explanatory

## How this was tested

existing tests