### PR TITLE
Document common usage of requestIDs for snow senders

### DIFF
--- a/snow/engine/common/sender.go
+++ b/snow/engine/common/sender.go
@@ -12,7 +12,28 @@ import (
 )
 
 // Sender defines how a consensus engine sends messages and requests to other
-// validators
+// validators.
+//
+// Messages can be categorized as either: requests, responses, or gossip. Gossip
+// messages do not include requestIDs, because no response is expected from the
+// peer. However, both requests and responses include requestIDs.
+//
+// It is expected that each [nodeID + requestID + expected response type] that
+// is outstanding at any given time is unique.
+//
+// As an example, it is valid to send `Get(nodeA, request0)` and
+// `PullQuery(nodeA, request0)` because they have different expected response
+// types, `Put` and `Chits`.
+//
+// Additionally, after having sent `Get(nodeA, request0)` and receiving either
+// `Put(nodeA, request0)` or `GetFailed(nodeA, request0)`, it is valid to resend
+// `Get(nodeA, request0)`. Because the initial `Get` request is no longer
+// outstanding.
+//
+// This means that requestIDs can be reused. In practice, requests always have a
+// reasonable maximum timeout, so it is generally safe to assume that by the
+// time the requestID space has been exhausted, the beginning of the requestID
+// space is free of conflicts.
 type Sender interface {
 	snow.Acceptor
 


### PR DESCRIPTION
## Why this should be merged

There was some confusion around how many requests the node (and VMs) could make over the p2p network. In practice it is unbounded.

## How this works

Documented expected requestID reuse.

## How this was tested

N/A