### PR TITLE
updated runner image and instance type

### DIFF
--- a/.github/packer/ubuntu-jammy-x86_64-public-ami.json
+++ b/.github/packer/ubuntu-jammy-x86_64-public-ami.json
@@ -23,7 +23,7 @@
         ]
       },
       "ssh_username": "ubuntu",
-      "instance_type": "t2.micro",
+      "instance_type": "c5.large",
       "ami_groups": "all",
       "tags": {
         "Name": "public-avalanche-ubuntu-{{ user `version` }}-{{ user `tag` }}-{{ isotime | clean_resource_name }}",

--- a/.github/workflows/build-public-ami.yml
+++ b/.github/workflows/build-public-ami.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-public-ami-and-upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
 
     steps:


### PR DESCRIPTION
## Why this should be merged
This will fix issues with the public ami uploader ringing json correctly as well as timeouts with the ami build.

## How this works
Using ubuntu 22.04 instead of 20.04 fixed some json parsing errors with the boto3 library.  Adjusting the image for build will make builds faster and not hit the 45 minute timeout.

## How this was tested
A private branch was created with these adjustments and we saw successful builds from github pipeline.