### PR TITLE
Prevent bytesNeeded overflow

### DIFF
--- a/x/merkledb/codec_test.go
+++ b/x/merkledb/codec_test.go
@@ -264,7 +264,7 @@ func FuzzEncodeHashValues(f *testing.F) {
 	)
 }
 
-func TestCodecDecodePathRegression(t *testing.T) {
+func TestCodecDecodePathLengthOverflowRegression(t *testing.T) {
 	codec := codec.(*codecImpl)
 	bytes := bytes.NewReader(binary.AppendUvarint(nil, math.MaxInt))
 	_, err := codec.decodePath(bytes, BranchFactor16)

--- a/x/merkledb/codec_test.go
+++ b/x/merkledb/codec_test.go
@@ -5,7 +5,9 @@ package merkledb
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -260,4 +262,11 @@ func FuzzEncodeHashValues(f *testing.F) {
 			}
 		},
 	)
+}
+
+func TestCodecDecodePathRegression(t *testing.T) {
+	codec := codec.(*codecImpl)
+	bytes := bytes.NewReader(binary.AppendUvarint(nil, math.MaxInt))
+	_, err := codec.decodePath(bytes, BranchFactor16)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }

--- a/x/merkledb/path.go
+++ b/x/merkledb/path.go
@@ -203,10 +203,17 @@ func (p Path) bitsToShift(index int) byte {
 	return 7 - endBitIndex
 }
 
-// bytesNeeded returns the number of bytes needed to store the passed number of tokens
+// bytesNeeded returns the number of bytes needed to store the passed number of
+// tokens.
+//
+// Invariant: [tokens] is a non-negative, but otherwise untrusted, input and
+// this method must never overflow.
 func (p Path) bytesNeeded(tokens int) int {
-	// adding p.tokensPerByte - 1 causes the division to always round up
-	return (tokens + p.tokensPerByte - 1) / p.tokensPerByte
+	size := tokens / p.tokensPerByte
+	if tokens%p.tokensPerByte != 0 {
+		size++
+	}
+	return size
 }
 
 // Extend returns a new Path that equals the passed Path appended to the current Path


### PR DESCRIPTION
## Why this should be merged

Currently path parsing can panic.

## How this works

Correctly prevent overflows when parsing paths.

## How this was tested

Added a regression test.