### PR TITLE
e2e: Ensure e2e.test is built with portable BLST

### DIFF
--- a/scripts/install_anr.sh
+++ b/scripts/install_anr.sh
@@ -9,9 +9,6 @@ AVALANCHE_PATH=$(
   cd .. && pwd
 )
 
-# Load the constants
-source "$AVALANCHE_PATH"/scripts/constants.sh
-
 #################################
 # download avalanche-network-runner
 # https://github.com/ava-labs/avalanche-network-runner

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -23,6 +23,12 @@ echo "installing avalanche-network-runner"
 ANR_WORKDIR="/tmp"
 ./scripts/install_anr.sh
 
+# Sourcing constants.sh ensures that the necessary CGO flags are set to
+# build the portable version of BLST. Without this, ginkgo may fail to
+# build the test binary if run on a host (e.g. github worker) that lacks
+# the instructions to build non-portable BLST.
+source ./scripts/constants.sh
+
 #################################
 echo "building e2e.test"
 # to install the ginkgo binary (required for test build and run)

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -56,6 +56,12 @@ echo "installing avalanche-network-runner"
 ANR_WORKDIR="/tmp"
 ./scripts/install_anr.sh
 
+# Sourcing constants.sh ensures that the necessary CGO flags are set to
+# build the portable version of BLST. Without this, ginkgo may fail to
+# build the test binary if run on a host (e.g. github worker) that lacks
+# the instructions to build non-portable BLST.
+source ./scripts/constants.sh
+
 #################################
 echo "building upgrade.test"
 # to install the ginkgo binary (required for test build and run)


### PR DESCRIPTION
## Why this should be merged

PR #1714 factored ANR installation into a common script, but in the process removed the CGO configuration for BLST from tests.e2e.sh. The result was [sporadic e2e job failure](https://github.com/ava-labs/avalanchego/actions/runs/5595760288/jobs/10231975913?pr=1729) whenever the github worker vm was missing the instructions non-portable BLST required. Ensuring CGO is explicitly configured for portable BLST in tests.e2e.sh should ensure the e2e test binary can once again be built reliably.

## How this works

## How this was tested
