### PR TITLE
Adjust `NewSizedCache` to take in a size function

### DIFF
--- a/cache/lru_cache_test.go
+++ b/cache/lru_cache_test.go
@@ -12,26 +12,26 @@ import (
 )
 
 func TestLRU(t *testing.T) {
-	cache := &LRU[ids.ID, TestSizedInt]{Size: 1}
+	cache := &LRU[ids.ID, int64]{Size: 1}
 
 	TestBasic(t, cache)
 }
 
 func TestLRUEviction(t *testing.T) {
-	cache := &LRU[ids.ID, TestSizedInt]{Size: 2}
+	cache := &LRU[ids.ID, int64]{Size: 2}
 
 	TestEviction(t, cache)
 }
 
 func TestLRUResize(t *testing.T) {
 	require := require.New(t)
-	cache := LRU[ids.ID, TestSizedInt]{Size: 2}
+	cache := LRU[ids.ID, int64]{Size: 2}
 
 	id1 := ids.ID{1}
 	id2 := ids.ID{2}
 
-	expectedVal1 := TestSizedInt{i: 1}
-	expectedVal2 := TestSizedInt{i: 2}
+	expectedVal1 := int64(1)
+	expectedVal2 := int64(2)
 	cache.Put(id1, expectedVal1)
 	cache.Put(id2, expectedVal2)
 

--- a/cache/lru_sized_cache_test.go
+++ b/cache/lru_sized_cache_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestSizedLRU(t *testing.T) {
-	cache := NewSizedLRU[ids.ID, TestSizedInt](TestSizedIntSize)
+	cache := NewSizedLRU[ids.ID, int64](TestIntSize, TestIntSizeFunc)
 
 	TestBasic(t, cache)
 }
 
 func TestSizedLRUEviction(t *testing.T) {
-	cache := NewSizedLRU[ids.ID, TestSizedInt](2 * TestSizedIntSize)
+	cache := NewSizedLRU[ids.ID, int64](2*TestIntSize, TestIntSizeFunc)
 
 	TestEviction(t, cache)
 }

--- a/cache/metercacher/cache_test.go
+++ b/cache/metercacher/cache_test.go
@@ -17,20 +17,20 @@ import (
 func TestInterface(t *testing.T) {
 	type scenario struct {
 		description string
-		setup       func(size int) cache.Cacher[ids.ID, cache.TestSizedInt]
+		setup       func(size int) cache.Cacher[ids.ID, int64]
 	}
 
 	scenarios := []scenario{
 		{
 			description: "cache LRU",
-			setup: func(size int) cache.Cacher[ids.ID, cache.TestSizedInt] {
-				return &cache.LRU[ids.ID, cache.TestSizedInt]{Size: size}
+			setup: func(size int) cache.Cacher[ids.ID, int64] {
+				return &cache.LRU[ids.ID, int64]{Size: size}
 			},
 		},
 		{
 			description: "sized cache LRU",
-			setup: func(size int) cache.Cacher[ids.ID, cache.TestSizedInt] {
-				return cache.NewSizedLRU[ids.ID, cache.TestSizedInt](size * cache.TestSizedIntSize)
+			setup: func(size int) cache.Cacher[ids.ID, int64] {
+				return cache.NewSizedLRU[ids.ID, int64](size*cache.TestIntSize, cache.TestIntSizeFunc)
 			},
 		},
 	}

--- a/cache/test_cacher.go
+++ b/cache/test_cacher.go
@@ -13,7 +13,9 @@ import (
 
 const TestIntSize = 8
 
-func TestIntSizeFunc(int64) int { return TestIntSize }
+func TestIntSizeFunc(int64) int {
+	return TestIntSize
+}
 
 // CacherTests is a list of all Cacher tests
 var CacherTests = []struct {

--- a/cache/test_cacher.go
+++ b/cache/test_cacher.go
@@ -11,34 +11,28 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 )
 
-const TestSizedIntSize = 8
+const TestIntSize = 8
 
-type TestSizedInt struct {
-	i int64
-}
-
-func (TestSizedInt) Size() int {
-	return TestSizedIntSize
-}
+var TestIntSizeFunc = func(int64) int { return TestIntSize }
 
 // CacherTests is a list of all Cacher tests
 var CacherTests = []struct {
 	Size int
-	Func func(t *testing.T, c Cacher[ids.ID, TestSizedInt])
+	Func func(t *testing.T, c Cacher[ids.ID, int64])
 }{
 	{Size: 1, Func: TestBasic},
 	{Size: 2, Func: TestEviction},
 }
 
-func TestBasic(t *testing.T, cache Cacher[ids.ID, TestSizedInt]) {
+func TestBasic(t *testing.T, cache Cacher[ids.ID, int64]) {
 	require := require.New(t)
 
 	id1 := ids.ID{1}
 	_, found := cache.Get(id1)
 	require.False(found)
 
-	expectedValue1 := TestSizedInt{i: 1}
-	cache.Put(id1, expectedValue1)
+	expectedValue1 := int64(1)
+	cache.Put(id1, 1)
 	value, found := cache.Get(id1)
 	require.True(found)
 	require.Equal(expectedValue1, value)
@@ -55,7 +49,7 @@ func TestBasic(t *testing.T, cache Cacher[ids.ID, TestSizedInt]) {
 
 	id2 := ids.ID{2}
 
-	expectedValue2 := TestSizedInt{i: 2}
+	expectedValue2 := int64(2)
 	cache.Put(id2, expectedValue2)
 	_, found = cache.Get(id1)
 	require.False(found)
@@ -65,16 +59,16 @@ func TestBasic(t *testing.T, cache Cacher[ids.ID, TestSizedInt]) {
 	require.Equal(expectedValue2, value)
 }
 
-func TestEviction(t *testing.T, cache Cacher[ids.ID, TestSizedInt]) {
+func TestEviction(t *testing.T, cache Cacher[ids.ID, int64]) {
 	require := require.New(t)
 
 	id1 := ids.ID{1}
 	id2 := ids.ID{2}
 	id3 := ids.ID{3}
 
-	expectedValue1 := TestSizedInt{i: 1}
-	expectedValue2 := TestSizedInt{i: 2}
-	expectedValue3 := TestSizedInt{i: 3}
+	expectedValue1 := int64(1)
+	expectedValue2 := int64(2)
+	expectedValue3 := int64(3)
 
 	cache.Put(id1, expectedValue1)
 	cache.Put(id2, expectedValue2)

--- a/cache/test_cacher.go
+++ b/cache/test_cacher.go
@@ -13,7 +13,7 @@ import (
 
 const TestIntSize = 8
 
-var TestIntSizeFunc = func(int64) int { return TestIntSize }
+func TestIntSizeFunc(int64) int { return TestIntSize }
 
 // CacherTests is a list of all Cacher tests
 var CacherTests = []struct {
@@ -32,7 +32,7 @@ func TestBasic(t *testing.T, cache Cacher[ids.ID, int64]) {
 	require.False(found)
 
 	expectedValue1 := int64(1)
-	cache.Put(id1, 1)
+	cache.Put(id1, expectedValue1)
 	value, found := cache.Get(id1)
 	require.True(found)
 	require.Equal(expectedValue1, value)

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -52,9 +52,7 @@ const (
 )
 
 var (
-	_ State              = (*state)(nil)
-	_ cache.SizedElement = (*stateBlk)(nil)
-	_ cache.SizedElement = (*txAndStatus)(nil)
+	_ State = (*state)(nil)
 
 	ErrDelegatorSubset              = errors.New("delegator's time range must be a subset of the validator's time range")
 	errMissingValidatorSet          = errors.New("missing validator set")
@@ -162,7 +160,7 @@ type stateBlk struct {
 	Status choices.Status `serialize:"true"`
 }
 
-func (b *stateBlk) Size() int {
+var stateBlkSizeFunc = func(b *stateBlk) int {
 	if b == nil {
 		return wrappers.LongLen
 	}
@@ -351,7 +349,7 @@ type txAndStatus struct {
 	status status.Status
 }
 
-func (t *txAndStatus) Size() int {
+var txAndStatusSizeFunc = func(t *txAndStatus) int {
 	if t == nil {
 		return wrappers.LongLen
 	}
@@ -406,7 +404,7 @@ func new(
 	blockCache, err := metercacher.New(
 		"block_cache",
 		metricsReg,
-		cache.NewSizedLRU[ids.ID, *stateBlk](blockCacheSize),
+		cache.NewSizedLRU[ids.ID, *stateBlk](blockCacheSize, stateBlkSizeFunc),
 	)
 	if err != nil {
 		return nil, err
@@ -451,7 +449,7 @@ func new(
 	txCache, err := metercacher.New(
 		"tx_cache",
 		metricsReg,
-		cache.NewSizedLRU[ids.ID, *txAndStatus](txCacheSize),
+		cache.NewSizedLRU[ids.ID, *txAndStatus](txCacheSize, txAndStatusSizeFunc),
 	)
 	if err != nil {
 		return nil, err
@@ -478,7 +476,7 @@ func new(
 	transformedSubnetCache, err := metercacher.New(
 		"transformed_subnet_cache",
 		metricsReg,
-		cache.NewSizedLRU[ids.ID, *txs.Tx](transformedSubnetTxCacheSize),
+		cache.NewSizedLRU[ids.ID, *txs.Tx](transformedSubnetTxCacheSize, func(tx *txs.Tx) int { return tx.Size() }),
 	)
 	if err != nil {
 		return nil, err

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -160,7 +160,7 @@ type stateBlk struct {
 	Status choices.Status `serialize:"true"`
 }
 
-var stateBlkSizeFunc = func(b *stateBlk) int {
+func stateBlkSizeFunc(b *stateBlk) int {
 	if b == nil {
 		return wrappers.LongLen
 	}
@@ -349,7 +349,7 @@ type txAndStatus struct {
 	status status.Status
 }
 
-var txAndStatusSizeFunc = func(t *txAndStatus) int {
+func txAndStatusSizeFunc(t *txAndStatus) int {
 	if t == nil {
 		return wrappers.LongLen
 	}

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -160,7 +160,7 @@ type stateBlk struct {
 	Status choices.Status `serialize:"true"`
 }
 
-func stateBlkSizeFunc(b *stateBlk) int {
+func stateBlkSize(b *stateBlk) int {
 	if b == nil {
 		return wrappers.LongLen
 	}
@@ -349,7 +349,7 @@ type txAndStatus struct {
 	status status.Status
 }
 
-func txAndStatusSizeFunc(t *txAndStatus) int {
+func txAndStatusSize(t *txAndStatus) int {
 	if t == nil {
 		return wrappers.LongLen
 	}
@@ -404,7 +404,7 @@ func new(
 	blockCache, err := metercacher.New(
 		"block_cache",
 		metricsReg,
-		cache.NewSizedLRU[ids.ID, *stateBlk](blockCacheSize, stateBlkSizeFunc),
+		cache.NewSizedLRU[ids.ID, *stateBlk](blockCacheSize, stateBlkSize),
 	)
 	if err != nil {
 		return nil, err
@@ -449,7 +449,7 @@ func new(
 	txCache, err := metercacher.New(
 		"tx_cache",
 		metricsReg,
-		cache.NewSizedLRU[ids.ID, *txAndStatus](txCacheSize, txAndStatusSizeFunc),
+		cache.NewSizedLRU[ids.ID, *txAndStatus](txCacheSize, txAndStatusSize),
 	)
 	if err != nil {
 		return nil, err
@@ -476,7 +476,7 @@ func new(
 	transformedSubnetCache, err := metercacher.New(
 		"transformed_subnet_cache",
 		metricsReg,
-		cache.NewSizedLRU[ids.ID, *txs.Tx](transformedSubnetTxCacheSize, func(tx *txs.Tx) int { return tx.Size() }),
+		cache.NewSizedLRU[ids.ID, *txs.Tx](transformedSubnetTxCacheSize, (*txs.Tx).Size),
 	)
 	if err != nil {
 		return nil, err

--- a/vms/platformvm/txs/tx.go
+++ b/vms/platformvm/txs/tx.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
@@ -20,8 +19,6 @@ import (
 )
 
 var (
-	_ cache.SizedElement = (*Tx)(nil)
-
 	ErrNilSignedTx = errors.New("nil signed tx is not valid")
 
 	errSignedTxNotInitialized = errors.New("signed tx was never initialized and is not valid")


### PR DESCRIPTION
## Why this should be merged

Explicit size functions can handle `nil` whereas `SizedElement` does not work for nil.

## How this works

Modifies the function signature.

## How this was tested

CI