### PR TITLE
[rpcchainvm] ensure process exists before sending shutdown rpc

### DIFF
--- a/utils/resource/usage.go
+++ b/utils/resource/usage.go
@@ -163,7 +163,7 @@ func (m *manager) HasProcess(pid int) bool {
 		return false
 	}
 	p, _ := os.FindProcess(int(proc.p.Pid))
-	// To properly check if a process exists, we need to send a 0 signal.
+	// To properly check if a process exists, we need to send signal 0.
 	// https://pkg.go.dev/os#FindProcess
 	return p.Signal(syscall.Signal(0)) == nil
 }

--- a/utils/resource/usage.go
+++ b/utils/resource/usage.go
@@ -5,8 +5,10 @@ package resource
 
 import (
 	"math"
+	"os"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -54,6 +56,9 @@ type ProcessTracker interface {
 	// TrackProcess adds [pid] to the list of processes that this tracker is
 	// currently managing. Duplicate requests are dropped.
 	TrackProcess(pid int)
+
+	// HasProcess returns true if [pid] is currently being tracked and still exists.
+	HasProcess(pid int) bool
 
 	// UntrackProcess removes [pid] from the list of processes that this tracker
 	// is currently managing. Untracking a currently untracked [pid] is a noop.
@@ -148,6 +153,19 @@ func (m *manager) TrackProcess(pid int) {
 	m.processesLock.Lock()
 	m.processes[pid] = process
 	m.processesLock.Unlock()
+}
+
+func (m *manager) HasProcess(pid int) bool {
+	m.processesLock.Lock()
+	defer m.processesLock.Unlock()
+	proc, ok := m.processes[pid]
+	if !ok {
+		return false
+	}
+	p, _ := os.FindProcess(int(proc.p.Pid))
+	// To properly check if a process exists, we need to send a 0 signal.
+	// https://pkg.go.dev/os#FindProcess
+	return p.Signal(syscall.Signal(0)) == nil
 }
 
 func (m *manager) UntrackProcess(pid int) {

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -365,7 +365,7 @@ func (vm *VMClient) Shutdown(ctx context.Context) error {
 
 	vm.runtime.Stop(ctx)
 
-	defer vm.processTracker.UntrackProcess(vm.pid)
+	vm.processTracker.UntrackProcess(vm.pid)
 	return errs.Err
 }
 

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -352,6 +352,12 @@ func (vm *VMClient) SetState(ctx context.Context, state snow.State) error {
 }
 
 func (vm *VMClient) Shutdown(ctx context.Context) error {
+	defer vm.processTracker.UntrackProcess(vm.pid)
+
+	if !vm.processTracker.HasProcess(vm.pid) {
+		return nil
+	}
+
 	errs := wrappers.Errs{}
 	_, err := vm.client.Shutdown(ctx, &emptypb.Empty{})
 	errs.Add(err)
@@ -363,7 +369,6 @@ func (vm *VMClient) Shutdown(ctx context.Context) error {
 
 	vm.runtime.Stop(ctx)
 
-	vm.processTracker.UntrackProcess(vm.pid)
 	return errs.Err
 }
 


### PR DESCRIPTION
## Why this should be merged

## How this works


We can reasonably check if a process is dead by sending it signal 0 and checking for error. This PR validates that the VM process exists before sending a block RPC call that will never return. Also on stop if the process is already dead fail fast.

ref. https://pkg.go.dev/os#FindProcess

## How this was tested
