### PR TITLE
Add minimum proposer window length

### DIFF
--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -29,6 +29,7 @@ import (
 const (
 	validatorSetsCacheSize        = 64
 	maxRecentlyAcceptedWindowSize = 64
+	minRecentlyAcceptedWindowSize = 16
 	recentlyAcceptedWindowTTL     = 2 * time.Minute
 )
 
@@ -67,6 +68,7 @@ func NewManager(
 			window.Config{
 				Clock:   clk,
 				MaxSize: maxRecentlyAcceptedWindowSize,
+				MinSize: minRecentlyAcceptedWindowSize,
 				TTL:     recentlyAcceptedWindowTTL,
 			},
 		),


### PR DESCRIPTION
## Why this should be merged

Followup to #1638 to add the minimum length to the window as discussed during the dev call.

## How this works

Only evicts old blocks if the window is sufficiently large.

## How this was tested

Added a new test.