### PR TITLE
Remove hanging TODO from prior change

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -368,7 +368,6 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Bool(TracingInsecureKey, true, "If true, don't use TLS when sending trace data")
 	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample")
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
-	// TODO add flag to take in headers to send from exporter
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego


### PR DESCRIPTION
## Why this should be merged

As we can see in the line above this TODO - we do allow the user to specify the headers provided to the tracing exporter.

## How this works

Delete

## How this was tested

N/A