### PR TITLE
`vms/platformvm`: Remove `EnableAdding` and `DisableAdding` from `Mempool` interface

### DIFF
--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -192,9 +192,7 @@ func (b *builder) ShutdownBlockTimer() {
 // This method removes the transactions from the returned
 // blocks from the mempool.
 func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
-	b.Mempool.DisableAdding()
 	defer func() {
-		b.Mempool.EnableAdding()
 		// If we need to advance the chain's timestamp in a standard block, but
 		// we build an invalid block, then we need to re-trigger block building.
 		//

--- a/vms/platformvm/txs/mempool/mock_mempool.go
+++ b/vms/platformvm/txs/mempool/mock_mempool.go
@@ -53,18 +53,6 @@ func (mr *MockMempoolMockRecorder) Add(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockMempool)(nil).Add), arg0)
 }
 
-// DisableAdding mocks base method.
-func (m *MockMempool) DisableAdding() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DisableAdding")
-}
-
-// DisableAdding indicates an expected call of DisableAdding.
-func (mr *MockMempoolMockRecorder) DisableAdding() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableAdding", reflect.TypeOf((*MockMempool)(nil).DisableAdding))
-}
-
 // DropExpiredStakerTxs mocks base method.
 func (m *MockMempool) DropExpiredStakerTxs(arg0 time.Time) []ids.ID {
 	m.ctrl.T.Helper()
@@ -77,18 +65,6 @@ func (m *MockMempool) DropExpiredStakerTxs(arg0 time.Time) []ids.ID {
 func (mr *MockMempoolMockRecorder) DropExpiredStakerTxs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropExpiredStakerTxs", reflect.TypeOf((*MockMempool)(nil).DropExpiredStakerTxs), arg0)
-}
-
-// EnableAdding mocks base method.
-func (m *MockMempool) EnableAdding() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "EnableAdding")
-}
-
-// EnableAdding indicates an expected call of EnableAdding.
-func (mr *MockMempoolMockRecorder) EnableAdding() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableAdding", reflect.TypeOf((*MockMempool)(nil).EnableAdding))
 }
 
 // Get mocks base method.


### PR DESCRIPTION
## Why this should be merged

These methods were added to prevent an infinite recursion bug. This recursion no longer exists -> cleanup 🧹

## How this works

Remove methods

## How this was tested

CI