### PR TITLE
e2e: Ensure all Issue* calls use the default context

### DIFF
--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -132,6 +132,7 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainL
 					Addrs:     []ids.ShortID{rewardKey.Address()},
 				},
 				delegationShare,
+				e2e.WithDefaultContext(),
 			)
 			require.NoError(err)
 		})
@@ -161,6 +162,7 @@ var _ = e2e.DescribeXChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainL
 					Threshold: 1,
 					Addrs:     []ids.ShortID{rewardKey.Address()},
 				},
+				e2e.WithDefaultContext(),
 			)
 			require.NoError(err)
 		})

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
 
-var _ = e2e.DescribeXChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainLabel), func() {
+var _ = e2e.DescribePChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainLabel), func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	const (

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -136,6 +136,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 					Addrs:     []ids.ShortID{alphaDelegationRewardKey.Address()},
 				},
 				delegationShare,
+				e2e.WithDefaultContext(),
 			)
 			require.NoError(err)
 		})
@@ -166,6 +167,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 					Addrs:     []ids.ShortID{betaDelegationRewardKey.Address()},
 				},
 				delegationShare,
+				e2e.WithDefaultContext(),
 			)
 			require.NoError(err)
 		})
@@ -189,6 +191,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{gammaDelegationRewardKey.Address()},
 				},
+				e2e.WithDefaultContext(),
 			)
 			require.NoError(err)
 		})
@@ -212,6 +215,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{deltaDelegationRewardKey.Address()},
 				},
+				e2e.WithDefaultContext(),
 			)
 			require.NoError(err)
 		})


### PR DESCRIPTION
## Why this should be merged

Some of the recently merged kurtosis test PRs were not setting contexts which resulted in [hour-long timeouts](https://github.com/ava-labs/avalanchego/actions/runs/6271079928/job/17030035461) when a flake occurred.

## How this works

Ensure all Issue* calls use `e2e.WithDefaultContext`.

## How this was tested

CI