### PR TITLE
Improve height monitoring

### DIFF
--- a/snow/consensus/metrics/height.go
+++ b/snow/consensus/metrics/height.go
@@ -3,29 +3,50 @@
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/math"
+)
 
 var _ Height = (*height)(nil)
 
-// Height reports the last accepted height
 type Height interface {
+	Verified(height uint64)
 	Accepted(height uint64)
 }
 
 type height struct {
-	// lastAcceptedHeight keeps track of the last accepted height
+	currentHighestVerifiedHeight uint64
+	highestVerifiedHeight        prometheus.Gauge
+
 	lastAcceptedHeight prometheus.Gauge
 }
 
 func NewHeight(namespace string, reg prometheus.Registerer) (Height, error) {
 	h := &height{
+		highestVerifiedHeight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "highest_verified_height",
+			Help:      "Highest verified height",
+		}),
 		lastAcceptedHeight: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "last_accepted_height",
 			Help:      "Last height accepted",
 		}),
 	}
-	return h, reg.Register(h.lastAcceptedHeight)
+	err := utils.Err(
+		reg.Register(h.lastAcceptedHeight),
+		reg.Register(h.highestVerifiedHeight),
+	)
+	return h, err
+}
+
+func (h *height) Verified(height uint64) {
+	h.currentHighestVerifiedHeight = math.Max(h.currentHighestVerifiedHeight, height)
+	h.highestVerifiedHeight.Set(float64(h.currentHighestVerifiedHeight))
 }
 
 func (h *height) Accepted(height uint64) {

--- a/snow/consensus/metrics/height.go
+++ b/snow/consensus/metrics/height.go
@@ -18,17 +18,17 @@ type Height interface {
 }
 
 type height struct {
-	currentHighestVerifiedHeight uint64
-	highestVerifiedHeight        prometheus.Gauge
+	currentMaxVerifiedHeight uint64
+	maxVerifiedHeight        prometheus.Gauge
 
 	lastAcceptedHeight prometheus.Gauge
 }
 
 func NewHeight(namespace string, reg prometheus.Registerer) (Height, error) {
 	h := &height{
-		highestVerifiedHeight: prometheus.NewGauge(prometheus.GaugeOpts{
+		maxVerifiedHeight: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
-			Name:      "highest_verified_height",
+			Name:      "max_verified_height",
 			Help:      "Highest verified height",
 		}),
 		lastAcceptedHeight: prometheus.NewGauge(prometheus.GaugeOpts{
@@ -39,14 +39,14 @@ func NewHeight(namespace string, reg prometheus.Registerer) (Height, error) {
 	}
 	err := utils.Err(
 		reg.Register(h.lastAcceptedHeight),
-		reg.Register(h.highestVerifiedHeight),
+		reg.Register(h.maxVerifiedHeight),
 	)
 	return h, err
 }
 
 func (h *height) Verified(height uint64) {
-	h.currentHighestVerifiedHeight = math.Max(h.currentHighestVerifiedHeight, height)
-	h.highestVerifiedHeight.Set(float64(h.currentHighestVerifiedHeight))
+	h.currentMaxVerifiedHeight = math.Max(h.currentMaxVerifiedHeight, height)
+	h.maxVerifiedHeight.Set(float64(h.currentMaxVerifiedHeight))
 }
 
 func (h *height) Accepted(height uint64) {

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -153,6 +153,7 @@ func (ts *Topological) Initialize(
 	ts.tail = rootID
 
 	// Initially set the metrics for the last accepted block.
+	ts.Height.Verified(ts.height)
 	ts.Height.Accepted(ts.height)
 	ts.Timestamp.Accepted(rootTime)
 
@@ -165,8 +166,10 @@ func (ts *Topological) NumProcessing() int {
 
 func (ts *Topological) Add(ctx context.Context, blk Block) error {
 	blkID := blk.ID()
+	height := blk.Height()
 	ts.ctx.Log.Verbo("adding block",
 		zap.Stringer("blkID", blkID),
+		zap.Uint64("height", height),
 	)
 
 	// Make sure a block is not inserted twice. This enforces the invariant that
@@ -178,6 +181,7 @@ func (ts *Topological) Add(ctx context.Context, blk Block) error {
 		return errDuplicateAdd
 	}
 
+	ts.Height.Verified(height)
 	ts.Latency.Issued(blkID, ts.pollNumber)
 
 	parentID := blk.Parent()
@@ -185,6 +189,7 @@ func (ts *Topological) Add(ctx context.Context, blk Block) error {
 	if !ok {
 		ts.ctx.Log.Verbo("block ancestor is missing, being rejected",
 			zap.Stringer("blkID", blkID),
+			zap.Uint64("height", height),
 			zap.Stringer("parentID", parentID),
 		)
 
@@ -209,11 +214,12 @@ func (ts *Topological) Add(ctx context.Context, blk Block) error {
 	if ts.tail == parentID {
 		ts.tail = blkID
 		ts.preferredIDs.Add(blkID)
-		ts.preferredHeights[blk.Height()] = blkID
+		ts.preferredHeights[height] = blkID
 	}
 
 	ts.ctx.Log.Verbo("added block",
 		zap.Stringer("blkID", blkID),
+		zap.Uint64("height", height),
 		zap.Stringer("parentID", parentID),
 	)
 	return nil
@@ -634,8 +640,10 @@ func (ts *Topological) acceptPreferredChild(ctx context.Context, n *snowmanBlock
 		return err
 	}
 
+	height := child.Height()
 	ts.ctx.Log.Trace("accepting block",
 		zap.Stringer("blkID", pref),
+		zap.Uint64("height", height),
 	)
 	if err := child.Accept(ctx); err != nil {
 		return err
@@ -643,14 +651,14 @@ func (ts *Topological) acceptPreferredChild(ctx context.Context, n *snowmanBlock
 
 	// Because this is the newest accepted block, this is the new head.
 	ts.head = pref
-	ts.height = child.Height()
+	ts.height = height
 	// Remove the decided block from the set of processing IDs, as its status
 	// now implies its preferredness.
 	ts.preferredIDs.Remove(pref)
-	delete(ts.preferredHeights, ts.height)
+	delete(ts.preferredHeights, height)
 
 	ts.Latency.Accepted(pref, ts.pollNumber, len(bytes))
-	ts.Height.Accepted(ts.height)
+	ts.Height.Accepted(height)
 	ts.Timestamp.Accepted(child.Timestamp())
 
 	// Because ts.blocks contains the last accepted block, we don't delete the
@@ -665,8 +673,9 @@ func (ts *Topological) acceptPreferredChild(ctx context.Context, n *snowmanBlock
 
 		ts.ctx.Log.Trace("rejecting block",
 			zap.String("reason", "conflict with accepted block"),
-			zap.Stringer("rejectedID", childID),
-			zap.Stringer("conflictedID", pref),
+			zap.Stringer("blkID", childID),
+			zap.Uint64("height", child.Height()),
+			zap.Stringer("conflictID", pref),
 		)
 		if err := child.Reject(ctx); err != nil {
 			return err
@@ -696,6 +705,12 @@ func (ts *Topological) rejectTransitively(ctx context.Context, rejected []ids.ID
 		delete(ts.blocks, rejectedID)
 
 		for childID, child := range rejectedNode.children {
+			ts.ctx.Log.Trace("rejecting block",
+				zap.String("reason", "rejected ancestor"),
+				zap.Stringer("blkID", childID),
+				zap.Uint64("height", child.Height()),
+				zap.Stringer("parentID", rejectedID),
+			)
 			if err := child.Reject(ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Why this should be merged

Exports additional information around block heights during:
- Issuance
- Acceptance
- Rejection

## How this works

Adds a new max verified height metric and logs block heights during issuance/acceptance/rejection.

## How this was tested

CI + locally.