### PR TITLE
WIP Reduce cost of e2e development

### DIFF
--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -33,12 +33,9 @@ var _ = ginkgo.Describe("[Banff]", func() {
 			"banff",
 		),
 		func() {
-			ginkgo.By("reload initial snapshot for test independence", func() {
-				err := e2e.Env.RestoreInitialState(true /*switchOffNetworkFirst*/)
-				gomega.Expect(err).Should(gomega.BeNil())
-			})
+			e2e.Env.EnsurePristineNetwork()
 
-			uris := e2e.Env.GetURIs()
+			uris := e2e.Env.GetURIsRW()
 			gomega.Expect(uris).ShouldNot(gomega.BeEmpty())
 
 			kc := secp256k1fx.NewKeychain(genesis.EWOQKey)

--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -42,12 +42,9 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 			"permissionless-subnets",
 		),
 		func() {
-			ginkgo.By("reload initial snapshot for test independence", func() {
-				err := e2e.Env.RestoreInitialState(true /*switchOffNetworkFirst*/)
-				gomega.Expect(err).Should(gomega.BeNil())
-			})
+			e2e.Env.EnsurePristineNetwork()
 
-			rpcEps := e2e.Env.GetURIs()
+			rpcEps := e2e.Env.GetURIsRW()
 			gomega.Expect(rpcEps).ShouldNot(gomega.BeEmpty())
 			nodeURI := rpcEps[0]
 

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -46,7 +46,7 @@ var _ = e2e.DescribePChain("[Workflow]", func() {
 		),
 		ginkgo.FlakeAttempts(2),
 		func() {
-			rpcEps := e2e.Env.GetURIs()
+			rpcEps := e2e.Env.GetURIsRW()
 			gomega.Expect(rpcEps).ShouldNot(gomega.BeEmpty())
 			nodeURI := rpcEps[0]
 

--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -111,7 +111,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 					},
 				},
 			}
-			uris := e2e.Env.GetURIs()
+			uris := e2e.Env.GetURIsRO()
 			gomega.Expect(uris).ShouldNot(gomega.BeEmpty())
 			staticClient := avm.NewStaticClient(uris[0])
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -184,7 +184,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 			Encoding:      formatting.Hex,
 		}
 
-		uris := e2e.Env.GetURIs()
+		uris := e2e.Env.GetURIsRO()
 		gomega.Expect(uris).ShouldNot(gomega.BeEmpty())
 
 		staticClient := api.NewStaticClient(uris[0])

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -43,7 +43,7 @@ var _ = e2e.DescribeXChain("[Virtuous Transfer Tx AVAX]", func() {
 			"virtuous-transfer-tx-avax",
 		),
 		func() {
-			rpcEps := e2e.Env.GetURIs()
+			rpcEps := e2e.Env.GetURIsRW()
 			gomega.Expect(rpcEps).ShouldNot(gomega.BeEmpty())
 
 			allMetrics := []string{


### PR DESCRIPTION
## Why this should be merged

https://github.com/ava-labs/avalanchego/issues/1547 (Kurtosis test migration) requires developing new e2e tests, and this change reduces the iteration time required to implement new tests.

## How this works

 - remove sleep on network creation that was costing ~50s per test run even if only running a single test
 - remove use of snapshots to ensure a pristine network state for some tests
   - easier to just create a new network and avoid the cost (~7s) of taking the initial snapshot
 - only create a new network where required
   - if the network hasn't yet been modified, no point in creating a new one
 - support using a persistent network directly from the network runner instead of having to supply urls

## How this was tested

```bash
# Started avalanche-network runner
/tmp/avalanche-network-runner server --log-level debug --port=":12342" --disable-grpc-gateway &

# Built the test binary
ginkgo build ./tests/e2e/

# Ran the e2e tests against test-managed networks
./tests/e2e/e2e.test --network-runner-avalanchego-path=$PWD/build/avalanchego --test-keys-file=$PWD/tests/test.insecure.secp256k1.keys --network-runner-grpc-endpoint=0.0.0.0:12342

# Started a network outside of testing
/tmp/avalanche-network-runner control start --avalanchego-path=$PWD/build/avalanchego --endpoint 0.0.0.0:12342

# Ran a test against a persistent network
./tests/e2e/e2e.test --network-runner-avalanchego-path=$PWD/build/avalanchego --test-keys-file=$PWD/tests/test.insecure.secp256k1.keys --network-runner-grpc-endpoint=0.0.0.0:12342 --use-persistent-network
```

TODO: Decide how to ensure ginkgo and avalanche-network-runner are available in a developers shell.