### PR TITLE
Update maintainer of the debian packages

### DIFF
--- a/.github/workflows/debian/template/control
+++ b/.github/workflows/debian/template/control
@@ -4,5 +4,5 @@ Section: misc
 Priority: optional
 Architecture: arm64 
 Depends:
-Maintainer: Fabio Barone <fabio@avalabs.org>
+Maintainer: Stephen Buttolph <stephen@avalabs.org>
 Description: The Avalanche platform binaries 


### PR DESCRIPTION
## Why this should be merged

Fabio no longer maintains the debian packages.

## How this works

Updates the name.

## How this was tested

N/A