### PR TITLE
Genesis validators cleanup

### DIFF
--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -418,8 +418,8 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 		delegationFee := json.Uint32(staker.DelegationFee)
 
 		platformvmArgs.Validators = append(platformvmArgs.Validators,
-			api.PermissionlessValidator{
-				Staker: api.Staker{
+			api.GenesisPermissionlessValidator{
+				GenesisStaker: api.GenesisStaker{
 					StartTime: json.Uint64(genesisTime.Unix()),
 					EndTime:   json.Uint64(endStakingTime.Unix()),
 					NodeID:    staker.NodeID,

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -419,7 +419,7 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 
 		platformvmArgs.Validators = append(platformvmArgs.Validators,
 			api.GenesisPermissionlessValidator{
-				GenesisStaker: api.GenesisStaker{
+				GenesisValidator: api.GenesisValidator{
 					StartTime: json.Uint64(genesisTime.Unix()),
 					EndTime:   json.Uint64(endStakingTime.Unix()),
 					NodeID:    staker.NodeID,

--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -141,13 +141,13 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 			}
 		}
 
-		genesisValidators := make([]api.PermissionlessValidator, len(keys))
+		genesisValidators := make([]api.GenesisPermissionlessValidator, len(keys))
 		for i, key := range keys {
 			id := key.PublicKey().Address()
 			addr, err := address.FormatBech32(hrp, id.Bytes())
 			require.NoError(err)
-			genesisValidators[i] = api.PermissionlessValidator{
-				Staker: api.Staker{
+			genesisValidators[i] = api.GenesisPermissionlessValidator{
+				GenesisStaker: api.GenesisStaker{
 					StartTime: json.Uint64(time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
 					EndTime:   json.Uint64(time.Date(1997, 1, 30, 0, 0, 0, 0, time.UTC).Unix()),
 					NodeID:    ids.NodeID(id),

--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 			addr, err := address.FormatBech32(hrp, id.Bytes())
 			require.NoError(err)
 			genesisValidators[i] = api.GenesisPermissionlessValidator{
-				GenesisStaker: api.GenesisStaker{
+				GenesisValidator: api.GenesisValidator{
 					StartTime: json.Uint64(time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
 					EndTime:   json.Uint64(time.Date(1997, 1, 30, 0, 0, 0, 0, time.UTC).Unix()),
 					NodeID:    ids.NodeID(id),

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -98,9 +98,8 @@ type Staker struct {
 	StakeAmount *json.Uint64 `json:"stakeAmount,omitempty"`
 }
 
-// GenesisStaker is structurally identical to Staker. For the time being it is
-// a placeholder type to be used for genesis validators only.
-type GenesisStaker = Staker
+// GenesisValidator should to be used for genesis validators only.
+type GenesisValidator = Staker
 
 // Owner is the repr. of a reward owner sent over APIs.
 type Owner struct {
@@ -136,8 +135,9 @@ type PermissionlessValidator struct {
 	Delegators      *[]PrimaryDelegator `json:"delegators,omitempty"`
 }
 
+// GenesisPermissionlessValidator should to be used for genesis validators only.
 type GenesisPermissionlessValidator struct {
-	GenesisStaker
+	GenesisValidator
 	RewardOwner        *Owner       `json:"rewardOwner,omitempty"`
 	DelegationFee      json.Float32 `json:"delegationFee"`
 	ExactDelegationFee *json.Uint32 `json:"exactDelegationFee,omitempty"`

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -98,6 +98,10 @@ type Staker struct {
 	StakeAmount *json.Uint64 `json:"stakeAmount,omitempty"`
 }
 
+// GenesisStaker is structurally identical to Staker. For the time being it is
+// a placeholder type to be used for genesis validators only.
+type GenesisStaker = Staker
+
 // Owner is the repr. of a reward owner sent over APIs.
 type Owner struct {
 	Locktime  json.Uint64 `json:"locktime"`
@@ -130,6 +134,14 @@ type PermissionlessValidator struct {
 	DelegatorCount  *json.Uint64        `json:"delegatorCount,omitempty"`
 	DelegatorWeight *json.Uint64        `json:"delegatorWeight,omitempty"`
 	Delegators      *[]PrimaryDelegator `json:"delegators,omitempty"`
+}
+
+type GenesisPermissionlessValidator struct {
+	GenesisStaker
+	RewardOwner        *Owner       `json:"rewardOwner,omitempty"`
+	DelegationFee      json.Float32 `json:"delegationFee"`
+	ExactDelegationFee *json.Uint32 `json:"exactDelegationFee,omitempty"`
+	Staked             []UTXO       `json:"staked,omitempty"`
 }
 
 // PermissionedValidator is the repr. of a permissioned validator sent over APIs.
@@ -170,15 +182,15 @@ type Chain struct {
 // [Chains] are the chains that exist at genesis.
 // [Time] is the Platform Chain's time at network genesis.
 type BuildGenesisArgs struct {
-	AvaxAssetID   ids.ID                    `json:"avaxAssetID"`
-	NetworkID     json.Uint32               `json:"networkID"`
-	UTXOs         []UTXO                    `json:"utxos"`
-	Validators    []PermissionlessValidator `json:"validators"`
-	Chains        []Chain                   `json:"chains"`
-	Time          json.Uint64               `json:"time"`
-	InitialSupply json.Uint64               `json:"initialSupply"`
-	Message       string                    `json:"message"`
-	Encoding      formatting.Encoding       `json:"encoding"`
+	AvaxAssetID   ids.ID                           `json:"avaxAssetID"`
+	NetworkID     json.Uint32                      `json:"networkID"`
+	UTXOs         []UTXO                           `json:"utxos"`
+	Validators    []GenesisPermissionlessValidator `json:"validators"`
+	Chains        []Chain                          `json:"chains"`
+	Time          json.Uint64                      `json:"time"`
+	InitialSupply json.Uint64                      `json:"initialSupply"`
+	Message       string                           `json:"message"`
+	Encoding      formatting.Encoding              `json:"encoding"`
 }
 
 // BuildGenesisReply is the reply from BuildGenesis

--- a/vms/platformvm/api/static_service_test.go
+++ b/vms/platformvm/api/static_service_test.go
@@ -27,8 +27,8 @@ func TestBuildGenesisInvalidUTXOBalance(t *testing.T) {
 		Amount:  0,
 	}
 	weight := json.Uint64(987654321)
-	validator := PermissionlessValidator{
-		Staker: Staker{
+	validator := GenesisPermissionlessValidator{
+		GenesisStaker: GenesisStaker{
 			EndTime: 15,
 			Weight:  weight,
 			NodeID:  nodeID,
@@ -47,7 +47,7 @@ func TestBuildGenesisInvalidUTXOBalance(t *testing.T) {
 		UTXOs: []UTXO{
 			utxo,
 		},
-		Validators: []PermissionlessValidator{
+		Validators: []GenesisPermissionlessValidator{
 			validator,
 		},
 		Time:     5,
@@ -71,8 +71,8 @@ func TestBuildGenesisInvalidStakeWeight(t *testing.T) {
 		Amount:  123456789,
 	}
 	weight := json.Uint64(0)
-	validator := PermissionlessValidator{
-		Staker: Staker{
+	validator := GenesisPermissionlessValidator{
+		GenesisStaker: GenesisStaker{
 			StartTime: 0,
 			EndTime:   15,
 			NodeID:    nodeID,
@@ -91,7 +91,7 @@ func TestBuildGenesisInvalidStakeWeight(t *testing.T) {
 		UTXOs: []UTXO{
 			utxo,
 		},
-		Validators: []PermissionlessValidator{
+		Validators: []GenesisPermissionlessValidator{
 			validator,
 		},
 		Time:     5,
@@ -116,8 +116,8 @@ func TestBuildGenesisInvalidEndtime(t *testing.T) {
 	}
 
 	weight := json.Uint64(987654321)
-	validator := PermissionlessValidator{
-		Staker: Staker{
+	validator := GenesisPermissionlessValidator{
+		GenesisStaker: GenesisStaker{
 			StartTime: 0,
 			EndTime:   5,
 			NodeID:    nodeID,
@@ -136,7 +136,7 @@ func TestBuildGenesisInvalidEndtime(t *testing.T) {
 		UTXOs: []UTXO{
 			utxo,
 		},
-		Validators: []PermissionlessValidator{
+		Validators: []GenesisPermissionlessValidator{
 			validator,
 		},
 		Time:     5,
@@ -161,8 +161,8 @@ func TestBuildGenesisReturnsSortedValidators(t *testing.T) {
 	}
 
 	weight := json.Uint64(987654321)
-	validator1 := PermissionlessValidator{
-		Staker: Staker{
+	validator1 := GenesisPermissionlessValidator{
+		GenesisStaker: GenesisStaker{
 			StartTime: 0,
 			EndTime:   20,
 			NodeID:    nodeID,
@@ -177,8 +177,8 @@ func TestBuildGenesisReturnsSortedValidators(t *testing.T) {
 		}},
 	}
 
-	validator2 := PermissionlessValidator{
-		Staker: Staker{
+	validator2 := GenesisPermissionlessValidator{
+		GenesisStaker: GenesisStaker{
 			StartTime: 3,
 			EndTime:   15,
 			NodeID:    nodeID,
@@ -193,8 +193,8 @@ func TestBuildGenesisReturnsSortedValidators(t *testing.T) {
 		}},
 	}
 
-	validator3 := PermissionlessValidator{
-		Staker: Staker{
+	validator3 := GenesisPermissionlessValidator{
+		GenesisStaker: GenesisStaker{
 			StartTime: 1,
 			EndTime:   10,
 			NodeID:    nodeID,
@@ -214,7 +214,7 @@ func TestBuildGenesisReturnsSortedValidators(t *testing.T) {
 		UTXOs: []UTXO{
 			utxo,
 		},
-		Validators: []PermissionlessValidator{
+		Validators: []GenesisPermissionlessValidator{
 			validator1,
 			validator2,
 			validator3,

--- a/vms/platformvm/api/static_service_test.go
+++ b/vms/platformvm/api/static_service_test.go
@@ -28,7 +28,7 @@ func TestBuildGenesisInvalidUTXOBalance(t *testing.T) {
 	}
 	weight := json.Uint64(987654321)
 	validator := GenesisPermissionlessValidator{
-		GenesisStaker: GenesisStaker{
+		GenesisValidator: GenesisValidator{
 			EndTime: 15,
 			Weight:  weight,
 			NodeID:  nodeID,
@@ -72,7 +72,7 @@ func TestBuildGenesisInvalidStakeWeight(t *testing.T) {
 	}
 	weight := json.Uint64(0)
 	validator := GenesisPermissionlessValidator{
-		GenesisStaker: GenesisStaker{
+		GenesisValidator: GenesisValidator{
 			StartTime: 0,
 			EndTime:   15,
 			NodeID:    nodeID,
@@ -117,7 +117,7 @@ func TestBuildGenesisInvalidEndtime(t *testing.T) {
 
 	weight := json.Uint64(987654321)
 	validator := GenesisPermissionlessValidator{
-		GenesisStaker: GenesisStaker{
+		GenesisValidator: GenesisValidator{
 			StartTime: 0,
 			EndTime:   5,
 			NodeID:    nodeID,
@@ -162,7 +162,7 @@ func TestBuildGenesisReturnsSortedValidators(t *testing.T) {
 
 	weight := json.Uint64(987654321)
 	validator1 := GenesisPermissionlessValidator{
-		GenesisStaker: GenesisStaker{
+		GenesisValidator: GenesisValidator{
 			StartTime: 0,
 			EndTime:   20,
 			NodeID:    nodeID,
@@ -178,7 +178,7 @@ func TestBuildGenesisReturnsSortedValidators(t *testing.T) {
 	}
 
 	validator2 := GenesisPermissionlessValidator{
-		GenesisStaker: GenesisStaker{
+		GenesisValidator: GenesisValidator{
 			StartTime: 3,
 			EndTime:   15,
 			NodeID:    nodeID,
@@ -194,7 +194,7 @@ func TestBuildGenesisReturnsSortedValidators(t *testing.T) {
 	}
 
 	validator3 := GenesisPermissionlessValidator{
-		GenesisStaker: GenesisStaker{
+		GenesisValidator: GenesisValidator{
 			StartTime: 1,
 			EndTime:   10,
 			NodeID:    nodeID,

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -357,13 +357,13 @@ func buildGenesisTest(t *testing.T, ctx *snow.Context) []byte {
 		}
 	}
 
-	genesisValidators := make([]api.PermissionlessValidator, len(preFundedKeys))
+	genesisValidators := make([]api.GenesisPermissionlessValidator, len(preFundedKeys))
 	for i, key := range preFundedKeys {
 		nodeID := ids.NodeID(key.PublicKey().Address())
 		addr, err := address.FormatBech32(constants.UnitTestHRP, nodeID.Bytes())
 		require.NoError(err)
-		genesisValidators[i] = api.PermissionlessValidator{
-			Staker: api.Staker{
+		genesisValidators[i] = api.GenesisPermissionlessValidator{
+			GenesisStaker: api.GenesisStaker{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -363,7 +363,7 @@ func buildGenesisTest(t *testing.T, ctx *snow.Context) []byte {
 		addr, err := address.FormatBech32(constants.UnitTestHRP, nodeID.Bytes())
 		require.NoError(err)
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
-			GenesisStaker: api.GenesisStaker{
+			GenesisValidator: api.GenesisValidator{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -399,15 +399,15 @@ func buildGenesisTest(ctx *snow.Context) []byte {
 		}
 	}
 
-	genesisValidators := make([]api.PermissionlessValidator, len(preFundedKeys))
+	genesisValidators := make([]api.GenesisPermissionlessValidator, len(preFundedKeys))
 	for i, key := range preFundedKeys {
 		nodeID := ids.NodeID(key.PublicKey().Address())
 		addr, err := address.FormatBech32(constants.UnitTestHRP, nodeID.Bytes())
 		if err != nil {
 			panic(err)
 		}
-		genesisValidators[i] = api.PermissionlessValidator{
-			Staker: api.Staker{
+		genesisValidators[i] = api.GenesisPermissionlessValidator{
+			GenesisStaker: api.GenesisStaker{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -407,7 +407,7 @@ func buildGenesisTest(ctx *snow.Context) []byte {
 			panic(err)
 		}
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
-			GenesisStaker: api.GenesisStaker{
+			GenesisValidator: api.GenesisValidator{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -374,7 +374,7 @@ func buildGenesisTest(ctx *snow.Context) []byte {
 			panic(err)
 		}
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
-			GenesisStaker: api.GenesisStaker{
+			GenesisValidator: api.GenesisValidator{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -366,15 +366,15 @@ func buildGenesisTest(ctx *snow.Context) []byte {
 		}
 	}
 
-	genesisValidators := make([]api.PermissionlessValidator, len(preFundedKeys))
+	genesisValidators := make([]api.GenesisPermissionlessValidator, len(preFundedKeys))
 	for i, key := range preFundedKeys {
 		nodeID := ids.NodeID(key.PublicKey().Address())
 		addr, err := address.FormatBech32(constants.UnitTestHRP, nodeID.Bytes())
 		if err != nil {
 			panic(err)
 		}
-		genesisValidators[i] = api.PermissionlessValidator{
-			Staker: api.Staker{
+		genesisValidators[i] = api.GenesisPermissionlessValidator{
+			GenesisStaker: api.GenesisStaker{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -850,7 +850,7 @@ func buildCustomGenesis() ([]byte, error) {
 	starTime := mockable.MaxTime.Add(-1 * defaultMinStakingDuration)
 	endTime := mockable.MaxTime
 	genesisValidator := api.GenesisPermissionlessValidator{
-		GenesisStaker: api.GenesisStaker{
+		GenesisValidator: api.GenesisValidator{
 			StartTime: json.Uint64(starTime.Unix()),
 			EndTime:   json.Uint64(endTime.Unix()),
 			NodeID:    nodeID,

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -849,8 +849,8 @@ func buildCustomGenesis() ([]byte, error) {
 
 	starTime := mockable.MaxTime.Add(-1 * defaultMinStakingDuration)
 	endTime := mockable.MaxTime
-	genesisValidator := api.PermissionlessValidator{
-		Staker: api.Staker{
+	genesisValidator := api.GenesisPermissionlessValidator{
+		GenesisStaker: api.GenesisStaker{
 			StartTime: json.Uint64(starTime.Unix()),
 			EndTime:   json.Uint64(endTime.Unix()),
 			NodeID:    nodeID,
@@ -871,7 +871,7 @@ func buildCustomGenesis() ([]byte, error) {
 		NetworkID:     json.Uint32(constants.UnitTestID),
 		AvaxAssetID:   avaxAssetID,
 		UTXOs:         genesisUTXOs,
-		Validators:    []api.PermissionlessValidator{genesisValidator},
+		Validators:    []api.GenesisPermissionlessValidator{genesisValidator},
 		Chains:        nil,
 		Time:          json.Uint64(defaultGenesisTime.Unix()),
 		InitialSupply: json.Uint64(360 * units.MegaAvax),

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -66,7 +66,7 @@ func BenchmarkGetValidatorSet(b *testing.B) {
 	require.NoError(err)
 
 	genesisValidators := []api.GenesisPermissionlessValidator{{
-		GenesisStaker: api.GenesisStaker{
+		GenesisValidator: api.GenesisValidator{
 			StartTime: json.Uint64(genesisTime.Unix()),
 			EndTime:   json.Uint64(genesisEndTime.Unix()),
 			NodeID:    ids.GenerateTestNodeID(),

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -65,8 +65,8 @@ func BenchmarkGetValidatorSet(b *testing.B) {
 	addr, err := address.FormatBech32(constants.UnitTestHRP, ids.GenerateTestShortID().Bytes())
 	require.NoError(err)
 
-	genesisValidators := []api.PermissionlessValidator{{
-		Staker: api.Staker{
+	genesisValidators := []api.GenesisPermissionlessValidator{{
+		GenesisStaker: api.GenesisStaker{
 			StartTime: json.Uint64(genesisTime.Unix()),
 			EndTime:   json.Uint64(genesisEndTime.Unix()),
 			NodeID:    ids.GenerateTestNodeID(),

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -175,13 +175,13 @@ func defaultGenesis(t *testing.T) (*api.BuildGenesisArgs, []byte) {
 		}
 	}
 
-	genesisValidators := make([]api.PermissionlessValidator, len(keys))
+	genesisValidators := make([]api.GenesisPermissionlessValidator, len(keys))
 	for i, key := range keys {
 		nodeID := ids.NodeID(key.PublicKey().Address())
 		addr, err := address.FormatBech32(constants.UnitTestHRP, nodeID.Bytes())
 		require.NoError(err)
-		genesisValidators[i] = api.PermissionlessValidator{
-			Staker: api.Staker{
+		genesisValidators[i] = api.GenesisPermissionlessValidator{
+			GenesisStaker: api.GenesisStaker{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,
@@ -243,14 +243,14 @@ func BuildGenesisTestWithArgs(t *testing.T, args *api.BuildGenesisArgs) (*api.Bu
 		}
 	}
 
-	genesisValidators := make([]api.PermissionlessValidator, len(keys))
+	genesisValidators := make([]api.GenesisPermissionlessValidator, len(keys))
 	for i, key := range keys {
 		nodeID := ids.NodeID(key.PublicKey().Address())
 		addr, err := address.FormatBech32(constants.UnitTestHRP, nodeID.Bytes())
 		require.NoError(err)
 
-		genesisValidators[i] = api.PermissionlessValidator{
-			Staker: api.Staker{
+		genesisValidators[i] = api.GenesisPermissionlessValidator{
+			GenesisStaker: api.GenesisStaker{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -181,7 +181,7 @@ func defaultGenesis(t *testing.T) (*api.BuildGenesisArgs, []byte) {
 		addr, err := address.FormatBech32(constants.UnitTestHRP, nodeID.Bytes())
 		require.NoError(err)
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
-			GenesisStaker: api.GenesisStaker{
+			GenesisValidator: api.GenesisValidator{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,
@@ -250,7 +250,7 @@ func BuildGenesisTestWithArgs(t *testing.T, args *api.BuildGenesisArgs) (*api.Bu
 		require.NoError(err)
 
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
-			GenesisStaker: api.GenesisStaker{
+			GenesisValidator: api.GenesisValidator{
 				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
 				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,


### PR DESCRIPTION
## Why this should be merged
In preparation for the introduction of variable lenght NodeID (which would unlock [ed25519 keys](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/20-ed25519-p2p.md), this PR improve distinctions among validators and validators included in Genesis.

## How this works
Validators included in Genesis will never change format (this would result in a genesis change). Ordinary validators will change. This PR distinguish these two objects via their type and make easier to figure out which type should be used where.

## How this was tested
CI
