### PR TITLE
Bump network start timeout

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -156,7 +156,7 @@ func (te *TestEnvironment) StartCluster() error {
 	switch te.clusterType {
 	case StandAlone:
 		tests.Outf("{{magenta}}starting network-runner with %q{{/}}\n", te.avalancheGoExecPath)
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		resp, err := te.GetRunnerClient().Start(ctx, te.avalancheGoExecPath,
 			runner_sdk.WithNumNodes(5),
 			runner_sdk.WithGlobalNodeConfig(fmt.Sprintf(`{"log-level":"%s"}`, te.avalancheGoLogLevel)),


### PR DESCRIPTION
## Why this should be merged

e2e jobs have started failing due to network start exceeding the 15s timeout. Since the speed of network start is a function of the resources available to the github worker, extending the timeout ensures toleration of variance in worker performance.

## How this works

## How this was tested
