### PR TITLE
Use zap.Stringer rather than zap.Any

### DIFF
--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -454,7 +454,7 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 		h.ctx.Log.Verbo("forwarding sync message to consensus",
 			zap.Stringer("nodeID", nodeID),
 			zap.Stringer("messageOp", op),
-			zap.Any("message", body),
+			zap.Stringer("message", body),
 		)
 	} else {
 		h.ctx.Log.Debug("forwarding sync message to consensus",
@@ -487,7 +487,7 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 				zap.Duration("msgHandlingTime", msgHandlingTime),
 				zap.Stringer("nodeID", nodeID),
 				zap.Stringer("messageOp", op),
-				zap.Any("message", body),
+				zap.Stringer("message", body),
 			)
 		}
 	}()
@@ -804,7 +804,7 @@ func (h *handler) executeAsyncMsg(ctx context.Context, msg Message) error {
 		h.ctx.Log.Verbo("forwarding async message to consensus",
 			zap.Stringer("nodeID", nodeID),
 			zap.Stringer("messageOp", op),
-			zap.Any("message", body),
+			zap.Stringer("message", body),
 		)
 	} else {
 		h.ctx.Log.Debug("forwarding async message to consensus",
@@ -904,7 +904,7 @@ func (h *handler) handleChanMsg(msg message.InboundMessage) error {
 	if h.ctx.Log.Enabled(logging.Verbo) {
 		h.ctx.Log.Verbo("forwarding chan message to consensus",
 			zap.Stringer("messageOp", op),
-			zap.Any("message", body),
+			zap.Stringer("message", body),
 		)
 	} else {
 		h.ctx.Log.Debug("forwarding chan message to consensus",
@@ -933,7 +933,7 @@ func (h *handler) handleChanMsg(msg message.InboundMessage) error {
 				zap.Duration("processingTime", processingTime),
 				zap.Duration("msgHandlingTime", msgHandlingTime),
 				zap.Stringer("messageOp", op),
-				zap.Any("message", body),
+				zap.Stringer("message", body),
 			)
 		}
 	}()


### PR DESCRIPTION
## Why this should be merged

Is more explicit and avoids a type switch.

## How this works

`zap.Any` -> `zap.Stringer`

## How this was tested

CI