### PR TITLE
tests/e2e: add support for scraping with Prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/holiman/big v0.0.0-20221017200358-a027dc42d04e // indirect
 	github.com/holiman/uint256 v1.2.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -101,6 +102,8 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,11 +290,13 @@ github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7Bd
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -332,13 +334,16 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
@@ -610,6 +615,7 @@ golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 h1:nt+Q6cXKz4MosCSpnbMtqiQ8Oz0pxTef2B4Vca2lvfk=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -790,6 +796,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -223,10 +223,10 @@ func (te *TestEnvironment) StartCluster() error {
 			return fmt.Errorf("could not start network-runner: %w", err)
 		}
 		tests.Outf("{{green}}successfully started network-runner: {{/}} %+v\n", resp.ClusterInfo.NodeNames)
-		te.rootDataDir = resp.ClusterInfo.GetRootDataDir()
 
 		// start is async, so wait some time for cluster health
 		time.Sleep(time.Minute)
+		te.rootDataDir = resp.ClusterInfo.GetRootDataDir()
 
 		ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
 		_, err = te.GetRunnerClient().Health(ctx)

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -158,7 +158,7 @@ func (te *TestEnvironment) StartPrometheus(prometheusExecPath string) error {
 	return nil
 }
 
-func(*TestEnvironment)  PrometheusSnapshot() error {
+func (*TestEnvironment) PrometheusSnapshot() error {
 	conn, err := api.NewClient(api.Config{
 		Address: "http://127.0.0.1:9090",
 	})

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -147,30 +147,31 @@ func (te *TestEnvironment) ConfigCluster(
 	}
 }
 
-func (te *TestEnvironment) StartMonitoring(prometheusExecPath string) error {
+func (te *TestEnvironment) StartPrometheus(prometheusExecPath string) error {
 	cmd := subprocess.NewCmd(prometheusExecPath, fmt.Sprintf("--config.file=%s/prometheus.yaml", te.rootDataDir))
 	err := cmd.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start prometheus: %w", err)
 	}
 	te.prometheusExec = cmd
+
 	return nil
 }
 
-func (te *TestEnvironment) SnapshotMetrics() error {
-	client, err := api.NewClient(api.Config{
+func (te *TestEnvironment) PrometheusSnapshot() error {
+	conn, err := api.NewClient(api.Config{
 		Address: "http://127.0.0.1:9090",
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create prometheus client: %w", err)
+		return fmt.Errorf("failed to create prometheus conn: %w", err)
 	}
-	v1api := v1.NewAPI(client)
 
-	v, err := v1api.Snapshot(context.Background(), false)
+	client := v1.NewAPI(conn)
+	v, err := client.Snapshot(context.Background(), false)
 	if err != nil {
 		return fmt.Errorf("failed to create prometheus snapshot: %w", err)
 	}
-	tests.Outf("{{green}}metrics snapshot completed %q{{/}}\n", v.Name)
+	tests.Outf("{{green}}prometheus snapshot completed %q{{/}}\n", v.Name)
 
 	return nil
 }

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -148,7 +148,7 @@ func (te *TestEnvironment) ConfigCluster(
 }
 
 func (te *TestEnvironment) StartPrometheus(prometheusExecPath string) error {
-	cmd := subprocess.NewCmd(prometheusExecPath, fmt.Sprintf("--config.file=%s/prometheus.yaml", te.rootDataDir))
+	cmd := subprocess.NewCmd(prometheusExecPath, fmt.Sprintf("--config.file=%s/prometheus.yaml", te.rootDataDir), "--web.enable-admin-api")
 	err := cmd.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start prometheus: %w", err)
@@ -158,7 +158,7 @@ func (te *TestEnvironment) StartPrometheus(prometheusExecPath string) error {
 	return nil
 }
 
-func (te *TestEnvironment) PrometheusSnapshot() error {
+func(*TestEnvironment)  PrometheusSnapshot() error {
 	conn, err := api.NewClient(api.Config{
 		Address: "http://127.0.0.1:9090",
 	})
@@ -178,7 +178,7 @@ func (te *TestEnvironment) PrometheusSnapshot() error {
 
 func (te *TestEnvironment) StopMonitoring() error {
 	cmd := te.prometheusExec
-	return cmd.Wait()
+	return cmd.Process.Kill()
 }
 
 func (te *TestEnvironment) LoadKeys() error {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -105,7 +105,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	err = e2e.Env.StartCluster()
 	gomega.Expect(err).Should(gomega.BeNil())
 
-	// start prometheus server
+	// start prometheus server if the exec path is defined
 	err = e2e.Env.StartPrometheus(networkRunnerPrometheusExecPath)
 	gomega.Expect(err).Should(gomega.BeNil())
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -105,12 +105,8 @@ var _ = ginkgo.BeforeSuite(func() {
 	err = e2e.Env.StartCluster()
 	gomega.Expect(err).Should(gomega.BeNil())
 
-	// start prometheus metrics collection
-	err = e2e.Env.StartMonitoring(networkRunnerPrometheusExecPath)
-	gomega.Expect(err).Should(gomega.BeNil())
-
-	// take a snapshot of current metrics
-	err = e2e.Env.SnapshotMetrics()
+	// start prometheus server
+	err = e2e.Env.StartPrometheus(networkRunnerPrometheusExecPath)
 	gomega.Expect(err).Should(gomega.BeNil())
 
 	// load keys
@@ -127,7 +123,9 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	err := e2e.Env.ShutdownCluster()
+	err := e2e.Env.PrometheusSnapshot()
+	gomega.Expect(err).Should(gomega.BeNil())
+	err = e2e.Env.ShutdownCluster()
 	gomega.Expect(err).Should(gomega.BeNil())
 	err = e2e.Env.StopMonitoring()
 	gomega.Expect(err).Should(gomega.BeNil())


### PR DESCRIPTION
## Why this should be merged

During Ci testing it is nice to have a Prometheus server scraping node metrics. This PR adds optional support for a Prometheus instance which starts and stops during the e2e tests and uses the config generated by ANR. It also performs a snapshot of the data collected in the test run that can be compressed and stored in github storage.

When a dev runs into a complex bug they can point some basic tooling at the e2e run. Which will pull the compressed metrics from github and setup a prometheus instance locally on top of it for review. In the past I used docker-compose for standing up a temporary prometheus instance using the snapshot as the db.

## How this works

## How this was tested
