### PR TITLE
use `require` in `api` and `utils/password` packages

### DIFF
--- a/api/admin/client_test.go
+++ b/api/admin/client_test.go
@@ -76,140 +76,114 @@ func (mc *mockClient) SendRequest(_ context.Context, _ string, _ interface{}, re
 }
 
 func TestStartCPUProfiler(t *testing.T) {
+	require := require.New(t)
+
 	tests := GetSuccessResponseTests()
 
 	for _, test := range tests {
 		mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.Err)}
 		err := mockClient.StartCPUProfiler(context.Background())
-		// if there is error as expected, the test passes
-		if err != nil && test.Err != nil {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
+		require.ErrorIs(err, test.Err)
 	}
 }
 
 func TestStopCPUProfiler(t *testing.T) {
+	require := require.New(t)
+
 	tests := GetSuccessResponseTests()
 
 	for _, test := range tests {
 		mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.Err)}
 		err := mockClient.StopCPUProfiler(context.Background())
-		// if there is error as expected, the test passes
-		if err != nil && test.Err != nil {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
+		require.ErrorIs(err, test.Err)
 	}
 }
 
 func TestMemoryProfile(t *testing.T) {
+	require := require.New(t)
+
 	tests := GetSuccessResponseTests()
 
 	for _, test := range tests {
 		mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.Err)}
 		err := mockClient.MemoryProfile(context.Background())
-		// if there is error as expected, the test passes
-		if err != nil && test.Err != nil {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
+		require.ErrorIs(err, test.Err)
 	}
 }
 
 func TestLockProfile(t *testing.T) {
+	require := require.New(t)
+
 	tests := GetSuccessResponseTests()
 
 	for _, test := range tests {
 		mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.Err)}
 		err := mockClient.LockProfile(context.Background())
-		// if there is error as expected, the test passes
-		if err != nil && test.Err != nil {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
+		require.ErrorIs(err, test.Err)
 	}
 }
 
 func TestAlias(t *testing.T) {
+	require := require.New(t)
+
 	tests := GetSuccessResponseTests()
 
 	for _, test := range tests {
 		mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.Err)}
 		err := mockClient.Alias(context.Background(), "alias", "alias2")
-		// if there is error as expected, the test passes
-		if err != nil && test.Err != nil {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
+		require.ErrorIs(err, test.Err)
 	}
 }
 
 func TestAliasChain(t *testing.T) {
+	require := require.New(t)
+
 	tests := GetSuccessResponseTests()
 
 	for _, test := range tests {
 		mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.Err)}
 		err := mockClient.AliasChain(context.Background(), "chain", "chain-alias")
-		// if there is error as expected, the test passes
-		if err != nil && test.Err != nil {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
+		require.ErrorIs(err, test.Err)
 	}
 }
 
 func TestGetChainAliases(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
+		require := require.New(t)
+
 		expectedReply := []string{"alias1", "alias2"}
 		mockClient := client{requester: NewMockClient(&GetChainAliasesReply{
 			Aliases: expectedReply,
 		}, nil)}
 
 		reply, err := mockClient.GetChainAliases(context.Background(), "chain")
-		require.NoError(t, err)
-		require.ElementsMatch(t, expectedReply, reply)
+		require.NoError(err)
+		require.Equal(expectedReply, reply)
 	})
 
 	t.Run("failure", func(t *testing.T) {
 		mockClient := client{requester: NewMockClient(&GetChainAliasesReply{}, errTest)}
-
 		_, err := mockClient.GetChainAliases(context.Background(), "chain")
-
 		require.ErrorIs(t, err, errTest)
 	})
 }
 
 func TestStacktrace(t *testing.T) {
+	require := require.New(t)
+
 	tests := GetSuccessResponseTests()
 
 	for _, test := range tests {
 		mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.Err)}
 		err := mockClient.Stacktrace(context.Background())
-		// if there is error as expected, the test passes
-		if err != nil && test.Err != nil {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
+		require.ErrorIs(err, test.Err)
 	}
 }
 
 func TestReloadInstalledVMs(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
+		require := require.New(t)
+
 		expectedNewVMs := map[ids.ID][]string{
 			ids.GenerateTestID(): {"foo"},
 			ids.GenerateTestID(): {"bar"},
@@ -224,16 +198,14 @@ func TestReloadInstalledVMs(t *testing.T) {
 		}, nil)}
 
 		loadedVMs, failedVMs, err := mockClient.LoadVMs(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, expectedNewVMs, loadedVMs)
-		require.Equal(t, expectedFailedVMs, failedVMs)
+		require.NoError(err)
+		require.Equal(expectedNewVMs, loadedVMs)
+		require.Equal(expectedFailedVMs, failedVMs)
 	})
 
 	t.Run("failure", func(t *testing.T) {
 		mockClient := client{requester: NewMockClient(&LoadVMsReply{}, errTest)}
-
 		_, _, err := mockClient.LoadVMs(context.Background())
-
 		require.ErrorIs(t, err, errTest)
 	})
 }
@@ -278,8 +250,6 @@ func TestSetLoggerLevel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-
 			c := client{
 				requester: NewMockClient(&api.EmptyReply{}, tt.serviceErr),
 			}
@@ -289,7 +259,7 @@ func TestSetLoggerLevel(t *testing.T) {
 				tt.logLevel,
 				tt.displayLevel,
 			)
-			require.ErrorIs(err, tt.clientErr)
+			require.ErrorIs(t, err, tt.clientErr)
 		})
 	}
 }
@@ -376,9 +346,10 @@ func TestGetConfig(t *testing.T) {
 			}
 			res, err := c.GetConfig(context.Background())
 			require.ErrorIs(err, tt.clientErr)
-			if tt.clientErr == nil {
-				require.Equal(resp, res)
+			if tt.clientErr != nil {
+				return
 			}
+			require.Equal(resp, res)
 		})
 	}
 }

--- a/api/admin/service_test.go
+++ b/api/admin/service_test.go
@@ -47,6 +47,8 @@ func initLoadVMsTest(t *testing.T) *loadVMsTest {
 
 // Tests behavior for LoadVMs if everything succeeds.
 func TestLoadVMsSuccess(t *testing.T) {
+	require := require.New(t)
+
 	resources := initLoadVMsTest(t)
 	defer resources.ctrl.Finish()
 
@@ -75,12 +77,14 @@ func TestLoadVMsSuccess(t *testing.T) {
 	reply := LoadVMsReply{}
 	err := resources.admin.LoadVMs(&http.Request{}, nil, &reply)
 
-	require.Equal(t, expectedVMRegistry, reply.NewVMs)
-	require.NoError(t, err)
+	require.Equal(expectedVMRegistry, reply.NewVMs)
+	require.NoError(err)
 }
 
 // Tests behavior for LoadVMs if we fail to reload vms.
 func TestLoadVMsReloadFails(t *testing.T) {
+	require := require.New(t)
+
 	resources := initLoadVMsTest(t)
 	defer resources.ctrl.Finish()
 
@@ -90,11 +94,13 @@ func TestLoadVMsReloadFails(t *testing.T) {
 
 	reply := LoadVMsReply{}
 	err := resources.admin.LoadVMs(&http.Request{}, nil, &reply)
-	require.ErrorIs(t, err, errTest)
+	require.ErrorIs(err, errTest)
 }
 
 // Tests behavior for LoadVMs if we fail to fetch our aliases
 func TestLoadVMsGetAliasesFails(t *testing.T) {
+	require := require.New(t)
+
 	resources := initLoadVMsTest(t)
 	defer resources.ctrl.Finish()
 
@@ -114,5 +120,5 @@ func TestLoadVMsGetAliasesFails(t *testing.T) {
 
 	reply := LoadVMsReply{}
 	err := resources.admin.LoadVMs(&http.Request{}, nil, &reply)
-	require.ErrorIs(t, err, errTest)
+	require.ErrorIs(err, errTest)
 }

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -69,14 +69,14 @@ func TestNewTokenHappyPath(t *testing.T) {
 		defer auth.lock.RUnlock()
 		return auth.password.Password[:], nil
 	})
-	require.NoError(err, "couldn't parse new token")
+	require.NoError(err)
 
 	require.IsType(&endpointClaims{}, token.Claims)
 	claims := token.Claims.(*endpointClaims)
-	require.Equal(endpoints, claims.Endpoints, "token has wrong endpoint claims")
+	require.Equal(endpoints, claims.Endpoints)
 
 	shouldExpireAt := jwt.NewNumericDate(now.Add(defaultTokenLifespan))
-	require.Equal(shouldExpireAt, claims.ExpiresAt, "token expiration time is wrong")
+	require.Equal(shouldExpireAt, claims.ExpiresAt)
 }
 
 func TestTokenHasWrongSig(t *testing.T) {
@@ -124,7 +124,7 @@ func TestChangePassword(t *testing.T) {
 	require.ErrorIs(err, password.ErrEmptyPassword)
 
 	require.NoError(auth.ChangePassword(testPassword, password2))
-	require.True(auth.password.Check(password2), "password should have been changed")
+	require.True(auth.password.Check(password2))
 
 	password3 := "ufwhwohwfohawfhwdwd" // #nosec G101
 
@@ -145,8 +145,8 @@ func TestRevokeToken(t *testing.T) {
 	require.NoError(err)
 
 	err = auth.RevokeToken(tokenStr, testPassword)
-	require.NoError(err, "should have succeeded")
-	require.Len(auth.revoked, 1, "revoked token list is incorrect")
+	require.NoError(err)
+	require.Len(auth.revoked, 1)
 }
 
 func TestWrapHandlerHappyPath(t *testing.T) {

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -51,6 +51,8 @@ func TestNewTokenWrongPassword(t *testing.T) {
 }
 
 func TestNewTokenHappyPath(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword).(*auth)
 
 	now := time.Now()
@@ -59,7 +61,7 @@ func TestNewTokenHappyPath(t *testing.T) {
 	// Make a token
 	endpoints := []string{"endpoint1", "endpoint2", "endpoint3"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, endpoints)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	// Parse the token
 	token, err := jwt.ParseWithClaims(tokenStr, &endpointClaims{}, func(*jwt.Token) (interface{}, error) {
@@ -67,14 +69,14 @@ func TestNewTokenHappyPath(t *testing.T) {
 		defer auth.lock.RUnlock()
 		return auth.password.Password[:], nil
 	})
-	require.NoError(t, err, "couldn't parse new token")
+	require.NoError(err, "couldn't parse new token")
 
-	require.IsType(t, &endpointClaims{}, token.Claims)
+	require.IsType(&endpointClaims{}, token.Claims)
 	claims := token.Claims.(*endpointClaims)
-	require.ElementsMatch(t, endpoints, claims.Endpoints, "token has wrong endpoint claims")
+	require.Equal(endpoints, claims.Endpoints, "token has wrong endpoint claims")
 
 	shouldExpireAt := jwt.NewNumericDate(now.Add(defaultTokenLifespan))
-	require.Equal(t, shouldExpireAt, claims.ExpiresAt, "token expiration time is wrong")
+	require.Equal(shouldExpireAt, claims.ExpiresAt, "token expiration time is wrong")
 }
 
 func TestTokenHasWrongSig(t *testing.T) {
@@ -121,8 +123,7 @@ func TestChangePassword(t *testing.T) {
 	err = auth.ChangePassword(testPassword, "")
 	require.ErrorIs(err, password.ErrEmptyPassword)
 
-	err = auth.ChangePassword(testPassword, password2)
-	require.NoError(err)
+	require.NoError(auth.ChangePassword(testPassword, password2))
 	require.True(auth.password.Check(password2), "password should have been changed")
 
 	password3 := "ufwhwohwfohawfhwdwd" // #nosec G101
@@ -130,30 +131,33 @@ func TestChangePassword(t *testing.T) {
 	err = auth.ChangePassword(testPassword, password3)
 	require.ErrorIs(err, errWrongPassword)
 
-	err = auth.ChangePassword(password2, password3)
-	require.NoError(err)
+	require.NoError(auth.ChangePassword(password2, password3))
 }
 
 func TestRevokeToken(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword).(*auth)
 
 	// Make a token
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, endpoints)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	err = auth.RevokeToken(tokenStr, testPassword)
-	require.NoError(t, err, "should have succeeded")
-	require.Len(t, auth.revoked, 1, "revoked token list is incorrect")
+	require.NoError(err, "should have succeeded")
+	require.Len(auth.revoked, 1, "revoked token list is incorrect")
 }
 
 func TestWrapHandlerHappyPath(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword)
 
 	// Make a token
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, endpoints)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	wrappedHandler := auth.WrapHandler(dummyHandler)
 
@@ -162,20 +166,21 @@ func TestWrapHandlerHappyPath(t *testing.T) {
 		req.Header.Add("Authorization", "Bearer "+tokenStr)
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
-		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(http.StatusOK, rr.Code)
 	}
 }
 
 func TestWrapHandlerRevokedToken(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword)
 
 	// Make a token
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, endpoints)
-	require.NoError(t, err)
+	require.NoError(err)
 
-	err = auth.RevokeToken(tokenStr, testPassword)
-	require.NoError(t, err)
+	require.NoError(auth.RevokeToken(tokenStr, testPassword))
 
 	wrappedHandler := auth.WrapHandler(dummyHandler)
 
@@ -184,13 +189,15 @@ func TestWrapHandlerRevokedToken(t *testing.T) {
 		req.Header.Add("Authorization", "Bearer "+tokenStr)
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
-		require.Equal(t, http.StatusUnauthorized, rr.Code)
-		require.Contains(t, rr.Body.String(), errTokenRevoked.Error())
-		require.Regexp(t, unAuthorizedResponseRegex, rr.Body.String())
+		require.Equal(http.StatusUnauthorized, rr.Code)
+		require.Contains(rr.Body.String(), errTokenRevoked.Error())
+		require.Regexp(unAuthorizedResponseRegex, rr.Body.String())
 	}
 }
 
 func TestWrapHandlerExpiredToken(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword).(*auth)
 
 	auth.clock.Set(time.Now().Add(-2 * defaultTokenLifespan))
@@ -198,7 +205,7 @@ func TestWrapHandlerExpiredToken(t *testing.T) {
 	// Make a token that expired well in the past
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, endpoints)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	wrappedHandler := auth.WrapHandler(dummyHandler)
 
@@ -207,13 +214,15 @@ func TestWrapHandlerExpiredToken(t *testing.T) {
 		req.Header.Add("Authorization", "Bearer "+tokenStr)
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
-		require.Equal(t, http.StatusUnauthorized, rr.Code)
-		require.Contains(t, rr.Body.String(), "expired")
-		require.Regexp(t, unAuthorizedResponseRegex, rr.Body.String())
+		require.Equal(http.StatusUnauthorized, rr.Code)
+		require.Contains(rr.Body.String(), "expired")
+		require.Regexp(unAuthorizedResponseRegex, rr.Body.String())
 	}
 }
 
 func TestWrapHandlerNoAuthToken(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword)
 
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics"}
@@ -222,19 +231,21 @@ func TestWrapHandlerNoAuthToken(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:9650%s", endpoint), strings.NewReader(""))
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
-		require.Equal(t, http.StatusUnauthorized, rr.Code)
-		require.Contains(t, rr.Body.String(), errNoToken.Error())
-		require.Regexp(t, unAuthorizedResponseRegex, rr.Body.String())
+		require.Equal(http.StatusUnauthorized, rr.Code)
+		require.Contains(rr.Body.String(), errNoToken.Error())
+		require.Regexp(unAuthorizedResponseRegex, rr.Body.String())
 	}
 }
 
 func TestWrapHandlerUnauthorizedEndpoint(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword)
 
 	// Make a token
 	endpoints := []string{"/ext/info"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, endpoints)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	unauthorizedEndpoints := []string{"/ext/bc/X", "/ext/metrics", "", "/foo", "/ext/info/foo"}
 
@@ -244,35 +255,39 @@ func TestWrapHandlerUnauthorizedEndpoint(t *testing.T) {
 		req.Header.Add("Authorization", "Bearer "+tokenStr)
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
-		require.Equal(t, http.StatusUnauthorized, rr.Code)
-		require.Contains(t, rr.Body.String(), errTokenInsufficientPermission.Error())
-		require.Regexp(t, unAuthorizedResponseRegex, rr.Body.String())
+		require.Equal(http.StatusUnauthorized, rr.Code)
+		require.Contains(rr.Body.String(), errTokenInsufficientPermission.Error())
+		require.Regexp(unAuthorizedResponseRegex, rr.Body.String())
 	}
 }
 
 func TestWrapHandlerAuthEndpoint(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword)
 
 	// Make a token
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics", "", "/foo", "/ext/info/foo"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, endpoints)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	wrappedHandler := auth.WrapHandler(dummyHandler)
 	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:9650/ext/auth", strings.NewReader(""))
 	req.Header.Add("Authorization", "Bearer "+tokenStr)
 	rr := httptest.NewRecorder()
 	wrappedHandler.ServeHTTP(rr, req)
-	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(http.StatusOK, rr.Code)
 }
 
 func TestWrapHandlerAccessAll(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword)
 
 	// Make a token that allows access to all endpoints
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics", "", "/foo", "/ext/foo/info"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, []string{"*"})
-	require.NoError(t, err)
+	require.NoError(err)
 
 	wrappedHandler := auth.WrapHandler(dummyHandler)
 	for _, endpoint := range endpoints {
@@ -280,27 +295,30 @@ func TestWrapHandlerAccessAll(t *testing.T) {
 		req.Header.Add("Authorization", "Bearer "+tokenStr)
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
-		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(http.StatusOK, rr.Code)
 	}
 }
 
 func TestWriteUnauthorizedResponse(t *testing.T) {
+	require := require.New(t)
+
 	rr := httptest.NewRecorder()
 	writeUnauthorizedResponse(rr, errTest)
-	require.Equal(t, http.StatusUnauthorized, rr.Code)
-	require.Equal(t, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"non-nil error\"},\"id\":1}\n", rr.Body.String())
+	require.Equal(http.StatusUnauthorized, rr.Code)
+	require.Equal("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"non-nil error\"},\"id\":1}\n", rr.Body.String())
 }
 
 func TestWrapHandlerMutatedRevokedToken(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword)
 
 	// Make a token
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics"}
 	tokenStr, err := auth.NewToken(testPassword, defaultTokenLifespan, endpoints)
-	require.NoError(t, err)
+	require.NoError(err)
 
-	err = auth.RevokeToken(tokenStr, testPassword)
-	require.NoError(t, err)
+	require.NoError(auth.RevokeToken(tokenStr, testPassword))
 
 	wrappedHandler := auth.WrapHandler(dummyHandler)
 
@@ -309,19 +327,20 @@ func TestWrapHandlerMutatedRevokedToken(t *testing.T) {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s=", tokenStr)) // The appended = at the end looks like padding
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
-		require.Equal(t, http.StatusUnauthorized, rr.Code)
+		require.Equal(http.StatusUnauthorized, rr.Code)
 	}
 }
 
 func TestWrapHandlerInvalidSigningMethod(t *testing.T) {
+	require := require.New(t)
+
 	auth := NewFromHash(logging.NoLog{}, "auth", hashedPassword).(*auth)
 
 	// Make a token
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics"}
 	idBytes := [tokenIDByteLen]byte{}
-	if _, err := rand.Read(idBytes[:]); err != nil {
-		t.Fatal(err)
-	}
+	_, err := rand.Read(idBytes[:])
+	require.NoError(err)
 	id := base64.RawURLEncoding.EncodeToString(idBytes[:])
 
 	claims := endpointClaims{
@@ -333,9 +352,7 @@ func TestWrapHandlerInvalidSigningMethod(t *testing.T) {
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS512, &claims)
 	tokenStr, err := token.SignedString(auth.password.Password[:])
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	wrappedHandler := auth.WrapHandler(dummyHandler)
 
@@ -344,8 +361,8 @@ func TestWrapHandlerInvalidSigningMethod(t *testing.T) {
 		req.Header.Add("Authorization", "Bearer "+tokenStr)
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
-		require.Equal(t, http.StatusUnauthorized, rr.Code)
-		require.Contains(t, rr.Body.String(), errInvalidSigningMethod.Error())
-		require.Regexp(t, unAuthorizedResponseRegex, rr.Body.String())
+		require.Equal(http.StatusUnauthorized, rr.Code)
+		require.Contains(rr.Body.String(), errInvalidSigningMethod.Error())
+		require.Regexp(unAuthorizedResponseRegex, rr.Body.String())
 	}
 }

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -25,7 +25,7 @@ import (
 var (
 	testPassword              = "password!@#$%$#@!"
 	hashedPassword            = password.Hash{}
-	unAuthorizedResponseRegex = "^{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"(.*)\"},\"id\":1}"
+	unAuthorizedResponseRegex = `^{"jsonrpc":"2.0","error":{"code":-32600,"message":"(.*)"},"id":1}`
 	errTest                   = errors.New("non-nil error")
 )
 
@@ -305,7 +305,7 @@ func TestWriteUnauthorizedResponse(t *testing.T) {
 	rr := httptest.NewRecorder()
 	writeUnauthorizedResponse(rr, errTest)
 	require.Equal(http.StatusUnauthorized, rr.Code)
-	require.Equal("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"non-nil error\"},\"id\":1}\n", rr.Body.String())
+	require.Equal(`{"jsonrpc":"2.0","error":{"code":-32600,"message":"non-nil error"},"id":1}`+"\n", rr.Body.String())
 }
 
 func TestWrapHandlerMutatedRevokedToken(t *testing.T) {

--- a/api/health/health_test.go
+++ b/api/health/health_test.go
@@ -28,16 +28,14 @@ const (
 var errUnhealthy = errors.New("unhealthy")
 
 func awaitReadiness(t *testing.T, r Reporter, ready bool) {
-	require := require.New(t)
-	require.Eventually(func() bool {
+	require.Eventually(t, func() bool {
 		_, ok := r.Readiness()
 		return ok == ready
 	}, awaitTimeout, awaitFreq)
 }
 
 func awaitHealthy(t *testing.T, r Reporter, healthy bool) {
-	require := require.New(t)
-	require.Eventually(func() bool {
+	require.Eventually(t, func() bool {
 		_, ok := r.Health()
 		return ok == healthy
 	}, awaitTimeout, awaitFreq)

--- a/api/health/health_test.go
+++ b/api/health/health_test.go
@@ -28,21 +28,24 @@ const (
 var errUnhealthy = errors.New("unhealthy")
 
 func awaitReadiness(t *testing.T, r Reporter, ready bool) {
-	require.Eventually(t, func() bool {
+	require := require.New(t)
+	require.Eventually(func() bool {
 		_, ok := r.Readiness()
 		return ok == ready
 	}, awaitTimeout, awaitFreq)
 }
 
 func awaitHealthy(t *testing.T, r Reporter, healthy bool) {
-	require.Eventually(t, func() bool {
+	require := require.New(t)
+	require.Eventually(func() bool {
 		_, ok := r.Health()
 		return ok == healthy
 	}, awaitTimeout, awaitFreq)
 }
 
 func awaitLiveness(t *testing.T, r Reporter, liveness bool) {
-	require.Eventually(t, func() bool {
+	require := require.New(t)
+	require.Eventually(func() bool {
 		_, ok := r.Liveness()
 		return ok == liveness
 	}, awaitTimeout, awaitFreq)
@@ -58,18 +61,15 @@ func TestDuplicatedRegistations(t *testing.T) {
 	h, err := New(logging.NoLog{}, prometheus.NewRegistry())
 	require.NoError(err)
 
-	err = h.RegisterReadinessCheck("check", check)
-	require.NoError(err)
+	require.NoError(h.RegisterReadinessCheck("check", check))
 	err = h.RegisterReadinessCheck("check", check)
 	require.ErrorIs(err, errDuplicateCheck)
 
-	err = h.RegisterHealthCheck("check", check)
-	require.NoError(err)
+	require.NoError(h.RegisterHealthCheck("check", check))
 	err = h.RegisterHealthCheck("check", check)
 	require.ErrorIs(err, errDuplicateCheck)
 
-	err = h.RegisterLivenessCheck("check", check)
-	require.NoError(err)
+	require.NoError(h.RegisterLivenessCheck("check", check))
 	err = h.RegisterLivenessCheck("check", check)
 	require.ErrorIs(err, errDuplicateCheck)
 }
@@ -85,8 +85,7 @@ func TestDefaultFailing(t *testing.T) {
 	require.NoError(err)
 
 	{
-		err = h.RegisterReadinessCheck("check", check)
-		require.NoError(err)
+		require.NoError(h.RegisterReadinessCheck("check", check))
 
 		readinessResult, readiness := h.Readiness()
 		require.Len(readinessResult, 1)
@@ -96,8 +95,7 @@ func TestDefaultFailing(t *testing.T) {
 	}
 
 	{
-		err = h.RegisterHealthCheck("check", check)
-		require.NoError(err)
+		require.NoError(h.RegisterHealthCheck("check", check))
 
 		healthResult, health := h.Health()
 		require.Len(healthResult, 1)
@@ -107,8 +105,7 @@ func TestDefaultFailing(t *testing.T) {
 	}
 
 	{
-		err = h.RegisterLivenessCheck("check", check)
-		require.NoError(err)
+		require.NoError(h.RegisterLivenessCheck("check", check))
 
 		livenessResult, liveness := h.Liveness()
 		require.Len(livenessResult, 1)
@@ -128,12 +125,9 @@ func TestPassingChecks(t *testing.T) {
 	h, err := New(logging.NoLog{}, prometheus.NewRegistry())
 	require.NoError(err)
 
-	err = h.RegisterReadinessCheck("check", check)
-	require.NoError(err)
-	err = h.RegisterHealthCheck("check", check)
-	require.NoError(err)
-	err = h.RegisterLivenessCheck("check", check)
-	require.NoError(err)
+	require.NoError(h.RegisterReadinessCheck("check", check))
+	require.NoError(h.RegisterHealthCheck("check", check))
+	require.NoError(h.RegisterLivenessCheck("check", check))
 
 	h.Start(context.Background(), checkFreq)
 	defer h.Stop()
@@ -195,12 +189,9 @@ func TestPassingThenFailingChecks(t *testing.T) {
 	h, err := New(logging.NoLog{}, prometheus.NewRegistry())
 	require.NoError(err)
 
-	err = h.RegisterReadinessCheck("check", check)
-	require.NoError(err)
-	err = h.RegisterHealthCheck("check", check)
-	require.NoError(err)
-	err = h.RegisterLivenessCheck("check", check)
-	require.NoError(err)
+	require.NoError(h.RegisterReadinessCheck("check", check))
+	require.NoError(h.RegisterHealthCheck("check", check))
+	require.NoError(h.RegisterLivenessCheck("check", check))
 
 	h.Start(context.Background(), checkFreq)
 	defer h.Stop()
@@ -275,16 +266,11 @@ func TestTags(t *testing.T) {
 
 	h, err := New(logging.NoLog{}, prometheus.NewRegistry())
 	require.NoError(err)
-	err = h.RegisterHealthCheck("check1", check)
-	require.NoError(err)
-	err = h.RegisterHealthCheck("check2", check, "tag1")
-	require.NoError(err)
-	err = h.RegisterHealthCheck("check3", check, "tag2")
-	require.NoError(err)
-	err = h.RegisterHealthCheck("check4", check, "tag1", "tag2")
-	require.NoError(err)
-	err = h.RegisterHealthCheck("check5", check, GlobalTag)
-	require.NoError(err)
+	require.NoError(h.RegisterHealthCheck("check1", check))
+	require.NoError(h.RegisterHealthCheck("check2", check, "tag1"))
+	require.NoError(h.RegisterHealthCheck("check3", check, "tag2"))
+	require.NoError(h.RegisterHealthCheck("check4", check, "tag1", "tag2"))
+	require.NoError(h.RegisterHealthCheck("check5", check, GlobalTag))
 
 	// default checks
 	{
@@ -374,8 +360,7 @@ func TestTags(t *testing.T) {
 
 	{
 		// now we'll add a new check which is unhealthy by default (notYetRunResult)
-		err = h.RegisterHealthCheck("check6", check, "tag1")
-		require.NoError(err)
+		require.NoError(h.RegisterHealthCheck("check6", check, "tag1"))
 
 		awaitHealthy(t, h, false)
 
@@ -396,8 +381,7 @@ func TestTags(t *testing.T) {
 		require.True(health)
 
 		// add global tag
-		err = h.RegisterHealthCheck("check7", check, GlobalTag)
-		require.NoError(err)
+		require.NoError(h.RegisterHealthCheck("check7", check, GlobalTag))
 
 		awaitHealthy(t, h, false)
 

--- a/api/health/service_test.go
+++ b/api/health/service_test.go
@@ -31,17 +31,13 @@ func TestServiceResponses(t *testing.T) {
 		health: h,
 	}
 
-	err = h.RegisterReadinessCheck("check", check)
-	require.NoError(err)
-	err = h.RegisterHealthCheck("check", check)
-	require.NoError(err)
-	err = h.RegisterLivenessCheck("check", check)
-	require.NoError(err)
+	require.NoError(h.RegisterReadinessCheck("check", check))
+	require.NoError(h.RegisterHealthCheck("check", check))
+	require.NoError(h.RegisterLivenessCheck("check", check))
 
 	{
 		reply := APIReply{}
-		err = s.Readiness(nil, &APIArgs{}, &reply)
-		require.NoError(err)
+		require.NoError(s.Readiness(nil, &APIArgs{}, &reply))
 
 		require.Len(reply.Checks, 1)
 		require.Contains(reply.Checks, "check")
@@ -51,8 +47,7 @@ func TestServiceResponses(t *testing.T) {
 
 	{
 		reply := APIReply{}
-		err = s.Health(nil, &APIArgs{}, &reply)
-		require.NoError(err)
+		require.NoError(s.Health(nil, &APIArgs{}, &reply))
 
 		require.Len(reply.Checks, 1)
 		require.Contains(reply.Checks, "check")
@@ -62,8 +57,7 @@ func TestServiceResponses(t *testing.T) {
 
 	{
 		reply := APIReply{}
-		err = s.Liveness(nil, &APIArgs{}, &reply)
-		require.NoError(err)
+		require.NoError(s.Liveness(nil, &APIArgs{}, &reply))
 
 		require.Len(reply.Checks, 1)
 		require.Contains(reply.Checks, "check")
@@ -80,8 +74,7 @@ func TestServiceResponses(t *testing.T) {
 
 	{
 		reply := APIReply{}
-		err = s.Readiness(nil, &APIArgs{}, &reply)
-		require.NoError(err)
+		require.NoError(s.Readiness(nil, &APIArgs{}, &reply))
 
 		result := reply.Checks["check"]
 		require.Equal("", result.Details)
@@ -92,8 +85,7 @@ func TestServiceResponses(t *testing.T) {
 
 	{
 		reply := APIReply{}
-		err = s.Health(nil, &APIArgs{}, &reply)
-		require.NoError(err)
+		require.NoError(s.Health(nil, &APIArgs{}, &reply))
 
 		result := reply.Checks["check"]
 		require.Equal("", result.Details)
@@ -104,8 +96,7 @@ func TestServiceResponses(t *testing.T) {
 
 	{
 		reply := APIReply{}
-		err = s.Liveness(nil, &APIArgs{}, &reply)
-		require.NoError(err)
+		require.NoError(s.Liveness(nil, &APIArgs{}, &reply))
 
 		result := reply.Checks["check"]
 		require.Equal("", result.Details)
@@ -170,14 +161,10 @@ func TestServiceTagResponse(t *testing.T) {
 
 			h, err := New(logging.NoLog{}, prometheus.NewRegistry())
 			require.NoError(err)
-			err = test.register(h, "check1", check)
-			require.NoError(err)
-			err = test.register(h, "check2", check, subnetID1.String())
-			require.NoError(err)
-			err = test.register(h, "check3", check, subnetID2.String())
-			require.NoError(err)
-			err = test.register(h, "check4", check, subnetID1.String(), subnetID2.String())
-			require.NoError(err)
+			require.NoError(test.register(h, "check1", check))
+			require.NoError(test.register(h, "check2", check, subnetID1.String()))
+			require.NoError(test.register(h, "check3", check, subnetID2.String()))
+			require.NoError(test.register(h, "check4", check, subnetID1.String(), subnetID2.String()))
 
 			s := &Service{
 				log:    logging.NoLog{},
@@ -187,8 +174,7 @@ func TestServiceTagResponse(t *testing.T) {
 			// default checks
 			{
 				reply := APIReply{}
-				err = test.check(s, nil, &APIArgs{}, &reply)
-				require.NoError(err)
+				require.NoError(test.check(s, nil, &APIArgs{}, &reply))
 				require.Len(reply.Checks, 4)
 				require.Contains(reply.Checks, "check1")
 				require.Contains(reply.Checks, "check2")
@@ -197,8 +183,7 @@ func TestServiceTagResponse(t *testing.T) {
 				require.Equal(notYetRunResult, reply.Checks["check1"])
 				require.False(reply.Healthy)
 
-				err = test.check(s, nil, &APIArgs{Tags: []string{subnetID1.String()}}, &reply)
-				require.NoError(err)
+				require.NoError(test.check(s, nil, &APIArgs{Tags: []string{subnetID1.String()}}, &reply))
 				require.Len(reply.Checks, 2)
 				require.Contains(reply.Checks, "check2")
 				require.Contains(reply.Checks, "check4")
@@ -212,8 +197,7 @@ func TestServiceTagResponse(t *testing.T) {
 
 			{
 				reply := APIReply{}
-				err = test.check(s, nil, &APIArgs{Tags: []string{subnetID1.String()}}, &reply)
-				require.NoError(err)
+				require.NoError(test.check(s, nil, &APIArgs{Tags: []string{subnetID1.String()}}, &reply))
 				require.Len(reply.Checks, 2)
 				require.Contains(reply.Checks, "check2")
 				require.Contains(reply.Checks, "check4")
@@ -225,12 +209,10 @@ func TestServiceTagResponse(t *testing.T) {
 
 			{
 				// now we'll add a new check which is unhealthy by default (notYetRunResult)
-				err = test.register(h, "check5", check, subnetID1.String())
-				require.NoError(err)
+				require.NoError(test.register(h, "check5", check, subnetID1.String()))
 
 				reply := APIReply{}
-				err = test.check(s, nil, &APIArgs{Tags: []string{subnetID1.String()}}, &reply)
-				require.NoError(err)
+				require.NoError(test.check(s, nil, &APIArgs{Tags: []string{subnetID1.String()}}, &reply))
 				require.Len(reply.Checks, 3)
 				require.Contains(reply.Checks, "check2")
 				require.Contains(reply.Checks, "check4")

--- a/api/info/service_test.go
+++ b/api/info/service_test.go
@@ -45,6 +45,8 @@ func initGetVMsTest(t *testing.T) *getVMsTest {
 
 // Tests GetVMs in the happy-case
 func TestGetVMsSuccess(t *testing.T) {
+	require := require.New(t)
+
 	resources := initGetVMsTest(t)
 	defer resources.ctrl.Finish()
 
@@ -69,12 +71,14 @@ func TestGetVMsSuccess(t *testing.T) {
 	reply := GetVMsReply{}
 	err := resources.info.GetVMs(nil, nil, &reply)
 
-	require.Equal(t, expectedVMRegistry, reply.VMs)
-	require.NoError(t, err)
+	require.Equal(expectedVMRegistry, reply.VMs)
+	require.NoError(err)
 }
 
 // Tests GetVMs if we fail to list our vms.
 func TestGetVMsVMsListFactoriesFails(t *testing.T) {
+	require := require.New(t)
+
 	resources := initGetVMsTest(t)
 	defer resources.ctrl.Finish()
 
@@ -83,11 +87,13 @@ func TestGetVMsVMsListFactoriesFails(t *testing.T) {
 
 	reply := GetVMsReply{}
 	err := resources.info.GetVMs(nil, nil, &reply)
-	require.ErrorIs(t, err, errTest)
+	require.ErrorIs(err, errTest)
 }
 
 // Tests GetVMs if we can't get our vm aliases.
 func TestGetVMsGetAliasesFails(t *testing.T) {
+	require := require.New(t)
+
 	resources := initGetVMsTest(t)
 	defer resources.ctrl.Finish()
 
@@ -103,5 +109,5 @@ func TestGetVMsGetAliasesFails(t *testing.T) {
 
 	reply := GetVMsReply{}
 	err := resources.info.GetVMs(nil, nil, &reply)
-	require.ErrorIs(t, err, errTest)
+	require.ErrorIs(err, errTest)
 }

--- a/api/info/service_test.go
+++ b/api/info/service_test.go
@@ -69,16 +69,12 @@ func TestGetVMsSuccess(t *testing.T) {
 	resources.mockVMManager.EXPECT().Aliases(id2).Times(1).Return(alias2, nil)
 
 	reply := GetVMsReply{}
-	err := resources.info.GetVMs(nil, nil, &reply)
-
+	require.NoError(resources.info.GetVMs(nil, nil, &reply))
 	require.Equal(expectedVMRegistry, reply.VMs)
-	require.NoError(err)
 }
 
 // Tests GetVMs if we fail to list our vms.
 func TestGetVMsVMsListFactoriesFails(t *testing.T) {
-	require := require.New(t)
-
 	resources := initGetVMsTest(t)
 	defer resources.ctrl.Finish()
 
@@ -87,13 +83,11 @@ func TestGetVMsVMsListFactoriesFails(t *testing.T) {
 
 	reply := GetVMsReply{}
 	err := resources.info.GetVMs(nil, nil, &reply)
-	require.ErrorIs(err, errTest)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests GetVMs if we can't get our vm aliases.
 func TestGetVMsGetAliasesFails(t *testing.T) {
-	require := require.New(t)
-
 	resources := initGetVMsTest(t)
 	defer resources.ctrl.Finish()
 
@@ -109,5 +103,5 @@ func TestGetVMsGetAliasesFails(t *testing.T) {
 
 	reply := GetVMsReply{}
 	err := resources.info.GetVMs(nil, nil, &reply)
-	require.ErrorIs(err, errTest)
+	require.ErrorIs(t, err, errTest)
 }

--- a/api/keystore/keystore.go
+++ b/api/keystore/keystore.go
@@ -28,8 +28,11 @@ const (
 )
 
 var (
-	errEmptyUsername = errors.New("empty username")
-	errUserMaxLength = fmt.Errorf("username exceeds maximum length of %d chars", maxUserLen)
+	errEmptyUsername     = errors.New("empty username")
+	errUserMaxLength     = fmt.Errorf("username exceeds maximum length of %d chars", maxUserLen)
+	errUserAlreadyExists = errors.New("user already exists")
+	errIncorrectPassword = errors.New("incorrect password")
+	errNonexistentUser   = errors.New("user doesn't exist")
 
 	usersPrefix = []byte("users")
 	bcsPrefix   = []byte("bcs")
@@ -158,7 +161,7 @@ func (ks *keystore) GetRawDatabase(bID ids.ID, username, pw string) (database.Da
 		return nil, err
 	}
 	if passwordHash == nil || !passwordHash.Check(pw) {
-		return nil, fmt.Errorf("incorrect password for user %q", username)
+		return nil, fmt.Errorf("%w: user %q", errIncorrectPassword, username)
 	}
 
 	userDB := prefixdb.New([]byte(username), ks.bcDB)
@@ -182,7 +185,7 @@ func (ks *keystore) CreateUser(username, pw string) error {
 		return err
 	}
 	if passwordHash != nil {
-		return fmt.Errorf("user already exists: %s", username)
+		return fmt.Errorf("%w: %s", errUserAlreadyExists, username)
 	}
 
 	if err := password.IsValid(pw, password.OK); err != nil {
@@ -224,9 +227,9 @@ func (ks *keystore) DeleteUser(username, pw string) error {
 	case err != nil:
 		return err
 	case passwordHash == nil:
-		return fmt.Errorf("user doesn't exist: %s", username)
+		return fmt.Errorf("%w: %s", errNonexistentUser, username)
 	case !passwordHash.Check(pw):
-		return fmt.Errorf("incorrect password for user %q", username)
+		return fmt.Errorf("%w: user %q", errIncorrectPassword, username)
 	}
 
 	userNameBytes := []byte(username)
@@ -290,7 +293,7 @@ func (ks *keystore) ImportUser(username, pw string, userBytes []byte) error {
 		return err
 	}
 	if passwordHash != nil {
-		return fmt.Errorf("user already exists: %s", username)
+		return fmt.Errorf("%w: %s", errUserAlreadyExists, username)
 	}
 
 	userData := user{}
@@ -298,7 +301,7 @@ func (ks *keystore) ImportUser(username, pw string, userBytes []byte) error {
 		return err
 	}
 	if !userData.Hash.Check(pw) {
-		return fmt.Errorf("incorrect password for user %q", username)
+		return fmt.Errorf("%w: user %q", errIncorrectPassword, username)
 	}
 
 	usrBytes, err := c.Marshal(codecVersion, &userData.Hash)
@@ -342,7 +345,7 @@ func (ks *keystore) ExportUser(username, pw string) ([]byte, error) {
 		return nil, err
 	}
 	if passwordHash == nil || !passwordHash.Check(pw) {
-		return nil, fmt.Errorf("incorrect password for user %q", username)
+		return nil, fmt.Errorf("%w: user %q", errIncorrectPassword, username)
 	}
 
 	userDB := prefixdb.New([]byte(username), ks.bcDB)

--- a/api/keystore/service_test.go
+++ b/api/keystore/service_test.go
@@ -4,15 +4,16 @@
 package keystore
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting"
+	"github.com/ava-labs/avalanchego/utils/password"
 )
 
 // strongPassword defines a password used for the following tests that
@@ -20,26 +21,22 @@ import (
 var strongPassword = "N_+=_jJ;^(<;{4,:*m6CET}'&N;83FYK.wtNpwp-Jt" // #nosec G101
 
 func TestServiceListNoUsers(t *testing.T) {
+	require := require.New(t)
+
 	ks, err := CreateTestKeystore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	s := service{ks: ks.(*keystore)}
 
 	reply := ListUsersReply{}
-	if err := s.ListUsers(nil, nil, &reply); err != nil {
-		t.Fatal(err)
-	}
-	if len(reply.Users) != 0 {
-		t.Fatalf("No users should have been created yet")
-	}
+	require.NoError(s.ListUsers(nil, nil, &reply))
+	require.Empty(reply.Users)
 }
 
 func TestServiceCreateUser(t *testing.T) {
+	require := require.New(t)
+
 	ks, err := CreateTestKeystore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	s := service{ks: ks.(*keystore)}
 
 	{
@@ -47,22 +44,14 @@ func TestServiceCreateUser(t *testing.T) {
 			Username: "bob",
 			Password: strongPassword,
 		}, &api.EmptyReply{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(err)
 	}
 
 	{
 		reply := ListUsersReply{}
-		if err := s.ListUsers(nil, nil, &reply); err != nil {
-			t.Fatal(err)
-		}
-		if len(reply.Users) != 1 {
-			t.Fatalf("One user should have been created")
-		}
-		if user := reply.Users[0]; user != "bob" {
-			t.Fatalf("'bob' should have been a user that was created")
-		}
+		require.NoError(s.ListUsers(nil, nil, &reply))
+		require.Len(reply.Users, 1)
+		require.Equal("bob", reply.Users[0])
 	}
 }
 
@@ -76,10 +65,10 @@ func genStr(n int) string {
 // TestServiceCreateUserArgsCheck generates excessively long usernames or
 // passwords to assure the sanity checks on string length are not exceeded
 func TestServiceCreateUserArgsCheck(t *testing.T) {
+	require := require.New(t)
+
 	ks, err := CreateTestKeystore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	s := service{ks: ks.(*keystore)}
 
 	{
@@ -88,10 +77,7 @@ func TestServiceCreateUserArgsCheck(t *testing.T) {
 			Username: genStr(maxUserLen + 1),
 			Password: strongPassword,
 		}, &reply)
-
-		if err != errUserMaxLength {
-			t.Fatal("User was created when it should have been rejected due to too long a Username, err =", err)
-		}
+		require.ErrorIs(err, errUserMaxLength)
 	}
 
 	{
@@ -100,31 +86,23 @@ func TestServiceCreateUserArgsCheck(t *testing.T) {
 			Username: "shortuser",
 			Password: genStr(maxUserLen + 1),
 		}, &reply)
-
-		if err == nil {
-			t.Fatal("User was created when it should have been rejected due to too long a Password, err =", err)
-		}
+		require.ErrorIs(err, password.ErrPassMaxLength)
 	}
 
 	{
 		reply := ListUsersReply{}
-		if err := s.ListUsers(nil, nil, &reply); err != nil {
-			t.Fatal(err)
-		}
-
-		if len(reply.Users) > 0 {
-			t.Fatalf("A user exists when there should be none")
-		}
+		require.NoError(s.ListUsers(nil, nil, &reply))
+		require.Empty(reply.Users)
 	}
 }
 
 // TestServiceCreateUserWeakPassword tests creating a new user with a weak
 // password to ensure the password strength check is working
 func TestServiceCreateUserWeakPassword(t *testing.T) {
+	require := require.New(t)
+
 	ks, err := CreateTestKeystore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	s := service{ks: ks.(*keystore)}
 
 	{
@@ -133,18 +111,15 @@ func TestServiceCreateUserWeakPassword(t *testing.T) {
 			Username: "bob",
 			Password: "weak",
 		}, &reply)
-
-		if err == nil {
-			t.Error("Expected error when testing weak password")
-		}
+		require.ErrorIs(err, password.ErrWeakPassword)
 	}
 }
 
 func TestServiceCreateDuplicate(t *testing.T) {
+	require := require.New(t)
+
 	ks, err := CreateTestKeystore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	s := service{ks: ks.(*keystore)}
 
 	{
@@ -152,9 +127,7 @@ func TestServiceCreateDuplicate(t *testing.T) {
 			Username: "bob",
 			Password: strongPassword,
 		}, &api.EmptyReply{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(err)
 	}
 
 	{
@@ -162,32 +135,29 @@ func TestServiceCreateDuplicate(t *testing.T) {
 			Username: "bob",
 			Password: strongPassword,
 		}, &api.EmptyReply{})
-		if err == nil {
-			t.Fatalf("Should have errored due to the username already existing")
-		}
+		require.ErrorIs(err, errUserAlreadyExists)
 	}
 }
 
 func TestServiceCreateUserNoName(t *testing.T) {
+	require := require.New(t)
+
 	ks, err := CreateTestKeystore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	s := service{ks: ks.(*keystore)}
 
 	reply := api.EmptyReply{}
-	if err := s.CreateUser(nil, &api.UserPass{
+	err = s.CreateUser(nil, &api.UserPass{
 		Password: strongPassword,
-	}, &reply); err == nil {
-		t.Fatalf("Shouldn't have allowed empty username")
-	}
+	}, &reply)
+	require.ErrorIs(err, errEmptyUsername)
 }
 
 func TestServiceUseBlockchainDB(t *testing.T) {
+	require := require.New(t)
+
 	ks, err := CreateTestKeystore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	s := service{ks: ks.(*keystore)}
 
 	{
@@ -195,41 +165,31 @@ func TestServiceUseBlockchainDB(t *testing.T) {
 			Username: "bob",
 			Password: strongPassword,
 		}, &api.EmptyReply{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(err)
 	}
 
 	{
 		db, err := ks.GetDatabase(ids.Empty, "bob", strongPassword)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := db.Put([]byte("hello"), []byte("world")); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(err)
+		require.NoError(db.Put([]byte("hello"), []byte("world")))
 	}
 
 	{
 		db, err := ks.GetDatabase(ids.Empty, "bob", strongPassword)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if val, err := db.Get([]byte("hello")); err != nil {
-			t.Fatal(err)
-		} else if !bytes.Equal(val, []byte("world")) {
-			t.Fatalf("Should have read '%s' from the db", "world")
-		}
+		require.NoError(err)
+		val, err := db.Get([]byte("hello"))
+		require.NoError(err)
+		require.Equal([]byte("world"), val)
 	}
 }
 
 func TestServiceExportImport(t *testing.T) {
+	require := require.New(t)
+
 	encodings := []formatting.Encoding{formatting.Hex}
 	for _, encoding := range encodings {
 		ks, err := CreateTestKeystore()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(err)
 		s := service{ks: ks.(*keystore)}
 
 		{
@@ -237,19 +197,13 @@ func TestServiceExportImport(t *testing.T) {
 				Username: "bob",
 				Password: strongPassword,
 			}, &api.EmptyReply{})
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(err)
 		}
 
 		{
 			db, err := ks.GetDatabase(ids.Empty, "bob", strongPassword)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := db.Put([]byte("hello"), []byte("world")); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(err)
+			require.NoError(db.Put([]byte("hello"), []byte("world")))
 		}
 
 		exportArgs := ExportUserArgs{
@@ -260,14 +214,10 @@ func TestServiceExportImport(t *testing.T) {
 			Encoding: encoding,
 		}
 		exportReply := ExportUserReply{}
-		if err := s.ExportUser(nil, &exportArgs, &exportReply); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(s.ExportUser(nil, &exportArgs, &exportReply))
 
 		newKS, err := CreateTestKeystore()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(err)
 		newS := service{ks: newKS.(*keystore)}
 
 		{
@@ -278,9 +228,7 @@ func TestServiceExportImport(t *testing.T) {
 				},
 				User: exportReply.User,
 			}, &api.EmptyReply{})
-			if err == nil {
-				t.Fatal("Should have errored due to incorrect password")
-			}
+			require.ErrorIs(err, errIncorrectPassword)
 		}
 
 		{
@@ -291,9 +239,7 @@ func TestServiceExportImport(t *testing.T) {
 				},
 				User: exportReply.User,
 			}, &api.EmptyReply{})
-			if err == nil {
-				t.Fatal("Should have errored due to empty username")
-			}
+			require.ErrorIs(err, errEmptyUsername)
 		}
 
 		{
@@ -305,21 +251,15 @@ func TestServiceExportImport(t *testing.T) {
 				User:     exportReply.User,
 				Encoding: encoding,
 			}, &api.EmptyReply{})
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.ErrorIs(err, nil)
 		}
 
 		{
 			db, err := newKS.GetDatabase(ids.Empty, "bob", strongPassword)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if val, err := db.Get([]byte("hello")); err != nil {
-				t.Fatal(err)
-			} else if !bytes.Equal(val, []byte("world")) {
-				t.Fatalf("Should have read '%s' from the db", "world")
-			}
+			require.NoError(err)
+			val, err := db.Get([]byte("hello"))
+			require.NoError(err)
+			require.Equal([]byte("world"), val)
 		}
 	}
 }
@@ -328,23 +268,23 @@ func TestServiceDeleteUser(t *testing.T) {
 	testUser := "testUser"
 	password := "passwTest@fake01ord"
 	tests := []struct {
-		desc      string
-		setup     func(ks *keystore) error
-		request   *api.UserPass
-		want      *api.EmptyReply
-		wantError bool
+		desc        string
+		setup       func(ks *keystore) error
+		request     *api.UserPass
+		want        *api.EmptyReply
+		expectedErr error
 	}{{
-		desc:      "empty user name case",
-		request:   &api.UserPass{},
-		wantError: true,
+		desc:        "empty user name case",
+		request:     &api.UserPass{},
+		expectedErr: errEmptyUsername,
 	}, {
-		desc:      "user not exists case",
-		request:   &api.UserPass{Username: "dummy"},
-		wantError: true,
+		desc:        "user not exists case",
+		request:     &api.UserPass{Username: "dummy"},
+		expectedErr: errNonexistentUser,
 	}, {
-		desc:      "user exists and invalid password case",
-		request:   &api.UserPass{Username: testUser, Password: "password"},
-		wantError: true,
+		desc:        "user exists and invalid password case",
+		request:     &api.UserPass{Username: testUser, Password: "password"},
+		expectedErr: errNonexistentUser,
 	}, {
 		desc: "user exists and valid password case",
 		setup: func(ks *keystore) error {
@@ -377,39 +317,28 @@ func TestServiceDeleteUser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			require := require.New(t)
+
 			ksIntf, err := CreateTestKeystore()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(err)
 			ks := ksIntf.(*keystore)
 			s := service{ks: ks}
 
 			if tt.setup != nil {
-				if err := tt.setup(ks); err != nil {
-					t.Fatalf("failed to create user setup in keystore: %v", err)
-				}
+				require.NoError(tt.setup(ks))
 			}
 			got := &api.EmptyReply{}
 			err = s.DeleteUser(nil, tt.request, got)
-			if (err != nil) != tt.wantError {
-				t.Fatalf("DeleteUser() failed: error %v, wantError %v", err, tt.wantError)
+			require.ErrorIs(err, tt.expectedErr)
+			if tt.expectedErr != nil {
+				return
 			}
+			require.Equal(tt.want, got)
+			_, ok := ks.usernameToPassword[testUser]
+			require.False(ok) // delete is successful
 
-			if !tt.wantError && !reflect.DeepEqual(tt.want, got) {
-				t.Fatalf("DeleteUser() failed: got %v, want %v", got, tt.want)
-			}
-
-			if err == nil { // delete is successful
-				if _, ok := ks.usernameToPassword[testUser]; ok {
-					t.Fatalf("DeleteUser() failed: expected the user %s should be delete from users map", testUser)
-				}
-
-				// deleted user details should be available to create user again.
-				err := s.CreateUser(nil, &api.UserPass{Username: testUser, Password: password}, &api.EmptyReply{})
-				if err != nil {
-					t.Fatalf("failed to create user: %v", err)
-				}
-			}
+			// deleted user details should be available to create user again.
+			require.NoError(s.CreateUser(nil, &api.UserPass{Username: testUser, Password: password}, &api.EmptyReply{}))
 		})
 	}
 }

--- a/api/keystore/service_test.go
+++ b/api/keystore/service_test.go
@@ -334,8 +334,7 @@ func TestServiceDeleteUser(t *testing.T) {
 				return
 			}
 			require.Equal(tt.want, got)
-			_, ok := ks.usernameToPassword[testUser]
-			require.False(ok) // delete is successful
+			require.NotContains(ks.usernameToPassword, testUser) // delete is successful
 
 			// deleted user details should be available to create user again.
 			require.NoError(s.CreateUser(nil, &api.UserPass{Username: testUser, Password: password}, &api.EmptyReply{}))

--- a/api/metrics/multi_gatherer_test.go
+++ b/api/metrics/multi_gatherer_test.go
@@ -27,14 +27,12 @@ func TestMultiGathererDuplicatedPrefix(t *testing.T) {
 	g := NewMultiGatherer()
 	og := NewOptionalGatherer()
 
-	err := g.Register("", og)
-	require.NoError(err)
+	require.NoError(g.Register("", og))
 
-	err = g.Register("", og)
+	err := g.Register("", og)
 	require.ErrorIs(err, errDuplicatedPrefix)
 
-	err = g.Register("lol", og)
-	require.NoError(err)
+	require.NoError(g.Register("lol", og))
 }
 
 func TestMultiGathererAddedError(t *testing.T) {
@@ -46,8 +44,7 @@ func TestMultiGathererAddedError(t *testing.T) {
 		err: errTest,
 	}
 
-	err := g.Register("", tg)
-	require.NoError(err)
+	require.NoError(g.Register("", tg))
 
 	mfs, err := g.Gather()
 	require.ErrorIs(err, errTest)
@@ -65,8 +62,7 @@ func TestMultiGathererNoAddedPrefix(t *testing.T) {
 		}},
 	}
 
-	err := g.Register("", tg)
-	require.NoError(err)
+	require.NoError(g.Register("", tg))
 
 	mfs, err := g.Gather()
 	require.NoError(err)
@@ -85,8 +81,7 @@ func TestMultiGathererAddedPrefix(t *testing.T) {
 		}},
 	}
 
-	err := g.Register(hello, tg)
-	require.NoError(err)
+	require.NoError(g.Register(hello, tg))
 
 	mfs, err := g.Gather()
 	require.NoError(err)
@@ -103,8 +98,7 @@ func TestMultiGathererJustPrefix(t *testing.T) {
 		mfs: []*dto.MetricFamily{{}},
 	}
 
-	err := g.Register(hello, tg)
-	require.NoError(err)
+	require.NoError(g.Register(hello, tg))
 
 	mfs, err := g.Gather()
 	require.NoError(err)
@@ -130,8 +124,7 @@ func TestMultiGathererSorted(t *testing.T) {
 		},
 	}
 
-	err := g.Register("", tg)
-	require.NoError(err)
+	require.NoError(g.Register("", tg))
 
 	mfs, err := g.Gather()
 	require.NoError(err)

--- a/api/metrics/optional_gatherer_test.go
+++ b/api/metrics/optional_gatherer_test.go
@@ -30,11 +30,8 @@ func TestOptionalGathererDuplicated(t *testing.T) {
 	g := NewOptionalGatherer()
 	og := NewOptionalGatherer()
 
-	err := g.Register(og)
-	require.NoError(err)
-
-	err = g.Register(og)
-	require.ErrorIs(err, errDuplicatedRegister)
+	require.NoError(g.Register(og))
+	require.ErrorIs(g.Register(og), errDuplicatedRegister)
 }
 
 func TestOptionalGathererAddedError(t *testing.T) {
@@ -46,8 +43,7 @@ func TestOptionalGathererAddedError(t *testing.T) {
 		err: errTest,
 	}
 
-	err := g.Register(tg)
-	require.NoError(err)
+	require.NoError(g.Register(tg))
 
 	mfs, err := g.Gather()
 	require.ErrorIs(err, errTest)
@@ -65,8 +61,7 @@ func TestMultiGathererAdded(t *testing.T) {
 		}},
 	}
 
-	err := g.Register(tg)
-	require.NoError(err)
+	require.NoError(g.Register(tg))
 
 	mfs, err := g.Gather()
 	require.NoError(err)

--- a/api/metrics/optional_gatherer_test.go
+++ b/api/metrics/optional_gatherer_test.go
@@ -31,7 +31,8 @@ func TestOptionalGathererDuplicated(t *testing.T) {
 	og := NewOptionalGatherer()
 
 	require.NoError(g.Register(og))
-	require.ErrorIs(g.Register(og), errDuplicatedRegister)
+	err := g.Register(og)
+	require.ErrorIs(err, errDuplicatedRegister)
 }
 
 func TestOptionalGathererAddedError(t *testing.T) {

--- a/api/server/router.go
+++ b/api/server/router.go
@@ -17,6 +17,7 @@ import (
 var (
 	errUnknownBaseURL  = errors.New("unknown base url")
 	errUnknownEndpoint = errors.New("unknown endpoint")
+	errAlreadyReserved = errors.New("route is either already aliased or already maps to a handle")
 )
 
 type router struct {
@@ -71,7 +72,7 @@ func (r *router) AddRouter(base, endpoint string, handler http.Handler) error {
 
 func (r *router) addRouter(base, endpoint string, handler http.Handler) error {
 	if r.reservedRoutes.Contains(base) {
-		return fmt.Errorf("couldn't route to %s as that route is either aliased or already maps to a handler", base)
+		return fmt.Errorf("%w: %s", errAlreadyReserved, base)
 	}
 
 	return r.forceAddRouter(base, endpoint, handler)
@@ -116,7 +117,7 @@ func (r *router) AddAlias(base string, aliases ...string) error {
 
 	for _, alias := range aliases {
 		if r.reservedRoutes.Contains(alias) {
-			return fmt.Errorf("couldn't alias to %s as that route is either already aliased or already maps to a handler", alias)
+			return fmt.Errorf("%w: %s", errAlreadyReserved, alias)
 		}
 	}
 

--- a/api/server/router_test.go
+++ b/api/server/router_test.go
@@ -6,6 +6,8 @@ package server
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type testHandler struct{ called bool }
@@ -15,63 +17,41 @@ func (t *testHandler) ServeHTTP(_ http.ResponseWriter, _ *http.Request) {
 }
 
 func TestAliasing(t *testing.T) {
+	require := require.New(t)
+
 	r := newRouter()
 
-	if err := r.AddAlias("1", "2", "3"); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.AddAlias("1", "4"); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.AddAlias("5", "1"); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.AddAlias("3", "6"); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.AddAlias("7", "4"); err == nil {
-		t.Fatalf("Already reserved %s", "4")
-	}
+	require.NoError(r.AddAlias("1", "2", "3"))
+	require.NoError(r.AddAlias("1", "4"))
+	require.NoError(r.AddAlias("5", "1"))
+	require.NoError(r.AddAlias("3", "6"))
+	require.ErrorIs(r.AddAlias("7", "4"), errAlreadyReserved)
 
 	handler1 := &testHandler{}
-	if err := r.AddRouter("2", "", handler1); err == nil {
-		t.Fatalf("Already reserved %s", "2")
-	}
-	if err := r.AddRouter("5", "", handler1); err != nil {
-		t.Fatal(err)
-	}
-	if handler, exists := r.routes["5"][""]; !exists {
-		t.Fatalf("Should have added %s", "5")
-	} else if handler != handler1 {
-		t.Fatalf("Registered unknown handler")
-	}
+	require.ErrorIs(r.AddRouter("2", "", handler1), errAlreadyReserved)
+	require.NoError(r.AddRouter("5", "", handler1))
 
-	if err := r.AddAlias("5", "7"); err != nil {
-		t.Fatal(err)
-	}
+	handler, exists := r.routes["5"][""]
+	require.True(exists)
+	require.Equal(handler1, handler)
 
-	if handler, exists := r.routes["7"][""]; !exists {
-		t.Fatalf("Should have added %s", "7")
-	} else if handler != handler1 {
-		t.Fatalf("Registered unknown handler")
-	}
+	require.NoError(r.AddAlias("5", "7"))
 
-	if handler, err := r.GetHandler("7", ""); err != nil {
-		t.Fatalf("Should have added %s", "7")
-	} else if handler != handler1 {
-		t.Fatalf("Registered unknown handler")
-	}
+	handler, exists = r.routes["7"][""]
+	require.True(exists)
+	require.Equal(handler1, handler)
+
+	handler, err := r.GetHandler("7", "")
+	require.NoError(err)
+	require.Equal(handler1, handler)
 }
 
 func TestBlock(t *testing.T) {
+	require := require.New(t)
 	r := newRouter()
 
-	if err := r.AddAlias("1", "1"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(r.AddAlias("1", "1"))
 
 	handler1 := &testHandler{}
-	if err := r.AddRouter("1", "", handler1); err == nil {
-		t.Fatalf("Permanently locked %s", "1")
-	}
+	require.ErrorIs(r.AddRouter("1", "", handler1), errAlreadyReserved)
 }

--- a/api/server/router_test.go
+++ b/api/server/router_test.go
@@ -25,10 +25,12 @@ func TestAliasing(t *testing.T) {
 	require.NoError(r.AddAlias("1", "4"))
 	require.NoError(r.AddAlias("5", "1"))
 	require.NoError(r.AddAlias("3", "6"))
-	require.ErrorIs(r.AddAlias("7", "4"), errAlreadyReserved)
+	err := r.AddAlias("7", "4")
+	require.ErrorIs(err, errAlreadyReserved)
 
 	handler1 := &testHandler{}
-	require.ErrorIs(r.AddRouter("2", "", handler1), errAlreadyReserved)
+	err = r.AddRouter("2", "", handler1)
+	require.ErrorIs(err, errAlreadyReserved)
 	require.NoError(r.AddRouter("5", "", handler1))
 
 	handler, exists := r.routes["5"][""]
@@ -41,7 +43,7 @@ func TestAliasing(t *testing.T) {
 	require.True(exists)
 	require.Equal(handler1, handler)
 
-	handler, err := r.GetHandler("7", "")
+	handler, err = r.GetHandler("7", "")
 	require.NoError(err)
 	require.Equal(handler1, handler)
 }
@@ -53,5 +55,6 @@ func TestBlock(t *testing.T) {
 	require.NoError(r.AddAlias("1", "1"))
 
 	handler1 := &testHandler{}
-	require.ErrorIs(r.AddRouter("1", "", handler1), errAlreadyReserved)
+	err := r.AddRouter("1", "", handler1)
+	require.ErrorIs(err, errAlreadyReserved)
 }

--- a/utils/password/hash_test.go
+++ b/utils/password/hash_test.go
@@ -5,20 +5,16 @@ package password
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHash(t *testing.T) {
+	require := require.New(t)
+
 	h := Hash{}
-	if err := h.Set("heytherepal"); err != nil {
-		t.Fatal(err)
-	}
-	if !h.Check("heytherepal") {
-		t.Fatalf("Should have verified the password")
-	}
-	if h.Check("heytherepal!") {
-		t.Fatalf("Shouldn't have verified the password")
-	}
-	if h.Check("") {
-		t.Fatalf("Shouldn't have verified the password")
-	}
+	require.NoError(h.Set("heytherepal"))
+	require.True(h.Check("heytherepal"))
+	require.False(h.Check("heytherepal!"))
+	require.False(h.Check(""))
 }

--- a/utils/password/password.go
+++ b/utils/password/password.go
@@ -52,8 +52,8 @@ const (
 
 var (
 	ErrEmptyPassword = errors.New("empty password")
-	errPassMaxLength = fmt.Errorf("password exceeds maximum length of %d chars", maxPassLen)
-	errWeakPassword  = errors.New("password is too weak")
+	ErrPassMaxLength = fmt.Errorf("password exceeds maximum length of %d chars", maxPassLen)
+	ErrWeakPassword  = errors.New("password is too weak")
 )
 
 // SufficientlyStrong returns true if [password] has strength greater than or
@@ -72,9 +72,9 @@ func IsValid(password string, minimumStrength Strength) error {
 	case len(password) == 0:
 		return ErrEmptyPassword
 	case len(password) > maxPassLen:
-		return errPassMaxLength
+		return ErrPassMaxLength
 	case !SufficientlyStrong(password, minimumStrength):
-		return errWeakPassword
+		return ErrWeakPassword
 	default:
 		return nil
 	}

--- a/utils/password/password_test.go
+++ b/utils/password/password_test.go
@@ -6,6 +6,8 @@ package password
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSufficientlyStrong(t *testing.T) {
@@ -32,64 +34,53 @@ func TestSufficientlyStrong(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s-%d", test.password, test.expected), func(t *testing.T) {
-			if !SufficientlyStrong(test.password, test.expected) {
-				t.Fatalf("expected %q to be rated stronger", test.password)
-			}
+			require.True(t, SufficientlyStrong(test.password, test.expected))
 		})
 	}
 }
 
 func TestIsValid(t *testing.T) {
 	tests := []struct {
-		password  string
-		expected  Strength
-		shouldErr bool
+		password    string
+		expected    Strength
+		expectedErr error
 	}{
 		{
-			password:  "",
-			expected:  VeryWeak,
-			shouldErr: true,
+			password:    "",
+			expected:    VeryWeak,
+			expectedErr: ErrEmptyPassword,
 		},
 		{
-			password:  "a",
-			expected:  VeryWeak,
-			shouldErr: false,
+			password: "a",
+			expected: VeryWeak,
 		},
 		{
-			password:  "password",
-			expected:  VeryWeak,
-			shouldErr: false,
+			password: "password",
+			expected: VeryWeak,
 		},
 		{
-			password:  "thisisareallylongandpresumablyverystrongpassword",
-			expected:  VeryStrong,
-			shouldErr: false,
+			password: "thisisareallylongandpresumablyverystrongpassword",
+			expected: VeryStrong,
 		},
 		{
-			password:  string(make([]byte, maxPassLen)),
-			expected:  VeryWeak,
-			shouldErr: false,
+			password: string(make([]byte, maxPassLen)),
+			expected: VeryWeak,
 		},
 		{
-			password:  string(make([]byte, maxPassLen+1)),
-			expected:  VeryWeak,
-			shouldErr: true,
+			password:    string(make([]byte, maxPassLen+1)),
+			expected:    VeryWeak,
+			expectedErr: ErrPassMaxLength,
 		},
 		{
-			password:  "password",
-			expected:  Weak,
-			shouldErr: true,
+			password:    "password",
+			expected:    Weak,
+			expectedErr: ErrWeakPassword,
 		},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s-%d", test.password, test.expected), func(t *testing.T) {
 			err := IsValid(test.password, test.expected)
-			if err == nil && test.shouldErr {
-				t.Fatalf("expected %q to be invalid", test.password)
-			}
-			if err != nil && !test.shouldErr {
-				t.Fatalf("expected %q to be valid but returned %s", test.password, err)
-			}
+			require.ErrorIs(t, err, test.expectedErr)
 		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged

factored out of #1453 

## How this works

`t.Fatalf` -> `require`

## How this was tested

CI
