### PR TITLE
use `http.Error` instead of separately writing error code and message

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -377,9 +377,7 @@ func lockMiddleware(
 func rejectMiddleware(handler http.Handler, ctx *snow.ConsensusContext) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { // If chain isn't done bootstrapping, ignore API calls
 		if ctx.State.Get().State != snow.NormalOp {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			// Doesn't matter if there's an error while writing. They'll get the StatusServiceUnavailable code.
-			_, _ = w.Write([]byte("API call rejected because chain is not done bootstrapping"))
+			http.Error(w, "API call rejected because chain is not done bootstrapping", http.StatusServiceUnavailable)
 		} else {
 			handler.ServeHTTP(w, r)
 		}

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRejectMiddleware(t *testing.T) {
+	type test struct {
+		name            string
+		handlerFunc     func(*require.Assertions) http.Handler
+		contextFunc     func() *snow.ConsensusContext
+		expectedErrCode int
+	}
+
+	tests := []test{
+		{
+			name: "chain is bootstrapping",
+			handlerFunc: func(require *require.Assertions) http.Handler {
+				return http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+					require.Fail("shouldn't have called handler")
+				})
+			},
+			contextFunc: func() *snow.ConsensusContext {
+				ctx := &snow.ConsensusContext{}
+				ctx.State.Set(snow.EngineState{
+					State: snow.Bootstrapping,
+				})
+				return ctx
+			},
+			expectedErrCode: http.StatusServiceUnavailable,
+		},
+		{
+			name: "chain is done bootstrapping",
+			handlerFunc: func(require *require.Assertions) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusTeapot)
+				})
+			},
+			contextFunc: func() *snow.ConsensusContext {
+				ctx := &snow.ConsensusContext{}
+				ctx.State.Set(snow.EngineState{
+					State: snow.NormalOp,
+				})
+				return ctx
+			},
+			expectedErrCode: http.StatusTeapot,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			middleware := rejectMiddleware(tt.handlerFunc(require), tt.contextFunc())
+			w := httptest.NewRecorder()
+			middleware.ServeHTTP(w, nil)
+			require.Equal(tt.expectedErrCode, w.Code)
+		})
+	}
+}

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -39,7 +39,7 @@ func TestRejectMiddleware(t *testing.T) {
 		},
 		{
 			name: "chain is done bootstrapping",
-			handlerFunc: func(require *require.Assertions) http.Handler {
+			handlerFunc: func(*require.Assertions) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusTeapot)
 				})

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -8,8 +8,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/snow"
 )
 
 func TestRejectMiddleware(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

It's a bit cleaner. Also adds a tests and is consistent with other usages of this function.

## How this works

Self-explanatory.

## How this was tested

New unit test featuring my favorite HTTP status code.