### PR TITLE
Move `AtomicAppHandler` to `snow` pkg

### DIFF
--- a/snow/engine/common/atomic_app_handler.go
+++ b/snow/engine/common/atomic_app_handler.go
@@ -1,36 +1,35 @@
 // Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package network
+package common
 
 import (
 	"context"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils"
 )
 
-var _ Atomic = (*atomic)(nil)
+var _ AtomicAppHandler = (*atomicAppHandler)(nil)
 
-type Atomic interface {
-	common.AppHandler
+type AtomicAppHandler interface {
+	AppHandler
 
-	Set(common.AppHandler)
+	Set(AppHandler)
 }
 
-type atomic struct {
-	handler utils.Atomic[common.AppHandler]
+type atomicAppHandler struct {
+	handler utils.Atomic[AppHandler]
 }
 
-func NewAtomic(h common.AppHandler) Atomic {
-	a := &atomic{}
+func NewAtomicAppHandler(h AppHandler) AtomicAppHandler {
+	a := &atomicAppHandler{}
 	a.handler.Set(h)
 	return a
 }
 
-func (a *atomic) CrossChainAppRequest(
+func (a *atomicAppHandler) CrossChainAppRequest(
 	ctx context.Context,
 	chainID ids.ID,
 	requestID uint32,
@@ -47,7 +46,7 @@ func (a *atomic) CrossChainAppRequest(
 	)
 }
 
-func (a *atomic) CrossChainAppRequestFailed(
+func (a *atomicAppHandler) CrossChainAppRequestFailed(
 	ctx context.Context,
 	chainID ids.ID,
 	requestID uint32,
@@ -60,7 +59,7 @@ func (a *atomic) CrossChainAppRequestFailed(
 	)
 }
 
-func (a *atomic) CrossChainAppResponse(
+func (a *atomicAppHandler) CrossChainAppResponse(
 	ctx context.Context,
 	chainID ids.ID,
 	requestID uint32,
@@ -75,7 +74,7 @@ func (a *atomic) CrossChainAppResponse(
 	)
 }
 
-func (a *atomic) AppRequest(
+func (a *atomicAppHandler) AppRequest(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	requestID uint32,
@@ -92,7 +91,7 @@ func (a *atomic) AppRequest(
 	)
 }
 
-func (a *atomic) AppRequestFailed(
+func (a *atomicAppHandler) AppRequestFailed(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	requestID uint32,
@@ -105,7 +104,7 @@ func (a *atomic) AppRequestFailed(
 	)
 }
 
-func (a *atomic) AppResponse(
+func (a *atomicAppHandler) AppResponse(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	requestID uint32,
@@ -120,7 +119,7 @@ func (a *atomic) AppResponse(
 	)
 }
 
-func (a *atomic) AppGossip(
+func (a *atomicAppHandler) AppGossip(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	msg []byte,
@@ -133,6 +132,6 @@ func (a *atomic) AppGossip(
 	)
 }
 
-func (a *atomic) Set(h common.AppHandler) {
+func (a *atomicAppHandler) Set(h AppHandler) {
 	a.handler.Set(h)
 }

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -65,7 +65,7 @@ var (
 )
 
 type VM struct {
-	network.Atomic
+	common.AtomicAppHandler
 
 	config.Config
 
@@ -152,7 +152,7 @@ func (vm *VM) Initialize(
 	appSender common.AppSender,
 ) error {
 	noopMessageHandler := common.NewNoOpAppHandler(ctx.Log)
-	vm.Atomic = network.NewAtomic(noopMessageHandler)
+	vm.AtomicAppHandler = common.NewAtomicAppHandler(noopMessageHandler)
 
 	avmConfig := Config{}
 	if len(configBytes) > 0 {
@@ -435,7 +435,7 @@ func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- 
 	// Note: It's important only to switch the networking stack after the full
 	// chainVM has been initialized. Traffic will immediately start being
 	// handled asynchronously.
-	vm.Atomic.Set(vm.network)
+	vm.AtomicAppHandler.Set(vm.network)
 
 	go func() {
 		err := vm.state.Prune(&vm.ctx.Lock, vm.ctx.Log)


### PR DESCRIPTION
## Why this should be merged

This isn't an `avm` specific thing. Moving to `snow/engine/common` for easier re-usability.

## How this works

Move + rename

## How this was tested

CI