### PR TITLE
Reduce the size of the OracleBlock interface

### DIFF
--- a/snow/consensus/snowman/oracle_block.go
+++ b/snow/consensus/snowman/oracle_block.go
@@ -16,8 +16,6 @@ var ErrNotOracle = errors.New("block isn't an oracle")
 // This ordering does not need to be deterministically created from the chain
 // state.
 type OracleBlock interface {
-	Block
-
 	// Options returns the possible children of this block in the order this
 	// validator prefers the blocks.
 	// Options is guaranteed to only be called on a verified block.

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -729,8 +729,7 @@ func TestRewardValidatorAccept(t *testing.T) {
 	require.NoError(blk.Verify(context.Background()))
 
 	// Assert preferences are correct
-	oracleBlk := blk.(smcon.OracleBlock)
-	options, err := oracleBlk.Options(context.Background())
+	options, err := blk.(smcon.OracleBlock).Options(context.Background())
 	require.NoError(err)
 
 	commit := options[0].(*blockexecutor.Block)
@@ -739,13 +738,13 @@ func TestRewardValidatorAccept(t *testing.T) {
 	require.IsType(&block.BanffAbortBlock{}, abort.Block)
 
 	// Assert block tries to reward a genesis validator
-	rewardTx := oracleBlk.(block.Block).Txs()[0].Unsigned
+	rewardTx := blk.(block.Block).Txs()[0].Unsigned
 	require.IsType(&txs.RewardValidatorTx{}, rewardTx)
 
 	// Verify options and accept commmit block
 	require.NoError(commit.Verify(context.Background()))
 	require.NoError(abort.Verify(context.Background()))
-	txID := oracleBlk.(block.Block).Txs()[0].ID()
+	txID := blk.(block.Block).Txs()[0].ID()
 	{
 		onAbort, ok := vm.manager.GetState(abort.ID())
 		require.True(ok)
@@ -755,7 +754,7 @@ func TestRewardValidatorAccept(t *testing.T) {
 		require.Equal(status.Aborted, txStatus)
 	}
 
-	require.NoError(oracleBlk.Accept(context.Background()))
+	require.NoError(blk.Accept(context.Background()))
 	require.NoError(commit.Accept(context.Background()))
 
 	// Verify that chain's timestamp has advanced


### PR DESCRIPTION
## Why this should be merged

There is no reason to embed the `Block` interface. This is useful if we add another optional block interface.

## How this works

Removes the embedded interface.

## How this was tested

CI