### PR TITLE
Deprecate keystore config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,16 +60,18 @@ const (
 	subnetConfigFileExt  = ".json"
 	ipResolutionTimeout  = 30 * time.Second
 
-	ipcDeprecationMsg = "IPC API is deprecated"
+	ipcDeprecationMsg      = "IPC API is deprecated"
+	keystoreDeprecationMsg = "keystore API is deprecated"
 )
 
 var (
 	// Deprecated key --> deprecation message (i.e. which key replaces it)
 	// TODO: deprecate "BootstrapIDsKey" and "BootstrapIPsKey"
 	deprecatedKeys = map[string]string{
-		IpcAPIEnabledKey: ipcDeprecationMsg,
-		IpcsChainIDsKey:  ipcDeprecationMsg,
-		IpcsPathKey:      ipcDeprecationMsg,
+		IpcAPIEnabledKey:      ipcDeprecationMsg,
+		IpcsChainIDsKey:       ipcDeprecationMsg,
+		IpcsPathKey:           ipcDeprecationMsg,
+		KeystoreAPIEnabledKey: keystoreDeprecationMsg,
 	}
 
 	errSybilProtectionDisabledStakerWeights   = errors.New("sybil protection disabled weights must be positive")


### PR DESCRIPTION
## Why this should be merged

People shouldn't use the Keystore API anymore. It's been deprecated.

## How this works

Deprecate flag

## How this was tested

N/A