### PR TITLE
[x/merkledb] Remove useless `err` check

### DIFF
--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -1052,8 +1052,6 @@ func (t *trieView) insertIntoTrie(
 		)
 		newNode.setValue(value)
 		return newNode, t.recordNodeChange(newNode)
-	} else if err != nil {
-		return nil, err
 	}
 
 	// if we have reached this point, then the [fullpath] we are trying to insert and


### PR DESCRIPTION
## Why this should be merged
This `err` condition can never be hit.

## How this works
Code should do something. This does not.

## How this was tested
N/A
