### PR TITLE
Require `txID`s in PeerList messages

### DIFF
--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -992,20 +992,16 @@ func (p *peer) handlePeerList(msg *p2p.PeerList) {
 			return
 		}
 
-		// TODO: After the next network upgrade, require txIDs to be populated.
-		var txID ids.ID
-		if len(claimedIPPort.TxId) > 0 {
-			txID, err = ids.ToID(claimedIPPort.TxId)
-			if err != nil {
-				p.Log.Debug("message with invalid field",
-					zap.Stringer("nodeID", p.id),
-					zap.Stringer("messageOp", message.PeerListOp),
-					zap.String("field", "txID"),
-					zap.Error(err),
-				)
-				p.StartClose()
-				return
-			}
+		txID, err := ids.ToID(claimedIPPort.TxId)
+		if err != nil {
+			p.Log.Debug("message with invalid field",
+				zap.Stringer("nodeID", p.id),
+				zap.Stringer("messageOp", message.PeerListOp),
+				zap.String("field", "txID"),
+				zap.Error(err),
+			)
+			p.StartClose()
+			return
 		}
 
 		discoveredIPs[i] = &ips.ClaimedIPPort{


### PR DESCRIPTION
## Why this should be merged

`txID`s were added to all peerlist messages before `v1.10.0`, so all node now provide this field correctly. Anyone not providing this field correctly should be disconnected.

## How this works

Drops the empty value check.

## How this was tested

CI