### PR TITLE
`merkledb` -- add codec test and move helper

### DIFF
--- a/x/merkledb/codec_test.go
+++ b/x/merkledb/codec_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"io"
 	"math/rand"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,54 +57,6 @@ func newRandomProofNode(r *rand.Rand) ProofNode {
 		KeyPath:     serializedKey,
 		ValueOrHash: valueOrHash,
 		Children:    children,
-	}
-}
-
-func nilEmptySlices(dest interface{}) {
-	if dest == nil {
-		return
-	}
-
-	destPtr := reflect.ValueOf(dest)
-	if destPtr.Kind() != reflect.Ptr {
-		return
-	}
-	nilEmptySlicesRec(destPtr.Elem())
-}
-
-func nilEmptySlicesRec(value reflect.Value) {
-	switch value.Kind() {
-	case reflect.Slice:
-		if value.Len() == 0 {
-			newValue := reflect.Zero(value.Type())
-			value.Set(newValue)
-			return
-		}
-
-		for i := 0; i < value.Len(); i++ {
-			f := value.Index(i)
-			nilEmptySlicesRec(f)
-		}
-	case reflect.Array:
-		for i := 0; i < value.Len(); i++ {
-			f := value.Index(i)
-			nilEmptySlicesRec(f)
-		}
-	case reflect.Interface, reflect.Ptr:
-		if value.IsNil() {
-			return
-		}
-		nilEmptySlicesRec(value.Elem())
-	case reflect.Struct:
-		t := value.Type()
-		numFields := value.NumField()
-		for i := 0; i < numFields; i++ {
-			tField := t.Field(i)
-			if tField.IsExported() {
-				field := value.Field(i)
-				nilEmptySlicesRec(field)
-			}
-		}
 	}
 }
 
@@ -267,9 +218,6 @@ func FuzzCodecDBNodeDeterministic(f *testing.F) {
 
 			var gotNode dbNode
 			require.NoError(codec.decodeDBNode(nodeBytes, &gotNode))
-
-			nilEmptySlices(&node)
-			nilEmptySlices(&gotNode)
 			require.Equal(node, gotNode)
 
 			nodeBytes2 := codec.encodeDBNode(&gotNode)

--- a/x/merkledb/codec_test.go
+++ b/x/merkledb/codec_test.go
@@ -12,53 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/maybe"
 )
 
 // TODO add more codec tests
-
-func newRandomProofNode(r *rand.Rand) ProofNode {
-	key := make([]byte, r.Intn(32)) // #nosec G404
-	_, _ = r.Read(key)              // #nosec G404
-	serializedKey := newPath(key).Serialize()
-
-	val := make([]byte, r.Intn(64)) // #nosec G404
-	_, _ = r.Read(val)              // #nosec G404
-
-	children := map[byte]ids.ID{}
-	for j := 0; j < NodeBranchFactor; j++ {
-		if r.Float64() < 0.5 {
-			var childID ids.ID
-			_, _ = r.Read(childID[:]) // #nosec G404
-			children[byte(j)] = childID
-		}
-	}
-
-	hasValue := rand.Intn(2) == 1 // #nosec G404
-	var valueOrHash maybe.Maybe[[]byte]
-	if hasValue {
-		// use the hash instead when length is greater than the hash length
-		if len(val) >= HashLength {
-			val = hashing.ComputeHash256(val)
-		} else if len(val) == 0 {
-			// We do this because when we encode a value of []byte{} we will later
-			// decode it as nil.
-			// Doing this prevents inconsistency when comparing the encoded and
-			// decoded values.
-			// Calling nilEmptySlices doesn't set this because it is a private
-			// variable on the struct
-			val = nil
-		}
-		valueOrHash = maybe.Some(val)
-	}
-
-	return ProofNode{
-		KeyPath:     serializedKey,
-		ValueOrHash: valueOrHash,
-		Children:    children,
-	}
-}
 
 func FuzzCodecBool(f *testing.F) {
 	f.Fuzz(

--- a/x/merkledb/codec_test.go
+++ b/x/merkledb/codec_test.go
@@ -187,8 +187,6 @@ func FuzzCodecDBNodeDeterministic(f *testing.F) {
 					// we will later decode it as nil.
 					// Doing this prevents inconsistency when comparing the
 					// encoded and decoded values below.
-					// Calling nilEmptySlices doesn't set this because it is a
-					// private variable on the struct
 					valueBytes = nil
 				}
 				value = maybe.Some(valueBytes)

--- a/x/merkledb/proof_test.go
+++ b/x/merkledb/proof_test.go
@@ -42,6 +42,7 @@ func writeBasicBatch(t *testing.T, db *merkleDB) {
 	require.NoError(batch.Put([]byte{4}, []byte{4}))
 	require.NoError(batch.Write())
 }
+
 func newRandomProofNode(r *rand.Rand) ProofNode {
 	key := make([]byte, r.Intn(32)) // #nosec G404
 	_, _ = r.Read(key)              // #nosec G404


### PR DESCRIPTION
## Why this should be merged

yay tests / cleanup

## How this works

Adds a test and moves a helper function to the file where it's used

## How this was tested

Run the tests
