### PR TITLE
Reduce number of test iterations

### DIFF
--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -689,7 +689,7 @@ func Test_MerkleDB_RandomCases_InitialValues(t *testing.T) {
 	require := require.New(t)
 
 	r := rand.New(rand.NewSource(int64(0))) // #nosec G404
-	runRandDBTest(require, r, generateInitialValues(require, r, 2000, 3500, 0.0))
+	runRandDBTest(require, r, generateInitialValues(require, r, 1000, 2500, 0.0))
 }
 
 // randTest performs random trie operations.

--- a/x/merkledb/history_test.go
+++ b/x/merkledb/history_test.go
@@ -100,7 +100,7 @@ func Test_History_Large(t *testing.T) {
 		require.NoError(err)
 		roots := []ids.ID{}
 		// make sure they stay in sync
-		for x := 0; x < 500; x++ {
+		for x := 0; x < 250; x++ {
 			addkey := make([]byte, r.Intn(50))
 			_, err := r.Read(addkey)
 			require.NoError(err)

--- a/x/merkledb/trie_test.go
+++ b/x/merkledb/trie_test.go
@@ -1163,7 +1163,7 @@ func Test_Trie_CommitToParentView_Concurrent(t *testing.T) {
 }
 
 func Test_Trie_CommitToParentDB_Concurrent(t *testing.T) {
-	for i := 0; i < 2000; i++ {
+	for i := 0; i < 1000; i++ {
 		dbTrie, err := getBasicDB()
 		require.NoError(t, err)
 		require.NotNil(t, dbTrie)

--- a/x/merkledb/trie_test.go
+++ b/x/merkledb/trie_test.go
@@ -1163,7 +1163,7 @@ func Test_Trie_CommitToParentView_Concurrent(t *testing.T) {
 }
 
 func Test_Trie_CommitToParentDB_Concurrent(t *testing.T) {
-	for i := 0; i < 5000; i++ {
+	for i := 0; i < 2000; i++ {
 		dbTrie, err := getBasicDB()
 		require.NoError(t, err)
 		require.NotNil(t, dbTrie)

--- a/x/merkledb/trie_test.go
+++ b/x/merkledb/trie_test.go
@@ -1111,7 +1111,7 @@ func TestTrieViewInvalidChildrenExcept(t *testing.T) {
 }
 
 func Test_Trie_CommitToParentView_Concurrent(t *testing.T) {
-	for i := 0; i < 5000; i++ {
+	for i := 0; i < 2000; i++ {
 		dbTrie, err := getBasicDB()
 		require.NoError(t, err)
 		require.NotNil(t, dbTrie)

--- a/x/merkledb/trie_test.go
+++ b/x/merkledb/trie_test.go
@@ -1111,7 +1111,7 @@ func TestTrieViewInvalidChildrenExcept(t *testing.T) {
 }
 
 func Test_Trie_CommitToParentView_Concurrent(t *testing.T) {
-	for i := 0; i < 2000; i++ {
+	for i := 0; i < 1000; i++ {
 		dbTrie, err := getBasicDB()
 		require.NoError(t, err)
 		require.NotNil(t, dbTrie)


### PR DESCRIPTION
## Why this should be merged

MerkleDB tests take a long time (~30s on my machine) when `-race` is used. Now they take ~15s.

## How this works

Make test data smaller / run fewer iterations of tests. New values chosen kind of arbitrarily. Just wanted them to be smaller than the old ones.

## How this was tested

N/A