### PR TITLE
chains: move "msgChan" closer to the first use (readability)

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -629,10 +629,6 @@ func (m *manager) createAvalancheChain(
 		return nil, err
 	}
 
-	// The channel through which a VM may send messages to the consensus engine
-	// VM uses this channel to notify engine that a block is ready to be made
-	msgChan := make(chan common.Message, defaultChannelSize)
-
 	// Passes messages from the avalanche engines to the network
 	avalancheMessageSender, err := sender.New(
 		ctx,
@@ -728,6 +724,10 @@ func (m *manager) createAvalancheChain(
 	}
 
 	ctx.Context.Metrics = avalancheRegisterer
+
+	// The channel through which a VM may send messages to the consensus engine
+	// VM uses this channel to notify engine that a block is ready to be made
+	msgChan := make(chan common.Message, defaultChannelSize)
 
 	// The only difference between using avalancheMessageSender and
 	// snowmanMessageSender here is where the metrics will be placed. Because we
@@ -1009,10 +1009,6 @@ func (m *manager) createSnowmanChain(
 		return nil, err
 	}
 
-	// The channel through which a VM may send messages to the consensus engine
-	// VM uses this channel to notify engine that a block is ready to be made
-	msgChan := make(chan common.Message, defaultChannelSize)
-
 	// Passes messages from the consensus engine to the network
 	messageSender, err := sender.New(
 		ctx,
@@ -1125,6 +1121,10 @@ func (m *manager) createSnowmanChain(
 	if m.TracingEnabled {
 		vm = tracedvm.NewBlockVM(vm, "proposervm", m.Tracer)
 	}
+
+	// The channel through which a VM may send messages to the consensus engine
+	// VM uses this channel to notify engine that a block is ready to be made
+	msgChan := make(chan common.Message, defaultChannelSize)
 
 	if err := vm.Initialize(
 		context.TODO(),


### PR DESCRIPTION
## Why this should be merged

in case the following calls fail and `msgChan` never used, and for better readability, move `msgChan` to right above the first use of the channel.

## How this works

N/A

## How this was tested

N/A