### PR TITLE
`vms/avm`: Simplify `Peek` function in mempool

### DIFF
--- a/vms/avm/block/builder/builder.go
+++ b/vms/avm/block/builder/builder.go
@@ -94,6 +94,11 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 	)
 	for {
 		tx := b.mempool.Peek()
+		// This will always pack at least one tx because of the following
+		// invariant. The resulting blocks will be packed at least
+		// 100 * [mempool.TxSize] / [targetBlockSize]%.
+		//
+		// Invariant: [mempool.MaxTxSize] < [targetBlockSize].
 		if tx == nil || len(tx.Bytes()) > remainingSize {
 			break
 		}

--- a/vms/avm/block/builder/builder.go
+++ b/vms/avm/block/builder/builder.go
@@ -93,8 +93,8 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 		remainingSize = targetBlockSize
 	)
 	for {
-		tx := b.mempool.Peek(remainingSize)
-		if tx == nil {
+		tx := b.mempool.Peek()
+		if tx == nil || len(tx.Bytes()) > remainingSize {
 			break
 		}
 		b.mempool.Remove([]*txs.Tx{tx})

--- a/vms/avm/block/builder/builder.go
+++ b/vms/avm/block/builder/builder.go
@@ -94,11 +94,10 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 	)
 	for {
 		tx := b.mempool.Peek()
-		// This will always pack at least one tx because of the following
-		// invariant. The resulting blocks will be packed at least
-		// 100 * [mempool.TxSize] / [targetBlockSize]%.
-		//
-		// Invariant: [mempool.MaxTxSize] < [targetBlockSize].
+		// Invariant: [mempool.MaxTxSize] < [targetBlockSize]. This guarantees
+		// that we will only stop building a block once there are no
+		// transactions in the mempool or the block is at least
+		// [targetBlockSize - mempool.MaxTxSize] bytes full.
 		if tx == nil || len(tx.Bytes()) > remainingSize {
 			break
 		}

--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -134,11 +134,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek(gomock.Any()).Return(tx)
+				mempool.EXPECT().Peek().Return(tx)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				mempool.EXPECT().MarkDropped(tx.ID(), errTest)
 				// Second loop iteration
-				mempool.EXPECT().Peek(gomock.Any()).Return(nil)
+				mempool.EXPECT().Peek().Return(nil)
 				mempool.EXPECT().RequestBuildBlock()
 
 				return New(
@@ -179,11 +179,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek(gomock.Any()).Return(tx)
+				mempool.EXPECT().Peek().Return(tx)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				mempool.EXPECT().MarkDropped(tx.ID(), errTest)
 				// Second loop iteration
-				mempool.EXPECT().Peek(gomock.Any()).Return(nil)
+				mempool.EXPECT().Peek().Return(nil)
 				mempool.EXPECT().RequestBuildBlock()
 
 				return New(
@@ -225,11 +225,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek(gomock.Any()).Return(tx)
+				mempool.EXPECT().Peek().Return(tx)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				mempool.EXPECT().MarkDropped(tx.ID(), errTest)
 				// Second loop iteration
-				mempool.EXPECT().Peek(gomock.Any()).Return(nil)
+				mempool.EXPECT().Peek().Return(nil)
 				mempool.EXPECT().RequestBuildBlock()
 
 				return New(
@@ -309,14 +309,14 @@ func TestBuilderBuildBlock(t *testing.T) {
 				)
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek(targetBlockSize).Return(tx1)
+				mempool.EXPECT().Peek().Return(tx1)
 				mempool.EXPECT().Remove([]*txs.Tx{tx1})
 				// Second loop iteration
-				mempool.EXPECT().Peek(targetBlockSize - len(tx1Bytes)).Return(tx2)
+				mempool.EXPECT().Peek().Return(tx2)
 				mempool.EXPECT().Remove([]*txs.Tx{tx2})
 				mempool.EXPECT().MarkDropped(tx2.ID(), blkexecutor.ErrConflictingBlockTxs)
 				// Third loop iteration
-				mempool.EXPECT().Peek(targetBlockSize - len(tx1Bytes)).Return(nil)
+				mempool.EXPECT().Peek().Return(nil)
 				mempool.EXPECT().RequestBuildBlock()
 
 				// To marshal the tx/block
@@ -385,10 +385,10 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek(gomock.Any()).Return(tx)
+				mempool.EXPECT().Peek().Return(tx)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				// Second loop iteration
-				mempool.EXPECT().Peek(gomock.Any()).Return(nil)
+				mempool.EXPECT().Peek().Return(nil)
 				mempool.EXPECT().RequestBuildBlock()
 
 				// To marshal the tx/block
@@ -459,10 +459,10 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek(gomock.Any()).Return(tx)
+				mempool.EXPECT().Peek().Return(tx)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				// Second loop iteration
-				mempool.EXPECT().Peek(gomock.Any()).Return(nil)
+				mempool.EXPECT().Peek().Return(nil)
 				mempool.EXPECT().RequestBuildBlock()
 
 				// To marshal the tx/block

--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -48,8 +48,8 @@ type Mempool interface {
 	Get(txID ids.ID) *txs.Tx
 	Remove(txs []*txs.Tx)
 
-	// Peek returns the first tx in the mempool whose size is <= [maxTxSize].
-	Peek(maxTxSize int) *txs.Tx
+	// Peek returns the oldest tx in the mempool.
+	Peek() *txs.Tx
 
 	// RequestBuildBlock notifies the consensus engine that a block should be
 	// built if there is at least one transaction in the mempool.
@@ -182,16 +182,9 @@ func (m *mempool) Remove(txsToRemove []*txs.Tx) {
 	}
 }
 
-func (m *mempool) Peek(maxTxSize int) *txs.Tx {
-	txIter := m.unissuedTxs.NewIterator()
-	for txIter.Next() {
-		tx := txIter.Value()
-		txSize := len(tx.Bytes())
-		if txSize <= maxTxSize {
-			return tx
-		}
-	}
-	return nil
+func (m *mempool) Peek() *txs.Tx {
+	_, tx, _ := m.unissuedTxs.Oldest()
+	return tx
 }
 
 func (m *mempool) RequestBuildBlock() {

--- a/vms/avm/txs/mempool/mempool_test.go
+++ b/vms/avm/txs/mempool/mempool_test.go
@@ -170,3 +170,31 @@ func createTestTxs(count int) []*txs.Tx {
 	}
 	return testTxs
 }
+
+func TestPeekTxs(t *testing.T) {
+	require := require.New(t)
+
+	registerer := prometheus.NewRegistry()
+	toEngine := make(chan common.Message, 100)
+	mempool, err := New("mempool", registerer, toEngine)
+	require.NoError(err)
+
+	testTxs := createTestTxs(2)
+
+	require.Nil(mempool.Peek())
+
+	require.NoError(mempool.Add(testTxs[0]))
+	require.NoError(mempool.Add(testTxs[1]))
+
+	require.Equal(mempool.Peek(), testTxs[0])
+	require.NotEqual(mempool.Peek(), testTxs[1])
+
+	mempool.Remove([]*txs.Tx{testTxs[0]})
+
+	require.NotEqual(mempool.Peek(), testTxs[0])
+	require.Equal(mempool.Peek(), testTxs[1])
+
+	mempool.Remove([]*txs.Tx{testTxs[1]})
+
+	require.Nil(mempool.Peek())
+}

--- a/vms/avm/txs/mempool/mock_mempool.go
+++ b/vms/avm/txs/mempool/mock_mempool.go
@@ -107,17 +107,17 @@ func (mr *MockMempoolMockRecorder) MarkDropped(arg0, arg1 interface{}) *gomock.C
 }
 
 // Peek mocks base method.
-func (m *MockMempool) Peek(arg0 int) *txs.Tx {
+func (m *MockMempool) Peek() *txs.Tx {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Peek", arg0)
+	ret := m.ctrl.Call(m, "Peek")
 	ret0, _ := ret[0].(*txs.Tx)
 	return ret0
 }
 
 // Peek indicates an expected call of Peek.
-func (mr *MockMempoolMockRecorder) Peek(arg0 interface{}) *gomock.Call {
+func (mr *MockMempoolMockRecorder) Peek() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peek", reflect.TypeOf((*MockMempool)(nil).Peek), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peek", reflect.TypeOf((*MockMempool)(nil).Peek))
 }
 
 // Remove mocks base method.


### PR DESCRIPTION
## Why this should be merged

We currently iterate through all the transactions in the mempool to build as full of a block as possible. This could cause an instance where we do this iteration many times:

Suppose we have a mempool with txs of size `[5, 6, 6, 6, 6, 1, 1, 1, 1, 1]` and we are attempting to build a block of size `10`. 

Pre-this PR, the blocks will be built like so:
```
[5, 1, 1, 1, 1, 1]
[6]
[6]
[6]
[6]
```

However, to get the txs of size `1` into the first block, we iterate through all the txs of size `6` five times. Instead, we could build a block with as many of the highest priority txs (oldest for avm and platformvm) and stop when we hit a transaction that exceeds our block size. This produces blocks like this with no iteration:
```
[5]
[6]
[6]
[6]
[6, 1, 1, 1, 1]
[1]
```

## How this works

Modify `Peek` to just return the oldest tx in the mempool. Check the size of the tx in the block builder itself.

## How this was tested

CI + added UT