### PR TITLE
Cleanup proposervm ancestors packing

### DIFF
--- a/vms/proposervm/batched_vm.go
+++ b/vms/proposervm/batched_vm.go
@@ -24,7 +24,7 @@ func (vm *VM) GetAncestors(
 	blkID ids.ID,
 	maxBlocksNum int,
 	maxBlocksSize int,
-	maxBlocksRetrivalTime time.Duration,
+	maxBlocksRetrievalTime time.Duration,
 ) ([][]byte, error) {
 	if vm.batchedVM == nil {
 		return nil, block.ErrRemoteVMNotImplemented
@@ -50,15 +50,13 @@ func (vm *VM) GetAncestors(
 		// is repr. by an int.
 		currentByteLength += wrappers.IntLen + len(blkBytes)
 		elapsedTime := vm.Clock.Time().Sub(startTime)
-		if len(res) > 0 && (currentByteLength >= maxBlocksSize || maxBlocksRetrivalTime <= elapsedTime) {
+		if len(res) > 0 && (currentByteLength >= maxBlocksSize || maxBlocksRetrievalTime <= elapsedTime) {
 			return res, nil // reached maximum size or ran out of time
 		}
 
 		res = append(res, blkBytes)
 		blkID = blk.ParentID()
-		maxBlocksNum--
-
-		if maxBlocksNum <= 0 {
+		if len(res) >= maxBlocksNum {
 			return res, nil
 		}
 	}
@@ -66,7 +64,7 @@ func (vm *VM) GetAncestors(
 	// snowman++ fork may have been hit.
 	preMaxBlocksNum := maxBlocksNum - len(res)
 	preMaxBlocksSize := maxBlocksSize - currentByteLength
-	preMaxBlocksRetrivalTime := maxBlocksRetrivalTime - time.Since(startTime)
+	preMaxBlocksRetrivalTime := maxBlocksRetrievalTime - time.Since(startTime)
 	innerBytes, err := vm.batchedVM.GetAncestors(
 		ctx,
 		blkID,


### PR DESCRIPTION
## Why this should be merged

Cleans up the `proposervm.GetAncestors` method

## How this works

Fixes a typo + unifies the logic between `maxBlocksNum` and `maxBlocksSize`

## How this was tested

CI