### PR TITLE
Return if element was deleted from `Hashmap`

### DIFF
--- a/utils/linkedhashmap/linkedhashmap.go
+++ b/utils/linkedhashmap/linkedhashmap.go
@@ -17,7 +17,7 @@ var _ LinkedHashmap[int, struct{}] = (*linkedHashmap[int, struct{}])(nil)
 type Hashmap[K, V any] interface {
 	Put(key K, val V)
 	Get(key K) (val V, exists bool)
-	Delete(key K)
+	Delete(key K) (deleted bool)
 	Len() int
 }
 
@@ -63,11 +63,11 @@ func (lh *linkedHashmap[K, V]) Get(key K) (V, bool) {
 	return lh.get(key)
 }
 
-func (lh *linkedHashmap[K, V]) Delete(key K) {
+func (lh *linkedHashmap[K, V]) Delete(key K) bool {
 	lh.lock.Lock()
 	defer lh.lock.Unlock()
 
-	lh.delete(key)
+	return lh.delete(key)
 }
 
 func (lh *linkedHashmap[K, V]) Len() int {
@@ -114,11 +114,13 @@ func (lh *linkedHashmap[K, V]) get(key K) (V, bool) {
 	return utils.Zero[V](), false
 }
 
-func (lh *linkedHashmap[K, V]) delete(key K) {
-	if e, ok := lh.entryMap[key]; ok {
+func (lh *linkedHashmap[K, V]) delete(key K) bool {
+	e, ok := lh.entryMap[key]
+	if ok {
 		lh.entryList.Remove(e)
 		delete(lh.entryMap, key)
 	}
+	return ok
 }
 
 func (lh *linkedHashmap[K, V]) len() int {

--- a/utils/linkedhashmap/linkedhashmap_test.go
+++ b/utils/linkedhashmap/linkedhashmap_test.go
@@ -62,7 +62,7 @@ func TestLinkedHashmap(t *testing.T) {
 	require.Equal(key1, rkey1, "wrong key")
 	require.Equal(1, val1, "wrong value")
 
-	lh.Delete(key0)
+	require.True(lh.Delete(key0))
 	require.Equal(1, lh.Len(), "wrong hashmap length")
 
 	_, exists = lh.Get(key0)
@@ -132,7 +132,7 @@ func TestIterator(t *testing.T) {
 		// Should be empty
 		require.False(iter.Next())
 		// Delete id1
-		lh.Delete(id1)
+		require.True(lh.Delete(id1))
 		iter = lh.NewIterator()
 		require.NotNil(iter)
 		// Should immediately be exhausted
@@ -169,8 +169,8 @@ func TestIterator(t *testing.T) {
 		iter := lh.NewIterator()
 		require.True(iter.Next())
 		require.True(iter.Next())
-		lh.Delete(id1)
-		lh.Delete(id2)
+		require.True(lh.Delete(id1))
+		require.True(lh.Delete(id2))
 		require.True(iter.Next())
 		require.Equal(id3, iter.Key())
 		require.Equal(3, iter.Value())

--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -168,16 +168,17 @@ func (m *mempool) Get(txID ids.ID) *txs.Tx {
 func (m *mempool) Remove(txsToRemove []*txs.Tx) {
 	for _, tx := range txsToRemove {
 		txID := tx.ID()
-		if m.unissuedTxs.Delete(txID) {
-			txBytes := tx.Bytes()
-			m.bytesAvailable += len(txBytes)
-			m.bytesAvailableMetric.Set(float64(m.bytesAvailable))
-
-			m.numTxs.Dec()
-
-			inputs := tx.Unsigned.InputIDs()
-			m.consumedUTXOs.Difference(inputs)
+		if !m.unissuedTxs.Delete(txID) {
+			continue
 		}
+
+		m.bytesAvailable += len(tx.Bytes())
+		m.bytesAvailableMetric.Set(float64(m.bytesAvailable))
+
+		m.numTxs.Dec()
+
+		inputs := tx.Unsigned.InputIDs()
+		m.consumedUTXOs.Difference(inputs)
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

Removes one `Get` call from avm mempool deletion.

## How this works

pretty straightforward

## How this was tested

CI