### PR TITLE
Add GetBalance examples for the P-chain and X-chain wallets

### DIFF
--- a/wallet/chain/x/backend.go
+++ b/wallet/chain/x/backend.go
@@ -33,16 +33,12 @@ type Backend interface {
 type backend struct {
 	Context
 	ChainUTXOs
-
-	chainID ids.ID
 }
 
-func NewBackend(ctx Context, chainID ids.ID, utxos ChainUTXOs) Backend {
+func NewBackend(ctx Context, utxos ChainUTXOs) Backend {
 	return &backend{
 		Context:    ctx,
 		ChainUTXOs: utxos,
-
-		chainID: chainID,
 	}
 }
 
@@ -56,19 +52,20 @@ func (b *backend) AcceptTx(ctx stdcontext.Context, tx *txs.Tx) error {
 		return err
 	}
 
+	chainID := b.Context.BlockchainID()
 	inputUTXOs := tx.Unsigned.InputUTXOs()
 	for _, utxoID := range inputUTXOs {
 		if utxoID.Symbol {
 			continue
 		}
-		if err := b.RemoveUTXO(ctx, b.chainID, utxoID.InputID()); err != nil {
+		if err := b.RemoveUTXO(ctx, chainID, utxoID.InputID()); err != nil {
 			return err
 		}
 	}
 
 	outputUTXOs := tx.UTXOs()
 	for _, utxo := range outputUTXOs {
-		if err := b.AddUTXO(ctx, b.chainID, utxo); err != nil {
+		if err := b.AddUTXO(ctx, chainID, utxo); err != nil {
 			return err
 		}
 	}

--- a/wallet/subnet/primary/examples/get-p-chain-balance/main.go
+++ b/wallet/subnet/primary/examples/get-p-chain-balance/main.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/wallet/chain/p"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
+)
+
+func main() {
+	uri := primary.LocalAPIURI
+	addrStr := "P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
+
+	addr, err := address.ParseToID(addrStr)
+	if err != nil {
+		log.Fatalf("failed to parse address: %s\n", err)
+	}
+
+	addresses := set.Set[ids.ShortID]{}
+	addresses.Add(addr)
+
+	ctx := context.Background()
+
+	fetchStartTime := time.Now()
+	pCtx, _, utxos, err := primary.FetchState(ctx, uri, addresses)
+	if err != nil {
+		log.Fatalf("failed to fetch state: %s\n", err)
+	}
+	log.Printf("fetched state of %s in %s\n", addrStr, time.Since(fetchStartTime))
+
+	pUTXOs := primary.NewChainUTXOs(constants.PlatformChainID, utxos)
+	pBackend := p.NewBackend(pCtx, pUTXOs, make(map[ids.ID]*txs.Tx))
+	pBuilder := p.NewBuilder(addresses, pBackend)
+
+	currentBalances, err := pBuilder.GetBalance()
+	if err != nil {
+		log.Fatalf("failed to get the balance: %s\n", err)
+	}
+
+	avaxID := pCtx.AVAXAssetID()
+	avaxBalance := currentBalances[avaxID]
+	log.Printf("current AVAX balance of %s is %d nAVAX\n", addrStr, avaxBalance)
+}

--- a/wallet/subnet/primary/examples/get-x-chain-balance/main.go
+++ b/wallet/subnet/primary/examples/get-x-chain-balance/main.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/wallet/chain/x"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
+)
+
+func main() {
+	uri := primary.LocalAPIURI
+	addrStr := "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
+
+	addr, err := address.ParseToID(addrStr)
+	if err != nil {
+		log.Fatalf("failed to parse address: %s\n", err)
+	}
+
+	addresses := set.Set[ids.ShortID]{}
+	addresses.Add(addr)
+
+	ctx := context.Background()
+
+	fetchStartTime := time.Now()
+	_, xCtx, utxos, err := primary.FetchState(ctx, uri, addresses)
+	if err != nil {
+		log.Fatalf("failed to fetch state: %s\n", err)
+	}
+	log.Printf("fetched state of %s in %s\n", addrStr, time.Since(fetchStartTime))
+
+	xChainID := xCtx.BlockchainID()
+
+	xUTXOs := primary.NewChainUTXOs(xChainID, utxos)
+	xBackend := x.NewBackend(xCtx, xUTXOs)
+	xBuilder := x.NewBuilder(addresses, xBackend)
+
+	currentBalances, err := xBuilder.GetFTBalance()
+	if err != nil {
+		log.Fatalf("failed to get the balance: %s\n", err)
+	}
+
+	avaxID := xCtx.AVAXAssetID()
+	avaxBalance := currentBalances[avaxID]
+	log.Printf("current AVAX balance of %s is %d nAVAX\n", addrStr, avaxBalance)
+}

--- a/wallet/subnet/primary/wallet.go
+++ b/wallet/subnet/primary/wallet.go
@@ -95,7 +95,7 @@ func NewWalletWithTxsAndState(
 
 	xChainID := xCTX.BlockchainID()
 	xUTXOs := NewChainUTXOs(xChainID, utxos)
-	xBackend := x.NewBackend(xCTX, xChainID, xUTXOs)
+	xBackend := x.NewBackend(xCTX, xUTXOs)
 	xBuilder := x.NewBuilder(addrs, xBackend)
 	xSigner := x.NewSigner(kc, xBackend)
 	xClient := avm.NewClient(uri, "X")


### PR DESCRIPTION
## Why this should be merged

- Adds examples for how to get balances of addresses on the P-chain and X-chain using only supported functions.
- Simplifies the creation for the X-chain builder.

## How this works

Removes a duplicate input and adds examples

## How this was tested

Locally running the examples.