### PR TITLE
Fix unexpected unlock

### DIFF
--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -222,8 +222,6 @@ func (h *handler) selectStartingGear(ctx context.Context) (common.Engine, error)
 func (h *handler) Start(ctx context.Context, recoverPanic bool) {
 	gear, err := h.selectStartingGear(ctx)
 	if err != nil {
-		h.ctx.Lock.Unlock()
-
 		h.ctx.Log.Error("chain failed to select starting gear",
 			zap.Error(err),
 		)


### PR DESCRIPTION
## Why this should be merged

There seems to have been a bad merge around when the lock was removed from `selectStartingGear`.

## How this works

Removes the unlock call

## How this was tested

Adds a regression test