### PR TITLE
migrate to `uber-go/mock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ docker run -t -i -v $(pwd):/opt/avalanche -w/opt/avalanche avalanche:protobuf_co
 
 ### Running mock codegen
 
-To regenerate the [gomock](https://github.com/golang/mock) code, run `scripts/mock.gen.sh` from the root of the repo.
+To regenerate the [gomock](https://github.com/uber-go/mock) code, run `scripts/mock.gen.sh` from the root of the repo.
 
 This should only be necessary when modifying exported interfaces or after modifying `scripts/mock.mockgen.txt`.
 

--- a/api/admin/service_test.go
+++ b/api/admin/service_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"

--- a/api/info/service_test.go
+++ b/api/info/service_test.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"

--- a/api/server/mock_server.go
+++ b/api/server/mock_server.go
@@ -13,7 +13,7 @@ import (
 
 	snow "github.com/ava-labs/avalanchego/snow"
 	common "github.com/ava-labs/avalanchego/snow/engine/common"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockServer is a mock of Server interface.

--- a/chains/atomic/mock_shared_memory.go
+++ b/chains/atomic/mock_shared_memory.go
@@ -12,7 +12,7 @@ import (
 
 	database "github.com/ava-labs/avalanchego/database"
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockSharedMemory is a mock of SharedMemory interface.

--- a/codec/mock_manager.go
+++ b/codec/mock_manager.go
@@ -10,7 +10,7 @@ package codec
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockManager is a mock of Manager interface.

--- a/database/mock_batch.go
+++ b/database/mock_batch.go
@@ -10,7 +10,7 @@ package database
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockBatch is a mock of Batch interface.

--- a/database/test_database.go
+++ b/database/test_database.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"golang.org/x/exp/slices"
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
-	github.com/golang/mock v1.6.0
 	github.com/google/btree v1.1.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/rpc v1.2.0
@@ -54,6 +53,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.11.0
 	go.opentelemetry.io/otel/trace v1.11.0
 	go.uber.org/goleak v1.2.1
+	go.uber.org/mock v0.2.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.1.0
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,6 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -665,6 +663,8 @@ go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
+go.uber.org/mock v0.2.0 h1:TaP3xedm7JaAgScZO7tlvlKrqT0p7I6OsdGB5YNSMDU=
+go.uber.org/mock v0.2.0/go.mod h1:J0y0rp9L3xiff1+ZBfKxlC1fz2+aO16tw0tsDOixfuM=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
@@ -944,7 +944,6 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/api/server"
 	"github.com/ava-labs/avalanchego/database/memdb"

--- a/message/mock_message.go
+++ b/message/mock_message.go
@@ -10,7 +10,7 @@ package message
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockOutboundMessage is a mock of OutboundMessage interface.

--- a/message/mock_outbound_message_builder.go
+++ b/message/mock_outbound_message_builder.go
@@ -14,7 +14,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	p2p "github.com/ava-labs/avalanchego/proto/pb/p2p"
 	ips "github.com/ava-labs/avalanchego/utils/ips"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockOutboundMsgBuilder is a mock of OutboundMsgBuilder interface.

--- a/network/p2p/mocks/mock_handler.go
+++ b/network/p2p/mocks/mock_handler.go
@@ -13,7 +13,7 @@ import (
 	time "time"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface.

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p/mocks"

--- a/network/peer/mock_gossip_tracker.go
+++ b/network/peer/mock_gossip_tracker.go
@@ -11,7 +11,7 @@ import (
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockGossipTracker is a mock of GossipTracker interface.

--- a/network/throttling/inbound_resource_throttler_test.go
+++ b/network/throttling/inbound_resource_throttler_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/network/throttling/outbound_msg_throttler_test.go
+++ b/network/throttling/outbound_msg_throttler_test.go
@@ -6,7 +6,7 @@ package throttling
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/node/beacon_manager_test.go
+++ b/node/beacon_manager_test.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/networking/router"

--- a/scripts/mock.gen.sh
+++ b/scripts/mock.gen.sh
@@ -10,8 +10,8 @@ fi
 if ! command -v mockgen &> /dev/null
 then
   echo "mockgen not found, installing..."
-  # https://github.com/golang/mock
-  go install -v github.com/golang/mock/mockgen@v1.6.0
+  # https://github.com/uber-go/mock
+  go install go.uber.org/mock/mockgen@v0.2.0
 fi
 
 if ! command -v go-license &> /dev/null

--- a/snow/consensus/snowman/mock_block.go
+++ b/snow/consensus/snowman/mock_block.go
@@ -14,7 +14,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	choices "github.com/ava-labs/avalanchego/snow/choices"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockBlock is a mock of Block interface.

--- a/snow/engine/avalanche/vertex/mock_vm.go
+++ b/snow/engine/avalanche/vertex/mock_vm.go
@@ -19,7 +19,7 @@ import (
 	snowstorm "github.com/ava-labs/avalanchego/snow/consensus/snowstorm"
 	common "github.com/ava-labs/avalanchego/snow/engine/common"
 	version "github.com/ava-labs/avalanchego/version"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockLinearizableVM is a mock of LinearizableVM interface.

--- a/snow/engine/common/mock_sender.go
+++ b/snow/engine/common/mock_sender.go
@@ -14,7 +14,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	snow "github.com/ava-labs/avalanchego/snow"
 	set "github.com/ava-labs/avalanchego/utils/set"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockSender is a mock of Sender interface.

--- a/snow/engine/snowman/block/mocks/build_block_with_context_vm.go
+++ b/snow/engine/snowman/block/mocks/build_block_with_context_vm.go
@@ -13,7 +13,7 @@ import (
 
 	snowman "github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	block "github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockBuildBlockWithContextChainVM is a mock of BuildBlockWithContextChainVM interface.

--- a/snow/engine/snowman/block/mocks/chain_vm.go
+++ b/snow/engine/snowman/block/mocks/chain_vm.go
@@ -18,7 +18,7 @@ import (
 	snowman "github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	common "github.com/ava-labs/avalanchego/snow/engine/common"
 	version "github.com/ava-labs/avalanchego/version"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockChainVM is a mock of ChainVM interface.

--- a/snow/engine/snowman/block/mocks/state_syncable_vm.go
+++ b/snow/engine/snowman/block/mocks/state_syncable_vm.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	block "github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockStateSyncableVM is a mock of StateSyncableVM interface.

--- a/snow/engine/snowman/block/mocks/with_verify_context.go
+++ b/snow/engine/snowman/block/mocks/with_verify_context.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	block "github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockWithVerifyContext is a mock of WithVerifyContext interface.

--- a/snow/engine/snowman/getter/getter_test.go
+++ b/snow/engine/snowman/getter/getter_test.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"

--- a/snow/networking/handler/message_queue_test.go
+++ b/snow/networking/handler/message_queue_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"

--- a/snow/networking/handler/mock_handler.go
+++ b/snow/networking/handler/mock_handler.go
@@ -14,7 +14,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	snow "github.com/ava-labs/avalanchego/snow"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface.

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/router/mock_router.go
+++ b/snow/networking/router/mock_router.go
@@ -20,7 +20,7 @@ import (
 	logging "github.com/ava-labs/avalanchego/utils/logging"
 	set "github.com/ava-labs/avalanchego/utils/set"
 	version "github.com/ava-labs/avalanchego/version"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 	prometheus "github.com/prometheus/client_golang/prometheus"
 )
 

--- a/snow/networking/sender/mock_external_sender.go
+++ b/snow/networking/sender/mock_external_sender.go
@@ -14,7 +14,7 @@ import (
 	message "github.com/ava-labs/avalanchego/message"
 	subnets "github.com/ava-labs/avalanchego/subnets"
 	set "github.com/ava-labs/avalanchego/utils/set"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockExternalSender is a mock of ExternalSender interface.

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"

--- a/snow/networking/timeout/mock_manager.go
+++ b/snow/networking/timeout/mock_manager.go
@@ -14,7 +14,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	message "github.com/ava-labs/avalanchego/message"
 	snow "github.com/ava-labs/avalanchego/snow"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockManager is a mock of Manager interface.

--- a/snow/networking/tracker/mock_resource_tracker.go
+++ b/snow/networking/tracker/mock_resource_tracker.go
@@ -12,7 +12,7 @@ import (
 	time "time"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockTracker is a mock of Tracker interface.

--- a/snow/networking/tracker/mock_targeter.go
+++ b/snow/networking/tracker/mock_targeter.go
@@ -11,7 +11,7 @@ import (
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockTargeter is a mock of Targeter interface.

--- a/snow/networking/tracker/resource_tracker_test.go
+++ b/snow/networking/tracker/resource_tracker_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/math/meter"

--- a/snow/networking/tracker/targeter_test.go
+++ b/snow/networking/tracker/targeter_test.go
@@ -6,9 +6,9 @@ package tracker
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"

--- a/snow/uptime/locked_calculator_test.go
+++ b/snow/uptime/locked_calculator_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"

--- a/snow/uptime/mock_calculator.go
+++ b/snow/uptime/mock_calculator.go
@@ -12,7 +12,7 @@ import (
 	time "time"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockCalculator is a mock of Calculator interface.

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"

--- a/snow/validators/mock_manager.go
+++ b/snow/validators/mock_manager.go
@@ -11,7 +11,7 @@ import (
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockManager is a mock of Manager interface.

--- a/snow/validators/mock_set.go
+++ b/snow/validators/mock_set.go
@@ -13,7 +13,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	bls "github.com/ava-labs/avalanchego/utils/crypto/bls"
 	set "github.com/ava-labs/avalanchego/utils/set"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockSet is a mock of Set interface.

--- a/snow/validators/mock_state.go
+++ b/snow/validators/mock_state.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockState is a mock of State interface.

--- a/snow/validators/mock_subnet_connector.go
+++ b/snow/validators/mock_subnet_connector.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockSubnetConnector is a mock of SubnetConnector interface.

--- a/utils/crypto/keychain/keychain_test.go
+++ b/utils/crypto/keychain/keychain_test.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 )

--- a/utils/crypto/keychain/mock_ledger.go
+++ b/utils/crypto/keychain/mock_ledger.go
@@ -12,7 +12,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	version "github.com/ava-labs/avalanchego/version"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockLedger is a mock of Ledger interface.

--- a/utils/filesystem/mock_io.go
+++ b/utils/filesystem/mock_io.go
@@ -11,7 +11,7 @@ import (
 	fs "io/fs"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockReader is a mock of Reader interface.

--- a/utils/hashing/consistent/ring_test.go
+++ b/utils/hashing/consistent/ring_test.go
@@ -6,9 +6,9 @@ package consistent
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/utils/hashing"
 )

--- a/utils/hashing/mock_hasher.go
+++ b/utils/hashing/mock_hasher.go
@@ -10,7 +10,7 @@ package hashing
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockHasher is a mock of Hasher interface.

--- a/utils/logging/mock_logger.go
+++ b/utils/logging/mock_logger.go
@@ -10,7 +10,7 @@ package logging
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 	zapcore "go.uber.org/zap/zapcore"
 )
 

--- a/utils/resource/mock_user.go
+++ b/utils/resource/mock_user.go
@@ -10,7 +10,7 @@ package resource
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockUser is a mock of User interface.

--- a/vms/avm/blocks/builder/builder_test.go
+++ b/vms/avm/blocks/builder/builder_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/database/manager"

--- a/vms/avm/blocks/executor/block_test.go
+++ b/vms/avm/blocks/executor/block_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/avm/blocks/executor/manager_test.go
+++ b/vms/avm/blocks/executor/manager_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"

--- a/vms/avm/blocks/executor/mock_manager.go
+++ b/vms/avm/blocks/executor/mock_manager.go
@@ -16,7 +16,7 @@ import (
 	blocks "github.com/ava-labs/avalanchego/vms/avm/blocks"
 	states "github.com/ava-labs/avalanchego/vms/avm/states"
 	txs "github.com/ava-labs/avalanchego/vms/avm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockManager is a mock of Manager interface.

--- a/vms/avm/blocks/mock_block.go
+++ b/vms/avm/blocks/mock_block.go
@@ -15,7 +15,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	snow "github.com/ava-labs/avalanchego/snow"
 	txs "github.com/ava-labs/avalanchego/vms/avm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockBlock is a mock of Block interface.

--- a/vms/avm/metrics/mock_metrics.go
+++ b/vms/avm/metrics/mock_metrics.go
@@ -13,8 +13,8 @@ import (
 
 	blocks "github.com/ava-labs/avalanchego/vms/avm/blocks"
 	txs "github.com/ava-labs/avalanchego/vms/avm/txs"
-	gomock "github.com/golang/mock/gomock"
 	rpc "github.com/gorilla/rpc/v2"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockMetrics is a mock of Metrics interface.

--- a/vms/avm/network/network_test.go
+++ b/vms/avm/network/network_test.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/bech32"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/chains/atomic"

--- a/vms/avm/states/mock_states.go
+++ b/vms/avm/states/mock_states.go
@@ -18,7 +18,7 @@ import (
 	blocks "github.com/ava-labs/avalanchego/vms/avm/blocks"
 	txs "github.com/ava-labs/avalanchego/vms/avm/txs"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockChain is a mock of Chain interface.

--- a/vms/avm/txs/executor/semantic_verifier_test.go
+++ b/vms/avm/txs/executor/semantic_verifier_test.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/avm/txs/mempool/mock_mempool.go
+++ b/vms/avm/txs/mempool/mock_mempool.go
@@ -12,7 +12,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	txs "github.com/ava-labs/avalanchego/vms/avm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockMempool is a mock of Mempool interface.

--- a/vms/avm/txs/mock_unsigned_tx.go
+++ b/vms/avm/txs/mock_unsigned_tx.go
@@ -14,7 +14,7 @@ import (
 	snow "github.com/ava-labs/avalanchego/snow"
 	set "github.com/ava-labs/avalanchego/utils/set"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockUnsignedTx is a mock of UnsignedTx interface.

--- a/vms/components/avax/mock_transferable_in.go
+++ b/vms/components/avax/mock_transferable_in.go
@@ -11,7 +11,7 @@ import (
 	reflect "reflect"
 
 	snow "github.com/ava-labs/avalanchego/snow"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockTransferableIn is a mock of TransferableIn interface.

--- a/vms/components/avax/mock_transferable_out.go
+++ b/vms/components/avax/mock_transferable_out.go
@@ -12,7 +12,7 @@ import (
 
 	snow "github.com/ava-labs/avalanchego/snow"
 	verify "github.com/ava-labs/avalanchego/vms/components/verify"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockTransferableOut is a mock of TransferableOut interface.

--- a/vms/components/verify/mock_verifiable.go
+++ b/vms/components/verify/mock_verifiable.go
@@ -10,7 +10,7 @@ package verify
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockVerifiable is a mock of Verifiable interface.

--- a/vms/components/verify/subnet_test.go
+++ b/vms/components/verify/subnet_test.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/mock_manager.go
+++ b/vms/mock_manager.go
@@ -13,7 +13,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	logging "github.com/ava-labs/avalanchego/utils/logging"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockFactory is a mock of Factory interface.

--- a/vms/platformvm/blocks/builder/builder_test.go
+++ b/vms/platformvm/blocks/builder/builder_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/platformvm/blocks/executor/acceptor_test.go
+++ b/vms/platformvm/blocks/executor/acceptor_test.go
@@ -6,9 +6,9 @@ package executor
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/blocks/executor/backend_test.go
+++ b/vms/platformvm/blocks/executor/backend_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/blocks/executor/block_test.go
+++ b/vms/platformvm/blocks/executor/block_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/blocks/executor/helpers_test.go
+++ b/vms/platformvm/blocks/executor/helpers_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains"
 	"github.com/ava-labs/avalanchego/chains/atomic"

--- a/vms/platformvm/blocks/executor/manager_test.go
+++ b/vms/platformvm/blocks/executor/manager_test.go
@@ -6,9 +6,9 @@ package executor
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/blocks/executor/mock_manager.go
+++ b/vms/platformvm/blocks/executor/mock_manager.go
@@ -14,7 +14,7 @@ import (
 	snowman "github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	blocks "github.com/ava-labs/avalanchego/vms/platformvm/blocks"
 	state "github.com/ava-labs/avalanchego/vms/platformvm/state"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockManager is a mock of Manager interface.

--- a/vms/platformvm/blocks/executor/proposal_block_test.go
+++ b/vms/platformvm/blocks/executor/proposal_block_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/blocks/executor/rejector_test.go
+++ b/vms/platformvm/blocks/executor/rejector_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/platformvm/blocks/executor/standard_block_test.go
+++ b/vms/platformvm/blocks/executor/standard_block_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/blocks/executor/verifier_test.go
+++ b/vms/platformvm/blocks/executor/verifier_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/blocks/mock_block.go
+++ b/vms/platformvm/blocks/mock_block.go
@@ -13,7 +13,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	snow "github.com/ava-labs/avalanchego/snow"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockBlock is a mock of Block interface.

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -12,7 +12,7 @@ import (
 
 	snow "github.com/ava-labs/avalanchego/snow"
 	verify "github.com/ava-labs/avalanchego/vms/components/verify"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockFx is a mock of Fx interface.

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -14,9 +14,9 @@ import (
 
 	stdjson "encoding/json"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/api/keystore"

--- a/vms/platformvm/stakeable/stakeable_lock_test.go
+++ b/vms/platformvm/stakeable/stakeable_lock_test.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 )

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -15,7 +15,7 @@ import (
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockChain is a mock of Chain interface.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -15,7 +15,7 @@ import (
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockDiff is a mock of Diff interface.

--- a/vms/platformvm/state/mock_staker_iterator.go
+++ b/vms/platformvm/state/mock_staker_iterator.go
@@ -10,7 +10,7 @@ package state
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockStakerIterator is a mock of StakerIterator interface.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -21,7 +21,7 @@ import (
 	blocks "github.com/ava-labs/avalanchego/vms/platformvm/blocks"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockState is a mock of State interface.

--- a/vms/platformvm/state/mock_versions.go
+++ b/vms/platformvm/state/mock_versions.go
@@ -11,7 +11,7 @@ import (
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockVersions is a mock of Versions interface.

--- a/vms/platformvm/state/staker_test.go
+++ b/vms/platformvm/state/staker_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"

--- a/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
@@ -9,9 +9,9 @@ import (
 
 	stdmath "math"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/platformvm/txs/add_permissionless_validator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx_test.go
@@ -9,9 +9,9 @@ import (
 
 	stdmath "math"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/platformvm/txs/builder/mock_builder.go
+++ b/vms/platformvm/txs/builder/mock_builder.go
@@ -14,7 +14,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	secp256k1 "github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockBuilder is a mock of Builder interface.

--- a/vms/platformvm/txs/executor/staker_tx_verification_test.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/txs/mempool/mock_mempool.go
+++ b/vms/platformvm/txs/mempool/mock_mempool.go
@@ -12,7 +12,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockMempool is a mock of Mempool interface.

--- a/vms/platformvm/txs/mock_staker.go
+++ b/vms/platformvm/txs/mock_staker.go
@@ -13,7 +13,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	bls "github.com/ava-labs/avalanchego/utils/crypto/bls"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockStaker is a mock of Staker interface.

--- a/vms/platformvm/txs/mock_unsigned_tx.go
+++ b/vms/platformvm/txs/mock_unsigned_tx.go
@@ -14,7 +14,7 @@ import (
 	snow "github.com/ava-labs/avalanchego/snow"
 	set "github.com/ava-labs/avalanchego/utils/set"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockUnsignedTx is a mock of UnsignedTx interface.

--- a/vms/platformvm/txs/remove_subnet_validator_tx_test.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx_test.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/platformvm/txs/transform_subnet_tx_test.go
+++ b/vms/platformvm/txs/transform_subnet_tx_test.go
@@ -6,9 +6,9 @@ package txs
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/platformvm/utxo/mock_verifier.go
+++ b/vms/platformvm/utxo/mock_verifier.go
@@ -14,7 +14,7 @@ import (
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
 	verify "github.com/ava-labs/avalanchego/vms/components/verify"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockVerifier is a mock of Verifier interface.

--- a/vms/platformvm/warp/signature_test.go
+++ b/vms/platformvm/warp/signature_test.go
@@ -9,9 +9,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"

--- a/vms/platformvm/warp/validator_test.go
+++ b/vms/platformvm/warp/validator_test.go
@@ -9,9 +9,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"

--- a/vms/proposervm/mock_post_fork_block.go
+++ b/vms/proposervm/mock_post_fork_block.go
@@ -16,7 +16,7 @@ import (
 	choices "github.com/ava-labs/avalanchego/snow/choices"
 	snowman "github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	block "github.com/ava-labs/avalanchego/vms/proposervm/block"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockPostForkBlock is a mock of PostForkBlock interface.

--- a/vms/proposervm/pre_fork_block_test.go
+++ b/vms/proposervm/pre_fork_block_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/proposervm/proposer/mock_windower.go
+++ b/vms/proposervm/proposer/mock_windower.go
@@ -13,7 +13,7 @@ import (
 	time "time"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockWindower is a mock of Windower interface.

--- a/vms/proposervm/state/mock_state.go
+++ b/vms/proposervm/state/mock_state.go
@@ -13,7 +13,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	choices "github.com/ava-labs/avalanchego/snow/choices"
 	block "github.com/ava-labs/avalanchego/vms/proposervm/block"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockState is a mock of State interface.

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database/manager"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/registry/mock_vm_getter.go
+++ b/vms/registry/mock_vm_getter.go
@@ -12,7 +12,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	vms "github.com/ava-labs/avalanchego/vms"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockVMGetter is a mock of VMGetter interface.

--- a/vms/registry/mock_vm_registerer.go
+++ b/vms/registry/mock_vm_registerer.go
@@ -13,7 +13,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	vms "github.com/ava-labs/avalanchego/vms"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockVMRegisterer is a mock of VMRegisterer interface.

--- a/vms/registry/mock_vm_registry.go
+++ b/vms/registry/mock_vm_registry.go
@@ -12,7 +12,7 @@ import (
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockVMRegistry is a mock of VMRegistry interface.

--- a/vms/registry/vm_getter_test.go
+++ b/vms/registry/vm_getter_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/filesystem"

--- a/vms/registry/vm_registerer_test.go
+++ b/vms/registry/vm_registerer_test.go
@@ -8,9 +8,9 @@ import (
 	"path"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/api/server"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/registry/vm_registry_test.go
+++ b/vms/registry/vm_registry_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms"

--- a/vms/rpcchainvm/batched_vm_test.go
+++ b/vms/rpcchainvm/batched_vm_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database/manager"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/rpcchainvm/state_syncable_vm_test.go
+++ b/vms/rpcchainvm/state_syncable_vm_test.go
@@ -9,9 +9,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database/manager"
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/rpcchainvm/vm_test.go
+++ b/vms/rpcchainvm/vm_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slices"
-
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block/mocks"

--- a/vms/rpcchainvm/with_context_vm_test.go
+++ b/vms/rpcchainvm/with_context_vm_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database/manager"
 	"github.com/ava-labs/avalanchego/ids"

--- a/x/merkledb/mock_db.go
+++ b/x/merkledb/mock_db.go
@@ -14,7 +14,7 @@ import (
 	database "github.com/ava-labs/avalanchego/database"
 	ids "github.com/ava-labs/avalanchego/ids"
 	maybe "github.com/ava-labs/avalanchego/utils/maybe"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockMerkleDB is a mock of MerkleDB interface.

--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"google.golang.org/protobuf/proto"
 

--- a/x/sync/mock_client.go
+++ b/x/sync/mock_client.go
@@ -13,7 +13,7 @@ import (
 
 	sync "github.com/ava-labs/avalanchego/proto/pb/sync"
 	merkledb "github.com/ava-labs/avalanchego/x/merkledb"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockClient is a mock of Client interface.

--- a/x/sync/mock_network_client.go
+++ b/x/sync/mock_network_client.go
@@ -10,7 +10,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	version "github.com/ava-labs/avalanchego/version"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockNetworkClient is a mock of NetworkClient interface.

--- a/x/sync/network_server_test.go
+++ b/x/sync/network_server_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"google.golang.org/protobuf/proto"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"golang.org/x/exp/slices"
 


### PR DESCRIPTION
## Why this should be merged

[`golang/mock`](https://github.com/golang/mock) is no longer maintained as of June 2023 (see repo disclaimer).

[`uber-go/mock`](https://github.com/uber-go/mock) is the maintained fork and is linked to by the `golang/mock` authors.

## How this works

find and replace :)

## How this was tested

CI