### PR TITLE
MerkleDB Improve Node Size Calculation

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1215,5 +1215,5 @@ func cacheEntrySize(p path, n *node) int {
 	if n == nil {
 		return len(p)
 	}
-	return len(p) + n.size
+	return len(p) + 2*len(n.marshal())
 }

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1215,5 +1215,5 @@ func cacheEntrySize(p path, n *node) int {
 	if n == nil {
 		return len(p)
 	}
-	return len(p) + len(n.marshal())
+	return len(p) + n.size
 }

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1211,9 +1211,11 @@ func addPrefixToKey(bufferPool *sync.Pool, prefix []byte, key []byte) []byte {
 	return prefixedKey
 }
 
+// cacheEntrySize returns a rough approximation of the memory consumed by storing the path and node
 func cacheEntrySize(p path, n *node) int {
 	if n == nil {
 		return len(p)
 	}
+	// nodes cache their bytes representation so the total memory consumed is roughly twice that
 	return len(p) + 2*len(n.bytes())
 }

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -27,7 +27,8 @@ type intermediateNodeDB struct {
 	// from the cache, which will call [OnEviction].
 	// A non-nil error returned from Put is considered fatal.
 	// Keys in [nodeCache] aren't prefixed with [intermediateNodePrefix].
-	nodeCache         onEvictCache[path, *node]
+	nodeCache onEvictCache[path, *node]
+	// the number of bytes to evict during an eviction batch
 	evictionBatchSize int
 	metrics           merkleMetrics
 }
@@ -67,6 +68,7 @@ func (db *intermediateNodeDB) onEviction(key path, n *node) error {
 	// and write them to disk. We write a batch of them, rather than
 	// just [n], so that we don't immediately evict and write another
 	// node, because each time this method is called we do a disk write.
+	// Evicts a total number of bytes, rather than a number of nodes
 	for totalSize < db.evictionBatchSize {
 		key, n, exists := db.nodeCache.removeOldest()
 		if !exists {

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -25,7 +25,7 @@ func TestIntermediateNodeDB(t *testing.T) {
 	require := require.New(t)
 
 	// use exact multiple of node size so require.Equal(1, db.nodeCache.fifo.Len()) is correct later
-	cacheSize := 204
+	cacheSize := 200
 	evictionBatchSize := cacheSize
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -25,7 +25,7 @@ func TestIntermediateNodeDB(t *testing.T) {
 	require := require.New(t)
 
 	// use exact multiple of node size so require.Equal(1, db.nodeCache.fifo.Len()) is correct later
-	cacheSize := 132
+	cacheSize := 204
 	evictionBatchSize := cacheSize
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -4,9 +4,10 @@
 package merkledb
 
 import (
-	"github.com/ava-labs/avalanchego/database"
 	"sync"
 	"testing"
+
+	"github.com/ava-labs/avalanchego/database"
 
 	"github.com/stretchr/testify/require"
 

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -97,8 +97,8 @@ func (n *node) hasValue() bool {
 func (n *node) marshal() []byte {
 	if n.nodeBytes == nil {
 		n.nodeBytes = codec.encodeDBNode(&n.dbNode)
+		n.size += len(n.nodeBytes)
 	}
-	n.size += len(n.nodeBytes)
 	return n.nodeBytes
 }
 
@@ -106,8 +106,8 @@ func (n *node) marshal() []byte {
 // for example, node ID and byte representation
 func (n *node) onNodeChanged() {
 	n.id = ids.Empty
-	n.nodeBytes = nil
 	n.size -= len(n.nodeBytes)
+	n.nodeBytes = nil
 }
 
 // Returns and caches the ID of this node.

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -79,7 +79,7 @@ func parseNode(key path, nodeBytes []byte) (*node, error) {
 		nodeBytes: nodeBytes,
 	}
 
-	result.size = len(n.value.Value()) + len(result.key) + boolSize + HashLength + intSize
+	result.size = len(nodeBytes) + len(n.value.Value()) + len(result.key) + boolSize + HashLength + intSize
 	for _, c := range result.children {
 		result.size += byteSize + HashLength + len(c.compressedPath)
 	}

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -161,6 +161,7 @@ func (n *node) removeChild(child *node) {
 // clone Returns a copy of [n].
 // Note: value isn't cloned because it is never edited, only overwritten
 // if this ever changes, value will need to be copied as well
+// it is safe to clone all fields because they are only written/read while one or both of the db locks are held
 func (n *node) clone() *node {
 	return &node{
 		id:  n.id,

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -61,7 +61,7 @@ func newNode(parent *node, key path) *node {
 		},
 		key: key,
 	}
-	// size of key + the bool from value + id + size + children map
+	// size of key + the empty value + id + size + children map
 	newNode.size = len(key) + maybeSize + HashLength + intSize + NodeBranchFactor
 	if parent != nil {
 		parent.addChild(newNode)
@@ -81,7 +81,8 @@ func parseNode(key path, nodeBytes []byte) (*node, error) {
 		nodeBytes: nodeBytes,
 	}
 
-	result.size = len(nodeBytes) + len(n.value.Value()) + len(result.key) + maybeSize + HashLength + intSize + NodeBranchFactor
+	// size of bytes + key + the value + id + size + children map
+	result.size = len(nodeBytes) + len(result.key) + len(n.value.Value()) + maybeSize + HashLength + intSize + NodeBranchFactor
 	for _, c := range result.children {
 		result.size += byteSize + HashLength + len(c.compressedPath)
 	}

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -86,7 +86,7 @@ func (n *node) bytes() []byte {
 	if n.nodeBytes == nil {
 		n.nodeBytes = codec.encodeDBNode(&n.dbNode)
 	}
-	
+
 	return n.nodeBytes
 }
 

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -86,6 +86,7 @@ func (n *node) marshal() []byte {
 	if n.nodeBytes == nil {
 		n.nodeBytes = codec.encodeDBNode(&n.dbNode)
 	}
+	
 	return n.nodeBytes
 }
 
@@ -154,10 +155,7 @@ func (n *node) addChildWithoutNode(index byte, compressedPath path, childID ids.
 // Removes [child] from [n]'s children.
 func (n *node) removeChild(child *node) {
 	n.onNodeChanged()
-	index := child.key[len(n.key)]
-	if _, ok := n.children[index]; ok {
-		delete(n.children, index)
-	}
+	delete(n.children, child.key[len(n.key)])
 }
 
 // clone Returns a copy of [n].

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -4,9 +4,10 @@
 package merkledb
 
 import (
+	"unsafe"
+
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
-	"unsafe"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/hashing"
@@ -97,7 +98,7 @@ func (n *node) marshal() []byte {
 	if n.nodeBytes == nil {
 		n.nodeBytes = codec.encodeDBNode(&n.dbNode)
 	}
-
+	n.size += len(n.nodeBytes)
 	return n.nodeBytes
 }
 
@@ -106,7 +107,7 @@ func (n *node) marshal() []byte {
 func (n *node) onNodeChanged() {
 	n.id = ids.Empty
 	n.nodeBytes = nil
-
+	n.size -= len(n.nodeBytes)
 }
 
 // Returns and caches the ID of this node.


### PR DESCRIPTION
The node that is being stored in the cache contains more than just its bytes, so make the size calculation more accurate by tracking its total size.