### PR TITLE
Add json marshal tests to existing serialization tests in `platformvm/txs` pkg

### DIFF
--- a/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
@@ -4,6 +4,7 @@
 package txs
 
 import (
+	"encoding/json"
 	"errors"
 	"math"
 	"testing"
@@ -601,6 +602,145 @@ func TestAddPermissionlessPrimaryDelegatorSerialization(t *testing.T) {
 	unsignedComplexAddPrimaryTxBytes, err := Codec.Marshal(Version, &unsignedComplexAddPrimaryTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexAddPrimaryTxBytes, unsignedComplexAddPrimaryTxBytes)
+
+	aliaser := ids.NewAliaser()
+	require.NoError(aliaser.Alias(constants.PlatformChainID, "P"))
+
+	unsignedComplexAddPrimaryTx.InitCtx(&snow.Context{
+		NetworkID:   1,
+		ChainID:     constants.PlatformChainID,
+		AVAXAssetID: avaxAssetID,
+		BCLookup:    aliaser,
+	})
+
+	unsignedComplexAddPrimaryTxJSONBytes, err := json.MarshalIndent(unsignedComplexAddPrimaryTx, "", "\t")
+	require.NoError(err)
+	require.Equal(`{
+	"networkID": 1,
+	"blockchainID": "11111111111111111111111111111111LpoYY",
+	"outputs": [
+		{
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"addresses": [
+					"P-avax1g32kvaugnx4tk3z4vemc3xd2hdz92enh972wxr"
+				],
+				"amount": 1,
+				"locktime": 0,
+				"threshold": 1
+			}
+		},
+		{
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 87654321,
+				"output": {
+					"addresses": [],
+					"amount": 1,
+					"locktime": 12345678,
+					"threshold": 0
+				}
+			}
+		},
+		{
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 876543210,
+				"output": {
+					"addresses": [
+						"P-avax1g32kvaugnx4tk3z4vemc3xd2hdz92enh972wxr"
+					],
+					"amount": 18446744073709551615,
+					"locktime": 0,
+					"threshold": 1
+				}
+			}
+		}
+	],
+	"inputs": [
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 1,
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"amount": 1000000000000000,
+				"signatureIndices": [
+					2,
+					5
+				]
+			}
+		},
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 2,
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"locktime": 876543210,
+				"input": {
+					"amount": 17293822569102704639,
+					"signatureIndices": [
+						0
+					]
+				}
+			}
+		},
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 3,
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"amount": 1152921504606846976,
+				"signatureIndices": []
+			}
+		}
+	],
+	"memo": "0xf09f98850a77656c6c2074686174277301234521",
+	"validator": {
+		"nodeID": "NodeID-2ZbTY9GatRTrfinAoYiYLcf6CvrPAUYgo",
+		"start": 12345,
+		"end": 17292345,
+		"weight": 5000000000000
+	},
+	"subnetID": "11111111111111111111111111111111LpoYY",
+	"stake": [
+		{
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"addresses": [
+					"P-avax1g32kvaugnx4tk3z4vemc3xd2hdz92enh972wxr"
+				],
+				"amount": 2000000000000,
+				"locktime": 0,
+				"threshold": 1
+			}
+		},
+		{
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 987654321,
+				"output": {
+					"addresses": [],
+					"amount": 3000000000000,
+					"locktime": 87654321,
+					"threshold": 0
+				}
+			}
+		}
+	],
+	"rewardsOwner": {
+		"addresses": [],
+		"locktime": 0,
+		"threshold": 0
+	}
+}`, string(unsignedComplexAddPrimaryTxJSONBytes))
 }
 
 func TestAddPermissionlessSubnetDelegatorSerialization(t *testing.T) {
@@ -1218,6 +1358,145 @@ func TestAddPermissionlessSubnetDelegatorSerialization(t *testing.T) {
 	unsignedComplexAddSubnetTxBytes, err := Codec.Marshal(Version, &unsignedComplexAddSubnetTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexAddSubnetTxBytes, unsignedComplexAddSubnetTxBytes)
+
+	aliaser := ids.NewAliaser()
+	require.NoError(aliaser.Alias(constants.PlatformChainID, "P"))
+
+	unsignedComplexAddSubnetTx.InitCtx(&snow.Context{
+		NetworkID:   1,
+		ChainID:     constants.PlatformChainID,
+		AVAXAssetID: avaxAssetID,
+		BCLookup:    aliaser,
+	})
+
+	unsignedComplexAddSubnetTxJSONBytes, err := json.MarshalIndent(unsignedComplexAddSubnetTx, "", "\t")
+	require.NoError(err)
+	require.Equal(`{
+	"networkID": 1,
+	"blockchainID": "11111111111111111111111111111111LpoYY",
+	"outputs": [
+		{
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"addresses": [
+					"P-avax1g32kvaugnx4tk3z4vemc3xd2hdz92enh972wxr"
+				],
+				"amount": 1,
+				"locktime": 0,
+				"threshold": 1
+			}
+		},
+		{
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 87654321,
+				"output": {
+					"addresses": [],
+					"amount": 1,
+					"locktime": 12345678,
+					"threshold": 0
+				}
+			}
+		},
+		{
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 876543210,
+				"output": {
+					"addresses": [
+						"P-avax1g32kvaugnx4tk3z4vemc3xd2hdz92enh972wxr"
+					],
+					"amount": 18446744073709551600,
+					"locktime": 0,
+					"threshold": 1
+				}
+			}
+		}
+	],
+	"inputs": [
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 1,
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"amount": 1000000000000000,
+				"signatureIndices": [
+					2,
+					5
+				]
+			}
+		},
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 2,
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"locktime": 876543210,
+				"input": {
+					"amount": 17293822569102704639,
+					"signatureIndices": [
+						0
+					]
+				}
+			}
+		},
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 3,
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"amount": 1152921504606846976,
+				"signatureIndices": []
+			}
+		}
+	],
+	"memo": "0xf09f98850a77656c6c2074686174277301234521",
+	"validator": {
+		"nodeID": "NodeID-2ZbTY9GatRTrfinAoYiYLcf6CvrPAUYgo",
+		"start": 12345,
+		"end": 12346,
+		"weight": 9
+	},
+	"subnetID": "SkB92YpWm4UpburLz9tEKZw2i67H3FF6YkjaU4BkFUDTG9Xm",
+	"stake": [
+		{
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"addresses": [
+					"P-avax1g32kvaugnx4tk3z4vemc3xd2hdz92enh972wxr"
+				],
+				"amount": 2,
+				"locktime": 0,
+				"threshold": 1
+			}
+		},
+		{
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 987654321,
+				"output": {
+					"addresses": [],
+					"amount": 7,
+					"locktime": 87654321,
+					"threshold": 0
+				}
+			}
+		}
+	],
+	"rewardsOwner": {
+		"addresses": [],
+		"locktime": 0,
+		"threshold": 0
+	}
+}`, string(unsignedComplexAddSubnetTxJSONBytes))
 }
 
 func TestAddPermissionlessDelegatorTxSyntacticVerify(t *testing.T) {

--- a/vms/platformvm/txs/base_tx_test.go
+++ b/vms/platformvm/txs/base_tx_test.go
@@ -41,13 +41,34 @@ func TestBaseTxMarshalJSON(t *testing.T) {
 		Memo: []byte{1, 2, 3},
 	}}
 
-	txBytes, err := json.Marshal(tx)
+	txJSONBytes, err := json.MarshalIndent(tx, "", "\t")
 	require.NoError(err)
 
-	asString := string(txBytes)
-
-	require.Contains(asString, `"networkID":4`)
-	require.Contains(asString, `"blockchainID":"SYXsAycDPUu4z2ZksJD5fh5nTDcH3vCFHnpcVye5XuJ2jArg"`)
-	require.Contains(asString, `"inputs":[{"txID":"t64jLxDRmxo8y48WjbRALPAZuSDZ6qPVaaeDzxHA4oSojhLt","outputIndex":5,"assetID":"2KdbbWvpeAShCx5hGbtdF15FMMepq9kajsNTqVvvEbhiCRSxU","fxID":"2mB8TguRrYvbGw7G2UBqKfmL8osS7CfmzAAHSzuZK8bwpRKdY","input":{"Err":null,"Val":100}}]`)
-	require.Contains(asString, `"outputs":[{"assetID":"2KdbbWvpeAShCx5hGbtdF15FMMepq9kajsNTqVvvEbhiCRSxU","fxID":"2mB8TguRrYvbGw7G2UBqKfmL8osS7CfmzAAHSzuZK8bwpRKdY","output":{"Err":null,"Val":100}}]`)
+	require.Equal(`{
+	"networkID": 4,
+	"blockchainID": "SYXsAycDPUu4z2ZksJD5fh5nTDcH3vCFHnpcVye5XuJ2jArg",
+	"outputs": [
+		{
+			"assetID": "2KdbbWvpeAShCx5hGbtdF15FMMepq9kajsNTqVvvEbhiCRSxU",
+			"fxID": "2mB8TguRrYvbGw7G2UBqKfmL8osS7CfmzAAHSzuZK8bwpRKdY",
+			"output": {
+				"Err": null,
+				"Val": 100
+			}
+		}
+	],
+	"inputs": [
+		{
+			"txID": "t64jLxDRmxo8y48WjbRALPAZuSDZ6qPVaaeDzxHA4oSojhLt",
+			"outputIndex": 5,
+			"assetID": "2KdbbWvpeAShCx5hGbtdF15FMMepq9kajsNTqVvvEbhiCRSxU",
+			"fxID": "2mB8TguRrYvbGw7G2UBqKfmL8osS7CfmzAAHSzuZK8bwpRKdY",
+			"input": {
+				"Err": null,
+				"Val": 100
+			}
+		}
+	],
+	"memo": "0x010203"
+}`, string(txJSONBytes))
 }

--- a/vms/platformvm/txs/remove_subnet_validator_tx_test.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx_test.go
@@ -4,6 +4,7 @@
 package txs
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -419,6 +420,99 @@ func TestRemoveSubnetValidatorTxSerialization(t *testing.T) {
 	unsignedComplexRemoveValidatorTxBytes, err := Codec.Marshal(Version, &unsignedComplexRemoveValidatorTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexRemoveValidatorTxBytes, unsignedComplexRemoveValidatorTxBytes)
+
+	aliaser := ids.NewAliaser()
+	require.NoError(aliaser.Alias(constants.PlatformChainID, "P"))
+
+	unsignedComplexRemoveValidatorTx.InitCtx(&snow.Context{
+		NetworkID:   1,
+		ChainID:     constants.PlatformChainID,
+		AVAXAssetID: avaxAssetID,
+		BCLookup:    aliaser,
+	})
+
+	unsignedComplexRemoveValidatorTxJSONBytes, err := json.MarshalIndent(unsignedComplexRemoveValidatorTx, "", "\t")
+	require.NoError(err)
+	require.Equal(`{
+	"networkID": 1,
+	"blockchainID": "11111111111111111111111111111111LpoYY",
+	"outputs": [
+		{
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 87654321,
+				"output": {
+					"addresses": [],
+					"amount": 1,
+					"locktime": 12345678,
+					"threshold": 0
+				}
+			}
+		},
+		{
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 876543210,
+				"output": {
+					"addresses": [
+						"P-avax1g32kvaugnx4tk3z4vemc3xd2hdz92enh972wxr"
+					],
+					"amount": 18446744073709551615,
+					"locktime": 0,
+					"threshold": 1
+				}
+			}
+		}
+	],
+	"inputs": [
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 1,
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"amount": 1000000000,
+				"signatureIndices": [
+					2,
+					5
+				]
+			}
+		},
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 2,
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"locktime": 876543210,
+				"input": {
+					"amount": 17293822569102704639,
+					"signatureIndices": [
+						0
+					]
+				}
+			}
+		},
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 3,
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"amount": 1152921504606846976,
+				"signatureIndices": []
+			}
+		}
+	],
+	"memo": "0xf09f98850a77656c6c2074686174277301234521",
+	"nodeID": "NodeID-2ZbTY9GatRTrfinAoYiYLcf6CvrPAUYgo",
+	"subnetID": "SkB92YpWm4UpburLz9tEKZw2i67H3FF6YkjaU4BkFUDTG9Xm",
+	"subnetAuthorization": {
+		"signatureIndices": []
+	}
+}`, string(unsignedComplexRemoveValidatorTxJSONBytes))
 }
 
 func TestRemoveSubnetValidatorTxSyntacticVerify(t *testing.T) {

--- a/vms/platformvm/txs/transform_subnet_tx_test.go
+++ b/vms/platformvm/txs/transform_subnet_tx_test.go
@@ -4,6 +4,7 @@
 package txs
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -522,6 +523,111 @@ func TestTransformSubnetTxSerialization(t *testing.T) {
 	unsignedComplexTransformTxBytes, err := Codec.Marshal(Version, &unsignedComplexTransformTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexTransformTxBytes, unsignedComplexTransformTxBytes)
+
+	aliaser := ids.NewAliaser()
+	require.NoError(aliaser.Alias(constants.PlatformChainID, "P"))
+
+	unsignedComplexTransformTx.InitCtx(&snow.Context{
+		NetworkID:   1,
+		ChainID:     constants.PlatformChainID,
+		AVAXAssetID: avaxAssetID,
+		BCLookup:    aliaser,
+	})
+
+	unsignedComplexTransformTxJSONBytes, err := json.MarshalIndent(unsignedComplexTransformTx, "", "\t")
+	require.NoError(err)
+	require.Equal(`{
+	"networkID": 1,
+	"blockchainID": "11111111111111111111111111111111LpoYY",
+	"outputs": [
+		{
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 87654321,
+				"output": {
+					"addresses": [],
+					"amount": 1,
+					"locktime": 12345678,
+					"threshold": 0
+				}
+			}
+		},
+		{
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"output": {
+				"locktime": 876543210,
+				"output": {
+					"addresses": [
+						"P-avax1g32kvaugnx4tk3z4vemc3xd2hdz92enh972wxr"
+					],
+					"amount": 18446744073709551615,
+					"locktime": 0,
+					"threshold": 1
+				}
+			}
+		}
+	],
+	"inputs": [
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 1,
+			"assetID": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"amount": 1000000000000,
+				"signatureIndices": [
+					2,
+					5
+				]
+			}
+		},
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 2,
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"locktime": 876543210,
+				"input": {
+					"amount": 17293822569102704639,
+					"signatureIndices": [
+						0
+					]
+				}
+			}
+		},
+		{
+			"txID": "2wiU5PnFTjTmoAXGZutHAsPF36qGGyLHYHj9G1Aucfmb3JFFGN",
+			"outputIndex": 3,
+			"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+			"fxID": "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ",
+			"input": {
+				"amount": 1152921504606846976,
+				"signatureIndices": []
+			}
+		}
+	],
+	"memo": "0xf09f98850a77656c6c2074686174277301234521",
+	"subnetID": "SkB92YpWm4UpburLz9tEKZw2i67H3FF6YkjaU4BkFUDTG9Xm",
+	"assetID": "2Ab62uWwJw1T6VvmKD36ufsiuGZuX1pGykXAvPX1LtjTRHxwcc",
+	"initialSupply": 1152921504606846976,
+	"maximumSupply": 1152921504606846976,
+	"minConsumptionRate": 0,
+	"maxConsumptionRate": 0,
+	"minValidatorStake": 1,
+	"maxValidatorStake": 1152921504606846976,
+	"minStakeDuration": 1,
+	"maxStakeDuration": 1,
+	"minDelegationFee": 0,
+	"minDelegatorStake": 18446744073709551615,
+	"maxValidatorWeightFactor": 255,
+	"uptimeRequirement": 0,
+	"subnetAuthorization": {
+		"signatureIndices": []
+	}
+}`, string(unsignedComplexTransformTxJSONBytes))
 }
 
 func TestTransformSubnetTxSyntacticVerify(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

Adds json marshalling tests to the existing serialization tests.

Also improves coverage:

```
// Before
ok  	github.com/ava-labs/avalanchego/vms/platformvm/txs	0.450s	coverage: 45.5% of statements

// After
ok  	github.com/ava-labs/avalanchego/vms/platformvm/txs	0.464s	coverage: 46.4% of statements
```

## How this works

pretty straightforward

## How this was tested

CI