### PR TITLE
Add a parameter to specify the max amount of AppRequests for AppRequestAny

### DIFF
--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -51,13 +51,14 @@ func (c *Client) AppRequestAny(
 	ctx context.Context,
 	appRequestBytes []byte,
 	onResponse AppResponseCallback,
+	n int,
 ) error {
-	sampled, err := c.nodeSampler.Sample(1)
+	sampled, err := c.nodeSampler.Sample(n)
 	if err != nil {
 		return fmt.Errorf("failed to sample peers: %w", err)
 	}
 
-	if len(sampled) != 1 {
+	if len(sampled) == 0 {
 		return ErrNoPeers
 	}
 

--- a/network/p2p/node_sampler.go
+++ b/network/p2p/node_sampler.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	safemath "github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/avalanchego/utils/sampler"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/version"
+)
+
+var (
+	_ NodeSampler = (*Validators)(nil)
+
+	_ validators.Connector = (*Peers)(nil)
+	_ NodeSampler          = (*Peers)(nil)
+)
+
+type NodeSampler interface {
+	// Sample returns at most [n] nodes. This may return fewer nodes if fewer
+	// than [n] are available.
+	Sample(n int) ([]ids.NodeID, error)
+}
+
+type Validators struct {
+	SubnetID   ids.ID
+	Validators validators.State
+}
+
+func (v Validators) Sample(n int) ([]ids.NodeID, error) {
+	currentHeight, err := v.Validators.GetCurrentHeight(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current height: %w", err)
+	}
+
+	validatorSet, err := v.Validators.GetValidatorSet(context.TODO(), currentHeight, v.SubnetID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current validator set: %w", err)
+	}
+
+	validatorIDs := maps.Keys(validatorSet)
+
+	s := sampler.NewUniform()
+	s.Initialize(uint64(len(validatorIDs)))
+
+	indices, _ := s.Sample(safemath.Min(len(validatorIDs), n))
+	sampled := make([]ids.NodeID, 0, len(indices))
+	for _, i := range indices {
+		sampled = append(sampled, validatorIDs[i])
+	}
+
+	return sampled, nil
+}
+
+type Peers struct {
+	lock  sync.RWMutex
+	peers set.SampleableSet[ids.NodeID]
+}
+
+func (p *Peers) Connected(_ context.Context, nodeID ids.NodeID, _ *version.Application) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.peers.Add(nodeID)
+
+	return nil
+}
+
+func (p *Peers) Disconnected(_ context.Context, nodeID ids.NodeID) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.peers.Remove(nodeID)
+
+	return nil
+}
+
+func (p *Peers) Sample(n int) ([]ids.NodeID, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.peers.Sample(n), nil
+}

--- a/network/p2p/node_sampler_test.go
+++ b/network/p2p/node_sampler_test.go
@@ -1,0 +1,162 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	safemath "github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/avalanchego/utils/set"
+)
+
+func TestPeersSample(t *testing.T) {
+	nodeID1 := ids.GenerateTestNodeID()
+	nodeID2 := ids.GenerateTestNodeID()
+	nodeID3 := ids.GenerateTestNodeID()
+
+	tests := []struct {
+		name         string
+		connected    set.Set[ids.NodeID]
+		disconnected set.Set[ids.NodeID]
+		n            int
+	}{
+		{
+			name: "no peers",
+			n:    1,
+		},
+		{
+			name:      "one peer connected",
+			connected: set.Of[ids.NodeID](nodeID1),
+			n:         1,
+		},
+		{
+			name:      "multiple peers connected",
+			connected: set.Of[ids.NodeID](nodeID1, nodeID2, nodeID3),
+			n:         1,
+		},
+		{
+			name:         "peer connects and disconnects - 1",
+			connected:    set.Of[ids.NodeID](nodeID1),
+			disconnected: set.Of[ids.NodeID](nodeID1),
+			n:            1,
+		},
+		{
+			name:         "peer connects and disconnects - 2",
+			connected:    set.Of[ids.NodeID](nodeID1, nodeID2),
+			disconnected: set.Of[ids.NodeID](nodeID2),
+			n:            1,
+		},
+		{
+			name:         "peer connects and disconnects - 2",
+			connected:    set.Of[ids.NodeID](nodeID1, nodeID2, nodeID3),
+			disconnected: set.Of[ids.NodeID](nodeID1, nodeID2),
+			n:            1,
+		},
+		{
+			name:      "less than n peers",
+			connected: set.Of[ids.NodeID](nodeID1, nodeID2, nodeID3),
+			n:         4,
+		},
+		{
+			name:      "n peers",
+			connected: set.Of[ids.NodeID](nodeID1, nodeID2, nodeID3),
+			n:         3,
+		},
+		{
+			name:      "more than n peers",
+			connected: set.Of[ids.NodeID](nodeID1, nodeID2, nodeID3),
+			n:         2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			sampler := Peers{}
+
+			for connected := range tt.connected {
+				require.NoError(sampler.Connected(context.Background(), connected, nil))
+			}
+
+			for disconnected := range tt.disconnected {
+				require.NoError(sampler.Disconnected(context.Background(), disconnected))
+			}
+
+			sampleable := set.Set[ids.NodeID]{}
+			sampleable.Union(tt.connected)
+			sampleable.Difference(tt.disconnected)
+
+			sampled, err := sampler.Sample(tt.n)
+			require.NoError(err)
+			require.Len(sampled, safemath.Min(tt.n, len(sampleable)))
+			require.Subset(sampleable, sampled)
+		})
+	}
+}
+
+func TestValidatorsSample(t *testing.T) {
+	tests := []struct {
+		name       string
+		validators []ids.NodeID
+		n          int
+	}{
+		{
+			name:       "less than n validators",
+			validators: []ids.NodeID{ids.GenerateTestNodeID()},
+			n:          2,
+		},
+		{
+			name: "equal to n validators",
+			validators: []ids.NodeID{
+				ids.GenerateTestNodeID(),
+				ids.GenerateTestNodeID(),
+			},
+			n: 2,
+		},
+		{
+			name: "greater than n validators",
+			validators: []ids.NodeID{
+				ids.GenerateTestNodeID(),
+				ids.GenerateTestNodeID(),
+				ids.GenerateTestNodeID(),
+			},
+			n: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+
+			subnetID := ids.GenerateTestID()
+
+			height := uint64(1234)
+			mockValidators := validators.NewMockState(ctrl)
+			mockValidators.EXPECT().GetCurrentHeight(gomock.Any()).Return(height, nil)
+
+			validatorSet := make(map[ids.NodeID]*validators.GetValidatorOutput, 0)
+			for _, validator := range tt.validators {
+				validatorSet[validator] = nil
+
+			}
+			mockValidators.EXPECT().GetValidatorSet(gomock.Any(), height, subnetID).Return(validatorSet, nil)
+
+			v := Validators{
+				SubnetID:   subnetID,
+				Validators: mockValidators,
+			}
+
+			sampled, err := v.Sample(tt.n)
+			require.NoError(err)
+			require.Len(sampled, safemath.Min(tt.n, len(tt.validators)))
+		})
+	}
+}

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -61,7 +61,7 @@ func TestAppRequestResponse(t *testing.T) {
 					require.Equal(t, response, actualResponse)
 				}
 
-				require.NoError(t, client.AppRequestAny(context.Background(), request, callback))
+				require.NoError(t, client.AppRequestAny(context.Background(), request, callback, 1))
 			},
 		},
 		{


### PR DESCRIPTION
## Why this should be merged

Allow us to make the same request to a set of nodes. This is useful because with the current AppRequestAny, if you want to make the same request across a range of nodes, you have to perform it in a loop which does not guarantee that you send the request to all unique nodes, since we use a new sampler instance each time we don't get the benefits of sampling with replacement.

## How this works

Adds a parameter to specify amount of requests

## How this was tested

Added a unit test
