### PR TITLE
`vms/platformvm`: Add `processStandardTxs` helper

### DIFF
--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -395,7 +395,7 @@ func (v *verifier) standardBlock(
 	b *block.ApricotStandardBlock,
 	onAcceptState state.Diff,
 ) error {
-	inputs, atomicRequests, onAcceptFunc, err := v.processStandardTxs(b.Txs(), onAcceptState, b.Parent())
+	inputs, atomicRequests, onAcceptFunc, err := v.processStandardTxs(b.Transactions, onAcceptState, b.Parent())
 	if err != nil {
 		return err
 	}

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -206,6 +206,8 @@ func (v *verifier) ApricotAtomicBlock(b *block.ApricotAtomicBlock) error {
 		return err
 	}
 
+	v.Mempool.Remove([]*txs.Tx{b.Tx})
+
 	blkID := b.ID()
 	v.blkIDToState[blkID] = &blockState{
 		statelessBlock: b,
@@ -216,8 +218,6 @@ func (v *verifier) ApricotAtomicBlock(b *block.ApricotAtomicBlock) error {
 		timestamp:      atomicExecutor.OnAccept.GetTimestamp(),
 		atomicRequests: atomicExecutor.AtomicRequests,
 	}
-
-	v.Mempool.Remove([]*txs.Tx{b.Tx})
 	return nil
 }
 
@@ -372,6 +372,8 @@ func (v *verifier) proposalBlock(
 	onCommitState.AddTx(b.Tx, status.Committed)
 	onAbortState.AddTx(b.Tx, status.Aborted)
 
+	v.Mempool.Remove([]*txs.Tx{b.Tx})
+
 	blkID := b.ID()
 	v.blkIDToState[blkID] = &blockState{
 		proposalBlockState: proposalBlockState{
@@ -386,7 +388,6 @@ func (v *verifier) proposalBlock(
 		timestamp: onAbortState.GetTimestamp(),
 	}
 
-	v.Mempool.Remove([]*txs.Tx{b.Tx})
 	return nil
 }
 
@@ -400,6 +401,8 @@ func (v *verifier) standardBlock(
 		return err
 	}
 
+	v.Mempool.Remove(b.Transactions)
+
 	blkID := b.ID()
 	v.blkIDToState[blkID] = &blockState{
 		statelessBlock: b,
@@ -411,8 +414,6 @@ func (v *verifier) standardBlock(
 		inputs:         inputs,
 		atomicRequests: atomicRequests,
 	}
-
-	v.Mempool.Remove(b.Transactions)
 	return nil
 }
 

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -387,7 +387,6 @@ func (v *verifier) proposalBlock(
 		// always be the same as the Banff Proposal Block.
 		timestamp: onAbortState.GetTimestamp(),
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged

Adds a `processStandardTxs` helper which will also be used in `ProposalBlock`s

Factored out of https://github.com/ava-labs/avalanchego/pull/2451

## How this works

pretty straightforward

## How this was tested

CI