### PR TITLE
Add p2p SDK Router metrics

### DIFF
--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -40,6 +40,7 @@ type CrossChainAppResponseCallback func(
 )
 
 type Client struct {
+	handlerID     uint64
 	handlerPrefix []byte
 	router        *Router
 	sender        common.AppSender
@@ -95,7 +96,10 @@ func (c *Client) AppRequest(
 			return err
 		}
 
-		c.router.pendingAppRequests[requestID] = onResponse
+		c.router.pendingAppRequests[requestID] = pendingAppRequest{
+			AppResponseCallback: onResponse,
+			metrics:             c.router.handlers[c.handlerID].metrics,
+		}
 		c.router.requestID += 2
 	}
 
@@ -155,7 +159,10 @@ func (c *Client) CrossChainAppRequest(
 		return err
 	}
 
-	c.router.pendingCrossChainAppRequests[requestID] = onResponse
+	c.router.pendingCrossChainAppRequests[requestID] = pendingCrossChainAppRequest{
+		CrossChainAppResponseCallback: onResponse,
+		metrics:                       c.router.handlers[c.handlerID].metrics,
+	}
 	c.router.requestID += 2
 
 	return nil

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -80,11 +80,11 @@ func TestGossiperGossip(t *testing.T) {
 			expectedLen:            2,
 		},
 		{
-			name:                   "gossip - max response size exceeded",
+			name:                   "gossip - target response size exceeded",
 			maxResponseSize:        32,
-			responder:              []*testTx{{id: ids.ID{0}}, {id: ids.ID{1}}},
-			expectedPossibleValues: []*testTx{{id: ids.ID{0}}, {id: ids.ID{1}}},
-			expectedLen:            1,
+			responder:              []*testTx{{id: ids.ID{0}}, {id: ids.ID{1}}, {id: ids.ID{2}}},
+			expectedPossibleValues: []*testTx{{id: ids.ID{0}}, {id: ids.ID{1}}, {id: ids.ID{2}}},
+			expectedLen:            2,
 		},
 	}
 

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"
@@ -94,7 +95,7 @@ func TestGossiperGossip(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			responseSender := common.NewMockSender(ctrl)
-			responseRouter := p2p.NewRouter(logging.NoLog{}, responseSender)
+			responseRouter := p2p.NewRouter(logging.NoLog{}, responseSender, prometheus.NewRegistry(), "")
 			responseBloom, err := NewBloomFilter(1000, 0.01)
 			require.NoError(err)
 			responseSet := testSet{
@@ -112,7 +113,7 @@ func TestGossiperGossip(t *testing.T) {
 			require.NoError(err)
 
 			requestSender := common.NewMockSender(ctrl)
-			requestRouter := p2p.NewRouter(logging.NoLog{}, requestSender)
+			requestRouter := p2p.NewRouter(logging.NoLog{}, requestSender, prometheus.NewRegistry(), "")
 
 			gossiped := make(chan struct{})
 			requestSender.EXPECT().SendAppRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"

--- a/network/p2p/peers_test.go
+++ b/network/p2p/peers_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"
@@ -132,7 +133,7 @@ func TestAppRequestAnyNodeSelection(t *testing.T) {
 			}
 			mockAppSender.EXPECT().SendAppRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(expectedCalls)
 
-			r := NewRouter(logging.NoLog{}, mockAppSender)
+			r := NewRouter(logging.NoLog{}, mockAppSender, prometheus.NewRegistry(), "")
 			peers := &Peers{}
 			for _, peer := range tt.peers {
 				require.NoError(peers.Connected(context.Background(), peer, nil))

--- a/network/p2p/peers_test.go
+++ b/network/p2p/peers_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -229,7 +229,6 @@ func (r *Router) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reques
 
 	pending.AppResponseCallback(ctx, nodeID, nil, ErrAppRequestFailed)
 	pending.appRequestFailedTime.Observe(float64(time.Since(start)))
-
 	return nil
 }
 
@@ -242,7 +241,6 @@ func (r *Router) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	pending.AppResponseCallback(ctx, nodeID, response, nil)
 	pending.appResponseTime.Observe(float64(time.Since(start)))
-
 	return nil
 }
 
@@ -260,7 +258,6 @@ func (r *Router) AppGossip(ctx context.Context, nodeID ids.NodeID, gossip []byte
 
 	if err := handler.AppGossip(ctx, nodeID, parsedMsg); err != nil {
 		return err
-
 	}
 
 	handler.metrics.appGossipTime.Observe(float64(time.Since(start)))
@@ -304,7 +301,6 @@ func (r *Router) CrossChainAppRequestFailed(ctx context.Context, chainID ids.ID,
 
 	pending.CrossChainAppResponseCallback(ctx, chainID, nil, ErrAppRequestFailed)
 	pending.crossChainAppRequestFailedTime.Observe(float64(time.Since(start)))
-
 	return nil
 }
 
@@ -317,7 +313,6 @@ func (r *Router) CrossChainAppResponse(ctx context.Context, chainID ids.ID, requ
 
 	pending.CrossChainAppResponseCallback(ctx, chainID, response, nil)
 	pending.crossChainAppResponseTime.Observe(float64(time.Since(start)))
-
 	return nil
 }
 

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -229,7 +229,6 @@ func (r *Router) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reques
 
 	pending.AppResponseCallback(ctx, nodeID, nil, ErrAppRequestFailed)
 	pending.appRequestFailedTime.Observe(float64(time.Since(start)))
-
 	return nil
 }
 
@@ -242,7 +241,6 @@ func (r *Router) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	pending.AppResponseCallback(ctx, nodeID, response, nil)
 	pending.appResponseTime.Observe(float64(time.Since(start)))
-
 	return nil
 }
 
@@ -304,7 +302,6 @@ func (r *Router) CrossChainAppRequestFailed(ctx context.Context, chainID ids.ID,
 
 	pending.CrossChainAppResponseCallback(ctx, chainID, nil, ErrAppRequestFailed)
 	pending.crossChainAppRequestFailedTime.Observe(float64(time.Since(start)))
-
 	return nil
 }
 
@@ -317,7 +314,6 @@ func (r *Router) CrossChainAppResponse(ctx context.Context, chainID ids.ID, requ
 
 	pending.CrossChainAppResponseCallback(ctx, chainID, response, nil)
 	pending.crossChainAppResponseTime.Observe(float64(time.Since(start)))
-
 	return nil
 }
 

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -103,72 +103,72 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 
 	appRequestTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("%d_app_request", handlerID),
+		fmt.Sprintf("handler_%d_app_request", handlerID),
 		"app request time (ns)",
 		r.metrics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register app request metric for %d: %w", handlerID, err)
+		return nil, fmt.Errorf("failed to register app request metric for handler_%d: %w", handlerID, err)
 	}
 
 	appRequestFailedTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("%d_app_request_failed", handlerID),
+		fmt.Sprintf("handler_%d_app_request_failed", handlerID),
 		"app request failed time (ns)",
 		r.metrics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register app request failed metric for %d: %w", handlerID, err)
+		return nil, fmt.Errorf("failed to register app request failed metric for handler_%d: %w", handlerID, err)
 	}
 
 	appResponseTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("%d_app_response", handlerID),
+		fmt.Sprintf("handler_%d_app_response", handlerID),
 		"app response time (ns)",
 		r.metrics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register app response metric for %d: %w", handlerID, err)
+		return nil, fmt.Errorf("failed to register app response metric for handler_%d: %w", handlerID, err)
 	}
 
 	appGossipTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("%d_app_gossip", handlerID),
+		fmt.Sprintf("handler_%d_app_gossip", handlerID),
 		"app gossip time (ns)",
 		r.metrics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register app gossip metric for %d: %w", handlerID, err)
+		return nil, fmt.Errorf("failed to register app gossip metric for handler_%d: %w", handlerID, err)
 	}
 
 	crossChainAppRequestTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("%d_cross_chain_app_request", handlerID),
+		fmt.Sprintf("handler_%d_cross_chain_app_request", handlerID),
 		"cross chain app request time (ns)",
 		r.metrics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register cross-chain app request metric for %d: %w", handlerID, err)
+		return nil, fmt.Errorf("failed to register cross-chain app request metric for handler_%d: %w", handlerID, err)
 	}
 
 	crossChainAppRequestFailedTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("%d_cross_chain_app_request_failed", handlerID),
+		fmt.Sprintf("handler_%d_cross_chain_app_request_failed", handlerID),
 		"app request failed time (ns)",
 		r.metrics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register app request failed metric for %d: %w", handlerID, err)
+		return nil, fmt.Errorf("failed to register app request failed metric for handler_%d: %w", handlerID, err)
 	}
 
 	crossChainAppResponseTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("%d_cross_chain_app_response", handlerID),
+		fmt.Sprintf("handler_%d_cross_chain_app_response", handlerID),
 		"cross chain app response time (ns)",
 		r.metrics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register cross-chain app response metric for %d: %w", handlerID, err)
+		return nil, fmt.Errorf("failed to register cross-chain app response metric for handler_%d: %w", handlerID, err)
 	}
 
 	r.handlers[handlerID] = &meteredHandler{

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -103,7 +103,7 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 
 	appRequestTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("router_%d_app_request", handlerID),
+		fmt.Sprintf("%d_app_request", handlerID),
 		"app request time (ns)",
 		r.metrics,
 	)
@@ -113,7 +113,7 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 
 	appRequestFailedTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("router_%d_app_request_failed", handlerID),
+		fmt.Sprintf("%d_app_request_failed", handlerID),
 		"app request failed time (ns)",
 		r.metrics,
 	)
@@ -123,7 +123,7 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 
 	appResponseTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("router_%d_app_response", handlerID),
+		fmt.Sprintf("%d_app_response", handlerID),
 		"app response time (ns)",
 		r.metrics,
 	)
@@ -133,7 +133,7 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 
 	appGossipTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("router_%d_app_gossip", handlerID),
+		fmt.Sprintf("%d_app_gossip", handlerID),
 		"app gossip time (ns)",
 		r.metrics,
 	)
@@ -143,7 +143,7 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 
 	crossChainAppRequestTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("router_%d_cross_chain_app_request", handlerID),
+		fmt.Sprintf("%d_cross_chain_app_request", handlerID),
 		"cross chain app request time (ns)",
 		r.metrics,
 	)
@@ -153,7 +153,7 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 
 	crossChainAppRequestFailedTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("router_%d_cross_chain_app_request_failed", handlerID),
+		fmt.Sprintf("%d_cross_chain_app_request_failed", handlerID),
 		"app request failed time (ns)",
 		r.metrics,
 	)
@@ -163,7 +163,7 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 
 	crossChainAppResponseTime, err := metric.NewAverager(
 		r.namespace,
-		fmt.Sprintf("router_%d_cross_chain_app_response", handlerID),
+		fmt.Sprintf("%d_cross_chain_app_response", handlerID),
 		"cross chain app response time (ns)",
 		r.metrics,
 	)

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -11,12 +11,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/metric"
 )
 
 var (
@@ -26,28 +28,64 @@ var (
 	_ common.AppHandler = (*Router)(nil)
 )
 
+type metrics struct {
+	appRequestTime                 metric.Averager
+	appRequestFailedTime           metric.Averager
+	appResponseTime                metric.Averager
+	appGossipTime                  metric.Averager
+	crossChainAppRequestTime       metric.Averager
+	crossChainAppRequestFailedTime metric.Averager
+	crossChainAppResponseTime      metric.Averager
+}
+
+type pendingAppRequest struct {
+	*metrics
+	AppResponseCallback
+}
+
+type pendingCrossChainAppRequest struct {
+	*metrics
+	CrossChainAppResponseCallback
+}
+
+type meteredHandler struct {
+	*responder
+	*metrics
+}
+
 // Router routes incoming application messages to the corresponding registered
 // app handler. App messages must be made using the registered handler's
 // corresponding Client.
 type Router struct {
-	log    logging.Logger
-	sender common.AppSender
+	log       logging.Logger
+	sender    common.AppSender
+	metrics   prometheus.Registerer
+	namespace string
 
 	lock                         sync.RWMutex
-	handlers                     map[uint64]*responder
-	pendingAppRequests           map[uint32]AppResponseCallback
-	pendingCrossChainAppRequests map[uint32]CrossChainAppResponseCallback
+	handlers                     map[uint64]*meteredHandler
+	pendingAppRequests           map[uint32]pendingAppRequest
+	pendingCrossChainAppRequests map[uint32]pendingCrossChainAppRequest
 	requestID                    uint32
 }
 
 // NewRouter returns a new instance of Router
-func NewRouter(log logging.Logger, sender common.AppSender) *Router {
+func NewRouter(
+	log logging.Logger,
+	sender common.AppSender,
+	metrics prometheus.Registerer,
+	namespace string,
+) *Router {
 	return &Router{
-		log:                          log,
-		sender:                       sender,
-		handlers:                     make(map[uint64]*responder),
-		pendingAppRequests:           make(map[uint32]AppResponseCallback),
-		pendingCrossChainAppRequests: make(map[uint32]CrossChainAppResponseCallback),
+		log:       log,
+		sender:    sender,
+		metrics:   metrics,
+		namespace: namespace,
+
+		handlers: make(map[uint64]*meteredHandler),
+
+		pendingAppRequests:           make(map[uint32]pendingAppRequest),
+		pendingCrossChainAppRequests: make(map[uint32]pendingCrossChainAppRequest),
 		// invariant: sdk uses odd-numbered requestIDs
 		requestID: 1,
 	}
@@ -64,14 +102,96 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 		return nil, fmt.Errorf("failed to register handler id %d: %w", handlerID, ErrExistingAppProtocol)
 	}
 
-	r.handlers[handlerID] = &responder{
-		handlerID: handlerID,
-		handler:   handler,
-		log:       r.log,
-		sender:    r.sender,
+	appRequestTime, err := metric.NewAverager(
+		"router",
+		fmt.Sprintf("%s_%d_app_request", r.namespace, handlerID),
+		"app request time (ns)",
+		r.metrics,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register app request metric for %d: %w", handlerID, err)
+	}
+
+	appRequestFailedTime, err := metric.NewAverager(
+		"router",
+		fmt.Sprintf("%s_%d_app_request_failed", r.namespace, handlerID),
+		"app request failed time (ns)",
+		r.metrics,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register app request failed metric for %d: %w", handlerID, err)
+	}
+
+	appResponseTime, err := metric.NewAverager(
+		"router",
+		fmt.Sprintf("%s_%d_app_response", r.namespace, handlerID),
+		"app response time (ns)",
+		r.metrics,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register app response metric for %d: %w", handlerID, err)
+	}
+
+	appGossipTime, err := metric.NewAverager(
+		"router",
+		fmt.Sprintf("%s_%d_app_gossip", r.namespace, handlerID),
+		"app gossip time (ns)",
+		r.metrics,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register app gossip metric for %d: %w", handlerID, err)
+	}
+
+	crossChainAppRequestTime, err := metric.NewAverager(
+		"router",
+		fmt.Sprintf("%s_%d_cross_chain_app_request", r.namespace, handlerID),
+		"cross chain app request time (ns)",
+		r.metrics,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register cross-chain app request metric for %d: %w", handlerID, err)
+	}
+
+	crossChainAppRequestFailedTime, err := metric.NewAverager(
+		"router",
+		fmt.Sprintf("%s_%d_cross_chain_app_request_failed", r.namespace, handlerID),
+		"app request failed time (ns)",
+		r.metrics,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register app request failed metric for %d: %w", handlerID, err)
+	}
+
+	crossChainAppResponseTime, err := metric.NewAverager(
+		"router",
+		fmt.Sprintf("%s_%d_cross_chain_app_response", r.namespace, handlerID),
+		"cross chain app response time (ns)",
+		r.metrics,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register cross-chain app response metric for %d: %w", handlerID, err)
+	}
+
+	r.handlers[handlerID] = &meteredHandler{
+		responder: &responder{
+			handlerID: handlerID,
+			handler:   handler,
+			log:       r.log,
+			sender:    r.sender,
+		},
+		metrics: &metrics{
+			appRequestTime:                 appRequestTime,
+			appRequestFailedTime:           appRequestFailedTime,
+			appResponseTime:                appResponseTime,
+			appGossipTime:                  appGossipTime,
+			crossChainAppRequestTime:       crossChainAppRequestTime,
+			crossChainAppRequestFailedTime: crossChainAppRequestFailedTime,
+			crossChainAppResponseTime:      crossChainAppResponseTime,
+		},
 	}
 
 	return &Client{
+		handlerID:     handlerID,
 		handlerPrefix: binary.AppendUvarint(nil, handlerID),
 		sender:        r.sender,
 		router:        r,
@@ -92,30 +212,41 @@ func (r *Router) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID ui
 		return nil
 	}
 
-	return handler.AppRequest(ctx, nodeID, requestID, deadline, parsedMsg)
+	start := time.Now()
+	err := handler.AppRequest(ctx, nodeID, requestID, deadline, parsedMsg)
+	handler.metrics.appRequestTime.Observe(float64(time.Since(start)))
+
+	return err
 }
 
 func (r *Router) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
-	callback, ok := r.clearAppRequest(requestID)
+	start := time.Now()
+	pending, ok := r.clearAppRequest(requestID)
 	if !ok {
 		return ErrUnrequestedResponse
 	}
 
-	callback(ctx, nodeID, nil, ErrAppRequestFailed)
+	pending.AppResponseCallback(ctx, nodeID, nil, ErrAppRequestFailed)
+	pending.appRequestFailedTime.Observe(float64(time.Since(start)))
+
 	return nil
 }
 
 func (r *Router) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
-	callback, ok := r.clearAppRequest(requestID)
+	start := time.Now()
+	pending, ok := r.clearAppRequest(requestID)
 	if !ok {
 		return ErrUnrequestedResponse
 	}
 
-	callback(ctx, nodeID, response, nil)
+	pending.AppResponseCallback(ctx, nodeID, response, nil)
+	pending.appResponseTime.Observe(float64(time.Since(start)))
+
 	return nil
 }
 
 func (r *Router) AppGossip(ctx context.Context, nodeID ids.NodeID, gossip []byte) error {
+	start := time.Now()
 	parsedMsg, handler, ok := r.parse(gossip)
 	if !ok {
 		r.log.Debug("failed to process message",
@@ -126,7 +257,10 @@ func (r *Router) AppGossip(ctx context.Context, nodeID ids.NodeID, gossip []byte
 		return nil
 	}
 
-	return handler.AppGossip(ctx, nodeID, parsedMsg)
+	err := handler.AppGossip(ctx, nodeID, parsedMsg)
+	handler.metrics.appGossipTime.Observe(float64(time.Since(start)))
+
+	return err
 }
 
 func (r *Router) CrossChainAppRequest(
@@ -136,6 +270,7 @@ func (r *Router) CrossChainAppRequest(
 	deadline time.Time,
 	msg []byte,
 ) error {
+	start := time.Now()
 	parsedMsg, handler, ok := r.parse(msg)
 	if !ok {
 		r.log.Debug("failed to process message",
@@ -148,26 +283,35 @@ func (r *Router) CrossChainAppRequest(
 		return nil
 	}
 
-	return handler.CrossChainAppRequest(ctx, chainID, requestID, deadline, parsedMsg)
+	err := handler.CrossChainAppRequest(ctx, chainID, requestID, deadline, parsedMsg)
+	handler.metrics.crossChainAppRequestTime.Observe(float64(time.Since(start)))
+
+	return err
 }
 
 func (r *Router) CrossChainAppRequestFailed(ctx context.Context, chainID ids.ID, requestID uint32) error {
-	callback, ok := r.clearCrossChainAppRequest(requestID)
+	start := time.Now()
+	pending, ok := r.clearCrossChainAppRequest(requestID)
 	if !ok {
 		return ErrUnrequestedResponse
 	}
 
-	callback(ctx, chainID, nil, ErrAppRequestFailed)
+	pending.CrossChainAppResponseCallback(ctx, chainID, nil, ErrAppRequestFailed)
+	pending.crossChainAppRequestFailedTime.Observe(float64(time.Since(start)))
+
 	return nil
 }
 
 func (r *Router) CrossChainAppResponse(ctx context.Context, chainID ids.ID, requestID uint32, response []byte) error {
-	callback, ok := r.clearCrossChainAppRequest(requestID)
+	start := time.Now()
+	pending, ok := r.clearCrossChainAppRequest(requestID)
 	if !ok {
 		return ErrUnrequestedResponse
 	}
 
-	callback(ctx, chainID, response, nil)
+	pending.CrossChainAppResponseCallback(ctx, chainID, response, nil)
+	pending.crossChainAppResponseTime.Observe(float64(time.Since(start)))
+
 	return nil
 }
 
@@ -180,7 +324,7 @@ func (r *Router) CrossChainAppResponse(ctx context.Context, chainID ids.ID, requ
 // - A boolean indicating that parsing succeeded.
 //
 // Invariant: Assumes [r.lock] isn't held.
-func (r *Router) parse(msg []byte) ([]byte, *responder, bool) {
+func (r *Router) parse(msg []byte) ([]byte, *meteredHandler, bool) {
 	handlerID, bytesRead := binary.Uvarint(msg)
 	if bytesRead <= 0 {
 		return nil, nil, false
@@ -194,7 +338,7 @@ func (r *Router) parse(msg []byte) ([]byte, *responder, bool) {
 }
 
 // Invariant: Assumes [r.lock] isn't held.
-func (r *Router) clearAppRequest(requestID uint32) (AppResponseCallback, bool) {
+func (r *Router) clearAppRequest(requestID uint32) (pendingAppRequest, bool) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -204,7 +348,7 @@ func (r *Router) clearAppRequest(requestID uint32) (AppResponseCallback, bool) {
 }
 
 // Invariant: Assumes [r.lock] isn't held.
-func (r *Router) clearCrossChainAppRequest(requestID uint32) (CrossChainAppResponseCallback, bool) {
+func (r *Router) clearCrossChainAppRequest(requestID uint32) (pendingCrossChainAppRequest, bool) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -22,10 +22,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/metric"
 )
 
-const (
-	metricsNamespace = "router"
-)
-
 var (
 	ErrExistingAppProtocol = errors.New("existing app protocol")
 	ErrUnrequestedResponse = errors.New("unrequested response")
@@ -106,8 +102,8 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 	}
 
 	appRequestTime, err := metric.NewAverager(
-		metricsNamespace,
-		fmt.Sprintf("%s_%d_app_request", r.namespace, handlerID),
+		r.namespace,
+		fmt.Sprintf("router_%d_app_request", handlerID),
 		"app request time (ns)",
 		r.metrics,
 	)
@@ -116,8 +112,8 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 	}
 
 	appRequestFailedTime, err := metric.NewAverager(
-		metricsNamespace,
-		fmt.Sprintf("%s_%d_app_request_failed", r.namespace, handlerID),
+		r.namespace,
+		fmt.Sprintf("router_%d_app_request_failed", handlerID),
 		"app request failed time (ns)",
 		r.metrics,
 	)
@@ -126,8 +122,8 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 	}
 
 	appResponseTime, err := metric.NewAverager(
-		metricsNamespace,
-		fmt.Sprintf("%s_%d_app_response", r.namespace, handlerID),
+		r.namespace,
+		fmt.Sprintf("router_%d_app_response", handlerID),
 		"app response time (ns)",
 		r.metrics,
 	)
@@ -136,8 +132,8 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 	}
 
 	appGossipTime, err := metric.NewAverager(
-		metricsNamespace,
-		fmt.Sprintf("%s_%d_app_gossip", r.namespace, handlerID),
+		r.namespace,
+		fmt.Sprintf("router_%d_app_gossip", handlerID),
 		"app gossip time (ns)",
 		r.metrics,
 	)
@@ -146,8 +142,8 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 	}
 
 	crossChainAppRequestTime, err := metric.NewAverager(
-		metricsNamespace,
-		fmt.Sprintf("%s_%d_cross_chain_app_request", r.namespace, handlerID),
+		r.namespace,
+		fmt.Sprintf("router_%d_cross_chain_app_request", handlerID),
 		"cross chain app request time (ns)",
 		r.metrics,
 	)
@@ -156,8 +152,8 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 	}
 
 	crossChainAppRequestFailedTime, err := metric.NewAverager(
-		metricsNamespace,
-		fmt.Sprintf("%s_%d_cross_chain_app_request_failed", r.namespace, handlerID),
+		r.namespace,
+		fmt.Sprintf("router_%d_cross_chain_app_request_failed", handlerID),
 		"app request failed time (ns)",
 		r.metrics,
 	)
@@ -166,8 +162,8 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 	}
 
 	crossChainAppResponseTime, err := metric.NewAverager(
-		metricsNamespace,
-		fmt.Sprintf("%s_%d_cross_chain_app_response", r.namespace, handlerID),
+		r.namespace,
+		fmt.Sprintf("router_%d_cross_chain_app_response", handlerID),
 		"cross chain app response time (ns)",
 		r.metrics,
 	)

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -158,7 +158,7 @@ func (r *Router) RegisterAppProtocol(handlerID uint64, handler Handler, nodeSamp
 		r.metrics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register app request failed metric for handler_%d: %w", handlerID, err)
+		return nil, fmt.Errorf("failed to register cross-chain app request failed metric for handler_%d: %w", handlerID, err)
 	}
 
 	crossChainAppResponseTime, err := metric.NewAverager(
@@ -229,6 +229,7 @@ func (r *Router) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reques
 
 	pending.AppResponseCallback(ctx, nodeID, nil, ErrAppRequestFailed)
 	pending.appRequestFailedTime.Observe(float64(time.Since(start)))
+
 	return nil
 }
 
@@ -241,6 +242,7 @@ func (r *Router) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	pending.AppResponseCallback(ctx, nodeID, response, nil)
 	pending.appResponseTime.Observe(float64(time.Since(start)))
+
 	return nil
 }
 
@@ -258,6 +260,7 @@ func (r *Router) AppGossip(ctx context.Context, nodeID ids.NodeID, gossip []byte
 
 	if err := handler.AppGossip(ctx, nodeID, parsedMsg); err != nil {
 		return err
+
 	}
 
 	handler.metrics.appGossipTime.Observe(float64(time.Since(start)))
@@ -301,6 +304,7 @@ func (r *Router) CrossChainAppRequestFailed(ctx context.Context, chainID ids.ID,
 
 	pending.CrossChainAppResponseCallback(ctx, chainID, nil, ErrAppRequestFailed)
 	pending.crossChainAppRequestFailedTime.Observe(float64(time.Since(start)))
+
 	return nil
 }
 
@@ -313,6 +317,7 @@ func (r *Router) CrossChainAppResponse(ctx context.Context, chainID ids.ID, requ
 
 	pending.CrossChainAppResponseCallback(ctx, chainID, response, nil)
 	pending.crossChainAppResponseTime.Observe(float64(time.Since(start)))
+
 	return nil
 }
 

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -258,7 +258,6 @@ func (r *Router) AppGossip(ctx context.Context, nodeID ids.NodeID, gossip []byte
 
 	if err := handler.AppGossip(ctx, nodeID, parsedMsg); err != nil {
 		return err
-
 	}
 
 	handler.metrics.appGossipTime.Observe(float64(time.Since(start)))

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"

--- a/network/p2p/router_test.go
+++ b/network/p2p/router_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"
@@ -200,7 +201,7 @@ func TestAppRequestResponse(t *testing.T) {
 
 			sender := common.NewMockSender(ctrl)
 			handler := mocks.NewMockHandler(ctrl)
-			router := NewRouter(logging.NoLog{}, sender)
+			router := NewRouter(logging.NoLog{}, sender, prometheus.NewRegistry(), "")
 			peers := &Peers{}
 			require.NoError(peers.Connected(context.Background(), nodeID, nil))
 			client, err := router.RegisterAppProtocol(handlerID, handler, peers)
@@ -298,7 +299,7 @@ func TestRouterDropMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			router := NewRouter(logging.NoLog{}, nil)
+			router := NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), "")
 
 			err := tt.requestFunc(router)
 			require.ErrorIs(err, tt.err)
@@ -315,7 +316,7 @@ func TestAppRequestDuplicateRequestIDs(t *testing.T) {
 
 	handler := mocks.NewMockHandler(ctrl)
 	sender := common.NewMockSender(ctrl)
-	router := NewRouter(logging.NoLog{}, sender)
+	router := NewRouter(logging.NoLog{}, sender, prometheus.NewRegistry(), "")
 	nodeID := ids.GenerateTestNodeID()
 
 	requestSent := &sync.WaitGroup{}


### PR DESCRIPTION
## Why this should be merged

Adds handler-level time metrics to the sdk

## How this works

Uses a map of averagers

## How this was tested

UT's pass
