### PR TITLE
x/merkle: remove unused map ops from changes

### DIFF
--- a/x/merkledb/trie.go
+++ b/x/merkledb/trie.go
@@ -53,7 +53,6 @@ type ReadOnlyTrie interface {
 
 type ViewChanges struct {
 	BatchOps []database.BatchOp
-	MapOps   map[string]maybe.Maybe[[]byte]
 	// ConsumeBytes when set to true will skip copying of bytes and assume
 	// ownership of the provided bytes.
 	ConsumeBytes bool

--- a/x/merkledb/trieview.go
+++ b/x/merkledb/trieview.go
@@ -157,7 +157,7 @@ func newTrieView(
 		root:       root,
 		db:         db,
 		parentTrie: parentTrie,
-		changes:    newChangeSummary(len(changes.BatchOps) + len(changes.MapOps)),
+		changes:    newChangeSummary(len(changes.BatchOps)),
 	}
 
 	for _, op := range changes.BatchOps {
@@ -170,14 +170,6 @@ func newTrieView(
 			newVal = maybe.Some(val)
 		}
 		if err := newView.recordValueChange(newPath(op.Key), newVal); err != nil {
-			return nil, err
-		}
-	}
-	for key, val := range changes.MapOps {
-		if !changes.ConsumeBytes {
-			val = maybe.Bind(val, slices.Clone[[]byte])
-		}
-		if err := newView.recordValueChange(newPath([]byte(key)), val); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This PR removes the unused `MapOps` field from `ViewChanges` in the merkledb.