### PR TITLE
[x/sync] Update target locking

### DIFF
--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -609,7 +609,7 @@ func (m *Manager) completeWorkItem(ctx context.Context, work *workItem, largestH
 	}
 
 	// update work queues (make sure to keep same locking order as [UpdateSyncTarget]
-	// or could cause a deadlock
+	// or could cause a deadlock)
 	m.workLock.Lock()
 	m.syncTargetLock.RLock()
 	var stale bool


### PR DESCRIPTION
Alternative: #1762 

## Why this should be merged
Might resolve: #1760 

## How this works
We ensure that the sync target cannot be updated while we are determining whether to re-add completed `workItems` to the queue or mark as processed.

## How this was tested
HyperSDK: https://github.com/ava-labs/hypersdk/pull/278