### PR TITLE
Switch to using require.TestingT interface in SenderTest struct

### DIFF
--- a/snow/engine/common/test_sender.go
+++ b/snow/engine/common/test_sender.go
@@ -6,7 +6,6 @@ package common
 import (
 	"context"
 	"errors"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +26,7 @@ var (
 
 // SenderTest is a test sender
 type SenderTest struct {
-	T *testing.T
+	T require.TestingT
 
 	CantAccept,
 	CantSendGetStateSummaryFrontier, CantSendStateSummaryFrontier,


### PR DESCRIPTION
This change is effectively a no-op for avalanchego but supports a coreth testing starting with https://github.com/ava-labs/coreth/pull/377

`require.TestingT` is the minimal subset of the `testing.T` struct used to instantiate `require.Assertions` instances. Switching `SenderTest` to use a minimal interface supports an effort to extend coreth integration testing to use ginkgo to execute against both minimal vm fixture and full-blown networks. Ginkgo's `TestingT` type is compatible with the `require.TestingT` interface but not the `testing.T` struct.

