### PR TITLE
Add last accepted height to the snowman interface

### DIFF
--- a/snow/consensus/snowman/consensus.go
+++ b/snow/consensus/snowman/consensus.go
@@ -45,8 +45,8 @@ type Consensus interface {
 	// chain.
 	IsPreferred(Block) bool
 
-	// Returns the ID of the last accepted decision.
-	LastAccepted() ids.ID
+	// Returns the ID and height of the last accepted decision.
+	LastAccepted() (ids.ID, uint64)
 
 	// Returns the ID of the tail of the strongly preferred sequence of
 	// decisions.

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -224,8 +224,8 @@ func (ts *Topological) IsPreferred(blk Block) bool {
 	return ts.preferredIDs.Contains(blk.ID())
 }
 
-func (ts *Topological) LastAccepted() ids.ID {
-	return ts.head
+func (ts *Topological) LastAccepted() (ids.ID, uint64) {
+	return ts.head, ts.height
 }
 
 func (ts *Topological) Preference() ids.ID {

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -454,7 +454,7 @@ func (t *Transitive) GetBlock(ctx context.Context, blkID ids.ID) (snowman.Block,
 }
 
 func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID uint32) {
-	lastAccepted := t.Consensus.LastAccepted()
+	lastAccepted, _ := t.Consensus.LastAccepted()
 	// If we aren't fully verifying blocks, only vote for blocks that are widely
 	// preferred by the validator set.
 	if t.Ctx.StateSyncing.Get() || t.Config.PartialSync {


### PR DESCRIPTION
## Why this should be merged

The last accepted height needs to be exposed to allow the user to determine if a block should be accepted or processing quickly.

## How this works

Exposes an already tracked value.

## How this was tested

Added additional unit tests.