### PR TITLE
Cleanup `ipcs` `Socket` test

### DIFF
--- a/ipcs/socket/socket_test.go
+++ b/ipcs/socket/socket_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +22,7 @@ func TestSocketSendAndReceive(t *testing.T) {
 	)
 
 	// Create socket and client; wait for client to connect
-	socket := NewSocket(socketName, nil)
+	socket := NewSocket(socketName, logging.NoLog{})
 	socket.accept, connCh = newTestAcceptFn(t)
 	require.NoError(socket.Listen())
 

--- a/ipcs/socket/socket_test.go
+++ b/ipcs/socket/socket_test.go
@@ -7,8 +7,9 @@ import (
 	"net"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
 func TestSocketSendAndReceive(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

Fixes a possible nil pointer panic.

## How this works

nil --> no-op log

## How this was tested

Run test