### PR TITLE
`vms/avm`: Add `exists` bool to mempool `Peek`

### DIFF
--- a/vms/avm/block/builder/builder.go
+++ b/vms/avm/block/builder/builder.go
@@ -98,7 +98,7 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 		// that we will only stop building a block once there are no
 		// transactions in the mempool or the block is at least
 		// [targetBlockSize - mempool.MaxTxSize] bytes full.
-		if !exists && tx == nil || len(tx.Bytes()) > remainingSize {
+		if !exists || len(tx.Bytes()) > remainingSize {
 			break
 		}
 		b.mempool.Remove([]*txs.Tx{tx})

--- a/vms/avm/block/builder/builder.go
+++ b/vms/avm/block/builder/builder.go
@@ -93,12 +93,12 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 		remainingSize = targetBlockSize
 	)
 	for {
-		tx := b.mempool.Peek()
+		tx, exists := b.mempool.Peek()
 		// Invariant: [mempool.MaxTxSize] < [targetBlockSize]. This guarantees
 		// that we will only stop building a block once there are no
 		// transactions in the mempool or the block is at least
 		// [targetBlockSize - mempool.MaxTxSize] bytes full.
-		if tx == nil || len(tx.Bytes()) > remainingSize {
+		if !exists && tx == nil || len(tx.Bytes()) > remainingSize {
 			break
 		}
 		b.mempool.Remove([]*txs.Tx{tx})

--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -134,11 +134,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek().Return(tx)
+				mempool.EXPECT().Peek().Return(tx, true)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				mempool.EXPECT().MarkDropped(tx.ID(), errTest)
 				// Second loop iteration
-				mempool.EXPECT().Peek().Return(nil)
+				mempool.EXPECT().Peek().Return(nil, false)
 				mempool.EXPECT().RequestBuildBlock()
 
 				return New(
@@ -179,11 +179,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek().Return(tx)
+				mempool.EXPECT().Peek().Return(tx, true)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				mempool.EXPECT().MarkDropped(tx.ID(), errTest)
 				// Second loop iteration
-				mempool.EXPECT().Peek().Return(nil)
+				mempool.EXPECT().Peek().Return(nil, false)
 				mempool.EXPECT().RequestBuildBlock()
 
 				return New(
@@ -225,11 +225,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek().Return(tx)
+				mempool.EXPECT().Peek().Return(tx, true)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				mempool.EXPECT().MarkDropped(tx.ID(), errTest)
 				// Second loop iteration
-				mempool.EXPECT().Peek().Return(nil)
+				mempool.EXPECT().Peek().Return(nil, false)
 				mempool.EXPECT().RequestBuildBlock()
 
 				return New(
@@ -309,14 +309,14 @@ func TestBuilderBuildBlock(t *testing.T) {
 				)
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek().Return(tx1)
+				mempool.EXPECT().Peek().Return(tx1, true)
 				mempool.EXPECT().Remove([]*txs.Tx{tx1})
 				// Second loop iteration
-				mempool.EXPECT().Peek().Return(tx2)
+				mempool.EXPECT().Peek().Return(tx2, true)
 				mempool.EXPECT().Remove([]*txs.Tx{tx2})
 				mempool.EXPECT().MarkDropped(tx2.ID(), blkexecutor.ErrConflictingBlockTxs)
 				// Third loop iteration
-				mempool.EXPECT().Peek().Return(nil)
+				mempool.EXPECT().Peek().Return(nil, false)
 				mempool.EXPECT().RequestBuildBlock()
 
 				// To marshal the tx/block
@@ -385,10 +385,10 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek().Return(tx)
+				mempool.EXPECT().Peek().Return(tx, true)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				// Second loop iteration
-				mempool.EXPECT().Peek().Return(nil)
+				mempool.EXPECT().Peek().Return(nil, false)
 				mempool.EXPECT().RequestBuildBlock()
 
 				// To marshal the tx/block
@@ -459,10 +459,10 @@ func TestBuilderBuildBlock(t *testing.T) {
 				tx := &txs.Tx{Unsigned: unsignedTx}
 
 				mempool := mempool.NewMockMempool(ctrl)
-				mempool.EXPECT().Peek().Return(tx)
+				mempool.EXPECT().Peek().Return(tx, true)
 				mempool.EXPECT().Remove([]*txs.Tx{tx})
 				// Second loop iteration
-				mempool.EXPECT().Peek().Return(nil)
+				mempool.EXPECT().Peek().Return(nil, false)
 				mempool.EXPECT().RequestBuildBlock()
 
 				// To marshal the tx/block

--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -49,7 +49,7 @@ type Mempool interface {
 	Remove(txs []*txs.Tx)
 
 	// Peek returns the oldest tx in the mempool.
-	Peek() *txs.Tx
+	Peek() (tx *txs.Tx, exists bool)
 
 	// RequestBuildBlock notifies the consensus engine that a block should be
 	// built if there is at least one transaction in the mempool.
@@ -182,9 +182,9 @@ func (m *mempool) Remove(txsToRemove []*txs.Tx) {
 	}
 }
 
-func (m *mempool) Peek() *txs.Tx {
-	_, tx, _ := m.unissuedTxs.Oldest()
-	return tx
+func (m *mempool) Peek() (*txs.Tx, bool) {
+	_, tx, exists := m.unissuedTxs.Oldest()
+	return tx, exists
 }
 
 func (m *mempool) RequestBuildBlock() {

--- a/vms/avm/txs/mempool/mempool_test.go
+++ b/vms/avm/txs/mempool/mempool_test.go
@@ -181,20 +181,28 @@ func TestPeekTxs(t *testing.T) {
 
 	testTxs := createTestTxs(2)
 
-	require.Nil(mempool.Peek())
+	tx, exists := mempool.Peek()
+	require.False(exists)
+	require.Nil(tx)
 
 	require.NoError(mempool.Add(testTxs[0]))
 	require.NoError(mempool.Add(testTxs[1]))
 
-	require.Equal(mempool.Peek(), testTxs[0])
-	require.NotEqual(mempool.Peek(), testTxs[1])
+	tx, exists = mempool.Peek()
+	require.True(exists)
+	require.Equal(tx, testTxs[0])
+	require.NotEqual(tx, testTxs[1])
 
 	mempool.Remove([]*txs.Tx{testTxs[0]})
 
-	require.NotEqual(mempool.Peek(), testTxs[0])
-	require.Equal(mempool.Peek(), testTxs[1])
+	tx, exists = mempool.Peek()
+	require.True(exists)
+	require.NotEqual(tx, testTxs[0])
+	require.Equal(tx, testTxs[1])
 
 	mempool.Remove([]*txs.Tx{testTxs[1]})
 
-	require.Nil(mempool.Peek())
+	tx, exists = mempool.Peek()
+	require.False(exists)
+	require.Nil(tx)
 }

--- a/vms/avm/txs/mempool/mock_mempool.go
+++ b/vms/avm/txs/mempool/mock_mempool.go
@@ -107,11 +107,12 @@ func (mr *MockMempoolMockRecorder) MarkDropped(arg0, arg1 interface{}) *gomock.C
 }
 
 // Peek mocks base method.
-func (m *MockMempool) Peek() *txs.Tx {
+func (m *MockMempool) Peek() (*txs.Tx, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Peek")
 	ret0, _ := ret[0].(*txs.Tx)
-	return ret0
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 // Peek indicates an expected call of Peek.


### PR DESCRIPTION
## Why this should be merged

Seems odd to use the zero value to determine non-existence, let's be explicit

## How this works

Adds an `exists` return param

## How this was tested

CI