### PR TITLE
P-chain Stakers interface minor cleanup

### DIFF
--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -33,14 +33,6 @@ type CurrentStakers interface {
 	// Invariant: [staker] is currently a CurrentValidator
 	DeleteCurrentValidator(staker *Staker)
 
-	// SetDelegateeReward sets the accrued delegation rewards for [nodeID] on
-	// [subnetID] to [amount].
-	SetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID, amount uint64) error
-
-	// GetDelegateeReward returns the accrued delegation rewards for [nodeID] on
-	// [subnetID].
-	GetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID) (uint64, error)
-
 	// GetCurrentDelegatorIterator returns the delegators associated with the
 	// validator on [subnetID] with [nodeID]. Delegators are sorted by their
 	// removal from current staker set.

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -103,6 +103,14 @@ type Chain interface {
 	GetRewardUTXOs(txID ids.ID) ([]*avax.UTXO, error)
 	AddRewardUTXO(txID ids.ID, utxo *avax.UTXO)
 
+	// SetDelegateeReward sets the accrued delegation rewards for [nodeID] on
+	// [subnetID] to [amount].
+	SetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID, amount uint64) error
+
+	// GetDelegateeReward returns the accrued delegation rewards for [nodeID] on
+	// [subnetID].
+	GetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID) (uint64, error)
+
 	GetSubnets() ([]*txs.Tx, error)
 	AddSubnet(createSubnetTx *txs.Tx)
 


### PR DESCRIPTION
## Why this should be merged
Just relocating `Get/SetDelegateeReward` to `state.Chain` from `CurrentStakers` interface. Reason is that:

- `Current/PendingStakers` interface contains the way we insert/update/delete and iterate stakers.
- `Get/SetDelegateeReward` methods deals with reward UTXOs that should be stored in P-chain state.

## How this works
Just moved the two methods from `state.CurrentStakers` to `state.Chain`.
Note that `state.Chain` is embedded in both `state.State` and `state.Diff`.
Also note that  `Get/SetDelegateeReward` methods are **not** implemented in `state.baseStaker` container (which holds all stakers). Instead they are implemented in state.diff and state.state structs. So really I am moving the two methods closer to the structs implementing them.

## How this was tested
CI
