### PR TITLE
Remove useless anon functions

### DIFF
--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -594,9 +594,7 @@ func (b *bootstrapper) checkFinish(ctx context.Context) error {
 	// If there is an additional callback, notify them that this chain has been
 	// synced.
 	if b.Bootstrapped != nil {
-		b.bootstrappedOnce.Do(func() {
-			b.Bootstrapped()
-		})
+		b.bootstrappedOnce.Do(b.Bootstrapped)
 	}
 
 	// Notify the subnet that this chain is synced

--- a/snow/networking/timeout/manager.go
+++ b/snow/networking/timeout/manager.go
@@ -163,7 +163,5 @@ func (m *manager) RegisterRequestToUnreachableValidator() {
 }
 
 func (m *manager) Stop() {
-	m.stopOnce.Do(func() {
-		m.tm.Stop()
-	})
+	m.stopOnce.Do(m.tm.Stop)
 }


### PR DESCRIPTION
## Why this should be merged

We can directly pass functions rather than wrapping them.

## How this works

delete

## How this was tested

CI