### PR TITLE
Mark preForkBlocks after the fork as Rejected

### DIFF
--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/proposervm/indexer"
@@ -54,8 +55,25 @@ var (
 	_ block.HeightIndexedChainVM = (*VM)(nil)
 	_ block.StateSyncableVM      = (*VM)(nil)
 
+	// TODO: remove after the X-chain supports height indexing.
+	mainnetXChainID ids.ID
+	fujiXChainID    ids.ID
+
 	dbPrefix = []byte("proposervm")
 )
+
+func init() {
+	var err error
+	mainnetXChainID, err = ids.FromString("2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM")
+	if err != nil {
+		panic(err)
+	}
+
+	fujiXChainID, err = ids.FromString("2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm")
+	if err != nil {
+		panic(err)
+	}
+}
 
 type VM struct {
 	block.ChainVM
@@ -219,7 +237,26 @@ func (vm *VM) Initialize(
 		return err
 	}
 
-	return vm.setLastAcceptedMetadata(ctx)
+	if err := vm.setLastAcceptedMetadata(ctx); err != nil {
+		return err
+	}
+
+	forkHeight, err := vm.getForkHeight()
+	switch err {
+	case nil:
+		chainCtx.Log.Info("initialized proposervm",
+			zap.String("state", "after fork"),
+			zap.Uint64("forkHeight", forkHeight),
+			zap.Uint64("lastAcceptedHeight", vm.lastAcceptedHeight),
+		)
+	case database.ErrNotFound:
+		chainCtx.Log.Info("initialized proposervm",
+			zap.String("state", "before fork"),
+		)
+	default:
+		return err
+	}
+	return nil
 }
 
 // shutdown ops then propagate shutdown to innerVM
@@ -654,6 +691,29 @@ func (vm *VM) getBlock(ctx context.Context, id ids.ID) (Block, error) {
 		return blk, nil
 	}
 	return vm.getPreForkBlock(ctx, id)
+}
+
+// TODO: remove after the P-chain and X-chain support height indexing.
+func (vm *VM) getForkHeight() (uint64, error) {
+	// The fork block can be easily identified with the provided links because
+	// the `Parent Hash` is equal to the `Proposer Parent ID`.
+	switch vm.ctx.ChainID {
+	case constants.PlatformChainID:
+		switch vm.ctx.NetworkID {
+		case constants.MainnetID:
+			return 805732, nil // https://subnets.avax.network/p-chain/block/805732
+		case constants.FujiID:
+			return 47529, nil // https://subnets-test.avax.network/p-chain/block/47529
+		default:
+			return 0, database.ErrNotFound
+		}
+	case mainnetXChainID:
+		return 1, nil // https://subnets.avax.network/x-chain/block/1
+	case fujiXChainID:
+		return 1, nil // https://subnets-test.avax.network/x-chain/block/1
+	default:
+		return vm.GetForkHeight()
+	}
 }
 
 func (vm *VM) getPostForkBlock(ctx context.Context, blkID ids.ID) (PostForkBlock, error) {

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -704,16 +704,13 @@ func (vm *VM) getForkHeight() (uint64, error) {
 			return 805732, nil // https://subnets.avax.network/p-chain/block/805732
 		case constants.FujiID:
 			return 47529, nil // https://subnets-test.avax.network/p-chain/block/47529
-		default:
-			return 0, database.ErrNotFound
 		}
 	case mainnetXChainID:
 		return 1, nil // https://subnets.avax.network/x-chain/block/1
 	case fujiXChainID:
 		return 1, nil // https://subnets-test.avax.network/x-chain/block/1
-	default:
-		return vm.GetForkHeight()
 	}
+	return vm.GetForkHeight()
 }
 
 func (vm *VM) getPostForkBlock(ctx context.Context, blkID ids.ID) (PostForkBlock, error) {

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/manager"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
@@ -2291,10 +2290,7 @@ func TestVMInnerBlkMarkedAcceptedRegression(t *testing.T) {
 	}
 
 	wrappedInnerBlock, err := proVM.GetBlock(context.Background(), innerBlock.ID())
-	if err != nil {
-		require.ErrorIs(err, database.ErrNotFound)
-		return
-	}
+	require.NoError(err)
 	require.Equal(choices.Rejected, wrappedInnerBlock.Status())
 }
 

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/manager"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
@@ -174,6 +175,7 @@ func initTestProposerVM(
 	}
 
 	ctx := snow.DefaultContextTest()
+	ctx.ChainID = ids.ID{1}
 	ctx.NodeID = ids.NodeIDFromCert(pTestCert.Leaf)
 	ctx.ValidatorState = valState
 
@@ -2254,6 +2256,46 @@ func TestVMInnerBlkCacheDeduplicationRegression(t *testing.T) {
 		choices.Accepted,
 		cachedXBlock.Status(),
 	)
+}
+
+func TestVMInnerBlkMarkedAcceptedRegression(t *testing.T) {
+	require := require.New(t)
+	forkTime := time.Unix(0, 0)
+	coreVM, _, proVM, gBlock, _ := initTestProposerVM(t, forkTime, 0)
+
+	// create an inner block and wrap it in an postForkBlock.
+	innerBlock := &snowman.TestBlock{
+		TestDecidable: choices.TestDecidable{
+			IDV:     ids.GenerateTestID(),
+			StatusV: choices.Processing,
+		},
+		BytesV:     []byte{1},
+		ParentV:    gBlock.ID(),
+		HeightV:    gBlock.Height() + 1,
+		TimestampV: gBlock.Timestamp(),
+	}
+
+	coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
+		return innerBlock, nil
+	}
+	outerBlock, err := proVM.BuildBlock(context.Background())
+	require.NoError(err)
+	coreVM.BuildBlockF = nil
+
+	require.NoError(outerBlock.Verify(context.Background()))
+	require.NoError(outerBlock.Accept(context.Background()))
+
+	coreVM.GetBlockF = func(_ context.Context, id ids.ID) (snowman.Block, error) {
+		require.Equal(innerBlock.ID(), id)
+		return innerBlock, nil
+	}
+
+	wrappedInnerBlock, err := proVM.GetBlock(context.Background(), innerBlock.ID())
+	if err != nil {
+		require.ErrorIs(err, database.ErrNotFound)
+		return
+	}
+	require.Equal(choices.Rejected, wrappedInnerBlock.Status())
 }
 
 type blockWithVerifyContext struct {


### PR DESCRIPTION
## Why this should be merged

Fixes DB corruption that can cause bootstrapping failures https://github.com/ava-labs/avalanchego/issues/1668. 

## How this works

The proposervm should only return preForkBlocks with an Accepted status if the block height is prior to the fork.

## How this was tested

Adds regression test