### PR TITLE
e2e: Cleanup test labeling

### DIFF
--- a/.github/workflows/test.e2e.persistent.yml
+++ b/.github/workflows/test.e2e.persistent.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./scripts/build.sh -r
       - name: Run e2e tests with persistent network
         shell: bash
-        run: E2E_SERIAL=1 ./scripts/tests.e2e.persistent.sh ./build/avalanchego
+        run: E2E_SERIAL=1 ./scripts/tests.e2e.persistent.sh
       - name: Upload testnet network dir
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/test.e2e.yml
+++ b/.github/workflows/test.e2e.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./scripts/build.sh -r
       - name: Run e2e tests
         shell: bash
-        run: E2E_SERIAL=1 ./scripts/tests.e2e.sh ./build/avalanchego
+        run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
       - name: Upload testnet network dir
         uses: actions/upload-artifact@v3
         if: always()

--- a/scripts/tests.e2e.persistent.sh
+++ b/scripts/tests.e2e.persistent.sh
@@ -17,10 +17,9 @@ if ! [[ "$0" =~ scripts/tests.e2e.persistent.sh ]]; then
   exit 255
 fi
 
-AVALANCHEGO_PATH="${AVALANCHEGO_PATH:-./build/avalanchego}"
 # Ensure an absolute path to avoid dependency on the working directory
 # of script execution.
-export AVALANCHEGO_PATH="$(realpath ${AVALANCHEGO_PATH})"
+export AVALANCHEGO_PATH="$(realpath ${AVALANCHEGO_PATH:-./build/avalanchego})"
 
 # Provide visual separation between testing and setup/teardown
 function print_separator {

--- a/scripts/tests.e2e.persistent.sh
+++ b/scripts/tests.e2e.persistent.sh
@@ -9,16 +9,17 @@ set -euo pipefail
 
 # e.g.,
 # ./scripts/build.sh
-# ./scripts/tests.e2e.persistent_network.sh ./build/avalanchego
+# ./scripts/tests.e2e.persistent.sh --ginkgo.label-filter=x               # All arguments are supplied to ginkgo
+# E2E_SERIAL=1 ./scripts/tests.e2e.sh                                     # Run tests serially
+# AVALANCHEGO_PATH=./build/avalanchego ./scripts/tests.e2e.persistent.sh  # Customization of avalanchego path
 if ! [[ "$0" =~ scripts/tests.e2e.persistent.sh ]]; then
   echo "must be run from repository root"
   exit 255
 fi
 
-AVALANCHEGO_PATH="${1-${AVALANCHEGO_PATH:-}}"
+AVALANCHEGO_PATH="${AVALANCHEGO_PATH:-./build/avalanchego}"
 if [[ -z "${AVALANCHEGO_PATH}" ]]; then
-  echo "Missing AVALANCHEGO_PATH argument!"
-  echo "Usage: ${0} [AVALANCHEGO_PATH]" >>/dev/stderr
+  echo "Empty AVALANCHEGO_PATH env var!"
   exit 255
 fi
 # Ensure an absolute path to avoid dependency on the working directory
@@ -55,6 +56,10 @@ else
 fi
 
 print_separator
-# Setting E2E_USE_PERSISTENT_NETWORK configures tests.e2e.sh to use
-# the persistent network identified by TESTNETCTL_NETWORK_DIR.
-E2E_USE_PERSISTENT_NETWORK=1 ./scripts/tests.e2e.sh
+# - Setting E2E_USE_PERSISTENT_NETWORK configures tests.e2e.sh to use
+#   the persistent network identified by TESTNETCTL_NETWORK_DIR.
+# - Only a single test is required to validate that a persistent
+#   network can be used by an e2e test suite run. Executing more tests
+#   would be duplicative of the testing performed against an ephemeral
+#   test network.
+E2E_USE_PERSISTENT_NETWORK=1 ./scripts/tests.e2e.sh --ginkgo.focus-file=permissionless_subnets.go

--- a/scripts/tests.e2e.persistent.sh
+++ b/scripts/tests.e2e.persistent.sh
@@ -18,10 +18,6 @@ if ! [[ "$0" =~ scripts/tests.e2e.persistent.sh ]]; then
 fi
 
 AVALANCHEGO_PATH="${AVALANCHEGO_PATH:-./build/avalanchego}"
-if [[ -z "${AVALANCHEGO_PATH}" ]]; then
-  echo "Empty AVALANCHEGO_PATH env var!"
-  exit 255
-fi
 # Ensure an absolute path to avoid dependency on the working directory
 # of script execution.
 export AVALANCHEGO_PATH="$(realpath ${AVALANCHEGO_PATH})"
@@ -58,8 +54,8 @@ fi
 print_separator
 # - Setting E2E_USE_PERSISTENT_NETWORK configures tests.e2e.sh to use
 #   the persistent network identified by TESTNETCTL_NETWORK_DIR.
-# - Only a single test is required to validate that a persistent
-#   network can be used by an e2e test suite run. Executing more tests
-#   would be duplicative of the testing performed against an ephemeral
-#   test network.
+# - Only a single test (selected with --ginkgo.focus-file) is required
+#   to validate that a persistent network can be used by an e2e test
+#   suite run. Executing more tests would be duplicative of the testing
+#   performed against an ephemeral test network.
 E2E_USE_PERSISTENT_NETWORK=1 ./scripts/tests.e2e.sh --ginkgo.focus-file=permissionless_subnets.go

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 
 # e.g.,
 # ./scripts/tests.e2e.sh
-# ./scripts/tests.e2e.sh --ginkgo.label-filter=x               # All arguments are supplied to ginkgo
-# E2E_SERIAL=1 ./scripts/tests.e2e.sh                          # Run tests serially
-# AVALANCHEGO_PATH=./build/avalanchego ./scripts/tests.e2e.sh  # Customization of avalanchego path
+# ./scripts/tests.e2e.sh --ginkgo.label-filter=x                                       # All arguments are supplied to ginkgo
+# E2E_SERIAL=1 ./scripts/tests.e2e.sh                                                  # Run tests serially
+# AVALANCHEGO_PATH=./build/avalanchego ./scripts/tests.e2e.sh                          # Customization of avalanchego path
+# E2E_USE_PERSISTENT_NETWORK=1 TESTNETCTL_NETWORK_DIR=/path/to ./scripts/tests.e2e.sh  # Execute against a persistent network
 if ! [[ "$0" =~ scripts/tests.e2e.sh ]]; then
   echo "must be run from repository root"
   exit 255
@@ -27,15 +28,13 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 ./tests/e2e/e2e.test --help
 
 #################################
-E2E_USE_PERSISTENT_NETWORK="${E2E_USE_PERSISTENT_NETWORK:-}"
-TESTNETCTL_NETWORK_DIR="${TESTNETCTL_NETWORK_DIR:-}"
-if [[ -n "${E2E_USE_PERSISTENT_NETWORK}" && -n "${TESTNETCTL_NETWORK_DIR}" ]]; then
-  echo "running e2e tests against a persistent network configured at ${TESTNETCTL_NETWORK_DIR}"
+# Since TESTNETCTL_NETWORK_DIR may be persistently set in the environment (e.g. to configure
+# ginkgo or testnetctl), configuring the use of a persistent network with this script
+# requires the extra step of setting E2E_USE_PERSISTENT_NETWORK=1.
+if [[ -n "${E2E_USE_PERSISTENT_NETWORK:-}" && -n "${TESTNETCTL_NETWORK_DIR:-}" ]]; then
   E2E_ARGS="--use-persistent-network"
 else
-  AVALANCHEGO_PATH="${AVALANCHEGO_PATH:-./build/avalanchego}"
-  AVALANCHEGO_PATH="$(realpath ${AVALANCHEGO_PATH})"
-  echo "running e2e tests against an ephemeral local cluster deployed with ${AVALANCHEGO_PATH}"
+  AVALANCHEGO_PATH="$(realpath ${AVALANCHEGO_PATH:-./build/avalanchego})"
   E2E_ARGS="--avalanchego-path=${AVALANCHEGO_PATH}"
 fi
 

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -34,12 +34,8 @@ if [[ -n "${E2E_USE_PERSISTENT_NETWORK}" && -n "${TESTNETCTL_NETWORK_DIR}" ]]; t
   E2E_ARGS="--use-persistent-network"
 else
   AVALANCHEGO_PATH="${AVALANCHEGO_PATH:-./build/avalanchego}"
-  if [[ -z "${AVALANCHEGO_PATH}" ]]; then
-    echo "Empty AVALANCHEGO_PATH env var!"
-    exit 255
-  fi
-  echo "running e2e tests against an ephemeral local cluster deployed with ${AVALANCHEGO_PATH}"
   AVALANCHEGO_PATH="$(realpath ${AVALANCHEGO_PATH})"
+  echo "running e2e tests against an ephemeral local cluster deployed with ${AVALANCHEGO_PATH}"
   E2E_ARGS="--avalanchego-path=${AVALANCHEGO_PATH}"
 fi
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,6 +16,25 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 
 See [`tests.e2e.sh`](../../scripts/tests.e2e.sh) for an example.
 
+### Filtering test execution with labels
+
+In cases where a change can be verified against only a subset of
+tests, it is possible to filter the tests that will be executed by the
+declarative labels that have been applied to them. Available labels
+are defined as constants in [`describe.go`](./describe.go) with names
+of the form `*Label`. The following example runs only those tests that
+primarily target the X-Chain:
+
+
+```bash
+./tests/e2e/e2e.test \
+--avalanchego-path=./build/avalanchego \
+--ginkgo.label-filter=x
+```
+
+The ginkgo docs provide further detail on [how to compose label
+queries](https://onsi.github.io/ginkgo/#spec-labels).
+
 ## Adding tests
 
 Define any flags/configurations in [`e2e.go`](./e2e.go).
@@ -67,7 +86,7 @@ Configure testnetctl to target this network by default with one of the following
 # Start a new test run using the persistent network
 ginkgo -v ./tests/e2e -- \
     --avalanchego-path=/path/to/avalanchego \
-    --ginkgo-focus-file=[name of file containing test] \
+    --ginkgo.focus-file=[name of file containing test] \
     --use-persistent-network \
     --network-dir=/path/to/network
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -28,8 +28,8 @@ primarily target the X-Chain:
 
 ```bash
 ./tests/e2e/e2e.test \
---avalanchego-path=./build/avalanchego \
---ginkgo.label-filter=x
+  --avalanchego-path=./build/avalanchego \
+  --ginkgo.label-filter=x
 ```
 
 The ginkgo docs provide further detail on [how to compose label

--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -23,12 +23,6 @@ var _ = ginkgo.Describe("[Banff]", func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	ginkgo.It("can send custom assets X->P and P->X",
-		// use this for filtering tests by labels
-		// ref. https://onsi.github.io/ginkgo/#spec-labels
-		ginkgo.Label(
-			"xp",
-			"banff",
-		),
 		func() {
 			keychain := e2e.Env.NewKeychain(1)
 			wallet := e2e.Env.NewWallet(keychain, e2e.Env.GetRandomNodeURI())

--- a/tests/e2e/describe.go
+++ b/tests/e2e/describe.go
@@ -8,17 +8,17 @@ import (
 )
 
 const (
-	// Labels for test filtering
-	// For usage in ginkgo invocation, see: https://onsi.github.io/ginkgo/#spec-labels
-	XChainLabel     = "x"
-	PChainLabel     = "p"
-	CChainLabel     = "c"
+	// For label usage in ginkgo invocation, see: https://onsi.github.io/ginkgo/#spec-labels
+
+	// Label for filtering a test that is not primarily a C-Chain test
+	// but nonentheless uses the C-Chain. Intended to support
+	// execution of all C-Chain tests by the coreth repo in an e2e job.
 	UsesCChainLabel = "uses-c"
 )
 
 // DescribeXChain annotates the tests for X-Chain.
 func DescribeXChain(text string, args ...interface{}) bool {
-	args = append(args, ginkgo.Label(XChainLabel))
+	args = append(args, ginkgo.Label("x"))
 	return ginkgo.Describe("[X-Chain] "+text, args...)
 }
 
@@ -30,12 +30,12 @@ func DescribeXChainSerial(text string, args ...interface{}) bool {
 
 // DescribePChain annotates the tests for P-Chain.
 func DescribePChain(text string, args ...interface{}) bool {
-	args = append(args, ginkgo.Label(PChainLabel))
+	args = append(args, ginkgo.Label("p"))
 	return ginkgo.Describe("[P-Chain] "+text, args...)
 }
 
 // DescribeCChain annotates the tests for C-Chain.
 func DescribeCChain(text string, args ...interface{}) bool {
-	args = append(args, ginkgo.Label(CChainLabel))
+	args = append(args, ginkgo.Label("c"))
 	return ginkgo.Describe("[C-Chain] "+text, args...)
 }

--- a/tests/e2e/describe.go
+++ b/tests/e2e/describe.go
@@ -7,26 +7,35 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
+const (
+	// Labels for test filtering
+	// For usage in ginkgo invocation, see: https://onsi.github.io/ginkgo/#spec-labels
+	XChainLabel     = "x"
+	PChainLabel     = "p"
+	CChainLabel     = "c"
+	UsesCChainLabel = "uses-c"
+)
+
 // DescribeXChain annotates the tests for X-Chain.
-// Can run with any type of cluster (e.g., local, fuji, mainnet).
-func DescribeXChain(text string, body func()) bool {
-	return ginkgo.Describe("[X-Chain] "+text, body)
+func DescribeXChain(text string, args ...interface{}) bool {
+	args = append(args, ginkgo.Label(XChainLabel))
+	return ginkgo.Describe("[X-Chain] "+text, args...)
 }
 
 // DescribeXChainSerial annotates serial tests for X-Chain.
-// Can run with any type of cluster (e.g., local, fuji, mainnet).
-func DescribeXChainSerial(text string, body func()) bool {
-	return ginkgo.Describe("[X-Chain] "+text, ginkgo.Serial, body)
+func DescribeXChainSerial(text string, args ...interface{}) bool {
+	args = append(args, ginkgo.Serial)
+	return DescribeXChain(text, args...)
 }
 
 // DescribePChain annotates the tests for P-Chain.
-// Can run with any type of cluster (e.g., local, fuji, mainnet).
-func DescribePChain(text string, body func()) bool {
-	return ginkgo.Describe("[P-Chain] "+text, body)
+func DescribePChain(text string, args ...interface{}) bool {
+	args = append(args, ginkgo.Label(PChainLabel))
+	return ginkgo.Describe("[P-Chain] "+text, args...)
 }
 
 // DescribeCChain annotates the tests for C-Chain.
-// Can run with any type of cluster (e.g., local, fuji, mainnet).
-func DescribeCChain(text string, body func()) bool {
-	return ginkgo.Describe("[C-Chain] "+text, body)
+func DescribeCChain(text string, args ...interface{}) bool {
+	args = append(args, ginkgo.Label(CChainLabel))
+	return ginkgo.Describe("[C-Chain] "+text, args...)
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -77,14 +77,12 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// Load or create a test network
 	var network *local.LocalNetwork
 	if len(persistentNetworkDir) > 0 {
-		tests.Outf("{{yellow}}Using a pre-existing network configured at %s{{/}}\n", persistentNetworkDir)
+		tests.Outf("{{yellow}}Using a persistent network configured at %s{{/}}\n", persistentNetworkDir)
 
 		var err error
 		network, err = local.ReadNetwork(persistentNetworkDir)
 		require.NoError(err)
 	} else {
-		tests.Outf("{{magenta}}Starting network with %q{{/}}\n", avalancheGoExecPath)
-
 		ctx, cancel := context.WithTimeout(context.Background(), local.DefaultNetworkStartTimeout)
 		defer cancel()
 		var err error

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
 
-var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
+var _ = e2e.DescribeXChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainLabel), func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	const (

--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -28,12 +28,6 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	ginkgo.It("subnets operations",
-		// use this for filtering tests by labels
-		// ref. https://onsi.github.io/ginkgo/#spec-labels
-		ginkgo.Label(
-			"xp",
-			"permissionless-subnets",
-		),
 		func() {
 			nodeURI := e2e.Env.GetRandomNodeURI()
 

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -33,13 +33,6 @@ var _ = e2e.DescribePChain("[Workflow]", func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	ginkgo.It("P-chain main operations",
-		// use this for filtering tests by labels
-		// ref. https://onsi.github.io/ginkgo/#spec-labels
-		ginkgo.Label(
-			"xp",
-			"workflow",
-		),
-		ginkgo.FlakeAttempts(2),
 		func() {
 			nodeURI := e2e.Env.GetRandomNodeURI()
 			keychain := e2e.Env.NewKeychain(2)

--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -29,11 +29,6 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	ginkgo.It("can make calls to avm static api",
-		// use this for filtering tests by labels
-		// ref. https://onsi.github.io/ginkgo/#spec-labels
-		ginkgo.Label(
-			"static-handlers",
-		),
 		func() {
 			addrMap := map[string]string{}
 			for _, addrStr := range []string{

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
 
-var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
+var _ = e2e.DescribeXChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainLabel), func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	const transferAmount = 10 * units.Avax

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -38,12 +38,6 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	ginkgo.It("can issue a virtuous transfer tx for AVAX asset",
-		// use this for filtering tests by labels
-		// ref. https://onsi.github.io/ginkgo/#spec-labels
-		ginkgo.Label(
-			"x",
-			"virtuous-transfer-tx-avax",
-		),
 		func() {
 			rpcEps := make([]string, len(e2e.Env.URIs))
 			for i, nodeURI := range e2e.Env.URIs {

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -128,7 +128,7 @@ func StartNetwork(
 	nodeCount int,
 	keyCount int,
 ) (*LocalNetwork, error) {
-	if _, err := fmt.Fprintln(w, "Preparing configuration for new local network..."); err != nil {
+	if _, err := fmt.Fprintf(w, "Preparing configuration for new local network with %s\n", network.ExecPath); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR is a precursor to replacing kurtosis e2e testing for coreth. The coreth e2e job will be able to run `./scripts/tests.e2e.sh --ginkgo.label-filter='c || uses-c'` to run only tests that interact with the C-Chain.

Tests also previously had a test-specific label applied which can be better accomplished with the `--focus-file` argument so long as major tests exist in separate files.