### PR TITLE
Simplify IP status calculation

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -1047,9 +1047,8 @@ func (n *network) authenticateIPs(ips []*ips.ClaimedIPPort) ([]*ipAuth, error) {
 // peerIPStatus assumes the caller holds [peersLock]
 func (n *network) peerIPStatus(nodeID ids.NodeID, ip *ips.ClaimedIPPort) (*ips.ClaimedIPPort, bool, bool, bool) {
 	prevIP, previouslyTracked := n.peerIPs[nodeID]
-	_, connected := n.connectedPeers.GetByID(nodeID)
 	shouldUpdateOurIP := previouslyTracked && prevIP.Timestamp < ip.Timestamp
-	shouldDial := !previouslyTracked && !connected && n.wantsConnection(nodeID)
+	shouldDial := !previouslyTracked && n.wantsConnection(nodeID)
 	return prevIP, previouslyTracked, shouldUpdateOurIP, shouldDial
 }
 


### PR DESCRIPTION
## Why this should be merged

`connected` implies `previouslyTracked`, so `!previouslyTracked && !connected` is equal to `!previouslyTracked`. So, we can avoid an additional set lookup.

## How this works

`previouslyTracked` is `true` if the peer:

- was attempted to be connected to in the past
- is currently in the process of connecting
- is `connected`

Because `previouslyTracked` is `true` when `connected`, we can simplify the expression.

## How this was tested

It's kind of hard to test that this is dead code...