### PR TITLE
use `errors.Is` for error checking

### DIFF
--- a/api/keystore/keystore.go
+++ b/api/keystore/keystore.go
@@ -373,7 +373,7 @@ func (ks *keystore) getPassword(username string) (*password.Hash, error) {
 
 	// The user is not in memory; try the database
 	userBytes, err := ks.userDB.Get([]byte(username))
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// The user doesn't exist
 		return nil, nil
 	}

--- a/database/linkeddb/linkeddb.go
+++ b/database/linkeddb/linkeddb.go
@@ -4,6 +4,7 @@
 package linkeddb
 
 import (
+	"errors"
 	"sync"
 
 	"golang.org/x/exp/maps"
@@ -142,7 +143,7 @@ func (ldb *linkedDB) Delete(key []byte) error {
 	defer ldb.lock.Unlock()
 
 	currentNode, err := ldb.getNode(key)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return nil
 	}
 	if err != nil {
@@ -205,7 +206,7 @@ func (ldb *linkedDB) Delete(key []byte) error {
 
 func (ldb *linkedDB) IsEmpty() (bool, error) {
 	_, err := ldb.HeadKey()
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return true, nil
 	}
 	return false, err
@@ -272,7 +273,7 @@ func (ldb *linkedDB) getHeadKey() ([]byte, error) {
 		ldb.headKey = headKey
 		return headKey, nil
 	}
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		ldb.headKeyIsSynced = true
 		ldb.headKeyExists = false
 		return nil, database.ErrNotFound
@@ -308,7 +309,7 @@ func (ldb *linkedDB) getNode(key []byte) (node, error) {
 	}
 
 	nodeBytes, err := ldb.db.Get(nodeKey(key))
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		ldb.nodeCache.Put(keyStr, nil)
 		return node{}, err
 	}
@@ -380,7 +381,7 @@ func (it *iterator) Next() bool {
 	if !it.initialized {
 		it.initialized = true
 		headKey, err := it.ldb.getHeadKey()
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			it.exhausted = true
 			it.key = nil
 			it.value = nil
@@ -397,7 +398,7 @@ func (it *iterator) Next() bool {
 	}
 
 	nextNode, err := it.ldb.getNode(it.nextKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		it.exhausted = true
 		it.key = nil
 		it.value = nil

--- a/indexer/index.go
+++ b/indexer/index.go
@@ -95,7 +95,7 @@ func newIndex(
 
 	// Get next accepted index from db
 	nextAcceptedIndex, err := database.GetUInt64(i.vDB, nextAcceptedIndexKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// Couldn't find it in the database. Must not have accepted any containers in previous runs.
 		i.log.Info("created new index",
 			zap.Uint64("nextAcceptedIndex", i.nextAcceptedIndex),

--- a/indexer/service.go
+++ b/indexer/service.go
@@ -4,6 +4,7 @@
 package indexer
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -139,7 +140,7 @@ func (s *service) IsAccepted(_ *http.Request, args *IsAcceptedArgs, reply *IsAcc
 		reply.IsAccepted = true
 		return nil
 	}
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		reply.IsAccepted = false
 		return nil
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -457,7 +457,7 @@ func (n *Node) initDatabase() error {
 	rawExpectedGenesisHash := hashing.ComputeHash256(n.Config.GenesisBytes)
 
 	rawGenesisHash, err := n.DB.Get(genesisHashKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		rawGenesisHash = rawExpectedGenesisHash
 		err = n.DB.Put(genesisHashKey, rawGenesisHash)
 	}

--- a/snow/engine/common/queue/jobs.go
+++ b/snow/engine/common/queue/jobs.go
@@ -5,6 +5,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -142,7 +143,7 @@ func (j *Jobs) ExecuteAll(
 		}
 
 		job, err := j.state.RemoveRunnableJob(ctx)
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			break
 		}
 		if err != nil {

--- a/snow/engine/common/queue/state.go
+++ b/snow/engine/common/queue/state.go
@@ -5,6 +5,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -94,7 +95,7 @@ func newState(
 
 func getNumJobs(d database.Database, jobs database.Iteratee) (uint64, error) {
 	numJobs, err := database.GetUInt64(d, numJobsKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// If we don't have a checkpoint, we need to initialize it.
 		count, err := database.Count(jobs)
 		return uint64(count), err

--- a/snow/engine/snowman/block/batched_vm.go
+++ b/snow/engine/snowman/block/batched_vm.go
@@ -59,7 +59,7 @@ func GetAncestors(
 	// RemoteVM did not work, try local logic
 	startTime := time.Now()
 	blk, err := vm.GetBlock(ctx, blkID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// special case ErrNotFound as an empty response: this signals
 		// the client to avoid contacting this node for further ancestors
 		// as they may have been pruned or unavailable due to state-sync.

--- a/snow/engine/snowman/getter/getter.go
+++ b/snow/engine/snowman/getter/getter.go
@@ -5,6 +5,7 @@ package getter
 
 import (
 	"context"
+	"errors"
 
 	"go.uber.org/zap"
 
@@ -104,7 +105,7 @@ func (gh *getter) GetAcceptedStateSummary(ctx context.Context, nodeID ids.NodeID
 	summaryIDs := make([]ids.ID, 0, len(heights))
 	for _, height := range heights {
 		summary, err := gh.ssVM.GetStateSummary(ctx, height)
-		if err == block.ErrStateSyncableVMNotImplemented {
+		if errors.Is(err, block.ErrStateSyncableVMNotImplemented) {
 			gh.log.Debug("dropping GetAcceptedStateSummary message",
 				zap.String("reason", "state sync not supported"),
 				zap.Stringer("nodeID", nodeID),

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -5,6 +5,7 @@ package snowman
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -386,7 +387,7 @@ func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 	if oracleBlk, ok := lastAccepted.(snowman.OracleBlock); ok {
 		options, err := oracleBlk.Options(ctx)
 		switch {
-		case err == snowman.ErrNotOracle:
+		case errors.Is(err, snowman.ErrNotOracle):
 			// if there aren't blocks we need to deliver on startup, we need to set
 			// the preference to the last accepted block
 			if err := t.VM.SetPreference(ctx, lastAcceptedID); err != nil {

--- a/snow/uptime/manager.go
+++ b/snow/uptime/manager.go
@@ -4,6 +4,7 @@
 package uptime
 
 import (
+	"errors"
 	"time"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -219,7 +220,7 @@ func (m *manager) updateSubnetUptime(nodeID ids.NodeID, subnetID ids.ID) error {
 	}
 
 	newDuration, newLastUpdated, err := m.CalculateUptime(nodeID, subnetID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// If a non-validator disconnects, we don't care
 		return nil
 	}

--- a/tests/http.go
+++ b/tests/http.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -62,10 +63,10 @@ func getHTTPLines(url string) ([]string, error) {
 	lines := []string{}
 	for {
 		line, err := rd.ReadString('\n')
+		if errors.Is(err, io.EOF) {
+			break
+		}
 		if err != nil {
-			if err == io.EOF {
-				break
-			}
 			_ = resp.Body.Close()
 			return nil, err
 		}

--- a/vms/avm/chain_state.go
+++ b/vms/avm/chain_state.go
@@ -4,6 +4,8 @@
 package avm
 
 import (
+	"errors"
+
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/choices"
@@ -29,7 +31,7 @@ func (s *chainState) GetTx(txID ids.ID) (*txs.Tx, error) {
 	// marked as Accepted. However, this function aims to only return accepted
 	// transactions.
 	status, err := s.State.GetStatus(txID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// If the status wasn't persisted, then the transaction was written
 		// after the linearization, and is accepted.
 		return tx, nil

--- a/vms/avm/states/state.go
+++ b/vms/avm/states/state.go
@@ -4,6 +4,7 @@
 package states
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -266,7 +267,7 @@ func (s *state) GetTx(txID ids.ID) (*txs.Tx, error) {
 	}
 
 	txBytes, err := s.txDB.Get(txID[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.txCache.Put(txID, nil)
 		return nil, database.ErrNotFound
 	}
@@ -303,7 +304,7 @@ func (s *state) GetBlockID(height uint64) (ids.ID, error) {
 	heightKey := database.PackUInt64(height)
 
 	blkID, err := database.GetID(s.blockIDDB, heightKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.blockIDCache.Put(height, ids.Empty)
 		return ids.Empty, database.ErrNotFound
 	}
@@ -328,7 +329,7 @@ func (s *state) GetBlock(blkID ids.ID) (blocks.Block, error) {
 	}
 
 	blkBytes, err := s.blockDB.Get(blkID[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.blockCache.Put(blkID, nil)
 		return nil, database.ErrNotFound
 	}
@@ -353,7 +354,7 @@ func (s *state) AddBlock(block blocks.Block) {
 
 func (s *state) InitializeChainState(stopVertexID ids.ID, genesisTimestamp time.Time) error {
 	lastAccepted, err := database.GetID(s.singletonDB, lastAcceptedKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return s.initializeChainState(stopVertexID, genesisTimestamp)
 	} else if err != nil {
 		return err
@@ -420,7 +421,7 @@ func (s *state) GetStatus(id ids.ID) (choices.Status, error) {
 	}
 
 	val, err := database.GetUInt32(s.statusDB, id[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.statusCache.Put(id, nil)
 		return choices.Unknown, database.ErrNotFound
 	}

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -755,7 +755,7 @@ func (vm *VM) onAccept(tx *txs.Tx) error {
 		}
 
 		utxo, err := vm.state.GetUTXOFromID(utxoID)
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			vm.ctx.Log.Debug("dropping utxo from index",
 				zap.Stringer("txID", txID),
 				zap.Stringer("utxoTxID", utxoID.TxID),

--- a/vms/components/avax/utxo_state.go
+++ b/vms/components/avax/utxo_state.go
@@ -4,6 +4,8 @@
 package avax
 
 import (
+	"errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/avalanchego/cache"
@@ -127,7 +129,7 @@ func (s *utxoState) GetUTXO(utxoID ids.ID) (*UTXO, error) {
 	}
 
 	bytes, err := s.utxoDB.Get(utxoID[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.utxoCache.Put(utxoID, nil)
 		return nil, database.ErrNotFound
 	}
@@ -174,7 +176,7 @@ func (s *utxoState) PutUTXO(utxo *UTXO) error {
 
 func (s *utxoState) DeleteUTXO(utxoID ids.ID) error {
 	utxo, err := s.GetUTXO(utxoID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return nil
 	}
 	if err != nil {

--- a/vms/components/chain/state.go
+++ b/vms/components/chain/state.go
@@ -246,7 +246,7 @@ func (s *State) GetBlock(ctx context.Context, blkID ids.ID) (snowman.Block, erro
 	blk, err := s.getBlock(ctx, blkID)
 	// If getBlock returns [database.ErrNotFound], State considers
 	// this a cacheable miss.
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.missingBlocks.Put(blkID, struct{}{})
 		return nil, err
 	} else if err != nil {

--- a/vms/components/index/index.go
+++ b/vms/components/index/index.go
@@ -215,7 +215,7 @@ func (i *indexer) Read(address []byte, assetID ids.ID, cursor, pageSize uint64) 
 func checkIndexStatus(db database.KeyValueReaderWriter, enableIndexing, allowIncomplete bool) error {
 	// verify whether the index is complete.
 	idxComplete, err := database.GetBool(db, idxCompleteKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// We've not run before. Mark whether indexing is enabled this run.
 		return database.PutBool(db, idxCompleteKey, enableIndexing)
 	} else if err != nil {

--- a/vms/components/keystore/user.go
+++ b/vms/components/keystore/user.go
@@ -4,6 +4,7 @@
 package keystore
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -64,7 +65,7 @@ func NewUserFromDB(db *encdb.Database) User {
 func (u *user) GetAddresses() ([]ids.ShortID, error) {
 	// Get user's addresses
 	addressBytes, err := u.db.Get(addressesKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// If user has no addresses, return empty list
 		return nil, nil
 	}
@@ -174,7 +175,7 @@ func GetKeychain(u User, addresses set.Set[ids.ShortID]) (*secp256k1fx.Keychain,
 	kc := secp256k1fx.NewKeychain()
 	for _, addr := range addrsList {
 		sk, err := u.GetKey(addr)
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			continue
 		}
 		if err != nil {

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -607,7 +607,7 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 		}
 
 		subnetTx, _, err := s.vm.state.GetTx(subnetID)
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			continue
 		}
 		if err != nil {
@@ -1954,7 +1954,7 @@ func (s *Service) chainExists(ctx context.Context, blockID ids.ID, chainID ids.I
 	}
 
 	tx, _, err := state.GetTx(chainID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return false, nil
 	}
 	if err != nil {
@@ -2453,7 +2453,7 @@ func (s *Service) GetMaxStakeAmount(_ *http.Request, args *GetMaxStakeAmountArgs
 	}
 
 	staker, err := executor.GetValidator(s.vm.state, args.SubnetID, args.NodeID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return nil
 	}
 	if err != nil {

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -672,7 +672,7 @@ func (s *state) GetSubnetTransformation(subnetID ids.ID) (*txs.Tx, error) {
 	}
 
 	transformSubnetTxID, err := database.GetID(s.transformedSubnetDB, subnetID[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.transformedSubnetCache.Put(subnetID, nil)
 		return nil, database.ErrNotFound
 	}
@@ -753,7 +753,7 @@ func (s *state) GetTx(txID ids.ID) (*txs.Tx, status.Status, error) {
 		return tx.tx, tx.status, nil
 	}
 	txBytes, err := s.txDB.Get(txID[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.txCache.Put(txID, nil)
 		return nil, status.Unknown, database.ErrNotFound
 	} else if err != nil {
@@ -884,7 +884,7 @@ func (s *state) GetCurrentSupply(subnetID ids.ID) (uint64, error) {
 	}
 
 	supply, err := database.GetUInt64(s.supplyDB, subnetID[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.supplyCache.Put(subnetID, nil)
 		return 0, database.ErrNotFound
 	}
@@ -1530,7 +1530,7 @@ func (s *state) GetStatelessBlock(blockID ids.ID) (blocks.Block, choices.Status,
 	}
 
 	blkBytes, err := s.blockDB.Get(blockID[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.blockCache.Put(blockID, nil)
 		return nil, choices.Processing, database.ErrNotFound // status does not matter here
 	} else if err != nil {

--- a/vms/platformvm/txs/executor/staker_tx_verification.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification.go
@@ -199,7 +199,7 @@ func verifyAddSubnetValidatorTx(
 	}
 
 	primaryNetworkValidator, err := GetValidator(chainState, constants.PrimaryNetworkID, tx.Validator.NodeID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return fmt.Errorf(
 			"%s %w of the primary network",
 			tx.Validator.NodeID,
@@ -270,7 +270,7 @@ func removeSubnetValidatorValidation(
 
 	isCurrentValidator := true
 	vdr, err := chainState.GetCurrentValidator(tx.Subnet, tx.NodeID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		vdr, err = chainState.GetPendingValidator(tx.Subnet, tx.NodeID)
 		isCurrentValidator = false
 	}

--- a/vms/proposervm/batched_vm.go
+++ b/vms/proposervm/batched_vm.go
@@ -5,6 +5,7 @@ package proposervm
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -132,7 +133,7 @@ func (vm *VM) BatchedParseBlock(ctx context.Context, blks [][]byte) ([]snowman.B
 		blkID := statelessBlk.ID()
 
 		_, status, err := vm.State.GetBlock(blkID)
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			status = choices.Processing
 		} else if err != nil {
 			return nil, err

--- a/vms/proposervm/height_indexed_vm.go
+++ b/vms/proposervm/height_indexed_vm.go
@@ -5,6 +5,7 @@ package proposervm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -27,7 +28,7 @@ func (vm *VM) shouldHeightIndexBeRepaired(ctx context.Context) (bool, error) {
 	// no checkpoint. Either index is complete or repair was never attempted.
 	// index is complete iff lastAcceptedBlock is indexed
 	latestProBlkID, err := vm.State.GetLastAccepted()
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return false, nil
 	}
 	if err != nil {

--- a/vms/proposervm/indexer/height_indexer.go
+++ b/vms/proposervm/indexer/height_indexer.go
@@ -5,6 +5,7 @@ package indexer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -85,7 +86,7 @@ func (hi *heightIndexer) MarkRepaired(repaired bool) {
 // and works asynchronously without blocking the VM.
 func (hi *heightIndexer) RepairHeightIndex(ctx context.Context) error {
 	startBlkID, err := hi.state.GetCheckpoint()
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		hi.MarkRepaired(true)
 		return nil // nothing to do
 	}
@@ -127,7 +128,7 @@ func (hi *heightIndexer) doRepair(ctx context.Context, currentProBlkID ids.ID, l
 
 		processingStart := time.Now()
 		currentAcceptedBlk, _, err := hi.state.GetBlock(currentProBlkID)
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			// We have visited all the proposerVM blocks. Because we previously
 			// verified that we needed to perform a repair, we know that this
 			// will not happen on the first iteration. This guarantees that

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -74,7 +74,7 @@ func (s *blockState) GetBlock(blkID ids.ID) (block.Block, choices.Status, error)
 	}
 
 	blkWrapperBytes, err := s.db.Get(blkID[:])
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		s.blkCache.Put(blkID, nil)
 		return nil, choices.Unknown, database.ErrNotFound
 	}

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"time"
 
@@ -330,7 +331,7 @@ func (vm *VM) SetPreference(ctx context.Context, preferred ids.ID) error {
 
 func (vm *VM) LastAccepted(ctx context.Context) (ids.ID, error) {
 	lastAccepted, err := vm.State.GetLastAccepted()
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return vm.ChainVM.LastAccepted(ctx)
 	}
 	return lastAccepted, err
@@ -436,7 +437,7 @@ func (vm *VM) repair(ctx context.Context) error {
 
 func (vm *VM) repairAcceptedChainByIteration(ctx context.Context) error {
 	lastAcceptedID, err := vm.GetLastAccepted()
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// If the last accepted block isn't indexed yet, then the underlying
 		// chain is the only chain and there is nothing to repair.
 		return nil
@@ -448,7 +449,7 @@ func (vm *VM) repairAcceptedChainByIteration(ctx context.Context) error {
 	// Revert accepted blocks that weren't committed to the database.
 	for {
 		lastAccepted, err := vm.getPostForkBlock(ctx, lastAcceptedID)
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			// If the post fork block can't be found, it's because we're
 			// reverting past the fork boundary. If this is the case, then there
 			// is only one database to keep consistent, so there is nothing to
@@ -489,7 +490,7 @@ func (vm *VM) repairAcceptedChainByIteration(ctx context.Context) error {
 		// If the indexer checkpoint was previously pointing to the last
 		// accepted block, roll it back to the new last accepted block.
 		checkpoint, err := vm.State.GetCheckpoint()
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			continue
 		}
 		if err != nil {
@@ -514,7 +515,7 @@ func (vm *VM) repairAcceptedChainByHeight(ctx context.Context) error {
 		return err
 	}
 	proLastAcceptedID, err := vm.State.GetLastAccepted()
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// If the last accepted block isn't indexed yet, then the underlying
 		// chain is the only chain and there is nothing to repair.
 		return nil
@@ -564,7 +565,7 @@ func (vm *VM) repairAcceptedChainByHeight(ctx context.Context) error {
 
 func (vm *VM) setLastAcceptedMetadata(ctx context.Context) error {
 	lastAcceptedID, err := vm.GetLastAccepted()
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// If the last accepted block wasn't a PostFork block, then we don't
 		// initialize the metadata.
 		vm.lastAcceptedHeight = 0

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -728,7 +728,7 @@ func (vm *VMClient) StateSyncEnabled(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	err = errEnumToError[resp.Err]
-	if err == block.ErrStateSyncableVMNotImplemented {
+	if errors.Is(err, block.ErrStateSyncableVMNotImplemented) {
 		return false, nil
 	}
 	return resp.Enabled, err

--- a/wallet/chain/p/signer_visitor.go
+++ b/wallet/chain/p/signer_visitor.go
@@ -182,7 +182,7 @@ func (s *signerVisitor) getSigners(sourceChainID ids.ID, ins []*avax.Transferabl
 
 		utxoID := transferInput.InputID()
 		utxo, err := s.backend.GetUTXO(s.ctx, sourceChainID, utxoID)
-		if err == database.ErrNotFound {
+		if errors.Is(err, database.ErrNotFound) {
 			// If we don't have access to the UTXO, then we can't sign this
 			// transaction. However, we can attempt to partially sign it.
 			continue


### PR DESCRIPTION
## Why this should be merged

Golang best practices state that we should be using `errors.Is`: https://github.com/golang/go/wiki/ErrorValueFAQ

We do this in various places in the codebase already, this PR fixes the remaining checks.

## How this works

pretty straightforward

## How this was tested

CI