### PR TITLE
Track all subnet validator sets in the validator manager

### DIFF
--- a/snow/validators/logger.go
+++ b/snow/validators/logger.go
@@ -7,7 +7,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -18,7 +17,6 @@ var _ SetCallbackListener = (*logger)(nil)
 
 type logger struct {
 	log      logging.Logger
-	enabled  *utils.Atomic[bool]
 	subnetID ids.ID
 	nodeIDs  set.Set[ids.NodeID]
 }
@@ -27,14 +25,12 @@ type logger struct {
 // the specified validators
 func NewLogger(
 	log logging.Logger,
-	enabled *utils.Atomic[bool],
 	subnetID ids.ID,
 	nodeIDs ...ids.NodeID,
 ) SetCallbackListener {
 	nodeIDSet := set.Of(nodeIDs...)
 	return &logger{
 		log:      log,
-		enabled:  enabled,
 		subnetID: subnetID,
 		nodeIDs:  nodeIDSet,
 	}
@@ -46,7 +42,7 @@ func (l *logger) OnValidatorAdded(
 	txID ids.ID,
 	weight uint64,
 ) {
-	if l.enabled.Get() && l.nodeIDs.Contains(nodeID) {
+	if l.nodeIDs.Contains(nodeID) {
 		var pkBytes []byte
 		if pk != nil {
 			pkBytes = bls.PublicKeyToBytes(pk)
@@ -65,7 +61,7 @@ func (l *logger) OnValidatorRemoved(
 	nodeID ids.NodeID,
 	weight uint64,
 ) {
-	if l.enabled.Get() && l.nodeIDs.Contains(nodeID) {
+	if l.nodeIDs.Contains(nodeID) {
 		l.log.Info("node removed from validator set",
 			zap.Stringer("subnetID", l.subnetID),
 			zap.Stringer("nodeID", nodeID),
@@ -79,7 +75,7 @@ func (l *logger) OnValidatorWeightChanged(
 	oldWeight uint64,
 	newWeight uint64,
 ) {
-	if l.enabled.Get() && l.nodeIDs.Contains(nodeID) {
+	if l.nodeIDs.Contains(nodeID) {
 		l.log.Info("validator weight changed",
 			zap.Stringer("subnetID", l.subnetID),
 			zap.Stringer("nodeID", nodeID),

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -236,7 +236,6 @@ func defaultState(
 		ctx,
 		metrics.Noop,
 		rewards,
-		&utils.Atomic[bool]{},
 	)
 	require.NoError(err)
 

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -275,7 +275,6 @@ func defaultState(
 		ctx,
 		metrics.Noop,
 		rewards,
-		&utils.Atomic[bool]{},
 	)
 	if err != nil {
 		panic(err)

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -947,7 +947,7 @@ func TestBanffProposalBlockTrackedSubnet(t *testing.T) {
 			require.NoError(propBlk.Accept(context.Background()))
 			require.NoError(commitBlk.Accept(context.Background()))
 			_, ok := env.config.Validators.GetValidator(subnetID, subnetValidatorNodeID)
-			require.Equal(tracked, ok)
+			require.True(ok)
 		})
 	}
 }

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -747,7 +747,7 @@ func TestBanffStandardBlockTrackedSubnet(t *testing.T) {
 			require.NoError(block.Verify(context.Background()))
 			require.NoError(block.Accept(context.Background()))
 			_, ok := env.config.Validators.GetValidator(subnetID, subnetValidatorNodeID)
-			require.Equal(tracked, ok)
+			require.True(ok)
 		})
 	}
 }

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -144,20 +144,6 @@ func (mr *MockStateMockRecorder) AddUTXO(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUTXO", reflect.TypeOf((*MockState)(nil).AddUTXO), arg0)
 }
 
-// ApplyCurrentValidators mocks base method.
-func (m *MockState) ApplyCurrentValidators(arg0 ids.ID, arg1 validators.Manager) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyCurrentValidators", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ApplyCurrentValidators indicates an expected call of ApplyCurrentValidators.
-func (mr *MockStateMockRecorder) ApplyCurrentValidators(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyCurrentValidators", reflect.TypeOf((*MockState)(nil).ApplyCurrentValidators), arg0, arg1)
-}
-
 // ApplyValidatorPublicKeyDiffs mocks base method.
 func (m *MockState) ApplyValidatorPublicKeyDiffs(arg0 context.Context, arg1 map[ids.NodeID]*validators.GetValidatorOutput, arg2, arg3 uint64) error {
 	m.ctrl.T.Helper()

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1667,15 +1667,15 @@ func (s *state) initValidatorSets() error {
 		}
 
 		for nodeID, validator := range validators {
-			staker := validator.validator
-			if err := s.cfg.Validators.AddStaker(subnetID, nodeID, staker.PublicKey, staker.TxID, staker.Weight); err != nil {
+			validatorStaker := validator.validator
+			if err := s.cfg.Validators.AddStaker(subnetID, nodeID, validatorStaker.PublicKey, validatorStaker.TxID, validatorStaker.Weight); err != nil {
 				return err
 			}
 
 			delegatorIterator := NewTreeIterator(validator.delegators)
 			for delegatorIterator.Next() {
-				staker := delegatorIterator.Value()
-				if err := s.cfg.Validators.AddWeight(subnetID, nodeID, staker.Weight); err != nil {
+				delegatorStaker := delegatorIterator.Value()
+				if err := s.cfg.Validators.AddWeight(subnetID, nodeID, delegatorStaker.Weight); err != nil {
 					delegatorIterator.Release()
 					return err
 				}

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/units"
@@ -178,7 +177,6 @@ func newStateFromDB(require *require.Assertions, db database.Database) State {
 			MintingPeriod:      365 * 24 * time.Hour,
 			SupplyCap:          720 * units.MegaAvax,
 		}),
-		&utils.Atomic[bool]{},
 	)
 	require.NoError(err)
 	require.NotNil(state)

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -617,7 +617,7 @@ func TestTrackedSubnet(t *testing.T) {
 			env.state.SetHeight(dummyHeight)
 			require.NoError(env.state.Commit())
 			_, ok := env.config.Validators.GetValidator(subnetID, ids.NodeID(subnetValidatorNodeID))
-			require.Equal(tracked, ok)
+			require.True(ok)
 		})
 	}
 }

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -224,7 +224,6 @@ func defaultState(
 		ctx,
 		metrics.Noop,
 		rewards,
-		&utils.Atomic[bool]{},
 	)
 	if err != nil {
 		panic(err)

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -48,10 +48,6 @@ type State interface {
 	GetLastAccepted() ids.ID
 	GetStatelessBlock(blockID ids.ID) (block.Block, error)
 
-	// ApplyCurrentValidators adds all the current validators and delegators of
-	// [subnetID] into [vdrs].
-	ApplyCurrentValidators(subnetID ids.ID, vdrs validators.Manager) error
-
 	// ApplyValidatorWeightDiffs iterates from [startHeight] towards the genesis
 	// block until it has applied all of the diffs up to and including
 	// [endHeight]. Applying the diffs modifies [validators].
@@ -346,22 +342,7 @@ func (m *manager) getCurrentValidatorSets(
 	ctx context.Context,
 	subnetID ids.ID,
 ) (map[ids.NodeID]*validators.GetValidatorOutput, map[ids.NodeID]*validators.GetValidatorOutput, uint64, error) {
-	subnetManager := m.cfg.Validators
-	if subnetManager.Count(subnetID) == 0 {
-		// If this subnet isn't tracked, there will not be any registered
-		// validators. To calculate the current validators we need to first
-		// fetch them from state. We generate a new manager as we don't want to
-		// modify that long-lived reference.
-		//
-		// TODO: remove this once all subnets are included in the validator
-		// manager.
-		subnetManager = validators.NewManager()
-		if err := m.state.ApplyCurrentValidators(subnetID, subnetManager); err != nil {
-			return nil, nil, 0, err
-		}
-	}
-
-	subnetMap := subnetManager.GetMap(subnetID)
+	subnetMap := m.cfg.Validators.GetMap(subnetID)
 	primaryMap := m.cfg.Validators.GetMap(constants.PrimaryNetworkID)
 	currentHeight, err := m.getCurrentHeight(ctx)
 	return subnetMap, primaryMap, currentHeight, err

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/formatting"
@@ -129,7 +128,6 @@ func BenchmarkGetValidatorSet(b *testing.B) {
 			MintingPeriod:      365 * 24 * time.Hour,
 			SupplyCap:          720 * units.MegaAvax,
 		}),
-		new(utils.Atomic[bool]),
 	)
 	require.NoError(err)
 

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -142,7 +142,6 @@ func (vm *VM) Initialize(
 		vm.ctx,
 		vm.metrics,
 		rewards,
-		&vm.bootstrapped,
 	)
 	if err != nil {
 		return err
@@ -304,17 +303,21 @@ func (vm *VM) onNormalOperationsStarted() error {
 	}
 
 	primaryVdrIDs := vm.Validators.GetValidatorIDs(constants.PrimaryNetworkID)
-
 	if err := vm.uptimeManager.StartTracking(primaryVdrIDs, constants.PrimaryNetworkID); err != nil {
 		return err
 	}
 
+	vl := validators.NewLogger(vm.ctx.Log, constants.PrimaryNetworkID, vm.ctx.NodeID)
+	vm.Validators.RegisterCallbackListener(constants.PrimaryNetworkID, vl)
+
 	for subnetID := range vm.TrackedSubnets {
 		vdrIDs := vm.Validators.GetValidatorIDs(subnetID)
-
 		if err := vm.uptimeManager.StartTracking(vdrIDs, subnetID); err != nil {
 			return err
 		}
+
+		vl := validators.NewLogger(vm.ctx.Log, subnetID, vm.ctx.NodeID)
+		vm.Validators.RegisterCallbackListener(subnetID, vl)
 	}
 
 	if err := vm.state.Commit(); err != nil {

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -1397,9 +1397,6 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 	require.NoError(createSubnetBlock.Accept(context.Background()))
 	require.NoError(vm.SetPreference(context.Background(), vm.manager.LastAccepted()))
 
-	vm.TrackedSubnets.Add(createSubnetTx.ID())
-	require.NoError(vm.state.ApplyCurrentValidators(createSubnetTx.ID(), vm.Validators))
-
 	addSubnetValidatorTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
 		defaultMaxValidatorStake,
 		uint64(validatorStartTime.Unix()),

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
@@ -659,7 +658,6 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 		vm.ctx,
 		metrics.Noop,
 		reward.NewCalculator(vm.Config.RewardConfig),
-		&utils.Atomic[bool]{},
 	)
 	require.NoError(err)
 
@@ -968,7 +966,6 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 		vm.ctx,
 		metrics.Noop,
 		reward.NewCalculator(vm.Config.RewardConfig),
-		&utils.Atomic[bool]{},
 	)
 	require.NoError(err)
 


### PR DESCRIPTION
## Why this should be merged

This improves the performance of warp and unblocks subnet specific logic in the networking layer.

## How this works

Modified the P-chain state to keep all subnets in the validator manager. This is not a significant increase in memory pressure because we already pin validators + delegators in memory on the P-chain.

## How this was tested

1. Locally verified that non-tracked subnets are now sample-able over the P-chain API (used WAGMI).
2. Updated the unit tests
3. CI