### PR TITLE
Defer parser initialization to Start

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -885,7 +885,6 @@ func (m *manager) createAvalancheChain(
 		VM:            vmWrappingProposerVM,
 	}
 	snowmanBootstrapper, err := smbootstrap.New(
-		context.TODO(),
 		bootstrapCfg,
 		snowmanEngine.Start,
 	)
@@ -939,7 +938,6 @@ func (m *manager) createAvalancheChain(
 	}
 
 	avalancheBootstrapper, err := avbootstrap.New(
-		context.TODO(),
 		avalancheBootstrapperConfig,
 		snowmanBootstrapper.Start,
 	)
@@ -1223,7 +1221,6 @@ func (m *manager) createSnowmanChain(
 		Bootstrapped:  bootstrapFunc,
 	}
 	bootstrapper, err := smbootstrap.New(
-		context.TODO(),
 		bootstrapCfg,
 		engine.Start,
 	)

--- a/snow/engine/avalanche/bootstrap/bootstrapper.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper.go
@@ -33,7 +33,6 @@ const (
 var _ common.BootstrapableEngine = (*bootstrapper)(nil)
 
 func New(
-	ctx context.Context,
 	config Config,
 	onFinished func(ctx context.Context, lastReqID uint32) error,
 ) (common.BootstrapableEngine, error) {
@@ -54,24 +53,6 @@ func New(
 	}
 
 	if err := b.metrics.Initialize("bs", config.Ctx.AvalancheRegisterer); err != nil {
-		return nil, err
-	}
-
-	if err := b.VtxBlocked.SetParser(ctx, &vtxParser{
-		log:         config.Ctx.Log,
-		numAccepted: b.numAcceptedVts,
-		numDropped:  b.numDroppedVts,
-		manager:     b.Manager,
-	}); err != nil {
-		return nil, err
-	}
-
-	if err := b.TxBlocked.SetParser(&txParser{
-		log:         config.Ctx.Log,
-		numAccepted: b.numAcceptedTxs,
-		numDropped:  b.numDroppedTxs,
-		vm:          b.VM,
-	}); err != nil {
 		return nil, err
 	}
 
@@ -313,6 +294,24 @@ func (b *bootstrapper) Start(ctx context.Context, startReqID uint32) error {
 	if err := b.VM.SetState(ctx, snow.Bootstrapping); err != nil {
 		return fmt.Errorf("failed to notify VM that bootstrapping has started: %w",
 			err)
+	}
+
+	if err := b.VtxBlocked.SetParser(ctx, &vtxParser{
+		log:         b.Ctx.Log,
+		numAccepted: b.numAcceptedVts,
+		numDropped:  b.numDroppedVts,
+		manager:     b.Manager,
+	}); err != nil {
+		return err
+	}
+
+	if err := b.TxBlocked.SetParser(&txParser{
+		log:         b.Ctx.Log,
+		numAccepted: b.numAcceptedTxs,
+		numDropped:  b.numDroppedTxs,
+		vm:          b.VM,
+	}); err != nil {
+		return err
 	}
 
 	b.Config.SharedCfg.RequestID = startReqID

--- a/snow/engine/avalanche/bootstrap/bootstrapper.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper.go
@@ -61,6 +61,8 @@ func New(
 	return b, nil
 }
 
+// Note: To align with the Snowman invariant, it should be guaranteed the VM is
+// not used until after the bootstrapper has been Started.
 type bootstrapper struct {
 	Config
 

--- a/snow/engine/avalanche/bootstrap/bootstrapper_test.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper_test.go
@@ -143,7 +143,6 @@ func TestBootstrapperSingleFrontier(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -253,7 +252,6 @@ func TestBootstrapperByzantineResponses(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -421,7 +419,6 @@ func TestBootstrapperTxDependencies(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -548,7 +545,6 @@ func TestBootstrapperIncompleteAncestors(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -660,7 +656,6 @@ func TestBootstrapperFinalized(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -788,7 +783,6 @@ func TestBootstrapperAcceptsAncestorsParents(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -953,7 +947,6 @@ func TestRestartBootstrapping(t *testing.T) {
 	}
 
 	bsIntf, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{

--- a/snow/engine/snowman/bootstrap/block_job.go
+++ b/snow/engine/snowman/bootstrap/block_job.go
@@ -35,7 +35,6 @@ func (p *parser) Parse(ctx context.Context, blkBytes []byte) (queue.Job, error) 
 		return nil, err
 	}
 	return &blockJob{
-		parser:      p,
 		log:         p.log,
 		numAccepted: p.numAccepted,
 		numDropped:  p.numDropped,
@@ -45,7 +44,6 @@ func (p *parser) Parse(ctx context.Context, blkBytes []byte) (queue.Job, error) 
 }
 
 type blockJob struct {
-	parser                  *parser
 	log                     logging.Logger
 	numAccepted, numDropped prometheus.Counter
 	blk                     snowman.Block

--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -81,7 +81,7 @@ type bootstrapper struct {
 	bootstrappedOnce sync.Once
 }
 
-func New(ctx context.Context, config Config, onFinished func(ctx context.Context, lastReqID uint32) error) (common.BootstrapableEngine, error) {
+func New(config Config, onFinished func(ctx context.Context, lastReqID uint32) error) (common.BootstrapableEngine, error) {
 	metrics, err := newMetrics("bs", config.Ctx.Registerer)
 	if err != nil {
 		return nil, err
@@ -103,16 +103,6 @@ func New(ctx context.Context, config Config, onFinished func(ctx context.Context
 		executedStateTransitions: math.MaxInt32,
 	}
 
-	b.parser = &parser{
-		log:         config.Ctx.Log,
-		numAccepted: b.numAccepted,
-		numDropped:  b.numDropped,
-		vm:          b.VM,
-	}
-	if err := b.Blocked.SetParser(ctx, b.parser); err != nil {
-		return nil, err
-	}
-
 	config.Bootstrapable = b
 	b.Bootstrapper = common.NewCommonBootstrapper(config.Config)
 
@@ -129,6 +119,16 @@ func (b *bootstrapper) Start(ctx context.Context, startReqID uint32) error {
 	if err := b.VM.SetState(ctx, snow.Bootstrapping); err != nil {
 		return fmt.Errorf("failed to notify VM that bootstrapping has started: %w",
 			err)
+	}
+
+	b.parser = &parser{
+		log:         b.Ctx.Log,
+		numAccepted: b.numAccepted,
+		numDropped:  b.numDropped,
+		vm:          b.VM,
+	}
+	if err := b.Blocked.SetParser(ctx, b.parser); err != nil {
+		return err
 	}
 
 	// Set the starting height

--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -458,7 +458,6 @@ func (b *bootstrapper) process(ctx context.Context, blk snowman.Block, processin
 		}
 
 		pushed, err := b.Blocked.Push(ctx, &blockJob{
-			parser:      b.parser,
 			log:         b.Ctx.Log,
 			numAccepted: b.numAccepted,
 			numDropped:  b.numDropped,

--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -34,6 +34,8 @@ var (
 	errUnexpectedTimeout = errors.New("unexpected timeout fired")
 )
 
+// Invariant: The VM is not guaranteed to be initialized until Start has been
+// called, so it must be guaranteed the VM is not used until after Start.
 type bootstrapper struct {
 	Config
 

--- a/snow/engine/snowman/bootstrap/bootstrapper_test.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper_test.go
@@ -1507,7 +1507,6 @@ func TestBootstrapNoParseOnNew(t *testing.T) {
 	require := require.New(t)
 
 	ctx := snow.DefaultConsensusContextTest()
-
 	peers := validators.NewSet()
 
 	sender := &common.SenderTest{}
@@ -1533,17 +1532,12 @@ func TestBootstrapNoParseOnNew(t *testing.T) {
 	sender.CantSendGetAcceptedFrontier = false
 
 	peer := ids.GenerateTestNodeID()
-	if err := peers.Add(peer, nil, ids.Empty, 1); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(peers.Add(peer, nil, ids.Empty, 1))
 
 	peerTracker := tracker.NewPeers()
 	startupTracker := tracker.NewStartup(peerTracker, peers.Weight()/2+1)
 	peers.RegisterCallbackListener(startupTracker)
-
-	if err := startupTracker.Connected(context.Background(), peer, version.CurrentApp); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(startupTracker.Connected(context.Background(), peer, version.CurrentApp))
 
 	commonConfig := common.Config{
 		Ctx:                            ctx,
@@ -1560,12 +1554,11 @@ func TestBootstrapNoParseOnNew(t *testing.T) {
 	}
 
 	snowGetHandler, err := getter.New(vm, commonConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	queueDB := memdb.New()
-	blocker, _ := queue.NewWithMissing(queueDB, "", prometheus.NewRegistry())
+	blocker, err := queue.NewWithMissing(queueDB, "", prometheus.NewRegistry())
+	require.NoError(err)
 
 	blk0 := &snowman.TestBlock{
 		TestDecidable: choices.TestDecidable{
@@ -1605,7 +1598,8 @@ func TestBootstrapNoParseOnNew(t *testing.T) {
 
 	vm.GetBlockF = nil
 
-	blocker, _ = queue.NewWithMissing(queueDB, "", prometheus.NewRegistry())
+	blocker, err = queue.NewWithMissing(queueDB, "", prometheus.NewRegistry())
+	require.NoError(err)
 
 	config := Config{
 		Config:        commonConfig,

--- a/snow/engine/snowman/bootstrap/bootstrapper_test.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper_test.go
@@ -173,7 +173,7 @@ func TestBootstrapperStartsOnlyIfEnoughStakeIsConnected(t *testing.T) {
 		})
 		return nil
 	}
-	bs, err := New(context.Background(), cfg, dummyCallback)
+	bs, err := New(cfg, dummyCallback)
 	require.NoError(err)
 
 	vm.CantSetState = false
@@ -245,7 +245,6 @@ func TestBootstrapperSingleFrontier(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -352,7 +351,6 @@ func TestBootstrapperUnknownByzantineResponse(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -516,7 +514,6 @@ func TestBootstrapperPartialFetch(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -683,7 +680,6 @@ func TestBootstrapperEmptyResponse(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -872,7 +868,6 @@ func TestBootstrapperAncestors(t *testing.T) {
 	}
 
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -1018,7 +1013,6 @@ func TestBootstrapperFinalized(t *testing.T) {
 		return blk0, nil
 	}
 	bs, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -1231,7 +1225,6 @@ func TestRestartBootstrapping(t *testing.T) {
 	}
 
 	bsIntf, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -1374,7 +1367,6 @@ func TestBootstrapOldBlockAfterStateSync(t *testing.T) {
 	}
 
 	bsIntf, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{
@@ -1464,7 +1456,6 @@ func TestBootstrapContinueAfterHalt(t *testing.T) {
 	}
 
 	bsIntf, err := New(
-		context.Background(),
 		config,
 		func(context.Context, uint32) error {
 			config.Ctx.State.Set(snow.EngineState{

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1855,7 +1855,6 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 	require.NoError(err)
 
 	bootstrapper, err := bootstrap.New(
-		context.Background(),
 		bootstrapConfig,
 		engine.Start,
 	)


### PR DESCRIPTION
## Why this should be merged

Resolves #1440

## How this works

On the X-chain, the Snowman VM is not guaranteed to be `Initialized` until `Start` is called on the bootstrapper engine. When initializing the job parser it is possible to call `ParseBlock`, so initializing the job parser must be deferred until `Start` has been called.

## How this was tested

TODO