### PR TITLE
Remove usage of timer.Timer in benchlist

### DIFF
--- a/snow/networking/benchlist/benchlist.go
+++ b/snow/networking/benchlist/benchlist.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/heap"
 	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/avalanchego/utils/timer"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 
 	safemath "github.com/ava-labs/avalanchego/utils/math"
@@ -54,9 +53,8 @@ type benchlist struct {
 	ctx     *snow.ConsensusContext
 	metrics metrics
 
-	// Fires when the next validator should leave the bench
-	// Calls [update] when it fires
-	timer *timer.Timer
+	// Used to notify the timer that it should recalculate when it should fire
+	resetTimer chan struct{}
 
 	// Tells the time. Can be faked for testing.
 	clock mockable.Clock
@@ -105,8 +103,10 @@ func NewBenchlist(
 	if maxPortion < 0 || maxPortion >= 1 {
 		return nil, fmt.Errorf("max portion of benched stake must be in [0,1) but got %f", maxPortion)
 	}
+
 	benchlist := &benchlist{
 		ctx:                    ctx,
+		resetTimer:             make(chan struct{}, 1),
 		failureStreaks:         make(map[ids.NodeID]failureStreak),
 		benchlistSet:           set.Set[ids.NodeID]{},
 		benchable:              benchable,
@@ -117,38 +117,77 @@ func NewBenchlist(
 		duration:               duration,
 		maxPortion:             maxPortion,
 	}
-	benchlist.timer = timer.NewTimer(benchlist.update)
-	go benchlist.timer.Dispatch()
-	return benchlist, benchlist.metrics.Initialize(ctx.Registerer)
+	if err := benchlist.metrics.Initialize(ctx.Registerer); err != nil {
+		return nil, err
+	}
+
+	go benchlist.run()
+	return benchlist, nil
 }
 
-// Update removes benched validators whose time on the bench is over
-func (b *benchlist) update() {
+// TODO: Close this goroutine during node shutdown
+func (b *benchlist) run() {
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		// Invariant: The [timer] is not stopped.
+		select {
+		case <-timer.C:
+		case <-b.resetTimer:
+			if !timer.Stop() {
+				<-timer.C
+			}
+		}
+
+		b.waitForBenchedNodes()
+
+		now := b.clock.Time()
+		b.removedExpiredNodes(now)
+
+		// Note: If there are no nodes to remove, [duration] will be 0 and we
+		// will immediately wait until there are benched nodes.
+		duration := b.durationToSleep(now)
+		timer.Reset(duration)
+	}
+}
+
+func (b *benchlist) waitForBenchedNodes() {
+	for {
+		b.lock.RLock()
+		_, _, ok := b.benchedHeap.Peek()
+		b.lock.RUnlock()
+		if ok {
+			return
+		}
+
+		// Invariant: Whenever a new node is benched we ensure that resetTimer
+		// has a pending message while the write lock is held.
+		<-b.resetTimer
+	}
+}
+
+func (b *benchlist) removedExpiredNodes(now time.Time) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	now := b.clock.Time()
 	for {
-		if !b.canUnbench(now) {
+		_, next, ok := b.benchedHeap.Peek()
+		if !ok {
 			break
 		}
-		b.remove()
+		if now.Before(next) {
+			break
+		}
+
+		nodeID, _, _ := b.benchedHeap.Pop()
+		b.ctx.Log.Debug("removing node from benchlist",
+			zap.Stringer("nodeID", nodeID),
+		)
+		b.benchlistSet.Remove(nodeID)
+		b.benchable.Unbenched(b.ctx.ChainID, nodeID)
 	}
-	// Set next time update will be called
-	b.setNextLeaveTime()
-}
 
-// Removes the next node from the benchlist
-// Assumes [b.lock] is held
-func (b *benchlist) remove() {
-	nodeID, _, _ := b.benchedHeap.Pop()
-	b.ctx.Log.Debug("removing node from benchlist",
-		zap.Stringer("nodeID", nodeID),
-	)
-	b.benchlistSet.Remove(nodeID)
-	b.benchable.Unbenched(b.ctx.ChainID, nodeID)
-
-	// Update metrics
 	b.metrics.numBenched.Set(float64(b.benchedHeap.Len()))
 	benchedStake, err := b.vdrs.SubsetWeight(b.ctx.SubnetID, b.benchlistSet)
 	if err != nil {
@@ -161,56 +200,35 @@ func (b *benchlist) remove() {
 	b.metrics.weightBenched.Set(float64(benchedStake))
 }
 
-// Returns if a validator should leave the bench at time [now].
-// False if no validator should.
-// Assumes [b.lock] is held
-func (b *benchlist) canUnbench(now time.Time) bool {
+func (b *benchlist) durationToSleep(now time.Time) time.Duration {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
 	_, next, ok := b.benchedHeap.Peek()
 	if !ok {
-		return false
+		return 0
 	}
-	return now.After(next)
+	return next.Sub(now)
 }
 
-// Set [b.timer] to fire when the next validator should leave the bench
-// Assumes [b.lock] is held
-func (b *benchlist) setNextLeaveTime() {
-	_, next, ok := b.benchedHeap.Peek()
-	if !ok {
-		b.timer.Cancel()
-		return
-	}
-	now := b.clock.Time()
-	nextLeave := next.Sub(now)
-	b.timer.SetTimeoutIn(nextLeave)
-}
-
-// IsBenched returns true if messages to [nodeID]
-// should not be sent over the network and should immediately fail.
+// IsBenched returns true if messages to [nodeID] should not be sent over the
+// network and should immediately fail.
 func (b *benchlist) IsBenched(nodeID ids.NodeID) bool {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	return b.isBenched(nodeID)
+
+	return b.benchlistSet.Contains(nodeID)
 }
 
-// isBenched checks if [nodeID] is currently benched
-// and calls cleanup if its benching period has elapsed
-// Assumes [b.lock] is held.
-func (b *benchlist) isBenched(nodeID ids.NodeID) bool {
-	if _, ok := b.benchlistSet[nodeID]; ok {
-		return true
-	}
-	return false
-}
-
-// RegisterResponse notes that we received a response from validator [validatorID]
+// RegisterResponse notes that we received a response from [nodeID]
 func (b *benchlist) RegisterResponse(nodeID ids.NodeID) {
 	b.streaklock.Lock()
 	defer b.streaklock.Unlock()
+
 	delete(b.failureStreaks, nodeID)
 }
 
-// RegisterResponse notes that a request to validator [validatorID] timed out
+// RegisterResponse notes that a request to [nodeID] timed out
 func (b *benchlist) RegisterFailure(nodeID ids.NodeID) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
@@ -295,6 +313,12 @@ func (b *benchlist) bench(nodeID ids.NodeID) {
 	diff := maxBenchedUntil.Sub(minBenchedUntil)
 	benchedUntil := minBenchedUntil.Add(time.Duration(rand.Float64() * float64(diff))) // #nosec G404
 
+	b.ctx.Log.Debug("benching validator after consecutive failed queries",
+		zap.Stringer("nodeID", nodeID),
+		zap.Duration("benchDuration", benchedUntil.Sub(now)),
+		zap.Int("numFailedQueries", b.threshold),
+	)
+
 	// Add to benchlist times with randomized delay
 	b.benchlistSet.Add(nodeID)
 	b.benchable.Benched(b.ctx.ChainID, nodeID)
@@ -304,14 +328,12 @@ func (b *benchlist) bench(nodeID ids.NodeID) {
 	b.streaklock.Unlock()
 
 	b.benchedHeap.Push(nodeID, benchedUntil)
-	b.ctx.Log.Debug("benching validator after consecutive failed queries",
-		zap.Stringer("nodeID", nodeID),
-		zap.Duration("benchDuration", benchedUntil.Sub(now)),
-		zap.Int("numFailedQueries", b.threshold),
-	)
 
-	// Set [b.timer] to fire when next validator should leave bench
-	b.setNextLeaveTime()
+	// Update the timer to account for the newly benched node.
+	select {
+	case b.resetTimer <- struct{}{}:
+	default:
+	}
 
 	// Update metrics
 	b.metrics.numBenched.Set(float64(b.benchedHeap.Len()))

--- a/snow/networking/benchlist/benchlist.go
+++ b/snow/networking/benchlist/benchlist.go
@@ -142,12 +142,11 @@ func (b *benchlist) run() {
 
 		b.waitForBenchedNodes()
 
-		now := b.clock.Time()
-		b.removedExpiredNodes(now)
+		b.removedExpiredNodes()
 
 		// Note: If there are no nodes to remove, [duration] will be 0 and we
 		// will immediately wait until there are benched nodes.
-		duration := b.durationToSleep(now)
+		duration := b.durationToSleep()
 		timer.Reset(duration)
 	}
 }
@@ -167,10 +166,11 @@ func (b *benchlist) waitForBenchedNodes() {
 	}
 }
 
-func (b *benchlist) removedExpiredNodes(now time.Time) {
+func (b *benchlist) removedExpiredNodes() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
+	now := b.clock.Time()
 	for {
 		_, next, ok := b.benchedHeap.Peek()
 		if !ok {
@@ -200,7 +200,7 @@ func (b *benchlist) removedExpiredNodes(now time.Time) {
 	b.metrics.weightBenched.Set(float64(benchedStake))
 }
 
-func (b *benchlist) durationToSleep(now time.Time) time.Duration {
+func (b *benchlist) durationToSleep() time.Duration {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
@@ -208,6 +208,8 @@ func (b *benchlist) durationToSleep(now time.Time) time.Duration {
 	if !ok {
 		return 0
 	}
+
+	now := b.clock.Time()
 	return next.Sub(now)
 }
 

--- a/snow/networking/benchlist/benchlist_test.go
+++ b/snow/networking/benchlist/benchlist_test.go
@@ -51,20 +51,14 @@ func TestBenchlistAdd(t *testing.T) {
 	)
 	require.NoError(err)
 	b := benchIntf.(*benchlist)
-	defer b.timer.Stop()
 	now := time.Now()
 	b.clock.Set(now)
 
 	// Nobody should be benched at the start
 	b.lock.Lock()
-	require.False(b.isBenched(vdrID0))
-	require.False(b.isBenched(vdrID1))
-	require.False(b.isBenched(vdrID2))
-	require.False(b.isBenched(vdrID3))
-	require.False(b.isBenched(vdrID4))
+	require.Empty(b.benchlistSet)
 	require.Empty(b.failureStreaks)
 	require.Zero(b.benchedHeap.Len())
-	require.Empty(b.benchlistSet)
 	b.lock.Unlock()
 
 	// Register [threshold - 1] failures in a row for vdr0
@@ -73,9 +67,8 @@ func TestBenchlistAdd(t *testing.T) {
 	}
 
 	// Still shouldn't be benched due to not enough consecutive failure
-	require.False(b.isBenched(vdrID0))
-	require.Zero(b.benchedHeap.Len())
 	require.Empty(b.benchlistSet)
+	require.Zero(b.benchedHeap.Len())
 	require.Len(b.failureStreaks, 1)
 	fs := b.failureStreaks[vdrID0]
 	require.Equal(threshold-1, fs.consecutive)
@@ -87,9 +80,8 @@ func TestBenchlistAdd(t *testing.T) {
 	// Still shouldn't be benched because not enough time (any in this case)
 	// has passed since the first failure
 	b.lock.Lock()
-	require.False(b.isBenched(vdrID0))
-	require.Zero(b.benchedHeap.Len())
 	require.Empty(b.benchlistSet)
+	require.Zero(b.benchedHeap.Len())
 	b.lock.Unlock()
 
 	// Move the time up
@@ -108,9 +100,9 @@ func TestBenchlistAdd(t *testing.T) {
 
 	// Now this validator should be benched
 	b.lock.Lock()
-	require.True(b.isBenched(vdrID0))
-	require.Equal(b.benchedHeap.Len(), 1)
-	require.Equal(b.benchlistSet.Len(), 1)
+	require.Contains(b.benchlistSet, vdrID0)
+	require.Equal(1, b.benchedHeap.Len())
+	require.Equal(1, b.benchlistSet.Len())
 
 	nodeID, benchedUntil, ok := b.benchedHeap.Peek()
 	require.True(ok)
@@ -133,10 +125,9 @@ func TestBenchlistAdd(t *testing.T) {
 	// vdr1 shouldn't be benched
 	// The response should have cleared its consecutive failures
 	b.lock.Lock()
-	require.True(b.isBenched(vdrID0))
-	require.False(b.isBenched(vdrID1))
-	require.Equal(b.benchedHeap.Len(), 1)
-	require.Equal(b.benchlistSet.Len(), 1)
+	require.Contains(b.benchlistSet, vdrID0)
+	require.Equal(1, b.benchedHeap.Len())
+	require.Equal(1, b.benchlistSet.Len())
 	require.Empty(b.failureStreaks)
 	b.lock.Unlock()
 
@@ -183,7 +174,6 @@ func TestBenchlistMaxStake(t *testing.T) {
 	)
 	require.NoError(err)
 	b := benchIntf.(*benchlist)
-	defer b.timer.Stop()
 	now := time.Now()
 	b.clock.Set(now)
 
@@ -209,11 +199,10 @@ func TestBenchlistMaxStake(t *testing.T) {
 	// Benching vdr2 (weight 1000) would cause the amount benched
 	// to exceed the maximum
 	b.lock.Lock()
-	require.True(b.isBenched(vdrID0))
-	require.True(b.isBenched(vdrID1))
-	require.False(b.isBenched(vdrID2))
-	require.Equal(b.benchedHeap.Len(), 2)
-	require.Equal(b.benchlistSet.Len(), 2)
+	require.Contains(b.benchlistSet, vdrID0)
+	require.Contains(b.benchlistSet, vdrID1)
+	require.Equal(2, b.benchedHeap.Len())
+	require.Equal(2, b.benchlistSet.Len())
 	require.Len(b.failureStreaks, 1)
 	fs := b.failureStreaks[vdrID2]
 	fs.consecutive = threshold
@@ -236,9 +225,9 @@ func TestBenchlistMaxStake(t *testing.T) {
 
 	// vdr4 should be benched now
 	b.lock.Lock()
-	require.True(b.isBenched(vdrID0))
-	require.True(b.isBenched(vdrID1))
-	require.True(b.isBenched(vdrID4))
+	require.Contains(b.benchlistSet, vdrID0)
+	require.Contains(b.benchlistSet, vdrID1)
+	require.Contains(b.benchlistSet, vdrID4)
 	require.Equal(3, b.benchedHeap.Len())
 	require.Equal(3, b.benchlistSet.Len())
 	require.Contains(b.benchlistSet, vdrID0)
@@ -254,10 +243,9 @@ func TestBenchlistMaxStake(t *testing.T) {
 	}
 
 	b.lock.Lock()
-	require.True(b.isBenched(vdrID0))
-	require.True(b.isBenched(vdrID1))
-	require.True(b.isBenched(vdrID4))
-	require.False(b.isBenched(vdrID2))
+	require.Contains(b.benchlistSet, vdrID0)
+	require.Contains(b.benchlistSet, vdrID1)
+	require.Contains(b.benchlistSet, vdrID4)
 	require.Equal(3, b.benchedHeap.Len())
 	require.Equal(3, b.benchlistSet.Len())
 	require.Len(b.failureStreaks, 1)
@@ -307,7 +295,6 @@ func TestBenchlistRemove(t *testing.T) {
 	)
 	require.NoError(err)
 	b := benchIntf.(*benchlist)
-	defer b.timer.Stop()
 	now := time.Now()
 	b.lock.Lock()
 	b.clock.Set(now)
@@ -332,9 +319,9 @@ func TestBenchlistRemove(t *testing.T) {
 
 	// All 3 should be benched
 	b.lock.Lock()
-	require.True(b.isBenched(vdrID0))
-	require.True(b.isBenched(vdrID1))
-	require.True(b.isBenched(vdrID2))
+	require.Contains(b.benchlistSet, vdrID0)
+	require.Contains(b.benchlistSet, vdrID1)
+	require.Contains(b.benchlistSet, vdrID2)
 	require.Equal(3, b.benchedHeap.Len())
 	require.Equal(3, b.benchlistSet.Len())
 	require.Empty(b.failureStreaks)


### PR DESCRIPTION
## Why this should be merged

`timer.Timer` is horrible code, I now know better. This helps to remove the abomination.

## How this works

Replaces the usage of `timer.Timer` with the standard lib's `time.Timer`

## How this was tested

CI