### PR TITLE
Fix json marshalling of Sets

### DIFF
--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -168,13 +168,13 @@ func (s *Set[T]) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (s *Set[_]) MarshalJSON() ([]byte, error) {
+func (s Set[_]) MarshalJSON() ([]byte, error) {
 	var (
-		eltBytes = make([][]byte, len(*s))
+		eltBytes = make([][]byte, len(s))
 		i        int
 		err      error
 	)
-	for elt := range *s {
+	for elt := range s {
 		eltBytes[i], err = stdjson.Marshal(elt)
 		if err != nil {
 			return nil, err

--- a/utils/set/set_test.go
+++ b/utils/set/set_test.go
@@ -229,3 +229,29 @@ func TestSetUnmarshalJSON(t *testing.T) {
 		require.Equal(set1, set2)
 	}
 }
+
+func TestSetReflectJSONMarshal(t *testing.T) {
+	require := require.New(t)
+	set := Set[int]{}
+	{
+		asJSON, err := json.Marshal(set)
+		require.NoError(err)
+		require.Equal("[]", string(asJSON))
+	}
+	id1JSON, err := json.Marshal(1)
+	require.NoError(err)
+	id2JSON, err := json.Marshal(2)
+	require.NoError(err)
+	set.Add(1)
+	{
+		asJSON, err := json.Marshal(set)
+		require.NoError(err)
+		require.Equal(fmt.Sprintf("[%s]", string(id1JSON)), string(asJSON))
+	}
+	set.Add(2)
+	{
+		asJSON, err := json.Marshal(set)
+		require.NoError(err)
+		require.Equal(fmt.Sprintf("[%s,%s]", string(id1JSON), string(id2JSON)), string(asJSON))
+	}
+}


### PR DESCRIPTION
## Why this should be merged

Currently `set.Set`s are not correctly using the custom `MarshalJSON` method correctly because the function is defined as a pointer receiver rather than on the struct.

## How this works

`s *Set[T]` -> `s Set[T]`

## How this was tested

- [X] Added a regression test
- [X] CI