### PR TITLE
Persist stateless block in AVM state

### DIFF
--- a/vms/avm/blocks/executor/block.go
+++ b/vms/avm/blocks/executor/block.go
@@ -197,7 +197,7 @@ func (b *Block) Verify(context.Context) error {
 	// Now that the block has been executed, we can add the block data to the
 	// state diff.
 	stateDiff.SetLastAccepted(blkID)
-	stateDiff.AddBlock(b)
+	stateDiff.AddBlock(b.Block)
 
 	b.manager.blkIDToState[blkID] = blockState
 	b.manager.mempool.Remove(txs)

--- a/vms/avm/blocks/executor/block_test.go
+++ b/vms/avm/blocks/executor/block_test.go
@@ -540,8 +540,9 @@ func TestBlockVerify(t *testing.T) {
 				require.Equal(b.Block, blockState.statelessBlock)
 
 				// Assert block is added to on accept state
-				_, err := blockState.onAcceptState.GetBlock(b.ID())
+				persistedBlock, err := blockState.onAcceptState.GetBlock(b.ID())
 				require.NoError(err)
+				require.Equal(b.Block, persistedBlock)
 
 				// Assert block is set to last accepted
 				lastAccepted := b.ID()


### PR DESCRIPTION
## Why this should be merged

We expect the AVM state to only reference stateless blocks. Currently we can wrap the same block multiple times or reference a stateful block when we expect it to be stateless. This isn't actually a correctness issue... But can cause unnecessary memory pressure + unnecessary function calls + unexpected json serialization.

## How this works

Persist the stateless block rather than the stateful block during verification.

## How this was tested

Added unit test that was failing and now passes. Also manually replicated the incorrect API behavior and verified it doesn't happen on this version.