### PR TITLE
Reduce the number of test health checks

### DIFF
--- a/api/health/health_test.go
+++ b/api/health/health_test.go
@@ -245,7 +245,7 @@ func TestDeadlockRegression(t *testing.T) {
 	h.Start(context.Background(), time.Nanosecond)
 	defer h.Stop()
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		lock.Lock()
 		require.NoError(h.RegisterHealthCheck(fmt.Sprintf("check-%d", i), check))
 		lock.Unlock()


### PR DESCRIPTION
## Why this should be merged

Saw this test flake in: https://github.com/ava-labs/avalanchego/actions/runs/5026990184/jobs/9015939696. Because each added check adds a new goroutine when running the period health check - I think running the thousand+ goroutines with `-race` enabled can sometimes take a very long time in the action env.

## How this works

`100` < `1000`. Smaller number faster test.

## How this was tested

CI