### PR TITLE
Decision txs in proposal blocks

### DIFF
--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
@@ -151,7 +152,8 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 		require.NoError(shutdownEnvironment(env))
 	}()
 	env.clk.Set(defaultGenesisTime)
-	env.config.BanffTime = time.Time{} // activate Banff
+	env.config.BanffTime = time.Time{} // activate Banff, but not Durango
+	env.config.DurangoTime = mockable.MaxTime
 
 	// create parentBlock. It's a standard one for simplicity
 	parentTime := defaultGenesisTime

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -467,8 +467,8 @@ func TestLatestForkVerifyUnverifiedParent(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				BanffTime:   time.Unix(0, 0),
-				DurangoTime: time.Unix(0, 0),
+				BanffTime:   time.Time{},
+				DurangoTime: time.Time{},
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -490,7 +490,7 @@ func TestLatestForkVerifyUnverifiedParent(t *testing.T) {
 	require.ErrorIs(err, database.ErrNotFound)
 }
 
-func TestBanffAbortBlockTimestampChecks(t *testing.T) {
+func TestLatestForkAbortBlockTimestampChecks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	now := defaultGenesisTime.Add(time.Hour)
@@ -543,7 +543,8 @@ func TestBanffAbortBlockTimestampChecks(t *testing.T) {
 			verifier := &verifier{
 				txExecutorBackend: &executor.Backend{
 					Config: &config.Config{
-						BanffTime: time.Time{}, // banff is activated
+						BanffTime:   time.Time{}, // banff is activated
+						DurangoTime: time.Time{}, // durango is not activated
 					},
 					Clk: &mockable.Clock{},
 				},
@@ -583,7 +584,7 @@ func TestBanffAbortBlockTimestampChecks(t *testing.T) {
 }
 
 // TODO combine with TestApricotCommitBlockTimestampChecks
-func TestBanffCommitBlockTimestampChecks(t *testing.T) {
+func TestLatestCommitBlockTimestampChecks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	now := defaultGenesisTime.Add(time.Hour)
@@ -636,7 +637,8 @@ func TestBanffCommitBlockTimestampChecks(t *testing.T) {
 			verifier := &verifier{
 				txExecutorBackend: &executor.Backend{
 					Config: &config.Config{
-						BanffTime: time.Time{}, // banff is activated
+						BanffTime:   time.Time{}, // banff is activated
+						DurangoTime: time.Time{}, // durango is activated
 					},
 					Clk: &mockable.Clock{},
 				},
@@ -675,7 +677,7 @@ func TestBanffCommitBlockTimestampChecks(t *testing.T) {
 	}
 }
 
-func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
+func TestApricotVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
@@ -716,6 +718,7 @@ func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 			Config: &config.Config{
 				ApricotPhase5Time: time.Now().Add(time.Hour),
 				BanffTime:         mockable.MaxTime, // banff is not activated
+				DurangoTime:       mockable.MaxTime, // durango is not activated
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -772,7 +775,7 @@ func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 	require.ErrorIs(err, errConflictingParentTxs)
 }
 
-func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) {
+func TestApricotVerifierVisitStandardBlockWithProposalBlockParent(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
@@ -804,7 +807,8 @@ func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) 
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				BanffTime: mockable.MaxTime, // banff is not activated
+				BanffTime:   mockable.MaxTime, // banff is not activated
+				DurangoTime: mockable.MaxTime, // durango is not activated
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -829,7 +833,7 @@ func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) 
 	require.ErrorIs(err, state.ErrMissingParentState)
 }
 
-func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
+func TestLatestForkVerifierVisitStandardBlockWithProposalBlockParent(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
@@ -862,7 +866,8 @@ func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				BanffTime: time.Time{}, // banff is activated
+				BanffTime:   time.Time{}, // banff is activated
+				DurangoTime: time.Time{}, // durango is activated
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -888,7 +893,7 @@ func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 	require.ErrorIs(err, state.ErrMissingParentState)
 }
 
-func TestVerifierVisitApricotCommitBlockUnexpectedParentState(t *testing.T) {
+func TestApricotVerifierVisitCommitBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
@@ -899,7 +904,8 @@ func TestVerifierVisitApricotCommitBlockUnexpectedParentState(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				BanffTime: mockable.MaxTime, // banff is not activated
+				BanffTime:   mockable.MaxTime, // banff is not activated
+				DurangoTime: mockable.MaxTime, // durango is not activated
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -930,7 +936,7 @@ func TestVerifierVisitApricotCommitBlockUnexpectedParentState(t *testing.T) {
 	require.ErrorIs(err, state.ErrMissingParentState)
 }
 
-func TestVerifierVisitBanffCommitBlockUnexpectedParentState(t *testing.T) {
+func TestLatestForkVerifierVisitCommitBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
@@ -942,7 +948,8 @@ func TestVerifierVisitBanffCommitBlockUnexpectedParentState(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				BanffTime: time.Time{}, // banff is activated
+				BanffTime:   time.Time{}, // banff is activated
+				DurangoTime: time.Time{}, // durango is activated
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -975,7 +982,7 @@ func TestVerifierVisitBanffCommitBlockUnexpectedParentState(t *testing.T) {
 	require.ErrorIs(err, state.ErrMissingParentState)
 }
 
-func TestVerifierVisitApricotAbortBlockUnexpectedParentState(t *testing.T) {
+func TestApricotVerifierVisitAbortBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
@@ -986,7 +993,8 @@ func TestVerifierVisitApricotAbortBlockUnexpectedParentState(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				BanffTime: mockable.MaxTime, // banff is not activated
+				BanffTime:   mockable.MaxTime, // banff is not activated
+				DurangoTime: mockable.MaxTime, // durango is not activated
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -1017,7 +1025,7 @@ func TestVerifierVisitApricotAbortBlockUnexpectedParentState(t *testing.T) {
 	require.ErrorIs(err, state.ErrMissingParentState)
 }
 
-func TestVerifierVisitBanffAbortBlockUnexpectedParentState(t *testing.T) {
+func TestLatestForkVerifierVisitAbortBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
@@ -1029,7 +1037,8 @@ func TestVerifierVisitBanffAbortBlockUnexpectedParentState(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				BanffTime: time.Time{}, // banff is activated
+				BanffTime:   time.Time{}, // banff is activated
+				DurangoTime: time.Time{}, // durango is activated
 			},
 			Clk: &mockable.Clock{},
 		},


### PR DESCRIPTION
## Why this should be merged

## How this works
Tentative end state:

- Version Timestamp changes + standardTx changes under proposal Block ID
- Version commit/aboirt specific changes under commit/abort blockID

## How this was tested
