### PR TITLE
e2e: Ensure interchain workflow coverage for X-Chain and C-Chain

### DIFF
--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package c
+
+import (
+	"math/big"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/plugin/evm"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests/e2e"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+)
+
+var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
+	require := require.New(ginkgo.GinkgoT())
+
+	const (
+		txAmount = 10 * units.Avax // Arbitrary amount to send and transfer
+		gasLimit = uint64(21000)   // Standard gas limit
+	)
+
+	ginkgo.It("should ensure that funds can be transferred from the C-Chain to the X-Chain and the P-Chain", func() {
+		ginkgo.By("allocating a pre-funded key to send from and a recipient key to deliver to")
+		senderKey := e2e.Env.AllocateFundedKey()
+		senderEthAddress := evm.GetEthAddress(senderKey)
+		factory := secp256k1.Factory{}
+		recipientKey, err := factory.NewPrivateKey()
+		require.NoError(err)
+		recipientEthAddress := evm.GetEthAddress(recipientKey)
+
+		ethClient := e2e.Env.NewEthClient()
+
+		ginkgo.By("sending funds from one address to another on the C-Chain", func() {
+			// Create transaction
+			acceptedNonce, err := ethClient.AcceptedNonceAt(e2e.DefaultContext(), senderEthAddress)
+			require.NoError(err)
+			gasPrice, err := ethClient.SuggestGasPrice(e2e.DefaultContext())
+			require.NoError(err)
+			tx := types.NewTransaction(
+				acceptedNonce,
+				recipientEthAddress,
+				big.NewInt(int64(txAmount)),
+				gasLimit,
+				gasPrice,
+				nil,
+			)
+
+			// Sign transaction
+			cChainID, err := ethClient.ChainID(e2e.DefaultContext())
+			require.NoError(err)
+			signer := types.NewEIP155Signer(cChainID)
+			signedTx, err := types.SignTx(tx, signer, senderKey.ToECDSA())
+			require.NoError(err)
+
+			require.NoError(ethClient.SendTransaction(e2e.DefaultContext(), signedTx))
+
+			ginkgo.By("waiting for the C-Chain recipient address to have received the sent funds")
+			e2e.Eventually(func() bool {
+				balance, err := ethClient.BalanceAt(e2e.DefaultContext(), recipientEthAddress, nil)
+				require.NoError(err)
+				return balance.Cmp(big.NewInt(0)) > 0
+			}, e2e.DefaultTimeout, e2e.DefaultPollingInterval, "failed to see funds delivered before timeout")
+		})
+
+		// Wallet must be initialized after sending funds on the
+		// C-Chain to ensure wallet state matches on-chain state
+		ginkgo.By("initializing a keychain and associated wallet")
+		keychain := secp256k1fx.NewKeychain(senderKey, recipientKey)
+		baseWallet := e2e.Env.NewWallet(keychain)
+		xWallet := baseWallet.X()
+		cWallet := baseWallet.C()
+		pWallet := baseWallet.P()
+
+		ginkgo.By("defining common configuration")
+		avaxAssetID := xWallet.AVAXAssetID()
+		// Use the same owner for import funds to X-Chain and P-Chain
+		recipientOwner := secp256k1fx.OutputOwners{
+			Threshold: 1,
+			Addrs: []ids.ShortID{
+				recipientKey.Address(),
+			},
+		}
+		// Use the same outputs for both X-Chain and P-Chain exports
+		exportOutputs := []*secp256k1fx.TransferOutput{
+			{
+				Amt: txAmount,
+				OutputOwners: secp256k1fx.OutputOwners{
+					Threshold: 1,
+					Addrs: []ids.ShortID{
+						keychain.Keys[0].Address(),
+					},
+				},
+			},
+		}
+
+		ginkgo.By("exporting AVAX from the C-Chain to the X-Chain")
+		_, err = cWallet.IssueExportTx(xWallet.BlockchainID(), exportOutputs, e2e.WithDefaultContext())
+		require.NoError(err)
+
+		ginkgo.By("importing AVAX from the C-Chain to the X-Chain")
+		_, err = xWallet.IssueImportTx(cWallet.BlockchainID(), &recipientOwner, e2e.WithDefaultContext())
+		require.NoError(err)
+
+		ginkgo.By("checking that the recipient address has received imported funds on the X-Chain", func() {
+			balances, err := xWallet.Builder().GetFTBalance(common.WithCustomAddresses(set.Of(
+				recipientKey.Address(),
+			)))
+			require.NoError(err)
+			require.Greater(balances[avaxAssetID], uint64(0))
+		})
+
+		ginkgo.By("exporting AVAX from the C-Chain to the P-Chain")
+		_, err = cWallet.IssueExportTx(constants.PlatformChainID, exportOutputs, e2e.WithDefaultContext())
+		require.NoError(err)
+
+		ginkgo.By("importing AVAX from the C-Chain to the P-Chain")
+		_, err = pWallet.IssueImportTx(cWallet.BlockchainID(), &recipientOwner, e2e.WithDefaultContext())
+		require.NoError(err)
+
+		ginkgo.By("checking that the recipient address has received imported funds on the P-Chain", func() {
+			balances, err := pWallet.Builder().GetBalance(common.WithCustomAddresses(set.Of(
+				recipientKey.Address(),
+			)))
+			require.NoError(err)
+			require.Greater(balances[avaxAssetID], uint64(0))
+		})
+	})
+})

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -133,7 +133,7 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 				recipientKey.Address(),
 			)))
 			require.NoError(err)
-			require.Greater(balances[avaxAssetID], uint64(0))
+			require.Positive(balances[avaxAssetID])
 		})
 
 		ginkgo.By("exporting AVAX from the C-Chain to the P-Chain", func() {

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -40,7 +40,11 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 		require.NoError(err)
 		recipientEthAddress := evm.GetEthAddress(recipientKey)
 
-		ethClient := e2e.Env.NewEthClient()
+		// Select a random node URI to use for both the eth client and
+		// the wallet to avoid having to verify that all nodes are at
+		// the same height before initializing the wallet.
+		nodeURI := e2e.Env.GetRandomNodeURI()
+		ethClient := e2e.Env.NewEthClientForURI(nodeURI)
 
 		ginkgo.By("sending funds from one address to another on the C-Chain", func() {
 			// Create transaction
@@ -75,10 +79,11 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 		})
 
 		// Wallet must be initialized after sending funds on the
-		// C-Chain to ensure wallet state matches on-chain state
+		// C-Chain with the same node URI to ensure wallet state
+		// matches on-chain state.
 		ginkgo.By("initializing a keychain and associated wallet")
 		keychain := secp256k1fx.NewKeychain(senderKey, recipientKey)
-		baseWallet := e2e.Env.NewWallet(keychain)
+		baseWallet := e2e.Env.NewWalletForURI(keychain, nodeURI)
 		xWallet := baseWallet.X()
 		cWallet := baseWallet.C()
 		pWallet := baseWallet.P()

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -105,13 +105,23 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 			},
 		}
 
-		ginkgo.By("exporting AVAX from the C-Chain to the X-Chain")
-		_, err = cWallet.IssueExportTx(xWallet.BlockchainID(), exportOutputs, e2e.WithDefaultContext())
-		require.NoError(err)
+		ginkgo.By("exporting AVAX from the C-Chain to the X-Chain", func() {
+			_, err := cWallet.IssueExportTx(
+				xWallet.BlockchainID(),
+				exportOutputs,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
 
-		ginkgo.By("importing AVAX from the C-Chain to the X-Chain")
-		_, err = xWallet.IssueImportTx(cWallet.BlockchainID(), &recipientOwner, e2e.WithDefaultContext())
-		require.NoError(err)
+		ginkgo.By("importing AVAX from the C-Chain to the X-Chain", func() {
+			_, err := xWallet.IssueImportTx(
+				cWallet.BlockchainID(),
+				&recipientOwner,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
 
 		ginkgo.By("checking that the recipient address has received imported funds on the X-Chain", func() {
 			balances, err := xWallet.Builder().GetFTBalance(common.WithCustomAddresses(set.Of(
@@ -121,13 +131,23 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 			require.Greater(balances[avaxAssetID], uint64(0))
 		})
 
-		ginkgo.By("exporting AVAX from the C-Chain to the P-Chain")
-		_, err = cWallet.IssueExportTx(constants.PlatformChainID, exportOutputs, e2e.WithDefaultContext())
-		require.NoError(err)
+		ginkgo.By("exporting AVAX from the C-Chain to the P-Chain", func() {
+			_, err := cWallet.IssueExportTx(
+				constants.PlatformChainID,
+				exportOutputs,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
 
-		ginkgo.By("importing AVAX from the C-Chain to the P-Chain")
-		_, err = pWallet.IssueImportTx(cWallet.BlockchainID(), &recipientOwner, e2e.WithDefaultContext())
-		require.NoError(err)
+		ginkgo.By("importing AVAX from the C-Chain to the P-Chain", func() {
+			_, err = pWallet.IssueImportTx(
+				cWallet.BlockchainID(),
+				&recipientOwner,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
 
 		ginkgo.By("checking that the recipient address has received imported funds on the P-Chain", func() {
 			balances, err := pWallet.Builder().GetBalance(common.WithCustomAddresses(set.Of(

--- a/tests/e2e/describe.go
+++ b/tests/e2e/describe.go
@@ -24,3 +24,9 @@ func DescribeXChainSerial(text string, body func()) bool {
 func DescribePChain(text string, body func()) bool {
 	return ginkgo.Describe("[P-Chain] "+text, body)
 }
+
+// DescribeCChain annotates the tests for C-Chain.
+// Can run with any type of cluster (e.g., local, fuji, mainnet).
+func DescribeCChain(text string, body func()) bool {
+	return ginkgo.Describe("[C-Chain] "+text, body)
+}

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -7,12 +7,16 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/coreth/ethclient"
 
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture"
@@ -21,6 +25,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
 
 const (
@@ -101,13 +106,56 @@ func (te *TestEnvironment) NewKeychain(count int) *secp256k1fx.Keychain {
 // Create a new wallet for the provided keychain.
 func (te *TestEnvironment) NewWallet(keychain *secp256k1fx.Keychain) primary.Wallet {
 	tests.Outf("{{blue}} initializing a new wallet {{/}}\n")
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
-	defer cancel()
-	wallet, err := primary.MakeWallet(ctx, &primary.WalletConfig{
+	wallet, err := primary.MakeWallet(DefaultContext(), &primary.WalletConfig{
 		URI:          te.GetRandomNodeURI(),
 		AVAXKeychain: keychain,
 		EthKeychain:  keychain,
 	})
 	te.require.NoError(err)
 	return wallet
+}
+
+// Create a new eth client targeting a random node.
+func (te *TestEnvironment) NewEthClient() ethclient.Client {
+	nodeURI := te.GetRandomNodeURI()
+	nodeAddress := strings.Split(nodeURI, "//")[1]
+	uri := fmt.Sprintf("ws://%s/ext/bc/C/ws", nodeAddress)
+	client, err := ethclient.Dial(uri)
+	te.require.NoError(err)
+	return client
+}
+
+// Helper simplifying use of a timed context by canceling the context on ginkgo teardown.
+func ContextWithTimeout(duration time.Duration) context.Context {
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	ginkgo.DeferCleanup(cancel)
+	return ctx
+}
+
+// Helper simplifying use of a timed context configured with the default timeout.
+func DefaultContext() context.Context {
+	return ContextWithTimeout(DefaultTimeout)
+}
+
+// Helper simplifying use via an option of a timed context configured with the default timeout.
+func WithDefaultContext() common.Option {
+	return common.WithContext(DefaultContext())
+}
+
+// Re-implementation of testify/require.Eventually that is compatible with ginkgo. testify's
+// version calls the condition function with a goroutine and ginkgo assertions don't work
+// properly in goroutines.
+func Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msg string) {
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), waitFor)
+	defer cancel()
+	for !condition() {
+		select {
+		case <-ctx.Done():
+			require.Fail(ginkgo.GinkgoT(), msg)
+		case <-ticker.C:
+		}
+	}
 }

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -103,11 +103,16 @@ func (te *TestEnvironment) NewKeychain(count int) *secp256k1fx.Keychain {
 	return secp256k1fx.NewKeychain(keys...)
 }
 
-// Create a new wallet for the provided keychain.
+// Create a new wallet for the provided keychain against a random node URI.
 func (te *TestEnvironment) NewWallet(keychain *secp256k1fx.Keychain) primary.Wallet {
+	return te.NewWalletForURI(keychain, te.GetRandomNodeURI())
+}
+
+// Create a new wallet for the provided keychain against the specified node URI.
+func (te *TestEnvironment) NewWalletForURI(keychain *secp256k1fx.Keychain, uri string) primary.Wallet {
 	tests.Outf("{{blue}} initializing a new wallet {{/}}\n")
 	wallet, err := primary.MakeWallet(DefaultContext(), &primary.WalletConfig{
-		URI:          te.GetRandomNodeURI(),
+		URI:          uri,
 		AVAXKeychain: keychain,
 		EthKeychain:  keychain,
 	})
@@ -117,7 +122,11 @@ func (te *TestEnvironment) NewWallet(keychain *secp256k1fx.Keychain) primary.Wal
 
 // Create a new eth client targeting a random node.
 func (te *TestEnvironment) NewEthClient() ethclient.Client {
-	nodeURI := te.GetRandomNodeURI()
+	return te.NewEthClientForURI(te.GetRandomNodeURI())
+}
+
+// Create a new eth client targeting the specified node URI.
+func (te *TestEnvironment) NewEthClientForURI(nodeURI string) ethclient.Client {
 	nodeAddress := strings.Split(nodeURI, "//")[1]
 	uri := fmt.Sprintf("ws://%s/ext/bc/C/ws", nodeAddress)
 	client, err := ethclient.Dial(uri)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -25,8 +25,10 @@ import (
 
 	// ensure test packages are scanned by ginkgo
 	_ "github.com/ava-labs/avalanchego/tests/e2e/banff"
+	_ "github.com/ava-labs/avalanchego/tests/e2e/c"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/p"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/static-handlers"
+	_ "github.com/ava-labs/avalanchego/tests/e2e/x"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/x/transfer"
 )
 

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -110,12 +110,13 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			require.NoError(err)
 		})
 
-		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain", func() {
-			ethClient := e2e.Env.NewEthClient()
+		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain")
+		ethClient := e2e.Env.NewEthClient()
+		e2e.Eventually(func() bool {
 			balance, err := ethClient.BalanceAt(e2e.DefaultContext(), recipientEthAddress, nil)
 			require.NoError(err)
-			require.Greater(balance.Cmp(big.NewInt(0)), 0)
-		})
+			return balance.Cmp(big.NewInt(0)) > 0
+		}, e2e.DefaultTimeout, e2e.DefaultPollingInterval, "failed to see recipient address funded before timeout")
 
 		ginkgo.By("exporting AVAX from the X-Chain to the P-Chain", func() {
 			_, err := xWallet.IssueExportTx(

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package x
+
+import (
+	"math/big"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/coreth/plugin/evm"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests/e2e"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+)
+
+var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
+	require := require.New(ginkgo.GinkgoT())
+
+	const transferAmount = 10 * units.Avax
+
+	ginkgo.It("should ensure that funds can be transferred from the X-Chain to the C-Chain and the P-Chain", func() {
+		ginkgo.By("creating wallet with a funded key to send from and recipient key to deliver to")
+		factory := secp256k1.Factory{}
+		recipientKey, err := factory.NewPrivateKey()
+		require.NoError(err)
+		keychain := e2e.Env.NewKeychain(1)
+		keychain.Add(recipientKey)
+		baseWallet := e2e.Env.NewWallet(keychain)
+		xWallet := baseWallet.X()
+		cWallet := baseWallet.C()
+		pWallet := baseWallet.P()
+
+		ginkgo.By("defining common configuration")
+		recipientEthAddress := evm.GetEthAddress(recipientKey)
+		avaxAssetID := xWallet.AVAXAssetID()
+		// Use the same owner for sending to X-Chain and importing funds to P-Chain
+		recipientOwner := secp256k1fx.OutputOwners{
+			Threshold: 1,
+			Addrs: []ids.ShortID{
+				recipientKey.Address(),
+			},
+		}
+		// Use the same outputs for both C-Chain and P-Chain exports
+		exportOutputs := []*avax.TransferableOutput{
+			{
+				Asset: avax.Asset{
+					ID: avaxAssetID,
+				},
+				Out: &secp256k1fx.TransferOutput{
+					Amt: transferAmount,
+					OutputOwners: secp256k1fx.OutputOwners{
+						Threshold: 1,
+						Addrs: []ids.ShortID{
+							keychain.Keys[0].Address(),
+						},
+					},
+				},
+			},
+		}
+
+		ginkgo.By("sending funds from one address to another on the X-Chain", func() {
+			_, err = xWallet.IssueBaseTx(
+				[]*avax.TransferableOutput{{
+					Asset: avax.Asset{
+						ID: avaxAssetID,
+					},
+					Out: &secp256k1fx.TransferOutput{
+						Amt:          transferAmount,
+						OutputOwners: recipientOwner,
+					},
+				}},
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("checking that the X-Chain recipient address has received the sent funds", func() {
+			balances, err := xWallet.Builder().GetFTBalance(common.WithCustomAddresses(set.Of(
+				recipientKey.Address(),
+			)))
+			require.NoError(err)
+			require.Greater(balances[avaxAssetID], uint64(0))
+		})
+
+		ginkgo.By("exporting AVAX from the X-Chain to the C-Chain", func() {
+			_, err := xWallet.IssueExportTx(
+				cWallet.BlockchainID(),
+				exportOutputs,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("importing AVAX from the X-Chain to the C-Chain", func() {
+			_, err := cWallet.IssueImportTx(
+				xWallet.BlockchainID(),
+				recipientEthAddress,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain", func() {
+			ethClient := e2e.Env.NewEthClient()
+			balance, err := ethClient.BalanceAt(e2e.DefaultContext(), recipientEthAddress, nil)
+			require.NoError(err)
+			require.Greater(balance.Cmp(big.NewInt(0)), 0)
+		})
+
+		ginkgo.By("exporting AVAX from the X-Chain to the P-Chain", func() {
+			_, err := xWallet.IssueExportTx(
+				constants.PlatformChainID,
+				exportOutputs,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("importing AVAX from the X-Chain to the P-Chain", func() {
+			_, err := pWallet.IssueImportTx(
+				xWallet.BlockchainID(),
+				&recipientOwner,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("checking that the recipient address has received imported funds on the P-Chain", func() {
+			balances, err := pWallet.Builder().GetBalance(common.WithCustomAddresses(set.Of(
+				recipientKey.Address(),
+			)))
+			require.NoError(err)
+			require.Greater(balances[avaxAssetID], uint64(0))
+		})
+	})
+})

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -68,7 +68,7 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 				metricBlksAccepted,
 			}
 
-			// Ensure the same set of 10 keys are used for all tests
+			// Ensure the same set of 10 keys is used for all tests
 			// by retrieving them outside of runFunc.
 			testKeys := e2e.Env.AllocateFundedKeys(10)
 

--- a/tests/fixture/testnet/config.go
+++ b/tests/fixture/testnet/config.go
@@ -36,7 +36,7 @@ const (
 	DefaultNodeCount      = 5
 	DefaultFundedKeyCount = 50
 
-	DefaultGasLimit = uint64(10_0000_000) // Arbitrary gas limit is arbitrary
+	DefaultGasLimit = uint64(100_000_000) // Gas limit is arbitrary
 
 	// Arbitrarily large amount of AVAX to fund keys on the X-Chain for testing
 	DefaultFundedKeyXChainAmount = 30 * units.MegaAvax

--- a/tests/fixture/testnet/config.go
+++ b/tests/fixture/testnet/config.go
@@ -56,11 +56,6 @@ var (
 	errInvalidKeypair              = fmt.Errorf("%q and %q must be provided together or not at all", config.StakingTLSKeyContentKey, config.StakingCertContentKey)
 )
 
-func init() {
-	// Arbitrarily large amount of AVAX (10^30) to fund keys on the C-Chain for testing
-	DefaultFundedKeyCChainAmount.Exp(big.NewInt(10), big.NewInt(30), nil)
-}
-
 // Defines a mapping of flag keys to values intended to be supplied to
 // an invocation of an AvalancheGo node.
 type FlagsMap map[string]interface{}
@@ -149,7 +144,7 @@ func (c *NetworkConfig) EnsureGenesis(networkID uint32, validatorIDs []ids.NodeI
 	for _, key := range c.FundedKeys {
 		xChainBalances[key.Address()] = DefaultFundedKeyXChainAmount
 		cChainBalances[evm.GetEthAddress(key)] = core.GenesisAccount{
-			Balance: &DefaultFundedKeyCChainAmount,
+			Balance: DefaultFundedKeyCChainAmount,
 		}
 	}
 

--- a/tests/fixture/testnet/config.go
+++ b/tests/fixture/testnet/config.go
@@ -43,9 +43,8 @@ const (
 )
 
 var (
-	// The actual value needs to be set in init() because it's not
-	// possible to statically define a value large enough for C-Chain.
-	DefaultFundedKeyCChainAmount big.Int
+	// Arbitrarily large amount of AVAX (10^12) to fund keys on the C-Chain for testing
+	DefaultFundedKeyCChainAmount = new(big.Int).Exp(big.NewInt(10), big.NewInt(30), nil)
 
 	errEmptyValidatorsForGenesis   = errors.New("failed to generate genesis: empty validator IDs")
 	errNoKeysForGenesis            = errors.New("failed to generate genesis: no keys to fund")

--- a/tests/fixture/testnet/config.go
+++ b/tests/fixture/testnet/config.go
@@ -8,11 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/cast"
+
+	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm"
 
 	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/genesis"
@@ -125,16 +130,17 @@ func (c *NetworkConfig) EnsureGenesis(networkID uint32, validatorIDs []ids.NodeI
 		return errNoKeysForGenesis
 	}
 
-	// Fund the provided keys
-	xChainBalances := []AddrAndBalance{}
+	// Ensure pre-funded keys have arbitrary large balances on both chains to support testing
+	xChainBalances := make(XChainBalanceMap, len(c.FundedKeys))
+	cChainBalances := make(core.GenesisAlloc, len(c.FundedKeys))
+	var cchainBalance big.Int
+	cchainBalance.Exp(big.NewInt(10), big.NewInt(30), nil)
 	for _, key := range c.FundedKeys {
-		xChainBalances = append(xChainBalances, AddrAndBalance{
-			key.Address(),
-			30 * units.MegaAvax, // Arbitrary large amount to support testing
-		})
+		xChainBalances[key.Address()] = 30 * units.MegaAvax
+		cChainBalances[evm.GetEthAddress(key)] = core.GenesisAccount{Balance: &cchainBalance}
 	}
 
-	genesis, err := NewTestGenesis(networkID, xChainBalances, validatorIDs)
+	genesis, err := NewTestGenesis(networkID, xChainBalances, cChainBalances, validatorIDs)
 	if err != nil {
 		return err
 	}
@@ -279,17 +285,16 @@ func (nc *NodeConfig) EnsureNodeID() error {
 	return nil
 }
 
-type AddrAndBalance struct {
-	Addr    ids.ShortID
-	Balance uint64
-}
+// Helper type to simplify configuring X-Chain genesis balances
+type XChainBalanceMap map[ids.ShortID]uint64
 
 // Create a genesis struct valid for bootstrapping a test
 // network. Note that many of the genesis fields (e.g. reward
 // addresses) are randomly generated or hard-coded.
 func NewTestGenesis(
 	networkID uint32,
-	xChainBalances []AddrAndBalance,
+	xChainBalances XChainBalanceMap,
+	cChainBalances core.GenesisAlloc,
 	validatorIDs []ids.NodeID,
 ) (*genesis.UnparsedConfig, error) {
 	// Validate inputs
@@ -300,7 +305,7 @@ func NewTestGenesis(
 	if len(validatorIDs) == 0 {
 		return nil, errMissingValidatorsForGenesis
 	}
-	if len(xChainBalances) == 0 {
+	if len(xChainBalances) == 0 || len(cChainBalances) == 0 {
 		return nil, errMissingBalancesForGenesis
 	}
 
@@ -344,22 +349,21 @@ func NewTestGenesis(
 		InitialStakedFunds:         []string{stakeAddress},
 		InitialStakeDuration:       365 * 24 * 60 * 60, // 1 year
 		InitialStakeDurationOffset: 90 * 60,            // 90 minutes
-		CChainGenesis:              genesis.LocalConfig.CChainGenesis,
 		Message:                    "hello avalanche!",
 	}
 
-	// Set xchain balances
-	for _, addressBalance := range xChainBalances {
-		address, err := address.Format("X", constants.GetHRP(networkID), addressBalance.Addr[:])
+	// Set X-Chain balances
+	for xChainAddress, balance := range xChainBalances {
+		avaxAddr, err := address.Format("X", constants.GetHRP(networkID), xChainAddress[:])
 		if err != nil {
-			return nil, fmt.Errorf("failed to format balance address: %w", err)
+			return nil, fmt.Errorf("failed to format X-Chain address: %w", err)
 		}
 		config.Allocations = append(
 			config.Allocations,
 			genesis.UnparsedAllocation{
 				ETHAddr:       ethAddress,
-				AVAXAddr:      address,
-				InitialAmount: addressBalance.Balance,
+				AVAXAddr:      avaxAddr,
+				InitialAmount: balance,
 				UnlockSchedule: []genesis.LockedAmount{
 					{
 						Amount: 20 * units.MegaAvax,
@@ -372,6 +376,21 @@ func NewTestGenesis(
 			},
 		)
 	}
+
+	// Define C-Chain genesis
+	cChainGenesis := &core.Genesis{
+		Config: &params.ChainConfig{
+			ChainID: big.NewInt(43112), // Arbitrary chain ID is arbitrary
+		},
+		Difficulty: big.NewInt(0),     // Difficulty is a mandatory field
+		GasLimit:   uint64(0x5f5e100), // Arbitrary gas limit is arbitrary
+		Alloc:      cChainBalances,
+	}
+	cChainGenesisBytes, err := json.Marshal(cChainGenesis)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal C-Chain genesis: %w", err)
+	}
+	config.CChainGenesis = string(cChainGenesisBytes)
 
 	// Give staking rewards for initial validators to a random address. Any testing of staking rewards
 	// will be easier to perform with nodes other than the initial validators since the timing of


### PR DESCRIPTION
## Why this should be merged

Fulfills one of the requirements for #1547 (migration of Kurtosis tests)

## How this works

- ensures coverage of interchain transfer equivalent to and extending from avalanche-testing's [C-Chain Atomic Workflow test](https://github.com/ava-labs/avalanche-testing/blob/master/tests/virtuouscchain/cchain_atomic_workflow.go)
- Previously pre-funded keys were only funded on the X-Chain, but now they are funded on the C-Chain too to support the new testing of the C-Chain workflow.

## How this was tested

CI

## TODO

- [x] Merge the parent PR (#1881)
- [x] Implement X-Chain workflow
- [x] Implement C-Chain workflow

Implementation of the P-Chain workflow will be tackled in a different PR due to the dependency on node addition added by #1573.