### PR TITLE
Bump coreth v0.12.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/ava-labs/avalanche-network-runner-sdk v0.3.0
-	github.com/ava-labs/coreth v0.12.3-rc.1
+	github.com/ava-labs/coreth v0.12.4-rc.0
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20230105152938-00a24d05a8c7
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0 h1:TVi9JEdKNU/RevYZ9PyW4pULbEdS+KQDA9Ki2DUvuAs=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0/go.mod h1:SgKJvtqvgo/Bl/c8fxEHCLaSxEbzimYfBopcfrajxQk=
-github.com/ava-labs/coreth v0.12.3-rc.1 h1:tJWdrjmqXNKApdng4EDixZIuh9bgiH2A/nPvF6P2SpI=
-github.com/ava-labs/coreth v0.12.3-rc.1/go.mod h1:0s9OD4SGh46mUhDd+VrbKv/g1NJrz5QtjLSu2Y2+f+0=
+github.com/ava-labs/coreth v0.12.4-rc.0 h1:/xARLNSrreCEkyHgNqtcauo4vnBJdJkHVfauyfA2XBM=
+github.com/ava-labs/coreth v0.12.4-rc.0/go.mod h1:550N2pndShlx1Xv8qCOyPUcIrgfU3dLq+OlHSrPri4E=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20230105152938-00a24d05a8c7 h1:EdxD90j5sClfL5Ngpz2TlnbnkNYdFPDXa0jDOjam65c=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20230105152938-00a24d05a8c7/go.mod h1:XhiXSrh90sHUbkERzaxEftCmUz53eCijshDLZ4fByVM=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -9,7 +9,7 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd ) # Direct
 avalanchego_path="$AVALANCHE_PATH/build/avalanchego"
 plugin_dir=${PLUGIN_DIR:-$HOME/.avalanchego/plugins}
 evm_path=${EVM_PATH:-$plugin_dir/evm}
-coreth_version=${CORETH_VERSION:-'v0.12.3-rc.1'}
+coreth_version=${CORETH_VERSION:-'v0.12.4-rc.0'}
 
 # Set the PATHS
 GOPATH="$(go env GOPATH)"


### PR DESCRIPTION
This PR bumps the Coreth version to v0.12.4-rc.0: https://github.com/ava-labs/coreth/pull/271