### PR TITLE
Apply state modifications once

### DIFF
--- a/vms/platformvm/block/executor/acceptor.go
+++ b/vms/platformvm/block/executor/acceptor.go
@@ -201,11 +201,11 @@ func (a *acceptor) optionBlock(b, parent block.Block, blockType string) error {
 	}
 
 	// Note that this method writes [batch] to the database.
-	if err := a.ctx.SharedMemory.Apply(blkState.atomicRequests, batch); err != nil {
+	if err := a.ctx.SharedMemory.Apply(parentState.atomicRequests, batch); err != nil {
 		return fmt.Errorf("failed to apply vm's state to shared memory: %w", err)
 	}
 
-	if onAcceptFunc := blkState.onAcceptFunc; onAcceptFunc != nil {
+	if onAcceptFunc := parentState.onAcceptFunc; onAcceptFunc != nil {
 		onAcceptFunc()
 	}
 

--- a/vms/platformvm/block/executor/acceptor.go
+++ b/vms/platformvm/block/executor/acceptor.go
@@ -172,6 +172,16 @@ func (a *acceptor) optionBlock(b, parent block.Block, blockType string) error {
 		return err
 	}
 
+	parentState, ok := a.blkIDToState[parentID]
+	if !ok {
+		return fmt.Errorf("%w %s", errMissingBlockState, parentID)
+	}
+	if parentState.onDecisionState != nil {
+		if err := parentState.onDecisionState.Apply(a.state); err != nil {
+			return err
+		}
+	}
+
 	blkState, ok := a.blkIDToState[blkID]
 	if !ok {
 		return fmt.Errorf("%w %s", errMissingBlockState, blkID)

--- a/vms/platformvm/block/executor/backend.go
+++ b/vms/platformvm/block/executor/backend.go
@@ -51,20 +51,20 @@ func (b *backend) GetState(blkID ids.ID) (state.Chain, bool) {
 	return b.state, blkID == b.state.GetLastAccepted()
 }
 
-func (b *backend) getBlkWithOnAbortState(blkID ids.ID) (*blockState, bool) {
+func (b *backend) getOnAbortState(blkID ids.ID) (state.Diff, bool) {
 	state, ok := b.blkIDToState[blkID]
 	if !ok || state.onAbortState == nil {
 		return nil, false
 	}
-	return state, true
+	return state.onAbortState, true
 }
 
-func (b *backend) getBlkWithOnCommitState(blkID ids.ID) (*blockState, bool) {
+func (b *backend) getOnCommitState(blkID ids.ID) (state.Diff, bool) {
 	state, ok := b.blkIDToState[blkID]
 	if !ok || state.onCommitState == nil {
 		return nil, false
 	}
-	return state, true
+	return state.onCommitState, true
 }
 
 func (b *backend) GetBlock(blkID ids.ID) (block.Block, error) {

--- a/vms/platformvm/block/executor/block_state.go
+++ b/vms/platformvm/block/executor/block_state.go
@@ -15,9 +15,9 @@ import (
 
 type proposalBlockState struct {
 	initiallyPreferCommit bool
+	onDecisionState       state.Diff
 	onCommitState         state.Diff
 	onAbortState          state.Diff
-	onDecisionState       state.Diff
 }
 
 // The state of a block.

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -335,7 +335,7 @@ func (v *verifier) commonBlock(b block.Block) error {
 // abortBlock populates the state of this block if [nil] is returned
 func (v *verifier) abortBlock(b block.Block) error {
 	parentID := b.Parent()
-	parentState, ok := v.getBlkWithOnAbortState(parentID)
+	onAbortState, ok := v.getOnAbortState(parentID)
 	if !ok {
 		return fmt.Errorf("%w: %s", state.ErrMissingParentState, parentID)
 	}
@@ -343,13 +343,8 @@ func (v *verifier) abortBlock(b block.Block) error {
 	blkID := b.ID()
 	v.blkIDToState[blkID] = &blockState{
 		statelessBlock: b,
-
-		onAcceptState: parentState.onAbortState,
-		onAcceptFunc:  parentState.onAcceptFunc,
-
-		inputs:         parentState.inputs,
-		timestamp:      parentState.onAbortState.GetTimestamp(),
-		atomicRequests: parentState.atomicRequests,
+		onAcceptState:  onAbortState,
+		timestamp:      onAbortState.GetTimestamp(),
 	}
 	return nil
 }
@@ -357,7 +352,7 @@ func (v *verifier) abortBlock(b block.Block) error {
 // commitBlock populates the state of this block if [nil] is returned
 func (v *verifier) commitBlock(b block.Block) error {
 	parentID := b.Parent()
-	parentState, ok := v.getBlkWithOnCommitState(parentID)
+	onCommitState, ok := v.getOnCommitState(parentID)
 	if !ok {
 		return fmt.Errorf("%w: %s", state.ErrMissingParentState, parentID)
 	}
@@ -365,13 +360,8 @@ func (v *verifier) commitBlock(b block.Block) error {
 	blkID := b.ID()
 	v.blkIDToState[blkID] = &blockState{
 		statelessBlock: b,
-
-		onAcceptState: parentState.onCommitState,
-		onAcceptFunc:  parentState.onAcceptFunc,
-
-		inputs:         parentState.inputs,
-		timestamp:      parentState.onCommitState.GetTimestamp(),
-		atomicRequests: parentState.atomicRequests,
+		onAcceptState:  onCommitState,
+		timestamp:      onCommitState.GetTimestamp(),
 	}
 	return nil
 }

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -356,7 +356,6 @@ func TestVerifierVisitCommitBlock(t *testing.T) {
 	timestamp := time.Now()
 	gomock.InOrder(
 		parentStatelessBlk.EXPECT().Height().Return(uint64(1)).Times(1),
-		parentOnDecisionState.EXPECT().Apply(parentOnCommitState).Return(nil),
 		parentOnCommitState.EXPECT().GetTimestamp().Return(timestamp).Times(1),
 	)
 
@@ -428,7 +427,6 @@ func TestVerifierVisitAbortBlock(t *testing.T) {
 	timestamp := time.Now()
 	gomock.InOrder(
 		parentStatelessBlk.EXPECT().Height().Return(uint64(1)).Times(1),
-		parentOnDecisionState.EXPECT().Apply(parentOnAbortState).Return(nil),
 		parentOnAbortState.EXPECT().GetTimestamp().Return(timestamp).Times(1),
 	)
 


### PR DESCRIPTION
## Why this should be merged

1. This improves the current performance of the P-chain because time changes are only applied once.
2. This improves the performance of the suggested change to the P-chain because it only applies decision transactions to one state diff.

## How this works

Moves state application from verification to accept.

## How this was tested

- [X] CI