### PR TITLE
Suggest HTTPs API cleanup

### DIFF
--- a/api/server/mock_server.go
+++ b/api/server/mock_server.go
@@ -105,11 +105,6 @@ func (mr *MockServerMockRecorder) AddRouteWithReadLock(arg0, arg1, arg2, arg3 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRouteWithReadLock", reflect.TypeOf((*MockServer)(nil).AddRouteWithReadLock), arg0, arg1, arg2, arg3)
 }
 
-// Not used in testing but required for interface compliance
-func (m *MockServer) GetURI() string {
-	return ""
-}
-
 // Dispatch mocks base method.
 func (m *MockServer) Dispatch() error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why this should be merged

Hoping to cleanup the `api.Server`.

## How this works

Rather than pushing more optionality into the `api.New` method - we can just inject the `net.Listener`.

## How this was tested

running locally (non-standard configs) created:
```json
{
  "PID": 95723,
  "URI": "http://127.0.0.1:9650",
  "BootstrapAddress": "127.0.0.1:56505"
}
```