### PR TITLE
Add log for ungraceful shutdown on startup

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -588,6 +588,7 @@ func (n *Node) initDatabase() error {
 	session := session{
 		Timestamp: time.Now(),
 	}
+
 	sessionBytes, err := json.Marshal(session)
 	if err != nil {
 		return fmt.Errorf("failed to marshal session metadata: %w", err)


### PR DESCRIPTION
## Why this should be merged

Adds a log to detect if a node previously shutdown ungracefully

## How this works

Upon node startup, the node writes a flag into the database. Upon shutdown it cleans up this flag.  If we see a prior flag upon startup we log it as a warning to the operator.

## How this was tested

Tested manually by killing a node and verifying the log on startup
```
[10-25|12:43:55.259] WARN node/node.go:568 detected previous ungraceful shutdown
```
