### PR TITLE
Removing errors from `p2p.Handler`

### DIFF
--- a/network/p2p/handler.go
+++ b/network/p2p/handler.go
@@ -53,7 +53,7 @@ type responder struct {
 func (r *responder) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID uint32, deadline time.Time, request []byte) error {
 	appResponse := r.handler.AppRequest(ctx, nodeID, deadline, request)
 	if len(appResponse) == 0 {
-		r.log.Debug("failed to handle message",
+		r.log.Debug("dropping empty response",
 			zap.Stringer("messageOp", message.AppRequestOp),
 			zap.Stringer("nodeID", nodeID),
 			zap.Uint32("requestID", requestID),
@@ -74,7 +74,7 @@ func (r *responder) AppGossip(ctx context.Context, nodeID ids.NodeID, msg []byte
 func (r *responder) CrossChainAppRequest(ctx context.Context, chainID ids.ID, requestID uint32, deadline time.Time, request []byte) error {
 	appResponse := r.handler.CrossChainAppRequest(ctx, chainID, deadline, request)
 	if len(appResponse) == 0 {
-		r.log.Debug("failed to handle message",
+		r.log.Debug("dropping empty response",
 			zap.Stringer("messageOp", message.CrossChainAppRequestOp),
 			zap.Stringer("chainID", chainID),
 			zap.Uint32("requestID", requestID),

--- a/network/p2p/mocks/mock_handler.go
+++ b/network/p2p/mocks/mock_handler.go
@@ -40,11 +40,9 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 }
 
 // AppGossip mocks base method.
-func (m *MockHandler) AppGossip(arg0 context.Context, arg1 ids.NodeID, arg2 []byte) error {
+func (m *MockHandler) AppGossip(arg0 context.Context, arg1 ids.NodeID, arg2 []byte) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppGossip", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "AppGossip", arg0, arg1, arg2)
 }
 
 // AppGossip indicates an expected call of AppGossip.
@@ -54,12 +52,11 @@ func (mr *MockHandlerMockRecorder) AppGossip(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // AppRequest mocks base method.
-func (m *MockHandler) AppRequest(arg0 context.Context, arg1 ids.NodeID, arg2 time.Time, arg3 []byte) ([]byte, error) {
+func (m *MockHandler) AppRequest(arg0 context.Context, arg1 ids.NodeID, arg2 time.Time, arg3 []byte) []byte {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppRequest", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // AppRequest indicates an expected call of AppRequest.
@@ -69,12 +66,11 @@ func (mr *MockHandlerMockRecorder) AppRequest(arg0, arg1, arg2, arg3 interface{}
 }
 
 // CrossChainAppRequest mocks base method.
-func (m *MockHandler) CrossChainAppRequest(arg0 context.Context, arg1 ids.ID, arg2 time.Time, arg3 []byte) ([]byte, error) {
+func (m *MockHandler) CrossChainAppRequest(arg0 context.Context, arg1 ids.ID, arg2 time.Time, arg3 []byte) []byte {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CrossChainAppRequest", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // CrossChainAppRequest indicates an expected call of CrossChainAppRequest.

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -144,7 +144,8 @@ func (r *Router) AppGossip(ctx context.Context, nodeID ids.NodeID, gossip []byte
 		return nil
 	}
 
-	return handler.AppGossip(ctx, nodeID, parsedMsg)
+	handler.AppGossip(ctx, nodeID, parsedMsg)
+	return nil
 }
 
 func (r *Router) CrossChainAppRequest(


### PR DESCRIPTION
## Why this should be merged

Currently, the `AppHandler` interface allows you to return an error to fatal a node during the handling of a request/response/gossip message. It might seem strange, why would you ever want to kill your node when handling a peer's message?

Currently, there is a valid use-case in the `rpcchainvm`. If avalanchego's rpcchainvm isn't able to communicate with the underlying vm process, this is a valid reason to kill your node. For most VMs however (pretty much anything that isn't the rpcchainvm), this will never occur and vms just log errors.

For anyone building a vm with the sdk, they're likely building application logic and therefore don't want to accidentally shoot themselves in the foot by fatal-ing their node on an error condition.

## How this works

This PR removes the error from the function signature and instead relies on a zero-length response to determine if a response should be sent or not.

## How this was tested

CI passes.
