### PR TITLE
Require poll metrics to be registered

### DIFF
--- a/snow/consensus/snowman/poll/set.go
+++ b/snow/consensus/snowman/poll/set.go
@@ -4,6 +4,7 @@
 package poll
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -17,6 +18,11 @@ import (
 	"github.com/ava-labs/avalanchego/utils/linkedhashmap"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/metric"
+)
+
+var (
+	errFailedPollsMetric         = errors.New("failed to register polls metric")
+	errFailedPollDurationMetrics = errors.New("failed to register poll_duration metrics")
 )
 
 type pollHolder interface {
@@ -52,16 +58,14 @@ func NewSet(
 	log logging.Logger,
 	namespace string,
 	reg prometheus.Registerer,
-) Set {
+) (Set, error) {
 	numPolls := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "polls",
 		Help:      "Number of pending network polls",
 	})
 	if err := reg.Register(numPolls); err != nil {
-		log.Error("failed to register polls statistics",
-			zap.Error(err),
-		)
+		return nil, fmt.Errorf("%w: %w", errFailedPollsMetric, err)
 	}
 
 	durPolls, err := metric.NewAverager(
@@ -71,9 +75,7 @@ func NewSet(
 		reg,
 	)
 	if err != nil {
-		log.Error("failed to register poll_duration statistics",
-			zap.Error(err),
-		)
+		return nil, fmt.Errorf("%w: %w", errFailedPollDurationMetrics, err)
 	}
 
 	return &set{
@@ -82,7 +84,7 @@ func NewSet(
 		durPolls: durPolls,
 		factory:  factory,
 		polls:    linkedhashmap.New[uint32, pollHolder](),
-	}
+	}, nil
 }
 
 // Add to the current set of polls

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -116,6 +116,16 @@ func newTransitive(config Config) (*Transitive, error) {
 		config.Params.AlphaPreference,
 		config.Params.AlphaConfidence,
 	)
+	polls, err := poll.NewSet(
+		factory,
+		config.Ctx.Log,
+		"",
+		config.Ctx.Registerer,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	t := &Transitive{
 		Config:                      config,
 		StateSummaryFrontierHandler: common.NewNoOpStateSummaryFrontierHandler(config.Ctx.Log),
@@ -129,12 +139,7 @@ func newTransitive(config Config) (*Transitive, error) {
 		nonVerifieds:                ancestor.NewTree(),
 		nonVerifiedCache:            nonVerifiedCache,
 		acceptedFrontiers:           acceptedFrontiers,
-		polls: poll.NewSet(
-			factory,
-			config.Ctx.Log,
-			"",
-			config.Ctx.Registerer,
-		),
+		polls:                       polls,
 	}
 
 	return t, t.metrics.Initialize("", config.Ctx.Registerer)


### PR DESCRIPTION
## Why this should be merged

The code isn't how we handle metrics in other parts of the code. This aligns the behavior and makes the code more obviously correct.

## How this works

Rather than logging an `Error` and managing un-registered metrics, creating the poll set should now just error.

## How this was tested

Added unit tests + CI