### PR TITLE
Gossip Avalanche frontier after the linearization

### DIFF
--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -874,6 +874,8 @@ func (h *handler) handleChanMsg(msg message.InboundMessage) error {
 		return engine.Notify(context.TODO(), common.Message(msg.Notification))
 
 	case *message.GossipRequest:
+		// TODO: After Cortina is activated, this can be removed as everyone
+		// will have accepted the StopVertex.
 		if state.Type == p2p.EngineType_ENGINE_TYPE_SNOWMAN {
 			avalancheEngine, ok := h.engineManager.Get(p2p.EngineType_ENGINE_TYPE_AVALANCHE).Get(state.State)
 			if ok {

--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -874,6 +874,17 @@ func (h *handler) handleChanMsg(msg message.InboundMessage) error {
 		return engine.Notify(context.TODO(), common.Message(msg.Notification))
 
 	case *message.GossipRequest:
+		if state.Type == p2p.EngineType_ENGINE_TYPE_SNOWMAN {
+			avalancheEngine, ok := h.engineManager.Get(p2p.EngineType_ENGINE_TYPE_AVALANCHE).Get(state.State)
+			if ok {
+				// This chain was linearized, so we should gossip the Avalanche
+				// accepted frontier to make sure everyone eventually linearizes
+				// the chain.
+				if err := avalancheEngine.Gossip(context.TODO()); err != nil {
+					return err
+				}
+			}
+		}
 		return engine.Gossip(context.TODO())
 
 	case *message.Timeout:


### PR DESCRIPTION
## Why this should be merged

Ensures that every node in the network will always eventually learn of the StopVertex.

## How this works

Gossips the stop vertex when we gossip the Snowman accepted frontier.

## How this was tested

CI + Fuji deployment