### PR TITLE
`MerkleDB` -- add eviction batch size config

### DIFF
--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -385,25 +385,17 @@ func sendChangeRequest(
 func TestGetChangeProof(t *testing.T) {
 	r := rand.New(rand.NewSource(1)) // #nosec G404
 
-	trieDBConfig := newDefaultDBConfig()
-	trieDBConfig.HistoryLength = defaultRequestKeyLimit
-	trieDBConfig.NodeCacheSize = defaultRequestKeyLimit
-
 	trieDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		trieDBConfig,
+		newDefaultDBConfig(),
 	)
 	require.NoError(t, err)
-
-	verificationDBConfig := newDefaultDBConfig()
-	verificationDBConfig.HistoryLength = defaultRequestKeyLimit
-	verificationDBConfig.NodeCacheSize = defaultRequestKeyLimit
 
 	verificationDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		verificationDBConfig,
+		newDefaultDBConfig(),
 	)
 	require.NoError(t, err)
 	startRoot, err := trieDB.GetMerkleRoot(context.Background())

--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
 
@@ -26,6 +27,16 @@ import (
 
 	syncpb "github.com/ava-labs/avalanchego/proto/pb/sync"
 )
+
+func newDefaultDBConfig() merkledb.Config {
+	return merkledb.Config{
+		EvictionBatchSize: 100,
+		HistoryLength:     defaultRequestKeyLimit,
+		NodeCacheSize:     defaultRequestKeyLimit,
+		Reg:               prometheus.NewRegistry(),
+		Tracer:            newNoopTracer(),
+	}
+}
 
 func sendRangeRequest(
 	t *testing.T,
@@ -374,24 +385,25 @@ func sendChangeRequest(
 func TestGetChangeProof(t *testing.T) {
 	r := rand.New(rand.NewSource(1)) // #nosec G404
 
+	trieDBConfig := newDefaultDBConfig()
+	trieDBConfig.HistoryLength = defaultRequestKeyLimit
+	trieDBConfig.NodeCacheSize = defaultRequestKeyLimit
+
 	trieDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: defaultRequestKeyLimit,
-			NodeCacheSize: defaultRequestKeyLimit,
-		},
+		trieDBConfig,
 	)
 	require.NoError(t, err)
+
+	verificationDBConfig := newDefaultDBConfig()
+	verificationDBConfig.HistoryLength = defaultRequestKeyLimit
+	verificationDBConfig.NodeCacheSize = defaultRequestKeyLimit
+
 	verificationDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: defaultRequestKeyLimit,
-			NodeCacheSize: defaultRequestKeyLimit,
-		},
+		verificationDBConfig,
 	)
 	require.NoError(t, err)
 	startRoot, err := trieDB.GetMerkleRoot(context.Background())

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -61,11 +61,7 @@ func Test_Creation(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: 0,
-			NodeCacheSize: 1000,
-		},
+		newDefaultDBConfig(),
 	)
 	require.NoError(t, err)
 
@@ -87,11 +83,7 @@ func Test_Completion(t *testing.T) {
 		emptyDB, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			merkledb.Config{
-				Tracer:        newNoopTracer(),
-				HistoryLength: 0,
-				NodeCacheSize: 1000,
-			},
+			newDefaultDBConfig(),
 		)
 		require.NoError(t, err)
 		emptyRoot, err := emptyDB.GetMerkleRoot(context.Background())
@@ -99,11 +91,7 @@ func Test_Completion(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			merkledb.Config{
-				Tracer:        newNoopTracer(),
-				HistoryLength: 0,
-				NodeCacheSize: 1000,
-			},
+			newDefaultDBConfig(),
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -198,11 +186,7 @@ func Test_Sync_FindNextKey_InSync(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			merkledb.Config{
-				Tracer:        newNoopTracer(),
-				HistoryLength: 0,
-				NodeCacheSize: 1000,
-			},
+			newDefaultDBConfig(),
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -267,11 +251,7 @@ func Test_Sync_FindNextKey_Deleted(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: 0,
-			NodeCacheSize: 1000,
-		},
+		newDefaultDBConfig(),
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x10}, []byte{1}))
@@ -313,11 +293,7 @@ func Test_Sync_FindNextKey_BranchInLocal(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: 0,
-			NodeCacheSize: 1000,
-		},
+		newDefaultDBConfig(),
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x11}, []byte{1}))
@@ -347,11 +323,7 @@ func Test_Sync_FindNextKey_BranchInReceived(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: 0,
-			NodeCacheSize: 1000,
-		},
+		newDefaultDBConfig(),
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x11}, []byte{1}))
@@ -389,11 +361,7 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			merkledb.Config{
-				Tracer:        newNoopTracer(),
-				HistoryLength: 0,
-				NodeCacheSize: 1000,
-			},
+			newDefaultDBConfig(),
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -466,11 +434,7 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			merkledb.Config{
-				Tracer:        newNoopTracer(),
-				HistoryLength: 0,
-				NodeCacheSize: 1000,
-			},
+			newDefaultDBConfig(),
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -514,22 +478,14 @@ func TestFindNextKeyRandom(t *testing.T) {
 	remoteDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: defaultRequestKeyLimit,
-			NodeCacheSize: defaultRequestKeyLimit,
-		},
+		newDefaultDBConfig(),
 	)
 	require.NoError(err)
 
 	localDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: defaultRequestKeyLimit,
-			NodeCacheSize: defaultRequestKeyLimit,
-		},
+		newDefaultDBConfig(),
 	)
 	require.NoError(err)
 
@@ -729,11 +685,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			merkledb.Config{
-				Tracer:        newNoopTracer(),
-				HistoryLength: 0,
-				NodeCacheSize: 1000,
-			},
+			newDefaultDBConfig(),
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -787,11 +739,7 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			merkledb.Config{
-				Tracer:        newNoopTracer(),
-				HistoryLength: 0,
-				NodeCacheSize: 1000,
-			},
+			newDefaultDBConfig(),
 		)
 		require.NoError(t, err)
 
@@ -856,11 +804,7 @@ func Test_Sync_Error_During_Sync(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: 0,
-			NodeCacheSize: 1000,
-		},
+		newDefaultDBConfig(),
 	)
 	require.NoError(err)
 
@@ -939,11 +883,7 @@ func Test_Sync_Result_Correct_Root_Update_Root_During(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			merkledb.Config{
-				Tracer:        newNoopTracer(),
-				HistoryLength: 0,
-				NodeCacheSize: 1000,
-			},
+			newDefaultDBConfig(),
 		)
 		require.NoError(err)
 
@@ -1062,11 +1002,7 @@ func generateTrieWithMinKeyLen(t *testing.T, r *rand.Rand, count int, minKeyLen 
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		merkledb.Config{
-			Tracer:        newNoopTracer(),
-			HistoryLength: 1000,
-			NodeCacheSize: 1000,
-		},
+		newDefaultDBConfig(),
 	)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Why this should be merged

This should be configurable.

## How this works

Adds config field for eviction batch size and default config function for use in tests. 

## How this was tested

Update existing UT.