### PR TITLE
Remove usage of timer.Timer in node

### DIFF
--- a/node/beacon_manager.go
+++ b/node/beacon_manager.go
@@ -4,13 +4,13 @@
 package node
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/networking/router"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/timer"
 	"github.com/ava-labs/avalanchego/version"
 )
 
@@ -18,10 +18,11 @@ var _ router.Router = (*beaconManager)(nil)
 
 type beaconManager struct {
 	router.Router
-	timer         *timer.Timer
-	beacons       validators.Manager
-	requiredConns int64
-	numConns      int64
+	beacons                     validators.Manager
+	requiredConns               int64
+	numConns                    int64
+	onSufficientlyConnected     chan struct{}
+	onceOnSufficientlyConnected sync.Once
 }
 
 func (b *beaconManager) Connected(nodeID ids.NodeID, nodeVersion *version.Application, subnetID ids.ID) {
@@ -29,7 +30,9 @@ func (b *beaconManager) Connected(nodeID ids.NodeID, nodeVersion *version.Applic
 	if isBeacon &&
 		constants.PrimaryNetworkID == subnetID &&
 		atomic.AddInt64(&b.numConns, 1) >= b.requiredConns {
-		b.timer.Cancel()
+		b.onceOnSufficientlyConnected.Do(func() {
+			close(b.onSufficientlyConnected)
+		})
 	}
 	b.Router.Connected(nodeID, nodeVersion, subnetID)
 }

--- a/node/beacon_manager_test.go
+++ b/node/beacon_manager_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/networking/router"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/timer"
 	"github.com/ava-labs/avalanchego/version"
 )
 
@@ -41,10 +40,10 @@ func TestBeaconManager_DataRace(t *testing.T) {
 	mockRouter := router.NewMockRouter(ctrl)
 
 	b := beaconManager{
-		Router:        mockRouter,
-		timer:         timer.NewTimer(nil),
-		beacons:       validatorSet,
-		requiredConns: numValidators,
+		Router:                  mockRouter,
+		beacons:                 validatorSet,
+		requiredConns:           numValidators,
+		onSufficientlyConnected: make(chan struct{}),
 	}
 
 	// connect numValidators validators, each with a weight of 1


### PR DESCRIPTION
## Why this should be merged

`timer.Timer` is horrible code, I now know better. This helps to remove the abomination.

## How this works

Replaces the usage of `timer.Timer` with the standard lib's `time.Timer`

## How this was tested

Ran locally when connected and disconnected from the internet and verified the log worked as expected.