### PR TITLE
e2e: Diagnose and fix flakes

### DIFF
--- a/tests/colors.go
+++ b/tests/colors.go
@@ -20,5 +20,11 @@ import (
 // for an exhaustive list of color options.
 func Outf(format string, args ...interface{}) {
 	s := formatter.F(format, args...)
+	// Use GinkgoWriter to ensure that output from this function is
+	// printed sequentially within other test output produced with
+	// GinkgoWriter (e.g. `STEP:...`) when tests are run in
+	// parallel. ginkgo collects and writes stdout separately from
+	// GinkgoWriter during parallel execution and the resulting output
+	// can be confusing.
 	ginkgo.GinkgoWriter.Print(s)
 }

--- a/tests/colors.go
+++ b/tests/colors.go
@@ -4,7 +4,7 @@
 package tests
 
 import (
-	"fmt"
+	ginkgo "github.com/onsi/ginkgo/v2"
 
 	"github.com/onsi/ginkgo/v2/formatter"
 )
@@ -20,5 +20,5 @@ import (
 // for an exhaustive list of color options.
 func Outf(format string, args ...interface{}) {
 	s := formatter.F(format, args...)
-	fmt.Fprint(formatter.ColorableStdOut, s)
+	ginkgo.GinkgoWriter.Print(s)
 }

--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -29,7 +29,7 @@ var _ = ginkgo.Describe("[Banff]", func() {
 		),
 		func() {
 			keychain := e2e.Env.NewKeychain(1)
-			wallet := e2e.Env.NewWallet(keychain)
+			wallet := e2e.Env.NewWallet(keychain, e2e.Env.GetRandomNodeURI())
 
 			// Get the P-chain and the X-chain wallets
 			pWallet := wallet.P()

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -111,24 +111,22 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 		}
 
 		ginkgo.By("exporting AVAX from the C-Chain to the X-Chain", func() {
-			e2e.LogTxAndCheck(
-				cWallet.IssueExportTx(
-					xWallet.BlockchainID(),
-					exportOutputs,
-					e2e.WithDefaultContext(),
-					e2e.WithSuggestedGasPrice(ethClient),
-				),
+			_, err := cWallet.IssueExportTx(
+				xWallet.BlockchainID(),
+				exportOutputs,
+				e2e.WithDefaultContext(),
+				e2e.WithSuggestedGasPrice(ethClient),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("importing AVAX from the C-Chain to the X-Chain", func() {
-			e2e.LogTxAndCheck(
-				xWallet.IssueImportTx(
-					cWallet.BlockchainID(),
-					&recipientOwner,
-					e2e.WithDefaultContext(),
-				),
+			_, err := xWallet.IssueImportTx(
+				cWallet.BlockchainID(),
+				&recipientOwner,
+				e2e.WithDefaultContext(),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("checking that the recipient address has received imported funds on the X-Chain", func() {
@@ -140,24 +138,22 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 		})
 
 		ginkgo.By("exporting AVAX from the C-Chain to the P-Chain", func() {
-			e2e.LogTxAndCheck(
-				cWallet.IssueExportTx(
-					constants.PlatformChainID,
-					exportOutputs,
-					e2e.WithDefaultContext(),
-					e2e.WithSuggestedGasPrice(ethClient),
-				),
+			_, err := cWallet.IssueExportTx(
+				constants.PlatformChainID,
+				exportOutputs,
+				e2e.WithDefaultContext(),
+				e2e.WithSuggestedGasPrice(ethClient),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("importing AVAX from the C-Chain to the P-Chain", func() {
-			e2e.LogTxAndCheck(
-				pWallet.IssueImportTx(
-					cWallet.BlockchainID(),
-					&recipientOwner,
-					e2e.WithDefaultContext(),
-				),
+			_, err = pWallet.IssueImportTx(
+				cWallet.BlockchainID(),
+				&recipientOwner,
+				e2e.WithDefaultContext(),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("checking that the recipient address has received imported funds on the P-Chain", func() {

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -32,10 +32,12 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 	)
 
 	ginkgo.It("should ensure that funds can be transferred from the C-Chain to the X-Chain and the P-Chain", func() {
+		ginkgo.By("initializing a new eth client")
 		// Select a random node URI to use for both the eth client and
 		// the wallet to avoid having to verify that all nodes are at
 		// the same height before initializing the wallet.
 		nodeURI := e2e.Env.GetRandomNodeURI()
+		ethClient := e2e.Env.NewEthClient(nodeURI)
 
 		ginkgo.By("allocating a pre-funded key to send from and a recipient key to deliver to")
 		senderKey := e2e.Env.AllocateFundedKey()
@@ -44,8 +46,6 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 		recipientKey, err := factory.NewPrivateKey()
 		require.NoError(err)
 		recipientEthAddress := evm.GetEthAddress(recipientKey)
-
-		ethClient := e2e.Env.NewEthClient(nodeURI)
 
 		ginkgo.By("sending funds from one address to another on the C-Chain", func() {
 			// Create transaction

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -51,8 +51,7 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 			// Create transaction
 			acceptedNonce, err := ethClient.AcceptedNonceAt(e2e.DefaultContext(), senderEthAddress)
 			require.NoError(err)
-			gasPrice, err := ethClient.SuggestGasPrice(e2e.DefaultContext())
-			require.NoError(err)
+			gasPrice := e2e.SuggestGasPrice(ethClient)
 			tx := types.NewTransaction(
 				acceptedNonce,
 				recipientEthAddress,
@@ -117,6 +116,7 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 					xWallet.BlockchainID(),
 					exportOutputs,
 					e2e.WithDefaultContext(),
+					e2e.WithSuggestedGasPrice(ethClient),
 				),
 			)
 		})
@@ -145,6 +145,7 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 					constants.PlatformChainID,
 					exportOutputs,
 					e2e.WithDefaultContext(),
+					e2e.WithSuggestedGasPrice(ethClient),
 				),
 			)
 		})

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -115,7 +115,6 @@ func (te *TestEnvironment) AllocateFundedKey() *secp256k1.PrivateKey {
 // Create a new keychain with the specified number of test keys.
 func (te *TestEnvironment) NewKeychain(count int) *secp256k1fx.Keychain {
 	keys := te.AllocateFundedKeys(count)
-	tests.Outf("{{blue}} initializing keychain with %d key(s) {{/}}\n", count)
 	return secp256k1fx.NewKeychain(keys...)
 }
 

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -201,27 +201,6 @@ func WaitForHealthy(node testnet.Node) {
 	require.NoError(ginkgo.GinkgoT(), testnet.WaitForHealthy(ctx, node))
 }
 
-// Interface to allow logging any type of transaction that has an ID method.
-type LoggableTx interface {
-	ID() ids.ID
-}
-
-// Ensures transaction id is logged if the transaction is non-nil. Should be
-// called before checking for an error to ensure traceability in the event
-// of a transaction being submitted but failing to be accepted.
-func LogTx(tx LoggableTx) {
-	if tx != nil {
-		tests.Outf(" tx id: %s\n", tx.ID())
-	}
-}
-
-// Ensures transaction id is logged if the transaction is non-nil and check
-// if an error occurred.
-func LogTxAndCheck(tx LoggableTx, err error) {
-	LogTx(tx)
-	require.NoError(ginkgo.GinkgoT(), err)
-}
-
 // Sends an eth transaction, waits for the transaction receipt to be issued
 // and checks that the receipt indicates success.
 func SendEthTransaction(ethClient ethclient.Client, signedTx *types.Transaction) *types.Receipt {

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -121,13 +121,20 @@ func (te *TestEnvironment) NewKeychain(count int) *secp256k1fx.Keychain {
 // Create a new wallet for the provided keychain against the specified node URI.
 func (te *TestEnvironment) NewWallet(keychain *secp256k1fx.Keychain, uri string) primary.Wallet {
 	tests.Outf("{{blue}} initializing a new wallet for URI: %s {{/}}\n", uri)
-	wallet, err := primary.MakeWallet(DefaultContext(), &primary.WalletConfig{
+	baseWallet, err := primary.MakeWallet(DefaultContext(), &primary.WalletConfig{
 		URI:          uri,
 		AVAXKeychain: keychain,
 		EthKeychain:  keychain,
 	})
 	te.require.NoError(err)
-	return wallet
+	return primary.NewWalletWithOptions(
+		baseWallet,
+		common.WithLogTxFunc(
+			func(id ids.ID) {
+				tests.Outf(" tx id: %s\n", id)
+			},
+		),
+	)
 }
 
 // Create a new eth client targeting the specified node URI.

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -226,7 +226,6 @@ func SendEthTransaction(ethClient ethclient.Client, signedTx *types.Transaction)
 		return true
 	}, DefaultTimeout, DefaultPollingInterval, "failed to see transaction acceptance before timeout")
 
-	// Retrieve the contract address
 	require.Equal(receipt.Status, types.ReceiptStatusSuccessful)
 	return receipt
 }

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -127,7 +127,7 @@ func (te *TestEnvironment) NewWallet(keychain *secp256k1fx.Keychain, nodeURI tes
 		baseWallet,
 		common.WithPostIssuanceFunc(
 			func(id ids.ID) {
-				tests.Outf(" tx id: %s\n", id)
+				tests.Outf(" issued transaction with ID: %s\n", id)
 			},
 		),
 	)
@@ -210,7 +210,7 @@ func SendEthTransaction(ethClient ethclient.Client, signedTx *types.Transaction)
 	require := require.New(ginkgo.GinkgoT())
 
 	txID := signedTx.Hash()
-	tests.Outf(" eth tx id: %s\n", txID)
+	tests.Outf(" sending eth transaction with ID: %s\n", txID)
 
 	require.NoError(ethClient.SendTransaction(DefaultContext(), signedTx))
 

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -125,7 +125,7 @@ func (te *TestEnvironment) NewWallet(keychain *secp256k1fx.Keychain, nodeURI tes
 	te.require.NoError(err)
 	return primary.NewWalletWithOptions(
 		baseWallet,
-		common.WithLogTxFunc(
+		common.WithPostIssuanceFunc(
 			func(id ids.ID) {
 				tests.Outf(" tx id: %s\n", id)
 			},

--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -70,7 +70,7 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 					common.WithContext(ctx),
 				)
 				cancel()
-				e2e.LogTx(subnetTx)
+
 				subnetID = subnetTx.ID()
 				gomega.Expect(subnetID, err).Should(gomega.Not(gomega.Equal(constants.PrimaryNetworkID)))
 			})
@@ -93,114 +93,108 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 					common.WithContext(ctx),
 				)
 				cancel()
-				e2e.LogTx(subnetAssetTx)
 				gomega.Expect(err).Should(gomega.BeNil())
 				subnetAssetID = subnetAssetTx.ID()
 			})
 
 			ginkgo.By(fmt.Sprintf("Send 100 MegaAvax of asset %s to the P-chain", subnetAssetID), func() {
 				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
-				e2e.LogTxAndCheck(
-					xWallet.IssueExportTx(
-						constants.PlatformChainID,
-						[]*avax.TransferableOutput{
-							{
-								Asset: avax.Asset{
-									ID: subnetAssetID,
-								},
-								Out: &secp256k1fx.TransferOutput{
-									Amt:          100 * units.MegaAvax,
-									OutputOwners: *owner,
-								},
+				_, err := xWallet.IssueExportTx(
+					constants.PlatformChainID,
+					[]*avax.TransferableOutput{
+						{
+							Asset: avax.Asset{
+								ID: subnetAssetID,
+							},
+							Out: &secp256k1fx.TransferOutput{
+								Amt:          100 * units.MegaAvax,
+								OutputOwners: *owner,
 							},
 						},
-						common.WithContext(ctx),
-					),
+					},
+					common.WithContext(ctx),
 				)
 				cancel()
+				gomega.Expect(err).Should(gomega.BeNil())
 			})
 
 			ginkgo.By(fmt.Sprintf("Import the 100 MegaAvax of asset %s from the X-chain into the P-chain", subnetAssetID), func() {
 				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
-				tx, err := pWallet.IssueImportTx(
+				_, err := pWallet.IssueImportTx(
 					xChainID,
 					owner,
 					common.WithContext(ctx),
 				)
 				cancel()
-				e2e.LogTx(tx)
 				gomega.Expect(err).Should(gomega.BeNil())
 			})
 
 			ginkgo.By("make subnet permissionless", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
-				e2e.LogTxAndCheck(
-					pWallet.IssueTransformSubnetTx(
-						subnetID,
-						subnetAssetID,
-						50*units.MegaAvax,
-						100*units.MegaAvax,
-						reward.PercentDenominator,
-						reward.PercentDenominator,
-						1,
-						100*units.MegaAvax,
-						time.Second,
-						365*24*time.Hour,
-						0,
-						1,
-						5,
-						.80*reward.PercentDenominator,
-						common.WithContext(ctx),
-					),
+				_, err := pWallet.IssueTransformSubnetTx(
+					subnetID,
+					subnetAssetID,
+					50*units.MegaAvax,
+					100*units.MegaAvax,
+					reward.PercentDenominator,
+					reward.PercentDenominator,
+					1,
+					100*units.MegaAvax,
+					time.Second,
+					365*24*time.Hour,
+					0,
+					1,
+					5,
+					.80*reward.PercentDenominator,
+					common.WithContext(ctx),
 				)
 				cancel()
+				gomega.Expect(err).Should(gomega.BeNil())
 			})
 
 			validatorStartTime := time.Now().Add(time.Minute)
 			ginkgo.By("add permissionless validator", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
-				e2e.LogTxAndCheck(
-					pWallet.IssueAddPermissionlessValidatorTx(
-						&txs.SubnetValidator{
-							Validator: txs.Validator{
-								NodeID: validatorID,
-								Start:  uint64(validatorStartTime.Unix()),
-								End:    uint64(validatorStartTime.Add(5 * time.Second).Unix()),
-								Wght:   25 * units.MegaAvax,
-							},
-							Subnet: subnetID,
+				_, err := pWallet.IssueAddPermissionlessValidatorTx(
+					&txs.SubnetValidator{
+						Validator: txs.Validator{
+							NodeID: validatorID,
+							Start:  uint64(validatorStartTime.Unix()),
+							End:    uint64(validatorStartTime.Add(5 * time.Second).Unix()),
+							Wght:   25 * units.MegaAvax,
 						},
-						&signer.Empty{},
-						subnetAssetID,
-						&secp256k1fx.OutputOwners{},
-						&secp256k1fx.OutputOwners{},
-						reward.PercentDenominator,
-						common.WithContext(ctx),
-					),
+						Subnet: subnetID,
+					},
+					&signer.Empty{},
+					subnetAssetID,
+					&secp256k1fx.OutputOwners{},
+					&secp256k1fx.OutputOwners{},
+					reward.PercentDenominator,
+					common.WithContext(ctx),
 				)
 				cancel()
+				gomega.Expect(err).Should(gomega.BeNil())
 			})
 
 			delegatorStartTime := validatorStartTime
 			ginkgo.By("add permissionless delegator", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
-				e2e.LogTxAndCheck(
-					pWallet.IssueAddPermissionlessDelegatorTx(
-						&txs.SubnetValidator{
-							Validator: txs.Validator{
-								NodeID: validatorID,
-								Start:  uint64(delegatorStartTime.Unix()),
-								End:    uint64(delegatorStartTime.Add(5 * time.Second).Unix()),
-								Wght:   25 * units.MegaAvax,
-							},
-							Subnet: subnetID,
+				_, err := pWallet.IssueAddPermissionlessDelegatorTx(
+					&txs.SubnetValidator{
+						Validator: txs.Validator{
+							NodeID: validatorID,
+							Start:  uint64(delegatorStartTime.Unix()),
+							End:    uint64(delegatorStartTime.Add(5 * time.Second).Unix()),
+							Wght:   25 * units.MegaAvax,
 						},
-						subnetAssetID,
-						&secp256k1fx.OutputOwners{},
-						common.WithContext(ctx),
-					),
+						Subnet: subnetID,
+					},
+					subnetAssetID,
+					&secp256k1fx.OutputOwners{},
+					common.WithContext(ctx),
 				)
 				cancel()
+				gomega.Expect(err).Should(gomega.BeNil())
 			})
 		})
 })

--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -46,7 +46,7 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 
 			var validatorID ids.NodeID
 			ginkgo.By("retrieving the node ID of a primary network validator", func() {
-				pChainClient := platformvm.NewClient(nodeURI)
+				pChainClient := platformvm.NewClient(nodeURI.URI)
 				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
 				validatorIDs, err := pChainClient.SampleValidators(ctx, constants.PrimaryNetworkID, 1)
 				cancel()

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -49,7 +49,7 @@ var _ = e2e.DescribePChain("[Workflow]", func() {
 			pWallet := baseWallet.P()
 			avaxAssetID := baseWallet.P().AVAXAssetID()
 			xWallet := baseWallet.X()
-			pChainClient := platformvm.NewClient(nodeURI)
+			pChainClient := platformvm.NewClient(nodeURI.URI)
 
 			tests.Outf("{{blue}} fetching minimal stake amounts {{/}}\n")
 			ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultWalletCreationTimeout)
@@ -60,7 +60,7 @@ var _ = e2e.DescribePChain("[Workflow]", func() {
 			tests.Outf("{{green}} minimal delegator stake: %d {{/}}\n", minDelStake)
 
 			tests.Outf("{{blue}} fetching tx fee {{/}}\n")
-			infoClient := info.NewClient(nodeURI)
+			infoClient := info.NewClient(nodeURI.URI)
 			ctx, cancel = context.WithTimeout(context.Background(), e2e.DefaultWalletCreationTimeout)
 			fees, err := infoClient.GetTxFee(ctx)
 			cancel()

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -44,7 +44,7 @@ var _ = e2e.DescribePChain("[Workflow]", func() {
 		func() {
 			nodeURI := e2e.Env.GetRandomNodeURI()
 			keychain := e2e.Env.NewKeychain(2)
-			baseWallet := e2e.Env.NewWallet(keychain)
+			baseWallet := e2e.Env.NewWallet(keychain, nodeURI)
 
 			pWallet := baseWallet.P()
 			avaxAssetID := baseWallet.P().AVAXAssetID()

--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -110,7 +110,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 					},
 				},
 			}
-			staticClient := avm.NewStaticClient(e2e.Env.GetRandomNodeURI())
+			staticClient := avm.NewStaticClient(e2e.Env.GetRandomNodeURI().URI)
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			resp, err := staticClient.BuildGenesis(ctx, &avmArgs)
 			cancel()
@@ -181,7 +181,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 			Encoding:      formatting.Hex,
 		}
 
-		staticClient := api.NewStaticClient(e2e.Env.GetRandomNodeURI())
+		staticClient := api.NewStaticClient(e2e.Env.GetRandomNodeURI().URI)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		resp, err := staticClient.BuildGenesis(ctx, &buildGenesisArgs)
 		cancel()

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -71,20 +71,19 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 		}
 
 		ginkgo.By("sending funds from one address to another on the X-Chain", func() {
-			e2e.LogTxAndCheck(
-				xWallet.IssueBaseTx(
-					[]*avax.TransferableOutput{{
-						Asset: avax.Asset{
-							ID: avaxAssetID,
-						},
-						Out: &secp256k1fx.TransferOutput{
-							Amt:          transferAmount,
-							OutputOwners: recipientOwner,
-						},
-					}},
-					e2e.WithDefaultContext(),
-				),
+			_, err = xWallet.IssueBaseTx(
+				[]*avax.TransferableOutput{{
+					Asset: avax.Asset{
+						ID: avaxAssetID,
+					},
+					Out: &secp256k1fx.TransferOutput{
+						Amt:          transferAmount,
+						OutputOwners: recipientOwner,
+					},
+				}},
+				e2e.WithDefaultContext(),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("checking that the X-Chain recipient address has received the sent funds", func() {
@@ -96,27 +95,25 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 		})
 
 		ginkgo.By("exporting AVAX from the X-Chain to the C-Chain", func() {
-			e2e.LogTxAndCheck(
-				xWallet.IssueExportTx(
-					cWallet.BlockchainID(),
-					exportOutputs,
-					e2e.WithDefaultContext(),
-				),
+			_, err := xWallet.IssueExportTx(
+				cWallet.BlockchainID(),
+				exportOutputs,
+				e2e.WithDefaultContext(),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("initializing a new eth client")
 		ethClient := e2e.Env.NewEthClient(nodeURI)
 
 		ginkgo.By("importing AVAX from the X-Chain to the C-Chain", func() {
-			e2e.LogTxAndCheck(
-				cWallet.IssueImportTx(
-					xWallet.BlockchainID(),
-					recipientEthAddress,
-					e2e.WithDefaultContext(),
-					e2e.WithSuggestedGasPrice(ethClient),
-				),
+			_, err := cWallet.IssueImportTx(
+				xWallet.BlockchainID(),
+				recipientEthAddress,
+				e2e.WithDefaultContext(),
+				e2e.WithSuggestedGasPrice(ethClient),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain")
@@ -127,23 +124,21 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 		}, e2e.DefaultTimeout, e2e.DefaultPollingInterval, "failed to see recipient address funded before timeout")
 
 		ginkgo.By("exporting AVAX from the X-Chain to the P-Chain", func() {
-			e2e.LogTxAndCheck(
-				xWallet.IssueExportTx(
-					constants.PlatformChainID,
-					exportOutputs,
-					e2e.WithDefaultContext(),
-				),
+			_, err := xWallet.IssueExportTx(
+				constants.PlatformChainID,
+				exportOutputs,
+				e2e.WithDefaultContext(),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("importing AVAX from the X-Chain to the P-Chain", func() {
-			e2e.LogTxAndCheck(
-				pWallet.IssueImportTx(
-					xWallet.BlockchainID(),
-					&recipientOwner,
-					e2e.WithDefaultContext(),
-				),
+			_, err := pWallet.IssueImportTx(
+				xWallet.BlockchainID(),
+				&recipientOwner,
+				e2e.WithDefaultContext(),
 			)
+			require.NoError(err)
 		})
 
 		ginkgo.By("checking that the recipient address has received imported funds on the P-Chain", func() {

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -105,18 +105,21 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", func() {
 			)
 		})
 
+		ginkgo.By("initializing a new eth client")
+		ethClient := e2e.Env.NewEthClient(nodeURI)
+
 		ginkgo.By("importing AVAX from the X-Chain to the C-Chain", func() {
 			e2e.LogTxAndCheck(
 				cWallet.IssueImportTx(
 					xWallet.BlockchainID(),
 					recipientEthAddress,
 					e2e.WithDefaultContext(),
+					e2e.WithSuggestedGasPrice(ethClient),
 				),
 			)
 		})
 
 		ginkgo.By("checking that the recipient address has received imported funds on the C-Chain")
-		ethClient := e2e.Env.NewEthClient(nodeURI)
 		e2e.Eventually(func() bool {
 			balance, err := ethClient.BalanceAt(e2e.DefaultContext(), recipientEthAddress, nil)
 			require.NoError(err)

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -14,6 +14,8 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/tests"
@@ -44,7 +46,7 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 			"virtuous-transfer-tx-avax",
 		),
 		func() {
-			rpcEps := e2e.Env.URIs
+			rpcEps := maps.Values(e2e.Env.URIs)
 
 			// Waiting for ongoing blocks to have completed before starting this
 			// test avoids the case of a previous test having initiated block
@@ -84,7 +86,7 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 				}
 
 				keychain := secp256k1fx.NewKeychain(testKeys...)
-				baseWallet := e2e.Env.NewWallet(keychain)
+				baseWallet := e2e.Env.NewWallet(keychain, e2e.Env.GetRandomNodeURI())
 				avaxAssetID := baseWallet.X().AVAXAssetID()
 
 				wallets := make([]primary.Wallet, len(testKeys))

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -14,8 +14,6 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 
-	"golang.org/x/exp/maps"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/tests"
@@ -46,7 +44,10 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 			"virtuous-transfer-tx-avax",
 		),
 		func() {
-			rpcEps := maps.Values(e2e.Env.URIs)
+			rpcEps := make([]string, len(e2e.Env.URIs))
+			for i, nodeURI := range e2e.Env.URIs {
+				rpcEps[i] = nodeURI.URI
+			}
 
 			// Waiting for ongoing blocks to have completed before starting this
 			// test avoids the case of a previous test having initiated block

--- a/tests/fixture/testnet/config.go
+++ b/tests/fixture/testnet/config.go
@@ -157,6 +157,12 @@ func (c *NetworkConfig) EnsureGenesis(networkID uint32, validatorIDs []ids.NodeI
 	return nil
 }
 
+// NodeURI associates a node ID with its API URI.
+type NodeURI struct {
+	NodeID ids.NodeID
+	URI    string
+}
+
 // NodeConfig defines configuration for an AvalancheGo node.
 type NodeConfig struct {
 	NodeID ids.NodeID

--- a/tests/fixture/testnet/local/config.go
+++ b/tests/fixture/testnet/local/config.go
@@ -46,6 +46,6 @@ func LocalCChainConfig() testnet.FlagsMap {
 	// values will be used. Available C-Chain configuration options are
 	// defined in the `github.com/ava-labs/coreth/evm` package.
 	return testnet.FlagsMap{
-		"log-level": "debug",
+		"log-level": "trace",
 	}
 }

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -407,16 +407,19 @@ func (ln *LocalNetwork) WaitForHealthy(ctx context.Context, w io.Writer) error {
 	return nil
 }
 
-// Retrieve API URIs for all nodes in the network. Assumes nodes have
-// been loaded.
-func (ln *LocalNetwork) GetURIs() map[ids.NodeID]string {
-	uris := make(map[ids.NodeID]string, len(ln.Nodes))
+// Retrieve API URIs for all running primary validator nodes. URIs for
+// ephemeral nodes are not returned.
+func (ln *LocalNetwork) GetURIs() []testnet.NodeURI {
+	uris := make([]testnet.NodeURI, 0, len(ln.Nodes))
 	for _, node := range ln.Nodes {
 		// Only append URIs that are not empty. A node may have an
 		// empty URI if it was not running at the time
 		// node.ReadProcessContext() was called.
 		if len(node.URI) > 0 {
-			uris[node.NodeID] = node.URI
+			uris = append(uris, testnet.NodeURI{
+				NodeID: node.NodeID,
+				URI:    node.URI,
+			})
 		}
 	}
 	return uris

--- a/tests/fixture/testnet/local/network.go
+++ b/tests/fixture/testnet/local/network.go
@@ -409,14 +409,14 @@ func (ln *LocalNetwork) WaitForHealthy(ctx context.Context, w io.Writer) error {
 
 // Retrieve API URIs for all nodes in the network. Assumes nodes have
 // been loaded.
-func (ln *LocalNetwork) GetURIs() []string {
-	uris := make([]string, 0, len(ln.Nodes))
+func (ln *LocalNetwork) GetURIs() map[ids.NodeID]string {
+	uris := make(map[ids.NodeID]string, len(ln.Nodes))
 	for _, node := range ln.Nodes {
 		// Only append URIs that are not empty. A node may have an
 		// empty URI if it was not running at the time
 		// node.ReadProcessContext() was called.
 		if len(node.URI) > 0 {
-			uris = append(uris, node.URI)
+			uris[node.NodeID] = node.URI
 		}
 	}
 	return uris

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -159,8 +159,8 @@ func (w *wallet) IssueAtomicTx(
 		return err
 	}
 
-	if logFunc := ops.LogTxIDFunc(); logFunc != nil {
-		logFunc(txID)
+	if f := ops.PostIssuanceFunc(); f != nil {
+		f(txID)
 	}
 
 	if ops.AssumeDecided() {

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -159,6 +159,10 @@ func (w *wallet) IssueAtomicTx(
 		return err
 	}
 
+	if logFunc := ops.LogTxIDFunc(); logFunc != nil {
+		logFunc(txID)
+	}
+
 	if ops.AssumeDecided() {
 		return w.Backend.AcceptAtomicTx(ctx, tx)
 	}

--- a/wallet/chain/p/wallet.go
+++ b/wallet/chain/p/wallet.go
@@ -489,8 +489,8 @@ func (w *wallet) IssueTx(
 		return err
 	}
 
-	if logFunc := ops.LogTxIDFunc(); logFunc != nil {
-		logFunc(txID)
+	if f := ops.PostIssuanceFunc(); f != nil {
+		f(txID)
 	}
 
 	if ops.AssumeDecided() {

--- a/wallet/chain/p/wallet.go
+++ b/wallet/chain/p/wallet.go
@@ -489,6 +489,10 @@ func (w *wallet) IssueTx(
 		return err
 	}
 
+	if logFunc := ops.LogTxIDFunc(); logFunc != nil {
+		logFunc(txID)
+	}
+
 	if ops.AssumeDecided() {
 		return w.Backend.AcceptTx(ctx, tx)
 	}

--- a/wallet/chain/x/wallet.go
+++ b/wallet/chain/x/wallet.go
@@ -305,8 +305,8 @@ func (w *wallet) IssueTx(
 		return err
 	}
 
-	if logFunc := ops.LogTxIDFunc(); logFunc != nil {
-		logFunc(txID)
+	if f := ops.PostIssuanceFunc(); f != nil {
+		f(txID)
 	}
 
 	if ops.AssumeDecided() {

--- a/wallet/chain/x/wallet.go
+++ b/wallet/chain/x/wallet.go
@@ -305,6 +305,10 @@ func (w *wallet) IssueTx(
 		return err
 	}
 
+	if logFunc := ops.LogTxIDFunc(); logFunc != nil {
+		logFunc(txID)
+	}
+
 	if ops.AssumeDecided() {
 		return w.Backend.AcceptTx(ctx, tx)
 	}

--- a/wallet/subnet/primary/common/options.go
+++ b/wallet/subnet/primary/common/options.go
@@ -17,7 +17,9 @@ import (
 
 const defaultPollFrequency = 100 * time.Millisecond
 
-type LogTxIDFunc func(ids.ID)
+// Signature of the function that will be called after a transaction
+// has been issued with the ID of the issued transaction.
+type PostIssuanceFunc func(ids.ID)
 
 type Option func(*Options)
 
@@ -46,7 +48,7 @@ type Options struct {
 	pollFrequencySet bool
 	pollFrequency    time.Duration
 
-	logTxIDFunc LogTxIDFunc
+	postIssuanceFunc PostIssuanceFunc
 }
 
 func NewOptions(ops []Option) *Options {
@@ -130,8 +132,8 @@ func (o *Options) PollFrequency() time.Duration {
 	return defaultPollFrequency
 }
 
-func (o *Options) LogTxIDFunc() LogTxIDFunc {
-	return o.logTxIDFunc
+func (o *Options) PostIssuanceFunc() PostIssuanceFunc {
+	return o.postIssuanceFunc
 }
 
 func WithContext(ctx context.Context) Option {
@@ -198,8 +200,8 @@ func WithPollFrequency(pollFrequency time.Duration) Option {
 	}
 }
 
-func WithLogTxFunc(logFunc LogTxIDFunc) Option {
+func WithPostIssuanceFunc(f PostIssuanceFunc) Option {
 	return func(o *Options) {
-		o.logTxIDFunc = logFunc
+		o.postIssuanceFunc = f
 	}
 }

--- a/wallet/subnet/primary/common/options.go
+++ b/wallet/subnet/primary/common/options.go
@@ -17,6 +17,8 @@ import (
 
 const defaultPollFrequency = 100 * time.Millisecond
 
+type LogTxIDFunc func(ids.ID)
+
 type Option func(*Options)
 
 type Options struct {
@@ -43,6 +45,8 @@ type Options struct {
 
 	pollFrequencySet bool
 	pollFrequency    time.Duration
+
+	logTxIDFunc LogTxIDFunc
 }
 
 func NewOptions(ops []Option) *Options {
@@ -126,6 +130,10 @@ func (o *Options) PollFrequency() time.Duration {
 	return defaultPollFrequency
 }
 
+func (o *Options) LogTxIDFunc() LogTxIDFunc {
+	return o.logTxIDFunc
+}
+
 func WithContext(ctx context.Context) Option {
 	return func(o *Options) {
 		o.ctx = ctx
@@ -187,5 +195,11 @@ func WithPollFrequency(pollFrequency time.Duration) Option {
 	return func(o *Options) {
 		o.pollFrequencySet = true
 		o.pollFrequency = pollFrequency
+	}
+}
+
+func WithLogTxFunc(logFunc LogTxIDFunc) Option {
+	return func(o *Options) {
+		o.logTxIDFunc = logFunc
 	}
 }


### PR DESCRIPTION
## Why this should be merged

The high incidence of e2e flakes suggests a need to increase the details logged in testing to aid in diagnosing failure. Also, tests are made more resilient to failure.

## How this works

 - Enable the wallet to accept an optional function to log a transaction ID immediately after issuance and ensure the e2e wallet helper configures the wallet with the option. 
 - Log the node ID used by a given test
   - Also ensure that tests use at most one node (where possible) to minimize the scope of log inspection
 - Resolve C-Chain flakes induced by (https://github.com/ava-labs/coreth/issues/314) by doubling the suggested gas price

## How this was tested

CI on this PR and on PRs based on it: 
 - #1767 
 - #1792
 - #1882