### PR TITLE
Refactor sampler seeding

### DIFF
--- a/snow/consensus/snowball/consensus_performance_test.go
+++ b/snow/consensus/snowball/consensus_performance_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/utils/sampler"
+	"gonum.org/v1/gonum/mathext/prng"
 )
 
 // Test that a network running the lower AlphaPreference converges faster than a
@@ -26,29 +26,28 @@ func TestDualAlphaOptimization(t *testing.T) {
 			BetaVirtuous:    15,
 			BetaRogue:       20,
 		}
-		seed uint64 = 0
+		seed   uint64 = 0
+		source        = prng.NewMT19937()
 	)
 
-	singleAlphaNetwork := Network{}
-	singleAlphaNetwork.Initialize(params, numColors)
+	singleAlphaNetwork := NewNetwork(params, numColors, source)
 
 	params.AlphaPreference = params.K/2 + 1
-	dualAlphaNetwork := Network{}
-	dualAlphaNetwork.Initialize(params, numColors)
+	dualAlphaNetwork := NewNetwork(params, numColors, source)
 
-	sampler.Seed(seed)
+	source.Seed(seed)
 	for i := 0; i < numNodes; i++ {
 		dualAlphaNetwork.AddNode(NewTree)
 	}
 
-	sampler.Seed(seed)
+	source.Seed(seed)
 	for i := 0; i < numNodes; i++ {
 		singleAlphaNetwork.AddNode(NewTree)
 	}
 
 	// Although this can theoretically fail with a correct implementation, it
 	// shouldn't in practice
-	runNetworksInLockstep(require, seed, &dualAlphaNetwork, &singleAlphaNetwork)
+	runNetworksInLockstep(require, seed, source, dualAlphaNetwork, singleAlphaNetwork)
 }
 
 // Test that a network running the snowball tree converges faster than a network
@@ -61,35 +60,34 @@ func TestTreeConvergenceOptimization(t *testing.T) {
 		numNodes         = 100
 		params           = DefaultParameters
 		seed      uint64 = 0
+		source           = prng.NewMT19937()
 	)
 
-	treeNetwork := Network{}
-	treeNetwork.Initialize(params, numColors)
+	treeNetwork := NewNetwork(params, numColors, source)
+	flatNetwork := NewNetwork(params, numColors, source)
 
-	flatNetwork := treeNetwork
-
-	sampler.Seed(seed)
+	source.Seed(seed)
 	for i := 0; i < numNodes; i++ {
 		treeNetwork.AddNode(NewTree)
 	}
 
-	sampler.Seed(seed)
+	source.Seed(seed)
 	for i := 0; i < numNodes; i++ {
 		flatNetwork.AddNode(NewFlat)
 	}
 
 	// Although this can theoretically fail with a correct implementation, it
 	// shouldn't in practice
-	runNetworksInLockstep(require, seed, &treeNetwork, &flatNetwork)
+	runNetworksInLockstep(require, seed, source, treeNetwork, flatNetwork)
 }
 
-func runNetworksInLockstep(require *require.Assertions, seed uint64, fast *Network, slow *Network) {
+func runNetworksInLockstep(require *require.Assertions, seed uint64, source *prng.MT19937, fast *Network, slow *Network) {
 	numRounds := 0
 	for !fast.Finalized() && !fast.Disagreement() && !slow.Finalized() && !slow.Disagreement() {
-		sampler.Seed(uint64(numRounds) + seed)
+		source.Seed(uint64(numRounds) + seed)
 		fast.Round()
 
-		sampler.Seed(uint64(numRounds) + seed)
+		source.Seed(uint64(numRounds) + seed)
 		slow.Round()
 		numRounds++
 	}

--- a/snow/consensus/snowball/consensus_reversibility_test.go
+++ b/snow/consensus/snowball/consensus_reversibility_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/utils/sampler"
+	"gonum.org/v1/gonum/mathext/prng"
 )
 
 func TestSnowballGovernance(t *testing.T) {
@@ -21,12 +21,12 @@ func TestSnowballGovernance(t *testing.T) {
 		numRed              = 55
 		params              = DefaultParameters
 		seed         uint64 = 0
+		source              = prng.NewMT19937()
 	)
 
-	nBitwise := Network{}
-	nBitwise.Initialize(params, numColors)
+	nBitwise := NewNetwork(params, numColors, source)
 
-	sampler.Seed(seed)
+	source.Seed(seed)
 	for i := 0; i < numRed; i++ {
 		nBitwise.AddNodeSpecificColor(NewTree, 0, []int{1})
 	}

--- a/snow/consensus/snowball/network_test.go
+++ b/snow/consensus/snowball/network_test.go
@@ -4,10 +4,9 @@
 package snowball
 
 import (
-	"math/rand"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/bag"
+	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/sampler"
 )
 
@@ -16,20 +15,24 @@ type newConsensusFunc func(params Parameters, choice ids.ID) Consensus
 type Network struct {
 	params         Parameters
 	colors         []ids.ID
+	rngSource      sampler.Source
 	nodes, running []Consensus
 }
 
-// Initialize sets the parameters for the network and adds [numColors] different
-// possible colors to the network configuration.
-func (n *Network) Initialize(params Parameters, numColors int) {
-	n.params = params
+// Create a new network with [numColors] different possible colors to finalize.
+func NewNetwork(params Parameters, numColors int, rngSource sampler.Source) *Network {
+	n := &Network{
+		params:    params,
+		rngSource: rngSource,
+	}
 	for i := 0; i < numColors; i++ {
 		n.colors = append(n.colors, ids.Empty.Prefix(uint64(i)))
 	}
+	return n
 }
 
 func (n *Network) AddNode(newConsensusFunc newConsensusFunc) Consensus {
-	s := sampler.NewUniform()
+	s := sampler.NewDeterministicUniform(n.rngSource)
 	s.Initialize(uint64(len(n.colors)))
 	indices, _ := s.Sample(len(n.colors))
 
@@ -78,15 +81,14 @@ func (n *Network) Finalized() bool {
 // performing an unbiased poll of the nodes in the network for that node.
 func (n *Network) Round() {
 	if len(n.running) > 0 {
-		runningInd := rand.Intn(len(n.running)) // #nosec G404
+		s := sampler.NewDeterministicUniform(n.rngSource)
+
+		s.Initialize(uint64(len(n.running)))
+		runningInd, _ := s.Next()
 		running := n.running[runningInd]
 
-		s := sampler.NewUniform()
 		s.Initialize(uint64(len(n.nodes)))
-		count := len(n.nodes)
-		if count > n.params.K {
-			count = n.params.K
-		}
+		count := math.Min(n.params.K, len(n.nodes))
 		indices, _ := s.Sample(count)
 		sampledColors := bag.Bag[ids.ID]{}
 		for _, index := range indices {

--- a/snow/consensus/snowball/tree_test.go
+++ b/snow/consensus/snowball/tree_test.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"gonum.org/v1/gonum/mathext/prng"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/bag"
-	"github.com/ava-labs/avalanchego/utils/sampler"
 )
 
 const initialUnaryDescription = "SB(PreferenceStrength = 0, SF(Confidence = 0, Finalized = false)) Bits = [0, 256)"
@@ -806,14 +807,13 @@ func TestSnowballConsistent(t *testing.T) {
 			BetaVirtuous:    20,
 			BetaRogue:       30,
 		}
-		seed uint64 = 0
+		seed   uint64 = 0
+		source        = prng.NewMT19937()
 	)
 
-	sampler.Seed(seed)
+	n := NewNetwork(params, numColors, source)
 
-	n := Network{}
-	n.Initialize(params, numColors)
-
+	source.Seed(seed)
 	for i := 0; i < numNodes; i++ {
 		n.AddNode(NewTree)
 	}

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -17,12 +17,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"gonum.org/v1/gonum/mathext/prng"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowball"
 	"github.com/ava-labs/avalanchego/utils/bag"
-	"github.com/ava-labs/avalanchego/utils/sampler"
 )
 
 type testFunc func(*testing.T, Factory)
@@ -1599,13 +1600,13 @@ func RandomizedConsistencyTest(t *testing.T, factory Factory) {
 			MaxOutstandingItems:   1,
 			MaxItemProcessingTime: 1,
 		}
-		seed uint64 = 0
+		seed   uint64 = 0
+		source        = prng.NewMT19937()
 	)
 
-	sampler.Seed(seed)
+	source.Seed(seed)
 
-	n := Network{}
-	n.Initialize(params, numColors)
+	n := NewNetwork(params, numColors, source)
 
 	for i := 0; i < numNodes; i++ {
 		require.NoError(n.AddNode(factory.New()))

--- a/snow/consensus/snowman/network_test.go
+++ b/snow/consensus/snowman/network_test.go
@@ -5,7 +5,6 @@ package snowman
 
 import (
 	"context"
-	"math/rand"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
@@ -19,11 +18,43 @@ import (
 type Network struct {
 	params         snowball.Parameters
 	colors         []*TestBlock
+	rngSource      sampler.Source
 	nodes, running []Consensus
 }
 
+func NewNetwork(params snowball.Parameters, numColors int, rngSource sampler.Source) *Network {
+	n := &Network{
+		params: params,
+		colors: []*TestBlock{{
+			TestDecidable: choices.TestDecidable{
+				IDV:     ids.Empty.Prefix(rngSource.Uint64()),
+				StatusV: choices.Processing,
+			},
+			ParentV: Genesis.IDV,
+			HeightV: 1,
+		}},
+		rngSource: rngSource,
+	}
+
+	s := sampler.NewDeterministicUniform(n.rngSource)
+	for i := 1; i < numColors; i++ {
+		s.Initialize(uint64(len(n.colors)))
+		dependencyInd, _ := s.Next()
+		dependency := n.colors[dependencyInd]
+		n.colors = append(n.colors, &TestBlock{
+			TestDecidable: choices.TestDecidable{
+				IDV:     ids.Empty.Prefix(rngSource.Uint64()),
+				StatusV: choices.Processing,
+			},
+			ParentV: dependency.IDV,
+			HeightV: dependency.HeightV + 1,
+		})
+	}
+	return n
+}
+
 func (n *Network) shuffleColors() {
-	s := sampler.NewUniform()
+	s := sampler.NewDeterministicUniform(n.rngSource)
 	s.Initialize(uint64(len(n.colors)))
 	indices, _ := s.Sample(len(n.colors))
 	colors := []*TestBlock(nil)
@@ -32,32 +63,6 @@ func (n *Network) shuffleColors() {
 	}
 	n.colors = colors
 	utils.Sort(n.colors)
-}
-
-func (n *Network) Initialize(params snowball.Parameters, numColors int) {
-	n.params = params
-	// #nosec G404
-	n.colors = append(n.colors, &TestBlock{
-		TestDecidable: choices.TestDecidable{
-			IDV:     ids.Empty.Prefix(uint64(rand.Int63())),
-			StatusV: choices.Processing,
-		},
-		ParentV: Genesis.IDV,
-		HeightV: 1,
-	})
-
-	for i := 1; i < numColors; i++ {
-		dependency := n.colors[rand.Intn(len(n.colors))] // #nosec G404
-		// #nosec G404
-		n.colors = append(n.colors, &TestBlock{
-			TestDecidable: choices.TestDecidable{
-				IDV:     ids.Empty.Prefix(uint64(rand.Int63())),
-				StatusV: choices.Processing,
-			},
-			ParentV: dependency.IDV,
-			HeightV: dependency.HeightV + 1,
-		})
-	}
 }
 
 func (n *Network) AddNode(sm Consensus) error {
@@ -101,10 +106,12 @@ func (n *Network) Round() error {
 		return nil
 	}
 
-	runningInd := rand.Intn(len(n.running)) // #nosec G404
+	s := sampler.NewDeterministicUniform(n.rngSource)
+	s.Initialize(uint64(len(n.running)))
+
+	runningInd, _ := s.Next()
 	running := n.running[runningInd]
 
-	s := sampler.NewUniform()
 	s.Initialize(uint64(len(n.nodes)))
 	indices, _ := s.Sample(n.params.K)
 	sampledColors := bag.Bag[ids.ID]{}

--- a/utils/sampler/rand.go
+++ b/utils/sampler/rand.go
@@ -11,36 +11,29 @@ import (
 	"gonum.org/v1/gonum/mathext/prng"
 )
 
-var globalRNG = newRNG()
+var globalRNG *rng
 
-func newRNG() *rng {
+func init() {
 	// We don't use a cryptographically secure source of randomness here, as
 	// there's no need to ensure a truly random sampling.
 	source := prng.NewMT19937()
 	source.Seed(uint64(time.Now().UnixNano()))
+	globalRNG = newRNG(source)
+}
+
+func newRNG(source Source) *rng {
 	return &rng{rng: source}
-}
-
-func Seed(seed uint64) {
-	globalRNG.Seed(seed)
-}
-
-type source interface {
-	Seed(uint64)
-	Uint64() uint64
 }
 
 type rng struct {
 	lock sync.Mutex
-	rng  source
+	rng  Source
 }
 
-// Seed uses the provided seed value to initialize the generator to a
-// deterministic state.
-func (r *rng) Seed(seed uint64) {
-	r.lock.Lock()
-	r.rng.Seed(seed)
-	r.lock.Unlock()
+type Source interface {
+	// Uint64 returns a random number in [0, MaxUint64] and advances the
+	// generator's state.
+	Uint64() uint64
 }
 
 // Uint64Inclusive returns a pseudo-random number in [0,n].

--- a/utils/sampler/rand.go
+++ b/utils/sampler/rand.go
@@ -11,17 +11,13 @@ import (
 	"gonum.org/v1/gonum/mathext/prng"
 )
 
-var globalRNG *rng
+var globalRNG = newRNG()
 
-func init() {
+func newRNG() *rng {
 	// We don't use a cryptographically secure source of randomness here, as
 	// there's no need to ensure a truly random sampling.
 	source := prng.NewMT19937()
 	source.Seed(uint64(time.Now().UnixNano()))
-	globalRNG = newRNG(source)
-}
-
-func newRNG(source Source) *rng {
 	return &rng{rng: source}
 }
 

--- a/utils/sampler/uniform.go
+++ b/utils/sampler/uniform.go
@@ -21,3 +21,12 @@ func NewUniform() Uniform {
 		rng: globalRNG,
 	}
 }
+
+// NewDeterministicUniform returns a new sampler
+func NewDeterministicUniform(source Source) Uniform {
+	return &uniformReplacer{
+		rng: &rng{
+			rng: source,
+		},
+	}
+}

--- a/utils/sampler/uniform.go
+++ b/utils/sampler/uniform.go
@@ -11,13 +11,13 @@ type Uniform interface {
 	// negative the implementation may panic.
 	Sample(length int) ([]uint64, error)
 
-	Seed(uint64)
-
 	Reset()
 	Next() (uint64, error)
 }
 
 // NewUniform returns a new sampler
 func NewUniform() Uniform {
-	return &uniformReplacer{}
+	return &uniformReplacer{
+		rng: globalRNG,
+	}
 }

--- a/utils/sampler/uniform.go
+++ b/utils/sampler/uniform.go
@@ -12,7 +12,6 @@ type Uniform interface {
 	Sample(length int) ([]uint64, error)
 
 	Seed(uint64)
-	ClearSeed()
 
 	Reset()
 	Next() (uint64, error)

--- a/utils/sampler/uniform_best.go
+++ b/utils/sampler/uniform_best.go
@@ -29,8 +29,12 @@ type uniformBest struct {
 func NewBestUniform(expectedSampleSize int) Uniform {
 	return &uniformBest{
 		samplers: []Uniform{
-			&uniformReplacer{},
-			&uniformResample{},
+			&uniformReplacer{
+				rng: globalRNG,
+			},
+			&uniformResample{
+				rng: globalRNG,
+			},
 		},
 		maxSampleSize:       expectedSampleSize,
 		benchmarkIterations: 100,

--- a/utils/sampler/uniform_replacer.go
+++ b/utils/sampler/uniform_replacer.go
@@ -27,15 +27,12 @@ func (m defaultMap) get(key uint64, defaultVal uint64) uint64 {
 // Sampling is performed in O(count) time and O(count) space.
 type uniformReplacer struct {
 	rng        *rng
-	seededRNG  *rng
 	length     uint64
 	drawn      defaultMap
 	drawsCount uint64
 }
 
 func (s *uniformReplacer) Initialize(length uint64) {
-	s.rng = globalRNG
-	s.seededRNG = newRNG()
 	s.length = length
 	s.drawn = make(defaultMap)
 	s.drawsCount = 0
@@ -53,11 +50,6 @@ func (s *uniformReplacer) Sample(count int) ([]uint64, error) {
 		results[i] = ret
 	}
 	return results, nil
-}
-
-func (s *uniformReplacer) Seed(seed uint64) {
-	s.rng = s.seededRNG
-	s.rng.Seed(seed)
 }
 
 func (s *uniformReplacer) Reset() {

--- a/utils/sampler/uniform_replacer.go
+++ b/utils/sampler/uniform_replacer.go
@@ -60,10 +60,6 @@ func (s *uniformReplacer) Seed(seed uint64) {
 	s.rng.Seed(seed)
 }
 
-func (s *uniformReplacer) ClearSeed() {
-	s.rng = globalRNG
-}
-
 func (s *uniformReplacer) Reset() {
 	maps.Clear(s.drawn)
 	s.drawsCount = 0

--- a/utils/sampler/uniform_resample.go
+++ b/utils/sampler/uniform_resample.go
@@ -47,10 +47,6 @@ func (s *uniformResample) Seed(seed uint64) {
 	s.rng.Seed(seed)
 }
 
-func (s *uniformResample) ClearSeed() {
-	s.rng = globalRNG
-}
-
 func (s *uniformResample) Reset() {
 	maps.Clear(s.drawn)
 }

--- a/utils/sampler/uniform_resample.go
+++ b/utils/sampler/uniform_resample.go
@@ -15,15 +15,12 @@ import "golang.org/x/exp/maps"
 //
 // Sampling is performed in O(count) time and O(count) space.
 type uniformResample struct {
-	rng       *rng
-	seededRNG *rng
-	length    uint64
-	drawn     map[uint64]struct{}
+	rng    *rng
+	length uint64
+	drawn  map[uint64]struct{}
 }
 
 func (s *uniformResample) Initialize(length uint64) {
-	s.rng = globalRNG
-	s.seededRNG = newRNG()
 	s.length = length
 	s.drawn = make(map[uint64]struct{})
 }
@@ -40,11 +37,6 @@ func (s *uniformResample) Sample(count int) ([]uint64, error) {
 		results[i] = ret
 	}
 	return results, nil
-}
-
-func (s *uniformResample) Seed(seed uint64) {
-	s.rng = s.seededRNG
-	s.rng.Seed(seed)
 }
 
 func (s *uniformResample) Reset() {

--- a/utils/sampler/uniform_test.go
+++ b/utils/sampler/uniform_test.go
@@ -19,12 +19,16 @@ var (
 		sampler Uniform
 	}{
 		{
-			name:    "replacer",
-			sampler: &uniformReplacer{},
+			name: "replacer",
+			sampler: &uniformReplacer{
+				rng: globalRNG,
+			},
 		},
 		{
-			name:    "resampler",
-			sampler: &uniformResample{},
+			name: "resampler",
+			sampler: &uniformResample{
+				rng: globalRNG,
+			},
 		},
 		{
 			name:    "best",
@@ -155,49 +159,4 @@ func UniformLazilySample(t *testing.T, s Uniform) {
 
 		s.Reset()
 	}
-}
-
-func TestSeeding(t *testing.T) {
-	require := require.New(t)
-
-	s1 := NewBestUniform(30)
-	s2 := NewBestUniform(30)
-
-	s1.Initialize(50)
-	s2.Initialize(50)
-
-	s1.Seed(0)
-
-	s1.Reset()
-	s1Val, err := s1.Next()
-	require.NoError(err)
-
-	s2.Seed(1)
-	s2.Reset()
-
-	s1.Seed(0)
-	v, err := s2.Next()
-	require.NoError(err)
-	require.NotEqual(s1Val, v)
-}
-
-func TestSeedingProducesTheSame(t *testing.T) {
-	require := require.New(t)
-
-	s := NewBestUniform(30)
-
-	s.Initialize(50)
-
-	s.Seed(0)
-	s.Reset()
-
-	val0, err := s.Next()
-	require.NoError(err)
-
-	s.Seed(0)
-	s.Reset()
-
-	val1, err := s.Next()
-	require.NoError(err)
-	require.Equal(val0, val1)
 }

--- a/utils/sampler/uniform_test.go
+++ b/utils/sampler/uniform_test.go
@@ -179,11 +179,6 @@ func TestSeeding(t *testing.T) {
 	v, err := s2.Next()
 	require.NoError(err)
 	require.NotEqual(s1Val, v)
-
-	s1.ClearSeed()
-
-	_, err = s1.Next()
-	require.NoError(err)
 }
 
 func TestSeedingProducesTheSame(t *testing.T) {

--- a/utils/sampler/weighted_without_replacement.go
+++ b/utils/sampler/weighted_without_replacement.go
@@ -14,9 +14,7 @@ type WeightedWithoutReplacement interface {
 // NewWeightedWithoutReplacement returns a new sampler
 func NewDeterministicWeightedWithoutReplacement(source Source) WeightedWithoutReplacement {
 	return &weightedWithoutReplacementGeneric{
-		u: &uniformReplacer{
-			rng: newRNG(source),
-		},
+		u: NewDeterministicUniform(source),
 		w: NewDeterministicWeighted(),
 	}
 }

--- a/utils/sampler/weighted_without_replacement.go
+++ b/utils/sampler/weighted_without_replacement.go
@@ -11,7 +11,6 @@ type WeightedWithoutReplacement interface {
 	Sample(count int) ([]int, error)
 
 	Seed(uint64)
-	ClearSeed()
 }
 
 // NewWeightedWithoutReplacement returns a new sampler

--- a/utils/sampler/weighted_without_replacement.go
+++ b/utils/sampler/weighted_without_replacement.go
@@ -12,12 +12,10 @@ type WeightedWithoutReplacement interface {
 }
 
 // NewWeightedWithoutReplacement returns a new sampler
-func NewDeterministicWeightedWithoutReplacement(seed uint64) WeightedWithoutReplacement {
-	rng := newRNG()
-	rng.Seed(seed)
+func NewDeterministicWeightedWithoutReplacement(source Source) WeightedWithoutReplacement {
 	return &weightedWithoutReplacementGeneric{
 		u: &uniformReplacer{
-			rng: rng,
+			rng: newRNG(source),
 		},
 		w: NewDeterministicWeighted(),
 	}

--- a/utils/sampler/weighted_without_replacement.go
+++ b/utils/sampler/weighted_without_replacement.go
@@ -9,14 +9,16 @@ package sampler
 type WeightedWithoutReplacement interface {
 	Initialize(weights []uint64) error
 	Sample(count int) ([]int, error)
-
-	Seed(uint64)
 }
 
 // NewWeightedWithoutReplacement returns a new sampler
-func NewDeterministicWeightedWithoutReplacement() WeightedWithoutReplacement {
+func NewDeterministicWeightedWithoutReplacement(seed uint64) WeightedWithoutReplacement {
+	rng := newRNG()
+	rng.Seed(seed)
 	return &weightedWithoutReplacementGeneric{
-		u: NewUniform(),
+		u: &uniformReplacer{
+			rng: rng,
+		},
 		w: NewDeterministicWeighted(),
 	}
 }

--- a/utils/sampler/weighted_without_replacement_generic.go
+++ b/utils/sampler/weighted_without_replacement_generic.go
@@ -41,11 +41,3 @@ func (s *weightedWithoutReplacementGeneric) Sample(count int) ([]int, error) {
 	}
 	return indices, nil
 }
-
-func (s *weightedWithoutReplacementGeneric) Seed(seed uint64) {
-	s.u.Seed(seed)
-}
-
-func (s *weightedWithoutReplacementGeneric) ClearSeed() {
-	s.u.ClearSeed()
-}

--- a/utils/sampler/weighted_without_replacement_test.go
+++ b/utils/sampler/weighted_without_replacement_test.go
@@ -23,7 +23,9 @@ var (
 		{
 			name: "generic with replacer and best",
 			sampler: &weightedWithoutReplacementGeneric{
-				u: &uniformReplacer{},
+				u: &uniformReplacer{
+					rng: globalRNG,
+				},
 				w: &weightedBest{
 					samplers: []Weighted{
 						&weightedArray{},

--- a/vms/proposervm/proposer/windower.go
+++ b/vms/proposervm/proposer/windower.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"time"
 
+	"gonum.org/v1/gonum/mathext/prng"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils"
@@ -102,7 +104,10 @@ func (w *windower) Proposers(ctx context.Context, chainHeight, pChainHeight uint
 	}
 
 	seed := chainHeight ^ w.chainSource
-	sampler := sampler.NewDeterministicWeightedWithoutReplacement(seed)
+
+	source := prng.NewMT19937()
+	source.Seed(seed)
+	sampler := sampler.NewDeterministicWeightedWithoutReplacement(source)
 	if err := sampler.Initialize(validatorWeights); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why this should be merged

1. This removes weird switching between global RNGs and seeded RNGs.
2. This allows users of the package to specify custom sources of RNG
3. This reduces code

## How this works

Rather than creating a sampler and then seeding it - we allow a custom source of RNG (which can already be seeded).

## How this was tested

- Existing tests verify that the proposervm windowing is deterministic and that the results are unmodified.