### PR TITLE
Write process context on node start to simplify test orchestration

### DIFF
--- a/api/server/mock_server.go
+++ b/api/server/mock_server.go
@@ -105,11 +105,6 @@ func (mr *MockServerMockRecorder) AddRouteWithReadLock(arg0, arg1, arg2, arg3 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRouteWithReadLock", reflect.TypeOf((*MockServer)(nil).AddRouteWithReadLock), arg0, arg1, arg2, arg3)
 }
 
-// Not used in testing but required for interface compliance
-func (m *MockServer) GetURI() string {
-	return ""
-}
-
 // Dispatch mocks base method.
 func (m *MockServer) Dispatch() error {
 	m.ctrl.T.Helper()

--- a/api/server/mock_server.go
+++ b/api/server/mock_server.go
@@ -105,6 +105,11 @@ func (mr *MockServerMockRecorder) AddRouteWithReadLock(arg0, arg1, arg2, arg3 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRouteWithReadLock", reflect.TypeOf((*MockServer)(nil).AddRouteWithReadLock), arg0, arg1, arg2, arg3)
 }
 
+// Not used in testing but required for interface compliance
+func (m *MockServer) GetURI() string {
+	return ""
+}
+
 // Dispatch mocks base method.
 func (m *MockServer) Dispatch() error {
 	m.ctrl.T.Helper()

--- a/api/server/mock_server.go
+++ b/api/server/mock_server.go
@@ -124,20 +124,6 @@ func (mr *MockServerMockRecorder) Dispatch() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dispatch", reflect.TypeOf((*MockServer)(nil).Dispatch))
 }
 
-// DispatchTLS mocks base method.
-func (m *MockServer) DispatchTLS(arg0, arg1 []byte) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DispatchTLS", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DispatchTLS indicates an expected call of DispatchTLS.
-func (mr *MockServerMockRecorder) DispatchTLS(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchTLS", reflect.TypeOf((*MockServer)(nil).DispatchTLS), arg0, arg1)
-}
-
 // RegisterChain mocks base method.
 func (m *MockServer) RegisterChain(arg0 string, arg1 *snow.ConsensusContext, arg2 common.VM) {
 	m.ctrl.T.Helper()

--- a/config/config.go
+++ b/config/config.go
@@ -1471,7 +1471,7 @@ func GetNodeConfig(v *viper.Viper) (node.Config, error) {
 
 	nodeConfig.ChainDataDir = GetExpandedArg(v, ChainDataDirKey)
 
-	nodeConfig.RuntimeStatePath = GetExpandedArg(v, RuntimeStatePathKey)
+	nodeConfig.RuntimeStateFilePath = GetExpandedArg(v, RuntimeStateFileKey)
 
 	nodeConfig.ProvidedFlags = providedFlags(v)
 	return nodeConfig, nil

--- a/config/config.go
+++ b/config/config.go
@@ -1471,7 +1471,7 @@ func GetNodeConfig(v *viper.Viper) (node.Config, error) {
 
 	nodeConfig.ChainDataDir = GetExpandedArg(v, ChainDataDirKey)
 
-	nodeConfig.RuntimeStatePath = v.GetString(RuntimeStatePathKey)
+	nodeConfig.RuntimeStatePath = GetExpandedArg(v, RuntimeStatePathKey)
 
 	nodeConfig.ProvidedFlags = providedFlags(v)
 	return nodeConfig, nil

--- a/config/config.go
+++ b/config/config.go
@@ -1471,6 +1471,8 @@ func GetNodeConfig(v *viper.Viper) (node.Config, error) {
 
 	nodeConfig.ChainDataDir = GetExpandedArg(v, ChainDataDirKey)
 
+	nodeConfig.RuntimeStatePath = v.GetString(RuntimeStatePathKey)
+
 	nodeConfig.ProvidedFlags = providedFlags(v)
 	return nodeConfig, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1471,7 +1471,7 @@ func GetNodeConfig(v *viper.Viper) (node.Config, error) {
 
 	nodeConfig.ChainDataDir = GetExpandedArg(v, ChainDataDirKey)
 
-	nodeConfig.RuntimeStateFilePath = GetExpandedArg(v, RuntimeStateFileKey)
+	nodeConfig.ProcessContextFilePath = GetExpandedArg(v, ProcessContextFileKey)
 
 	nodeConfig.ProvidedFlags = providedFlags(v)
 	return nodeConfig, nil

--- a/config/flags.go
+++ b/config/flags.go
@@ -370,7 +370,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample")
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
 
-	fs.String(RuntimeStatePathKey, defaultRuntimeStatePath, "The path to write runtime state to (including PID, API URI, and bootstrap address).")
+	fs.String(RuntimeStatePathKey, defaultRuntimeStatePath, "The path to write runtime state to (including PID, API URI, and bootstrap address). If empty, runtime state will not be written.")
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego

--- a/config/flags.go
+++ b/config/flags.go
@@ -370,7 +370,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample")
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
 
-	fs.String(RuntimeStatePathKey, defaultRuntimeStatePath, "The path to write runtime state to (including PID, API URI, and bootstrap address). If empty, runtime state will not be written.")
+	fs.String(RuntimeStateFileKey, defaultRuntimeStatePath, "The path to write runtime state to (including PID, API URI, and staking address).")
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego

--- a/config/flags.go
+++ b/config/flags.go
@@ -368,6 +368,8 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Bool(TracingInsecureKey, true, "If true, don't use TLS when sending trace data")
 	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample")
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
+
+	fs.String(RuntimeStatePathKey, "", "The path to write runtime state to (including uri, bootstrap address and pid). If empty, runtime state will not be written.")
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego

--- a/config/flags.go
+++ b/config/flags.go
@@ -50,7 +50,7 @@ var (
 	defaultSubnetConfigDir      = filepath.Join(defaultConfigDir, "subnets")
 	defaultPluginDir            = filepath.Join(defaultUnexpandedDataDir, "plugins")
 	defaultChainDataDir         = filepath.Join(defaultUnexpandedDataDir, "chainData")
-	defaultRuntimeStatePath     = filepath.Join(defaultUnexpandedDataDir, "runtime.json")
+	defaultProcessContextPath   = filepath.Join(defaultUnexpandedDataDir, "process.json")
 )
 
 func deprecateFlags(fs *pflag.FlagSet) error {
@@ -370,7 +370,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample")
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
 
-	fs.String(RuntimeStateFileKey, defaultRuntimeStatePath, "The path to write runtime state to (including PID, API URI, and staking address).")
+	fs.String(ProcessContextFileKey, defaultProcessContextPath, "The path to write process context to (including PID, API URI, and staking address).")
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego

--- a/config/flags.go
+++ b/config/flags.go
@@ -50,6 +50,7 @@ var (
 	defaultSubnetConfigDir      = filepath.Join(defaultConfigDir, "subnets")
 	defaultPluginDir            = filepath.Join(defaultUnexpandedDataDir, "plugins")
 	defaultChainDataDir         = filepath.Join(defaultUnexpandedDataDir, "chainData")
+	defaultRuntimeStatePath     = filepath.Join(defaultUnexpandedDataDir, "runtime.json")
 )
 
 func deprecateFlags(fs *pflag.FlagSet) error {
@@ -369,7 +370,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample")
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
 
-	fs.String(RuntimeStatePathKey, "", "The path to write runtime state to (including uri, bootstrap address and pid). If empty, runtime state will not be written.")
+	fs.String(RuntimeStatePathKey, defaultRuntimeStatePath, "The path to write runtime state to (including PID, API URI, and bootstrap address).")
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego

--- a/config/keys.go
+++ b/config/keys.go
@@ -209,4 +209,5 @@ const (
 	TracingSampleRateKey                               = "tracing-sample-rate"
 	TracingExporterTypeKey                             = "tracing-exporter-type"
 	TracingHeadersKey                                  = "tracing-headers"
+	RuntimeStatePathKey                                = "runtime-state-path"
 )

--- a/config/keys.go
+++ b/config/keys.go
@@ -209,5 +209,5 @@ const (
 	TracingSampleRateKey                               = "tracing-sample-rate"
 	TracingExporterTypeKey                             = "tracing-exporter-type"
 	TracingHeadersKey                                  = "tracing-headers"
-	RuntimeStateFileKey                                = "runtime-state-file"
+	ProcessContextFileKey                              = "process-context-file"
 )

--- a/config/keys.go
+++ b/config/keys.go
@@ -209,5 +209,5 @@ const (
 	TracingSampleRateKey                               = "tracing-sample-rate"
 	TracingExporterTypeKey                             = "tracing-exporter-type"
 	TracingHeadersKey                                  = "tracing-headers"
-	RuntimeStatePathKey                                = "runtime-state-path"
+	RuntimeStateFileKey                                = "runtime-state-file"
 )

--- a/node/config.go
+++ b/node/config.go
@@ -234,7 +234,8 @@ type Config struct {
 	// write arbitrary data.
 	ChainDataDir string `json:"chainDataDir"`
 
-	// Path to write runtime state to (including uri, bootstrap
-	// address and pid). If empty, runtime state will not be written.
+	// Path to write runtime state to (including PID, API URI, and
+	// bootstrap address). If empty, runtime state will not be
+	// written.
 	RuntimeStatePath string `json:"runtimeStatePath"`
 }

--- a/node/config.go
+++ b/node/config.go
@@ -234,7 +234,7 @@ type Config struct {
 	// write arbitrary data.
 	ChainDataDir string `json:"chainDataDir"`
 
-	// Path to write runtime state to (including PID, API URI, and
+	// Path to write process context to (including PID, API URI, and
 	// staking address).
-	RuntimeStateFilePath string `json:"runtimeStateFilePath"`
+	ProcessContextFilePath string `json:"processContextFilePath"`
 }

--- a/node/config.go
+++ b/node/config.go
@@ -233,4 +233,8 @@ type Config struct {
 	// ChainDataDir is the root path for per-chain directories where VMs can
 	// write arbitrary data.
 	ChainDataDir string `json:"chainDataDir"`
+
+	// Path to write runtime state to (including uri, bootstrap
+	// address and pid). If empty, runtime state will not be written.
+	RuntimeStatePath string `json:"runtimeStatePath"`
 }

--- a/node/config.go
+++ b/node/config.go
@@ -235,7 +235,6 @@ type Config struct {
 	ChainDataDir string `json:"chainDataDir"`
 
 	// Path to write runtime state to (including PID, API URI, and
-	// bootstrap address). If empty, runtime state will not be
-	// written.
-	RuntimeStatePath string `json:"runtimeStatePath"`
+	// staking address).
+	RuntimeStateFilePath string `json:"runtimeStateFilePath"`
 }

--- a/node/node.go
+++ b/node/node.go
@@ -498,7 +498,8 @@ func (n *Node) Dispatch() error {
 	n.DoneShuttingDown.Wait()
 
 	if len(n.Config.RuntimeStatePath) > 0 {
-		// Attempt to remove the runtime state path
+		// Attempt to remove the runtime state path to communicate to an
+		// orchestrator that the node is no longer running.
 		if err := os.Remove(n.Config.RuntimeStatePath); err != nil && !os.IsNotExist(err) {
 			n.Log.Error("removal of runtime state file failed",
 				zap.String("path", n.Config.RuntimeStatePath),


### PR DESCRIPTION
## Why this should be merged

The new local network fixture proposed in #1700 requires the following process context for each node to manage a local network a) without a daemon and b) with dynamically assigned ports:

 - `PID`: used to check if the node process is running and to enable stopping the node
 - `URI`: used to connect to the node's API (e.g. for health checks)
 - `staking address`: used by other nodes to bootstrap themselves

Initially these details were discovered by the fixture (e.g. addresses from logs and pid from process start), but it seemed more maintainable to have the node write the necessary data directly. Having the node write the process context directly also supports the start/stop and debug of test network nodes without explicit use of the test fixture.

## How this works

- On node start, process context (PID, URI, and staking address) is collected into the `NodeProcessContext` type, marshaled to JSON, and written to `[base-data-dir]/process.json`.  On shutdown the file will be removed.
 - Consumers can read the process context file and unmarshal the resulting JSON to the `NodeProcessContext` type.

## How this was tested

- The new test fixture in #1700 was refactored to depend on the new process context file and e2e tests were successfully executed against a fixture-managed network.