### PR TITLE
vms/platformvm: document/clarify connected/uptime scale in fraction

### DIFF
--- a/vms/platformvm/metrics/metrics.go
+++ b/vms/platformvm/metrics/metrics.go
@@ -62,13 +62,13 @@ func New(
 		percentConnected: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "percent_connected",
-			Help:      "Percent of connected stake",
+			Help:      "Percent of connected stake (fraction of 1)",
 		}),
 		subnetPercentConnected: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "percent_connected_subnet",
-				Help:      "Percent of connected subnet weight",
+				Help:      "Percent of connected subnet weight (fraction of 1)",
 			},
 			[]string{"subnetID"},
 		),

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -681,9 +681,10 @@ func (vm *VM) Logger() logging.Logger {
 	return vm.ctx.Log
 }
 
-// Returns the percentage of the total stake of the subnet connected to this
+// Returns the fraction of the total stake of the subnet connected to this
 // node.
-func (vm *VM) getPercentConnected(subnetID ids.ID) (float64, error) {
+// If total validator set weight is 0, it returns 1.
+func (vm *VM) getConnectedInFraction(subnetID ids.ID) (float64, error) {
 	vdrSet, exists := vm.Validators.Get(subnetID)
 	if !exists {
 		return 0, errMissingValidatorSet


### PR DESCRIPTION
## Why this should be merged

We need to clarify the percent connected metrics is actually in the fraction of 1, not 100.

Found this as I was going through the metrics.

## How this works

Just add comments on the metrics doc, and rename functions to accurately describe what it does.

## How this was tested

N/A

## TODO

Should we rename the metrics as well? Super confusing right now. The health check message does `*100` to accurately say what it is, but metrics are not.
