### PR TITLE
Remove write lock option from the avm wallet API

### DIFF
--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -342,7 +342,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]*common.HTTPHandler, e
 
 	return map[string]*common.HTTPHandler{
 		"":        {Handler: rpcServer},
-		"/wallet": {Handler: walletServer},
+		"/wallet": {LockOptions: common.NoLock, Handler: walletServer},
 		"/events": {LockOptions: common.NoLock, Handler: vm.pubsub},
 	}, err
 }

--- a/vms/avm/wallet_service.go
+++ b/vms/avm/wallet_service.go
@@ -141,6 +141,10 @@ func (w *WalletService) IssueTx(_ *http.Request, args *api.FormattedTx, reply *a
 	if err != nil {
 		return fmt.Errorf("problem decoding transaction: %w", err)
 	}
+
+	w.vm.ctx.Lock.Lock()
+	defer w.vm.ctx.Lock.Unlock()
+
 	txID, err := w.issue(txBytes)
 	reply.TxID = txID
 	return err
@@ -178,6 +182,9 @@ func (w *WalletService) SendMultiple(_ *http.Request, args *SendMultipleArgs, re
 	if err != nil {
 		return fmt.Errorf("couldn't parse 'From' addresses: %w", err)
 	}
+
+	w.vm.ctx.Lock.Lock()
+	defer w.vm.ctx.Lock.Unlock()
 
 	// Load user's UTXOs/keys
 	utxos, kc, err := w.vm.LoadUser(args.Username, args.Password, fromAddrs)

--- a/vms/avm/wallet_service_test.go
+++ b/vms/avm/wallet_service_test.go
@@ -25,6 +25,8 @@ func TestWalletService_SendMultiple(t *testing.T) {
 					initialKeys: keys,
 				}},
 			})
+			env.vm.ctx.Lock.Unlock()
+
 			defer func() {
 				require.NoError(env.vm.Shutdown(context.Background()))
 				env.vm.ctx.Lock.Unlock()
@@ -64,6 +66,8 @@ func TestWalletService_SendMultiple(t *testing.T) {
 			reply := &api.JSONTxIDChangeAddr{}
 			require.NoError(env.walletService.SendMultiple(nil, args, reply))
 			require.Equal(changeAddrStr, reply.ChangeAddr)
+
+			env.vm.ctx.Lock.Lock()
 
 			buildAndAccept(require, env.vm, env.issuer, reply.TxID)
 


### PR DESCRIPTION
## Why this should be merged

Factored out of #2148

## How this works

Moves locking from the RPC server into the individual RPC methods.

## How this was tested

CI