### PR TITLE
Add error logs for unexpected proposervm BuildBlock failures

### DIFF
--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -190,6 +190,11 @@ func (p *postForkCommonComponents) buildChild(
 	// is at least the parent's P-Chain height
 	pChainHeight, err := p.vm.optimalPChainHeight(ctx, parentPChainHeight)
 	if err != nil {
+		p.vm.ctx.Log.Error("unexpected build block failure",
+			zap.String("reason", "failed to calculate optimal P-chain height"),
+			zap.Stringer("parentID", parentID),
+			zap.Error(err),
+		)
 		return nil, err
 	}
 
@@ -199,6 +204,11 @@ func (p *postForkCommonComponents) buildChild(
 		proposerID := p.vm.ctx.NodeID
 		minDelay, err := p.vm.Windower.Delay(ctx, parentHeight+1, parentPChainHeight, proposerID)
 		if err != nil {
+			p.vm.ctx.Log.Error("unexpected build block failure",
+				zap.String("reason", "failed to calculate required timestamp delay"),
+				zap.Stringer("parentID", parentID),
+				zap.Error(err),
+			)
 			return nil, err
 		}
 
@@ -254,6 +264,12 @@ func (p *postForkCommonComponents) buildChild(
 		)
 	}
 	if err != nil {
+		p.vm.ctx.Log.Error("unexpected build block failure",
+			zap.String("reason", "failed to generate proposervm block header"),
+			zap.Stringer("parentID", parentID),
+			zap.Stringer("blkID", innerBlock.ID()),
+			zap.Error(err),
+		)
 		return nil, err
 	}
 

--- a/vms/proposervm/post_fork_option.go
+++ b/vms/proposervm/post_fork_option.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/vms/proposervm/block"
@@ -113,13 +115,19 @@ func (*postForkOption) verifyPostForkOption(context.Context, *postForkOption) er
 }
 
 func (b *postForkOption) buildChild(ctx context.Context) (Block, error) {
+	parentID := b.ID()
 	parentPChainHeight, err := b.pChainHeight(ctx)
 	if err != nil {
+		b.vm.ctx.Log.Error("unexpected build block failure",
+			zap.String("reason", "failed to fetch parent's P-chain height"),
+			zap.Stringer("parentID", parentID),
+			zap.Error(err),
+		)
 		return nil, err
 	}
 	return b.postForkCommonComponents.buildChild(
 		ctx,
-		b.ID(),
+		parentID,
 		b.Timestamp(),
 		parentPChainHeight,
 	)

--- a/vms/proposervm/pre_fork_block.go
+++ b/vms/proposervm/pre_fork_block.go
@@ -207,6 +207,11 @@ func (b *preForkBlock) buildChild(ctx context.Context) (Block, error) {
 	// is at least the minimum height
 	pChainHeight, err := b.vm.optimalPChainHeight(ctx, b.vm.minimumPChainHeight)
 	if err != nil {
+		b.vm.ctx.Log.Error("unexpected build block failure",
+			zap.String("reason", "failed to calculate optimal P-chain height"),
+			zap.Stringer("parentID", parentID),
+			zap.Error(err),
+		)
 		return nil, err
 	}
 

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -306,6 +306,11 @@ func (vm *VM) SetState(ctx context.Context, newState snow.State) error {
 func (vm *VM) BuildBlock(ctx context.Context) (snowman.Block, error) {
 	preferredBlock, err := vm.getBlock(ctx, vm.preferred)
 	if err != nil {
+		vm.ctx.Log.Error("unexpected build block failure",
+			zap.String("reason", "failed to fetch preferred block"),
+			zap.Stringer("parentID", vm.preferred),
+			zap.Error(err),
+		)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Why this should be merged

Failing to build a block inside the proposervm unexpectedly can violate the consensus invariant that `BuildBlock` will be called at least once after receiving a `PendingTxs` message.

## How this works

If the proposervm fails to build a block outside of the inner vm's control, an error should be logged. The exception to this is if  the proposervm windower hasn't progressed far enough to attempt to build a block. In this case, we manually mock a `PendingTxs` message from the inner VM.

## How this was tested

N/A