### PR TITLE
ban function params for `require.ErrorIs`

### DIFF
--- a/codec/test_codec.go
+++ b/codec/test_codec.go
@@ -157,7 +157,8 @@ func TestRegisterStructTwice(codec GeneralCodec, t testing.TB) {
 	require := require.New(t)
 
 	require.NoError(codec.RegisterType(&MyInnerStruct{}))
-	require.ErrorIs(codec.RegisterType(&MyInnerStruct{}), ErrDuplicateType)
+	err := codec.RegisterType(&MyInnerStruct{})
+	require.ErrorIs(err, ErrDuplicateType)
 }
 
 func TestUInt32(codec GeneralCodec, t testing.TB) {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,7 +21,7 @@ fi
 # by default, "./scripts/lint.sh" runs all lint tests
 # to run only "license_header" test
 # TESTS='license_header' ./scripts/lint.sh
-TESTS=${TESTS:-"golangci_lint license_header, require_error_is_no_funcs_as_params"}
+TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params"}
 
 function test_golangci_lint {
   go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,7 +21,7 @@ fi
 # by default, "./scripts/lint.sh" runs all lint tests
 # to run only "license_header" test
 # TESTS='license_header' ./scripts/lint.sh
-TESTS=${TESTS:-"golangci_lint license_header"}
+TESTS=${TESTS:-"golangci_lint license_header, require_error_is_no_funcs_as_params"}
 
 function test_golangci_lint {
   go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
@@ -49,6 +49,13 @@ function test_license_header {
   -f ./LICENSE.header \
   ${_addlicense_flags} \
   "${files[@]}"
+}
+
+function test_require_error_is_no_funcs_as_params {
+  if grep -R -zo -P 'require.ErrorIs\(.+?\)[^\n]*\)\n' .; then
+    echo ""
+    return 1
+  fi
 }
 
 function run {

--- a/snow/choices/status_test.go
+++ b/snow/choices/status_test.go
@@ -17,7 +17,8 @@ func TestStatusValid(t *testing.T) {
 	require.NoError(Rejected.Valid())
 	require.NoError(Processing.Valid())
 	require.NoError(Unknown.Valid())
-	require.ErrorIs(Status(math.MaxInt32).Valid(), errUnknownStatus)
+	err := Status(math.MaxInt32).Valid()
+	require.ErrorIs(err, errUnknownStatus)
 }
 
 func TestStatusDecided(t *testing.T) {

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -1751,7 +1751,8 @@ func ErrorOnAddDecidedBlock(t *testing.T, factory Factory) {
 		ParentV: Genesis.IDV,
 		HeightV: Genesis.HeightV + 1,
 	}
-	require.ErrorIs(sm.Add(context.Background(), block0), errDuplicateAdd)
+	err := sm.Add(context.Background(), block0)
+	require.ErrorIs(err, errDuplicateAdd)
 }
 
 func ErrorOnAddDuplicateBlockID(t *testing.T, factory Factory) {
@@ -1789,7 +1790,8 @@ func ErrorOnAddDuplicateBlockID(t *testing.T, factory Factory) {
 	}
 
 	require.NoError(sm.Add(context.Background(), block0))
-	require.ErrorIs(sm.Add(context.Background(), block1), errDuplicateAdd)
+	err := sm.Add(context.Background(), block1)
+	require.ErrorIs(err, errDuplicateAdd)
 }
 
 func gatherCounterGauge(t *testing.T, reg *prometheus.Registry) map[string]float64 {

--- a/vms/platformvm/blocks/executor/standard_block_test.go
+++ b/vms/platformvm/blocks/executor/standard_block_test.go
@@ -264,7 +264,8 @@ func TestBanffStandardBlockTimeVerification(t *testing.T) {
 		)
 		require.NoError(err)
 		block := env.blkManager.NewBlock(banffChildBlk)
-		require.ErrorIs(block.Verify(context.Background()), errBanffStandardBlockWithoutChanges)
+		err = block.Verify(context.Background())
+		require.ErrorIs(err, errBanffStandardBlockWithoutChanges)
 	}
 
 	{

--- a/vms/platformvm/signer/proof_of_possession_test.go
+++ b/vms/platformvm/signer/proof_of_possession_test.go
@@ -22,17 +22,20 @@ func TestProofOfPossession(t *testing.T) {
 	blsPOP, err = newProofOfPossession()
 	require.NoError(err)
 	blsPOP.ProofOfPossession = [bls.SignatureLen]byte{}
-	require.ErrorIs(blsPOP.Verify(), bls.ErrFailedSignatureDecompress)
+	err = blsPOP.Verify()
+	require.ErrorIs(err, bls.ErrFailedSignatureDecompress)
 
 	blsPOP, err = newProofOfPossession()
 	require.NoError(err)
 	blsPOP.PublicKey = [bls.PublicKeyLen]byte{}
-	require.ErrorIs(blsPOP.Verify(), bls.ErrFailedPublicKeyDecompress)
+	err = blsPOP.Verify()
+	require.ErrorIs(err, bls.ErrFailedPublicKeyDecompress)
 
 	newBLSPOP, err := newProofOfPossession()
 	require.NoError(err)
 	newBLSPOP.ProofOfPossession = blsPOP.ProofOfPossession
-	require.ErrorIs(newBLSPOP.Verify(), errInvalidProofOfPossession)
+	err = newBLSPOP.Verify()
+	require.ErrorIs(err, errInvalidProofOfPossession)
 }
 
 func TestNewProofOfPossessionDeterministic(t *testing.T) {

--- a/vms/platformvm/txs/add_delegator_test.go
+++ b/vms/platformvm/txs/add_delegator_test.go
@@ -34,10 +34,12 @@ func TestAddDelegatorTxSyntacticVerify(t *testing.T) {
 	)
 
 	// Case : signed tx is nil
-	require.ErrorIs(stx.SyntacticVerify(ctx), ErrNilSignedTx)
+	err = stx.SyntacticVerify(ctx)
+	require.ErrorIs(err, ErrNilSignedTx)
 
 	// Case : unsigned tx is nil
-	require.ErrorIs(addDelegatorTx.SyntacticVerify(ctx), ErrNilTx)
+	err = addDelegatorTx.SyntacticVerify(ctx)
+	require.ErrorIs(err, ErrNilTx)
 
 	validatorWeight := uint64(2022)
 	inputs := []*avax.TransferableInput{{
@@ -98,7 +100,8 @@ func TestAddDelegatorTxSyntacticVerify(t *testing.T) {
 
 	// Case: signed tx not initialized
 	stx = &Tx{Unsigned: addDelegatorTx}
-	require.ErrorIs(stx.SyntacticVerify(ctx), errSignedTxNotInitialized)
+	err = stx.SyntacticVerify(ctx)
+	require.ErrorIs(err, errSignedTxNotInitialized)
 
 	// Case: valid tx
 	stx, err = NewSigned(addDelegatorTx, Codec, signers)
@@ -119,7 +122,8 @@ func TestAddDelegatorTxSyntacticVerify(t *testing.T) {
 	addDelegatorTx.Wght = 2 * validatorWeight
 	stx, err = NewSigned(addDelegatorTx, Codec, signers)
 	require.NoError(err)
-	require.ErrorIs(stx.SyntacticVerify(ctx), errDelegatorWeightMismatch)
+	err = stx.SyntacticVerify(ctx)
+	require.ErrorIs(err, errDelegatorWeightMismatch)
 	addDelegatorTx.Wght = validatorWeight
 }
 

--- a/vms/platformvm/txs/add_subnet_validator_test.go
+++ b/vms/platformvm/txs/add_subnet_validator_test.go
@@ -32,10 +32,12 @@ func TestAddSubnetValidatorTxSyntacticVerify(t *testing.T) {
 	)
 
 	// Case : signed tx is nil
-	require.ErrorIs(stx.SyntacticVerify(ctx), ErrNilSignedTx)
+	err = stx.SyntacticVerify(ctx)
+	require.ErrorIs(err, ErrNilSignedTx)
 
 	// Case : unsigned tx is nil
-	require.ErrorIs(addSubnetValidatorTx.SyntacticVerify(ctx), ErrNilTx)
+	err = addSubnetValidatorTx.SyntacticVerify(ctx)
+	require.ErrorIs(err, ErrNilTx)
 
 	validatorWeight := uint64(2022)
 	subnetID := ids.ID{'s', 'u', 'b', 'n', 'e', 't', 'I', 'D'}

--- a/vms/platformvm/txs/add_validator_test.go
+++ b/vms/platformvm/txs/add_validator_test.go
@@ -33,10 +33,12 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 	)
 
 	// Case : signed tx is nil
-	require.ErrorIs(stx.SyntacticVerify(ctx), ErrNilSignedTx)
+	err = stx.SyntacticVerify(ctx)
+	require.ErrorIs(err, ErrNilSignedTx)
 
 	// Case : unsigned tx is nil
-	require.ErrorIs(addValidatorTx.SyntacticVerify(ctx), ErrNilTx)
+	err = addValidatorTx.SyntacticVerify(ctx)
+	require.ErrorIs(err, ErrNilTx)
 
 	validatorWeight := uint64(2022)
 	rewardAddress := preFundedKeys[0].PublicKey().Address()

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -58,7 +58,8 @@ func TestRewardValidatorTxExecuteOnCommit(t *testing.T) {
 		Backend:       &env.backend,
 		Tx:            tx,
 	}
-	require.ErrorIs(tx.Unsigned.Visit(&txExecutor), ErrRemoveStakerTooEarly)
+	err = tx.Unsigned.Visit(&txExecutor)
+	require.ErrorIs(err, ErrRemoveStakerTooEarly)
 
 	// Advance chain timestamp to time that next validator leaves
 	env.state.SetTimestamp(stakerToRemove.EndTime)
@@ -79,7 +80,8 @@ func TestRewardValidatorTxExecuteOnCommit(t *testing.T) {
 		Backend:       &env.backend,
 		Tx:            tx,
 	}
-	require.ErrorIs(tx.Unsigned.Visit(&txExecutor), ErrRemoveWrongStaker)
+	err = tx.Unsigned.Visit(&txExecutor)
+	require.ErrorIs(err, ErrRemoveWrongStaker)
 
 	// Case 3: Happy path
 	tx, err = env.txBuilder.NewRewardValidatorTx(stakerToRemove.TxID)
@@ -159,7 +161,8 @@ func TestRewardValidatorTxExecuteOnAbort(t *testing.T) {
 		Backend:       &env.backend,
 		Tx:            tx,
 	}
-	require.ErrorIs(tx.Unsigned.Visit(&txExecutor), ErrRemoveStakerTooEarly)
+	err = tx.Unsigned.Visit(&txExecutor)
+	require.ErrorIs(err, ErrRemoveStakerTooEarly)
 
 	// Advance chain timestamp to time that next validator leaves
 	env.state.SetTimestamp(stakerToRemove.EndTime)
@@ -174,7 +177,8 @@ func TestRewardValidatorTxExecuteOnAbort(t *testing.T) {
 		Backend:       &env.backend,
 		Tx:            tx,
 	}
-	require.ErrorIs(tx.Unsigned.Visit(&txExecutor), ErrRemoveWrongStaker)
+	err = tx.Unsigned.Visit(&txExecutor)
+	require.ErrorIs(err, ErrRemoveWrongStaker)
 
 	// Case 3: Happy path
 	tx, err = env.txBuilder.NewRewardValidatorTx(stakerToRemove.TxID)

--- a/vms/platformvm/txs/subnet_validator_test.go
+++ b/vms/platformvm/txs/subnet_validator_test.go
@@ -21,7 +21,8 @@ func TestSubnetValidatorVerifySubnetID(t *testing.T) {
 			Subnet: constants.PrimaryNetworkID,
 		}
 
-		require.ErrorIs(vdr.Verify(), errBadSubnetID)
+		err := vdr.Verify()
+		require.ErrorIs(err, errBadSubnetID)
 	}
 
 	// Happy path

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -610,9 +610,10 @@ func TestNoStateSummariesServedWhileRepairingHeightIndex(t *testing.T) {
 
 	// set height index to reindexing
 	proVM.hIndexer.MarkRepaired(false)
-	require.ErrorIs(proVM.VerifyHeightIndex(context.Background()), block.ErrIndexIncomplete)
+	err := proVM.VerifyHeightIndex(context.Background())
+	require.ErrorIs(err, block.ErrIndexIncomplete)
 
-	_, err := proVM.GetLastStateSummary(context.Background())
+	_, err = proVM.GetLastStateSummary(context.Background())
 	require.ErrorIs(err, block.ErrIndexIncomplete)
 
 	_, err = proVM.GetStateSummary(context.Background(), summaryHeight)

--- a/vms/registry/vm_registerer_test.go
+++ b/vms/registry/vm_registerer_test.go
@@ -33,7 +33,8 @@ func TestRegisterRegisterVMFails(t *testing.T) {
 	// We fail to register the VM
 	resources.mockManager.EXPECT().RegisterFactory(gomock.Any(), id, vmFactory).Times(1).Return(errTest)
 
-	require.ErrorIs(t, resources.registerer.Register(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.Register(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests Register if a VM doesn't actually implement VM.
@@ -48,7 +49,8 @@ func TestRegisterBadVM(t *testing.T) {
 	// Since this factory produces a bad vm, we should get an error.
 	vmFactory.EXPECT().New(logging.NoLog{}).Times(1).Return(vm, nil)
 
-	require.ErrorIs(t, resources.registerer.Register(context.Background(), id, vmFactory), errNotVM)
+	err := resources.registerer.Register(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errNotVM)
 }
 
 // Tests Register if creating endpoints for a VM fails + shutdown fails
@@ -65,7 +67,8 @@ func TestRegisterCreateHandlersAndShutdownFails(t *testing.T) {
 	vm.EXPECT().CreateStaticHandlers(gomock.Any()).Return(nil, errTest).Times(1)
 	vm.EXPECT().Shutdown(gomock.Any()).Return(errTest).Times(1)
 
-	require.ErrorIs(t, resources.registerer.Register(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.Register(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests Register if creating endpoints for a VM fails + shutdown succeeds
@@ -82,7 +85,8 @@ func TestRegisterCreateHandlersFails(t *testing.T) {
 	vm.EXPECT().CreateStaticHandlers(gomock.Any()).Return(nil, errTest).Times(1)
 	vm.EXPECT().Shutdown(gomock.Any()).Return(nil).Times(1)
 
-	require.ErrorIs(t, resources.registerer.Register(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.Register(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests Register if we fail to register the new endpoint on the server.
@@ -111,7 +115,8 @@ func TestRegisterAddRouteFails(t *testing.T) {
 		Times(1).
 		Return(errTest)
 
-	require.ErrorIs(t, resources.registerer.Register(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.Register(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests Register we can't find the alias for the newly registered vm
@@ -141,7 +146,8 @@ func TestRegisterAliasLookupFails(t *testing.T) {
 		Return(nil)
 	resources.mockManager.EXPECT().Aliases(id).Times(1).Return(nil, errTest)
 
-	require.ErrorIs(t, resources.registerer.Register(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.Register(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests Register if adding aliases for the newly registered vm fails
@@ -179,7 +185,8 @@ func TestRegisterAddAliasesFails(t *testing.T) {
 		).
 		Return(errTest)
 
-	require.ErrorIs(t, resources.registerer.Register(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.Register(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests Register if no errors are thrown
@@ -230,7 +237,8 @@ func TestRegisterWithReadLockRegisterVMFails(t *testing.T) {
 	// We fail to register the VM
 	resources.mockManager.EXPECT().RegisterFactory(gomock.Any(), id, vmFactory).Times(1).Return(errTest)
 
-	require.ErrorIs(t, resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests RegisterWithReadLock if a VM doesn't actually implement VM.
@@ -245,7 +253,8 @@ func TestRegisterWithReadLockBadVM(t *testing.T) {
 	// Since this factory produces a bad vm, we should get an error.
 	vmFactory.EXPECT().New(logging.NoLog{}).Times(1).Return(vm, nil)
 
-	require.ErrorIs(t, resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory), errNotVM)
+	err := resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errNotVM)
 }
 
 // Tests RegisterWithReadLock if creating endpoints for a VM fails + shutdown fails
@@ -262,7 +271,8 @@ func TestRegisterWithReadLockCreateHandlersAndShutdownFails(t *testing.T) {
 	vm.EXPECT().CreateStaticHandlers(gomock.Any()).Return(nil, errTest).Times(1)
 	vm.EXPECT().Shutdown(gomock.Any()).Return(errTest).Times(1)
 
-	require.ErrorIs(t, resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests RegisterWithReadLock if creating endpoints for a VM fails + shutdown succeeds
@@ -279,7 +289,8 @@ func TestRegisterWithReadLockCreateHandlersFails(t *testing.T) {
 	vm.EXPECT().CreateStaticHandlers(gomock.Any()).Return(nil, errTest).Times(1)
 	vm.EXPECT().Shutdown(gomock.Any()).Return(nil).Times(1)
 
-	require.ErrorIs(t, resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests RegisterWithReadLock if we fail to register the new endpoint on the server.
@@ -308,7 +319,8 @@ func TestRegisterWithReadLockAddRouteWithReadLockFails(t *testing.T) {
 		Times(1).
 		Return(errTest)
 
-	require.ErrorIs(t, resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests RegisterWithReadLock we can't find the alias for the newly registered vm
@@ -338,7 +350,8 @@ func TestRegisterWithReadLockAliasLookupFails(t *testing.T) {
 		Return(nil)
 	resources.mockManager.EXPECT().Aliases(id).Times(1).Return(nil, errTest)
 
-	require.ErrorIs(t, resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests RegisterWithReadLock if adding aliases for the newly registered vm fails
@@ -376,7 +389,8 @@ func TestRegisterWithReadLockAddAliasesFails(t *testing.T) {
 		).
 		Return(errTest)
 
-	require.ErrorIs(t, resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory), errTest)
+	err := resources.registerer.RegisterWithReadLock(context.Background(), id, vmFactory)
+	require.ErrorIs(t, err, errTest)
 }
 
 // Tests RegisterWithReadLock if no errors are thrown

--- a/vms/secp256k1fx/credential_test.go
+++ b/vms/secp256k1fx/credential_test.go
@@ -23,7 +23,8 @@ func TestCredentialVerify(t *testing.T) {
 func TestCredentialVerifyNil(t *testing.T) {
 	require := require.New(t)
 	cred := (*Credential)(nil)
-	require.ErrorIs(cred.Verify(), ErrNilCredential)
+	err := cred.Verify()
+	require.ErrorIs(err, ErrNilCredential)
 }
 
 func TestCredentialSerialize(t *testing.T) {

--- a/vms/secp256k1fx/fx_test.go
+++ b/vms/secp256k1fx/fx_test.go
@@ -64,7 +64,8 @@ func TestFxInitialize(t *testing.T) {
 func TestFxInitializeInvalid(t *testing.T) {
 	require := require.New(t)
 	fx := Fx{}
-	require.ErrorIs(fx.Initialize(nil), ErrWrongVMType)
+	err := fx.Initialize(nil)
+	require.ErrorIs(err, ErrWrongVMType)
 }
 
 func TestFxVerifyTransfer(t *testing.T) {
@@ -137,7 +138,8 @@ func TestFxVerifyTransferNilTx(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(nil, in, cred, out), ErrWrongTxType)
+	err := fx.VerifyTransfer(nil, in, cred, out)
+	require.ErrorIs(err, ErrWrongTxType)
 }
 
 func TestFxVerifyTransferNilOutput(t *testing.T) {
@@ -163,7 +165,8 @@ func TestFxVerifyTransferNilOutput(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, nil), ErrWrongUTXOType)
+	err := fx.VerifyTransfer(tx, in, cred, nil)
+	require.ErrorIs(err, ErrWrongUTXOType)
 }
 
 func TestFxVerifyTransferNilInput(t *testing.T) {
@@ -193,7 +196,8 @@ func TestFxVerifyTransferNilInput(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, nil, cred, out), ErrWrongInputType)
+	err := fx.VerifyTransfer(tx, nil, cred, out)
+	require.ErrorIs(err, ErrWrongInputType)
 }
 
 func TestFxVerifyTransferNilCredential(t *testing.T) {
@@ -224,7 +228,8 @@ func TestFxVerifyTransferNilCredential(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, in, nil, out), ErrWrongCredentialType)
+	err := fx.VerifyTransfer(tx, in, nil, out)
+	require.ErrorIs(err, ErrWrongCredentialType)
 }
 
 func TestFxVerifyTransferInvalidOutput(t *testing.T) {
@@ -260,7 +265,8 @@ func TestFxVerifyTransferInvalidOutput(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), ErrOutputUnoptimized)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, ErrOutputUnoptimized)
 }
 
 func TestFxVerifyTransferWrongAmounts(t *testing.T) {
@@ -296,7 +302,8 @@ func TestFxVerifyTransferWrongAmounts(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), ErrMismatchedAmounts)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, ErrMismatchedAmounts)
 }
 
 func TestFxVerifyTransferTimelocked(t *testing.T) {
@@ -332,7 +339,8 @@ func TestFxVerifyTransferTimelocked(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), ErrTimelocked)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, ErrTimelocked)
 }
 
 func TestFxVerifyTransferTooManySigners(t *testing.T) {
@@ -369,7 +377,8 @@ func TestFxVerifyTransferTooManySigners(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), ErrTooManySigners)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, ErrTooManySigners)
 }
 
 func TestFxVerifyTransferTooFewSigners(t *testing.T) {
@@ -403,7 +412,8 @@ func TestFxVerifyTransferTooFewSigners(t *testing.T) {
 		Sigs: [][secp256k1.SignatureLen]byte{},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), ErrTooFewSigners)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, ErrTooFewSigners)
 }
 
 func TestFxVerifyTransferMismatchedSigners(t *testing.T) {
@@ -440,7 +450,8 @@ func TestFxVerifyTransferMismatchedSigners(t *testing.T) {
 		},
 	}
 
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), ErrInputCredentialSignersMismatch)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, ErrInputCredentialSignersMismatch)
 }
 
 func TestFxVerifyTransferInvalidSignature(t *testing.T) {
@@ -479,7 +490,8 @@ func TestFxVerifyTransferInvalidSignature(t *testing.T) {
 
 	require.NoError(fx.VerifyTransfer(tx, in, cred, out))
 	require.NoError(fx.Bootstrapped())
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), secp256k1.ErrInvalidSig)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, secp256k1.ErrInvalidSig)
 }
 
 func TestFxVerifyTransferWrongSigner(t *testing.T) {
@@ -518,7 +530,8 @@ func TestFxVerifyTransferWrongSigner(t *testing.T) {
 
 	require.NoError(fx.VerifyTransfer(tx, in, cred, out))
 	require.NoError(fx.Bootstrapped())
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), ErrWrongSig)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, ErrWrongSig)
 }
 
 func TestFxVerifyTransferSigIndexOOB(t *testing.T) {
@@ -557,7 +570,8 @@ func TestFxVerifyTransferSigIndexOOB(t *testing.T) {
 
 	require.NoError(fx.VerifyTransfer(tx, in, cred, out))
 	require.NoError(fx.Bootstrapped())
-	require.ErrorIs(fx.VerifyTransfer(tx, in, cred, out), ErrInputOutputIndexOutOfBounds)
+	err := fx.VerifyTransfer(tx, in, cred, out)
+	require.ErrorIs(err, ErrInputOutputIndexOutOfBounds)
 }
 
 func TestFxVerifyOperation(t *testing.T) {
@@ -660,7 +674,8 @@ func TestFxVerifyOperationUnknownTx(t *testing.T) {
 	}
 
 	utxos := []interface{}{utxo}
-	require.ErrorIs(fx.VerifyOperation(nil, op, cred, utxos), ErrWrongTxType)
+	err := fx.VerifyOperation(nil, op, cred, utxos)
+	require.ErrorIs(err, ErrWrongTxType)
 }
 
 func TestFxVerifyOperationUnknownOperation(t *testing.T) {
@@ -689,7 +704,8 @@ func TestFxVerifyOperationUnknownOperation(t *testing.T) {
 	}
 
 	utxos := []interface{}{utxo}
-	require.ErrorIs(fx.VerifyOperation(tx, nil, cred, utxos), ErrWrongOpType)
+	err := fx.VerifyOperation(tx, nil, cred, utxos)
+	require.ErrorIs(err, ErrWrongOpType)
 }
 
 func TestFxVerifyOperationUnknownCredential(t *testing.T) {
@@ -736,7 +752,8 @@ func TestFxVerifyOperationUnknownCredential(t *testing.T) {
 	}
 
 	utxos := []interface{}{utxo}
-	require.ErrorIs(fx.VerifyOperation(tx, op, nil, utxos), ErrWrongCredentialType)
+	err := fx.VerifyOperation(tx, op, nil, utxos)
+	require.ErrorIs(err, ErrWrongCredentialType)
 }
 
 func TestFxVerifyOperationWrongNumberOfUTXOs(t *testing.T) {
@@ -788,7 +805,8 @@ func TestFxVerifyOperationWrongNumberOfUTXOs(t *testing.T) {
 	}
 
 	utxos := []interface{}{utxo, utxo}
-	require.ErrorIs(fx.VerifyOperation(tx, op, cred, utxos), ErrWrongNumberOfUTXOs)
+	err := fx.VerifyOperation(tx, op, cred, utxos)
+	require.ErrorIs(err, ErrWrongNumberOfUTXOs)
 }
 
 func TestFxVerifyOperationUnknownUTXOType(t *testing.T) {
@@ -832,7 +850,8 @@ func TestFxVerifyOperationUnknownUTXOType(t *testing.T) {
 	}
 
 	utxos := []interface{}{nil}
-	require.ErrorIs(fx.VerifyOperation(tx, op, cred, utxos), ErrWrongUTXOType)
+	err := fx.VerifyOperation(tx, op, cred, utxos)
+	require.ErrorIs(err, ErrWrongUTXOType)
 }
 
 func TestFxVerifyOperationInvalidOperationVerify(t *testing.T) {
@@ -881,7 +900,8 @@ func TestFxVerifyOperationInvalidOperationVerify(t *testing.T) {
 	}
 
 	utxos := []interface{}{utxo}
-	require.ErrorIs(fx.VerifyOperation(tx, op, cred, utxos), ErrOutputUnspendable)
+	err := fx.VerifyOperation(tx, op, cred, utxos)
+	require.ErrorIs(err, ErrOutputUnspendable)
 }
 
 func TestFxVerifyOperationMismatchedMintOutputs(t *testing.T) {
@@ -928,7 +948,8 @@ func TestFxVerifyOperationMismatchedMintOutputs(t *testing.T) {
 	}
 
 	utxos := []interface{}{utxo}
-	require.ErrorIs(fx.VerifyOperation(tx, op, cred, utxos), ErrWrongMintCreated)
+	err := fx.VerifyOperation(tx, op, cred, utxos)
+	require.ErrorIs(err, ErrWrongMintCreated)
 }
 
 func TestVerifyPermission(t *testing.T) {

--- a/vms/secp256k1fx/input_test.go
+++ b/vms/secp256k1fx/input_test.go
@@ -39,8 +39,8 @@ func TestInputVerifyNil(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-			require.ErrorIs(tt.in.Verify(), tt.expectedErr)
+			err := tt.in.Verify()
+			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}
 }

--- a/vms/secp256k1fx/mint_operation_test.go
+++ b/vms/secp256k1fx/mint_operation_test.go
@@ -123,8 +123,8 @@ func TestMintOperationVerify(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-			require.ErrorIs(tt.op.Verify(), tt.expectedErr)
+			err := tt.op.Verify()
+			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}
 }

--- a/vms/secp256k1fx/mint_output_test.go
+++ b/vms/secp256k1fx/mint_output_test.go
@@ -46,8 +46,10 @@ func TestMintOutputVerify(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.ErrorIs(t, tt.out.Verify(), tt.expectedErr)
-			require.ErrorIs(t, tt.out.VerifyState(), tt.expectedErr)
+			err := tt.out.Verify()
+			require.ErrorIs(t, err, tt.expectedErr)
+			err = tt.out.VerifyState()
+			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}
 }

--- a/vms/secp256k1fx/mint_output_test.go
+++ b/vms/secp256k1fx/mint_output_test.go
@@ -46,10 +46,11 @@ func TestMintOutputVerify(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
 			err := tt.out.Verify()
-			require.ErrorIs(t, err, tt.expectedErr)
+			require.ErrorIs(err, tt.expectedErr)
 			err = tt.out.VerifyState()
-			require.ErrorIs(t, err, tt.expectedErr)
+			require.ErrorIs(err, tt.expectedErr)
 		})
 	}
 }

--- a/vms/secp256k1fx/output_owners_test.go
+++ b/vms/secp256k1fx/output_owners_test.go
@@ -67,8 +67,10 @@ func TestOutputOwnersVerify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			require.ErrorIs(tt.out.Verify(), tt.expectedErr)
-			require.ErrorIs(tt.out.VerifyState(), tt.expectedErr)
+			err := tt.out.Verify()
+			require.ErrorIs(err, tt.expectedErr)
+			err = tt.out.VerifyState()
+			require.ErrorIs(err, tt.expectedErr)
 		})
 	}
 }

--- a/vms/secp256k1fx/transfer_input_test.go
+++ b/vms/secp256k1fx/transfer_input_test.go
@@ -38,7 +38,8 @@ func TestTransferInputVerify(t *testing.T) {
 func TestTransferInputVerifyNil(t *testing.T) {
 	require := require.New(t)
 	in := (*TransferInput)(nil)
-	require.ErrorIs(in.Verify(), ErrNilInput)
+	err := in.Verify()
+	require.ErrorIs(err, ErrNilInput)
 }
 
 func TestTransferInputVerifyNoValue(t *testing.T) {
@@ -49,7 +50,8 @@ func TestTransferInputVerifyNoValue(t *testing.T) {
 			SigIndices: []uint32{0, 1},
 		},
 	}
-	require.ErrorIs(in.Verify(), ErrNoValueInput)
+	err := in.Verify()
+	require.ErrorIs(err, ErrNoValueInput)
 }
 
 func TestTransferInputVerifyDuplicated(t *testing.T) {
@@ -60,7 +62,8 @@ func TestTransferInputVerifyDuplicated(t *testing.T) {
 			SigIndices: []uint32{0, 0},
 		},
 	}
-	require.ErrorIs(in.Verify(), ErrInputIndicesNotSortedUnique)
+	err := in.Verify()
+	require.ErrorIs(err, ErrInputIndicesNotSortedUnique)
 }
 
 func TestTransferInputVerifyUnsorted(t *testing.T) {
@@ -71,7 +74,8 @@ func TestTransferInputVerifyUnsorted(t *testing.T) {
 			SigIndices: []uint32{1, 0},
 		},
 	}
-	require.ErrorIs(in.Verify(), ErrInputIndicesNotSortedUnique)
+	err := in.Verify()
+	require.ErrorIs(err, ErrInputIndicesNotSortedUnique)
 }
 
 func TestTransferInputSerialize(t *testing.T) {

--- a/vms/secp256k1fx/transfer_output_test.go
+++ b/vms/secp256k1fx/transfer_output_test.go
@@ -47,7 +47,8 @@ func TestOutputVerify(t *testing.T) {
 func TestOutputVerifyNil(t *testing.T) {
 	require := require.New(t)
 	out := (*TransferOutput)(nil)
-	require.ErrorIs(out.Verify(), ErrNilOutput)
+	err := out.Verify()
+	require.ErrorIs(err, ErrNilOutput)
 }
 
 func TestOutputVerifyNoValue(t *testing.T) {
@@ -62,7 +63,8 @@ func TestOutputVerifyNoValue(t *testing.T) {
 			},
 		},
 	}
-	require.ErrorIs(out.Verify(), ErrNoValueOutput)
+	err := out.Verify()
+	require.ErrorIs(err, ErrNoValueOutput)
 }
 
 func TestOutputVerifyUnspendable(t *testing.T) {
@@ -77,7 +79,8 @@ func TestOutputVerifyUnspendable(t *testing.T) {
 			},
 		},
 	}
-	require.ErrorIs(out.Verify(), ErrOutputUnspendable)
+	err := out.Verify()
+	require.ErrorIs(err, ErrOutputUnspendable)
 }
 
 func TestOutputVerifyUnoptimized(t *testing.T) {
@@ -92,7 +95,8 @@ func TestOutputVerifyUnoptimized(t *testing.T) {
 			},
 		},
 	}
-	require.ErrorIs(out.Verify(), ErrOutputUnoptimized)
+	err := out.Verify()
+	require.ErrorIs(err, ErrOutputUnoptimized)
 }
 
 func TestOutputVerifyUnsorted(t *testing.T) {
@@ -108,7 +112,8 @@ func TestOutputVerifyUnsorted(t *testing.T) {
 			},
 		},
 	}
-	require.ErrorIs(out.Verify(), ErrAddrsNotSortedUnique)
+	err := out.Verify()
+	require.ErrorIs(err, ErrAddrsNotSortedUnique)
 }
 
 func TestOutputVerifyDuplicated(t *testing.T) {
@@ -124,7 +129,8 @@ func TestOutputVerifyDuplicated(t *testing.T) {
 			},
 		},
 	}
-	require.ErrorIs(out.Verify(), ErrAddrsNotSortedUnique)
+	err := out.Verify()
+	require.ErrorIs(err, ErrAddrsNotSortedUnique)
 }
 
 func TestOutputSerialize(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

more consistent and readable usage of `require.ErrorIs`

## How this works

find and replace

## How this was tested

CI