### PR TITLE
E2E tests -- use appropriate timeouts

### DIFF
--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -89,7 +89,7 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 
 			var subnetAssetID ids.ID
 			ginkgo.By("create a custom asset for the permissionless subnet", func() {
-				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultWalletCreationTimeout)
+				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultConfirmTxTimeout)
 				subnetAssetTx, err := xWallet.IssueCreateAssetTx(
 					"RnM",
 					"RNM",
@@ -115,7 +115,7 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 			})
 
 			ginkgo.By(fmt.Sprintf("Send 100 MegaAvax of asset %s to the P-chain", subnetAssetID), func() {
-				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultWalletCreationTimeout)
+				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultConfirmTxTimeout)
 				_, err := xWallet.IssueExportTx(
 					constants.PlatformChainID,
 					[]*avax.TransferableOutput{
@@ -136,7 +136,7 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 			})
 
 			ginkgo.By(fmt.Sprintf("Import the 100 MegaAvax of asset %s from the X-chain into the P-chain", subnetAssetID), func() {
-				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultWalletCreationTimeout)
+				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultConfirmTxTimeout)
 				_, err := pWallet.IssueImportTx(
 					xChainID,
 					owner,


### PR DESCRIPTION
## Why this should be merged

Saw a [flake](https://github.com/ava-labs/avalanchego/actions/runs/5856712074/job/15877035450?pr=1816#step:5:1724) in an E2E test. It seems like we're using the wallet creation timeout in some places we should be using the tx acceptance timeout.

## How this works

Use tx acceptance timeout instead of wallet creation timeout as needed

## How this was tested

N/A