### PR TITLE
Add contexts to SDK callbacks

### DIFF
--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -23,6 +23,7 @@ var (
 // issued by Client.
 // Callers should check [err] to see whether the AppRequest failed or not.
 type AppResponseCallback func(
+	ctx context.Context,
 	nodeID ids.NodeID,
 	responseBytes []byte,
 	err error,
@@ -32,6 +33,7 @@ type AppResponseCallback func(
 // CrossChainAppResponse for a CrossChainAppRequest issued by Client.
 // Callers should check [err] to see whether the AppRequest failed or not.
 type CrossChainAppResponseCallback func(
+	ctx context.Context,
 	chainID ids.ID,
 	responseBytes []byte,
 	err error,

--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -92,6 +92,7 @@ func (g *Gossiper[_, _]) gossip(ctx context.Context) error {
 }
 
 func (g *Gossiper[T, U]) handleResponse(
+	_ context.Context,
 	nodeID ids.NodeID,
 	responseBytes []byte,
 	err error,

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -93,23 +93,23 @@ func (r *Router) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID ui
 	return handler.AppRequest(ctx, nodeID, requestID, deadline, parsedMsg)
 }
 
-func (r *Router) AppRequestFailed(_ context.Context, nodeID ids.NodeID, requestID uint32) error {
+func (r *Router) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
 	callback, ok := r.clearAppRequest(requestID)
 	if !ok {
 		return ErrUnrequestedResponse
 	}
 
-	callback(nodeID, nil, ErrAppRequestFailed)
+	callback(ctx, nodeID, nil, ErrAppRequestFailed)
 	return nil
 }
 
-func (r *Router) AppResponse(_ context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
+func (r *Router) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
 	callback, ok := r.clearAppRequest(requestID)
 	if !ok {
 		return ErrUnrequestedResponse
 	}
 
-	callback(nodeID, response, nil)
+	callback(ctx, nodeID, response, nil)
 	return nil
 }
 
@@ -149,23 +149,23 @@ func (r *Router) CrossChainAppRequest(
 	return handler.CrossChainAppRequest(ctx, chainID, requestID, deadline, parsedMsg)
 }
 
-func (r *Router) CrossChainAppRequestFailed(_ context.Context, chainID ids.ID, requestID uint32) error {
+func (r *Router) CrossChainAppRequestFailed(ctx context.Context, chainID ids.ID, requestID uint32) error {
 	callback, ok := r.clearCrossChainAppRequest(requestID)
 	if !ok {
 		return ErrUnrequestedResponse
 	}
 
-	callback(chainID, nil, ErrAppRequestFailed)
+	callback(ctx, chainID, nil, ErrAppRequestFailed)
 	return nil
 }
 
-func (r *Router) CrossChainAppResponse(_ context.Context, chainID ids.ID, requestID uint32, response []byte) error {
+func (r *Router) CrossChainAppResponse(ctx context.Context, chainID ids.ID, requestID uint32, response []byte) error {
 	callback, ok := r.clearCrossChainAppRequest(requestID)
 	if !ok {
 		return ErrUnrequestedResponse
 	}
 
-	callback(chainID, response, nil)
+	callback(ctx, chainID, response, nil)
 	return nil
 }
 

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -27,7 +27,8 @@ func TestAppRequestResponse(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 	chainID := ids.GenerateTestID()
 
-	var ctxKey, ctxVal *string
+	ctxKey := new(string)
+	ctxVal := new(string)
 	*ctxKey = "foo"
 	*ctxVal = "bar"
 

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -54,7 +54,7 @@ func TestAppRequestResponse(t *testing.T) {
 						return response, nil
 					})
 
-				callback := func(actualNodeID ids.NodeID, actualResponse []byte, err error) {
+				callback := func(_ context.Context, actualNodeID ids.NodeID, actualResponse []byte, err error) {
 					defer wg.Done()
 
 					require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestAppRequestResponse(t *testing.T) {
 						}
 					})
 
-				callback := func(actualNodeID ids.NodeID, actualResponse []byte, err error) {
+				callback := func(_ context.Context, actualNodeID ids.NodeID, actualResponse []byte, err error) {
 					defer wg.Done()
 
 					require.ErrorIs(t, err, ErrAppRequestFailed)
@@ -110,7 +110,7 @@ func TestAppRequestResponse(t *testing.T) {
 						return response, nil
 					})
 
-				callback := func(actualChainID ids.ID, actualResponse []byte, err error) {
+				callback := func(_ context.Context, actualChainID ids.ID, actualResponse []byte, err error) {
 					defer wg.Done()
 					require.NoError(t, err)
 					require.Equal(t, chainID, actualChainID)
@@ -130,7 +130,7 @@ func TestAppRequestResponse(t *testing.T) {
 						}()
 					})
 
-				callback := func(actualChainID ids.ID, actualResponse []byte, err error) {
+				callback := func(_ context.Context, actualChainID ids.ID, actualResponse []byte, err error) {
 					defer wg.Done()
 
 					require.ErrorIs(t, err, ErrAppRequestFailed)

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -27,7 +27,7 @@ func TestAppRequestResponse(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 	chainID := ids.GenerateTestID()
 	foo := "foo"
-	bar := "foo"
+	bar := "bar"
 
 	tests := []struct {
 		name        string

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -26,8 +26,10 @@ func TestAppRequestResponse(t *testing.T) {
 	response := []byte("response")
 	nodeID := ids.GenerateTestNodeID()
 	chainID := ids.GenerateTestID()
-	foo := "foo"
-	bar := "bar"
+
+	var ctxKey, ctxVal *string
+	*ctxKey = "foo"
+	*ctxVal = "bar"
 
 	tests := []struct {
 		name        string
@@ -47,7 +49,7 @@ func TestAppRequestResponse(t *testing.T) {
 				sender.EXPECT().SendAppResponse(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(ctx context.Context, _ ids.NodeID, requestID uint32, response []byte) {
 						go func() {
-							ctx = context.WithValue(ctx, foo, bar)
+							ctx = context.WithValue(ctx, ctxKey, ctxVal)
 							require.NoError(t, router.AppResponse(ctx, nodeID, requestID, response))
 						}()
 					}).AnyTimes()
@@ -61,7 +63,7 @@ func TestAppRequestResponse(t *testing.T) {
 					defer wg.Done()
 
 					require.NoError(t, err)
-					require.Equal(t, bar, ctx.Value(foo))
+					require.Equal(t, ctxVal, ctx.Value(ctxKey))
 					require.Equal(t, nodeID, actualNodeID)
 					require.Equal(t, response, actualResponse)
 				}
@@ -105,7 +107,7 @@ func TestAppRequestResponse(t *testing.T) {
 				sender.EXPECT().SendCrossChainAppResponse(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(ctx context.Context, chainID ids.ID, requestID uint32, response []byte) {
 						go func() {
-							ctx = context.WithValue(ctx, foo, bar)
+							ctx = context.WithValue(ctx, ctxKey, ctxVal)
 							require.NoError(t, router.CrossChainAppResponse(ctx, chainID, requestID, response))
 						}()
 					}).AnyTimes()
@@ -118,7 +120,7 @@ func TestAppRequestResponse(t *testing.T) {
 				callback := func(ctx context.Context, actualChainID ids.ID, actualResponse []byte, err error) {
 					defer wg.Done()
 					require.NoError(t, err)
-					require.Equal(t, bar, ctx.Value(foo))
+					require.Equal(t, ctxVal, ctx.Value(ctxKey))
 					require.Equal(t, chainID, actualChainID)
 					require.Equal(t, response, actualResponse)
 				}


### PR DESCRIPTION
## Why this should be merged

resolves #1976 

## How this works

Wires the VM's context into the SDK callbacks

## How this was tested

Added unit test