### PR TITLE
Merkle db fix new return type

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -286,11 +286,6 @@ func (db *merkleDB) rebuild(ctx context.Context) error {
 
 // New returns a new merkle database.
 func New(ctx context.Context, db database.Database, config Config) (MerkleDB, error) {
-	return newDB(ctx, db, config)
-}
-
-// newDB returns a new merkle database.
-func newDB(ctx context.Context, db database.Database, config Config) (*merkleDB, error) {
 	metrics, err := newMetrics("merkleDB", config.Reg)
 	if err != nil {
 		return nil, err

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -285,7 +285,12 @@ func (db *merkleDB) rebuild(ctx context.Context) error {
 }
 
 // New returns a new merkle database.
-func New(ctx context.Context, db database.Database, config Config) (*merkleDB, error) {
+func New(ctx context.Context, db database.Database, config Config) (MerkleDB, error) {
+	return newDB(ctx, db, config)
+}
+
+// newDB returns a new merkle database.
+func newDB(ctx context.Context, db database.Database, config Config) (*merkleDB, error) {
 	metrics, err := newMetrics("merkleDB", config.Reg)
 	if err != nil {
 		return nil, err

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -148,7 +148,7 @@ func Test_MerkleDB_DB_Rebuild(t *testing.T) {
 	config := newDefaultConfig()
 	config.NodeCacheSize = initialSize
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		rdb,
 		config,

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -25,6 +25,15 @@ import (
 
 const defaultHistoryLength = 300
 
+// newDB returns a new merkle database with the underlying type so that tests can access unexported fields
+func newDB(ctx context.Context, db database.Database, config Config) (*merkleDB, error) {
+	db, err := New(ctx, db, config)
+	if err != nil {
+		return nil, err
+	}
+	return db.(*merkleDB), nil
+}
+
 func newNoopTracer() trace.Tracer {
 	tracer, _ := trace.New(trace.Config{Enabled: false})
 	return tracer

--- a/x/merkledb/history_test.go
+++ b/x/merkledb/history_test.go
@@ -19,7 +19,7 @@ import (
 func Test_History_Simple(t *testing.T) {
 	require := require.New(t)
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		newDefaultConfig(),
@@ -148,7 +148,7 @@ func Test_History_Bad_GetValueChanges_Input(t *testing.T) {
 	config := newDefaultConfig()
 	config.HistoryLength = 5
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		config,
@@ -215,7 +215,7 @@ func Test_History_Trigger_History_Queue_Looping(t *testing.T) {
 	config := newDefaultConfig()
 	config.HistoryLength = 2
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		config,
@@ -269,7 +269,7 @@ func Test_History_Values_Lookup_Over_Queue_Break(t *testing.T) {
 
 	config := newDefaultConfig()
 	config.HistoryLength = 4
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		config,
@@ -317,7 +317,7 @@ func Test_History_Values_Lookup_Over_Queue_Break(t *testing.T) {
 func Test_History_RepeatedRoot(t *testing.T) {
 	require := require.New(t)
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		newDefaultConfig(),
@@ -361,7 +361,7 @@ func Test_History_RepeatedRoot(t *testing.T) {
 func Test_History_ExcessDeletes(t *testing.T) {
 	require := require.New(t)
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		newDefaultConfig(),
@@ -393,7 +393,7 @@ func Test_History_ExcessDeletes(t *testing.T) {
 func Test_History_DontIncludeAllNodes(t *testing.T) {
 	require := require.New(t)
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		newDefaultConfig(),
@@ -421,7 +421,7 @@ func Test_History_DontIncludeAllNodes(t *testing.T) {
 func Test_History_Branching2Nodes(t *testing.T) {
 	require := require.New(t)
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		newDefaultConfig(),
@@ -449,7 +449,7 @@ func Test_History_Branching2Nodes(t *testing.T) {
 func Test_History_Branching3Nodes(t *testing.T) {
 	require := require.New(t)
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		newDefaultConfig(),
@@ -479,7 +479,7 @@ func Test_History_MaxLength(t *testing.T) {
 
 	config := newDefaultConfig()
 	config.HistoryLength = 2
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		config,
@@ -509,7 +509,7 @@ func Test_History_MaxLength(t *testing.T) {
 func Test_Change_List(t *testing.T) {
 	require := require.New(t)
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		newDefaultConfig(),

--- a/x/merkledb/metrics_test.go
+++ b/x/merkledb/metrics_test.go
@@ -19,7 +19,7 @@ func Test_Metrics_Basic_Usage(t *testing.T) {
 	// merkledb.
 	config.Reg = nil
 
-	db, err := New(
+	db, err := newDB(
 		context.Background(),
 		memdb.New(),
 		config,


### PR DESCRIPTION
The New function on merkledb currently returns an unexported type instead of the exported interface.  This PR fixes the return type and adds a test only new function that tests can use to access unexported fields.