### PR TITLE
Map reflect fixes

### DIFF
--- a/codec/test_codec.go
+++ b/codec/test_codec.go
@@ -212,7 +212,7 @@ func TestStruct(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myStructInstance)
 	require.NoError(err)
-	require.Equal(len(myStructBytes), bytesLen)
+	require.Len(myStructBytes, bytesLen)
 
 	myStructUnmarshaled := &myStruct{}
 	version, err := manager.Unmarshal(myStructBytes, myStructUnmarshaled)
@@ -248,7 +248,7 @@ func TestUInt32(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, number)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var numberUnmarshaled uint32
 	version, err := manager.Unmarshal(bytes, &numberUnmarshaled)
@@ -281,7 +281,7 @@ func TestSlice(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, mySlice)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var sliceUnmarshaled []bool
 	version, err := manager.Unmarshal(bytes, &sliceUnmarshaled)
@@ -305,7 +305,7 @@ func TestMaxSizeSlice(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, mySlice)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var sliceUnmarshaled []string
 	version, err := manager.Unmarshal(bytes, &sliceUnmarshaled)
@@ -327,7 +327,7 @@ func TestBool(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myBool)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var boolUnmarshaled bool
 	version, err := manager.Unmarshal(bytes, &boolUnmarshaled)
@@ -349,7 +349,7 @@ func TestArray(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myArr)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var myArrUnmarshaled [5]uint64
 	version, err := manager.Unmarshal(bytes, &myArrUnmarshaled)
@@ -371,7 +371,7 @@ func TestBigArray(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myArr)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var myArrUnmarshaled [30000]uint64
 	version, err := manager.Unmarshal(bytes, &myArrUnmarshaled)
@@ -393,7 +393,7 @@ func TestPointerToStruct(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myPtr)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var myPtrUnmarshaled *MyInnerStruct
 	version, err := manager.Unmarshal(bytes, &myPtrUnmarshaled)
@@ -428,7 +428,7 @@ func TestSliceOfStruct(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, mySlice)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var mySliceUnmarshaled []MyInnerStruct3
 	version, err := manager.Unmarshal(bytes, &mySliceUnmarshaled)
@@ -452,7 +452,7 @@ func TestInterface(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, &f)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var unmarshaledFoo Foo
 	version, err := manager.Unmarshal(bytes, &unmarshaledFoo)
@@ -483,7 +483,7 @@ func TestSliceOfInterface(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, mySlice)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var mySliceUnmarshaled []Foo
 	version, err := manager.Unmarshal(bytes, &mySliceUnmarshaled)
@@ -514,7 +514,7 @@ func TestArrayOfInterface(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myArray)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var myArrayUnmarshaled [2]Foo
 	version, err := manager.Unmarshal(bytes, &myArrayUnmarshaled)
@@ -540,7 +540,7 @@ func TestPointerToInterface(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, &myPtr)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var myPtrUnmarshaled *Foo
 	version, err := manager.Unmarshal(bytes, &myPtrUnmarshaled)
@@ -562,7 +562,7 @@ func TestString(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myString)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var stringUnmarshaled string
 	version, err := manager.Unmarshal(bytes, &stringUnmarshaled)
@@ -588,7 +588,7 @@ func TestNilSlice(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myStruct)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	var structUnmarshaled structWithSlice
 	version, err := manager.Unmarshal(bytes, &structUnmarshaled)
@@ -643,7 +643,7 @@ func TestSerializeOfNoSerializeField(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myS)
 	require.NoError(err)
-	require.Equal(len(marshalled), bytesLen)
+	require.Len(marshalled, bytesLen)
 
 	unmarshalled := s{}
 	version, err := manager.Unmarshal(marshalled, &unmarshalled)
@@ -673,7 +673,7 @@ func TestNilSliceSerialization(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, val)
 	require.NoError(err)
-	require.Equal(len(result), bytesLen)
+	require.Len(result, bytesLen)
 
 	valUnmarshaled := &simpleSliceStruct{}
 	version, err := manager.Unmarshal(result, &valUnmarshaled)
@@ -701,7 +701,7 @@ func TestEmptySliceSerialization(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, val)
 	require.NoError(err)
-	require.Equal(len(result), bytesLen)
+	require.Len(result, bytesLen)
 
 	valUnmarshaled := &simpleSliceStruct{}
 	version, err := manager.Unmarshal(result, &valUnmarshaled)
@@ -733,7 +733,7 @@ func TestSliceWithEmptySerialization(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, val)
 	require.NoError(err)
-	require.Equal(len(result), bytesLen)
+	require.Len(result, bytesLen)
 
 	unmarshaled := nestedSliceStruct{}
 	version, err := manager.Unmarshal(expected, &unmarshaled)
@@ -797,7 +797,7 @@ func TestNegativeNumbers(codec GeneralCodec, t testing.TB) {
 
 	bytesLen, err := manager.Size(0, myS)
 	require.NoError(err)
-	require.Equal(len(bytes), bytesLen)
+	require.Len(bytes, bytesLen)
 
 	mySUnmarshaled := s{}
 	version, err := manager.Unmarshal(bytes, &mySUnmarshaled)
@@ -965,17 +965,29 @@ func TestMultipleTags(codec GeneralCodec, t testing.TB) {
 func TestMap(codec GeneralCodec, t testing.TB) {
 	require := require.New(t)
 
-	data1 := make(map[string]MyInnerStruct2)
-	data1["test"] = MyInnerStruct2{true}
-	data1["bar"] = MyInnerStruct2{false}
+	data1 := map[string]MyInnerStruct2{
+		"test": {true},
+		"bar":  {false},
+	}
 
-	data2 := make(map[string]MyInnerStruct2)
-	data2["bar"] = MyInnerStruct2{false}
-	data2["test"] = MyInnerStruct2{true}
+	data2 := map[string]MyInnerStruct2{
+		"bar":  {false},
+		"test": {true},
+	}
+
+	data3 := map[string]MyInnerStruct2{
+		"bar": {false},
+	}
 
 	outerMap := make(map[int32]map[string]MyInnerStruct2)
 	outerMap[3] = data1
 	outerMap[19] = data2
+
+	outerArray := [3]map[string]MyInnerStruct2{
+		data1,
+		data2,
+		data3,
+	}
 
 	manager := NewDefaultManager()
 	require.NoError(manager.RegisterCodec(0, codec))
@@ -992,7 +1004,7 @@ func TestMap(codec GeneralCodec, t testing.TB) {
 	// Make sure Size returns the correct size for the marshalled data
 	data1Size, err := manager.Size(0, data1)
 	require.NoError(err)
-	require.Equal(len(data1Bytes), data1Size)
+	require.Len(data1Bytes, data1Size)
 
 	var unmarshalledData1 map[string]MyInnerStruct2
 	_, err = manager.Unmarshal(data1Bytes, &unmarshalledData1)
@@ -1004,10 +1016,17 @@ func TestMap(codec GeneralCodec, t testing.TB) {
 
 	outerMapSize, err := manager.Size(0, outerMap)
 	require.NoError(err)
-	require.Equal(len(outerMapBytes), outerMapSize)
+	require.Len(outerMapBytes, outerMapSize)
 
 	var unmarshalledOuterMap map[int32]map[string]MyInnerStruct2
 	_, err = manager.Unmarshal(outerMapBytes, &unmarshalledOuterMap)
 	require.NoError(err)
 	require.Equal(outerMap, unmarshalledOuterMap)
+
+	outerArrayBytes, err := manager.Marshal(0, outerArray)
+	require.NoError(err)
+
+	outerArraySize, err := manager.Size(0, outerArray)
+	require.NoError(err)
+	require.Len(outerArrayBytes, outerArraySize)
 }


### PR DESCRIPTION
## Why this should be merged

- Improves the performance of `Size` when provided maps.
- Fixes incorrect results returned from `Size` when maps are included inside another data structure.
- Also does some minor code quality improvements.

## How this works

- Previously we were not using the result of `constSize` to optimize `map` size calculations.
- Previously we were returning `constSize` from map calculations even though a `map` can never have constant size.

## How this was tested

CI