### PR TITLE
Update perms.WriteFile to write atomically 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/google/btree v1.1.2
+	github.com/google/renameio/v2 v2.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/rpc v1.2.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -312,6 +312,8 @@ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
+github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/node/node.go
+++ b/node/node.go
@@ -414,7 +414,7 @@ func (n *Node) writeProcessContext() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal process context: %w", err)
 	}
-	if err := os.WriteFile(n.Config.ProcessContextFilePath, bytes, perms.ReadWrite); err != nil {
+	if err := perms.WriteFile(n.Config.ProcessContextFilePath, bytes, perms.ReadWrite); err != nil {
 		return fmt.Errorf("failed to write process context: %w", err)
 	}
 	return nil

--- a/utils/perms/write_file.go
+++ b/utils/perms/write_file.go
@@ -7,13 +7,12 @@ import (
 	"errors"
 	"os"
 
-	// `maybe.WriteFile` will use `ioutil.WriteFile` (non-atomic) on
-	// windows, and `renameio.WriteFile` (atomic) on everything else.
 	"github.com/google/renameio/v2/maybe"
 )
 
 // WriteFile writes [data] to [filename] and ensures that [filename] has [perm]
-// permissions.
+// permissions. Will write atomically on linux/macos and fall back to non-atomic
+// ioutil.WriteFile on windows.
 func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	info, err := os.Stat(filename)
 	if errors.Is(err, os.ErrNotExist) {

--- a/utils/perms/write_file.go
+++ b/utils/perms/write_file.go
@@ -6,6 +6,10 @@ package perms
 import (
 	"errors"
 	"os"
+
+	// `maybe.WriteFile` will use `ioutil.WriteFile` (non-atomic) on
+	// windows, and `renameio.WriteFile` (atomic) on everything else.
+	"github.com/google/renameio/v2/maybe"
 )
 
 // WriteFile writes [data] to [filename] and ensures that [filename] has [perm]
@@ -14,7 +18,7 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	info, err := os.Stat(filename)
 	if errors.Is(err, os.ErrNotExist) {
 		// The file doesn't exist, so try to write it.
-		return os.WriteFile(filename, data, perm)
+		return maybe.WriteFile(filename, data, perm)
 	}
 	if err != nil {
 		return err
@@ -27,5 +31,5 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	}
 	// The file has the right permissions, so truncate any data and write the
 	// file.
-	return os.WriteFile(filename, data, perm)
+	return maybe.WriteFile(filename, data, perm)
 }


### PR DESCRIPTION
## Why this should be merged

This ensures that files are written atomically to avoid readers from reading partial files. There have been recent [flakes](https://github.com/ava-labs/avalanchego/actions/runs/6247796901/job/16961089819#step:5:3481) caused by the process context file not being written completely before being read by the testnet fixture.

## How this works

- update `perms.WriteFile` to write files atomically with renameio.WriteFile
  - on windows writing files atomically is not reliable and ioutil.WriteFile will be used instead  
- write process context file with `perms.WriteFile`

## How this was tested

CI