### PR TITLE
Remove `genesis.State`

### DIFF
--- a/vms/platformvm/genesis/genesis.go
+++ b/vms/platformvm/genesis/genesis.go
@@ -41,32 +41,3 @@ func Parse(genesisBytes []byte) (*Genesis, error) {
 	}
 	return gen, nil
 }
-
-// State represents the genesis state of the platform chain
-type State struct {
-	UTXOs         []*avax.UTXO
-	Validators    []*txs.Tx
-	Chains        []*txs.Tx
-	Timestamp     uint64
-	InitialSupply uint64
-}
-
-func ParseState(genesisBytes []byte) (*State, error) {
-	genesis, err := Parse(genesisBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	utxos := make([]*avax.UTXO, 0, len(genesis.UTXOs))
-	for _, utxo := range genesis.UTXOs {
-		utxos = append(utxos, &utxo.UTXO) //nolint:gosec
-	}
-
-	return &State{
-		UTXOs:         utxos,
-		Validators:    genesis.Validators,
-		Chains:        genesis.Chains,
-		Timestamp:     genesis.Timestamp,
-		InitialSupply: genesis.InitialSupply,
-	}, nil
-}

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1285,7 +1285,8 @@ func (s *state) syncGenesis(genesisBlk block.Block, genesis *genesis.Genesis) er
 
 	// Persist UTXOs that exist at genesis
 	for _, utxo := range genesis.UTXOs {
-		s.AddUTXO(&utxo.UTXO)
+		avaxUtxo := utxo.UTXO
+		s.AddUTXO(&avaxUtxo)
 	}
 
 	// Persist primary network validator set at genesis

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1276,7 +1276,7 @@ func (s *state) ApplyValidatorPublicKeyDiffs(
 	return diffIter.Error()
 }
 
-func (s *state) syncGenesis(genesisBlk block.Block, genesis *genesis.State) error {
+func (s *state) syncGenesis(genesisBlk block.Block, genesis *genesis.Genesis) error {
 	genesisBlkID := genesisBlk.ID()
 	s.SetLastAccepted(genesisBlkID)
 	s.SetTimestamp(time.Unix(int64(genesis.Timestamp), 0))
@@ -1285,7 +1285,7 @@ func (s *state) syncGenesis(genesisBlk block.Block, genesis *genesis.State) erro
 
 	// Persist UTXOs that exist at genesis
 	for _, utxo := range genesis.UTXOs {
-		s.AddUTXO(utxo)
+		s.AddUTXO(&utxo.UTXO)
 	}
 
 	// Persist primary network validator set at genesis
@@ -1757,11 +1757,11 @@ func (s *state) init(genesisBytes []byte) error {
 		return err
 	}
 
-	genesisState, err := genesis.ParseState(genesisBytes)
+	genesis, err := genesis.Parse(genesisBytes)
 	if err != nil {
 		return err
 	}
-	if err := s.syncGenesis(genesisBlock, genesisState); err != nil {
+	if err := s.syncGenesis(genesisBlock, genesis); err != nil {
 		return err
 	}
 

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1285,8 +1285,8 @@ func (s *state) syncGenesis(genesisBlk block.Block, genesis *genesis.Genesis) er
 
 	// Persist UTXOs that exist at genesis
 	for _, utxo := range genesis.UTXOs {
-		avaxUtxo := utxo.UTXO
-		s.AddUTXO(&avaxUtxo)
+		avaxUTXO := utxo.UTXO
+		s.AddUTXO(&avaxUTXO)
 	}
 
 	// Persist primary network validator set at genesis

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -120,17 +120,20 @@ func newInitializedState(require *require.Assertions) (State, database.Database)
 	require.NoError(initialChainTx.Initialize(txs.Codec))
 
 	genesisBlkID := ids.GenerateTestID()
-	genesisState := &genesis.State{
-		UTXOs: []*avax.UTXO{
+	genesisState := &genesis.Genesis{
+		UTXOs: []*genesis.UTXO{
 			{
-				UTXOID: avax.UTXOID{
-					TxID:        initialTxID,
-					OutputIndex: 0,
+				UTXO: avax.UTXO{
+					UTXOID: avax.UTXOID{
+						TxID:        initialTxID,
+						OutputIndex: 0,
+					},
+					Asset: avax.Asset{ID: initialTxID},
+					Out: &secp256k1fx.TransferOutput{
+						Amt: units.Schmeckle,
+					},
 				},
-				Asset: avax.Asset{ID: initialTxID},
-				Out: &secp256k1fx.TransferOutput{
-					Amt: units.Schmeckle,
-				},
+				Message: nil,
 			},
 		},
 		Validators: []*txs.Tx{


### PR DESCRIPTION
## Why this should be merged

`genesis.State` seems to be very similar to `genesis.Genesis`

## How this works

Removes `genesis.State` and switches code to use `genesis.Genesis`

## How this was tested

CI