### PR TITLE
Fix race in view iteration

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -202,7 +202,7 @@ type merkleDB struct {
 	history *trieHistory
 
 	// True iff the db has been closed.
-	closed utils.Atomic[bool]
+	closed bool
 
 	metrics merkleMetrics
 
@@ -361,7 +361,7 @@ func (db *merkleDB) CommitChangeProof(ctx context.Context, proof *ChangeProof) e
 	db.commitLock.Lock()
 	defer db.commitLock.Unlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 	ops := make([]database.BatchOp, len(proof.KeyChanges))
@@ -384,7 +384,7 @@ func (db *merkleDB) CommitRangeProof(ctx context.Context, start, end maybe.Maybe
 	db.commitLock.Lock()
 	defer db.commitLock.Unlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 
@@ -423,7 +423,7 @@ func (db *merkleDB) CommitRangeProof(ctx context.Context, start, end maybe.Maybe
 }
 
 func (db *merkleDB) Compact(start []byte, limit []byte) error {
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 	return db.baseDB.Compact(start, limit)
@@ -436,11 +436,14 @@ func (db *merkleDB) Close() error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 
-	db.closed.Set(true)
+	// mark all children as no longer valid because the db has closed
+	db.invalidateChildrenExcept(nil)
+
+	db.closed = true
 	db.valueNodeDB.Close()
 	// Flush intermediary nodes to disk.
 	if err := db.intermediateNodeDB.Flush(); err != nil {
@@ -455,7 +458,7 @@ func (db *merkleDB) PrefetchPaths(keys [][]byte) error {
 	db.commitLock.RLock()
 	defer db.commitLock.RUnlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 
@@ -477,7 +480,7 @@ func (db *merkleDB) PrefetchPath(key []byte) error {
 	db.commitLock.RLock()
 	defer db.commitLock.RUnlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 	tempView, err := newTrieView(db, db, ViewChanges{})
@@ -568,7 +571,7 @@ func (db *merkleDB) getValue(key Key) ([]byte, error) {
 // Returns database.ErrNotFound if it doesn't exist.
 // Assumes [db.lock] is read locked.
 func (db *merkleDB) getValueWithoutLock(key Key) ([]byte, error) {
-	if db.closed.Get() {
+	if db.closed {
 		return nil, database.ErrClosed
 	}
 
@@ -589,7 +592,7 @@ func (db *merkleDB) GetMerkleRoot(ctx context.Context) (ids.ID, error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return ids.Empty, database.ErrClosed
 	}
 
@@ -610,7 +613,7 @@ func (db *merkleDB) GetProof(ctx context.Context, key []byte) (*Proof, error) {
 
 // Assumes [db.commitLock] is read locked.
 func (db *merkleDB) getProof(ctx context.Context, key []byte) (*Proof, error) {
-	if db.closed.Get() {
+	if db.closed {
 		return nil, database.ErrClosed
 	}
 
@@ -657,7 +660,7 @@ func (db *merkleDB) getRangeProofAtRoot(
 	maxLength int,
 ) (*RangeProof, error) {
 	switch {
-	case db.closed.Get():
+	case db.closed:
 		return nil, database.ErrClosed
 	case maxLength <= 0:
 		return nil, fmt.Errorf("%w but was %d", ErrInvalidMaxLength, maxLength)
@@ -692,7 +695,7 @@ func (db *merkleDB) GetChangeProof(
 	db.commitLock.RLock()
 	defer db.commitLock.RUnlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return nil, database.ErrClosed
 	}
 
@@ -784,7 +787,7 @@ func (db *merkleDB) NewView(
 	db.commitLock.RLock()
 	defer db.commitLock.RUnlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return nil, database.ErrClosed
 	}
 
@@ -805,7 +808,7 @@ func (db *merkleDB) Has(k []byte) (bool, error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return false, database.ErrClosed
 	}
 
@@ -820,7 +823,7 @@ func (db *merkleDB) HealthCheck(ctx context.Context) (interface{}, error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return nil, database.ErrClosed
 	}
 	return db.baseDB.HealthCheck(ctx)
@@ -857,7 +860,7 @@ func (db *merkleDB) PutContext(ctx context.Context, k, v []byte) error {
 	db.commitLock.Lock()
 	defer db.commitLock.Unlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 
@@ -876,7 +879,7 @@ func (db *merkleDB) DeleteContext(ctx context.Context, key []byte) error {
 	db.commitLock.Lock()
 	defer db.commitLock.Unlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 
@@ -900,7 +903,7 @@ func (db *merkleDB) commitBatch(ops []database.BatchOp) error {
 	db.commitLock.Lock()
 	defer db.commitLock.Unlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 
@@ -918,7 +921,7 @@ func (db *merkleDB) commitChanges(ctx context.Context, trieToCommit *trieView) e
 	defer db.lock.Unlock()
 
 	switch {
-	case db.closed.Get():
+	case db.closed:
 		return database.ErrClosed
 	case trieToCommit == nil:
 		return nil
@@ -1079,7 +1082,7 @@ func (db *merkleDB) VerifyChangeProof(
 	db.commitLock.RLock()
 	defer db.commitLock.RUnlock()
 
-	if db.closed.Get() {
+	if db.closed {
 		return database.ErrClosed
 	}
 
@@ -1280,7 +1283,7 @@ func (db *merkleDB) getEditableNode(key Key, hasValue bool) (*node, error) {
 // Assumes [db.lock] is read locked.
 func (db *merkleDB) getNode(key Key, hasValue bool) (*node, error) {
 	switch {
-	case db.closed.Get():
+	case db.closed:
 		return nil, database.ErrClosed
 	case db.root.HasValue() && key == db.root.Value().key:
 		return db.root.Value(), nil

--- a/x/merkledb/view_iterator.go
+++ b/x/merkledb/view_iterator.go
@@ -71,13 +71,13 @@ type viewIterator struct {
 // based on if the in memory changes or the underlying db should be read next
 func (it *viewIterator) Next() bool {
 	switch {
-	case it.view.db.closed:
+	case it.view.db.closed.Get():
 		// Short-circuit and set an error if the underlying database has been closed.
 		it.key = nil
 		it.value = nil
 		it.err = database.ErrClosed
 		return false
-	case it.view.invalidated:
+	case it.view.isInvalid():
 		it.key = nil
 		it.value = nil
 		it.err = ErrInvalid

--- a/x/merkledb/view_iterator.go
+++ b/x/merkledb/view_iterator.go
@@ -71,12 +71,6 @@ type viewIterator struct {
 // based on if the in memory changes or the underlying db should be read next
 func (it *viewIterator) Next() bool {
 	switch {
-	case it.view.db.closed.Get():
-		// Short-circuit and set an error if the underlying database has been closed.
-		it.key = nil
-		it.value = nil
-		it.err = database.ErrClosed
-		return false
 	case it.view.isInvalid():
 		it.key = nil
 		it.value = nil

--- a/x/merkledb/view_iterator_test.go
+++ b/x/merkledb/view_iterator_test.go
@@ -78,7 +78,8 @@ func Test_TrieView_Iterator_DBClosed(t *testing.T) {
 	require.False(iterator.Next())
 	require.Nil(iterator.Key())
 	require.Nil(iterator.Value())
-	require.ErrorIs(iterator.Error(), ErrInvalid)
+	err := iterator.Error()
+	require.ErrorIs(err, ErrInvalid)
 }
 
 // Test_TrieView_IteratorStart tests to make sure the iterator can be configured to

--- a/x/merkledb/view_iterator_test.go
+++ b/x/merkledb/view_iterator_test.go
@@ -34,7 +34,8 @@ func Test_TrieView_Iterator(t *testing.T) {
 	require.NoError(db.Put(key1, value1))
 	require.NoError(db.Put(key2, value2))
 
-	iterator := db.NewIterator()
+	view, err := db.NewView(context.Background(), ViewChanges{})
+	iterator := view.NewIterator()
 	require.NotNil(iterator)
 
 	defer iterator.Release()
@@ -53,6 +54,32 @@ func Test_TrieView_Iterator(t *testing.T) {
 	require.NoError(iterator.Error())
 }
 
+func Test_TrieView_Iterator_DBClosed(t *testing.T) {
+	require := require.New(t)
+
+	key1 := []byte("hello1")
+	value1 := []byte("world1")
+
+	db, err := getBasicDB()
+	require.NoError(err)
+
+	require.NoError(db.Put(key1, value1))
+
+	view, err := db.NewView(context.Background(), ViewChanges{})
+	require.NoError(err)
+	iterator := view.NewIterator()
+	require.NotNil(iterator)
+
+	defer iterator.Release()
+
+	require.NoError(db.Close())
+
+	require.False(iterator.Next())
+	require.Nil(iterator.Key())
+	require.Nil(iterator.Value())
+	require.ErrorIs(iterator.Error(), ErrInvalid)
+}
+
 // Test_TrieView_IteratorStart tests to make sure the iterator can be configured to
 // start midway through the database.
 func Test_TrieView_IteratorStart(t *testing.T) {
@@ -69,7 +96,9 @@ func Test_TrieView_IteratorStart(t *testing.T) {
 	require.NoError(db.Put(key1, value1))
 	require.NoError(db.Put(key2, value2))
 
-	iterator := db.NewIteratorWithStart(key2)
+	view, err := db.NewView(context.Background(), ViewChanges{})
+	require.NoError(err)
+	iterator := view.NewIteratorWithStart(key2)
 	require.NotNil(iterator)
 
 	defer iterator.Release()
@@ -104,7 +133,9 @@ func Test_TrieView_IteratorPrefix(t *testing.T) {
 	require.NoError(db.Put(key2, value2))
 	require.NoError(db.Put(key3, value3))
 
-	iterator := db.NewIteratorWithPrefix([]byte("h"))
+	view, err := db.NewView(context.Background(), ViewChanges{})
+	require.NoError(err)
+	iterator := view.NewIteratorWithPrefix([]byte("h"))
 	require.NotNil(iterator)
 
 	defer iterator.Release()
@@ -139,7 +170,9 @@ func Test_TrieView_IteratorStartPrefix(t *testing.T) {
 	require.NoError(db.Put(key2, value2))
 	require.NoError(db.Put(key3, value3))
 
-	iterator := db.NewIteratorWithStartAndPrefix(key1, []byte("h"))
+	view, err := db.NewView(context.Background(), ViewChanges{})
+	require.NoError(err)
+	iterator := view.NewIteratorWithStartAndPrefix(key1, []byte("h"))
 	require.NotNil(iterator)
 
 	defer iterator.Release()

--- a/x/merkledb/view_iterator_test.go
+++ b/x/merkledb/view_iterator_test.go
@@ -35,6 +35,7 @@ func Test_TrieView_Iterator(t *testing.T) {
 	require.NoError(db.Put(key2, value2))
 
 	view, err := db.NewView(context.Background(), ViewChanges{})
+	require.NoError(err)
 	iterator := view.NewIterator()
 	require.NotNil(iterator)
 

--- a/x/merkledb/view_iterator_test.go
+++ b/x/merkledb/view_iterator_test.go
@@ -78,7 +78,7 @@ func Test_TrieView_Iterator_DBClosed(t *testing.T) {
 	require.False(iterator.Next())
 	require.Nil(iterator.Key())
 	require.Nil(iterator.Value())
-	err := iterator.Error()
+	err = iterator.Error()
 	require.ErrorIs(err, ErrInvalid)
 }
 


### PR DESCRIPTION
Avoids race when reading view.invalidated or view.db.closed during iteration