### PR TITLE
Ensure upgrade test uses the correct binary on restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   go_version: '~1.20.12'
+  tmpnet_data_path: ~/.tmpnet/networks/1000
 
 jobs:
   Unit:
@@ -72,8 +73,9 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: e2e-artifact
-          path: ~/.tmpnet/networks/1000
+          name: e2e-tmpnet-data
+          path: ${{ env.tmpnet_data_path }}
+          if-no-files-found: error
   e2e_existing_network:
     runs-on: ubuntu-latest
     steps:
@@ -92,8 +94,9 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: e2e-existing-network-tmpnet-artifact
-          path: ~/.tmpnet/networks/1000
+          name: e2e-existing-network-tmpnet-data
+          path: ${{ env.tmpnet_data_path }}
+          if-no-files-found: error
   Upgrade:
     runs-on: ubuntu-latest
     steps:
@@ -107,15 +110,14 @@ jobs:
         run: ./scripts/build.sh
       - name: Run e2e tests
         shell: bash
-        # 1.10.7 is the first version compatible with the ephnet fixture by
-        # virtue of writing a process context file on node start.
-        run: ./scripts/tests.upgrade.sh 1.10.7
-      - name: Upload ephnet network dir
+        run: ./scripts/tests.upgrade.sh
+      - name: Upload tmpnet network dir
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: upgrade-artifact
-          path: ~/.ephnet/networks/1000
+          name: upgrade-tmpnet-data
+          path: ${{ env.tmpnet_data_path }}
+          if-no-files-found: error
   Lint:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -3,14 +3,21 @@
 set -euo pipefail
 
 # e.g.,
-# ./scripts/tests.upgrade.sh 1.7.16
-# AVALANCHEGO_PATH=./path/to/avalanchego ./scripts/tests.upgrade.sh 1.7.16 # Customization of avalanchego path
+# ./scripts/tests.upgrade.sh                                                # Use default version
+# ./scripts/tests.upgrade.sh 1.10.18                                        # Specify a version
+# AVALANCHEGO_PATH=./path/to/avalanchego ./scripts/tests.upgrade.sh 1.10.18 # Customization of avalanchego path
 if ! [[ "$0" =~ scripts/tests.upgrade.sh ]]; then
   echo "must be run from repository root"
   exit 255
 fi
 
-VERSION="${1:-}"
+# 1.10.17 is the first version compatible with bls signing keys being
+# included in the genesis. Attempting to upgrade from prior versions
+# will result in nodes failing to boot due to the hash of the genesis
+# not matching the hash of the committed genesis block.
+DEFAULT_VERSION="1.10.17"
+
+VERSION="${1:-${DEFAULT_VERSION}}"
 if [[ -z "${VERSION}" ]]; then
   echo "Missing version argument!"
   echo "Usage: ${0} [VERSION]" >>/dev/stderr

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -69,7 +69,9 @@ var _ = ginkgo.Describe("[Upgrade]", func() {
 			node.Flags[config.BootstrapIPsKey] = strings.Join(bootstrapIPs, ",")
 			require.NoError(node.WriteConfig())
 
-			require.NoError(node.Start(ginkgo.GinkgoWriter, avalancheGoExecPath))
+			// Ensure the new node starts with the upgrade binary
+			node.ExecPath = avalancheGoExecPathToUpgradeTo
+			require.NoError(node.Start(ginkgo.GinkgoWriter, "" /* defaultExecPath */))
 
 			ginkgo.By(fmt.Sprintf("waiting for node %q to report healthy after restart", node.GetID()))
 			e2e.WaitForHealthy(node)


### PR DESCRIPTION
Also:

- Fix upgrade test workflow to target the correct path for artifact upload

- Ensure all tmpnet artifact upload reports an error if files are missing

- Move the default upgrade version in the tests.upgrade.sh to simplify local execution (no longer have to provide a compatible version to the script)