### PR TITLE
Cleanup goroutines on health.Stop

### DIFF
--- a/api/health/health.go
+++ b/api/health/health.go
@@ -28,7 +28,12 @@ type Health interface {
 	Registerer
 	Reporter
 
+	// Start running periodic health checks at the specified frequency.
+	// Repeated calls to Start will be no-ops.
 	Start(ctx context.Context, freq time.Duration)
+
+	// Stop running periodic health checks. Stop should only be called after
+	// Start. Once Stop returns, no more health checks will be executed.
 	Stop()
 }
 


### PR DESCRIPTION
## Why this should be merged

Fixes a flaky test.

## How this works

Stop will now block until all of the goroutines have shut down.

## How this was tested

CI + inspection