### PR TITLE
Replace unique slices with sets in the engine interface

### DIFF
--- a/snow/engine/avalanche/getter/getter.go
+++ b/snow/engine/avalanche/getter/getter.go
@@ -73,7 +73,7 @@ func (gh *getter) GetStateSummaryFrontier(_ context.Context, nodeID ids.NodeID, 
 	return nil
 }
 
-func (gh *getter) GetAcceptedStateSummary(_ context.Context, nodeID ids.NodeID, requestID uint32, _ []uint64) error {
+func (gh *getter) GetAcceptedStateSummary(_ context.Context, nodeID ids.NodeID, requestID uint32, _ set.Set[uint64]) error {
 	gh.log.Debug("dropping request",
 		zap.String("reason", "unhandled by this gear"),
 		zap.Stringer("messageOp", message.GetAcceptedStateSummaryOp),
@@ -96,9 +96,9 @@ func (gh *getter) GetAcceptedFrontier(ctx context.Context, validatorID ids.NodeI
 }
 
 // TODO: Remove support for GetAccepted messages after v1.11.x is activated.
-func (gh *getter) GetAccepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs []ids.ID) error {
-	acceptedVtxIDs := make([]ids.ID, 0, len(containerIDs))
-	for _, vtxID := range containerIDs {
+func (gh *getter) GetAccepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs set.Set[ids.ID]) error {
+	acceptedVtxIDs := make([]ids.ID, 0, containerIDs.Len())
+	for vtxID := range containerIDs {
 		if vtx, err := gh.storage.GetVtx(ctx, vtxID); err == nil && vtx.Status() == choices.Accepted {
 			acceptedVtxIDs = append(acceptedVtxIDs, vtxID)
 		}

--- a/snow/engine/avalanche/getter/getter_test.go
+++ b/snow/engine/avalanche/getter/getter_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/avalanche/vertex"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 var errUnknownVertex = errors.New("unknown vertex")
@@ -99,7 +100,7 @@ func TestFilterAccepted(t *testing.T) {
 		accepted = frontier
 	}
 
-	vtxIDs := []ids.ID{vtxID0, vtxID1, vtxID2}
+	vtxIDs := set.Of(vtxID0, vtxID1, vtxID2)
 	require.NoError(bs.GetAccepted(context.Background(), ids.EmptyNodeID, 0, vtxIDs))
 
 	require.Contains(accepted, vtxID0)

--- a/snow/engine/common/bootstrapper.go
+++ b/snow/engine/common/bootstrapper.go
@@ -184,7 +184,7 @@ func (b *bootstrapper) markAcceptedFrontierReceived(ctx context.Context, nodeID 
 	return nil
 }
 
-func (b *bootstrapper) Accepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs []ids.ID) error {
+func (b *bootstrapper) Accepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs set.Set[ids.ID]) error {
 	// ignores any late responses
 	if requestID != b.Config.SharedCfg.RequestID {
 		b.Ctx.Log.Debug("received out-of-sync Accepted message",
@@ -205,7 +205,7 @@ func (b *bootstrapper) Accepted(ctx context.Context, nodeID ids.NodeID, requestI
 	b.pendingReceiveAccepted.Remove(nodeID)
 
 	weight := b.Beacons.GetWeight(b.Ctx.SubnetID, nodeID)
-	for _, containerID := range containerIDs {
+	for containerID := range containerIDs {
 		previousWeight := b.acceptedVotes[containerID]
 		newWeight, err := safemath.Add64(weight, previousWeight)
 		if err != nil {

--- a/snow/engine/common/engine.go
+++ b/snow/engine/common/engine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 // Engine describes the standard interface of a consensus engine.
@@ -108,7 +109,7 @@ type GetAcceptedStateSummaryHandler interface {
 		ctx context.Context,
 		nodeID ids.NodeID,
 		requestID uint32,
-		heights []uint64,
+		heights set.Set[uint64],
 	) error
 }
 
@@ -122,7 +123,7 @@ type AcceptedStateSummaryHandler interface {
 		ctx context.Context,
 		nodeID ids.NodeID,
 		requestID uint32,
-		summaryIDs []ids.ID,
+		summaryIDs set.Set[ids.ID],
 	) error
 
 	// Notify this engine that a GetAcceptedStateSummary request it issued has
@@ -182,7 +183,7 @@ type GetAcceptedHandler interface {
 		ctx context.Context,
 		nodeID ids.NodeID,
 		requestID uint32,
-		containerIDs []ids.ID,
+		containerIDs set.Set[ids.ID],
 	) error
 }
 
@@ -196,7 +197,7 @@ type AcceptedHandler interface {
 		ctx context.Context,
 		nodeID ids.NodeID,
 		requestID uint32,
-		containerIDs []ids.ID,
+		containerIDs set.Set[ids.ID],
 	) error
 
 	// Notify this engine that a GetAccepted request it issued has failed.

--- a/snow/engine/common/no_ops_handlers.go
+++ b/snow/engine/common/no_ops_handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/message"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
 )
 
@@ -65,7 +66,7 @@ func NewNoOpAcceptedStateSummaryHandler(log logging.Logger) AcceptedStateSummary
 	return &noOpAcceptedStateSummaryHandler{log: log}
 }
 
-func (nop *noOpAcceptedStateSummaryHandler) AcceptedStateSummary(_ context.Context, nodeID ids.NodeID, requestID uint32, _ []ids.ID) error {
+func (nop *noOpAcceptedStateSummaryHandler) AcceptedStateSummary(_ context.Context, nodeID ids.NodeID, requestID uint32, _ set.Set[ids.ID]) error {
 	nop.log.Debug("dropping request",
 		zap.String("reason", "unhandled by this gear"),
 		zap.Stringer("messageOp", message.AcceptedStateSummaryOp),
@@ -122,7 +123,7 @@ func NewNoOpAcceptedHandler(log logging.Logger) AcceptedHandler {
 	return &noOpAcceptedHandler{log: log}
 }
 
-func (nop *noOpAcceptedHandler) Accepted(_ context.Context, nodeID ids.NodeID, requestID uint32, _ []ids.ID) error {
+func (nop *noOpAcceptedHandler) Accepted(_ context.Context, nodeID ids.NodeID, requestID uint32, _ set.Set[ids.ID]) error {
 	nop.log.Debug("dropping request",
 		zap.String("reason", "unhandled by this gear"),
 		zap.Stringer("messageOp", message.AcceptedOp),

--- a/snow/engine/common/test_engine.go
+++ b/snow/engine/common/test_engine.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
 )
 
@@ -119,15 +120,15 @@ type EngineTest struct {
 	PushQueryF                   func(ctx context.Context, nodeID ids.NodeID, requestID uint32, container []byte, requestedHeight uint64) error
 	AncestorsF                   func(ctx context.Context, nodeID ids.NodeID, requestID uint32, containers [][]byte) error
 	AcceptedFrontierF            func(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerID ids.ID) error
-	GetAcceptedF, AcceptedF      func(ctx context.Context, nodeID ids.NodeID, requestID uint32, preferredIDs []ids.ID) error
+	GetAcceptedF, AcceptedF      func(ctx context.Context, nodeID ids.NodeID, requestID uint32, preferredIDs set.Set[ids.ID]) error
 	ChitsF                       func(ctx context.Context, nodeID ids.NodeID, requestID uint32, preferredID ids.ID, preferredIDAtHeight ids.ID, acceptedID ids.ID) error
 	GetStateSummaryFrontierF, GetStateSummaryFrontierFailedF, GetAcceptedStateSummaryFailedF,
 	GetAcceptedFrontierF, GetFailedF, GetAncestorsFailedF,
 	QueryFailedF, GetAcceptedFrontierFailedF, GetAcceptedFailedF func(ctx context.Context, nodeID ids.NodeID, requestID uint32) error
 	AppRequestFailedF           func(ctx context.Context, nodeID ids.NodeID, requestID uint32) error
 	StateSummaryFrontierF       func(ctx context.Context, nodeID ids.NodeID, requestID uint32, summary []byte) error
-	GetAcceptedStateSummaryF    func(ctx context.Context, nodeID ids.NodeID, requestID uint32, keys []uint64) error
-	AcceptedStateSummaryF       func(ctx context.Context, nodeID ids.NodeID, requestID uint32, summaryIDs []ids.ID) error
+	GetAcceptedStateSummaryF    func(ctx context.Context, nodeID ids.NodeID, requestID uint32, keys set.Set[uint64]) error
+	AcceptedStateSummaryF       func(ctx context.Context, nodeID ids.NodeID, requestID uint32, summaryIDs set.Set[ids.ID]) error
 	ConnectedF                  func(ctx context.Context, nodeID ids.NodeID, nodeVersion *version.Application) error
 	DisconnectedF               func(ctx context.Context, nodeID ids.NodeID) error
 	HealthF                     func(context.Context) (interface{}, error)
@@ -314,7 +315,7 @@ func (e *EngineTest) GetStateSummaryFrontierFailed(ctx context.Context, validato
 	return errGetStateSummaryFrontierFailed
 }
 
-func (e *EngineTest) GetAcceptedStateSummary(ctx context.Context, validatorID ids.NodeID, requestID uint32, keys []uint64) error {
+func (e *EngineTest) GetAcceptedStateSummary(ctx context.Context, validatorID ids.NodeID, requestID uint32, keys set.Set[uint64]) error {
 	if e.GetAcceptedStateSummaryF != nil {
 		return e.GetAcceptedStateSummaryF(ctx, validatorID, requestID, keys)
 	}
@@ -327,7 +328,7 @@ func (e *EngineTest) GetAcceptedStateSummary(ctx context.Context, validatorID id
 	return errGetAcceptedStateSummary
 }
 
-func (e *EngineTest) AcceptedStateSummary(ctx context.Context, validatorID ids.NodeID, requestID uint32, summaryIDs []ids.ID) error {
+func (e *EngineTest) AcceptedStateSummary(ctx context.Context, validatorID ids.NodeID, requestID uint32, summaryIDs set.Set[ids.ID]) error {
 	if e.AcceptedStateSummaryF != nil {
 		return e.AcceptedStateSummaryF(ctx, validatorID, requestID, summaryIDs)
 	}
@@ -392,7 +393,7 @@ func (e *EngineTest) AcceptedFrontier(ctx context.Context, nodeID ids.NodeID, re
 	return errAcceptedFrontier
 }
 
-func (e *EngineTest) GetAccepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs []ids.ID) error {
+func (e *EngineTest) GetAccepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs set.Set[ids.ID]) error {
 	if e.GetAcceptedF != nil {
 		return e.GetAcceptedF(ctx, nodeID, requestID, containerIDs)
 	}
@@ -418,7 +419,7 @@ func (e *EngineTest) GetAcceptedFailed(ctx context.Context, nodeID ids.NodeID, r
 	return errGetAcceptedFailed
 }
 
-func (e *EngineTest) Accepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs []ids.ID) error {
+func (e *EngineTest) Accepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs set.Set[ids.ID]) error {
 	if e.AcceptedF != nil {
 		return e.AcceptedF(ctx, nodeID, requestID, containerIDs)
 	}

--- a/snow/engine/common/traced_engine.go
+++ b/snow/engine/common/traced_engine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/trace"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
 )
 
@@ -62,22 +63,22 @@ func (e *tracedEngine) GetStateSummaryFrontierFailed(ctx context.Context, nodeID
 	return e.engine.GetStateSummaryFrontierFailed(ctx, nodeID, requestID)
 }
 
-func (e *tracedEngine) GetAcceptedStateSummary(ctx context.Context, nodeID ids.NodeID, requestID uint32, heights []uint64) error {
+func (e *tracedEngine) GetAcceptedStateSummary(ctx context.Context, nodeID ids.NodeID, requestID uint32, heights set.Set[uint64]) error {
 	ctx, span := e.tracer.Start(ctx, "tracedEngine.GetAcceptedStateSummary", oteltrace.WithAttributes(
 		attribute.Stringer("nodeID", nodeID),
 		attribute.Int64("requestID", int64(requestID)),
-		attribute.Int("numHeights", len(heights)),
+		attribute.Int("numHeights", heights.Len()),
 	))
 	defer span.End()
 
 	return e.engine.GetAcceptedStateSummary(ctx, nodeID, requestID, heights)
 }
 
-func (e *tracedEngine) AcceptedStateSummary(ctx context.Context, nodeID ids.NodeID, requestID uint32, summaryIDs []ids.ID) error {
+func (e *tracedEngine) AcceptedStateSummary(ctx context.Context, nodeID ids.NodeID, requestID uint32, summaryIDs set.Set[ids.ID]) error {
 	ctx, span := e.tracer.Start(ctx, "tracedEngine.AcceptedStateSummary", oteltrace.WithAttributes(
 		attribute.Stringer("nodeID", nodeID),
 		attribute.Int64("requestID", int64(requestID)),
-		attribute.Int("numSummaryIDs", len(summaryIDs)),
+		attribute.Int("numSummaryIDs", summaryIDs.Len()),
 	))
 	defer span.End()
 
@@ -125,22 +126,22 @@ func (e *tracedEngine) GetAcceptedFrontierFailed(ctx context.Context, nodeID ids
 	return e.engine.GetAcceptedFrontierFailed(ctx, nodeID, requestID)
 }
 
-func (e *tracedEngine) GetAccepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs []ids.ID) error {
+func (e *tracedEngine) GetAccepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs set.Set[ids.ID]) error {
 	ctx, span := e.tracer.Start(ctx, "tracedEngine.GetAccepted", oteltrace.WithAttributes(
 		attribute.Stringer("nodeID", nodeID),
 		attribute.Int64("requestID", int64(requestID)),
-		attribute.Int("numContainerIDs", len(containerIDs)),
+		attribute.Int("numContainerIDs", containerIDs.Len()),
 	))
 	defer span.End()
 
 	return e.engine.GetAccepted(ctx, nodeID, requestID, containerIDs)
 }
 
-func (e *tracedEngine) Accepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs []ids.ID) error {
+func (e *tracedEngine) Accepted(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs set.Set[ids.ID]) error {
 	ctx, span := e.tracer.Start(ctx, "tracedEngine.Accepted", oteltrace.WithAttributes(
 		attribute.Stringer("nodeID", nodeID),
 		attribute.Int64("requestID", int64(requestID)),
-		attribute.Int("numContainerIDs", len(containerIDs)),
+		attribute.Int("numContainerIDs", containerIDs.Len()),
 	))
 	defer span.End()
 

--- a/snow/engine/snowman/getter/getter_test.go
+++ b/snow/engine/snowman/getter/getter_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block/mocks"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 var errUnknownBlock = errors.New("unknown block")
@@ -110,7 +111,7 @@ func TestFilterAccepted(t *testing.T) {
 		accepted = frontier
 	}
 
-	blkIDs := []ids.ID{blkID0, blkID1, blkID2}
+	blkIDs := set.Of(blkID0, blkID1, blkID2)
 	require.NoError(bs.GetAccepted(context.Background(), ids.EmptyNodeID, 0, blkIDs))
 
 	require.Len(accepted, 2)

--- a/snow/engine/snowman/syncer/state_syncer.go
+++ b/snow/engine/snowman/syncer/state_syncer.go
@@ -223,7 +223,7 @@ func (ss *stateSyncer) receivedStateSummaryFrontier(ctx context.Context) error {
 	return nil
 }
 
-func (ss *stateSyncer) AcceptedStateSummary(ctx context.Context, nodeID ids.NodeID, requestID uint32, summaryIDs []ids.ID) error {
+func (ss *stateSyncer) AcceptedStateSummary(ctx context.Context, nodeID ids.NodeID, requestID uint32, summaryIDs set.Set[ids.ID]) error {
 	// ignores any late responses
 	if requestID != ss.requestID {
 		ss.Ctx.Log.Debug("received out-of-sync AcceptedStateSummary message",
@@ -248,10 +248,10 @@ func (ss *stateSyncer) AcceptedStateSummary(ctx context.Context, nodeID ids.Node
 	ss.Ctx.Log.Debug("adding weight to summaries",
 		zap.Stringer("nodeID", nodeID),
 		zap.Stringer("subnetID", ss.Ctx.SubnetID),
-		zap.Stringers("summaryIDs", summaryIDs),
+		zap.Reflect("summaryIDs", summaryIDs),
 		zap.Uint64("nodeWeight", nodeWeight),
 	)
-	for _, summaryID := range summaryIDs {
+	for summaryID := range summaryIDs {
 		ws, ok := ss.weightedSummaries[summaryID]
 		if !ok {
 			ss.Ctx.Log.Debug("skipping summary",

--- a/snow/engine/snowman/syncer/state_syncer_test.go
+++ b/snow/engine/snowman/syncer/state_syncer_test.go
@@ -805,7 +805,7 @@ func TestUnRequestedVotesAreDropped(t *testing.T) {
 		context.Background(),
 		responsiveVoterID,
 		math.MaxInt32,
-		[]ids.ID{summaryID},
+		set.Of(summaryID),
 	))
 
 	// responsiveVoter still pending
@@ -818,7 +818,7 @@ func TestUnRequestedVotesAreDropped(t *testing.T) {
 		context.Background(),
 		unsolicitedVoterID,
 		responsiveVoterReqID,
-		[]ids.ID{summaryID},
+		set.Of(summaryID),
 	))
 	require.Zero(syncer.weightedSummaries[summaryID].weight)
 
@@ -827,7 +827,7 @@ func TestUnRequestedVotesAreDropped(t *testing.T) {
 		context.Background(),
 		responsiveVoterID,
 		responsiveVoterReqID,
-		[]ids.ID{summaryID},
+		set.Of(summaryID),
 	))
 
 	// responsiveBeacon not pending anymore
@@ -928,7 +928,7 @@ func TestVotesForUnknownSummariesAreDropped(t *testing.T) {
 		context.Background(),
 		responsiveVoterID,
 		responsiveVoterReqID,
-		[]ids.ID{unknownSummaryID},
+		set.Of(unknownSummaryID),
 	))
 	_, found = syncer.weightedSummaries[unknownSummaryID]
 	require.False(found)
@@ -939,7 +939,7 @@ func TestVotesForUnknownSummariesAreDropped(t *testing.T) {
 		context.Background(),
 		responsiveVoterID,
 		responsiveVoterReqID,
-		[]ids.ID{summaryID},
+		set.Of(summaryID),
 	))
 	require.Zero(syncer.weightedSummaries[summaryID].weight)
 
@@ -1073,7 +1073,7 @@ func TestStateSummaryIsPassedToVMAsMajorityOfVotesIsCastedForIt(t *testing.T) {
 				context.Background(),
 				voterID,
 				reqID,
-				[]ids.ID{summaryID, minoritySummaryID},
+				set.Of(summaryID, minoritySummaryID),
 			))
 			cumulatedWeight += vdrs.GetWeight(ctx.SubnetID, voterID)
 
@@ -1082,7 +1082,7 @@ func TestStateSummaryIsPassedToVMAsMajorityOfVotesIsCastedForIt(t *testing.T) {
 				context.Background(),
 				voterID,
 				reqID,
-				[]ids.ID{summaryID},
+				set.Of(summaryID),
 			))
 			cumulatedWeight += vdrs.GetWeight(ctx.SubnetID, voterID)
 
@@ -1200,7 +1200,7 @@ func TestVotingIsRestartedIfMajorityIsNotReachedDueToTimeouts(t *testing.T) {
 				context.Background(),
 				voterID,
 				reqID,
-				[]ids.ID{summaryID},
+				set.Of(summaryID),
 			))
 		}
 	}
@@ -1343,7 +1343,7 @@ func TestStateSyncIsStoppedIfEnoughVotesAreCastedWithNoClearMajority(t *testing.
 				context.Background(),
 				voterID,
 				reqID,
-				[]ids.ID{minoritySummary1.ID(), minoritySummary2.ID()},
+				set.Of(minoritySummary1.ID(), minoritySummary2.ID()),
 			))
 			votingWeightStake += vdrs.GetWeight(ctx.SubnetID, voterID)
 
@@ -1352,7 +1352,7 @@ func TestStateSyncIsStoppedIfEnoughVotesAreCastedWithNoClearMajority(t *testing.
 				context.Background(),
 				voterID,
 				reqID,
-				[]ids.ID{{'u', 'n', 'k', 'n', 'o', 'w', 'n', 'I', 'D'}},
+				set.Of(ids.ID{'u', 'n', 'k', 'n', 'o', 'w', 'n', 'I', 'D'}),
 			))
 			votingWeightStake += vdrs.GetWeight(ctx.SubnetID, voterID)
 		}

--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 
 	commontracker "github.com/ava-labs/avalanchego/snow/engine/common/tracker"
@@ -556,23 +557,11 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 		return engine.GetStateSummaryFrontierFailed(ctx, nodeID, msg.RequestID)
 
 	case *p2p.GetAcceptedStateSummary:
-		// TODO: Enforce that the numbers are sorted to make this verification
-		//       more efficient.
-		if !utils.IsUnique(msg.Heights) {
-			h.ctx.Log.Debug("message with invalid field",
-				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("messageOp", message.GetAcceptedStateSummaryOp),
-				zap.Uint32("requestID", msg.RequestId),
-				zap.String("field", "Heights"),
-			)
-			return engine.GetAcceptedStateSummaryFailed(ctx, nodeID, msg.RequestId)
-		}
-
 		return engine.GetAcceptedStateSummary(
 			ctx,
 			nodeID,
 			msg.RequestId,
-			msg.Heights,
+			set.Of(msg.Heights...),
 		)
 
 	case *p2p.AcceptedStateSummary:

--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -557,6 +557,17 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 		return engine.GetStateSummaryFrontierFailed(ctx, nodeID, msg.RequestID)
 
 	case *p2p.GetAcceptedStateSummary:
+		heights := set.Of(msg.Heights...)
+		if heights.Len() != len(msg.Heights) {
+			h.ctx.Log.Debug("message with invalid field",
+				zap.Stringer("nodeID", nodeID),
+				zap.Stringer("messageOp", message.GetAcceptedStateSummaryOp),
+				zap.Uint32("requestID", msg.RequestId),
+				zap.String("field", "Heights"),
+			)
+			return engine.GetAcceptedStateSummaryFailed(ctx, nodeID, msg.RequestId)
+		}
+
 		return engine.GetAcceptedStateSummary(
 			ctx,
 			nodeID,

--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -557,17 +557,6 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 		return engine.GetStateSummaryFrontierFailed(ctx, nodeID, msg.RequestID)
 
 	case *p2p.GetAcceptedStateSummary:
-		heights := set.Of(msg.Heights...)
-		if heights.Len() != len(msg.Heights) {
-			h.ctx.Log.Debug("message with invalid field",
-				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("messageOp", message.GetAcceptedStateSummaryOp),
-				zap.Uint32("requestID", msg.RequestId),
-				zap.String("field", "Heights"),
-			)
-			return engine.GetAcceptedStateSummaryFailed(ctx, nodeID, msg.RequestId)
-		}
-
 		return engine.GetAcceptedStateSummary(
 			ctx,
 			nodeID,

--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils/math/meter"
 	"github.com/ava-labs/avalanchego/utils/resource"
+	"github.com/ava-labs/avalanchego/utils/set"
 
 	commontracker "github.com/ava-labs/avalanchego/snow/engine/common/tracker"
 )
@@ -78,11 +79,11 @@ func TestHandlerDropsTimedOutMessages(t *testing.T) {
 	bootstrapper.ContextF = func() *snow.ConsensusContext {
 		return ctx
 	}
-	bootstrapper.GetAcceptedFrontierF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
+	bootstrapper.GetAcceptedFrontierF = func(context.Context, ids.NodeID, uint32) error {
 		require.FailNow("GetAcceptedFrontier message should have timed out")
 		return nil
 	}
-	bootstrapper.GetAcceptedF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32, containerIDs []ids.ID) error {
+	bootstrapper.GetAcceptedF = func(context.Context, ids.NodeID, uint32, set.Set[ids.ID]) error {
 		called <- struct{}{}
 		return nil
 	}

--- a/snow/networking/handler/parser.go
+++ b/snow/networking/handler/parser.go
@@ -4,27 +4,18 @@
 package handler
 
 import (
-	"errors"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
 
-var errDuplicatedID = errors.New("inbound message contains duplicated ID")
-
-func getIDs(idsBytes [][]byte) ([]ids.ID, error) {
-	res := make([]ids.ID, len(idsBytes))
-	idSet := set.NewSet[ids.ID](len(idsBytes))
-	for i, bytes := range idsBytes {
+func getIDs(idsBytes [][]byte) (set.Set[ids.ID], error) {
+	var res set.Set[ids.ID]
+	for _, bytes := range idsBytes {
 		id, err := ids.ToID(bytes)
 		if err != nil {
 			return nil, err
 		}
-		if idSet.Contains(id) {
-			return nil, errDuplicatedID
-		}
-		res[i] = id
-		idSet.Add(id)
+		res.Add(id)
 	}
 	return res, nil
 }

--- a/snow/networking/handler/parser.go
+++ b/snow/networking/handler/parser.go
@@ -4,13 +4,9 @@
 package handler
 
 import (
-	"errors"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
-
-var errDuplicatedID = errors.New("inbound message contains duplicated ID")
 
 func getIDs(idsBytes [][]byte) (set.Set[ids.ID], error) {
 	var res set.Set[ids.ID]
@@ -20,9 +16,6 @@ func getIDs(idsBytes [][]byte) (set.Set[ids.ID], error) {
 			return nil, err
 		}
 		res.Add(id)
-	}
-	if res.Len() != len(idsBytes) {
-		return nil, errDuplicatedID
 	}
 	return res, nil
 }

--- a/snow/networking/handler/parser.go
+++ b/snow/networking/handler/parser.go
@@ -4,9 +4,13 @@
 package handler
 
 import (
+	"errors"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
+
+var errDuplicatedID = errors.New("inbound message contains duplicated ID")
 
 func getIDs(idsBytes [][]byte) (set.Set[ids.ID], error) {
 	var res set.Set[ids.ID]
@@ -16,6 +20,9 @@ func getIDs(idsBytes [][]byte) (set.Set[ids.ID], error) {
 			return nil, err
 		}
 		res.Add(id)
+	}
+	if res.Len() != len(idsBytes) {
+		return nil, errDuplicatedID
 	}
 	return res, nil
 }

--- a/utils/sorting.go
+++ b/utils/sorting.go
@@ -87,16 +87,3 @@ func IsSortedAndUniqueByHash[T ~[]byte](s []T) bool {
 	}
 	return true
 }
-
-// Returns true iff the elements in [s] are unique.
-func IsUnique[T comparable](s []T) bool {
-	// Can't use set.Set because it'd be a circular import.
-	asMap := make(map[T]struct{}, len(s))
-	for _, elt := range s {
-		if _, ok := asMap[elt]; ok {
-			return false
-		}
-		asMap[elt] = struct{}{}
-	}
-	return true
-}

--- a/utils/sorting_test.go
+++ b/utils/sorting_test.go
@@ -104,31 +104,6 @@ func TestIsSortedAndUniqueSortable(t *testing.T) {
 	require.False(IsSortedAndUnique(s))
 }
 
-func TestIsUnique(t *testing.T) {
-	require := require.New(t)
-
-	var s []int
-	require.True(IsUnique(s))
-
-	s = []int{}
-	require.True(IsUnique(s))
-
-	s = []int{1}
-	require.True(IsUnique(s))
-
-	s = []int{1, 2}
-	require.True(IsUnique(s))
-
-	s = []int{1, 1}
-	require.False(IsUnique(s))
-
-	s = []int{2, 1}
-	require.True(IsUnique(s))
-
-	s = []int{1, 2, 1}
-	require.False(IsUnique(s))
-}
-
 func TestSortByHash(t *testing.T) {
 	require := require.New(t)
 

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1615,7 +1615,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		return nodeIDs
 	}
 
-	frontier := []ids.ID{advanceTimeBlkID}
+	frontier := set.Of(advanceTimeBlkID)
 	require.NoError(bootstrapper.Accepted(context.Background(), peerID, reqID, frontier))
 
 	externalSender.SendF = nil


### PR DESCRIPTION
## Why this should be merged

It's nice for the engine interface to explicitly enforce that the uniqueness of elements in slices by the type.

## How this works

replaces `[]xxx` with `set.Set[xxx]`.

## How this was tested

CI