### PR TITLE
Fix platformvm.SetPreference

### DIFF
--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -132,7 +132,7 @@ func TestNoErrorOnUnexpectedSetPreferenceDuringBootstrapping(t *testing.T) {
 		require.NoError(shutdownEnvironment(env))
 	}()
 
-	require.False(env.blkManager.SetPreference(ids.GenerateTestID())) // should not panic
+	require.True(env.blkManager.SetPreference(ids.GenerateTestID())) // should not panic
 }
 
 func TestGetNextStakerToReward(t *testing.T) {

--- a/vms/platformvm/block/executor/manager.go
+++ b/vms/platformvm/block/executor/manager.go
@@ -107,9 +107,9 @@ func (m *manager) NewBlock(blk block.Block) snowman.Block {
 	}
 }
 
-func (m *manager) SetPreference(blockID ids.ID) (updated bool) {
-	updated = m.preferred == blockID
-	m.preferred = blockID
+func (m *manager) SetPreference(blkID ids.ID) bool {
+	updated := m.preferred != blkID
+	m.preferred = blkID
 	return updated
 }
 

--- a/vms/platformvm/block/executor/manager_test.go
+++ b/vms/platformvm/block/executor/manager_test.go
@@ -72,3 +72,18 @@ func TestManagerLastAccepted(t *testing.T) {
 
 	require.Equal(t, lastAcceptedID, manager.LastAccepted())
 }
+
+func TestManagerSetPreference(t *testing.T) {
+	require := require.New(t)
+
+	initialPreference := ids.GenerateTestID()
+	manager := &manager{
+		preferred: initialPreference,
+	}
+	require.False(manager.SetPreference(initialPreference))
+
+	newPreference := ids.GenerateTestID()
+	require.True(manager.SetPreference(newPreference))
+	require.False(manager.SetPreference(newPreference))
+	require.True(manager.SetPreference(initialPreference))
+}


### PR DESCRIPTION
## Why this should be merged

`SetPreference` is supposed to return `true` if the preference was updated.

## How this works

`==` -> `!=`

## How this was tested

- [X] Fixed incorrect test
- [X] Added explicit test
- [X] CI