### PR TITLE
Cleanup early poll termination logic

### DIFF
--- a/snow/consensus/snowman/poll/early_term_no_traversal_test.go
+++ b/snow/consensus/snowman/poll/early_term_no_traversal_test.go
@@ -8,48 +8,36 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/bag"
 )
 
 func TestEarlyTermNoTraversalResults(t *testing.T) {
 	require := require.New(t)
 
+	vdrs := bag.Of(vdr1) // k = 1
 	alpha := 1
-
-	vtxID := ids.ID{1}
-
-	vdr1 := ids.NodeID{1} // k = 1
-
-	vdrs := bag.Of(vdr1)
 
 	factory := NewEarlyTermNoTraversalFactory(alpha)
 	poll := factory.New(vdrs)
 
-	poll.Vote(vdr1, vtxID)
+	poll.Vote(vdr1, blkID1)
 	require.True(poll.Finished())
 
 	result := poll.Result()
 	list := result.List()
 	require.Len(list, 1)
-	require.Equal(vtxID, list[0])
-	require.Equal(1, result.Count(vtxID))
+	require.Equal(blkID1, list[0])
+	require.Equal(1, result.Count(blkID1))
 }
 
 func TestEarlyTermNoTraversalString(t *testing.T) {
+	vdrs := bag.Of(vdr1, vdr2) // k = 2
 	alpha := 2
-
-	vtxID := ids.ID{1}
-
-	vdr1 := ids.NodeID{1}
-	vdr2 := ids.NodeID{2} // k = 2
-
-	vdrs := bag.Of(vdr1, vdr2)
 
 	factory := NewEarlyTermNoTraversalFactory(alpha)
 	poll := factory.New(vdrs)
 
-	poll.Vote(vdr1, vtxID)
+	poll.Vote(vdr1, blkID1)
 
 	expected := `waiting on Bag[ids.NodeID]: (Size = 1)
     NodeID-BaMPFdqMUQ46BV8iRcwbVfsam55kMqcp: 1
@@ -61,104 +49,28 @@ received Bag[ids.ID]: (Size = 1)
 func TestEarlyTermNoTraversalDropsDuplicatedVotes(t *testing.T) {
 	require := require.New(t)
 
+	vdrs := bag.Of(vdr1, vdr2) // k = 2
 	alpha := 2
 
-	vtxID := ids.ID{1}
-
-	vdr1 := ids.NodeID{1}
-	vdr2 := ids.NodeID{2} // k = 2
-
-	vdrs := bag.Of(vdr1, vdr2)
-
 	factory := NewEarlyTermNoTraversalFactory(alpha)
 	poll := factory.New(vdrs)
 
-	poll.Vote(vdr1, vtxID)
+	poll.Vote(vdr1, blkID1)
 	require.False(poll.Finished())
 
-	poll.Vote(vdr1, vtxID)
+	poll.Vote(vdr1, blkID1)
 	require.False(poll.Finished())
 
-	poll.Vote(vdr2, vtxID)
+	poll.Vote(vdr2, blkID1)
 	require.True(poll.Finished())
 }
 
-func TestEarlyTermNoTraversalTerminatesEarly(t *testing.T) {
+// Tests case 2
+func TestEarlyTermNoTraversalTerminatesEarlyWithoutAlpha(t *testing.T) {
 	require := require.New(t)
 
-	alpha := 3
-
-	vtxID := ids.ID{1}
-
-	vdr1 := ids.NodeID{1}
-	vdr2 := ids.NodeID{2}
-	vdr3 := ids.NodeID{3}
-	vdr4 := ids.NodeID{4}
-	vdr5 := ids.NodeID{5} // k = 5
-
-	vdrs := bag.Of(vdr1, vdr2, vdr3, vdr4, vdr5)
-
-	factory := NewEarlyTermNoTraversalFactory(alpha)
-	poll := factory.New(vdrs)
-
-	poll.Vote(vdr1, vtxID)
-	require.False(poll.Finished())
-
-	poll.Vote(vdr2, vtxID)
-	require.False(poll.Finished())
-
-	poll.Vote(vdr3, vtxID)
-	require.True(poll.Finished())
-}
-
-func TestEarlyTermNoTraversalForSharedAncestor(t *testing.T) {
-	require := require.New(t)
-
-	alpha := 4
-
-	vtxA := ids.ID{1}
-	vtxB := ids.ID{2}
-	vtxC := ids.ID{3}
-	vtxD := ids.ID{4}
-
-	// If validators 1-3 vote for frontier vertices
-	// B, C, and D respectively, which all share the common ancestor
-	// A, then we cannot terminate early with alpha = k = 4
-	// If the final vote is cast for any of A, B, C, or D, then
-	// vertex A will have transitively received alpha = 4 votes
-	vdr1 := ids.NodeID{1}
-	vdr2 := ids.NodeID{2}
-	vdr3 := ids.NodeID{3}
-	vdr4 := ids.NodeID{4}
-
-	vdrs := bag.Of(vdr1, vdr2, vdr3, vdr4)
-
-	factory := NewEarlyTermNoTraversalFactory(alpha)
-	poll := factory.New(vdrs)
-
-	poll.Vote(vdr1, vtxB)
-	require.False(poll.Finished())
-
-	poll.Vote(vdr2, vtxC)
-	require.False(poll.Finished())
-
-	poll.Vote(vdr3, vtxD)
-	require.False(poll.Finished())
-
-	poll.Vote(vdr4, vtxA)
-	require.True(poll.Finished())
-}
-
-func TestEarlyTermNoTraversalWithFastDrops(t *testing.T) {
-	require := require.New(t)
-
+	vdrs := bag.Of(vdr1, vdr2, vdr3) // k = 3
 	alpha := 2
-
-	vdr1 := ids.NodeID{1}
-	vdr2 := ids.NodeID{2}
-	vdr3 := ids.NodeID{3} // k = 3
-
-	vdrs := bag.Of(vdr1, vdr2, vdr3)
 
 	factory := NewEarlyTermNoTraversalFactory(alpha)
 	poll := factory.New(vdrs)
@@ -170,38 +82,75 @@ func TestEarlyTermNoTraversalWithFastDrops(t *testing.T) {
 	require.True(poll.Finished())
 }
 
-func TestEarlyTermNoTraversalWithWeightedResponses(t *testing.T) {
+// Tests case 3
+func TestEarlyTermNoTraversalTerminatesEarlyWithAlpha(t *testing.T) {
 	require := require.New(t)
 
-	alpha := 2
-
-	vtxID := ids.ID{1}
-
-	vdr1 := ids.NodeID{2}
-	vdr2 := ids.NodeID{3}
-
-	vdrs := bag.Of(vdr1, vdr2, vdr2) // k = 3
+	vdrs := bag.Of(vdr1, vdr2, vdr3, vdr4, vdr5) // k = 5
+	alpha := 3
 
 	factory := NewEarlyTermNoTraversalFactory(alpha)
 	poll := factory.New(vdrs)
 
-	poll.Vote(vdr2, vtxID)
+	poll.Vote(vdr1, blkID1)
+	require.False(poll.Finished())
+
+	poll.Vote(vdr2, blkID1)
+	require.False(poll.Finished())
+
+	poll.Vote(vdr3, blkID1)
+	require.True(poll.Finished())
+}
+
+// If validators 1-3 vote for blocks B, C, and D respectively, which all share
+// the common ancestor A, then we cannot terminate early with alpha = k = 4.
+//
+// If the final vote is cast for any of A, B, C, or D, then A will have
+// transitively received alpha = 4 votes
+func TestEarlyTermNoTraversalForSharedAncestor(t *testing.T) {
+	require := require.New(t)
+
+	vdrs := bag.Of(vdr1, vdr2, vdr3, vdr4) // k = 4
+	alpha := 4
+
+	factory := NewEarlyTermNoTraversalFactory(alpha)
+	poll := factory.New(vdrs)
+
+	poll.Vote(vdr1, blkID2)
+	require.False(poll.Finished())
+
+	poll.Vote(vdr2, blkID3)
+	require.False(poll.Finished())
+
+	poll.Vote(vdr3, blkID4)
+	require.False(poll.Finished())
+
+	poll.Vote(vdr4, blkID1)
+	require.True(poll.Finished())
+}
+
+func TestEarlyTermNoTraversalWithWeightedResponses(t *testing.T) {
+	require := require.New(t)
+
+	vdrs := bag.Of(vdr1, vdr2, vdr2) // k = 3
+	alpha := 2
+
+	factory := NewEarlyTermNoTraversalFactory(alpha)
+	poll := factory.New(vdrs)
+
+	poll.Vote(vdr2, blkID1)
 	require.True(poll.Finished())
 
 	result := poll.Result()
 	list := result.List()
 	require.Len(list, 1)
-	require.Equal(vtxID, list[0])
-	require.Equal(2, result.Count(vtxID))
+	require.Equal(blkID1, list[0])
+	require.Equal(2, result.Count(blkID1))
 }
 
 func TestEarlyTermNoTraversalDropWithWeightedResponses(t *testing.T) {
-	alpha := 2
-
-	vdr1 := ids.NodeID{1}
-	vdr2 := ids.NodeID{2}
-
 	vdrs := bag.Of(vdr1, vdr2, vdr2) // k = 3
+	alpha := 2
 
 	factory := NewEarlyTermNoTraversalFactory(alpha)
 	poll := factory.New(vdrs)

--- a/snow/consensus/snowman/poll/no_early_term_test.go
+++ b/snow/consensus/snowman/poll/no_early_term_test.go
@@ -8,44 +8,34 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/bag"
 )
 
 func TestNoEarlyTermResults(t *testing.T) {
 	require := require.New(t)
 
-	vtxID := ids.ID{1}
-
-	vdr1 := ids.NodeID{1} // k = 1
-
-	vdrs := bag.Of(vdr1)
+	vdrs := bag.Of(vdr1) // k = 1
 
 	factory := NewNoEarlyTermFactory()
 	poll := factory.New(vdrs)
 
-	poll.Vote(vdr1, vtxID)
+	poll.Vote(vdr1, blkID1)
 	require.True(poll.Finished())
 
 	result := poll.Result()
 	list := result.List()
 	require.Len(list, 1)
-	require.Equal(vtxID, list[0])
-	require.Equal(1, result.Count(vtxID))
+	require.Equal(blkID1, list[0])
+	require.Equal(1, result.Count(blkID1))
 }
 
 func TestNoEarlyTermString(t *testing.T) {
-	vtxID := ids.ID{1}
-
-	vdr1 := ids.NodeID{1}
-	vdr2 := ids.NodeID{2} // k = 2
-
-	vdrs := bag.Of(vdr1, vdr2)
+	vdrs := bag.Of(vdr1, vdr2) // k = 2
 
 	factory := NewNoEarlyTermFactory()
 	poll := factory.New(vdrs)
 
-	poll.Vote(vdr1, vtxID)
+	poll.Vote(vdr1, blkID1)
 
 	expected := `waiting on Bag[ids.NodeID]: (Size = 1)
     NodeID-BaMPFdqMUQ46BV8iRcwbVfsam55kMqcp: 1
@@ -57,25 +47,20 @@ received Bag[ids.ID]: (Size = 1)
 func TestNoEarlyTermDropsDuplicatedVotes(t *testing.T) {
 	require := require.New(t)
 
-	vtxID := ids.ID{1}
-
-	vdr1 := ids.NodeID{1}
-	vdr2 := ids.NodeID{2} // k = 2
-
-	vdrs := bag.Of(vdr1, vdr2)
+	vdrs := bag.Of(vdr1, vdr2) // k = 2
 
 	factory := NewNoEarlyTermFactory()
 	poll := factory.New(vdrs)
 
-	poll.Vote(vdr1, vtxID)
+	poll.Vote(vdr1, blkID1)
 	require.False(poll.Finished())
 
-	poll.Vote(vdr1, vtxID)
+	poll.Vote(vdr1, blkID1)
 	require.False(poll.Finished())
 
 	poll.Drop(vdr1)
 	require.False(poll.Finished())
 
-	poll.Vote(vdr2, vtxID)
+	poll.Vote(vdr2, blkID1)
 	require.True(poll.Finished())
 }


### PR DESCRIPTION
## Why this should be merged

- Improves (marginally) the performance of the early poll termination logic.
- Significantly improves the readability of the early poll termination logic.
- Cleans up the tests for the early poll termination logic (vertices are _out_ blocks are _in_).

## How this works

Mainly just nit cleanup.

## How this was tested

- [X] CI