### PR TITLE
`MerkleDB` -- remove codec version

### DIFF
--- a/x/merkledb/codec.go
+++ b/x/merkledb/codec.go
@@ -17,13 +17,11 @@ import (
 )
 
 const (
-	codecVersion         = 0
 	trueByte             = 1
 	falseByte            = 0
 	minVarIntLen         = 1
 	boolLen              = 1
 	idLen                = hashing.HashLen
-	minCodecVersionLen   = minVarIntLen
 	minSerializedPathLen = minVarIntLen
 	minByteSliceLen      = minVarIntLen
 	minMaybeByteSliceLen = boolLen
@@ -31,11 +29,11 @@ const (
 	minKeyValueLen       = 2 * minByteSliceLen
 	minKeyChangeLen      = minByteSliceLen + minMaybeByteSliceLen
 	minProofNodeLen      = minSerializedPathLen + minMaybeByteSliceLen + minVarIntLen
-	minProofLen          = minCodecVersionLen + minProofPathLen + minByteSliceLen
-	minChangeProofLen    = minCodecVersionLen + boolLen + 2*minProofPathLen + minVarIntLen
-	minRangeProofLen     = minCodecVersionLen + 2*minProofPathLen + minVarIntLen
-	minDBNodeLen         = minCodecVersionLen + minMaybeByteSliceLen + minVarIntLen
-	minHashValuesLen     = minCodecVersionLen + minVarIntLen + minMaybeByteSliceLen + minSerializedPathLen
+	minProofLen          = minProofPathLen + minByteSliceLen
+	minChangeProofLen    = boolLen + 2*minProofPathLen + minVarIntLen
+	minRangeProofLen     = 2*minProofPathLen + minVarIntLen
+	minDBNodeLen         = minMaybeByteSliceLen + minVarIntLen
+	minHashValuesLen     = minVarIntLen + minMaybeByteSliceLen + minSerializedPathLen
 	minProofNodeChildLen = minVarIntLen + idLen
 	minChildLen          = minVarIntLen + minSerializedPathLen + idLen
 )
@@ -46,7 +44,6 @@ var (
 	trueBytes  = []byte{trueByte}
 	falseBytes = []byte{falseByte}
 
-	errUnknownVersion       = errors.New("unknown codec version")
 	errEncodeNil            = errors.New("can't encode nil pointer or interface")
 	errDecodeNil            = errors.New("can't decode nil")
 	errNegativeNumChildren  = errors.New("number of children is negative")
@@ -59,7 +56,6 @@ var (
 	errNonZeroNibblePadding = errors.New("nibbles should be padded with 0s")
 	errExtraSpace           = errors.New("trailing buffer space")
 	errNegativeSliceLength  = errors.New("negative slice length")
-	errInvalidCodecVersion  = errors.New("invalid codec version")
 )
 
 // encoderDecoder defines the interface needed by merkleDB to marshal
@@ -70,41 +66,34 @@ type encoderDecoder interface {
 }
 
 type encoder interface {
-	encodeDBNode(version uint16, n *dbNode) ([]byte, error)
-	encodeHashValues(version uint16, hv *hashValues) ([]byte, error)
+	encodeDBNode(n *dbNode) ([]byte, error)
+	encodeHashValues(hv *hashValues) ([]byte, error)
 }
 
 type decoder interface {
-	decodeDBNode(bytes []byte, n *dbNode) (uint16, error)
+	decodeDBNode(bytes []byte, n *dbNode) error
 }
 
-func newCodec() (encoderDecoder, uint16) {
+func newCodec() encoderDecoder {
 	return &codecImpl{
 		varIntPool: sync.Pool{
 			New: func() interface{} {
 				return make([]byte, binary.MaxVarintLen64)
 			},
 		},
-	}, codecVersion
+	}
 }
 
 type codecImpl struct {
 	varIntPool sync.Pool
 }
 
-func (c *codecImpl) encodeDBNode(version uint16, n *dbNode) ([]byte, error) {
+func (c *codecImpl) encodeDBNode(n *dbNode) ([]byte, error) {
 	if n == nil {
 		return nil, errEncodeNil
 	}
 
-	if version != codecVersion {
-		return nil, fmt.Errorf("%w: %d", errUnknownVersion, version)
-	}
-
 	buf := &bytes.Buffer{}
-	if err := c.encodeInt(buf, int(version)); err != nil {
-		return nil, err
-	}
 	if err := c.encodeMaybeByteSlice(buf, n.value); err != nil {
 		return nil, err
 	}
@@ -129,20 +118,12 @@ func (c *codecImpl) encodeDBNode(version uint16, n *dbNode) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (c *codecImpl) encodeHashValues(version uint16, hv *hashValues) ([]byte, error) {
+func (c *codecImpl) encodeHashValues(hv *hashValues) ([]byte, error) {
 	if hv == nil {
 		return nil, errEncodeNil
 	}
 
-	if version != codecVersion {
-		return nil, fmt.Errorf("%w: %d", errUnknownVersion, version)
-	}
-
 	buf := &bytes.Buffer{}
-
-	if err := c.encodeInt(buf, int(version)); err != nil {
-		return nil, err
-	}
 
 	length := len(hv.Children)
 	if err := c.encodeInt(buf, length); err != nil {
@@ -170,12 +151,12 @@ func (c *codecImpl) encodeHashValues(version uint16, hv *hashValues) ([]byte, er
 	return buf.Bytes(), nil
 }
 
-func (c *codecImpl) decodeDBNode(b []byte, n *dbNode) (uint16, error) {
+func (c *codecImpl) decodeDBNode(b []byte, n *dbNode) error {
 	if n == nil {
-		return 0, errDecodeNil
+		return errDecodeNil
 	}
 	if minDBNodeLen > len(b) {
-		return 0, io.ErrUnexpectedEOF
+		return io.ErrUnexpectedEOF
 	}
 
 	var (
@@ -183,29 +164,21 @@ func (c *codecImpl) decodeDBNode(b []byte, n *dbNode) (uint16, error) {
 		err error
 	)
 
-	gotCodecVersion, err := c.decodeInt(src)
-	if err != nil {
-		return 0, err
-	}
-	if codecVersion != gotCodecVersion {
-		return 0, fmt.Errorf("%w: %d", errInvalidCodecVersion, gotCodecVersion)
-	}
-
 	if n.value, err = c.decodeMaybeByteSlice(src); err != nil {
-		return 0, err
+		return err
 	}
 
 	numChildren, err := c.decodeInt(src)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	switch {
 	case numChildren < 0:
-		return 0, errNegativeNumChildren
+		return errNegativeNumChildren
 	case numChildren > NodeBranchFactor:
-		return 0, errTooManyChildren
+		return errTooManyChildren
 	case numChildren > src.Len()/minChildLen:
-		return 0, io.ErrUnexpectedEOF
+		return io.ErrUnexpectedEOF
 	}
 
 	n.children = make(map[byte]child, NodeBranchFactor)
@@ -213,20 +186,20 @@ func (c *codecImpl) decodeDBNode(b []byte, n *dbNode) (uint16, error) {
 	for i := 0; i < numChildren; i++ {
 		var index int
 		if index, err = c.decodeInt(src); err != nil {
-			return 0, err
+			return err
 		}
 		if index <= previousChild || index > NodeBranchFactor-1 {
-			return 0, errChildIndexTooLarge
+			return errChildIndexTooLarge
 		}
 		previousChild = index
 
 		var compressedPath SerializedPath
 		if compressedPath, err = c.decodeSerializedPath(src); err != nil {
-			return 0, err
+			return err
 		}
 		var childID ids.ID
 		if childID, err = c.decodeID(src); err != nil {
-			return 0, err
+			return err
 		}
 		n.children[byte(index)] = child{
 			compressedPath: compressedPath.deserialize(),
@@ -234,9 +207,9 @@ func (c *codecImpl) decodeDBNode(b []byte, n *dbNode) (uint16, error) {
 		}
 	}
 	if src.Len() != 0 {
-		return 0, errExtraSpace
+		return errExtraSpace
 	}
-	return codecVersion, err
+	return err
 }
 
 func (*codecImpl) encodeBool(dst io.Writer, value bool) error {

--- a/x/merkledb/codec.go
+++ b/x/merkledb/codec.go
@@ -25,16 +25,8 @@ const (
 	minSerializedPathLen = minVarIntLen
 	minByteSliceLen      = minVarIntLen
 	minMaybeByteSliceLen = boolLen
-	minProofPathLen      = minVarIntLen
-	minKeyValueLen       = 2 * minByteSliceLen
-	minKeyChangeLen      = minByteSliceLen + minMaybeByteSliceLen
 	minProofNodeLen      = minSerializedPathLen + minMaybeByteSliceLen + minVarIntLen
-	minProofLen          = minProofPathLen + minByteSliceLen
-	minChangeProofLen    = boolLen + 2*minProofPathLen + minVarIntLen
-	minRangeProofLen     = 2*minProofPathLen + minVarIntLen
 	minDBNodeLen         = minMaybeByteSliceLen + minVarIntLen
-	minHashValuesLen     = minVarIntLen + minMaybeByteSliceLen + minSerializedPathLen
-	minProofNodeChildLen = minVarIntLen + idLen
 	minChildLen          = minVarIntLen + minSerializedPathLen + idLen
 )
 

--- a/x/merkledb/codec.go
+++ b/x/merkledb/codec.go
@@ -20,11 +20,10 @@ const (
 	trueByte             = 1
 	falseByte            = 0
 	minVarIntLen         = 1
-	boolLen              = 1
+	minMaybeByteSliceLen = 1
 	idLen                = hashing.HashLen
 	minSerializedPathLen = minVarIntLen
 	minByteSliceLen      = minVarIntLen
-	minMaybeByteSliceLen = boolLen
 	minDBNodeLen         = minMaybeByteSliceLen + minVarIntLen
 	minChildLen          = minVarIntLen + minSerializedPathLen + idLen
 )

--- a/x/merkledb/codec.go
+++ b/x/merkledb/codec.go
@@ -25,7 +25,6 @@ const (
 	minSerializedPathLen = minVarIntLen
 	minByteSliceLen      = minVarIntLen
 	minMaybeByteSliceLen = boolLen
-	minProofNodeLen      = minSerializedPathLen + minMaybeByteSliceLen + minVarIntLen
 	minDBNodeLen         = minMaybeByteSliceLen + minVarIntLen
 	minChildLen          = minVarIntLen + minSerializedPathLen + idLen
 )

--- a/x/merkledb/codec_test.go
+++ b/x/merkledb/codec_test.go
@@ -205,13 +205,12 @@ func FuzzCodecDBNodeCanonical(f *testing.F) {
 
 			codec := codec.(*codecImpl)
 			node := &dbNode{}
-			got, err := codec.decodeDBNode(b, node)
-			if err != nil {
+			if err := codec.decodeDBNode(b, node); err != nil {
 				return
 			}
 
 			// Encoding [node] should be the same as [b].
-			buf, err := codec.encodeDBNode(got, node)
+			buf, err := codec.encodeDBNode(node)
 			require.NoError(err)
 			require.Equal(b, buf)
 		},
@@ -264,19 +263,17 @@ func FuzzCodecDBNodeDeterministic(f *testing.F) {
 				children: children,
 			}
 
-			nodeBytes, err := codec.encodeDBNode(version, &node)
+			nodeBytes, err := codec.encodeDBNode(&node)
 			require.NoError(err)
 
 			var gotNode dbNode
-			gotVersion, err := codec.decodeDBNode(nodeBytes, &gotNode)
-			require.NoError(err)
-			require.Equal(version, gotVersion)
+			require.NoError(codec.decodeDBNode(nodeBytes, &gotNode))
 
 			nilEmptySlices(&node)
 			nilEmptySlices(&gotNode)
 			require.Equal(node, gotNode)
 
-			nodeBytes2, err := codec.encodeDBNode(version, &gotNode)
+			nodeBytes2, err := codec.encodeDBNode(&gotNode)
 			require.NoError(err)
 			require.Equal(nodeBytes, nodeBytes2)
 		},
@@ -286,14 +283,14 @@ func FuzzCodecDBNodeDeterministic(f *testing.F) {
 func TestCodec_DecodeDBNode(t *testing.T) {
 	require := require.New(t)
 
-	_, err := codec.decodeDBNode([]byte{1}, nil)
+	err := codec.decodeDBNode([]byte{1}, nil)
 	require.ErrorIs(err, errDecodeNil)
 
 	var (
 		parsedDBNode  dbNode
 		tooShortBytes = make([]byte, minDBNodeLen-1)
 	)
-	_, err = codec.decodeDBNode(tooShortBytes, &parsedDBNode)
+	err = codec.decodeDBNode(tooShortBytes, &parsedDBNode)
 	require.ErrorIs(err, io.ErrUnexpectedEOF)
 
 	proof := dbNode{
@@ -301,7 +298,7 @@ func TestCodec_DecodeDBNode(t *testing.T) {
 		children: map[byte]child{},
 	}
 
-	nodeBytes, err := codec.encodeDBNode(version, &proof)
+	nodeBytes, err := codec.encodeDBNode(&proof)
 	require.NoError(err)
 
 	// Remove num children (0) from end
@@ -310,7 +307,7 @@ func TestCodec_DecodeDBNode(t *testing.T) {
 	// Put num children -1 at end
 	require.NoError(codec.(*codecImpl).encodeInt(proofBytesBuf, -1))
 
-	_, err = codec.decodeDBNode(proofBytesBuf.Bytes(), &parsedDBNode)
+	err = codec.decodeDBNode(proofBytesBuf.Bytes(), &parsedDBNode)
 	require.ErrorIs(err, errNegativeNumChildren)
 
 	// Remove num children from end
@@ -320,6 +317,6 @@ func TestCodec_DecodeDBNode(t *testing.T) {
 	// Put num children NodeBranchFactor+1 at end
 	require.NoError(codec.(*codecImpl).encodeInt(proofBytesBuf, NodeBranchFactor+1))
 
-	_, err = codec.decodeDBNode(proofBytesBuf.Bytes(), &parsedDBNode)
+	err = codec.decodeDBNode(proofBytesBuf.Bytes(), &parsedDBNode)
 	require.ErrorIs(err, errTooManyChildren)
 }

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -39,7 +39,7 @@ var (
 	_ TrieView = (*merkleDB)(nil)
 	_ MerkleDB = (*merkleDB)(nil)
 
-	codec, version = newCodec()
+	codec = newCodec()
 
 	rootKey                 []byte
 	nodePrefix              = []byte("node")

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -60,7 +60,7 @@ func newNode(parent *node, key path) *node {
 // Parse [nodeBytes] to a node and set its key to [key].
 func parseNode(key path, nodeBytes []byte) (*node, error) {
 	n := dbNode{}
-	if _, err := codec.decodeDBNode(nodeBytes, &n); err != nil {
+	if err := codec.decodeDBNode(nodeBytes, &n); err != nil {
 		return nil, err
 	}
 	result := &node{
@@ -84,7 +84,7 @@ func (n *node) marshal() ([]byte, error) {
 		return n.nodeBytes, nil
 	}
 
-	nodeBytes, err := codec.encodeDBNode(version, &(n.dbNode))
+	nodeBytes, err := codec.encodeDBNode(&n.dbNode)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (n *node) calculateID(metrics merkleMetrics) error {
 		Key:      n.key.Serialize(),
 	}
 
-	bytes, err := codec.encodeHashValues(version, hv)
+	bytes, err := codec.encodeHashValues(hv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why this should be merged

The codec version is kind of useless

## How this works

Remove it

## How this was tested

Update existing UT