### PR TITLE
Add ids length constants

### DIFF
--- a/ids/id.go
+++ b/ids/id.go
@@ -15,7 +15,10 @@ import (
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
 
-const nullStr = "null"
+const (
+	IDLen   = 32
+	nullStr = "null"
+)
 
 var (
 	// Empty is a useful all zero value
@@ -27,7 +30,7 @@ var (
 )
 
 // ID wraps a 32 byte hash used as an identifier
-type ID [32]byte
+type ID [IDLen]byte
 
 // ToID attempt to convert a byte slice into an id
 func ToID(bytes []byte) (ID, error) {
@@ -84,7 +87,7 @@ func (id *ID) UnmarshalText(text []byte) error {
 // This will return a new id and not modify the original id.
 func (id ID) Prefix(prefixes ...uint64) ID {
 	packer := wrappers.Packer{
-		Bytes: make([]byte, len(prefixes)*wrappers.LongLen+hashing.HashLen),
+		Bytes: make([]byte, len(prefixes)*wrappers.LongLen+IDLen),
 	}
 
 	for _, prefix := range prefixes {

--- a/ids/node_id.go
+++ b/ids/node_id.go
@@ -13,7 +13,10 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 )
 
-const NodeIDPrefix = "NodeID-"
+const (
+	NodeIDPrefix = "NodeID-"
+	NodeIDLen    = ShortIDLen
+)
 
 var (
 	EmptyNodeID = NodeID{}

--- a/ids/short.go
+++ b/ids/short.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 )
 
+const ShortIDLen = 20
+
 // ShortEmpty is a useful all zero value
 var (
 	ShortEmpty = ShortID{}
@@ -22,7 +24,7 @@ var (
 )
 
 // ShortID wraps a 20 byte hash as an identifier
-type ShortID [20]byte
+type ShortID [ShortIDLen]byte
 
 // ToShortID attempt to convert a byte slice into an id
 func ToShortID(bytes []byte) (ShortID, error) {

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -39,9 +38,9 @@ const (
 	// Assumes no containers are larger than math.MaxUint32
 	// wrappers.IntLen accounts for the size of the container bytes
 	// wrappers.LongLen accounts for the timestamp of the container
-	// hashing.HashLen accounts for the container ID
+	// ids.IDLen accounts for the container ID
 	// wrappers.ShortLen accounts for the codec version
-	codecMaxSize = int(constants.DefaultMaxMessageSize) + wrappers.IntLen + wrappers.LongLen + hashing.HashLen + wrappers.ShortLen
+	codecMaxSize = int(constants.DefaultMaxMessageSize) + wrappers.IntLen + wrappers.LongLen + ids.IDLen + wrappers.ShortLen
 )
 
 var (
@@ -333,9 +332,9 @@ func (i *indexer) registerChainHelper(
 	name, endpoint string,
 	acceptorGroup snow.AcceptorGroup,
 ) (Index, error) {
-	prefix := make([]byte, hashing.HashLen+wrappers.ByteLen)
+	prefix := make([]byte, ids.IDLen+wrappers.ByteLen)
 	copy(prefix, chainID[:])
-	prefix[hashing.HashLen] = prefixEnd
+	prefix[ids.IDLen] = prefixEnd
 	indexDB := prefixdb.New(prefix, i.db)
 	index, err := newIndex(indexDB, i.log, i.codec, i.clock)
 	if err != nil {
@@ -409,32 +408,32 @@ func (i *indexer) close() error {
 }
 
 func (i *indexer) markIncomplete(chainID ids.ID) error {
-	key := make([]byte, hashing.HashLen+wrappers.ByteLen)
+	key := make([]byte, ids.IDLen+wrappers.ByteLen)
 	copy(key, chainID[:])
-	key[hashing.HashLen] = isIncompletePrefix
+	key[ids.IDLen] = isIncompletePrefix
 	return i.db.Put(key, nil)
 }
 
 // Returns true if this chain is incomplete
 func (i *indexer) isIncomplete(chainID ids.ID) (bool, error) {
-	key := make([]byte, hashing.HashLen+wrappers.ByteLen)
+	key := make([]byte, ids.IDLen+wrappers.ByteLen)
 	copy(key, chainID[:])
-	key[hashing.HashLen] = isIncompletePrefix
+	key[ids.IDLen] = isIncompletePrefix
 	return i.db.Has(key)
 }
 
 func (i *indexer) markPreviouslyIndexed(chainID ids.ID) error {
-	key := make([]byte, hashing.HashLen+wrappers.ByteLen)
+	key := make([]byte, ids.IDLen+wrappers.ByteLen)
 	copy(key, chainID[:])
-	key[hashing.HashLen] = previouslyIndexedPrefix
+	key[ids.IDLen] = previouslyIndexedPrefix
 	return i.db.Put(key, nil)
 }
 
 // Returns true if this chain is incomplete
 func (i *indexer) previouslyIndexed(chainID ids.ID) (bool, error) {
-	key := make([]byte, hashing.HashLen+wrappers.ByteLen)
+	key := make([]byte, ids.IDLen+wrappers.ByteLen)
 	copy(key, chainID[:])
-	key[hashing.HashLen] = previouslyIndexedPrefix
+	key[ids.IDLen] = previouslyIndexedPrefix
 	return i.db.Has(key)
 }
 

--- a/snow/engine/avalanche/state/state.go
+++ b/snow/engine/avalanche/state/state.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/snow/engine/avalanche/vertex"
-	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
@@ -109,7 +108,7 @@ func (s *state) Edge(id ids.ID) []ids.ID {
 		frontierSize := p.UnpackInt()
 		frontier := make([]ids.ID, frontierSize)
 		for i := 0; i < int(frontierSize) && !p.Errored(); i++ {
-			id, err := ids.ToID(p.UnpackFixedBytes(hashing.HashLen))
+			id, err := ids.ToID(p.UnpackFixedBytes(ids.IDLen))
 			p.Add(err)
 			frontier[i] = id
 		}
@@ -137,7 +136,7 @@ func (s *state) SetEdge(id ids.ID, frontier []ids.ID) error {
 		return s.db.Delete(id[:])
 	}
 
-	size := wrappers.IntLen + hashing.HashLen*len(frontier)
+	size := wrappers.IntLen + ids.IDLen*len(frontier)
 	p := wrappers.Packer{Bytes: make([]byte, size)}
 	p.PackInt(uint32(len(frontier)))
 	for _, id := range frontier {

--- a/x/merkledb/codec.go
+++ b/x/merkledb/codec.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/hashing"
 )
 
 const (
@@ -21,11 +20,10 @@ const (
 	falseByte            = 0
 	minVarIntLen         = 1
 	minMaybeByteSliceLen = 1
-	idLen                = hashing.HashLen
 	minSerializedPathLen = minVarIntLen
 	minByteSliceLen      = minVarIntLen
 	minDBNodeLen         = minMaybeByteSliceLen + minVarIntLen
-	minChildLen          = minVarIntLen + minSerializedPathLen + idLen
+	minChildLen          = minVarIntLen + minSerializedPathLen + ids.IDLen
 )
 
 var (
@@ -352,7 +350,7 @@ func (c *codecImpl) encodeByteSlice(dst io.Writer, value []byte) error {
 }
 
 func (*codecImpl) decodeID(src *bytes.Reader) (ids.ID, error) {
-	if idLen > src.Len() {
+	if ids.IDLen > src.Len() {
 		return ids.ID{}, io.ErrUnexpectedEOF
 	}
 

--- a/x/sync/network_server.go
+++ b/x/sync/network_server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/x/merkledb"
@@ -141,8 +140,8 @@ func (s *NetworkServer) HandleChangeProofRequest(
 ) error {
 	if req.BytesLimit == 0 ||
 		req.KeyLimit == 0 ||
-		len(req.StartRootHash) != hashing.HashLen ||
-		len(req.EndRootHash) != hashing.HashLen ||
+		len(req.StartRootHash) != ids.IDLen ||
+		len(req.EndRootHash) != ids.IDLen ||
 		(len(req.EndKey) > 0 && bytes.Compare(req.StartKey, req.EndKey) > 0) {
 		s.log.Debug(
 			"dropping invalid change proof request",
@@ -222,7 +221,7 @@ func (s *NetworkServer) HandleRangeProofRequest(
 ) error {
 	if req.BytesLimit == 0 ||
 		req.KeyLimit == 0 ||
-		len(req.RootHash) != hashing.HashLen ||
+		len(req.RootHash) != ids.IDLen ||
 		(len(req.EndKey) > 0 && bytes.Compare(req.StartKey, req.EndKey) > 0) {
 		s.log.Debug(
 			"dropping invalid range proof request",


### PR DESCRIPTION
## Why this should be merged

Rather than relying on the `hashing` package constants - it's more user friendly to expose the constants from the `ids` package.

## How this works

Move constants.

## How this was tested

N/A