### PR TITLE
Use default e2e timeouts everywhere

### DIFF
--- a/tests/e2e/ping/suites.go
+++ b/tests/e2e/ping/suites.go
@@ -6,7 +6,6 @@ package ping
 
 import (
 	"context"
-	"time"
 
 	"github.com/ava-labs/avalanchego/tests/e2e"
 
@@ -30,7 +29,7 @@ var _ = ginkgo.Describe("[Ping]", func() {
 			runnerCli := e2e.Env.GetRunnerClient()
 			gomega.Expect(runnerCli).ShouldNot(gomega.BeNil())
 
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
 			_, err := runnerCli.Ping(ctx)
 			cancel()
 			gomega.Expect(err).Should(gomega.BeNil())

--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 			uris := e2e.Env.GetURIs()
 			gomega.Expect(uris).ShouldNot(gomega.BeEmpty())
 			staticClient := avm.NewStaticClient(uris[0])
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
 			resp, err := staticClient.BuildGenesis(ctx, &avmArgs)
 			cancel()
 			gomega.Expect(err).Should(gomega.BeNil())
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 		gomega.Expect(uris).ShouldNot(gomega.BeEmpty())
 
 		staticClient := api.NewStaticClient(uris[0])
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
 		resp, err := staticClient.BuildGenesis(ctx, &buildGenesisArgs)
 		cancel()
 		gomega.Expect(err).Should(gomega.BeNil())

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/ava-labs/avalanchego/tests"
 )
 
+const DefaultTimeout = 2 * time.Minute
+
 func TestUpgrade(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "upgrade test suites")
@@ -82,14 +84,14 @@ var _ = ginkgo.BeforeSuite(func() {
 	})
 	gomega.Expect(err).Should(gomega.BeNil())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	presp, err := runnerCli.Ping(ctx)
 	cancel()
 	gomega.Expect(err).Should(gomega.BeNil())
 	tests.Outf("{{green}}network-runner running in PID %d{{/}}\n", presp.Pid)
 
 	tests.Outf("{{magenta}}starting network-runner with %q{{/}}\n", networkRunnerAvalancheGoExecPath)
-	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), DefaultTimeout)
 	resp, err := runnerCli.Start(ctx, networkRunnerAvalancheGoExecPath,
 		runner_sdk.WithNumNodes(5),
 		runner_sdk.WithGlobalNodeConfig(fmt.Sprintf(`{"log-level":"%s"}`, networkRunnerAvalancheGoLogLevel)),
@@ -101,7 +103,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	// start is async, so wait some time for cluster health
 	time.Sleep(time.Minute)
 
-	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel = context.WithTimeout(context.Background(), DefaultTimeout)
 	_, err = runnerCli.Health(ctx)
 	cancel()
 	gomega.Expect(err).Should(gomega.BeNil())
@@ -109,7 +111,7 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	tests.Outf("{{red}}shutting down network-runner cluster{{/}}\n")
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	_, err := runnerCli.Stop(ctx)
 	cancel()
 	gomega.Expect(err).Should(gomega.BeNil())
@@ -122,21 +124,21 @@ var _ = ginkgo.AfterSuite(func() {
 var _ = ginkgo.Describe("[Upgrade]", func() {
 	ginkgo.It("can upgrade versions", func() {
 		tests.Outf("{{magenta}}starting upgrade tests %q{{/}}\n", networkRunnerAvalancheGoExecPathToUpgrade)
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 		sresp, err := runnerCli.Status(ctx)
 		cancel()
 		gomega.Expect(err).Should(gomega.BeNil())
 
 		for _, name := range sresp.ClusterInfo.NodeNames {
 			tests.Outf("{{magenta}}restarting the node %q{{/}} with %q\n", name, networkRunnerAvalancheGoExecPathToUpgrade)
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 			resp, err := runnerCli.RestartNode(ctx, name, runner_sdk.WithExecPath(networkRunnerAvalancheGoExecPathToUpgrade))
 			cancel()
 			gomega.Expect(err).Should(gomega.BeNil())
 
 			time.Sleep(20 * time.Second)
 
-			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+			ctx, cancel = context.WithTimeout(context.Background(), DefaultTimeout)
 			_, err = runnerCli.Health(ctx)
 			cancel()
 			gomega.Expect(err).Should(gomega.BeNil())


### PR DESCRIPTION
## Why this should be merged

Updates the `upgrade` e2e test timeouts similarly to the `e2e` flow.

## How this works

📈 timeouts to avoid e2e test flakes (likely caused by running with the race detector).

## How this was tested

CI