### PR TITLE
Merkle db cleanup view creation

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -844,7 +844,8 @@ func (db *merkleDB) DeleteContext(ctx context.Context, key []byte) error {
 				Key:    key,
 				Delete: true,
 			}},
-			ConsumeBytes: true})
+			ConsumeBytes: true,
+		})
 	if err != nil {
 		return err
 	}
@@ -900,7 +901,9 @@ func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) e
 	// move any child views of the committed trie onto the db
 	db.moveChildViewsToDB(trieToCommit)
 
-	if len(changes.nodes) == 0 {
+	// see if any changes need to be applied to the db
+	// use changed values and not changed nodes because the root should always be present in changes.nodes
+	if len(changes.values) == 0 {
 		return nil
 	}
 

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -258,7 +258,7 @@ func (db *merkleDB) rebuild(ctx context.Context) error {
 
 	for it.Next() {
 		if len(currentOps) >= viewSizeLimit {
-			view, err := db.newUntrackedView(currentOps, true)
+			view, err := newTrieView(db, db, ViewChanges{BatchOps: currentOps, ConsumeBytes: true})
 			if err != nil {
 				return err
 			}
@@ -285,7 +285,7 @@ func (db *merkleDB) rebuild(ctx context.Context) error {
 	if err := it.Error(); err != nil {
 		return err
 	}
-	view, err := db.newUntrackedView(currentOps, true)
+	view, err := newTrieView(db, db, ViewChanges{BatchOps: currentOps, ConsumeBytes: true})
 	if err != nil {
 		return err
 	}
@@ -311,7 +311,7 @@ func (db *merkleDB) CommitChangeProof(ctx context.Context, proof *ChangeProof) e
 		}
 	}
 
-	view, err := db.newUntrackedView(ops, false)
+	view, err := newTrieView(db, db, ViewChanges{BatchOps: ops})
 	if err != nil {
 		return err
 	}
@@ -352,7 +352,7 @@ func (db *merkleDB) CommitRangeProof(ctx context.Context, start maybe.Maybe[[]by
 	}
 
 	// Don't need to lock [view] because nobody else has a reference to it.
-	view, err := db.newUntrackedView(ops, false)
+	view, err := newTrieView(db, db, ViewChanges{BatchOps: ops})
 	if err != nil {
 		return err
 	}
@@ -507,7 +507,7 @@ func (db *merkleDB) getProof(ctx context.Context, key []byte) (*Proof, error) {
 		return nil, database.ErrClosed
 	}
 
-	view, err := db.newUntrackedView(nil, true)
+	view, err := newTrieView(db, db, ViewChanges{})
 	if err != nil {
 		return nil, err
 	}
@@ -677,7 +677,7 @@ func (db *merkleDB) NewView(
 		return nil, database.ErrClosed
 	}
 
-	newView, err := newTrieView(db, db, db.root.clone(), changes)
+	newView, err := newTrieView(db, db, changes)
 	if err != nil {
 		return nil, err
 	}
@@ -688,21 +688,6 @@ func (db *merkleDB) NewView(
 
 	db.childViews = append(db.childViews, newView)
 	return newView, nil
-}
-
-// Returns a new view that isn't tracked in [db.childViews].
-// For internal use only, namely in methods that create short-lived views.
-// Assumes [db.lock] isn't held and [db.commitLock] is read locked.
-func (db *merkleDB) newUntrackedView(batchOps []database.BatchOp, consumeBytes bool) (*trieView, error) {
-	return newTrieView(
-		db,
-		db,
-		db.root.clone(),
-		ViewChanges{
-			BatchOps:     batchOps,
-			ConsumeBytes: consumeBytes,
-		},
-	)
 }
 
 func (db *merkleDB) Has(k []byte) (bool, error) {
@@ -834,13 +819,7 @@ func (db *merkleDB) PutContext(ctx context.Context, k, v []byte) error {
 		return database.ErrClosed
 	}
 
-	view, err := db.newUntrackedView(
-		[]database.BatchOp{{
-			Key:   k,
-			Value: v,
-		}},
-		false,
-	)
+	view, err := newTrieView(db, db, ViewChanges{BatchOps: []database.BatchOp{{Key: k, Value: v}}})
 	if err != nil {
 		return err
 	}
@@ -859,13 +838,13 @@ func (db *merkleDB) DeleteContext(ctx context.Context, key []byte) error {
 		return database.ErrClosed
 	}
 
-	view, err := db.newUntrackedView(
-		[]database.BatchOp{{
-			Key:    key,
-			Delete: true,
-		}},
-		true,
-	)
+	view, err := newTrieView(db, db,
+		ViewChanges{
+			BatchOps: []database.BatchOp{{
+				Key:    key,
+				Delete: true,
+			}},
+			ConsumeBytes: true})
 	if err != nil {
 		return err
 	}
@@ -882,7 +861,7 @@ func (db *merkleDB) commitBatch(ops []database.BatchOp) error {
 		return database.ErrClosed
 	}
 
-	view, err := db.newUntrackedView(ops, true)
+	view, err := newTrieView(db, db, ViewChanges{BatchOps: ops, ConsumeBytes: true})
 	if err != nil {
 		return err
 	}
@@ -1097,7 +1076,7 @@ func (db *merkleDB) VerifyChangeProof(
 	}
 
 	// Don't need to lock [view] because nobody else has a reference to it.
-	view, err := db.newUntrackedView(ops, true)
+	view, err := newTrieView(db, db, ViewChanges{BatchOps: ops, ConsumeBytes: true})
 	if err != nil {
 		return err
 	}
@@ -1207,7 +1186,7 @@ func (db *merkleDB) getHistoricalViewForRange(
 	// looking for the trie's current root id, so return the trie unmodified
 	if currentRootID == rootID {
 		// create an empty trie
-		return newTrieView(db, db, db.root.clone(), ViewChanges{})
+		return newTrieView(db, db, ViewChanges{})
 	}
 
 	changeHistory, err := db.history.getChangesToGetToRoot(rootID, start, end)

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -902,8 +902,7 @@ func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) e
 	db.moveChildViewsToDB(trieToCommit)
 
 	// see if any changes need to be applied to the db
-	// use changed values and not changed nodes because the root should always be present in changes.nodes
-	if len(changes.values) == 0 {
+	if len(changes.nodes) == 0 {
 		return nil
 	}
 

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -901,7 +901,6 @@ func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) e
 	// move any child views of the committed trie onto the db
 	db.moveChildViewsToDB(trieToCommit)
 
-	// see if any changes need to be applied to the db
 	if len(changes.nodes) == 0 {
 		return nil
 	}

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -458,7 +458,9 @@ func TestDatabaseNewUntrackedView(t *testing.T) {
 	require.NoError(err)
 
 	// Create a new untracked view.
-	view, err := newTrieView(db, db,
+	view, err := newTrieView(
+		db,
+		db,
 		ViewChanges{
 			BatchOps: []database.BatchOp{
 				{Key: []byte{1}, Value: []byte{1}},

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -458,11 +458,12 @@ func TestDatabaseNewUntrackedView(t *testing.T) {
 	require.NoError(err)
 
 	// Create a new untracked view.
-	view, err := db.newUntrackedView(
-		[]database.BatchOp{
-			{Key: []byte{1}, Value: []byte{1}},
+	view, err := newTrieView(db, db,
+		ViewChanges{
+			BatchOps: []database.BatchOp{
+				{Key: []byte{1}, Value: []byte{1}},
+			},
 		},
-		false,
 	)
 	require.NoError(err)
 	require.Empty(db.childViews)

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -878,5 +878,5 @@ func getStandaloneTrieView(ctx context.Context, ops []database.BatchOp) (*trieVi
 		return nil, err
 	}
 
-	return db.newUntrackedView(ops, true)
+	return newTrieView(db, db, ViewChanges{BatchOps: ops, ConsumeBytes: true})
 }

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -128,7 +128,7 @@ func (t *trieView) NewView(
 		return nil, err
 	}
 
-	newView, err := newTrieView(t.db, t, t.root.clone(), changes)
+	newView, err := newTrieView(t.db, t, changes)
 	if err != nil {
 		return nil, err
 	}
@@ -148,11 +148,14 @@ func (t *trieView) NewView(
 func newTrieView(
 	db *merkleDB,
 	parentTrie TrieView,
-	root *node,
 	changes ViewChanges,
 ) (*trieView, error) {
-	if root == nil {
-		return nil, ErrNoValidRoot
+	root, err := parentTrie.getEditableNode(RootPath)
+	if err != nil {
+		if err == database.ErrNotFound {
+			return nil, ErrNoValidRoot
+		}
+		return nil, err
 	}
 
 	newView := &trieView{

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -165,12 +165,6 @@ func newTrieView(
 		changes:    newChangeSummary(len(changes.BatchOps) + len(changes.MapOps)),
 	}
 
-	// record that the root of this trie will be changing
-	// ensures that the root is present in the newView's t.changes.nodes
-	if err := newView.recordNodeChange(root); err != nil {
-		return nil, err
-	}
-
 	for _, op := range changes.BatchOps {
 		newVal := maybe.Nothing[[]byte]()
 		if !op.Delete {

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -165,6 +165,12 @@ func newTrieView(
 		changes:    newChangeSummary(len(changes.BatchOps) + len(changes.MapOps)),
 	}
 
+	// record that the root of this trie will be changing
+	// ensures that the root is present in the newView's t.changes.nodes
+	if err := newView.recordNodeChange(root); err != nil {
+		return nil, err
+	}
+
 	for _, op := range changes.BatchOps {
 		newVal := maybe.Nothing[[]byte]()
 		if !op.Delete {


### PR DESCRIPTION
Remove the mostly duplicate function newUntrackedView from db.go and no longer pass in the root to newTrieView to reduce possibility of calling the function incorrectly with a noncloned/not editable root.  Additionally fixed tests that called trieview.insert() directly instead of using NewView since that isn't an accurate usage of views.