### PR TITLE
Log chain shutdown duration

### DIFF
--- a/snow/networking/handler/mock_handler.go
+++ b/snow/networking/handler/mock_handler.go
@@ -40,6 +40,21 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
 }
 
+// AwaitStopped mocks base method.
+func (m *MockHandler) AwaitStopped(arg0 context.Context) (time.Duration, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AwaitStopped", arg0)
+	ret0, _ := ret[0].(time.Duration)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AwaitStopped indicates an expected call of AwaitStopped.
+func (mr *MockHandlerMockRecorder) AwaitStopped(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitStopped", reflect.TypeOf((*MockHandler)(nil).AwaitStopped), arg0)
+}
+
 // Context mocks base method.
 func (m *MockHandler) Context() *snow.ConsensusContext {
 	m.ctrl.T.Helper()
@@ -193,18 +208,4 @@ func (m *MockHandler) StopWithError(arg0 context.Context, arg1 error) {
 func (mr *MockHandlerMockRecorder) StopWithError(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopWithError", reflect.TypeOf((*MockHandler)(nil).StopWithError), arg0, arg1)
-}
-
-// Stopped mocks base method.
-func (m *MockHandler) Stopped() chan struct{} {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stopped")
-	ret0, _ := ret[0].(chan struct{})
-	return ret0
-}
-
-// Stopped indicates an expected call of Stopped.
-func (mr *MockHandlerMockRecorder) Stopped() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stopped", reflect.TypeOf((*MockHandler)(nil).Stopped))
 }

--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -381,7 +381,7 @@ func (cr *ChainRouter) Shutdown(ctx context.Context) {
 			)
 		} else {
 			chainLog.Info("chain shutdown",
-				zap.Duration("shutdownTime", shutdownDuration),
+				zap.Duration("shutdownDuration", shutdownDuration),
 			)
 		}
 	}
@@ -663,7 +663,7 @@ func (cr *ChainRouter) removeChain(ctx context.Context, chainID ids.ID) {
 		)
 	} else {
 		chainLog.Info("chain shutdown",
-			zap.Duration("shutdownTime", shutdownDuration),
+			zap.Duration("shutdownDuration", shutdownDuration),
 		)
 	}
 

--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -368,15 +368,21 @@ func (cr *ChainRouter) Shutdown(ctx context.Context) {
 		chain.Stop(ctx)
 	}
 
-	ticker := time.NewTicker(cr.closeTimeout)
-	defer ticker.Stop()
+	ctx, cancel := context.WithTimeout(ctx, cr.closeTimeout)
+	defer cancel()
 
 	for _, chain := range prevChains {
-		select {
-		case <-chain.Stopped():
-		case <-ticker.C:
-			cr.log.Warn("timed out while shutting down the chains")
-			return
+		shutdownDuration, err := chain.AwaitStopped(ctx)
+
+		chainLog := chain.Context().Log
+		if err != nil {
+			chainLog.Warn("timed out while shutting down",
+				zap.Error(err),
+			)
+		} else {
+			chainLog.Info("chain shutdown",
+				zap.Duration("shutdownTime", shutdownDuration),
+			)
 		}
 	}
 }
@@ -646,12 +652,19 @@ func (cr *ChainRouter) removeChain(ctx context.Context, chainID ids.ID) {
 
 	chain.Stop(ctx)
 
-	ticker := time.NewTicker(cr.closeTimeout)
-	defer ticker.Stop()
-	select {
-	case <-chain.Stopped():
-	case <-ticker.C:
-		chain.Context().Log.Warn("timed out while shutting down")
+	ctx, cancel := context.WithTimeout(ctx, cr.closeTimeout)
+	shutdownDuration, err := chain.AwaitStopped(ctx)
+	cancel()
+
+	chainLog := chain.Context().Log
+	if err != nil {
+		chainLog.Warn("timed out while shutting down",
+			zap.Error(err),
+		)
+	} else {
+		chainLog.Info("chain shutdown",
+			zap.Duration("shutdownTime", shutdownDuration),
+		)
 	}
 
 	if cr.onFatal != nil && cr.criticalChains.Contains(chainID) {

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -42,9 +42,12 @@ const (
 )
 
 func TestShutdown(t *testing.T) {
+	require := require.New(t)
+
 	vdrs := validators.NewSet()
 	err := vdrs.Add(ids.GenerateTestNodeID(), nil, ids.Empty, 1)
-	require.NoError(t, err)
+	require.NoError(err)
+
 	benchlist := benchlist.NewNoBenchlist()
 	tm, err := timeout.NewManager(
 		&timer.AdaptiveTimeoutConfig{
@@ -58,7 +61,7 @@ func TestShutdown(t *testing.T) {
 		"",
 		prometheus.NewRegistry(),
 	)
-	require.NoError(t, err)
+	require.NoError(err)
 	go tm.Dispatch()
 
 	chainRouter := ChainRouter{}
@@ -75,29 +78,30 @@ func TestShutdown(t *testing.T) {
 		"",
 		prometheus.NewRegistry(),
 	)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	shutdownCalled := make(chan struct{}, 1)
 
-	ctx := snow.DefaultConsensusContextTest()
+	chainCtx := snow.DefaultConsensusContextTest()
 	resourceTracker, err := tracker.NewResourceTracker(
 		prometheus.NewRegistry(),
 		resource.NoUsage,
 		meter.ContinuousFactory{},
 		time.Second,
 	)
-	require.NoError(t, err)
+	require.NoError(err)
+
 	h, err := handler.New(
-		ctx,
+		chainCtx,
 		vdrs,
 		nil,
 		time.Second,
 		testThreadPoolSize,
 		resourceTracker,
 		validators.UnhandledSubnetConnector,
-		subnets.New(ctx.NodeID, subnets.Config{}),
+		subnets.New(chainCtx.NodeID, subnets.Config{}),
 	)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	bootstrapper := &common.BootstrapperTest{
 		BootstrapableTest: common.BootstrapableTest{
@@ -110,7 +114,7 @@ func TestShutdown(t *testing.T) {
 	bootstrapper.Default(true)
 	bootstrapper.CantGossip = false
 	bootstrapper.ContextF = func() *snow.ConsensusContext {
-		return ctx
+		return chainCtx
 	}
 	bootstrapper.ShutdownF = func(context.Context) error {
 		shutdownCalled <- struct{}{}
@@ -125,7 +129,7 @@ func TestShutdown(t *testing.T) {
 	engine.Default(true)
 	engine.CantGossip = false
 	engine.ContextF = func() *snow.ConsensusContext {
-		return ctx
+		return chainCtx
 	}
 	engine.ShutdownF = func(context.Context) error {
 		shutdownCalled <- struct{}{}
@@ -147,7 +151,7 @@ func TestShutdown(t *testing.T) {
 			Consensus:    engine,
 		},
 	})
-	ctx.State.Set(snow.EngineState{
+	chainCtx.State.Set(snow.EngineState{
 		Type:  engineType,
 		State: snow.NormalOp, // assumed bootstrapping is done
 	})
@@ -161,18 +165,19 @@ func TestShutdown(t *testing.T) {
 
 	chainRouter.Shutdown(context.Background())
 
-	ticker := time.NewTicker(250 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
 	select {
-	case <-ticker.C:
-		t.Fatalf("Handler shutdown was not called or timed out after 250ms during chainRouter shutdown")
+	case <-ctx.Done():
+		require.FailNow("Handler shutdown was not called or timed out after 250ms during chainRouter shutdown")
 	case <-shutdownCalled:
 	}
 
-	select {
-	case <-h.Stopped():
-	default:
-		t.Fatal("handler shutdown but never closed its closing channel")
-	}
+	shutdownDuration, err := h.AwaitStopped(ctx)
+	require.NoError(err)
+	require.Greater(shutdownDuration, time.Duration(0))
+	require.Less(shutdownDuration, 250*time.Millisecond)
 }
 
 func TestShutdownTimesOut(t *testing.T) {

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -176,7 +176,7 @@ func TestShutdown(t *testing.T) {
 
 	shutdownDuration, err := h.AwaitStopped(ctx)
 	require.NoError(err)
-	require.Greater(shutdownDuration, time.Duration(0))
+	require.GreaterOrEqual(shutdownDuration, time.Duration(0))
 	require.Less(shutdownDuration, 250*time.Millisecond)
 }
 


### PR DESCRIPTION
## Why this should be merged

Improves visibility of chain shutdown times to ensure the default shutdown timeout is reasonable.

## How this works

Marks the time that chain shutdown starts and calculate the total duration. This always replaces the `Stopped` function (which returned a chan) with `AwaitStopped` that takes in a context (similarly to the networking code). This enables more easily returning the time spent shutting down.

By using `AwaitStopped`, this also is able to pinpoint all chains that timed out, rather than just the first chain that timed out during the shutdown process.

## How this was tested

Manually:
```
[05-22|22:16:04.776] INFO <C Chain> router/chain_router.go:383 chain shutdown {"shutdownTime": "7.115917ms"}
[05-22|22:16:04.776] INFO <X Chain> router/chain_router.go:383 chain shutdown {"shutdownTime": "493.959µs"}
[05-22|22:16:04.776] INFO <P Chain> router/chain_router.go:383 chain shutdown {"shutdownTime": "4.124042ms"}
```