### PR TITLE
Ensure scripts/lint.sh failure when used with incompatible grep

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -16,7 +16,7 @@ fi
 grep -P 'lint.sh' scripts/lint.sh &> /dev/null || (\
   >&2 echo "error: This script requires a recent version of gnu grep.";\
   >&2 echo "       On macos, gnu grep can be installed with 'brew install grep'.";\
-  >&2 echo "       It will also be necessary to that ensure gnu grep is available in the path.";\
+  >&2 echo "       It will also be necessary to ensure that gnu grep is available in the path.";\
   exit 255 )
 
 if [ "$#" -eq 0 ]; then

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,6 +9,16 @@ if ! [[ "$0" =~ scripts/lint.sh ]]; then
   exit 255
 fi
 
+# The -P option is not supported by the grep version installed by
+# default on macos. Since `-o errexit` is ignored in an if
+# conditional, triggering the problem here ensures script failure when
+# using an unsupported version of grep.
+grep -P 'lint.sh' scripts/lint.sh &> /dev/null || (\
+  >&2 echo "error: This script requires a recent version of gnu grep.";\
+  >&2 echo "       On macos, gnu grep can be installed with 'brew install grep'.";\
+  >&2 echo "       It will also be necessary to that ensure gnu grep is available in the path.";\
+  exit 255 )
+
 if [ "$#" -eq 0 ]; then
   # by default, check all source code
   # to test only "snow" package


### PR DESCRIPTION
## Why this should be merged

scripts/lint.sh requires the use of GNU grep due to dependency on the `-P / --perl-regexp` flag, and the default version installed on MacOS is not compatible. Previously this compatibility problem wasn't resulting in script failure due to how bash ignores `set -o errexit` when running commands in conditionals. Adding an explicit compatibility check ensures an obvious failure mode and path to resolution.

## How this works

Running `grep -P` with a regex that is guaranteed to match will succeed for gnu grep and fail with an informative message with macos' default grep.

## How this was tested

 - scripts/lint.sh was tested to succeed with gnu grep and fail with the expected output with macos' default grep