### PR TITLE
e2e: Ensure pre-funded test keys are also funded on the C-Chain

### DIFF
--- a/tests/fixture/testnet/config.go
+++ b/tests/fixture/testnet/config.go
@@ -8,11 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/cast"
+
+	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm"
 
 	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/genesis"
@@ -125,16 +130,17 @@ func (c *NetworkConfig) EnsureGenesis(networkID uint32, validatorIDs []ids.NodeI
 		return errNoKeysForGenesis
 	}
 
-	// Fund the provided keys
-	xChainBalances := []AddrAndBalance{}
+	// Ensure pre-funded keys have arbitrary large balances on both chains to support testing
+	xChainBalances := make(XChainBalanceMap, len(c.FundedKeys))
+	cChainBalances := make(core.GenesisAlloc, len(c.FundedKeys))
+	var cchainBalance big.Int
+	cchainBalance.Exp(big.NewInt(10), big.NewInt(30), nil)
 	for _, key := range c.FundedKeys {
-		xChainBalances = append(xChainBalances, AddrAndBalance{
-			key.Address(),
-			30 * units.MegaAvax, // Arbitrary large amount to support testing
-		})
+		xChainBalances[key.Address()] = 30 * units.MegaAvax
+		cChainBalances[evm.GetEthAddress(key)] = core.GenesisAccount{Balance: &cchainBalance}
 	}
 
-	genesis, err := NewTestGenesis(networkID, xChainBalances, validatorIDs)
+	genesis, err := NewTestGenesis(networkID, xChainBalances, cChainBalances, validatorIDs)
 	if err != nil {
 		return err
 	}
@@ -278,17 +284,16 @@ func (nc *NodeConfig) EnsureNodeID() error {
 	return nil
 }
 
-type AddrAndBalance struct {
-	Addr    ids.ShortID
-	Balance uint64
-}
+// Helper type to simplify configuring X-Chain genesis balances
+type XChainBalanceMap map[ids.ShortID]uint64
 
 // Create a genesis struct valid for bootstrapping a test
 // network. Note that many of the genesis fields (e.g. reward
 // addresses) are randomly generated or hard-coded.
 func NewTestGenesis(
 	networkID uint32,
-	xChainBalances []AddrAndBalance,
+	xChainBalances XChainBalanceMap,
+	cChainBalances core.GenesisAlloc,
 	validatorIDs []ids.NodeID,
 ) (*genesis.UnparsedConfig, error) {
 	// Validate inputs
@@ -299,7 +304,7 @@ func NewTestGenesis(
 	if len(validatorIDs) == 0 {
 		return nil, errMissingValidatorsForGenesis
 	}
-	if len(xChainBalances) == 0 {
+	if len(xChainBalances) == 0 || len(cChainBalances) == 0 {
 		return nil, errMissingBalancesForGenesis
 	}
 
@@ -343,22 +348,21 @@ func NewTestGenesis(
 		InitialStakedFunds:         []string{stakeAddress},
 		InitialStakeDuration:       365 * 24 * 60 * 60, // 1 year
 		InitialStakeDurationOffset: 90 * 60,            // 90 minutes
-		CChainGenesis:              genesis.LocalConfig.CChainGenesis,
 		Message:                    "hello avalanche!",
 	}
 
-	// Set xchain balances
-	for _, addressBalance := range xChainBalances {
-		address, err := address.Format("X", constants.GetHRP(networkID), addressBalance.Addr[:])
+	// Set X-Chain balances
+	for xChainAddress, balance := range xChainBalances {
+		avaxAddr, err := address.Format("X", constants.GetHRP(networkID), xChainAddress[:])
 		if err != nil {
-			return nil, fmt.Errorf("failed to format balance address: %w", err)
+			return nil, fmt.Errorf("failed to format X-Chain address: %w", err)
 		}
 		config.Allocations = append(
 			config.Allocations,
 			genesis.UnparsedAllocation{
 				ETHAddr:       ethAddress,
-				AVAXAddr:      address,
-				InitialAmount: addressBalance.Balance,
+				AVAXAddr:      avaxAddr,
+				InitialAmount: balance,
 				UnlockSchedule: []genesis.LockedAmount{
 					{
 						Amount: 20 * units.MegaAvax,
@@ -371,6 +375,21 @@ func NewTestGenesis(
 			},
 		)
 	}
+
+	// Define C-Chain genesis
+	cChainGenesis := &core.Genesis{
+		Config: &params.ChainConfig{
+			ChainID: big.NewInt(43112), // Arbitrary chain ID is arbitrary
+		},
+		Difficulty: big.NewInt(0),     // Difficulty is a mandatory field
+		GasLimit:   uint64(0x5f5e100), // Arbitrary gas limit is arbitrary
+		Alloc:      cChainBalances,
+	}
+	cChainGenesisBytes, err := json.Marshal(cChainGenesis)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal C-Chain genesis: %w", err)
+	}
+	config.CChainGenesis = string(cChainGenesisBytes)
 
 	// Give staking rewards for initial validators to a random address. Any testing of staking rewards
 	// will be easier to perform with nodes other than the initial validators since the timing of


### PR DESCRIPTION
## Why this should be merged

Previously pre-funded keys were only funded on the X-Chain. This change ensures that pre-funded keys are also funded on the C-Chain to ensure C-Chain tests have the same isolation guarantees.

## How this works

The keys generated with a testnet network are funded in the C-Chain genesis.

## How this was tested

CI will ensure that this doesn't break anything. #1871 will validate that C-Chain funding was successful.

## TODO

- [ ] Check that https://github.com/ava-labs/avalanchego/pull/1871 is passing which indicates pre-funded keys are funded on the C-Chain.