### PR TITLE
Add support for providing tracing headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1265,7 +1265,7 @@ func getTraceConfig(v *viper.Viper) (trace.Config, error) {
 			Type:     exporterType,
 			Endpoint: endpoint,
 			Insecure: v.GetBool(TracingInsecureKey),
-			// TODO add support for headers
+			Headers:  v.GetStringMapString(TracingHeadersKey),
 		},
 		Enabled:         true,
 		TraceSampleRate: v.GetFloat64(TracingSampleRateKey),

--- a/config/flags.go
+++ b/config/flags.go
@@ -386,6 +386,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.String(TracingEndpointKey, "localhost:4317", "The endpoint to send trace data to")
 	fs.Bool(TracingInsecureKey, true, "If true, don't use TLS when sending trace data")
 	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample")
+	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
 	// TODO add flag to take in headers to send from exporter
 }
 

--- a/config/keys.go
+++ b/config/keys.go
@@ -218,4 +218,5 @@ const (
 	TracingInsecureKey                                 = "tracing-insecure"
 	TracingSampleRateKey                               = "tracing-sample-rate"
 	TracingExporterTypeKey                             = "tracing-exporter-type"
+	TracingHeadersKey                                  = "tracing-headers"
 )


### PR DESCRIPTION
## Why this should be merged

Allows exporting traces to [uptrace](https://uptrace.dev/) without requiring code changes.

## How this works

Uptrace requires providing a secret using the `uptrace-dsn` header.

## How this was tested

When running the simple `uptrace` demo: https://github.com/uptrace/uptrace/tree/master/example/docker

```(sh)
avalanchego --tracing-enabled=true --tracing-endpoint="localhost:14317" --tracing-exporter-type=grpc --tracing-sample-rate=1 --tracing-headers="uptrace-dsn"="http://project2_secret_token@localhost:14317/2"
```

Results in ingesting traces:

![image](https://github.com/ava-labs/avalanchego/assets/22109487/2c9cba50-2870-4199-9258-5092a114a48b)