### PR TITLE
Expand consensus health check

### DIFF
--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -22,7 +22,9 @@ import (
 )
 
 var (
-	errDuplicateAdd = errors.New("duplicate block add")
+	errDuplicateAdd            = errors.New("duplicate block add")
+	errTooManyProcessingBlocks = errors.New("too many processing blocks")
+	errBlockProcessingTooLong  = errors.New("block processing too long")
 
 	_ Factory   = (*TopologicalFactory)(nil)
 	_ Consensus = (*Topological)(nil)
@@ -329,11 +331,6 @@ func (ts *Topological) RecordPoll(ctx context.Context, voteBag bag.Bag[ids.ID]) 
 	}
 	return nil
 }
-
-var (
-	errTooManyProcessingBlocks = errors.New("too many processing blocks")
-	errBlockProcessingTooLong  = errors.New("block processing too long")
-)
 
 // HealthCheck returns information about the consensus health.
 func (ts *Topological) HealthCheck(context.Context) (interface{}, error) {

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -361,8 +361,8 @@ func (ts *Topological) HealthCheck(context.Context) (interface{}, error) {
 
 	return map[string]interface{}{
 		"processingBlocks":       numProcessingBlks,
-		"longestProcessingBlock": maxTimeProcessing.String(),
-		"lastAcceptedID":         ts.lastAcceptedID.String(),
+		"longestProcessingBlock": maxTimeProcessing.String(), // .String() is needed here to ensure a human readable format
+		"lastAcceptedID":         ts.lastAcceptedID,
 		"lastAcceptedHeight":     ts.lastAcceptedHeight,
 	}, errors.Join(errs...)
 }

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -331,32 +330,41 @@ func (ts *Topological) RecordPoll(ctx context.Context, voteBag bag.Bag[ids.ID]) 
 	return nil
 }
 
+var (
+	errTooManyProcessingBlocks = errors.New("too many processing blocks")
+	errBlockProcessingTooLong  = errors.New("block processing too long")
+)
+
 // HealthCheck returns information about the consensus health.
 func (ts *Topological) HealthCheck(context.Context) (interface{}, error) {
-	numOutstandingBlks := ts.NumProcessing()
-	isOutstandingBlks := numOutstandingBlks <= ts.params.MaxOutstandingItems
-	healthy := isOutstandingBlks
-	details := map[string]interface{}{
-		"outstandingBlocks": numOutstandingBlks,
+	var errs []error
+
+	numProcessingBlks := ts.NumProcessing()
+	if numProcessingBlks > ts.params.MaxOutstandingItems {
+		err := fmt.Errorf("%w: %d > %d",
+			errTooManyProcessingBlocks,
+			numProcessingBlks,
+			ts.params.MaxOutstandingItems,
+		)
+		errs = append(errs, err)
 	}
 
-	// check for long running blocks
-	timeReqRunning := ts.metrics.MeasureAndGetOldestDuration()
-	isProcessingTime := timeReqRunning <= ts.params.MaxItemProcessingTime
-	healthy = healthy && isProcessingTime
-	details["longestRunningBlock"] = timeReqRunning.String()
-
-	if !healthy {
-		var errorReasons []string
-		if !isOutstandingBlks {
-			errorReasons = append(errorReasons, fmt.Sprintf("number of outstanding blocks %d > %d", numOutstandingBlks, ts.params.MaxOutstandingItems))
-		}
-		if !isProcessingTime {
-			errorReasons = append(errorReasons, fmt.Sprintf("block processing time %s > %s", timeReqRunning, ts.params.MaxItemProcessingTime))
-		}
-		return details, fmt.Errorf("snowman consensus is not healthy reason: %s", strings.Join(errorReasons, ", "))
+	maxTimeProcessing := ts.metrics.MeasureAndGetOldestDuration()
+	if maxTimeProcessing > ts.params.MaxItemProcessingTime {
+		err := fmt.Errorf("%w: %s > %s",
+			errBlockProcessingTooLong,
+			maxTimeProcessing,
+			ts.params.MaxItemProcessingTime,
+		)
+		errs = append(errs, err)
 	}
-	return details, nil
+
+	return map[string]interface{}{
+		"processingBlocks":       numProcessingBlks,
+		"longestProcessingBlock": maxTimeProcessing.String(),
+		"lastAcceptedID":         ts.lastAcceptedID.String(),
+		"lastAcceptedHeight":     ts.lastAcceptedHeight,
+	}, errors.Join(errs...)
 }
 
 // takes in a list of votes and sets up the topological ordering. Returns the


### PR DESCRIPTION
## Why this should be merged

This adds the lastAcceptedID and lastAcceptedHeight to the health check output. Additionally it uses newer golang error handling that is much cleaner to understand.

## How this works

Changes up the healthcheck slightly

## How this was tested

N/A