### PR TITLE
Remove method `CappedList` from `set.Set`

### DIFF
--- a/snow/engine/avalanche/bootstrap/bootstrapper.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper.go
@@ -401,8 +401,7 @@ func (b *bootstrapper) HealthCheck(ctx context.Context) (interface{}, error) {
 func (b *bootstrapper) fetch(ctx context.Context, vtxIDs ...ids.ID) error {
 	b.needToFetch.Add(vtxIDs...)
 	for b.needToFetch.Len() > 0 && b.outstandingRequests.Len() < maxOutstandingGetAncestorsRequests {
-		vtxID := b.needToFetch.CappedList(1)[0]
-		b.needToFetch.Remove(vtxID)
+		vtxID, _ := b.needToFetch.Pop() // Length checked in predicate above
 
 		// Make sure we haven't already requested this vertex
 		if b.outstandingRequests.HasValue(vtxID) {

--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -118,27 +118,6 @@ func (s Set[T]) List() []T {
 	return maps.Keys(s)
 }
 
-// CappedList returns a list of length at most [size].
-// Size should be >= 0. If size < 0, returns nil.
-func (s Set[T]) CappedList(size int) []T {
-	if size < 0 {
-		return nil
-	}
-	if l := s.Len(); l < size {
-		size = l
-	}
-	i := 0
-	elts := make([]T, size)
-	for elt := range s {
-		if i >= size {
-			break
-		}
-		elts[i] = elt
-		i++
-	}
-	return elts
-}
-
 // Equals returns true if the sets contain the same elements
 func (s Set[T]) Equals(other Set[T]) bool {
 	return maps.Equal(s, other)

--- a/utils/set/set_test.go
+++ b/utils/set/set_test.go
@@ -87,35 +87,6 @@ func TestOf(t *testing.T) {
 	}
 }
 
-func TestSetCappedList(t *testing.T) {
-	require := require.New(t)
-	s := Set[int]{}
-
-	id := 0
-
-	require.Empty(s.CappedList(0))
-
-	s.Add(id)
-
-	require.Empty(s.CappedList(0))
-	require.Len(s.CappedList(1), 1)
-	require.Equal(s.CappedList(1)[0], id)
-	require.Len(s.CappedList(2), 1)
-	require.Equal(s.CappedList(2)[0], id)
-
-	id2 := 1
-	s.Add(id2)
-
-	require.Empty(s.CappedList(0))
-	require.Len(s.CappedList(1), 1)
-	require.Len(s.CappedList(2), 2)
-	require.Len(s.CappedList(3), 2)
-	gotList := s.CappedList(2)
-	require.Contains(gotList, id)
-	require.Contains(gotList, id2)
-	require.NotEqual(gotList[0], gotList[1])
-}
-
 func TestSetClear(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
## Why this should be merged

This method is used in one place, which is easily replaceable with `Pop`.

## How this works

Self-explanatory.

## How this was tested

Existing tests.