### PR TITLE
Add benchmark for gRPC GetValidatorSet

### DIFF
--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -189,12 +189,12 @@ func BenchmarkGetValidatorSet(b *testing.B) {
 	for _, i := range []int{1, 10, 1000, 2000} {
 		vs := setupValidatorSet(b, i)
 		b.Run(fmt.Sprintf("get_validator_set_%d_validators", i), func(b *testing.B) {
-			benchmarkGetValidatorSet(b, i, vs)
+			benchmarkGetValidatorSet(b, vs)
 		})
 	}
 }
 
-func benchmarkGetValidatorSet(b *testing.B, i int, vs map[ids.NodeID]*validators.GetValidatorOutput) {
+func benchmarkGetValidatorSet(b *testing.B, vs map[ids.NodeID]*validators.GetValidatorOutput) {
 	require := require.New(b)
 	ctrl := gomock.NewController(b)
 	state := setupState(b, ctrl)

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -219,7 +219,7 @@ func setupValidatorSet(b *testing.B, size int) map[ids.NodeID]*validators.GetVal
 	set := make(map[ids.NodeID]*validators.GetValidatorOutput, size)
 	sk, _ := bls.NewSecretKey()
 	pk := bls.PublicFromSecretKey(sk)
-	for i := 0; i < size-1; i++ {
+	for i := 0; i < size; i++ {
 		id := ids.GenerateTestNodeID()
 		set[id] = &validators.GetValidatorOutput{
 			NodeID:    id,

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -6,6 +6,7 @@ package gvalidators
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -180,4 +181,51 @@ func TestGetValidatorSet(t *testing.T) {
 
 	_, err = state.client.GetValidatorSet(context.Background(), height, subnetID)
 	require.Error(err)
+}
+
+// BenchmarkGetValidatorSet measures the time it takes complete a gRPC client
+// request based on a mocked validator set.
+func BenchmarkGetValidatorSet(b *testing.B) {
+	for _, i := range []int{1, 10, 1000, 2000} {
+		b.Run(fmt.Sprintf("get_validator_set_%d_validators", i), func(b *testing.B) {
+			vs := setupValidatorSet(b, i)
+			b.ResetTimer()
+			benchmarkGetValidatorSet(b, i, vs)
+		})
+	}
+}
+
+func benchmarkGetValidatorSet(b *testing.B, i int, vs map[ids.NodeID]*validators.GetValidatorOutput) {
+	require := require.New(b)
+	ctrl := gomock.NewController(b)
+	state := setupState(b, ctrl)
+	defer func() {
+		ctrl.Finish()
+		state.closeFn()
+	}()
+
+	height := uint64(1337)
+	subnetID := ids.GenerateTestID()
+	for i := 0; i < b.N; i++ {
+		state.server.EXPECT().GetValidatorSet(gomock.Any(), height, subnetID).Return(vs, nil)
+		_, err := state.client.GetValidatorSet(context.Background(), height, subnetID)
+		require.NoError(err)
+	}
+}
+
+func setupValidatorSet(b *testing.B, size int) map[ids.NodeID]*validators.GetValidatorOutput {
+	b.Helper()
+
+	set := make(map[ids.NodeID]*validators.GetValidatorOutput, size)
+	sk, _ := bls.NewSecretKey()
+	pk := bls.PublicFromSecretKey(sk)
+	for i := 0; i < size-1; i++ {
+		id := ids.GenerateTestNodeID()
+		set[id] = &validators.GetValidatorOutput{
+			NodeID:    id,
+			PublicKey: pk,
+			Weight:    uint64(i),
+		}
+	}
+	return set
 }

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -187,9 +187,8 @@ func TestGetValidatorSet(t *testing.T) {
 // request based on a mocked validator set.
 func BenchmarkGetValidatorSet(b *testing.B) {
 	for _, i := range []int{1, 10, 1000, 2000} {
+		vs := setupValidatorSet(b, i)
 		b.Run(fmt.Sprintf("get_validator_set_%d_validators", i), func(b *testing.B) {
-			vs := setupValidatorSet(b, i)
-			b.ResetTimer()
 			benchmarkGetValidatorSet(b, i, vs)
 		})
 	}


### PR DESCRIPTION
## Why this should be merged

It is important to understand the cost of requesting a large validator set over gRPC. Even though the call is local there is a cost for serialization. The wire cost for the RPC is only about 1.6ms. The rest of the time is spent converting bytes to BLS keys (cgo).

ref https://github.com/ava-labs/avalanchego/blob/7d73b59cb4838d304387ea680b9cc4053b72620c/snow/validators/gvalidators/validator_state_client.go#L75

```
$ go test -benchmem -run=^$ -bench ^BenchmarkGetValidatorSet$ github.com/ava-labs/avalanchego/snow/validators/gvalidators -memprofile benchvset.mem -cpuprofile benchvset.cpu

goos: linux
goarch: amd64
pkg: github.com/ava-labs/avalanchego/snow/validators/gvalidators
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkGetValidatorSet/get_validator_set_1_validators-12                 12841            106797 ns/op            9913 B/op        194 allocs/op
BenchmarkGetValidatorSet/get_validator_set_10_validators-12                 1710            670164 ns/op           16391 B/op        266 allocs/op
BenchmarkGetValidatorSet/get_validator_set_500_validators-12                  37          28670401 ns/op          386569 B/op       3744 allocs/op
BenchmarkGetValidatorSet/get_validator_set_1000_validators-12                 19          56178525 ns/op          763855 B/op       7269 allocs/op
BenchmarkGetValidatorSet/get_validator_set_2000_validators-12                  9         111610799 ns/op         1503906 B/op      14323 allocs/op
```
### profiles
[benchvset.cpu](https://github.com/ava-labs/avalanchego/files/11201944/benchvset.cpu.txt)
[benchvset.mem](https://github.com/ava-labs/avalanchego/files/11201959/benchvset.mem.txt)

## How this works

Uses golang native benchmark tooling

## How this was tested

manual


