### PR TITLE
Initialize FxID fields in GetBlock and GetBlockByHeight

### DIFF
--- a/vms/avm/service.go
+++ b/vms/avm/service.go
@@ -81,6 +81,17 @@ func (s *Service) GetBlock(_ *http.Request, args *api.GetBlockArgs, reply *api.G
 
 	if args.Encoding == formatting.JSON {
 		block.InitCtx(s.vm.ctx)
+		for _, tx := range block.Txs() {
+			err := tx.Unsigned.Visit(&txInit{
+				tx:            tx,
+				ctx:           s.vm.ctx,
+				typeToFxIndex: s.vm.typeToFxIndex,
+				fxs:           s.vm.fxs,
+			})
+			if err != nil {
+				return err
+			}
+		}
 		reply.Block = block
 		return nil
 	}
@@ -121,6 +132,17 @@ func (s *Service) GetBlockByHeight(_ *http.Request, args *api.GetBlockByHeightAr
 
 	if args.Encoding == formatting.JSON {
 		block.InitCtx(s.vm.ctx)
+		for _, tx := range block.Txs() {
+			err := tx.Unsigned.Visit(&txInit{
+				tx:            tx,
+				ctx:           s.vm.ctx,
+				typeToFxIndex: s.vm.typeToFxIndex,
+				fxs:           s.vm.fxs,
+			})
+			if err != nil {
+				return err
+			}
+		}
 		reply.Block = block
 		return nil
 	}

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -2681,6 +2681,7 @@ func TestServiceGetBlock(t *testing.T) {
 			serviceAndExpectedBlockFunc: func(ctrl *gomock.Controller) (*Service, interface{}) {
 				block := blocks.NewMockBlock(ctrl)
 				block.EXPECT().InitCtx(gomock.Any())
+				block.EXPECT().Txs().Return(nil)
 
 				manager := executor.NewMockManager(ctrl)
 				manager.EXPECT().GetStatelessBlock(blockID).Return(block, nil)
@@ -2865,6 +2866,7 @@ func TestServiceGetBlockByHeight(t *testing.T) {
 			serviceAndExpectedBlockFunc: func(ctrl *gomock.Controller) (*Service, interface{}) {
 				block := blocks.NewMockBlock(ctrl)
 				block.EXPECT().InitCtx(gomock.Any())
+				block.EXPECT().Txs().Return(nil)
 
 				state := states.NewMockState(ctrl)
 				state.EXPECT().GetBlockID(blockHeight).Return(blockID, nil)


### PR DESCRIPTION
## Why this should be merged

`FxID`s are used to specify how to parse a json struct. Currently they are left uninitialized as `11111111111111111111111111111111LpoYY`.

## How this works

Initializes the `FxID` fields like we do in in the `avm.getTx` API for `avm.getBlock` and `avm.getBlockByHeight`.

## How this was tested

Before:
```
{
    "jsonrpc": "2.0",
    "result": {
        "block": {
            "parentID": "aku3My3D5NZvsSLhkw1orTEvmCn3GS1nDnFQhivbvfFFUxdLw",
            "height": 5,
            "time": 1680889438,
            "merkleRoot": "11111111111111111111111111111111LpoYY",
            "txs": [
                {
                    "unsignedTx": {
                        "networkID": 12345,
                        "blockchainID": "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed",
                        "outputs": [
                            {
                                "assetID": "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe",
                                "fxID": "11111111111111111111111111111111LpoYY",
                                "output": {
                                    "addresses": [
                                        "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
                                    ],
                                    "amount": 299999999995000000,
                                    "locktime": 0,
                                    "threshold": 1
                                }
                            }
                        ],
                        "inputs": [
                            {
                                "txID": "oW48Xytve3bEfiUGaMLbqfPpxGojfrwvi32SVHqS5cLWJju7R",
                                "outputIndex": 0,
                                "assetID": "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe",
                                "fxID": "11111111111111111111111111111111LpoYY",
                                "input": {
                                    "amount": 299999999996000000,
                                    "signatureIndices": [
                                        0
                                    ]
                                }
                            }
                        ],
                        "memo": "0x",
                        "name": "HI",
                        "symbol": "HI",
                        "denomination": 1,
                        "initialStates": [
                            {
                                "fxIndex": 0,
                                "fxID": "11111111111111111111111111111111LpoYY",
                                "outputs": [
                                    {
                                        "addresses": [
                                            "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
                                        ],
                                        "amount": 49463,
                                        "locktime": 0,
                                        "threshold": 1
                                    }
                                ]
                            }
                        ]
                    },
                    "credentials": [
                        {
                            "fxID": "11111111111111111111111111111111LpoYY",
                            "credential": {
                                "signatures": [
                                    "0xcfe2a011413cf60a8d343b4a6ebce55757c2818149550d9118868833d09739170aa91d123de6c658ac679e07bfd67ce2328deb64c8ef8955b9db49e9410c60dd01"
                                ]
                            }
                        }
                    ]
                }
            ]
        },
        "encoding": "json"
    },
    "id": 1
}
```

After:
```
{
    "jsonrpc": "2.0",
    "result": {
        "block": {
            "parentID": "aku3My3D5NZvsSLhkw1orTEvmCn3GS1nDnFQhivbvfFFUxdLw",
            "height": 5,
            "time": 1680889438,
            "merkleRoot": "11111111111111111111111111111111LpoYY",
            "txs": [
                {
                    "unsignedTx": {
                        "networkID": 12345,
                        "blockchainID": "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed",
                        "outputs": [
                            {
                                "assetID": "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe",
                                "fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
                                "output": {
                                    "addresses": [
                                        "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
                                    ],
                                    "amount": 299999999995000000,
                                    "locktime": 0,
                                    "threshold": 1
                                }
                            }
                        ],
                        "inputs": [
                            {
                                "txID": "oW48Xytve3bEfiUGaMLbqfPpxGojfrwvi32SVHqS5cLWJju7R",
                                "outputIndex": 0,
                                "assetID": "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe",
                                "fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
                                "input": {
                                    "amount": 299999999996000000,
                                    "signatureIndices": [
                                        0
                                    ]
                                }
                            }
                        ],
                        "memo": "0x",
                        "name": "HI",
                        "symbol": "HI",
                        "denomination": 1,
                        "initialStates": [
                            {
                                "fxIndex": 0,
                                "fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
                                "outputs": [
                                    {
                                        "addresses": [
                                            "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
                                        ],
                                        "amount": 49463,
                                        "locktime": 0,
                                        "threshold": 1
                                    }
                                ]
                            }
                        ]
                    },
                    "credentials": [
                        {
                            "fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
                            "credential": {
                                "signatures": [
                                    "0xcfe2a011413cf60a8d343b4a6ebce55757c2818149550d9118868833d09739170aa91d123de6c658ac679e07bfd67ce2328deb64c8ef8955b9db49e9410c60dd01"
                                ]
                            }
                        }
                    ]
                }
            ]
        },
        "encoding": "json"
    },
    "id": 1
}
```