### PR TITLE
[x/sync] Acquire Lock Before `TrackBandwidth` Update

### DIFF
--- a/x/sync/network_client.go
+++ b/x/sync/network_client.go
@@ -269,7 +269,7 @@ func (c *networkClient) request(
 	c.lock.Unlock()
 
 	if requestErr != nil {
-		c.log.Debug("did not recieve response from peer",
+		c.log.Debug("did not receive response from peer",
 			zap.Stringer("nodeID", nodeID),
 			zap.Uint32("requestID", requestID),
 			zap.Error(requestErr),


### PR DESCRIPTION
## Why this should be merged
Resolves: #1750 

## How this works
Acquire lock to avoid concurrent map write

## How this was tested
Fixed issue on `hypersdk`: https://github.com/ava-labs/hypersdk/pull/268
