### PR TITLE
Replace List() with Map() on validators.Set

### DIFF
--- a/snow/engine/common/bootstrapper.go
+++ b/snow/engine/common/bootstrapper.go
@@ -307,8 +307,8 @@ func (b *bootstrapper) Startup(ctx context.Context) error {
 	b.acceptedFrontierSet.Clear()
 
 	b.pendingSendAccepted.Clear()
-	for _, vdr := range b.Beacons.List() {
-		b.pendingSendAccepted.Add(vdr.NodeID)
+	for nodeID := range b.Beacons.Map() {
+		b.pendingSendAccepted.Add(nodeID)
 	}
 
 	b.pendingReceiveAccepted.Clear()

--- a/snow/engine/snowman/syncer/state_syncer.go
+++ b/snow/engine/snowman/syncer/state_syncer.go
@@ -447,8 +447,8 @@ func (ss *stateSyncer) startup(ctx context.Context) error {
 	}
 
 	// list all beacons, to reach them for voting on frontier
-	for _, vdr := range ss.StateSyncBeacons.List() {
-		ss.targetVoters.Add(vdr.NodeID)
+	for nodeID := range ss.StateSyncBeacons.Map() {
+		ss.targetVoters.Add(nodeID)
 	}
 
 	// check if there is an ongoing state sync; if so add its state summary

--- a/snow/engine/snowman/syncer/state_syncer_test.go
+++ b/snow/engine/snowman/syncer/state_syncer_test.go
@@ -174,8 +174,8 @@ func TestStateSyncLocalSummaryIsIncludedAmongFrontiersIfAvailable(t *testing.T) 
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 
 	require.Equal(localSummary, syncer.locallyAvailableSummary)
@@ -211,8 +211,8 @@ func TestStateSyncNotFoundOngoingSummaryIsNotIncludedAmongFrontiers(t *testing.T
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 
 	require.Nil(syncer.locallyAvailableSummary)
@@ -246,8 +246,8 @@ func TestBeaconsAreReachedForFrontiersUponStartup(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 
 	// check that vdrs are reached out for frontiers
@@ -290,8 +290,8 @@ func TestUnRequestedStateSummaryFrontiersAreDropped(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 
 	initiallyReachedOutBeaconsSize := len(contactedFrontiersProviders)
@@ -383,8 +383,8 @@ func TestMalformedStateSummaryFrontiersAreDropped(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 
 	initiallyReachedOutBeaconsSize := len(contactedFrontiersProviders)
@@ -455,8 +455,8 @@ func TestLateResponsesFromUnresponsiveFrontiersAreNotRecorded(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 
 	initiallyReachedOutBeaconsSize := len(contactedFrontiersProviders)
@@ -568,8 +568,8 @@ func TestStateSyncIsRestartedIfTooManyFrontierSeedersTimeout(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 	require.NotEmpty(syncer.pendingSeeders)
 
@@ -654,8 +654,8 @@ func TestVoteRequestsAreSentAsAllFrontierBeaconsResponded(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 	require.NotEmpty(syncer.pendingSeeders)
 
@@ -727,8 +727,8 @@ func TestUnRequestedVotesAreDropped(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 	require.NotEmpty(syncer.pendingSeeders)
 
@@ -847,8 +847,8 @@ func TestVotesForUnknownSummariesAreDropped(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 	require.NotEmpty(syncer.pendingSeeders)
 
@@ -969,8 +969,8 @@ func TestStateSummaryIsPassedToVMAsMajorityOfVotesIsCastedForIt(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 	require.NotEmpty(syncer.pendingSeeders)
 
@@ -1104,8 +1104,8 @@ func TestVotingIsRestartedIfMajorityIsNotReachedDueToTimeouts(t *testing.T) {
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 	require.NotEmpty(syncer.pendingSeeders)
 
@@ -1226,8 +1226,8 @@ func TestStateSyncIsStoppedIfEnoughVotesAreCastedWithNoClearMajority(t *testing.
 	}
 
 	// Connect enough stake to start syncer
-	for _, vdr := range vdrs.List() {
-		require.NoError(syncer.Connected(context.Background(), vdr.NodeID, version.CurrentApp))
+	for nodeID := range vdrs.Map() {
+		require.NoError(syncer.Connected(context.Background(), nodeID, version.CurrentApp))
 	}
 	require.NotEmpty(syncer.pendingSeeders)
 

--- a/snow/networking/handler/health_test.go
+++ b/snow/networking/handler/health_test.go
@@ -124,8 +124,8 @@ func TestHealthCheckSubnet(t *testing.T) {
 				require.NoError(vdrs.Add(vdrID, nil, ids.Empty, 100))
 			}
 
-			for index, vdr := range vdrs.List() {
-				require.NoError(peerTracker.Connected(context.Background(), vdr.NodeID, nil))
+			for index, nodeID := range vdrIDs.List() {
+				require.NoError(peerTracker.Connected(context.Background(), nodeID, nil))
 
 				details, err := handlerIntf.HealthCheck(context.Background())
 				expectedPercentConnected := float64(index+1) / float64(testVdrCount)

--- a/snow/validators/manager.go
+++ b/snow/validators/manager.go
@@ -19,7 +19,7 @@ import (
 var (
 	_ Manager = (*manager)(nil)
 
-	errMissingValidators = errors.New("missing validators")
+	ErrMissingValidators = errors.New("missing validators")
 )
 
 // Manager holds the validator set of each subnet
@@ -104,7 +104,7 @@ func (m *manager) String() string {
 func Add(m Manager, subnetID ids.ID, nodeID ids.NodeID, pk *bls.PublicKey, txID ids.ID, weight uint64) error {
 	vdrs, ok := m.Get(subnetID)
 	if !ok {
-		return fmt.Errorf("%w: %s", errMissingValidators, subnetID)
+		return fmt.Errorf("%w: %s", ErrMissingValidators, subnetID)
 	}
 	return vdrs.Add(nodeID, pk, txID, weight)
 }
@@ -117,7 +117,7 @@ func Add(m Manager, subnetID ids.ID, nodeID ids.NodeID, pk *bls.PublicKey, txID 
 func AddWeight(m Manager, subnetID ids.ID, nodeID ids.NodeID, weight uint64) error {
 	vdrs, ok := m.Get(subnetID)
 	if !ok {
-		return fmt.Errorf("%w: %s", errMissingValidators, subnetID)
+		return fmt.Errorf("%w: %s", ErrMissingValidators, subnetID)
 	}
 	return vdrs.AddWeight(nodeID, weight)
 }
@@ -130,7 +130,7 @@ func AddWeight(m Manager, subnetID ids.ID, nodeID ids.NodeID, weight uint64) err
 func RemoveWeight(m Manager, subnetID ids.ID, nodeID ids.NodeID, weight uint64) error {
 	vdrs, ok := m.Get(subnetID)
 	if !ok {
-		return fmt.Errorf("%w: %s", errMissingValidators, subnetID)
+		return fmt.Errorf("%w: %s", ErrMissingValidators, subnetID)
 	}
 	return vdrs.RemoveWeight(nodeID, weight)
 }
@@ -149,13 +149,9 @@ func Contains(m Manager, subnetID ids.ID, nodeID ids.NodeID) bool {
 func NodeIDs(m Manager, subnetID ids.ID) ([]ids.NodeID, error) {
 	vdrs, exist := m.Get(subnetID)
 	if !exist {
-		return nil, fmt.Errorf("%w: %s", errMissingValidators, subnetID)
+		return nil, fmt.Errorf("%w: %s", ErrMissingValidators, subnetID)
 	}
 
-	vdrsList := vdrs.List()
-	nodeIDs := make([]ids.NodeID, len(vdrsList))
-	for i, vdr := range vdrsList {
-		nodeIDs[i] = vdr.NodeID
-	}
-	return nodeIDs, nil
+	vdrsMap := vdrs.Map()
+	return maps.Keys(vdrsMap), nil
 }

--- a/snow/validators/manager_test.go
+++ b/snow/validators/manager_test.go
@@ -20,7 +20,7 @@ func TestAdd(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 
 	err := Add(m, subnetID, nodeID, nil, ids.Empty, 1)
-	require.ErrorIs(err, errMissingValidators)
+	require.ErrorIs(err, ErrMissingValidators)
 
 	s := NewSet()
 	m.Add(subnetID, s)
@@ -39,7 +39,7 @@ func TestAddWeight(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 
 	err := AddWeight(m, subnetID, nodeID, 1)
-	require.ErrorIs(err, errMissingValidators)
+	require.ErrorIs(err, ErrMissingValidators)
 
 	s := NewSet()
 	m.Add(subnetID, s)
@@ -63,7 +63,7 @@ func TestRemoveWeight(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 
 	err := RemoveWeight(m, subnetID, nodeID, 1)
-	require.ErrorIs(err, errMissingValidators)
+	require.ErrorIs(err, ErrMissingValidators)
 
 	s := NewSet()
 	m.Add(subnetID, s)

--- a/snow/validators/mock_set.go
+++ b/snow/validators/mock_set.go
@@ -124,18 +124,18 @@ func (mr *MockSetMockRecorder) Len() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockSet)(nil).Len))
 }
 
-// List mocks base method.
-func (m *MockSet) List() []*Validator {
+// Map mocks base method.
+func (m *MockSet) Map() map[ids.NodeID]*GetValidatorOutput {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List")
-	ret0, _ := ret[0].([]*Validator)
+	ret := m.ctrl.Call(m, "Map")
+	ret0, _ := ret[0].(map[ids.NodeID]*GetValidatorOutput)
 	return ret0
 }
 
-// List indicates an expected call of List.
-func (mr *MockSetMockRecorder) List() *gomock.Call {
+// Map indicates an expected call of Map.
+func (mr *MockSetMockRecorder) Map() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockSet)(nil).List))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Map", reflect.TypeOf((*MockSet)(nil).Map))
 }
 
 // PrefixedString mocks base method.

--- a/snow/validators/set.go
+++ b/snow/validators/set.go
@@ -70,8 +70,8 @@ type Set interface {
 	// Len returns the number of validators currently in the set.
 	Len() int
 
-	// List all the validators in this group
-	List() []*Validator
+	// Map of the validators in this set
+	Map() map[ids.NodeID]*GetValidatorOutput
 
 	// Weight returns the cumulative weight of all validators in the set.
 	Weight() uint64
@@ -318,20 +318,19 @@ func (s *vdrSet) len() int {
 	return len(s.vdrSlice)
 }
 
-func (s *vdrSet) List() []*Validator {
+func (s *vdrSet) Map() map[ids.NodeID]*GetValidatorOutput {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	return s.list()
-}
-
-func (s *vdrSet) list() []*Validator {
-	list := make([]*Validator, len(s.vdrSlice))
-	for i, vdr := range s.vdrSlice {
-		copiedVdr := *vdr
-		list[i] = &copiedVdr
+	set := make(map[ids.NodeID]*GetValidatorOutput, len(s.vdrSlice))
+	for _, vdr := range s.vdrSlice {
+		set[vdr.NodeID] = &GetValidatorOutput{
+			NodeID:    vdr.NodeID,
+			PublicKey: vdr.PublicKey,
+			Weight:    vdr.Weight,
+		}
 	}
-	return list
+	return set
 }
 
 func (s *vdrSet) Sample(size int) ([]ids.NodeID, error) {

--- a/snow/validators/set_test.go
+++ b/snow/validators/set_test.go
@@ -234,13 +234,13 @@ func TestSetLen(t *testing.T) {
 	require.Zero(len)
 }
 
-func TestSetList(t *testing.T) {
+func TestSetMap(t *testing.T) {
 	require := require.New(t)
 
 	s := NewSet()
 
-	list := s.List()
-	require.Empty(list)
+	m := s.Map()
+	require.Empty(m)
 
 	sk, err := bls.NewSecretKey()
 	require.NoError(err)
@@ -249,10 +249,11 @@ func TestSetList(t *testing.T) {
 	nodeID0 := ids.GenerateTestNodeID()
 	require.NoError(s.Add(nodeID0, pk, ids.Empty, 2))
 
-	list = s.List()
-	require.Len(list, 1)
+	m = s.Map()
+	require.Len(m, 1)
+	require.Contains(m, nodeID0)
 
-	node0 := list[0]
+	node0 := m[nodeID0]
 	require.Equal(nodeID0, node0.NodeID)
 	require.Equal(pk, node0.PublicKey)
 	require.Equal(uint64(2), node0.Weight)
@@ -260,15 +261,17 @@ func TestSetList(t *testing.T) {
 	nodeID1 := ids.GenerateTestNodeID()
 	require.NoError(s.Add(nodeID1, nil, ids.Empty, 1))
 
-	list = s.List()
-	require.Len(list, 2)
+	m = s.Map()
+	require.Len(m, 2)
+	require.Contains(m, nodeID0)
+	require.Contains(m, nodeID1)
 
-	node0 = list[0]
+	node0 = m[nodeID0]
 	require.Equal(nodeID0, node0.NodeID)
 	require.Equal(pk, node0.PublicKey)
 	require.Equal(uint64(2), node0.Weight)
 
-	node1 := list[1]
+	node1 := m[nodeID1]
 	require.Equal(nodeID1, node1.NodeID)
 	require.Nil(node1.PublicKey)
 	require.Equal(uint64(1), node1.Weight)
@@ -278,32 +281,35 @@ func TestSetList(t *testing.T) {
 	require.Equal(pk, node0.PublicKey)
 	require.Equal(uint64(2), node0.Weight)
 
-	list = s.List()
-	require.Len(list, 2)
+	m = s.Map()
+	require.Len(m, 2)
+	require.Contains(m, nodeID0)
+	require.Contains(m, nodeID1)
 
-	node0 = list[0]
+	node0 = m[nodeID0]
 	require.Equal(nodeID0, node0.NodeID)
 	require.Equal(pk, node0.PublicKey)
 	require.Equal(uint64(1), node0.Weight)
 
-	node1 = list[1]
+	node1 = m[nodeID1]
 	require.Equal(nodeID1, node1.NodeID)
 	require.Nil(node1.PublicKey)
 	require.Equal(uint64(1), node1.Weight)
 
 	require.NoError(s.RemoveWeight(nodeID0, 1))
 
-	list = s.List()
-	require.Len(list, 1)
+	m = s.Map()
+	require.Len(m, 1)
+	require.Contains(m, nodeID1)
 
-	node0 = list[0]
-	require.Equal(nodeID1, node0.NodeID)
-	require.Nil(node0.PublicKey)
-	require.Equal(uint64(1), node0.Weight)
+	node1 = m[nodeID1]
+	require.Equal(nodeID1, node1.NodeID)
+	require.Nil(node1.PublicKey)
+	require.Equal(uint64(1), node1.Weight)
 
 	require.NoError(s.RemoveWeight(nodeID1, 1))
 
-	require.Empty(s.List())
+	require.Empty(s.Map())
 }
 
 func TestSetWeight(t *testing.T) {

--- a/vms/platformvm/blocks/builder/helpers_test.go
+++ b/vms/platformvm/blocks/builder/helpers_test.go
@@ -78,8 +78,7 @@ var (
 	testSubnet1            *txs.Tx
 	testSubnet1ControlKeys = preFundedKeys[0:3]
 
-	errMissingPrimaryValidators = errors.New("missing primary validator set")
-	errMissing                  = errors.New("missing")
+	errMissing = errors.New("missing")
 )
 
 type mutableSharedMemory struct {
@@ -410,15 +409,9 @@ func buildGenesisTest(t *testing.T, ctx *snow.Context) []byte {
 
 func shutdownEnvironment(env *environment) error {
 	if env.isBootstrapped.Get() {
-		primaryValidatorSet, exist := env.config.Validators.Get(constants.PrimaryNetworkID)
-		if !exist {
-			return errMissingPrimaryValidators
-		}
-		primaryValidators := primaryValidatorSet.List()
-
-		validatorIDs := make([]ids.NodeID, len(primaryValidators))
-		for i, vdr := range primaryValidators {
-			validatorIDs[i] = vdr.NodeID
+		validatorIDs, err := validators.NodeIDs(env.config.Validators, constants.PrimaryNetworkID)
+		if err != nil {
+			return err
 		}
 
 		if err := env.uptimes.StopTracking(validatorIDs, constants.PrimaryNetworkID); err != nil {

--- a/vms/platformvm/blocks/executor/helpers_test.go
+++ b/vms/platformvm/blocks/executor/helpers_test.go
@@ -83,8 +83,7 @@ var (
 	genesisBlkID ids.ID
 	testSubnet1  *txs.Tx
 
-	errMissingPrimaryValidators = errors.New("missing primary validator set")
-	errMissing                  = errors.New("missing")
+	errMissing = errors.New("missing")
 )
 
 type stakerStatus uint
@@ -463,15 +462,9 @@ func shutdownEnvironment(t *environment) error {
 	}
 
 	if t.isBootstrapped.Get() {
-		primaryValidatorSet, exist := t.config.Validators.Get(constants.PrimaryNetworkID)
-		if !exist {
-			return errMissingPrimaryValidators
-		}
-		primaryValidators := primaryValidatorSet.List()
-
-		validatorIDs := make([]ids.NodeID, len(primaryValidators))
-		for i, vdr := range primaryValidators {
-			validatorIDs[i] = vdr.NodeID
+		validatorIDs, err := validators.NodeIDs(t.config.Validators, constants.PrimaryNetworkID)
+		if err != nil {
+			return err
 		}
 
 		if err := t.uptimes.StopTracking(validatorIDs, constants.PrimaryNetworkID); err != nil {

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -217,18 +217,10 @@ func (m *manager) makePrimaryNetworkValidatorSet(
 		)
 		return nil, ErrMissingValidatorSet
 	}
-	currentValidatorList := currentValidators.List()
 
 	// Node ID --> Validator information for the node validating the Primary
 	// Network.
-	validatorSet := make(map[ids.NodeID]*validators.GetValidatorOutput, len(currentValidatorList))
-	for _, vdr := range currentValidatorList {
-		validatorSet[vdr.NodeID] = &validators.GetValidatorOutput{
-			NodeID:    vdr.NodeID,
-			PublicKey: vdr.PublicKey,
-			Weight:    vdr.Weight,
-		}
-	}
+	validatorSet := currentValidators.Map()
 
 	// Rebuild primary network validators at [height]
 	for diffHeight := currentHeight; diffHeight > targetHeight; diffHeight-- {
@@ -269,17 +261,9 @@ func (m *manager) makeSubnetValidatorSet(
 			return nil, err
 		}
 	}
-	currentValidatorList := currentValidators.List()
 
 	// Node ID --> Validator information for the node validating the Subnet.
-	subnetValidatorSet := make(map[ids.NodeID]*validators.GetValidatorOutput, len(currentValidatorList))
-	for _, vdr := range currentValidatorList {
-		subnetValidatorSet[vdr.NodeID] = &validators.GetValidatorOutput{
-			NodeID: vdr.NodeID,
-			// PublicKey will be picked from primary validators
-			Weight: vdr.Weight,
-		}
-	}
+	subnetValidatorSet := currentValidators.Map()
 
 	// Rebuild subnet validators at [targetHeight]
 	for diffHeight := currentHeight; diffHeight > targetHeight; diffHeight-- {

--- a/vms/platformvm/validators/manager_test.go
+++ b/vms/platformvm/validators/manager_test.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/exp/maps"
-
 	"github.com/ava-labs/avalanchego/chains"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
@@ -45,14 +43,14 @@ func TestVM_GetValidatorSet(t *testing.T) {
 	var (
 		numVdrs        = 4
 		vdrBaseWeight  = uint64(1_000)
-		testValidators []*validators.Validator
+		testValidators []*validators.GetValidatorOutput
 	)
 
 	for i := 0; i < numVdrs; i++ {
 		sk, err := bls.NewSecretKey()
 		require.NoError(t, err)
 
-		testValidators = append(testValidators, &validators.Validator{
+		testValidators = append(testValidators, &validators.GetValidatorOutput{
 			NodeID:    ids.GenerateTestNodeID(),
 			PublicKey: bls.PublicFromSecretKey(sk),
 			Weight:    vdrBaseWeight + uint64(i),
@@ -66,8 +64,8 @@ func TestVM_GetValidatorSet(t *testing.T) {
 		lastAcceptedHeight uint64
 		subnetID           ids.ID
 		// Validator sets at tip
-		currentPrimaryNetworkValidators map[ids.NodeID]*validators.Validator
-		currentSubnetValidators         []*validators.Validator
+		currentPrimaryNetworkValidators map[ids.NodeID]*validators.GetValidatorOutput
+		currentSubnetValidators         map[ids.NodeID]*validators.GetValidatorOutput
 
 		// height --> nodeID --> weightDiff
 		weightDiffs map[uint64]map[ids.NodeID]*state.ValidatorWeightDiff
@@ -91,11 +89,11 @@ func TestVM_GetValidatorSet(t *testing.T) {
 			subnetID:           constants.PrimaryNetworkID,
 			height:             1,
 			lastAcceptedHeight: 1,
-			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.Validator{
+			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				testValidators[0].NodeID: copyPrimaryValidator(testValidators[0]),
 			},
-			currentSubnetValidators: []*validators.Validator{
-				copySubnetValidator(testValidators[0]),
+			currentSubnetValidators: map[ids.NodeID]*validators.GetValidatorOutput{
+				testValidators[0].NodeID: copySubnetValidator(testValidators[0]),
 			},
 			expectedVdrSet: map[ids.NodeID]*validators.GetValidatorOutput{
 				testValidators[0].NodeID: {
@@ -110,14 +108,14 @@ func TestVM_GetValidatorSet(t *testing.T) {
 			name:               "1 before tip",
 			height:             2,
 			lastAcceptedHeight: 3,
-			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.Validator{
+			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				testValidators[0].NodeID: copyPrimaryValidator(testValidators[0]),
 				testValidators[1].NodeID: copyPrimaryValidator(testValidators[1]),
 			},
-			currentSubnetValidators: []*validators.Validator{
+			currentSubnetValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				// At tip we have these 2 validators
-				copySubnetValidator(testValidators[0]),
-				copySubnetValidator(testValidators[1]),
+				testValidators[0].NodeID: copySubnetValidator(testValidators[0]),
+				testValidators[1].NodeID: copySubnetValidator(testValidators[1]),
 			},
 			weightDiffs: map[uint64]map[ids.NodeID]*state.ValidatorWeightDiff{
 				3: {
@@ -165,14 +163,14 @@ func TestVM_GetValidatorSet(t *testing.T) {
 			name:               "2 before tip",
 			height:             3,
 			lastAcceptedHeight: 5,
-			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.Validator{
+			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				testValidators[0].NodeID: copyPrimaryValidator(testValidators[0]),
 				testValidators[1].NodeID: copyPrimaryValidator(testValidators[1]),
 			},
-			currentSubnetValidators: []*validators.Validator{
+			currentSubnetValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				// At tip we have these 2 validators
-				copySubnetValidator(testValidators[0]),
-				copySubnetValidator(testValidators[1]),
+				testValidators[0].NodeID: copySubnetValidator(testValidators[0]),
+				testValidators[1].NodeID: copySubnetValidator(testValidators[1]),
 			},
 			weightDiffs: map[uint64]map[ids.NodeID]*state.ValidatorWeightDiff{
 				5: {
@@ -232,14 +230,14 @@ func TestVM_GetValidatorSet(t *testing.T) {
 			name:               "1 before tip; nil public key",
 			height:             4,
 			lastAcceptedHeight: 5,
-			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.Validator{
+			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				testValidators[0].NodeID: copyPrimaryValidator(testValidators[0]),
 				testValidators[1].NodeID: copyPrimaryValidator(testValidators[1]),
 			},
-			currentSubnetValidators: []*validators.Validator{
+			currentSubnetValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				// At tip we have these 2 validators
-				copySubnetValidator(testValidators[0]),
-				copySubnetValidator(testValidators[1]),
+				testValidators[0].NodeID: copySubnetValidator(testValidators[0]),
+				testValidators[1].NodeID: copySubnetValidator(testValidators[1]),
 			},
 			weightDiffs: map[uint64]map[ids.NodeID]*state.ValidatorWeightDiff{
 				5: {
@@ -285,15 +283,15 @@ func TestVM_GetValidatorSet(t *testing.T) {
 			height:             5,
 			lastAcceptedHeight: 6,
 			subnetID:           ids.GenerateTestID(),
-			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.Validator{
+			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				testValidators[0].NodeID: copyPrimaryValidator(testValidators[0]),
 				testValidators[1].NodeID: copyPrimaryValidator(testValidators[1]),
 				testValidators[3].NodeID: copyPrimaryValidator(testValidators[3]),
 			},
-			currentSubnetValidators: []*validators.Validator{
+			currentSubnetValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				// At tip we have these 2 validators
-				copySubnetValidator(testValidators[0]),
-				copySubnetValidator(testValidators[1]),
+				testValidators[0].NodeID: copySubnetValidator(testValidators[0]),
+				testValidators[1].NodeID: copySubnetValidator(testValidators[1]),
 			},
 			weightDiffs: map[uint64]map[ids.NodeID]*state.ValidatorWeightDiff{
 				6: {
@@ -339,11 +337,11 @@ func TestVM_GetValidatorSet(t *testing.T) {
 			height:             4,
 			lastAcceptedHeight: 5,
 			subnetID:           ids.GenerateTestID(),
-			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.Validator{
+			currentPrimaryNetworkValidators: map[ids.NodeID]*validators.GetValidatorOutput{
 				testValidators[0].NodeID: copyPrimaryValidator(testValidators[0]),
 			},
-			currentSubnetValidators: []*validators.Validator{
-				copySubnetValidator(testValidators[0]),
+			currentSubnetValidators: map[ids.NodeID]*validators.GetValidatorOutput{
+				testValidators[0].NodeID: copySubnetValidator(testValidators[0]),
 			},
 			weightDiffs: map[uint64]map[ids.NodeID]*state.ValidatorWeightDiff{
 				5: {},
@@ -390,20 +388,26 @@ func TestVM_GetValidatorSet(t *testing.T) {
 
 			// Mock the VM's validators
 			mockPrimaryVdrSet := validators.NewMockSet(ctrl)
-			mockPrimaryVdrSet.EXPECT().List().Return(maps.Values(tt.currentPrimaryNetworkValidators)).AnyTimes()
+			mockPrimaryVdrSet.EXPECT().Map().Return(tt.currentPrimaryNetworkValidators).AnyTimes()
 			vdrs.EXPECT().Get(constants.PrimaryNetworkID).Return(mockPrimaryVdrSet, true).AnyTimes()
 
-			mockSubnetVdrSet := mockPrimaryVdrSet
 			if tt.subnetID != constants.PrimaryNetworkID {
-				mockSubnetVdrSet = validators.NewMockSet(ctrl)
-				mockSubnetVdrSet.EXPECT().List().Return(tt.currentSubnetValidators).AnyTimes()
+				mockSubnetVdrSet := validators.NewMockSet(ctrl)
+				mockSubnetVdrSet.EXPECT().Map().Return(tt.currentSubnetValidators).AnyTimes()
+				vdrs.EXPECT().Get(tt.subnetID).Return(mockSubnetVdrSet, true).AnyTimes()
 			}
-			vdrs.EXPECT().Get(tt.subnetID).Return(mockSubnetVdrSet, true).AnyTimes()
 
 			for _, vdr := range testValidators {
 				_, current := tt.currentPrimaryNetworkValidators[vdr.NodeID]
 				if current {
-					mockPrimaryVdrSet.EXPECT().Get(vdr.NodeID).Return(vdr, true).AnyTimes()
+					mockPrimaryVdrSet.EXPECT().Get(vdr.NodeID).Return(
+						&validators.Validator{
+							NodeID:    vdr.NodeID,
+							PublicKey: vdr.PublicKey,
+							Weight:    vdr.Weight,
+						},
+						true,
+					).AnyTimes()
 				} else {
 					mockPrimaryVdrSet.EXPECT().Get(vdr.NodeID).Return(nil, false).AnyTimes()
 				}
@@ -436,12 +440,12 @@ func TestVM_GetValidatorSet(t *testing.T) {
 	}
 }
 
-func copyPrimaryValidator(vdr *validators.Validator) *validators.Validator {
+func copyPrimaryValidator(vdr *validators.GetValidatorOutput) *validators.GetValidatorOutput {
 	newVdr := *vdr
 	return &newVdr
 }
 
-func copySubnetValidator(vdr *validators.Validator) *validators.Validator {
+func copySubnetValidator(vdr *validators.GetValidatorOutput) *validators.GetValidatorOutput {
 	newVdr := *vdr
 	newVdr.PublicKey = nil
 	return &newVdr

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -427,9 +427,7 @@ func TestGenesis(t *testing.T) {
 	// Ensure current validator set of primary network is correct
 	vdrSet, ok := vm.Validators.Get(constants.PrimaryNetworkID)
 	require.True(ok)
-
-	currentValidators := vdrSet.List()
-	require.Len(genesisState.Validators, len(currentValidators))
+	require.Len(genesisState.Validators, vdrSet.Len())
 
 	for _, key := range keys {
 		nodeID := ids.NodeID(key.PublicKey().Address())


### PR DESCRIPTION
## Why this should be merged

This reduces a validator set copy in `vms/platformvm/validators/manager.go` on the hot path of Warp message verification.

## How this works

Rather than calling `List` and then converting the result into a `Map` - we can just directly create the `Map` inside the validator set manager.

## How this was tested

CI