### PR TITLE
Support `height` as a string in `avm.getBlockByHeight`

### DIFF
--- a/api/common_args_responses.go
+++ b/api/common_args_responses.go
@@ -69,7 +69,7 @@ type GetBlockArgs struct {
 
 // GetBlockByHeightArgs is the parameters supplied to the GetBlockByHeight API
 type GetBlockByHeightArgs struct {
-	Height   uint64              `json:"height"`
+	Height   json.Uint64         `json:"height"`
 	Encoding formatting.Encoding `json:"encoding"`
 }
 

--- a/vms/avm/client.go
+++ b/vms/avm/client.go
@@ -15,9 +15,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/rpc"
-
-	cjson "github.com/ava-labs/avalanchego/utils/json"
 )
 
 var _ Client = (*client)(nil)
@@ -251,7 +250,7 @@ func (c *client) GetBlock(ctx context.Context, blkID ids.ID, options ...rpc.Opti
 func (c *client) GetBlockByHeight(ctx context.Context, height uint64, options ...rpc.Option) ([]byte, error) {
 	res := &api.FormattedBlock{}
 	err := c.requester.SendRequest(ctx, "avm.getBlockByHeight", &api.GetBlockByHeightArgs{
-		Height:   height,
+		Height:   json.Uint64(height),
 		Encoding: formatting.HexNC,
 	}, res, options...)
 	if err != nil {
@@ -349,7 +348,7 @@ func (c *client) GetAtomicUTXOs(
 	err := c.requester.SendRequest(ctx, "avm.getUTXOs", &api.GetUTXOsArgs{
 		Addresses:   ids.ShortIDsToStrings(addrs),
 		SourceChain: sourceChain,
-		Limit:       cjson.Uint32(limit),
+		Limit:       json.Uint32(limit),
 		StartIndex: api.Index{
 			Address: startAddress.String(),
 			UTXO:    startUTXOID.String(),
@@ -442,14 +441,14 @@ func (c *client) CreateAsset(
 	holders := make([]*Holder, len(clientHolders))
 	for i, clientHolder := range clientHolders {
 		holders[i] = &Holder{
-			Amount:  cjson.Uint64(clientHolder.Amount),
+			Amount:  json.Uint64(clientHolder.Amount),
 			Address: clientHolder.Address.String(),
 		}
 	}
 	minters := make([]Owners, len(clientMinters))
 	for i, clientMinter := range clientMinters {
 		minters[i] = Owners{
-			Threshold: cjson.Uint32(clientMinter.Threshold),
+			Threshold: json.Uint32(clientMinter.Threshold),
 			Minters:   ids.ShortIDsToStrings(clientMinter.Minters),
 		}
 	}
@@ -483,7 +482,7 @@ func (c *client) CreateFixedCapAsset(
 	holders := make([]*Holder, len(clientHolders))
 	for i, clientHolder := range clientHolders {
 		holders[i] = &Holder{
-			Amount:  cjson.Uint64(clientHolder.Amount),
+			Amount:  json.Uint64(clientHolder.Amount),
 			Address: clientHolder.Address.String(),
 		}
 	}
@@ -516,7 +515,7 @@ func (c *client) CreateVariableCapAsset(
 	minters := make([]Owners, len(clientMinters))
 	for i, clientMinter := range clientMinters {
 		minters[i] = Owners{
-			Threshold: cjson.Uint32(clientMinter.Threshold),
+			Threshold: json.Uint32(clientMinter.Threshold),
 			Minters:   ids.ShortIDsToStrings(clientMinter.Minters),
 		}
 	}
@@ -548,7 +547,7 @@ func (c *client) CreateNFTAsset(
 	minters := make([]Owners, len(clientMinters))
 	for i, clientMinter := range clientMinters {
 		minters[i] = Owners{
-			Threshold: cjson.Uint32(clientMinter.Threshold),
+			Threshold: json.Uint32(clientMinter.Threshold),
 			Minters:   ids.ShortIDsToStrings(clientMinter.Minters),
 		}
 	}
@@ -623,7 +622,7 @@ func (c *client) Send(
 			JSONChangeAddr: api.JSONChangeAddr{ChangeAddr: changeAddr.String()},
 		},
 		SendOutput: SendOutput{
-			Amount:  cjson.Uint64(amount),
+			Amount:  json.Uint64(amount),
 			AssetID: assetID,
 			To:      to.String(),
 		},
@@ -645,7 +644,7 @@ func (c *client) SendMultiple(
 	outputs := make([]SendOutput, len(clientOutputs))
 	for i, clientOutput := range clientOutputs {
 		outputs[i] = SendOutput{
-			Amount:  cjson.Uint64(clientOutput.Amount),
+			Amount:  json.Uint64(clientOutput.Amount),
 			AssetID: clientOutput.AssetID,
 			To:      clientOutput.To.String(),
 		}
@@ -679,7 +678,7 @@ func (c *client) Mint(
 			JSONFromAddrs:  api.JSONFromAddrs{From: ids.ShortIDsToStrings(from)},
 			JSONChangeAddr: api.JSONChangeAddr{ChangeAddr: changeAddr.String()},
 		},
-		Amount:  cjson.Uint64(amount),
+		Amount:  json.Uint64(amount),
 		AssetID: assetID,
 		To:      to.String(),
 	}, res, options...)
@@ -704,7 +703,7 @@ func (c *client) SendNFT(
 			JSONChangeAddr: api.JSONChangeAddr{ChangeAddr: changeAddr.String()},
 		},
 		AssetID: assetID,
-		GroupID: cjson.Uint32(groupID),
+		GroupID: json.Uint32(groupID),
 		To:      to.String(),
 	}, res, options...)
 	return res.TxID, err
@@ -767,7 +766,7 @@ func (c *client) Export(
 			JSONFromAddrs:  api.JSONFromAddrs{From: ids.ShortIDsToStrings(from)},
 			JSONChangeAddr: api.JSONChangeAddr{ChangeAddr: changeAddr.String()},
 		},
-		Amount:      cjson.Uint64(amount),
+		Amount:      json.Uint64(amount),
 		TargetChain: targetChain,
 		To:          to.String(),
 		AssetID:     assetID,

--- a/vms/avm/service.go
+++ b/vms/avm/service.go
@@ -109,7 +109,7 @@ func (s *Service) GetBlockByHeight(_ *http.Request, args *api.GetBlockByHeightAr
 	s.vm.ctx.Log.Debug("API called",
 		zap.String("service", "avm"),
 		zap.String("method", "getBlockByHeight"),
-		zap.Uint64("height", args.Height),
+		zap.Uint64("height", uint64(args.Height)),
 	)
 
 	if s.vm.chainManager == nil {
@@ -117,7 +117,7 @@ func (s *Service) GetBlockByHeight(_ *http.Request, args *api.GetBlockByHeightAr
 	}
 	reply.Encoding = args.Encoding
 
-	blockID, err := s.vm.state.GetBlockID(args.Height)
+	blockID, err := s.vm.state.GetBlockID(uint64(args.Height))
 	if err != nil {
 		return fmt.Errorf("couldn't get block at height %d: %w", args.Height, err)
 	}

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -2975,7 +2975,7 @@ func TestServiceGetBlockByHeight(t *testing.T) {
 			service, expected := tt.serviceAndExpectedBlockFunc(ctrl)
 
 			args := &api.GetBlockByHeightArgs{
-				Height:   blockHeight,
+				Height:   json.Uint64(blockHeight),
 				Encoding: tt.encoding,
 			}
 			reply := &api.GetBlockResponse{}


### PR DESCRIPTION
## Why this should be merged

In our APIs, we let callers specify numbers as strings or numbers because javascript represents all numbers as floating point (so the precision is only 2^53). So we allow users to specify numbers as strings to avoid any unintended rounding issues in javascript.

## How this works

Using the `json.Uint64` type as in other APIs.

## How this was tested

CI
