### PR TITLE
Cleanup type assertions in the linkedHashmap

### DIFF
--- a/utils/linkedhashmap/iterator.go
+++ b/utils/linkedhashmap/iterator.go
@@ -59,8 +59,9 @@ func (it *iterator[K, V]) Next() bool {
 	// It's important to ensure that [it.next] is not nil
 	// by not deleting elements that have not yet been iterated
 	// over from [it.lh]
-	it.key = it.next.Value.(keyValue[K, V]).key
-	it.value = it.next.Value.(keyValue[K, V]).value
+	kv := it.next.Value.(keyValue[K, V])
+	it.key = kv.key
+	it.value = kv.value
 	it.next = it.next.Next() // Next time, return next element
 	it.exhausted = it.next == nil
 	return true

--- a/utils/linkedhashmap/linkedhashmap.go
+++ b/utils/linkedhashmap/linkedhashmap.go
@@ -108,7 +108,8 @@ func (lh *linkedHashmap[K, V]) put(key K, value V) {
 
 func (lh *linkedHashmap[K, V]) get(key K) (V, bool) {
 	if e, ok := lh.entryMap[key]; ok {
-		return e.Value.(keyValue[K, V]).value, true
+		kv := e.Value.(keyValue[K, V])
+		return kv.value, true
 	}
 	return utils.Zero[V](), false
 }
@@ -126,14 +127,16 @@ func (lh *linkedHashmap[K, V]) len() int {
 
 func (lh *linkedHashmap[K, V]) oldest() (K, V, bool) {
 	if val := lh.entryList.Front(); val != nil {
-		return val.Value.(keyValue[K, V]).key, val.Value.(keyValue[K, V]).value, true
+		kv := val.Value.(keyValue[K, V])
+		return kv.key, kv.value, true
 	}
 	return utils.Zero[K](), utils.Zero[V](), false
 }
 
 func (lh *linkedHashmap[K, V]) newest() (K, V, bool) {
 	if val := lh.entryList.Back(); val != nil {
-		return val.Value.(keyValue[K, V]).key, val.Value.(keyValue[K, V]).value, true
+		kv := val.Value.(keyValue[K, V])
+		return kv.key, kv.value, true
 	}
 	return utils.Zero[K](), utils.Zero[V](), false
 }


### PR DESCRIPTION
## Why this should be merged

Just a small code cleanup I noticed when reviewing the locking change.

## How this works

Avoids referencing a field of a struct that we just performed a type assertion on... On some places this reduces the number of type assertions... There may technically be a performance hit in some places because it copies the struct into a new var... If there is I don't really care... (and I feel like the compiler should be able to optimize it out if it's smart enough)

## How this was tested

CI