### PR TITLE
Pchain bls diffs fix cleanup

### DIFF
--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -199,8 +199,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 			list := v.([]uint8)
 			return len(list) > 0 && (list[0] == startPrimaryWithBLS || list[0] == startPrimaryWithoutBLS)
 		}),
-	),
-	)
+	))
 
 	properties.TestingRun(t)
 }
@@ -603,8 +602,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			list := v.([]uint8)
 			return len(list) > 0 && (list[0] == startPrimaryWithBLS || list[0] == startPrimaryWithoutBLS)
 		}),
-	),
-	)
+	))
 
 	properties.Property("subnet validators are returned in sequence", prop.ForAll(
 		func(events []uint8) string {
@@ -656,8 +654,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			list := v.([]uint8)
 			return len(list) > 0 && (list[0] == startPrimaryWithBLS || list[0] == startPrimaryWithoutBLS)
 		}),
-	),
-	)
+	))
 
 	properties.Property("subnet validators' times are bound by a primary validator's times", prop.ForAll(
 		func(events []uint8) string {
@@ -695,8 +692,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			list := v.([]uint8)
 			return len(list) > 0 && (list[0] == startPrimaryWithBLS || list[0] == startPrimaryWithoutBLS)
 		}),
-	),
-	)
+	))
 
 	properties.TestingRun(t)
 }


### PR DESCRIPTION
## Why this should be merged

- [X] Prevents duplicate iteration when fetching the primary network validator set
- [X] Uses the caching of the primary network validator set to avoid additional state iteration
- [X] Avoids unnecessary subnet validator set iteration
- [X] Avoids needing to handle the edge case when `currentHeight == targetHeight` for subnet BLS key tracking

## How this works

Kept the majority of the code - just restructured it to be more efficient + have less edge cases.

## How this was tested

CI