### PR TITLE
Add `recentTxsLock` to platform `network` struct

### DIFF
--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -154,7 +154,7 @@ func (b *builder) AddUnverifiedTx(tx *txs.Tx) error {
 			return err
 		}
 	}
-	return b.GossipTx(tx)
+	return b.GossipTx(context.TODO(), tx)
 }
 
 // BuildBlock builds a block to be added to consensus.

--- a/vms/platformvm/block/builder/network.go
+++ b/vms/platformvm/block/builder/network.go
@@ -7,7 +7,7 @@ package builder
 
 import (
 	"context"
-	"fmt"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -29,7 +29,7 @@ type Network interface {
 	common.AppHandler
 
 	// GossipTx gossips the transaction to some of the connected peers
-	GossipTx(tx *txs.Tx) error
+	GossipTx(ctx context.Context, tx *txs.Tx) error
 }
 
 type network struct {
@@ -38,10 +38,11 @@ type network struct {
 
 	ctx        *snow.Context
 	blkBuilder *builder
+	appSender  common.AppSender
 
 	// gossip related attributes
-	appSender common.AppSender
-	recentTxs *cache.LRU[ids.ID, struct{}]
+	recentTxsLock sync.Mutex
+	recentTxs     *cache.LRU[ids.ID, struct{}]
 }
 
 func NewNetwork(
@@ -120,22 +121,42 @@ func (n *network) AppGossip(_ context.Context, nodeID ids.NodeID, msgBytes []byt
 	return nil
 }
 
-func (n *network) GossipTx(tx *txs.Tx) error {
-	txID := tx.ID()
-	// Don't gossip a transaction if it has been recently gossiped.
-	if _, has := n.recentTxs.Get(txID); has {
-		return nil
+func (n *network) GossipTx(ctx context.Context, tx *txs.Tx) error {
+	txBytes := tx.Bytes()
+	msg := &message.Tx{
+		Tx: txBytes,
 	}
+	msgBytes, err := message.Build(msg)
+	if err != nil {
+		return err
+	}
+
+	txID := tx.ID()
+	n.gossipTx(ctx, txID, msgBytes)
+	return nil
+}
+
+func (n *network) gossipTx(ctx context.Context, txID ids.ID, msgBytes []byte) {
+	// This lock is just to ensure there isn't racy behavior between checking if
+	// the tx was gossiped and marking the tx as gossiped.
+	n.recentTxsLock.Lock()
+	_, has := n.recentTxs.Get(txID)
 	n.recentTxs.Put(txID, struct{}{})
+	n.recentTxsLock.Unlock()
+
+	// Don't gossip a transaction if it has been recently gossiped.
+	if has {
+		return
+	}
 
 	n.ctx.Log.Debug("gossiping tx",
 		zap.Stringer("txID", txID),
 	)
 
-	msg := &message.Tx{Tx: tx.Bytes()}
-	msgBytes, err := message.Build(msg)
-	if err != nil {
-		return fmt.Errorf("GossipTx: failed to build Tx message: %w", err)
+	if err := n.appSender.SendAppGossip(ctx, msgBytes); err != nil {
+		n.ctx.Log.Error("failed to gossip tx",
+			zap.Stringer("txID", txID),
+			zap.Error(err),
+		)
 	}
-	return n.appSender.SendAppGossip(context.TODO(), msgBytes)
 }


### PR DESCRIPTION
## Why this should be merged

Paves the way for adding concurrency to the P-chain. Aligns more closely with the AVM networking impl: https://github.com/ava-labs/avalanchego/blob/v1.10.15/vms/avm/network/network.go#L182-L205

## How this works

pretty straightforward

## How this was tested

CI