### PR TITLE
Remove comment referencing old IP based tracking

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -746,13 +746,6 @@ func (n *network) Dispatch() error {
 		// Note: listener.Accept is rate limited outside of this package, so a
 		// peer can not just arbitrarily spin up goroutines here.
 		go func() {
-			// We pessimistically drop an incoming connection if the remote
-			// address is found in connectedIPs, myIPs, or peerAliasIPs. This
-			// protects our node from spending CPU cycles on TLS handshakes to
-			// upgrade connections from existing peers. Specifically, this can
-			// occur when one of our existing peers attempts to connect to one
-			// our IP aliases (that they aren't yet aware is an alias).
-			//
 			// Note: Calling [RemoteAddr] with the Proxy protocol enabled may
 			// block for up to ProxyReadHeaderTimeout. Therefore, we ensure to
 			// call this function inside the go-routine, rather than the main


### PR DESCRIPTION
## Why this should be merged

Addresses question raised in the discord channel.

Previously the networking library supported non-TLS communication. This required IP based tracking of new potential peers. This proved to be overly complex, and the library now requires TLS communication. The library now tracks potential peers solely by nodeID. However, this comment referenced the prior IP based tracking logic.

## How this works

Removes the reference to the old IP based tracking.

## How this was tested

N/A