### PR TITLE
Update TestDialContext to use ManuallyTrack

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -649,8 +649,8 @@ func TestDialContext(t *testing.T) {
 		}
 	)
 
-	network.manuallyTrackedIDs.Add(neverDialedNodeID)
-	network.manuallyTrackedIDs.Add(dialedNodeID)
+	network.ManuallyTrack(neverDialedNodeID, neverDialedIP.ip)
+	network.ManuallyTrack(dialedNodeID, dialedIP.ip)
 
 	// Sanity check that when a non-cancelled context is given,
 	// we actually dial the peer.


### PR DESCRIPTION
## Why this should be merged

Use `ManuallyTrack` instead of directly modifying the internal state of the network struct. https://github.com/ava-labs/avalanchego/pull/2204 Introduces a lock around `manuallyTrackedIPs` so we should always access it through `ManuallyTrack` as opposed to directly. This is not a bug in this test because this test is not concurrent.

## How this works

See above

## How this was tested

UT
