### PR TITLE
ci: run each fuzz test for 10 seconds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           check-latest: true
       - name: fuzz_test
         shell: bash
-        run: ./scripts/build_fuzz.sh 15 # Run each fuzz test 15 seconds
+        run: ./scripts/build_fuzz.sh 10 # Run each fuzz test 10 seconds
   e2e:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why this should be merged

Our fuzz tests are by far the longest workflow on our CI. This reduces the time for each fuzz test from 15 seconds to 10 seconds.

## How this works

15 -> 10

## How this was tested

CI