### PR TITLE
Add gossip Marshaller interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3
+	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219231451-224728dbacb4
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219224055-4fd7077b41bf
+	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231213223840-6e78d609ed32
+	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219171107-9c5eb752bfed
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3
+	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219224055-4fd7077b41bf
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219171107-9c5eb752bfed
+	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3 h1:9W1ebuMdEkGm3yavyGMXsRMHXve7xevjhD+lqSAzCCM=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3/go.mod h1:vUu7RULpCCSamkHyRoH2ytqubuvk+gz8mgbdPDyO3no=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219224055-4fd7077b41bf h1:ulbHrX0Z7EAJvXH7CnlzW8za5YXVJopRCm/+Woghr/A=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219224055-4fd7077b41bf/go.mod h1:X+BgnExUdidznJo9T7QLtn212Y9C49lWH/2plWtSOd4=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34 h1:mg9Uw6oZFJKytJxgxnl3uxZOs/SB8CVHg6Io4Tf99Zc=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3 h1:9W1ebuMdEkGm3yavyGMXsRMHXve7xevjhD+lqSAzCCM=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3/go.mod h1:vUu7RULpCCSamkHyRoH2ytqubuvk+gz8mgbdPDyO3no=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219231451-224728dbacb4 h1:LXL5nSxcblyBFR5/zdO4TAqSWqoB15bT3sGb1Nkh7o4=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219231451-224728dbacb4/go.mod h1:84JZyt3colgzGI/jOYGB5Wzxr/wNP0zjebHiWZjFthk=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34 h1:mg9Uw6oZFJKytJxgxnl3uxZOs/SB8CVHg6Io4Tf99Zc=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219224055-4fd7077b41bf h1:ulbHrX0Z7EAJvXH7CnlzW8za5YXVJopRCm/+Woghr/A=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219224055-4fd7077b41bf/go.mod h1:X+BgnExUdidznJo9T7QLtn212Y9C49lWH/2plWtSOd4=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3 h1:9W1ebuMdEkGm3yavyGMXsRMHXve7xevjhD+lqSAzCCM=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3/go.mod h1:vUu7RULpCCSamkHyRoH2ytqubuvk+gz8mgbdPDyO3no=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34 h1:mg9Uw6oZFJKytJxgxnl3uxZOs/SB8CVHg6Io4Tf99Zc=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231213223840-6e78d609ed32 h1:CZ1N++oMSL6yKV/FcCx/7/2cmpAk3rQse797Xz/6Ro0=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231213223840-6e78d609ed32/go.mod h1:bHPGzEjcBOLIKGbik9ZzETOhHxnzdLyVX+Q/XvGmGeE=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219171107-9c5eb752bfed h1:yGrev2OuX+9cDGEIqJY9eqyze/fYRqOcqyfcRPZRNlA=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219171107-9c5eb752bfed/go.mod h1:vUu7RULpCCSamkHyRoH2ytqubuvk+gz8mgbdPDyO3no=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34 h1:mg9Uw6oZFJKytJxgxnl3uxZOs/SB8CVHg6Io4Tf99Zc=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219171107-9c5eb752bfed h1:yGrev2OuX+9cDGEIqJY9eqyze/fYRqOcqyfcRPZRNlA=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219171107-9c5eb752bfed/go.mod h1:vUu7RULpCCSamkHyRoH2ytqubuvk+gz8mgbdPDyO3no=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3 h1:9W1ebuMdEkGm3yavyGMXsRMHXve7xevjhD+lqSAzCCM=
+github.com/ava-labs/coreth v0.12.9-rc.9.0.20231219172304-64e232bc25e3/go.mod h1:vUu7RULpCCSamkHyRoH2ytqubuvk+gz8mgbdPDyO3no=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34 h1:mg9Uw6oZFJKytJxgxnl3uxZOs/SB8CVHg6Io4Tf99Zc=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/network/p2p/gossip/bloom.go
+++ b/network/p2p/gossip/bloom.go
@@ -46,7 +46,7 @@ type BloomFilter struct {
 }
 
 func (b *BloomFilter) Add(gossipable Gossipable) {
-	h := gossipable.GetID()
+	h := gossipable.GetGossipID()
 	salted := &hasher{
 		hash: h[:],
 		salt: b.Salt,
@@ -55,7 +55,7 @@ func (b *BloomFilter) Add(gossipable Gossipable) {
 }
 
 func (b *BloomFilter) Has(gossipable Gossipable) bool {
-	h := gossipable.GetID()
+	h := gossipable.GetGossipID()
 	salted := &hasher{
 		hash: h[:],
 		salt: b.Salt,

--- a/network/p2p/gossip/bloom.go
+++ b/network/p2p/gossip/bloom.go
@@ -46,7 +46,7 @@ type BloomFilter struct {
 }
 
 func (b *BloomFilter) Add(gossipable Gossipable) {
-	h := gossipable.GetGossipID()
+	h := gossipable.GossipID()
 	salted := &hasher{
 		hash: h[:],
 		salt: b.Salt,
@@ -55,7 +55,7 @@ func (b *BloomFilter) Add(gossipable Gossipable) {
 }
 
 func (b *BloomFilter) Has(gossipable Gossipable) bool {
-	h := gossipable.GetGossipID()
+	h := gossipable.GossipID()
 	salted := &hasher{
 		hash: h[:],
 		salt: b.Salt,

--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	_ Gossiper = (*ValidatorGossiper)(nil)
-	_ Gossiper = (*PullGossiper[testTx, *testTx])(nil)
+	_ Gossiper = (*PullGossiper[*testTx])(nil)
 	_ Gossiper = (*NoOpGossiper)(nil)
 
 	_ Accumulator[*testTx] = (*PushGossiper[*testTx])(nil)
@@ -51,13 +51,6 @@ type Accumulator[T Gossipable] interface {
 	Gossiper
 	// Add queues gossipables to be gossiped
 	Add(gossipables ...T)
-}
-
-// GossipableAny exists to help create non-nil pointers to a concrete Gossipable
-// ref: https://stackoverflow.com/questions/69573113/how-can-i-instantiate-a-non-nil-pointer-of-type-argument-with-generic-go
-type GossipableAny[T any] interface {
-	*T
-	Gossipable
 }
 
 // ValidatorGossiper only calls [Gossip] if the given node is a validator
@@ -121,35 +114,38 @@ func (v ValidatorGossiper) Gossip(ctx context.Context) error {
 	return v.Gossiper.Gossip(ctx)
 }
 
-func NewPullGossiper[T any, U GossipableAny[T]](
+func NewPullGossiper[T Gossipable](
 	log logging.Logger,
-	set Set[U],
+	marshaller Marshaller[T],
+	set Set[T],
 	client *p2p.Client,
 	metrics Metrics,
 	pollSize int,
-) *PullGossiper[T, U] {
-	return &PullGossiper[T, U]{
-		log:      log,
-		set:      set,
-		client:   client,
-		metrics:  metrics,
-		pollSize: pollSize,
+) *PullGossiper[T] {
+	return &PullGossiper[T]{
+		log:        log,
+		marshaller: marshaller,
+		set:        set,
+		client:     client,
+		metrics:    metrics,
+		pollSize:   pollSize,
 		labels: prometheus.Labels{
 			typeLabel: pullType,
 		},
 	}
 }
 
-type PullGossiper[T any, U GossipableAny[T]] struct {
-	log      logging.Logger
-	set      Set[U]
-	client   *p2p.Client
-	metrics  Metrics
-	pollSize int
-	labels   prometheus.Labels
+type PullGossiper[T Gossipable] struct {
+	log        logging.Logger
+	marshaller Marshaller[T]
+	set        Set[T]
+	client     *p2p.Client
+	metrics    Metrics
+	pollSize   int
+	labels     prometheus.Labels
 }
 
-func (p *PullGossiper[_, _]) Gossip(ctx context.Context) error {
+func (p *PullGossiper[_]) Gossip(ctx context.Context) error {
 	bloom, salt, err := p.set.GetFilter()
 	if err != nil {
 		return err
@@ -173,7 +169,7 @@ func (p *PullGossiper[_, _]) Gossip(ctx context.Context) error {
 	return nil
 }
 
-func (p *PullGossiper[T, U]) handleResponse(
+func (p *PullGossiper[T]) handleResponse(
 	_ context.Context,
 	nodeID ids.NodeID,
 	responseBytes []byte,
@@ -198,8 +194,8 @@ func (p *PullGossiper[T, U]) handleResponse(
 	for _, bytes := range response.Gossip {
 		receivedBytes += len(bytes)
 
-		gossipable := U(new(T))
-		if err := gossipable.Unmarshal(bytes); err != nil {
+		gossipable, err := p.marshaller.GossipUnmarshal(bytes)
+		if err != nil {
 			p.log.Debug(
 				"failed to unmarshal gossip",
 				zap.Stringer("nodeID", nodeID),
@@ -242,8 +238,9 @@ func (p *PullGossiper[T, U]) handleResponse(
 }
 
 // NewPushGossiper returns an instance of PushGossiper
-func NewPushGossiper[T Gossipable](client *p2p.Client, metrics Metrics, targetGossipSize int) *PushGossiper[T] {
+func NewPushGossiper[T Gossipable](marshaller Marshaller[T], client *p2p.Client, metrics Metrics, targetGossipSize int) *PushGossiper[T] {
 	return &PushGossiper[T]{
+		marshaller:       marshaller,
 		client:           client,
 		metrics:          metrics,
 		targetGossipSize: targetGossipSize,
@@ -256,6 +253,7 @@ func NewPushGossiper[T Gossipable](client *p2p.Client, metrics Metrics, targetGo
 
 // PushGossiper broadcasts gossip to peers randomly in the network
 type PushGossiper[T Gossipable] struct {
+	marshaller       Marshaller[T]
 	client           *p2p.Client
 	metrics          Metrics
 	targetGossipSize int
@@ -286,7 +284,7 @@ func (p *PushGossiper[T]) Gossip(ctx context.Context) error {
 			break
 		}
 
-		bytes, err := gossipable.Marshal()
+		bytes, err := p.marshaller.GossipMarshal(gossipable)
 		if err != nil {
 			// remove this item so we don't get stuck in a loop
 			_, _ = p.pending.PopLeft()

--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -204,7 +204,7 @@ func (p *PullGossiper[_]) handleResponse(
 			continue
 		}
 
-		hash := gossipable.GetGossipID()
+		hash := gossipable.GossipID()
 		p.log.Debug(
 			"received gossip",
 			zap.Stringer("nodeID", nodeID),

--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -194,7 +194,7 @@ func (p *PullGossiper[_]) handleResponse(
 	for _, bytes := range response.Gossip {
 		receivedBytes += len(bytes)
 
-		gossipable, err := p.marshaller.GossipUnmarshal(bytes)
+		gossipable, err := p.marshaller.UnmarshalGossip(bytes)
 		if err != nil {
 			p.log.Debug(
 				"failed to unmarshal gossip",
@@ -204,7 +204,7 @@ func (p *PullGossiper[_]) handleResponse(
 			continue
 		}
 
-		hash := gossipable.GetID()
+		hash := gossipable.GetGossipID()
 		p.log.Debug(
 			"received gossip",
 			zap.Stringer("nodeID", nodeID),
@@ -284,7 +284,7 @@ func (p *PushGossiper[T]) Gossip(ctx context.Context) error {
 			break
 		}
 
-		bytes, err := p.marshaller.GossipMarshal(gossipable)
+		bytes, err := p.marshaller.MarshalGossip(gossipable)
 		if err != nil {
 			// remove this item so we don't get stuck in a loop
 			_, _ = p.pending.PopLeft()

--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -169,7 +169,7 @@ func (p *PullGossiper[_]) Gossip(ctx context.Context) error {
 	return nil
 }
 
-func (p *PullGossiper[T]) handleResponse(
+func (p *PullGossiper[_]) handleResponse(
 	_ context.Context,
 	nodeID ids.NodeID,
 	responseBytes []byte,

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"golang.org/x/exp/maps"
 
 	"google.golang.org/protobuf/proto"

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"golang.org/x/exp/maps"
 
 	"google.golang.org/protobuf/proto"
@@ -32,8 +31,9 @@ var (
 )
 
 func TestGossiperShutdown(*testing.T) {
-	gossiper := NewPullGossiper[testTx](
+	gossiper := NewPullGossiper[*testTx](
 		logging.NoLog{},
+		nil,
 		nil,
 		nil,
 		Metrics{},
@@ -127,8 +127,10 @@ func TestGossiperGossip(t *testing.T) {
 
 			metrics, err := NewMetrics(prometheus.NewRegistry(), "")
 			require.NoError(err)
-			handler := NewHandler[testTx, *testTx](
+			marshaller := testMarshaller{}
+			handler := NewHandler[*testTx](
 				logging.NoLog{},
+				marshaller,
 				NoOpAccumulator[*testTx]{},
 				responseSet,
 				metrics,
@@ -158,8 +160,9 @@ func TestGossiperGossip(t *testing.T) {
 			requestClient := requestNetwork.NewClient(0x0)
 
 			require.NoError(err)
-			gossiper := NewPullGossiper[testTx, *testTx](
+			gossiper := NewPullGossiper[*testTx](
 				logging.NoLog{},
+				marshaller,
 				requestSet,
 				requestClient,
 				metrics,
@@ -322,7 +325,13 @@ func TestPushGossiper(t *testing.T) {
 			client := network.NewClient(0)
 			metrics, err := NewMetrics(prometheus.NewRegistry(), "")
 			require.NoError(err)
-			gossiper := NewPushGossiper[*testTx](client, metrics, units.MiB)
+			marshaller := testMarshaller{}
+			gossiper := NewPushGossiper[*testTx](
+				marshaller,
+				client,
+				metrics,
+				units.MiB,
+			)
 
 			for _, gossipables := range tt.cycles {
 				gossiper.Add(gossipables...)
@@ -333,7 +342,7 @@ func TestPushGossiper(t *testing.T) {
 				}
 
 				for _, gossipable := range gossipables {
-					bytes, err := gossipable.Marshal()
+					bytes, err := marshaller.GossipMarshal(gossipable)
 					require.NoError(err)
 
 					want.Gossip = append(want.Gossip, bytes)
@@ -378,10 +387,17 @@ func TestPushGossipE2E(t *testing.T) {
 
 	metrics, err := NewMetrics(prometheus.NewRegistry(), "")
 	require.NoError(err)
-	forwarderGossiper := NewPushGossiper[*testTx](client, metrics, units.MiB)
+	marshaller := testMarshaller{}
+	forwarderGossiper := NewPushGossiper[*testTx](
+		marshaller,
+		client,
+		metrics,
+		units.MiB,
+	)
 
-	handler := NewHandler[testTx, *testTx](
+	handler := NewHandler[*testTx](
 		log,
+		marshaller,
 		forwarderGossiper,
 		set,
 		metrics,
@@ -397,7 +413,12 @@ func TestPushGossipE2E(t *testing.T) {
 	require.NoError(err)
 	issuerClient := issuerNetwork.NewClient(handlerID)
 	require.NoError(err)
-	issuerGossiper := NewPushGossiper[*testTx](issuerClient, metrics, units.MiB)
+	issuerGossiper := NewPushGossiper[*testTx](
+		marshaller,
+		issuerClient,
+		metrics,
+		units.MiB,
+	)
 
 	want := []*testTx{
 		{id: ids.GenerateTestID()},
@@ -430,9 +451,10 @@ func TestPushGossipE2E(t *testing.T) {
 	require.Len(forwardedMsg.Gossip, len(want))
 
 	gotForwarded := make([]*testTx, 0, len(addedToSet))
+
 	for _, bytes := range forwardedMsg.Gossip {
-		tx := &testTx{}
-		require.NoError(tx.Unmarshal(bytes))
+		tx, err := marshaller.GossipUnmarshal(bytes)
+		require.NoError(err)
 		gotForwarded = append(gotForwarded, tx)
 	}
 

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -342,7 +342,7 @@ func TestPushGossiper(t *testing.T) {
 				}
 
 				for _, gossipable := range gossipables {
-					bytes, err := marshaller.GossipMarshal(gossipable)
+					bytes, err := marshaller.MarshalGossip(gossipable)
 					require.NoError(err)
 
 					want.Gossip = append(want.Gossip, bytes)
@@ -453,7 +453,7 @@ func TestPushGossipE2E(t *testing.T) {
 	gotForwarded := make([]*testTx, 0, len(addedToSet))
 
 	for _, bytes := range forwardedMsg.Gossip {
-		tx, err := marshaller.GossipUnmarshal(bytes)
+		tx, err := marshaller.UnmarshalGossip(bytes)
 		require.NoError(err)
 		gotForwarded = append(gotForwarded, tx)
 	}

--- a/network/p2p/gossip/gossipable.go
+++ b/network/p2p/gossip/gossipable.go
@@ -10,7 +10,7 @@ type Gossipable interface {
 	GetGossipID() ids.ID
 }
 
-// Marshaller creates concrete Gossipable types from bytes
+// Marshaller handles parsing logic for a concrete Gossipable type
 type Marshaller[T Gossipable] interface {
 	MarshalGossip(T) ([]byte, error)
 	UnmarshalGossip([]byte) (T, error)

--- a/network/p2p/gossip/gossipable.go
+++ b/network/p2p/gossip/gossipable.go
@@ -8,8 +8,12 @@ import "github.com/ava-labs/avalanchego/ids"
 // Gossipable is an item that can be gossiped across the network
 type Gossipable interface {
 	GetID() ids.ID
-	Marshal() ([]byte, error)
-	Unmarshal(bytes []byte) error
+}
+
+// Marshaller creates concrete Gossipable types from bytes
+type Marshaller[T Gossipable] interface {
+	GossipMarshal(T) ([]byte, error)
+	GossipUnmarshal([]byte) (T, error)
 }
 
 // Set holds a set of known Gossipable items

--- a/network/p2p/gossip/gossipable.go
+++ b/network/p2p/gossip/gossipable.go
@@ -7,7 +7,7 @@ import "github.com/ava-labs/avalanchego/ids"
 
 // Gossipable is an item that can be gossiped across the network
 type Gossipable interface {
-	GetGossipID() ids.ID
+	GossipID() ids.ID
 }
 
 // Marshaller handles parsing logic for a concrete Gossipable type

--- a/network/p2p/gossip/gossipable.go
+++ b/network/p2p/gossip/gossipable.go
@@ -12,8 +12,8 @@ type Gossipable interface {
 
 // Marshaller creates concrete Gossipable types from bytes
 type Marshaller[T Gossipable] interface {
-	GossipMarshal(T) ([]byte, error)
-	GossipUnmarshal([]byte) (T, error)
+	MarshalGossip(T) ([]byte, error)
+	UnmarshalGossip([]byte) (T, error)
 }
 
 // Set holds a set of known Gossipable items

--- a/network/p2p/gossip/gossipable.go
+++ b/network/p2p/gossip/gossipable.go
@@ -7,7 +7,7 @@ import "github.com/ava-labs/avalanchego/ids"
 
 // Gossipable is an item that can be gossiped across the network
 type Gossipable interface {
-	GetID() ids.ID
+	GetGossipID() ids.ID
 }
 
 // Marshaller creates concrete Gossipable types from bytes

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -124,7 +124,7 @@ func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, req
 	return proto.Marshal(response)
 }
 
-func (h Handler[T]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipBytes []byte) {
+func (h Handler[_]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipBytes []byte) {
 	msg := &sdk.PushGossip{}
 	if err := proto.Unmarshal(gossipBytes, msg); err != nil {
 		h.log.Debug("failed to unmarshal gossip", zap.Error(err))

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -87,7 +87,7 @@ func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, req
 		}
 
 		var bytes []byte
-		bytes, err = h.marshaller.GossipMarshal(gossipable)
+		bytes, err = h.marshaller.MarshalGossip(gossipable)
 		if err != nil {
 			return false
 		}
@@ -134,7 +134,7 @@ func (h Handler[_]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipByte
 	receivedBytes := 0
 	for _, bytes := range msg.Gossip {
 		receivedBytes += len(bytes)
-		gossipable, err := h.marshaller.GossipUnmarshal(bytes)
+		gossipable, err := h.marshaller.UnmarshalGossip(bytes)
 		if err != nil {
 			h.log.Debug("failed to unmarshal gossip",
 				zap.Stringer("nodeID", nodeID),
@@ -147,7 +147,7 @@ func (h Handler[_]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipByte
 			h.log.Debug(
 				"failed to add gossip to the known set",
 				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("id", gossipable.GetID()),
+				zap.Stringer("id", gossipable.GetGossipID()),
 				zap.Error(err),
 			)
 			continue

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -147,7 +147,7 @@ func (h Handler[_]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipByte
 			h.log.Debug(
 				"failed to add gossip to the known set",
 				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("id", gossipable.GetGossipID()),
+				zap.Stringer("id", gossipable.GossipID()),
 				zap.Error(err),
 			)
 			continue

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -22,18 +22,20 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
-var _ p2p.Handler = (*Handler[testTx, *testTx])(nil)
+var _ p2p.Handler = (*Handler[*testTx])(nil)
 
-func NewHandler[T any, U GossipableAny[T]](
+func NewHandler[T Gossipable](
 	log logging.Logger,
-	accumulator Accumulator[U],
-	set Set[U],
+	marshaller Marshaller[T],
+	accumulator Accumulator[T],
+	set Set[T],
 	metrics Metrics,
 	targetResponseSize int,
-) *Handler[T, U] {
-	return &Handler[T, U]{
+) *Handler[T] {
+	return &Handler[T]{
 		Handler:            p2p.NoOpHandler{},
 		log:                log,
+		marshaller:         marshaller,
 		accumulator:        accumulator,
 		set:                set,
 		metrics:            metrics,
@@ -44,11 +46,12 @@ func NewHandler[T any, U GossipableAny[T]](
 	}
 }
 
-type Handler[T any, U GossipableAny[T]] struct {
+type Handler[T Gossipable] struct {
 	p2p.Handler
-	accumulator        Accumulator[U]
+	marshaller         Marshaller[T]
+	accumulator        Accumulator[T]
 	log                logging.Logger
-	set                Set[U]
+	set                Set[T]
 	metrics            Metrics
 	targetResponseSize int
 
@@ -56,7 +59,7 @@ type Handler[T any, U GossipableAny[T]] struct {
 	pushLabels prometheus.Labels
 }
 
-func (h Handler[_, U]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, requestBytes []byte) ([]byte, error) {
+func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, requestBytes []byte) ([]byte, error) {
 	request := &sdk.PullGossipRequest{}
 	if err := proto.Unmarshal(requestBytes, request); err != nil {
 		return nil, err
@@ -77,14 +80,14 @@ func (h Handler[_, U]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, 
 
 	responseSize := 0
 	gossipBytes := make([][]byte, 0)
-	h.set.Iterate(func(gossipable U) bool {
+	h.set.Iterate(func(gossipable T) bool {
 		// filter out what the requesting peer already knows about
 		if filter.Has(gossipable) {
 			return true
 		}
 
 		var bytes []byte
-		bytes, err = gossipable.Marshal()
+		bytes, err = h.marshaller.GossipMarshal(gossipable)
 		if err != nil {
 			return false
 		}
@@ -121,7 +124,7 @@ func (h Handler[_, U]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, 
 	return proto.Marshal(response)
 }
 
-func (h Handler[T, U]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipBytes []byte) {
+func (h Handler[T]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipBytes []byte) {
 	msg := &sdk.PushGossip{}
 	if err := proto.Unmarshal(gossipBytes, msg); err != nil {
 		h.log.Debug("failed to unmarshal gossip", zap.Error(err))
@@ -131,8 +134,8 @@ func (h Handler[T, U]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipB
 	receivedBytes := 0
 	for _, bytes := range msg.Gossip {
 		receivedBytes += len(bytes)
-		gossipable := U(new(T))
-		if err := gossipable.Unmarshal(bytes); err != nil {
+		gossipable, err := h.marshaller.GossipUnmarshal(bytes)
+		if err != nil {
 			h.log.Debug("failed to unmarshal gossip",
 				zap.Stringer("nodeID", nodeID),
 				zap.Error(err),

--- a/network/p2p/gossip/test_gossip.go
+++ b/network/p2p/gossip/test_gossip.go
@@ -30,9 +30,10 @@ func (testMarshaller) MarshalGossip(tx *testTx) ([]byte, error) {
 }
 
 func (testMarshaller) UnmarshalGossip(bytes []byte) (*testTx, error) {
+	id, err := ids.ToID(bytes)
 	return &testTx{
-		id: ids.ID(bytes),
-	}, nil
+		id: id,
+	}, err
 }
 
 type testSet struct {

--- a/network/p2p/gossip/test_gossip.go
+++ b/network/p2p/gossip/test_gossip.go
@@ -19,7 +19,7 @@ type testTx struct {
 	id ids.ID
 }
 
-func (t *testTx) GetGossipID() ids.ID {
+func (t *testTx) GossipID() ids.ID {
 	return t.id
 }
 

--- a/network/p2p/gossip/test_gossip.go
+++ b/network/p2p/gossip/test_gossip.go
@@ -25,11 +25,11 @@ func (t *testTx) GetID() ids.ID {
 
 type testMarshaller struct{}
 
-func (t testMarshaller) GossipMarshal(tx *testTx) ([]byte, error) {
+func (testMarshaller) GossipMarshal(tx *testTx) ([]byte, error) {
 	return tx.id[:], nil
 }
 
-func (t testMarshaller) GossipUnmarshal(bytes []byte) (*testTx, error) {
+func (testMarshaller) GossipUnmarshal(bytes []byte) (*testTx, error) {
 	return &testTx{
 		id: ids.ID(bytes),
 	}, nil

--- a/network/p2p/gossip/test_gossip.go
+++ b/network/p2p/gossip/test_gossip.go
@@ -19,17 +19,17 @@ type testTx struct {
 	id ids.ID
 }
 
-func (t *testTx) GetID() ids.ID {
+func (t *testTx) GetGossipID() ids.ID {
 	return t.id
 }
 
 type testMarshaller struct{}
 
-func (testMarshaller) GossipMarshal(tx *testTx) ([]byte, error) {
+func (testMarshaller) MarshalGossip(tx *testTx) ([]byte, error) {
 	return tx.id[:], nil
 }
 
-func (testMarshaller) GossipUnmarshal(bytes []byte) (*testTx, error) {
+func (testMarshaller) UnmarshalGossip(bytes []byte) (*testTx, error) {
 	return &testTx{
 		id: ids.ID(bytes),
 	}, nil

--- a/network/p2p/gossip/test_gossip.go
+++ b/network/p2p/gossip/test_gossip.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	_ Gossipable   = (*testTx)(nil)
-	_ Set[*testTx] = (*testSet)(nil)
+	_ Gossipable          = (*testTx)(nil)
+	_ Set[*testTx]        = (*testSet)(nil)
+	_ Marshaller[*testTx] = (*testMarshaller)(nil)
 )
 
 type testTx struct {
@@ -22,14 +23,16 @@ func (t *testTx) GetID() ids.ID {
 	return t.id
 }
 
-func (t *testTx) Marshal() ([]byte, error) {
-	return t.id[:], nil
+type testMarshaller struct{}
+
+func (t testMarshaller) GossipMarshal(tx *testTx) ([]byte, error) {
+	return tx.id[:], nil
 }
 
-func (t *testTx) Unmarshal(bytes []byte) error {
-	t.id = ids.ID{}
-	copy(t.id[:], bytes)
-	return nil
+func (t testMarshaller) GossipUnmarshal(bytes []byte) (*testTx, error) {
+	return &testTx{
+		id: ids.ID(bytes),
+	}, nil
 }
 
 type testSet struct {


### PR DESCRIPTION
## Why this should be merged

Required to unblock the X-Chain's integration for the sdk gossip

## How this works

Refactors marshal and unmarshal to be on its own interface instead of attached to the `Gossipable` interface

## How this was tested

UTs pass
