### PR TITLE
[WIP] Merkle db find next key bug

### DIFF
--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -382,10 +382,8 @@ func (m *Manager) findNextKey(
 	rangeEnd maybe.Maybe[[]byte],
 	endProof []merkledb.ProofNode,
 ) (maybe.Maybe[[]byte], error) {
-	if len(endProof) == 0 || (rangeEnd.HasValue() && bytes.Equal(rangeEnd.Value(), lastReceivedKey)) {
-		// The range is already complete if
-		// * endproof is empty if no end key was provided and no key values were sent back
-		// * the last key is equal to the end of the range
+	if len(endProof) == 0 {
+		// The range is already complete if endproof is empty since no end key was provided and no key values were sent back
 		return maybe.Nothing[[]byte](), nil
 	}
 

--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -375,9 +375,9 @@ func (m *Manager) getAndApplyRangeProof(ctx context.Context, work *workItem) {
 // Invariant 1: [lastReceivedKey] < [rangeEnd].
 // If [rangeEnd] is Nothing it's considered > [lastReceivedKey].
 
-// Invariant 2: len(endproof) > 0
-// This should only occur if no keys were returned and no endkey was specified
-// if that happens then [lastReceivedKey] would equal [rangeEnd], which would violate Invariant 1
+// Invariant 2: len([endProof]) > 0
+// This only occurs when no keys were returned and no endkey was specified.
+// When that happens, [lastReceivedKey] would equal [rangeEnd], which would violate Invariant 1
 func (m *Manager) findNextKey(
 	ctx context.Context,
 	lastReceivedKey []byte,

--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -372,8 +372,12 @@ func (m *Manager) getAndApplyRangeProof(ctx context.Context, work *workItem) {
 //
 // [endProof] is the end proof of the last proof received.
 //
-// Invariant: [lastReceivedKey] < [rangeEnd].
+// Invariant 1: [lastReceivedKey] < [rangeEnd].
 // If [rangeEnd] is Nothing it's considered > [lastReceivedKey].
+
+// Invariant 2: len(endproof) > 0
+// This should only occur if no keys were returned and no endkey was specified
+// if that happens then [lastReceivedKey] would equal [rangeEnd], which would violate Invariant 1
 func (m *Manager) findNextKey(
 	ctx context.Context,
 	lastReceivedKey []byte,

--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -383,8 +383,9 @@ func (m *Manager) findNextKey(
 	endProof []merkledb.ProofNode,
 ) (maybe.Maybe[[]byte], error) {
 	if len(endProof) == 0 || (rangeEnd.HasValue() && bytes.Equal(rangeEnd.Value(), lastReceivedKey)) {
-		// Endproof is empty if no end key was provided and no key values were sent back, so the range is complete
-		// The range is also complete if the last key is the end of the range
+		// The range is already complete if
+		// * endproof is empty if no end key was provided and no key values were sent back
+		// * the last key is equal to the end of the range
 		return maybe.Nothing[[]byte](), nil
 	}
 

--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -382,13 +382,10 @@ func (m *Manager) findNextKey(
 	rangeEnd maybe.Maybe[[]byte],
 	endProof []merkledb.ProofNode,
 ) (maybe.Maybe[[]byte], error) {
-	if len(endProof) == 0 {
-		// We try to find the next key to fetch by looking at the end proof.
-		// If the end proof is empty, we have no information to use.
-		// Start fetching from the next key after [lastReceivedKey].
-		nextKey := lastReceivedKey
-		nextKey = append(nextKey, 0)
-		return maybe.Some(nextKey), nil
+	if len(endProof) == 0 || (rangeEnd.HasValue() && bytes.Equal(rangeEnd.Value(), lastReceivedKey)) {
+		// Endproof is empty if no end key was provided and no key values were sent back, so the range is complete
+		// The range is also complete if the last key is the end of the range
+		return maybe.Nothing[[]byte](), nil
 	}
 
 	// We want the first key larger than the [lastReceivedKey].


### PR DESCRIPTION
FindNextKey was returning an incorrect result when the endproof was empty.  This only occurs when the end key was nothing and no keys were returned, so appending 0 to it was incorrect.