### PR TITLE
Add metric for the number of elements in a cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -19,6 +19,9 @@ type Cacher[K comparable, V any] interface {
 	// Flush removes all entries from the cache
 	Flush()
 
+	// Returns the number of elements currently in the cache
+	Len() int
+
 	// Returns fraction of cache currently filled (0 --> 1)
 	PortionFilled() float64
 }

--- a/cache/empty_cache.go
+++ b/cache/empty_cache.go
@@ -19,6 +19,10 @@ func (*Empty[K, _]) Evict(K) {}
 
 func (*Empty[_, _]) Flush() {}
 
+func (*Empty[_, _]) Len() int {
+	return 0
+}
+
 func (*Empty[_, _]) PortionFilled() float64 {
 	return 0
 }

--- a/cache/lru_cache.go
+++ b/cache/lru_cache.go
@@ -50,6 +50,13 @@ func (c *LRU[_, _]) Flush() {
 	c.flush()
 }
 
+func (c *LRU[_, _]) Len() int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.len()
+}
+
 func (c *LRU[_, _]) PortionFilled() float64 {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -88,8 +95,15 @@ func (c *LRU[K, V]) flush() {
 	c.elements = linkedhashmap.New[K, V]()
 }
 
+func (c *LRU[_, _]) len() int {
+	if c.elements == nil {
+		return 0
+	}
+	return c.elements.Len()
+}
+
 func (c *LRU[_, _]) portionFilled() float64 {
-	return float64(c.elements.Len()) / float64(c.Size)
+	return float64(c.len()) / float64(c.Size)
 }
 
 // Initializes [c.elements] if it's nil.

--- a/cache/lru_sized_cache.go
+++ b/cache/lru_sized_cache.go
@@ -59,6 +59,13 @@ func (c *sizedLRU[K, V]) Flush() {
 	c.flush()
 }
 
+func (c *sizedLRU[_, _]) Len() int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.len()
+}
+
 func (c *sizedLRU[_, _]) PortionFilled() float64 {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -108,6 +115,10 @@ func (c *sizedLRU[K, _]) evict(key K) {
 func (c *sizedLRU[K, V]) flush() {
 	c.elements = linkedhashmap.New[K, V]()
 	c.currentSize = 0
+}
+
+func (c *sizedLRU[_, _]) len() int {
+	return c.elements.Len()
 }
 
 func (c *sizedLRU[_, _]) portionFilled() float64 {

--- a/cache/metercacher/cache.go
+++ b/cache/metercacher/cache.go
@@ -33,6 +33,7 @@ func (c *Cache[K, V]) Put(key K, value V) {
 	c.Cacher.Put(key, value)
 	end := c.clock.Time()
 	c.put.Observe(float64(end.Sub(start)))
+	c.len.Set(float64(c.Cacher.Len()))
 	c.portionFilled.Set(c.Cacher.PortionFilled())
 }
 
@@ -52,10 +53,12 @@ func (c *Cache[K, V]) Get(key K) (V, bool) {
 
 func (c *Cache[K, _]) Evict(key K) {
 	c.Cacher.Evict(key)
+	c.len.Set(float64(c.Cacher.Len()))
 	c.portionFilled.Set(c.Cacher.PortionFilled())
 }
 
 func (c *Cache[_, _]) Flush() {
 	c.Cacher.Flush()
+	c.len.Set(float64(c.Cacher.Len()))
 	c.portionFilled.Set(c.Cacher.PortionFilled())
 }

--- a/cache/metercacher/metrics.go
+++ b/cache/metercacher/metrics.go
@@ -33,11 +33,12 @@ func newCounterMetric(namespace, name string, reg prometheus.Registerer, errs *w
 }
 
 type metrics struct {
-	get,
-	put metric.Averager
+	get           metric.Averager
+	put           metric.Averager
+	len           prometheus.Gauge
 	portionFilled prometheus.Gauge
-	hit,
-	miss prometheus.Counter
+	hit           prometheus.Counter
+	miss          prometheus.Counter
 }
 
 func (m *metrics) Initialize(
@@ -47,6 +48,13 @@ func (m *metrics) Initialize(
 	errs := wrappers.Errs{}
 	m.get = newAveragerMetric(namespace, "get", reg, &errs)
 	m.put = newAveragerMetric(namespace, "put", reg, &errs)
+	m.len = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "len",
+			Help:      "number of entries",
+		},
+	)
 	m.portionFilled = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,

--- a/cache/test_cacher.go
+++ b/cache/test_cacher.go
@@ -72,8 +72,15 @@ func TestEviction(t *testing.T, cache Cacher[ids.ID, int64]) {
 	expectedValue2 := int64(2)
 	expectedValue3 := int64(3)
 
+	require.Zero(cache.Len())
+
 	cache.Put(id1, expectedValue1)
+
+	require.Equal(1, cache.Len())
+
 	cache.Put(id2, expectedValue2)
+
+	require.Equal(2, cache.Len())
 
 	val, found := cache.Get(id1)
 	require.True(found)
@@ -87,6 +94,7 @@ func TestEviction(t *testing.T, cache Cacher[ids.ID, int64]) {
 	require.False(found)
 
 	cache.Put(id3, expectedValue3)
+	require.Equal(2, cache.Len())
 
 	_, found = cache.Get(id1)
 	require.False(found)


### PR DESCRIPTION
## Why this should be merged

As we convert some of our caches to be size based, the length of the cache is a useful metric.

## How this works

Adds `Len` to the cache interface and tracks it in the `metercacher`

## How this was tested

CI