### PR TITLE
`vms/platformvm`: Move `VerifyUniqueInputs` from `verifier` to `backend`

### DIFF
--- a/vms/avm/block/executor/manager.go
+++ b/vms/avm/block/executor/manager.go
@@ -43,8 +43,8 @@ type Manager interface {
 	// preferred state. This should *not* be used to verify transactions in a block.
 	VerifyTx(tx *txs.Tx) error
 
-	// VerifyUniqueInputs verifies that the inputs are not duplicated in the
-	// provided blk or any of its ancestors pinned in memory.
+	// VerifyUniqueInputs returns nil iff no blocks in the inclusive
+	// ancestry of [blkID] consume an input in [inputs].
 	VerifyUniqueInputs(blkID ids.ID, inputs set.Set[ids.ID]) error
 }
 

--- a/vms/platformvm/block/executor/backend.go
+++ b/vms/platformvm/block/executor/backend.go
@@ -4,6 +4,7 @@
 package executor
 
 import (
+	"errors"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -13,6 +14,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
 )
+
+var errConflictingParentTxs = errors.New("block contains a transaction that conflicts with a transaction in a parent block")
 
 // Shared fields used by visitors.
 type backend struct {

--- a/vms/platformvm/block/executor/backend.go
+++ b/vms/platformvm/block/executor/backend.go
@@ -100,8 +100,8 @@ func (b *backend) getTimestamp(blkID ids.ID) time.Time {
 	return b.state.GetTimestamp()
 }
 
-// VerifyUniqueInputs verifies that the inputs are not duplicated in the
-// provided blk or any of its ancestors pinned in memory.
+// VerifyUniqueInputs returns nil iff no blocks in the inclusive
+// ancestry of [blkID] consume an input in [inputs].
 func (b *backend) VerifyUniqueInputs(blkID ids.ID, inputs set.Set[ids.ID]) error {
 	if inputs.Len() == 0 {
 		return nil

--- a/vms/platformvm/block/executor/backend.go
+++ b/vms/platformvm/block/executor/backend.go
@@ -100,9 +100,9 @@ func (b *backend) getTimestamp(blkID ids.ID) time.Time {
 	return b.state.GetTimestamp()
 }
 
-// VerifyUniqueInputs returns nil iff no blocks in the inclusive
+// verifyUniqueInputs returns nil iff no blocks in the inclusive
 // ancestry of [blkID] consume an input in [inputs].
-func (b *backend) VerifyUniqueInputs(blkID ids.ID, inputs set.Set[ids.ID]) error {
+func (b *backend) verifyUniqueInputs(blkID ids.ID, inputs set.Set[ids.ID]) error {
 	if inputs.Len() == 0 {
 		return nil
 	}

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
@@ -203,7 +202,7 @@ func (v *verifier) ApricotAtomicBlock(b *block.ApricotAtomicBlock) error {
 
 	atomicExecutor.OnAccept.AddTx(b.Tx, status.Committed)
 
-	if err := v.verifyUniqueInputs(b, atomicExecutor.Inputs); err != nil {
+	if err := v.VerifyUniqueInputs(b.Parent(), atomicExecutor.Inputs); err != nil {
 		return err
 	}
 
@@ -441,7 +440,7 @@ func (v *verifier) standardBlock(
 		}
 	}
 
-	if err := v.verifyUniqueInputs(b, blkState.inputs); err != nil {
+	if err := v.VerifyUniqueInputs(b.Parent(), blkState.inputs); err != nil {
 		return err
 	}
 
@@ -460,29 +459,4 @@ func (v *verifier) standardBlock(
 
 	v.Mempool.Remove(b.Transactions)
 	return nil
-}
-
-// verifyUniqueInputs verifies that the inputs of the given block are not
-// duplicated in any of the parent blocks pinned in memory.
-func (v *verifier) verifyUniqueInputs(block block.Block, inputs set.Set[ids.ID]) error {
-	if inputs.Len() == 0 {
-		return nil
-	}
-
-	// Check for conflicts in ancestors.
-	for {
-		parentID := block.Parent()
-		parentState, ok := v.blkIDToState[parentID]
-		if !ok {
-			// The parent state isn't pinned in memory.
-			// This means the parent must be accepted already.
-			return nil
-		}
-
-		if parentState.inputs.Overlaps(inputs) {
-			return errConflictingParentTxs
-		}
-
-		block = parentState.statelessBlock
-	}
 }

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -25,7 +25,6 @@ var (
 	errIncorrectBlockHeight                       = errors.New("incorrect block height")
 	errChildBlockEarlierThanParent                = errors.New("proposed timestamp before current chain time")
 	errConflictingBatchTxs                        = errors.New("block contains conflicting transactions")
-	errConflictingParentTxs                       = errors.New("block contains a transaction that conflicts with a transaction in a parent block")
 	errOptionBlockTimestampNotMatchingParent      = errors.New("option block proposed timestamp not matching parent block one")
 )
 

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -201,7 +201,7 @@ func (v *verifier) ApricotAtomicBlock(b *block.ApricotAtomicBlock) error {
 
 	atomicExecutor.OnAccept.AddTx(b.Tx, status.Committed)
 
-	if err := v.VerifyUniqueInputs(b.Parent(), atomicExecutor.Inputs); err != nil {
+	if err := v.verifyUniqueInputs(b.Parent(), atomicExecutor.Inputs); err != nil {
 		return err
 	}
 
@@ -439,7 +439,7 @@ func (v *verifier) standardBlock(
 		}
 	}
 
-	if err := v.VerifyUniqueInputs(b.Parent(), blkState.inputs); err != nil {
+	if err := v.verifyUniqueInputs(b.Parent(), blkState.inputs); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Why this should be merged

This function relies on fields in the `backend` struct only. Hoisting it there will allow us to use it when verifying mempool txs before putting them in a block.

Refactored it slightly to take in a `blkID`.

Factored out of https://github.com/ava-labs/avalanchego/pull/2359

## How this works

pretty straightforward

## How this was tested

CI