### PR TITLE
`sync` -- add exponential backoff

### DIFF
--- a/x/sync/client.go
+++ b/x/sync/client.go
@@ -26,7 +26,7 @@ import (
 const (
 	initialRetryWait = 10 * time.Millisecond
 	maxRetryWait     = time.Second
-	retryWaitFactor  = 1.5
+	retryWaitFactor  = 1.5 // Larger --> timeout grows more quickly
 
 	epsilon = 1e-6 // small amount to add to time to avoid division by 0
 )

--- a/x/sync/client.go
+++ b/x/sync/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -23,7 +24,9 @@ import (
 )
 
 const (
-	failedRequestSleepInterval = 10 * time.Millisecond
+	initialRetryWait = 10 * time.Millisecond
+	maxRetryWait     = time.Second
+	retryWaitFactor  = 1.5
 
 	epsilon = 1e-6 // small amount to add to time to avoid division by 0
 )
@@ -211,6 +214,11 @@ func getAndParse[T any](
 			lastErr = err
 		}
 
+		retryWait := initialRetryWait * time.Duration(math.Pow(retryWaitFactor, float64(attempt)))
+		if retryWait > maxRetryWait || retryWait < 0 { // Handle overflows with negative check.
+			retryWait = maxRetryWait
+		}
+
 		select {
 		case <-ctx.Done():
 			if lastErr != nil {
@@ -221,7 +229,7 @@ func getAndParse[T any](
 				)
 			}
 			return nil, ctx.Err()
-		case <-time.After(failedRequestSleepInterval):
+		case <-time.After(retryWait):
 		}
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Prevent retry storms. 

Table of attempt number and timeout:

```
1 10ms
2 20ms
3 30ms
4 50ms
5 70ms
6 110ms
7 170ms
8 250ms
9 380ms
10 570ms
11 860ms
12 1s
```

all subsequent requests will wait 1s

## How this works

Add exponential backoff

## How this was tested

Existing UT
