### PR TITLE
`vms/platformvm`: Move `GetRewardUTXOs`, `GetSubnets`, and `GetChains` to `State` interface

### DIFF
--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -47,10 +47,8 @@ type diff struct {
 	subnetOwners map[ids.ID]fx.Owner
 	// Subnet ID --> Tx that transforms the subnet
 	transformedSubnets map[ids.ID]*txs.Tx
-	cachedSubnets      []*txs.Tx
 
-	addedChains  map[ids.ID][]*txs.Tx
-	cachedChains map[ids.ID][]*txs.Tx
+	addedChains map[ids.ID][]*txs.Tx
 
 	addedRewardUTXOs map[ids.ID][]*avax.UTXO
 
@@ -261,9 +259,6 @@ func (d *diff) GetPendingStakerIterator() (StakerIterator, error) {
 
 func (d *diff) AddSubnet(createSubnetTx *txs.Tx) {
 	d.addedSubnets = append(d.addedSubnets, createSubnetTx)
-	if d.cachedSubnets != nil {
-		d.cachedSubnets = append(d.cachedSubnets, createSubnetTx)
-	}
 }
 
 func (d *diff) GetSubnetOwner(subnetID ids.ID) (fx.Owner, error) {
@@ -318,12 +313,6 @@ func (d *diff) AddChain(createChainTx *txs.Tx) {
 	} else {
 		d.addedChains[tx.SubnetID] = append(d.addedChains[tx.SubnetID], createChainTx)
 	}
-
-	cachedChains, cached := d.cachedChains[tx.SubnetID]
-	if !cached {
-		return
-	}
-	d.cachedChains[tx.SubnetID] = append(cachedChains, createChainTx)
 }
 
 func (d *diff) GetTx(txID ids.ID) (*txs.Tx, status.Status, error) {

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -259,36 +259,6 @@ func (d *diff) GetPendingStakerIterator() (StakerIterator, error) {
 	return d.pendingStakerDiffs.GetStakerIterator(parentIterator), nil
 }
 
-func (d *diff) GetSubnets() ([]*txs.Tx, error) {
-	if len(d.addedSubnets) == 0 {
-		parentState, ok := d.stateVersions.GetState(d.parentID)
-		if !ok {
-			return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
-		}
-		return parentState.GetSubnets()
-	}
-
-	if len(d.cachedSubnets) != 0 {
-		return d.cachedSubnets, nil
-	}
-
-	parentState, ok := d.stateVersions.GetState(d.parentID)
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
-	}
-	subnets, err := parentState.GetSubnets()
-	if err != nil {
-		return nil, err
-	}
-	newSubnets := make([]*txs.Tx, len(subnets)+len(d.addedSubnets))
-	copy(newSubnets, subnets)
-	for i, subnet := range d.addedSubnets {
-		newSubnets[i+len(subnets)] = subnet
-	}
-	d.cachedSubnets = newSubnets
-	return newSubnets, nil
-}
-
 func (d *diff) AddSubnet(createSubnetTx *txs.Tx) {
 	d.addedSubnets = append(d.addedSubnets, createSubnetTx)
 	if d.cachedSubnets != nil {
@@ -339,48 +309,6 @@ func (d *diff) AddSubnetTransformation(transformSubnetTxIntf *txs.Tx) {
 	}
 }
 
-func (d *diff) GetChains(subnetID ids.ID) ([]*txs.Tx, error) {
-	addedChains := d.addedChains[subnetID]
-	if len(addedChains) == 0 {
-		// No chains have been added to this subnet
-		parentState, ok := d.stateVersions.GetState(d.parentID)
-		if !ok {
-			return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
-		}
-		return parentState.GetChains(subnetID)
-	}
-
-	// There have been chains added to the requested subnet
-
-	if d.cachedChains == nil {
-		// This is the first time we are going to be caching the subnet chains
-		d.cachedChains = make(map[ids.ID][]*txs.Tx)
-	}
-
-	cachedChains, cached := d.cachedChains[subnetID]
-	if cached {
-		return cachedChains, nil
-	}
-
-	// This chain wasn't cached yet
-	parentState, ok := d.stateVersions.GetState(d.parentID)
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
-	}
-	chains, err := parentState.GetChains(subnetID)
-	if err != nil {
-		return nil, err
-	}
-
-	newChains := make([]*txs.Tx, len(chains)+len(addedChains))
-	copy(newChains, chains)
-	for i, chain := range addedChains {
-		newChains[i+len(chains)] = chain
-	}
-	d.cachedChains[subnetID] = newChains
-	return newChains, nil
-}
-
 func (d *diff) AddChain(createChainTx *txs.Tx) {
 	tx := createChainTx.Unsigned.(*txs.CreateChainTx)
 	if d.addedChains == nil {
@@ -423,18 +351,6 @@ func (d *diff) AddTx(tx *txs.Tx, status status.Status) {
 	} else {
 		d.addedTxs[txID] = txStatus
 	}
-}
-
-func (d *diff) GetRewardUTXOs(txID ids.ID) ([]*avax.UTXO, error) {
-	if utxos, exists := d.addedRewardUTXOs[txID]; exists {
-		return utxos, nil
-	}
-
-	parentState, ok := d.stateVersions.GetState(d.parentID)
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
-	}
-	return parentState.GetRewardUTXOs(txID)
 }
 
 func (d *diff) AddRewardUTXO(txID ids.ID, utxo *avax.UTXO) {

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -246,7 +246,7 @@ func TestDiffPendingDelegator(t *testing.T) {
 	require.False(gotPendingDelegatorIter.Next())
 }
 
-func TestDiffSubnetCreation(t *testing.T) {
+func TestDiffSubnet(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -274,7 +274,7 @@ func TestDiffSubnet(t *testing.T) {
 	diff, err := NewDiff(lastAcceptedID, states)
 	require.NoError(err)
 
-	// Add a subnet to the diff
+	// Put a subnet
 	createSubnetTx := &txs.Tx{
 		Unsigned: &txs.CreateSubnetTx{
 			Owner: fx.NewMockOwner(ctrl),

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -180,21 +180,6 @@ func (mr *MockChainMockRecorder) DeleteUTXO(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUTXO", reflect.TypeOf((*MockChain)(nil).DeleteUTXO), arg0)
 }
 
-// GetChains mocks base method.
-func (m *MockChain) GetChains(arg0 ids.ID) ([]*txs.Tx, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChains", arg0)
-	ret0, _ := ret[0].([]*txs.Tx)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetChains indicates an expected call of GetChains.
-func (mr *MockChainMockRecorder) GetChains(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChains", reflect.TypeOf((*MockChain)(nil).GetChains), arg0)
-}
-
 // GetCurrentDelegatorIterator mocks base method.
 func (m *MockChain) GetCurrentDelegatorIterator(arg0 ids.ID, arg1 ids.NodeID) (StakerIterator, error) {
 	m.ctrl.T.Helper()
@@ -315,21 +300,6 @@ func (mr *MockChainMockRecorder) GetPendingValidator(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockChain)(nil).GetPendingValidator), arg0, arg1)
 }
 
-// GetRewardUTXOs mocks base method.
-func (m *MockChain) GetRewardUTXOs(arg0 ids.ID) ([]*avax.UTXO, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRewardUTXOs", arg0)
-	ret0, _ := ret[0].([]*avax.UTXO)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRewardUTXOs indicates an expected call of GetRewardUTXOs.
-func (mr *MockChainMockRecorder) GetRewardUTXOs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRewardUTXOs", reflect.TypeOf((*MockChain)(nil).GetRewardUTXOs), arg0)
-}
-
 // GetSubnetOwner mocks base method.
 func (m *MockChain) GetSubnetOwner(arg0 ids.ID) (fx.Owner, error) {
 	m.ctrl.T.Helper()
@@ -358,21 +328,6 @@ func (m *MockChain) GetSubnetTransformation(arg0 ids.ID) (*txs.Tx, error) {
 func (mr *MockChainMockRecorder) GetSubnetTransformation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetTransformation", reflect.TypeOf((*MockChain)(nil).GetSubnetTransformation), arg0)
-}
-
-// GetSubnets mocks base method.
-func (m *MockChain) GetSubnets() ([]*txs.Tx, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubnets")
-	ret0, _ := ret[0].([]*txs.Tx)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSubnets indicates an expected call of GetSubnets.
-func (mr *MockChainMockRecorder) GetSubnets() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnets", reflect.TypeOf((*MockChain)(nil).GetSubnets))
 }
 
 // GetTimestamp mocks base method.
@@ -687,21 +642,6 @@ func (mr *MockDiffMockRecorder) DeleteUTXO(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUTXO", reflect.TypeOf((*MockDiff)(nil).DeleteUTXO), arg0)
 }
 
-// GetChains mocks base method.
-func (m *MockDiff) GetChains(arg0 ids.ID) ([]*txs.Tx, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChains", arg0)
-	ret0, _ := ret[0].([]*txs.Tx)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetChains indicates an expected call of GetChains.
-func (mr *MockDiffMockRecorder) GetChains(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChains", reflect.TypeOf((*MockDiff)(nil).GetChains), arg0)
-}
-
 // GetCurrentDelegatorIterator mocks base method.
 func (m *MockDiff) GetCurrentDelegatorIterator(arg0 ids.ID, arg1 ids.NodeID) (StakerIterator, error) {
 	m.ctrl.T.Helper()
@@ -822,21 +762,6 @@ func (mr *MockDiffMockRecorder) GetPendingValidator(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockDiff)(nil).GetPendingValidator), arg0, arg1)
 }
 
-// GetRewardUTXOs mocks base method.
-func (m *MockDiff) GetRewardUTXOs(arg0 ids.ID) ([]*avax.UTXO, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRewardUTXOs", arg0)
-	ret0, _ := ret[0].([]*avax.UTXO)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRewardUTXOs indicates an expected call of GetRewardUTXOs.
-func (mr *MockDiffMockRecorder) GetRewardUTXOs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRewardUTXOs", reflect.TypeOf((*MockDiff)(nil).GetRewardUTXOs), arg0)
-}
-
 // GetSubnetOwner mocks base method.
 func (m *MockDiff) GetSubnetOwner(arg0 ids.ID) (fx.Owner, error) {
 	m.ctrl.T.Helper()
@@ -865,21 +790,6 @@ func (m *MockDiff) GetSubnetTransformation(arg0 ids.ID) (*txs.Tx, error) {
 func (mr *MockDiffMockRecorder) GetSubnetTransformation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetTransformation", reflect.TypeOf((*MockDiff)(nil).GetSubnetTransformation), arg0)
-}
-
-// GetSubnets mocks base method.
-func (m *MockDiff) GetSubnets() ([]*txs.Tx, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubnets")
-	ret0, _ := ret[0].([]*txs.Tx)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSubnets indicates an expected call of GetSubnets.
-func (mr *MockDiffMockRecorder) GetSubnets() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnets", reflect.TypeOf((*MockDiff)(nil).GetSubnets))
 }
 
 // GetTimestamp mocks base method.

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -106,10 +106,8 @@ type Chain interface {
 	GetCurrentSupply(subnetID ids.ID) (uint64, error)
 	SetCurrentSupply(subnetID ids.ID, cs uint64)
 
-	GetRewardUTXOs(txID ids.ID) ([]*avax.UTXO, error)
 	AddRewardUTXO(txID ids.ID, utxo *avax.UTXO)
 
-	GetSubnets() ([]*txs.Tx, error)
 	AddSubnet(createSubnetTx *txs.Tx)
 
 	GetSubnetOwner(subnetID ids.ID) (fx.Owner, error)
@@ -118,7 +116,6 @@ type Chain interface {
 	GetSubnetTransformation(subnetID ids.ID) (*txs.Tx, error)
 	AddSubnetTransformation(transformSubnetTx *txs.Tx)
 
-	GetChains(subnetID ids.ID) ([]*txs.Tx, error)
 	AddChain(createChainTx *txs.Tx)
 
 	GetTx(txID ids.ID) (*txs.Tx, status.Status, error)
@@ -139,6 +136,10 @@ type State interface {
 	AddStatelessBlock(block block.Block)
 
 	GetBlockIDAtHeight(height uint64) (ids.ID, error)
+
+	GetRewardUTXOs(txID ids.ID) ([]*avax.UTXO, error)
+	GetSubnets() ([]*txs.Tx, error)
+	GetChains(subnetID ids.ID) ([]*txs.Tx, error)
 
 	// ApplyValidatorWeightDiffs iterates from [startHeight] towards the genesis
 	// block until it has applied all of the diffs up to and including


### PR DESCRIPTION
## Why this should be merged

We should remove `GetRewardUTXOs`, `GetSubnets`, and `GetChains` from the [state.Chain](https://github.com/ava-labs/avalanchego/blob/master/vms/platformvm/state/state.go#L97) interface and put them into `state.State`. Then we can remove those functions from `state.Diff` (which are never used and never should be)

## How this works

pretty straightforward

## How this was tested

CI