### PR TITLE
Update account nonce on exportTx accept

### DIFF
--- a/wallet/chain/c/backend.go
+++ b/wallet/chain/c/backend.go
@@ -124,7 +124,7 @@ func (b *backend) AcceptAtomicTx(ctx stdcontext.Context, tx *evm.Tx) error {
 			if err != nil {
 				return err
 			}
-			input.Nonce = newNonce
+			account.Nonce = newNonce
 		}
 	default:
 		return fmt.Errorf("%w: %T", errUnknownTxType, tx)


### PR DESCRIPTION
## Why this should be merged

Previously we updated the transaction variable rather than the account variable when accepting the ExportTx in the new wallet.

## How this works

`input` -> `account`

## How this was tested

Ran on #1871 and the test passed.