### PR TITLE
Cleanup uptime manager constructor

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/math/meter"
 	"github.com/ava-labs/avalanchego/utils/resource"
 	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/version"
 )
@@ -114,7 +115,7 @@ var (
 
 		CompressionType: constants.DefaultNetworkCompressionType,
 
-		UptimeCalculator:  uptime.NewManager(uptime.NewTestState()),
+		UptimeCalculator:  uptime.NewManager(uptime.NewTestState(), &mockable.Clock{}),
 		UptimeMetricFreq:  30 * time.Second,
 		UptimeRequirement: .8,
 

--- a/snow/uptime/manager.go
+++ b/snow/uptime/manager.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 )
 
-var _ TestManager = (*manager)(nil)
+var _ Manager = (*manager)(nil)
 
 type Manager interface {
 	Tracker
@@ -35,22 +35,18 @@ type Calculator interface {
 	CalculateUptimePercentFrom(nodeID ids.NodeID, subnetID ids.ID, startTime time.Time) (float64, error)
 }
 
-type TestManager interface {
-	Manager
-	SetTime(time.Time)
-}
-
 type manager struct {
 	// Used to get time. Useful for faking time during tests.
-	clock mockable.Clock
+	clock *mockable.Clock
 
 	state          State
 	connections    map[ids.NodeID]map[ids.ID]time.Time // nodeID -> subnetID -> time
 	trackedSubnets set.Set[ids.ID]
 }
 
-func NewManager(state State) Manager {
+func NewManager(state State, clk *mockable.Clock) Manager {
 	return &manager{
+		clock:       clk,
 		state:       state,
 		connections: make(map[ids.NodeID]map[ids.ID]time.Time),
 	}
@@ -204,10 +200,6 @@ func (m *manager) CalculateUptimePercentFrom(nodeID ids.NodeID, subnetID ids.ID,
 	}
 	uptime := float64(upDuration) / float64(bestPossibleUpDuration)
 	return uptime, nil
-}
-
-func (m *manager) SetTime(newTime time.Time) {
-	m.clock.Set(newTime)
 }
 
 // updateSubnetUptime updates the subnet uptime of the node on the state by the amount

--- a/snow/uptime/manager_test.go
+++ b/snow/uptime/manager_test.go
@@ -28,7 +28,7 @@ func TestStartTracking(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	currentTime := startTime.Add(time.Second)
 	clk.Set(currentTime)
@@ -38,7 +38,7 @@ func TestStartTracking(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(time.Second, duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 }
 
 func TestStartTrackingDBError(t *testing.T) {
@@ -53,7 +53,7 @@ func TestStartTrackingDBError(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	currentTime := startTime.Add(time.Second)
 	clk.Set(currentTime)
@@ -67,7 +67,7 @@ func TestStartTrackingNonValidator(t *testing.T) {
 
 	s := NewTestState()
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	nodeID0 := ids.GenerateTestNodeID()
 	subnetID := ids.GenerateTestID()
@@ -87,7 +87,7 @@ func TestStartTrackingInThePast(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	currentTime := startTime.Add(-time.Second)
 	clk.Set(currentTime)
@@ -112,7 +112,7 @@ func TestStopTrackingDecreasesUptime(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
@@ -129,7 +129,7 @@ func TestStopTrackingDecreasesUptime(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(time.Duration(0), duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 }
 
 func TestStopTrackingIncreasesUptime(t *testing.T) {
@@ -144,7 +144,7 @@ func TestStopTrackingIncreasesUptime(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
@@ -163,7 +163,7 @@ func TestStopTrackingIncreasesUptime(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(time.Second, duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 }
 
 func TestStopTrackingDisconnectedNonValidator(t *testing.T) {
@@ -174,7 +174,7 @@ func TestStopTrackingDisconnectedNonValidator(t *testing.T) {
 
 	s := NewTestState()
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	require.NoError(up.StartTracking(nil, subnetID))
 
@@ -192,7 +192,7 @@ func TestStopTrackingConnectedDBError(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	require.NoError(up.StartTracking(nil, subnetID))
 
@@ -214,7 +214,7 @@ func TestStopTrackingNonConnectedPast(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
@@ -241,7 +241,7 @@ func TestStopTrackingNonConnectedDBError(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
@@ -278,7 +278,7 @@ func TestConnectAndDisconnect(t *testing.T) {
 
 			s := NewTestState()
 			clk := mockable.Clock{}
-			up := NewManager(s, &clk).(*manager)
+			up := NewManager(s, &clk)
 			clk.Set(currentTime)
 
 			for _, subnetID := range tt.subnetIDs {
@@ -295,7 +295,7 @@ func TestConnectAndDisconnect(t *testing.T) {
 				duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 				require.NoError(err)
 				require.Equal(time.Duration(0), duration)
-				require.Equal(up.clock.UnixTime(), lastUpdated)
+				require.Equal(clk.UnixTime(), lastUpdated)
 
 				require.NoError(up.Connect(nodeID0, subnetID))
 
@@ -310,7 +310,7 @@ func TestConnectAndDisconnect(t *testing.T) {
 				duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 				require.NoError(err)
 				require.Equal(time.Second, duration)
-				require.Equal(up.clock.UnixTime(), lastUpdated)
+				require.Equal(clk.UnixTime(), lastUpdated)
 			}
 
 			require.NoError(up.Disconnect(nodeID0))
@@ -327,7 +327,7 @@ func TestConnectAndDisconnect(t *testing.T) {
 				duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 				require.NoError(err)
 				require.Equal(time.Second, duration)
-				require.Equal(up.clock.UnixTime(), lastUpdated)
+				require.Equal(clk.UnixTime(), lastUpdated)
 			}
 		})
 	}
@@ -345,7 +345,7 @@ func TestConnectAndDisconnectBeforeTracking(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	currentTime = currentTime.Add(time.Second)
 	clk.Set(currentTime)
 
@@ -361,7 +361,7 @@ func TestConnectAndDisconnectBeforeTracking(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(2*time.Second, duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 }
 
 func TestUnrelatedNodeDisconnect(t *testing.T) {
@@ -377,7 +377,7 @@ func TestUnrelatedNodeDisconnect(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
@@ -385,7 +385,7 @@ func TestUnrelatedNodeDisconnect(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(time.Duration(0), duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 
 	require.NoError(up.Connect(nodeID0, subnetID))
 
@@ -397,7 +397,7 @@ func TestUnrelatedNodeDisconnect(t *testing.T) {
 	duration, lastUpdated, err = up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(time.Second, duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 
 	require.NoError(up.Disconnect(nodeID1))
 
@@ -407,7 +407,7 @@ func TestUnrelatedNodeDisconnect(t *testing.T) {
 	duration, lastUpdated, err = up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(2*time.Second, duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 }
 
 func TestCalculateUptimeWhenNeverTracked(t *testing.T) {
@@ -421,7 +421,7 @@ func TestCalculateUptimeWhenNeverTracked(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	currentTime := startTime.Add(time.Second)
 	clk.Set(currentTime)
@@ -429,7 +429,7 @@ func TestCalculateUptimeWhenNeverTracked(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(time.Second, duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, subnetID, startTime.Truncate(time.Second))
 	require.NoError(err)
@@ -446,7 +446,7 @@ func TestCalculateUptimeWhenNeverConnected(t *testing.T) {
 	s := NewTestState()
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	require.NoError(up.StartTracking([]ids.NodeID{}, subnetID))
 
@@ -458,7 +458,7 @@ func TestCalculateUptimeWhenNeverConnected(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(time.Duration(0), duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, subnetID, startTime)
 	require.NoError(err)
@@ -477,7 +477,7 @@ func TestCalculateUptimeWhenConnectedBeforeTracking(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	require.NoError(up.Connect(nodeID0, subnetID))
@@ -493,7 +493,7 @@ func TestCalculateUptimeWhenConnectedBeforeTracking(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(2*time.Second, duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 }
 
 func TestCalculateUptimeWhenConnectedInFuture(t *testing.T) {
@@ -508,7 +508,7 @@ func TestCalculateUptimeWhenConnectedInFuture(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
@@ -524,7 +524,7 @@ func TestCalculateUptimeWhenConnectedInFuture(t *testing.T) {
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
 	require.Equal(time.Duration(0), duration)
-	require.Equal(up.clock.UnixTime(), lastUpdated)
+	require.Equal(clk.UnixTime(), lastUpdated)
 }
 
 func TestCalculateUptimeNonValidator(t *testing.T) {
@@ -537,7 +537,7 @@ func TestCalculateUptimeNonValidator(t *testing.T) {
 	s := NewTestState()
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	_, err := up.CalculateUptimePercentFrom(nodeID0, subnetID, startTime)
 	require.ErrorIs(err, database.ErrNotFound)
@@ -555,7 +555,7 @@ func TestCalculateUptimePercentageDivBy0(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, subnetID, startTime.Truncate(time.Second))
@@ -575,7 +575,7 @@ func TestCalculateUptimePercentage(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -599,7 +599,7 @@ func TestStopTrackingUnixTimeRegression(t *testing.T) {
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	clk := mockable.Clock{}
-	up := NewManager(s, &clk).(*manager)
+	up := NewManager(s, &clk)
 	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))

--- a/snow/uptime/manager_test.go
+++ b/snow/uptime/manager_test.go
@@ -123,7 +123,6 @@ func TestStopTrackingDecreasesUptime(t *testing.T) {
 	require.NoError(up.StopTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	up = NewManager(s, &clk).(*manager)
-	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -158,7 +157,6 @@ func TestStopTrackingIncreasesUptime(t *testing.T) {
 	require.NoError(up.StopTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	up = NewManager(s, &clk).(*manager)
-	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 

--- a/snow/uptime/manager_test.go
+++ b/snow/uptime/manager_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 )
 
 var errTest = errors.New("non-nil error")
@@ -26,10 +27,11 @@ func TestStartTracking(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	currentTime := startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -50,10 +52,11 @@ func TestStartTrackingDBError(t *testing.T) {
 	s.dbWriteError = errTest
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	currentTime := startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	err := up.StartTracking([]ids.NodeID{nodeID0}, subnetID)
 	require.ErrorIs(err, errTest)
@@ -63,7 +66,8 @@ func TestStartTrackingNonValidator(t *testing.T) {
 	require := require.New(t)
 
 	s := NewTestState()
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	nodeID0 := ids.GenerateTestNodeID()
 	subnetID := ids.GenerateTestID()
@@ -82,10 +86,11 @@ func TestStartTrackingInThePast(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	currentTime := startTime.Add(-time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -106,18 +111,19 @@ func TestStopTrackingDecreasesUptime(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	currentTime = startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.StopTracking([]ids.NodeID{nodeID0}, subnetID))
 
-	up = NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	up = NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -138,20 +144,21 @@ func TestStopTrackingIncreasesUptime(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	require.NoError(up.Connect(nodeID0, subnetID))
 
 	currentTime = startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.StopTracking([]ids.NodeID{nodeID0}, subnetID))
 
-	up = NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	up = NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -168,7 +175,8 @@ func TestStopTrackingDisconnectedNonValidator(t *testing.T) {
 	subnetID := ids.GenerateTestID()
 
 	s := NewTestState()
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	require.NoError(up.StartTracking(nil, subnetID))
 
@@ -185,7 +193,8 @@ func TestStopTrackingConnectedDBError(t *testing.T) {
 
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	require.NoError(up.StartTracking(nil, subnetID))
 
@@ -206,13 +215,14 @@ func TestStopTrackingNonConnectedPast(t *testing.T) {
 
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	currentTime = currentTime.Add(-time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.StopTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -232,13 +242,14 @@ func TestStopTrackingNonConnectedDBError(t *testing.T) {
 
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	currentTime = currentTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	s.dbWriteError = errTest
 	err := up.StopTracking([]ids.NodeID{nodeID0}, subnetID)
@@ -268,8 +279,9 @@ func TestConnectAndDisconnect(t *testing.T) {
 			startTime := currentTime
 
 			s := NewTestState()
-			up := NewManager(s).(*manager)
-			up.clock.Set(currentTime)
+			clk := mockable.Clock{}
+			up := NewManager(s, &clk).(*manager)
+			clk.Set(currentTime)
 
 			for _, subnetID := range tt.subnetIDs {
 				s.AddNode(nodeID0, subnetID, startTime)
@@ -294,7 +306,7 @@ func TestConnectAndDisconnect(t *testing.T) {
 			}
 
 			currentTime = currentTime.Add(time.Second)
-			up.clock.Set(currentTime)
+			clk.Set(currentTime)
 
 			for _, subnetID := range tt.subnetIDs {
 				duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
@@ -311,7 +323,7 @@ func TestConnectAndDisconnect(t *testing.T) {
 			}
 
 			currentTime = currentTime.Add(time.Second)
-			up.clock.Set(currentTime)
+			clk.Set(currentTime)
 
 			for _, subnetID := range tt.subnetIDs {
 				duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
@@ -334,14 +346,15 @@ func TestConnectAndDisconnectBeforeTracking(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 	currentTime = currentTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.Connect(nodeID0, subnetID))
 
 	currentTime = currentTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.Disconnect(nodeID0))
 
@@ -365,8 +378,9 @@ func TestUnrelatedNodeDisconnect(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -380,7 +394,7 @@ func TestUnrelatedNodeDisconnect(t *testing.T) {
 	require.NoError(up.Connect(nodeID1, subnetID))
 
 	currentTime = currentTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	duration, lastUpdated, err = up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
@@ -390,7 +404,7 @@ func TestUnrelatedNodeDisconnect(t *testing.T) {
 	require.NoError(up.Disconnect(nodeID1))
 
 	currentTime = currentTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	duration, lastUpdated, err = up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
@@ -408,10 +422,11 @@ func TestCalculateUptimeWhenNeverTracked(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	currentTime := startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
@@ -432,14 +447,15 @@ func TestCalculateUptimeWhenNeverConnected(t *testing.T) {
 
 	s := NewTestState()
 
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	require.NoError(up.StartTracking([]ids.NodeID{}, subnetID))
 
 	s.AddNode(nodeID0, subnetID, startTime)
 
 	currentTime := startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
@@ -462,18 +478,19 @@ func TestCalculateUptimeWhenConnectedBeforeTracking(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.Connect(nodeID0, subnetID))
 
 	currentTime = currentTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	currentTime = currentTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
@@ -492,18 +509,19 @@ func TestCalculateUptimeWhenConnectedInFuture(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	currentTime = currentTime.Add(2 * time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.Connect(nodeID0, subnetID))
 
 	currentTime = currentTime.Add(-time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0, subnetID)
 	require.NoError(err)
@@ -520,7 +538,8 @@ func TestCalculateUptimeNonValidator(t *testing.T) {
 
 	s := NewTestState()
 
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	_, err := up.CalculateUptimePercentFrom(nodeID0, subnetID, startTime)
 	require.ErrorIs(err, database.ErrNotFound)
@@ -537,8 +556,9 @@ func TestCalculateUptimePercentageDivBy0(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, subnetID, startTime.Truncate(time.Second))
 	require.NoError(err)
@@ -556,12 +576,13 @@ func TestCalculateUptimePercentage(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	currentTime = currentTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, subnetID, startTime.Truncate(time.Second))
 	require.NoError(err)
@@ -579,32 +600,33 @@ func TestStopTrackingUnixTimeRegression(t *testing.T) {
 	s := NewTestState()
 	s.AddNode(nodeID0, subnetID, startTime)
 
-	up := NewManager(s).(*manager)
-	up.clock.Set(currentTime)
+	clk := mockable.Clock{}
+	up := NewManager(s, &clk).(*manager)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	require.NoError(up.Connect(nodeID0, subnetID))
 
 	currentTime = startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.StopTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	currentTime = startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
-	up = NewManager(s).(*manager)
+	up = NewManager(s, &clk).(*manager)
 
 	currentTime = startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
 	require.NoError(up.Connect(nodeID0, subnetID))
 
 	currentTime = startTime.Add(time.Second)
-	up.clock.Set(currentTime)
+	clk.Set(currentTime)
 
 	perc, err := up.CalculateUptimePercent(nodeID0, subnetID)
 	require.NoError(err)

--- a/snow/uptime/manager_test.go
+++ b/snow/uptime/manager_test.go
@@ -122,7 +122,7 @@ func TestStopTrackingDecreasesUptime(t *testing.T) {
 
 	require.NoError(up.StopTracking([]ids.NodeID{nodeID0}, subnetID))
 
-	up = NewManager(s, &clk).(*manager)
+	up = NewManager(s, &clk)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -156,7 +156,7 @@ func TestStopTrackingIncreasesUptime(t *testing.T) {
 
 	require.NoError(up.StopTracking([]ids.NodeID{nodeID0}, subnetID))
 
-	up = NewManager(s, &clk).(*manager)
+	up = NewManager(s, &clk)
 
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}, subnetID))
 
@@ -614,7 +614,7 @@ func TestStopTrackingUnixTimeRegression(t *testing.T) {
 	currentTime = startTime.Add(time.Second)
 	clk.Set(currentTime)
 
-	up = NewManager(s, &clk).(*manager)
+	up = NewManager(s, &clk)
 
 	currentTime = startTime.Add(time.Second)
 	clk.Set(currentTime)

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -129,7 +129,7 @@ func newEnvironment(t *testing.T) *environment {
 	res.state = defaultState(t, res.config, res.ctx, res.baseDB, rewardsCalc)
 
 	res.atomicUTXOs = avax.NewAtomicUTXOManager(res.ctx.SharedMemory, txs.Codec)
-	res.uptimes = uptime.NewManager(res.state)
+	res.uptimes = uptime.NewManager(res.state, res.clk)
 	res.utxosHandler = utxo.NewHandler(res.ctx, res.clk, res.fx)
 
 	res.txBuilder = txbuilder.New(

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -145,7 +145,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller) *environment {
 
 	if ctrl == nil {
 		res.state = defaultState(res.config, res.ctx, res.baseDB, rewardsCalc)
-		res.uptimes = uptime.NewManager(res.state)
+		res.uptimes = uptime.NewManager(res.state, res.clk)
 		res.utxosHandler = utxo.NewHandler(res.ctx, res.clk, res.fx)
 		res.txBuilder = p_tx_builder.New(
 			res.ctx,
@@ -159,7 +159,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller) *environment {
 	} else {
 		genesisBlkID = ids.GenerateTestID()
 		res.mockedState = state.NewMockState(ctrl)
-		res.uptimes = uptime.NewManager(res.mockedState)
+		res.uptimes = uptime.NewManager(res.mockedState, res.clk)
 		res.utxosHandler = utxo.NewHandler(res.ctx, res.clk, res.fx)
 		res.txBuilder = p_tx_builder.New(
 			res.ctx,

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -131,7 +131,7 @@ func newEnvironment(t *testing.T, postBanff, postCortina bool) *environment {
 	baseState := defaultState(&config, ctx, baseDB, rewards)
 
 	atomicUTXOs := avax.NewAtomicUTXOManager(ctx.SharedMemory, txs.Codec)
-	uptimes := uptime.NewManager(baseState)
+	uptimes := uptime.NewManager(baseState, clk)
 	utxoHandler := utxo.NewHandler(ctx, clk, fx)
 
 	txBuilder := builder.New(

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -155,7 +155,7 @@ func (vm *VM) Initialize(
 	vm.State = validatorManager
 	vm.atomicUtxosManager = avax.NewAtomicUTXOManager(chainCtx.SharedMemory, txs.Codec)
 	utxoHandler := utxo.NewHandler(vm.ctx, &vm.clock, vm.fx)
-	vm.uptimeManager = uptime.NewManager(vm.state)
+	vm.uptimeManager = uptime.NewManager(vm.state, &vm.clock)
 	vm.UptimeLockedCalculator.SetCalculator(&vm.bootstrapped, &chainCtx.Lock, vm.uptimeManager)
 
 	vm.txBuilder = txbuilder.New(

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1969,13 +1969,12 @@ func TestUptimeDisallowedWithRestart(t *testing.T) {
 
 	initialClkTime := banffForkTime.Add(time.Second)
 	firstVM.clock.Set(initialClkTime)
-	firstVM.uptimeManager.(uptime.TestManager).SetTime(initialClkTime)
 
 	require.NoError(firstVM.SetState(context.Background(), snow.Bootstrapping))
 	require.NoError(firstVM.SetState(context.Background(), snow.NormalOp))
 
 	// Fast forward clock to time for genesis validators to leave
-	firstVM.uptimeManager.(uptime.TestManager).SetTime(defaultValidateEndTime)
+	firstVM.clock.Set(defaultValidateEndTime)
 
 	require.NoError(firstVM.Shutdown(context.Background()))
 	firstCtx.Lock.Unlock()
@@ -2013,13 +2012,11 @@ func TestUptimeDisallowedWithRestart(t *testing.T) {
 	))
 
 	secondVM.clock.Set(defaultValidateStartTime.Add(2 * defaultMinStakingDuration))
-	secondVM.uptimeManager.(uptime.TestManager).SetTime(defaultValidateStartTime.Add(2 * defaultMinStakingDuration))
 
 	require.NoError(secondVM.SetState(context.Background(), snow.Bootstrapping))
 	require.NoError(secondVM.SetState(context.Background(), snow.NormalOp))
 
 	secondVM.clock.Set(defaultValidateEndTime)
-	secondVM.uptimeManager.(uptime.TestManager).SetTime(defaultValidateEndTime)
 
 	blk, err := secondVM.Builder.BuildBlock(context.Background()) // should advance time
 	require.NoError(err)
@@ -2148,14 +2145,12 @@ func TestUptimeDisallowedAfterNeverConnecting(t *testing.T) {
 
 	initialClkTime := banffForkTime.Add(time.Second)
 	vm.clock.Set(initialClkTime)
-	vm.uptimeManager.(uptime.TestManager).SetTime(initialClkTime)
 
 	require.NoError(vm.SetState(context.Background(), snow.Bootstrapping))
 	require.NoError(vm.SetState(context.Background(), snow.NormalOp))
 
 	// Fast forward clock to time for genesis validators to leave
 	vm.clock.Set(defaultValidateEndTime)
-	vm.uptimeManager.(uptime.TestManager).SetTime(defaultValidateEndTime)
 
 	blk, err := vm.Builder.BuildBlock(context.Background()) // should advance time
 	require.NoError(err)


### PR DESCRIPTION
## Why this should be merged
In platformvm we take care of passing vm.Clock to vm objects as a reference to be able to set time in test for all objects at the same time. uptime.Manager was not built that way and had its own SetTime method to explicitly control time in UTs. This PR fixes the situation and make uptime.Manager handle time as other platformVM objects

## How this works
Drop TestManager interface, drop SetTime method, pass clock reference in uptime.Manager ctor

## How this was tested
CI
