### PR TITLE
Remove `common.Config` functions

### DIFF
--- a/snow/engine/common/config.go
+++ b/snow/engine/common/config.go
@@ -36,15 +36,6 @@ type Config struct {
 	SharedCfg *SharedConfig
 }
 
-func (c *Config) Context() *snow.ConsensusContext {
-	return c.Ctx
-}
-
-// IsBootstrapped returns true iff this chain is done bootstrapping
-func (c *Config) IsBootstrapped() bool {
-	return c.Ctx.State.Get().State == snow.NormalOp
-}
-
 // Shared among common.bootstrapper and snowman/avalanche bootstrapper
 type SharedConfig struct {
 	// Tracks the last requestID that was used in a request

--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -111,6 +111,10 @@ func New(config Config, onFinished func(ctx context.Context, lastReqID uint32) e
 	return b, nil
 }
 
+func (b *bootstrapper) Context() *snow.ConsensusContext {
+	return b.Ctx
+}
+
 func (b *bootstrapper) Start(ctx context.Context, startReqID uint32) error {
 	b.Ctx.Log.Info("starting bootstrapper")
 
@@ -556,7 +560,7 @@ func (b *bootstrapper) checkFinish(ctx context.Context) error {
 		return nil
 	}
 
-	if b.IsBootstrapped() || b.awaitingTimeout {
+	if b.Ctx.State.Get().State == snow.NormalOp || b.awaitingTimeout {
 		return nil
 	}
 

--- a/snow/engine/snowman/syncer/state_syncer.go
+++ b/snow/engine/snowman/syncer/state_syncer.go
@@ -108,6 +108,10 @@ func New(
 	}
 }
 
+func (ss *stateSyncer) Context() *snow.ConsensusContext {
+	return ss.Ctx
+}
+
 func (ss *stateSyncer) StateSummaryFrontier(ctx context.Context, nodeID ids.NodeID, requestID uint32, summaryBytes []byte) error {
 	// ignores any late responses
 	if requestID != ss.requestID {


### PR DESCRIPTION
## Why this should be merged

I'm working to remove the `common.Config` - this is reducing the (large) diff for that effort.

## How this works

Move functions around

## How this was tested

CI