### PR TITLE
Add throttler implementation to SDK

### DIFF
--- a/network/p2p/handler.go
+++ b/network/p2p/handler.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
+var _ Handler = (*NoOpHandler)(nil)
+
 // Handler is the server-side logic for virtual machine application protocols.
 type Handler interface {
 	// AppGossip is called when handling an AppGossip message.
@@ -40,6 +42,20 @@ type Handler interface {
 		deadline time.Time,
 		requestBytes []byte,
 	) ([]byte, error)
+}
+
+type NoOpHandler struct{}
+
+func (NoOpHandler) AppGossip(context.Context, ids.NodeID, []byte) error {
+	return nil
+}
+
+func (NoOpHandler) AppRequest(context.Context, ids.NodeID, time.Time, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (NoOpHandler) CrossChainAppRequest(context.Context, ids.ID, time.Time, []byte) ([]byte, error) {
+	return nil, nil
 }
 
 // responder automatically sends the response for a given request

--- a/network/p2p/throttler.go
+++ b/network/p2p/throttler.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package p2p
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/time/rate"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+var _ Throttler = (*TokenBucketThrottler)(nil)
+
+type Throttler interface {
+	Throttle(ctx context.Context, nodeID ids.NodeID, tokens int) error
+}
+
+func NewTokenBucketThrottler(refill rate.Limit, burst int) *TokenBucketThrottler {
+	return &TokenBucketThrottler{
+		refill:       refill,
+		burst:        burst,
+		tokenBuckets: make(map[ids.NodeID]*rate.Limiter),
+	}
+}
+
+type TokenBucketThrottler struct {
+	refill rate.Limit
+	burst  int
+
+	lock         sync.Mutex
+	tokenBuckets map[ids.NodeID]*rate.Limiter
+}
+
+func (t *TokenBucketThrottler) Throttle(ctx context.Context, nodeID ids.NodeID, tokens int) error {
+	t.lock.Lock()
+	tokenBucket, ok := t.tokenBuckets[nodeID]
+	if !ok {
+		tokenBucket = rate.NewLimiter(t.refill, t.burst)
+		t.tokenBuckets[nodeID] = tokenBucket
+	}
+	t.lock.Unlock()
+
+	return tokenBucket.WaitN(ctx, tokens)
+}

--- a/network/p2p/throttler_test.go
+++ b/network/p2p/throttler_test.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package p2p
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+func TestThrottler(t *testing.T) {
+	tests := []struct {
+		name string
+
+		refill rate.Limit
+		burst  int
+
+		tokens      int
+		expectedErr bool
+	}{
+		{
+			name:   "take less than burst tokens",
+			refill: rate.Every(time.Second),
+			burst:  10,
+			tokens: 9,
+		},
+		{
+			name:   "take burst tokens",
+			refill: rate.Every(time.Second),
+			burst:  10,
+			tokens: 10,
+		},
+		{
+			name:        "take more than burst tokens",
+			refill:      rate.Every(time.Second),
+			burst:       10,
+			tokens:      11,
+			expectedErr: true,
+		},
+		{
+			name:   "take zero tokens",
+			refill: rate.Every(time.Second),
+			burst:  10,
+			tokens: 0,
+		},
+		{
+			name:   "take negative tokens",
+			refill: rate.Every(time.Second),
+			burst:  10,
+			tokens: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			throttler := NewTokenBucketThrottler(tt.refill, tt.burst)
+
+			nodeID := ids.GenerateTestNodeID()
+			err := throttler.Throttle(context.Background(), nodeID, tt.tokens)
+			if tt.expectedErr {
+				require.NotNil(err)
+			} else {
+				require.Nil(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why this should be merged

Adds a throttler implementation to the SDK

## How this works

User configures a refill and burst rate for their throttler. Caller deducts a set amount of tokens from the `nodeID`.

## How this was tested

Added unit test