### PR TITLE
`vms/platformvm`: Initialize txs in `Transactions` field for `BanffProposalBlock`

### DIFF
--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -53,13 +53,10 @@ func (b *BanffProposalBlock) Timestamp() time.Time {
 
 func (b *BanffProposalBlock) Txs() []*txs.Tx {
 	l := len(b.Transactions)
-	if l == 0 {
-		return []*txs.Tx{b.Tx}
-	}
-
 	txs := make([]*txs.Tx, l+1)
-	_ = copy(txs, b.Transactions)
-	return append(txs, b.Tx)
+	copy(txs, b.Transactions)
+	txs[l] = b.Tx
+	return txs
 }
 
 func (b *BanffProposalBlock) Visit(v Visitor) error {

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -52,8 +52,13 @@ func (b *BanffProposalBlock) Timestamp() time.Time {
 }
 
 func (b *BanffProposalBlock) Txs() []*txs.Tx {
-	txs := make([]*txs.Tx, len(b.Transactions)+1)
-	copy(txs, b.Transactions)
+	l := len(b.Transactions)
+	if l == 0 {
+		return []*txs.Tx{b.Tx}
+	}
+
+	txs := make([]*txs.Tx, l+1)
+	_ = copy(txs, b.Transactions)
 	return append(txs, b.Tx)
 }
 

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -28,6 +28,19 @@ type BanffProposalBlock struct {
 	ApricotProposalBlock `serialize:"true"`
 }
 
+func (b *BanffProposalBlock) initialize(bytes []byte) error {
+	b.CommonBlock.initialize(bytes)
+	if err := b.Tx.Initialize(txs.Codec); err != nil {
+		return fmt.Errorf("failed to initialize tx: %w", err)
+	}
+	for _, tx := range b.Transactions {
+		if err := tx.Initialize(txs.Codec); err != nil {
+			return fmt.Errorf("failed to initialize tx: %w", err)
+		}
+	}
+	return nil
+}
+
 func (b *BanffProposalBlock) InitCtx(ctx *snow.Context) {
 	for _, tx := range b.Transactions {
 		tx.Unsigned.InitCtx(ctx)
@@ -37,6 +50,10 @@ func (b *BanffProposalBlock) InitCtx(ctx *snow.Context) {
 
 func (b *BanffProposalBlock) Timestamp() time.Time {
 	return time.Unix(int64(b.Time), 0)
+}
+
+func (b *BanffProposalBlock) Txs() []*txs.Tx {
+	return append(b.Transactions, b.Tx)
 }
 
 func (b *BanffProposalBlock) Visit(v Visitor) error {

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -52,7 +52,9 @@ func (b *BanffProposalBlock) Timestamp() time.Time {
 }
 
 func (b *BanffProposalBlock) Txs() []*txs.Tx {
-	return append(b.Transactions, b.Tx)
+	txs := make([]*txs.Tx, len(b.Transactions)+1)
+	copy(txs, b.Transactions)
+	return append(txs, b.Tx)
 }
 
 func (b *BanffProposalBlock) Visit(v Visitor) error {

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -29,9 +29,8 @@ type BanffProposalBlock struct {
 }
 
 func (b *BanffProposalBlock) initialize(bytes []byte) error {
-	b.CommonBlock.initialize(bytes)
-	if err := b.Tx.Initialize(txs.Codec); err != nil {
-		return fmt.Errorf("failed to initialize tx: %w", err)
+	if err := b.ApricotProposalBlock.initialize(bytes); err != nil {
+		return err
 	}
 	for _, tx := range b.Transactions {
 		if err := tx.Initialize(txs.Codec); err != nil {

--- a/vms/platformvm/block/standard_block.go
+++ b/vms/platformvm/block/standard_block.go
@@ -58,7 +58,7 @@ func (b *ApricotStandardBlock) initialize(bytes []byte) error {
 	b.CommonBlock.initialize(bytes)
 	for _, tx := range b.Transactions {
 		if err := tx.Initialize(txs.Codec); err != nil {
-			return fmt.Errorf("failed to sign block: %w", err)
+			return fmt.Errorf("failed to initialize tx: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Why this should be merged

These should be initialized. We do not currently support this field to be populated in the verifier so this is a no-op change.

Factored out of https://github.com/ava-labs/avalanchego/pull/2411

## How this works

add methods

## How this was tested

CI