### PR TITLE
Fix network compression type flag usage

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1307,7 +1307,7 @@ func (n *Node) Initialize(
 		n.Log,
 		n.MetricsRegisterer,
 		n.networkNamespace,
-		constants.DefaultNetworkCompressionType,
+		n.Config.NetworkConfig.CompressionType,
 		n.Config.NetworkConfig.MaximumInboundMessageTimeout,
 	)
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged

We currently always provide the default compression value to the message creator rather than honoring the requested compression type.

## How this works

Replaces the global constant with the expected config value.

## How this was tested

Locally