### PR TITLE
e2e: Ensure interchain workflow coverage for the P-Chain

### DIFF
--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -161,7 +161,7 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 				recipientKey.Address(),
 			)))
 			require.NoError(err)
-			require.Greater(balances[avaxAssetID], uint64(0))
+			require.Positive(balances[avaxAssetID])
 		})
 
 		e2e.CheckBootstrapIsPossible(e2e.Env.GetNetwork())

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -63,6 +63,11 @@ const (
 	// Start time must be a minimum of 15s ahead of the current time
 	// or validator addition will fail.
 	DefaultValidatorStartTimeDiff = 20 * time.Second
+
+	// Setting this env will disable post-test bootstrap
+	// checks. Useful for speeding up iteration during test
+	// development.
+	SkipBootstrapChecksEnvName = "E2E_SKIP_BOOTSTRAP_CHECKS"
 )
 
 // Env is used to access shared test fixture. Intended to be

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ava-labs/avalanchego/tests/fixture/testnet"
 	"github.com/ava-labs/avalanchego/tests/fixture/testnet/local"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
@@ -60,9 +61,10 @@ const (
 	// development.
 	SkipBootstrapChecksEnvName = "E2E_SKIP_BOOTSTRAP_CHECKS"
 
-	// Start time must be a minimum of 15s ahead of the current time
-	// or validator addition will fail.
-	DefaultValidatorStartTimeDiff = 20 * time.Second
+	// Validator start time must be a minimum of SyncBound from the
+	// current time for validator addition to succeed, and adding 5
+	// seconds provides a buffer in case of any delay in processing.
+	DefaultValidatorStartTimeDiff = executor.SyncBound + 5*time.Second
 )
 
 // Env is used to access shared test fixture. Intended to be

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -59,6 +59,10 @@ const (
 	// checks. Useful for speeding up iteration during test
 	// development.
 	SkipBootstrapChecksEnvName = "E2E_SKIP_BOOTSTRAP_CHECKS"
+
+	// Start time must be a minimum of 15s ahead of the current time
+	// or validator addition will fail.
+	DefaultValidatorStartTimeDiff = 20 * time.Second
 )
 
 // Env is used to access shared test fixture. Intended to be

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -63,11 +63,6 @@ const (
 	// Start time must be a minimum of 15s ahead of the current time
 	// or validator addition will fail.
 	DefaultValidatorStartTimeDiff = 20 * time.Second
-
-	// Setting this env will disable post-test bootstrap
-	// checks. Useful for speeding up iteration during test
-	// development.
-	SkipBootstrapChecksEnvName = "E2E_SKIP_BOOTSTRAP_CHECKS"
 )
 
 // Env is used to access shared test fixture. Intended to be

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -106,8 +106,10 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			rewardKey, err := factory.NewPrivateKey()
 			require.NoError(err)
 
-			delegationPercent := 0.10 // 10%
-			delegationFee := uint32(reward.PercentDenominator * delegationPercent)
+			const (
+				delegationPercent = 0.10 // 10%
+				delegationFee     = reward.PercentDenominator * delegationPercent
+			)
 
 			_, err = pWallet.IssueAddPermissionlessValidatorTx(
 				&txs.SubnetValidator{Validator: txs.Validator{

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -180,7 +180,7 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 				recipientKey.Address(),
 			)))
 			require.NoError(err)
-			require.Greater(balances[avaxAssetID], uint64(0))
+			require.Positive(balances[avaxAssetID])
 		})
 
 		ginkgo.By("exporting AVAX from the P-Chain to the C-Chain", func() {

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -1,0 +1,203 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package p
+
+import (
+	"math/big"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/coreth/plugin/evm"
+
+	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests/e2e"
+	"github.com/ava-labs/avalanchego/tests/fixture/testnet"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+)
+
+var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
+	require := require.New(ginkgo.GinkgoT())
+
+	const (
+		transferAmount = 10 * units.Avax
+		weight         = 2_000 * units.Avax // Used for both validation and delegation
+	)
+
+	ginkgo.It("should ensure that funds can be transferred from the P-Chain to the X-Chain and the C-Chain", func() {
+		ginkgo.By("creating wallet with a funded key to send from and recipient key to deliver to")
+		factory := secp256k1.Factory{}
+		recipientKey, err := factory.NewPrivateKey()
+		require.NoError(err)
+		keychain := e2e.Env.NewKeychain(1)
+		keychain.Add(recipientKey)
+		nodeURI := e2e.Env.GetRandomNodeURI()
+		baseWallet := e2e.Env.NewWallet(keychain, nodeURI)
+		xWallet := baseWallet.X()
+		cWallet := baseWallet.C()
+		pWallet := baseWallet.P()
+
+		ginkgo.By("defining common configuration")
+		recipientEthAddress := evm.GetEthAddress(recipientKey)
+		avaxAssetID := xWallet.AVAXAssetID()
+		// Use the same owner for sending to X-Chain and importing funds to P-Chain
+		recipientOwner := secp256k1fx.OutputOwners{
+			Threshold: 1,
+			Addrs: []ids.ShortID{
+				recipientKey.Address(),
+			},
+		}
+		// Use the same outputs for both X-Chain and C-Chain exports
+		exportOutputs := []*avax.TransferableOutput{
+			{
+				Asset: avax.Asset{
+					ID: avaxAssetID,
+				},
+				Out: &secp256k1fx.TransferOutput{
+					Amt: transferAmount,
+					OutputOwners: secp256k1fx.OutputOwners{
+						Threshold: 1,
+						Addrs: []ids.ShortID{
+							keychain.Keys[0].Address(),
+						},
+					},
+				},
+			},
+		}
+
+		ginkgo.By("adding new node and waiting for it to report healthy")
+		network := e2e.Env.GetNetwork()
+		node := e2e.AddEphemeralNode(network, testnet.FlagsMap{})
+		e2e.WaitForHealthy(node)
+
+		ginkgo.By("retrieving new node's id and pop")
+		infoClient := info.NewClient(node.GetProcessContext().URI)
+		nodeID, nodePOP, err := infoClient.GetNodeID(e2e.DefaultContext())
+		require.NoError(err)
+
+		ginkgo.By("adding the new node as a validator", func() {
+			startTime := time.Now().Add(e2e.DefaultValidatorStartTimeDiff)
+			// Validation duration doesn't actually matter to this
+			// test - it is only ensuring that adding a validator
+			// doesn't break interchain transfer.
+			endTime := startTime.Add(30 * time.Second)
+
+			rewardKey, err := factory.NewPrivateKey()
+			require.NoError(err)
+
+			delegationPercent := 0.10 // 10%
+			delegationFee := uint32(reward.PercentDenominator * delegationPercent)
+
+			_, err = pWallet.IssueAddPermissionlessValidatorTx(
+				&txs.SubnetValidator{Validator: txs.Validator{
+					NodeID: nodeID,
+					Start:  uint64(startTime.Unix()),
+					End:    uint64(endTime.Unix()),
+					Wght:   weight,
+				}},
+				nodePOP,
+				pWallet.AVAXAssetID(),
+				&secp256k1fx.OutputOwners{
+					Threshold: 1,
+					Addrs:     []ids.ShortID{rewardKey.Address()},
+				},
+				&secp256k1fx.OutputOwners{
+					Threshold: 1,
+					Addrs:     []ids.ShortID{rewardKey.Address()},
+				},
+				delegationFee,
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("adding a delegator to the new node", func() {
+			startTime := time.Now().Add(e2e.DefaultValidatorStartTimeDiff)
+			// Delegation duration doesn't actually matter to this
+			// test - it is only ensuring that adding a delegator
+			// doesn't break interchain transfer.
+			endTime := startTime.Add(15 * time.Second)
+
+			rewardKey, err := factory.NewPrivateKey()
+			require.NoError(err)
+
+			_, err = pWallet.IssueAddPermissionlessDelegatorTx(
+				&txs.SubnetValidator{Validator: txs.Validator{
+					NodeID: nodeID,
+					Start:  uint64(startTime.Unix()),
+					End:    uint64(endTime.Unix()),
+					Wght:   weight,
+				}},
+				pWallet.AVAXAssetID(),
+				&secp256k1fx.OutputOwners{
+					Threshold: 1,
+					Addrs:     []ids.ShortID{rewardKey.Address()},
+				},
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("exporting AVAX from the P-Chain to the X-Chain", func() {
+			_, err := pWallet.IssueExportTx(
+				xWallet.BlockchainID(),
+				exportOutputs,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("importing AVAX from the P-Chain to the X-Chain", func() {
+			_, err := xWallet.IssueImportTx(
+				constants.PlatformChainID,
+				&recipientOwner,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("checking that the recipient address has received imported funds on the X-Chain", func() {
+			balances, err := xWallet.Builder().GetFTBalance(common.WithCustomAddresses(set.Of(
+				recipientKey.Address(),
+			)))
+			require.NoError(err)
+			require.Greater(balances[avaxAssetID], uint64(0))
+		})
+
+		ginkgo.By("exporting AVAX from the P-Chain to the C-Chain", func() {
+			_, err := pWallet.IssueExportTx(
+				cWallet.BlockchainID(),
+				exportOutputs,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("importing AVAX from the P-Chain to the C-Chain", func() {
+			_, err := cWallet.IssueImportTx(
+				constants.PlatformChainID,
+				recipientEthAddress,
+				e2e.WithDefaultContext(),
+			)
+			require.NoError(err)
+		})
+
+		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain")
+		ethClient := e2e.Env.NewEthClient(nodeURI)
+		e2e.Eventually(func() bool {
+			balance, err := ethClient.BalanceAt(e2e.DefaultContext(), recipientEthAddress, nil)
+			require.NoError(err)
+			return balance.Cmp(big.NewInt(0)) > 0
+		}, e2e.DefaultTimeout, e2e.DefaultPollingInterval, "failed to see recipient address funded before timeout")
+	})
+})

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -9,11 +9,14 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 
+	"github.com/spf13/cast"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/coreth/plugin/evm"
 
 	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/testnet"
@@ -37,6 +40,12 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 	)
 
 	ginkgo.It("should ensure that funds can be transferred from the P-Chain to the X-Chain and the C-Chain", func() {
+		ginkgo.By("checking that the network has a compatible minimum stake duration", func() {
+			network := e2e.Env.GetNetwork()
+			minStakeDuration := cast.ToDuration(network.GetConfig().DefaultFlags[config.MinStakeDurationKey])
+			require.Equal(testnet.DefaultMinStakeDuration, minStakeDuration)
+		})
+
 		ginkgo.By("creating wallet with a funded key to send from and recipient key to deliver to")
 		factory := secp256k1.Factory{}
 		recipientKey, err := factory.NewPrivateKey()

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -112,12 +112,15 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			)
 
 			_, err = pWallet.IssueAddPermissionlessValidatorTx(
-				&txs.SubnetValidator{Validator: txs.Validator{
-					NodeID: nodeID,
-					Start:  uint64(startTime.Unix()),
-					End:    uint64(endTime.Unix()),
-					Wght:   weight,
-				}},
+				&txs.SubnetValidator{
+					Validator: txs.Validator{
+						NodeID: nodeID,
+						Start:  uint64(startTime.Unix()),
+						End:    uint64(endTime.Unix()),
+						Wght:   weight,
+					},
+					Subnet: constants.PrimaryNetworkID,
+				},
 				nodePOP,
 				pWallet.AVAXAssetID(),
 				&secp256k1fx.OutputOwners{
@@ -145,13 +148,13 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 
 			_, err = pWallet.IssueAddPermissionlessDelegatorTx(
 				&txs.SubnetValidator{
-					Subnet: constants.PrimaryNetworkID,
 					Validator: txs.Validator{
 						NodeID: nodeID,
 						Start:  uint64(startTime.Unix()),
 						End:    uint64(endTime.Unix()),
 						Wght:   weight,
 					},
+					Subnet: constants.PrimaryNetworkID,
 				},
 				pWallet.AVAXAssetID(),
 				&secp256k1fx.OutputOwners{

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -109,26 +109,27 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			delegationPercent := 0.10 // 10%
 			delegationFee := uint32(reward.PercentDenominator * delegationPercent)
 
-			_, err = pWallet.IssueAddPermissionlessValidatorTx(
-				&txs.SubnetValidator{Validator: txs.Validator{
-					NodeID: nodeID,
-					Start:  uint64(startTime.Unix()),
-					End:    uint64(endTime.Unix()),
-					Wght:   weight,
-				}},
-				nodePOP,
-				pWallet.AVAXAssetID(),
-				&secp256k1fx.OutputOwners{
-					Threshold: 1,
-					Addrs:     []ids.ShortID{rewardKey.Address()},
-				},
-				&secp256k1fx.OutputOwners{
-					Threshold: 1,
-					Addrs:     []ids.ShortID{rewardKey.Address()},
-				},
-				delegationFee,
+			e2e.LogTxAndCheck(
+				pWallet.IssueAddPermissionlessValidatorTx(
+					&txs.SubnetValidator{Validator: txs.Validator{
+						NodeID: nodeID,
+						Start:  uint64(startTime.Unix()),
+						End:    uint64(endTime.Unix()),
+						Wght:   weight,
+					}},
+					nodePOP,
+					pWallet.AVAXAssetID(),
+					&secp256k1fx.OutputOwners{
+						Threshold: 1,
+						Addrs:     []ids.ShortID{rewardKey.Address()},
+					},
+					&secp256k1fx.OutputOwners{
+						Threshold: 1,
+						Addrs:     []ids.ShortID{rewardKey.Address()},
+					},
+					delegationFee,
+				),
 			)
-			require.NoError(err)
 		})
 
 		ginkgo.By("adding a delegator to the new node", func() {
@@ -141,39 +142,40 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			rewardKey, err := factory.NewPrivateKey()
 			require.NoError(err)
 
-			_, err = pWallet.IssueAddPermissionlessDelegatorTx(
-				&txs.SubnetValidator{Validator: txs.Validator{
-					NodeID: nodeID,
-					Start:  uint64(startTime.Unix()),
-					End:    uint64(endTime.Unix()),
-					Wght:   weight,
-				}},
-				pWallet.AVAXAssetID(),
-				&secp256k1fx.OutputOwners{
-					Threshold: 1,
-					Addrs:     []ids.ShortID{rewardKey.Address()},
-				},
+			e2e.LogTxAndCheck(
+				pWallet.IssueAddPermissionlessDelegatorTx(
+					&txs.SubnetValidator{Validator: txs.Validator{
+						NodeID: nodeID,
+						Start:  uint64(startTime.Unix()),
+						End:    uint64(endTime.Unix()),
+						Wght:   weight,
+					}},
+					pWallet.AVAXAssetID(),
+					&secp256k1fx.OutputOwners{
+						Threshold: 1,
+						Addrs:     []ids.ShortID{rewardKey.Address()},
+					},
+				),
 			)
-			require.NoError(err)
 		})
 
-		ginkgo.By("exporting AVAX from the P-Chain to the X-Chain", func() {
-			_, err := pWallet.IssueExportTx(
+		ginkgo.By("exporting AVAX from the P-Chain to the X-Chain")
+		e2e.LogTxAndCheck(
+			pWallet.IssueExportTx(
 				xWallet.BlockchainID(),
 				exportOutputs,
 				e2e.WithDefaultContext(),
-			)
-			require.NoError(err)
-		})
+			),
+		)
 
-		ginkgo.By("importing AVAX from the P-Chain to the X-Chain", func() {
-			_, err := xWallet.IssueImportTx(
+		ginkgo.By("importing AVAX from the P-Chain to the X-Chain")
+		e2e.LogTxAndCheck(
+			xWallet.IssueImportTx(
 				constants.PlatformChainID,
 				&recipientOwner,
 				e2e.WithDefaultContext(),
-			)
-			require.NoError(err)
-		})
+			),
+		)
 
 		ginkgo.By("checking that the recipient address has received imported funds on the X-Chain", func() {
 			balances, err := xWallet.Builder().GetFTBalance(common.WithCustomAddresses(set.Of(
@@ -183,23 +185,23 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			require.Positive(balances[avaxAssetID])
 		})
 
-		ginkgo.By("exporting AVAX from the P-Chain to the C-Chain", func() {
-			_, err := pWallet.IssueExportTx(
+		ginkgo.By("exporting AVAX from the P-Chain to the C-Chain")
+		e2e.LogTxAndCheck(
+			pWallet.IssueExportTx(
 				cWallet.BlockchainID(),
 				exportOutputs,
 				e2e.WithDefaultContext(),
-			)
-			require.NoError(err)
-		})
+			),
+		)
 
-		ginkgo.By("importing AVAX from the P-Chain to the C-Chain", func() {
-			_, err := cWallet.IssueImportTx(
+		ginkgo.By("importing AVAX from the P-Chain to the C-Chain")
+		e2e.LogTxAndCheck(
+			cWallet.IssueImportTx(
 				constants.PlatformChainID,
 				recipientEthAddress,
 				e2e.WithDefaultContext(),
-			)
-			require.NoError(err)
-		})
+			),
+		)
 
 		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain")
 		ethClient := e2e.Env.NewEthClient(nodeURI)

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -194,17 +194,20 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			),
 		)
 
+		ginkgo.By("initializing a new eth client")
+		ethClient := e2e.Env.NewEthClient(nodeURI)
+
 		ginkgo.By("importing AVAX from the P-Chain to the C-Chain")
 		e2e.LogTxAndCheck(
 			cWallet.IssueImportTx(
 				constants.PlatformChainID,
 				recipientEthAddress,
 				e2e.WithDefaultContext(),
+				e2e.WithSuggestedGasPrice(ethClient),
 			),
 		)
 
 		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain")
-		ethClient := e2e.Env.NewEthClient(nodeURI)
 		e2e.Eventually(func() bool {
 			balance, err := ethClient.BalanceAt(e2e.DefaultContext(), recipientEthAddress, nil)
 			require.NoError(err)

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -40,8 +40,9 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 	)
 
 	ginkgo.It("should ensure that funds can be transferred from the P-Chain to the X-Chain and the C-Chain", func() {
+		network := e2e.Env.GetNetwork()
+
 		ginkgo.By("checking that the network has a compatible minimum stake duration", func() {
-			network := e2e.Env.GetNetwork()
 			minStakeDuration := cast.ToDuration(network.GetConfig().DefaultFlags[config.MinStakeDurationKey])
 			require.Equal(testnet.DefaultMinStakeDuration, minStakeDuration)
 		})
@@ -87,7 +88,6 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 		}
 
 		ginkgo.By("adding new node and waiting for it to report healthy")
-		network := e2e.Env.GetNetwork()
 		node := e2e.AddEphemeralNode(network, testnet.FlagsMap{})
 		e2e.WaitForHealthy(node)
 
@@ -208,5 +208,10 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			require.NoError(err)
 			return balance.Cmp(big.NewInt(0)) > 0
 		}, e2e.DefaultTimeout, e2e.DefaultPollingInterval, "failed to see recipient address funded before timeout")
+
+		ginkgo.By("stopping validator node to free up resources for a bootstrap check")
+		require.NoError(node.Stop())
+
+		e2e.CheckBootstrapIsPossible(network)
 	})
 })

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -108,7 +108,7 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 
 			const (
 				delegationPercent = 0.10 // 10%
-				delegationFee     = reward.PercentDenominator * delegationPercent
+				delegationShare   = reward.PercentDenominator * delegationPercent
 			)
 
 			_, err = pWallet.IssueAddPermissionlessValidatorTx(
@@ -128,7 +128,7 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{rewardKey.Address()},
 				},
-				delegationFee,
+				delegationShare,
 			)
 			require.NoError(err)
 		})
@@ -144,12 +144,15 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			require.NoError(err)
 
 			_, err = pWallet.IssueAddPermissionlessDelegatorTx(
-				&txs.SubnetValidator{Validator: txs.Validator{
-					NodeID: nodeID,
-					Start:  uint64(startTime.Unix()),
-					End:    uint64(endTime.Unix()),
-					Wght:   weight,
-				}},
+				&txs.SubnetValidator{
+					Subnet: constants.PrimaryNetworkID,
+					Validator: txs.Validator{
+						NodeID: nodeID,
+						Start:  uint64(startTime.Unix()),
+						End:    uint64(endTime.Unix()),
+						Wght:   weight,
+					},
+				},
 				pWallet.AVAXAssetID(),
 				&secp256k1fx.OutputOwners{
 					Threshold: 1,

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -208,11 +208,9 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 		})
 
 		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain")
-		e2e.Eventually(func() bool {
-			balance, err := ethClient.BalanceAt(e2e.DefaultContext(), recipientEthAddress, nil)
-			require.NoError(err)
-			return balance.Cmp(big.NewInt(0)) > 0
-		}, e2e.DefaultTimeout, e2e.DefaultPollingInterval, "failed to see recipient address funded before timeout")
+		balance, err := ethClient.BalanceAt(e2e.DefaultContext(), recipientEthAddress, nil)
+		require.NoError(err)
+		require.Positive(balance.Cmp(big.NewInt(0)))
 
 		ginkgo.By("stopping validator node to free up resources for a bootstrap check")
 		require.NoError(node.Stop())

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -91,7 +91,7 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 				recipientKey.Address(),
 			)))
 			require.NoError(err)
-			require.Greater(balances[avaxAssetID], uint64(0))
+			require.Positive(balances[avaxAssetID])
 		})
 
 		ginkgo.By("exporting AVAX from the X-Chain to the C-Chain", func() {
@@ -146,7 +146,7 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 				recipientKey.Address(),
 			)))
 			require.NoError(err)
-			require.Greater(balances[avaxAssetID], uint64(0))
+			require.Positive(balances[avaxAssetID])
 		})
 
 		e2e.CheckBootstrapIsPossible(e2e.Env.GetNetwork())

--- a/tests/fixture/testnet/config.go
+++ b/tests/fixture/testnet/config.go
@@ -40,6 +40,9 @@ const (
 
 	// Arbitrarily large amount of AVAX to fund keys on the X-Chain for testing
 	DefaultFundedKeyXChainAmount = 30 * units.MegaAvax
+
+	// A short min stake duration enables testing of staking logic.
+	DefaultMinStakeDuration = time.Second
 )
 
 var (

--- a/tests/fixture/testnet/local/config.go
+++ b/tests/fixture/testnet/local/config.go
@@ -37,6 +37,9 @@ func LocalFlags() testnet.FlagsMap {
 		config.IndexEnabledKey:              true,
 		config.LogDisplayLevelKey:           "INFO",
 		config.LogLevelKey:                  "DEBUG",
+
+		// A short min stake duration enables testing of staking logic.
+		config.MinStakeDurationKey: "1s",
 	}
 }
 

--- a/tests/fixture/testnet/local/config.go
+++ b/tests/fixture/testnet/local/config.go
@@ -37,9 +37,7 @@ func LocalFlags() testnet.FlagsMap {
 		config.IndexEnabledKey:              true,
 		config.LogDisplayLevelKey:           "INFO",
 		config.LogLevelKey:                  "DEBUG",
-
-		// A short min stake duration enables testing of staking logic.
-		config.MinStakeDurationKey: "1s",
+		config.MinStakeDurationKey:          testnet.DefaultMinStakeDuration.String(),
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

Fulfills one of the requirements for #1547 (migration of Kurtosis tests)

## How this works

- ensures coverage of interchain transfer for the P-Chain equivalent to and extending from avalanche-testing's [C-Chain Atomic Workflow test](https://github.com/ava-labs/avalanche-testing/blob/master/tests/virtuouscchain/cchain_atomic_workflow.go)

## How this was tested

CI

## TODO

- [x] Merge the parent PR (#1941)