### PR TITLE
Ignore AppResponse timeouts for benching

### DIFF
--- a/snow/networking/timeout/manager.go
+++ b/snow/networking/timeout/manager.go
@@ -125,8 +125,10 @@ func (m *manager) RegisterRequest(
 	timeoutHandler func(),
 ) {
 	newTimeoutHandler := func() {
-		// If this request timed out, tell the benchlist manager
-		m.benchlistMgr.RegisterFailure(chainID, nodeID)
+		if requestID.Op != byte(message.AppResponseOp) {
+			// If this request timed out, tell the benchlist manager
+			m.benchlistMgr.RegisterFailure(chainID, nodeID)
+		}
 		timeoutHandler()
 	}
 	m.tm.Put(requestID, measureLatency, newTimeoutHandler)

--- a/snow/networking/timeout/manager.go
+++ b/snow/networking/timeout/manager.go
@@ -126,7 +126,8 @@ func (m *manager) RegisterRequest(
 ) {
 	newTimeoutHandler := func() {
 		if requestID.Op != byte(message.AppResponseOp) {
-			// If this request timed out, tell the benchlist manager
+			// If the request timed out and wasn't an AppRequest, tell the
+			// benchlist manager.
 			m.benchlistMgr.RegisterFailure(chainID, nodeID)
 		}
 		timeoutHandler()


### PR DESCRIPTION
## Why this should be merged

## How this works

## How this was tested
