### PR TITLE
RPCChainVM fail-fast health RPCs

### DIFF
--- a/vms/rpcchainvm/factory.go
+++ b/vms/rpcchainvm/factory.go
@@ -13,8 +13,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/grpcutils"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime/subprocess"
-
-	vmpb "github.com/ava-labs/avalanchego/proto/pb/vm"
 )
 
 var _ vms.Factory = (*factory)(nil)
@@ -61,8 +59,7 @@ func (f *factory) New(log logging.Logger) (interface{}, error) {
 		return nil, err
 	}
 
-	vm := NewClient(vmpb.NewVMClient(clientConn))
-	vm.conns = append(vm.conns, clientConn)
+	vm := NewClient(clientConn)
 	vm.SetProcess(stopper, status.Pid, f.processTracker)
 
 	f.runtimeTracker.TrackRuntime(stopper)

--- a/vms/rpcchainvm/factory.go
+++ b/vms/rpcchainvm/factory.go
@@ -62,6 +62,7 @@ func (f *factory) New(log logging.Logger) (interface{}, error) {
 	}
 
 	vm := NewClient(vmpb.NewVMClient(clientConn))
+	vm.conns = append(vm.conns, clientConn)
 	vm.SetProcess(stopper, status.Pid, f.processTracker)
 
 	f.runtimeTracker.TrackRuntime(stopper)

--- a/vms/rpcchainvm/grpcutils/client_test.go
+++ b/vms/rpcchainvm/grpcutils/client_test.go
@@ -94,7 +94,7 @@ func TestWaitForReadyCallOption(t *testing.T) {
 	conn, err := Dial(listener.Addr().String())
 	require.NoError(err)
 	// close listener causes RPC to fail fast.
-	listener.Close()
+	_ = listener.Close()
 
 	db := pb.NewDatabaseClient(conn)
 	_, err = db.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}, grpc.WaitForReady(false))

--- a/vms/rpcchainvm/grpcutils/client_test.go
+++ b/vms/rpcchainvm/grpcutils/client_test.go
@@ -4,6 +4,8 @@
 package grpcutils
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -55,12 +57,11 @@ func TestWaitForReady(t *testing.T) {
 		Serve(listener, server)
 	}()
 
-	// The default includes grpc.WaitForReady(true).
+	// The default is WaitForReady = true.
 	conn, err := Dial(listener.Addr().String())
 	require.NoError(err)
 
 	db := rpcdb.NewClient(pb.NewDatabaseClient(conn))
-
 	require.NoError(db.Put([]byte("foo"), []byte("bar")))
 
 	noWaitListener, err := NewListener()
@@ -83,4 +84,22 @@ func TestWaitForReady(t *testing.T) {
 	status, ok := status.FromError(err)
 	require.True(ok)
 	require.Equal(codes.Unavailable, status.Code())
+}
+
+func TestWaitForReadyCallOption(t *testing.T) {
+	require := require.New(t)
+
+	listener, err := NewListener()
+	require.NoError(err)
+	conn, err := Dial(listener.Addr().String())
+	require.NoError(err)
+	// close listener causes RPC to fail fast.
+	listener.Close()
+
+	db := pb.NewDatabaseClient(conn)
+	_, err = db.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}, grpc.WaitForReady(false))
+	s, ok := status.FromError(err)
+	fmt.Printf("status: %v\n", s)
+	require.True(ok)
+	require.Equal(codes.Unavailable, s.Code())
 }

--- a/vms/rpcchainvm/state_syncable_vm_test.go
+++ b/vms/rpcchainvm/state_syncable_vm_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/grpcutils"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime/subprocess"
-
-	vmpb "github.com/ava-labs/avalanchego/proto/pb/vm"
 )
 
 var (
@@ -295,7 +293,7 @@ func buildClientHelper(require *require.Assertions, testKey string) (*VMClient, 
 	clientConn, err := grpcutils.Dial(status.Addr)
 	require.NoError(err)
 
-	return NewClient(vmpb.NewVMClient(clientConn)), stopper
+	return NewClient(clientConn), stopper
 }
 
 func TestStateSyncEnabled(t *testing.T) {

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -353,7 +353,10 @@ func (vm *VMClient) SetState(ctx context.Context, state snow.State) error {
 
 func (vm *VMClient) Shutdown(ctx context.Context) error {
 	errs := wrappers.Errs{}
-	_, err := vm.client.Shutdown(ctx, &emptypb.Empty{})
+	// Shutdown is a special case, where we want to fail fast instead of block
+	// here.
+	failFast := grpc.WaitForReady(false)
+	_, err := vm.client.Shutdown(ctx, &emptypb.Empty{}, failFast)
 	errs.Add(err)
 
 	vm.serverCloser.Stop()
@@ -527,7 +530,10 @@ func (vm *VMClient) SetPreference(ctx context.Context, blkID ids.ID) error {
 }
 
 func (vm *VMClient) HealthCheck(ctx context.Context) (interface{}, error) {
-	health, err := vm.client.Health(ctx, &emptypb.Empty{})
+	// HealthCheck is a special case, where we want to fail fast instead of block
+	// here.
+	failFast := grpc.WaitForReady(false)
+	health, err := vm.client.Health(ctx, &emptypb.Empty{}, failFast)
 	if err != nil {
 		return nil, fmt.Errorf("health check failed: %w", err)
 	}


### PR DESCRIPTION
## Why this should be merged

Currently the default client config defines all RPCs to `WaitForReady` this means the client call will block forever in the case that the server is terminated.

HealthChecks should fail fast to report a failing health check for a VM that has been terminated.

## How this works

Fine tune `WaitForReady` as RPC CallOption.
ref. https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md

## How this was tested

Manually and CI

TODO: test with ANR and subnet
