### PR TITLE
Change merkledb caches to be size based

### DIFF
--- a/x/merkledb/cache_test.go
+++ b/x/merkledb/cache_test.go
@@ -16,13 +16,16 @@ func TestNewOnEvictCache(t *testing.T) {
 	require := require.New(t)
 
 	called := false
+	size := func(int, int) int {
+		return 1
+	}
 	onEviction := func(int, int) error {
 		called = true
 		return nil
 	}
 	maxSize := 10
 
-	cache := newOnEvictCache[int](maxSize, onEviction)
+	cache := newOnEvictCache(maxSize, size, onEviction)
 	require.Equal(maxSize, cache.maxSize)
 	require.NotNil(cache.fifo)
 	require.Zero(cache.fifo.Len())
@@ -40,6 +43,9 @@ func TestOnEvictCacheNoOnEvictionError(t *testing.T) {
 
 	evictedKey := []int{}
 	evictedValue := []int{}
+	size := func(int, int) int {
+		return 1
+	}
 	onEviction := func(k, n int) error {
 		evictedKey = append(evictedKey, k)
 		evictedValue = append(evictedValue, n)
@@ -47,7 +53,7 @@ func TestOnEvictCacheNoOnEvictionError(t *testing.T) {
 	}
 	maxSize := 3
 
-	cache := newOnEvictCache[int](maxSize, onEviction)
+	cache := newOnEvictCache(maxSize, size, onEviction)
 
 	// Get non-existent key
 	_, ok := cache.Get(0)
@@ -162,8 +168,11 @@ func TestOnEvictCacheNoOnEvictionError(t *testing.T) {
 // Note this test assumes the cache is FIFO.
 func TestOnEvictCacheOnEvictionError(t *testing.T) {
 	var (
-		require    = require.New(t)
-		evicted    = []int{}
+		require = require.New(t)
+		evicted = []int{}
+		size    = func(int, int) int {
+			return 1
+		}
 		onEviction = func(_, n int) error {
 			// Evicting even keys errors
 			evicted = append(evicted, n)
@@ -175,7 +184,7 @@ func TestOnEvictCacheOnEvictionError(t *testing.T) {
 		maxSize = 2
 	)
 
-	cache := newOnEvictCache[int](maxSize, onEviction)
+	cache := newOnEvictCache(maxSize, size, onEviction)
 
 	// Fill the cache
 	for i := 0; i < maxSize; i++ {

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	DefaultEvictionBatchSize = 100
+	DefaultEvictionBatchSize = 256 * units.KiB
 	RootPath                 = EmptyPath
 
 	// TODO: name better
@@ -129,13 +129,15 @@ type Config struct {
 	// If 0 is specified, [runtime.NumCPU] will be used. If -1 is specified,
 	// no limit will be used.
 	RootGenConcurrency int
-	// The number of nodes that are evicted from the cache and written to
-	// disk at a time.
+	// The number of bytes to write to disk when intermediate nodes are evicted
+	// from their cache and written to disk.
 	EvictionBatchSize int
 	// The number of changes to the database that we store in memory in order to
 	// serve change proofs.
-	HistoryLength             int
-	ValueNodeCacheSize        int
+	HistoryLength int
+	// The number of bytes to cache nodes with values.
+	ValueNodeCacheSize int
+	// The number of bytes to cache nodes without values.
 	IntermediateNodeCacheSize int
 	// If [Reg] is nil, metrics are collected locally but not exported through
 	// Prometheus.
@@ -1208,4 +1210,11 @@ func addPrefixToKey(bufferPool *sync.Pool, prefix []byte, key []byte) []byte {
 	copy(prefixedKey, prefix)
 	copy(prefixedKey[prefixLen:], key)
 	return prefixedKey
+}
+
+func cacheEntrySize(p path, n *node) int {
+	if n == nil {
+		return len(p)
+	}
+	return len(p) + len(n.marshal())
 }

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -38,8 +38,8 @@ func newDefaultConfig() Config {
 	return Config{
 		EvictionBatchSize:         10,
 		HistoryLength:             defaultHistoryLength,
-		ValueNodeCacheSize:        1_000,
-		IntermediateNodeCacheSize: 1_000,
+		ValueNodeCacheSize:        units.MiB,
+		IntermediateNodeCacheSize: units.MiB,
 		Reg:                       prometheus.NewRegistry(),
 		Tracer:                    trace.Noop,
 	}

--- a/x/merkledb/value_node_db.go
+++ b/x/merkledb/value_node_db.go
@@ -24,7 +24,7 @@ type valueNodeDB struct {
 
 	// If a value is nil, the corresponding key isn't in the trie.
 	// Paths in [nodeCache] aren't prefixed with [valueNodePrefix].
-	nodeCache cache.LRU[path, *node]
+	nodeCache cache.Cacher[path, *node]
 	metrics   merkleMetrics
 
 	closed utils.Atomic[bool]
@@ -35,7 +35,7 @@ func newValueNodeDB(db database.Database, bufferPool *sync.Pool, metrics merkleM
 		metrics:    metrics,
 		baseDB:     db,
 		bufferPool: bufferPool,
-		nodeCache:  cache.LRU[path, *node]{Size: size},
+		nodeCache:  cache.NewSizedLRU(size, cacheEntrySize),
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

Allows slightly more fine-grained cache size tuning. Specifically useful for the value caches whose entry size can very significantly.

## How this works

LRU -> SizedLRU

## How this was tested

updated the tests