### PR TITLE
Fix P-chain Import

### DIFF
--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/version"
-	"github.com/ava-labs/avalanchego/vms/avm/blocks/executor"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
@@ -47,6 +46,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
 	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/blocks/executor"
+	txexecutor "github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
 )
 
 const (
@@ -474,7 +474,7 @@ type validatorInputData struct {
 func buildTimestampsList(events []uint8, currentTime time.Time, nodeID ids.NodeID) ([]*validatorInputData, error) {
 	res := make([]*validatorInputData, 0, len(events))
 
-	currentTime = currentTime.Add(executor.SyncBound)
+	currentTime = currentTime.Add(txexecutor.SyncBound)
 	switch endTime := currentTime.Add(defaultMinStakingDuration); events[0] {
 	case startPrimaryWithBLS:
 		sk, err := bls.NewSecretKey()
@@ -505,7 +505,7 @@ func buildTimestampsList(events []uint8, currentTime time.Time, nodeID ids.NodeI
 	// covers all of its subnet validators
 	currentPrimaryVal := res[0]
 	for i := 1; i < len(events); i++ {
-		currentTime = currentTime.Add(executor.SyncBound)
+		currentTime = currentTime.Add(txexecutor.SyncBound)
 
 		switch currentEvent := events[i]; currentEvent {
 		case startSubnetValidator:
@@ -522,7 +522,7 @@ func buildTimestampsList(events []uint8, currentTime time.Time, nodeID ids.NodeI
 			currentTime = endTime.Add(time.Second)
 
 		case startPrimaryWithBLS:
-			currentTime = currentPrimaryVal.endTime.Add(executor.SyncBound)
+			currentTime = currentPrimaryVal.endTime.Add(txexecutor.SyncBound)
 			sk, err := bls.NewSecretKey()
 			if err != nil {
 				return nil, fmt.Errorf("could not make private key: %w", err)
@@ -540,7 +540,7 @@ func buildTimestampsList(events []uint8, currentTime time.Time, nodeID ids.NodeI
 			currentPrimaryVal = val
 
 		case startPrimaryWithoutBLS:
-			currentTime = currentPrimaryVal.endTime.Add(executor.SyncBound)
+			currentTime = currentPrimaryVal.endTime.Add(txexecutor.SyncBound)
 			endTime := currentTime.Add(defaultMinStakingDuration)
 			val := &validatorInputData{
 				eventType: startPrimaryWithoutBLS,


### PR DESCRIPTION
## Why this should be merged

The `avm` should _never_ be imported from the `platformvm` package.

## How this works

Fixes import to use the correct `platformvm` package rather than the currently used `avm` package.

## How this was tested

CI