### PR TITLE
compact path bytes -- make branch factor field of codec

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -44,7 +44,7 @@ var (
 	RootKey []byte
 	_       MerkleDB = (*merkleDB)(nil)
 
-	codec = newCodec()
+	codec = newCodec(BranchFactor16)
 
 	metadataPrefix         = []byte{0}
 	valueNodePrefix        = []byte{1}

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -60,7 +60,7 @@ func newNode(parent *node, key Path) *node {
 // Parse [nodeBytes] to a node and set its key to [key].
 func parseNode(key Path, nodeBytes []byte) (*node, error) {
 	n := dbNode{}
-	if err := codec.decodeDBNode(nodeBytes, &n, key.branchFactor); err != nil {
+	if err := codec.decodeDBNode(nodeBytes, &n); err != nil {
 		return nil, err
 	}
 	result := &node{
@@ -81,7 +81,7 @@ func (n *node) hasValue() bool {
 // Returns the byte representation of this node.
 func (n *node) bytes() []byte {
 	if n.nodeBytes == nil {
-		n.nodeBytes = codec.encodeDBNode(&n.dbNode, n.key.branchFactor)
+		n.nodeBytes = codec.encodeDBNode(&n.dbNode)
 	}
 
 	return n.nodeBytes


### PR DESCRIPTION
## Why this should be merged

It's nice to not have to pass the branch factor in a bunch of places.

## How this works

Make branch factor a codec field instead of method parameter.

## How this was tested

Existing UT.