### PR TITLE
Standardize consensus variable names in tests

### DIFF
--- a/snow/engine/common/test_sender.go
+++ b/snow/engine/common/test_sender.go
@@ -199,9 +199,9 @@ func (s *SenderTest) SendAccepted(ctx context.Context, validatorID ids.NodeID, r
 // SendGet calls SendGetF if it was initialized. If it wasn't initialized and
 // this function shouldn't be called and testing was initialized, then testing
 // will fail.
-func (s *SenderTest) SendGet(ctx context.Context, vdr ids.NodeID, requestID uint32, vtxID ids.ID) {
+func (s *SenderTest) SendGet(ctx context.Context, vdr ids.NodeID, requestID uint32, containerID ids.ID) {
 	if s.SendGetF != nil {
-		s.SendGetF(ctx, vdr, requestID, vtxID)
+		s.SendGetF(ctx, vdr, requestID, containerID)
 	} else if s.CantSendGet && s.T != nil {
 		require.FailNow(s.T, "Unexpectedly called SendGet")
 	}
@@ -210,9 +210,9 @@ func (s *SenderTest) SendGet(ctx context.Context, vdr ids.NodeID, requestID uint
 // SendGetAncestors calls SendGetAncestorsF if it was initialized. If it wasn't
 // initialized and this function shouldn't be called and testing was
 // initialized, then testing will fail.
-func (s *SenderTest) SendGetAncestors(ctx context.Context, validatorID ids.NodeID, requestID uint32, vtxID ids.ID) {
+func (s *SenderTest) SendGetAncestors(ctx context.Context, validatorID ids.NodeID, requestID uint32, containerID ids.ID) {
 	if s.SendGetAncestorsF != nil {
-		s.SendGetAncestorsF(ctx, validatorID, requestID, vtxID)
+		s.SendGetAncestorsF(ctx, validatorID, requestID, containerID)
 	} else if s.CantSendGetAncestors && s.T != nil {
 		require.FailNow(s.T, "Unexpectedly called SendCantSendGetAncestors")
 	}
@@ -221,9 +221,9 @@ func (s *SenderTest) SendGetAncestors(ctx context.Context, validatorID ids.NodeI
 // SendPut calls SendPutF if it was initialized. If it wasn't initialized and
 // this function shouldn't be called and testing was initialized, then testing
 // will fail.
-func (s *SenderTest) SendPut(ctx context.Context, vdr ids.NodeID, requestID uint32, vtx []byte) {
+func (s *SenderTest) SendPut(ctx context.Context, vdr ids.NodeID, requestID uint32, container []byte) {
 	if s.SendPutF != nil {
-		s.SendPutF(ctx, vdr, requestID, vtx)
+		s.SendPutF(ctx, vdr, requestID, container)
 	} else if s.CantSendPut && s.T != nil {
 		require.FailNow(s.T, "Unexpectedly called SendPut")
 	}
@@ -232,9 +232,9 @@ func (s *SenderTest) SendPut(ctx context.Context, vdr ids.NodeID, requestID uint
 // SendAncestors calls SendAncestorsF if it was initialized. If it wasn't
 // initialized and this function shouldn't be called and testing was
 // initialized, then testing will fail.
-func (s *SenderTest) SendAncestors(ctx context.Context, vdr ids.NodeID, requestID uint32, vtxs [][]byte) {
+func (s *SenderTest) SendAncestors(ctx context.Context, vdr ids.NodeID, requestID uint32, containers [][]byte) {
 	if s.SendAncestorsF != nil {
-		s.SendAncestorsF(ctx, vdr, requestID, vtxs)
+		s.SendAncestorsF(ctx, vdr, requestID, containers)
 	} else if s.CantSendAncestors && s.T != nil {
 		require.FailNow(s.T, "Unexpectedly called SendAncestors")
 	}
@@ -243,9 +243,9 @@ func (s *SenderTest) SendAncestors(ctx context.Context, vdr ids.NodeID, requestI
 // SendPushQuery calls SendPushQueryF if it was initialized. If it wasn't
 // initialized and this function shouldn't be called and testing was
 // initialized, then testing will fail.
-func (s *SenderTest) SendPushQuery(ctx context.Context, vdrs set.Set[ids.NodeID], requestID uint32, vtx []byte) {
+func (s *SenderTest) SendPushQuery(ctx context.Context, vdrs set.Set[ids.NodeID], requestID uint32, container []byte) {
 	if s.SendPushQueryF != nil {
-		s.SendPushQueryF(ctx, vdrs, requestID, vtx)
+		s.SendPushQueryF(ctx, vdrs, requestID, container)
 	} else if s.CantSendPushQuery && s.T != nil {
 		require.FailNow(s.T, "Unexpectedly called SendPushQuery")
 	}
@@ -254,9 +254,9 @@ func (s *SenderTest) SendPushQuery(ctx context.Context, vdrs set.Set[ids.NodeID]
 // SendPullQuery calls SendPullQueryF if it was initialized. If it wasn't
 // initialized and this function shouldn't be called and testing was
 // initialized, then testing will fail.
-func (s *SenderTest) SendPullQuery(ctx context.Context, vdrs set.Set[ids.NodeID], requestID uint32, vtxID ids.ID) {
+func (s *SenderTest) SendPullQuery(ctx context.Context, vdrs set.Set[ids.NodeID], requestID uint32, containerID ids.ID) {
 	if s.SendPullQueryF != nil {
-		s.SendPullQueryF(ctx, vdrs, requestID, vtxID)
+		s.SendPullQueryF(ctx, vdrs, requestID, containerID)
 	} else if s.CantSendPullQuery && s.T != nil {
 		require.FailNow(s.T, "Unexpectedly called SendPullQuery")
 	}

--- a/snow/engine/snowman/bootstrap/bootstrapper_test.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper_test.go
@@ -390,9 +390,9 @@ func TestBootstrapperUnknownByzantineResponse(t *testing.T) {
 	}
 
 	requestID := new(uint32)
-	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, vtxID ids.ID) {
+	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, blkID ids.ID) {
 		require.Equal(peerID, vdr)
-		require.Equal(blkID1, vtxID)
+		require.Equal(blkID1, blkID)
 		*requestID = reqID
 	}
 
@@ -538,11 +538,11 @@ func TestBootstrapperPartialFetch(t *testing.T) {
 
 	requestID := new(uint32)
 	requested := ids.Empty
-	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, vtxID ids.ID) {
+	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, blkID ids.ID) {
 		require.Equal(peerID, vdr)
-		require.Contains([]ids.ID{blkID1, blkID2}, vtxID)
+		require.Contains([]ids.ID{blkID1, blkID2}, blkID)
 		*requestID = reqID
-		requested = vtxID
+		requested = blkID
 	}
 
 	require.NoError(bs.ForceAccepted(context.Background(), acceptedIDs)) // should request blk2
@@ -844,11 +844,11 @@ func TestBootstrapperAncestors(t *testing.T) {
 
 	requestID := new(uint32)
 	requested := ids.Empty
-	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, vtxID ids.ID) {
+	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, blkID ids.ID) {
 		require.Equal(peerID, vdr)
-		require.Contains([]ids.ID{blkID1, blkID2}, vtxID)
+		require.Contains([]ids.ID{blkID1, blkID2}, blkID)
 		*requestID = reqID
-		requested = vtxID
+		requested = blkID
 	}
 
 	require.NoError(bs.ForceAccepted(context.Background(), acceptedIDs))                                    // should request blk2
@@ -963,9 +963,9 @@ func TestBootstrapperFinalized(t *testing.T) {
 	}
 
 	requestIDs := map[ids.ID]uint32{}
-	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, vtxID ids.ID) {
+	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, blkID ids.ID) {
 		require.Equal(peerID, vdr)
-		requestIDs[vtxID] = reqID
+		requestIDs[blkID] = reqID
 	}
 
 	require.NoError(bs.ForceAccepted(context.Background(), []ids.ID{blkID1, blkID2})) // should request blk2 and blk1
@@ -1123,9 +1123,9 @@ func TestRestartBootstrapping(t *testing.T) {
 	require.NoError(bs.Start(context.Background(), 0))
 
 	requestIDs := map[ids.ID]uint32{}
-	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, vtxID ids.ID) {
+	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, blkID ids.ID) {
 		require.Equal(peerID, vdr)
-		requestIDs[vtxID] = reqID
+		requestIDs[blkID] = reqID
 	}
 
 	// Force Accept blk3
@@ -1229,9 +1229,9 @@ func TestBootstrapOldBlockAfterStateSync(t *testing.T) {
 	require.NoError(bs.Start(context.Background(), 0))
 
 	requestIDs := map[ids.ID]uint32{}
-	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, vtxID ids.ID) {
+	sender.SendGetAncestorsF = func(_ context.Context, vdr ids.NodeID, reqID uint32, blkID ids.ID) {
 		require.Equal(peerID, vdr)
-		requestIDs[vtxID] = reqID
+		requestIDs[blkID] = reqID
 	}
 
 	// Force Accept, the already transitively accepted, blk0


### PR DESCRIPTION
## Why this should be merged

Factors out some rote changes from #2102 and cleans up some testing functions.

## How this works

Just variable name changes.

## How this was tested

CI