### PR TITLE
Revert PRs 1534 and 1586

### DIFF
--- a/x/merkledb/cache.go
+++ b/x/merkledb/cache.go
@@ -26,15 +26,6 @@ func newOnEvictCache[K comparable, V any](maxSize int, onEviction func(V) error)
 	}
 }
 
-// removeOldest returns and removes the oldest element from this cache.
-func (c *onEvictCache[K, V]) removeOldest() (K, V, bool) {
-	k, v, exists := c.fifo.Oldest()
-	if exists {
-		c.fifo.Delete(k)
-	}
-	return k, v, exists
-}
-
 // Get an element from this cache.
 func (c *onEvictCache[K, V]) Get(key K) (V, bool) {
 	c.lock.RLock()
@@ -53,14 +44,14 @@ func (c *onEvictCache[K, V]) Put(key K, value V) error {
 	c.fifo.Put(key, value) // Mark as MRU
 
 	if c.fifo.Len() > c.maxSize {
-		oldestKey, oldestVal, _ := c.fifo.Oldest()
+		oldestKey, oldsetVal, _ := c.fifo.Oldest()
 		c.fifo.Delete(oldestKey)
-		return c.onEviction(oldestVal)
+		return c.onEviction(oldsetVal)
 	}
 	return nil
 }
 
-// Flush removes all elements from the cache.
+// Removes all elements from the cache.
 // Returns the last non-nil error during [c.onEviction], if any.
 // If [c.onEviction] errors, it will still be called for any
 // subsequent elements and the cache will still be emptied.
@@ -74,8 +65,8 @@ func (c *onEvictCache[K, V]) Flush() error {
 	var errs wrappers.Errs
 	iter := c.fifo.NewIterator()
 	for iter.Next() {
-		errs.Add(c.onEviction(iter.Value()))
+		val := iter.Value()
+		errs.Add(c.onEviction(val))
 	}
-
 	return errs.Err
 }

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils"
@@ -29,6 +30,7 @@ import (
 
 const (
 	RootPath = EmptyPath
+
 	// TODO: name better
 	rebuildViewSizeFractionOfCacheSize = 50
 	minRebuildViewSizePerCommit        = 1000
@@ -115,9 +117,6 @@ type MerkleDB interface {
 }
 
 type Config struct {
-	// The number of nodes that are evicted from the cache and written to
-	// disk at a time.
-	EvictionBatchSize int
 	// The number of changes to the database that we store in memory in order to
 	// serve change proofs.
 	HistoryLength int
@@ -140,15 +139,16 @@ type merkleDB struct {
 	// Should be held before taking [db.lock]
 	commitLock sync.RWMutex
 
-	nodeDB database.Database
+	// versiondb that the other dbs are built on.
+	// Allows the changes made to the snapshot and [nodeDB] to be atomic.
+	nodeDB *versiondb.Database
 
 	// Stores data about the database's current state.
 	metadataDB database.Database
 
 	// If a value is nil, the corresponding key isn't in the trie.
-	nodeCache         onEvictCache[path, *node]
-	onEvictionErr     utils.Atomic[error]
-	evictionBatchSize int
+	nodeCache     onEvictCache[path, *node]
+	onEvictionErr utils.Atomic[error]
 
 	// Stores change lists. Used to serve change proofs and construct
 	// historical views of the trie.
@@ -175,13 +175,12 @@ func newDatabase(
 	metrics merkleMetrics,
 ) (*merkleDB, error) {
 	trieDB := &merkleDB{
-		metrics:           metrics,
-		nodeDB:            prefixdb.New(nodePrefix, db),
-		metadataDB:        prefixdb.New(metadataPrefix, db),
-		history:           newTrieHistory(config.HistoryLength),
-		tracer:            config.Tracer,
-		childViews:        make([]*trieView, 0, defaultPreallocationSize),
-		evictionBatchSize: config.EvictionBatchSize,
+		metrics:    metrics,
+		nodeDB:     versiondb.New(prefixdb.New(nodePrefix, db)),
+		metadataDB: prefixdb.New(metadataPrefix, db),
+		history:    newTrieHistory(config.HistoryLength),
+		tracer:     config.Tracer,
+		childViews: make([]*trieView, 0, defaultPreallocationSize),
 	}
 
 	// Note: trieDB.OnEviction is responsible for writing intermediary nodes to
@@ -266,7 +265,8 @@ func (db *merkleDB) rebuild(ctx context.Context) error {
 				return err
 			}
 			currentViewSize++
-		} else if err := db.nodeDB.Delete(key); err != nil {
+		}
+		if err := db.nodeDB.Delete(key); err != nil {
 			return err
 		}
 	}
@@ -351,6 +351,10 @@ func (db *merkleDB) Close() error {
 	if err := db.nodeCache.Flush(); err != nil {
 		// There was an error during cache eviction.
 		// Don't commit to disk.
+		return err
+	}
+
+	if err := db.nodeDB.Commit(); err != nil {
 		return err
 	}
 
@@ -745,58 +749,29 @@ func (db *merkleDB) NewIteratorWithStartAndPrefix(start, prefix []byte) database
 // the movement of [node] from [db.nodeCache] to [db.nodeDB] is atomic.
 // As soon as [db.nodeCache] no longer has [node], [db.nodeDB] does.
 // Non-nil error is fatal -- causes [db] to close.
-func (db *merkleDB) onEviction(n *node) error {
-	// the evicted node isn't an intermediary node, so skip writing.
-	if n == nil || n.hasValue() {
+func (db *merkleDB) onEviction(node *node) error {
+	if node == nil || node.hasValue() {
+		// only persist intermediary nodes
 		return nil
 	}
 
-	batch := db.nodeDB.NewBatch()
-	if err := writeNodeToBatch(batch, n); err != nil {
+	nodeBytes, err := node.marshal()
+	if err != nil {
+		db.onEvictionErr.Set(err)
+		// Prevent reads/writes from/to [db.nodeDB] to avoid inconsistent state.
+		_ = db.nodeDB.Close()
+		// This is a fatal error.
+		go db.Close()
 		return err
 	}
 
-	// Evict the oldest [evictionBatchSize] nodes from the cache
-	// and write them to disk. We write a batch of them, rather than
-	// just [n], so that we don't immediately evict and write another
-	// node, because each time this method is called we do a disk write.
-	var err error
-	for removedCount := 0; removedCount < db.evictionBatchSize; removedCount++ {
-		_, n, exists := db.nodeCache.removeOldest()
-		if !exists {
-			// The cache is empty.
-			break
-		}
-		if n == nil || n.hasValue() {
-			// only persist intermediary nodes
-			continue
-		}
-		// Note this must be = not := since we check
-		// [err] outside the loop.
-		if err = writeNodeToBatch(batch, n); err != nil {
-			break
-		}
-	}
-	if err == nil {
-		err = batch.Write()
-	}
-	if err != nil {
+	if err := db.nodeDB.Put(node.key.Bytes(), nodeBytes); err != nil {
 		db.onEvictionErr.Set(err)
 		_ = db.nodeDB.Close()
 		go db.Close()
 		return err
 	}
 	return nil
-}
-
-// Writes [n] to [batch]. Assumes [n] is non-nil.
-func writeNodeToBatch(batch database.Batch, n *node) error {
-	nodeBytes, err := n.marshal()
-	if err != nil {
-		return err
-	}
-
-	return batch.Put(n.key.Bytes(), nodeBytes)
 }
 
 // Put upserts the key/value pair into the db.
@@ -884,13 +859,19 @@ func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) e
 		return errNoNewRoot
 	}
 
-	batch := db.nodeDB.NewBatch()
+	// commit any outstanding cache evicted nodes.
+	// Note that we do this here because below we may Abort
+	// [db.nodeDB], which would cause us to lose these changes.
+	if err := db.nodeDB.Commit(); err != nil {
+		return err
+	}
 
 	_, nodesSpan := db.tracer.Start(ctx, "MerkleDB.commitChanges.writeNodes")
 	for key, nodeChange := range changes.nodes {
 		if nodeChange.after == nil {
 			db.metrics.IOKeyWrite()
-			if err := batch.Delete(key.Bytes()); err != nil {
+			if err := db.nodeDB.Delete(key.Bytes()); err != nil {
+				db.nodeDB.Abort()
 				nodesSpan.End()
 				return err
 			}
@@ -902,7 +883,15 @@ func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) e
 			// Otherwise, intermediary nodes are persisted on cache eviction or
 			// shutdown.
 			db.metrics.IOKeyWrite()
-			if err := writeNodeToBatch(batch, nodeChange.after); err != nil {
+			nodeBytes, err := nodeChange.after.marshal()
+			if err != nil {
+				db.nodeDB.Abort()
+				nodesSpan.End()
+				return err
+			}
+
+			if err := db.nodeDB.Put(key.Bytes(), nodeBytes); err != nil {
+				db.nodeDB.Abort()
 				nodesSpan.End()
 				return err
 			}
@@ -911,9 +900,10 @@ func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) e
 	nodesSpan.End()
 
 	_, commitSpan := db.tracer.Start(ctx, "MerkleDB.commitChanges.dbCommit")
-	err := batch.Write()
+	err := db.nodeDB.Commit()
 	commitSpan.End()
 	if err != nil {
+		db.nodeDB.Abort()
 		return err
 	}
 
@@ -1132,13 +1122,11 @@ func (db *merkleDB) initializeRootIfNeeded() (ids.ID, error) {
 	if err != nil {
 		return ids.Empty, err
 	}
-
-	batch := db.nodeDB.NewBatch()
-	if err := batch.Put(rootKey, rootBytes); err != nil {
+	if err := db.nodeDB.Put(rootKey, rootBytes); err != nil {
 		return ids.Empty, err
 	}
 
-	return db.root.id, batch.Write()
+	return db.root.id, db.nodeDB.Commit()
 }
 
 // Returns a view of the trie as it was when it had root [rootID] for keys within range [start, end].

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -25,16 +24,6 @@ const minCacheSize = 1000
 func newNoopTracer() trace.Tracer {
 	tracer, _ := trace.New(trace.Config{Enabled: false})
 	return tracer
-}
-
-func newDefaultConfig() Config {
-	return Config{
-		EvictionBatchSize: 100,
-		HistoryLength:     100,
-		NodeCacheSize:     1_000,
-		Reg:               prometheus.NewRegistry(),
-		Tracer:            newNoopTracer(),
-	}
 }
 
 func Test_MerkleDB_Get_Safety(t *testing.T) {
@@ -97,7 +86,11 @@ func Test_MerkleDB_DB_Load_Root_From_DB(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		rdb,
-		newDefaultConfig(),
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 100,
+			NodeCacheSize: 100,
+		},
 	)
 	require.NoError(err)
 
@@ -119,7 +112,11 @@ func Test_MerkleDB_DB_Load_Root_From_DB(t *testing.T) {
 	db, err = New(
 		context.Background(),
 		rdb,
-		newDefaultConfig(),
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 100,
+			NodeCacheSize: 100,
+		},
 	)
 	require.NoError(err)
 	reloadedRoot, err := db.GetMerkleRoot(context.Background())
@@ -135,13 +132,14 @@ func Test_MerkleDB_DB_Rebuild(t *testing.T) {
 
 	initialSize := 10_000
 
-	config := newDefaultConfig()
-	config.NodeCacheSize = initialSize
-
 	db, err := New(
 		context.Background(),
 		rdb,
-		config,
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 100,
+			NodeCacheSize: initialSize,
+		},
 	)
 	require.NoError(err)
 
@@ -169,7 +167,10 @@ func Test_MerkleDB_Failed_Batch_Commit(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		memDB,
-		newDefaultConfig(),
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 300,
+		},
 	)
 	require.NoError(t, err)
 
@@ -189,7 +190,11 @@ func Test_MerkleDB_Value_Cache(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		memDB,
-		newDefaultConfig(),
+		Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 300,
+			NodeCacheSize: minCacheSize,
+		},
 	)
 	require.NoError(t, err)
 
@@ -810,7 +815,11 @@ func runRandDBTest(require *require.Assertions, r *rand.Rand, rt randTest) {
 			dbTrie, err := newDatabase(
 				context.Background(),
 				memdb.New(),
-				newDefaultConfig(),
+				Config{
+					Tracer:        newNoopTracer(),
+					HistoryLength: 0,
+					NodeCacheSize: minCacheSize,
+				},
 				&mockMetrics{},
 			)
 			require.NoError(err)

--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,16 +26,6 @@ import (
 
 	syncpb "github.com/ava-labs/avalanchego/proto/pb/sync"
 )
-
-func newDefaultDBConfig() merkledb.Config {
-	return merkledb.Config{
-		EvictionBatchSize: 100,
-		HistoryLength:     defaultRequestKeyLimit,
-		NodeCacheSize:     defaultRequestKeyLimit,
-		Reg:               prometheus.NewRegistry(),
-		Tracer:            newNoopTracer(),
-	}
-}
 
 func sendRangeRequest(
 	t *testing.T,
@@ -388,14 +377,21 @@ func TestGetChangeProof(t *testing.T) {
 	trieDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: defaultRequestKeyLimit,
+			NodeCacheSize: defaultRequestKeyLimit,
+		},
 	)
 	require.NoError(t, err)
-
 	verificationDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: defaultRequestKeyLimit,
+			NodeCacheSize: defaultRequestKeyLimit,
+		},
 	)
 	require.NoError(t, err)
 	startRoot, err := trieDB.GetMerkleRoot(context.Background())

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -61,7 +61,11 @@ func Test_Creation(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(t, err)
 
@@ -83,7 +87,11 @@ func Test_Completion(t *testing.T) {
 		emptyDB, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		emptyRoot, err := emptyDB.GetMerkleRoot(context.Background())
@@ -91,7 +99,11 @@ func Test_Completion(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -186,7 +198,11 @@ func Test_Sync_FindNextKey_InSync(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -251,7 +267,11 @@ func Test_Sync_FindNextKey_Deleted(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x10}, []byte{1}))
@@ -293,7 +313,11 @@ func Test_Sync_FindNextKey_BranchInLocal(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x11}, []byte{1}))
@@ -323,7 +347,11 @@ func Test_Sync_FindNextKey_BranchInReceived(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Put([]byte{0x11}, []byte{1}))
@@ -361,7 +389,11 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -434,7 +466,11 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -478,14 +514,22 @@ func TestFindNextKeyRandom(t *testing.T) {
 	remoteDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: defaultRequestKeyLimit,
+			NodeCacheSize: defaultRequestKeyLimit,
+		},
 	)
 	require.NoError(err)
 
 	localDB, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: defaultRequestKeyLimit,
+			NodeCacheSize: defaultRequestKeyLimit,
+		},
 	)
 	require.NoError(err)
 
@@ -685,7 +729,11 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 		syncer, err := NewStateSyncManager(StateSyncConfig{
@@ -739,7 +787,11 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(t, err)
 
@@ -804,7 +856,11 @@ func Test_Sync_Error_During_Sync(t *testing.T) {
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 0,
+			NodeCacheSize: 1000,
+		},
 	)
 	require.NoError(err)
 
@@ -883,7 +939,11 @@ func Test_Sync_Result_Correct_Root_Update_Root_During(t *testing.T) {
 		db, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
-			newDefaultDBConfig(),
+			merkledb.Config{
+				Tracer:        newNoopTracer(),
+				HistoryLength: 0,
+				NodeCacheSize: 1000,
+			},
 		)
 		require.NoError(err)
 
@@ -1002,7 +1062,11 @@ func generateTrieWithMinKeyLen(t *testing.T, r *rand.Rand, count int, minKeyLen 
 	db, err := merkledb.New(
 		context.Background(),
 		memdb.New(),
-		newDefaultDBConfig(),
+		merkledb.Config{
+			Tracer:        newNoopTracer(),
+			HistoryLength: 1000,
+			NodeCacheSize: 1000,
+		},
 	)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Why this should be merged

There's a bug in #1534. #1586 is built atop 1534.

The iterator of `linkedhashmap`, used by the node cache, says:

```go
// Assumes the underlying LinkedHashmap is not modified while
// the iterator is in use, except to delete elements that
// have already been iterated over.
```

but in `onEvictCache`'s `Flush` method, called on `Close`, we do exactly this. Namely, when we call `c.onEviction`, we call `removeOldest` on the cache which modifies the `linkedHashmap`.

Will make a subsequent PR to revert #1534. #1586 was built atop #1534.

## How this works

Revert #1534 and #1586

## How this was tested

N/A