### PR TITLE
Allow OutputOwners to be json marshalled without InitCtx

### DIFF
--- a/vms/secp256k1fx/output_owners.go
+++ b/vms/secp256k1fx/output_owners.go
@@ -21,7 +21,6 @@ var (
 	ErrOutputUnspendable    = errors.New("output is unspendable")
 	ErrOutputUnoptimized    = errors.New("output representation should be optimized")
 	ErrAddrsNotSortedUnique = errors.New("addresses not sorted and unique")
-	ErrMarshal              = errors.New("cannot marshal without ctx")
 )
 
 type OutputOwners struct {
@@ -37,8 +36,8 @@ type OutputOwners struct {
 	ctx *snow.Context
 }
 
-// InitCtx assigns the OutputOwners.ctx object to given [ctx] object
-// Must be called at least once for MarshalJSON to work successfully
+// InitCtx allows addresses to be formatted into their human readable format
+// during json marshalling.
 func (out *OutputOwners) InitCtx(ctx *snow.Context) {
 	out.ctx = ctx
 }
@@ -59,14 +58,7 @@ func (out *OutputOwners) MarshalJSON() ([]byte, error) {
 // Fields returns JSON keys in a map that can be used with marshal JSON
 // to serialize OutputOwners struct
 func (out *OutputOwners) Fields() (map[string]interface{}, error) {
-	addrsLen := len(out.Addrs)
-
-	// we need out.ctx to do this, if its absent, throw error
-	if addrsLen > 0 && out.ctx == nil {
-		return nil, ErrMarshal
-	}
-
-	addresses := make([]string, addrsLen)
+	addresses := make([]string, len(out.Addrs))
 	for i, addr := range out.Addrs {
 		// for each [addr] in [Addrs] we attempt to format it given
 		// the [out.ctx] object
@@ -138,8 +130,13 @@ func (out *OutputOwners) Sort() {
 }
 
 // formatAddress formats a given [addr] into human readable format using
-// [ChainID] and [NetworkID] from the provided [ctx].
+// [ChainID] and [NetworkID] if a non-nil [ctx] is provided. If [ctx] is not
+// provided, the address will be returned in cb58 format.
 func formatAddress(ctx *snow.Context, addr ids.ShortID) (string, error) {
+	if ctx == nil {
+		return addr.String(), nil
+	}
+
 	chainIDAlias, err := ctx.BCLookup.PrimaryAlias(ctx.ChainID)
 	if err != nil {
 		return "", err

--- a/vms/secp256k1fx/output_owners_test.go
+++ b/vms/secp256k1fx/output_owners_test.go
@@ -149,31 +149,20 @@ func TestOutputOwnerEquals(t *testing.T) {
 	}
 }
 
-func TestMarshalJSONRequiresCtxWhenAddrsArePresent(t *testing.T) {
+func TestMarshalJSONDoesNotRequireCtx(t *testing.T) {
 	require := require.New(t)
 	out := &OutputOwners{
 		Threshold: 1,
+		Locktime:  2,
 		Addrs: []ids.ShortID{
 			{1},
 			{0},
 		},
 	}
 
-	_, err := out.MarshalJSON()
-	require.ErrorIs(err, ErrMarshal)
-}
-
-func TestMarshalJSONDoesNotRequireCtxWhenAddrsAreAbsent(t *testing.T) {
-	require := require.New(t)
-	out := &OutputOwners{
-		Threshold: 1,
-		Locktime:  2,
-		Addrs:     []ids.ShortID{},
-	}
-
 	b, err := out.MarshalJSON()
 	require.NoError(err)
 
 	jsonData := string(b)
-	require.Equal(jsonData, "{\"addresses\":[],\"locktime\":2,\"threshold\":1}")
+	require.Equal(jsonData, `{"addresses":["6HgC8KRBEhXYbF4riJyJFLSHt37UNuRt","111111111111111111116DBWJs"],"locktime":2,"threshold":1}`)
 }


### PR DESCRIPTION
## Why this should be merged

It is often unreasonable to require a consumer of our transactions to have a reference to `*snow.Context`. However, `json.Marshal`ing a transaction is often one of the easiest ways to manually inspect a transaction.

This allows users to `json.Marshal` a transaction without a reference to a `*snow.Context`.

## How this works

Falls back to a less human readable address format.

## How this was tested

- [X] CI