### PR TITLE
e2e: Ensure testnet network dir is archived on failed test run

### DIFF
--- a/.github/workflows/test.e2e.persistent.yml
+++ b/.github/workflows/test.e2e.persistent.yml
@@ -31,6 +31,7 @@ jobs:
         run: ./scripts/tests.e2e.persistent.sh ./build/avalanchego
       - name: Upload testnet network dir
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: testnet-data
           path: ~/.testnetctl/networks/1000

--- a/.github/workflows/test.e2e.yml
+++ b/.github/workflows/test.e2e.yml
@@ -31,6 +31,7 @@ jobs:
         run: ./scripts/tests.e2e.sh ./build/avalanchego
       - name: Upload testnet network dir
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: testnet-data
           path: ~/.testnetctl/networks/1000


### PR DESCRIPTION
## Why this should be merged

Previously the testnet archive was not being archived if the test run failed. With this change, the testnet dir should always be archived.