### PR TITLE
[DISCUSS] vms/platformvm: only add to mempool/cache on successful gossip

### DIFF
--- a/vms/platformvm/blocks/builder/network.go
+++ b/vms/platformvm/blocks/builder/network.go
@@ -153,7 +153,6 @@ func (n *network) GossipTx(tx *txs.Tx) error {
 	if _, has := n.recentTxs.Get(txID); has {
 		return nil
 	}
-	n.recentTxs.Put(txID, struct{}{})
 
 	n.ctx.Log.Debug("gossiping tx",
 		zap.Stringer("txID", txID),
@@ -164,5 +163,11 @@ func (n *network) GossipTx(tx *txs.Tx) error {
 	if err != nil {
 		return fmt.Errorf("GossipTx: failed to build Tx message: %w", err)
 	}
-	return n.appSender.SendAppGossip(context.TODO(), msgBytes)
+
+	err = n.appSender.SendAppGossip(context.TODO(), msgBytes)
+	if err == nil {
+		// only cache iff successful
+		n.recentTxs.Put(txID, struct{}{})
+	}
+	return err
 }


### PR DESCRIPTION
## Why this should be merged

Only add successfully gossiped transactiosn to its mempool and cache, in case of transient message send errors (e.g., send app gossip message failures due to network timeouts).

## How this works

Only add if there was no error.

## How this was tested

UT

## Discuss

Is it better if we let the transaction stuck in the mempool on send app gossip failures, or allow `AddUnverifiedTx` retries to resend the app gossip?