### PR TITLE
Update buf version to v1.23.1

### DIFF
--- a/.github/workflows/buf-lint.yml
+++ b/.github/workflows/buf-lint.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1.19.0
+      - uses: bufbuild/buf-setup-action@v1.23.1
         with:
           github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1.19.0
+      - uses: bufbuild/buf-setup-action@v1.23.1
       - uses: bufbuild/buf-push-action@v1
         with:
           input: "proto"

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ To regenerate the protobuf go code, run `scripts/protobuf_codegen.sh` from the r
 
 This should only be necessary when upgrading protobuf versions or modifying .proto definition files.
 
-To use this script, you must have [buf](https://docs.buf.build/installation) (v1.11.0), protoc-gen-go (v1.28.0) and protoc-gen-go-grpc (v1.2.0) installed.
+To use this script, you must have [buf](https://docs.buf.build/installation) (v1.23.1), protoc-gen-go (v1.28.0) and protoc-gen-go-grpc (v1.2.0) installed.
 
 To install the buf dependencies:
 

--- a/proto/Dockerfile.buf
+++ b/proto/Dockerfile.buf
@@ -1,4 +1,4 @@
-FROM bufbuild/buf:1.11.0 AS builder
+FROM bufbuild/buf:1.23.1 AS builder
 
 FROM ubuntu:20.04
 

--- a/scripts/protobuf_codegen.sh
+++ b/scripts/protobuf_codegen.sh
@@ -9,7 +9,7 @@ fi
 # any version changes here should also be bumped in Dockerfile.buf
 # ref. https://docs.buf.build/installation
 # ref. https://github.com/bufbuild/buf/releases
-BUF_VERSION='1.19.0'
+BUF_VERSION='1.23.1'
 if [[ $(buf --version | cut -f2 -d' ') != "${BUF_VERSION}" ]]; then
   echo "could not find buf ${BUF_VERSION}, is it installed + in PATH?"
   exit 255


### PR DESCRIPTION
## Why this should be merged

This PR updates the buf version in the README and that required by `scripts/protobuf_codegen.sh` to v1.23.1

## How this works

This updates the required buf version.

## How this was tested

CI + running the modified script
