### PR TITLE
`tmpnet`: Add support for subnets

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 
 	// ensure test packages are scanned by ginkgo
 	_ "github.com/ava-labs/avalanchego/tests/e2e/banff"
@@ -35,7 +36,7 @@ func init() {
 
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// Run only once in the first ginkgo process
-	return e2e.NewTestEnvironment(flagVars).Marshal()
+	return e2e.NewTestEnvironment(flagVars, &tmpnet.Network{}).Marshal()
 }, func(envBytes []byte) {
 	// Run in every ginkgo process
 

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -88,8 +88,10 @@ func NewTestEnvironment(flagVars *FlagVars, desiredNetwork *tmpnet.Network) *Tes
 	// Wait for chains to have bootstrapped on all nodes
 	Eventually(func() bool {
 		for _, subnet := range network.Subnets {
-			for _, node := range network.Nodes {
-				infoClient := info.NewClient(node.URI)
+			for _, validatorID := range subnet.ValidatorIDs {
+				uri, err := network.GetURIForNodeID(validatorID)
+				require.NoError(err)
+				infoClient := info.NewClient(uri)
 				for _, chain := range subnet.Chains {
 					isBootstrapped, err := infoClient.IsBootstrapped(DefaultContext(), chain.ChainID.String())
 					// Ignore errors since a chain id that is not yet known will result in a recoverable error.

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
@@ -29,10 +30,9 @@ var Env *TestEnvironment
 func InitSharedTestEnvironment(envBytes []byte) {
 	require := require.New(ginkgo.GinkgoT())
 	require.Nil(Env, "env already initialized")
-	Env = &TestEnvironment{
-		require: require,
-	}
+	Env = &TestEnvironment{}
 	require.NoError(json.Unmarshal(envBytes, Env))
+	Env.require = require
 }
 
 type TestEnvironment struct {
@@ -53,7 +53,7 @@ func (te *TestEnvironment) Marshal() []byte {
 }
 
 // Initialize a new test environment with a shared network (either pre-existing or newly created).
-func NewTestEnvironment(flagVars *FlagVars) *TestEnvironment {
+func NewTestEnvironment(flagVars *FlagVars, desiredNetwork *tmpnet.Network) *TestEnvironment {
 	require := require.New(ginkgo.GinkgoT())
 
 	networkDir := flagVars.NetworkDir()
@@ -65,9 +65,24 @@ func NewTestEnvironment(flagVars *FlagVars) *TestEnvironment {
 		network, err = tmpnet.ReadNetwork(networkDir)
 		require.NoError(err)
 		tests.Outf("{{yellow}}Using an existing network configured at %s{{/}}\n", network.Dir)
+
+		// Set the desired subnet configuration to ensure subsequent creation.
+		for _, subnet := range desiredNetwork.Subnets {
+			if existing := network.GetSubnet(subnet.Name); existing != nil {
+				// Already present
+				continue
+			}
+			network.Subnets = append(network.Subnets, subnet)
+		}
 	} else {
-		network = StartNetwork(flagVars.AvalancheGoExecPath(), DefaultNetworkDir)
+		network = desiredNetwork
+		StartNetwork(network, DefaultNetworkDir, flagVars.AvalancheGoExecPath(), flagVars.PluginDir())
 	}
+
+	// A new network will always need subnet creation and an existing
+	// network will also need subnets to be created the first time it
+	// is used.
+	require.NoError(network.CreateSubnets(DefaultContext(), ginkgo.GinkgoWriter))
 
 	uris := network.GetNodeURIs()
 	require.NotEmpty(uris, "network contains no nodes")
@@ -83,6 +98,7 @@ func NewTestEnvironment(flagVars *FlagVars) *TestEnvironment {
 		NetworkDir:        network.Dir,
 		URIs:              uris,
 		TestDataServerURI: testDataServerURI,
+		require:           require,
 	}
 }
 
@@ -127,10 +143,22 @@ func (te *TestEnvironment) NewPrivateNetwork() *tmpnet.Network {
 	sharedNetwork, err := tmpnet.ReadNetwork(te.NetworkDir)
 	te.require.NoError(err)
 
+	network := &tmpnet.Network{}
+
 	// The private networks dir is under the shared network dir to ensure it
 	// will be included in the artifact uploaded in CI.
 	privateNetworksDir := filepath.Join(sharedNetwork.Dir, PrivateNetworksDirName)
 	te.require.NoError(os.MkdirAll(privateNetworksDir, perms.ReadWriteExecute))
 
-	return StartNetwork(sharedNetwork.DefaultRuntimeConfig.AvalancheGoPath, privateNetworksDir)
+	pluginDir, err := sharedNetwork.DefaultFlags.GetStringVal(config.PluginDirKey)
+	te.require.NoError(err)
+
+	StartNetwork(
+		network,
+		privateNetworksDir,
+		sharedNetwork.DefaultRuntimeConfig.AvalancheGoPath,
+		pluginDir,
+	)
+
+	return network
 }

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -13,8 +13,17 @@ import (
 
 type FlagVars struct {
 	avalancheGoExecPath string
+	pluginDir           string
 	networkDir          string
 	useExistingNetwork  bool
+}
+
+func (v *FlagVars) AvalancheGoExecPath() string {
+	return v.avalancheGoExecPath
+}
+
+func (v *FlagVars) PluginDir() string {
+	return v.pluginDir
 }
 
 func (v *FlagVars) NetworkDir() string {
@@ -25,10 +34,6 @@ func (v *FlagVars) NetworkDir() string {
 		return v.networkDir
 	}
 	return os.Getenv(tmpnet.NetworkDirEnvName)
-}
-
-func (v *FlagVars) AvalancheGoExecPath() string {
-	return v.avalancheGoExecPath
 }
 
 func (v *FlagVars) UseExistingNetwork() bool {
@@ -42,6 +47,12 @@ func RegisterFlags() *FlagVars {
 		"avalanchego-path",
 		os.Getenv(tmpnet.AvalancheGoPathEnvName),
 		fmt.Sprintf("avalanchego executable path (required if not using an existing network). Also possible to configure via the %s env variable.", tmpnet.AvalancheGoPathEnvName),
+	)
+	flag.StringVar(
+		&vars.pluginDir,
+		"plugin-dir",
+		os.ExpandEnv("$HOME/.avalanchego/plugins"),
+		"[optional] the dir containing VM plugins.",
 	)
 	flag.StringVar(
 		&vars.networkDir,

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -34,14 +34,14 @@ const (
 	// contention.
 	DefaultTimeout = 2 * time.Minute
 
-	// Interval appropriate for network operations that should be
-	// retried periodically but not too often.
-	DefaultPollingInterval = 500 * time.Millisecond
+	DefaultPollingInterval = tmpnet.DefaultPollingInterval
 
 	// Setting this env will disable post-test bootstrap
 	// checks. Useful for speeding up iteration during test
 	// development.
 	SkipBootstrapChecksEnvName = "E2E_SKIP_BOOTSTRAP_CHECKS"
+
+	DefaultValidatorStartTimeDiff = tmpnet.DefaultValidatorStartTimeDiff
 
 	DefaultGasLimit = uint64(21000) // Standard gas limit
 
@@ -217,13 +217,20 @@ func CheckBootstrapIsPossible(network *tmpnet.Network) {
 }
 
 // Start a temporary network with the provided avalanchego binary.
-func StartNetwork(avalancheGoExecPath string, rootNetworkDir string) *tmpnet.Network {
+func StartNetwork(network *tmpnet.Network, rootNetworkDir string, avalancheGoExecPath string, pluginDir string) {
 	require := require.New(ginkgo.GinkgoT())
 
-	network, err := tmpnet.NewDefaultNetwork(ginkgo.GinkgoWriter, avalancheGoExecPath, tmpnet.DefaultNodeCount)
-	require.NoError(err)
-	require.NoError(network.Create(rootNetworkDir))
-	require.NoError(network.Start(DefaultContext(), ginkgo.GinkgoWriter))
+	require.NoError(
+		tmpnet.StartNewNetwork(
+			DefaultContext(),
+			ginkgo.GinkgoWriter,
+			network,
+			rootNetworkDir,
+			avalancheGoExecPath,
+			pluginDir,
+			tmpnet.DefaultNodeCount,
+		),
+	)
 
 	ginkgo.DeferCleanup(func() {
 		tests.Outf("Shutting down network\n")
@@ -233,6 +240,4 @@ func StartNetwork(avalancheGoExecPath string, rootNetworkDir string) *tmpnet.Net
 	})
 
 	tests.Outf("{{green}}Successfully started network{{/}}\n")
-
-	return network
 }

--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -34,6 +34,7 @@ the following non-test files:
 | node.go           | Node        | Orchestrates and configures nodes              |
 | node_config.go    | Node        | Reads and writes node configuration            |
 | node_process.go   | NodeProcess | Orchestrates node processes                    |
+| subnet.go         | Subnet      | Orchestrates subnets                           |
 | utils.go          |             | Defines shared utility functions               |
 
 ## Usage
@@ -103,6 +104,10 @@ avalanchego on node start. The use of dynamic ports supports testing
 with many temporary networks without having to manually select compatible
 port ranges.
 
+## Subnet configuration
+
+TODO(marun)
+
 ## Configuration on disk
 
 A temporary network relies on configuration written to disk in the following structure:
@@ -125,11 +130,16 @@ HOME
             │   │   └── ...
             │   └── process.json                         // Node process details (PID, API URI, staking address)
             ├── chains
-            │   └── C
-            │       └── config.json                      // C-Chain config for all nodes
+            │   ├── C
+            │   │   └── config.json                      // C-Chain config for all nodes
+            │   └── raZ51bwfepaSaZ1MNSRNYNs3ZPfj...U7pa3
+            │       └── config.json                      // Custom chain configuration for all nodes
             ├── config.json                              // Common configuration (including defaults and pre-funded keys)
             ├── genesis.json                             // Genesis for all nodes
-            └── network.env                              // Sets network dir env var to simplify network usage
+            ├── network.env                              // Sets network dir env var to simplify network usage
+            └── subnets                                  // Parent directory for subnet definitions
+                ├─ subnet-a.json                         // Configuration for subnet-a and its chain(s)
+                └─ subnet-b.json                         // Configuration for subnet-b and its chain(s)
 ```
 
 ### Common networking configuration

--- a/tests/fixture/tmpnet/cmd/main.go
+++ b/tests/fixture/tmpnet/cmd/main.go
@@ -26,10 +26,12 @@ var (
 )
 
 func main() {
+	var networkDir string
 	rootCmd := &cobra.Command{
 		Use:   "tmpnetctl",
 		Short: "tmpnetctl commands",
 	}
+	rootCmd.PersistentFlags().StringVar(&networkDir, "network-dir", os.Getenv(tmpnet.NetworkDirEnvName), "The path to the configuration directory of a temporary network")
 
 	versionCmd := &cobra.Command{
 		Use:   "version",
@@ -46,35 +48,38 @@ func main() {
 	rootCmd.AddCommand(versionCmd)
 
 	var (
-		rootDir   string
-		execPath  string
-		nodeCount uint8
+		rootDir         string
+		avalancheGoPath string
+		pluginDir       string
+		nodeCount       uint8
 	)
 	startNetworkCmd := &cobra.Command{
 		Use:   "start-network",
 		Short: "Start a new temporary network",
 		RunE: func(*cobra.Command, []string) error {
-			if len(execPath) == 0 {
+			if len(avalancheGoPath) == 0 {
 				return errAvalancheGoRequired
 			}
 
 			// Root dir will be defaulted on start if not provided
 
-			network, err := tmpnet.NewDefaultNetwork(os.Stdout, execPath, int(nodeCount))
-			if err != nil {
-				return err
-			}
-
-			if err := network.Create(rootDir); err != nil {
-				return err
-			}
+			network := &tmpnet.Network{}
 
 			// Extreme upper bound, should never take this long
 			networkStartTimeout := 2 * time.Minute
 
 			ctx, cancel := context.WithTimeout(context.Background(), networkStartTimeout)
 			defer cancel()
-			if err := network.Start(ctx, os.Stdout); err != nil {
+			err := tmpnet.StartNewNetwork(
+				ctx,
+				os.Stdout,
+				network,
+				rootDir,
+				avalancheGoPath,
+				pluginDir,
+				int(nodeCount),
+			)
+			if err != nil {
 				return err
 			}
 
@@ -98,11 +103,11 @@ func main() {
 		},
 	}
 	startNetworkCmd.PersistentFlags().StringVar(&rootDir, "root-dir", os.Getenv(tmpnet.RootDirEnvName), "The path to the root directory for temporary networks")
-	startNetworkCmd.PersistentFlags().StringVar(&execPath, "avalanchego-path", os.Getenv(tmpnet.AvalancheGoPathEnvName), "The path to an avalanchego binary")
+	startNetworkCmd.PersistentFlags().StringVar(&avalancheGoPath, "avalanchego-path", os.Getenv(tmpnet.AvalancheGoPathEnvName), "The path to an avalanchego binary")
+	startNetworkCmd.PersistentFlags().StringVar(&pluginDir, "plugin-dir", os.ExpandEnv("$HOME/.avalanchego/plugins"), "[optional] the dir containing VM plugins")
 	startNetworkCmd.PersistentFlags().Uint8Var(&nodeCount, "node-count", tmpnet.DefaultNodeCount, "Number of nodes the network should initially consist of")
 	rootCmd.AddCommand(startNetworkCmd)
 
-	var networkDir string
 	stopNetworkCmd := &cobra.Command{
 		Use:   "stop-network",
 		Short: "Stop a temporary network",
@@ -119,8 +124,21 @@ func main() {
 			return nil
 		},
 	}
-	stopNetworkCmd.PersistentFlags().StringVar(&networkDir, "network-dir", os.Getenv(tmpnet.NetworkDirEnvName), "The path to the configuration directory of a temporary network")
 	rootCmd.AddCommand(stopNetworkCmd)
+
+	restartNetworkCmd := &cobra.Command{
+		Use:   "restart-network",
+		Short: "Restart a temporary network",
+		RunE: func(*cobra.Command, []string) error {
+			if len(networkDir) == 0 {
+				return errNetworkDirRequired
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), tmpnet.DefaultNetworkTimeout)
+			defer cancel()
+			return tmpnet.RestartNetwork(ctx, os.Stdout, networkDir)
+		},
+	}
+	rootCmd.AddCommand(restartNetworkCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "tmpnetctl failed: %v\n", err)

--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -7,9 +7,19 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/config"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
 )
 
 const (
+	// Interval appropriate for network operations that should be
+	// retried periodically but not too often.
+	DefaultPollingInterval = 500 * time.Millisecond
+
+	// Validator start time must be a minimum of SyncBound from the
+	// current time for validator addition to succeed, and adding 20
+	// seconds provides a buffer in case of any delay in processing.
+	DefaultValidatorStartTimeDiff = executor.SyncBound + 20*time.Second
+
 	DefaultNetworkTimeout = 2 * time.Minute
 
 	// Minimum required to ensure connectivity-based health checks will pass
@@ -50,7 +60,8 @@ func DefaultChainConfigs() map[string]FlagsMap {
 		// values will be used. Available C-Chain configuration options are
 		// defined in the `github.com/ava-labs/coreth/evm` package.
 		"C": {
-			"log-level": "trace",
+			"warp-api-enabled": true,
+			"log-level":        "trace",
 		},
 	}
 }

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -577,7 +577,7 @@ func (n *Network) CreateSubnets(ctx context.Context, w io.Writer) error {
 	// Wait for nodes to become subnet validators
 	pChainClient := platformvm.NewClient(n.Nodes[0].URI)
 	for _, subnet := range createdSubnets {
-		if err := waitForActiveValidators(ctx, w, pChainClient, subnet, n.Nodes); err != nil {
+		if err := waitForActiveValidators(ctx, w, pChainClient, subnet); err != nil {
 			return err
 		}
 
@@ -593,6 +593,15 @@ func (n *Network) CreateSubnets(ctx context.Context, w io.Writer) error {
 	}
 
 	return nil
+}
+
+func (n *Network) GetURIForNodeID(nodeID ids.NodeID) (string, error) {
+	for _, node := range n.Nodes {
+		if node.NodeID == nodeID {
+			return node.URI, nil
+		}
+	}
+	return "", fmt.Errorf("%s is not known to the network", nodeID)
 }
 
 func (n *Network) GetNodeURIs() []NodeURI {

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -493,11 +493,7 @@ func (n *Network) EnsureNodeConfig(node *Node) error {
 		}
 		subnetIDs = append(subnetIDs, subnet.SubnetID.String())
 	}
-	subnetIDsValue := ""
-	if len(subnetIDs) > 0 {
-		subnetIDsValue = strings.Join(subnetIDs, ",")
-	}
-	flags[config.TrackSubnetsKey] = subnetIDsValue
+	flags[config.TrackSubnetsKey] = strings.Join(subnetIDs, ",")
 
 	return nil
 }

--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -25,7 +25,10 @@ func (n *Network) Read() error {
 	if err := n.readNetwork(); err != nil {
 		return err
 	}
-	return n.readNodes()
+	if err := n.readNodes(); err != nil {
+		return err
+	}
+	return n.readSubnets()
 }
 
 // Write network configuration to disk.
@@ -216,5 +219,18 @@ func (n *Network) writeEnvFile() error {
 	if err := os.WriteFile(n.EnvFilePath(), []byte(n.EnvFileContents()), perms.ReadWrite); err != nil {
 		return fmt.Errorf("failed to write network env file: %w", err)
 	}
+	return nil
+}
+
+func (n *Network) getSubnetDir() string {
+	return filepath.Join(n.Dir, defaultSubnetDirName)
+}
+
+func (n *Network) readSubnets() error {
+	subnets, err := readSubnets(n.getSubnetDir())
+	if err != nil {
+		return err
+	}
+	n.Subnets = subnets
 	return nil
 }

--- a/tests/fixture/tmpnet/network_test.go
+++ b/tests/fixture/tmpnet/network_test.go
@@ -15,10 +15,9 @@ func TestNetworkSerialization(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	network, err := NewDefaultNetwork(&bytes.Buffer{}, "/path/to/avalanche/go", 1)
-	require.NoError(err)
+	network := &Network{}
+	require.NoError(network.EnsureDefaultConfig(&bytes.Buffer{}, "/path/to/avalanche/go", "", 1))
 	require.NoError(network.Create(tmpDir))
-
 	// Ensure node runtime is initialized
 	require.NoError(network.readNodes())
 

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -83,6 +83,15 @@ func NewNode(dataDir string) *Node {
 	}
 }
 
+// Initializes the specified number of nodes.
+func NewNodes(count int) []*Node {
+	nodes := make([]*Node, count)
+	for i := range nodes {
+		nodes[i] = NewNode("")
+	}
+	return nodes
+}
+
 // Reads a node's configuration from the specified directory.
 func ReadNode(dataDir string) (*Node, error) {
 	node := NewNode(dataDir)

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -1,0 +1,297 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package tmpnet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/perms"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/avalanchego/wallet/chain/p"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+)
+
+const defaultSubnetDirName = "subnets"
+
+type Chain struct {
+	// Set statically
+	VMName  string
+	Config  string
+	Genesis []byte
+
+	// Set at runtime
+	ChainID      ids.ID
+	PreFundedKey *secp256k1.PrivateKey
+}
+
+// Write the chain configuration to the specified directory.
+func (c *Chain) WriteConfig(chainDir string) error {
+	if len(c.Config) == 0 {
+		return nil
+	}
+
+	chainConfigDir := filepath.Join(chainDir, c.ChainID.String())
+	if err := os.MkdirAll(chainConfigDir, perms.ReadWriteExecute); err != nil {
+		return fmt.Errorf("failed to create chain config dir: %w", err)
+	}
+
+	path := filepath.Join(chainConfigDir, defaultConfigFilename)
+	if err := os.WriteFile(path, []byte(c.Config), perms.ReadWrite); err != nil {
+		return fmt.Errorf("failed to write chain config: %w", err)
+	}
+
+	return nil
+}
+
+type Subnet struct {
+	// A unique string that can be used to refer to the subnet across different temporary
+	// networks (since the SubnetID will be different every time the subnet is created)
+	Name string
+
+	// The ID of the transaction that created the subnet
+	SubnetID ids.ID
+
+	// The private key that owns the subnet
+	OwningKey *secp256k1.PrivateKey
+
+	Chains []*Chain
+}
+
+// Retrieves a wallet configured for use with the subnet
+func (s *Subnet) GetWallet(ctx context.Context, uri string) (primary.Wallet, error) {
+	keychain := secp256k1fx.NewKeychain(s.OwningKey)
+
+	// Only fetch the subnet transaction if a subnet ID is present. This won't be true when
+	// the wallet is first used to create the subnet.
+	txIDs := set.Set[ids.ID]{}
+	if s.SubnetID != ids.Empty {
+		txIDs.Add(s.SubnetID)
+	}
+
+	return primary.MakeWallet(ctx, &primary.WalletConfig{
+		URI:              uri,
+		AVAXKeychain:     keychain,
+		EthKeychain:      keychain,
+		PChainTxsToFetch: txIDs,
+	})
+}
+
+// Issues the subnet creation transaction and retains the result. The URI of a node is
+// required to issue the transaction.
+func (s *Subnet) Create(ctx context.Context, pWallet p.Wallet) error {
+	owner := &secp256k1fx.OutputOwners{
+		Threshold: 1,
+		Addrs: []ids.ShortID{
+			s.OwningKey.Address(),
+		},
+	}
+
+	subnetTx, err := pWallet.IssueCreateSubnetTx(
+		owner,
+		common.WithContext(ctx),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create subnet %s: %w", s.Name, err)
+	}
+	s.SubnetID = subnetTx.ID()
+
+	for _, chain := range s.Chains {
+		vmID, err := GetVMID(chain.VMName)
+		if err != nil {
+			return fmt.Errorf("failed to derive VM ID from its name: %w", err)
+		}
+
+		createChainTx, err := pWallet.IssueCreateChainTx(
+			s.SubnetID,
+			chain.Genesis,
+			vmID,
+			nil,
+			chain.VMName,
+			common.WithContext(ctx),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create chain: %w", err)
+		}
+
+		chain.ChainID = createChainTx.ID()
+	}
+	return nil
+}
+
+// Add validators to the subnet
+func (s *Subnet) AddValidators(ctx context.Context, nodes []*Node) error {
+	apiURI := nodes[0].URI
+
+	wallet, err := s.GetWallet(ctx, apiURI)
+	if err != nil {
+		return err
+	}
+	pWallet := wallet.P()
+
+	// Collect the end times for current validators to reuse for subnet validators
+	pvmClient := platformvm.NewClient(apiURI)
+	validators, err := pvmClient.GetCurrentValidators(ctx, constants.PrimaryNetworkID, nil)
+	if err != nil {
+		return err
+	}
+	endTimes := make(map[ids.NodeID]uint64)
+	for _, validator := range validators {
+		endTimes[validator.NodeID] = validator.EndTime
+	}
+
+	startTime := time.Now().Add(DefaultValidatorStartTimeDiff)
+	for _, node := range nodes {
+		endTime, ok := endTimes[node.NodeID]
+		if !ok {
+			return fmt.Errorf("failed to find end time for %s", node.NodeID)
+		}
+
+		_, err := pWallet.IssueAddSubnetValidatorTx(
+			&txs.SubnetValidator{
+				Validator: txs.Validator{
+					NodeID: node.NodeID,
+					Start:  uint64(startTime.Unix()),
+					End:    endTime,
+					Wght:   units.Schmeckle,
+				},
+				Subnet: s.SubnetID,
+			},
+			common.WithContext(ctx),
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Write the subnet configuration to disk
+func (s *Subnet) Write(subnetDir string, chainDir string) error {
+	if err := os.MkdirAll(subnetDir, perms.ReadWriteExecute); err != nil {
+		return fmt.Errorf("failed to create subnet dir: %w", err)
+	}
+	path := filepath.Join(subnetDir, s.Name+".json")
+	_, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		return fmt.Errorf("a subnet with alias %s already exists", s.Name)
+	}
+	bytes, err := DefaultJSONMarshal(s)
+	if err != nil {
+		return fmt.Errorf("failed to marshal subnet %s: %w", s.Name, err)
+	}
+	if err := os.WriteFile(path, bytes, perms.ReadWrite); err != nil {
+		return fmt.Errorf("failed to write subnet %s: %w", s.Name, err)
+	}
+
+	for _, chain := range s.Chains {
+		if err := chain.WriteConfig(chainDir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func waitForActiveValidators(
+	ctx context.Context,
+	w io.Writer,
+	pChainClient platformvm.Client,
+	subnet *Subnet,
+	nodes []*Node,
+) error {
+	ticker := time.NewTicker(DefaultPollingInterval)
+	defer ticker.Stop()
+
+	if _, err := fmt.Fprintf(w, " "); err != nil {
+		return err
+	}
+
+	for {
+		if _, err := fmt.Fprintf(w, "."); err != nil {
+			return err
+		}
+		validators, err := pChainClient.GetCurrentValidators(ctx, subnet.SubnetID, nil)
+		if err != nil {
+			return err
+		}
+		validatorSet := set.NewSet[ids.NodeID](len(validators))
+		for _, validator := range validators {
+			validatorSet.Add(validator.NodeID)
+		}
+		allActive := true
+		for _, node := range nodes {
+			if !validatorSet.Contains(node.NodeID) {
+				allActive = false
+			}
+		}
+		if allActive {
+			if _, err := fmt.Fprintf(w, "\n saw the expected active validators of subnet %s\n", subnet.Name); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("failed to see the expected active validators of %s before timeout", subnet.Name)
+		case <-ticker.C:
+		}
+	}
+}
+
+// Reads subnets from [network dir]/subnets/[subnet alias].json
+func readSubnets(subnetDir string) ([]*Subnet, error) {
+	if _, err := os.Stat(subnetDir); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(subnetDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read subnet dir: %w", err)
+	}
+
+	subnets := []*Subnet{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Looking only for files
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			// Subnet files should have a .json extension
+			continue
+		}
+
+		subnetPath := filepath.Join(subnetDir, entry.Name())
+		bytes, err := os.ReadFile(subnetPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read subnet file %s: %w", subnetPath, err)
+		}
+		subnet := &Subnet{}
+		if err := json.Unmarshal(bytes, subnet); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal subnet from %s: %w", subnetPath, err)
+		}
+		subnets = append(subnets, subnet)
+	}
+
+	return subnets, nil
+}

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -29,7 +29,7 @@ const defaultSubnetDirName = "subnets"
 
 type Chain struct {
 	// Set statically
-	VMName  string
+	VMID    ids.ID
 	Config  string
 	Genesis []byte
 
@@ -131,17 +131,12 @@ func (s *Subnet) CreateChains(ctx context.Context, w io.Writer, uri string) erro
 	}
 
 	for _, chain := range s.Chains {
-		vmID, err := GetVMID(chain.VMName)
-		if err != nil {
-			return fmt.Errorf("failed to derive VM ID from its name: %w", err)
-		}
-
 		createChainTx, err := pWallet.IssueCreateChainTx(
 			s.SubnetID,
 			chain.Genesis,
-			vmID,
+			chain.VMID,
 			nil,
-			chain.VMName,
+			"",
 			common.WithContext(ctx),
 		)
 		if err != nil {
@@ -149,7 +144,7 @@ func (s *Subnet) CreateChains(ctx context.Context, w io.Writer, uri string) erro
 		}
 		chain.ChainID = createChainTx.ID()
 
-		if _, err := fmt.Fprintf(w, " created chain %q for VM %q on subnet %q\n", chain.ChainID, chain.VMName, s.Name); err != nil {
+		if _, err := fmt.Fprintf(w, " created chain %q for VM %q on subnet %q\n", chain.ChainID, chain.VMID, s.Name); err != nil {
 			return err
 		}
 	}

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -126,6 +126,10 @@ func (s *Subnet) CreateChains(ctx context.Context, w io.Writer, uri string) erro
 	}
 	pWallet := wallet.P()
 
+	if _, err := fmt.Fprintf(w, "Creating chains for subnet %q\n", s.Name); err != nil {
+		return err
+	}
+
 	for _, chain := range s.Chains {
 		vmID, err := GetVMID(chain.VMName)
 		if err != nil {
@@ -145,7 +149,7 @@ func (s *Subnet) CreateChains(ctx context.Context, w io.Writer, uri string) erro
 		}
 		chain.ChainID = createChainTx.ID()
 
-		if _, err := fmt.Fprintf(w, " created chain with ID %s for VM %s on subnet %s\n", chain.ChainID, chain.VMName, s.Name); err != nil {
+		if _, err := fmt.Fprintf(w, " created chain %q for VM %q on subnet %q\n", chain.ChainID, chain.VMName, s.Name); err != nil {
 			return err
 		}
 	}
@@ -196,7 +200,7 @@ func (s *Subnet) AddValidators(ctx context.Context, w io.Writer, nodes []*Node) 
 			return err
 		}
 
-		if _, err := fmt.Fprintf(w, " added %s as validator for subnet %s\n", node.NodeID, s.Name); err != nil {
+		if _, err := fmt.Fprintf(w, " added %s as validator for subnet `%s`\n", node.NodeID, s.Name); err != nil {
 			return err
 		}
 
@@ -253,7 +257,7 @@ func waitForActiveValidators(
 	ticker := time.NewTicker(DefaultPollingInterval)
 	defer ticker.Stop()
 
-	if _, err := fmt.Fprintf(w, " waiting for validators for subnet %s to become active\n", subnet.Name); err != nil {
+	if _, err := fmt.Fprintf(w, "Waiting for validators of subnet %q to become active\n", subnet.Name); err != nil {
 		return err
 	}
 
@@ -280,7 +284,7 @@ func waitForActiveValidators(
 			}
 		}
 		if allActive {
-			if _, err := fmt.Fprintf(w, "\n saw the expected active validators of subnet %s\n", subnet.Name); err != nil {
+			if _, err := fmt.Fprintf(w, "\n saw the expected active validators of subnet %q\n", subnet.Name); err != nil {
 				return err
 			}
 			return nil
@@ -288,7 +292,7 @@ func waitForActiveValidators(
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("failed to see the expected active validators of %s before timeout", subnet.Name)
+			return fmt.Errorf("failed to see the expected active validators of subnet %q before timeout", subnet.Name)
 		case <-ticker.C:
 		}
 	}

--- a/tests/fixture/tmpnet/utils.go
+++ b/tests/fixture/tmpnet/utils.go
@@ -87,3 +87,12 @@ func NewPrivateKeys(keyCount int) ([]*secp256k1.PrivateKey, error) {
 	}
 	return keys, nil
 }
+
+func GetVMID(vmName string) (ids.ID, error) {
+	if len(vmName) > 32 {
+		return ids.Empty, fmt.Errorf("VM name must be <= 32 bytes, found %d", len(vmName))
+	}
+	b := make([]byte, 32)
+	copy(b, []byte(vmName))
+	return ids.ToID(b)
+}

--- a/tests/fixture/tmpnet/utils.go
+++ b/tests/fixture/tmpnet/utils.go
@@ -87,12 +87,3 @@ func NewPrivateKeys(keyCount int) ([]*secp256k1.PrivateKey, error) {
 	}
 	return keys, nil
 }
-
-func GetVMID(vmName string) (ids.ID, error) {
-	if len(vmName) > 32 {
-		return ids.Empty, fmt.Errorf("VM name must be <= 32 bytes, found %d", len(vmName))
-	}
-	b := make([]byte, 32)
-	copy(b, []byte(vmName))
-	return ids.ToID(b)
-}

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 )
 
 func TestUpgrade(t *testing.T) {
@@ -46,7 +47,8 @@ var _ = ginkgo.Describe("[Upgrade]", func() {
 	require := require.New(ginkgo.GinkgoT())
 
 	ginkgo.It("can upgrade versions", func() {
-		network := e2e.StartNetwork(avalancheGoExecPath, e2e.DefaultNetworkDir)
+		network := &tmpnet.Network{}
+		e2e.StartNetwork(network, e2e.DefaultNetworkDir, avalancheGoExecPath, "" /* pluginDir */)
 
 		ginkgo.By(fmt.Sprintf("restarting all nodes with %q binary", avalancheGoExecPathToUpgradeTo))
 		for _, node := range network.Nodes {


### PR DESCRIPTION
Add subnet support to tmpnet fixture to support both in-repo subnet testing and tmpnet usage by subnet-evm.

Follow-on PRs that use this code include:
 - https://github.com/ava-labs/avalanchego/pull/2043 
 - https://github.com/ava-labs/avalanchego/pull/2493
   - e2e is passing (validating tmpnet's subnet support), but a bit more work is required to get this ready for review  
 - https://github.com/ava-labs/subnet-evm/pull/1027
   - e2e tests are capable of passing locally, need to figure out why that isn't replicating in CI

## TODO

 - [x] Update README to reflect subnet support
 - [x] Improve output of subnet creation process