### PR TITLE
`sync` -- reduce test sizes

### DIFF
--- a/x/sync/network_server_test.go
+++ b/x/sync/network_server_test.go
@@ -156,8 +156,8 @@ func Test_Server_GetChangeProof(t *testing.T) {
 	require.NoError(t, err)
 
 	// create changes
-	ops := make([]database.BatchOp, 0, 600)
-	for x := 0; x < 600; x++ {
+	ops := make([]database.BatchOp, 0, 300)
+	for x := 0; x < 300; x++ {
 		key := make([]byte, r.Intn(100))
 		_, err = r.Read(key)
 		require.NoError(t, err)


### PR DESCRIPTION
## Why this should be merged

These tests take a long time with the `-race` flag, especially on Windows. This seems to reduce the sync test run time with `-race` by about 1/3.

## How this works

Self-explanatory

## How this was tested

Run `go test -race -timeout 30s github.com/ava-labs/avalanchego/x/sync/... -v`