### PR TITLE
Fix validator set diff tests

### DIFF
--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -189,7 +189,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 						return fmt.Sprintf("failed GetValidatorSet: %s", err.Error())
 					}
 					if !reflect.DeepEqual(validatorsSet, res) {
-						return fmt.Sprintf("failed validators set comparison: %s", err.Error())
+						return "failed validators set comparison"
 					}
 				}
 			}


### PR DESCRIPTION
## Why this should be merged

Some of the validator set diff tests currently act unexpectedly.

- Panic rather than fail
- Fail if the underlying implementation doesn't cache values

Refactored out of #1611.

## How this works

Fixes the tests

## How this was tested

Running the tests