### PR TITLE
Remove context.TODO from tests

### DIFF
--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -621,7 +621,7 @@ func TestDynamicEngineTypeDispatch(t *testing.T) {
 			}
 
 			handler.Start(context.Background(), false)
-			handler.Push(context.TODO(), Message{
+			handler.Push(context.Background(), Message{
 				InboundMessage: message.InboundChits(
 					ids.Empty,
 					uint32(0),

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -935,7 +935,7 @@ func TestExpiredBuildBlock(t *testing.T) {
 		nil,
 	))
 	defer func() {
-		require.NoError(proVM.Shutdown(context.TODO()))
+		require.NoError(proVM.Shutdown(context.Background()))
 	}()
 
 	// Initialize shouldn't be called again


### PR DESCRIPTION
## Why this should be merged

`context.TODO()` should be used when a method doesn't have access to a context but should in the future. We will never have a better context to provide to these functions during the unit tests.

## How this works

`TODO` -> `Background`

## How this was tested

CI