### PR TITLE
e2e: Migrate duplicate node id test from kurtosis

### DIFF
--- a/.github/workflows/test.e2e.persistent.yml
+++ b/.github/workflows/test.e2e.persistent.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./scripts/build.sh -r
       - name: Run e2e tests with persistent network
         shell: bash
-        run: ./scripts/tests.e2e.persistent.sh ./build/avalanchego
+        run: E2E_SERIAL=1 ./scripts/tests.e2e.persistent.sh ./build/avalanchego
       - name: Upload testnet network dir
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.e2e.yml
+++ b/.github/workflows/test.e2e.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./scripts/build.sh -r
       - name: Run e2e tests
         shell: bash
-        run: ./scripts/tests.e2e.sh ./build/avalanchego
+        run: E2E_SERIAL=1 ./scripts/tests.e2e.sh ./build/avalanchego
       - name: Upload testnet network dir
         uses: actions/upload-artifact@v3
         with:

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # e.g.,
 # ./scripts/build.sh
 # ./scripts/tests.e2e.sh ./build/avalanchego
+# E2E_SERIAL=1 ./scripts/tests.e2e.sh ./build/avalanchego
 if ! [[ "$0" =~ scripts/tests.e2e.sh ]]; then
   echo "must be run from repository root"
   exit 255
@@ -54,9 +55,10 @@ if [[ -n "${E2E_SERIAL:-}" ]]; then
   # on powerful development workstations.
   echo "tests will be executed serially to minimize resource requirements"
 else
-  # Enable parallel execution of specs defined in the test binary, which
-  # requires invoking the binary via the ginkgo cli. The test binary by
-  # itself isn't capable of executing specs in parallel.
+  # Enable parallel execution of specs defined in the test binary by
+  # default. This requires invoking the binary via the ginkgo cli
+  # since the test binary isn't capable of executing specs in
+  # parallel.
   echo "tests will be executed in parallel"
   GINKGO_ARGS="-p"
 fi

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/ava-labs/coreth/ethclient"
 
-	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture"
 	"github.com/ava-labs/avalanchego/tests/fixture/testnet"

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -174,23 +174,20 @@ func Eventually(condition func() bool, waitFor time.Duration, tick time.Duration
 	}
 }
 
-// Add a temporary node that is only intended to be used by a single test. Its ID and
+// Add an ephemeral node that is only intended to be used by a single test. Its ID and
 // URI are not intended to be returned from the Network instance to minimize
 // accessibility from other tests.
-func AddTemporaryNode(network testnet.Network, flags testnet.FlagsMap) testnet.Node {
+func AddEphemeralNode(network testnet.Network, flags testnet.FlagsMap) testnet.Node {
 	require := require.New(ginkgo.GinkgoT())
 
-	// A temporary location ensures the node won't be accessible from
-	// the Network instance.
-	flags[config.DataDirKey] = ginkgo.GinkgoT().TempDir()
-
-	node, err := network.AddNode(ginkgo.GinkgoWriter, flags)
+	node, err := network.AddEphemeralNode(ginkgo.GinkgoWriter, flags)
 	require.NoError(err)
 
-	// Ensure node is stopped and its configuration removed on teardown
+	// Ensure node is stopped on teardown. It's configuration is not removed to enable
+	// collection in CI to aid in troubleshooting failures.
 	ginkgo.DeferCleanup(func() {
-		tests.Outf("Shutting down temporary node %s\n", node.GetID())
-		require.NoError(node.Remove())
+		tests.Outf("Shutting down ephemeral node %s\n", node.GetID())
+		require.NoError(node.Stop())
 	})
 
 	return node

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -197,5 +197,5 @@ func AddEphemeralNode(network testnet.Network, flags testnet.FlagsMap) testnet.N
 func WaitForHealthy(node testnet.Node) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()
-	require.NoError(ginkgo.GinkgoT(), node.WaitForHealthy(ctx))
+	require.NoError(ginkgo.GinkgoT(), testnet.WaitForHealthy(ctx, node))
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -26,6 +26,7 @@ import (
 	// ensure test packages are scanned by ginkgo
 	_ "github.com/ava-labs/avalanchego/tests/e2e/banff"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/c"
+	_ "github.com/ava-labs/avalanchego/tests/e2e/faultinjection"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/p"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/static-handlers"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/x"

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -46,9 +46,7 @@ var _ = ginkgo.Describe("Duplicate node handling", func() {
 		node2 := e2e.AddEphemeralNode(network, node2Flags)
 
 		ginkgo.By("checking that the second new node fails to become healthy before timeout")
-		ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultNodeStartTimeout)
-		defer cancel()
-		err := testnet.WaitForHealthy(ctx, node2)
+		err := testnet.WaitForHealthy(e2e.DefaultContext(), node2)
 		require.ErrorIs(err, context.DeadlineExceeded)
 
 		ginkgo.By("stopping the first new node")

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -47,7 +47,7 @@ var _ = ginkgo.Describe("Duplicate node handling", func() {
 		ginkgo.By("checking that the second new node fails to become healthy before timeout")
 		ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultNodeStartTimeout)
 		defer cancel()
-		err := node2.WaitForHealthy(ctx)
+		err := testnet.WaitForHealthy(ctx, node2)
 		require.ErrorIs(err, context.DeadlineExceeded)
 
 		ginkgo.By("stopping the first new node")

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -44,7 +44,7 @@ var _ = ginkgo.Describe("Duplicate node handling", func() {
 		}
 		node2 := e2e.AddEphemeralNode(network, node2Flags)
 
-		ginkgo.By("checking that the second new node fails to become healthy within timeout")
+		ginkgo.By("checking that the second new node fails to become healthy before timeout")
 		ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultNodeStartTimeout)
 		defer cancel()
 		err := node2.WaitForHealthy(ctx)

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package faultinjection
+
+import (
+	"context"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/api/info"
+	cfg "github.com/ava-labs/avalanchego/config"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests/e2e"
+	"github.com/ava-labs/avalanchego/tests/fixture/testnet"
+	"github.com/ava-labs/avalanchego/utils/set"
+)
+
+var _ = ginkgo.Describe("Duplicate node handling", func() {
+	require := require.New(ginkgo.GinkgoT())
+
+	ginkgo.It("should ensure that a given Node ID (i.e. staking keypair) can be used at most once on a network", func() {
+		network := e2e.Env.GetNetwork()
+		nodes := network.GetNodes()
+
+		ginkgo.By("creating new node")
+		node1 := e2e.AddTemporaryNode(network, testnet.FlagsMap{})
+		e2e.WaitForHealthy(node1)
+
+		ginkgo.By("checking that the new node is connected to its peers")
+		checkConnectedPeers(nodes, node1)
+
+		ginkgo.By("creating a second new node with the same staking keypair as the first new node")
+		node1Flags := node1.GetConfig().Flags
+		node2Flags := testnet.FlagsMap{
+			cfg.StakingTLSKeyContentKey: node1Flags[cfg.StakingTLSKeyContentKey],
+			cfg.StakingCertContentKey:   node1Flags[cfg.StakingCertContentKey],
+		}
+		node2 := e2e.AddTemporaryNode(network, node2Flags)
+
+		ginkgo.By("checking that the second new node fails to become healthy within timeout")
+		ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultNodeStartTimeout)
+		defer cancel()
+		err := node2.WaitForHealthy(ctx)
+		require.ErrorIs(err, context.DeadlineExceeded)
+
+		ginkgo.By("stopping the first new node")
+		require.NoError(node1.Stop())
+
+		ginkgo.By("checking that the second new node becomes healthy within timeout")
+		e2e.WaitForHealthy(node2)
+
+		ginkgo.By("checking that the second new node is connected to its peers")
+		checkConnectedPeers(nodes, node2)
+	})
+})
+
+// Check that a new node is connected to existing nodes and vice versa
+func checkConnectedPeers(existingNodes []testnet.Node, newNode testnet.Node) {
+	require := require.New(ginkgo.GinkgoT())
+
+	// Collect the node ids of the new node's peers
+	infoClient := info.NewClient(newNode.GetProcessContext().URI)
+	peers, err := infoClient.Peers(context.Background())
+	require.NoError(err)
+	peerIDs := set.NewSet[ids.NodeID](len(existingNodes))
+	for _, peer := range peers {
+		peerIDs.Add(peer.ID)
+	}
+
+	newNodeID := newNode.GetID()
+	for _, existingNode := range existingNodes {
+		// Check that the existing node is a peer of the new node
+		require.True(peerIDs.Contains(existingNode.GetID()))
+
+		// Check that the new node is a peer
+		infoClient := info.NewClient(existingNode.GetProcessContext().URI)
+		peers, err := infoClient.Peers(context.Background())
+		require.NoError(err)
+		isPeer := false
+		for _, peer := range peers {
+			if peer.ID == newNodeID {
+				isPeer = true
+				break
+			}
+		}
+		require.True(isPeer)
+	}
+}

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api/info"

--- a/tests/fixture/testnet/common.go
+++ b/tests/fixture/testnet/common.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package testnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	DefaultNodeTickerInterval = 50 * time.Millisecond
+)
+
+var ErrNotRunning = errors.New("not running")
+
+// WaitForHealthy blocks until Node.IsHealthy returns true or an error (including context timeout) is observed.
+func WaitForHealthy(ctx context.Context, node Node) error {
+	if _, ok := ctx.Deadline(); !ok {
+		return fmt.Errorf("unable to wait for health for node %q with a context without a deadline", node.GetID())
+	}
+	ticker := time.NewTicker(DefaultNodeTickerInterval)
+	defer ticker.Stop()
+
+	for {
+		healthy, err := node.IsHealthy(ctx)
+		if err != nil && !errors.Is(err, ErrNotRunning) {
+			return fmt.Errorf("failed to wait for health of node %q: %w", node.GetID(), err)
+		}
+		if healthy {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("failed to wait for health of node %q before timeout: %w", node.GetID(), ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}

--- a/tests/fixture/testnet/interfaces.go
+++ b/tests/fixture/testnet/interfaces.go
@@ -16,6 +16,7 @@ type Network interface {
 	GetConfig() NetworkConfig
 	GetNodes() []Node
 	AddNode(w io.Writer, flags FlagsMap) (Node, error)
+	AddEphemeralNode(w io.Writer, flags FlagsMap) (Node, error)
 }
 
 // Defines node capabilities supportable regardless of how a network is orchestrated.
@@ -26,5 +27,4 @@ type Node interface {
 	IsHealthy(ctx context.Context) (bool, error)
 	WaitForHealthy(ctx context.Context) error
 	Stop() error
-	Remove() error
 }

--- a/tests/fixture/testnet/interfaces.go
+++ b/tests/fixture/testnet/interfaces.go
@@ -15,7 +15,6 @@ import (
 type Network interface {
 	GetConfig() NetworkConfig
 	GetNodes() []Node
-	AddNode(w io.Writer, flags FlagsMap) (Node, error)
 	AddEphemeralNode(w io.Writer, flags FlagsMap) (Node, error)
 }
 

--- a/tests/fixture/testnet/interfaces.go
+++ b/tests/fixture/testnet/interfaces.go
@@ -24,6 +24,5 @@ type Node interface {
 	GetConfig() NodeConfig
 	GetProcessContext() node.NodeProcessContext
 	IsHealthy(ctx context.Context) (bool, error)
-	WaitForHealthy(ctx context.Context) error
 	Stop() error
 }

--- a/tests/fixture/testnet/interfaces.go
+++ b/tests/fixture/testnet/interfaces.go
@@ -4,6 +4,9 @@
 package testnet
 
 import (
+	"context"
+	"io"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/node"
 )
@@ -12,6 +15,7 @@ import (
 type Network interface {
 	GetConfig() NetworkConfig
 	GetNodes() []Node
+	AddNode(w io.Writer, flags FlagsMap) (Node, error)
 }
 
 // Defines node capabilities supportable regardless of how a network is orchestrated.
@@ -19,4 +23,8 @@ type Node interface {
 	GetID() ids.NodeID
 	GetConfig() NodeConfig
 	GetProcessContext() node.NodeProcessContext
+	IsHealthy(ctx context.Context) (bool, error)
+	WaitForHealthy(ctx context.Context) error
+	Stop() error
+	Remove() error
 }

--- a/tests/fixture/testnet/local/README.md
+++ b/tests/fixture/testnet/local/README.md
@@ -152,7 +152,10 @@ HOME
             │       └── config.json                      // C-Chain config for all nodes
             ├── defaults.json                            // Default flags and configuration for network
             ├── genesis.json                             // Genesis for all nodes
-            └── network.env                              // Sets network dir env to simplify use of network
+            ├── network.env                              // Sets network dir env to simplify use of network
+            └── ephemeral                                // Parent directory for ephemeral nodes (e.g. created by tests)
+                └─ NodeID-FdxnAvr4jK9XXAwsYZPgWAHW2QnwSZ // Data dir for an ephemeral node
+                   └── ...
 
 ```
 

--- a/tests/fixture/testnet/local/config.go
+++ b/tests/fixture/testnet/local/config.go
@@ -20,7 +20,6 @@ const (
 	DefaultNetworkStartTimeout = 2 * time.Minute
 	DefaultNodeInitTimeout     = 10 * time.Second
 	DefaultNodeStopTimeout     = 5 * time.Second
-	DefaultNodeTickerInterval  = 50 * time.Millisecond
 )
 
 // A set of flags appropriate for local testing.

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -649,6 +649,8 @@ func (ln *LocalNetwork) AddLocalNode(w io.Writer, node *LocalNode) (*LocalNode, 
 	// Assume network configuration has been written to disk and is current in memory
 
 	if node == nil {
+		// Set an empty data dir so that PopulateNodeConfig will know
+		// to set the default of `[network dir]/[node id]`.
 		node = NewLocalNode("")
 	}
 	if err := ln.PopulateNodeConfig(node); err != nil {

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -106,8 +106,8 @@ func (ln *LocalNetwork) GetNodes() []testnet.Node {
 	return nodes
 }
 
-// Internal method supporting AddNode and AddEphemeralNode in creating a backend-agnostic node.
-func (ln *LocalNetwork) addNode(w io.Writer, flags testnet.FlagsMap, isEphemeral bool) (testnet.Node, error) {
+// Adds a backend-agnostic ephemeral node to the network
+func (ln *LocalNetwork) AddEphemeralNode(w io.Writer, flags testnet.FlagsMap) (testnet.Node, error) {
 	if flags == nil {
 		flags = testnet.FlagsMap{}
 	}
@@ -115,17 +115,7 @@ func (ln *LocalNetwork) addNode(w io.Writer, flags testnet.FlagsMap, isEphemeral
 		NodeConfig: testnet.NodeConfig{
 			Flags: flags,
 		},
-	}, isEphemeral)
-}
-
-// Adds a backend-agnostic node to the network
-func (ln *LocalNetwork) AddNode(w io.Writer, flags testnet.FlagsMap) (testnet.Node, error) {
-	return ln.addNode(w, flags, false /* isEphemeral */)
-}
-
-// Adds a backend-agnostic ephemeral node to the network
-func (ln *LocalNetwork) AddEphemeralNode(w io.Writer, flags testnet.FlagsMap) (testnet.Node, error) {
-	return ln.addNode(w, flags, true /* isEphemeral */)
+	}, true /* isEphemeral */)
 }
 
 // Starts a new network stored under the provided root dir. Required

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -677,16 +677,20 @@ func (ln *LocalNetwork) AddLocalNode(w io.Writer, node *LocalNode, isEphemeral b
 		return nil, err
 	}
 
-	// Use dynamic port allocation.
-	var httpPort uint16 = 0
-	var stakingPort uint16 = 0
-
 	// Collect staking addresses of running nodes for use in bootstraping the new node
 	if err := ln.ReadNodes(); err != nil {
 		return nil, fmt.Errorf("failed to read local network nodes: %w", err)
 	}
-	bootstrapIPs := make([]string, 0, len(ln.Nodes))
-	bootstrapIDs := make([]string, 0, len(ln.Nodes))
+
+	var (
+		// Use dynamic port allocation.
+		httpPort    uint16 = 0
+		stakingPort uint16 = 0
+
+		bootstrapIPs = make([]string, 0, len(ln.Nodes))
+		bootstrapIDs = make([]string, 0, len(ln.Nodes))
+	)
+
 	for _, node := range ln.Nodes {
 		if len(node.StakingAddress) == 0 {
 			// Node is not running

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -385,7 +385,7 @@ func (ln *LocalNetwork) WaitForHealthy(ctx context.Context, w io.Writer) error {
 			}
 
 			healthy, err := node.IsHealthy(ctx)
-			if err != nil && !errors.Is(err, errProcessNotRunning) {
+			if err != nil && !errors.Is(err, testnet.ErrNotRunning) {
 				return err
 			}
 			if !healthy {

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -662,14 +662,14 @@ func (ln *LocalNetwork) AddLocalNode(w io.Writer, node *LocalNode, isEphemeral b
 	// Default to a data dir of [network-dir]/[node-ID]
 	nodeParentDir := ln.Dir
 	if isEphemeral {
-		// For an ephemeral node, default to a data dir of [network-dir]/[ephemeral-dir][node-ID]
+		// For an ephemeral node, default to a data dir of [network-dir]/[ephemeral-dir]/[node-ID]
 		// to provide a clear separation between nodes that are expected to expose stable API
 		// endpoints and those that will live for only a short time (e.g. a node started by a test
-		// and stopped on test teardown).
+		// and stopped on teardown).
 		//
-		// The data for an ephemeral node is still in the file tree rooted at the network dir to
-		// ensure that archiving the network dir in CI will collect all node data used for a test
-		// run. Otherwise the data dir of ephemeral nodes could be stored in a random temp dir.
+		// The data for an ephemeral node is still stored in the file tree rooted at the network
+		// dir to ensure that recursively archiving the network dir in CI will collect all node
+		// data used for a test run.
 		nodeParentDir = filepath.Join(ln.Dir, defaultEphemeralDirName)
 	}
 

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -709,9 +709,5 @@ func (ln *LocalNetwork) AddLocalNode(w io.Writer, node *LocalNode, isEphemeral b
 	if err := node.WriteConfig(); err != nil {
 		return nil, err
 	}
-	if err := node.Start(w, ln.ExecPath); err != nil {
-		return nil, err
-	}
-
-	return node, nil
+	return node, node.Start(w, ln.ExecPath)
 }

--- a/tests/fixture/testnet/local/node.go
+++ b/tests/fixture/testnet/local/node.go
@@ -192,7 +192,7 @@ func (n *LocalNode) Start(w io.Writer, defaultExecPath string) error {
 	if isTemporaryNode {
 		// Qualify the description for a temporary node with its path
 		// since it won't be stored in the network's directory.
-		nodeDescription = fmt.Sprintf("temporary node %q @ %s", n.NodeID, n.GetDataDir())
+		nodeDescription = fmt.Sprintf("temporary node %q with path: %s", n.NodeID, n.GetDataDir())
 	} else {
 		nodeDescription = fmt.Sprintf("node %q", n.NodeID)
 	}

--- a/tests/fixture/testnet/local/node.go
+++ b/tests/fixture/testnet/local/node.go
@@ -322,7 +322,11 @@ func (n *LocalNode) IsHealthy(ctx context.Context) (bool, error) {
 	return false, fmt.Errorf("failed to query node health: %w", err)
 }
 
+// WaitForHealthy blocks until IsHealthy returns true or an error (including context timeout) is observed.
 func (n *LocalNode) WaitForHealthy(ctx context.Context) error {
+	if _, ok := ctx.Deadline(); !ok {
+		return fmt.Errorf("unable to wait for health for node %q with a context without a deadline", n.NodeID)
+	}
 	ticker := time.NewTicker(DefaultNodeTickerInterval)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Why this should be merged

Fulfills one of the requirements for #1547 (migration of Kurtosis tests)

## How this works

- adds node add/stop to testnet fixture
- reimplements avalanche testing's [duplicate node test](https://github.com/ava-labs/avalanche-testing/blob/master/tests/duplicate_node_id.go)

## How this was tested

Ran ./scripts/test.e2e.sh

## TODO

- [x] Merge the parent PR (#1709)