### PR TITLE
Change the default value of `--network-allow-private-ips` to `false` for `mainnet` and `fuji`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -303,6 +303,7 @@ func getGossipConfig(v *viper.Viper) subnets.GossipConfig {
 
 func getNetworkConfig(
 	v *viper.Viper,
+	networkID uint32,
 	sybilProtectionEnabled bool,
 	halflife time.Duration,
 ) (network.Config, error) {
@@ -313,14 +314,14 @@ func getNetworkConfig(
 	upgradeCooldownInSeconds := upgradeCooldown.Seconds()
 	maxRecentConnsUpgraded := int(math.Ceil(maxInboundConnsPerSec * upgradeCooldownInSeconds))
 
-	var (
-		compressionType compression.Type
-		err             error
-	)
-
-	compressionType, err = compression.TypeFromString(v.GetString(NetworkCompressionTypeKey))
+	compressionType, err := compression.TypeFromString(v.GetString(NetworkCompressionTypeKey))
 	if err != nil {
 		return network.Config{}, err
+	}
+
+	allowPrivateIPs := networkID != constants.MainnetID && networkID != constants.FujiID
+	if v.IsSet(NetworkAllowPrivateIPsKey) {
+		allowPrivateIPs = v.GetBool(NetworkAllowPrivateIPsKey)
 	}
 
 	config := network.Config{
@@ -398,7 +399,7 @@ func getNetworkConfig(
 		MaxClockDifference:           v.GetDuration(NetworkMaxClockDifferenceKey),
 		CompressionType:              compressionType,
 		PingFrequency:                v.GetDuration(NetworkPingFrequencyKey),
-		AllowPrivateIPs:              v.GetBool(NetworkAllowPrivateIPsKey),
+		AllowPrivateIPs:              allowPrivateIPs,
 		UptimeMetricFreq:             v.GetDuration(UptimeMetricFreqKey),
 		MaximumInboundMessageTimeout: v.GetDuration(NetworkMaximumInboundTimeoutKey),
 
@@ -1371,7 +1372,12 @@ func GetNodeConfig(v *viper.Viper) (node.Config, error) {
 	}
 
 	// Network Config
-	nodeConfig.NetworkConfig, err = getNetworkConfig(v, nodeConfig.SybilProtectionEnabled, healthCheckAveragerHalflife)
+	nodeConfig.NetworkConfig, err = getNetworkConfig(
+		v,
+		nodeConfig.NetworkID,
+		nodeConfig.SybilProtectionEnabled,
+		healthCheckAveragerHalflife,
+	)
 	if err != nil {
 		return node.Config{}, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -319,7 +319,7 @@ func getNetworkConfig(
 		return network.Config{}, err
 	}
 
-	allowPrivateIPs := networkID != constants.MainnetID && networkID != constants.FujiID
+	allowPrivateIPs := !constants.ProductionNetworkIDs.Contains(networkID)
 	if v.IsSet(NetworkAllowPrivateIPsKey) {
 		allowPrivateIPs = v.GetBool(NetworkAllowPrivateIPsKey)
 	}

--- a/config/flags.go
+++ b/config/flags.go
@@ -149,7 +149,10 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.String(NetworkCompressionTypeKey, constants.DefaultNetworkCompressionType.String(), fmt.Sprintf("Compression type for outbound messages. Must be one of [%s, %s, %s]", compression.TypeGzip, compression.TypeZstd, compression.TypeNone))
 
 	fs.Duration(NetworkMaxClockDifferenceKey, constants.DefaultNetworkMaxClockDifference, "Max allowed clock difference value between this node and peers")
-	fs.Bool(NetworkAllowPrivateIPsKey, constants.DefaultNetworkAllowPrivateIPs, fmt.Sprintf("Allows the node to initiate outbound connection attempts to peers with private IPs. If the provided --%s is one of [%s, %s] the default is false. Oterhwise, the default is true", NetworkNameKey, constants.MainnetName, constants.FujiName))
+	// Note: The default value is set to false here because the default
+	// networkID is mainnet. The real default value of NetworkAllowPrivateIPs is
+	// based on the networkID.
+	fs.Bool(NetworkAllowPrivateIPsKey, false, fmt.Sprintf("Allows the node to initiate outbound connection attempts to peers with private IPs. If the provided --%s is one of [%s, %s] the default is false. Oterhwise, the default is true", NetworkNameKey, constants.MainnetName, constants.FujiName))
 	fs.Bool(NetworkRequireValidatorToConnectKey, constants.DefaultNetworkRequireValidatorToConnect, "If true, this node will only maintain a connection with another node if this node is a validator, the other node is a validator, or the other node is a beacon")
 	fs.Uint(NetworkPeerReadBufferSizeKey, constants.DefaultNetworkPeerReadBufferSize, "Size, in bytes, of the buffer that we read peer messages into (there is one buffer per peer)")
 	fs.Uint(NetworkPeerWriteBufferSizeKey, constants.DefaultNetworkPeerWriteBufferSize, "Size, in bytes, of the buffer that we write peer messages into (there is one buffer per peer)")

--- a/config/flags.go
+++ b/config/flags.go
@@ -149,7 +149,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.String(NetworkCompressionTypeKey, constants.DefaultNetworkCompressionType.String(), fmt.Sprintf("Compression type for outbound messages. Must be one of [%s, %s, %s]", compression.TypeGzip, compression.TypeZstd, compression.TypeNone))
 
 	fs.Duration(NetworkMaxClockDifferenceKey, constants.DefaultNetworkMaxClockDifference, "Max allowed clock difference value between this node and peers")
-	fs.Bool(NetworkAllowPrivateIPsKey, constants.DefaultNetworkAllowPrivateIPs, "Allows the node to initiate outbound connection attempts to peers with private IPs")
+	fs.Bool(NetworkAllowPrivateIPsKey, constants.DefaultNetworkAllowPrivateIPs, fmt.Sprintf("Allows the node to initiate outbound connection attempts to peers with private IPs. If the provided --%s is one of [%s, %s] the default is false. Oterhwise, the default is true", NetworkNameKey, constants.MainnetName, constants.FujiName))
 	fs.Bool(NetworkRequireValidatorToConnectKey, constants.DefaultNetworkRequireValidatorToConnect, "If true, this node will only maintain a connection with another node if this node is a validator, the other node is a validator, or the other node is a beacon")
 	fs.Uint(NetworkPeerReadBufferSizeKey, constants.DefaultNetworkPeerReadBufferSize, "Size, in bytes, of the buffer that we read peer messages into (there is one buffer per peer)")
 	fs.Uint(NetworkPeerWriteBufferSizeKey, constants.DefaultNetworkPeerWriteBufferSize, "Size, in bytes, of the buffer that we write peer messages into (there is one buffer per peer)")

--- a/network/test_network.go
+++ b/network/test_network.go
@@ -166,7 +166,7 @@ func NewTestNetwork(
 		MaxClockDifference:           constants.DefaultNetworkMaxClockDifference,
 		CompressionType:              constants.DefaultNetworkCompressionType,
 		PingFrequency:                constants.DefaultPingFrequency,
-		AllowPrivateIPs:              constants.DefaultNetworkAllowPrivateIPs,
+		AllowPrivateIPs:              !constants.ProductionNetworkIDs.Contains(networkID),
 		UptimeMetricFreq:             constants.DefaultUptimeMetricFreq,
 		MaximumInboundMessageTimeout: constants.DefaultNetworkMaximumInboundTimeout,
 

--- a/utils/constants/network_ids.go
+++ b/utils/constants/network_ids.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 // Const variables to be exported
@@ -85,6 +86,10 @@ var (
 		FujiHRP:     FujiID,
 		UnitTestHRP: UnitTestID,
 		LocalHRP:    LocalID,
+	}
+	ProductionNetworkIDs = set.Set[uint32]{
+		MainnetID: struct{}{},
+		FujiID:    struct{}{},
 	}
 
 	ValidNetworkPrefix = "network-"

--- a/utils/constants/networking.go
+++ b/utils/constants/networking.go
@@ -53,7 +53,6 @@ const (
 	DefaultNetworkCompressionEnabled        = true // TODO remove when NetworkCompressionEnabledKey is removed
 	DefaultNetworkCompressionType           = compression.TypeGzip
 	DefaultNetworkMaxClockDifference        = time.Minute
-	DefaultNetworkAllowPrivateIPs           = false
 	DefaultNetworkRequireValidatorToConnect = false
 	DefaultNetworkPeerReadBufferSize        = 8 * units.KiB
 	DefaultNetworkPeerWriteBufferSize       = 8 * units.KiB

--- a/utils/constants/networking.go
+++ b/utils/constants/networking.go
@@ -53,7 +53,7 @@ const (
 	DefaultNetworkCompressionEnabled        = true // TODO remove when NetworkCompressionEnabledKey is removed
 	DefaultNetworkCompressionType           = compression.TypeGzip
 	DefaultNetworkMaxClockDifference        = time.Minute
-	DefaultNetworkAllowPrivateIPs           = true
+	DefaultNetworkAllowPrivateIPs           = false
 	DefaultNetworkRequireValidatorToConnect = false
 	DefaultNetworkPeerReadBufferSize        = 8 * units.KiB
 	DefaultNetworkPeerWriteBufferSize       = 8 * units.KiB


### PR DESCRIPTION
## Why this should be merged

It's generally [unexpected behavior](https://github.com/ava-labs/avalanchego/issues/1768) that avalanchego may attempt to connect to private IPs when run with the default configurations.

## How this works

Because it is fairly common for nodes to need to connect to private IPs with non-production networks, this doesn't change the default value of `--network-allow-private-ips` for non-production networks. However, for `mainnet` and `fuji` the default value will be `false`.

## How this was tested

Running on mainnet - this PR blocks a large number of connection dial attempts:
```
[07-27|13:36:56.025] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-LBA1YYYBbxwYMMAA9odGhR69d9SCbyq8v", "peerIP": "10.6.4.10", "delay": "1.857536142s"}
[07-27|13:36:56.161] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-Hbf2ZY1Zs1s8KMp3rA1zK36N7zt5fSLkz", "peerIP": "10.8.11.6", "delay": "1.150304756s"}
[07-27|13:36:56.166] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-AdCK93Gj4MnPU5Qj1tzRH166uiVBGzg7w", "peerIP": "10.70.2.1", "delay": "1.17332004s"}
[07-27|13:36:56.198] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-6S8zAjmFJ4JdZwPURyFGp8Q8tqQ5NcEbX", "peerIP": "172.17.112.56", "delay": "1.760768527s"}
[07-27|13:36:56.215] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-DJbw4TrSRu9uovTKqo6w12axPLHWHsjJD", "peerIP": "10.6.4.11", "delay": "1.465906138s"}
[07-27|13:36:56.215] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-Aua1pVxQsWLvTTf8bNVw2ZCA2NfogNqiE", "peerIP": "10.0.0.246", "delay": "1.89626065s"}
[07-27|13:36:56.246] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-6w8NN8PeYXnpxojbo73BUUXq6tDmV6hzr", "peerIP": "10.3.65.12", "delay": "1.129021199s"}
[07-27|13:36:56.246] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-D7JFYevRv4N7LXa8ihCwdzVtc5szT9Q7j", "peerIP": "10.20.4.5", "delay": "1.462733755s"}
[07-27|13:36:56.304] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-FF2Szx54cN5iys83j9H5xaEqHiz3RipkG", "peerIP": "10.20.3.5", "delay": "1.807390667s"}
[07-27|13:36:56.362] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-HWwYYkiTKnXgYycNN5gXQfxhhA8TZdBvs", "peerIP": "10.6.0.13", "delay": "1.868898153s"}
[07-27|13:36:56.579] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-AU27Fz35YmQuM6d2pM9HsvLtgwGT5xwnd", "peerIP": "172.18.0.3", "delay": "1.105249361s"}
[07-27|13:36:56.582] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-L9HsJPQ9TF5aXjdx3KnQrh1eWaHJaNXNj", "peerIP": "10.121.0.6", "delay": "1.348036315s"}
[07-27|13:36:56.615] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-4kRVv9q9bLrAVCdpgVXJfEBEUXSGkobMU", "peerIP": "172.18.0.3", "delay": "1.895168099s"}
[07-27|13:36:56.874] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-LG2NYC4RxxzCG4zFGWoAwSo4U8mjMux1f", "peerIP": "10.20.1.4", "delay": "1.514356098s"}
[07-27|13:36:56.952] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-7843EeyboY1mZSmdzjqdJodxHycNn7Kv2", "peerIP": "10.0.132.31", "delay": "1.279405893s"}
[07-27|13:36:57.026] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-JDS6pq6tZxZxePaDc77TvrmNnY5HBUNX4", "peerIP": "192.168.1.70", "delay": "1.650950491s"}
[07-27|13:36:57.117] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-KeyQeQwf1D4bzdcHVP34xXXWhJzFjVTSj", "peerIP": "172.31.45.225", "delay": "1.524901703s"}
[07-27|13:36:57.143] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-DvwWC5ed3j5iG6e4Y5yxAUacPkXvrxLFT", "peerIP": "10.6.0.12", "delay": "1.9147983s"}
[07-27|13:36:57.183] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-2eBu8RjbvCFTZMcxu1oh2oKtfHT7V4zyM", "peerIP": "10.21.10.140", "delay": "1.991633748s"}
[07-27|13:36:57.281] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-EoNXC39QyT1eHFPXb5PgvDNigBN8tMeCC", "peerIP": "172.18.0.6", "delay": "1.487049639s"}
[07-27|13:36:57.313] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-Hbf2ZY1Zs1s8KMp3rA1zK36N7zt5fSLkz", "peerIP": "10.8.11.6", "delay": "1.163580698s"}
[07-27|13:36:57.339] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-AdCK93Gj4MnPU5Qj1tzRH166uiVBGzg7w", "peerIP": "10.70.2.1", "delay": "1.663089539s"}
[07-27|13:36:57.376] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-6w8NN8PeYXnpxojbo73BUUXq6tDmV6hzr", "peerIP": "10.3.65.12", "delay": "1.621173601s"}
[07-27|13:36:57.409] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-EbqMEDUpxHXexLzcBabL696xQp2QEWWa5", "peerIP": "192.168.1.247", "delay": "1.778510485s"}
[07-27|13:36:57.418] VERBO network/network.go:1135 skipping connection dial {"reason": "outbound connections to private IPs are prohibited", "nodeID": "NodeID-HkEQ2sJogxEps4tmqFRDuVG9hyfxe8vMg", "peerIP": "10.0.141.95", "delay": "1.304702368s"}
```
(the list goes on, but this was just the first few I cared to see)