### PR TITLE
Remove duplicate code from proposervm block acceptance

### DIFF
--- a/vms/proposervm/post_fork_block.go
+++ b/vms/proposervm/post_fork_block.go
@@ -34,16 +34,8 @@ func (b *postForkBlock) acceptOuterBlk() error {
 	// Update in-memory references
 	b.status = choices.Accepted
 	b.vm.lastAcceptedTime = b.Timestamp()
-	b.vm.lastAcceptedHeight = b.Height()
 
-	blkID := b.ID()
-	delete(b.vm.verifiedBlocks, blkID)
-
-	// Persist this block, its height index, and its status
-	if err := b.vm.State.SetLastAccepted(blkID); err != nil {
-		return err
-	}
-	return b.vm.storePostForkBlock(b)
+	return b.vm.acceptPostForkBlock(b)
 }
 
 func (b *postForkBlock) acceptInnerBlk(ctx context.Context) error {

--- a/vms/proposervm/post_fork_option.go
+++ b/vms/proposervm/post_fork_option.go
@@ -41,16 +41,8 @@ func (b *postForkOption) Accept(ctx context.Context) error {
 func (b *postForkOption) acceptOuterBlk() error {
 	// Update in-memory references
 	b.status = choices.Accepted
-	b.vm.lastAcceptedHeight = b.Height()
 
-	blkID := b.ID()
-	delete(b.vm.verifiedBlocks, blkID)
-
-	// Persist this block, its height index, and its status
-	if err := b.vm.State.SetLastAccepted(blkID); err != nil {
-		return err
-	}
-	return b.vm.storePostForkBlock(b)
+	return b.vm.acceptPostForkBlock(b)
 }
 
 func (b *postForkOption) acceptInnerBlk(ctx context.Context) error {

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -776,12 +776,21 @@ func (vm *VM) getPreForkBlock(ctx context.Context, blkID ids.ID) (*preForkBlock,
 	}, err
 }
 
-func (vm *VM) storePostForkBlock(blk PostForkBlock) error {
-	if err := vm.State.PutBlock(blk.getStatelessBlk(), blk.Status()); err != nil {
-		return err
-	}
+func (vm *VM) acceptPostForkBlock(blk PostForkBlock) error {
 	height := blk.Height()
 	blkID := blk.ID()
+
+	vm.lastAcceptedHeight = height
+	delete(vm.verifiedBlocks, blkID)
+
+	// Persist this block, its height index, and its status
+	if err := vm.State.SetLastAccepted(blkID); err != nil {
+		return err
+	}
+
+	if err := vm.State.PutBlock(blk.getStatelessBlk(), choices.Accepted); err != nil {
+		return err
+	}
 	if err := vm.updateHeightIndex(height, blkID); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why this should be merged

We're working towards supporting block deletion in the proposervm. This makes it a bit more clear around the typical acceptance flow of a block.

## How this works

Moves duplicate code into the helper function.

## How this was tested

CI