### PR TITLE
Revert "`MerkleDB` -- add eviction batch size config"

### DIFF
--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -25,16 +24,6 @@ const minCacheSize = 1000
 func newNoopTracer() trace.Tracer {
 	tracer, _ := trace.New(trace.Config{Enabled: false})
 	return tracer
-}
-
-func newDefaultConfig() Config {
-	return Config{
-		EvictionBatchSize: 100,
-		HistoryLength:     100,
-		NodeCacheSize:     1_000,
-		Reg:               prometheus.NewRegistry(),
-		Tracer:            newNoopTracer(),
-	}
 }
 
 func Test_MerkleDB_Get_Safety(t *testing.T) {
@@ -97,7 +86,11 @@ func Test_MerkleDB_DB_Load_Root_From_DB(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		rdb,
-		newDefaultConfig(),
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 100,
+			NodeCacheSize: 100,
+		},
 	)
 	require.NoError(err)
 
@@ -119,7 +112,11 @@ func Test_MerkleDB_DB_Load_Root_From_DB(t *testing.T) {
 	db, err = New(
 		context.Background(),
 		rdb,
-		newDefaultConfig(),
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 100,
+			NodeCacheSize: 100,
+		},
 	)
 	require.NoError(err)
 	reloadedRoot, err := db.GetMerkleRoot(context.Background())
@@ -135,13 +132,14 @@ func Test_MerkleDB_DB_Rebuild(t *testing.T) {
 
 	initialSize := 10_000
 
-	config := newDefaultConfig()
-	config.NodeCacheSize = initialSize
-
 	db, err := New(
 		context.Background(),
 		rdb,
-		config,
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 100,
+			NodeCacheSize: initialSize,
+		},
 	)
 	require.NoError(err)
 
@@ -169,7 +167,10 @@ func Test_MerkleDB_Failed_Batch_Commit(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		memDB,
-		newDefaultConfig(),
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 300,
+		},
 	)
 	require.NoError(t, err)
 
@@ -189,7 +190,11 @@ func Test_MerkleDB_Value_Cache(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		memDB,
-		newDefaultConfig(),
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 300,
+			NodeCacheSize: minCacheSize,
+		},
 	)
 	require.NoError(t, err)
 
@@ -810,7 +815,11 @@ func runRandDBTest(require *require.Assertions, r *rand.Rand, rt randTest) {
 			dbTrie, err := newDatabase(
 				context.Background(),
 				memdb.New(),
-				newDefaultConfig(),
+				Config{
+					Tracer:        newNoopTracer(),
+					HistoryLength: 0,
+					NodeCacheSize: minCacheSize,
+				},
 				&mockMetrics{},
 			)
 			require.NoError(err)

--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,16 +26,6 @@ import (
 
 	syncpb "github.com/ava-labs/avalanchego/proto/pb/sync"
 )
-
-func newDefaultDBConfig() merkledb.Config {
-	return merkledb.Config{
-		EvictionBatchSize: 100,
-		HistoryLength:     defaultRequestKeyLimit,
-		NodeCacheSize:     defaultRequestKeyLimit,
-		Reg:               prometheus.NewRegistry(),
-		Tracer:            newNoopTracer(),
-	}
-}
 
 func sendRangeRequest(
 	t *testing.T,
@@ -388,14 +377,21 @@ func TestGetChangeProof(t *testing.T) {
 	trieDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: defaultRequestKeyLimit,
+			NodeCacheSize: defaultRequestKeyLimit,
+		},
 	)
 	require.NoError(t, err)
-
 	verificationDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: defaultRequestKeyLimit,
+			NodeCacheSize: defaultRequestKeyLimit,
+		},
 	)
 	require.NoError(t, err)
 	startRoot, err := trieDB.GetMerkleRoot(context.Background())

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -61,7 +61,11 @@ func Test_Creation(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(t, err)
 
@@ -83,7 +87,11 @@ func Test_Completion(t *testing.T) {
 		emptyDB, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		emptyRoot, err := emptyDB.GetMerkleRoot(context.Background())
@@ -91,7 +99,11 @@ func Test_Completion(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -186,7 +198,11 @@ func Test_Sync_FindNextKey_InSync(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -251,7 +267,11 @@ func Test_Sync_FindNextKey_Deleted(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x10}, []byte{1}))
@@ -293,7 +313,11 @@ func Test_Sync_FindNextKey_BranchInLocal(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x11}, []byte{1}))
@@ -323,7 +347,11 @@ func Test_Sync_FindNextKey_BranchInReceived(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x11}, []byte{1}))
@@ -361,7 +389,11 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -434,7 +466,11 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -478,14 +514,22 @@ func TestFindNextKeyRandom(t *testing.T) {
 	remoteDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: defaultRequestKeyLimit,
+			NodeCacheSize: defaultRequestKeyLimit,
+		},
 	)
 	require.NoError(err)
 
 	localDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: defaultRequestKeyLimit,
+			NodeCacheSize: defaultRequestKeyLimit,
+		},
 	)
 	require.NoError(err)
 
@@ -685,7 +729,11 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -739,7 +787,11 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 
@@ -804,7 +856,11 @@ func Test_Sync_Error_During_Sync(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(err)
 
@@ -883,7 +939,11 @@ func Test_Sync_Result_Correct_Root_Update_Root_During(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(err)
 
@@ -1002,7 +1062,11 @@ func generateTrieWithMinKeyLen(t *testing.T, r *rand.Rand, count int, minKeyLen 
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 1000,
+			NodeCacheSize: 1000,
+		},
 	)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Reverts ava-labs/avalanchego#1586

There's a bug in https://github.com/ava-labs/avalanchego/pull/1534. 

The iterator of linkedhashmap, used by the node cache, says:

```go
// Assumes the underlying LinkedHashmap is not modified while
// the iterator is in use, except to delete elements that
// have already been iterated over.
```

but in `onEvictCache`'s `Flush` method, called on `Close`, we do exactly this. Namely, when we call `c.onEviction`, we call `removeOldest` on the cache which modifies the `linkedHashmap`.

Will make a subsequent PR to revert #1534. #1586 was built atop #1534.