### PR TITLE
Fix flaky BuildBlockIsIdempotent test

### DIFF
--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -264,7 +264,9 @@ func TestBuildBlockIsIdempotent(t *testing.T) {
 		return coreBlk, nil
 	}
 
-	// test
+	// Mock the clock time to make sure that block timestamps will be equal
+	proVM.Clock.Set(time.Now())
+
 	builtBlk1, err := proVM.BuildBlock(context.Background())
 	require.NoError(err)
 


### PR DESCRIPTION
## Why this should be merged

Fixes a [flaky](https://github.com/ava-labs/avalanchego/actions/runs/6317125081/job/17153229946) test.

## How this works

Mocks the clock so that the observed time doesn't change between calls to `BuildBlock`.

## How this was tested

CI