### PR TITLE
ban `require.NotEqualValues`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,7 @@ linters-settings:
       - 'require\.Error$(# ErrorIs should be used instead)?'
       - 'require\.ErrorContains$(# ErrorIs should be used instead)?'
       - 'require\.EqualValues$(# Equal should be used instead)?'
+      - 'require\.NotEqualValues$(# NotEqual should be used instead)?'
     exclude_godoc_examples: false
   # https://golangci-lint.run/usage/linters#gosec
   gosec:

--- a/network/peer/ip_signer_test.go
+++ b/network/peer/ip_signer_test.go
@@ -51,5 +51,5 @@ func TestIPSigner(t *testing.T) {
 	require.NoError(err)
 	require.Equal(dynIP.IPPort(), signedIP3.IPPort)
 	require.Equal(uint64(11), signedIP3.Timestamp)
-	require.NotEqualValues(signedIP2.Signature, signedIP3.Signature)
+	require.NotEqual(signedIP2.Signature, signedIP3.Signature)
 }

--- a/utils/sampler/uniform_test.go
+++ b/utils/sampler/uniform_test.go
@@ -175,7 +175,7 @@ func TestSeeding(t *testing.T) {
 	s1.Seed(0)
 	v, err := s2.Next()
 	require.NoError(err)
-	require.NotEqualValues(s1Val, v)
+	require.NotEqual(s1Val, v)
 
 	s1.ClearSeed()
 


### PR DESCRIPTION
## Why this should be merged

factored out of #1453 

## How this works

find + replace

## How this was tested

CI
