### PR TITLE
Simplify version logic

### DIFF
--- a/version/compatibility.json
+++ b/version/compatibility.json
@@ -1,73 +1,242 @@
 {
   "30": [
-    "v1.10.15",
-    "v1.10.16",
-    "v1.10.17"
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 17
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 16
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 15
+    }
   ],
   "29": [
-    "v1.10.13",
-    "v1.10.14"
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 14
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 13
+    }
   ],
   "28": [
-    "v1.10.9",
-    "v1.10.10",
-    "v1.10.11",
-    "v1.10.12"
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 12
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 11
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 10
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 9
+    }
   ],
   "27": [
-    "v1.10.5",
-    "v1.10.6",
-    "v1.10.7",
-    "v1.10.8"
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 8
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 7
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 6
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 5
+    }
   ],
   "26": [
-    "v1.10.1",
-    "v1.10.2",
-    "v1.10.3",
-    "v1.10.4"
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 4
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 3
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 2
+    },
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 1
+    }
   ],
   "25": [
-    "v1.10.0"
+    {
+      "major": 1,
+      "minor": 10,
+      "patch": 0
+    }
   ],
   "24": [
-    "v1.9.10",
-    "v1.9.11",
-    "v1.9.12",
-    "v1.9.14",
-    "v1.9.15",
-    "v1.9.16"
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 16
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 15
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 14
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 13
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 12
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 11
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 10
+    }
   ],
   "23": [
-    "v1.9.9"
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 9
+    }
   ],
   "22": [
-    "v1.9.6",
-    "v1.9.7",
-    "v1.9.8"
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 8
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 7
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 6
+    }
   ],
   "21": [
-    "v1.9.5"
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 5
+    }
   ],
   "20": [
-    "v1.9.4"
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 4
+    }
   ],
   "19": [
-    "v1.9.2",
-    "v1.9.3"
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 3
+    },
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 2
+    }
   ],
   "18": [
-    "v1.9.1"
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 1
+    }
   ],
   "17": [
-    "v1.9.0"
+    {
+      "major": 1,
+      "minor": 9,
+      "patch": 0
+    }
   ],
   "16": [
-    "v1.8.0",
-    "v1.8.1",
-    "v1.8.2",
-    "v1.8.3",
-    "v1.8.4",
-    "v1.8.5",
-    "v1.8.6"
+    {
+      "major": 1,
+      "minor": 8,
+      "patch": 6
+    },
+    {
+      "major": 1,
+      "minor": 8,
+      "patch": 5
+    },
+    {
+      "major": 1,
+      "minor": 8,
+      "patch": 4
+    },
+    {
+      "major": 1,
+      "minor": 8,
+      "patch": 3
+    },
+    {
+      "major": 1,
+      "minor": 8,
+      "patch": 2
+    },
+    {
+      "major": 1,
+      "minor": 8,
+      "patch": 1
+    },
+    {
+      "major": 1,
+      "minor": 8,
+      "patch": 0
+    }
   ]
 }

--- a/version/constants.go
+++ b/version/constants.go
@@ -106,23 +106,9 @@ var (
 )
 
 func init() {
-	var parsedRPCChainVMCompatibility map[uint][]string
-	err := json.Unmarshal(rpcChainVMProtocolCompatibilityBytes, &parsedRPCChainVMCompatibility)
+	err := json.Unmarshal(rpcChainVMProtocolCompatibilityBytes, &RPCChainVMProtocolCompatibility)
 	if err != nil {
 		panic(err)
-	}
-
-	RPCChainVMProtocolCompatibility = make(map[uint][]*Semantic)
-	for rpcChainVMProtocol, versionStrings := range parsedRPCChainVMCompatibility {
-		versions := make([]*Semantic, len(versionStrings))
-		for i, versionString := range versionStrings {
-			version, err := Parse(versionString)
-			if err != nil {
-				panic(err)
-			}
-			versions[i] = version
-		}
-		RPCChainVMProtocolCompatibility[rpcChainVMProtocol] = versions
 	}
 
 	// The mainnet stop vertex is well known. It can be verified on any fully

--- a/version/parser.go
+++ b/version/parser.go
@@ -11,28 +11,9 @@ import (
 )
 
 var (
-	errMissingVersionPrefix     = errors.New("missing required version prefix")
 	errMissingApplicationPrefix = errors.New("missing required application prefix")
 	errMissingVersions          = errors.New("missing version numbers")
 )
-
-func Parse(s string) (*Semantic, error) {
-	if !strings.HasPrefix(s, "v") {
-		return nil, fmt.Errorf("%w: %q", errMissingVersionPrefix, s)
-	}
-
-	s = s[1:]
-	major, minor, patch, err := parseVersions(s)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Semantic{
-		Major: major,
-		Minor: minor,
-		Patch: patch,
-	}, nil
-}
 
 func ParseApplication(s string) (*Application, error) {
 	if !strings.HasPrefix(s, "avalanche/") {
@@ -40,9 +21,24 @@ func ParseApplication(s string) (*Application, error) {
 	}
 
 	s = s[10:]
-	major, minor, patch, err := parseVersions(s)
+	splitVersion := strings.SplitN(s, ".", 3)
+	if numSeperators := len(splitVersion); numSeperators != 3 {
+		return nil, fmt.Errorf("%w: expected 3 only got %d", errMissingVersions, numSeperators)
+	}
+
+	major, err := strconv.Atoi(splitVersion[0])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse %s as a version: %w", s, err)
+	}
+
+	minor, err := strconv.Atoi(splitVersion[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s as a version: %w", s, err)
+	}
+
+	patch, err := strconv.Atoi(splitVersion[2])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s as a version: %w", s, err)
 	}
 
 	return &Application{
@@ -50,28 +46,4 @@ func ParseApplication(s string) (*Application, error) {
 		Minor: minor,
 		Patch: patch,
 	}, nil
-}
-
-func parseVersions(s string) (int, int, int, error) {
-	splitVersion := strings.SplitN(s, ".", 3)
-	if numSeperators := len(splitVersion); numSeperators != 3 {
-		return 0, 0, 0, fmt.Errorf("%w: expected 3 only got %d", errMissingVersions, numSeperators)
-	}
-
-	major, err := strconv.Atoi(splitVersion[0])
-	if err != nil {
-		return 0, 0, 0, fmt.Errorf("failed to parse %s as a version: %w", s, err)
-	}
-
-	minor, err := strconv.Atoi(splitVersion[1])
-	if err != nil {
-		return 0, 0, 0, fmt.Errorf("failed to parse %s as a version: %w", s, err)
-	}
-
-	patch, err := strconv.Atoi(splitVersion[2])
-	if err != nil {
-		return 0, 0, 0, fmt.Errorf("failed to parse %s as a version: %w", s, err)
-	}
-
-	return major, minor, patch, nil
 }

--- a/version/parser_test.go
+++ b/version/parser_test.go
@@ -10,61 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParse(t *testing.T) {
-	v, err := Parse("v1.2.3")
-
-	require.NoError(t, err)
-	require.NotNil(t, v)
-	require.Equal(t, "v1.2.3", v.String())
-	require.Equal(t, 1, v.Major)
-	require.Equal(t, 2, v.Minor)
-	require.Equal(t, 3, v.Patch)
-
-	tests := []struct {
-		version     string
-		expectedErr error
-	}{
-		{
-			version:     "",
-			expectedErr: errMissingVersionPrefix,
-		},
-		{
-			version:     "1.2.3",
-			expectedErr: errMissingVersionPrefix,
-		},
-		{
-			version:     "z1.2.3",
-			expectedErr: errMissingVersionPrefix,
-		},
-		{
-			version:     "v1.2",
-			expectedErr: errMissingVersions,
-		},
-		{
-			version:     "vz.2.3",
-			expectedErr: strconv.ErrSyntax,
-		},
-		{
-			version:     "v1.z.3",
-			expectedErr: strconv.ErrSyntax,
-		},
-		{
-			version:     "v1.2.z",
-			expectedErr: strconv.ErrSyntax,
-		},
-		{
-			version:     "v1.2.3.4",
-			expectedErr: strconv.ErrSyntax,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.version, func(t *testing.T) {
-			_, err := Parse(test.version)
-			require.ErrorIs(t, err, test.expectedErr)
-		})
-	}
-}
-
 func TestParseApplication(t *testing.T) {
 	v, err := ParseApplication("avalanche/1.2.3")
 

--- a/version/version.go
+++ b/version/version.go
@@ -5,11 +5,11 @@ package version
 
 import (
 	"fmt"
-	"sync/atomic"
+	"sync"
 )
 
 var (
-	// V1_0_0 is a useful version to use in tests
+	// v1_0_0 is a useful version to use in tests
 	Semantic1_0_0 = &Semantic{
 		Major: 1,
 		Minor: 0,
@@ -24,25 +24,24 @@ type Semantic struct {
 	Minor int `json:"minor" yaml:"minor"`
 	Patch int `json:"patch" yaml:"patch"`
 
-	str atomic.Value
+	initStrOnce sync.Once
+	str         string
 }
 
 // The only difference here between Semantic and Application is that Semantic
 // prepends "v" rather than "avalanche/".
 func (s *Semantic) String() string {
-	strIntf := s.str.Load()
-	if strIntf != nil {
-		return strIntf.(string)
-	}
+	s.initStrOnce.Do(s.initString)
+	return s.str
+}
 
-	str := fmt.Sprintf(
+func (s *Semantic) initString() {
+	s.str = fmt.Sprintf(
 		"v%d.%d.%d",
 		s.Major,
 		s.Minor,
 		s.Patch,
 	)
-	s.str.Store(str)
-	return str
 }
 
 // Compare returns a positive number if s > o, 0 if s == o, or a negative number


### PR DESCRIPTION
## Why this should be merged

This change allows us to completely remove `version.Parse`. After #2188 is merged, we can fully remove string parsing of versions.

## How this works

Currently we only use `Parse` in tests and when parsing the version compatibility file.

## How this was tested

- [X] CI
- [ ] Verified with the CLI team that this will not break their tooling.