### PR TITLE
Update minimum golang version to v1.20.12

### DIFF
--- a/.github/workflows/auto-generated-checker.yml
+++ b/.github/workflows/auto-generated-checker.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - uses: bufbuild/buf-setup-action@v1.26.1
       - shell: bash
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - shell: bash
         run: scripts/mock.gen.sh
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - shell: bash
         run: go mod tidy

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
 
       - run: go version
@@ -81,7 +81,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
 
       - run: go version

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - run: go version
 

--- a/.github/workflows/build-public-ami.yml
+++ b/.github/workflows/build-public-ami.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - run: go version
 

--- a/.github/workflows/build-ubuntu-amd64-release.yml
+++ b/.github/workflows/build-ubuntu-amd64-release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - run: go version
 
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - run: go version
 

--- a/.github/workflows/build-ubuntu-arm64-release.yml
+++ b/.github/workflows/build-ubuntu-arm64-release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - run: go version
 
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - run: go version
 

--- a/.github/workflows/build-win-release.yml
+++ b/.github/workflows/build-win-release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
 
       - run: go version

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: Run fuzz tests
         shell: bash

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: Run static analysis tests
         shell: bash

--- a/.github/workflows/test.e2e.existing.yml
+++ b/.github/workflows/test.e2e.existing.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: Build the avalanchego binary
         shell: bash

--- a/.github/workflows/test.e2e.yml
+++ b/.github/workflows/test.e2e.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: Build the avalanchego binary
         shell: bash

--- a/.github/workflows/test.unit.yml
+++ b/.github/workflows/test.unit.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: Set timeout on Windows # Windows UT run slower and need a longer timeout
         shell: bash

--- a/.github/workflows/test.upgrade.yml
+++ b/.github/workflows/test.upgrade.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: Build the avalanchego binary
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 To start developing on AvalancheGo, you'll need a few things installed.
 
-- Golang version >= 1.20.8
+- Golang version >= 1.20.12
 - gcc
 - g++
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # README.md
 # go.mod
 # ============= Compilation Stage ================
-FROM golang:1.20.10-bullseye AS builder
+FROM golang:1.20.12-bullseye AS builder
 
 WORKDIR /build
 # Copy and download avalanche dependencies using go mod

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The minimum recommended hardware specification for nodes connected to Mainnet is
 
 If you plan to build AvalancheGo from source, you will also need the following software:
 
-- [Go](https://golang.org/doc/install) version >= 1.20.10
+- [Go](https://golang.org/doc/install) version >= 1.20.12
 - [gcc](https://gcc.gnu.org/)
 - g++
 

--- a/proto/Dockerfile.buf
+++ b/proto/Dockerfile.buf
@@ -6,7 +6,7 @@ RUN apt-get update && apt -y install bash curl unzip git
 WORKDIR /opt
 
 RUN \
-  curl -L https://golang.org/dl/go1.20.8.linux-amd64.tar.gz > golang.tar.gz && \
+  curl -L https://golang.org/dl/go1.20.12.linux-amd64.tar.gz > golang.tar.gz && \
   mkdir golang && \
   tar -zxvf golang.tar.gz -C golang/
 

--- a/scripts/build_avalanche.sh
+++ b/scripts/build_avalanche.sh
@@ -27,7 +27,7 @@ done
 # Dockerfile
 # README.md
 # go.mod
-go_version_minimum="1.20.10"
+go_version_minimum="1.20.12"
 
 go_version() {
     go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'


### PR DESCRIPTION
## Why this should be merged

Addresses [CVE-2023-39326](https://www.cve.org/CVERecord?id=CVE-2023-39326).

## How this works

Updates the minimum golang version to include [the fix](https://github.com/golang/go/issues/64434).

## How this was tested

CI