### PR TITLE
Rename `node.marshal` to `node.bytes`

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1215,5 +1215,5 @@ func cacheEntrySize(p path, n *node) int {
 	if n == nil {
 		return len(p)
 	}
-	return len(p) + len(n.marshal())
+	return len(p) + len(n.bytes())
 }

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -91,7 +91,7 @@ func (db *intermediateNodeDB) addToBatch(b database.Batch, key path, n *node) er
 	if n == nil {
 		return b.Delete(prefixedKey)
 	}
-	return b.Put(prefixedKey, n.marshal())
+	return b.Put(prefixedKey, n.bytes())
 }
 
 func (db *intermediateNodeDB) Get(key path) (*node, error) {

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -82,7 +82,7 @@ func (n *node) hasValue() bool {
 }
 
 // Returns the byte representation of this node.
-func (n *node) marshal() []byte {
+func (n *node) bytes() []byte {
 	if n.nodeBytes == nil {
 		n.nodeBytes = codec.encodeDBNode(&n.dbNode)
 	}

--- a/x/merkledb/node_test.go
+++ b/x/merkledb/node_test.go
@@ -24,7 +24,7 @@ func Test_Node_Marshal(t *testing.T) {
 	require.NoError(t, childNode.calculateID(&mockMetrics{}))
 	root.addChild(childNode)
 
-	data := root.marshal()
+	data := root.bytes()
 	rootParsed, err := parseNode(newPath([]byte("")), data)
 	require.NoError(t, err)
 	require.Len(t, rootParsed.children, 1)
@@ -56,7 +56,7 @@ func Test_Node_Marshal_Errors(t *testing.T) {
 	require.NoError(t, childNode2.calculateID(&mockMetrics{}))
 	root.addChild(childNode2)
 
-	data := root.marshal()
+	data := root.bytes()
 
 	for i := 1; i < len(data); i++ {
 		broken := data[:i]

--- a/x/merkledb/value_node_db.go
+++ b/x/merkledb/value_node_db.go
@@ -109,7 +109,7 @@ func (b *valueNodeBatch) Write() error {
 			if err := dbBatch.Delete(prefixedKey); err != nil {
 				return err
 			}
-		} else if err := dbBatch.Put(prefixedKey, n.marshal()); err != nil {
+		} else if err := dbBatch.Put(prefixedKey, n.bytes()); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Why this should be merged

Consistency with rest of avalanchego

## How this works

n/a

## How this was tested

n/a