### PR TITLE
use blank identifier for interface compliance

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -58,6 +58,7 @@ function test_require_error_is_no_funcs_as_params {
   fi
 }
 
+# Ref: https://go.dev/doc/effective_go#blank_implements
 function test_interface_compliance_nil {
   if ggrep -R -o -P '_ .+? = &.+?\{\}' .; then
     echo ""

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -60,7 +60,7 @@ function test_require_error_is_no_funcs_as_params {
 
 # Ref: https://go.dev/doc/effective_go#blank_implements
 function test_interface_compliance_nil {
-  if ggrep -R -o -P '_ .+? = &.+?\{\}' .; then
+  if grep -R -o -P '_ .+? = &.+?\{\}' .; then
     echo ""
     echo "Interface compliance checks need to be of the form:"
     echo "  var _ json.Marshaler = (*RawMessage)(nil)"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -62,6 +62,9 @@ function test_require_error_is_no_funcs_as_params {
 function test_interface_compliance_nil {
   if ggrep -R -o -P '_ .+? = &.+?\{\}' .; then
     echo ""
+    echo "Interface compliance checks need to be of the form:"
+    echo "  var _ json.Marshaler = (*RawMessage)(nil)"
+    echo ""
     return 1
   fi
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,7 +21,7 @@ fi
 # by default, "./scripts/lint.sh" runs all lint tests
 # to run only "license_header" test
 # TESTS='license_header' ./scripts/lint.sh
-TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params"}
+TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params interface_compliance_nil"}
 
 function test_golangci_lint {
   go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
@@ -53,6 +53,13 @@ function test_license_header {
 
 function test_require_error_is_no_funcs_as_params {
   if grep -R -zo -P 'require.ErrorIs\(.+?\)[^\n]*\)\n' .; then
+    echo ""
+    return 1
+  fi
+}
+
+function test_interface_compliance_nil {
+  if ggrep -R -o -P '_ .+? = &.+?\{\}' .; then
     echo ""
     return 1
   fi

--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	_ Mempool = &mempool{}
+	_ Mempool = (*mempool)(nil)
 
 	errDuplicateTx          = errors.New("duplicate tx")
 	errTxTooLarge           = errors.New("tx too large")

--- a/vms/rpcchainvm/gruntime/runtime_server.go
+++ b/vms/rpcchainvm/gruntime/runtime_server.go
@@ -13,7 +13,7 @@ import (
 	pb "github.com/ava-labs/avalanchego/proto/pb/vm/runtime"
 )
 
-var _ pb.RuntimeServer = &Server{}
+var _ pb.RuntimeServer = (*Server)(nil)
 
 // Server is a VM runtime initializer controlled by RPC.
 type Server struct {

--- a/x/merkledb/batch.go
+++ b/x/merkledb/batch.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 )
 
-var _ database.Batch = &batch{}
+var _ database.Batch = (*batch)(nil)
 
 // batch is a write-only database that commits changes to its host database
 // when Write is called.

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -38,8 +38,8 @@ const (
 )
 
 var (
-	_ TrieView          = &Database{}
-	_ database.Database = &Database{}
+	_ TrieView          = (*Database)(nil)
+	_ database.Database = (*Database)(nil)
 
 	Codec, Version = newCodec()
 

--- a/x/merkledb/iterator.go
+++ b/x/merkledb/iterator.go
@@ -5,7 +5,7 @@ package merkledb
 
 import "github.com/ava-labs/avalanchego/database"
 
-var _ database.Iterator = &iterator{}
+var _ database.Iterator = (*iterator)(nil)
 
 type iterator struct {
 	db       *Database

--- a/x/merkledb/metrics.go
+++ b/x/merkledb/metrics.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	_ merkleMetrics = &mockMetrics{}
-	_ merkleMetrics = &metrics{}
+	_ merkleMetrics = (*mockMetrics)(nil)
+	_ merkleMetrics = (*metrics)(nil)
 )
 
 type merkleMetrics interface {

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -26,6 +26,8 @@ import (
 const defaultPreallocationSize = 100
 
 var (
+	_ TrieView = (*trieView)(nil)
+
 	ErrCommitted          = errors.New("view has been committed")
 	ErrInvalid            = errors.New("the trie this view was based on has changed, rendering this view invalid")
 	ErrOddLengthWithValue = errors.New(
@@ -35,8 +37,6 @@ var (
 	ErrStartAfterEnd    = errors.New("start key > end key")
 	ErrViewIsNotAChild  = errors.New("passed in view is required to be a child of the current view")
 	ErrNoValidRoot      = errors.New("a valid root was not provided to the trieView constructor")
-
-	_ TrieView = &trieView{}
 
 	numCPU = runtime.NumCPU()
 )

--- a/x/sync/client.go
+++ b/x/sync/client.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	_ Client = &client{}
+	_ Client = (*client)(nil)
 
 	errInvalidRangeProof = errors.New("failed to verify range proof")
 	errTooManyKeys       = errors.New("response contains more than requested keys")

--- a/x/sync/metrics.go
+++ b/x/sync/metrics.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	_ SyncMetrics = &mockMetrics{}
-	_ SyncMetrics = &metrics{}
+	_ SyncMetrics = (*mockMetrics)(nil)
+	_ SyncMetrics = (*metrics)(nil)
 )
 
 type SyncMetrics interface {

--- a/x/sync/network_client.go
+++ b/x/sync/network_client.go
@@ -25,7 +25,7 @@ import (
 const minRequestHandlingDuration = 100 * time.Millisecond
 
 var (
-	_ NetworkClient = &networkClient{}
+	_ NetworkClient = (*networkClient)(nil)
 
 	ErrAcquiringSemaphore = errors.New("error acquiring semaphore")
 	ErrRequestFailed      = errors.New("request failed")

--- a/x/sync/response_handler.go
+++ b/x/sync/response_handler.go
@@ -7,7 +7,7 @@ package sync
 // Look into making a struct to handle requests/responses that uses a sync pool
 // to avoid allocations.
 
-var _ ResponseHandler = &responseHandler{}
+var _ ResponseHandler = (*responseHandler)(nil)
 
 // Handles responses/failure notifications for a sent request.
 // Exactly one of OnResponse or OnFailure is eventually called.

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -26,7 +26,7 @@ import (
 	syncpb "github.com/ava-labs/avalanchego/proto/pb/sync"
 )
 
-var _ Client = &mockClient{}
+var _ Client = (*mockClient)(nil)
 
 func newNoopTracer() trace.Tracer {
 	tracer, _ := trace.New(trace.Config{Enabled: false})

--- a/x/sync/syncworkheap.go
+++ b/x/sync/syncworkheap.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/btree"
 )
 
-var _ heap.Interface = &syncWorkHeap{}
+var _ heap.Interface = (*syncWorkHeap)(nil)
 
 type heapItem struct {
 	workItem  *syncWorkItem


### PR DESCRIPTION
## Why this should be merged

modifies the interface compliance check to be in-line with effective go

https://go.dev/doc/effective_go#blank_implements

We had a PR cleaning this up before so this adds a linter to ensure this is the last PR cleaning this up :)

## How this works

Avoids extra pointer allocations

## How this was tested

CI