### PR TITLE
remove `*pathConfig` from `Path` struct

### DIFF
--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -133,7 +133,7 @@ func (db *intermediateNodeDB) constructDBKey(key Path) []byte {
 
 	// add one additional byte to store padding when the path
 	// has a length that fits into a whole number of bytes
-	tokensInLastByte := key.length % key.tokensPerByte
+	tokensInLastByte := key.length % key.tokensPerByte()
 	bufferLen := len(pathBytes)
 	if tokensInLastByte == 0 {
 		bufferLen++
@@ -160,7 +160,7 @@ func (db *intermediateNodeDB) constructDBKey(key Path) []byte {
 	// |branchFactor16  |1000_0000|xxxx_1000|         |         |         |         |         |         |
 	// +----------------+---------+---------+---------+---------+---------+---------+---------+---------+
 
-	dbKey[bufferLen-1] |= 0b0000_0001 << (7 - (byte(tokensInLastByte) * key.tokenBitSize))
+	dbKey[bufferLen-1] |= 0b0000_0001 << (7 - byte(tokensInLastByte)*key.tokenBitSize())
 
 	return addPrefixToKey(db.bufferPool, intermediateNodePrefix, dbKey)
 }

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -177,7 +177,7 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 			require.Equal(p.Bytes(), constructedKey[len(intermediateNodePrefix):])
 		case p.hasPartialByte():
 			require.Len(constructedKey, baseLength)
-			require.Equal(p.Append(1<<(p.tokenBitSize-1)).Bytes(), constructedKey[len(intermediateNodePrefix):])
+			require.Equal(p.Append(1<<(p.tokenBitSize()-1)).Bytes(), constructedKey[len(intermediateNodePrefix):])
 		default:
 			// when a whole number of bytes, there is an extra padding byte
 			require.Len(constructedKey, baseLength+1)

--- a/x/merkledb/path.go
+++ b/x/merkledb/path.go
@@ -40,7 +40,7 @@ type Path struct {
 }
 
 var (
-	branchFactorToPathConfig = map[BranchFactor]*pathConfig{
+	branchFactorToPathConfig = map[BranchFactor]pathConfig{
 		BranchFactorUnspecified: {},
 		BranchFactor2: {
 			branchFactor:    BranchFactor2,

--- a/x/merkledb/path_test.go
+++ b/x/merkledb/path_test.go
@@ -77,12 +77,12 @@ func Test_Path_Has_Prefix(t *testing.T) {
 func Test_Path_HasPrefix_BadInput(t *testing.T) {
 	require := require.New(t)
 
-	a := Path{pathConfig: branchFactorToPathConfig[BranchFactor16]}
-	b := Path{length: 1, pathConfig: branchFactorToPathConfig[BranchFactor16]}
+	a := Path{branchFactor: BranchFactor16}
+	b := Path{length: 1, branchFactor: BranchFactor16}
 	require.False(a.HasPrefix(b))
 
-	a = Path{length: 10, pathConfig: branchFactorToPathConfig[BranchFactor16]}
-	b = Path{value: string([]byte{0x10}), length: 1, pathConfig: branchFactorToPathConfig[BranchFactor16]}
+	a = Path{length: 10, branchFactor: BranchFactor16}
+	b = Path{value: string([]byte{0x10}), length: 1, branchFactor: BranchFactor16}
 	require.False(a.HasPrefix(b))
 }
 

--- a/x/merkledb/proof_test.go
+++ b/x/merkledb/proof_test.go
@@ -1205,9 +1205,9 @@ func TestVerifyProofPath(t *testing.T) {
 				{KeyPath: NewPath([]byte{1, 2}, BranchFactor16)},
 				{
 					KeyPath: Path{
-						value:      string([]byte{1, 2, 240}),
-						length:     5,
-						pathConfig: branchFactorToPathConfig[BranchFactor16],
+						value:        string([]byte{1, 2, 240}),
+						length:       5,
+						branchFactor: BranchFactor16,
 					},
 					ValueOrHash: maybe.Some([]byte{1}),
 				},


### PR DESCRIPTION
## Why this should be merged

Pros of this change:

* Using `Path`s as map keys is now more obviously correct. (Previous usage was also OK because all `Path`s had the same `*pathConfig` but it looked kind of sus.)
* Fewer values to copy on `Path` creation.

Cons of this change:
* Need to use function calls rather than field values in some places.

## How this works

Self-explanatory.

## How this was tested

Existing UT.