### PR TITLE
Support json marshalling txs returned from the wallet

### DIFF
--- a/wallet/chain/c/builder.go
+++ b/wallet/chain/c/builder.go
@@ -201,6 +201,7 @@ func (b *builder) NewImportTx(
 		importedInputs = append(importedInputs, &avax.TransferableInput{
 			UTXOID: utxo.UTXOID,
 			Asset:  utxo.Asset,
+			FxID:   secp256k1fx.ID,
 			In: &secp256k1fx.TransferInput{
 				Amt: amount,
 				Input: secp256k1fx.Input{
@@ -267,6 +268,7 @@ func (b *builder) NewExportTx(
 	for i, output := range outputs {
 		exportedOutputs[i] = &avax.TransferableOutput{
 			Asset: avax.Asset{ID: avaxAssetID},
+			FxID:  secp256k1fx.ID,
 			Out:   output,
 		}
 
@@ -376,6 +378,14 @@ func (b *builder) NewExportTx(
 
 	utils.Sort(inputs)
 	tx.Ins = inputs
+
+	snowCtx, err := newSnowContext(b.backend)
+	if err != nil {
+		return nil, err
+	}
+	for _, out := range tx.ExportedOutputs {
+		out.InitCtx(snowCtx)
+	}
 	return tx, nil
 }
 

--- a/wallet/chain/c/context.go
+++ b/wallet/chain/c/context.go
@@ -8,8 +8,13 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/avm"
 )
+
+const Alias = "C"
 
 var _ Context = (*context)(nil)
 
@@ -41,7 +46,7 @@ func NewContextFromClients(
 		return nil, err
 	}
 
-	chainID, err := infoClient.GetBlockchainID(ctx, "C")
+	chainID, err := infoClient.GetBlockchainID(ctx, Alias)
 	if err != nil {
 		return nil, err
 	}
@@ -80,4 +85,18 @@ func (c *context) BlockchainID() ids.ID {
 
 func (c *context) AVAXAssetID() ids.ID {
 	return c.avaxAssetID
+}
+
+func newSnowContext(c Context) (*snow.Context, error) {
+	chainID := c.BlockchainID()
+	lookup := ids.NewAliaser()
+	return &snow.Context{
+		NetworkID:   c.NetworkID(),
+		SubnetID:    constants.PrimaryNetworkID,
+		ChainID:     chainID,
+		CChainID:    chainID,
+		AVAXAssetID: c.AVAXAssetID(),
+		Log:         logging.NoLog{},
+		BCLookup:    lookup,
+	}, lookup.Alias(chainID, Alias)
 }

--- a/wallet/chain/p/builder.go
+++ b/wallet/chain/p/builder.go
@@ -311,7 +311,7 @@ func (b *builder) NewBaseTx(
 	outputs = append(outputs, changeOutputs...)
 	avax.SortTransferableOutputs(outputs, txs.Codec) // sort the outputs
 
-	return &txs.CreateSubnetTx{
+	tx := &txs.CreateSubnetTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -320,7 +320,8 @@ func (b *builder) NewBaseTx(
 			Memo:         ops.Memo(),
 		}},
 		Owner: &secp256k1fx.OutputOwners{},
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewAddValidatorTx(
@@ -343,7 +344,7 @@ func (b *builder) NewAddValidatorTx(
 	}
 
 	utils.Sort(rewardsOwner.Addrs)
-	return &txs.AddValidatorTx{
+	tx := &txs.AddValidatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -355,7 +356,8 @@ func (b *builder) NewAddValidatorTx(
 		StakeOuts:        stakeOutputs,
 		RewardsOwner:     rewardsOwner,
 		DelegationShares: shares,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewAddSubnetValidatorTx(
@@ -377,7 +379,7 @@ func (b *builder) NewAddSubnetValidatorTx(
 		return nil, err
 	}
 
-	return &txs.AddSubnetValidatorTx{
+	tx := &txs.AddSubnetValidatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -387,7 +389,8 @@ func (b *builder) NewAddSubnetValidatorTx(
 		}},
 		SubnetValidator: *vdr,
 		SubnetAuth:      subnetAuth,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewRemoveSubnetValidatorTx(
@@ -410,7 +413,7 @@ func (b *builder) NewRemoveSubnetValidatorTx(
 		return nil, err
 	}
 
-	return &txs.RemoveSubnetValidatorTx{
+	tx := &txs.RemoveSubnetValidatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -421,7 +424,8 @@ func (b *builder) NewRemoveSubnetValidatorTx(
 		Subnet:     subnetID,
 		NodeID:     nodeID,
 		SubnetAuth: subnetAuth,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewAddDelegatorTx(
@@ -443,7 +447,7 @@ func (b *builder) NewAddDelegatorTx(
 	}
 
 	utils.Sort(rewardsOwner.Addrs)
-	return &txs.AddDelegatorTx{
+	tx := &txs.AddDelegatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -454,7 +458,8 @@ func (b *builder) NewAddDelegatorTx(
 		Validator:              *vdr,
 		StakeOuts:              stakeOutputs,
 		DelegationRewardsOwner: rewardsOwner,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewCreateChainTx(
@@ -481,7 +486,7 @@ func (b *builder) NewCreateChainTx(
 	}
 
 	utils.Sort(fxIDs)
-	return &txs.CreateChainTx{
+	tx := &txs.CreateChainTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -495,7 +500,8 @@ func (b *builder) NewCreateChainTx(
 		FxIDs:       fxIDs,
 		GenesisData: genesis,
 		SubnetAuth:  subnetAuth,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewCreateSubnetTx(
@@ -513,7 +519,7 @@ func (b *builder) NewCreateSubnetTx(
 	}
 
 	utils.Sort(owner.Addrs)
-	return &txs.CreateSubnetTx{
+	tx := &txs.CreateSubnetTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -522,7 +528,8 @@ func (b *builder) NewCreateSubnetTx(
 			Memo:         ops.Memo(),
 		}},
 		Owner: owner,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewImportTx(
@@ -618,7 +625,7 @@ func (b *builder) NewImportTx(
 	}
 
 	avax.SortTransferableOutputs(outputs, txs.Codec) // sort imported outputs
-	return &txs.ImportTx{
+	tx := &txs.ImportTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -628,7 +635,8 @@ func (b *builder) NewImportTx(
 		}},
 		SourceChain:    sourceChainID,
 		ImportedInputs: importedInputs,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewExportTx(
@@ -656,7 +664,7 @@ func (b *builder) NewExportTx(
 	}
 
 	avax.SortTransferableOutputs(outputs, txs.Codec) // sort exported outputs
-	return &txs.ExportTx{
+	tx := &txs.ExportTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -666,7 +674,8 @@ func (b *builder) NewExportTx(
 		}},
 		DestinationChain: chainID,
 		ExportedOutputs:  outputs,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewTransformSubnetTx(
@@ -702,7 +711,7 @@ func (b *builder) NewTransformSubnetTx(
 		return nil, err
 	}
 
-	return &txs.TransformSubnetTx{
+	tx := &txs.TransformSubnetTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -725,7 +734,8 @@ func (b *builder) NewTransformSubnetTx(
 		MaxValidatorWeightFactor: maxValidatorWeightFactor,
 		UptimeRequirement:        uptimeRequirement,
 		SubnetAuth:               subnetAuth,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewAddPermissionlessValidatorTx(
@@ -755,7 +765,7 @@ func (b *builder) NewAddPermissionlessValidatorTx(
 
 	utils.Sort(validationRewardsOwner.Addrs)
 	utils.Sort(delegationRewardsOwner.Addrs)
-	return &txs.AddPermissionlessValidatorTx{
+	tx := &txs.AddPermissionlessValidatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -770,7 +780,8 @@ func (b *builder) NewAddPermissionlessValidatorTx(
 		ValidatorRewardsOwner: validationRewardsOwner,
 		DelegatorRewardsOwner: delegationRewardsOwner,
 		DelegationShares:      shares,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewAddPermissionlessDelegatorTx(
@@ -796,7 +807,7 @@ func (b *builder) NewAddPermissionlessDelegatorTx(
 	}
 
 	utils.Sort(rewardsOwner.Addrs)
-	return &txs.AddPermissionlessDelegatorTx{
+	tx := &txs.AddPermissionlessDelegatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: constants.PlatformChainID,
@@ -808,7 +819,8 @@ func (b *builder) NewAddPermissionlessDelegatorTx(
 		Subnet:                 vdr.Subnet,
 		StakeOuts:              stakeOutputs,
 		DelegationRewardsOwner: rewardsOwner,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) getBalance(
@@ -1116,4 +1128,14 @@ func (b *builder) authorizeSubnet(subnetID ids.ID, options *common.Options) (*se
 	return &secp256k1fx.Input{
 		SigIndices: inputSigIndices,
 	}, nil
+}
+
+func (b *builder) initCtx(tx txs.UnsignedTx) error {
+	ctx, err := newSnowContext(b.backend)
+	if err != nil {
+		return err
+	}
+
+	tx.InitCtx(ctx)
+	return nil
 }

--- a/wallet/chain/p/context.go
+++ b/wallet/chain/p/context.go
@@ -8,8 +8,13 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/avm"
 )
+
+const Alias = "P"
 
 var _ Context = (*context)(nil)
 
@@ -143,4 +148,16 @@ func (c *context) AddSubnetValidatorFee() uint64 {
 
 func (c *context) AddSubnetDelegatorFee() uint64 {
 	return c.addSubnetDelegatorFee
+}
+
+func newSnowContext(c Context) (*snow.Context, error) {
+	lookup := ids.NewAliaser()
+	return &snow.Context{
+		NetworkID:   c.NetworkID(),
+		SubnetID:    constants.PrimaryNetworkID,
+		ChainID:     constants.PlatformChainID,
+		AVAXAssetID: c.AVAXAssetID(),
+		Log:         logging.NoLog{},
+		BCLookup:    lookup,
+	}, lookup.Alias(constants.PlatformChainID, Alias)
 }

--- a/wallet/chain/x/builder.go
+++ b/wallet/chain/x/builder.go
@@ -26,6 +26,12 @@ var (
 	errNoChangeAddress   = errors.New("no possible change address")
 	errInsufficientFunds = errors.New("insufficient funds")
 
+	fxIndexToID = map[uint32]ids.ID{
+		0: secp256k1fx.ID,
+		1: nftfx.ID,
+		2: propertyfx.ID,
+	}
+
 	_ Builder = (*builder)(nil)
 )
 
@@ -213,13 +219,14 @@ func (b *builder) NewBaseTx(
 	outputs = append(outputs, changeOutputs...)
 	avax.SortTransferableOutputs(outputs, Parser.Codec()) // sort the outputs
 
-	return &txs.BaseTx{BaseTx: avax.BaseTx{
+	tx := &txs.BaseTx{BaseTx: avax.BaseTx{
 		NetworkID:    b.backend.NetworkID(),
 		BlockchainID: b.backend.BlockchainID(),
 		Ins:          inputs,
 		Outs:         outputs,
 		Memo:         ops.Memo(),
-	}}, nil
+	}}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewCreateAssetTx(
@@ -243,12 +250,14 @@ func (b *builder) NewCreateAssetTx(
 	for fxIndex, outs := range initialState {
 		state := &txs.InitialState{
 			FxIndex: fxIndex,
+			FxID:    fxIndexToID[fxIndex],
 			Outs:    outs,
 		}
 		state.Sort(codec) // sort the outputs
 		states = append(states, state)
 	}
 
+	utils.Sort(states) // sort the initial states
 	tx := &txs.CreateAssetTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
@@ -262,8 +271,7 @@ func (b *builder) NewCreateAssetTx(
 		Denomination: denomination,
 		States:       states,
 	}
-	utils.Sort(tx.States) // sort the initial states
-	return tx, nil
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewOperationTx(
@@ -280,7 +288,7 @@ func (b *builder) NewOperationTx(
 	}
 
 	txs.SortOperations(operations, Parser.Codec())
-	return &txs.OperationTx{
+	tx := &txs.OperationTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: b.backend.BlockchainID(),
@@ -289,7 +297,8 @@ func (b *builder) NewOperationTx(
 			Memo:         ops.Memo(),
 		}},
 		Ops: operations,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewOperationTxMintFT(
@@ -380,6 +389,7 @@ func (b *builder) NewImportTx(
 		importedInputs = append(importedInputs, &avax.TransferableInput{
 			UTXOID: utxo.UTXOID,
 			Asset:  utxo.Asset,
+			FxID:   secp256k1fx.ID,
 			In: &secp256k1fx.TransferInput{
 				Amt: out.Amt,
 				Input: secp256k1fx.Input{
@@ -428,6 +438,7 @@ func (b *builder) NewImportTx(
 	for assetID, amount := range importedAmounts {
 		outputs = append(outputs, &avax.TransferableOutput{
 			Asset: avax.Asset{ID: assetID},
+			FxID:  secp256k1fx.ID,
 			Out: &secp256k1fx.TransferOutput{
 				Amt:          amount,
 				OutputOwners: *to,
@@ -436,7 +447,7 @@ func (b *builder) NewImportTx(
 	}
 
 	avax.SortTransferableOutputs(outputs, Parser.Codec())
-	return &txs.ImportTx{
+	tx := &txs.ImportTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: b.backend.BlockchainID(),
@@ -446,7 +457,8 @@ func (b *builder) NewImportTx(
 		}},
 		SourceChain: chainID,
 		ImportedIns: importedInputs,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) NewExportTx(
@@ -473,7 +485,7 @@ func (b *builder) NewExportTx(
 	}
 
 	avax.SortTransferableOutputs(outputs, Parser.Codec())
-	return &txs.ExportTx{
+	tx := &txs.ExportTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.backend.NetworkID(),
 			BlockchainID: b.backend.BlockchainID(),
@@ -483,7 +495,8 @@ func (b *builder) NewExportTx(
 		}},
 		DestinationChain: chainID,
 		ExportedOuts:     outputs,
-	}, nil
+	}
+	return tx, b.initCtx(tx)
 }
 
 func (b *builder) getBalance(
@@ -578,6 +591,7 @@ func (b *builder) spend(
 		inputs = append(inputs, &avax.TransferableInput{
 			UTXOID: utxo.UTXOID,
 			Asset:  utxo.Asset,
+			FxID:   secp256k1fx.ID,
 			In: &secp256k1fx.TransferInput{
 				Amt: out.Amt,
 				Input: secp256k1fx.Input{
@@ -596,6 +610,7 @@ func (b *builder) spend(
 			// This input had extra value, so some of it must be returned
 			outputs = append(outputs, &avax.TransferableOutput{
 				Asset: utxo.Asset,
+				FxID:  secp256k1fx.ID,
 				Out: &secp256k1fx.TransferOutput{
 					Amt:          remainingAmount,
 					OutputOwners: *changeOwner,
@@ -656,6 +671,7 @@ func (b *builder) mintFTs(
 		operations = append(operations, &txs.Operation{
 			Asset:   utxo.Asset,
 			UTXOIDs: []*avax.UTXOID{&utxo.UTXOID},
+			FxID:    secp256k1fx.ID,
 			Op: &secp256k1fx.MintOperation{
 				MintInput: secp256k1fx.Input{
 					SigIndices: inputSigIndices,
@@ -719,6 +735,7 @@ func (b *builder) mintNFTs(
 			UTXOIDs: []*avax.UTXOID{
 				&utxo.UTXOID,
 			},
+			FxID: nftfx.ID,
 			Op: &nftfx.MintOperation{
 				MintInput: secp256k1fx.Input{
 					SigIndices: inputSigIndices,
@@ -775,6 +792,7 @@ func (b *builder) mintProperty(
 			UTXOIDs: []*avax.UTXOID{
 				&utxo.UTXOID,
 			},
+			FxID: propertyfx.ID,
 			Op: &propertyfx.MintOperation{
 				MintInput: secp256k1fx.Input{
 					SigIndices: inputSigIndices,
@@ -831,6 +849,7 @@ func (b *builder) burnProperty(
 			UTXOIDs: []*avax.UTXOID{
 				&utxo.UTXOID,
 			},
+			FxID: propertyfx.ID,
 			Op: &propertyfx.BurnOperation{
 				Input: secp256k1fx.Input{
 					SigIndices: inputSigIndices,
@@ -846,4 +865,14 @@ func (b *builder) burnProperty(
 		)
 	}
 	return operations, nil
+}
+
+func (b *builder) initCtx(tx txs.UnsignedTx) error {
+	ctx, err := newSnowContext(b.backend)
+	if err != nil {
+		return err
+	}
+
+	tx.InitCtx(ctx)
+	return nil
 }

--- a/wallet/chain/x/context.go
+++ b/wallet/chain/x/context.go
@@ -8,8 +8,13 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/avm"
 )
+
+const Alias = "X"
 
 var _ Context = (*context)(nil)
 
@@ -31,7 +36,7 @@ type context struct {
 
 func NewContextFromURI(ctx stdcontext.Context, uri string) (Context, error) {
 	infoClient := info.NewClient(uri)
-	xChainClient := avm.NewClient(uri, "X")
+	xChainClient := avm.NewClient(uri, Alias)
 	return NewContextFromClients(ctx, infoClient, xChainClient)
 }
 
@@ -45,7 +50,7 @@ func NewContextFromClients(
 		return nil, err
 	}
 
-	chainID, err := infoClient.GetBlockchainID(ctx, "X")
+	chainID, err := infoClient.GetBlockchainID(ctx, Alias)
 	if err != nil {
 		return nil, err
 	}
@@ -103,4 +108,18 @@ func (c *context) BaseTxFee() uint64 {
 
 func (c *context) CreateAssetTxFee() uint64 {
 	return c.createAssetTxFee
+}
+
+func newSnowContext(c Context) (*snow.Context, error) {
+	chainID := c.BlockchainID()
+	lookup := ids.NewAliaser()
+	return &snow.Context{
+		NetworkID:   c.NetworkID(),
+		SubnetID:    constants.PrimaryNetworkID,
+		ChainID:     chainID,
+		XChainID:    chainID,
+		AVAXAssetID: c.AVAXAssetID(),
+		Log:         logging.NoLog{},
+		BCLookup:    lookup,
+	}, lookup.Alias(chainID, Alias)
 }

--- a/wallet/chain/x/signer_visitor.go
+++ b/wallet/chain/x/signer_visitor.go
@@ -245,10 +245,13 @@ func sign(tx *txs.Tx, creds []verify.Verifiable, txSigners [][]keychain.Signer) 
 		var cred *secp256k1fx.Credential
 		switch credImpl := credIntf.(type) {
 		case *secp256k1fx.Credential:
+			fxCred.FxID = secp256k1fx.ID
 			cred = credImpl
 		case *nftfx.Credential:
+			fxCred.FxID = nftfx.ID
 			cred = &credImpl.Credential
 		case *propertyfx.Credential:
+			fxCred.FxID = propertyfx.ID
 			cred = &credImpl.Credential
 		default:
 			return errUnknownCredentialType


### PR DESCRIPTION
## Why this should be merged

This improves the UX of the wallet by supporting `json.Marshal` of transactions returned by the wallet.

## How this works

- Initializes the chain context with `InitCtx` to allow json marshalling of `OutputOwners`.
- Initializes `FxID`(`s`).

## How this was tested

- [X] CI
- [X] Manually `json` marshalling txs against a local network