### PR TITLE
Fetch process resource stats as best-effort

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1197,6 +1197,7 @@ func (n *Node) initVdrs() validators.Set {
 // Initialize [n.resourceManager].
 func (n *Node) initResourceManager(reg prometheus.Registerer) error {
 	n.resourceManager = resource.NewManager(
+		n.Log,
 		n.Config.DatabaseConfig.Path,
 		n.Config.SystemTrackerFrequency,
 		n.Config.SystemTrackerCPUHalflife,

--- a/vms/registry/vm_getter_test.go
+++ b/vms/registry/vm_getter_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/filesystem"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/resource"
 	"github.com/ava-labs/avalanchego/vms"
 )
@@ -149,7 +150,7 @@ func initVMGetterTest(t *testing.T) *vmGetterTestResources {
 			FileReader:      mockReader,
 			Manager:         mockManager,
 			PluginDirectory: pluginDir,
-			CPUTracker:      resource.NewManager("", time.Hour, time.Hour, time.Hour),
+			CPUTracker:      resource.NewManager(logging.NoLog{}, "", time.Hour, time.Hour, time.Hour),
 		},
 	)
 


### PR DESCRIPTION
## Why this should be merged

IOCounters is not implemented on macos (and currently prevents getting CPU counts)

## How this works

Rather than setting both CPU and disk values to 0 if fetching either of them fails, we only zero out the values that errored.

## How this was tested

Manually on macos.