### PR TITLE
Remove write lock option from the avm static API

### DIFF
--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -348,16 +348,17 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]*common.HTTPHandler, e
 }
 
 func (*VM) CreateStaticHandlers(context.Context) (map[string]*common.HTTPHandler, error) {
-	newServer := rpc.NewServer()
+	server := rpc.NewServer()
 	codec := json.NewCodec()
-	newServer.RegisterCodec(codec, "application/json")
-	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
-
-	// name this service "avm"
+	server.RegisterCodec(codec, "application/json")
+	server.RegisterCodec(codec, "application/json;charset=UTF-8")
 	staticService := CreateStaticService()
 	return map[string]*common.HTTPHandler{
-		"": {LockOptions: common.WriteLock, Handler: newServer},
-	}, newServer.RegisterService(staticService, "avm")
+		"": {
+			LockOptions: common.NoLock,
+			Handler:     server,
+		},
+	}, server.RegisterService(staticService, "avm")
 }
 
 /*


### PR DESCRIPTION
## Why this should be merged

Factored out of #2148

## How this works

Removes unneeded locking from the AVM static API

## How this was tested

N/A