### PR TITLE
utils/logging: add "Enabled" method to remove redundant verbo logs

### DIFF
--- a/snow/engine/snowman/syncer/state_syncer.go
+++ b/snow/engine/snowman/syncer/state_syncer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
@@ -142,13 +143,16 @@ func (ss *stateSyncer) StateSummaryFrontier(ctx context.Context, nodeID ids.Node
 			ss.uniqueSummariesHeights = append(ss.uniqueSummariesHeights, height)
 		}
 	} else {
-		ss.Ctx.Log.Debug("failed to parse summary",
-			zap.Error(err),
-		)
-		ss.Ctx.Log.Verbo("failed to parse summary",
-			zap.Binary("summary", summaryBytes),
-			zap.Error(err),
-		)
+		if ss.Ctx.Log.Enabled(logging.Verbo) {
+			ss.Ctx.Log.Verbo("failed to parse summary",
+				zap.Binary("summary", summaryBytes),
+				zap.Error(err),
+			)
+		} else {
+			ss.Ctx.Log.Debug("failed to parse summary",
+				zap.Error(err),
+			)
+		}
 	}
 
 	return ss.receivedStateSummaryFrontier(ctx)

--- a/snow/networking/sender/sender.go
+++ b/snow/networking/sender/sender.go
@@ -232,7 +232,6 @@ func (s *sender) SendStateSummaryFrontier(ctx context.Context, nodeID ids.NodeID
 				zap.Uint32("requestID", requestID),
 			)
 		}
-
 	}
 }
 

--- a/snow/networking/sender/sender.go
+++ b/snow/networking/sender/sender.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
 
@@ -215,19 +216,23 @@ func (s *sender) SendStateSummaryFrontier(ctx context.Context, nodeID ids.NodeID
 		s.subnet,
 	)
 	if sentTo.Len() == 0 {
-		s.ctx.Log.Debug("failed to send message",
-			zap.Stringer("messageOp", message.StateSummaryFrontierOp),
-			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("chainID", s.ctx.ChainID),
-			zap.Uint32("requestID", requestID),
-		)
-		s.ctx.Log.Verbo("failed to send message",
-			zap.Stringer("messageOp", message.StateSummaryFrontierOp),
-			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("chainID", s.ctx.ChainID),
-			zap.Uint32("requestID", requestID),
-			zap.Binary("summary", summary),
-		)
+		if s.ctx.Log.Enabled(logging.Verbo) {
+			s.ctx.Log.Verbo("failed to send message",
+				zap.Stringer("messageOp", message.StateSummaryFrontierOp),
+				zap.Stringer("nodeID", nodeID),
+				zap.Stringer("chainID", s.ctx.ChainID),
+				zap.Uint32("requestID", requestID),
+				zap.Binary("summary", summary),
+			)
+		} else {
+			s.ctx.Log.Debug("failed to send message",
+				zap.Stringer("messageOp", message.StateSummaryFrontierOp),
+				zap.Stringer("nodeID", nodeID),
+				zap.Stringer("chainID", s.ctx.ChainID),
+				zap.Uint32("requestID", requestID),
+			)
+		}
+
 	}
 }
 
@@ -993,19 +998,22 @@ func (s *sender) SendPushQuery(ctx context.Context, nodeIDs set.Set[ids.NodeID],
 
 	for nodeID := range nodeIDs {
 		if !sentTo.Contains(nodeID) {
-			s.ctx.Log.Debug("failed to send message",
-				zap.Stringer("messageOp", message.PushQueryOp),
-				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("chainID", s.ctx.ChainID),
-				zap.Uint32("requestID", requestID),
-			)
-			s.ctx.Log.Verbo("failed to send message",
-				zap.Stringer("messageOp", message.PushQueryOp),
-				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("chainID", s.ctx.ChainID),
-				zap.Uint32("requestID", requestID),
-				zap.Binary("container", container),
-			)
+			if s.ctx.Log.Enabled(logging.Verbo) {
+				s.ctx.Log.Verbo("failed to send message",
+					zap.Stringer("messageOp", message.PushQueryOp),
+					zap.Stringer("nodeID", nodeID),
+					zap.Stringer("chainID", s.ctx.ChainID),
+					zap.Uint32("requestID", requestID),
+					zap.Binary("container", container),
+				)
+			} else {
+				s.ctx.Log.Debug("failed to send message",
+					zap.Stringer("messageOp", message.PushQueryOp),
+					zap.Stringer("nodeID", nodeID),
+					zap.Stringer("chainID", s.ctx.ChainID),
+					zap.Uint32("requestID", requestID),
+				)
+			}
 
 			// Register failures for nodes we didn't send a request to.
 			s.timeouts.RegisterRequestToUnreachableValidator()
@@ -1337,19 +1345,22 @@ func (s *sender) SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID]
 
 	for nodeID := range nodeIDs {
 		if !sentTo.Contains(nodeID) {
-			s.ctx.Log.Debug("failed to send message",
-				zap.Stringer("messageOp", message.AppRequestOp),
-				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("chainID", s.ctx.ChainID),
-				zap.Uint32("requestID", requestID),
-			)
-			s.ctx.Log.Verbo("failed to send message",
-				zap.Stringer("messageOp", message.AppRequestOp),
-				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("chainID", s.ctx.ChainID),
-				zap.Uint32("requestID", requestID),
-				zap.Binary("payload", appRequestBytes),
-			)
+			if s.ctx.Log.Enabled(logging.Verbo) {
+				s.ctx.Log.Verbo("failed to send message",
+					zap.Stringer("messageOp", message.AppRequestOp),
+					zap.Stringer("nodeID", nodeID),
+					zap.Stringer("chainID", s.ctx.ChainID),
+					zap.Uint32("requestID", requestID),
+					zap.Binary("payload", appRequestBytes),
+				)
+			} else {
+				s.ctx.Log.Debug("failed to send message",
+					zap.Stringer("messageOp", message.AppRequestOp),
+					zap.Stringer("nodeID", nodeID),
+					zap.Stringer("chainID", s.ctx.ChainID),
+					zap.Uint32("requestID", requestID),
+				)
+			}
 
 			// Register failures for nodes we didn't send a request to.
 			s.timeouts.RegisterRequestToUnreachableValidator()
@@ -1407,19 +1418,22 @@ func (s *sender) SendAppResponse(ctx context.Context, nodeID ids.NodeID, request
 		s.subnet,
 	)
 	if sentTo.Len() == 0 {
-		s.ctx.Log.Debug("failed to send message",
-			zap.Stringer("messageOp", message.AppResponseOp),
-			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("chainID", s.ctx.ChainID),
-			zap.Uint32("requestID", requestID),
-		)
-		s.ctx.Log.Verbo("failed to send message",
-			zap.Stringer("messageOp", message.AppResponseOp),
-			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("chainID", s.ctx.ChainID),
-			zap.Uint32("requestID", requestID),
-			zap.Binary("payload", appResponseBytes),
-		)
+		if s.ctx.Log.Enabled(logging.Verbo) {
+			s.ctx.Log.Verbo("failed to send message",
+				zap.Stringer("messageOp", message.AppResponseOp),
+				zap.Stringer("nodeID", nodeID),
+				zap.Stringer("chainID", s.ctx.ChainID),
+				zap.Uint32("requestID", requestID),
+				zap.Binary("payload", appResponseBytes),
+			)
+		} else {
+			s.ctx.Log.Debug("failed to send message",
+				zap.Stringer("messageOp", message.AppResponseOp),
+				zap.Stringer("nodeID", nodeID),
+				zap.Stringer("chainID", s.ctx.ChainID),
+				zap.Uint32("requestID", requestID),
+			)
+		}
 	}
 	return nil
 }
@@ -1447,17 +1461,20 @@ func (s *sender) SendAppGossipSpecific(_ context.Context, nodeIDs set.Set[ids.No
 	if sentTo.Len() == 0 {
 		for nodeID := range nodeIDs {
 			if !sentTo.Contains(nodeID) {
-				s.ctx.Log.Debug("failed to send message",
-					zap.Stringer("messageOp", message.AppGossipOp),
-					zap.Stringer("nodeID", nodeID),
-					zap.Stringer("chainID", s.ctx.ChainID),
-				)
-				s.ctx.Log.Verbo("failed to send message",
-					zap.Stringer("messageOp", message.AppGossipOp),
-					zap.Stringer("nodeID", nodeID),
-					zap.Stringer("chainID", s.ctx.ChainID),
-					zap.Binary("payload", appGossipBytes),
-				)
+				if s.ctx.Log.Enabled(logging.Verbo) {
+					s.ctx.Log.Verbo("failed to send message",
+						zap.Stringer("messageOp", message.AppGossipOp),
+						zap.Stringer("nodeID", nodeID),
+						zap.Stringer("chainID", s.ctx.ChainID),
+						zap.Binary("payload", appGossipBytes),
+					)
+				} else {
+					s.ctx.Log.Debug("failed to send message",
+						zap.Stringer("messageOp", message.AppGossipOp),
+						zap.Stringer("nodeID", nodeID),
+						zap.Stringer("chainID", s.ctx.ChainID),
+					)
+				}
 			}
 		}
 	}
@@ -1492,15 +1509,18 @@ func (s *sender) SendAppGossip(_ context.Context, appGossipBytes []byte) error {
 		s.subnet,
 	)
 	if sentTo.Len() == 0 {
-		s.ctx.Log.Debug("failed to send message",
-			zap.Stringer("messageOp", message.AppGossipOp),
-			zap.Stringer("chainID", s.ctx.ChainID),
-		)
-		s.ctx.Log.Verbo("failed to send message",
-			zap.Stringer("messageOp", message.AppGossipOp),
-			zap.Stringer("chainID", s.ctx.ChainID),
-			zap.Binary("payload", appGossipBytes),
-		)
+		if s.ctx.Log.Enabled(logging.Verbo) {
+			s.ctx.Log.Verbo("failed to send message",
+				zap.Stringer("messageOp", message.AppGossipOp),
+				zap.Stringer("chainID", s.ctx.ChainID),
+				zap.Binary("payload", appGossipBytes),
+			)
+		} else {
+			s.ctx.Log.Debug("failed to send message",
+				zap.Stringer("messageOp", message.AppGossipOp),
+				zap.Stringer("chainID", s.ctx.ChainID),
+			)
+		}
 	}
 	return nil
 }
@@ -1534,15 +1554,18 @@ func (s *sender) SendGossip(_ context.Context, container []byte) {
 		s.subnet,
 	)
 	if sentTo.Len() == 0 {
-		s.ctx.Log.Debug("failed to send message",
-			zap.Stringer("messageOp", message.PutOp),
-			zap.Stringer("chainID", s.ctx.ChainID),
-		)
-		s.ctx.Log.Verbo("failed to send message",
-			zap.Stringer("messageOp", message.PutOp),
-			zap.Stringer("chainID", s.ctx.ChainID),
-			zap.Binary("container", container),
-		)
+		if s.ctx.Log.Enabled(logging.Verbo) {
+			s.ctx.Log.Verbo("failed to send message",
+				zap.Stringer("messageOp", message.PutOp),
+				zap.Stringer("chainID", s.ctx.ChainID),
+				zap.Binary("container", container),
+			)
+		} else {
+			s.ctx.Log.Debug("failed to send message",
+				zap.Stringer("messageOp", message.PutOp),
+				zap.Stringer("chainID", s.ctx.ChainID),
+			)
+		}
 	}
 }
 
@@ -1580,15 +1603,18 @@ func (s *sender) Accept(ctx *snow.ConsensusContext, _ ids.ID, container []byte) 
 		s.subnet,
 	)
 	if sentTo.Len() == 0 {
-		s.ctx.Log.Debug("failed to send message",
-			zap.Stringer("messageOp", message.PutOp),
-			zap.Stringer("chainID", s.ctx.ChainID),
-		)
-		s.ctx.Log.Verbo("failed to send message",
-			zap.Stringer("messageOp", message.PutOp),
-			zap.Stringer("chainID", s.ctx.ChainID),
-			zap.Binary("container", container),
-		)
+		if s.ctx.Log.Enabled(logging.Verbo) {
+			s.ctx.Log.Verbo("failed to send message",
+				zap.Stringer("messageOp", message.PutOp),
+				zap.Stringer("chainID", s.ctx.ChainID),
+				zap.Binary("container", container),
+			)
+		} else {
+			s.ctx.Log.Debug("failed to send message",
+				zap.Stringer("messageOp", message.PutOp),
+				zap.Stringer("chainID", s.ctx.ChainID),
+			)
+		}
 	}
 	return nil
 }

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -71,6 +71,11 @@ func (l *log) Stop() {
 	}
 }
 
+// Enabled returns true if the given level is at or above this level.
+func (l *log) Enabled(lvl Level) bool {
+	return l.internalLogger.Level().Enabled(zapcore.Level(lvl))
+}
+
 // Should only be called from [Level] functions.
 func (l *log) log(level Level, msg string, fields ...zap.Field) {
 	if ce := l.internalLogger.Check(zapcore.Level(level), msg); ce != nil {

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -38,6 +38,8 @@ type Logger interface {
 
 	// SetLevel that this logger should log to
 	SetLevel(level Level)
+	// Enabled returns true if the given level is at or above this level.
+	Enabled(lvl Level) bool
 
 	// Recovers a panic, logs the error, and rethrows the panic.
 	StopOnPanic()

--- a/utils/logging/mock_logger.go
+++ b/utils/logging/mock_logger.go
@@ -54,6 +54,20 @@ func (mr *MockLoggerMockRecorder) Debug(arg0 interface{}, arg1 ...interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debug", reflect.TypeOf((*MockLogger)(nil).Debug), varargs...)
 }
 
+// Enabled mocks base method.
+func (m *MockLogger) Enabled(arg0 Level) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Enabled", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Enabled indicates an expected call of Enabled.
+func (mr *MockLoggerMockRecorder) Enabled(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enabled", reflect.TypeOf((*MockLogger)(nil).Enabled), arg0)
+}
+
 // Error mocks base method.
 func (m *MockLogger) Error(arg0 string, arg1 ...zapcore.Field) {
 	m.ctrl.T.Helper()

--- a/utils/logging/test_log.go
+++ b/utils/logging/test_log.go
@@ -38,6 +38,8 @@ func (NoLog) Verbo(string, ...zap.Field) {}
 
 func (NoLog) SetLevel(Level) {}
 
+func (NoLog) Enabled(Level) bool { return false }
+
 func (NoLog) StopOnPanic() {}
 
 func (NoLog) RecoverAndPanic(f func()) {

--- a/utils/logging/test_log.go
+++ b/utils/logging/test_log.go
@@ -38,7 +38,9 @@ func (NoLog) Verbo(string, ...zap.Field) {}
 
 func (NoLog) SetLevel(Level) {}
 
-func (NoLog) Enabled(Level) bool { return false }
+func (NoLog) Enabled(Level) bool {
+	return false
+}
 
 func (NoLog) StopOnPanic() {}
 


### PR DESCRIPTION
## Why this should be merged

Remove duplicate debug logging when verbo is enabled.

## How this works

Add `Enabled(Level)` method to logging interface.

## How this was tested

N/A