### PR TITLE
increase health await timeout

### DIFF
--- a/api/health/health_test.go
+++ b/api/health/health_test.go
@@ -22,7 +22,7 @@ import (
 const (
 	checkFreq    = time.Millisecond
 	awaitFreq    = 50 * time.Microsecond
-	awaitTimeout = 10 * time.Second
+	awaitTimeout = 30 * time.Second
 )
 
 var errUnhealthy = errors.New("unhealthy")


### PR DESCRIPTION
Tests on windows takes around  ~10 sec, this increases the timeout to 30 sec. 
