### PR TITLE
Add async DB deletion helper

### DIFF
--- a/database/helpers.go
+++ b/database/helpers.go
@@ -170,11 +170,11 @@ func IsEmpty(db Iteratee) (bool, error) {
 	return !iterator.Next(), iterator.Error()
 }
 
-func Clear(readerDB Iteratee, deleterDB KeyValueDeleter) error {
-	return ClearPrefix(readerDB, deleterDB, nil)
+func AtomicClear(readerDB Iteratee, deleterDB KeyValueDeleter) error {
+	return AtomicClearPrefix(readerDB, deleterDB, nil)
 }
 
-func ClearPrefix(readerDB Iteratee, deleterDB KeyValueDeleter, prefix []byte) error {
+func AtomicClearPrefix(readerDB Iteratee, deleterDB KeyValueDeleter, prefix []byte) error {
 	iterator := readerDB.NewIteratorWithPrefix(prefix)
 	defer iterator.Release()
 
@@ -185,4 +185,48 @@ func ClearPrefix(readerDB Iteratee, deleterDB KeyValueDeleter, prefix []byte) er
 		}
 	}
 	return iterator.Error()
+}
+
+func Clear(db Database, writeSize int) error {
+	return ClearPrefix(db, nil, writeSize)
+}
+
+func ClearPrefix(db Database, prefix []byte, writeSize int) error {
+	b := db.NewBatch()
+	it := db.NewIteratorWithPrefix(prefix)
+	// Defer the release of the iterator inside a closure to guarantee that the
+	// latest, not the first, iterator is released on return.
+	defer func() {
+		it.Release()
+	}()
+
+	for it.Next() {
+		key := it.Key()
+		if err := b.Delete(key); err != nil {
+			return err
+		}
+
+		// Avoid too much memory pressure by periodically writing to the
+		// database.
+		if b.Size() < writeSize {
+			continue
+		}
+
+		if err := b.Write(); err != nil {
+			return err
+		}
+		b.Reset()
+
+		// Reset the iterator to release references to now deleted keys.
+		if err := it.Error(); err != nil {
+			return err
+		}
+		it.Release()
+		it = db.NewIteratorWithPrefix(prefix)
+	}
+
+	if err := b.Write(); err != nil {
+		return err
+	}
+	return it.Error()
 }

--- a/database/test_database.go
+++ b/database/test_database.go
@@ -49,7 +49,9 @@ var Tests = []func(t *testing.T, db Database){
 	TestCompactNoPanic,
 	TestMemorySafetyDatabase,
 	TestMemorySafetyBatch,
+	TestAtomicClear,
 	TestClear,
+	TestAtomicClearPrefix,
 	TestClearPrefix,
 	TestModifyValueAfterPut,
 	TestModifyValueAfterBatchPut,
@@ -922,8 +924,20 @@ func TestCompactNoPanic(t *testing.T, db Database) {
 	require.ErrorIs(err, ErrClosed)
 }
 
-// TestClear tests to make sure the deletion helper works as expected.
+func TestAtomicClear(t *testing.T, db Database) {
+	testClear(t, db, func(db Database) error {
+		return AtomicClear(db, db)
+	})
+}
+
 func TestClear(t *testing.T, db Database) {
+	testClear(t, db, func(db Database) error {
+		return Clear(db, math.MaxInt)
+	})
+}
+
+// testClear tests to make sure the deletion helper works as expected.
+func testClear(t *testing.T, db Database, clearF func(Database) error) {
 	require := require.New(t)
 
 	key1 := []byte("hello1")
@@ -943,7 +957,7 @@ func TestClear(t *testing.T, db Database) {
 	require.NoError(err)
 	require.Equal(3, count)
 
-	require.NoError(Clear(db, math.MaxInt))
+	require.NoError(clearF(db))
 
 	count, err = Count(db)
 	require.NoError(err)
@@ -952,8 +966,20 @@ func TestClear(t *testing.T, db Database) {
 	require.NoError(db.Close())
 }
 
-// TestClearPrefix tests to make sure prefix deletion works as expected.
+func TestAtomicClearPrefix(t *testing.T, db Database) {
+	testClearPrefix(t, db, func(db Database, prefix []byte) error {
+		return AtomicClearPrefix(db, db, prefix)
+	})
+}
+
 func TestClearPrefix(t *testing.T, db Database) {
+	testClearPrefix(t, db, func(db Database, prefix []byte) error {
+		return ClearPrefix(db, prefix, math.MaxInt)
+	})
+}
+
+// testClearPrefix tests to make sure prefix deletion works as expected.
+func testClearPrefix(t *testing.T, db Database, clearF func(Database, []byte) error) {
 	require := require.New(t)
 
 	key1 := []byte("hello1")
@@ -973,7 +999,7 @@ func TestClearPrefix(t *testing.T, db Database) {
 	require.NoError(err)
 	require.Equal(3, count)
 
-	require.NoError(ClearPrefix(db, []byte("hello"), math.MaxInt))
+	require.NoError(clearF(db, []byte("hello")))
 
 	count, err = Count(db)
 	require.NoError(err)

--- a/database/test_database.go
+++ b/database/test_database.go
@@ -6,6 +6,7 @@ package database
 import (
 	"bytes"
 	"io"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -942,7 +943,7 @@ func TestClear(t *testing.T, db Database) {
 	require.NoError(err)
 	require.Equal(3, count)
 
-	require.NoError(Clear(db, db))
+	require.NoError(Clear(db, math.MaxInt))
 
 	count, err = Count(db)
 	require.NoError(err)
@@ -972,7 +973,7 @@ func TestClearPrefix(t *testing.T, db Database) {
 	require.NoError(err)
 	require.Equal(3, count)
 
-	require.NoError(ClearPrefix(db, db, []byte("hello")))
+	require.NoError(ClearPrefix(db, []byte("hello"), math.MaxInt))
 
 	count, err = Count(db)
 	require.NoError(err)

--- a/snow/engine/common/queue/jobs_test.go
+++ b/snow/engine/common/queue/jobs_test.go
@@ -6,6 +6,7 @@ package queue
 import (
 	"bytes"
 	"context"
+	"math"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -451,7 +452,7 @@ func TestInitializeNumJobs(t *testing.T) {
 	require.Equal(uint64(2), jobs.state.numJobs)
 
 	require.NoError(jobs.Commit())
-	require.NoError(database.Clear(jobs.state.metadataDB, jobs.state.metadataDB))
+	require.NoError(database.Clear(jobs.state.metadataDB, math.MaxInt))
 	require.NoError(jobs.Commit())
 
 	jobs, err = NewWithMissing(db, "", prometheus.NewRegistry())


### PR DESCRIPTION
## Why this should be merged

Adds a helper for clearing state from a database with a capped memory usage.

## How this works

Changes the prior functions to be prefixed with `Atomic` and implements new async functions.

## How this was tested

Repurposed some existing clear tests