### PR TITLE
`merkledb` -- commit to db only

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -870,11 +870,6 @@ func (db *merkleDB) commitBatch(ops []database.BatchOp) error {
 	return view.commitToDB(context.Background())
 }
 
-// CommitToParent is a no-op for the db because it has no parent
-func (*merkleDB) CommitToParent(context.Context) error {
-	return nil
-}
-
 // commitToDB is a no-op for the db because it is the db
 func (*merkleDB) commitToDB(context.Context) error {
 	return nil

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -875,7 +875,8 @@ func (*merkleDB) commitToDB(context.Context) error {
 	return nil
 }
 
-// commitChanges commits the changes in trieToCommit to the db
+// commitChanges commits the changes in [trieToCommit] to [db].
+// Assumes [trieToCommit]'s node IDs have been calculated.
 func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
@@ -887,6 +888,10 @@ func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) e
 		return nil
 	case trieToCommit.isInvalid():
 		return ErrInvalid
+	case trieToCommit.committed:
+		return ErrCommitted
+	case trieToCommit.db != trieToCommit.getParentTrie():
+		return ErrParentNotDatabase
 	}
 
 	changes := trieToCommit.changes

--- a/x/merkledb/trie.go
+++ b/x/merkledb/trie.go
@@ -63,12 +63,10 @@ type Trie interface {
 type TrieView interface {
 	Trie
 
-	// CommitToDB takes the changes of this trie and commits them down the view stack
-	// until all changes in the stack commit to the database
-	// Takes the DB commit lock
+	// CommitToDB writes the changes in this view to the database.
+	// Takes the DB commit lock.
 	CommitToDB(ctx context.Context) error
 
-	// commits changes in the trie to its parent
-	// then commits the combined changes down the stack until all changes in the stack commit to the database
+	// Same as CommitToDB but doesn't take the DB commit lock.
 	commitToDB(ctx context.Context) error
 }

--- a/x/merkledb/trie.go
+++ b/x/merkledb/trie.go
@@ -71,7 +71,4 @@ type TrieView interface {
 	// commits changes in the trie to its parent
 	// then commits the combined changes down the stack until all changes in the stack commit to the database
 	commitToDB(ctx context.Context) error
-
-	// commits changes in the trieToCommit into the current trie
-	commitChanges(ctx context.Context, trieToCommit *trieView) error
 }

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -500,13 +500,10 @@ func (t *trieView) commitToDB(ctx context.Context) error {
 	))
 	defer span.End()
 
-	switch {
-	case t.isInvalid():
-		return ErrInvalid
-	case t.committed:
-		return ErrCommitted
-	case t.db != t.getParentTrie():
-		return ErrParentNotDatabase
+	// Call this here instead of in [t.db.commitChanges]
+	// because doing so there would be a deadlock.
+	if err := t.calculateNodeIDs(ctx); err != nil {
+		return err
 	}
 
 	if err := t.db.commitChanges(ctx, t); err != nil {

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -500,13 +500,12 @@ func (t *trieView) commitToDB(ctx context.Context) error {
 	))
 	defer span.End()
 
-	if t.isInvalid() {
+	switch {
+	case t.isInvalid():
 		return ErrInvalid
-	}
-	if t.committed {
+	case t.committed:
 		return ErrCommitted
-	}
-	if t.db != t.getParentTrie() {
+	case t.db != t.getParentTrie():
 		return ErrParentNotDatabase
 	}
 

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -36,10 +36,11 @@ var (
 	ErrOddLengthWithValue = errors.New(
 		"the underlying db only supports whole number of byte keys, so cannot record changes with odd nibble length",
 	)
-	ErrGetPathToFailure = errors.New("GetPathTo failed to return the closest node")
-	ErrStartAfterEnd    = errors.New("start key > end key")
-	ErrViewIsNotAChild  = errors.New("passed in view is required to be a child of the current view")
-	ErrNoValidRoot      = errors.New("a valid root was not provided to the trieView constructor")
+	ErrGetPathToFailure  = errors.New("GetPathTo failed to return the closest node")
+	ErrStartAfterEnd     = errors.New("start key > end key")
+	ErrViewIsNotAChild   = errors.New("passed in view is required to be a child of the current view")
+	ErrNoValidRoot       = errors.New("a valid root was not provided to the trieView constructor")
+	ErrParentNotDatabase = errors.New("parent trie is not database")
 
 	numCPU = runtime.NumCPU()
 )
@@ -487,105 +488,6 @@ func (t *trieView) CommitToDB(ctx context.Context) error {
 	return t.commitToDB(ctx)
 }
 
-// Adds the changes from [trieToCommit] to this trie.
-// Assumes [trieToCommit.lock] is held if trieToCommit is not nil.
-func (t *trieView) commitChanges(ctx context.Context, trieToCommit *trieView) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
-	_, span := t.db.tracer.Start(ctx, "MerkleDB.trieview.commitChanges", oteltrace.WithAttributes(
-		attribute.Int("changeCount", len(t.changes.values)),
-	))
-	defer span.End()
-
-	switch {
-	case t.isInvalid():
-		// don't apply changes to an invalid view
-		return ErrInvalid
-	case trieToCommit == nil:
-		// no changes to apply
-		return nil
-	case trieToCommit.getParentTrie() != t:
-		// trieToCommit needs to be a child of t, otherwise the changes merge would not work
-		return ErrViewIsNotAChild
-	case trieToCommit.isInvalid():
-		// don't apply changes from an invalid view
-		return ErrInvalid
-	}
-
-	// Invalidate all child views except the view being committed.
-	// Note that we invalidate children before modifying their ancestor [t]
-	// to uphold the invariant on [t.invalidated].
-	t.invalidateChildrenExcept(trieToCommit)
-
-	if err := trieToCommit.calculateNodeIDs(ctx); err != nil {
-		return err
-	}
-
-	for key, nodeChange := range trieToCommit.changes.nodes {
-		if existing, ok := t.changes.nodes[key]; ok {
-			existing.after = nodeChange.after
-		} else {
-			t.changes.nodes[key] = &change[*node]{
-				before: nodeChange.before,
-				after:  nodeChange.after,
-			}
-		}
-	}
-
-	for key, valueChange := range trieToCommit.changes.values {
-		if existing, ok := t.changes.values[key]; ok {
-			existing.after = valueChange.after
-		} else {
-			t.changes.values[key] = &change[maybe.Maybe[[]byte]]{
-				before: valueChange.before,
-				after:  valueChange.after,
-			}
-		}
-	}
-	// update this view's root info to match the newly committed root
-	t.root = trieToCommit.root
-	t.changes.rootID = trieToCommit.changes.rootID
-
-	// move the children from the incoming trieview to the current trieview
-	// do this after the current view has been updated
-	// this allows child views calls to their parent to remain consistent during the move
-	t.moveChildViewsToView(trieToCommit)
-
-	return nil
-}
-
-// commitToParent commits the changes from this view to its parent Trie
-// assumes [t.lock] is held
-func (t *trieView) commitToParent(ctx context.Context) error {
-	ctx, span := t.db.tracer.Start(ctx, "MerkleDB.trieview.commitToParent")
-	defer span.End()
-
-	if t.isInvalid() {
-		return ErrInvalid
-	}
-	if t.committed {
-		return ErrCommitted
-	}
-
-	// ensure all of this view's changes have been calculated
-	if err := t.calculateNodeIDs(ctx); err != nil {
-		return err
-	}
-
-	// write this view's changes into its parent
-	if err := t.getParentTrie().commitChanges(ctx, t); err != nil {
-		return err
-	}
-	if t.isInvalid() {
-		return ErrInvalid
-	}
-
-	t.committed = true
-
-	return nil
-}
-
 // Commits the changes from [trieToCommit] to this view,
 // this view to its parent, and so on until committing to the db.
 // Assumes [t.db.commitLock] is held.
@@ -598,13 +500,23 @@ func (t *trieView) commitToDB(ctx context.Context) error {
 	))
 	defer span.End()
 
-	// first merge changes into the parent trie
-	if err := t.commitToParent(ctx); err != nil {
+	if t.isInvalid() {
+		return ErrInvalid
+	}
+	if t.committed {
+		return ErrCommitted
+	}
+	if t.db != t.getParentTrie() {
+		return ErrParentNotDatabase
+	}
+
+	if err := t.db.commitChanges(ctx, t); err != nil {
 		return err
 	}
 
-	// now commit the parent trie to the db
-	return t.getParentTrie().commitToDB(ctx)
+	t.committed = true
+
+	return nil
 }
 
 // Assumes [t.validityTrackingLock] isn't held.
@@ -635,21 +547,6 @@ func (t *trieView) invalidate() {
 // Assumes [t.validityTrackingLock] isn't held.
 func (t *trieView) invalidateChildren() {
 	t.invalidateChildrenExcept(nil)
-}
-
-// moveChildViewsToView removes any child views from the trieToCommit and moves them to the current trie view
-func (t *trieView) moveChildViewsToView(trieToCommit *trieView) {
-	t.validityTrackingLock.Lock()
-	defer t.validityTrackingLock.Unlock()
-
-	trieToCommit.validityTrackingLock.Lock()
-	defer trieToCommit.validityTrackingLock.Unlock()
-
-	for _, childView := range trieToCommit.childViews {
-		childView.updateParent(t)
-		t.childViews = append(t.childViews, childView)
-	}
-	trieToCommit.childViews = make([]*trieView, 0, defaultPreallocationSize)
 }
 
 func (t *trieView) updateParent(newParent TrieView) {


### PR DESCRIPTION
## Why this should be merged

We want to change merkledb so that views can be committed only to the database

## How this works

Remove trieView methods used for committing to a parent trieView

## How this was tested

New UT