### PR TITLE
Support proposervm historical block deletion

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -751,14 +751,19 @@ func (m *manager) createAvalancheChain(
 	}
 
 	// Initialize the ProposerVM and the vm wrapped inside it
-	minBlockDelay := proposervm.DefaultMinBlockDelay
+	var (
+		minBlockDelay       = proposervm.DefaultMinBlockDelay
+		numHistoricalBlocks = proposervm.DefaultNumHistoricalBlocks
+	)
 	if subnetCfg, ok := m.SubnetConfigs[ctx.SubnetID]; ok {
 		minBlockDelay = subnetCfg.ProposerMinBlockDelay
+		numHistoricalBlocks = subnetCfg.ProposerNumHistoricalBlocks
 	}
 	m.Log.Info("creating proposervm wrapper",
 		zap.Time("activationTime", m.ApricotPhase4Time),
 		zap.Uint64("minPChainHeight", m.ApricotPhase4MinPChainHeight),
 		zap.Duration("minBlockDelay", minBlockDelay),
+		zap.Uint64("numHistoricalBlocks", numHistoricalBlocks),
 	)
 
 	chainAlias := m.PrimaryAliasOrDefault(ctx.ChainID)
@@ -778,6 +783,7 @@ func (m *manager) createAvalancheChain(
 		m.ApricotPhase4Time,
 		m.ApricotPhase4MinPChainHeight,
 		minBlockDelay,
+		numHistoricalBlocks,
 		m.stakingSigner,
 		m.stakingCert,
 	)
@@ -1100,14 +1106,19 @@ func (m *manager) createSnowmanChain(
 		return nil, fmt.Errorf("error while fetching chain config: %w", err)
 	}
 
-	minBlockDelay := proposervm.DefaultMinBlockDelay
+	var (
+		minBlockDelay       = proposervm.DefaultMinBlockDelay
+		numHistoricalBlocks = proposervm.DefaultNumHistoricalBlocks
+	)
 	if subnetCfg, ok := m.SubnetConfigs[ctx.SubnetID]; ok {
 		minBlockDelay = subnetCfg.ProposerMinBlockDelay
+		numHistoricalBlocks = subnetCfg.ProposerNumHistoricalBlocks
 	}
 	m.Log.Info("creating proposervm wrapper",
 		zap.Time("activationTime", m.ApricotPhase4Time),
 		zap.Uint64("minPChainHeight", m.ApricotPhase4MinPChainHeight),
 		zap.Duration("minBlockDelay", minBlockDelay),
+		zap.Uint64("numHistoricalBlocks", numHistoricalBlocks),
 	)
 
 	chainAlias := m.PrimaryAliasOrDefault(ctx.ChainID)
@@ -1120,6 +1131,7 @@ func (m *manager) createSnowmanChain(
 		m.ApricotPhase4Time,
 		m.ApricotPhase4MinPChainHeight,
 		minBlockDelay,
+		numHistoricalBlocks,
 		m.stakingSigner,
 		m.stakingCert,
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -1161,10 +1161,11 @@ func getSubnetConfigsFromDir(v *viper.Viper, subnetIDs []ids.ID) (map[ids.ID]sub
 
 func getDefaultSubnetConfig(v *viper.Viper) subnets.Config {
 	return subnets.Config{
-		ConsensusParameters:   getConsensusConfig(v),
-		ValidatorOnly:         false,
-		GossipConfig:          getGossipConfig(v),
-		ProposerMinBlockDelay: proposervm.DefaultMinBlockDelay,
+		ConsensusParameters:         getConsensusConfig(v),
+		ValidatorOnly:               false,
+		GossipConfig:                getGossipConfig(v),
+		ProposerMinBlockDelay:       proposervm.DefaultMinBlockDelay,
+		ProposerNumHistoricalBlocks: proposervm.DefaultNumHistoricalBlocks,
 	}
 }
 

--- a/subnets/config.go
+++ b/subnets/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	//
 	// Invariant: This value must be set such that the proposervm never needs to
 	// roll back more blocks than have been deleted. On startup, the proposervm
-	// rolls back it's accepted chain to match the innerVM's accepted chain. If
+	// rolls back its accepted chain to match the innerVM's accepted chain. If
 	// the innerVM is not persisting its last accepted block quickly enough, the
 	// database can become corrupted.
 	//

--- a/subnets/config.go
+++ b/subnets/config.go
@@ -42,8 +42,16 @@ type Config struct {
 
 	// ProposerMinBlockDelay is the minimum delay this node will enforce when
 	// building a snowman++ block.
+	//
 	// TODO: Remove this flag once all VMs throttle their own block production.
 	ProposerMinBlockDelay time.Duration `json:"proposerMinBlockDelay" yaml:"proposerMinBlockDelay"`
+	// ProposerNumHistoricalBlocks is the number of historical snowman++ blocks
+	// this node will index per chain. If set to 0, the node will index all
+	// snowman++ blocks.
+	//
+	// TODO: Move this flag once the proposervm is configurable on a per-chain
+	// basis.
+	ProposerNumHistoricalBlocks uint64 `json:"proposerNumHistoricalBlocks" yaml:"proposerNumHistoricalBlocks"`
 }
 
 func (c *Config) Valid() error {

--- a/subnets/config.go
+++ b/subnets/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	// database and the innerVM's database.
 	//
 	// Invariant: This value must be set such that the proposervm never needs to
-	// roll back more blocks than have been deleted. On startup, the proposervm
+	// rollback more blocks than have been deleted. On startup, the proposervm
 	// rolls back its accepted chain to match the innerVM's accepted chain. If
 	// the innerVM is not persisting its last accepted block quickly enough, the
 	// database can become corrupted.

--- a/subnets/config.go
+++ b/subnets/config.go
@@ -49,6 +49,11 @@ type Config struct {
 	// this node will index per chain. If set to 0, the node will index all
 	// snowman++ blocks.
 	//
+	// Note: The last accepted block is not considered a historical block. This
+	// prevents the user from only storing the last accepted block, which can
+	// never be safe due to the non-atomic commits between the proposervm
+	// database and the innerVM's database.
+	//
 	// Invariant: This value must be set such that the proposervm never needs to
 	// roll back more blocks than have been deleted. On startup, the proposervm
 	// rolls back its accepted chain to match the innerVM's accepted chain. If

--- a/subnets/config.go
+++ b/subnets/config.go
@@ -49,6 +49,12 @@ type Config struct {
 	// this node will index per chain. If set to 0, the node will index all
 	// snowman++ blocks.
 	//
+	// Invariant: This value must be set such that the proposervm never needs to
+	// roll back more blocks than have been deleted. On startup, the proposervm
+	// rolls back it's accepted chain to match the innerVM's accepted chain. If
+	// the innerVM is not persisting its last accepted block quickly enough, the
+	// database can become corrupted.
+	//
 	// TODO: Move this flag once the proposervm is configurable on a per-chain
 	// basis.
 	ProposerNumHistoricalBlocks uint64 `json:"proposerNumHistoricalBlocks" yaml:"proposerNumHistoricalBlocks"`

--- a/vms/proposervm/batched_vm_test.go
+++ b/vms/proposervm/batched_vm_test.go
@@ -1022,6 +1022,7 @@ func initTestRemoteProposerVM(
 		proBlkStartTime,
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)

--- a/vms/proposervm/height_indexed_vm.go
+++ b/vms/proposervm/height_indexed_vm.go
@@ -176,6 +176,7 @@ func (vm *VM) storeHeightEntry(height uint64, blkID ids.ID) error {
 	return nil
 }
 
+// TODO: Support async deletion of old blocks.
 func (vm *VM) pruneOldBlocks() error {
 	if vm.numHistoricalBlocks == 0 {
 		return nil
@@ -187,6 +188,7 @@ func (vm *VM) pruneOldBlocks() error {
 		return nil
 	}
 
+	// TODO: Refactor to use DB iterators and commit periodically.
 	for vm.lastAcceptedHeight-height > vm.numHistoricalBlocks {
 		blockToDelete, err := vm.State.GetBlockIDAtHeight(height)
 		if err != nil {

--- a/vms/proposervm/height_indexed_vm.go
+++ b/vms/proposervm/height_indexed_vm.go
@@ -189,6 +189,9 @@ func (vm *VM) pruneOldBlocks() error {
 	}
 
 	// TODO: Refactor to use DB iterators and commit periodically.
+	//
+	// Note: vm.lastAcceptedHeight is guaranteed to be >= height, so the
+	// subtraction can never underflow.
 	for vm.lastAcceptedHeight-height > vm.numHistoricalBlocks {
 		blockToDelete, err := vm.State.GetBlockIDAtHeight(height)
 		if err != nil {

--- a/vms/proposervm/post_fork_option_test.go
+++ b/vms/proposervm/post_fork_option_test.go
@@ -664,6 +664,7 @@ func TestOptionTimestampValidity(t *testing.T) {
 		time.Time{},
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)

--- a/vms/proposervm/state/block_height_index.go
+++ b/vms/proposervm/state/block_height_index.go
@@ -24,6 +24,7 @@ var (
 )
 
 type HeightIndexGetter interface {
+	GetMinimumHeight() (uint64, error)
 	GetBlockIDAtHeight(height uint64) (ids.ID, error)
 
 	// Fork height is stored when the first post-fork block/option is accepted.
@@ -32,8 +33,9 @@ type HeightIndexGetter interface {
 }
 
 type HeightIndexWriter interface {
-	SetBlockIDAtHeight(height uint64, blkID ids.ID) error
 	SetForkHeight(height uint64) error
+	SetBlockIDAtHeight(height uint64, blkID ids.ID) error
+	DeleteBlockIDAtHeight(height uint64) error
 }
 
 // A checkpoint is the blockID of the next block to be considered
@@ -75,6 +77,21 @@ func NewHeightIndex(db database.Database, commitable versiondb.Commitable) Heigh
 	}
 }
 
+func (hi *heightIndex) GetMinimumHeight() (uint64, error) {
+	it := hi.heightDB.NewIterator()
+	defer it.Release()
+
+	if !it.Next() {
+		return 0, database.ErrNotFound
+	}
+
+	height, err := database.ParseUInt64(it.Key())
+	if err != nil {
+		return 0, err
+	}
+	return height, it.Error()
+}
+
 func (hi *heightIndex) GetBlockIDAtHeight(height uint64) (ids.ID, error) {
 	if blkID, found := hi.heightsCache.Get(height); found {
 		return blkID, nil
@@ -93,6 +110,12 @@ func (hi *heightIndex) SetBlockIDAtHeight(height uint64, blkID ids.ID) error {
 	hi.heightsCache.Put(height, blkID)
 	key := database.PackUInt64(height)
 	return database.PutID(hi.heightDB, key, blkID)
+}
+
+func (hi *heightIndex) DeleteBlockIDAtHeight(height uint64) error {
+	hi.heightsCache.Evict(height)
+	key := database.PackUInt64(height)
+	return hi.heightDB.Delete(key)
 }
 
 func (hi *heightIndex) GetForkHeight() (uint64, error) {

--- a/vms/proposervm/state/block_height_index.go
+++ b/vms/proposervm/state/block_height_index.go
@@ -24,6 +24,8 @@ var (
 )
 
 type HeightIndexGetter interface {
+	// GetMinimumHeight return the smallest height of an indexed blockID. If
+	// there are no indexed blockIDs, ErrNotFound will be returned.
 	GetMinimumHeight() (uint64, error)
 	GetBlockIDAtHeight(height uint64) (ids.ID, error)
 

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -31,6 +31,7 @@ var (
 type BlockState interface {
 	GetBlock(blkID ids.ID) (block.Block, choices.Status, error)
 	PutBlock(blk block.Block, status choices.Status) error
+	DeleteBlock(blkID ids.ID) error
 }
 
 type blockState struct {
@@ -133,4 +134,9 @@ func (s *blockState) PutBlock(blk block.Block, status choices.Status) error {
 	blkID := blk.ID()
 	s.blkCache.Put(blkID, &blkWrapper)
 	return s.db.Put(blkID[:], bytes)
+}
+
+func (s *blockState) DeleteBlock(blkID ids.ID) error {
+	s.blkCache.Evict(blkID)
+	return s.db.Delete(blkID[:])
 }

--- a/vms/proposervm/state/mock_state.go
+++ b/vms/proposervm/state/mock_state.go
@@ -53,6 +53,34 @@ func (mr *MockStateMockRecorder) Commit() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockState)(nil).Commit))
 }
 
+// DeleteBlock mocks base method.
+func (m *MockState) DeleteBlock(arg0 ids.ID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBlock", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBlock indicates an expected call of DeleteBlock.
+func (mr *MockStateMockRecorder) DeleteBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBlock", reflect.TypeOf((*MockState)(nil).DeleteBlock), arg0)
+}
+
+// DeleteBlockIDAtHeight mocks base method.
+func (m *MockState) DeleteBlockIDAtHeight(arg0 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBlockIDAtHeight", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBlockIDAtHeight indicates an expected call of DeleteBlockIDAtHeight.
+func (mr *MockStateMockRecorder) DeleteBlockIDAtHeight(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBlockIDAtHeight", reflect.TypeOf((*MockState)(nil).DeleteBlockIDAtHeight), arg0)
+}
+
 // DeleteCheckpoint mocks base method.
 func (m *MockState) DeleteCheckpoint() error {
 	m.ctrl.T.Helper()
@@ -155,6 +183,21 @@ func (m *MockState) GetLastAccepted() (ids.ID, error) {
 func (mr *MockStateMockRecorder) GetLastAccepted() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastAccepted", reflect.TypeOf((*MockState)(nil).GetLastAccepted))
+}
+
+// GetMinimumHeight mocks base method.
+func (m *MockState) GetMinimumHeight() (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMinimumHeight")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMinimumHeight indicates an expected call of GetMinimumHeight.
+func (mr *MockStateMockRecorder) GetMinimumHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinimumHeight", reflect.TypeOf((*MockState)(nil).GetMinimumHeight))
 }
 
 // PutBlock mocks base method.

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -76,6 +76,7 @@ func helperBuildStateSyncTestObjects(t *testing.T) (*fullVM, *VM) {
 		time.Time{},
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -601,6 +601,11 @@ func (vm *VM) repairAcceptedChainByHeight(ctx context.Context) error {
 		return nil
 	}
 
+	vm.ctx.Log.Info("repairing accepted chain by height",
+		zap.Uint64("outerHeight", proLastAcceptedHeight),
+		zap.Uint64("innerHeight", innerLastAcceptedHeight),
+	)
+
 	// The inner vm must be behind the proposer vm, so we must roll the
 	// proposervm back.
 	forkHeight, err := vm.State.GetForkHeight()

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -6,6 +6,7 @@ package proposervm
 import (
 	"context"
 	"crypto"
+	"errors"
 	"fmt"
 	"time"
 
@@ -45,6 +46,9 @@ const (
 	// DefaultMinBlockDelay should be kept as whole seconds because block
 	// timestamps are only specific to the second.
 	DefaultMinBlockDelay = time.Second
+	// DefaultNumHistoricalBlocks as 0 results in never deleting any historical
+	// blocks.
+	DefaultNumHistoricalBlocks uint64 = 0
 
 	checkIndexedFrequency = 10 * time.Second
 	innerBlkCacheSize     = 64 * units.MiB
@@ -60,6 +64,8 @@ var (
 	fujiXChainID    ids.ID
 
 	dbPrefix = []byte("proposervm")
+
+	errHeightIndexInvalidWhilePruning = errors.New("height index invalid while pruning old blocks")
 )
 
 func init() {
@@ -88,6 +94,7 @@ type VM struct {
 	activationTime      time.Time
 	minimumPChainHeight uint64
 	minBlkDelay         time.Duration
+	numHistoricalBlocks uint64
 	// block signer
 	stakingLeafSigner crypto.Signer
 	// block certificate
@@ -135,6 +142,7 @@ func New(
 	activationTime time.Time,
 	minimumPChainHeight uint64,
 	minBlkDelay time.Duration,
+	numHistoricalBlocks uint64,
 	stakingLeafSigner crypto.Signer,
 	stakingCertLeaf *staking.Certificate,
 ) *VM {
@@ -150,6 +158,7 @@ func New(
 		activationTime:      activationTime,
 		minimumPChainHeight: minimumPChainHeight,
 		minBlkDelay:         minBlkDelay,
+		numHistoricalBlocks: numHistoricalBlocks,
 		stakingLeafSigner:   stakingLeafSigner,
 		stakingCertLeaf:     stakingCertLeaf,
 	}
@@ -245,6 +254,10 @@ func (vm *VM) Initialize(
 	}
 
 	if err := vm.setLastAcceptedMetadata(ctx); err != nil {
+		return err
+	}
+
+	if err := vm.pruneOldBlocks(); err != nil {
 		return err
 	}
 
@@ -406,6 +419,11 @@ func (vm *VM) repair(ctx context.Context) error {
 	case block.ErrIndexIncomplete:
 	default:
 		return err
+	}
+
+	if vm.numHistoricalBlocks != 0 {
+		vm.ctx.Log.Fatal("block height index must be valid when pruning historical blocks")
+		return errHeightIndexInvalidWhilePruning
 	}
 
 	// innerVM height index is incomplete. Sync vm and innerVM chains first.

--- a/vms/proposervm/vm_regression_test.go
+++ b/vms/proposervm/vm_regression_test.go
@@ -48,6 +48,7 @@ func TestProposerVMInitializeShouldFailIfInnerVMCantVerifyItsHeightIndex(t *test
 		time.Time{},
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -16,6 +16,7 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/manager"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
@@ -2528,4 +2529,214 @@ func TestVM_VerifyBlockWithContext(t *testing.T) {
 		blk.EXPECT().ID().Return(blkID).AnyTimes()
 		require.NoError(vm.verifyAndRecordInnerBlk(context.Background(), nil, blk))
 	}
+}
+
+func TestHistoricalBlockDeletion(t *testing.T) {
+	require := require.New(t)
+
+	coreGenBlk := &snowman.TestBlock{
+		TestDecidable: choices.TestDecidable{
+			IDV:     ids.GenerateTestID(),
+			StatusV: choices.Accepted,
+		},
+		HeightV:    0,
+		TimestampV: genesisTimestamp,
+		BytesV:     utils.RandomBytes(1024),
+	}
+	acceptedBlocks := []snowman.Block{coreGenBlk}
+
+	initialState := []byte("genesis state")
+	coreVM := &block.TestVM{
+		TestVM: common.TestVM{
+			T: t,
+			InitializeF: func(context.Context, *snow.Context, manager.Manager, []byte, []byte, []byte, chan<- common.Message, []*common.Fx, common.AppSender) error {
+				return nil
+			},
+		},
+		LastAcceptedF: func(context.Context) (ids.ID, error) {
+			return acceptedBlocks[len(acceptedBlocks)-1].ID(), nil
+		},
+		GetBlockF: func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
+			for _, blk := range acceptedBlocks {
+				if blkID == blk.ID() {
+					return blk, nil
+				}
+			}
+			return nil, errUnknownBlock
+		},
+		ParseBlockF: func(_ context.Context, b []byte) (snowman.Block, error) {
+			for _, blk := range acceptedBlocks {
+				if bytes.Equal(b, blk.Bytes()) {
+					return blk, nil
+				}
+			}
+			return nil, errUnknownBlock
+		},
+		VerifyHeightIndexF: func(context.Context) error {
+			return nil
+		},
+		GetBlockIDAtHeightF: func(_ context.Context, height uint64) (ids.ID, error) {
+			if height >= uint64(len(acceptedBlocks)) {
+				return ids.ID{}, errTooHigh
+			}
+			return acceptedBlocks[height].ID(), nil
+		},
+	}
+
+	ctx := snow.DefaultContextTest()
+	ctx.NodeID = ids.NodeIDFromCert(pTestCert)
+	ctx.ValidatorState = &validators.TestState{
+		T: t,
+		GetMinimumHeightF: func(context.Context) (uint64, error) {
+			return coreGenBlk.HeightV, nil
+		},
+		GetCurrentHeightF: func(context.Context) (uint64, error) {
+			return defaultPChainHeight, nil
+		},
+		GetValidatorSetF: func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+			return nil, nil
+		},
+	}
+
+	dummyDBManager := manager.NewMemDB(version.Semantic1_0_0)
+	// make sure that DBs are compressed correctly
+	dummyDBManager = dummyDBManager.NewPrefixDBManager([]byte{})
+
+	proVM := New(
+		coreVM,
+		time.Time{},
+		0,
+		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
+		pTestSigner,
+		pTestCert,
+	)
+
+	require.NoError(proVM.Initialize(
+		context.Background(),
+		ctx,
+		dummyDBManager,
+		initialState,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	))
+
+	lastAcceptedID, err := proVM.LastAccepted(context.Background())
+	require.NoError(err)
+
+	require.NoError(proVM.SetState(context.Background(), snow.NormalOp))
+	require.NoError(proVM.SetPreference(context.Background(), lastAcceptedID))
+	require.NoError(proVM.VerifyHeightIndex(context.Background()))
+
+	issueBlock := func() {
+		lastAcceptedBlock := acceptedBlocks[len(acceptedBlocks)-1]
+		innerBlock := &snowman.TestBlock{
+			TestDecidable: choices.TestDecidable{
+				IDV:     ids.GenerateTestID(),
+				StatusV: choices.Processing,
+			},
+			ParentV:    lastAcceptedBlock.ID(),
+			HeightV:    lastAcceptedBlock.Height() + 1,
+			TimestampV: lastAcceptedBlock.Timestamp(),
+			BytesV:     utils.RandomBytes(1024),
+		}
+
+		coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
+			return innerBlock, nil
+		}
+		proBlock, err := proVM.BuildBlock(context.Background())
+		require.NoError(err)
+
+		require.NoError(proBlock.Verify(context.Background()))
+		require.NoError(proVM.SetPreference(context.Background(), proBlock.ID()))
+		require.NoError(proBlock.Accept(context.Background()))
+
+		acceptedBlocks = append(acceptedBlocks, innerBlock)
+	}
+
+	requireHeights := func(start, end uint64) {
+		for i := start; i <= end; i++ {
+			_, err := proVM.GetBlockIDAtHeight(context.Background(), i)
+			require.NoError(err)
+		}
+	}
+
+	requireMissingHeights := func(start, end uint64) {
+		for i := start; i <= end; i++ {
+			_, err := proVM.GetBlockIDAtHeight(context.Background(), i)
+			require.ErrorIs(err, database.ErrNotFound)
+		}
+	}
+
+	// Because block pruning is disabled by default, the heights should be
+	// populated for every accepted block.
+	requireHeights(0, 0)
+
+	issueBlock()
+	requireHeights(0, 1)
+
+	issueBlock()
+	requireHeights(0, 2)
+
+	issueBlock()
+	requireHeights(0, 3)
+
+	issueBlock()
+	requireHeights(0, 4)
+
+	issueBlock()
+	requireHeights(0, 5)
+
+	require.NoError(proVM.Shutdown(context.Background()))
+
+	proVM = New(
+		coreVM,
+		time.Time{},
+		0,
+		DefaultMinBlockDelay,
+		2,
+		pTestSigner,
+		pTestCert,
+	)
+
+	require.NoError(proVM.Initialize(
+		context.Background(),
+		ctx,
+		dummyDBManager,
+		initialState,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	))
+	defer func() {
+		require.NoError(proVM.Shutdown(context.Background()))
+	}()
+
+	lastAcceptedID, err = proVM.LastAccepted(context.Background())
+	require.NoError(err)
+
+	require.NoError(proVM.SetState(context.Background(), snow.NormalOp))
+	require.NoError(proVM.SetPreference(context.Background(), lastAcceptedID))
+	require.NoError(proVM.VerifyHeightIndex(context.Background()))
+
+	// Verify that old blocks were pruned during startup
+	requireHeights(0, 0) // The inner VM exposes their height index
+	requireMissingHeights(1, 2)
+	requireHeights(3, 5)
+
+	// As we issue new blocks, the oldest indexed height should be pruned.
+	issueBlock()
+	requireHeights(0, 0)
+	requireMissingHeights(1, 3)
+	requireHeights(4, 6)
+
+	issueBlock()
+	requireHeights(0, 0)
+	requireMissingHeights(1, 4)
+	requireHeights(5, 7)
 }

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -136,6 +136,7 @@ func initTestProposerVM(
 		proBlkStartTime,
 		minPChainHeight,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)
@@ -874,6 +875,7 @@ func TestExpiredBuildBlock(t *testing.T) {
 		time.Time{},
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)
@@ -1216,6 +1218,7 @@ func TestInnerVMRollback(t *testing.T) {
 		time.Time{},
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)
@@ -1302,6 +1305,7 @@ func TestInnerVMRollback(t *testing.T) {
 		time.Time{},
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)
@@ -1793,6 +1797,7 @@ func TestRejectedHeightNotIndexed(t *testing.T) {
 		time.Time{},
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)
@@ -1996,6 +2001,7 @@ func TestRejectedOptionHeightNotIndexed(t *testing.T) {
 		time.Time{},
 		0,
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)
@@ -2155,6 +2161,7 @@ func TestVMInnerBlkCache(t *testing.T) {
 		time.Time{}, // fork is active
 		0,           // minimum P-Chain height
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)
@@ -2387,6 +2394,7 @@ func TestVM_VerifyBlockWithContext(t *testing.T) {
 		time.Time{}, // fork is active
 		0,           // minimum P-Chain height
 		DefaultMinBlockDelay,
+		DefaultNumHistoricalBlocks,
 		pTestSigner,
 		pTestCert,
 	)


### PR DESCRIPTION
## Why this should be merged

High performance blockchains issue large blocks and issue blocks frequently. Even if such blockchain has a robust state bloat prevention mechanism, the block data also needs to be maintained. This allows node operators to restrict the number of historical blocks that will be kept on disk.

It's important for a network maintainer to be aware however that historical block state may be lost if every node is configured to delete historical state. Thankfully historical block state isn't required for validators, so specialized storage solutions can be readily applied here.

## How this works

- Added `proposerNumHistoricalBlocks` option to subnet configs.
- Added block pruner that runs on startup to cleanup stale blocks.
- Added historical block deletion that runs as part of block acceptance.
- Required that the height index is fully repaired for any chain attempting to prune old blocks.
- Should guaranteed that the indexed heights are continuous in the range `[lastAcceptedHeight - proposerNumHistoricalBlocks, lastAcceptedHeight]`
  - ex: `lastAcceptedHeight=10` `proposerNumHistoricalBlocks=2` indexed heights should be `[8,10]` because `10` is not historical, `9` and `8` are the 2 most recent historical blocks.

## How this was tested

- [X] Unit test
- [X] Local testing (see below)

```
- Start new network with proposerNumHistoricalBlocks = 0 (infinite default)

[08-25|19:23:05.869] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "2Qpky4XexDu2dDhWbvYmNJ97SUWr1SKhyFKwnnMcqZadfZumsS", "height": 1}
[08-25|19:23:23.392] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "269AoJMCD9jGwjhRmQDqbtoMTFDXwDjcxMoKsoyDVdrdXr6tNQ", "height": 2}
[08-25|19:23:29.030] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "2anCvpG5waoVNC3DbMMgAExqDPXFDcgWwsFumvoYiskYvKxXrw", "height": 3}
[08-25|19:23:34.191] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "i16mGnEHTzniergZNXS38igngeLBY3AtwoowFj7t2vdD2TeLm", "height": 4}
[08-25|19:23:39.273] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "MdKWNyXTanP1gkeYUevsnJAqvWGs3SDpjC6Q2Z4dnTDbBmQhy", "height": 5}

- Restart setting proposerNumHistoricalBlocks = 2

[08-25|19:27:56.258] DEBUG <X Chain> proposervm/height_indexed_vm.go:205 deleted block {"blkID": "2Qpky4XexDu2dDhWbvYmNJ97SUWr1SKhyFKwnnMcqZadfZumsS", "height": 1}
[08-25|19:27:56.258] DEBUG <X Chain> proposervm/height_indexed_vm.go:205 deleted block {"blkID": "269AoJMCD9jGwjhRmQDqbtoMTFDXwDjcxMoKsoyDVdrdXr6tNQ", "height": 2}
[08-25|19:30:31.626] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "ct964fFALeNqzV7tjEtJ7HMnQhBkfgX6tKnNYcvCbWLjcq1sG", "height": 6}
[08-25|19:30:31.626] DEBUG <X Chain> proposervm/height_indexed_vm.go:172 deleted block {"blkID": "2anCvpG5waoVNC3DbMMgAExqDPXFDcgWwsFumvoYiskYvKxXrw", "height": 3}
[08-25|19:30:56.282] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "KCv9wv9kHwSN3iVTVeN4cU4zyrNGPJNpwpr6SEGqi4R1A7jaU", "height": 7}
[08-25|19:30:56.282] DEBUG <X Chain> proposervm/height_indexed_vm.go:172 deleted block {"blkID": "i16mGnEHTzniergZNXS38igngeLBY3AtwoowFj7t2vdD2TeLm", "height": 4}

- Restart setting proposerNumHistoricalBlocks = 4

[08-25|19:32:02.101] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "2oEHCZHJf34m6LrUwyHX4ui7oAbG39rRNbibZVChRYmSiRC4RK", "height": 8}
[08-25|19:33:00.551] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "2UhLwuwAyZDVTXsEiwjiaV55HhyxXciBkxcQaTd94kc4UQYkYb", "height": 9}
[08-25|19:33:17.375] DEBUG <X Chain> proposervm/height_indexed_vm.go:132 indexed block {"blkID": "2TqxFYspbjLFdVgBaENaLSe83z2vLkxTmB3dD6yVkRE2oqB2pJ", "height": 10}
[08-25|19:33:17.375] DEBUG <X Chain> proposervm/height_indexed_vm.go:172 deleted block {"blkID": "MdKWNyXTanP1gkeYUevsnJAqvWGs3SDpjC6Q2Z4dnTDbBmQhy", "height": 5}
```