### PR TITLE
e2e: Refactor keychain and wallet creation to test helpers

### DIFF
--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -5,8 +5,6 @@
 package banff
 
 import (
-	"context"
-
 	ginkgo "github.com/onsi/ginkgo/v2"
 
 	"github.com/onsi/gomega"
@@ -19,7 +17,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
-	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
 )
 
 var _ = ginkgo.Describe("[Banff]", func() {
@@ -31,25 +28,8 @@ var _ = ginkgo.Describe("[Banff]", func() {
 			"banff",
 		),
 		func() {
-			key := e2e.Env.AllocateFundedKey()
-			kc := secp256k1fx.NewKeychain(key)
-			var wallet primary.Wallet
-			ginkgo.By("initialize wallet", func() {
-				walletURI := e2e.Env.GetRandomNodeURI()
-
-				// 5-second is enough to fetch initial UTXOs for test cluster in "primary.NewWallet"
-				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultWalletCreationTimeout)
-				var err error
-				wallet, err = primary.MakeWallet(ctx, &primary.WalletConfig{
-					URI:          walletURI,
-					AVAXKeychain: kc,
-					EthKeychain:  kc,
-				})
-				cancel()
-				gomega.Expect(err).Should(gomega.BeNil())
-
-				tests.Outf("{{green}}created wallet{{/}}\n")
-			})
+			keychain := e2e.Env.NewKeychain(1)
+			wallet := e2e.Env.NewWallet(keychain)
 
 			// Get the P-chain and the X-chain wallets
 			pWallet := wallet.P()
@@ -60,7 +40,7 @@ var _ = ginkgo.Describe("[Banff]", func() {
 			owner := &secp256k1fx.OutputOwners{
 				Threshold: 1,
 				Addrs: []ids.ShortID{
-					key.Address(),
+					keychain.Keys[0].Address(),
 				},
 			}
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -128,6 +128,5 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// Run in every ginkgo process
 
 	// Initialize the local test environment from the global state
-	e2e.Env = e2e.TestEnvironment{}
-	require.NoError(ginkgo.GinkgoT(), json.Unmarshal(envBytes, &e2e.Env))
+	e2e.InitTestEnvironment(envBytes)
 })

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -82,23 +82,9 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 						testKeys[i], testKeys[j] = testKeys[j], testKeys[i]
 					})
 				}
-				keyChain := secp256k1fx.NewKeychain(testKeys...)
 
-				var baseWallet primary.Wallet
-				var err error
-				ginkgo.By("setting up a base wallet", func() {
-					walletURI := e2e.Env.GetRandomNodeURI()
-
-					// 5-second is enough to fetch initial UTXOs for test cluster in "primary.MakeWallet"
-					ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultWalletCreationTimeout)
-					baseWallet, err = primary.MakeWallet(ctx, &primary.WalletConfig{
-						URI:          walletURI,
-						AVAXKeychain: keyChain,
-						EthKeychain:  keyChain,
-					})
-					cancel()
-					gomega.Expect(err).Should(gomega.BeNil())
-				})
+				keychain := secp256k1fx.NewKeychain(testKeys...)
+				baseWallet := e2e.Env.NewWallet(keychain)
 				avaxAssetID := baseWallet.X().AVAXAssetID()
 
 				wallets := make([]primary.Wallet, len(testKeys))
@@ -168,7 +154,7 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 
 				ginkgo.By("X-Chain transfer with wrong amount must fail", func() {
 					ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultConfirmTxTimeout)
-					_, err = wallets[fromIdx].X().IssueBaseTx(
+					_, err := wallets[fromIdx].X().IssueBaseTx(
 						[]*avax.TransferableOutput{{
 							Asset: avax.Asset{
 								ID: avaxAssetID,


### PR DESCRIPTION
## Why this should be merged

Simplifies e2e tests that use keychains and wallets.

## How this works

Refactors keychain and wallet creation to test helpers to simplify the e2e tests that use them.

## How this was tested

CI

## TODO

- [x] Merge the parent PR (#1850)