### PR TITLE
P-Chain merkledb -- remove caches

### DIFF
--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -243,14 +243,11 @@ func defaultState(
 ) state.State {
 	require := require.New(t)
 
-	execCfg, _ := config.GetExecutionConfig([]byte(`{}`))
 	genesisBytes := buildGenesisTest(t, ctx)
 	state, err := state.New(
 		db,
 		genesisBytes,
-		prometheus.NewRegistry(),
 		validators,
-		execCfg,
 		ctx,
 		metrics.Noop,
 		rewards,

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -269,13 +269,10 @@ func defaultState(
 	rewards reward.Calculator,
 ) state.State {
 	genesisBytes := buildGenesisTest(ctx)
-	execCfg, _ := config.GetExecutionConfig([]byte(`{}`))
 	state, err := state.New(
 		db,
 		genesisBytes,
-		prometheus.NewRegistry(),
 		validators,
-		execCfg,
 		ctx,
 		metrics.Noop,
 		rewards,

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"
@@ -29,7 +27,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
-	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/metrics"
@@ -164,16 +161,13 @@ func newUninitializedState(require *require.Assertions) (State, database.Databas
 }
 
 func newStateFromDB(require *require.Assertions, db database.Database) State {
-	execCfg, _ := config.GetExecutionConfig(nil)
 	state, err := newState(
 		db,
 		metrics.Noop,
 		validators.NewManager(),
-		execCfg,
 		&snow.Context{
 			Log: logging.NoLog{},
 		},
-		prometheus.NewRegistry(),
 		reward.NewCalculator(reward.Config{
 			MaxConsumptionRate: .12 * reward.PercentDenominator,
 			MinConsumptionRate: .1 * reward.PercentDenominator,

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/chains"
@@ -224,13 +222,10 @@ func defaultState(
 	rewards reward.Calculator,
 ) state.State {
 	genesisBytes := buildGenesisTest(ctx)
-	execCfg, _ := config.GetExecutionConfig(nil)
 	state, err := state.New(
 		db,
 		genesisBytes,
-		prometheus.NewRegistry(),
 		validators,
-		execCfg,
 		ctx,
 		metrics.Noop,
 		rewards,

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -102,18 +102,13 @@ func BenchmarkGetValidatorSet(b *testing.B) {
 
 	vdrs := validators.NewManager()
 
-	execConfig, err := config.GetExecutionConfig(nil)
-	require.NoError(err)
-
 	metrics, err := metrics.New("", prometheus.NewRegistry())
 	require.NoError(err)
 
 	s, err := state.New(
 		db,
 		genesisBytes,
-		prometheus.NewRegistry(),
 		vdrs,
-		execConfig,
 		&snow.Context{
 			NetworkID: constants.UnitTestID,
 			NodeID:    ids.GenerateTestNodeID(),

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -135,9 +135,7 @@ func (vm *VM) Initialize(
 	vm.state, err = state.New(
 		vm.db,
 		genesisBytes,
-		registerer,
 		vm.Config.Validators,
-		execConfig,
 		vm.ctx,
 		vm.metrics,
 		rewards,

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/chains"
@@ -643,13 +641,10 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 
 	// Force a reload of the state from the database.
 	vm.Config.Validators = validators.NewManager()
-	execCfg, _ := config.GetExecutionConfig(nil)
 	newState, err := state.New(
 		vm.db,
 		nil,
-		prometheus.NewRegistry(),
 		vm.Config.Validators,
-		execCfg,
 		vm.ctx,
 		metrics.Noop,
 		reward.NewCalculator(vm.Config.RewardConfig),
@@ -950,13 +945,10 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 
 	// Force a reload of the state from the database.
 	vm.Config.Validators = validators.NewManager()
-	execCfg, _ := config.GetExecutionConfig(nil)
 	newState, err := state.New(
 		vm.db,
 		nil,
-		prometheus.NewRegistry(),
 		vm.Config.Validators,
-		execCfg,
 		vm.ctx,
 		metrics.Noop,
 		reward.NewCalculator(vm.Config.RewardConfig),


### PR DESCRIPTION
## Why this should be merged

merkledb does its own caching. Instead of caching in both `state` and `merkledb`, we can just rely on merkledb to cache bytes and parse those bytes.

## How this works

CTRL + X

## How this was tested

Existing UT