### PR TITLE
Remove Finalized from the consensus interface

### DIFF
--- a/snow/consensus/snowman/consensus.go
+++ b/snow/consensus/snowman/consensus.go
@@ -55,9 +55,4 @@ type Consensus interface {
 	// RecordPoll collects the results of a network poll. Assumes all decisions
 	// have been previously added. Returns if a critical error has occurred.
 	RecordPoll(context.Context, bag.Bag[ids.ID]) error
-
-	// Finalized returns true if all decisions that have been added have been
-	// finalized. Note, it is possible that after returning finalized, a new
-	// decision may be added such that this instance is no longer finalized.
-	Finalized() bool
 }

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -428,7 +428,7 @@ func RecordPollAcceptSingleBlockTest(t *testing.T, factory Factory) {
 	votes := bag.Of(block.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(block.ID(), sm.Preference())
-	require.NotZero(sm.NumProcessing())
+	require.Equal(1, sm.NumProcessing())
 	require.Equal(choices.Processing, block.Status())
 
 	require.NoError(sm.RecordPoll(context.Background(), votes))
@@ -479,7 +479,7 @@ func RecordPollAcceptAndRejectTest(t *testing.T, factory Factory) {
 
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(firstBlock.ID(), sm.Preference())
-	require.NotZero(sm.NumProcessing())
+	require.Equal(2, sm.NumProcessing())
 	require.Equal(choices.Processing, firstBlock.Status())
 	require.Equal(choices.Processing, secondBlock.Status())
 
@@ -535,7 +535,7 @@ func RecordPollSplitVoteNoChangeTest(t *testing.T, factory Factory) {
 	// The first poll will accept shared bits
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(firstBlock.ID(), sm.Preference())
-	require.NotZero(sm.NumProcessing())
+	require.Equal(2, sm.NumProcessing())
 
 	metrics := gatherCounterGauge(t, registerer)
 	require.Zero(metrics["polls_failed"])
@@ -544,7 +544,7 @@ func RecordPollSplitVoteNoChangeTest(t *testing.T, factory Factory) {
 	// The second poll will do nothing
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(firstBlock.ID(), sm.Preference())
-	require.NotZero(sm.NumProcessing())
+	require.Equal(2, sm.NumProcessing())
 
 	metrics = gatherCounterGauge(t, registerer)
 	require.Equal(float64(1), metrics["polls_failed"])
@@ -709,21 +709,21 @@ func RecordPollTransitivelyResetConfidenceTest(t *testing.T, factory Factory) {
 
 	votesFor2 := bag.Of(block2.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votesFor2))
-	require.NotZero(sm.NumProcessing())
+	require.Equal(4, sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 
 	emptyVotes := bag.Bag[ids.ID]{}
 	require.NoError(sm.RecordPoll(context.Background(), emptyVotes))
-	require.NotZero(sm.NumProcessing())
+	require.Equal(4, sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 
 	require.NoError(sm.RecordPoll(context.Background(), votesFor2))
-	require.NotZero(sm.NumProcessing())
+	require.Equal(4, sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 
 	votesFor3 := bag.Of(block3.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votesFor3))
-	require.NotZero(sm.NumProcessing())
+	require.Equal(2, sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 
 	require.NoError(sm.RecordPoll(context.Background(), votesFor3))
@@ -771,7 +771,7 @@ func RecordPollInvalidVoteTest(t *testing.T, factory Factory) {
 	invalidVotes := bag.Of(unknownBlockID)
 	require.NoError(sm.RecordPoll(context.Background(), invalidVotes))
 	require.NoError(sm.RecordPoll(context.Background(), validVotes))
-	require.NotZero(sm.NumProcessing())
+	require.Equal(1, sm.NumProcessing())
 	require.Equal(block.ID(), sm.Preference())
 }
 
@@ -861,7 +861,7 @@ func RecordPollTransitiveVotingTest(t *testing.T, factory Factory) {
 	// 2   4
 	// Tail = 2
 
-	require.NotZero(sm.NumProcessing())
+	require.Equal(4, sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 	require.Equal(choices.Accepted, block0.Status())
 	require.Equal(choices.Processing, block1.Status())
@@ -1082,7 +1082,7 @@ func RecordPollDivergedVotingWithNoConflictingBitTest(t *testing.T, factory Fact
 	votes3 := bag.Of(block3.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votes3))
 
-	require.NotZero(sm.NumProcessing())
+	require.Equal(4, sm.NumProcessing())
 	require.Equal(choices.Processing, block0.Status())
 	require.Equal(choices.Processing, block1.Status())
 	require.Equal(choices.Processing, block2.Status())

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -107,7 +107,7 @@ func InitializeTest(t *testing.T, factory Factory) {
 	require.NoError(sm.Initialize(ctx, params, GenesisID, GenesisHeight, GenesisTimestamp))
 
 	require.Equal(GenesisID, sm.Preference())
-	require.True(sm.Finalized())
+	require.Zero(sm.NumProcessing())
 }
 
 // Make sure that the number of processing blocks is tracked correctly
@@ -428,12 +428,12 @@ func RecordPollAcceptSingleBlockTest(t *testing.T, factory Factory) {
 	votes := bag.Of(block.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(block.ID(), sm.Preference())
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 	require.Equal(choices.Processing, block.Status())
 
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(block.ID(), sm.Preference())
-	require.True(sm.Finalized())
+	require.Zero(sm.NumProcessing())
 	require.Equal(choices.Accepted, block.Status())
 }
 
@@ -479,13 +479,13 @@ func RecordPollAcceptAndRejectTest(t *testing.T, factory Factory) {
 
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(firstBlock.ID(), sm.Preference())
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 	require.Equal(choices.Processing, firstBlock.Status())
 	require.Equal(choices.Processing, secondBlock.Status())
 
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(firstBlock.ID(), sm.Preference())
-	require.True(sm.Finalized())
+	require.Zero(sm.NumProcessing())
 	require.Equal(choices.Accepted, firstBlock.Status())
 	require.Equal(choices.Rejected, secondBlock.Status())
 }
@@ -535,7 +535,7 @@ func RecordPollSplitVoteNoChangeTest(t *testing.T, factory Factory) {
 	// The first poll will accept shared bits
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(firstBlock.ID(), sm.Preference())
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 
 	metrics := gatherCounterGauge(t, registerer)
 	require.Zero(metrics["polls_failed"])
@@ -544,7 +544,7 @@ func RecordPollSplitVoteNoChangeTest(t *testing.T, factory Factory) {
 	// The second poll will do nothing
 	require.NoError(sm.RecordPoll(context.Background(), votes))
 	require.Equal(firstBlock.ID(), sm.Preference())
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 
 	metrics = gatherCounterGauge(t, registerer)
 	require.Equal(float64(1), metrics["polls_failed"])
@@ -571,7 +571,7 @@ func RecordPollWhenFinalizedTest(t *testing.T, factory Factory) {
 
 	votes := bag.Of(GenesisID)
 	require.NoError(sm.RecordPoll(context.Background(), votes))
-	require.True(sm.Finalized())
+	require.Zero(sm.NumProcessing())
 	require.Equal(GenesisID, sm.Preference())
 }
 
@@ -637,7 +637,7 @@ func RecordPollRejectTransitivelyTest(t *testing.T, factory Factory) {
 	// 0
 	// Tail = 0
 
-	require.True(sm.Finalized())
+	require.Zero(sm.NumProcessing())
 	require.Equal(block0.ID(), sm.Preference())
 	require.Equal(choices.Accepted, block0.Status())
 	require.Equal(choices.Rejected, block1.Status())
@@ -709,25 +709,25 @@ func RecordPollTransitivelyResetConfidenceTest(t *testing.T, factory Factory) {
 
 	votesFor2 := bag.Of(block2.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votesFor2))
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 
 	emptyVotes := bag.Bag[ids.ID]{}
 	require.NoError(sm.RecordPoll(context.Background(), emptyVotes))
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 
 	require.NoError(sm.RecordPoll(context.Background(), votesFor2))
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 
 	votesFor3 := bag.Of(block3.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votesFor3))
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 
 	require.NoError(sm.RecordPoll(context.Background(), votesFor3))
-	require.True(sm.Finalized())
+	require.Zero(sm.NumProcessing())
 	require.Equal(block3.ID(), sm.Preference())
 	require.Equal(choices.Rejected, block0.Status())
 	require.Equal(choices.Accepted, block1.Status())
@@ -771,7 +771,7 @@ func RecordPollInvalidVoteTest(t *testing.T, factory Factory) {
 	invalidVotes := bag.Of(unknownBlockID)
 	require.NoError(sm.RecordPoll(context.Background(), invalidVotes))
 	require.NoError(sm.RecordPoll(context.Background(), validVotes))
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 	require.Equal(block.ID(), sm.Preference())
 }
 
@@ -861,7 +861,7 @@ func RecordPollTransitiveVotingTest(t *testing.T, factory Factory) {
 	// 2   4
 	// Tail = 2
 
-	require.False(sm.Finalized())
+	require.NotZero(sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 	require.Equal(choices.Accepted, block0.Status())
 	require.Equal(choices.Processing, block1.Status())
@@ -876,7 +876,7 @@ func RecordPollTransitiveVotingTest(t *testing.T, factory Factory) {
 	//   2
 	// Tail = 2
 
-	require.True(sm.Finalized())
+	require.Zero(sm.NumProcessing())
 	require.Equal(block2.ID(), sm.Preference())
 	require.Equal(choices.Accepted, block0.Status())
 	require.Equal(choices.Accepted, block1.Status())
@@ -980,8 +980,8 @@ func RecordPollDivergedVotingTest(t *testing.T, factory Factory) {
 	votes3 := bag.Of(block3.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votes3))
 
-	require.True(sm.Finalized(), "finalized too late")
-	require.Equal(choices.Accepted, block0.Status(), "should be accepted")
+	require.Zero(sm.NumProcessing())
+	require.Equal(choices.Accepted, block0.Status())
 	require.Equal(choices.Rejected, block1.Status())
 	require.Equal(choices.Rejected, block2.Status())
 	require.Equal(choices.Rejected, block3.Status())
@@ -1082,7 +1082,7 @@ func RecordPollDivergedVotingWithNoConflictingBitTest(t *testing.T, factory Fact
 	votes3 := bag.Of(block3.ID())
 	require.NoError(sm.RecordPoll(context.Background(), votes3))
 
-	require.False(sm.Finalized(), "finalized too early")
+	require.NotZero(sm.NumProcessing())
 	require.Equal(choices.Processing, block0.Status())
 	require.Equal(choices.Processing, block1.Status())
 	require.Equal(choices.Processing, block2.Status())

--- a/snow/consensus/snowman/network_test.go
+++ b/snow/consensus/snowman/network_test.go
@@ -118,7 +118,7 @@ func (n *Network) Round() error {
 	}
 
 	// If this node has been finalized, remove it from the poller
-	if running.Finalized() {
+	if running.NumProcessing() == 0 {
 		newSize := len(n.running) - 1
 		n.running[runningInd] = n.running[newSize]
 		n.running = n.running[:newSize]

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -309,10 +309,6 @@ func (ts *Topological) RecordPoll(ctx context.Context, voteBag bag.Bag[ids.ID]) 
 	return nil
 }
 
-func (ts *Topological) Finalized() bool {
-	return len(ts.blocks) == 1
-}
-
 // HealthCheck returns information about the consensus health.
 func (ts *Topological) HealthCheck(context.Context) (interface{}, error) {
 	numOutstandingBlks := ts.Latency.NumProcessing()

--- a/snow/engine/snowman/transitive_test.go
+++ b/snow/engine/snowman/transitive_test.go
@@ -1977,7 +1977,7 @@ func TestEngineRejectionAmplification(t *testing.T) {
 
 	require.NoError(te.Chits(context.Background(), vdr, reqID, acceptedBlk.ID(), acceptedBlk.ID()))
 
-	require.True(te.Consensus.Finalized())
+	require.Zero(te.Consensus.NumProcessing())
 
 	queried = false
 	var asked bool
@@ -2080,11 +2080,11 @@ func TestEngineTransitiveRejectionAmplificationDueToRejectedParent(t *testing.T)
 
 	require.NoError(te.Chits(context.Background(), vdr, reqID, acceptedBlk.ID(), acceptedBlk.ID()))
 
-	require.True(te.Consensus.Finalized())
+	require.Zero(te.Consensus.NumProcessing())
 
 	require.NoError(te.Put(context.Background(), vdr, 0, pendingBlk.Bytes()))
 
-	require.True(te.Consensus.Finalized())
+	require.Zero(te.Consensus.NumProcessing())
 
 	require.Empty(te.pending)
 }
@@ -2177,7 +2177,7 @@ func TestEngineTransitiveRejectionAmplificationDueToInvalidParent(t *testing.T) 
 	require.NoError(te.Chits(context.Background(), vdr, reqID, acceptedBlk.ID(), acceptedBlk.ID()))
 
 	require.NoError(te.Put(context.Background(), vdr, 0, pendingBlk.Bytes()))
-	require.True(te.Consensus.Finalized())
+	require.Zero(te.Consensus.NumProcessing())
 	require.Empty(te.pending)
 }
 

--- a/snow/engine/snowman/voter.go
+++ b/snow/engine/snowman/voter.go
@@ -79,7 +79,7 @@ func (v *voter) Update(ctx context.Context) {
 		return
 	}
 
-	if v.t.Consensus.Finalized() {
+	if v.t.Consensus.NumProcessing() == 0 {
 		v.t.Ctx.Log.Debug("Snowman engine can quiesce")
 		return
 	}


### PR DESCRIPTION
## Why this should be merged

`NumProcessing` already exposes this information, more generally, so I feel like we don't need this function.

## How this works

Replace usages of `Finalized` with `NumProcessing`.

## How this was tested

CI