### PR TITLE
codec: remove "SetMaxSize" from "Manager", remove unnecessary lock

### DIFF
--- a/codec/manager.go
+++ b/codec/manager.go
@@ -116,7 +116,6 @@ func (m *manager) Marshal(version uint16, value interface{}) ([]byte, error) {
 	m.lock.RLock()
 	c, exists := m.codecs[version]
 	m.lock.RUnlock()
-
 	if !exists {
 		return nil, ErrUnknownVersion
 	}
@@ -139,22 +138,19 @@ func (m *manager) Unmarshal(bytes []byte, dest interface{}) (uint16, error) {
 		return 0, errUnmarshalNil
 	}
 
-	m.lock.RLock()
 	if byteLen := len(bytes); byteLen > m.maxSize {
-		m.lock.RUnlock()
 		return 0, fmt.Errorf("%w: %d > %d", errUnmarshalTooBig, byteLen, m.maxSize)
 	}
 
 	p := wrappers.Packer{
 		Bytes: bytes,
 	}
-
 	version := p.UnpackShort()
 	if p.Errored() { // Make sure the codec version is correct
-		m.lock.RUnlock()
 		return 0, errCantUnpackVersion
 	}
 
+	m.lock.RLock()
 	c, exists := m.codecs[version]
 	m.lock.RUnlock()
 	if !exists {

--- a/codec/manager.go
+++ b/codec/manager.go
@@ -40,10 +40,6 @@ type Manager interface {
 	// Associate the given codec with the given version ID
 	RegisterCodec(version uint16, codec Codec) error
 
-	// Define the maximum size, in bytes, of something serialized/deserialized
-	// by this codec manager
-	SetMaxSize(int)
-
 	// Size returns the size, in bytes, of [value] when it's marshaled
 	// using the codec with the given version.
 	// RegisterCodec must have been called with that version.
@@ -90,13 +86,6 @@ func (m *manager) RegisterCodec(version uint16, codec Codec) error {
 	}
 	m.codecs[version] = codec
 	return nil
-}
-
-// SetMaxSize of bytes allowed
-func (m *manager) SetMaxSize(size int) {
-	m.lock.Lock()
-	m.maxSize = size
-	m.lock.Unlock()
 }
 
 func (m *manager) Size(version uint16, value interface{}) (int, error) {

--- a/codec/mock_manager.go
+++ b/codec/mock_manager.go
@@ -65,18 +65,6 @@ func (mr *MockManagerMockRecorder) RegisterCodec(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCodec", reflect.TypeOf((*MockManager)(nil).RegisterCodec), arg0, arg1)
 }
 
-// SetMaxSize mocks base method.
-func (m *MockManager) SetMaxSize(arg0 int) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMaxSize", arg0)
-}
-
-// SetMaxSize indicates an expected call of SetMaxSize.
-func (mr *MockManagerMockRecorder) SetMaxSize(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxSize", reflect.TypeOf((*MockManager)(nil).SetMaxSize), arg0)
-}
-
 // Size mocks base method.
 func (m *MockManager) Size(arg0 uint16, arg1 interface{}) (int, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why this should be merged

We should not expose `SetMaxSize` of codec (I don't see any use case to switch the codec max size after initialization).

## How this works

Remove `SetMaxSize` and unnecessary locks during unpacking the version field.

## How this was tested

UT