### PR TITLE
Update cgo usage

### DIFF
--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -32,7 +32,7 @@ fi
 #
 # We use "export" here instead of just setting a bash variable because we need
 # to pass this flag to all child processes spawned by the shell.
-export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+export CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"
 # While CGO_ENABLED doesn't need to be explicitly set, it produces a much more
 # clear error due to the default value change in go1.20.
 export CGO_ENABLED=1

--- a/scripts/mock.gen.sh
+++ b/scripts/mock.gen.sh
@@ -21,6 +21,8 @@ then
   go install -v github.com/palantir/go-license@v1.25.0
 fi
 
+source ./scripts/constants.sh
+
 # tuples of (source interface import path, comma-separated interface names, output file path)
 input="scripts/mocks.mockgen.txt"
 while IFS= read -r line


### PR DESCRIPTION
## Why this should be merged

1. `-O2` is the default optimization level
2. It seems like `mockgen` should be run portably: [ref](https://github.com/ava-labs/avalanchego/actions/runs/6563098014/job/17828881093?pr=2181#step:4:219)

## How this works

1. Updates the optimization level
2. Passes the CGO envs to `mockgen`

## How this was tested

CI