### PR TITLE
Add buf-push github workflow

### DIFF
--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -1,0 +1,20 @@
+name: buf-push
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+    paths:
+      - "proto/**"
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1.19.0
+      - uses: bufbuild/buf-push-action@v1
+        with:
+          input: "proto"
+          buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
## Why this should be merged

This PR adds the buf-push github action which pushes a tag to the buf registry using the git commit hash as the tag on push. 

TODO: needs a GH secret added

## How this works

https://github.com/bufbuild/buf-push-action

## How this was tested
