### PR TITLE
CODEOWNERS: add marun to tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,5 +20,5 @@
 /vms/proposervm/ @abi87 @StephenButtolph
 /vms/rpcchainvm/ @hexfusion @StephenButtolph
 /vms/registry/ @joshua-kim
-/tests/ @abi87 @gyuho
+/tests/ @abi87 @gyuho @marun
 /x/ @danlaine @darioush @dboehm-avalabs


### PR DESCRIPTION
## Why this should be merged

@marun is our testing guru

## How this works

do stuff own stuff

## How this was tested