### PR TITLE
Reduce log level of failing to send a peerList message

### DIFF
--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -989,8 +989,11 @@ func (p *peer) handleVersion(msg *p2p.Version) {
 	}
 
 	if !p.Send(p.onClosingCtx, peerListMsg) {
-		p.Log.Error("failed to send peer list for handshake",
+		// Because throttling was marked to be bypassed with this message,
+		// sending should only fail if the peer has started closing.
+		p.Log.Debug("failed to send peer list for handshake",
 			zap.Stringer("nodeID", p.id),
+			zap.Error(p.onClosingCtx.Err()),
 		)
 	}
 }


### PR DESCRIPTION
## Why this should be merged

`ERROR` logs are only intended to be used for unexpected errors. This error can happen if a peer terminates its connection during the handshake.

## How this works

Documents the behavior + reduces the log level to `DEBUG` from `ERROR`

## How this was tested

N/A