### PR TITLE
Expose GetEngineManager from the chain Handler

### DIFF
--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -57,6 +57,7 @@ type Handler interface {
 	ShouldHandle(nodeID ids.NodeID) bool
 
 	SetEngineManager(engineManager *EngineManager)
+	GetEngineManager() *EngineManager
 
 	SetOnStopped(onStopped func())
 	Start(ctx context.Context, recoverPanic bool)
@@ -167,6 +168,10 @@ func (h *handler) ShouldHandle(nodeID ids.NodeID) bool {
 
 func (h *handler) SetEngineManager(engineManager *EngineManager) {
 	h.engineManager = engineManager
+}
+
+func (h *handler) GetEngineManager() *EngineManager {
+	return h.engineManager
 }
 
 func (h *handler) SetOnStopped(onStopped func()) {

--- a/snow/networking/handler/mock_handler.go
+++ b/snow/networking/handler/mock_handler.go
@@ -54,6 +54,20 @@ func (mr *MockHandlerMockRecorder) Context() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockHandler)(nil).Context))
 }
 
+// GetEngineManager mocks base method.
+func (m *MockHandler) GetEngineManager() *EngineManager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEngineManager")
+	ret0, _ := ret[0].(*EngineManager)
+	return ret0
+}
+
+// GetEngineManager indicates an expected call of GetEngineManager.
+func (mr *MockHandlerMockRecorder) GetEngineManager() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEngineManager", reflect.TypeOf((*MockHandler)(nil).GetEngineManager))
+}
+
 // HealthCheck mocks base method.
 func (m *MockHandler) HealthCheck(arg0 context.Context) (interface{}, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why this should be merged

We need access to the engine manager to override the engine manager inside of the custom node testing framework.

## How this works

Exposes  `GetEngineManager` on the `handler.Handler` interface.

## How this was tested

N/A