### PR TITLE
Minor pchain UTs cleanup

### DIFF
--- a/vms/platformvm/blocks/builder/helpers_test.go
+++ b/vms/platformvm/blocks/builder/helpers_test.go
@@ -250,11 +250,6 @@ func defaultState(
 	if err := state.Commit(); err != nil {
 		panic(err)
 	}
-	state.SetHeight( /*height*/ 0)
-	if err := state.Commit(); err != nil {
-		panic(err)
-	}
-
 	return state
 }
 

--- a/vms/platformvm/blocks/executor/helpers_test.go
+++ b/vms/platformvm/blocks/executor/helpers_test.go
@@ -287,10 +287,6 @@ func defaultState(
 	if err := state.Commit(); err != nil {
 		panic(err)
 	}
-	state.SetHeight( /*height*/ 0)
-	if err := state.Commit(); err != nil {
-		panic(err)
-	}
 	genesisBlkID = state.GetLastAccepted()
 	return state
 }

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -240,10 +240,6 @@ func defaultState(
 	if err := state.Commit(); err != nil {
 		panic(err)
 	}
-	state.SetHeight( /*height*/ 0)
-	if err := state.Commit(); err != nil {
-		panic(err)
-	}
 	lastAcceptedID = state.GetLastAccepted()
 	return state
 }


### PR DESCRIPTION
## Why this should be merged
Just a minor platformVM UTs cleanup.

## How this works
Removed some duplicated ops in UTs

## How this was tested
I didn't change the implementation and tests still pass. "If you use a ruler to measure a table you may also be using the table to measure the ruler.” (aka Wittgenstein’s ruler)