### PR TITLE
database: comment that Get returns ErrNotFound if key is not present

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -21,6 +21,7 @@ type KeyValueReader interface {
 	Has(key []byte) (bool, error)
 
 	// Get retrieves the given key if it's present in the key-value data store.
+	// Returns ErrNotFound if the key is not present in the key-value data store.
 	//
 	// Note: [key] is safe to modify and read after calling Get.
 	// The returned byte slice is safe to read, but cannot be modified.


### PR DESCRIPTION
This PR adds a comment to the database `KeyValueReader` interface that specifies if a key is not present in the database, it should return `database.ErrNotFound`.