### PR TITLE
`vms/platformvm`: Remove `standardBlockState` struct

### DIFF
--- a/vms/platformvm/block/executor/acceptor_test.go
+++ b/vms/platformvm/block/executor/acceptor_test.go
@@ -210,13 +210,12 @@ func TestAcceptorVisitStandardBlock(t *testing.T) {
 	atomicRequests := map[ids.ID]*atomic.Requests{ids.GenerateTestID(): nil}
 	calledOnAcceptFunc := false
 	acceptor.backend.blkIDToState[blk.ID()] = &blockState{
-		onAcceptState:  onAcceptState,
-		atomicRequests: atomicRequests,
-		standardBlockState: standardBlockState{
-			onAcceptFunc: func() {
-				calledOnAcceptFunc = true
-			},
+		onAcceptState: onAcceptState,
+		onAcceptFunc: func() {
+			calledOnAcceptFunc = true
 		},
+
+		atomicRequests: atomicRequests,
 	}
 	// Give [blk] a child.
 	childOnAcceptState := state.NewMockDiff(ctrl)

--- a/vms/platformvm/block/executor/block_state.go
+++ b/vms/platformvm/block/executor/block_state.go
@@ -13,11 +13,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 )
 
-type standardBlockState struct {
-	onAcceptFunc func()
-	inputs       set.Set[ids.ID]
-}
-
 type proposalBlockState struct {
 	initiallyPreferCommit bool
 	onCommitState         state.Diff
@@ -27,11 +22,13 @@ type proposalBlockState struct {
 // The state of a block.
 // Note that not all fields will be set for a given block.
 type blockState struct {
-	standardBlockState
 	proposalBlockState
 	statelessBlock block.Block
-	onAcceptState  state.Diff
 
+	onAcceptState state.Diff
+	onAcceptFunc  func()
+
+	inputs         set.Set[ids.ID]
 	timestamp      time.Time
 	atomicRequests map[ids.ID]*atomic.Requests
 }

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -207,11 +207,11 @@ func (v *verifier) ApricotAtomicBlock(b *block.ApricotAtomicBlock) error {
 
 	blkID := b.ID()
 	v.blkIDToState[blkID] = &blockState{
-		standardBlockState: standardBlockState{
-			inputs: atomicExecutor.Inputs,
-		},
 		statelessBlock: b,
-		onAcceptState:  atomicExecutor.OnAccept,
+
+		onAcceptState: atomicExecutor.OnAccept,
+
+		inputs:         atomicExecutor.Inputs,
 		timestamp:      atomicExecutor.OnAccept.GetTimestamp(),
 		atomicRequests: atomicExecutor.AtomicRequests,
 	}

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -322,7 +322,6 @@ func TestVerifierVisitCommitBlock(t *testing.T) {
 					onCommitState: parentOnCommitState,
 					onAbortState:  parentOnAbortState,
 				},
-				standardBlockState: standardBlockState{},
 			},
 		},
 		Mempool: mempool,
@@ -392,7 +391,6 @@ func TestVerifierVisitAbortBlock(t *testing.T) {
 					onCommitState: parentOnCommitState,
 					onAbortState:  parentOnAbortState,
 				},
-				standardBlockState: standardBlockState{},
 			},
 		},
 		Mempool: mempool,
@@ -686,11 +684,9 @@ func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 	backend := &backend{
 		blkIDToState: map[ids.ID]*blockState{
 			grandParentID: {
-				standardBlockState: standardBlockState{
-					inputs: atomicInputs,
-				},
 				statelessBlock: grandParentStatelessBlk,
 				onAcceptState:  grandParentState,
+				inputs:         atomicInputs,
 			},
 			parentID: {
 				statelessBlock: parentStatelessBlk,
@@ -784,7 +780,6 @@ func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) 
 					onCommitState: parentOnCommitState,
 					onAbortState:  parentOnAbortState,
 				},
-				standardBlockState: standardBlockState{},
 			},
 		},
 		Mempool: mempool,
@@ -842,7 +837,6 @@ func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 					onCommitState: parentOnCommitState,
 					onAbortState:  parentOnAbortState,
 				},
-				standardBlockState: standardBlockState{},
 			},
 		},
 		Mempool: mempool,


### PR DESCRIPTION
## Why this should be merged

Factored out of https://github.com/ava-labs/avalanchego/pull/2442

## How this works

Removes the struct and in-lines the fields into `blockState`.

## How this was tested

CI