### PR TITLE
vms/avm: remove unnecessary Tx nil check in "Dependencies"

### DIFF
--- a/vms/avm/unique_tx.go
+++ b/vms/avm/unique_tx.go
@@ -189,7 +189,7 @@ func (tx *UniqueTx) Status() choices.Status {
 // Dependencies returns the set of transactions this transaction builds on
 func (tx *UniqueTx) Dependencies() ([]snowstorm.Tx, error) {
 	tx.refresh()
-	if tx.Tx == nil || len(tx.deps) != 0 {
+	if len(tx.deps) != 0 {
 		return tx.deps, nil
 	}
 


### PR DESCRIPTION
## Why this should be merged

`tx.refresh` already ensures `tx.Tx != nil`.

## How this works

Remove `tx.Tx == nil` check.

## How this was tested

U/T