### PR TITLE
Remove unused `clk` params from `avm`

### DIFF
--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -529,7 +529,6 @@ func TestBlockBuilderAddLocalTx(t *testing.T) {
 	state, err := states.New(baseDB, parser, registerer, trackChecksums)
 	require.NoError(err)
 
-	clk := &mockable.Clock{}
 	onAccept := func(*txs.Tx) error { return nil }
 	now := time.Now()
 	parentTimestamp := now.Add(-2 * time.Second)
@@ -545,11 +544,11 @@ func TestBlockBuilderAddLocalTx(t *testing.T) {
 	metrics, err := metrics.New("", registerer)
 	require.NoError(err)
 
-	manager := blkexecutor.NewManager(mempool, metrics, state, backend, clk, onAccept)
+	manager := blkexecutor.NewManager(mempool, metrics, state, backend, onAccept)
 
 	manager.SetPreference(parentBlk.ID())
 
-	builder := New(backend, manager, clk, mempool)
+	builder := New(backend, manager, &mockable.Clock{}, mempool)
 
 	// show that build block fails if tx is invalid
 	_, err = builder.BuildBlock(context.Background())

--- a/vms/avm/block/executor/manager.go
+++ b/vms/avm/block/executor/manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/avm/block"
 	"github.com/ava-labs/avalanchego/vms/avm/metrics"
 	"github.com/ava-labs/avalanchego/vms/avm/states"
@@ -73,7 +72,6 @@ type manager struct {
 	state   states.State
 	metrics metrics.Metrics
 	mempool mempool.Mempool
-	clk     *mockable.Clock
 	// Invariant: onAccept is called when [tx] is being marked as accepted, but
 	// before its state changes are applied.
 	// Invariant: any error returned by onAccept should be considered fatal.

--- a/vms/avm/block/executor/manager.go
+++ b/vms/avm/block/executor/manager.go
@@ -53,7 +53,6 @@ func NewManager(
 	metrics metrics.Metrics,
 	state states.State,
 	backend *executor.Backend,
-	clk *mockable.Clock,
 	onAccept func(*txs.Tx) error,
 ) Manager {
 	lastAccepted := state.GetLastAccepted()
@@ -62,7 +61,6 @@ func NewManager(
 		state:        state,
 		metrics:      metrics,
 		mempool:      mempool,
-		clk:          clk,
 		onAccept:     onAccept,
 		blkIDToState: map[ids.ID]*blockState{},
 		lastAccepted: lastAccepted,

--- a/vms/avm/utxo/spender.go
+++ b/vms/avm/utxo/spender.go
@@ -91,12 +91,8 @@ type Spender interface {
 	)
 }
 
-func NewSpender(
-	clk *mockable.Clock,
-	codec codec.Manager,
-) Spender {
+func NewSpender(codec codec.Manager) Spender {
 	return &spender{
-		clock: clk,
 		codec: codec,
 	}
 }

--- a/vms/avm/utxo/spender.go
+++ b/vms/avm/utxo/spender.go
@@ -91,8 +91,12 @@ type Spender interface {
 	)
 }
 
-func NewSpender(codec codec.Manager) Spender {
+func NewSpender(
+	clk *mockable.Clock,
+	codec codec.Manager,
+) Spender {
 	return &spender{
+		clock: clk,
 		codec: codec,
 	}
 }

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -218,7 +218,7 @@ func (vm *VM) Initialize(
 
 	codec := vm.parser.Codec()
 	vm.AtomicUTXOManager = avax.NewAtomicUTXOManager(ctx.SharedMemory, codec)
-	vm.Spender = utxo.NewSpender(codec)
+	vm.Spender = utxo.NewSpender(&vm.clock, codec)
 
 	state, err := states.New(
 		vm.db,

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -218,7 +218,7 @@ func (vm *VM) Initialize(
 
 	codec := vm.parser.Codec()
 	vm.AtomicUTXOManager = avax.NewAtomicUTXOManager(ctx.SharedMemory, codec)
-	vm.Spender = utxo.NewSpender(&vm.clock, codec)
+	vm.Spender = utxo.NewSpender(codec)
 
 	state, err := states.New(
 		vm.db,
@@ -413,7 +413,6 @@ func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- 
 		vm.metrics,
 		vm.state,
 		vm.txBackend,
-		&vm.clock,
 		vm.onAccept,
 	)
 


### PR DESCRIPTION
## Why this should be merged

Unusued params 🧹 

## How this works

Delete 🗑️ 

## How this was tested

CI