### PR TITLE
Use odd-numbered request ids for SDK

### DIFF
--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -94,7 +94,7 @@ func (c *Client) AppRequest(
 		}
 
 		c.router.pendingAppRequests[requestID] = onResponse
-		c.router.requestID++
+		c.router.requestID += 2
 	}
 
 	return nil
@@ -147,14 +147,14 @@ func (c *Client) CrossChainAppRequest(
 	if err := c.sender.SendCrossChainAppRequest(
 		ctx,
 		chainID,
-		c.router.requestID,
+		requestID,
 		c.prefixMessage(appRequestBytes),
 	); err != nil {
 		return err
 	}
 
 	c.router.pendingCrossChainAppRequests[requestID] = onResponse
-	c.router.requestID++
+	c.router.requestID += 2
 
 	return nil
 }

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -48,6 +48,8 @@ func NewRouter(log logging.Logger, sender common.AppSender) *Router {
 		handlers:                     make(map[uint64]*responder),
 		pendingAppRequests:           make(map[uint32]AppResponseCallback),
 		pendingCrossChainAppRequests: make(map[uint32]CrossChainAppResponseCallback),
+		// invariant: sdk uses odd-numbered requestIDs
+		requestID: 1,
 	}
 }
 

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -339,7 +339,7 @@ func TestAppRequestDuplicateRequestIDs(t *testing.T) {
 	requestSent.Wait()
 
 	// force the router to use the same requestID
-	router.requestID = 0
+	router.requestID = 1
 	timeout.Add(1)
 	err = client.AppRequest(context.Background(), set.Of(nodeID), []byte{}, nil)
 	requestSent.Wait()


### PR DESCRIPTION
## Why this should be merged

Prevents request-id collision edge-cases when upgrading with an existing VM

## How this works

Restricts request ids in sdk to be odd-numbered

## How this was tested

N/A
