### PR TITLE
`vms/platformvm`: Move `toEngine` channel to mempool

### DIFF
--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
-	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/timer"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
@@ -58,9 +57,6 @@ type builder struct {
 	txExecutorBackend *txexecutor.Backend
 	blkManager        blockexecutor.Manager
 
-	// channel to send messages to the consensus engine
-	toEngine chan<- common.Message
-
 	// This timer goes off when it is time for the next validator to add/leave
 	// the validator set. When it goes off ResetTimer() is called, potentially
 	// triggering creation of a new block.
@@ -72,14 +68,12 @@ func New(
 	txBuilder txbuilder.Builder,
 	txExecutorBackend *txexecutor.Backend,
 	blkManager blockexecutor.Manager,
-	toEngine chan<- common.Message,
 ) Builder {
 	builder := &builder{
 		Mempool:           mempool,
 		txBuilder:         txBuilder,
 		txExecutorBackend: txExecutorBackend,
 		blkManager:        blkManager,
-		toEngine:          toEngine,
 	}
 
 	builder.timer = timer.NewTimer(builder.setNextBuildBlockTime)
@@ -192,7 +186,7 @@ func (b *builder) setNextBuildBlockTime() {
 
 	if _, err := b.buildBlock(); err == nil {
 		// We can build a block now
-		b.notifyBlockReady()
+		b.Mempool.RequestBuildBlock(true)
 		return
 	}
 
@@ -227,16 +221,6 @@ func (b *builder) setNextBuildBlockTime() {
 
 	// Wake up when it's time to add/remove the next validator
 	b.timer.SetTimeoutIn(waitTime)
-}
-
-// notifyBlockReady tells the consensus engine that a new block is ready to be
-// created
-func (b *builder) notifyBlockReady() {
-	select {
-	case b.toEngine <- common.PendingTxs:
-	default:
-		b.txExecutorBackend.Ctx.Log.Debug("dropping message to consensus engine")
-	}
 }
 
 // [timestamp] is min(max(now, parent timestamp), next staker change time)

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -169,7 +169,7 @@ func newEnvironment(t *testing.T) *environment {
 	metrics, err := metrics.New("", registerer)
 	require.NoError(err)
 
-	res.mempool, err = mempool.New("mempool", registerer, res)
+	res.mempool, err = mempool.New("mempool", registerer, nil)
 	require.NoError(err)
 
 	res.blkManager = blockexecutor.NewManager(
@@ -193,7 +193,6 @@ func newEnvironment(t *testing.T) *environment {
 		res.txBuilder,
 		&res.backend,
 		res.blkManager,
-		nil, // toEngine,
 	)
 
 	res.blkManager.SetPreference(genesisID)

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -63,8 +63,6 @@ const (
 )
 
 var (
-	_ mempool.BlockTimer = (*environment)(nil)
-
 	defaultMinStakingDuration = 24 * time.Hour
 	defaultMaxStakingDuration = 365 * 24 * time.Hour
 	defaultGenesisTime        = time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -131,10 +129,6 @@ type environment struct {
 	backend        *executor.Backend
 }
 
-func (*environment) ResetBlockTimer() {
-	// dummy call, do nothing for now
-}
-
 func newEnvironment(t *testing.T, ctrl *gomock.Controller) *environment {
 	res := &environment{
 		isBootstrapped: &utils.Atomic[bool]{},
@@ -199,7 +193,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller) *environment {
 	metrics := metrics.Noop
 
 	var err error
-	res.mempool, err = mempool.New("mempool", registerer, res)
+	res.mempool, err = mempool.New("mempool", registerer, nil)
 	if err != nil {
 		panic(fmt.Errorf("failed to create mempool: %w", err))
 	}

--- a/vms/platformvm/block/executor/rejector.go
+++ b/vms/platformvm/block/executor/rejector.go
@@ -82,5 +82,7 @@ func (r *rejector) rejectBlock(b block.Block, blockType string) error {
 		}
 	}
 
+	r.Mempool.RequestBuildBlock(false)
+
 	return nil
 }

--- a/vms/platformvm/block/executor/rejector_test.go
+++ b/vms/platformvm/block/executor/rejector_test.go
@@ -142,6 +142,8 @@ func TestRejectBlock(t *testing.T) {
 				mempool.EXPECT().Add(tx).Return(nil).Times(1)
 			}
 
+			mempool.EXPECT().RequestBuildBlock(false).Times(1)
+
 			require.NoError(tt.rejectFunc(rejector, blk))
 			// Make sure block and its parent are removed from the state map.
 			require.NotContains(rejector.blkIDToState, blk.ID())

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -181,6 +181,8 @@ func (n *network) issueTx(tx *txs.Tx) error {
 		return err
 	}
 
+	n.mempool.RequestBuildBlock(false)
+
 	return nil
 }
 

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -284,6 +284,7 @@ func TestNetworkIssueTx(t *testing.T) {
 				mempool := mempool.NewMockMempool(ctrl)
 				mempool.EXPECT().Has(gomock.Any()).Return(false)
 				mempool.EXPECT().Add(gomock.Any()).Return(nil)
+				mempool.EXPECT().RequestBuildBlock(false)
 				return mempool
 			},
 			managerFunc: func(ctrl *gomock.Controller) executor.Manager {

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -20,12 +20,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
-var _ BlockTimer = (*noopBlkTimer)(nil)
-
-type noopBlkTimer struct{}
-
-func (*noopBlkTimer) ResetBlockTimer() {}
-
 var preFundedKeys = secp256k1.TestKeys()
 
 // shows that valid tx is not added to mempool if this would exceed its maximum
@@ -34,7 +28,7 @@ func TestBlockBuilderMaxMempoolSizeHandling(t *testing.T) {
 	require := require.New(t)
 
 	registerer := prometheus.NewRegistry()
-	mpool, err := New("mempool", registerer, &noopBlkTimer{})
+	mpool, err := New("mempool", registerer, nil)
 	require.NoError(err)
 
 	decisionTxs, err := createTestDecisionTxs(1)
@@ -58,7 +52,7 @@ func TestDecisionTxsInMempool(t *testing.T) {
 	require := require.New(t)
 
 	registerer := prometheus.NewRegistry()
-	mpool, err := New("mempool", registerer, &noopBlkTimer{})
+	mpool, err := New("mempool", registerer, nil)
 	require.NoError(err)
 
 	decisionTxs, err := createTestDecisionTxs(2)
@@ -110,7 +104,7 @@ func TestProposalTxsInMempool(t *testing.T) {
 	require := require.New(t)
 
 	registerer := prometheus.NewRegistry()
-	mpool, err := New("mempool", registerer, &noopBlkTimer{})
+	mpool, err := New("mempool", registerer, nil)
 	require.NoError(err)
 
 	// The proposal txs are ordered by decreasing start time. This means after

--- a/vms/platformvm/txs/mempool/mock_mempool.go
+++ b/vms/platformvm/txs/mempool/mock_mempool.go
@@ -197,3 +197,15 @@ func (mr *MockMempoolMockRecorder) Remove(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMempool)(nil).Remove), arg0)
 }
+
+// RequestBuildBlock mocks base method.
+func (m *MockMempool) RequestBuildBlock(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RequestBuildBlock", arg0)
+}
+
+// RequestBuildBlock indicates an expected call of RequestBuildBlock.
+func (mr *MockMempoolMockRecorder) RequestBuildBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestBuildBlock", reflect.TypeOf((*MockMempool)(nil).RequestBuildBlock), arg0)
+}

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -177,9 +177,7 @@ func (vm *VM) Initialize(
 		Bootstrapped: &vm.bootstrapped,
 	}
 
-	// Note: There is a circular dependency between the mempool and block
-	//       builder which is broken by passing in the vm.
-	mempool, err := mempool.New("mempool", registerer, vm)
+	mempool, err := mempool.New("mempool", registerer, toEngine)
 	if err != nil {
 		return fmt.Errorf("failed to create mempool: %w", err)
 	}
@@ -203,7 +201,6 @@ func (vm *VM) Initialize(
 		vm.txBuilder,
 		txExecutorBackend,
 		vm.manager,
-		toEngine,
 	)
 
 	// Create all of the chains that the database says exist


### PR DESCRIPTION
## Why this should be merged

Removes the circular dependency when creating the `mempool`

## How this works

The `mempool` will be the only interaction with the consensus engine. Consumers, like the block builder, will rely on the mempool reference to send messages to the engine.

## How this was tested

CI