### PR TITLE
Reduce block cache sizes to 64 MiB

### DIFF
--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
 
-const nonVerifiedCacheSize = 128 * units.MiB
+const nonVerifiedCacheSize = 64 * units.MiB
 
 var _ Engine = (*Transitive)(nil)
 

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/proposervm/block"
 )
 
-const blockCacheSize = 256 * units.MiB
+const blockCacheSize = 64 * units.MiB
 
 var (
 	errBlockWrongVersion = errors.New("wrong version")

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -47,7 +47,7 @@ const (
 	DefaultMinBlockDelay = time.Second
 
 	checkIndexedFrequency = 10 * time.Second
-	innerBlkCacheSize     = 128 * units.MiB
+	innerBlkCacheSize     = 64 * units.MiB
 )
 
 var (

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -65,7 +65,7 @@ import (
 
 // TODO: Enable these to be configured by the user
 const (
-	decidedCacheSize    = 256 * units.MiB
+	decidedCacheSize    = 64 * units.MiB
 	missingCacheSize    = 2048
 	unverifiedCacheSize = 64 * units.MiB
 	bytesToIDCacheSize  = 64 * units.MiB


### PR DESCRIPTION
## Why this should be merged

After monitoring the number of cache entries on Fuji + Mainnet, the initial size based cache sizes unintentionally increased the number of entries tracked. While this isn't necessarily a bad thing, this change should maintain the prior behavior better.

## How this works

`256` and `128` -> `64`.

## How this was tested

CI