### PR TITLE
Cleanup fx interface compliance

### DIFF
--- a/scripts/mocks.mockgen.txt
+++ b/scripts/mocks.mockgen.txt
@@ -29,11 +29,9 @@ github.com/ava-labs/avalanchego/vms/avm/metrics=Metrics=vms/avm/metrics/mock_met
 github.com/ava-labs/avalanchego/vms/avm/states=Chain,State,Diff=vms/avm/states/mock_states.go
 github.com/ava-labs/avalanchego/vms/avm/txs/mempool=Mempool=vms/avm/txs/mempool/mock_mempool.go
 github.com/ava-labs/avalanchego/vms/components/avax=TransferableIn=vms/components/avax/mock_transferable_in.go
-github.com/ava-labs/avalanchego/vms/components/avax=TransferableOut=vms/components/avax/mock_transferable_out.go
 github.com/ava-labs/avalanchego/vms/components/verify=Verifiable=vms/components/verify/mock_verifiable.go
 github.com/ava-labs/avalanchego/vms/platformvm/blocks/executor=Manager=vms/platformvm/blocks/executor/mock_manager.go
 github.com/ava-labs/avalanchego/vms/platformvm/blocks=Block=vms/platformvm/blocks/mock_block.go
-github.com/ava-labs/avalanchego/vms/platformvm/fx=Fx,Owner=vms/platformvm/fx/mock_fx.go
 github.com/ava-labs/avalanchego/vms/platformvm/state=Chain=vms/platformvm/state/mock_chain.go
 github.com/ava-labs/avalanchego/vms/platformvm/state=Diff=vms/platformvm/state/mock_diff.go
 github.com/ava-labs/avalanchego/vms/platformvm/state=StakerIterator=vms/platformvm/state/mock_staker_iterator.go

--- a/vms/avm/state_test.go
+++ b/vms/avm/state_test.go
@@ -29,7 +29,7 @@ func TestSetsAndGets(t *testing.T) {
 			Fx: &FxTest{
 				InitializeF: func(vmIntf interface{}) error {
 					vm := vmIntf.(secp256k1fx.VM)
-					return vm.CodecRegistry().RegisterType(&avax.TestVerifiable{})
+					return vm.CodecRegistry().RegisterType(&avax.TestState{})
 				},
 			},
 		}},
@@ -51,7 +51,7 @@ func TestSetsAndGets(t *testing.T) {
 			OutputIndex: 1,
 		},
 		Asset: avax.Asset{ID: ids.Empty},
-		Out:   &avax.TestVerifiable{},
+		Out:   &avax.TestState{},
 	}
 	utxoID := utxo.InputID()
 
@@ -116,7 +116,7 @@ func TestFundingNoAddresses(t *testing.T) {
 			Fx: &FxTest{
 				InitializeF: func(vmIntf interface{}) error {
 					vm := vmIntf.(secp256k1fx.VM)
-					return vm.CodecRegistry().RegisterType(&avax.TestVerifiable{})
+					return vm.CodecRegistry().RegisterType(&avax.TestState{})
 				},
 			},
 		}},
@@ -138,7 +138,7 @@ func TestFundingNoAddresses(t *testing.T) {
 			OutputIndex: 1,
 		},
 		Asset: avax.Asset{ID: ids.Empty},
-		Out:   &avax.TestVerifiable{},
+		Out:   &avax.TestState{},
 	}
 
 	state.AddUTXO(utxo)

--- a/vms/avm/txs/initial_state_test.go
+++ b/vms/avm/txs/initial_state_test.go
@@ -135,7 +135,7 @@ func TestInitialStateVerifyNilOutput(t *testing.T) {
 
 func TestInitialStateVerifyInvalidOutput(t *testing.T) {
 	c := linearcodec.NewDefault()
-	if err := c.RegisterType(&avax.TestVerifiable{}); err != nil {
+	if err := c.RegisterType(&avax.TestState{}); err != nil {
 		t.Fatal(err)
 	}
 	m := codec.NewDefaultManager()
@@ -146,7 +146,7 @@ func TestInitialStateVerifyInvalidOutput(t *testing.T) {
 
 	is := InitialState{
 		FxIndex: 0,
-		Outs:    []verify.State{&avax.TestVerifiable{Err: errTest}},
+		Outs:    []verify.State{&avax.TestState{Err: errTest}},
 	}
 	if err := is.Verify(m, numFxs); err == nil {
 		t.Fatalf("Should have erred due to an invalid output")

--- a/vms/components/avax/mock_transferable_out.go
+++ b/vms/components/avax/mock_transferable_out.go
@@ -11,11 +11,14 @@ import (
 	reflect "reflect"
 
 	snow "github.com/ava-labs/avalanchego/snow"
+	verify "github.com/ava-labs/avalanchego/vms/components/verify"
 	gomock "github.com/golang/mock/gomock"
 )
 
 // MockTransferableOut is a mock of TransferableOut interface.
 type MockTransferableOut struct {
+	verify.IsState
+
 	ctrl     *gomock.Controller
 	recorder *MockTransferableOutMockRecorder
 }
@@ -75,18 +78,4 @@ func (m *MockTransferableOut) Verify() error {
 func (mr *MockTransferableOutMockRecorder) Verify() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockTransferableOut)(nil).Verify))
-}
-
-// VerifyState mocks base method.
-func (m *MockTransferableOut) VerifyState() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyState")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// VerifyState indicates an expected call of VerifyState.
-func (mr *MockTransferableOutMockRecorder) VerifyState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyState", reflect.TypeOf((*MockTransferableOut)(nil).VerifyState))
 }

--- a/vms/components/avax/test_verifiable.go
+++ b/vms/components/avax/test_verifiable.go
@@ -3,22 +3,31 @@
 
 package avax
 
-import "github.com/ava-labs/avalanchego/snow"
+import (
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+)
 
-type TestVerifiable struct{ Err error }
+var (
+	_ verify.State    = (*TestState)(nil)
+	_ TransferableOut = (*TestTransferable)(nil)
+	_ Addressable     = (*TestAddressable)(nil)
+)
 
-func (*TestVerifiable) InitCtx(*snow.Context) {}
+type TestState struct {
+	verify.IsState `json:"-"`
 
-func (v *TestVerifiable) Verify() error {
-	return v.Err
+	Err error
 }
 
-func (v *TestVerifiable) VerifyState() error {
+func (*TestState) InitCtx(*snow.Context) {}
+
+func (v *TestState) Verify() error {
 	return v.Err
 }
 
 type TestTransferable struct {
-	TestVerifiable
+	TestState
 
 	Val uint64 `serialize:"true"`
 }

--- a/vms/components/verify/verification.go
+++ b/vms/components/verify/verification.go
@@ -5,16 +5,22 @@ package verify
 
 import "github.com/ava-labs/avalanchego/snow"
 
-// Verifiable can be verified
 type Verifiable interface {
 	Verify() error
 }
 
-// State that can be verified
 type State interface {
 	snow.ContextInitializable
 	Verifiable
-	VerifyState() error
+	IsState
+}
+
+type IsState interface {
+	isState()
+}
+
+type IsNotState interface {
+	isState() error
 }
 
 // All returns nil if all the verifiables were verified with no errors

--- a/vms/nftfx/mint_output.go
+++ b/vms/nftfx/mint_output.go
@@ -6,10 +6,15 @@ package nftfx
 import (
 	"encoding/json"
 
+	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
+var _ verify.State = (*MintOutput)(nil)
+
 type MintOutput struct {
+	verify.IsState `json:"-"`
+
 	GroupID                  uint32 `serialize:"true" json:"groupID"`
 	secp256k1fx.OutputOwners `serialize:"true"`
 }

--- a/vms/nftfx/transfer_output.go
+++ b/vms/nftfx/transfer_output.go
@@ -26,6 +26,8 @@ var (
 )
 
 type TransferOutput struct {
+	verify.IsState `json:"-"`
+
 	GroupID                  uint32              `serialize:"true" json:"groupID"`
 	Payload                  types.JSONByteSlice `serialize:"true" json:"payload"`
 	secp256k1fx.OutputOwners `serialize:"true"`
@@ -54,8 +56,4 @@ func (out *TransferOutput) Verify() error {
 	default:
 		return out.OutputOwners.Verify()
 	}
-}
-
-func (out *TransferOutput) VerifyState() error {
-	return out.Verify()
 }

--- a/vms/platformvm/blocks/codec.go
+++ b/vms/platformvm/blocks/codec.go
@@ -31,7 +31,7 @@ func init() {
 	GenesisCodec = codec.NewManager(math.MaxInt32)
 
 	errs := wrappers.Errs{}
-	for _, c := range []codec.Registry{c, gc} {
+	for _, c := range []linearcodec.Codec{c, gc} {
 		errs.Add(
 			RegisterApricotBlockTypes(c),
 			txs.RegisterUnsignedTxsTypes(c),

--- a/vms/platformvm/fx/fx.go
+++ b/vms/platformvm/fx/fx.go
@@ -9,7 +9,11 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
-var _ Fx = (*secp256k1fx.Fx)(nil)
+var (
+	_ Fx    = (*secp256k1fx.Fx)(nil)
+	_ Owner = (*secp256k1fx.OutputOwners)(nil)
+	_ Owned = (*secp256k1fx.TransferOutput)(nil)
+)
 
 // Fx is the interface a feature extension must implement to support the
 // Platform Chain.
@@ -40,6 +44,8 @@ type Fx interface {
 }
 
 type Owner interface {
+	verify.IsNotState
+
 	verify.Verifiable
 	snow.ContextInitializable
 }

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -11,6 +11,7 @@ import (
 	reflect "reflect"
 
 	snow "github.com/ava-labs/avalanchego/snow"
+	verify "github.com/ava-labs/avalanchego/vms/components/verify"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -124,6 +125,8 @@ func (mr *MockFxMockRecorder) VerifyTransfer(arg0, arg1, arg2, arg3 interface{})
 
 // MockOwner is a mock of Owner interface.
 type MockOwner struct {
+	verify.IsNotState
+
 	ctrl     *gomock.Controller
 	recorder *MockOwnerMockRecorder
 }

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -53,19 +53,22 @@ func init() {
 
 // RegisterUnsignedTxsTypes allows registering relevant type of unsigned package
 // in the right sequence. Following repackaging of platformvm package, a few
-// subpackage-level codecs were introduced, each handling serialization of specific types.
+// subpackage-level codecs were introduced, each handling serialization of
+// specific types.
+//
 // RegisterUnsignedTxsTypes is made exportable so to guarantee that other codecs
 // are coherent with components one.
-func RegisterUnsignedTxsTypes(targetCodec codec.Registry) error {
+func RegisterUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
 	errs := wrappers.Errs{}
+
+	// The Fx is registered here because this is the same place it is registered
+	// in the AVM. This ensures that the typeIDs match up for utxos in shared
+	// memory.
+	errs.Add(targetCodec.RegisterType(&secp256k1fx.TransferInput{}))
+	targetCodec.SkipRegistrations(1)
+	errs.Add(targetCodec.RegisterType(&secp256k1fx.TransferOutput{}))
+	targetCodec.SkipRegistrations(1)
 	errs.Add(
-		// The Fx is registered here because this is the same place it is
-		// registered in the AVM. This ensures that the typeIDs match up for
-		// utxos in shared memory.
-		targetCodec.RegisterType(&secp256k1fx.TransferInput{}),
-		targetCodec.RegisterType(&secp256k1fx.MintOutput{}),
-		targetCodec.RegisterType(&secp256k1fx.TransferOutput{}),
-		targetCodec.RegisterType(&secp256k1fx.MintOperation{}),
 		targetCodec.RegisterType(&secp256k1fx.Credential{}),
 		targetCodec.RegisterType(&secp256k1fx.Input{}),
 		targetCodec.RegisterType(&secp256k1fx.OutputOwners{}),

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -61,9 +61,9 @@ func init() {
 func RegisterUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
 	errs := wrappers.Errs{}
 
-	// The Fx is registered here because this is the same place it is registered
-	// in the AVM. This ensures that the typeIDs match up for utxos in shared
-	// memory.
+	// The secp256k1fx is registered here because this is the same place it is
+	// registered in the AVM. This ensures that the typeIDs match up for utxos
+	// in shared memory.
 	errs.Add(targetCodec.RegisterType(&secp256k1fx.TransferInput{}))
 	targetCodec.SkipRegistrations(1)
 	errs.Add(targetCodec.RegisterType(&secp256k1fx.TransferOutput{}))

--- a/vms/propertyfx/mint_output.go
+++ b/vms/propertyfx/mint_output.go
@@ -3,8 +3,15 @@
 
 package propertyfx
 
-import "github.com/ava-labs/avalanchego/vms/secp256k1fx"
+import (
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+var _ verify.State = (*MintOutput)(nil)
 
 type MintOutput struct {
+	verify.IsState `json:"-"`
+
 	secp256k1fx.OutputOwners `serialize:"true"`
 }

--- a/vms/propertyfx/owned_output.go
+++ b/vms/propertyfx/owned_output.go
@@ -3,8 +3,15 @@
 
 package propertyfx
 
-import "github.com/ava-labs/avalanchego/vms/secp256k1fx"
+import (
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+var _ verify.State = (*OwnedOutput)(nil)
 
 type OwnedOutput struct {
+	verify.IsState `json:"-"`
+
 	secp256k1fx.OutputOwners `serialize:"true"`
 }

--- a/vms/secp256k1fx/mint_output.go
+++ b/vms/secp256k1fx/mint_output.go
@@ -8,6 +8,8 @@ import "github.com/ava-labs/avalanchego/vms/components/verify"
 var _ verify.State = (*MintOutput)(nil)
 
 type MintOutput struct {
+	verify.IsState `json:"-"`
+
 	OutputOwners `serialize:"true"`
 }
 
@@ -18,8 +20,4 @@ func (out *MintOutput) Verify() error {
 	default:
 		return out.OutputOwners.Verify()
 	}
-}
-
-func (out *MintOutput) VerifyState() error {
-	return out.Verify()
 }

--- a/vms/secp256k1fx/mint_output_test.go
+++ b/vms/secp256k1fx/mint_output_test.go
@@ -49,8 +49,6 @@ func TestMintOutputVerify(t *testing.T) {
 			require := require.New(t)
 			err := tt.out.Verify()
 			require.ErrorIs(err, tt.expectedErr)
-			err = tt.out.VerifyState()
-			require.ErrorIs(err, tt.expectedErr)
 		})
 	}
 }

--- a/vms/secp256k1fx/output_owners.go
+++ b/vms/secp256k1fx/output_owners.go
@@ -22,11 +22,11 @@ var (
 	ErrOutputUnoptimized    = errors.New("output representation should be optimized")
 	ErrAddrsNotSortedUnique = errors.New("addresses not sorted and unique")
 	ErrMarshal              = errors.New("cannot marshal without ctx")
-
-	_ verify.State = (*OutputOwners)(nil)
 )
 
 type OutputOwners struct {
+	verify.IsNotState `json:"-"`
+
 	Locktime  uint64        `serialize:"true" json:"locktime"`
 	Threshold uint32        `serialize:"true" json:"threshold"`
 	Addrs     []ids.ShortID `serialize:"true" json:"addresses"`
@@ -133,10 +133,6 @@ func (out *OutputOwners) Verify() error {
 	default:
 		return nil
 	}
-}
-
-func (out *OutputOwners) VerifyState() error {
-	return out.Verify()
 }
 
 func (out *OutputOwners) Sort() {

--- a/vms/secp256k1fx/output_owners_test.go
+++ b/vms/secp256k1fx/output_owners_test.go
@@ -69,8 +69,6 @@ func TestOutputOwnersVerify(t *testing.T) {
 			require := require.New(t)
 			err := tt.out.Verify()
 			require.ErrorIs(err, tt.expectedErr)
-			err = tt.out.VerifyState()
-			require.ErrorIs(err, tt.expectedErr)
 		})
 	}
 }

--- a/vms/secp256k1fx/transfer_output.go
+++ b/vms/secp256k1fx/transfer_output.go
@@ -11,12 +11,14 @@ import (
 )
 
 var (
-	_ verify.State = (*OutputOwners)(nil)
+	_ verify.State = (*TransferOutput)(nil)
 
 	ErrNoValueOutput = errors.New("output has no value")
 )
 
 type TransferOutput struct {
+	verify.IsState `json:"-"`
+
 	Amt uint64 `serialize:"true" json:"amount"`
 
 	OutputOwners `serialize:"true"`
@@ -49,10 +51,6 @@ func (out *TransferOutput) Verify() error {
 	default:
 		return out.OutputOwners.Verify()
 	}
-}
-
-func (out *TransferOutput) VerifyState() error {
-	return out.Verify()
 }
 
 func (out *TransferOutput) Owners() interface{} {


### PR DESCRIPTION
## Why this should be merged

- [X] Removes unused types from P-chain codec registration
- [X] Removes unused functions from Fx outputs

## How this works

1. It is impossible to introduce `*secp256k1fx.MintOutput` and `*secp256k1fx.MintOperation` in the P-chain, so we don't need to register them with the codec.
2. It is more idiomatic to use unimplementable private method interface compliance than an implementable public method interface.

## How this was tested

CI