### PR TITLE
Make goroutine limit global across all views

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -11,12 +11,11 @@ import (
 	"runtime"
 	"sync"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -184,8 +183,8 @@ type merkleDB struct {
 	// Valid children of this trie.
 	childViews []*trieView
 
-	// rootGenConcurrency is the number of goroutines to use when
-	// generating a new state root.
+	// rootGenConcurrency is the max number of goroutines to use when
+	// generating new state roots. Shared across all views.
 	rootGenConcurrency errgroup.Group
 }
 

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -300,7 +300,7 @@ func (t *trieView) calculateNodeIDsHelper(ctx context.Context, n *node) error {
 	wg.Wait()
 	close(updatedChildren)
 
-	// check for errors from updateChild function
+	// check for errors from [calculateChild]
 	if updateErr != nil {
 		return updateErr
 	}

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/exp/slices"
+
 	"go.opentelemetry.io/otel/attribute"
 
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -18,7 +20,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/maybe"
-	"golang.org/x/exp/slices"
 )
 
 const (


### PR DESCRIPTION
We don't want to spawn arbitrarily large number of goroutines during root calculation, so add a cap for the entire db on the number of goroutines spawned during the calculation of a new root.