### PR TITLE
Removes calls to ctrl.Finish

### DIFF
--- a/api/admin/service_test.go
+++ b/api/admin/service_test.go
@@ -50,7 +50,6 @@ func TestLoadVMsSuccess(t *testing.T) {
 	require := require.New(t)
 
 	resources := initLoadVMsTest(t)
-	defer resources.ctrl.Finish()
 
 	id1 := ids.GenerateTestID()
 	id2 := ids.GenerateTestID()
@@ -84,7 +83,6 @@ func TestLoadVMsReloadFails(t *testing.T) {
 	require := require.New(t)
 
 	resources := initLoadVMsTest(t)
-	defer resources.ctrl.Finish()
 
 	resources.mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).Times(1)
 	// Reload fails
@@ -100,7 +98,6 @@ func TestLoadVMsGetAliasesFails(t *testing.T) {
 	require := require.New(t)
 
 	resources := initLoadVMsTest(t)
-	defer resources.ctrl.Finish()
 
 	id1 := ids.GenerateTestID()
 	id2 := ids.GenerateTestID()

--- a/api/info/service_test.go
+++ b/api/info/service_test.go
@@ -48,7 +48,6 @@ func TestGetVMsSuccess(t *testing.T) {
 	require := require.New(t)
 
 	resources := initGetVMsTest(t)
-	defer resources.ctrl.Finish()
 
 	id1 := ids.GenerateTestID()
 	id2 := ids.GenerateTestID()
@@ -76,7 +75,6 @@ func TestGetVMsSuccess(t *testing.T) {
 // Tests GetVMs if we fail to list our vms.
 func TestGetVMsVMsListFactoriesFails(t *testing.T) {
 	resources := initGetVMsTest(t)
-	defer resources.ctrl.Finish()
 
 	resources.mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).Times(1)
 	resources.mockVMManager.EXPECT().ListFactories().Times(1).Return(nil, errTest)
@@ -89,7 +87,6 @@ func TestGetVMsVMsListFactoriesFails(t *testing.T) {
 // Tests GetVMs if we can't get our vm aliases.
 func TestGetVMsGetAliasesFails(t *testing.T) {
 	resources := initGetVMsTest(t)
-	defer resources.ctrl.Finish()
 
 	id1 := ids.GenerateTestID()
 	id2 := ids.GenerateTestID()

--- a/database/test_database.go
+++ b/database/test_database.go
@@ -432,8 +432,6 @@ func TestBatchRewrite(t *testing.T, db Database) {
 // contents.
 func TestBatchReplay(t *testing.T, db Database) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 
 	key1 := []byte("hello1")
@@ -469,8 +467,6 @@ func TestBatchReplay(t *testing.T, db Database) {
 // propagate any returned error during Replay.
 func TestBatchReplayPropagateError(t *testing.T, db Database) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 
 	key1 := []byte("hello1")

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -128,7 +128,6 @@ func TestMarkHasRunAndShutdown(t *testing.T) {
 func TestIndexer(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	baseDB := memdb.New()
 	db := versiondb.New(baseDB)
@@ -399,7 +398,6 @@ func TestIncompleteIndex(t *testing.T) {
 	// Create an indexer with indexing disabled
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	baseDB := memdb.New()
 	config := Config{
@@ -481,7 +479,6 @@ func TestIncompleteIndex(t *testing.T) {
 func TestIgnoreNonDefaultChains(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	baseDB := memdb.New()
 	db := versiondb.New(baseDB)

--- a/network/throttling/inbound_resource_throttler_test.go
+++ b/network/throttling/inbound_resource_throttler_test.go
@@ -23,8 +23,6 @@ import (
 
 func TestNewSystemThrottler(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 	reg := prometheus.NewRegistry()
 	clock := mockable.Clock{}
@@ -50,8 +48,6 @@ func TestNewSystemThrottler(t *testing.T) {
 
 func TestSystemThrottler(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 
 	// Setup
@@ -135,7 +131,6 @@ func TestSystemThrottler(t *testing.T) {
 func TestSystemThrottlerContextCancel(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Setup
 	mockTracker := tracker.NewMockTracker(ctrl)

--- a/network/throttling/outbound_msg_throttler_test.go
+++ b/network/throttling/outbound_msg_throttler_test.go
@@ -20,8 +20,6 @@ import (
 
 func TestSybilOutboundMsgThrottler(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 	config := MsgByteThrottlerConfig{
 		VdrAllocSize:        1024,
@@ -166,8 +164,6 @@ func TestSybilOutboundMsgThrottler(t *testing.T) {
 // Ensure that the limit on taking from the at-large allocation is enforced
 func TestSybilOutboundMsgThrottlerMaxNonVdr(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 	config := MsgByteThrottlerConfig{
 		VdrAllocSize:        100,
@@ -215,8 +211,6 @@ func TestSybilOutboundMsgThrottlerMaxNonVdr(t *testing.T) {
 // Ensure that the throttler honors requested bypasses
 func TestBypassThrottling(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 	config := MsgByteThrottlerConfig{
 		VdrAllocSize:        100,

--- a/snow/engine/snowman/getter/getter_test.go
+++ b/snow/engine/snowman/getter/getter_test.go
@@ -81,9 +81,7 @@ func testSetup(
 
 func TestAcceptedFrontier(t *testing.T) {
 	require := require.New(t)
-
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	vm, sender, config := testSetup(t, ctrl)
 
@@ -122,9 +120,7 @@ func TestAcceptedFrontier(t *testing.T) {
 
 func TestFilterAccepted(t *testing.T) {
 	require := require.New(t)
-
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	vm, sender, config := testSetup(t, ctrl)
 

--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -398,7 +398,6 @@ func TestHandlerSubnetConnector(t *testing.T) {
 	)
 	require.NoError(err)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	connector := validators.NewMockSubnetConnector(ctrl)
 
 	nodeID := ids.GenerateTestNodeID()

--- a/snow/networking/handler/message_queue_test.go
+++ b/snow/networking/handler/message_queue_test.go
@@ -26,8 +26,6 @@ const engineType = p2p.EngineType_ENGINE_TYPE_SNOWMAN
 
 func TestQueue(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 	cpuTracker := tracker.NewMockTracker(ctrl)
 	vdrs := validators.NewSet()

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -678,8 +678,6 @@ func TestRouterTimeout(t *testing.T) {
 
 func TestRouterHonorsRequestedEngine(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	require := require.New(t)
 
 	// Create a timeout manager
@@ -1391,9 +1389,7 @@ func TestRouterCrossChainMessages(t *testing.T) {
 
 func TestConnectedSubnet(t *testing.T) {
 	require := require.New(t)
-
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	tm, err := timeout.NewManager(
 		&timer.AdaptiveTimeoutConfig{

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -841,7 +841,6 @@ func TestSender_Bootstrap_Requests(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			var (
 				msgCreator     = message.NewMockOutboundMsgBuilder(ctrl)
@@ -1067,7 +1066,6 @@ func TestSender_Bootstrap_Responses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			var (
 				msgCreator     = message.NewMockOutboundMsgBuilder(ctrl)
@@ -1239,7 +1237,6 @@ func TestSender_Single_Request(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			var (
 				msgCreator     = message.NewMockOutboundMsgBuilder(ctrl)

--- a/snow/networking/tracker/targeter_test.go
+++ b/snow/networking/tracker/targeter_test.go
@@ -18,7 +18,6 @@ import (
 func TestNewTargeter(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	config := &TargeterConfig{
 		VdrAlloc:           10,
@@ -43,7 +42,6 @@ func TestNewTargeter(t *testing.T) {
 
 func TestTarget(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	vdr := ids.NodeID{1}
 	vdrWeight := uint64(1)

--- a/snow/uptime/locked_calculator_test.go
+++ b/snow/uptime/locked_calculator_test.go
@@ -19,7 +19,6 @@ import (
 func TestLockedCalculator(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	lc := NewLockedCalculator()
 	require.NotNil(lc)

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -63,7 +63,6 @@ func setupState(t testing.TB, ctrl *gomock.Controller) *testState {
 func TestGetMinimumHeight(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := setupState(t, ctrl)
 	defer state.closeFn()
@@ -87,7 +86,6 @@ func TestGetMinimumHeight(t *testing.T) {
 func TestGetCurrentHeight(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := setupState(t, ctrl)
 	defer state.closeFn()
@@ -111,7 +109,6 @@ func TestGetCurrentHeight(t *testing.T) {
 func TestGetSubnetID(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := setupState(t, ctrl)
 	defer state.closeFn()
@@ -136,7 +133,6 @@ func TestGetSubnetID(t *testing.T) {
 func TestGetValidatorSet(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := setupState(t, ctrl)
 	defer state.closeFn()

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -210,7 +210,6 @@ func benchmarkGetValidatorSet(b *testing.B, vs map[ids.NodeID]*validators.GetVal
 	ctrl := gomock.NewController(b)
 	state := setupState(b, ctrl)
 	defer func() {
-		ctrl.Finish()
 		state.closeFn()
 	}()
 

--- a/utils/crypto/keychain/keychain_test.go
+++ b/utils/crypto/keychain/keychain_test.go
@@ -19,7 +19,6 @@ var errTest = errors.New("test")
 func TestNewLedgerKeychain(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	addr := ids.GenerateTestShortID()
 
@@ -50,7 +49,6 @@ func TestNewLedgerKeychain(t *testing.T) {
 func TestLedgerKeychain_Addresses(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	addr1 := ids.GenerateTestShortID()
 	addr2 := ids.GenerateTestShortID()
@@ -82,7 +80,6 @@ func TestLedgerKeychain_Addresses(t *testing.T) {
 func TestLedgerKeychain_Get(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	addr1 := ids.GenerateTestShortID()
 	addr2 := ids.GenerateTestShortID()
@@ -126,7 +123,6 @@ func TestLedgerKeychain_Get(t *testing.T) {
 func TestLedgerSigner_SignHash(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	addr1 := ids.GenerateTestShortID()
 	addr2 := ids.GenerateTestShortID()
@@ -210,7 +206,6 @@ func TestLedgerSigner_SignHash(t *testing.T) {
 func TestNewLedgerKeychainFromIndices(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	addr := ids.GenerateTestShortID()
 	_ = addr
@@ -242,7 +237,6 @@ func TestNewLedgerKeychainFromIndices(t *testing.T) {
 func TestLedgerKeychainFromIndices_Addresses(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	addr1 := ids.GenerateTestShortID()
 	addr2 := ids.GenerateTestShortID()
@@ -302,7 +296,6 @@ func TestLedgerKeychainFromIndices_Addresses(t *testing.T) {
 func TestLedgerKeychainFromIndices_Get(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	addr1 := ids.GenerateTestShortID()
 	addr2 := ids.GenerateTestShortID()
@@ -348,7 +341,6 @@ func TestLedgerKeychainFromIndices_Get(t *testing.T) {
 func TestLedgerSignerFromIndices_SignHash(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	addr1 := ids.GenerateTestShortID()
 	addr2 := ids.GenerateTestShortID()

--- a/utils/hashing/consistent/ring_test.go
+++ b/utils/hashing/consistent/ring_test.go
@@ -178,8 +178,7 @@ func TestGetMapsToClockwiseNode(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
-			ring, hasher, ctrl := setupTest(t, 1)
-			defer ctrl.Finish()
+			ring, hasher, _ := setupTest(t, 1)
 
 			// setup expected calls
 			calls := make([]*gomock.Call, len(test.ringNodes)+1)
@@ -205,8 +204,7 @@ func TestGetMapsToClockwiseNode(t *testing.T) {
 
 // Tests that if we have an empty ring, trying to call Get results in an error, as there is no node to route to.
 func TestGetOnEmptyRingReturnsError(t *testing.T) {
-	ring, _, ctrl := setupTest(t, 1)
-	defer ctrl.Finish()
+	ring, _, _ := setupTest(t, 1)
 
 	foo := testKey{
 		key:  "foo",
@@ -218,8 +216,7 @@ func TestGetOnEmptyRingReturnsError(t *testing.T) {
 
 // Tests that trying to call Remove on a node that doesn't exist should return false.
 func TestRemoveNonExistentKeyReturnsFalse(t *testing.T) {
-	ring, hasher, ctrl := setupTest(t, 1)
-	defer ctrl.Finish()
+	ring, hasher, _ := setupTest(t, 1)
 
 	gomock.InOrder(
 		hasher.EXPECT().Hash(getHashKey(node1.ConsistentHashKey(), 0)).Return(uint64(1)).Times(1),
@@ -231,8 +228,7 @@ func TestRemoveNonExistentKeyReturnsFalse(t *testing.T) {
 
 // Tests that trying to call Remove on a node that doesn't exist should return true.
 func TestRemoveExistingKeyReturnsTrue(t *testing.T) {
-	ring, hasher, ctrl := setupTest(t, 1)
-	defer ctrl.Finish()
+	ring, hasher, _ := setupTest(t, 1)
 
 	gomock.InOrder(
 		hasher.EXPECT().Hash(getHashKey(node1.ConsistentHashKey(), 0)).Return(uint64(1)).Times(1),
@@ -258,9 +254,7 @@ func TestRemoveExistingKeyReturnsTrue(t *testing.T) {
 // Tests that if we have a collision, the node is replaced.
 func TestAddCollisionReplacement(t *testing.T) {
 	require := require.New(t)
-
-	ring, hasher, ctrl := setupTest(t, 1)
-	defer ctrl.Finish()
+	ring, hasher, _ := setupTest(t, 1)
 
 	foo := testKey{
 		key:  "foo",
@@ -290,9 +284,7 @@ func TestAddCollisionReplacement(t *testing.T) {
 // Tests that virtual nodes are replicated on Add.
 func TestAddVirtualNodes(t *testing.T) {
 	require := require.New(t)
-
-	ring, hasher, ctrl := setupTest(t, 3)
-	defer ctrl.Finish()
+	ring, hasher, _ := setupTest(t, 3)
 
 	gomock.InOrder(
 		// we should see 3 virtual nodes created (0, 1, 2) when we insert a node into the ring.
@@ -356,9 +348,7 @@ func TestAddVirtualNodes(t *testing.T) {
 // Tests that the node routed to changes if an Add results in a key shuffle.
 func TestGetShuffleOnAdd(t *testing.T) {
 	require := require.New(t)
-
-	ring, hasher, ctrl := setupTest(t, 1)
-	defer ctrl.Finish()
+	ring, hasher, _ := setupTest(t, 1)
 
 	foo := testKey{
 		key:  "foo",
@@ -405,9 +395,7 @@ func TestGetShuffleOnAdd(t *testing.T) {
 // Tests that we can iterate around the ring.
 func TestIteration(t *testing.T) {
 	require := require.New(t)
-
-	ring, hasher, ctrl := setupTest(t, 1)
-	defer ctrl.Finish()
+	ring, hasher, _ := setupTest(t, 1)
 
 	foo := testKey{
 		key:  "foo",

--- a/utils/hashing/consistent/ring_test.go
+++ b/utils/hashing/consistent/ring_test.go
@@ -178,7 +178,7 @@ func TestGetMapsToClockwiseNode(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
-			ring, hasher, _ := setupTest(t, 1)
+			ring, hasher := setupTest(t, 1)
 
 			// setup expected calls
 			calls := make([]*gomock.Call, len(test.ringNodes)+1)
@@ -204,7 +204,7 @@ func TestGetMapsToClockwiseNode(t *testing.T) {
 
 // Tests that if we have an empty ring, trying to call Get results in an error, as there is no node to route to.
 func TestGetOnEmptyRingReturnsError(t *testing.T) {
-	ring, _, _ := setupTest(t, 1)
+	ring, _ := setupTest(t, 1)
 
 	foo := testKey{
 		key:  "foo",
@@ -216,7 +216,7 @@ func TestGetOnEmptyRingReturnsError(t *testing.T) {
 
 // Tests that trying to call Remove on a node that doesn't exist should return false.
 func TestRemoveNonExistentKeyReturnsFalse(t *testing.T) {
-	ring, hasher, _ := setupTest(t, 1)
+	ring, hasher := setupTest(t, 1)
 
 	gomock.InOrder(
 		hasher.EXPECT().Hash(getHashKey(node1.ConsistentHashKey(), 0)).Return(uint64(1)).Times(1),
@@ -228,7 +228,7 @@ func TestRemoveNonExistentKeyReturnsFalse(t *testing.T) {
 
 // Tests that trying to call Remove on a node that doesn't exist should return true.
 func TestRemoveExistingKeyReturnsTrue(t *testing.T) {
-	ring, hasher, _ := setupTest(t, 1)
+	ring, hasher := setupTest(t, 1)
 
 	gomock.InOrder(
 		hasher.EXPECT().Hash(getHashKey(node1.ConsistentHashKey(), 0)).Return(uint64(1)).Times(1),
@@ -254,7 +254,7 @@ func TestRemoveExistingKeyReturnsTrue(t *testing.T) {
 // Tests that if we have a collision, the node is replaced.
 func TestAddCollisionReplacement(t *testing.T) {
 	require := require.New(t)
-	ring, hasher, _ := setupTest(t, 1)
+	ring, hasher := setupTest(t, 1)
 
 	foo := testKey{
 		key:  "foo",
@@ -284,7 +284,7 @@ func TestAddCollisionReplacement(t *testing.T) {
 // Tests that virtual nodes are replicated on Add.
 func TestAddVirtualNodes(t *testing.T) {
 	require := require.New(t)
-	ring, hasher, _ := setupTest(t, 3)
+	ring, hasher := setupTest(t, 3)
 
 	gomock.InOrder(
 		// we should see 3 virtual nodes created (0, 1, 2) when we insert a node into the ring.
@@ -348,7 +348,7 @@ func TestAddVirtualNodes(t *testing.T) {
 // Tests that the node routed to changes if an Add results in a key shuffle.
 func TestGetShuffleOnAdd(t *testing.T) {
 	require := require.New(t)
-	ring, hasher, _ := setupTest(t, 1)
+	ring, hasher := setupTest(t, 1)
 
 	foo := testKey{
 		key:  "foo",
@@ -395,7 +395,7 @@ func TestGetShuffleOnAdd(t *testing.T) {
 // Tests that we can iterate around the ring.
 func TestIteration(t *testing.T) {
 	require := require.New(t)
-	ring, hasher, _ := setupTest(t, 1)
+	ring, hasher := setupTest(t, 1)
 
 	foo := testKey{
 		key:  "foo",
@@ -436,7 +436,7 @@ func TestIteration(t *testing.T) {
 	require.Equal(node2, node)
 }
 
-func setupTest(t *testing.T, virtualNodes int) (Ring, *hashing.MockHasher, *gomock.Controller) {
+func setupTest(t *testing.T, virtualNodes int) (Ring, *hashing.MockHasher) {
 	ctrl := gomock.NewController(t)
 	hasher := hashing.NewMockHasher(ctrl)
 
@@ -444,5 +444,5 @@ func setupTest(t *testing.T, virtualNodes int) (Ring, *hashing.MockHasher, *gomo
 		VirtualNodes: virtualNodes,
 		Hasher:       hasher,
 		Degree:       2,
-	}), hasher, ctrl
+	}), hasher
 }

--- a/vms/avm/blocks/builder/builder_test.go
+++ b/vms/avm/blocks/builder/builder_test.go
@@ -490,7 +490,6 @@ func TestBuilderBuildBlock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			builder := tt.builderFunc(ctrl)
 			_, err := builder.BuildBlock(context.Background())
@@ -513,9 +512,6 @@ func TestBlockBuilderAddLocalTx(t *testing.T) {
 	txID := tx.ID()
 	require.NoError(mempool.Add(tx))
 	require.True(mempool.Has(txID))
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	parser, err := blocks.NewParser([]fxs.Fx{
 		&secp256k1fx.Fx{},

--- a/vms/avm/blocks/executor/block_test.go
+++ b/vms/avm/blocks/executor/block_test.go
@@ -561,7 +561,6 @@ func TestBlockVerify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			b := tt.blockFunc(ctrl)
 			err := b.Verify(context.Background())
@@ -792,7 +791,6 @@ func TestBlockAccept(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			b := tt.blockFunc(ctrl)
 			err := b.Accept(context.Background())
@@ -951,7 +949,6 @@ func TestBlockReject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			b := tt.blockFunc(ctrl)
 			require.NoError(b.Reject(context.Background()))
@@ -1055,7 +1052,6 @@ func TestBlockStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			b := tt.blockFunc(ctrl)
 			require.Equal(tt.expected, b.Status())

--- a/vms/avm/blocks/executor/manager_test.go
+++ b/vms/avm/blocks/executor/manager_test.go
@@ -30,7 +30,6 @@ var (
 func TestManagerGetStatelessBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := states.NewMockState(ctrl)
 	m := &manager{
@@ -73,7 +72,6 @@ func TestManagerGetStatelessBlock(t *testing.T) {
 func TestManagerGetState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := states.NewMockState(ctrl)
 	m := &manager{
@@ -299,7 +297,6 @@ func TestManagerVerifyTx(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			m := test.managerF(ctrl)
 			tx := test.txF(ctrl)
@@ -312,7 +309,6 @@ func TestManagerVerifyTx(t *testing.T) {
 func TestVerifyUniqueInputs(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Case: No inputs
 	{

--- a/vms/avm/network/network_test.go
+++ b/vms/avm/network/network_test.go
@@ -140,7 +140,6 @@ func TestNetworkAppGossip(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			parser, err := txs.NewParser([]fxs.Fx{
 				&secp256k1fx.Fx{},
@@ -280,7 +279,6 @@ func TestNetworkIssueTx(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			parser, err := txs.NewParser([]fxs.Fx{
 				&secp256k1fx.Fx{},
@@ -307,7 +305,6 @@ func TestNetworkIssueTx(t *testing.T) {
 func TestNetworkGossipTx(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	parser, err := txs.NewParser([]fxs.Fx{
 		&secp256k1fx.Fx{},

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -1957,7 +1957,6 @@ func TestImport(t *testing.T) {
 
 func TestServiceGetBlock(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	blockID := ids.GenerateTestID()
 
@@ -2119,7 +2118,6 @@ func TestServiceGetBlock(t *testing.T) {
 
 func TestServiceGetBlockByHeight(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	blockID := ids.GenerateTestID()
 	blockHeight := uint64(1337)
@@ -2322,7 +2320,6 @@ func TestServiceGetBlockByHeight(t *testing.T) {
 
 func TestServiceGetHeight(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	blockID := ids.GenerateTestID()
 	blockHeight := uint64(1337)

--- a/vms/avm/txs/executor/semantic_verifier_test.go
+++ b/vms/avm/txs/executor/semantic_verifier_test.go
@@ -373,7 +373,6 @@ func TestSemanticVerifierBaseTx(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			state := test.stateFunc(ctrl)
 			tx := test.txFunc(require)
@@ -390,9 +389,7 @@ func TestSemanticVerifierBaseTx(t *testing.T) {
 
 func TestSemanticVerifierExportTx(t *testing.T) {
 	ctx := newContext(t)
-
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	validatorState := validators.NewMockState(ctrl)
 	validatorState.EXPECT().GetSubnetID(gomock.Any(), ctx.CChainID).AnyTimes().Return(ctx.SubnetID, nil)
@@ -742,7 +739,6 @@ func TestSemanticVerifierExportTx(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			state := test.stateFunc(ctrl)
 			tx := test.txFunc(require)
@@ -759,11 +755,9 @@ func TestSemanticVerifierExportTx(t *testing.T) {
 
 func TestSemanticVerifierExportTxDifferentSubnet(t *testing.T) {
 	require := require.New(t)
+	ctrl := gomock.NewController(t)
 
 	ctx := newContext(t)
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	validatorState := validators.NewMockState(ctrl)
 	validatorState.EXPECT().GetSubnetID(gomock.Any(), ctx.CChainID).AnyTimes().Return(ids.GenerateTestID(), nil)
@@ -880,10 +874,9 @@ func TestSemanticVerifierExportTxDifferentSubnet(t *testing.T) {
 }
 
 func TestSemanticVerifierImportTx(t *testing.T) {
-	ctx := newContext(t)
-
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+
+	ctx := newContext(t)
 
 	validatorState := validators.NewMockState(ctrl)
 	validatorState.EXPECT().GetSubnetID(gomock.Any(), ctx.CChainID).AnyTimes().Return(ctx.SubnetID, nil)
@@ -1127,9 +1120,7 @@ func TestSemanticVerifierImportTx(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
-
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			state := test.stateFunc(ctrl)
 			tx := test.txFunc(require)

--- a/vms/components/verify/subnet_test.go
+++ b/vms/components/verify/subnet_test.go
@@ -90,8 +90,6 @@ func TestSameSubnet(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
 			ctx := test.ctxF(ctrl)
 
 			result := SameSubnet(context.Background(), ctx, test.chainID)

--- a/vms/platformvm/blocks/builder/builder_test.go
+++ b/vms/platformvm/blocks/builder/builder_test.go
@@ -281,7 +281,6 @@ func TestGetNextStakerToReward(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			state := tt.stateF(ctrl)
 			txID, shouldReward, err := getNextStakerToReward(tt.timestamp, state)
@@ -659,7 +658,6 @@ func TestBuildBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			gotBlk, err := buildBlock(
 				tt.builderF(ctrl),

--- a/vms/platformvm/blocks/executor/acceptor_test.go
+++ b/vms/platformvm/blocks/executor/acceptor_test.go
@@ -29,7 +29,6 @@ import (
 func TestAcceptorVisitProposalBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	lastAcceptedID := ids.GenerateTestID()
 
@@ -81,7 +80,6 @@ func TestAcceptorVisitProposalBlock(t *testing.T) {
 func TestAcceptorVisitAtomicBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	s := state.NewMockState(ctrl)
 	sharedMemory := atomic.NewMockSharedMemory(ctrl)
@@ -161,7 +159,6 @@ func TestAcceptorVisitAtomicBlock(t *testing.T) {
 func TestAcceptorVisitStandardBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	s := state.NewMockState(ctrl)
 	sharedMemory := atomic.NewMockSharedMemory(ctrl)
@@ -253,7 +250,6 @@ func TestAcceptorVisitStandardBlock(t *testing.T) {
 func TestAcceptorVisitCommitBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	s := state.NewMockState(ctrl)
 	sharedMemory := atomic.NewMockSharedMemory(ctrl)
@@ -345,7 +341,6 @@ func TestAcceptorVisitCommitBlock(t *testing.T) {
 func TestAcceptorVisitAbortBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	s := state.NewMockState(ctrl)
 	sharedMemory := atomic.NewMockSharedMemory(ctrl)

--- a/vms/platformvm/blocks/executor/backend_test.go
+++ b/vms/platformvm/blocks/executor/backend_test.go
@@ -20,7 +20,6 @@ import (
 func TestGetState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	var (
 		mockState     = state.NewMockState(ctrl)
@@ -71,7 +70,6 @@ func TestGetState(t *testing.T) {
 func TestBackendGetBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	var (
 		blkID1       = ids.GenerateTestID()
@@ -150,7 +148,6 @@ func TestGetTimestamp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			backend := tt.backendF(ctrl)
 			gotTimestamp := backend.getTimestamp(blkID)

--- a/vms/platformvm/blocks/executor/block_test.go
+++ b/vms/platformvm/blocks/executor/block_test.go
@@ -117,7 +117,6 @@ func TestStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			blk := tt.blockF(ctrl)
 			require.Equal(t, tt.expectedStatus, blk.Status())
@@ -241,8 +240,6 @@ func TestBlockOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			blk := tt.blkF()
 			options, err := blk.Options(context.Background())

--- a/vms/platformvm/blocks/executor/manager_test.go
+++ b/vms/platformvm/blocks/executor/manager_test.go
@@ -19,7 +19,6 @@ import (
 func TestGetBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	statelessBlk, err := blocks.NewApricotCommitBlock(ids.GenerateTestID() /*parent*/, 2 /*height*/)
 	require.NoError(err)

--- a/vms/platformvm/blocks/executor/proposal_block_test.go
+++ b/vms/platformvm/blocks/executor/proposal_block_test.go
@@ -32,7 +32,6 @@ import (
 func TestApricotProposalBlockTimeVerification(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	env := newEnvironment(t, ctrl)
 	defer func() {
@@ -145,7 +144,6 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	env := newEnvironment(t, ctrl)
 	defer func() {

--- a/vms/platformvm/blocks/executor/rejector_test.go
+++ b/vms/platformvm/blocks/executor/rejector_test.go
@@ -115,7 +115,6 @@ func TestRejectBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			blk, err := tt.newBlockFunc()
 			require.NoError(err)

--- a/vms/platformvm/blocks/executor/standard_block_test.go
+++ b/vms/platformvm/blocks/executor/standard_block_test.go
@@ -30,7 +30,6 @@ import (
 func TestApricotStandardBlockTimeVerification(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	env := newEnvironment(t, ctrl)
 	defer func() {
@@ -87,7 +86,6 @@ func TestApricotStandardBlockTimeVerification(t *testing.T) {
 func TestBanffStandardBlockTimeVerification(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	env := newEnvironment(t, ctrl)
 	defer func() {

--- a/vms/platformvm/blocks/executor/verifier_test.go
+++ b/vms/platformvm/blocks/executor/verifier_test.go
@@ -32,7 +32,6 @@ import (
 func TestVerifierVisitProposalBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	s := state.NewMockState(ctrl)
 	mempool := mempool.NewMockMempool(ctrl)
@@ -119,7 +118,6 @@ func TestVerifierVisitProposalBlock(t *testing.T) {
 func TestVerifierVisitAtomicBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -208,7 +206,6 @@ func TestVerifierVisitAtomicBlock(t *testing.T) {
 func TestVerifierVisitStandardBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -308,7 +305,6 @@ func TestVerifierVisitStandardBlock(t *testing.T) {
 func TestVerifierVisitCommitBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -379,7 +375,6 @@ func TestVerifierVisitCommitBlock(t *testing.T) {
 func TestVerifierVisitAbortBlock(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -451,7 +446,6 @@ func TestVerifierVisitAbortBlock(t *testing.T) {
 func TestVerifyUnverifiedParent(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -490,7 +484,6 @@ func TestVerifyUnverifiedParent(t *testing.T) {
 
 func TestBanffAbortBlockTimestampChecks(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	now := defaultGenesisTime.Add(time.Hour)
 
@@ -584,7 +577,6 @@ func TestBanffAbortBlockTimestampChecks(t *testing.T) {
 // TODO combine with TestApricotCommitBlockTimestampChecks
 func TestBanffCommitBlockTimestampChecks(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	now := defaultGenesisTime.Add(time.Hour)
 
@@ -678,7 +670,6 @@ func TestBanffCommitBlockTimestampChecks(t *testing.T) {
 func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -778,7 +769,6 @@ func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -836,7 +826,6 @@ func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) 
 func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -896,7 +885,6 @@ func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 func TestVerifierVisitApricotCommitBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -939,7 +927,6 @@ func TestVerifierVisitApricotCommitBlockUnexpectedParentState(t *testing.T) {
 func TestVerifierVisitBanffCommitBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -985,7 +972,6 @@ func TestVerifierVisitBanffCommitBlockUnexpectedParentState(t *testing.T) {
 func TestVerifierVisitApricotAbortBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
@@ -1028,7 +1014,6 @@ func TestVerifierVisitApricotAbortBlockUnexpectedParentState(t *testing.T) {
 func TestVerifierVisitBanffAbortBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)

--- a/vms/platformvm/stakeable/stakeable_lock_test.go
+++ b/vms/platformvm/stakeable/stakeable_lock_test.go
@@ -64,7 +64,6 @@ func TestLockOutVerify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			lockOut := &LockOut{
 				Locktime:        tt.locktime,
@@ -123,7 +122,6 @@ func TestLockInVerify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			lockOut := &LockIn{
 				Locktime:       tt.locktime,

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -22,7 +22,6 @@ import (
 
 func TestDiffMissingState(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	versions := NewMockVersions(ctrl)
 
@@ -36,7 +35,6 @@ func TestDiffMissingState(t *testing.T) {
 func TestDiffCreation(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	lastAcceptedID := ids.GenerateTestID()
 	state, _ := newInitializedState(require)
@@ -51,7 +49,6 @@ func TestDiffCreation(t *testing.T) {
 func TestDiffCurrentSupply(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	lastAcceptedID := ids.GenerateTestID()
 	state, _ := newInitializedState(require)
@@ -79,7 +76,6 @@ func TestDiffCurrentSupply(t *testing.T) {
 func TestDiffCurrentValidator(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	lastAcceptedID := ids.GenerateTestID()
 	state := NewMockState(ctrl)
@@ -117,7 +113,6 @@ func TestDiffCurrentValidator(t *testing.T) {
 func TestDiffPendingValidator(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	lastAcceptedID := ids.GenerateTestID()
 	state := NewMockState(ctrl)
@@ -155,7 +150,6 @@ func TestDiffPendingValidator(t *testing.T) {
 func TestDiffCurrentDelegator(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	currentDelegator := &Staker{
 		TxID:     ids.GenerateTestID(),
@@ -205,7 +199,6 @@ func TestDiffCurrentDelegator(t *testing.T) {
 func TestDiffPendingDelegator(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	pendingDelegator := &Staker{
 		TxID:     ids.GenerateTestID(),
@@ -255,7 +248,6 @@ func TestDiffPendingDelegator(t *testing.T) {
 func TestDiffSubnet(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := NewMockState(ctrl)
 	// Called in NewDiff
@@ -286,7 +278,6 @@ func TestDiffSubnet(t *testing.T) {
 func TestDiffChain(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := NewMockState(ctrl)
 	// Called in NewDiff
@@ -326,7 +317,6 @@ func TestDiffChain(t *testing.T) {
 func TestDiffTx(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := NewMockState(ctrl)
 	// Called in NewDiff
@@ -377,7 +367,6 @@ func TestDiffTx(t *testing.T) {
 func TestDiffRewardUTXO(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := NewMockState(ctrl)
 	// Called in NewDiff
@@ -423,7 +412,6 @@ func TestDiffRewardUTXO(t *testing.T) {
 func TestDiffUTXO(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := NewMockState(ctrl)
 	// Called in NewDiff

--- a/vms/platformvm/state/staker_test.go
+++ b/vms/platformvm/state/staker_test.go
@@ -135,7 +135,6 @@ func TestStakerLess(t *testing.T) {
 func TestNewCurrentStaker(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	txID := ids.GenerateTestID()
 	nodeID := ids.GenerateTestNodeID()
@@ -181,7 +180,6 @@ func TestNewCurrentStaker(t *testing.T) {
 func TestNewPendingStaker(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	txID := ids.GenerateTestID()
 	nodeID := ids.GenerateTestNodeID()

--- a/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
@@ -1570,7 +1570,6 @@ func TestAddPermissionlessDelegatorTxSyntacticVerify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			tx := tt.txFunc(ctrl)
 			err := tx.SyntacticVerify(ctx)

--- a/vms/platformvm/txs/add_permissionless_validator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx_test.go
@@ -1822,7 +1822,6 @@ func TestAddPermissionlessValidatorTxSyntacticVerify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			tx := tt.txFunc(ctrl)
 			err := tx.SyntacticVerify(ctx)

--- a/vms/platformvm/txs/executor/export_test.go
+++ b/vms/platformvm/txs/executor/export_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -51,8 +49,6 @@ func TestNewExportTx(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			require := require.New(t)
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			tx, err := env.txBuilder.NewExportTx(
 				defaultBalance-defaultTxFee, // Amount of tokens to export

--- a/vms/platformvm/txs/executor/staker_tx_verification_test.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_test.go
@@ -530,7 +530,6 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			var (
 				backend = tt.backendF(ctrl)
@@ -652,7 +651,6 @@ func TestGetValidatorRules(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			chainState := tt.chainStateF(ctrl)
 			rules, err := getValidatorRules(tt.backend, chainState, tt.subnetID)
@@ -771,7 +769,6 @@ func TestGetDelegatorRules(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			chainState := tt.chainStateF(ctrl)
 			rules, err := getDelegatorRules(tt.backend, chainState, tt.subnetID)

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -1319,7 +1319,6 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			unsignedTx, executor := tt.newExecutor(ctrl)
 			err := executor.RemoveSubnetValidatorTx(unsignedTx)
@@ -1601,7 +1600,6 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			unsignedTx, executor := tt.newExecutor(ctrl)
 			err := executor.TransformSubnetTx(unsignedTx)

--- a/vms/platformvm/txs/remove_subnet_validator_tx_test.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx_test.go
@@ -540,7 +540,6 @@ func TestRemoveSubnetValidatorTxSyntacticVerify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			tx := tt.txFunc(ctrl)
 			err := tx.SyntacticVerify(ctx)

--- a/vms/platformvm/txs/transform_subnet_tx_test.go
+++ b/vms/platformvm/txs/transform_subnet_tx_test.go
@@ -933,7 +933,6 @@ func TestTransformSubnetTxSyntacticVerify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			tx := tt.txFunc(ctrl)
 			err := tx.SyntacticVerify(ctx)

--- a/vms/platformvm/warp/signature_test.go
+++ b/vms/platformvm/warp/signature_test.go
@@ -827,7 +827,6 @@ func TestSignatureVerification(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			msg := tt.msgF(require)
 			pChainState := tt.stateF(ctrl)

--- a/vms/platformvm/warp/validator_test.go
+++ b/vms/platformvm/warp/validator_test.go
@@ -135,7 +135,6 @@ func TestGetCanonicalValidatorSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			state := tt.stateF(ctrl)
 

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -33,7 +33,6 @@ import (
 func TestPostForkCommonComponents_buildChild(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	pChainHeight := uint64(1337)
 	parentID := ids.GenerateTestID()

--- a/vms/proposervm/pre_fork_block_test.go
+++ b/vms/proposervm/pre_fork_block_test.go
@@ -763,7 +763,6 @@ func TestBlockVerify_ForkBlockIsOracleBlockButChildrenAreSigned(t *testing.T) {
 func TestPreForkBlock_BuildBlockWithContext(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	pChainHeight := uint64(1337)
 	blkID := ids.GenerateTestID()

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -2160,7 +2160,6 @@ func TestRejectedOptionHeightNotIndexed(t *testing.T) {
 func TestVMInnerBlkCache(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create a VM
 	innerVM := mocks.NewMockChainVM(ctrl)
@@ -2385,7 +2384,6 @@ type blockWithVerifyContext struct {
 func TestVM_VerifyBlockWithContext(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Create a VM
 	innerVM := mocks.NewMockChainVM(ctrl)

--- a/vms/registry/vm_getter_test.go
+++ b/vms/registry/vm_getter_test.go
@@ -66,7 +66,6 @@ var (
 // Get should fail if we hit an io issue when reading files on the disk
 func TestGet_ReadDirFails(t *testing.T) {
 	resources := initVMGetterTest(t)
-	defer resources.ctrl.Finish()
 
 	// disk read fails
 	resources.mockReader.EXPECT().ReadDir(pluginDir).Times(1).Return(nil, errTest)
@@ -78,7 +77,6 @@ func TestGet_ReadDirFails(t *testing.T) {
 // Get should fail if we see an invalid VM id
 func TestGet_InvalidVMName(t *testing.T) {
 	resources := initVMGetterTest(t)
-	defer resources.ctrl.Finish()
 
 	resources.mockReader.EXPECT().ReadDir(pluginDir).Times(1).Return(invalidVMs, nil)
 	// didn't find an alias, so we'll try using this invalid vm name
@@ -91,7 +89,6 @@ func TestGet_InvalidVMName(t *testing.T) {
 // Get should fail if we can't get the VM factory
 func TestGet_GetFactoryFails(t *testing.T) {
 	resources := initVMGetterTest(t)
-	defer resources.ctrl.Finish()
 
 	vm, _ := ids.FromString("vmId")
 
@@ -109,7 +106,6 @@ func TestGet_Success(t *testing.T) {
 	require := require.New(t)
 
 	resources := initVMGetterTest(t)
-	defer resources.ctrl.Finish()
 
 	registeredVMId := ids.GenerateTestID()
 	unregisteredVMId := ids.GenerateTestID()

--- a/vms/registry/vm_registerer_test.go
+++ b/vms/registry/vm_registerer_test.go
@@ -26,7 +26,6 @@ var id = ids.GenerateTestID()
 // Register should succeed even if we can't register a VM
 func TestRegisterRegisterVMFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 
@@ -40,7 +39,6 @@ func TestRegisterRegisterVMFails(t *testing.T) {
 // Tests Register if a VM doesn't actually implement VM.
 func TestRegisterBadVM(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := "this is not a vm..."
@@ -56,7 +54,6 @@ func TestRegisterBadVM(t *testing.T) {
 // Tests Register if creating endpoints for a VM fails + shutdown fails
 func TestRegisterCreateHandlersAndShutdownFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -74,7 +71,6 @@ func TestRegisterCreateHandlersAndShutdownFails(t *testing.T) {
 // Tests Register if creating endpoints for a VM fails + shutdown succeeds
 func TestRegisterCreateHandlersFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -92,7 +88,6 @@ func TestRegisterCreateHandlersFails(t *testing.T) {
 // Tests Register if we fail to register the new endpoint on the server.
 func TestRegisterAddRouteFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -122,7 +117,6 @@ func TestRegisterAddRouteFails(t *testing.T) {
 // Tests Register we can't find the alias for the newly registered vm
 func TestRegisterAliasLookupFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -153,7 +147,6 @@ func TestRegisterAliasLookupFails(t *testing.T) {
 // Tests Register if adding aliases for the newly registered vm fails
 func TestRegisterAddAliasesFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -192,7 +185,6 @@ func TestRegisterAddAliasesFails(t *testing.T) {
 // Tests Register if no errors are thrown
 func TestRegisterHappyCase(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -230,7 +222,6 @@ func TestRegisterHappyCase(t *testing.T) {
 // RegisterWithReadLock should succeed even if we can't register a VM
 func TestRegisterWithReadLockRegisterVMFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 
@@ -244,7 +235,6 @@ func TestRegisterWithReadLockRegisterVMFails(t *testing.T) {
 // Tests RegisterWithReadLock if a VM doesn't actually implement VM.
 func TestRegisterWithReadLockBadVM(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := "this is not a vm..."
@@ -260,7 +250,6 @@ func TestRegisterWithReadLockBadVM(t *testing.T) {
 // Tests RegisterWithReadLock if creating endpoints for a VM fails + shutdown fails
 func TestRegisterWithReadLockCreateHandlersAndShutdownFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -278,7 +267,6 @@ func TestRegisterWithReadLockCreateHandlersAndShutdownFails(t *testing.T) {
 // Tests RegisterWithReadLock if creating endpoints for a VM fails + shutdown succeeds
 func TestRegisterWithReadLockCreateHandlersFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -296,7 +284,6 @@ func TestRegisterWithReadLockCreateHandlersFails(t *testing.T) {
 // Tests RegisterWithReadLock if we fail to register the new endpoint on the server.
 func TestRegisterWithReadLockAddRouteWithReadLockFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -326,7 +313,6 @@ func TestRegisterWithReadLockAddRouteWithReadLockFails(t *testing.T) {
 // Tests RegisterWithReadLock we can't find the alias for the newly registered vm
 func TestRegisterWithReadLockAliasLookupFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -357,7 +343,6 @@ func TestRegisterWithReadLockAliasLookupFails(t *testing.T) {
 // Tests RegisterWithReadLock if adding aliases for the newly registered vm fails
 func TestRegisterWithReadLockAddAliasesFails(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)
@@ -396,7 +381,6 @@ func TestRegisterWithReadLockAddAliasesFails(t *testing.T) {
 // Tests RegisterWithReadLock if no errors are thrown
 func TestRegisterWithReadLockHappyCase(t *testing.T) {
 	resources := initRegistererTest(t)
-	defer resources.ctrl.Finish()
 
 	vmFactory := vms.NewMockFactory(resources.ctrl)
 	vm := mocks.NewMockChainVM(resources.ctrl)

--- a/vms/registry/vm_registry_test.go
+++ b/vms/registry/vm_registry_test.go
@@ -27,7 +27,6 @@ func TestReload_Success(t *testing.T) {
 	require := require.New(t)
 
 	resources := initVMRegistryTest(t)
-	defer resources.ctrl.Finish()
 
 	factory1 := vms.NewMockFactory(resources.ctrl)
 	factory2 := vms.NewMockFactory(resources.ctrl)
@@ -68,7 +67,6 @@ func TestReload_GetNewVMsFails(t *testing.T) {
 	require := require.New(t)
 
 	resources := initVMRegistryTest(t)
-	defer resources.ctrl.Finish()
 
 	resources.mockVMGetter.EXPECT().Get().Times(1).Return(nil, nil, errTest)
 
@@ -83,7 +81,6 @@ func TestReload_PartialRegisterFailure(t *testing.T) {
 	require := require.New(t)
 
 	resources := initVMRegistryTest(t)
-	defer resources.ctrl.Finish()
 
 	factory1 := vms.NewMockFactory(resources.ctrl)
 	factory2 := vms.NewMockFactory(resources.ctrl)
@@ -126,7 +123,6 @@ func TestReloadWithReadLock_Success(t *testing.T) {
 	require := require.New(t)
 
 	resources := initVMRegistryTest(t)
-	defer resources.ctrl.Finish()
 
 	factory1 := vms.NewMockFactory(resources.ctrl)
 	factory2 := vms.NewMockFactory(resources.ctrl)
@@ -167,7 +163,6 @@ func TestReloadWithReadLock_GetNewVMsFails(t *testing.T) {
 	require := require.New(t)
 
 	resources := initVMRegistryTest(t)
-	defer resources.ctrl.Finish()
 
 	resources.mockVMGetter.EXPECT().Get().Times(1).Return(nil, nil, errTest)
 
@@ -182,7 +177,6 @@ func TestReloadWithReadLock_PartialRegisterFailure(t *testing.T) {
 	require := require.New(t)
 
 	resources := initVMRegistryTest(t)
-	defer resources.ctrl.Finish()
 
 	factory1 := vms.NewMockFactory(resources.ctrl)
 	factory2 := vms.NewMockFactory(resources.ctrl)

--- a/vms/rpcchainvm/batched_vm_test.go
+++ b/vms/rpcchainvm/batched_vm_test.go
@@ -38,7 +38,7 @@ var (
 	time2 = time.Unix(2, 0)
 )
 
-func batchedParseBlockCachingTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func batchedParseBlockCachingTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "batchedParseBlockCachingTestKey"
 
 	// create mock
@@ -76,7 +76,7 @@ func batchedParseBlockCachingTestPlugin(t *testing.T, loadExpectations bool) (bl
 		)
 	}
 
-	return vm, ctrl
+	return vm
 }
 
 func TestBatchedParseBlockCaching(t *testing.T) {

--- a/vms/rpcchainvm/state_syncable_vm_test.go
+++ b/vms/rpcchainvm/state_syncable_vm_test.go
@@ -72,7 +72,7 @@ type StateSyncEnabledMock struct {
 	*mocks.MockStateSyncableVM
 }
 
-func stateSyncEnabledTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func stateSyncEnabledTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "stateSyncEnabledTestKey"
 
 	// create mock
@@ -91,10 +91,10 @@ func stateSyncEnabledTestPlugin(t *testing.T, loadExpectations bool) (block.Chai
 		)
 	}
 
-	return ssVM, ctrl
+	return ssVM
 }
 
-func getOngoingSyncStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func getOngoingSyncStateSummaryTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "getOngoingSyncStateSummaryTestKey"
 
 	// create mock
@@ -112,10 +112,10 @@ func getOngoingSyncStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (
 		)
 	}
 
-	return ssVM, ctrl
+	return ssVM
 }
 
-func getLastStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func getLastStateSummaryTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "getLastStateSummaryTestKey"
 
 	// create mock
@@ -133,10 +133,10 @@ func getLastStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.C
 		)
 	}
 
-	return ssVM, ctrl
+	return ssVM
 }
 
-func parseStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func parseStateSummaryTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "parseStateSummaryTestKey"
 
 	// create mock
@@ -155,10 +155,10 @@ func parseStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.Cha
 		)
 	}
 
-	return ssVM, ctrl
+	return ssVM
 }
 
-func getStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func getStateSummaryTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "getStateSummaryTestKey"
 
 	// create mock
@@ -176,10 +176,10 @@ func getStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.Chain
 		)
 	}
 
-	return ssVM, ctrl
+	return ssVM
 }
 
-func acceptStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func acceptStateSummaryTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "acceptStateSummaryTestKey"
 
 	// create mock
@@ -222,10 +222,10 @@ func acceptStateSummaryTestPlugin(t *testing.T, loadExpectations bool) (block.Ch
 		)
 	}
 
-	return ssVM, ctrl
+	return ssVM
 }
 
-func lastAcceptedBlockPostStateSummaryAcceptTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func lastAcceptedBlockPostStateSummaryAcceptTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "lastAcceptedBlockPostStateSummaryAcceptTestKey"
 
 	// create mock
@@ -261,7 +261,7 @@ func lastAcceptedBlockPostStateSummaryAcceptTestPlugin(t *testing.T, loadExpecta
 		)
 	}
 
-	return ssVM, ctrl
+	return ssVM
 }
 
 func buildClientHelper(require *require.Assertions, testKey string) (*VMClient, runtime.Stopper) {

--- a/vms/rpcchainvm/vm_test.go
+++ b/vms/rpcchainvm/vm_test.go
@@ -41,7 +41,7 @@ const (
 	batchedParseBlockCachingTestKey                = "batchedParseBlockCachingTest"
 )
 
-var TestServerPluginMap = map[string]func(*testing.T, bool) (block.ChainVM, *gomock.Controller){
+var TestServerPluginMap = map[string]func(*testing.T, bool) block.ChainVM{
 	stateSyncEnabledTestKey:                        stateSyncEnabledTestPlugin,
 	getOngoingSyncStateSummaryTestKey:              getOngoingSyncStateSummaryTestPlugin,
 	getLastStateSummaryTestKey:                     getLastStateSummaryTestPlugin,
@@ -92,12 +92,11 @@ func TestHelperProcess(t *testing.T) {
 		select {}
 	}
 
-	mockedVM, ctrl := TestServerPluginMap[testKey](t, true /*loadExpectations*/)
+	mockedVM := TestServerPluginMap[testKey](t, true /*loadExpectations*/)
 	err := Serve(context.Background(), mockedVM)
 	if err != nil {
 		os.Exit(1)
 	}
-	ctrl.Finish()
 
 	os.Exit(0)
 }

--- a/vms/rpcchainvm/vm_test.go
+++ b/vms/rpcchainvm/vm_test.go
@@ -174,7 +174,6 @@ func TestRuntimeSubprocessBootstrap(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			vm := mocks.NewMockChainVM(ctrl)
-			defer ctrl.Finish()
 
 			listener, err := grpcutils.NewListener()
 			require.NoError(err)

--- a/vms/rpcchainvm/with_context_vm_test.go
+++ b/vms/rpcchainvm/with_context_vm_test.go
@@ -47,7 +47,7 @@ type ContextEnabledBlockMock struct {
 	*mocks.MockWithVerifyContext
 }
 
-func contextEnabledTestPlugin(t *testing.T, loadExpectations bool) (block.ChainVM, *gomock.Controller) {
+func contextEnabledTestPlugin(t *testing.T, loadExpectations bool) block.ChainVM {
 	// test key is "contextTestKey"
 
 	// create mock
@@ -88,7 +88,7 @@ func contextEnabledTestPlugin(t *testing.T, loadExpectations bool) (block.ChainV
 		)
 	}
 
-	return ctxVM, ctrl
+	return ctxVM
 }
 
 func TestContextVMSummary(t *testing.T) {

--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -52,7 +52,6 @@ func sendRangeRequest(
 
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sender := common.NewMockSender(ctrl)
 	handler := NewNetworkServer(sender, db, logging.NoLog{})
@@ -312,7 +311,6 @@ func sendChangeRequest(
 
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sender := common.NewMockSender(ctrl)
 	handler := NewNetworkServer(sender, db, logging.NoLog{})

--- a/x/sync/network_server_test.go
+++ b/x/sync/network_server_test.go
@@ -98,7 +98,6 @@ func Test_Server_GetRangeProof(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			sender := common.NewMockSender(ctrl)
 			var proof *merkledb.RangeProof
 			sender.EXPECT().SendAppResponse(
@@ -248,7 +247,6 @@ func Test_Server_GetChangeProof(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			sender := common.NewMockSender(ctrl)
 			var proofResult *merkledb.ChangeProof
 			sender.EXPECT().SendAppResponse(

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -82,8 +82,6 @@ func Test_Completion(t *testing.T) {
 	require := require.New(t)
 
 	for i := 0; i < 10; i++ {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		emptyDB, err := merkledb.New(
 			context.Background(),
 			memdb.New(),
@@ -867,7 +865,6 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 func Test_Sync_Error_During_Sync(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	now := time.Now().UnixNano()
 	t.Logf("seed: %d", now)
 	r := rand.New(rand.NewSource(now)) // #nosec G404
@@ -920,7 +917,6 @@ func Test_Sync_Error_During_Sync(t *testing.T) {
 func Test_Sync_Result_Correct_Root_Update_Root_During(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	for i := 0; i < 3; i++ {
 		now := time.Now().UnixNano()
@@ -1029,7 +1025,6 @@ func Test_Sync_Result_Correct_Root_Update_Root_During(t *testing.T) {
 func Test_Sync_UpdateSyncTarget(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	m, err := NewManager(ManagerConfig{
 		DB:                    merkledb.NewMockMerkleDB(ctrl), // Not used


### PR DESCRIPTION
## Why this should be merged
Removes unneeded code to make tests easier to read.

## How this works
@joshua-kim found out that since go1.14+ it's not needed to call `defer ctrl.Finish()` if you pass `t` to the controller initialization. Docs: https://pkg.go.dev/github.com/golang/mock/gomock#Controller.Finish
The gomock library uses the `t.Cleanup()` pattern instead.

## How this was tested
UTs
