### PR TITLE
Restrict GOPROXY

### DIFF
--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -36,3 +36,6 @@ export CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"
 # While CGO_ENABLED doesn't need to be explicitly set, it produces a much more
 # clear error due to the default value change in go1.20.
 export CGO_ENABLED=1
+
+# Disable version control fallbacks
+export GOPROXY="https://proxy.golang.org"


### PR DESCRIPTION
## Why this should be merged

`go1.20.12` included a security fix relating to the GOPROXY fallback. To avoid any potential future issues with GOPROXY fallbacks, this explicitly disables the fallback mechanism.

## How this works

The default value of `GOPROXY` is `https://proxy.golang.org,direct`. This removes the `direct` option.

## How this was tested

CI