### PR TITLE
[x/merkledb] `Prefetcher` interface

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -114,6 +114,19 @@ type RangeProofer interface {
 	CommitRangeProof(ctx context.Context, start, end maybe.Maybe[[]byte], proof *RangeProof) error
 }
 
+type Prefetcher interface {
+	// PrefetchPath attempts to load all trie nodes on the path of [key]
+	// into the cache.
+	PrefetchPath(key []byte) error
+
+	// PrefetchPaths attempts to load all trie nodes on the paths of [keys]
+	// into the cache.
+	//
+	// Using PrefetchPaths can be more efficient than PrefetchPath because
+	// the underlying view used to compute each path can be reused.
+	PrefetchPaths(keys [][]byte) error
+}
+
 type MerkleDB interface {
 	database.Database
 	Trie
@@ -121,6 +134,7 @@ type MerkleDB interface {
 	ProofGetter
 	ChangeProofer
 	RangeProofer
+	Prefetcher
 }
 
 type Config struct {

--- a/x/merkledb/mock_db.go
+++ b/x/merkledb/mock_db.go
@@ -345,6 +345,34 @@ func (mr *MockMerkleDBMockRecorder) NewView(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewView", reflect.TypeOf((*MockMerkleDB)(nil).NewView), arg0, arg1)
 }
 
+// PrefetchPath mocks base method.
+func (m *MockMerkleDB) PrefetchPath(arg0 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrefetchPath", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrefetchPath indicates an expected call of PrefetchPath.
+func (mr *MockMerkleDBMockRecorder) PrefetchPath(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchPath", reflect.TypeOf((*MockMerkleDB)(nil).PrefetchPath), arg0)
+}
+
+// PrefetchPaths mocks base method.
+func (m *MockMerkleDB) PrefetchPaths(arg0 [][]byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrefetchPaths", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrefetchPaths indicates an expected call of PrefetchPaths.
+func (mr *MockMerkleDBMockRecorder) PrefetchPaths(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchPaths", reflect.TypeOf((*MockMerkleDB)(nil).PrefetchPaths), arg0)
+}
+
 // Put mocks base method.
 func (m *MockMerkleDB) Put(arg0, arg1 []byte) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why this should be merged
Callers don't have access to the newly added `PrefetchPath` and `PrefetchPaths` functions because `New` only returns a `MerkleDB` interface.

## How this works
Add an embedded interface to `MerkleDB` that exposes the new functions.

## How this was tested
