### PR TITLE
Remove Banff check from mempool verifier

### DIFF
--- a/vms/platformvm/txs/executor/tx_mempool_verifier.go
+++ b/vms/platformvm/txs/executor/tx_mempool_verifier.go
@@ -102,9 +102,6 @@ func (v *MempoolTxVerifier) standardTx(tx txs.UnsignedTx) error {
 	return err
 }
 
-// Upon Banff activation, txs are not verified against current chain time
-// but against the block timestamp. [baseTime] calculates
-// the right timestamp to be used to mempool tx verification
 func (v *MempoolTxVerifier) standardBaseState() (state.Diff, error) {
 	state, err := state.NewDiff(v.ParentID, v.StateVersions)
 	if err != nil {
@@ -116,14 +113,6 @@ func (v *MempoolTxVerifier) standardBaseState() (state.Diff, error) {
 		return nil, err
 	}
 
-	if !v.Backend.Config.IsBanffActivated(nextBlkTime) {
-		// next tx would be included into an Apricot block
-		// so we verify it against current chain state
-		return state, nil
-	}
-
-	// next tx would be included into a Banff block
-	// so we verify it against duly updated chain state
 	changes, err := AdvanceTimeTo(v.Backend, state, nextBlkTime)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Why this should be merged

This check will never be hit so we can remove it.

## How this works

Delete 🚮

## How this was tested

CI