### PR TITLE
Dedupe secp256k1 key usage in tests

### DIFF
--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
-	"github.com/ava-labs/avalanchego/utils/cb58"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
@@ -114,20 +113,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 		})
 
 	ginkgo.It("can make calls to platformvm static api", func() {
-		keys := []*secp256k1.PrivateKey{}
-		for _, key := range []string{
-			"24jUJ9vZexUM6expyMcT48LBx27k1m7xpraoV62oSQAHdziao5",
-			"2MMvUMsxx6zsHSNXJdFD8yc5XkancvwyKPwpw4xUK3TCGDuNBY",
-			"cxb7KpGWhDMALTjNNSJ7UQkkomPesyWAPUaWRGdyeBNzR6f35",
-			"ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN",
-			"2RWLv6YVEXDiWLpaCbXhhqxtLbnFaKQsWPSSMSPhpWo47uJAeV",
-		} {
-			privKeyBytes, err := cb58.Decode(key)
-			require.NoError(err)
-			pk, err := secp256k1.ToPrivateKey(privKeyBytes)
-			require.NoError(err)
-			keys = append(keys, pk)
-		}
+		keys := secp256k1.TestKeys()
 
 		genesisUTXOs := make([]api.UTXO, len(keys))
 		hrp := constants.NetworkIDToHRP[constants.UnitTestID]

--- a/vms/avm/environment_test.go
+++ b/vms/avm/environment_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/utils/cb58"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
@@ -70,22 +69,16 @@ var (
 	chainID = ids.ID{5, 4, 3, 2, 1}
 	assetID = ids.ID{1, 2, 3}
 
-	keys  []*secp256k1.PrivateKey
+	keys  = secp256k1.TestKeys()
 	addrs []ids.ShortID // addrs[i] corresponds to keys[i]
 
 	errMissing = errors.New("missing")
 )
 
 func init() {
-	for _, key := range []string{
-		"24jUJ9vZexUM6expyMcT48LBx27k1m7xpraoV62oSQAHdziao5",
-		"2MMvUMsxx6zsHSNXJdFD8yc5XkancvwyKPwpw4xUK3TCGDuNBY",
-		"cxb7KpGWhDMALTjNNSJ7UQkkomPesyWAPUaWRGdyeBNzR6f35",
-	} {
-		keyBytes, _ := cb58.Decode(key)
-		pk, _ := secp256k1.ToPrivateKey(keyBytes)
-		keys = append(keys, pk)
-		addrs = append(addrs, pk.PublicKey().Address())
+	addrs = make([]ids.ShortID, len(keys))
+	for i, key := range keys {
+		addrs[i] = key.Address()
 	}
 }
 

--- a/vms/avm/environment_test.go
+++ b/vms/avm/environment_test.go
@@ -69,8 +69,8 @@ var (
 	chainID = ids.ID{5, 4, 3, 2, 1}
 	assetID = ids.ID{1, 2, 3}
 
-	keys  = secp256k1.TestKeys()[:3]
-	addrs []ids.ShortID // addrs[i] corresponds to keys[i]
+	keys  = secp256k1.TestKeys()[:3] // TODO: Remove [:3]
+	addrs []ids.ShortID              // addrs[i] corresponds to keys[i]
 
 	errMissing = errors.New("missing")
 )

--- a/vms/avm/environment_test.go
+++ b/vms/avm/environment_test.go
@@ -69,7 +69,7 @@ var (
 	chainID = ids.ID{5, 4, 3, 2, 1}
 	assetID = ids.ID{1, 2, 3}
 
-	keys  = secp256k1.TestKeys()
+	keys  = secp256k1.TestKeys()[:3]
 	addrs []ids.ShortID // addrs[i] corresponds to keys[i]
 
 	errMissing = errors.New("missing")

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -1627,6 +1627,8 @@ func TestCreateVariableCapAsset(t *testing.T) {
 }
 
 func TestNFTWorkflow(t *testing.T) {
+	addrs := addrs[:3]
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -1627,8 +1627,6 @@ func TestCreateVariableCapAsset(t *testing.T) {
 }
 
 func TestNFTWorkflow(t *testing.T) {
-	addrs := addrs[:3]
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)


### PR DESCRIPTION
## Why this should be merged

De-dupes code

## How this works

use existing `secp256k1.TestKeys()` helper function: https://github.com/ava-labs/avalanchego/blob/dev/utils/crypto/secp256k1/test_keys.go

## How this was tested

CI