### PR TITLE
remove some of the reliance on the exp pkg

### DIFF
--- a/api/metrics/multi_gatherer.go
+++ b/api/metrics/multi_gatherer.go
@@ -91,7 +91,14 @@ func (g *multiGatherer) Register(namespace string, gatherer prometheus.Gatherer)
 }
 
 func sortMetrics(m []*dto.MetricFamily) {
-	slices.SortFunc(m, func(i, j *dto.MetricFamily) bool {
-		return *i.Name < *j.Name
+	slices.SortFunc(m, func(i, j *dto.MetricFamily) int {
+		if *i.Name < *j.Name {
+			return -1
+		}
+		if *i.Name > *j.Name {
+			return 1
+		}
+
+		return 0
 	})
 }

--- a/codec/reflectcodec/type_codec.go
+++ b/codec/reflectcodec/type_codec.go
@@ -490,10 +490,10 @@ func (c *genericCodec) marshal(
 			endOffset = p.Offset
 		}
 
-		slices.SortFunc(sortedKeys, func(a, b keyTuple) bool {
+		slices.SortFunc(sortedKeys, func(a, b keyTuple) int {
 			aBytes := p.Bytes[a.startIndex:a.endIndex]
 			bBytes := p.Bytes[b.startIndex:b.endIndex]
-			return bytes.Compare(aBytes, bBytes) < 0
+			return bytes.Compare(aBytes, bBytes)
 		})
 
 		allKeyBytes := slices.Clone(p.Bytes[startOffset:p.Offset])

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	go.uber.org/mock v0.2.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.14.0
-	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
+	golang.org/x/exp v0.0.0-20231127185646-65229373498e
 	golang.org/x/net v0.17.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/term v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -704,8 +704,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df h1:UA2aFVmmsIlefxMk29Dp2juaUSth8Pyn3Tq5Y5mJGME=
-golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20231127185646-65229373498e h1:Gvh4YaCaXNs6dKTlfgismwWZKyjVZXwOPfIyUaqU3No=
+golang.org/x/exp v0.0.0-20231127185646-65229373498e/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/utils/sorting.go
+++ b/utils/sorting.go
@@ -5,8 +5,9 @@ package utils
 
 import (
 	"bytes"
-	"cmp"
-	"slices"
+
+	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/slices"
 
 	"github.com/ava-labs/avalanchego/utils/hashing"
 )
@@ -23,7 +24,10 @@ func Sort[T Sortable[T]](s []T) {
 		if a.Less(b) {
 			return -1
 		}
-		return 1
+		if b.Less(a) {
+			return 1
+		}
+		return 0
 	})
 }
 
@@ -66,7 +70,7 @@ func IsSortedAndUnique[T Sortable[T]](s []T) bool {
 }
 
 // Returns true iff the elements in [s] are unique and sorted.
-func IsSortedAndUniqueOrdered[T cmp.Ordered](s []T) bool {
+func IsSortedAndUniqueOrdered[T constraints.Ordered](s []T) bool {
 	for i := 0; i < len(s)-1; i++ {
 		if s[i] >= s[i+1] {
 			return false

--- a/utils/sorting.go
+++ b/utils/sorting.go
@@ -5,9 +5,8 @@ package utils
 
 import (
 	"bytes"
-
-	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/slices"
+	"cmp"
+	"slices"
 
 	"github.com/ava-labs/avalanchego/utils/hashing"
 )
@@ -20,15 +19,20 @@ type Sortable[T any] interface {
 
 // Sorts the elements of [s].
 func Sort[T Sortable[T]](s []T) {
-	slices.SortFunc(s, T.Less)
+	slices.SortFunc(s, func(a, b T) int {
+		if a.Less(b) {
+			return -1
+		}
+		return 1
+	})
 }
 
 // Sorts the elements of [s] based on their hashes.
 func SortByHash[T ~[]byte](s []T) {
-	slices.SortFunc(s, func(i, j T) bool {
+	slices.SortFunc(s, func(i, j T) int {
 		iHash := hashing.ComputeHash256(i)
 		jHash := hashing.ComputeHash256(j)
-		return bytes.Compare(iHash, jHash) == -1
+		return bytes.Compare(iHash, jHash)
 	})
 }
 
@@ -36,8 +40,8 @@ func SortByHash[T ~[]byte](s []T) {
 // Each byte slice is not sorted internally; the byte slices are sorted relative
 // to one another.
 func SortBytes[T ~[]byte](s []T) {
-	slices.SortFunc(s, func(i, j T) bool {
-		return bytes.Compare(i, j) == -1
+	slices.SortFunc(s, func(i, j T) int {
+		return bytes.Compare(i, j)
 	})
 }
 
@@ -62,7 +66,7 @@ func IsSortedAndUnique[T Sortable[T]](s []T) bool {
 }
 
 // Returns true iff the elements in [s] are unique and sorted.
-func IsSortedAndUniqueOrdered[T constraints.Ordered](s []T) bool {
+func IsSortedAndUniqueOrdered[T cmp.Ordered](s []T) bool {
 	for i := 0; i < len(s)-1; i++ {
 		if s[i] >= s[i+1] {
 			return false


### PR DESCRIPTION
Notes:
- Updates the `x/exp` pkg 

## Why this should be merged
- the signature of the SortFunc has changed in the exp pkg from `func(i, j T) bool` to `func(i, j T) int` so upgrading now will prevent issues in the future


## How this works

## How this was tested
- should be handled by test suite