### PR TITLE
Only gracefully exit rpcchainvm server after Shutdown

### DIFF
--- a/vms/rpcchainvm/vm.go
+++ b/vms/rpcchainvm/vm.go
@@ -56,9 +56,9 @@ func Serve(ctx context.Context, vm block.ChainVM, opts ...grpcutils.ServerOption
 
 				switch s {
 				case syscall.SIGINT:
-					fmt.Println("runtime engine: ignoring signal: SIGINT")
+					fmt.Printf("runtime engine: ignoring signal: %s\n", s)
 				case syscall.SIGTERM:
-					fmt.Println("runtime engine: received shutdown signal: SIGTERM")
+					fmt.Printf("runtime engine: received shutdown signal: %s\n", s)
 					return
 				}
 			case <-ctx.Done():

--- a/vms/rpcchainvm/vm.go
+++ b/vms/rpcchainvm/vm.go
@@ -49,6 +49,9 @@ func Serve(ctx context.Context, vm block.ChainVM, opts ...grpcutils.ServerOption
 		for {
 			select {
 			case s := <-signals:
+				// We drop all signals until our parent process has notified us
+				// that we are shutting down. Once we are in the shutdown
+				// workflow, we will gracefully exit upon receiving a SIGTERM.
 				if !allowShutdown.Get() {
 					fmt.Printf("runtime engine: ignoring signal: %s\n", s)
 					continue

--- a/vms/rpcchainvm/vm_server.go
+++ b/vms/rpcchainvm/vm_server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/common/appsender"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/validators/gvalidators"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
@@ -71,6 +72,8 @@ type VMServer struct {
 	// If nil, the underlying VM doesn't implement the interface.
 	ssVM block.StateSyncableVM
 
+	allowShutdown *utils.Atomic[bool]
+
 	processMetrics prometheus.Gatherer
 	dbManager      manager.Manager
 	log            logging.Logger
@@ -83,7 +86,7 @@ type VMServer struct {
 }
 
 // NewServer returns a vm instance connected to a remote vm instance
-func NewServer(vm block.ChainVM) *VMServer {
+func NewServer(vm block.ChainVM, allowShutdown *utils.Atomic[bool]) *VMServer {
 	bVM, _ := vm.(block.BuildBlockWithContextChainVM)
 	ssVM, _ := vm.(block.StateSyncableVM)
 	return &VMServer{
@@ -316,6 +319,7 @@ func (vm *VMServer) SetState(ctx context.Context, stateReq *vmpb.SetStateRequest
 }
 
 func (vm *VMServer) Shutdown(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
+	vm.allowShutdown.Set(true)
 	if vm.closed == nil {
 		return &emptypb.Empty{}, nil
 	}

--- a/vms/rpcchainvm/vm_server.go
+++ b/vms/rpcchainvm/vm_server.go
@@ -90,9 +90,10 @@ func NewServer(vm block.ChainVM, allowShutdown *utils.Atomic[bool]) *VMServer {
 	bVM, _ := vm.(block.BuildBlockWithContextChainVM)
 	ssVM, _ := vm.(block.StateSyncableVM)
 	return &VMServer{
-		vm:   vm,
-		bVM:  bVM,
-		ssVM: ssVM,
+		vm:            vm,
+		bVM:           bVM,
+		ssVM:          ssVM,
+		allowShutdown: allowShutdown,
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

This gives us the following nice properties:
1. This solution doesn't require user intervention (systemd will just start working correctly for newer plugin versions)
2. We do not ungracefully kill the subprocess (as it is able to catch the signal we send and gracefully exit with code 0)
3. We still use a signal designed for immediately terminating a process to terminate the subprocess

## How this works

1. Upon startup register a signal handler to SIGINT and SIGTERM on the plugin side to avoid systemd from unexpectedly killing the subprocess.
2. During the shutdown flow avalanchego will call Shutdown over the gRPC.
3. During the handling of the Shutdown call - update the signal handler to now honor SIGTERM signals.
4. After Shutdown has been called send the SIGTERM call as we did previously.

## How this was tested

CI
