### PR TITLE
Export warp errors for external use

### DIFF
--- a/vms/platformvm/warp/signature.go
+++ b/vms/platformvm/warp/signature.go
@@ -75,7 +75,7 @@ func (s *BitSetSignature) Verify(
 	quorumDen uint64,
 ) error {
 	if msg.NetworkID != networkID {
-		return errWrongNetworkID
+		return ErrWrongNetworkID
 	}
 
 	subnetID, err := pChainState.GetSubnetID(ctx, msg.SourceChainID)

--- a/vms/platformvm/warp/signature_test.go
+++ b/vms/platformvm/warp/signature_test.go
@@ -819,7 +819,7 @@ func TestSignatureVerification(t *testing.T) {
 				require.NoError(err)
 				return msg
 			},
-			err: errWrongNetworkID,
+			err: ErrWrongNetworkID,
 		},
 	}
 

--- a/vms/platformvm/warp/signer.go
+++ b/vms/platformvm/warp/signer.go
@@ -13,8 +13,8 @@ import (
 var (
 	_ Signer = (*signer)(nil)
 
-	errWrongSourceChainID = errors.New("wrong SourceChainID")
-	errWrongNetworkID     = errors.New("wrong networkID")
+	ErrWrongSourceChainID = errors.New("wrong SourceChainID")
+	ErrWrongNetworkID     = errors.New("wrong networkID")
 )
 
 type Signer interface {
@@ -42,10 +42,10 @@ type signer struct {
 
 func (s *signer) Sign(msg *UnsignedMessage) ([]byte, error) {
 	if msg.SourceChainID != s.chainID {
-		return nil, errWrongSourceChainID
+		return nil, ErrWrongSourceChainID
 	}
 	if msg.NetworkID != s.networkID {
-		return nil, errWrongNetworkID
+		return nil, ErrWrongNetworkID
 	}
 
 	msgBytes := msg.Bytes()

--- a/vms/platformvm/warp/test_signer.go
+++ b/vms/platformvm/warp/test_signer.go
@@ -31,7 +31,7 @@ func TestSignerWrongChainID(t *testing.T, s Signer, _ *bls.SecretKey, _ uint32, 
 	require.NoError(err)
 
 	_, err = s.Sign(msg)
-	// TODO: require error to be errWrongSourceChainID
+	// TODO: require error to be ErrWrongSourceChainID
 	require.Error(err) //nolint:forbidigo // currently returns grpc errors too
 }
 
@@ -47,7 +47,7 @@ func TestSignerWrongNetworkID(t *testing.T, s Signer, _ *bls.SecretKey, networkI
 	require.NoError(err)
 
 	_, err = s.Sign(msg)
-	// TODO: require error to be errWrongNetworkID
+	// TODO: require error to be ErrWrongNetworkID
 	require.Error(err) //nolint:forbidigo // currently returns grpc errors too
 }
 


### PR DESCRIPTION
## Why this should be merged

This PR exports the un-exported warp errors, so that they can be consumed by an external package. For example, in Subnet-EVM we copy the same test coverage from AvalancheGo warp to ensure that any change in behavior will be noticed and picked up by those tests.

Exporting these variables ensures that we can add the same test coverage and assert an exact error match.

If we'd prefer to draw a different line between them and assume that Subnet-EVM will depend on AvalancheGo for this test coverage and only worry about whether `signature.Verify(...)` returns true or false, then we should close this PR.

## How this works

Exports the previously un-exported errors in the warp package.

## How this was tested

CI
