### PR TITLE
Add read-only database flag (`--db-read-only`) 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -928,7 +928,8 @@ func getDatabaseConfig(v *viper.Viper, networkID uint32) (node.DatabaseConfig, e
 	}
 
 	return node.DatabaseConfig{
-		Name: v.GetString(DBTypeKey),
+		ReadOnly: v.GetBool(DBReadOnlyKey),
+		Name:     v.GetString(DBTypeKey),
 		Path: filepath.Join(
 			GetExpandedArg(v, DBPathKey),
 			constants.NetworkName(networkID),

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/server"
 	"github.com/ava-labs/avalanchego/chains"
+	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/ipcs"
@@ -927,9 +928,18 @@ func getDatabaseConfig(v *viper.Viper, networkID uint32) (node.DatabaseConfig, e
 		}
 	}
 
+	var (
+		dbName   = v.GetString(DBTypeKey)
+		readOnly = v.GetBool(DBReadOnlyKey)
+	)
+
+	if readOnly && dbName == memdb.Name {
+		return node.DatabaseConfig{}, fmt.Errorf("database type %s cannot be read only", dbName)
+	}
+
 	return node.DatabaseConfig{
-		ReadOnly: v.GetBool(DBReadOnlyKey),
-		Name:     v.GetString(DBTypeKey),
+		ReadOnly: readOnly,
+		Name:     dbName,
 		Path: filepath.Join(
 			GetExpandedArg(v, DBPathKey),
 			constants.NetworkName(networkID),

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/server"
 	"github.com/ava-labs/avalanchego/chains"
-	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/ipcs"
@@ -928,18 +927,9 @@ func getDatabaseConfig(v *viper.Viper, networkID uint32) (node.DatabaseConfig, e
 		}
 	}
 
-	var (
-		dbName   = v.GetString(DBTypeKey)
-		readOnly = v.GetBool(DBReadOnlyKey)
-	)
-
-	if readOnly && dbName == memdb.Name {
-		return node.DatabaseConfig{}, fmt.Errorf("database type %s cannot be read only", dbName)
-	}
-
 	return node.DatabaseConfig{
-		ReadOnly: readOnly,
-		Name:     dbName,
+		ReadOnly: v.GetBool(DBReadOnlyKey),
+		Name:     v.GetString(DBTypeKey),
 		Path: filepath.Join(
 			GetExpandedArg(v, DBPathKey),
 			constants.NetworkName(networkID),

--- a/config/config.go
+++ b/config/config.go
@@ -928,8 +928,8 @@ func getDatabaseConfig(v *viper.Viper, networkID uint32) (node.DatabaseConfig, e
 	}
 
 	return node.DatabaseConfig{
-		ReadOnly: v.GetBool(DBReadOnlyKey),
 		Name:     v.GetString(DBTypeKey),
+		ReadOnly: v.GetBool(DBReadOnlyKey),
 		Path: filepath.Join(
 			GetExpandedArg(v, DBPathKey),
 			constants.NetworkName(networkID),

--- a/config/flags.go
+++ b/config/flags.go
@@ -105,6 +105,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 
 	// Database
 	fs.String(DBTypeKey, leveldb.Name, fmt.Sprintf("Database type to use. Must be one of {%s, %s, %s}", leveldb.Name, memdb.Name, pebble.Name))
+	fs.Bool(DBReadOnlyKey, false, "If true, database writes are to memory and never persisted")
 	fs.String(DBPathKey, defaultDBDir, "Path to database directory")
 	fs.String(DBConfigFileKey, "", fmt.Sprintf("Path to database config file. Ignored if %s is specified", DBConfigContentKey))
 	fs.String(DBConfigContentKey, "", "Specifies base64 encoded database config content")

--- a/config/flags.go
+++ b/config/flags.go
@@ -105,7 +105,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 
 	// Database
 	fs.String(DBTypeKey, leveldb.Name, fmt.Sprintf("Database type to use. Must be one of {%s, %s, %s}", leveldb.Name, memdb.Name, pebble.Name))
-	fs.Bool(DBReadOnlyKey, false, "If true, database writes are to memory and never persisted")
+	fs.Bool(DBReadOnlyKey, false, "If true, database writes are to memory and never persisted. May still initialize database directory/files on disk if they don't exist")
 	fs.String(DBPathKey, defaultDBDir, "Path to database directory")
 	fs.String(DBConfigFileKey, "", fmt.Sprintf("Path to database config file. Ignored if %s is specified", DBConfigContentKey))
 	fs.String(DBConfigContentKey, "", "Specifies base64 encoded database config content")

--- a/config/keys.go
+++ b/config/keys.go
@@ -34,6 +34,7 @@ const (
 	StakeMintingPeriodKey                              = "stake-minting-period"
 	StakeSupplyCapKey                                  = "stake-supply-cap"
 	DBTypeKey                                          = "db-type"
+	DBReadOnlyKey                                      = "db-read-only"
 	DBPathKey                                          = "db-dir"
 	DBConfigFileKey                                    = "db-config-file"
 	DBConfigContentKey                                 = "db-config-file-content"

--- a/node/config.go
+++ b/node/config.go
@@ -131,6 +131,9 @@ type BootstrapConfig struct {
 }
 
 type DatabaseConfig struct {
+	// If true, all writes are to memory and are discarded at node shutdown.
+	ReadOnly bool `json:"readOnly"`
+
 	// Path to database
 	Path string `json:"path"`
 

--- a/node/node.go
+++ b/node/node.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ava-labs/avalanchego/database/meterdb"
 	"github.com/ava-labs/avalanchego/database/pebble"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/indexer"
@@ -529,6 +530,10 @@ func (n *Node) initDatabase() error {
 			memdb.Name,
 			pebble.Name,
 		)
+	}
+
+	if n.Config.ReadOnly && n.Config.DatabaseConfig.Name != memdb.Name {
+		n.DB = versiondb.New(n.DB)
 	}
 
 	var err error


### PR DESCRIPTION
## Why this should be merged

Resolves #1395

## How this works

* Adds flag `--db-read-only`.
* If true, wraps node database in versiondb and never writes it. i.e. writes are never persisted to disk.

## How this was tested

* Start node with empty database and `--db-read-only`.
* Bootstrap Fuji P-Chain
* Shut off node
* Start node
* Observe that bootstrapping starts from beginning