### PR TITLE
Remove unused networking constant

### DIFF
--- a/utils/constants/networking.go
+++ b/utils/constants/networking.go
@@ -50,7 +50,6 @@ const (
 	DefaultNetworkTimeoutCoefficient    = 2
 	DefaultNetworkReadHandshakeTimeout  = 15 * time.Second
 
-	DefaultNetworkCompressionEnabled        = true // TODO remove when NetworkCompressionEnabledKey is removed
 	DefaultNetworkCompressionType           = compression.TypeGzip
 	DefaultNetworkMaxClockDifference        = time.Minute
 	DefaultNetworkAllowPrivateIPs           = true


### PR DESCRIPTION
## Why this should be merged

Addresses TODO to remove unused constant.

## How this works

This constant is no longer used due to the removal of the deprecated configs... However, we forgot to remove the constant.

## How this was tested

It compiles.