### PR TITLE
move load snapshop time to 2 minutes

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -324,7 +324,7 @@ func (te *TestEnvironment) RestoreInitialState(switchOffNetworkFirst bool) error
 		gomega.Expect(err).Should(gomega.BeNil())
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	_, err := te.GetRunnerClient().LoadSnapshot(ctx, te.snapshotName)
 	cancel()
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged
Increases load snapshot time, which in 1.7.0 in blocking but in 1.4.0 was not

## How this works

## How this was tested
