### PR TITLE
Refactor `reward.Calculator` into a static function

### DIFF
--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -274,19 +274,13 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 		currentSupply, _, err := pvmClient.GetCurrentSupply(e2e.DefaultContext(), constants.PrimaryNetworkID)
 		require.NoError(err)
 		expectedValidationReward := reward.Calculate(
-			rewardConfig.MaxConsumptionRate,
-			rewardConfig.MinConsumptionRate,
-			rewardConfig.MintingPeriod,
-			rewardConfig.SupplyCap,
+			rewardConfig,
 			validationPeriod,
 			weight,
 			currentSupply,
 		)
 		potentialDelegationReward := reward.Calculate(
-			rewardConfig.MaxConsumptionRate,
-			rewardConfig.MinConsumptionRate,
-			rewardConfig.MintingPeriod,
-			rewardConfig.SupplyCap,
+			rewardConfig,
 			delegationPeriod,
 			weight,
 			currentSupply,

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -273,9 +273,24 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 		ginkgo.By("determining expected validation and delegation rewards")
 		currentSupply, _, err := pvmClient.GetCurrentSupply(e2e.DefaultContext(), constants.PrimaryNetworkID)
 		require.NoError(err)
-		calculator := reward.NewCalculator(rewardConfig)
-		expectedValidationReward := calculator.Calculate(validationPeriod, weight, currentSupply)
-		potentialDelegationReward := calculator.Calculate(delegationPeriod, weight, currentSupply)
+		expectedValidationReward := reward.Calculate(
+			rewardConfig.MaxConsumptionRate,
+			rewardConfig.MinConsumptionRate,
+			rewardConfig.MintingPeriod,
+			rewardConfig.SupplyCap,
+			validationPeriod,
+			weight,
+			currentSupply,
+		)
+		potentialDelegationReward := reward.Calculate(
+			rewardConfig.MaxConsumptionRate,
+			rewardConfig.MinConsumptionRate,
+			rewardConfig.MintingPeriod,
+			rewardConfig.SupplyCap,
+			delegationPeriod,
+			weight,
+			currentSupply,
+		)
 		expectedDelegationFee, expectedDelegatorReward := reward.Split(potentialDelegationReward, delegationShare)
 
 		ginkgo.By("checking expected rewards against actual rewards")

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -125,8 +125,7 @@ func newEnvironment(t *testing.T) *environment {
 
 	res.fx = defaultFx(t, res.clk, res.ctx.Log, res.isBootstrapped.Get())
 
-	rewardsCalc := reward.NewCalculator(res.config.RewardConfig)
-	res.state = defaultState(t, res.config, res.ctx, res.baseDB, rewardsCalc)
+	res.state = defaultState(t, res.config, res.ctx, res.baseDB)
 
 	res.atomicUTXOs = avax.NewAtomicUTXOManager(res.ctx.SharedMemory, txs.Codec)
 	res.uptimes = uptime.NewManager(res.state)
@@ -151,7 +150,6 @@ func newEnvironment(t *testing.T) *environment {
 		Fx:           res.fx,
 		FlowChecker:  res.utxosHandler,
 		Uptimes:      res.uptimes,
-		Rewards:      rewardsCalc,
 	}
 
 	registerer := prometheus.NewRegistry()
@@ -224,7 +222,6 @@ func defaultState(
 	cfg *config.Config,
 	ctx *snow.Context,
 	db database.Database,
-	rewards reward.Calculator,
 ) state.State {
 	require := require.New(t)
 
@@ -238,7 +235,6 @@ func defaultState(
 		execCfg,
 		ctx,
 		metrics.Noop,
-		rewards,
 		&utils.Atomic[bool]{},
 	)
 	require.NoError(err)

--- a/vms/platformvm/reward/calculator.go
+++ b/vms/platformvm/reward/calculator.go
@@ -10,53 +10,42 @@ import (
 	"github.com/ava-labs/avalanchego/utils/math"
 )
 
-var _ Calculator = (*calculator)(nil)
-
-type Calculator interface {
-	Calculate(stakedDuration time.Duration, stakedAmount, currentSupply uint64) uint64
-}
-
-type calculator struct {
-	maxSubMinConsumptionRate *big.Int
-	minConsumptionRate       *big.Int
-	mintingPeriod            *big.Int
-	supplyCap                uint64
-}
-
-func NewCalculator(c Config) Calculator {
-	return &calculator{
-		maxSubMinConsumptionRate: new(big.Int).SetUint64(c.MaxConsumptionRate - c.MinConsumptionRate),
-		minConsumptionRate:       new(big.Int).SetUint64(c.MinConsumptionRate),
-		mintingPeriod:            new(big.Int).SetUint64(uint64(c.MintingPeriod)),
-		supplyCap:                c.SupplyCap,
-	}
-}
-
-// Reward returns the amount of tokens to reward the staker with.
+// Calculate returns the amount of tokens to reward a staker with.
 //
 // RemainingSupply = SupplyCap - ExistingSupply
 // PortionOfExistingSupply = StakedAmount / ExistingSupply
 // PortionOfStakingDuration = StakingDuration / MaximumStakingDuration
 // MintingRate = MinMintingRate + MaxSubMinMintingRate * PortionOfStakingDuration
 // Reward = RemainingSupply * PortionOfExistingSupply * MintingRate * PortionOfStakingDuration
-func (c *calculator) Calculate(stakedDuration time.Duration, stakedAmount, currentSupply uint64) uint64 {
+func Calculate(
+	maxConsumptionRate uint64,
+	minConsumptionRate uint64,
+	mintingPeriod time.Duration,
+	supplyCap uint64,
+	stakedDuration time.Duration,
+	stakedAmount uint64,
+	currentSupply uint64,
+) uint64 {
+	bigMaxSubMinConsumptionRate := new(big.Int).SetUint64(maxConsumptionRate - minConsumptionRate)
+	bigMinConsumptionRate := new(big.Int).SetUint64(minConsumptionRate)
+	bigMintingPeriod := new(big.Int).SetUint64(uint64(mintingPeriod))
 	bigStakedDuration := new(big.Int).SetUint64(uint64(stakedDuration))
 	bigStakedAmount := new(big.Int).SetUint64(stakedAmount)
 	bigCurrentSupply := new(big.Int).SetUint64(currentSupply)
 
-	adjustedConsumptionRateNumerator := new(big.Int).Mul(c.maxSubMinConsumptionRate, bigStakedDuration)
-	adjustedMinConsumptionRateNumerator := new(big.Int).Mul(c.minConsumptionRate, c.mintingPeriod)
+	adjustedConsumptionRateNumerator := new(big.Int).Mul(bigMaxSubMinConsumptionRate, bigStakedDuration)
+	adjustedMinConsumptionRateNumerator := new(big.Int).Mul(bigMinConsumptionRate, bigMintingPeriod)
 	adjustedConsumptionRateNumerator.Add(adjustedConsumptionRateNumerator, adjustedMinConsumptionRateNumerator)
-	adjustedConsumptionRateDenominator := new(big.Int).Mul(c.mintingPeriod, consumptionRateDenominator)
+	adjustedConsumptionRateDenominator := new(big.Int).Mul(bigMintingPeriod, consumptionRateDenominator)
 
-	remainingSupply := c.supplyCap - currentSupply
+	remainingSupply := supplyCap - currentSupply
 	reward := new(big.Int).SetUint64(remainingSupply)
 	reward.Mul(reward, adjustedConsumptionRateNumerator)
 	reward.Mul(reward, bigStakedAmount)
 	reward.Mul(reward, bigStakedDuration)
 	reward.Div(reward, adjustedConsumptionRateDenominator)
 	reward.Div(reward, bigCurrentSupply)
-	reward.Div(reward, c.mintingPeriod)
+	reward.Div(reward, bigMintingPeriod)
 
 	if !reward.IsUint64() {
 		return remainingSupply

--- a/vms/platformvm/reward/calculator.go
+++ b/vms/platformvm/reward/calculator.go
@@ -18,17 +18,14 @@ import (
 // MintingRate = MinMintingRate + MaxSubMinMintingRate * PortionOfStakingDuration
 // Reward = RemainingSupply * PortionOfExistingSupply * MintingRate * PortionOfStakingDuration
 func Calculate(
-	maxConsumptionRate uint64,
-	minConsumptionRate uint64,
-	mintingPeriod time.Duration,
-	supplyCap uint64,
+	config Config,
 	stakedDuration time.Duration,
 	stakedAmount uint64,
 	currentSupply uint64,
 ) uint64 {
-	bigMaxSubMinConsumptionRate := new(big.Int).SetUint64(maxConsumptionRate - minConsumptionRate)
-	bigMinConsumptionRate := new(big.Int).SetUint64(minConsumptionRate)
-	bigMintingPeriod := new(big.Int).SetUint64(uint64(mintingPeriod))
+	bigMaxSubMinConsumptionRate := new(big.Int).SetUint64(config.MaxConsumptionRate - config.MinConsumptionRate)
+	bigMinConsumptionRate := new(big.Int).SetUint64(config.MinConsumptionRate)
+	bigMintingPeriod := new(big.Int).SetUint64(uint64(config.MintingPeriod))
 	bigStakedDuration := new(big.Int).SetUint64(uint64(stakedDuration))
 	bigStakedAmount := new(big.Int).SetUint64(stakedAmount)
 	bigCurrentSupply := new(big.Int).SetUint64(currentSupply)
@@ -38,7 +35,7 @@ func Calculate(
 	adjustedConsumptionRateNumerator.Add(adjustedConsumptionRateNumerator, adjustedMinConsumptionRateNumerator)
 	adjustedConsumptionRateDenominator := new(big.Int).Mul(bigMintingPeriod, consumptionRateDenominator)
 
-	remainingSupply := supplyCap - currentSupply
+	remainingSupply := config.SupplyCap - currentSupply
 	reward := new(big.Int).SetUint64(remainingSupply)
 	reward.Mul(reward, adjustedConsumptionRateNumerator)
 	reward.Mul(reward, bigStakedAmount)

--- a/vms/platformvm/reward/calculator_test.go
+++ b/vms/platformvm/reward/calculator_test.go
@@ -34,10 +34,7 @@ func TestLongerDurationBonus(t *testing.T) {
 	shortBalance := units.KiloAvax
 	for i := 0; i < int(totalDuration/shortDuration); i++ {
 		r := Calculate(
-			defaultConfig.MaxConsumptionRate,
-			defaultConfig.MinConsumptionRate,
-			defaultConfig.MintingPeriod,
-			defaultConfig.SupplyCap,
+			defaultConfig,
 			shortDuration,
 			shortBalance,
 			359*units.MegaAvax+shortBalance,
@@ -45,10 +42,7 @@ func TestLongerDurationBonus(t *testing.T) {
 		shortBalance += r
 	}
 	reward := Calculate(
-		defaultConfig.MaxConsumptionRate,
-		defaultConfig.MinConsumptionRate,
-		defaultConfig.MintingPeriod,
-		defaultConfig.SupplyCap,
+		defaultConfig,
 		totalDuration%shortDuration,
 		shortBalance,
 		359*units.MegaAvax+shortBalance,
@@ -57,10 +51,7 @@ func TestLongerDurationBonus(t *testing.T) {
 
 	longBalance := units.KiloAvax
 	longBalance += Calculate(
-		defaultConfig.MaxConsumptionRate,
-		defaultConfig.MinConsumptionRate,
-		defaultConfig.MintingPeriod,
-		defaultConfig.SupplyCap,
+		defaultConfig,
 		totalDuration,
 		longBalance,
 		359*units.MegaAvax+longBalance,
@@ -146,10 +137,7 @@ func TestRewards(t *testing.T) {
 		)
 		t.Run(name, func(t *testing.T) {
 			reward := Calculate(
-				defaultConfig.MaxConsumptionRate,
-				defaultConfig.MinConsumptionRate,
-				defaultConfig.MintingPeriod,
-				defaultConfig.SupplyCap,
+				defaultConfig,
 				test.duration,
 				test.stakeAmount,
 				test.existingAmount,
@@ -165,10 +153,12 @@ func TestRewardsOverflow(t *testing.T) {
 		initialSupply uint64 = 1
 	)
 	reward := Calculate(
-		PercentDenominator,
-		PercentDenominator,
-		defaultMinStakingDuration,
-		maxSupply,
+		Config{
+			MaxConsumptionRate: PercentDenominator,
+			MinConsumptionRate: PercentDenominator,
+			MintingPeriod:      defaultMinStakingDuration,
+			SupplyCap:          maxSupply,
+		},
 		defaultMinStakingDuration,
 		maxSupply, // The staked amount is larger than the current supply
 		initialSupply,
@@ -182,10 +172,12 @@ func TestRewardsMint(t *testing.T) {
 		initialSupply uint64 = 1
 	)
 	rewards := Calculate(
-		PercentDenominator,
-		PercentDenominator,
-		defaultMinStakingDuration,
-		maxSupply,
+		Config{
+			MaxConsumptionRate: PercentDenominator,
+			MinConsumptionRate: PercentDenominator,
+			MintingPeriod:      defaultMinStakingDuration,
+			SupplyCap:          maxSupply,
+		},
 		defaultMinStakingDuration,
 		maxSupply, // The staked amount is larger than the current supply
 		initialSupply,

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1298,10 +1298,7 @@ func (s *state) syncGenesis(genesisBlk block.Block, genesis *genesis.State) erro
 		}
 
 		potentialReward := reward.Calculate(
-			s.cfg.RewardConfig.MaxConsumptionRate,
-			s.cfg.RewardConfig.MinConsumptionRate,
-			s.cfg.RewardConfig.MintingPeriod,
-			s.cfg.RewardConfig.SupplyCap,
+			s.cfg.RewardConfig,
 			stakeDuration,
 			stakeAmount,
 			currentSupply,

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -166,16 +166,16 @@ func newStateFromDB(require *require.Assertions, db database.Database) State {
 		metrics.Noop,
 		&config.Config{
 			Validators: vdrs,
+			RewardConfig: reward.Config{
+				MaxConsumptionRate: .12 * reward.PercentDenominator,
+				MinConsumptionRate: .1 * reward.PercentDenominator,
+				MintingPeriod:      365 * 24 * time.Hour,
+				SupplyCap:          720 * units.MegaAvax,
+			},
 		},
 		execCfg,
 		&snow.Context{},
 		prometheus.NewRegistry(),
-		reward.NewCalculator(reward.Config{
-			MaxConsumptionRate: .12 * reward.PercentDenominator,
-			MinConsumptionRate: .1 * reward.PercentDenominator,
-			MintingPeriod:      365 * 24 * time.Hour,
-			SupplyCap:          720 * units.MegaAvax,
-		}),
 		&utils.Atomic[bool]{},
 	)
 	require.NoError(err)

--- a/vms/platformvm/txs/executor/backend.go
+++ b/vms/platformvm/txs/executor/backend.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
-	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
 )
 
@@ -21,6 +20,5 @@ type Backend struct {
 	Fx           fx.Fx
 	FlowChecker  utxo.Verifier
 	Uptimes      uptime.Manager
-	Rewards      reward.Calculator
 	Bootstrapped *utils.Atomic[bool]
 }

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -127,8 +127,7 @@ func newEnvironment(t *testing.T, postBanff, postCortina bool) *environment {
 
 	fx := defaultFx(clk, ctx.Log, isBootstrapped.Get())
 
-	rewards := reward.NewCalculator(config.RewardConfig)
-	baseState := defaultState(&config, ctx, baseDB, rewards)
+	baseState := defaultState(&config, ctx, baseDB)
 
 	atomicUTXOs := avax.NewAtomicUTXOManager(ctx.SharedMemory, txs.Codec)
 	uptimes := uptime.NewManager(baseState)
@@ -152,7 +151,6 @@ func newEnvironment(t *testing.T, postBanff, postCortina bool) *environment {
 		Fx:           fx,
 		FlowChecker:  utxoHandler,
 		Uptimes:      uptimes,
-		Rewards:      rewards,
 	}
 
 	env := &environment{
@@ -217,7 +215,6 @@ func defaultState(
 	cfg *config.Config,
 	ctx *snow.Context,
 	db database.Database,
-	rewards reward.Calculator,
 ) state.State {
 	genesisBytes := buildGenesisTest(ctx)
 	execCfg, _ := config.GetExecutionConfig(nil)
@@ -229,7 +226,6 @@ func defaultState(
 		execCfg,
 		ctx,
 		metrics.Noop,
-		rewards,
 		&utils.Atomic[bool]{},
 	)
 	if err != nil {

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -220,10 +220,7 @@ func calculateReward(
 ) (uint64, error) {
 	if subnetID == constants.PrimaryNetworkID {
 		return reward.Calculate(
-			rewardConfig.MaxConsumptionRate,
-			rewardConfig.MinConsumptionRate,
-			rewardConfig.MintingPeriod,
-			rewardConfig.SupplyCap,
+			rewardConfig,
 			stakedDuration,
 			stakedAmount,
 			currentSupply,
@@ -236,10 +233,12 @@ func calculateReward(
 	}
 
 	return reward.Calculate(
-		transformSubnet.MaxConsumptionRate,
-		transformSubnet.MinConsumptionRate,
-		rewardConfig.MintingPeriod,
-		transformSubnet.MaximumSupply,
+		reward.Config{
+			MaxConsumptionRate: transformSubnet.MaxConsumptionRate,
+			MinConsumptionRate: transformSubnet.MinConsumptionRate,
+			MintingPeriod:      rewardConfig.MintingPeriod,
+			SupplyCap:          transformSubnet.MaximumSupply,
+		},
 		stakedDuration,
 		stakedAmount,
 		currentSupply,

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -124,12 +124,6 @@ func BenchmarkGetValidatorSet(b *testing.B) {
 			Log:       logging.NoLog{},
 		},
 		metrics,
-		reward.NewCalculator(reward.Config{
-			MaxConsumptionRate: .12 * reward.PercentDenominator,
-			MinConsumptionRate: .10 * reward.PercentDenominator,
-			MintingPeriod:      365 * 24 * time.Hour,
-			SupplyCap:          720 * units.MegaAvax,
-		}),
 		new(utils.Atomic[bool]),
 	)
 	require.NoError(err)

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -37,7 +37,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/metrics"
-	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
@@ -134,8 +133,6 @@ func (vm *VM) Initialize(
 		return err
 	}
 
-	rewards := reward.NewCalculator(vm.RewardConfig)
-
 	vm.state, err = state.New(
 		vm.dbManager.Current().Database,
 		genesisBytes,
@@ -144,7 +141,6 @@ func (vm *VM) Initialize(
 		execConfig,
 		vm.ctx,
 		vm.metrics,
-		rewards,
 		&vm.bootstrapped,
 	)
 	if err != nil {
@@ -175,7 +171,6 @@ func (vm *VM) Initialize(
 		Fx:           vm.fx,
 		FlowChecker:  utxoHandler,
 		Uptimes:      vm.uptimeManager,
-		Rewards:      rewards,
 		Bootstrapped: &vm.bootstrapped,
 	}
 

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -663,7 +663,6 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 		execCfg,
 		vm.ctx,
 		metrics.Noop,
-		reward.NewCalculator(vm.Config.RewardConfig),
 		&utils.Atomic[bool]{},
 	)
 	require.NoError(err)
@@ -973,7 +972,6 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 		execCfg,
 		vm.ctx,
 		metrics.Noop,
-		reward.NewCalculator(vm.Config.RewardConfig),
 		&utils.Atomic[bool]{},
 	)
 	require.NoError(err)


### PR DESCRIPTION
## Why this should be merged

I don't think there's a reason for us to expose this as an interface/struct, the main reason seems to be to avoid some overhead in creation of `big.Int` values.

## How this works

Refactors into static function.

## How this was tested

Existing UT's