### PR TITLE
Remove duplicate TLS verification

### DIFF
--- a/vms/proposervm/block/block.go
+++ b/vms/proposervm/block/block.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
@@ -92,10 +91,6 @@ func (b *statelessBlock) initialize(bytes []byte) error {
 
 	cert, err := x509.ParseCertificate(b.StatelessBlock.Certificate)
 	if err != nil {
-		return err
-	}
-
-	if err := staking.VerifyCertificate(cert); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Why this should be merged

Since `go1.19` `x509.ParseCertificate` enforces that extension IDs are unique, so there is no need to verify that externally.

## How this works

Removes the external duplicate checks.

## How this was tested

CI