### PR TITLE
update goreleaser-action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: v4.3.0
+          version: v1.18.2
           # TODO: automate github release page announce and artifact uploads
           # https://goreleaser.com/cmd/goreleaser_release/
           args: release --rm-dist --skip-announce --skip-publish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           go-version: '~1.19.6'
           check-latest: true
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: v1.13.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           version: v1.18.2
           # TODO: automate github release page announce and artifact uploads
           # https://goreleaser.com/cmd/goreleaser_release/
-          args: release --rm-dist --skip-announce --skip-publish
+          args: release --clean --skip-announce --skip-publish
 
         # to automate release announcement
         # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: v1.13.1
+          version: v4.3.0
           # TODO: automate github release page announce and artifact uploads
           # https://goreleaser.com/cmd/goreleaser_release/
           args: release --rm-dist --skip-announce --skip-publish


### PR DESCRIPTION
## Why this should be merged

Fixes this warning about deprecated GH action 

https://github.com/ava-labs/avalanchego/actions/runs/5327202595

## How this works

2 --> 4

## How this was tested

Look at CI and the warning is gone