### PR TITLE
Remove embedding of `verify.Verifiable` in `FxCredential`

### DIFF
--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -588,7 +588,7 @@ func createTxs() []*txs.Tx {
 		}},
 		Creds: []*fxs.FxCredential{
 			{
-				Verifiable: &secp256k1fx.Credential{},
+				Credential: &secp256k1fx.Credential{},
 			},
 		},
 	}}

--- a/vms/avm/fxs/fx.go
+++ b/vms/avm/fxs/fx.go
@@ -14,9 +14,10 @@ import (
 )
 
 var (
-	_ Fx = (*secp256k1fx.Fx)(nil)
-	_ Fx = (*nftfx.Fx)(nil)
-	_ Fx = (*propertyfx.Fx)(nil)
+	_ Fx                = (*secp256k1fx.Fx)(nil)
+	_ Fx                = (*nftfx.Fx)(nil)
+	_ Fx                = (*propertyfx.Fx)(nil)
+	_ verify.Verifiable = (*FxCredential)(nil)
 )
 
 type ParsedFx struct {
@@ -58,6 +59,10 @@ type FxOperation interface {
 }
 
 type FxCredential struct {
-	FxID              ids.ID `serialize:"false" json:"fxID"`
-	verify.Verifiable `serialize:"true" json:"credential"`
+	FxID       ids.ID            `serialize:"false" json:"fxID"`
+	Credential verify.Verifiable `serialize:"true"  json:"credential"`
+}
+
+func (f *FxCredential) Verify() error {
+	return f.Credential.Verify()
 }

--- a/vms/avm/tx_init.go
+++ b/vms/avm/tx_init.go
@@ -44,7 +44,7 @@ func (t *txInit) init() error {
 	t.tx.Unsigned.InitCtx(t.ctx)
 
 	for _, cred := range t.tx.Creds {
-		fx, err := t.getParsedFx(cred.Verifiable)
+		fx, err := t.getParsedFx(cred.Credential)
 		if err != nil {
 			return err
 		}

--- a/vms/avm/txs/executor/semantic_verifier.go
+++ b/vms/avm/txs/executor/semantic_verifier.go
@@ -34,7 +34,7 @@ func (v *SemanticVerifier) BaseTx(tx *txs.BaseTx) error {
 	for i, in := range tx.Ins {
 		// Note: Verification of the length of [t.tx.Creds] happens during
 		// syntactic verification, which happens before semantic verification.
-		cred := v.Tx.Creds[i].Verifiable
+		cred := v.Tx.Creds[i].Credential
 		if err := v.verifyTransfer(tx, in, cred); err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func (v *SemanticVerifier) OperationTx(tx *txs.OperationTx) error {
 	for i, op := range tx.Ops {
 		// Note: Verification of the length of [t.tx.Creds] happens during
 		// syntactic verification, which happens before semantic verification.
-		cred := v.Tx.Creds[i+offset].Verifiable
+		cred := v.Tx.Creds[i+offset].Credential
 		if err := v.verifyOperation(tx, op, cred); err != nil {
 			return err
 		}
@@ -113,7 +113,7 @@ func (v *SemanticVerifier) ImportTx(tx *txs.ImportTx) error {
 
 		// Note: Verification of the length of [t.tx.Creds] happens during
 		// syntactic verification, which happens before semantic verification.
-		cred := v.Tx.Creds[i+offset].Verifiable
+		cred := v.Tx.Creds[i+offset].Credential
 		if err := v.verifyTransferOfUTXO(tx, in, cred, &utxo); err != nil {
 			return err
 		}

--- a/vms/avm/txs/executor/syntactic_verifier_test.go
+++ b/vms/avm/txs/executor/syntactic_verifier_test.go
@@ -102,7 +102,7 @@ func TestSyntacticVerifierBaseTx(t *testing.T) {
 		},
 	}
 	cred := fxs.FxCredential{
-		Verifiable: &secp256k1fx.Credential{},
+		Credential: &secp256k1fx.Credential{},
 	}
 	creds := []*fxs.FxCredential{
 		&cred,
@@ -350,7 +350,7 @@ func TestSyntacticVerifierBaseTx(t *testing.T) {
 				return &txs.Tx{
 					Unsigned: &txs.BaseTx{BaseTx: baseTx},
 					Creds: []*fxs.FxCredential{{
-						Verifiable: (*secp256k1fx.Credential)(nil),
+						Credential: (*secp256k1fx.Credential)(nil),
 					}},
 				}
 			},
@@ -487,7 +487,7 @@ func TestSyntacticVerifierCreateAssetTx(t *testing.T) {
 		},
 	}
 	cred := fxs.FxCredential{
-		Verifiable: &secp256k1fx.Credential{},
+		Credential: &secp256k1fx.Credential{},
 	}
 	creds := []*fxs.FxCredential{
 		&cred,
@@ -957,7 +957,7 @@ func TestSyntacticVerifierCreateAssetTx(t *testing.T) {
 				return &txs.Tx{
 					Unsigned: &tx,
 					Creds: []*fxs.FxCredential{{
-						Verifiable: (*secp256k1fx.Credential)(nil),
+						Credential: (*secp256k1fx.Credential)(nil),
 					}},
 				}
 			},
@@ -1101,7 +1101,7 @@ func TestSyntacticVerifierOperationTx(t *testing.T) {
 		},
 	}
 	cred := fxs.FxCredential{
-		Verifiable: &secp256k1fx.Credential{},
+		Credential: &secp256k1fx.Credential{},
 	}
 	creds := []*fxs.FxCredential{
 		&cred,
@@ -1444,7 +1444,7 @@ func TestSyntacticVerifierOperationTx(t *testing.T) {
 				return &txs.Tx{
 					Unsigned: &tx,
 					Creds: []*fxs.FxCredential{{
-						Verifiable: (*secp256k1fx.Credential)(nil),
+						Credential: (*secp256k1fx.Credential)(nil),
 					}},
 				}
 			},
@@ -1570,7 +1570,7 @@ func TestSyntacticVerifierImportTx(t *testing.T) {
 		},
 	}
 	cred := fxs.FxCredential{
-		Verifiable: &secp256k1fx.Credential{},
+		Credential: &secp256k1fx.Credential{},
 	}
 	creds := []*fxs.FxCredential{
 		&cred,
@@ -1842,7 +1842,7 @@ func TestSyntacticVerifierImportTx(t *testing.T) {
 				return &txs.Tx{
 					Unsigned: &tx,
 					Creds: []*fxs.FxCredential{{
-						Verifiable: (*secp256k1fx.Credential)(nil),
+						Credential: (*secp256k1fx.Credential)(nil),
 					}},
 				}
 			},
@@ -1968,7 +1968,7 @@ func TestSyntacticVerifierExportTx(t *testing.T) {
 		},
 	}
 	cred := fxs.FxCredential{
-		Verifiable: &secp256k1fx.Credential{},
+		Credential: &secp256k1fx.Credential{},
 	}
 	creds := []*fxs.FxCredential{
 		&cred,
@@ -2252,7 +2252,7 @@ func TestSyntacticVerifierExportTx(t *testing.T) {
 				return &txs.Tx{
 					Unsigned: &tx,
 					Creds: []*fxs.FxCredential{{
-						Verifiable: (*secp256k1fx.Credential)(nil),
+						Credential: (*secp256k1fx.Credential)(nil),
 					}},
 				}
 			},

--- a/vms/avm/txs/tx.go
+++ b/vms/avm/txs/tx.go
@@ -107,7 +107,7 @@ func (t *Tx) SignSECP256K1Fx(c codec.Manager, signers [][]*secp256k1.PrivateKey)
 			}
 			copy(cred.Sigs[i][:], sig)
 		}
-		t.Creds = append(t.Creds, &fxs.FxCredential{Verifiable: cred})
+		t.Creds = append(t.Creds, &fxs.FxCredential{Credential: cred})
 	}
 
 	signedBytes, err := c.Marshal(CodecVersion, t)
@@ -136,7 +136,7 @@ func (t *Tx) SignPropertyFx(c codec.Manager, signers [][]*secp256k1.PrivateKey) 
 			}
 			copy(cred.Sigs[i][:], sig)
 		}
-		t.Creds = append(t.Creds, &fxs.FxCredential{Verifiable: cred})
+		t.Creds = append(t.Creds, &fxs.FxCredential{Credential: cred})
 	}
 
 	signedBytes, err := c.Marshal(CodecVersion, t)
@@ -165,7 +165,7 @@ func (t *Tx) SignNFTFx(c codec.Manager, signers [][]*secp256k1.PrivateKey) error
 			}
 			copy(cred.Sigs[i][:], sig)
 		}
-		t.Creds = append(t.Creds, &fxs.FxCredential{Verifiable: cred})
+		t.Creds = append(t.Creds, &fxs.FxCredential{Credential: cred})
 	}
 
 	signedBytes, err := c.Marshal(CodecVersion, t)

--- a/vms/avm/vm_test.go
+++ b/vms/avm/vm_test.go
@@ -218,7 +218,9 @@ func TestIssueNFT(t *testing.T) {
 			}},
 		},
 		Creds: []*fxs.FxCredential{
-			{Verifiable: &nftfx.Credential{}},
+			{
+				Credential: &nftfx.Credential{},
+			},
 		},
 	}
 	require.NoError(env.vm.parser.InitializeTx(transferNFTTx))

--- a/wallet/chain/x/signer_visitor.go
+++ b/wallet/chain/x/signer_visitor.go
@@ -236,10 +236,10 @@ func sign(tx *txs.Tx, creds []verify.Verifiable, txSigners [][]keychain.Signer) 
 			fxCred = &fxs.FxCredential{}
 			tx.Creds[credIndex] = fxCred
 		}
-		credIntf := fxCred.Verifiable
+		credIntf := fxCred.Credential
 		if credIntf == nil {
 			credIntf = creds[credIndex]
-			fxCred.Verifiable = credIntf
+			fxCred.Credential = credIntf
 		}
 
 		var cred *secp256k1fx.Credential


### PR DESCRIPTION
## Why this should be merged

Embedding `verify.Verifiable` in a struct seems strange. We now use `Credential` instead to better tag the field.

## How this works

pretty straightforward

## How this was tested

CI