### PR TITLE
return accrued delegator rewards in `GetCurrentValidators`

### DIFF
--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -115,15 +115,15 @@ type PermissionlessValidator struct {
 	ValidationRewardOwner *Owner `json:"validationRewardOwner,omitempty"`
 	// The owner of the rewards from delegations during the validation period,
 	// if applicable.
-	DelegationRewardOwner    *Owner                    `json:"delegationRewardOwner,omitempty"`
-	PotentialReward          *json.Uint64              `json:"potentialReward,omitempty"`
-	PotentialDelegateeReward *json.Uint64              `json:"potentialDelegateeReward,omitempty"`
-	DelegationFee            json.Float32              `json:"delegationFee"`
-	ExactDelegationFee       *json.Uint32              `json:"exactDelegationFee,omitempty"`
-	Uptime                   *json.Float32             `json:"uptime,omitempty"`
-	Connected                bool                      `json:"connected"`
-	Staked                   []UTXO                    `json:"staked,omitempty"`
-	Signer                   *signer.ProofOfPossession `json:"signer,omitempty"`
+	DelegationRewardOwner  *Owner                    `json:"delegationRewardOwner,omitempty"`
+	PotentialReward        *json.Uint64              `json:"potentialReward,omitempty"`
+	AccruedDelegateeReward *json.Uint64              `json:"accruedDelegateeReward,omitempty"`
+	DelegationFee          json.Float32              `json:"delegationFee"`
+	ExactDelegationFee     *json.Uint32              `json:"exactDelegationFee,omitempty"`
+	Uptime                 *json.Float32             `json:"uptime,omitempty"`
+	Connected              bool                      `json:"connected"`
+	Staked                 []UTXO                    `json:"staked,omitempty"`
+	Signer                 *signer.ProofOfPossession `json:"signer,omitempty"`
 
 	// The delegators delegating to this validator
 	DelegatorCount  *json.Uint64        `json:"delegatorCount,omitempty"`

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -115,14 +115,15 @@ type PermissionlessValidator struct {
 	ValidationRewardOwner *Owner `json:"validationRewardOwner,omitempty"`
 	// The owner of the rewards from delegations during the validation period,
 	// if applicable.
-	DelegationRewardOwner *Owner                    `json:"delegationRewardOwner,omitempty"`
-	PotentialReward       *json.Uint64              `json:"potentialReward,omitempty"`
-	DelegationFee         json.Float32              `json:"delegationFee"`
-	ExactDelegationFee    *json.Uint32              `json:"exactDelegationFee,omitempty"`
-	Uptime                *json.Float32             `json:"uptime,omitempty"`
-	Connected             bool                      `json:"connected"`
-	Staked                []UTXO                    `json:"staked,omitempty"`
-	Signer                *signer.ProofOfPossession `json:"signer,omitempty"`
+	DelegationRewardOwner    *Owner                    `json:"delegationRewardOwner,omitempty"`
+	PotentialReward          *json.Uint64              `json:"potentialReward,omitempty"`
+	PotentialDelegateeReward *json.Uint64              `json:"potentialDelegateeReward,omitempty"`
+	DelegationFee            json.Float32              `json:"delegationFee"`
+	ExactDelegationFee       *json.Uint32              `json:"exactDelegationFee,omitempty"`
+	Uptime                   *json.Float32             `json:"uptime,omitempty"`
+	Connected                bool                      `json:"connected"`
+	Staked                   []UTXO                    `json:"staked,omitempty"`
+	Signer                   *signer.ProofOfPossession `json:"signer,omitempty"`
 
 	// The delegators delegating to this validator
 	DelegatorCount  *json.Uint64        `json:"delegatorCount,omitempty"`

--- a/vms/platformvm/client_permissionless_validator.go
+++ b/vms/platformvm/client_permissionless_validator.go
@@ -39,13 +39,14 @@ type ClientOwner struct {
 // over client
 type ClientPermissionlessValidator struct {
 	ClientStaker
-	ValidationRewardOwner *ClientOwner
-	DelegationRewardOwner *ClientOwner
-	PotentialReward       *uint64
-	DelegationFee         float32
-	Uptime                *float32
-	Connected             *bool
-	Signer                *signer.ProofOfPossession
+	ValidationRewardOwner  *ClientOwner
+	DelegationRewardOwner  *ClientOwner
+	PotentialReward        *uint64
+	AccruedDelegateeReward *uint64
+	DelegationFee          float32
+	Uptime                 *float32
+	Connected              *bool
+	Signer                 *signer.ProofOfPossession
 	// The delegators delegating to this validator
 	DelegatorCount  *uint64
 	DelegatorWeight *uint64

--- a/vms/platformvm/client_permissionless_validator.go
+++ b/vms/platformvm/client_permissionless_validator.go
@@ -126,17 +126,18 @@ func getClientPermissionlessValidators(validatorsSliceIntf []interface{}) ([]Cli
 		}
 
 		clientValidators[i] = ClientPermissionlessValidator{
-			ClientStaker:          apiStakerToClientStaker(apiValidator.Staker),
-			ValidationRewardOwner: validationRewardOwner,
-			DelegationRewardOwner: delegationRewardOwner,
-			PotentialReward:       (*uint64)(apiValidator.PotentialReward),
-			DelegationFee:         float32(apiValidator.DelegationFee),
-			Uptime:                (*float32)(apiValidator.Uptime),
-			Connected:             &apiValidator.Connected,
-			Signer:                apiValidator.Signer,
-			DelegatorCount:        (*uint64)(apiValidator.DelegatorCount),
-			DelegatorWeight:       (*uint64)(apiValidator.DelegatorWeight),
-			Delegators:            clientDelegators,
+			ClientStaker:           apiStakerToClientStaker(apiValidator.Staker),
+			ValidationRewardOwner:  validationRewardOwner,
+			DelegationRewardOwner:  delegationRewardOwner,
+			PotentialReward:        (*uint64)(apiValidator.PotentialReward),
+			AccruedDelegateeReward: (*uint64)(apiValidator.AccruedDelegateeReward),
+			DelegationFee:          float32(apiValidator.DelegationFee),
+			Uptime:                 (*float32)(apiValidator.Uptime),
+			Connected:              &apiValidator.Connected,
+			Signer:                 apiValidator.Signer,
+			DelegatorCount:         (*uint64)(apiValidator.DelegatorCount),
+			DelegatorWeight:        (*uint64)(apiValidator.DelegatorWeight),
+			Delegators:             clientDelegators,
 		}
 	}
 	return clientValidators, nil

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -823,11 +823,11 @@ func (s *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentValidato
 		}
 		potentialReward := json.Uint64(currentStaker.PotentialReward)
 
-		potentialDelegateeReward, err := s.vm.state.GetDelegateeReward(currentStaker.SubnetID, currentStaker.NodeID)
+		delegateeReward, err := s.vm.state.GetDelegateeReward(currentStaker.SubnetID, currentStaker.NodeID)
 		if err != nil {
-			potentialDelegateeReward = 0
+			return err
 		}
-		jsonPotentialDelegateeReward := json.Uint64(potentialDelegateeReward)
+		jsonDelegateeReward := json.Uint64(delegateeReward)
 
 		switch currentStaker.Priority {
 		case txs.PrimaryNetworkValidatorCurrentPriority, txs.SubnetPermissionlessValidatorCurrentPriority:
@@ -865,16 +865,16 @@ func (s *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentValidato
 			}
 
 			vdr := platformapi.PermissionlessValidator{
-				Staker:                   apiStaker,
-				Uptime:                   uptime,
-				Connected:                connected,
-				PotentialReward:          &potentialReward,
-				PotentialDelegateeReward: &jsonPotentialDelegateeReward,
-				RewardOwner:              validationRewardOwner,
-				ValidationRewardOwner:    validationRewardOwner,
-				DelegationRewardOwner:    delegationRewardOwner,
-				DelegationFee:            delegationFee,
-				Signer:                   attr.proofOfPossession,
+				Staker:                 apiStaker,
+				Uptime:                 uptime,
+				Connected:              connected,
+				PotentialReward:        &potentialReward,
+				AccruedDelegateeReward: &jsonDelegateeReward,
+				RewardOwner:            validationRewardOwner,
+				ValidationRewardOwner:  validationRewardOwner,
+				DelegationRewardOwner:  delegationRewardOwner,
+				DelegationFee:          delegationFee,
+				Signer:                 attr.proofOfPossession,
 			}
 			reply.Validators = append(reply.Validators, vdr)
 

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -823,6 +823,12 @@ func (s *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentValidato
 		}
 		potentialReward := json.Uint64(currentStaker.PotentialReward)
 
+		potentialDelegateeReward, err := s.vm.state.GetDelegateeReward(currentStaker.SubnetID, currentStaker.NodeID)
+		if err != nil {
+			potentialDelegateeReward = 0
+		}
+		jsonPotentialDelegateeReward := json.Uint64(potentialDelegateeReward)
+
 		switch currentStaker.Priority {
 		case txs.PrimaryNetworkValidatorCurrentPriority, txs.SubnetPermissionlessValidatorCurrentPriority:
 			attr, err := s.loadStakerTxAttributes(currentStaker.TxID)
@@ -859,15 +865,16 @@ func (s *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentValidato
 			}
 
 			vdr := platformapi.PermissionlessValidator{
-				Staker:                apiStaker,
-				Uptime:                uptime,
-				Connected:             connected,
-				PotentialReward:       &potentialReward,
-				RewardOwner:           validationRewardOwner,
-				ValidationRewardOwner: validationRewardOwner,
-				DelegationRewardOwner: delegationRewardOwner,
-				DelegationFee:         delegationFee,
-				Signer:                attr.proofOfPossession,
+				Staker:                   apiStaker,
+				Uptime:                   uptime,
+				Connected:                connected,
+				PotentialReward:          &potentialReward,
+				PotentialDelegateeReward: &jsonPotentialDelegateeReward,
+				RewardOwner:              validationRewardOwner,
+				ValidationRewardOwner:    validationRewardOwner,
+				DelegationRewardOwner:    delegationRewardOwner,
+				DelegationFee:            delegationFee,
+				Signer:                   attr.proofOfPossession,
 			}
 			reply.Validators = append(reply.Validators, vdr)
 

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -690,7 +690,7 @@ func TestGetCurrentValidators(t *testing.T) {
 	require.NoError(err)
 	service.vm.state.AddTx(tx, status.Committed)
 	service.vm.state.DeleteCurrentDelegator(staker)
-	service.vm.state.SetDelegateeReward(staker.SubnetID, staker.NodeID, 100000)
+	require.NoError(service.vm.state.SetDelegateeReward(staker.SubnetID, staker.NodeID, 100000))
 	require.NoError(service.vm.state.Commit())
 
 	// Call getValidators

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -703,7 +703,7 @@ func TestGetCurrentValidators(t *testing.T) {
 		if vdr.NodeID != validatorNodeID {
 			continue
 		}
-		require.Equal(uint64(100000), uint64(*vdr.PotentialDelegateeReward))
+		require.Equal(uint64(100000), uint64(*vdr.AccruedDelegateeReward))
 	}
 }
 

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -623,7 +623,7 @@ func TestGetCurrentValidators(t *testing.T) {
 	delegatorStartTime := uint64(defaultValidateStartTime.Unix())
 	delegatorEndTime := uint64(defaultValidateStartTime.Add(defaultMinStakingDuration).Unix())
 
-	tx, err := service.vm.txBuilder.NewAddDelegatorTx(
+	delTx, err := service.vm.txBuilder.NewAddDelegatorTx(
 		stakeAmount,
 		delegatorStartTime,
 		delegatorEndTime,
@@ -635,14 +635,14 @@ func TestGetCurrentValidators(t *testing.T) {
 	require.NoError(err)
 
 	staker, err := state.NewCurrentStaker(
-		tx.ID(),
-		tx.Unsigned.(*txs.AddDelegatorTx),
+		delTx.ID(),
+		delTx.Unsigned.(*txs.AddDelegatorTx),
 		0,
 	)
 	require.NoError(err)
 
 	service.vm.state.PutCurrentDelegator(staker)
-	service.vm.state.AddTx(tx, status.Committed)
+	service.vm.state.AddTx(delTx, status.Committed)
 	err = service.vm.state.Commit()
 	require.NoError(err)
 
@@ -684,6 +684,27 @@ func TestGetCurrentValidators(t *testing.T) {
 		require.Equal(uint64(delegator.Weight), stakeAmount)
 	}
 	require.True(found)
+
+	// Reward the delegator
+	tx, err := service.vm.txBuilder.NewRewardValidatorTx(delTx.ID())
+	require.NoError(err)
+	service.vm.state.AddTx(tx, status.Committed)
+	service.vm.state.DeleteCurrentDelegator(staker)
+	service.vm.state.SetDelegateeReward(staker.SubnetID, staker.NodeID, 100000)
+	require.NoError(service.vm.state.Commit())
+
+	// Call getValidators
+	response = GetCurrentValidatorsReply{}
+	require.NoError(service.GetCurrentValidators(nil, &args, &response))
+	require.Equal(len(genesis.Validators), len(response.Validators))
+
+	for i := 0; i < len(response.Validators); i++ {
+		vdr := response.Validators[i].(pchainapi.PermissionlessValidator)
+		if vdr.NodeID != validatorNodeID {
+			continue
+		}
+		require.Equal(uint64(100000), uint64(*vdr.PotentialDelegateeReward))
+	}
 }
 
 func TestGetTimestamp(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

Provides a way to see how much a validator has accrued from delegations.

## How this works

Modifies `GetCurrentValidators` in the service API

## How this was tested

CI