### PR TITLE
Move channel lock from Handler into Engines

### DIFF
--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -277,6 +277,9 @@ func (b *bootstrapper) Disconnected(ctx context.Context, nodeID ids.NodeID) erro
 }
 
 func (b *bootstrapper) Timeout(ctx context.Context) error {
+	b.Ctx.Lock.Lock()
+	defer b.Ctx.Lock.Unlock()
+
 	if !b.awaitingTimeout {
 		return errUnexpectedTimeout
 	}

--- a/snow/engine/snowman/syncer/state_syncer.go
+++ b/snow/engine/snowman/syncer/state_syncer.go
@@ -555,6 +555,9 @@ func (ss *stateSyncer) Notify(ctx context.Context, msg common.Message) error {
 		return nil
 	}
 
+	ss.Ctx.Lock.Lock()
+	defer ss.Ctx.Lock.Unlock()
+
 	ss.Ctx.StateSyncing.Set(false)
 	return ss.onDoneStateSyncing(ctx, ss.requestID)
 }

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -342,6 +342,9 @@ func (*Transitive) Timeout(context.Context) error {
 }
 
 func (t *Transitive) Gossip(ctx context.Context) error {
+	t.Ctx.Lock.Lock()
+	defer t.Ctx.Lock.Unlock()
+
 	blkID, err := t.VM.LastAccepted(ctx)
 	if err != nil {
 		return err
@@ -373,6 +376,9 @@ func (t *Transitive) Shutdown(ctx context.Context) error {
 func (t *Transitive) Notify(ctx context.Context, msg common.Message) error {
 	switch msg {
 	case common.PendingTxs:
+		t.Ctx.Lock.Lock()
+		defer t.Ctx.Lock.Unlock()
+
 		// the pending txs message means we should attempt to build a block.
 		t.pendingBuildBlocks++
 		return t.buildBlocks(ctx)


### PR DESCRIPTION
## Why this should be merged

Continuing the effort to remove the `snow.Context.Lock` - this pushes the lock from `Handler.handleChanMsg` into the `Engine`s' functions.

## How this works

- `h.engineManager.Get(state.Type).Get(state.State)` only references immutable values.
- `Gossip` and `Timeout` are fairly easy to see that there isn't a major concern around dispatching messages to and older engine. `Notify` is still correct because `ctx.State` is updated prior to calling `VM.SetState` and the delivery of messages is async. So either the `Notify` message is required in order to transition to the next state, or it's already possible for the next state to receive the message.

## How this was tested

CI