### PR TITLE
Change max response size to target response size

### DIFF
--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -80,11 +80,11 @@ func TestGossiperGossip(t *testing.T) {
 			expectedLen:            2,
 		},
 		{
-			name:                   "gossip - max response size exceeded",
+			name:                   "gossip - target response size exceeded",
 			maxResponseSize:        32,
-			responder:              []*testTx{{id: ids.ID{0}}, {id: ids.ID{1}}},
-			expectedPossibleValues: []*testTx{{id: ids.ID{0}}, {id: ids.ID{1}}},
-			expectedLen:            1,
+			responder:              []*testTx{{id: ids.ID{0}}, {id: ids.ID{1}}, {id: ids.ID{2}}},
+			expectedPossibleValues: []*testTx{{id: ids.ID{0}}, {id: ids.ID{1}}, {id: ids.ID{2}}},
+			expectedLen:            2,
 		},
 	}
 

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -23,18 +23,18 @@ var (
 	ErrInvalidID = errors.New("invalid id")
 )
 
-func NewHandler[T Gossipable](set Set[T], maxResponseSize int) *Handler[T] {
+func NewHandler[T Gossipable](set Set[T], targetResponseSize int) *Handler[T] {
 	return &Handler[T]{
-		Handler:         p2p.NoOpHandler{},
-		set:             set,
-		maxResponseSize: maxResponseSize,
+		Handler:            p2p.NoOpHandler{},
+		set:                set,
+		targetResponseSize: targetResponseSize,
 	}
 }
 
 type Handler[T Gossipable] struct {
 	p2p.Handler
-	set             Set[T]
-	maxResponseSize int
+	set                Set[T]
+	targetResponseSize int
 }
 
 func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, requestBytes []byte) ([]byte, error) {
@@ -70,13 +70,14 @@ func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, req
 			return false
 		}
 
-		// check that this doesn't exceed our maximum configured response size
+		// check that this doesn't exceed our maximum configured target response
+		// size
+		gossipBytes = append(gossipBytes, bytes)
+
 		responseSize += len(bytes)
-		if responseSize > h.maxResponseSize {
+		if responseSize > h.targetResponseSize {
 			return false
 		}
-
-		gossipBytes = append(gossipBytes, bytes)
 
 		return true
 	})

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -73,13 +73,9 @@ func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, req
 		// check that this doesn't exceed our maximum configured target response
 		// size
 		gossipBytes = append(gossipBytes, bytes)
-
 		responseSize += len(bytes)
-		if responseSize > h.targetResponseSize {
-			return false
-		}
 
-		return true
+		return responseSize <= h.targetResponseSize
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged

Prevent edge-cases where a gossiped item might never get gossiped

## How this works

Changes the max gossip size to a target size

## How this was tested

Changed unit test