### PR TITLE
Fix CI failing due to not being able to find git tag

### DIFF
--- a/.github/workflows/test.unit.yml
+++ b/.github/workflows/test.unit.yml
@@ -25,8 +25,6 @@ jobs:
         os: [macos-12, ubuntu-20.04, ubuntu-22.04, windows-2022, [self-hosted, linux, ARM64, focal], [self-hosted, linux, ARM64, jammy]]
     steps:
       - uses: actions/checkout@v3
-        with:
-           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
           go-version: '~1.20.10'

--- a/.github/workflows/test.unit.yml
+++ b/.github/workflows/test.unit.yml
@@ -25,6 +25,8 @@ jobs:
         os: [macos-12, ubuntu-20.04, ubuntu-22.04, windows-2022, [self-hosted, linux, ARM64, focal], [self-hosted, linux, ARM64, jammy]]
     steps:
       - uses: actions/checkout@v3
+        with:
+           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
           go-version: '~1.20.10'

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -8,4 +8,4 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 source "$AVALANCHE_PATH"/scripts/constants.sh
 
 # Ensure execution of fixture unit tests under tests/ but exclude ginkgo tests in tests/e2e and tests/upgrade
-go test -shuffle=on -race -timeout=${TIMEOUT:-"120s"} -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v /mocks | grep -v proto | grep -v tests/e2e | grep -v tests/upgrade)
+go test -v -shuffle=on -race -timeout=${TIMEOUT:-"120s"} -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v /mocks | grep -v proto | grep -v tests/e2e | grep -v tests/upgrade)


### PR DESCRIPTION
## Why this should be merged

Broken CI due to not being able to find a tag
```
fatal: no tag exactly matches 'f52725ba7b6f4cba51a6399fd3ca14ba17862d16'
```

## How this works

Fetches tags first

## How this was tested

CI
