### PR TITLE
`merkledb` -- fix nil check in test

### DIFF
--- a/x/merkledb/trie_test.go
+++ b/x/merkledb/trie_test.go
@@ -43,7 +43,7 @@ func getNodeValue(t ReadOnlyTrie, key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if result.key != path || result == nil {
+	if result == nil || result.key != path {
 		return nil, database.ErrNotFound
 	}
 


### PR DESCRIPTION
## Why this should be merged

The order of these checks is wrong. Pulled out of https://github.com/ava-labs/avalanchego/pull/2177.

## How this works

Swap evaluation order.

## How this was tested

N/A.