### PR TITLE
`vms/platformvm`: Remove `HasTxs` and `PeekTxs` from `Mempool` interface

### DIFF
--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -98,18 +98,13 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 		b.ResetBlockTimer()
 	}()
 
-	ctx := b.txExecutorBackend.Ctx
-	ctx.Log.Debug("starting to attempt to build a block")
+	b.txExecutorBackend.Ctx.Log.Debug("starting to attempt to build a block")
 
 	statelessBlk, err := b.buildBlock()
 	if err != nil {
 		return nil, err
 	}
 
-	// Remove selected txs from mempool now that we are returning the block to
-	// the consensus engine.
-	txs := statelessBlk.Txs()
-	b.Mempool.Remove(txs)
 	return b.blkManager.NewBlock(statelessBlk), nil
 }
 
@@ -278,8 +273,24 @@ func buildBlock(
 		)
 	}
 
+	var (
+		blockTxs      []*txs.Tx
+		remainingSize = targetBlockSize
+	)
+
+	for {
+		tx := builder.Mempool.Peek(remainingSize)
+		if tx == nil {
+			break
+		}
+		builder.Mempool.Remove([]*txs.Tx{tx})
+
+		remainingSize -= len(tx.Bytes())
+		blockTxs = append(blockTxs, tx)
+	}
+
 	// If there is no reason to build a block, don't.
-	if !builder.Mempool.HasTxs() && !forceAdvanceTime {
+	if len(blockTxs) == 0 && !forceAdvanceTime {
 		builder.txExecutorBackend.Ctx.Log.Debug("no pending txs to issue into a block")
 		return nil, ErrNoPendingBlocks
 	}
@@ -289,7 +300,7 @@ func buildBlock(
 		timestamp,
 		parentID,
 		height,
-		builder.Mempool.PeekTxs(targetBlockSize),
+		blockTxs,
 	)
 }
 

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -400,10 +400,15 @@ func TestBuildBlock(t *testing.T) {
 			builderF: func(ctrl *gomock.Controller) *builder {
 				mempool := mempool.NewMockMempool(ctrl)
 
-				// There are txs.
 				mempool.EXPECT().DropExpiredStakerTxs(gomock.Any()).Return([]ids.ID{})
-				mempool.EXPECT().HasTxs().Return(true)
-				mempool.EXPECT().PeekTxs(targetBlockSize).Return(transactions)
+
+				gomock.InOrder(
+					mempool.EXPECT().Peek(targetBlockSize).Return(transactions[0]),
+					mempool.EXPECT().Remove([]*txs.Tx{transactions[0]}),
+					// Second loop iteration
+					mempool.EXPECT().Peek(gomock.Any()).Return(nil),
+				)
+
 				return &builder{
 					Mempool: mempool,
 				}
@@ -449,7 +454,7 @@ func TestBuildBlock(t *testing.T) {
 
 				// There are no txs.
 				mempool.EXPECT().DropExpiredStakerTxs(gomock.Any()).Return([]ids.ID{})
-				mempool.EXPECT().HasTxs().Return(false)
+				mempool.EXPECT().Peek(gomock.Any()).Return(nil)
 
 				clk := &mockable.Clock{}
 				clk.Set(now)
@@ -497,8 +502,7 @@ func TestBuildBlock(t *testing.T) {
 
 				// There are no txs.
 				mempool.EXPECT().DropExpiredStakerTxs(gomock.Any()).Return([]ids.ID{})
-				mempool.EXPECT().HasTxs().Return(false)
-				mempool.EXPECT().PeekTxs(targetBlockSize).Return(nil)
+				mempool.EXPECT().Peek(gomock.Any()).Return(nil)
 
 				clk := &mockable.Clock{}
 				clk.Set(now)
@@ -552,8 +556,13 @@ func TestBuildBlock(t *testing.T) {
 
 				// There is a tx.
 				mempool.EXPECT().DropExpiredStakerTxs(gomock.Any()).Return([]ids.ID{})
-				mempool.EXPECT().HasTxs().Return(true)
-				mempool.EXPECT().PeekTxs(targetBlockSize).Return([]*txs.Tx{transactions[0]})
+
+				gomock.InOrder(
+					mempool.EXPECT().Peek(targetBlockSize).Return(transactions[0]),
+					mempool.EXPECT().Remove([]*txs.Tx{transactions[0]}),
+					// Second loop iteration
+					mempool.EXPECT().Peek(gomock.Any()).Return(nil),
+				)
 
 				clk := &mockable.Clock{}
 				clk.Set(now)
@@ -606,8 +615,13 @@ func TestBuildBlock(t *testing.T) {
 				// There are no decision txs
 				// There is a staker tx.
 				mempool.EXPECT().DropExpiredStakerTxs(gomock.Any()).Return([]ids.ID{})
-				mempool.EXPECT().HasTxs().Return(true)
-				mempool.EXPECT().PeekTxs(targetBlockSize).Return([]*txs.Tx{transactions[0]})
+
+				gomock.InOrder(
+					mempool.EXPECT().Peek(targetBlockSize).Return(transactions[0]),
+					mempool.EXPECT().Remove([]*txs.Tx{transactions[0]}),
+					// Second loop iteration
+					mempool.EXPECT().Peek(gomock.Any()).Return(nil),
+				)
 
 				clk := &mockable.Clock{}
 				clk.Set(now)

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -5,7 +5,6 @@ package mempool
 
 import (
 	"errors"
-	"math"
 	"testing"
 	"time"
 
@@ -66,9 +65,6 @@ func TestDecisionTxsInMempool(t *testing.T) {
 	decisionTxs, err := createTestDecisionTxs(2)
 	require.NoError(err)
 
-	// txs must not already there before we start
-	require.False(mpool.HasTxs())
-
 	for _, tx := range decisionTxs {
 		// tx not already there
 		require.False(mpool.Has(tx.ID()))
@@ -82,20 +78,6 @@ func TestDecisionTxsInMempool(t *testing.T) {
 		retrieved := mpool.Get(tx.ID())
 		require.NotNil(retrieved)
 		require.Equal(tx, retrieved)
-
-		// we can peek it
-		peeked := mpool.PeekTxs(math.MaxInt)
-
-		// tx will be among those peeked,
-		// in NO PARTICULAR ORDER
-		found := false
-		for _, pk := range peeked {
-			if pk.ID() == tx.ID() {
-				found = true
-				break
-			}
-		}
-		require.True(found)
 
 		// once removed it cannot be there
 		mpool.Remove([]*txs.Tx{tx})
@@ -121,7 +103,7 @@ func TestProposalTxsInMempool(t *testing.T) {
 	proposalTxs, err := createTestProposalTxs(2)
 	require.NoError(err)
 
-	for i, tx := range proposalTxs {
+	for _, tx := range proposalTxs {
 		require.False(mpool.Has(tx.ID()))
 
 		// we can insert
@@ -133,23 +115,6 @@ func TestProposalTxsInMempool(t *testing.T) {
 		retrieved := mpool.Get(tx.ID())
 		require.NotNil(retrieved)
 		require.Equal(tx, retrieved)
-
-		{
-			// we can peek it
-			peeked := mpool.PeekTxs(math.MaxInt)
-			require.Len(peeked, i+1)
-
-			// tx will be among those peeked,
-			// in NO PARTICULAR ORDER
-			found := false
-			for _, pk := range peeked {
-				if pk.ID() == tx.ID() {
-					found = true
-					break
-				}
-			}
-			require.True(found)
-		}
 
 		// once removed it cannot be there
 		mpool.Remove([]*txs.Tx{tx})

--- a/vms/platformvm/txs/mempool/mock_mempool.go
+++ b/vms/platformvm/txs/mempool/mock_mempool.go
@@ -133,20 +133,6 @@ func (mr *MockMempoolMockRecorder) Has(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Has", reflect.TypeOf((*MockMempool)(nil).Has), arg0)
 }
 
-// HasTxs mocks base method.
-func (m *MockMempool) HasTxs() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasTxs")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// HasTxs indicates an expected call of HasTxs.
-func (mr *MockMempoolMockRecorder) HasTxs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasTxs", reflect.TypeOf((*MockMempool)(nil).HasTxs))
-}
-
 // MarkDropped mocks base method.
 func (m *MockMempool) MarkDropped(arg0 ids.ID, arg1 error) {
 	m.ctrl.T.Helper()
@@ -159,18 +145,18 @@ func (mr *MockMempoolMockRecorder) MarkDropped(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkDropped", reflect.TypeOf((*MockMempool)(nil).MarkDropped), arg0, arg1)
 }
 
-// PeekTxs mocks base method.
-func (m *MockMempool) PeekTxs(arg0 int) []*txs.Tx {
+// Peek mocks base method.
+func (m *MockMempool) Peek(arg0 int) *txs.Tx {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PeekTxs", arg0)
-	ret0, _ := ret[0].([]*txs.Tx)
+	ret := m.ctrl.Call(m, "Peek", arg0)
+	ret0, _ := ret[0].(*txs.Tx)
 	return ret0
 }
 
-// PeekTxs indicates an expected call of PeekTxs.
-func (mr *MockMempoolMockRecorder) PeekTxs(arg0 interface{}) *gomock.Call {
+// Peek indicates an expected call of Peek.
+func (mr *MockMempoolMockRecorder) Peek(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeekTxs", reflect.TypeOf((*MockMempool)(nil).PeekTxs), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peek", reflect.TypeOf((*MockMempool)(nil).Peek), arg0)
 }
 
 // Remove mocks base method.


### PR DESCRIPTION
## Why this should be merged

Preparatory work for verifying each tx individually before putting it into the block.

## How this works

- Remove `HasTxs` and `PeekTxs` from `Mempool` interface
- Add `Peek` method to `Mempool` interface
- Duly update consumers of these methods to use `Peek` or remove usage altogether

## How this was tested

CI
