### PR TITLE
`mempool.NewMempool` -> `mempool.New`

### DIFF
--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -157,7 +157,7 @@ func newEnvironment(t *testing.T) *environment {
 	metrics, err := metrics.New("", registerer)
 	require.NoError(err)
 
-	res.mempool, err = mempool.NewMempool("mempool", registerer, res)
+	res.mempool, err = mempool.New("mempool", registerer, res)
 	require.NoError(err)
 
 	res.blkManager = blockexecutor.NewManager(

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -189,7 +189,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller) *environment {
 	metrics := metrics.Noop
 
 	var err error
-	res.mempool, err = mempool.NewMempool("mempool", registerer, res)
+	res.mempool, err = mempool.New("mempool", registerer, res)
 	if err != nil {
 		panic(fmt.Errorf("failed to create mempool: %w", err))
 	}

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -97,7 +97,7 @@ type mempool struct {
 	blkTimer BlockTimer
 }
 
-func NewMempool(
+func New(
 	namespace string,
 	registerer prometheus.Registerer,
 	blkTimer BlockTimer,

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -34,7 +34,7 @@ func TestBlockBuilderMaxMempoolSizeHandling(t *testing.T) {
 	require := require.New(t)
 
 	registerer := prometheus.NewRegistry()
-	mpool, err := NewMempool("mempool", registerer, &noopBlkTimer{})
+	mpool, err := New("mempool", registerer, &noopBlkTimer{})
 	require.NoError(err)
 
 	decisionTxs, err := createTestDecisionTxs(1)
@@ -58,7 +58,7 @@ func TestDecisionTxsInMempool(t *testing.T) {
 	require := require.New(t)
 
 	registerer := prometheus.NewRegistry()
-	mpool, err := NewMempool("mempool", registerer, &noopBlkTimer{})
+	mpool, err := New("mempool", registerer, &noopBlkTimer{})
 	require.NoError(err)
 
 	decisionTxs, err := createTestDecisionTxs(2)
@@ -110,7 +110,7 @@ func TestProposalTxsInMempool(t *testing.T) {
 	require := require.New(t)
 
 	registerer := prometheus.NewRegistry()
-	mpool, err := NewMempool("mempool", registerer, &noopBlkTimer{})
+	mpool, err := New("mempool", registerer, &noopBlkTimer{})
 	require.NoError(err)
 
 	// The proposal txs are ordered by decreasing start time. This means after

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -177,7 +177,7 @@ func (vm *VM) Initialize(
 
 	// Note: There is a circular dependency between the mempool and block
 	//       builder which is broken by passing in the vm.
-	mempool, err := mempool.NewMempool("mempool", registerer, vm)
+	mempool, err := mempool.New("mempool", registerer, vm)
 	if err != nil {
 		return fmt.Errorf("failed to create mempool: %w", err)
 	}


### PR DESCRIPTION
## Why this should be merged

Removes stutter from `mempool.NewMempool`

## How this works

Renames it to `mempool.New`

## How this was tested

CI