### PR TITLE
Fix racy avm tx access

### DIFF
--- a/vms/avm/network/network.go
+++ b/vms/avm/network/network.go
@@ -103,14 +103,17 @@ func (n *network) AppGossip(ctx context.Context, nodeID ids.NodeID, msgBytes []b
 		)
 		return nil
 	}
+	txID := tx.ID()
 
 	// We need to grab the context lock here to avoid racy behavior with
 	// transaction verification + mempool modifications.
+	//
+	// Invariant: tx should not be referenced again without the context lock
+	// held to avoid any data races.
 	n.ctx.Lock.Lock()
 	err = n.issueTx(tx)
 	n.ctx.Lock.Unlock()
 	if err == nil {
-		txID := tx.ID()
 		n.gossipTx(ctx, txID, msgBytes)
 	}
 	return nil


### PR DESCRIPTION
## Why this should be merged

Fixes a data-race with avm tx fields being accessed without the context lock held after being provided to the mempool (with the context lock held).

## How this works

Fetches the ID before providing the tx to the mempool, so the caller still has sole ownership of the struct.

## How this was tested

CI