### PR TITLE
Change seed from int64 to uint64

### DIFF
--- a/snow/consensus/snowball/consensus_performance_test.go
+++ b/snow/consensus/snowball/consensus_performance_test.go
@@ -16,16 +16,18 @@ import (
 func TestDualAlphaOptimization(t *testing.T) {
 	require := require.New(t)
 
-	numColors := 10
-	numNodes := 100
-	params := Parameters{
-		K:               20,
-		AlphaPreference: 15,
-		AlphaConfidence: 15,
-		BetaVirtuous:    15,
-		BetaRogue:       20,
-	}
-	seed := int64(0)
+	var (
+		numColors = 10
+		numNodes  = 100
+		params    = Parameters{
+			K:               20,
+			AlphaPreference: 15,
+			AlphaConfidence: 15,
+			BetaVirtuous:    15,
+			BetaRogue:       20,
+		}
+		seed uint64 = 0
+	)
 
 	singleAlphaNetwork := Network{}
 	singleAlphaNetwork.Initialize(params, numColors)
@@ -54,10 +56,12 @@ func TestDualAlphaOptimization(t *testing.T) {
 func TestTreeConvergenceOptimization(t *testing.T) {
 	require := require.New(t)
 
-	numColors := 10
-	numNodes := 100
-	params := DefaultParameters
-	seed := int64(0)
+	var (
+		numColors        = 10
+		numNodes         = 100
+		params           = DefaultParameters
+		seed      uint64 = 0
+	)
 
 	treeNetwork := Network{}
 	treeNetwork.Initialize(params, numColors)
@@ -79,13 +83,13 @@ func TestTreeConvergenceOptimization(t *testing.T) {
 	runNetworksInLockstep(require, seed, &treeNetwork, &flatNetwork)
 }
 
-func runNetworksInLockstep(require *require.Assertions, seed int64, fast *Network, slow *Network) {
+func runNetworksInLockstep(require *require.Assertions, seed uint64, fast *Network, slow *Network) {
 	numRounds := 0
 	for !fast.Finalized() && !fast.Disagreement() && !slow.Finalized() && !slow.Disagreement() {
-		sampler.Seed(int64(numRounds) + seed)
+		sampler.Seed(uint64(numRounds) + seed)
 		fast.Round()
 
-		sampler.Seed(int64(numRounds) + seed)
+		sampler.Seed(uint64(numRounds) + seed)
 		slow.Round()
 		numRounds++
 	}

--- a/snow/consensus/snowball/consensus_reversibility_test.go
+++ b/snow/consensus/snowball/consensus_reversibility_test.go
@@ -14,12 +14,14 @@ import (
 func TestSnowballGovernance(t *testing.T) {
 	require := require.New(t)
 
-	numColors := 2
-	numNodes := 100
-	numByzantine := 10
-	numRed := 55
-	params := DefaultParameters
-	seed := int64(0)
+	var (
+		numColors           = 2
+		numNodes            = 100
+		numByzantine        = 10
+		numRed              = 55
+		params              = DefaultParameters
+		seed         uint64 = 0
+	)
 
 	nBitwise := Network{}
 	nBitwise.Initialize(params, numColors)

--- a/snow/consensus/snowball/tree_test.go
+++ b/snow/consensus/snowball/tree_test.go
@@ -796,16 +796,18 @@ func TestSnowballDoubleAdd(t *testing.T) {
 func TestSnowballConsistent(t *testing.T) {
 	require := require.New(t)
 
-	numColors := 50
-	numNodes := 100
-	params := Parameters{
-		K:               20,
-		AlphaPreference: 15,
-		AlphaConfidence: 15,
-		BetaVirtuous:    20,
-		BetaRogue:       30,
-	}
-	seed := int64(0)
+	var (
+		numColors = 50
+		numNodes  = 100
+		params    = Parameters{
+			K:               20,
+			AlphaPreference: 15,
+			AlphaConfidence: 15,
+			BetaVirtuous:    20,
+			BetaRogue:       30,
+		}
+		seed uint64 = 0
+	)
 
 	sampler.Seed(seed)
 

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -1585,20 +1585,22 @@ func ErrorOnTransitiveRejectionTest(t *testing.T, factory Factory) {
 func RandomizedConsistencyTest(t *testing.T, factory Factory) {
 	require := require.New(t)
 
-	numColors := 50
-	numNodes := 100
-	params := snowball.Parameters{
-		K:                     20,
-		AlphaPreference:       15,
-		AlphaConfidence:       15,
-		BetaVirtuous:          20,
-		BetaRogue:             30,
-		ConcurrentRepolls:     1,
-		OptimalProcessing:     1,
-		MaxOutstandingItems:   1,
-		MaxItemProcessingTime: 1,
-	}
-	seed := int64(0)
+	var (
+		numColors = 50
+		numNodes  = 100
+		params    = snowball.Parameters{
+			K:                     20,
+			AlphaPreference:       15,
+			AlphaConfidence:       15,
+			BetaVirtuous:          20,
+			BetaRogue:             30,
+			ConcurrentRepolls:     1,
+			OptimalProcessing:     1,
+			MaxOutstandingItems:   1,
+			MaxItemProcessingTime: 1,
+		}
+		seed uint64 = 0
+	)
 
 	sampler.Seed(seed)
 

--- a/utils/sampler/rand.go
+++ b/utils/sampler/rand.go
@@ -21,7 +21,7 @@ func newRNG() *rng {
 	return &rng{rng: source}
 }
 
-func Seed(seed int64) {
+func Seed(seed uint64) {
 	globalRNG.Seed(seed)
 }
 
@@ -37,9 +37,9 @@ type rng struct {
 
 // Seed uses the provided seed value to initialize the generator to a
 // deterministic state.
-func (r *rng) Seed(seed int64) {
+func (r *rng) Seed(seed uint64) {
 	r.lock.Lock()
-	r.rng.Seed(uint64(seed))
+	r.rng.Seed(seed)
 	r.lock.Unlock()
 }
 

--- a/utils/sampler/uniform.go
+++ b/utils/sampler/uniform.go
@@ -11,7 +11,7 @@ type Uniform interface {
 	// negative the implementation may panic.
 	Sample(length int) ([]uint64, error)
 
-	Seed(int64)
+	Seed(uint64)
 	ClearSeed()
 
 	Reset()

--- a/utils/sampler/uniform_replacer.go
+++ b/utils/sampler/uniform_replacer.go
@@ -55,7 +55,7 @@ func (s *uniformReplacer) Sample(count int) ([]uint64, error) {
 	return results, nil
 }
 
-func (s *uniformReplacer) Seed(seed int64) {
+func (s *uniformReplacer) Seed(seed uint64) {
 	s.rng = s.seededRNG
 	s.rng.Seed(seed)
 }

--- a/utils/sampler/uniform_resample.go
+++ b/utils/sampler/uniform_resample.go
@@ -42,7 +42,7 @@ func (s *uniformResample) Sample(count int) ([]uint64, error) {
 	return results, nil
 }
 
-func (s *uniformResample) Seed(seed int64) {
+func (s *uniformResample) Seed(seed uint64) {
 	s.rng = s.seededRNG
 	s.rng.Seed(seed)
 }

--- a/utils/sampler/weighted_without_replacement.go
+++ b/utils/sampler/weighted_without_replacement.go
@@ -10,7 +10,7 @@ type WeightedWithoutReplacement interface {
 	Initialize(weights []uint64) error
 	Sample(count int) ([]int, error)
 
-	Seed(int64)
+	Seed(uint64)
 	ClearSeed()
 }
 

--- a/utils/sampler/weighted_without_replacement_generic.go
+++ b/utils/sampler/weighted_without_replacement_generic.go
@@ -42,7 +42,7 @@ func (s *weightedWithoutReplacementGeneric) Sample(count int) ([]int, error) {
 	return indices, nil
 }
 
-func (s *weightedWithoutReplacementGeneric) Seed(seed int64) {
+func (s *weightedWithoutReplacementGeneric) Seed(seed uint64) {
 	s.u.Seed(seed)
 }
 

--- a/vms/proposervm/proposer/windower.go
+++ b/vms/proposervm/proposer/windower.go
@@ -113,7 +113,7 @@ func (w *windower) Proposers(ctx context.Context, chainHeight, pChainHeight uint
 	}
 
 	seed := chainHeight ^ w.chainSource
-	w.sampler.Seed(int64(seed))
+	w.sampler.Seed(seed)
 
 	indices, err := w.sampler.Sample(numToSample)
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged

Previously we used `int64` for the `seed` to stay in-line with the standard library... However, internally casting from `int64` to `uint64` is weird. Additionally, we currently do a number of bitwise operations (`uint64`) to generate the seed in the proposervm.

## How this works

Reduces the number of casts we need to do.

## How this was tested

CI