### PR TITLE
`merkledb` --  fix `findNextKey`

### DIFF
--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -469,7 +469,7 @@ func TestFindNextKeyEmptyEndProof(t *testing.T) {
 			nil, /* endProof */
 		)
 		require.NoError(err)
-		require.Equal(lastReceivedKey, nextKey)
+		require.Equal(append(lastReceivedKey, 0), nextKey)
 	}
 }
 

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -430,6 +430,49 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 	}
 }
 
+func TestFindNextKeyEmptyEndProof(t *testing.T) {
+	require := require.New(t)
+	now := time.Now().UnixNano()
+	t.Logf("seed: %d", now)
+	r := rand.New(rand.NewSource(now)) // #nosec G404
+
+	db, err := merkledb.New(
+		context.Background(),
+		memdb.New(),
+		newDefaultDBConfig(),
+	)
+	require.NoError(err)
+
+	syncer, err := NewStateSyncManager(StateSyncConfig{
+		SyncDB:                db,
+		Client:                &mockClient{db: nil},
+		TargetRoot:            ids.Empty,
+		SimultaneousWorkLimit: 5,
+		Log:                   logging.NoLog{},
+	})
+	require.NoError(err)
+	require.NotNil(syncer)
+
+	for i := 0; i < 100; i++ {
+		lastReceivedKeyLen := r.Intn(16)
+		lastReceivedKey := make([]byte, lastReceivedKeyLen)
+		_, _ = r.Read(lastReceivedKey) // #nosec G404
+
+		rangeEndLen := r.Intn(16)
+		rangeEnd := make([]byte, rangeEndLen)
+		_, _ = r.Read(rangeEnd) // #nosec G404
+
+		nextKey, err := syncer.findNextKey(
+			context.Background(),
+			lastReceivedKey,
+			rangeEnd,
+			nil, /* endProof */
+		)
+		require.NoError(err)
+		require.Equal(lastReceivedKey, nextKey)
+	}
+}
+
 func isPrefix(data []byte, prefix []byte) bool {
 	if prefix[len(prefix)-1]%16 == 0 {
 		index := 0

--- a/x/sync/syncmanager.go
+++ b/x/sync/syncmanager.go
@@ -355,6 +355,8 @@ func (m *StateSyncManager) getAndApplyRangeProof(ctx context.Context, workItem *
 //
 // [endProof] is the end proof of the last proof received.
 // Namely it's an inclusion/exclusion proof for [lastReceivedKey].
+//
+// Invariant: [lastReceivedKey] < [rangeEnd].
 func (m *StateSyncManager) findNextKey(
 	ctx context.Context,
 	lastReceivedKey []byte,
@@ -364,7 +366,8 @@ func (m *StateSyncManager) findNextKey(
 	if len(endProof) == 0 {
 		// We try to find the next key to fetch by looking at the end proof.
 		// If the end proof is empty, we have no information to use.
-		return lastReceivedKey, nil
+		// Start fetching from the next key after [lastReceivedKey].
+		return append(lastReceivedKey, 0), nil
 	}
 
 	// We want the first key larger than the [lastReceivedKey].
@@ -472,9 +475,9 @@ func (m *StateSyncManager) findNextKey(
 		}
 	}
 
-	// If the nextKey is before or equal to the lastReceivedKey
-	// then we couldn't find a better answer than the lastReceivedKey.
-	// Set the nextKey to lastReceivedKey + 0, which is the first key in
+	// If the nextKey is before or equal to the [lastReceivedKey]
+	// then we couldn't find a better answer than the [lastReceivedKey].
+	// Set the nextKey to [lastReceivedKey] + 0, which is the first key in
 	// the open range (lastReceivedKey, rangeEnd).
 	if nextKey != nil && bytes.Compare(nextKey, lastReceivedKey) <= 0 {
 		nextKey = lastReceivedKey


### PR DESCRIPTION
## Why this should be merged

Fixes a bug.

## How this works

It's possible for the `endProof` passed into `findNextKey` to be length 0. In this case we  panic on `if !proofKeyPath.HasPrefix(receivedProofNodes[len(receivedProofNodes)-1].KeyPath) {`

This PR fixes the bug by handling this case.

Also improves comment on `findNextKey`.

## How this was tested

New UT, also separate merkledb testing tool