### PR TITLE
Proposervm height index repair fix

### DIFF
--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -399,7 +399,7 @@ func (vm *VM) repair(ctx context.Context) error {
 		return vm.repairAcceptedChainByIteration(ctx)
 	}
 
-	switch vm.hVM.VerifyHeightIndex(ctx) {
+	switch err := vm.hVM.VerifyHeightIndex(ctx); err {
 	case nil:
 		// InnerVM height index is complete. We can immediately verify
 		// and repair this VM height index.
@@ -414,7 +414,7 @@ func (vm *VM) repair(ctx context.Context) error {
 		}
 	case block.ErrIndexIncomplete:
 	default:
-		return nil
+		return err
 	}
 
 	// innerVM height index is incomplete. Sync vm and innerVM chains first.

--- a/vms/proposervm/vm_regression_test.go
+++ b/vms/proposervm/vm_regression_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package proposervm
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database/manager"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/version"
+)
+
+func TestProposerVMInitializeShouldFailIfInnerVMCantVerifyItsHeightIndex(t *testing.T) {
+	require := require.New(t)
+
+	innerVM := &fullVM{
+		TestVM: &block.TestVM{
+			TestVM: common.TestVM{
+				T: t,
+			},
+		},
+		TestHeightIndexedVM: &block.TestHeightIndexedVM{
+			T: t,
+		},
+	}
+
+	// let innerVM fail verifying its height index with
+	// a non-special error (like block.ErrIndexIncomplete)
+	customError := errors.New("custom error")
+	innerVM.VerifyHeightIndexF = func(_ context.Context) error {
+		return customError
+	}
+
+	innerVM.InitializeF = func(context.Context, *snow.Context, manager.Manager,
+		[]byte, []byte, []byte, chan<- common.Message,
+		[]*common.Fx, common.AppSender,
+	) error {
+		return nil
+	}
+
+	proVM := New(
+		innerVM,
+		time.Time{},
+		0,
+		DefaultMinBlockDelay,
+		pTestCert.PrivateKey.(crypto.Signer),
+		pTestCert.Leaf,
+	)
+	defer func() {
+		// avoids leaking goroutines
+		require.NoError(proVM.Shutdown(context.Background()))
+	}()
+
+	ctx := snow.DefaultContextTest()
+	dummyDBManager := manager.NewMemDB(version.Semantic1_0_0)
+	dummyDBManager = dummyDBManager.NewPrefixDBManager([]byte{})
+	initialState := []byte("genesis state")
+
+	err := proVM.Initialize(
+		context.Background(),
+		ctx,
+		dummyDBManager,
+		initialState,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.ErrorIs(customError, err)
+}


### PR DESCRIPTION
## Why this should be merged
ProposerVM does not correctly propagate error if its innerVM has an height index and it's not able to verify its completeness

## How this works
Propagate error, making proposerVM initialization fail.

## How this was tested
new regresssion test
