### PR TITLE
Document PendingTxs + BuildBlock consensus engine requirement

### DIFF
--- a/snow/engine/common/message.go
+++ b/snow/engine/common/message.go
@@ -11,9 +11,13 @@ import "fmt"
 type Message uint32
 
 const (
-	// PendingTxs notifies a consensus engine that
-	// its VM has pending transactions
-	// (i.e. it would like to add a new block/vertex to consensus)
+	// PendingTxs notifies a consensus engine that its VM has pending
+	// transactions.
+	//
+	// The consensus engine must eventually call BuildBlock at least once after
+	// receiving this message. If the consensus engine receives multiple
+	// PendingTxs messages between calls to BuildBlock, the engine may only call
+	// BuildBlock once.
 	PendingTxs Message = iota + 1
 
 	// StateSyncDone notifies the state syncer engine that the VM has finishing


### PR DESCRIPTION
## Why this should be merged

Documents an invariant the consensus engine maintains.

## How this works

Adds a comment.

## How this was tested

N/A