### PR TITLE
Revert networking AllowConnection change

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -470,7 +470,11 @@ func (n *network) Connected(nodeID ids.NodeID) {
 // of peers, then it should only connect if this node is a validator, or the
 // peer is a validator/beacon.
 func (n *network) AllowConnection(nodeID ids.NodeID) bool {
-	return !n.config.RequireValidatorToConnect || n.WantsConnection(nodeID)
+	if !n.config.RequireValidatorToConnect {
+		return true
+	}
+	_, isValidator := n.config.Validators.GetValidator(constants.PrimaryNetworkID, n.config.MyNodeID)
+	return isValidator || n.WantsConnection(nodeID)
 }
 
 func (n *network) Track(peerID ids.NodeID, claimedIPPorts []*ips.ClaimedIPPort) ([]*p2p.PeerAck, error) {


### PR DESCRIPTION
## Why this should be merged

I thought this was a duplicated check here: #2204 but I was wrong. The check is for different nodeIDs and is required.

## How this works

Reverts the breaking change.

## How this was tested

Added a regression test