### PR TITLE
Improve `codec/` error handling

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -3,7 +3,19 @@
 
 package codec
 
-import "github.com/ava-labs/avalanchego/utils/wrappers"
+import (
+	"errors"
+
+	"github.com/ava-labs/avalanchego/utils/wrappers"
+)
+
+var (
+	ErrUnsupportedType           = errors.New("unsupported type")
+	ErrMaxSliceLenExceeded       = errors.New("max slice length exceeded")
+	ErrDoesNotImplementInterface = errors.New("does not implement interface")
+	ErrUnexportedField           = errors.New("unexported field")
+	ErrExtraSpace                = errors.New("trailing buffer space")
+)
 
 // Codec marshals and unmarshals
 type Codec interface {

--- a/codec/hierarchycodec/codec.go
+++ b/codec/hierarchycodec/codec.go
@@ -89,7 +89,7 @@ func (c *hierarchyCodec) RegisterType(val interface{}) error {
 
 	valType := reflect.TypeOf(val)
 	if _, exists := c.typeToTypeID[valType]; exists {
-		return fmt.Errorf("type %v has already been registered", valType)
+		return fmt.Errorf("%w: %v", codec.ErrDuplicateType, valType)
 	}
 
 	valTypeID := typeID{
@@ -142,7 +142,11 @@ func (c *hierarchyCodec) UnpackPrefix(p *wrappers.Packer, valueType reflect.Type
 	}
 	// Ensure type actually does implement the interface
 	if !implementingType.Implements(valueType) {
-		return reflect.Value{}, fmt.Errorf("couldn't unmarshal interface: %s does not implement interface %s", implementingType, valueType)
+		return reflect.Value{}, fmt.Errorf("couldn't unmarshal interface: %s %w %s",
+			implementingType,
+			codec.ErrDoesNotImplementInterface,
+			valueType,
+		)
 	}
 	return reflect.New(implementingType).Elem(), nil // instance of the proper type
 }

--- a/codec/linearcodec/codec.go
+++ b/codec/linearcodec/codec.go
@@ -79,7 +79,7 @@ func (c *linearCodec) RegisterType(val interface{}) error {
 
 	valType := reflect.TypeOf(val)
 	if _, exists := c.typeToTypeID[valType]; exists {
-		return fmt.Errorf("type %v has already been registered", valType)
+		return fmt.Errorf("%w: %v", codec.ErrDuplicateType, valType)
 	}
 
 	c.typeIDToType[c.nextTypeID] = valType
@@ -120,7 +120,11 @@ func (c *linearCodec) UnpackPrefix(p *wrappers.Packer, valueType reflect.Type) (
 	}
 	// Ensure type actually does implement the interface
 	if !implementingType.Implements(valueType) {
-		return reflect.Value{}, fmt.Errorf("couldn't unmarshal interface: %s does not implement interface %s", implementingType, valueType)
+		return reflect.Value{}, fmt.Errorf("couldn't unmarshal interface: %s %w %s",
+			implementingType,
+			codec.ErrDoesNotImplementInterface,
+			valueType,
+		)
 	}
 	return reflect.New(implementingType).Elem(), nil // instance of the proper type
 }

--- a/codec/reflectcodec/struct_fielder.go
+++ b/codec/reflectcodec/struct_fielder.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+
+	"github.com/ava-labs/avalanchego/codec"
 )
 
 const (
@@ -91,7 +93,10 @@ func (s *structFielder) GetSerializedFields(t reflect.Type) ([]FieldDesc, error)
 			continue
 		}
 		if !field.IsExported() { // Can only marshal exported fields
-			return nil, fmt.Errorf("can't marshal un-exported field %s", field.Name)
+			return nil, fmt.Errorf("can not marshal %w: %s",
+				codec.ErrUnexportedField,
+				field.Name,
+			)
 		}
 		sliceLenField := field.Tag.Get(SliceLenTagName)
 		maxSliceLen := s.maxSliceLen

--- a/codec/reflectcodec/type_codec.go
+++ b/codec/reflectcodec/type_codec.go
@@ -19,12 +19,9 @@ const (
 )
 
 var (
-	ErrMaxMarshalSliceLimitExceeded = errors.New("maximum marshal slice limit exceeded")
-
 	errMarshalNil   = errors.New("can't marshal nil pointer or interface")
 	errUnmarshalNil = errors.New("can't unmarshal nil")
 	errNeedPointer  = errors.New("argument to unmarshal must be a pointer")
-	errExtraSpace   = errors.New("trailing buffer space")
 )
 
 var _ codec.Codec = (*genericCodec)(nil)
@@ -278,9 +275,10 @@ func (c *genericCodec) marshal(value reflect.Value, p *wrappers.Packer, maxSlice
 		numElts := value.Len() // # elements in the slice/array. 0 if this slice is nil.
 		if uint32(numElts) > maxSliceLen {
 			return fmt.Errorf("%w; slice length, %d, exceeds maximum length, %d",
-				ErrMaxMarshalSliceLimitExceeded,
+				codec.ErrMaxSliceLenExceeded,
 				numElts,
-				maxSliceLen)
+				maxSliceLen,
+			)
 		}
 		p.PackInt(uint32(numElts)) // pack # elements
 		if p.Err != nil {
@@ -312,7 +310,11 @@ func (c *genericCodec) marshal(value reflect.Value, p *wrappers.Packer, maxSlice
 			return p.Err
 		}
 		if uint32(numElts) > c.maxSliceLen {
-			return fmt.Errorf("%w; array length, %d, exceeds maximum length, %d", ErrMaxMarshalSliceLimitExceeded, numElts, c.maxSliceLen)
+			return fmt.Errorf("%w; array length, %d, exceeds maximum length, %d",
+				codec.ErrMaxSliceLenExceeded,
+				numElts,
+				c.maxSliceLen,
+			)
 		}
 		for i := 0; i < numElts; i++ { // Process each element in the array
 			if err := c.marshal(value.Index(i), p, c.maxSliceLen); err != nil {
@@ -332,7 +334,7 @@ func (c *genericCodec) marshal(value reflect.Value, p *wrappers.Packer, maxSlice
 		}
 		return nil
 	default:
-		return fmt.Errorf("can't marshal unknown kind %s", valueKind)
+		return fmt.Errorf("%w: %s", codec.ErrUnsupportedType, valueKind)
 	}
 }
 
@@ -354,7 +356,11 @@ func (c *genericCodec) Unmarshal(bytes []byte, dest interface{}) error {
 		return err
 	}
 	if p.Offset != len(bytes) {
-		return errExtraSpace
+		return fmt.Errorf("%w: read %d provided %d",
+			codec.ErrExtraSpace,
+			p.Offset,
+			len(bytes),
+		)
 	}
 	return nil
 }
@@ -424,15 +430,17 @@ func (c *genericCodec) unmarshal(p *wrappers.Packer, value reflect.Value, maxSli
 		}
 		if numElts32 > maxSliceLen {
 			return fmt.Errorf("%w; array length, %d, exceeds maximum length, %d",
-				ErrMaxMarshalSliceLimitExceeded,
+				codec.ErrMaxSliceLenExceeded,
 				numElts32,
-				maxSliceLen)
+				maxSliceLen,
+			)
 		}
 		if numElts32 > math.MaxInt32 {
 			return fmt.Errorf("%w; array length, %d, exceeds maximum length, %d",
-				ErrMaxMarshalSliceLimitExceeded,
+				codec.ErrMaxSliceLenExceeded,
 				numElts32,
-				math.MaxInt32)
+				math.MaxInt32,
+			)
 		}
 		numElts := int(numElts32)
 

--- a/codec/registry.go
+++ b/codec/registry.go
@@ -3,6 +3,10 @@
 
 package codec
 
+import "errors"
+
+var ErrDuplicateType = errors.New("duplicate type registration")
+
 // Registry registers new types that can be marshaled into
 type Registry interface {
 	RegisterType(interface{}) error


### PR DESCRIPTION
## Why this should be merged

Factored out of #1346

## How this works

Mainly changes to expose specific errors + update tests

## How this was tested

CI