### PR TITLE
Remove unnecessary transaction verification

### DIFF
--- a/snow/consensus/snowstorm/test_tx.go
+++ b/snow/consensus/snowstorm/test_tx.go
@@ -4,8 +4,6 @@
 package snowstorm
 
 import (
-	"context"
-
 	"github.com/ava-labs/avalanchego/snow/choices"
 )
 
@@ -17,16 +15,11 @@ type TestTx struct {
 
 	DependenciesV    []Tx
 	DependenciesErrV error
-	VerifyV          error
 	BytesV           []byte
 }
 
 func (t *TestTx) Dependencies() ([]Tx, error) {
 	return t.DependenciesV, t.DependenciesErrV
-}
-
-func (t *TestTx) Verify(context.Context) error {
-	return t.VerifyV
 }
 
 func (t *TestTx) Bytes() []byte {

--- a/snow/consensus/snowstorm/test_tx.go
+++ b/snow/consensus/snowstorm/test_tx.go
@@ -3,9 +3,7 @@
 
 package snowstorm
 
-import (
-	"github.com/ava-labs/avalanchego/snow/choices"
-)
+import "github.com/ava-labs/avalanchego/snow/choices"
 
 var _ Tx = (*TestTx)(nil)
 

--- a/snow/consensus/snowstorm/tx.go
+++ b/snow/consensus/snowstorm/tx.go
@@ -4,8 +4,6 @@
 package snowstorm
 
 import (
-	"context"
-
 	"github.com/ava-labs/avalanchego/snow/choices"
 )
 
@@ -20,14 +18,6 @@ type Tx interface {
 	// Similarly, each element of Dependencies must be accepted before this
 	// transaction is accepted.
 	Dependencies() ([]Tx, error)
-
-	// Verify that the state transition this transaction would make if it were
-	// accepted is valid. If the state transition is invalid, a non-nil error
-	// should be returned.
-	//
-	// It is guaranteed that when Verify is called, all the dependencies of
-	// this transaction have already been successfully verified.
-	Verify(context.Context) error
 
 	// Bytes returns the binary representation of this transaction.
 	//

--- a/snow/consensus/snowstorm/tx.go
+++ b/snow/consensus/snowstorm/tx.go
@@ -3,9 +3,7 @@
 
 package snowstorm
 
-import (
-	"github.com/ava-labs/avalanchego/snow/choices"
-)
+import "github.com/ava-labs/avalanchego/snow/choices"
 
 // Tx consumes state.
 type Tx interface {

--- a/snow/engine/avalanche/bootstrap/tx_job.go
+++ b/snow/engine/avalanche/bootstrap/tx_job.go
@@ -96,16 +96,8 @@ func (t *txJob) Execute(ctx context.Context) error {
 		t.numDropped.Inc()
 		return fmt.Errorf("attempting to execute transaction with status %s", status)
 	case choices.Processing:
-		txID := t.tx.ID()
-		if err := t.tx.Verify(ctx); err != nil {
-			t.log.Error("transaction failed verification during bootstrapping",
-				zap.Stringer("txID", txID),
-				zap.Error(err),
-			)
-			return fmt.Errorf("failed to verify transaction in bootstrapping: %w", err)
-		}
-
 		t.numAccepted.Inc()
+		txID := t.tx.ID()
 		t.log.Trace("accepting transaction in bootstrapping",
 			zap.Stringer("txID", txID),
 		)

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -460,6 +460,14 @@ func (vm *VM) ParseTx(_ context.Context, bytes []byte) (snowstorm.Tx, error) {
 		return nil, err
 	}
 
+	err = rawTx.Unsigned.Visit(&txexecutor.SyntacticVerifier{
+		Backend: vm.txBackend,
+		Tx:      rawTx,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	tx := &UniqueTx{
 		TxCachedState: &TxCachedState{
 			Tx: rawTx,
@@ -467,10 +475,6 @@ func (vm *VM) ParseTx(_ context.Context, bytes []byte) (snowstorm.Tx, error) {
 		vm:   vm,
 		txID: rawTx.ID(),
 	}
-	if err := tx.SyntacticVerify(); err != nil {
-		return nil, err
-	}
-
 	if tx.Status() == choices.Unknown {
 		vm.state.AddTx(tx.Tx)
 		tx.setStatus(choices.Processing)

--- a/vms/avm/vm_test.go
+++ b/vms/avm/vm_test.go
@@ -564,13 +564,11 @@ func TestTxAcceptAfterParseTx(t *testing.T) {
 	parsedFirstTx, err := env.vm.ParseTx(context.Background(), firstTx.Bytes())
 	require.NoError(err)
 
-	require.NoError(parsedFirstTx.Verify(context.Background()))
 	require.NoError(parsedFirstTx.Accept(context.Background()))
 
 	parsedSecondTx, err := env.vm.ParseTx(context.Background(), secondTx.Bytes())
 	require.NoError(err)
 
-	require.NoError(parsedSecondTx.Verify(context.Background()))
 	require.NoError(parsedSecondTx.Accept(context.Background()))
 
 	firstTxStatus, err := env.vm.state.GetStatus(firstTx.ID())
@@ -737,7 +735,6 @@ func TestForceAcceptImportTx(t *testing.T) {
 	parsedTx, err := env.vm.ParseTx(context.Background(), tx.Bytes())
 	require.NoError(err)
 
-	require.NoError(parsedTx.Verify(context.Background()))
 	require.NoError(parsedTx.Accept(context.Background()))
 
 	assertIndexedTX(t, env.vm.db, 0, key.PublicKey().Address(), txAssetID.AssetID(), tx.ID())

--- a/vms/avm/wallet_service.go
+++ b/vms/avm/wallet_service.go
@@ -4,6 +4,7 @@
 package avm
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -21,6 +22,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
+
+var errMissingUTXO = errors.New("missing utxo")
 
 type WalletService struct {
 	vm         *VM

--- a/vms/metervm/vertex_metrics.go
+++ b/vms/metervm/vertex_metrics.go
@@ -13,8 +13,6 @@ import (
 type vertexMetrics struct {
 	parse,
 	parseErr,
-	verify,
-	verifyErr,
 	accept,
 	reject metric.Averager
 }
@@ -26,8 +24,6 @@ func (m *vertexMetrics) Initialize(
 	errs := wrappers.Errs{}
 	m.parse = newAverager(namespace, "parse_tx", reg, &errs)
 	m.parseErr = newAverager(namespace, "parse_tx_err", reg, &errs)
-	m.verify = newAverager(namespace, "verify_tx", reg, &errs)
-	m.verifyErr = newAverager(namespace, "verify_tx_err", reg, &errs)
 	m.accept = newAverager(namespace, "accept", reg, &errs)
 	m.reject = newAverager(namespace, "reject", reg, &errs)
 	return errs.Err

--- a/vms/metervm/vertex_vm.go
+++ b/vms/metervm/vertex_vm.go
@@ -98,19 +98,6 @@ type meterTx struct {
 	vm *vertexVM
 }
 
-func (mtx *meterTx) Verify(ctx context.Context) error {
-	start := mtx.vm.clock.Time()
-	err := mtx.Tx.Verify(ctx)
-	end := mtx.vm.clock.Time()
-	duration := float64(end.Sub(start))
-	if err != nil {
-		mtx.vm.vertexMetrics.verifyErr.Observe(duration)
-	} else {
-		mtx.vm.vertexMetrics.verify.Observe(duration)
-	}
-	return err
-}
-
 func (mtx *meterTx) Accept(ctx context.Context) error {
 	start := mtx.vm.clock.Time()
 	err := mtx.Tx.Accept(ctx)

--- a/vms/tracedvm/tx.go
+++ b/vms/tracedvm/tx.go
@@ -22,15 +22,6 @@ type tracedTx struct {
 	tracer trace.Tracer
 }
 
-func (t *tracedTx) Verify(ctx context.Context) error {
-	ctx, span := t.tracer.Start(ctx, "tracedTx.Verify", oteltrace.WithAttributes(
-		attribute.Stringer("txID", t.ID()),
-	))
-	defer span.End()
-
-	return t.Tx.Verify(ctx)
-}
-
 func (t *tracedTx) Accept(ctx context.Context) error {
 	ctx, span := t.tracer.Start(ctx, "tracedTx.Accept", oteltrace.WithAttributes(
 		attribute.Stringer("txID", t.ID()),


### PR DESCRIPTION
## Why this should be merged

Transactions can never fail verification during bootstrapping anymore. Because they are already verified to have been included in the network prior to the X-chain linearization.

## How this works

Deletes redundant pre-linearization tx verification.

## How this was tested

CI.