### PR TITLE
Remove write lock option from the xsvm API

### DIFF
--- a/vms/example/xsvm/api/server.go
+++ b/vms/example/xsvm/api/server.go
@@ -135,7 +135,10 @@ func (s *server) IssueTx(r *http.Request, args *IssueTxArgs, reply *IssueTxReply
 	}
 
 	ctx := r.Context()
-	if err := s.builder.AddTx(ctx, newTx); err != nil {
+	s.ctx.Lock.Lock()
+	err = s.builder.AddTx(ctx, newTx)
+	s.ctx.Lock.Unlock()
+	if err != nil {
 		return err
 	}
 
@@ -150,7 +153,9 @@ type LastAcceptedReply struct {
 }
 
 func (s *server) LastAccepted(_ *http.Request, _ *struct{}, reply *LastAcceptedReply) error {
+	s.ctx.Lock.RLock()
 	reply.BlockID = s.chain.LastAccepted()
+	s.ctx.Lock.RUnlock()
 	blkBytes, err := state.GetBlock(s.state, reply.BlockID)
 	if err != nil {
 		return err

--- a/vms/example/xsvm/vm.go
+++ b/vms/example/xsvm/vm.go
@@ -129,15 +129,12 @@ func (vm *VM) CreateHandlers(_ context.Context) (map[string]*common.HTTPHandler,
 		vm.chain,
 		vm.builder,
 	)
-	if err := server.RegisterService(api, Name); err != nil {
-		return nil, err
-	}
 	return map[string]*common.HTTPHandler{
 		"": {
-			LockOptions: common.WriteLock,
+			LockOptions: common.NoLock,
 			Handler:     server,
 		},
-	}, nil
+	}, server.RegisterService(api, Name)
 }
 
 func (*VM) HealthCheck(context.Context) (interface{}, error) {

--- a/vms/example/xsvm/vm.go
+++ b/vms/example/xsvm/vm.go
@@ -118,7 +118,7 @@ func (*VM) CreateStaticHandlers(context.Context) (map[string]*common.HTTPHandler
 	return nil, nil
 }
 
-func (vm *VM) CreateHandlers(_ context.Context) (map[string]*common.HTTPHandler, error) {
+func (vm *VM) CreateHandlers(context.Context) (map[string]*common.HTTPHandler, error) {
 	server := rpc.NewServer()
 	server.RegisterCodec(json.NewCodec(), "application/json")
 	server.RegisterCodec(json.NewCodec(), "application/json;charset=UTF-8")


### PR DESCRIPTION
## Why this should be merged

Factored out of #2148

## How this works

Significantly reduces the amount of locking done by the xsvm API.

## How this was tested

N/A