### PR TITLE
`vms/platformvm`: Process `atomicRequests` and `onAcceptFunc` in option blocks

### DIFF
--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1873,6 +1873,10 @@ func TestUptimeDisallowedWithRestart(t *testing.T) {
 		secondCtx.Lock.Unlock()
 	}()
 
+	atomicDB := prefixdb.New([]byte{1}, db)
+	m := atomic.NewMemory(atomicDB)
+	secondCtx.SharedMemory = m.NewSharedMemory(secondCtx.ChainID)
+
 	secondMsgChan := make(chan common.Message, 1)
 	require.NoError(secondVM.Initialize(
 		context.Background(),
@@ -1961,6 +1965,10 @@ func TestUptimeDisallowedAfterNeverConnecting(t *testing.T) {
 
 	ctx := defaultContext(t)
 	ctx.Lock.Lock()
+
+	atomicDB := prefixdb.New([]byte{1}, db)
+	m := atomic.NewMemory(atomicDB)
+	ctx.SharedMemory = m.NewSharedMemory(ctx.ChainID)
 
 	msgChan := make(chan common.Message, 1)
 	appSender := &common.SenderTest{T: t}


### PR DESCRIPTION
## Why this should be merged

Once `ProposalBlock`s contain decision txs, these fields will be populated. We must duly process them.

This is a no-op change currently as these fields are not populated.

Factored out of https://github.com/ava-labs/avalanchego/pull/2451

## How this works

Copied relevant processing code from the `standardBlock` function.

## How this was tested

CI