### PR TITLE
Introduce GetHeightReader() function

### DIFF
--- a/x/archivedb/db.go
+++ b/x/archivedb/db.go
@@ -4,7 +4,6 @@
 package archivedb
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -85,61 +84,35 @@ func (db *archiveDB) GetLastBlock(key []byte) ([]byte, uint64, error) {
 	return db.Get(key, db.currentHeight)
 }
 
+// Returns an object which implements the database.KeyValueReader trait for all
+// keys defined at the given height.
+func (db *archiveDB) GetHeightReader(height uint64) (dbHeightReader, error) {
+	if height > db.currentHeight || height == 0 {
+		return dbHeightReader{}, ErrUnknownHeight
+	}
+	return dbHeightReader{
+		db:                 db,
+		height:             height,
+		heightLastFoundKey: 0,
+	}, nil
+}
+
 // Fetches the value of a given prefix at a given height.
 //
 // If the value does not exists or it was actually removed an error is returned.
 // Otherwise a value does exists it will be returned, alongside with the height
 // at which it was updated prior the requested height.
 func (db *archiveDB) Get(key []byte, height uint64) ([]byte, uint64, error) {
-	if height > db.currentHeight || height == 0 {
-		return nil, db.currentHeight, ErrUnknownHeight
+	reader, err := db.GetHeightReader(height)
+	if err != nil {
+		return nil, 0, err
+	}
+	value, err := reader.Get(key)
+	if err != nil {
+		return nil, 0, err
 	}
 
-	internalKey := newInternalKey(key, height)
-	iterator := db.rawDB.NewIteratorWithStart(internalKey.Bytes())
-	keyLength := len(key)
-
-	defer iterator.Release()
-
-	for {
-		if !iterator.Next() {
-			// There is no available key with the requested prefix
-			return nil, 0, database.ErrNotFound
-		}
-
-		internalKey, err := parseKey(iterator.Key())
-		if err != nil {
-			return nil, 0, err
-		}
-
-		if !bytes.Equal(internalKey.key, key) {
-			if keyLength < len(internalKey.key) {
-				// The current key is a longer than the requested key, now check
-				// if they match at the same length as `key`, if that is the
-				// case we should continue to the next key, until the exact
-				// requested key is found or anothe prefix is found and by that
-				// point it would exit
-				if bytes.Equal(internalKey.key[0:keyLength], key) {
-					// Same prefix, read the next key until the prefix is
-					// different or the exact requested key is found
-					continue
-				}
-			}
-			// The previous key that was found does has another prefix, because the
-			// iterator is not aware of prefixes. If this happens it means the
-			// prefix at the requested height does not exists.
-			return nil, 0, database.ErrNotFound
-		}
-
-		if internalKey.isDeleted {
-			// The database is append only, so when removing a record creates a new
-			// record with an special flag is being created. Before returning the
-			// value we check if the deleted flag is present or not.
-			return nil, 0, database.ErrNotFound
-		}
-
-		return iterator.Value(), internalKey.height, nil
-	}
+	return value, reader.heightLastFoundKey, nil
 }
 
 // Creates a new batch to append database changes in a given height

--- a/x/archivedb/db.go
+++ b/x/archivedb/db.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 )
 
+var (
+	_ database.Batch          = (*batchWithHeight)(nil)
+	_ database.KeyValueReader = (*dbHeightReader)(nil)
+)
+
 // ArchiveDb
 //
 // Creates a thin database layer on top of database.Database. ArchiveDb is an
@@ -168,4 +173,12 @@ func (c *batchWithHeight) Size() int {
 // Removed all pending writes and deletes to the database
 func (c *batchWithHeight) Reset() {
 	c.batch.Reset()
+}
+
+func (c *batchWithHeight) Inner() database.Batch {
+	return c.batch
+}
+
+func (c *batchWithHeight) Replay(w database.KeyValueWriterDeleter) error {
+	return c.batch.Replay(w)
 }

--- a/x/archivedb/key_value_reader.go
+++ b/x/archivedb/key_value_reader.go
@@ -18,8 +18,8 @@ type dbHeightReader struct {
 // Builds a database.Iterator where the next value is the requested *value*. If
 // the value is not found a database.ErrNotFound is returned.
 //
-// This is a private function which helps Get() and Has() to be share the key
-// look up logic
+// This is a private function which helps Get() and Has() to share the key
+// lookup logic
 func (reader *dbHeightReader) getIteratorToValue(key []byte) (database.Iterator, error) {
 	internalKey := newInternalKey(key, reader.height)
 	iterator := reader.db.rawDB.NewIteratorWithStart(internalKey.Bytes())

--- a/x/archivedb/key_value_reader.go
+++ b/x/archivedb/key_value_reader.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package archivedb
+
+import (
+	"bytes"
+
+	"github.com/ava-labs/avalanchego/database"
+)
+
+type dbHeightReader struct {
+	db                 *archiveDB
+	height             uint64
+	heightLastFoundKey uint64
+}
+
+// Builds a database.Iterator where the next value is the requested *value*. If
+// the value is not found a database.ErrNotFound is returned.
+//
+// This is a private function which helps Get() and Has() to be share the key
+// look up logic
+func (reader *dbHeightReader) getIteratorToValue(key []byte) (database.Iterator, error) {
+	internalKey := newInternalKey(key, reader.height)
+	iterator := reader.db.rawDB.NewIteratorWithStart(internalKey.Bytes())
+	keyLength := len(key)
+
+	reader.heightLastFoundKey = 0
+
+	for {
+		if !iterator.Next() {
+			// There is no available key with the requested prefix
+			return iterator, database.ErrNotFound
+		}
+		internalKey, err := parseKey(iterator.Key())
+		if err != nil {
+			return iterator, err
+		}
+		if !bytes.Equal(internalKey.key, key) {
+			if keyLength < len(internalKey.key) {
+				// The current key is a longer than the requested key, now check
+				// if they match at the same length as `key`, if that is the
+				// case we should continue to the next key, until the exact
+				// requested key is found or anothe prefix is found and by that
+				// point it would exit
+				if bytes.Equal(internalKey.key[0:keyLength], key) {
+					// Same prefix, read the next key until the prefix is
+					// different or the exact requested key is found
+					continue
+				}
+			}
+			// The previous key that was found does has another prefix, because the
+			// iterator is not aware of prefixes. If this happens it means the
+			// prefix at the requested height does not exists.
+			return iterator, database.ErrNotFound
+		}
+
+		if internalKey.isDeleted {
+			// The database is append only, so when removing a record creates a new
+			// record with an special flag is being created. Before returning the
+			// value we check if the deleted flag is present or not.
+			return iterator, database.ErrNotFound
+		}
+
+		reader.heightLastFoundKey = internalKey.height
+
+		return iterator, nil
+	}
+}
+
+// Has retrieves if a key is present in the key-value data store.
+func (reader *dbHeightReader) Has(key []byte) (bool, error) {
+	iterator, err := reader.getIteratorToValue(key)
+	defer iterator.Release()
+	if err == database.ErrNotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Get retrieves the given key if it's present in the key-value data store.
+func (reader *dbHeightReader) Get(key []byte) ([]byte, error) {
+	iterator, err := reader.getIteratorToValue(key)
+	defer iterator.Release()
+	if err != nil {
+		return nil, err
+	}
+	return iterator.Value(), nil
+}
+
+// Returns the height value where a key has been found. If the last key was not
+// found an error will be thrown
+func (reader *dbHeightReader) GetHeightFromLastFoundKey() (uint64, error) {
+	if reader.heightLastFoundKey == 0 {
+		return 0, database.ErrNotFound
+	}
+	return reader.heightLastFoundKey, nil
+}


### PR DESCRIPTION
## Why this should be merged

`GetHeightReader()` will take the current height and will return a `database.KeyValueReader`

## How this works

Move all the key lookup logic to its own file/struct, which implements the database.KeyValueReader struct.

## How this was tested

Tests