### PR TITLE
snowman/consensus: add PreferenceHeight to track preference by height

### DIFF
--- a/snow/consensus/snowman/consensus.go
+++ b/snow/consensus/snowman/consensus.go
@@ -51,6 +51,8 @@ type Consensus interface {
 	// Returns the ID of the tail of the strongly preferred sequence of
 	// decisions.
 	Preference() ids.ID
+	// Returns the preference height.
+	PreferenceHeight() uint64
 
 	// RecordPoll collects the results of a network poll. Assumes all decisions
 	// have been previously added. Returns if a critical error has occurred.

--- a/snow/engine/snowman/voter.go
+++ b/snow/engine/snowman/voter.go
@@ -74,6 +74,7 @@ func (v *voter) Update(ctx context.Context) {
 		return
 	}
 
+	// TODO: track preference by height
 	if err := v.t.VM.SetPreference(ctx, v.t.Consensus.Preference()); err != nil {
 		v.t.errs.Add(err)
 		return


### PR DESCRIPTION
## Why this should be merged

To track preference by height (later to be used for bubble votes)

## How this works

Add `PreferenceHeight` method for the current preference

## How this was tested

Consensus unit tests.
