### PR TITLE
snow, proposervm: nits on comment, error format string, clarify vars

### DIFF
--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -121,8 +121,8 @@ func (p *postForkCommonComponents) Verify(
 		return errTimeTooAdvanced
 	}
 
-	// If the node is currently syncing - we don't assume that the P-chain has
-	// been synced up to this point yet.
+	// if this node is done with bootstrapped,
+	// assume the P-chain has been synced up to this point
 	if p.vm.consensusState == snow.NormalOp {
 		childID := child.ID()
 		currentPChainHeight, err := p.vm.ctx.ValidatorState.GetCurrentHeight(ctx)


### PR DESCRIPTION

## Why this should be merged

> If there is more than one %w verb, the returned error will implement an Unwrap method returning a []error containing all the %w operands in the order they appear in the arguments.

ref. https://pkg.go.dev/fmt#Errorf

## How this works

And just cleanups in variables.

## How this was tested

N/A
