### PR TITLE
Fix default validator start time

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -51,9 +51,9 @@ const (
 	SkipBootstrapChecksEnvName = "E2E_SKIP_BOOTSTRAP_CHECKS"
 
 	// Validator start time must be a minimum of SyncBound from the
-	// current time for validator addition to succeed, and adding 5
+	// current time for validator addition to succeed, and adding 10
 	// seconds provides a buffer in case of any delay in processing.
-	DefaultValidatorStartTimeDiff = executor.SyncBound + 5*time.Second
+	DefaultValidatorStartTimeDiff = executor.SyncBound + 10*time.Second
 )
 
 // Env is used to access shared test fixture. Intended to be


### PR DESCRIPTION
## Why this should be merged

The suggestion that SyncBound + 5s was sufficient for validator start time diff proved incorrect as per [a flake](https://github.com/ava-labs/avalanchego/actions/runs/6265196099/job/17013483873#step:5:465) occurring immediately after merge.

## How this works

Bump the default validator start time diff to SyncBound + 10s (20s) which was the older and flake-free value.

## How this was tested

CI