### PR TITLE
Reduce log level of an error during Prune

### DIFF
--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -444,9 +444,11 @@ func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- 
 
 	go func() {
 		err := vm.state.Prune(&vm.ctx.Lock, vm.ctx.Log)
-		vm.ctx.Log.Info("state pruning finished",
-			zap.Error(err),
-		)
+		if err != nil {
+			vm.ctx.Log.Warn("state pruning failed",
+				zap.Error(err),
+			)
+		}
 	}()
 
 	return nil

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -445,7 +445,11 @@ func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- 
 	go func() {
 		err := vm.state.Prune(&vm.ctx.Lock, vm.ctx.Log)
 		if err != nil {
-			vm.ctx.Log.Error("state pruning failed",
+			// It isn't easy to allow cancelling Prune, because Shutdown is
+			// called with the context lock held and Prune may be blocked on
+			// acquiring the context lock. So, it is expected that Prune may
+			// return an error during VM shutdown.
+			vm.ctx.Log.Debug("state pruning failed",
 				zap.Error(err),
 			)
 		}

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -444,15 +444,9 @@ func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- 
 
 	go func() {
 		err := vm.state.Prune(&vm.ctx.Lock, vm.ctx.Log)
-		if err != nil {
-			// It isn't easy to allow cancelling Prune, because Shutdown is
-			// called with the context lock held and Prune may be blocked on
-			// acquiring the context lock. So, it is expected that Prune may
-			// return an error during VM shutdown.
-			vm.ctx.Log.Debug("state pruning failed",
-				zap.Error(err),
-			)
-		}
+		vm.ctx.Log.Info("state pruning finished",
+			zap.Error(err),
+		)
 	}()
 
 	return nil

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -448,7 +448,9 @@ func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- 
 			vm.ctx.Log.Warn("state pruning failed",
 				zap.Error(err),
 			)
+			return
 		}
+		vm.ctx.Log.Info("state pruning finished")
 	}()
 
 	return nil


### PR DESCRIPTION
## Why this should be merged

It isn't easy to allow cancelling Prune, because Shutdown is called with the context lock held and Prune may be blocked on acquiring the context lock. So, it is expected that Prune may return an error during VM shutdown. This is still normally unexpected, so keeping the level at WARN.

## How this works

`ERROR` -> `WARN`

## How this was tested

CI