### PR TITLE
`merkledb` -- remove needs recalculation

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -691,11 +691,7 @@ func (db *merkleDB) newUntrackedView(batchOps []database.BatchOp) (*trieView, er
 		return nil, database.ErrClosed
 	}
 
-	newView, err := newTrieView(db, db, db.root.clone(), batchOps)
-	if err != nil {
-		return nil, err
-	}
-	return newView, nil
+	return newTrieView(db, db, db.root.clone(), batchOps)
 }
 
 func (db *merkleDB) Has(k []byte) (bool, error) {

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -180,12 +180,14 @@ func newTrieViewWithChanges(
 		return nil, ErrNoValidRoot
 	}
 
-	return &trieView{
+	view := &trieView{
 		root:       passedRootChange.after,
 		db:         db,
 		parentTrie: parentTrie,
 		changes:    changes,
-	}, nil
+	}
+
+	return view, view.calculateNodeIDs(context.TODO())
 }
 
 // Recalculates the node IDs for all changed nodes in the trie.
@@ -657,9 +659,6 @@ func (t *trieView) GetMerkleRoot(ctx context.Context) (ids.ID, error) {
 // Returns the ID of the root node of this trie.
 // Assumes [t.lock] is held.
 func (t *trieView) getMerkleRoot(ctx context.Context) (ids.ID, error) {
-	if err := t.calculateNodeIDs(ctx); err != nil {
-		return ids.Empty, err
-	}
 	return t.root.id, nil
 }
 


### PR DESCRIPTION
WIP not r4r.

## Why this should be merged

Now that views are not editable after creation, we can calculate node IDs when its created and then never again.

## How this works

Remove logic that was in place to check whether we need to update node IDs.

## How this was tested

TODO