### PR TITLE
[WIP] Use `int64` for serialized timestamps

### DIFF
--- a/genesis/config.go
+++ b/genesis/config.go
@@ -28,7 +28,7 @@ var (
 
 type LockedAmount struct {
 	Amount   uint64 `json:"amount"`
-	Locktime uint64 `json:"locktime"`
+	Locktime int64  `json:"locktime"`
 }
 
 type Allocation struct {
@@ -87,7 +87,7 @@ type Config struct {
 
 	Allocations []Allocation `json:"allocations"`
 
-	StartTime                  uint64        `json:"startTime"`
+	StartTime                  int64         `json:"startTime"`
 	InitialStakeDuration       uint64        `json:"initialStakeDuration"`
 	InitialStakeDurationOffset uint64        `json:"initialStakeDurationOffset"`
 	InitialStakedFunds         []ids.ShortID `json:"initialStakedFunds"`

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -133,7 +133,7 @@ func validateConfig(networkID uint32, config *Config, stakingCfg *StakingConfig)
 		return errNoSupply
 	}
 
-	startTime := time.Unix(int64(config.StartTime), 0)
+	startTime := time.Unix(config.StartTime, 0)
 	if time.Since(startTime) < 0 {
 		return fmt.Errorf(
 			"%w: %s",
@@ -335,7 +335,7 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 		return nil, ids.ID{}, fmt.Errorf("couldn't generate AVAX asset ID: %w", err)
 	}
 
-	genesisTime := time.Unix(int64(config.StartTime), 0)
+	genesisTime := time.Unix(config.StartTime, 0)
 	initialSupply, err := config.InitialSupply()
 	if err != nil {
 		return nil, ids.ID{}, fmt.Errorf("couldn't calculate the initial supply: %w", err)

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -348,7 +348,7 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 	platformvmArgs := api.BuildGenesisArgs{
 		AvaxAssetID:   avaxAssetID,
 		NetworkID:     json.Uint32(config.NetworkID),
-		Time:          json.Uint64(config.StartTime),
+		Time:          json.Int64(config.StartTime),
 		InitialSupply: json.Uint64(initialSupply),
 		Message:       config.Message,
 		Encoding:      defaultEncoding,
@@ -370,7 +370,7 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 				}
 				platformvmArgs.UTXOs = append(platformvmArgs.UTXOs,
 					api.UTXO{
-						Locktime: json.Uint64(unlock.Locktime),
+						Locktime: json.Int64(unlock.Locktime),
 						Amount:   json.Uint64(unlock.Amount),
 						Address:  addr,
 						Message:  msgStr,
@@ -406,7 +406,7 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 					return nil, ids.Empty, fmt.Errorf("couldn't encode message: %w", err)
 				}
 				utxos = append(utxos, api.UTXO{
-					Locktime: json.Uint64(unlock.Locktime),
+					Locktime: json.Int64(unlock.Locktime),
 					Amount:   json.Uint64(unlock.Amount),
 					Address:  addr,
 					Message:  msgStr,
@@ -420,8 +420,8 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 		platformvmArgs.Validators = append(platformvmArgs.Validators,
 			api.GenesisPermissionlessValidator{
 				GenesisValidator: api.GenesisValidator{
-					StartTime: json.Uint64(genesisTime.Unix()),
-					EndTime:   json.Uint64(endStakingTime.Unix()),
+					StartTime: json.Int64(genesisTime.Unix()),
+					EndTime:   json.Int64(endStakingTime.Unix()),
 					NodeID:    staker.NodeID,
 				},
 				RewardOwner: &api.Owner{

--- a/genesis/unparsed_config.go
+++ b/genesis/unparsed_config.go
@@ -86,7 +86,7 @@ type UnparsedConfig struct {
 
 	Allocations []UnparsedAllocation `json:"allocations"`
 
-	StartTime                  uint64           `json:"startTime"`
+	StartTime                  int64            `json:"startTime"`
 	InitialStakeDuration       uint64           `json:"initialStakeDuration"`
 	InitialStakeDurationOffset uint64           `json:"initialStakeDurationOffset"`
 	InitialStakedFunds         []string         `json:"initialStakedFunds"`

--- a/message/messages_test.go
+++ b/message/messages_test.go
@@ -46,7 +46,7 @@ func TestMessage(t *testing.T) {
 	testTLSCert, err := staking.LoadTLSCertFromBytes(testKeyRaw, testCertRaw)
 	require.NoError(t, err)
 
-	nowUnix := time.Now().Unix()
+	nowUnix := uint64(time.Now().Unix())
 
 	tests := []struct {
 		desc             string
@@ -128,11 +128,11 @@ func TestMessage(t *testing.T) {
 				Message: &p2p.Message_Version{
 					Version: &p2p.Version{
 						NetworkId:      uint32(1337),
-						MyTime:         uint64(nowUnix),
+						MyTime:         nowUnix,
 						IpAddr:         []byte(net.IPv6zero),
 						IpPort:         9651,
 						MyVersion:      "v1.2.3",
-						MyVersionTime:  uint64(nowUnix),
+						MyVersionTime:  nowUnix,
 						Sig:            []byte{'y', 'e', 'e', 't'},
 						TrackedSubnets: [][]byte{testID[:]},
 					},
@@ -175,7 +175,7 @@ func TestMessage(t *testing.T) {
 								X509Certificate: testTLSCert.Certificate[0],
 								IpAddr:          []byte(net.IPv6zero),
 								IpPort:          9651,
-								Timestamp:       uint64(nowUnix),
+								Timestamp:       nowUnix,
 								Signature:       compressibleContainers[0],
 							},
 						},
@@ -197,7 +197,7 @@ func TestMessage(t *testing.T) {
 								X509Certificate: testTLSCert.Certificate[0],
 								IpAddr:          []byte(net.IPv6zero),
 								IpPort:          9651,
-								Timestamp:       uint64(nowUnix),
+								Timestamp:       nowUnix,
 								Signature:       compressibleContainers[0],
 							},
 						},

--- a/message/mock_outbound_message_builder.go
+++ b/message/mock_outbound_message_builder.go
@@ -371,7 +371,7 @@ func (mr *MockOutboundMsgBuilderMockRecorder) StateSummaryFrontier(arg0, arg1, a
 }
 
 // Version mocks base method.
-func (m *MockOutboundMsgBuilder) Version(arg0 uint32, arg1 uint64, arg2 ips.IPPort, arg3, arg4 string, arg5, arg6, arg7 uint32, arg8 uint64, arg9 []byte, arg10 []ids.ID, arg11, arg12 []uint32) (OutboundMessage, error) {
+func (m *MockOutboundMsgBuilder) Version(arg0 uint32, arg1 int64, arg2 ips.IPPort, arg3, arg4 string, arg5, arg6, arg7 uint32, arg8 int64, arg9 []byte, arg10 []ids.ID, arg11, arg12 []uint32) (OutboundMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
 	ret0, _ := ret[0].(OutboundMessage)

--- a/message/outbound_msg_builder.go
+++ b/message/outbound_msg_builder.go
@@ -20,14 +20,14 @@ var _ OutboundMsgBuilder = (*outMsgBuilder)(nil)
 type OutboundMsgBuilder interface {
 	Version(
 		networkID uint32,
-		myTime uint64,
+		myTime int64,
 		ip ips.IPPort,
 		myVersion string,
 		client string,
 		major uint32,
 		minor uint32,
 		patch uint32,
-		myVersionTime uint64,
+		myVersionTime int64,
 		sig []byte,
 		trackedSubnets []ids.ID,
 		supportedACPs []uint32,
@@ -232,14 +232,14 @@ func (b *outMsgBuilder) Pong(
 
 func (b *outMsgBuilder) Version(
 	networkID uint32,
-	myTime uint64,
+	myTime int64,
 	ip ips.IPPort,
 	myVersion string,
 	client string,
 	major uint32,
 	minor uint32,
 	patch uint32,
-	myVersionTime uint64,
+	myVersionTime int64,
 	sig []byte,
 	trackedSubnets []ids.ID,
 	supportedACPs []uint32,
@@ -252,11 +252,11 @@ func (b *outMsgBuilder) Version(
 			Message: &p2p.Message_Version{
 				Version: &p2p.Version{
 					NetworkId:      networkID,
-					MyTime:         myTime,
+					MyTime:         uint64(myTime),
 					IpAddr:         ip.IP.To16(),
 					IpPort:         uint32(ip.Port),
 					MyVersion:      myVersion,
-					MyVersionTime:  myVersionTime,
+					MyVersionTime:  uint64(myVersionTime),
 					Sig:            sig,
 					TrackedSubnets: subnetIDBytes,
 					Client: &p2p.Client{
@@ -282,7 +282,7 @@ func (b *outMsgBuilder) PeerList(peers []ips.ClaimedIPPort, bypassThrottling boo
 			X509Certificate: p.Cert.Raw,
 			IpAddr:          p.IPPort.IP.To16(),
 			IpPort:          uint32(p.IPPort.Port),
-			Timestamp:       p.Timestamp,
+			Timestamp:       uint64(p.Timestamp),
 			Signature:       p.Signature,
 			TxId:            p.TxID[:],
 		}

--- a/network/network.go
+++ b/network/network.go
@@ -500,7 +500,7 @@ func (n *network) Track(peerID ids.NodeID, claimedIPPorts []*ips.ClaimedIPPort) 
 
 	// Information for them to update about us
 	ipLen := len(claimedIPPorts)
-	newestTimestamp := make(map[ids.ID]uint64, ipLen)
+	newestTimestamp := make(map[ids.ID]int64, ipLen)
 	// Information for us to update about them
 	txIDsWithUpToDateIP := make([]ids.ID, 0, ipLen)
 
@@ -607,7 +607,7 @@ func (n *network) Track(peerID ids.NodeID, claimedIPPorts []*ips.ClaimedIPPort) 
 			// the peer provided us, we may be able to avoid some unnecessary
 			// gossip in the case that the peer is about to update this
 			// validator's IP.
-			Timestamp: newestTimestamp[txID],
+			Timestamp: uint64(newestTimestamp[txID]),
 		}
 	}
 	return peerAcks, nil
@@ -637,7 +637,7 @@ func (n *network) MarkTracked(peerID ids.NodeID, ips []*p2p.PeerAck) error {
 		// response to. That means that I should re-gossip this node's IP to the
 		// peer.
 		myIP, previouslyTracked := n.peerIPs[nodeID]
-		if previouslyTracked && myIP.Timestamp <= ip.Timestamp {
+		if previouslyTracked && myIP.Timestamp <= int64(ip.Timestamp) { // todo remove cast
 			txIDs = append(txIDs, txID)
 		}
 	}

--- a/network/peer/ip.go
+++ b/network/peer/ip.go
@@ -18,7 +18,7 @@ import (
 // validator.
 type UnsignedIP struct {
 	ips.IPPort
-	Timestamp uint64
+	Timestamp int64
 }
 
 // Sign this IP with the provided signer and return the signed IP.
@@ -39,7 +39,7 @@ func (ip *UnsignedIP) bytes() []byte {
 		Bytes: make([]byte, wrappers.IPLen+wrappers.LongLen),
 	}
 	ips.PackIP(&p, ip.IPPort)
-	p.PackLong(ip.Timestamp)
+	p.PackLong(uint64(ip.Timestamp))
 	return p.Bytes
 }
 

--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -875,13 +875,13 @@ func (p *peer) handleVersion(msg *p2p.Version) {
 			p.Log.Warn("beacon reports out of sync time",
 				zap.Stringer("nodeID", p.id),
 				zap.Uint64("peerTime", msg.MyTime),
-				zap.Uint64("myTime", myTime),
+				zap.Int64("myTime", myTime),
 			)
 		} else {
 			p.Log.Debug("peer reports out of sync time",
 				zap.Stringer("nodeID", p.id),
 				zap.Uint64("peerTime", msg.MyTime),
-				zap.Uint64("myTime", myTime),
+				zap.Int64("myTime", myTime),
 			)
 		}
 		p.StartClose()
@@ -1003,7 +1003,7 @@ func (p *peer) handleVersion(msg *p2p.Version) {
 				IP:   msg.IpAddr,
 				Port: uint16(msg.IpPort),
 			},
-			Timestamp: msg.MyVersionTime,
+			Timestamp: int64(msg.MyVersionTime),
 		},
 		Signature: msg.Sig,
 	}
@@ -1105,7 +1105,7 @@ func (p *peer) handlePeerList(msg *p2p.PeerList) {
 				IP:   claimedIPPort.IpAddr,
 				Port: uint16(claimedIPPort.IpPort),
 			},
-			Timestamp: claimedIPPort.Timestamp,
+			Timestamp: int64(claimedIPPort.Timestamp), // todo remove cast
 			Signature: claimedIPPort.Signature,
 			TxID:      txID,
 		}

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -110,7 +110,7 @@ var _ = e2e.DescribePChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainL
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
 						NodeID: nodeID,
-						End:    uint64(endTime.Unix()),
+						End:    endTime.Unix(),
 						Wght:   weight,
 					},
 					Subnet: constants.PrimaryNetworkID,
@@ -140,7 +140,7 @@ var _ = e2e.DescribePChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainL
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
 						NodeID: nodeID,
-						End:    uint64(endTime.Unix()),
+						End:    endTime.Unix(),
 						Wght:   weight,
 					},
 					Subnet: constants.PrimaryNetworkID,

--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -140,7 +140,7 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 					&txs.SubnetValidator{
 						Validator: txs.Validator{
 							NodeID: validatorID,
-							End:    uint64(endTime.Unix()),
+							End:    endTime.Unix(),
 							Wght:   25 * units.MegaAvax,
 						},
 						Subnet: subnetID,
@@ -160,7 +160,7 @@ var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {
 					&txs.SubnetValidator{
 						Validator: txs.Validator{
 							NodeID: validatorID,
-							End:    uint64(endTime.Unix()),
+							End:    endTime.Unix(),
 							Wght:   25 * units.MegaAvax,
 						},
 						Subnet: subnetID,

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
 						NodeID: alphaNodeID,
-						End:    uint64(alphaValidatorsEndTime.Unix()),
+						End:    alphaValidatorsEndTime.Unix(),
 						Wght:   weight,
 					},
 					Subnet: constants.PrimaryNetworkID,
@@ -155,7 +155,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
 						NodeID: betaNodeID,
-						End:    uint64(betaValidatorEndTime.Unix()),
+						End:    betaValidatorEndTime.Unix(),
 						Wght:   weight,
 					},
 					Subnet: constants.PrimaryNetworkID,
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
 						NodeID: alphaNodeID,
-						End:    uint64(gammaDelegatorEndTime.Unix()),
+						End:    gammaDelegatorEndTime.Unix(),
 						Wght:   weight,
 					},
 					Subnet: constants.PrimaryNetworkID,
@@ -211,7 +211,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
 						NodeID: betaNodeID,
-						End:    uint64(deltaDelegatorEndTime.Unix()),
+						End:    deltaDelegatorEndTime.Unix(),
 						Wght:   weight,
 					},
 					Subnet: constants.PrimaryNetworkID,

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -76,7 +76,7 @@ var _ = e2e.DescribePChain("[Workflow]", func() {
 
 			vdr := &txs.Validator{
 				NodeID: validatorID,
-				End:    uint64(time.Now().Add(72 * time.Hour).Unix()),
+				End:    time.Now().Add(72 * time.Hour).Unix(),
 				Wght:   minValStake,
 			}
 			rewardOwner := &secp256k1fx.OutputOwners{

--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -134,8 +134,8 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 			require.NoError(err)
 			genesisValidators[i] = api.GenesisPermissionlessValidator{
 				GenesisValidator: api.GenesisValidator{
-					StartTime: json.Uint64(time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
-					EndTime:   json.Uint64(time.Date(1997, 1, 30, 0, 0, 0, 0, time.UTC).Unix()),
+					StartTime: json.Int64(time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
+					EndTime:   json.Int64(time.Date(1997, 1, 30, 0, 0, 0, 0, time.UTC).Unix()),
 					NodeID:    ids.BuildTestNodeID(id[:]),
 				},
 				RewardOwner: &api.Owner{
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("[StaticHandlers]", func() {
 			UTXOs:         genesisUTXOs,
 			Validators:    genesisValidators,
 			Chains:        nil,
-			Time:          json.Uint64(time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
+			Time:          json.Int64(time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
 			InitialSupply: json.Uint64(360 * units.MegaAvax),
 			Encoding:      formatting.Hex,
 		}

--- a/tests/fixture/tmpnet/genesis.go
+++ b/tests/fixture/tmpnet/genesis.go
@@ -98,12 +98,12 @@ func NewTestGenesis(
 				UnlockSchedule: []genesis.LockedAmount{ // Provides stake to validators
 					{
 						Amount:   totalStake,
-						Locktime: uint64(now.Add(7 * 24 * time.Hour).Unix()), // 1 Week
+						Locktime: now.Add(7 * 24 * time.Hour).Unix(), // 1 Week
 					},
 				},
 			},
 		},
-		StartTime:                  uint64(now.Unix()),
+		StartTime:                  now.Unix(),
 		InitialStakedFunds:         []string{stakeAddress},
 		InitialStakeDuration:       365 * 24 * 60 * 60, // 1 year
 		InitialStakeDurationOffset: 90 * 60,            // 90 minutes
@@ -139,7 +139,7 @@ func NewTestGenesis(
 					},
 					{
 						Amount:   totalStake,
-						Locktime: uint64(now.Add(7 * 24 * time.Hour).Unix()), // 1 Week
+						Locktime: now.Add(7 * 24 * time.Hour).Unix(), // 1 Week
 					},
 				},
 			},

--- a/utils/ips/claimed_ip_port.go
+++ b/utils/ips/claimed_ip_port.go
@@ -26,7 +26,7 @@ type ClaimedIPPort struct {
 	// The peer's claimed IP and port.
 	IPPort IPPort
 	// The time the peer claimed to own this IP and port.
-	Timestamp uint64
+	Timestamp int64
 	// [Cert]'s signature over the IPPort and timestamp.
 	// This is used in the networking library to ensure that this IPPort was
 	// actually claimed by the peer in question, and not by a malicious peer

--- a/utils/json/int64.go
+++ b/utils/json/int64.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package json
+
+import "strconv"
+
+// TODO test
+type Int64 int64
+
+func (i Int64) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + strconv.FormatInt(int64(i), 10) + `"`), nil
+}
+
+func (i *Int64) UnmarshalJSON(b []byte) error {
+	str := string(b)
+	if str == Null {
+		return nil
+	}
+	if len(str) >= 2 {
+		if lastIndex := len(str) - 1; str[0] == '"' && str[lastIndex] == '"' {
+			str = str[1:lastIndex]
+		}
+	}
+	val, err := strconv.ParseInt(str, 10, 64)
+	*i = Int64(val)
+	return err
+}

--- a/utils/timer/mockable/clock.go
+++ b/utils/timer/mockable/clock.go
@@ -35,10 +35,10 @@ func (c *Clock) UnixTime() time.Time {
 }
 
 // Unix returns the unix timestamp on this clock.
-func (c *Clock) Unix() uint64 {
+func (c *Clock) Unix() int64 {
 	unix := c.Time().Unix()
 	if unix < 0 {
 		unix = 0
 	}
-	return uint64(unix)
+	return unix
 }

--- a/vms/avm/block/standard_block.go
+++ b/vms/avm/block/standard_block.go
@@ -60,7 +60,7 @@ func (b *StandardBlock) Height() uint64 {
 }
 
 func (b *StandardBlock) Timestamp() time.Time {
-	return time.Unix(int64(b.Time), 0)
+	return time.Unix(b.Time, 0)
 }
 
 func (b *StandardBlock) MerkleRoot() ids.ID {

--- a/vms/avm/block/standard_block.go
+++ b/vms/avm/block/standard_block.go
@@ -21,7 +21,7 @@ type StandardBlock struct {
 	PrntID ids.ID `serialize:"true" json:"parentID"`
 	// This block's height. The genesis block is at height 0.
 	Hght uint64 `serialize:"true" json:"height"`
-	Time uint64 `serialize:"true" json:"time"`
+	Time int64  `serialize:"true" json:"time"`
 	Root ids.ID `serialize:"true" json:"merkleRoot"`
 	// List of transactions contained in this block.
 	Transactions []*txs.Tx `serialize:"true" json:"txs"`
@@ -85,7 +85,7 @@ func NewStandardBlock(
 	blk := &StandardBlock{
 		PrntID:       parentID,
 		Hght:         height,
-		Time:         uint64(timestamp.Unix()),
+		Time:         timestamp.Unix(),
 		Transactions: txs,
 	}
 	return blk, initialize(blk, cm)

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -232,7 +232,7 @@ func TestServiceGetBalanceStrict(t *testing.T) {
 		Out: &secp256k1fx.TransferOutput{
 			Amt: 1337,
 			OutputOwners: secp256k1fx.OutputOwners{
-				Locktime:  uint64(now.Add(10 * time.Hour).Unix()),
+				Locktime:  now.Add(10 * time.Hour).Unix(),
 				Threshold: 1,
 				Addrs:     []ids.ShortID{addr},
 			},
@@ -424,7 +424,7 @@ func TestServiceGetAllBalances(t *testing.T) {
 		Out: &secp256k1fx.TransferOutput{
 			Amt: 1337,
 			OutputOwners: secp256k1fx.OutputOwners{
-				Locktime:  uint64(now.Add(10 * time.Hour).Unix()),
+				Locktime:  now.Add(10 * time.Hour).Unix(),
 				Threshold: 1,
 				Addrs:     []ids.ShortID{addr},
 			},

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -318,8 +318,8 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 			}}
 			validator = txs.Validator{
 				NodeID: vdr.NodeID,
-				Start:  uint64(args.Time),
-				End:    uint64(vdr.EndTime),
+				Start:  int64(args.Time),
+				End:    int64(vdr.EndTime),
 				Wght:   weight,
 			}
 			tx *txs.Tx

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -43,7 +43,7 @@ type StaticService struct{}
 
 // UTXO is a UTXO on the Platform Chain that exists at the chain's genesis.
 type UTXO struct {
-	Locktime json.Uint64 `json:"locktime"`
+	Locktime json.Int64  `json:"locktime"`
 	Amount   json.Uint64 `json:"amount"`
 	Address  string      `json:"address"`
 	Message  string      `json:"message"`
@@ -83,8 +83,8 @@ func (utxo UTXO) Compare(other UTXO) int {
 // [Uptime] is the observed uptime of this staker
 type Staker struct {
 	TxID      ids.ID      `json:"txID"`
-	StartTime json.Uint64 `json:"startTime"`
-	EndTime   json.Uint64 `json:"endTime"`
+	StartTime json.Int64  `json:"startTime"`
+	EndTime   json.Int64  `json:"endTime"`
 	Weight    json.Uint64 `json:"weight"`
 	NodeID    ids.NodeID  `json:"nodeID"`
 
@@ -98,7 +98,7 @@ type GenesisValidator Staker
 
 // Owner is the repr. of a reward owner sent over APIs.
 type Owner struct {
-	Locktime  json.Uint64 `json:"locktime"`
+	Locktime  json.Int64  `json:"locktime"`
 	Threshold json.Uint32 `json:"threshold"`
 	Addresses []string    `json:"addresses"`
 }
@@ -183,7 +183,7 @@ type BuildGenesisArgs struct {
 	UTXOs         []UTXO                           `json:"utxos"`
 	Validators    []GenesisPermissionlessValidator `json:"validators"`
 	Chains        []Chain                          `json:"chains"`
-	Time          json.Uint64                      `json:"time"`
+	Time          json.Int64                       `json:"time"`
 	InitialSupply json.Uint64                      `json:"initialSupply"`
 	Message       string                           `json:"message"`
 	Encoding      formatting.Encoding              `json:"encoding"`
@@ -289,7 +289,7 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 		if weight == 0 {
 			return errValidatorHasNoWeight
 		}
-		if uint64(vdr.EndTime) <= uint64(args.Time) {
+		if vdr.EndTime <= args.Time {
 			return errValidatorAlreadyExited
 		}
 

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -384,7 +384,7 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 		UTXOs:         utxos,
 		Validators:    validatorTxs,
 		Chains:        chains,
-		Timestamp:     uint64(args.Time),
+		Timestamp:     int64(args.Time), // TODO
 		InitialSupply: uint64(args.InitialSupply),
 		Message:       args.Message,
 	}

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -234,7 +234,7 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 		}
 		if apiUTXO.Locktime > args.Time {
 			utxo.Out = &stakeable.LockOut{
-				Locktime:        uint64(apiUTXO.Locktime),
+				Locktime:        int64(apiUTXO.Locktime), // TODO fix
 				TransferableOut: utxo.Out.(avax.TransferableOut),
 			}
 		}
@@ -273,7 +273,7 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 			}
 			if apiUTXO.Locktime > args.Time {
 				utxo.Out = &stakeable.LockOut{
-					Locktime:        uint64(apiUTXO.Locktime),
+					Locktime:        int64(apiUTXO.Locktime), // TODO fix
 					TransferableOut: utxo.Out,
 				}
 			}
@@ -294,7 +294,7 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 		}
 
 		owner := &secp256k1fx.OutputOwners{
-			Locktime:  uint64(vdr.RewardOwner.Locktime),
+			Locktime:  int64(vdr.RewardOwner.Locktime), // TODO fix
 			Threshold: uint32(vdr.RewardOwner.Threshold),
 		}
 		for _, addrStr := range vdr.RewardOwner.Addresses {

--- a/vms/platformvm/block/abort_block.go
+++ b/vms/platformvm/block/abort_block.go
@@ -22,7 +22,7 @@ type BanffAbortBlock struct {
 }
 
 func (b *BanffAbortBlock) Timestamp() time.Time {
-	return time.Unix(int64(b.Time), 0)
+	return time.Unix(b.Time, 0)
 }
 
 func (b *BanffAbortBlock) Visit(v Visitor) error {

--- a/vms/platformvm/block/abort_block.go
+++ b/vms/platformvm/block/abort_block.go
@@ -17,7 +17,7 @@ var (
 )
 
 type BanffAbortBlock struct {
-	Time              uint64 `serialize:"true" json:"time"`
+	Time              int64 `serialize:"true" json:"time"`
 	ApricotAbortBlock `serialize:"true"`
 }
 
@@ -35,7 +35,7 @@ func NewBanffAbortBlock(
 	height uint64,
 ) (*BanffAbortBlock, error) {
 	blk := &BanffAbortBlock{
-		Time: uint64(timestamp.Unix()),
+		Time: timestamp.Unix(),
 		ApricotAbortBlock: ApricotAbortBlock{
 			CommonBlock: CommonBlock{
 				PrntID: parentID,

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -111,8 +111,8 @@ func TestBuildBlockShouldReward(t *testing.T) {
 	// Create a valid [AddValidatorTx]
 	tx, err := env.txBuilder.NewAddValidatorTx(
 		defaultValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		preFundedKeys[0].PublicKey().Address(),
 		reward.PercentDenominator,
@@ -301,8 +301,8 @@ func TestBuildBlockDropExpiredStakerTxs(t *testing.T) {
 
 	tx1, err := env.txBuilder.NewAddValidatorTx(
 		defaultValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		preFundedKeys[0].PublicKey().Address(),
 		reward.PercentDenominator,
@@ -320,8 +320,8 @@ func TestBuildBlockDropExpiredStakerTxs(t *testing.T) {
 
 	tx2, err := env.txBuilder.NewAddValidatorTx(
 		defaultValidatorStake,
-		uint64(validator2StartTime.Unix()),
-		uint64(validator2EndTime.Unix()),
+		validator2StartTime.Unix(),
+		validator2EndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		preFundedKeys[1].PublicKey().Address(),
 		reward.PercentDenominator,
@@ -339,8 +339,8 @@ func TestBuildBlockDropExpiredStakerTxs(t *testing.T) {
 
 	tx3, err := env.txBuilder.NewAddValidatorTx(
 		defaultValidatorStake,
-		uint64(validator3StartTime.Unix()),
-		uint64(validator3EndTime.Unix()),
+		validator3StartTime.Unix(),
+		validator3EndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		preFundedKeys[2].PublicKey().Address(),
 		reward.PercentDenominator,
@@ -400,8 +400,8 @@ func TestBuildBlockInvalidStakingDurations(t *testing.T) {
 
 	tx1, err := env.txBuilder.NewAddValidatorTx(
 		defaultValidatorStake,
-		uint64(now.Unix()),
-		uint64(validatorEndTime.Unix()),
+		now.Unix(),
+		validatorEndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		preFundedKeys[0].PublicKey().Address(),
 		reward.PercentDenominator,
@@ -418,8 +418,8 @@ func TestBuildBlockInvalidStakingDurations(t *testing.T) {
 
 	tx2, err := env.txBuilder.NewAddValidatorTx(
 		defaultValidatorStake,
-		uint64(now.Unix()),
-		uint64(validator2EndTime.Unix()),
+		now.Unix(),
+		validator2EndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		preFundedKeys[2].PublicKey().Address(),
 		reward.PercentDenominator,

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -382,8 +382,8 @@ func buildGenesisTest(t *testing.T, ctx *snow.Context) []byte {
 		require.NoError(err)
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
 			GenesisValidator: api.GenesisValidator{
-				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
-				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
+				StartTime: json.Int64(defaultValidateStartTime.Unix()),
+				EndTime:   json.Int64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,
 			},
 			RewardOwner: &api.Owner{
@@ -404,7 +404,7 @@ func buildGenesisTest(t *testing.T, ctx *snow.Context) []byte {
 		UTXOs:         genesisUTXOs,
 		Validators:    genesisValidators,
 		Chains:        nil,
-		Time:          json.Uint64(defaultGenesisTime.Unix()),
+		Time:          json.Int64(defaultGenesisTime.Unix()),
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
 		Encoding:      formatting.Hex,
 	}

--- a/vms/platformvm/block/commit_block.go
+++ b/vms/platformvm/block/commit_block.go
@@ -22,7 +22,7 @@ type BanffCommitBlock struct {
 }
 
 func (b *BanffCommitBlock) Timestamp() time.Time {
-	return time.Unix(int64(b.Time), 0)
+	return time.Unix(b.Time, 0)
 }
 
 func (b *BanffCommitBlock) Visit(v Visitor) error {

--- a/vms/platformvm/block/commit_block.go
+++ b/vms/platformvm/block/commit_block.go
@@ -17,7 +17,7 @@ var (
 )
 
 type BanffCommitBlock struct {
-	Time               uint64 `serialize:"true" json:"time"`
+	Time               int64 `serialize:"true" json:"time"`
 	ApricotCommitBlock `serialize:"true"`
 }
 
@@ -35,7 +35,7 @@ func NewBanffCommitBlock(
 	height uint64,
 ) (*BanffCommitBlock, error) {
 	blk := &BanffCommitBlock{
-		Time: uint64(timestamp.Unix()),
+		Time: timestamp.Unix(),
 		ApricotCommitBlock: ApricotCommitBlock{
 			CommonBlock: CommonBlock{
 				PrntID: parentID,

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -411,8 +411,8 @@ func buildGenesisTest(ctx *snow.Context) []byte {
 		}
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
 			GenesisValidator: api.GenesisValidator{
-				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
-				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
+				StartTime: json.Int64(defaultValidateStartTime.Unix()),
+				EndTime:   json.Int64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,
 			},
 			RewardOwner: &api.Owner{
@@ -433,7 +433,7 @@ func buildGenesisTest(ctx *snow.Context) []byte {
 		UTXOs:         genesisUTXOs,
 		Validators:    genesisValidators,
 		Chains:        nil,
-		Time:          json.Uint64(defaultGenesisTime.Unix()),
+		Time:          json.Int64(defaultGenesisTime.Unix()),
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
 		Encoding:      formatting.Hex,
 	}

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -489,8 +489,8 @@ func addPendingValidator(
 ) (*txs.Tx, error) {
 	addPendingValidatorTx, err := env.txBuilder.NewAddValidatorTx(
 		env.config.MinValidatorStake,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		nodeID,
 		rewardAddress,
 		reward.PercentDenominator,

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -63,7 +63,7 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 	// create a proposal transaction to be included into proposal block
 	utx := &txs.AddValidatorTx{
 		BaseTx:    txs.BaseTx{},
-		Validator: txs.Validator{End: uint64(chainTime.Unix())},
+		Validator: txs.Validator{End: int64(chainTime.Unix())},
 		StakeOuts: []*avax.TransferableOutput{
 			{
 				Asset: avax.Asset{
@@ -194,7 +194,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	nextStakerTime := chainTime.Add(executor.SyncBound).Add(-1 * time.Second)
 	unsignedNextStakerTx := &txs.AddValidatorTx{
 		BaseTx:    txs.BaseTx{},
-		Validator: txs.Validator{End: uint64(nextStakerTime.Unix())},
+		Validator: txs.Validator{End: int64(nextStakerTime.Unix())},
 		StakeOuts: []*avax.TransferableOutput{
 			{
 				Asset: avax.Asset{

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -580,8 +580,8 @@ func TestBanffProposalBlockUpdateStakers(t *testing.T) {
 			for _, staker := range test.stakers {
 				tx, err := env.txBuilder.NewAddValidatorTx(
 					env.config.MinValidatorStake,
-					uint64(staker.startTime.Unix()),
-					uint64(staker.endTime.Unix()),
+					staker.startTime.Unix(),
+					staker.endTime.Unix(),
 					staker.nodeID,
 					staker.rewardAddress,
 					reward.PercentDenominator,
@@ -604,8 +604,8 @@ func TestBanffProposalBlockUpdateStakers(t *testing.T) {
 			for _, subStaker := range test.subnetStakers {
 				tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 					10, // Weight
-					uint64(subStaker.startTime.Unix()),
-					uint64(subStaker.endTime.Unix()),
+					subStaker.startTime.Unix(),
+					subStaker.endTime.Unix(),
 					subStaker.nodeID, // validator ID
 					subnetID,         // Subnet ID
 					[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
@@ -632,8 +632,8 @@ func TestBanffProposalBlockUpdateStakers(t *testing.T) {
 				staker0.endTime = newTime
 				addStaker0, err := env.txBuilder.NewAddValidatorTx(
 					10,
-					uint64(staker0.startTime.Unix()),
-					uint64(staker0.endTime.Unix()),
+					staker0.startTime.Unix(),
+					staker0.endTime.Unix(),
 					staker0.nodeID,
 					staker0.rewardAddress,
 					reward.PercentDenominator,
@@ -735,11 +735,11 @@ func TestBanffProposalBlockRemoveSubnetValidator(t *testing.T) {
 	subnetVdr1StartTime := defaultValidateStartTime
 	subnetVdr1EndTime := defaultValidateStartTime.Add(defaultMinStakingDuration)
 	tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-		1,                                  // Weight
-		uint64(subnetVdr1StartTime.Unix()), // Start time
-		uint64(subnetVdr1EndTime.Unix()),   // end time
-		subnetValidatorNodeID,              // Node ID
-		subnetID,                           // Subnet ID
+		1,                          // Weight
+		subnetVdr1StartTime.Unix(), // Start time
+		subnetVdr1EndTime.Unix(),   // end time
+		subnetValidatorNodeID,      // Node ID
+		subnetID,                   // Subnet ID
 		[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
 		ids.ShortEmpty,
 	)
@@ -764,8 +764,8 @@ func TestBanffProposalBlockRemoveSubnetValidator(t *testing.T) {
 	subnetVdr2NodeID := genesisNodeIDs[1]
 	tx, err = env.txBuilder.NewAddSubnetValidatorTx(
 		1, // Weight
-		uint64(subnetVdr1EndTime.Add(time.Second).Unix()),                                // Start time
-		uint64(subnetVdr1EndTime.Add(time.Second).Add(defaultMinStakingDuration).Unix()), // end time
+		subnetVdr1EndTime.Add(time.Second).Unix(),                                // Start time
+		subnetVdr1EndTime.Add(time.Second).Add(defaultMinStakingDuration).Unix(), // end time
 		subnetVdr2NodeID, // Node ID
 		subnetID,         // Subnet ID
 		[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
@@ -794,8 +794,8 @@ func TestBanffProposalBlockRemoveSubnetValidator(t *testing.T) {
 	staker0EndTime := subnetVdr1EndTime
 	addStaker0, err := env.txBuilder.NewAddValidatorTx(
 		10,
-		uint64(staker0StartTime.Unix()),
-		uint64(staker0EndTime.Unix()),
+		staker0StartTime.Unix(),
+		staker0EndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -880,11 +880,11 @@ func TestBanffProposalBlockTrackedSubnet(t *testing.T) {
 			subnetVdr1StartTime := defaultGenesisTime.Add(1 * time.Minute)
 			subnetVdr1EndTime := defaultGenesisTime.Add(10 * defaultMinStakingDuration).Add(1 * time.Minute)
 			tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-				1,                                  // Weight
-				uint64(subnetVdr1StartTime.Unix()), // Start time
-				uint64(subnetVdr1EndTime.Unix()),   // end time
-				subnetValidatorNodeID,              // Node ID
-				subnetID,                           // Subnet ID
+				1,                          // Weight
+				subnetVdr1StartTime.Unix(), // Start time
+				subnetVdr1EndTime.Unix(),   // end time
+				subnetValidatorNodeID,      // Node ID
+				subnetID,                   // Subnet ID
 				[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
 				ids.ShortEmpty,
 			)
@@ -909,8 +909,8 @@ func TestBanffProposalBlockTrackedSubnet(t *testing.T) {
 			staker0EndTime := subnetVdr1StartTime
 			addStaker0, err := env.txBuilder.NewAddValidatorTx(
 				10,
-				uint64(staker0StartTime.Unix()),
-				uint64(staker0EndTime.Unix()),
+				staker0StartTime.Unix(),
+				staker0EndTime.Unix(),
 				ids.GenerateTestNodeID(),
 				ids.GenerateTestShortID(),
 				reward.PercentDenominator,
@@ -998,8 +998,8 @@ func TestBanffProposalBlockDelegatorStakerWeight(t *testing.T) {
 	staker0EndTime := pendingValidatorStartTime
 	addStaker0, err := env.txBuilder.NewAddValidatorTx(
 		10,
-		uint64(staker0StartTime.Unix()),
-		uint64(staker0EndTime.Unix()),
+		staker0StartTime.Unix(),
+		staker0EndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -1063,8 +1063,8 @@ func TestBanffProposalBlockDelegatorStakerWeight(t *testing.T) {
 
 	addDelegatorTx, err := env.txBuilder.NewAddDelegatorTx(
 		env.config.MinDelegatorStake,
-		uint64(pendingDelegatorStartTime.Unix()),
-		uint64(pendingDelegatorEndTime.Unix()),
+		pendingDelegatorStartTime.Unix(),
+		pendingDelegatorEndTime.Unix(),
 		nodeID,
 		preFundedKeys[0].PublicKey().Address(),
 		[]*secp256k1.PrivateKey{
@@ -1092,8 +1092,8 @@ func TestBanffProposalBlockDelegatorStakerWeight(t *testing.T) {
 	staker0EndTime = pendingDelegatorStartTime
 	addStaker0, err = env.txBuilder.NewAddValidatorTx(
 		10,
-		uint64(staker0StartTime.Unix()),
-		uint64(staker0EndTime.Unix()),
+		staker0StartTime.Unix(),
+		staker0EndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -1185,8 +1185,8 @@ func TestBanffProposalBlockDelegatorStakers(t *testing.T) {
 	staker0EndTime := pendingValidatorStartTime
 	addStaker0, err := env.txBuilder.NewAddValidatorTx(
 		10,
-		uint64(staker0StartTime.Unix()),
-		uint64(staker0EndTime.Unix()),
+		staker0StartTime.Unix(),
+		staker0EndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -1249,8 +1249,8 @@ func TestBanffProposalBlockDelegatorStakers(t *testing.T) {
 	pendingDelegatorEndTime := pendingDelegatorStartTime.Add(defaultMinStakingDuration)
 	addDelegatorTx, err := env.txBuilder.NewAddDelegatorTx(
 		env.config.MinDelegatorStake,
-		uint64(pendingDelegatorStartTime.Unix()),
-		uint64(pendingDelegatorEndTime.Unix()),
+		pendingDelegatorStartTime.Unix(),
+		pendingDelegatorEndTime.Unix(),
 		nodeID,
 		preFundedKeys[0].PublicKey().Address(),
 		[]*secp256k1.PrivateKey{
@@ -1278,8 +1278,8 @@ func TestBanffProposalBlockDelegatorStakers(t *testing.T) {
 	staker0EndTime = pendingDelegatorStartTime
 	addStaker0, err = env.txBuilder.NewAddValidatorTx(
 		10,
-		uint64(staker0StartTime.Unix()),
-		uint64(staker0EndTime.Unix()),
+		staker0StartTime.Unix(),
+		staker0EndTime.Unix(),
 		ids.GenerateTestNodeID(),
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -1358,8 +1358,8 @@ func TestAddValidatorProposalBlock(t *testing.T) {
 
 	addValidatorTx, err := env.txBuilder.NewAddValidatorTx(
 		env.config.MinValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		preFundedKeys[0].PublicKey().Address(),
 		10000,
@@ -1429,8 +1429,8 @@ func TestAddValidatorProposalBlock(t *testing.T) {
 
 	addValidatorTx2, err := env.txBuilder.NewAddValidatorTx(
 		env.config.MinValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		preFundedKeys[0].PublicKey().Address(),
 		10000,

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -339,7 +339,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 		// wrong tx content (no advance time txs)
 		invalidTx := &txs.Tx{
 			Unsigned: &txs.AdvanceTimeTx{
-				Time: uint64(nextStakerTime.Unix()),
+				Time: nextStakerTime.Unix(),
 			},
 		}
 		require.NoError(invalidTx.Initialize(txs.Codec))

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -526,8 +526,8 @@ func TestBanffStandardBlockUpdateStakers(t *testing.T) {
 			for _, staker := range test.subnetStakers {
 				tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 					10, // Weight
-					uint64(staker.startTime.Unix()),
-					uint64(staker.endTime.Unix()),
+					staker.startTime.Unix(),
+					staker.endTime.Unix(),
 					staker.nodeID, // validator ID
 					subnetID,      // Subnet ID
 					[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
@@ -618,11 +618,11 @@ func TestBanffStandardBlockRemoveSubnetValidator(t *testing.T) {
 	subnetVdr1StartTime := defaultValidateStartTime
 	subnetVdr1EndTime := defaultValidateStartTime.Add(defaultMinStakingDuration)
 	tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-		1,                                  // Weight
-		uint64(subnetVdr1StartTime.Unix()), // Start time
-		uint64(subnetVdr1EndTime.Unix()),   // end time
-		subnetValidatorNodeID,              // Node ID
-		subnetID,                           // Subnet ID
+		1,                          // Weight
+		subnetVdr1StartTime.Unix(), // Start time
+		subnetVdr1EndTime.Unix(),   // end time
+		subnetValidatorNodeID,      // Node ID
+		subnetID,                   // Subnet ID
 		[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
 		ids.ShortEmpty,
 	)
@@ -647,8 +647,8 @@ func TestBanffStandardBlockRemoveSubnetValidator(t *testing.T) {
 	subnetVdr2NodeID := genesisNodeIDs[1]
 	tx, err = env.txBuilder.NewAddSubnetValidatorTx(
 		1, // Weight
-		uint64(subnetVdr1EndTime.Add(time.Second).Unix()),                                // Start time
-		uint64(subnetVdr1EndTime.Add(time.Second).Add(defaultMinStakingDuration).Unix()), // end time
+		subnetVdr1EndTime.Add(time.Second).Unix(),                                // Start time
+		subnetVdr1EndTime.Add(time.Second).Add(defaultMinStakingDuration).Unix(), // end time
 		subnetVdr2NodeID, // Node ID
 		subnetID,         // Subnet ID
 		[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
@@ -719,11 +719,11 @@ func TestBanffStandardBlockTrackedSubnet(t *testing.T) {
 			subnetVdr1StartTime := defaultGenesisTime.Add(1 * time.Minute)
 			subnetVdr1EndTime := defaultGenesisTime.Add(10 * defaultMinStakingDuration).Add(1 * time.Minute)
 			tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-				1,                                  // Weight
-				uint64(subnetVdr1StartTime.Unix()), // Start time
-				uint64(subnetVdr1EndTime.Unix()),   // end time
-				subnetValidatorNodeID,              // Node ID
-				subnetID,                           // Subnet ID
+				1,                          // Weight
+				subnetVdr1StartTime.Unix(), // Start time
+				subnetVdr1EndTime.Unix(),   // end time
+				subnetValidatorNodeID,      // Node ID
+				subnetID,                   // Subnet ID
 				[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
 				ids.ShortEmpty,
 			)
@@ -814,8 +814,8 @@ func TestBanffStandardBlockDelegatorStakerWeight(t *testing.T) {
 
 	addDelegatorTx, err := env.txBuilder.NewAddDelegatorTx(
 		env.config.MinDelegatorStake,
-		uint64(pendingDelegatorStartTime.Unix()),
-		uint64(pendingDelegatorEndTime.Unix()),
+		pendingDelegatorStartTime.Unix(),
+		pendingDelegatorEndTime.Unix(),
 		nodeID,
 		preFundedKeys[0].PublicKey().Address(),
 		[]*secp256k1.PrivateKey{

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -48,7 +48,7 @@ func (b *BanffProposalBlock) InitCtx(ctx *snow.Context) {
 }
 
 func (b *BanffProposalBlock) Timestamp() time.Time {
-	return time.Unix(int64(b.Time), 0)
+	return time.Unix(b.Time, 0)
 }
 
 func (b *BanffProposalBlock) Txs() []*txs.Tx {

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -18,7 +18,7 @@ var (
 )
 
 type BanffProposalBlock struct {
-	Time uint64 `serialize:"true" json:"time"`
+	Time int64 `serialize:"true" json:"time"`
 	// Transactions is currently unused. This is populated so that introducing
 	// them in the future will not require a codec change.
 	//
@@ -72,7 +72,7 @@ func NewBanffProposalBlock(
 ) (*BanffProposalBlock, error) {
 	blk := &BanffProposalBlock{
 		Transactions: decisionTxs,
-		Time:         uint64(timestamp.Unix()),
+		Time:         timestamp.Unix(),
 		ApricotProposalBlock: ApricotProposalBlock{
 			CommonBlock: CommonBlock{
 				PrntID: parentID,

--- a/vms/platformvm/block/standard_block.go
+++ b/vms/platformvm/block/standard_block.go
@@ -23,7 +23,7 @@ type BanffStandardBlock struct {
 }
 
 func (b *BanffStandardBlock) Timestamp() time.Time {
-	return time.Unix(int64(b.Time), 0)
+	return time.Unix(b.Time, 0)
 }
 
 func (b *BanffStandardBlock) Visit(v Visitor) error {

--- a/vms/platformvm/block/standard_block.go
+++ b/vms/platformvm/block/standard_block.go
@@ -18,7 +18,7 @@ var (
 )
 
 type BanffStandardBlock struct {
-	Time                 uint64 `serialize:"true" json:"time"`
+	Time                 int64 `serialize:"true" json:"time"`
 	ApricotStandardBlock `serialize:"true"`
 }
 
@@ -37,7 +37,7 @@ func NewBanffStandardBlock(
 	txs []*txs.Tx,
 ) (*BanffStandardBlock, error) {
 	blk := &BanffStandardBlock{
-		Time: uint64(timestamp.Unix()),
+		Time: timestamp.Unix(),
 		ApricotStandardBlock: ApricotStandardBlock{
 			CommonBlock: CommonBlock{
 				PrntID: parentID,

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -94,9 +94,9 @@ type Client interface {
 		changeAddr ids.ShortID,
 		rewardAddress ids.ShortID,
 		nodeID ids.NodeID,
-		stakeAmount,
+		stakeAmount uint64,
 		startTime,
-		endTime uint64,
+		endTime int64,
 		delegationFeeRate float32,
 		options ...rpc.Option,
 	) (ids.ID, error)
@@ -112,9 +112,9 @@ type Client interface {
 		changeAddr ids.ShortID,
 		rewardAddress ids.ShortID,
 		nodeID ids.NodeID,
-		stakeAmount,
+		stakeAmount uint64,
 		startTime,
-		endTime uint64,
+		endTime int64,
 		options ...rpc.Option,
 	) (ids.ID, error)
 	// AddSubnetValidator issues a transaction to add validator [nodeID] to subnet
@@ -129,9 +129,9 @@ type Client interface {
 		changeAddr ids.ShortID,
 		subnetID ids.ID,
 		nodeID ids.NodeID,
-		stakeAmount,
+		stakeAmount uint64,
 		startTime,
-		endTime uint64,
+		endTime int64,
 		options ...rpc.Option,
 	) (ids.ID, error)
 	// CreateSubnet issues a transaction to create [subnet] and returns the txID
@@ -241,8 +241,8 @@ type Client interface {
 		ctx context.Context,
 		subnetID ids.ID,
 		nodeID ids.NodeID,
-		startTime uint64,
-		endTime uint64,
+		startTime int64,
+		endTime int64,
 		options ...rpc.Option,
 	) (uint64, error)
 	// GetRewardUTXOs returns the reward UTXOs for a transaction
@@ -479,9 +479,9 @@ func (c *client) AddValidator(
 	changeAddr ids.ShortID,
 	rewardAddress ids.ShortID,
 	nodeID ids.NodeID,
-	stakeAmount,
+	stakeAmount uint64,
 	startTime,
-	endTime uint64,
+	endTime int64,
 	delegationFeeRate float32,
 	options ...rpc.Option,
 ) (ids.ID, error) {
@@ -497,8 +497,8 @@ func (c *client) AddValidator(
 			NodeID:      nodeID,
 			Weight:      jsonStakeAmount,
 			StakeAmount: &jsonStakeAmount,
-			StartTime:   json.Uint64(startTime),
-			EndTime:     json.Uint64(endTime),
+			StartTime:   json.Int64(startTime),
+			EndTime:     json.Int64(endTime),
 		},
 		RewardAddress:     rewardAddress.String(),
 		DelegationFeeRate: json.Float32(delegationFeeRate),
@@ -513,9 +513,9 @@ func (c *client) AddDelegator(
 	changeAddr ids.ShortID,
 	rewardAddress ids.ShortID,
 	nodeID ids.NodeID,
-	stakeAmount,
+	stakeAmount uint64,
 	startTime,
-	endTime uint64,
+	endTime int64,
 	options ...rpc.Option,
 ) (ids.ID, error) {
 	res := &api.JSONTxID{}
@@ -530,8 +530,8 @@ func (c *client) AddDelegator(
 			NodeID:      nodeID,
 			Weight:      jsonStakeAmount,
 			StakeAmount: &jsonStakeAmount,
-			StartTime:   json.Uint64(startTime),
-			EndTime:     json.Uint64(endTime),
+			StartTime:   json.Int64(startTime),
+			EndTime:     json.Int64(endTime),
 		},
 		RewardAddress: rewardAddress.String(),
 	}, res, options...)
@@ -545,9 +545,9 @@ func (c *client) AddSubnetValidator(
 	changeAddr ids.ShortID,
 	subnetID ids.ID,
 	nodeID ids.NodeID,
-	stakeAmount,
+	stakeAmount uint64,
 	startTime,
-	endTime uint64,
+	endTime int64,
 	options ...rpc.Option,
 ) (ids.ID, error) {
 	res := &api.JSONTxID{}
@@ -562,8 +562,8 @@ func (c *client) AddSubnetValidator(
 			NodeID:      nodeID,
 			Weight:      jsonStakeAmount,
 			StakeAmount: &jsonStakeAmount,
-			StartTime:   json.Uint64(startTime),
-			EndTime:     json.Uint64(endTime),
+			StartTime:   json.Int64(startTime),
+			EndTime:     json.Int64(endTime),
 		},
 		SubnetID: subnetID.String(),
 	}, res, options...)
@@ -821,13 +821,13 @@ func (c *client) GetTotalStake(ctx context.Context, subnetID ids.ID, options ...
 	return uint64(amount), err
 }
 
-func (c *client) GetMaxStakeAmount(ctx context.Context, subnetID ids.ID, nodeID ids.NodeID, startTime, endTime uint64, options ...rpc.Option) (uint64, error) {
+func (c *client) GetMaxStakeAmount(ctx context.Context, subnetID ids.ID, nodeID ids.NodeID, startTime, endTime int64, options ...rpc.Option) (uint64, error) {
 	res := &GetMaxStakeAmountReply{}
 	err := c.requester.SendRequest(ctx, "platform.getMaxStakeAmount", &GetMaxStakeAmountArgs{
 		SubnetID:  subnetID,
 		NodeID:    nodeID,
-		StartTime: json.Uint64(startTime),
-		EndTime:   json.Uint64(endTime),
+		StartTime: json.Int64(startTime),
+		EndTime:   json.Int64(endTime),
 	}, res, options...)
 	return uint64(res.Amount), err
 }

--- a/vms/platformvm/client_permissionless_validator.go
+++ b/vms/platformvm/client_permissionless_validator.go
@@ -30,7 +30,7 @@ type ClientStaker struct {
 
 // ClientOwner is the repr. of a reward owner sent over client
 type ClientOwner struct {
-	Locktime  uint64
+	Locktime  int64
 	Threshold uint32
 	Addresses []ids.ShortID
 }
@@ -78,7 +78,7 @@ func apiOwnerToClientOwner(rewardOwner *api.Owner) (*ClientOwner, error) {
 
 	addrs, err := address.ParseToIDs(rewardOwner.Addresses)
 	return &ClientOwner{
-		Locktime:  uint64(rewardOwner.Locktime),
+		Locktime:  int64(rewardOwner.Locktime),
 		Threshold: uint32(rewardOwner.Threshold),
 		Addresses: addrs,
 	}, err

--- a/vms/platformvm/client_permissionless_validator.go
+++ b/vms/platformvm/client_permissionless_validator.go
@@ -17,9 +17,9 @@ type ClientStaker struct {
 	// the txID of the transaction that added this staker.
 	TxID ids.ID
 	// the Unix time when they start staking
-	StartTime uint64
+	StartTime int64
 	// the Unix time when they are done staking
-	EndTime uint64
+	EndTime int64
 	// the validator weight when sampling validators
 	Weight uint64
 	// the amount of tokens being staked.
@@ -63,8 +63,8 @@ type ClientDelegator struct {
 func apiStakerToClientStaker(validator api.Staker) ClientStaker {
 	return ClientStaker{
 		TxID:        validator.TxID,
-		StartTime:   uint64(validator.StartTime),
-		EndTime:     uint64(validator.EndTime),
+		StartTime:   int64(validator.StartTime), // TODO
+		EndTime:     int64(validator.EndTime),   // TODO
 		Weight:      uint64(validator.Weight),
 		StakeAmount: (*uint64)(validator.StakeAmount),
 		NodeID:      validator.NodeID,

--- a/vms/platformvm/genesis/genesis.go
+++ b/vms/platformvm/genesis/genesis.go
@@ -19,7 +19,7 @@ type Genesis struct {
 	UTXOs         []*UTXO   `serialize:"true"`
 	Validators    []*txs.Tx `serialize:"true"`
 	Chains        []*txs.Tx `serialize:"true"`
-	Timestamp     uint64    `serialize:"true"`
+	Timestamp     int64     `serialize:"true"`
 	InitialSupply uint64    `serialize:"true"`
 	Message       string    `serialize:"true"`
 }

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1267,8 +1267,8 @@ func (s *Service) AddValidator(req *http.Request, args *AddValidatorArgs, reply 
 	// Create the transaction
 	tx, err := s.vm.txBuilder.NewAddValidatorTx(
 		uint64(args.Weight),                  // Stake amount
-		uint64(args.StartTime),               // Start time
-		uint64(args.EndTime),                 // End time
+		int64(args.StartTime),                // TODO                       // Start time
+		int64(args.EndTime),                  // TODO                      // End time
 		nodeID,                               // Node ID
 		rewardAddress,                        // Reward Address
 		uint32(10000*args.DelegationFeeRate), // Shares
@@ -1377,13 +1377,13 @@ func (s *Service) AddDelegator(req *http.Request, args *AddDelegatorArgs, reply 
 
 	// Create the transaction
 	tx, err := s.vm.txBuilder.NewAddDelegatorTx(
-		uint64(args.Weight),    // Stake amount
-		uint64(args.StartTime), // Start time
-		uint64(args.EndTime),   // End time
-		nodeID,                 // Node ID
-		rewardAddress,          // Reward Address
-		privKeys.Keys,          // Private keys
-		changeAddr,             // Change address
+		uint64(args.Weight),   // Stake amount
+		int64(args.StartTime), // TODO // Start time
+		int64(args.EndTime),   // TODO // End time
+		nodeID,                // Node ID
+		rewardAddress,         // Reward Address
+		privKeys.Keys,         // Private keys
+		changeAddr,            // Change address
 	)
 	if err != nil {
 		return fmt.Errorf("couldn't create tx: %w", err)
@@ -1483,11 +1483,11 @@ func (s *Service) AddSubnetValidator(req *http.Request, args *AddSubnetValidator
 
 	// Create the transaction
 	tx, err := s.vm.txBuilder.NewAddSubnetValidatorTx(
-		uint64(args.Weight),    // Stake amount
-		uint64(args.StartTime), // Start time
-		uint64(args.EndTime),   // End time
-		args.NodeID,            // Node ID
-		subnetID,               // Subnet ID
+		uint64(args.Weight),   // Stake amount
+		int64(args.StartTime), // TODO // Start time
+		int64(args.EndTime),   // TODO // End time
+		args.NodeID,           // Node ID
+		subnetID,              // Subnet ID
 		keys.Keys,
 		changeAddr,
 	)

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -835,8 +835,8 @@ func (s *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentValidato
 		weight := json.Uint64(currentStaker.Weight)
 		apiStaker := platformapi.Staker{
 			TxID:        currentStaker.TxID,
-			StartTime:   json.Uint64(currentStaker.StartTime.Unix()),
-			EndTime:     json.Uint64(currentStaker.EndTime.Unix()),
+			StartTime:   json.Int64(currentStaker.StartTime.Unix()),
+			EndTime:     json.Int64(currentStaker.EndTime.Unix()),
 			Weight:      weight,
 			StakeAmount: &weight,
 			NodeID:      nodeID,
@@ -1051,8 +1051,8 @@ func (s *Service) GetPendingValidators(_ *http.Request, args *GetPendingValidato
 		apiStaker := platformapi.Staker{
 			TxID:        pendingStaker.TxID,
 			NodeID:      nodeID,
-			StartTime:   json.Uint64(pendingStaker.StartTime.Unix()),
-			EndTime:     json.Uint64(pendingStaker.EndTime.Unix()),
+			StartTime:   json.Int64(pendingStaker.StartTime.Unix()),
+			EndTime:     json.Int64(pendingStaker.EndTime.Unix()),
 			Weight:      weight,
 			StakeAmount: &weight,
 		}
@@ -1193,9 +1193,9 @@ func (s *Service) AddValidator(req *http.Request, args *AddValidatorArgs, reply 
 
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
-	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
+	minAddStakerUnix := json.Int64(minAddStakerTime.Unix())
 	maxAddStakerTime := now.Add(executor.MaxFutureStartTime)
-	maxAddStakerUnix := json.Uint64(maxAddStakerTime.Unix())
+	maxAddStakerUnix := json.Int64(maxAddStakerTime.Unix())
 
 	if args.StartTime == 0 {
 		args.StartTime = minAddStakerUnix
@@ -1307,9 +1307,9 @@ func (s *Service) AddDelegator(req *http.Request, args *AddDelegatorArgs, reply 
 
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
-	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
+	minAddStakerUnix := json.Int64(minAddStakerTime.Unix())
 	maxAddStakerTime := now.Add(executor.MaxFutureStartTime)
-	maxAddStakerUnix := json.Uint64(maxAddStakerTime.Unix())
+	maxAddStakerUnix := json.Int64(maxAddStakerTime.Unix())
 
 	if args.StartTime == 0 {
 		args.StartTime = minAddStakerUnix
@@ -1418,9 +1418,9 @@ func (s *Service) AddSubnetValidator(req *http.Request, args *AddSubnetValidator
 
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
-	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
+	minAddStakerUnix := json.Int64(minAddStakerTime.Unix())
 	maxAddStakerTime := now.Add(executor.MaxFutureStartTime)
-	maxAddStakerUnix := json.Uint64(maxAddStakerTime.Unix())
+	maxAddStakerUnix := json.Int64(maxAddStakerTime.Unix())
 
 	if args.StartTime == 0 {
 		args.StartTime = minAddStakerUnix
@@ -2472,10 +2472,10 @@ func (s *Service) GetTotalStake(_ *http.Request, args *GetTotalStakeArgs, reply 
 
 // GetMaxStakeAmountArgs is the request for calling GetMaxStakeAmount.
 type GetMaxStakeAmountArgs struct {
-	SubnetID  ids.ID      `json:"subnetID"`
-	NodeID    ids.NodeID  `json:"nodeID"`
-	StartTime json.Uint64 `json:"startTime"`
-	EndTime   json.Uint64 `json:"endTime"`
+	SubnetID  ids.ID     `json:"subnetID"`
+	NodeID    ids.NodeID `json:"nodeID"`
+	StartTime json.Int64 `json:"startTime"`
+	EndTime   json.Int64 `json:"endTime"`
 }
 
 // GetMaxStakeAmountReply is the response from calling GetMaxStakeAmount.
@@ -2775,7 +2775,7 @@ func (s *Service) getAPIUptime(staker *state.Staker) (*json.Float32, error) {
 
 func (s *Service) getAPIOwner(owner *secp256k1fx.OutputOwners) (*platformapi.Owner, error) {
 	apiOwner := &platformapi.Owner{
-		Locktime:  json.Uint64(owner.Locktime),
+		Locktime:  json.Int64(owner.Locktime),
 		Threshold: json.Uint32(owner.Threshold),
 		Addresses: make([]string, 0, len(owner.Addrs)),
 	}

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -288,8 +288,8 @@ func TestGetTx(t *testing.T) {
 			func(service *Service) (*txs.Tx, error) {
 				return service.vm.txBuilder.NewAddValidatorTx( // Test GetTx works for proposal blocks
 					service.vm.MinValidatorStake,
-					uint64(service.vm.clock.Time().Add(txexecutor.SyncBound).Unix()),
-					uint64(service.vm.clock.Time().Add(txexecutor.SyncBound).Add(defaultMinStakingDuration).Unix()),
+					service.vm.clock.Time().Add(txexecutor.SyncBound).Unix(),
+					service.vm.clock.Time().Add(txexecutor.SyncBound).Add(defaultMinStakingDuration).Unix(),
 					ids.GenerateTestNodeID(),
 					ids.GenerateTestShortID(),
 					0,
@@ -504,8 +504,8 @@ func TestGetStake(t *testing.T) {
 	delegatorEndTime := defaultGenesisTime.Add(defaultMinStakingDuration)
 	tx, err := service.vm.txBuilder.NewAddDelegatorTx(
 		stakeAmount,
-		uint64(delegatorStartTime.Unix()),
-		uint64(delegatorEndTime.Unix()),
+		delegatorStartTime.Unix(),
+		delegatorEndTime.Unix(),
 		delegatorNodeID,
 		ids.GenerateTestShortID(),
 		[]*secp256k1.PrivateKey{keys[0]},
@@ -555,10 +555,10 @@ func TestGetStake(t *testing.T) {
 	// Add a pending staker
 	stakeAmount = service.vm.MinValidatorStake + 54321
 	pendingStakerNodeID := ids.GenerateTestNodeID()
-	pendingStakerEndTime := uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix())
+	pendingStakerEndTime := defaultGenesisTime.Add(defaultMinStakingDuration).Unix()
 	tx, err = service.vm.txBuilder.NewAddValidatorTx(
 		stakeAmount,
-		uint64(defaultGenesisTime.Unix()),
+		defaultGenesisTime.Unix(),
 		pendingStakerEndTime,
 		pendingStakerNodeID,
 		ids.GenerateTestShortID(),
@@ -642,8 +642,8 @@ func TestGetCurrentValidators(t *testing.T) {
 
 	delTx, err := service.vm.txBuilder.NewAddDelegatorTx(
 		stakeAmount,
-		uint64(delegatorStartTime.Unix()),
-		uint64(delegatorEndTime.Unix()),
+		delegatorStartTime.Unix(),
+		delegatorEndTime.Unix(),
 		validatorNodeID,
 		ids.GenerateTestShortID(),
 		[]*secp256k1.PrivateKey{keys[0]},

--- a/vms/platformvm/stakeable/stakeable_lock.go
+++ b/vms/platformvm/stakeable/stakeable_lock.go
@@ -15,7 +15,7 @@ var (
 )
 
 type LockOut struct {
-	Locktime             uint64 `serialize:"true" json:"locktime"`
+	Locktime             int64 `serialize:"true" json:"locktime"`
 	avax.TransferableOut `serialize:"true" json:"output"`
 }
 
@@ -37,7 +37,7 @@ func (s *LockOut) Verify() error {
 }
 
 type LockIn struct {
-	Locktime            uint64 `serialize:"true" json:"locktime"`
+	Locktime            int64 `serialize:"true" json:"locktime"`
 	avax.TransferableIn `serialize:"true" json:"input"`
 }
 

--- a/vms/platformvm/stakeable/stakeable_lock_test.go
+++ b/vms/platformvm/stakeable/stakeable_lock_test.go
@@ -19,7 +19,7 @@ var errTest = errors.New("hi mom")
 func TestLockOutVerify(t *testing.T) {
 	tests := []struct {
 		name             string
-		locktime         uint64
+		locktime         int64
 		transferableOutF func(*gomock.Controller) avax.TransferableOut
 		expectedErr      error
 	}{
@@ -77,7 +77,7 @@ func TestLockOutVerify(t *testing.T) {
 func TestLockInVerify(t *testing.T) {
 	tests := []struct {
 		name            string
-		locktime        uint64
+		locktime        int64
 		transferableInF func(*gomock.Controller) avax.TransferableIn
 		expectedErr     error
 	}{

--- a/vms/platformvm/state/metadata_delegator.go
+++ b/vms/platformvm/state/metadata_delegator.go
@@ -10,7 +10,7 @@ import (
 
 type delegatorMetadata struct {
 	PotentialReward uint64 `v1:"true"`
-	StakerStartTime uint64 `v1:"true"`
+	StakerStartTime int64  `v1:"true"`
 
 	txID ids.ID
 }

--- a/vms/platformvm/state/metadata_validator.go
+++ b/vms/platformvm/state/metadata_validator.go
@@ -23,16 +23,16 @@ var _ validatorState = (*metadata)(nil)
 
 type preDelegateeRewardMetadata struct {
 	UpDuration      time.Duration `v0:"true"`
-	LastUpdated     uint64        `v0:"true"` // Unix time in seconds
+	LastUpdated     int64         `v0:"true"` // Unix time in seconds
 	PotentialReward uint64        `v0:"true"`
 }
 
 type validatorMetadata struct {
 	UpDuration               time.Duration `v0:"true"`
-	LastUpdated              uint64        `v0:"true"` // Unix time in seconds
+	LastUpdated              int64         `v0:"true"` // Unix time in seconds
 	PotentialReward          uint64        `v0:"true"`
 	PotentialDelegateeReward uint64        `v0:"true"`
-	StakerStartTime          uint64        `          v1:"true"`
+	StakerStartTime          int64         `          v1:"true"`
 
 	txID        ids.ID
 	lastUpdated time.Time
@@ -72,7 +72,7 @@ func parseValidatorMetadata(bytes []byte, metadata *validatorMetadata) error {
 			return err
 		}
 	}
-	metadata.lastUpdated = time.Unix(int64(metadata.LastUpdated), 0)
+	metadata.lastUpdated = time.Unix(metadata.LastUpdated, 0)
 	return nil
 }
 
@@ -237,7 +237,7 @@ func (m *metadata) WriteValidatorMetadata(
 	for vdrID, updatedSubnets := range m.updatedMetadata {
 		for subnetID := range updatedSubnets {
 			metadata := m.metadata[vdrID][subnetID]
-			metadata.LastUpdated = uint64(metadata.lastUpdated.Unix())
+			metadata.LastUpdated = metadata.lastUpdated.Unix()
 
 			metadataBytes, err := metadataCodec.Marshal(codecVersion, metadata)
 			if err != nil {

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1310,7 +1310,7 @@ func (s *state) ApplyValidatorPublicKeyDiffs(
 func (s *state) syncGenesis(genesisBlk block.Block, genesis *genesis.Genesis) error {
 	genesisBlkID := genesisBlk.ID()
 	s.SetLastAccepted(genesisBlkID)
-	s.SetTimestamp(time.Unix(int64(genesis.Timestamp), 0))
+	s.SetTimestamp(time.Unix(genesis.Timestamp, 0))
 	s.SetCurrentSupply(constants.PrimaryNetworkID, genesis.InitialSupply)
 	s.AddStatelessBlock(genesisBlk)
 
@@ -1475,7 +1475,7 @@ func (s *state) loadCurrentValidators() error {
 			//
 			// Note: We do not populate [LastUpdated] since it is expected to
 			// always be present on disk.
-			metadata.StakerStartTime = uint64(scheduledStakerTx.StartTime().Unix())
+			metadata.StakerStartTime = scheduledStakerTx.StartTime().Unix()
 		}
 		if err := parseValidatorMetadata(metadataBytes, metadata); err != nil {
 			return err
@@ -1484,7 +1484,7 @@ func (s *state) loadCurrentValidators() error {
 		staker, err := NewCurrentStaker(
 			txID,
 			stakerTx,
-			time.Unix(int64(metadata.StakerStartTime), 0),
+			time.Unix(metadata.StakerStartTime, 0),
 			metadata.PotentialReward)
 		if err != nil {
 			return err
@@ -1523,7 +1523,7 @@ func (s *state) loadCurrentValidators() error {
 		if scheduledStakerTx, ok := tx.Unsigned.(txs.ScheduledStaker); ok {
 			// Populate [StakerStartTime] and [LastUpdated] using the tx as a
 			// default in the event they are not stored in the database.
-			startTime := uint64(scheduledStakerTx.StartTime().Unix())
+			startTime := scheduledStakerTx.StartTime().Unix()
 			metadata.StakerStartTime = startTime
 			metadata.LastUpdated = startTime
 		}
@@ -1534,7 +1534,7 @@ func (s *state) loadCurrentValidators() error {
 		staker, err := NewCurrentStaker(
 			txID,
 			stakerTx,
-			time.Unix(int64(metadata.StakerStartTime), 0),
+			time.Unix(metadata.StakerStartTime, 0),
 			metadata.PotentialReward,
 		)
 		if err != nil {
@@ -1579,7 +1579,7 @@ func (s *state) loadCurrentValidators() error {
 				// Populate [StakerStartTime] using the tx as a default in the
 				// event it was added pre-durango and is not stored in the
 				// database.
-				metadata.StakerStartTime = uint64(scheduledStakerTx.StartTime().Unix())
+				metadata.StakerStartTime = scheduledStakerTx.StartTime().Unix()
 			}
 			err = parseDelegatorMetadata(metadataBytes, metadata)
 			if err != nil {
@@ -1589,7 +1589,7 @@ func (s *state) loadCurrentValidators() error {
 			staker, err := NewCurrentStaker(
 				txID,
 				stakerTx,
-				time.Unix(int64(metadata.StakerStartTime), 0),
+				time.Unix(metadata.StakerStartTime, 0),
 				metadata.PotentialReward,
 			)
 			if err != nil {
@@ -2029,7 +2029,7 @@ func (s *state) writeCurrentStakers(updateValidators bool, height uint64, codecV
 				//
 				// Invariant: It's impossible for a delegator to have been
 				// rewarded in the same block that the validator was added.
-				startTime := uint64(staker.StartTime.Unix())
+				startTime := staker.StartTime.Unix()
 				metadata := &validatorMetadata{
 					txID:        staker.TxID,
 					lastUpdated: staker.StartTime,
@@ -2184,7 +2184,7 @@ func writeCurrentDelegatorDiff(
 		metadata := &delegatorMetadata{
 			txID:            staker.TxID,
 			PotentialReward: staker.PotentialReward,
-			StakerStartTime: uint64(staker.StartTime.Unix()),
+			StakerStartTime: staker.StartTime.Unix(),
 		}
 		if err := writeDelegatorMetadata(currentDelegatorList, metadata, codecVersion); err != nil {
 			return fmt.Errorf("failed to write current delegator to list: %w", err)

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -94,8 +94,8 @@ func newInitializedState(require *require.Assertions) (State, database.Database)
 	initialValidator := &txs.AddValidatorTx{
 		Validator: txs.Validator{
 			NodeID: initialNodeID,
-			Start:  uint64(initialTime.Unix()),
-			End:    uint64(initialValidatorEndTime.Unix()),
+			Start:  initialTime.Unix(),
+			End:    initialValidatorEndTime.Unix(),
 			Wght:   units.Avax,
 		},
 		StakeOuts: []*avax.TransferableOutput{

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -144,7 +144,7 @@ func newInitializedState(require *require.Assertions) (State, database.Database)
 		Chains: []*txs.Tx{
 			initialChainTx,
 		},
-		Timestamp:     uint64(initialTime.Unix()),
+		Timestamp:     initialTime.Unix(),
 		InitialSupply: units.Schmeckle + units.Avax,
 	}
 

--- a/vms/platformvm/txs/add_delegator_test.go
+++ b/vms/platformvm/txs/add_delegator_test.go
@@ -66,7 +66,7 @@ func TestAddDelegatorTxSyntacticVerify(t *testing.T) {
 	stakes := []*avax.TransferableOutput{{
 		Asset: avax.Asset{ID: ctx.AVAXAssetID},
 		Out: &stakeable.LockOut{
-			Locktime: uint64(clk.Time().Add(time.Second).Unix()),
+			Locktime: clk.Time().Add(time.Second).Unix(),
 			TransferableOut: &secp256k1fx.TransferOutput{
 				Amt: validatorWeight,
 				OutputOwners: secp256k1fx.OutputOwners{
@@ -166,7 +166,7 @@ func TestAddDelegatorTxSyntacticVerifyNotAVAX(t *testing.T) {
 	stakes := []*avax.TransferableOutput{{
 		Asset: avax.Asset{ID: assetID},
 		Out: &stakeable.LockOut{
-			Locktime: uint64(clk.Time().Add(time.Second).Unix()),
+			Locktime: clk.Time().Add(time.Second).Unix(),
 			TransferableOut: &secp256k1fx.TransferOutput{
 				Amt: validatorWeight,
 				OutputOwners: secp256k1fx.OutputOwners{

--- a/vms/platformvm/txs/add_delegator_test.go
+++ b/vms/platformvm/txs/add_delegator_test.go
@@ -86,8 +86,8 @@ func TestAddDelegatorTxSyntacticVerify(t *testing.T) {
 		}},
 		Validator: Validator{
 			NodeID: ctx.NodeID,
-			Start:  uint64(clk.Time().Unix()),
-			End:    uint64(clk.Time().Add(time.Hour).Unix()),
+			Start:  clk.Time().Unix(),
+			End:    clk.Time().Add(time.Hour).Unix(),
 			Wght:   validatorWeight,
 		},
 		StakeOuts: stakes,
@@ -186,8 +186,8 @@ func TestAddDelegatorTxSyntacticVerifyNotAVAX(t *testing.T) {
 		}},
 		Validator: Validator{
 			NodeID: ctx.NodeID,
-			Start:  uint64(clk.Time().Unix()),
-			End:    uint64(clk.Time().Add(time.Hour).Unix()),
+			Start:  clk.Time().Unix(),
+			End:    clk.Time().Add(time.Hour).Unix(),
 			Wght:   validatorWeight,
 		},
 		StakeOuts: stakes,

--- a/vms/platformvm/txs/add_subnet_validator_test.go
+++ b/vms/platformvm/txs/add_subnet_validator_test.go
@@ -76,8 +76,8 @@ func TestAddSubnetValidatorTxSyntacticVerify(t *testing.T) {
 		SubnetValidator: SubnetValidator{
 			Validator: Validator{
 				NodeID: ctx.NodeID,
-				Start:  uint64(clk.Time().Unix()),
-				End:    uint64(clk.Time().Add(time.Hour).Unix()),
+				Start:  clk.Time().Unix(),
+				End:    clk.Time().Add(time.Hour).Unix(),
 				Wght:   validatorWeight,
 			},
 			Subnet: subnetID,
@@ -187,8 +187,8 @@ func TestAddSubnetValidatorMarshal(t *testing.T) {
 		SubnetValidator: SubnetValidator{
 			Validator: Validator{
 				NodeID: ctx.NodeID,
-				Start:  uint64(clk.Time().Unix()),
-				End:    uint64(clk.Time().Add(time.Hour).Unix()),
+				Start:  clk.Time().Unix(),
+				End:    clk.Time().Add(time.Hour).Unix(),
 				Wght:   validatorWeight,
 			},
 			Subnet: subnetID,

--- a/vms/platformvm/txs/add_validator_test.go
+++ b/vms/platformvm/txs/add_validator_test.go
@@ -66,7 +66,7 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 	stakes := []*avax.TransferableOutput{{
 		Asset: avax.Asset{ID: ctx.AVAXAssetID},
 		Out: &stakeable.LockOut{
-			Locktime: uint64(clk.Time().Add(time.Second).Unix()),
+			Locktime: clk.Time().Add(time.Second).Unix(),
 			TransferableOut: &secp256k1fx.TransferOutput{
 				Amt: validatorWeight,
 				OutputOwners: secp256k1fx.OutputOwners{
@@ -183,7 +183,7 @@ func TestAddValidatorTxSyntacticVerifyNotAVAX(t *testing.T) {
 	stakes := []*avax.TransferableOutput{{
 		Asset: avax.Asset{ID: assetID},
 		Out: &stakeable.LockOut{
-			Locktime: uint64(clk.Time().Add(time.Second).Unix()),
+			Locktime: clk.Time().Add(time.Second).Unix(),
 			TransferableOut: &secp256k1fx.TransferOutput{
 				Amt: validatorWeight,
 				OutputOwners: secp256k1fx.OutputOwners{

--- a/vms/platformvm/txs/add_validator_test.go
+++ b/vms/platformvm/txs/add_validator_test.go
@@ -85,8 +85,8 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 		}},
 		Validator: Validator{
 			NodeID: ctx.NodeID,
-			Start:  uint64(clk.Time().Unix()),
-			End:    uint64(clk.Time().Add(time.Hour).Unix()),
+			Start:  clk.Time().Unix(),
+			End:    clk.Time().Add(time.Hour).Unix(),
 			Wght:   validatorWeight,
 		},
 		StakeOuts: stakes,
@@ -202,8 +202,8 @@ func TestAddValidatorTxSyntacticVerifyNotAVAX(t *testing.T) {
 		}},
 		Validator: Validator{
 			NodeID: ctx.NodeID,
-			Start:  uint64(clk.Time().Unix()),
-			End:    uint64(clk.Time().Add(time.Hour).Unix()),
+			Start:  clk.Time().Unix(),
+			End:    clk.Time().Add(time.Hour).Unix(),
 			Wght:   validatorWeight,
 		},
 		StakeOuts: stakes,

--- a/vms/platformvm/txs/advance_time_tx.go
+++ b/vms/platformvm/txs/advance_time_tx.go
@@ -22,7 +22,7 @@ var _ UnsignedTx = (*AdvanceTimeTx)(nil)
 // - proposed timestamp <= [time for next staker set change]
 type AdvanceTimeTx struct {
 	// Unix time this block proposes increasing the timestamp to
-	Time uint64 `serialize:"true" json:"time"`
+	Time int64 `serialize:"true" json:"time"`
 
 	unsignedBytes []byte // Unsigned byte representation of this data
 }
@@ -39,7 +39,7 @@ func (*AdvanceTimeTx) InitCtx(*snow.Context) {}
 
 // Timestamp returns the time this block is proposing the chain should be set to
 func (tx *AdvanceTimeTx) Timestamp() time.Time {
-	return time.Unix(int64(tx.Time), 0)
+	return time.Unix(tx.Time, 0)
 }
 
 func (*AdvanceTimeTx) InputIDs() set.Set[ids.ID] {

--- a/vms/platformvm/txs/builder/builder.go
+++ b/vms/platformvm/txs/builder/builder.go
@@ -616,7 +616,7 @@ func (b *builder) NewRemoveSubnetValidatorTx(
 }
 
 func (b *builder) NewAdvanceTimeTx(timestamp time.Time) (*txs.Tx, error) {
-	utx := &txs.AdvanceTimeTx{Time: uint64(timestamp.Unix())}
+	utx := &txs.AdvanceTimeTx{Time: timestamp.Unix()}
 	tx, err := txs.NewSigned(utx, txs.Codec, nil)
 	if err != nil {
 		return nil, err

--- a/vms/platformvm/txs/builder/builder.go
+++ b/vms/platformvm/txs/builder/builder.go
@@ -115,9 +115,9 @@ type ProposalTxBuilder interface {
 	// keys: Keys providing the staked tokens
 	// changeAddr: Address to send change to, if there is any
 	NewAddValidatorTx(
-		stakeAmount,
+		stakeAmount uint64,
 		startTime,
-		endTime uint64,
+		endTime int64,
 		nodeID ids.NodeID,
 		rewardAddress ids.ShortID,
 		shares uint32,
@@ -133,9 +133,9 @@ type ProposalTxBuilder interface {
 	// keys: keys providing the staked tokens
 	// changeAddr: address to send change to, if there is any
 	NewAddDelegatorTx(
-		stakeAmount,
+		stakeAmount uint64,
 		startTime,
-		endTime uint64,
+		endTime int64,
 		nodeID ids.NodeID,
 		rewardAddress ids.ShortID,
 		keys []*secp256k1.PrivateKey,
@@ -150,9 +150,9 @@ type ProposalTxBuilder interface {
 	// keys: keys to use for adding the validator
 	// changeAddr: address to send change to, if there is any
 	NewAddSubnetValidatorTx(
-		weight,
+		weight uint64,
 		startTime,
-		endTime uint64,
+		endTime int64,
 		nodeID ids.NodeID,
 		subnetID ids.ID,
 		keys []*secp256k1.PrivateKey,
@@ -450,9 +450,9 @@ func (b *builder) NewCreateSubnetTx(
 }
 
 func (b *builder) NewAddValidatorTx(
-	stakeAmount,
+	stakeAmount uint64,
 	startTime,
-	endTime uint64,
+	endTime int64,
 	nodeID ids.NodeID,
 	rewardAddress ids.ShortID,
 	shares uint32,
@@ -473,8 +473,8 @@ func (b *builder) NewAddValidatorTx(
 		}},
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  startTime,
-			End:    endTime,
+			Start:  uint64(startTime), // TODO
+			End:    uint64(endTime),   // TODO
 			Wght:   stakeAmount,
 		},
 		StakeOuts: stakedOuts,
@@ -493,9 +493,9 @@ func (b *builder) NewAddValidatorTx(
 }
 
 func (b *builder) NewAddDelegatorTx(
-	stakeAmount,
+	stakeAmount uint64,
 	startTime,
-	endTime uint64,
+	endTime int64,
 	nodeID ids.NodeID,
 	rewardAddress ids.ShortID,
 	keys []*secp256k1.PrivateKey,
@@ -515,8 +515,8 @@ func (b *builder) NewAddDelegatorTx(
 		}},
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  startTime,
-			End:    endTime,
+			Start:  uint64(startTime), // TODO
+			End:    uint64(endTime),   // TODO
 			Wght:   stakeAmount,
 		},
 		StakeOuts: lockedOuts,
@@ -534,9 +534,9 @@ func (b *builder) NewAddDelegatorTx(
 }
 
 func (b *builder) NewAddSubnetValidatorTx(
-	weight,
+	weight uint64,
 	startTime,
-	endTime uint64,
+	endTime int64,
 	nodeID ids.NodeID,
 	subnetID ids.ID,
 	keys []*secp256k1.PrivateKey,
@@ -564,8 +564,8 @@ func (b *builder) NewAddSubnetValidatorTx(
 		SubnetValidator: txs.SubnetValidator{
 			Validator: txs.Validator{
 				NodeID: nodeID,
-				Start:  startTime,
-				End:    endTime,
+				Start:  uint64(startTime), // TODO
+				End:    uint64(endTime),   // TODO
 				Wght:   weight,
 			},
 			Subnet: subnetID,

--- a/vms/platformvm/txs/builder/builder.go
+++ b/vms/platformvm/txs/builder/builder.go
@@ -473,8 +473,8 @@ func (b *builder) NewAddValidatorTx(
 		}},
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  uint64(startTime), // TODO
-			End:    uint64(endTime),   // TODO
+			Start:  startTime,
+			End:    endTime,
 			Wght:   stakeAmount,
 		},
 		StakeOuts: stakedOuts,
@@ -515,8 +515,8 @@ func (b *builder) NewAddDelegatorTx(
 		}},
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  uint64(startTime), // TODO
-			End:    uint64(endTime),   // TODO
+			Start:  startTime,
+			End:    endTime,
 			Wght:   stakeAmount,
 		},
 		StakeOuts: lockedOuts,
@@ -564,8 +564,8 @@ func (b *builder) NewAddSubnetValidatorTx(
 		SubnetValidator: txs.SubnetValidator{
 			Validator: txs.Validator{
 				NodeID: nodeID,
-				Start:  uint64(startTime), // TODO
-				End:    uint64(endTime),   // TODO
+				Start:  startTime,
+				End:    endTime,
 				Wght:   weight,
 			},
 			Subnet: subnetID,

--- a/vms/platformvm/txs/builder/mock_builder.go
+++ b/vms/platformvm/txs/builder/mock_builder.go
@@ -42,7 +42,7 @@ func (m *MockBuilder) EXPECT() *MockBuilderMockRecorder {
 }
 
 // NewAddDelegatorTx mocks base method.
-func (m *MockBuilder) NewAddDelegatorTx(arg0, arg1, arg2 uint64, arg3 ids.NodeID, arg4 ids.ShortID, arg5 []*secp256k1.PrivateKey, arg6 ids.ShortID) (*txs.Tx, error) {
+func (m *MockBuilder) NewAddDelegatorTx(arg0 uint64, arg1, arg2 int64, arg3 ids.NodeID, arg4 ids.ShortID, arg5 []*secp256k1.PrivateKey, arg6 ids.ShortID) (*txs.Tx, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewAddDelegatorTx", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*txs.Tx)
@@ -57,7 +57,7 @@ func (mr *MockBuilderMockRecorder) NewAddDelegatorTx(arg0, arg1, arg2, arg3, arg
 }
 
 // NewAddSubnetValidatorTx mocks base method.
-func (m *MockBuilder) NewAddSubnetValidatorTx(arg0, arg1, arg2 uint64, arg3 ids.NodeID, arg4 ids.ID, arg5 []*secp256k1.PrivateKey, arg6 ids.ShortID) (*txs.Tx, error) {
+func (m *MockBuilder) NewAddSubnetValidatorTx(arg0 uint64, arg1, arg2 int64, arg3 ids.NodeID, arg4 ids.ID, arg5 []*secp256k1.PrivateKey, arg6 ids.ShortID) (*txs.Tx, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewAddSubnetValidatorTx", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*txs.Tx)
@@ -72,7 +72,7 @@ func (mr *MockBuilderMockRecorder) NewAddSubnetValidatorTx(arg0, arg1, arg2, arg
 }
 
 // NewAddValidatorTx mocks base method.
-func (m *MockBuilder) NewAddValidatorTx(arg0, arg1, arg2 uint64, arg3 ids.NodeID, arg4 ids.ShortID, arg5 uint32, arg6 []*secp256k1.PrivateKey, arg7 ids.ShortID) (*txs.Tx, error) {
+func (m *MockBuilder) NewAddValidatorTx(arg0 uint64, arg1, arg2 int64, arg3 ids.NodeID, arg4 ids.ShortID, arg5 uint32, arg6 []*secp256k1.PrivateKey, arg7 ids.ShortID) (*txs.Tx, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewAddValidatorTx", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(*txs.Tx)

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -377,8 +377,8 @@ func TestAdvanceTimeTxUpdateStakers(t *testing.T) {
 			for _, staker := range test.subnetStakers {
 				tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 					10, // Weight
-					uint64(staker.startTime.Unix()),
-					uint64(staker.endTime.Unix()),
+					staker.startTime.Unix(),
+					staker.endTime.Unix(),
 					staker.nodeID, // validator ID
 					subnetID,      // Subnet ID
 					[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
@@ -472,11 +472,11 @@ func TestAdvanceTimeTxRemoveSubnetValidator(t *testing.T) {
 	subnetVdr1StartTime := defaultValidateStartTime
 	subnetVdr1EndTime := defaultValidateStartTime.Add(defaultMinStakingDuration)
 	tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-		1,                                  // Weight
-		uint64(subnetVdr1StartTime.Unix()), // Start time
-		uint64(subnetVdr1EndTime.Unix()),   // end time
-		subnetValidatorNodeID,              // Node ID
-		subnetID,                           // Subnet ID
+		1,                          // Weight
+		subnetVdr1StartTime.Unix(), // Start time
+		subnetVdr1EndTime.Unix(),   // end time
+		subnetValidatorNodeID,      // Node ID
+		subnetID,                   // Subnet ID
 		[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
 		ids.ShortEmpty,
 	)
@@ -502,8 +502,8 @@ func TestAdvanceTimeTxRemoveSubnetValidator(t *testing.T) {
 	subnetVdr2NodeID := genesisNodeIDs[1]
 	tx, err = env.txBuilder.NewAddSubnetValidatorTx(
 		1, // Weight
-		uint64(subnetVdr1EndTime.Add(time.Second).Unix()),                                // Start time
-		uint64(subnetVdr1EndTime.Add(time.Second).Add(defaultMinStakingDuration).Unix()), // end time
+		subnetVdr1EndTime.Add(time.Second).Unix(),                                // Start time
+		subnetVdr1EndTime.Add(time.Second).Add(defaultMinStakingDuration).Unix(), // end time
 		subnetVdr2NodeID, // Node ID
 		subnetID,         // Subnet ID
 		[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]}, // Keys
@@ -579,11 +579,11 @@ func TestTrackedSubnet(t *testing.T) {
 			subnetVdr1StartTime := defaultValidateStartTime.Add(1 * time.Minute)
 			subnetVdr1EndTime := defaultValidateStartTime.Add(10 * defaultMinStakingDuration).Add(1 * time.Minute)
 			tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-				1,                                  // Weight
-				uint64(subnetVdr1StartTime.Unix()), // Start time
-				uint64(subnetVdr1EndTime.Unix()),   // end time
-				subnetValidatorNodeID,              // Node ID
-				subnetID,                           // Subnet ID
+				1,                          // Weight
+				subnetVdr1StartTime.Unix(), // Start time
+				subnetVdr1EndTime.Unix(),   // end time
+				subnetValidatorNodeID,      // Node ID
+				subnetID,                   // Subnet ID
 				[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1]},
 				ids.ShortEmpty,
 			)
@@ -684,8 +684,8 @@ func TestAdvanceTimeTxDelegatorStakerWeight(t *testing.T) {
 
 	addDelegatorTx, err := env.txBuilder.NewAddDelegatorTx(
 		env.config.MinDelegatorStake,
-		uint64(pendingDelegatorStartTime.Unix()),
-		uint64(pendingDelegatorEndTime.Unix()),
+		pendingDelegatorStartTime.Unix(),
+		pendingDelegatorEndTime.Unix(),
 		nodeID,
 		preFundedKeys[0].PublicKey().Address(),
 		[]*secp256k1.PrivateKey{
@@ -784,8 +784,8 @@ func TestAdvanceTimeTxDelegatorStakers(t *testing.T) {
 	pendingDelegatorEndTime := pendingDelegatorStartTime.Add(defaultMinStakingDuration)
 	addDelegatorTx, err := env.txBuilder.NewAddDelegatorTx(
 		env.config.MinDelegatorStake,
-		uint64(pendingDelegatorStartTime.Unix()),
-		uint64(pendingDelegatorEndTime.Unix()),
+		pendingDelegatorStartTime.Unix(),
+		pendingDelegatorEndTime.Unix(),
 		nodeID,
 		preFundedKeys[0].PublicKey().Address(),
 		[]*secp256k1.PrivateKey{preFundedKeys[0], preFundedKeys[1], preFundedKeys[4]},
@@ -931,8 +931,8 @@ func addPendingValidator(
 ) (*txs.Tx, error) {
 	addPendingValidatorTx, err := env.txBuilder.NewAddValidatorTx(
 		env.config.MinValidatorStake,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		nodeID,
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -390,8 +390,8 @@ func buildGenesisTest(ctx *snow.Context) []byte {
 		}
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
 			GenesisValidator: api.GenesisValidator{
-				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
-				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
+				StartTime: json.Int64(defaultValidateStartTime.Unix()),
+				EndTime:   json.Int64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,
 			},
 			RewardOwner: &api.Owner{
@@ -412,7 +412,7 @@ func buildGenesisTest(ctx *snow.Context) []byte {
 		UTXOs:         genesisUTXOs,
 		Validators:    genesisValidators,
 		Chains:        nil,
-		Time:          json.Uint64(defaultGenesisTime.Unix()),
+		Time:          json.Int64(defaultGenesisTime.Unix()),
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
 		Encoding:      formatting.Hex,
 	}

--- a/vms/platformvm/txs/executor/proposal_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor_test.go
@@ -28,8 +28,8 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 	nodeID := genesisNodeIDs[0]
 
 	newValidatorID := ids.GenerateTestNodeID()
-	newValidatorStartTime := uint64(defaultValidateStartTime.Add(5 * time.Second).Unix())
-	newValidatorEndTime := uint64(defaultValidateEndTime.Add(-5 * time.Second).Unix())
+	newValidatorStartTime := defaultValidateStartTime.Add(5 * time.Second).Unix()
+	newValidatorEndTime := defaultValidateEndTime.Add(-5 * time.Second).Unix()
 
 	// [addMinStakeValidator] adds a new validator to the primary network's
 	// pending validator set with the minimum staking amount
@@ -97,8 +97,8 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 	type test struct {
 		description   string
 		stakeAmount   uint64
-		startTime     uint64
-		endTime       uint64
+		startTime     int64
+		endTime       int64
 		nodeID        ids.NodeID
 		rewardAddress ids.ShortID
 		feeKeys       []*secp256k1.PrivateKey
@@ -111,8 +111,8 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 		{
 			description:   "validator stops validating earlier than delegator",
 			stakeAmount:   dummyH.config.MinDelegatorStake,
-			startTime:     uint64(defaultValidateStartTime.Unix()) + 1,
-			endTime:       uint64(defaultValidateEndTime.Unix()) + 1,
+			startTime:     defaultValidateStartTime.Unix() + 1,
+			endTime:       defaultValidateEndTime.Unix() + 1,
 			nodeID:        nodeID,
 			rewardAddress: rewardAddress,
 			feeKeys:       []*secp256k1.PrivateKey{preFundedKeys[0]},
@@ -123,8 +123,8 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 		{
 			description:   fmt.Sprintf("delegator should not be added more than (%s) in the future", MaxFutureStartTime),
 			stakeAmount:   dummyH.config.MinDelegatorStake,
-			startTime:     uint64(currentTimestamp.Add(MaxFutureStartTime + time.Second).Unix()),
-			endTime:       uint64(currentTimestamp.Add(MaxFutureStartTime + defaultMinStakingDuration + time.Second).Unix()),
+			startTime:     currentTimestamp.Add(MaxFutureStartTime + time.Second).Unix(),
+			endTime:       currentTimestamp.Add(MaxFutureStartTime + defaultMinStakingDuration + time.Second).Unix(),
 			nodeID:        nodeID,
 			rewardAddress: rewardAddress,
 			feeKeys:       []*secp256k1.PrivateKey{preFundedKeys[0]},
@@ -135,8 +135,8 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 		{
 			description:   "validator not in the current or pending validator sets",
 			stakeAmount:   dummyH.config.MinDelegatorStake,
-			startTime:     uint64(defaultValidateStartTime.Add(5 * time.Second).Unix()),
-			endTime:       uint64(defaultValidateEndTime.Add(-5 * time.Second).Unix()),
+			startTime:     defaultValidateStartTime.Add(5 * time.Second).Unix(),
+			endTime:       defaultValidateEndTime.Add(-5 * time.Second).Unix(),
 			nodeID:        newValidatorID,
 			rewardAddress: rewardAddress,
 			feeKeys:       []*secp256k1.PrivateKey{preFundedKeys[0]},
@@ -183,8 +183,8 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 		{
 			description:   "starts delegating at current timestamp",
 			stakeAmount:   dummyH.config.MinDelegatorStake,           // weight
-			startTime:     uint64(currentTimestamp.Unix()),           // start time
-			endTime:       uint64(defaultValidateEndTime.Unix()),     // end time
+			startTime:     currentTimestamp.Unix(),                   // start time
+			endTime:       defaultValidateEndTime.Unix(),             // end time
 			nodeID:        nodeID,                                    // node ID
 			rewardAddress: rewardAddress,                             // Reward Address
 			feeKeys:       []*secp256k1.PrivateKey{preFundedKeys[0]}, // tx fee payer
@@ -194,12 +194,12 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 		},
 		{
 			description:   "tx fee paying key has no funds",
-			stakeAmount:   dummyH.config.MinDelegatorStake,             // weight
-			startTime:     uint64(defaultValidateStartTime.Unix()) + 1, // start time
-			endTime:       uint64(defaultValidateEndTime.Unix()),       // end time
-			nodeID:        nodeID,                                      // node ID
-			rewardAddress: rewardAddress,                               // Reward Address
-			feeKeys:       []*secp256k1.PrivateKey{preFundedKeys[1]},   // tx fee payer
+			stakeAmount:   dummyH.config.MinDelegatorStake,           // weight
+			startTime:     defaultValidateStartTime.Unix() + 1,       // start time
+			endTime:       defaultValidateEndTime.Unix(),             // end time
+			nodeID:        nodeID,                                    // node ID
+			rewardAddress: rewardAddress,                             // Reward Address
+			feeKeys:       []*secp256k1.PrivateKey{preFundedKeys[1]}, // tx fee payer
 			setup: func(target *environment) { // Remove all UTXOs owned by keys[1]
 				utxoIDs, err := target.state.UTXOIDs(
 					preFundedKeys[1].PublicKey().Address().Bytes(),
@@ -299,8 +299,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// (note that keys[0] is a genesis validator)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(defaultValidateStartTime.Unix())+1,
-			uint64(defaultValidateEndTime.Unix())+1,
+			defaultValidateStartTime.Unix()+1,
+			defaultValidateEndTime.Unix()+1,
 			nodeID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -331,8 +331,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// (note that keys[0] is a genesis validator)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(defaultValidateStartTime.Unix())+1,
-			uint64(defaultValidateEndTime.Unix()),
+			defaultValidateStartTime.Unix()+1,
+			defaultValidateEndTime.Unix(),
 			nodeID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -363,8 +363,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 
 	addDSTx, err := env.txBuilder.NewAddValidatorTx(
 		env.config.MinValidatorStake, // stake amount
-		uint64(dsStartTime.Unix()),   // start time
-		uint64(dsEndTime.Unix()),     // end time
+		dsStartTime.Unix(),           // start time
+		dsEndTime.Unix(),             // end time
 		pendingDSValidatorID,         // node ID
 		ids.GenerateTestShortID(),    // reward address
 		reward.PercentDenominator,    // shares
@@ -377,8 +377,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// Case: Proposed validator isn't in pending or current validator sets
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(dsStartTime.Unix()), // start validating subnet before primary network
-			uint64(dsEndTime.Unix()),
+			dsStartTime.Unix(), // start validating subnet before primary network
+			dsEndTime.Unix(),
 			pendingDSValidatorID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -424,8 +424,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// but starts validating subnet before primary network
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(dsStartTime.Unix())-1, // start validating subnet before primary network
-			uint64(dsEndTime.Unix()),
+			dsStartTime.Unix()-1, // start validating subnet before primary network
+			dsEndTime.Unix(),
 			pendingDSValidatorID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -454,8 +454,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// but stops validating subnet after primary network
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(dsStartTime.Unix()),
-			uint64(dsEndTime.Unix())+1, // stop validating subnet after stopping validating primary network
+			dsStartTime.Unix(),
+			dsEndTime.Unix()+1, // stop validating subnet after stopping validating primary network
 			pendingDSValidatorID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -484,8 +484,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// period validating subnet is subset of time validating primary network
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(dsStartTime.Unix()), // same start time as for primary network
-			uint64(dsEndTime.Unix()),   // same end time as for primary network
+			dsStartTime.Unix(), // same start time as for primary network
+			dsEndTime.Unix(),   // same end time as for primary network
 			pendingDSValidatorID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -515,9 +515,9 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 
 	{
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight,               // weight
-			uint64(newTimestamp.Unix()), // start time
-			uint64(newTimestamp.Add(defaultMinStakingDuration).Unix()), // end time
+			defaultWeight,       // weight
+			newTimestamp.Unix(), // start time
+			newTimestamp.Add(defaultMinStakingDuration).Unix(), // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -547,11 +547,11 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	// Case: Proposed validator already validating the subnet
 	// First, add validator as validator of subnet
 	subnetTx, err := env.txBuilder.NewAddSubnetValidatorTx(
-		defaultWeight,                           // weight
-		uint64(defaultValidateStartTime.Unix()), // start time
-		uint64(defaultValidateEndTime.Unix()),   // end time
-		nodeID,                                  // node ID
-		testSubnet1.ID(),                        // subnet ID
+		defaultWeight,                   // weight
+		defaultValidateStartTime.Unix(), // start time
+		defaultValidateEndTime.Unix(),   // end time
+		nodeID,                          // node ID
+		testSubnet1.ID(),                // subnet ID
 		[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
 		ids.ShortEmpty,
 	)
@@ -574,11 +574,11 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	{
 		// Node with ID nodeIDKey.PublicKey().Address() now validating subnet with ID testSubnet1.ID
 		duplicateSubnetTx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight, // weight
-			uint64(defaultValidateStartTime.Unix())+1, // start time
-			uint64(defaultValidateEndTime.Unix()),     // end time
-			nodeID,                                    // node ID
-			testSubnet1.ID(),                          // subnet ID
+			defaultWeight,                     // weight
+			defaultValidateStartTime.Unix()+1, // start time
+			defaultValidateEndTime.Unix(),     // end time
+			nodeID,                            // node ID
+			testSubnet1.ID(),                  // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
 			ids.ShortEmpty, // change addr
 		)
@@ -607,9 +607,9 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Too few signatures
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight, // weight
-			uint64(defaultValidateStartTime.Unix())+1,                                // start time
-			uint64(defaultValidateStartTime.Add(defaultMinStakingDuration).Unix())+1, // end time
+			defaultWeight,                     // weight
+			defaultValidateStartTime.Unix()+1, // start time
+			defaultValidateStartTime.Add(defaultMinStakingDuration).Unix()+1, // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[2]},
@@ -643,9 +643,9 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Control Signature from invalid key (keys[3] is not a control key)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight, // weight
-			uint64(defaultValidateStartTime.Unix())+1,                                // start time
-			uint64(defaultValidateStartTime.Add(defaultMinStakingDuration).Unix())+1, // end time
+			defaultWeight,                     // weight
+			defaultValidateStartTime.Unix()+1, // start time
+			defaultValidateStartTime.Add(defaultMinStakingDuration).Unix()+1, // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], preFundedKeys[1]},
@@ -678,9 +678,9 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// Case: Proposed validator in pending validator set for subnet
 		// First, add validator to pending validator set of subnet
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight, // weight
-			uint64(defaultValidateStartTime.Unix())+1,                                // start time
-			uint64(defaultValidateStartTime.Add(defaultMinStakingDuration).Unix())+1, // end time
+			defaultWeight,                     // weight
+			defaultValidateStartTime.Unix()+1, // start time
+			defaultValidateStartTime.Add(defaultMinStakingDuration).Unix()+1, // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -734,8 +734,8 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 		// Case: Validator's start time too early
 		tx, err := env.txBuilder.NewAddValidatorTx(
 			env.config.MinValidatorStake,
-			uint64(chainTime.Unix()),
-			uint64(defaultValidateEndTime.Unix()),
+			chainTime.Unix(),
+			defaultValidateEndTime.Unix(),
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator,
@@ -764,8 +764,8 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 		// Case: Validator's start time too far in the future
 		tx, err := env.txBuilder.NewAddValidatorTx(
 			env.config.MinValidatorStake,
-			uint64(defaultValidateStartTime.Add(MaxFutureStartTime).Unix()+1),
-			uint64(defaultValidateStartTime.Add(MaxFutureStartTime).Add(defaultMinStakingDuration).Unix()+1),
+			defaultValidateStartTime.Add(MaxFutureStartTime).Unix()+1,
+			defaultValidateStartTime.Add(MaxFutureStartTime).Add(defaultMinStakingDuration).Unix()+1,
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator,
@@ -796,8 +796,8 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 		// Case: Validator already validating primary network
 		tx, err := env.txBuilder.NewAddValidatorTx(
 			env.config.MinValidatorStake,
-			uint64(defaultValidateStartTime.Unix())+1,
-			uint64(defaultValidateEndTime.Unix()),
+			defaultValidateStartTime.Unix()+1,
+			defaultValidateEndTime.Unix(),
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator,
@@ -826,9 +826,9 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 		// Case: Validator in pending validator set of primary network
 		startTime := defaultValidateStartTime.Add(1 * time.Second)
 		tx, err := env.txBuilder.NewAddValidatorTx(
-			env.config.MinValidatorStake,                            // stake amount
-			uint64(startTime.Unix()),                                // start time
-			uint64(startTime.Add(defaultMinStakingDuration).Unix()), // end time
+			env.config.MinValidatorStake,                    // stake amount
+			startTime.Unix(),                                // start time
+			startTime.Add(defaultMinStakingDuration).Unix(), // end time
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator, // shares
@@ -872,8 +872,8 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 		// Case: Validator doesn't have enough tokens to cover stake amount
 		tx, err := env.txBuilder.NewAddValidatorTx( // create the tx
 			env.config.MinValidatorStake,
-			uint64(defaultValidateStartTime.Unix())+1,
-			uint64(defaultValidateEndTime.Unix()),
+			defaultValidateStartTime.Unix()+1,
+			defaultValidateEndTime.Unix(),
 			ids.GenerateTestNodeID(),
 			ids.ShortEmpty,
 			reward.PercentDenominator,

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -234,8 +234,8 @@ func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 	vdrRewardAddress := ids.GenerateTestShortID()
 	delRewardAddress := ids.GenerateTestShortID()
 
-	vdrStartTime := uint64(defaultValidateStartTime.Unix()) + 1
-	vdrEndTime := uint64(defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix())
+	vdrStartTime := defaultValidateStartTime.Unix() + 1
+	vdrEndTime := defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix()
 	vdrNodeID := ids.GenerateTestNodeID()
 
 	vdrTx, err := env.txBuilder.NewAddValidatorTx(
@@ -286,7 +286,7 @@ func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 	env.state.AddTx(vdrTx, status.Committed)
 	env.state.PutCurrentDelegator(delStaker)
 	env.state.AddTx(delTx, status.Committed)
-	env.state.SetTimestamp(time.Unix(int64(delEndTime), 0))
+	env.state.SetTimestamp(time.Unix(delEndTime, 0))
 	env.state.SetHeight(dummyHeight)
 	require.NoError(env.state.Commit())
 
@@ -358,8 +358,8 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	vdrRewardAddress := ids.GenerateTestShortID()
 	delRewardAddress := ids.GenerateTestShortID()
 
-	vdrStartTime := uint64(defaultValidateStartTime.Unix()) + 1
-	vdrEndTime := uint64(defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix())
+	vdrStartTime := defaultValidateStartTime.Unix() + 1
+	vdrEndTime := defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix()
 	vdrNodeID := ids.GenerateTestNodeID()
 
 	vdrTx, err := env.txBuilder.NewAddValidatorTx(
@@ -393,7 +393,7 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	vdrStaker, err := state.NewCurrentStaker(
 		vdrTx.ID(),
 		addValTx,
-		time.Unix(int64(vdrStartTime), 0),
+		time.Unix(vdrStartTime, 0),
 		vdrRewardAmt,
 	)
 	require.NoError(err)
@@ -403,7 +403,7 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	delStaker, err := state.NewCurrentStaker(
 		delTx.ID(),
 		addDelTx,
-		time.Unix(int64(delStartTime), 0),
+		time.Unix(delStartTime, 0),
 		delRewardAmt,
 	)
 	require.NoError(err)
@@ -412,7 +412,7 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	env.state.AddTx(vdrTx, status.Committed)
 	env.state.PutCurrentDelegator(delStaker)
 	env.state.AddTx(delTx, status.Committed)
-	env.state.SetTimestamp(time.Unix(int64(vdrEndTime), 0))
+	env.state.SetTimestamp(time.Unix(vdrEndTime, 0))
 	env.state.SetHeight(dummyHeight)
 	require.NoError(env.state.Commit())
 
@@ -577,8 +577,8 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 	vdrRewardAddress := ids.GenerateTestShortID()
 	delRewardAddress := ids.GenerateTestShortID()
 
-	vdrStartTime := uint64(defaultValidateStartTime.Unix()) + 1
-	vdrEndTime := uint64(defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix())
+	vdrStartTime := defaultValidateStartTime.Unix() + 1
+	vdrEndTime := defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix()
 	vdrNodeID := ids.GenerateTestNodeID()
 
 	vdrTx, err := env.txBuilder.NewAddValidatorTx(
@@ -622,7 +622,7 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 	delStaker, err := state.NewCurrentStaker(
 		delTx.ID(),
 		addDelTx,
-		time.Unix(int64(delStartTime), 0),
+		time.Unix(delStartTime, 0),
 		delRewardAmt,
 	)
 	require.NoError(err)
@@ -631,7 +631,7 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 	env.state.AddTx(vdrTx, status.Committed)
 	env.state.PutCurrentDelegator(delStaker)
 	env.state.AddTx(delTx, status.Committed)
-	env.state.SetTimestamp(time.Unix(int64(vdrEndTime), 0))
+	env.state.SetTimestamp(time.Unix(vdrEndTime, 0))
 	env.state.SetHeight(dummyHeight)
 	require.NoError(env.state.Commit())
 
@@ -742,8 +742,8 @@ func TestRewardDelegatorTxExecuteOnAbort(t *testing.T) {
 	vdrRewardAddress := ids.GenerateTestShortID()
 	delRewardAddress := ids.GenerateTestShortID()
 
-	vdrStartTime := uint64(defaultValidateStartTime.Unix()) + 1
-	vdrEndTime := uint64(defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix())
+	vdrStartTime := defaultValidateStartTime.Unix() + 1
+	vdrEndTime := defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix()
 	vdrNodeID := ids.GenerateTestNodeID()
 
 	vdrTx, err := env.txBuilder.NewAddValidatorTx(
@@ -793,7 +793,7 @@ func TestRewardDelegatorTxExecuteOnAbort(t *testing.T) {
 	env.state.AddTx(vdrTx, status.Committed)
 	env.state.PutCurrentDelegator(delStaker)
 	env.state.AddTx(delTx, status.Committed)
-	env.state.SetTimestamp(time.Unix(int64(delEndTime), 0))
+	env.state.SetTimestamp(time.Unix(delEndTime, 0))
 	env.state.SetHeight(dummyHeight)
 	require.NoError(env.state.Commit())
 

--- a/vms/platformvm/txs/executor/staker_tx_verification_test.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_test.go
@@ -74,7 +74,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				NodeID: ids.GenerateTestNodeID(),
 				// Note: [Start] is not set here as it will be ignored
 				// Post-Durango in favor of the current chain time
-				End:  uint64(endTime.Unix()),
+				End:  endTime.Unix(),
 				Wght: unsignedTransformTx.MinValidatorStake,
 			},
 			Subnet: subnetID,
@@ -289,7 +289,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				tx.DelegationShares = unsignedTransformTx.MinDelegationFee
 
 				// Note the duration is 1 less than the minimum
-				tx.Validator.End = tx.Validator.Start + uint64(unsignedTransformTx.MinStakeDuration) - 1
+				tx.Validator.End = tx.Validator.Start + int64(unsignedTransformTx.MinStakeDuration) - 1
 				return &tx
 			},
 			expectedErr: ErrStakeTooShort,
@@ -322,7 +322,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				tx.DelegationShares = unsignedTransformTx.MinDelegationFee
 
 				// Note the duration is more than the maximum
-				tx.Validator.End = uint64(unsignedTransformTx.MaxStakeDuration) + 2
+				tx.Validator.End = int64(unsignedTransformTx.MaxStakeDuration) + 2
 				return &tx
 			},
 			expectedErr: ErrStakeTooLong,
@@ -517,8 +517,8 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 			txF: func() *txs.AddPermissionlessValidatorTx {
 				// Note this copies [verifiedTx]
 				tx := verifiedTx
-				tx.Validator.Start = uint64(now.Add(MaxFutureStartTime).Add(time.Second).Unix())
-				tx.Validator.End = tx.Validator.Start + uint64(unsignedTransformTx.MinStakeDuration)
+				tx.Validator.Start = now.Add(MaxFutureStartTime).Add(time.Second).Unix()
+				tx.Validator.End = tx.Validator.Start + int64(unsignedTransformTx.MinStakeDuration)
 				return &tx
 			},
 			expectedErr: ErrFutureStakeTime,

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -73,8 +73,8 @@ func TestStandardTxExecutorAddValidatorTxEmptyID(t *testing.T) {
 
 		tx, err := env.txBuilder.NewAddValidatorTx( // create the tx
 			env.config.MinValidatorStake,
-			uint64(startTime.Unix()),
-			uint64(defaultValidateEndTime.Unix()),
+			startTime.Unix(),
+			defaultValidateEndTime.Unix(),
 			ids.EmptyNodeID,
 			ids.GenerateTestShortID(),
 			reward.PercentDenominator,
@@ -109,12 +109,12 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 	// pending validator set with the minimum staking amount
 	addMinStakeValidator := func(target *environment) {
 		tx, err := target.txBuilder.NewAddValidatorTx(
-			target.config.MinValidatorStake,      // stake amount
-			uint64(newValidatorStartTime.Unix()), // start time
-			uint64(newValidatorEndTime.Unix()),   // end time
-			newValidatorID,                       // node ID
-			rewardAddress,                        // Reward Address
-			reward.PercentDenominator,            // Shares
+			target.config.MinValidatorStake, // stake amount
+			newValidatorStartTime.Unix(),    // start time
+			newValidatorEndTime.Unix(),      // end time
+			newValidatorID,                  // node ID
+			rewardAddress,                   // Reward Address
+			reward.PercentDenominator,       // Shares
 			[]*secp256k1.PrivateKey{preFundedKeys[0]},
 			ids.ShortEmpty,
 		)
@@ -139,12 +139,12 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 	// pending validator set with the maximum staking amount
 	addMaxStakeValidator := func(target *environment) {
 		tx, err := target.txBuilder.NewAddValidatorTx(
-			target.config.MaxValidatorStake,      // stake amount
-			uint64(newValidatorStartTime.Unix()), // start time
-			uint64(newValidatorEndTime.Unix()),   // end time
-			newValidatorID,                       // node ID
-			rewardAddress,                        // Reward Address
-			reward.PercentDenominator,            // Shared
+			target.config.MaxValidatorStake, // stake amount
+			newValidatorStartTime.Unix(),    // start time
+			newValidatorEndTime.Unix(),      // end time
+			newValidatorID,                  // node ID
+			rewardAddress,                   // Reward Address
+			reward.PercentDenominator,       // Shared
 			[]*secp256k1.PrivateKey{preFundedKeys[0]},
 			ids.ShortEmpty,
 		)
@@ -338,8 +338,8 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 
 			tx, err := freshTH.txBuilder.NewAddDelegatorTx(
 				tt.stakeAmount,
-				uint64(tt.startTime.Unix()),
-				uint64(tt.endTime.Unix()),
+				tt.startTime.Unix(),
+				tt.endTime.Unix(),
 				tt.nodeID,
 				tt.rewardAddress,
 				tt.feeKeys,
@@ -393,8 +393,8 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		startTime := defaultValidateStartTime.Add(time.Second)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(startTime.Unix()),
-			uint64(defaultValidateEndTime.Unix())+1,
+			startTime.Unix(),
+			defaultValidateEndTime.Unix()+1,
 			nodeID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -421,8 +421,8 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// (note that keys[0] is a genesis validator)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(defaultValidateStartTime.Unix()+1),
-			uint64(defaultValidateEndTime.Unix()),
+			defaultValidateStartTime.Unix()+1,
+			defaultValidateEndTime.Unix(),
 			nodeID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -449,8 +449,8 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 
 	addDSTx, err := env.txBuilder.NewAddValidatorTx(
 		env.config.MinValidatorStake, // stake amount
-		uint64(dsStartTime.Unix()),   // start time
-		uint64(dsEndTime.Unix()),     // end time
+		dsStartTime.Unix(),           // start time
+		dsEndTime.Unix(),             // end time
 		pendingDSValidatorID,         // node ID
 		ids.GenerateTestShortID(),    // reward address
 		reward.PercentDenominator,    // shares
@@ -463,8 +463,8 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// Case: Proposed validator isn't in pending or current validator sets
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(dsStartTime.Unix()), // start validating subnet before primary network
-			uint64(dsEndTime.Unix()),
+			dsStartTime.Unix(), // start validating subnet before primary network
+			dsEndTime.Unix(),
 			pendingDSValidatorID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -506,8 +506,8 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// but starts validating subnet before primary network
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(dsStartTime.Unix())-1, // start validating subnet before primary network
-			uint64(dsEndTime.Unix()),
+			dsStartTime.Unix()-1, // start validating subnet before primary network
+			dsEndTime.Unix(),
 			pendingDSValidatorID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -532,8 +532,8 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// but stops validating subnet after primary network
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(dsStartTime.Unix()),
-			uint64(dsEndTime.Unix())+1, // stop validating subnet after stopping validating primary network
+			dsStartTime.Unix(),
+			dsEndTime.Unix()+1, // stop validating subnet after stopping validating primary network
 			pendingDSValidatorID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -558,8 +558,8 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// period validating subnet is subset of time validating primary network
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
 			defaultWeight,
-			uint64(dsStartTime.Unix()), // same start time as for primary network
-			uint64(dsEndTime.Unix()),   // same end time as for primary network
+			dsStartTime.Unix(), // same start time as for primary network
+			dsEndTime.Unix(),   // same end time as for primary network
 			pendingDSValidatorID,
 			testSubnet1.ID(),
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -584,9 +584,9 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 
 	{
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight,               // weight
-			uint64(newTimestamp.Unix()), // start time
-			uint64(newTimestamp.Add(defaultMinStakingDuration).Unix()), // end time
+			defaultWeight,       // weight
+			newTimestamp.Unix(), // start time
+			newTimestamp.Add(defaultMinStakingDuration).Unix(), // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -612,11 +612,11 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	// Case: Proposed validator already validating the subnet
 	// First, add validator as validator of subnet
 	subnetTx, err := env.txBuilder.NewAddSubnetValidatorTx(
-		defaultWeight,                           // weight
-		uint64(defaultValidateStartTime.Unix()), // start time
-		uint64(defaultValidateEndTime.Unix()),   // end time
-		nodeID,                                  // node ID
-		testSubnet1.ID(),                        // subnet ID
+		defaultWeight,                   // weight
+		defaultValidateStartTime.Unix(), // start time
+		defaultValidateEndTime.Unix(),   // end time
+		nodeID,                          // node ID
+		testSubnet1.ID(),                // subnet ID
 		[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
 		ids.ShortEmpty,
 	)
@@ -640,11 +640,11 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// Node with ID nodeIDKey.PublicKey().Address() now validating subnet with ID testSubnet1.ID
 		startTime := defaultValidateStartTime.Add(time.Second)
 		duplicateSubnetTx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight,                         // weight
-			uint64(startTime.Unix()),              // start time
-			uint64(defaultValidateEndTime.Unix()), // end time
-			nodeID,                                // node ID
-			testSubnet1.ID(),                      // subnet ID
+			defaultWeight,                 // weight
+			startTime.Unix(),              // start time
+			defaultValidateEndTime.Unix(), // end time
+			nodeID,                        // node ID
+			testSubnet1.ID(),              // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
 			ids.ShortEmpty, // change addr
 		)
@@ -670,9 +670,9 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// Case: Duplicate signatures
 		startTime := defaultValidateStartTime.Add(time.Second)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight,            // weight
-			uint64(startTime.Unix()), // start time
-			uint64(startTime.Add(defaultMinStakingDuration).Unix())+1, // end time
+			defaultWeight,    // weight
+			startTime.Unix(), // start time
+			startTime.Add(defaultMinStakingDuration).Unix()+1, // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1], testSubnet1ControlKeys[2]},
@@ -703,9 +703,9 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// Case: Too few signatures
 		startTime := defaultValidateStartTime.Add(time.Second)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight,            // weight
-			uint64(startTime.Unix()), // start time
-			uint64(startTime.Add(defaultMinStakingDuration).Unix()), // end time
+			defaultWeight,    // weight
+			startTime.Unix(), // start time
+			startTime.Add(defaultMinStakingDuration).Unix(), // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[2]},
@@ -736,9 +736,9 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// Case: Control Signature from invalid key (keys[3] is not a control key)
 		startTime := defaultValidateStartTime.Add(time.Second)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight,            // weight
-			uint64(startTime.Unix()), // start time
-			uint64(startTime.Add(defaultMinStakingDuration).Unix()), // end time
+			defaultWeight,    // weight
+			startTime.Unix(), // start time
+			startTime.Add(defaultMinStakingDuration).Unix(), // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], preFundedKeys[1]},
@@ -768,9 +768,9 @@ func TestStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// First, add validator to pending validator set of subnet
 		startTime := defaultValidateStartTime.Add(time.Second)
 		tx, err := env.txBuilder.NewAddSubnetValidatorTx(
-			defaultWeight,              // weight
-			uint64(startTime.Unix())+1, // start time
-			uint64(startTime.Add(defaultMinStakingDuration).Unix())+1, // end time
+			defaultWeight,      // weight
+			startTime.Unix()+1, // start time
+			startTime.Add(defaultMinStakingDuration).Unix()+1, // end time
 			nodeID,           // node ID
 			testSubnet1.ID(), // subnet ID
 			[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -819,8 +819,8 @@ func TestStandardTxExecutorBanffAddValidator(t *testing.T) {
 		// Case: Validator's start time too early
 		tx, err := env.txBuilder.NewAddValidatorTx(
 			env.config.MinValidatorStake,
-			uint64(defaultValidateStartTime.Unix())-1,
-			uint64(defaultValidateEndTime.Unix()),
+			defaultValidateStartTime.Unix()-1,
+			defaultValidateEndTime.Unix(),
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator,
@@ -845,8 +845,8 @@ func TestStandardTxExecutorBanffAddValidator(t *testing.T) {
 		// Case: Validator's start time too far in the future
 		tx, err := env.txBuilder.NewAddValidatorTx(
 			env.config.MinValidatorStake,
-			uint64(defaultValidateStartTime.Add(MaxFutureStartTime).Unix()+1),
-			uint64(defaultValidateStartTime.Add(MaxFutureStartTime).Add(defaultMinStakingDuration).Unix()+1),
+			defaultValidateStartTime.Add(MaxFutureStartTime).Unix()+1,
+			defaultValidateStartTime.Add(MaxFutureStartTime).Add(defaultMinStakingDuration).Unix()+1,
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator,
@@ -871,9 +871,9 @@ func TestStandardTxExecutorBanffAddValidator(t *testing.T) {
 		// Case: Validator in current validator set of primary network
 		startTime := defaultValidateStartTime.Add(1 * time.Second)
 		tx, err := env.txBuilder.NewAddValidatorTx(
-			env.config.MinValidatorStake,                            // stake amount
-			uint64(startTime.Unix()),                                // start time
-			uint64(startTime.Add(defaultMinStakingDuration).Unix()), // end time
+			env.config.MinValidatorStake,                    // stake amount
+			startTime.Unix(),                                // start time
+			startTime.Add(defaultMinStakingDuration).Unix(), // end time
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator, // shares
@@ -910,9 +910,9 @@ func TestStandardTxExecutorBanffAddValidator(t *testing.T) {
 		// Case: Validator in pending validator set of primary network
 		startTime := defaultValidateStartTime.Add(1 * time.Second)
 		tx, err := env.txBuilder.NewAddValidatorTx(
-			env.config.MinValidatorStake,                            // stake amount
-			uint64(startTime.Unix()),                                // start time
-			uint64(startTime.Add(defaultMinStakingDuration).Unix()), // end time
+			env.config.MinValidatorStake,                    // stake amount
+			startTime.Unix(),                                // start time
+			startTime.Add(defaultMinStakingDuration).Unix(), // end time
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator, // shares
@@ -947,8 +947,8 @@ func TestStandardTxExecutorBanffAddValidator(t *testing.T) {
 		startTime := defaultValidateStartTime.Add(1 * time.Second)
 		tx, err := env.txBuilder.NewAddValidatorTx( // create the tx
 			env.config.MinValidatorStake,
-			uint64(startTime.Unix()),
-			uint64(startTime.Add(defaultMinStakingDuration).Unix()),
+			startTime.Unix(),
+			startTime.Add(defaultMinStakingDuration).Unix(),
 			nodeID,
 			ids.ShortEmpty,
 			reward.PercentDenominator,
@@ -996,7 +996,7 @@ func TestStandardTxExecutorDurangoAddValidator(t *testing.T) {
 	addValTx, err := env.txBuilder.NewAddValidatorTx(
 		env.config.MinValidatorStake,
 		0,
-		uint64(endTime.Unix()),
+		endTime.Unix(),
 		nodeID,
 		ids.ShortEmpty,
 		reward.PercentDenominator,

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -172,7 +172,7 @@ func createTestProposalTxs(count int) ([]*txs.Tx, error) {
 	proposalTxs := make([]*txs.Tx, 0, count)
 	for i := 0; i < count; i++ {
 		tx, err := generateAddValidatorTx(
-			uint64(now.Add(time.Duration(count-i)*time.Second).Unix()), // startTime
+			now.Add(time.Duration(count-i)*time.Second).Unix(), // startTime
 			0, // endTime
 		)
 		if err != nil {
@@ -183,7 +183,7 @@ func createTestProposalTxs(count int) ([]*txs.Tx, error) {
 	return proposalTxs, nil
 }
 
-func generateAddValidatorTx(startTime uint64, endTime uint64) (*txs.Tx, error) {
+func generateAddValidatorTx(startTime int64, endTime int64) (*txs.Tx, error) {
 	utx := &txs.AddValidatorTx{
 		BaseTx: txs.BaseTx{},
 		Validator: txs.Validator{

--- a/vms/platformvm/txs/txheap/by_end_time_test.go
+++ b/vms/platformvm/txs/txheap/by_end_time_test.go
@@ -24,8 +24,8 @@ func TestByEndTime(t *testing.T) {
 	utx0 := &txs.AddValidatorTx{
 		Validator: txs.Validator{
 			NodeID: ids.BuildTestNodeID([]byte{0}),
-			Start:  uint64(baseTime.Unix()),
-			End:    uint64(baseTime.Unix()) + 1,
+			Start:  baseTime.Unix(),
+			End:    baseTime.Unix() + 1,
 		},
 		RewardsOwner: &secp256k1fx.OutputOwners{},
 	}
@@ -35,8 +35,8 @@ func TestByEndTime(t *testing.T) {
 	utx1 := &txs.AddValidatorTx{
 		Validator: txs.Validator{
 			NodeID: ids.BuildTestNodeID([]byte{1}),
-			Start:  uint64(baseTime.Unix()),
-			End:    uint64(baseTime.Unix()) + 2,
+			Start:  baseTime.Unix(),
+			End:    baseTime.Unix() + 2,
 		},
 		RewardsOwner: &secp256k1fx.OutputOwners{},
 	}
@@ -46,8 +46,8 @@ func TestByEndTime(t *testing.T) {
 	utx2 := &txs.AddValidatorTx{
 		Validator: txs.Validator{
 			NodeID: ids.BuildTestNodeID([]byte{1}),
-			Start:  uint64(baseTime.Unix()),
-			End:    uint64(baseTime.Unix()) + 3,
+			Start:  baseTime.Unix(),
+			End:    baseTime.Unix() + 3,
 		},
 		RewardsOwner: &secp256k1fx.OutputOwners{},
 	}

--- a/vms/platformvm/txs/validator.go
+++ b/vms/platformvm/txs/validator.go
@@ -21,10 +21,10 @@ type Validator struct {
 	NodeID ids.NodeID `serialize:"true" json:"nodeID"`
 
 	// Unix time this validator starts validating
-	Start uint64 `serialize:"true" json:"start"`
+	Start int64 `serialize:"true" json:"start"`
 
 	// Unix time this validator stops validating
-	End uint64 `serialize:"true" json:"end"`
+	End int64 `serialize:"true" json:"end"`
 
 	// Weight of this validator used when sampling
 	Wght uint64 `serialize:"true" json:"weight"`

--- a/vms/platformvm/txs/validator_test.go
+++ b/vms/platformvm/txs/validator_test.go
@@ -19,8 +19,8 @@ func TestBoundedBy(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 
 	// case 1: a starts, a finishes, b starts, b finishes
-	aStartTime := uint64(0)
-	aEndTIme := uint64(1)
+	aStartTime := int64(0)
+	aEndTIme := int64(1)
 	a := &Validator{
 		NodeID: nodeID,
 		Start:  aStartTime,
@@ -28,8 +28,8 @@ func TestBoundedBy(t *testing.T) {
 		Wght:   defaultWeight,
 	}
 
-	bStartTime := uint64(2)
-	bEndTime := uint64(3)
+	bStartTime := int64(2)
+	bEndTime := int64(3)
 	b := &Validator{
 		NodeID: nodeID,
 		Start:  bStartTime,

--- a/vms/platformvm/utxo/handler.go
+++ b/vms/platformvm/utxo/handler.go
@@ -171,7 +171,7 @@ func (h *handler) Spend(
 	kc := secp256k1fx.NewKeychain(keys...) // Keychain consumes UTXOs and creates new ones
 
 	// Minimum time this transaction will be issued at
-	now := uint64(h.clk.Time().Unix())
+	now := h.clk.Time().Unix()
 
 	ins := []*avax.TransferableInput{}
 	returnedOuts := []*avax.TransferableOutput{}
@@ -418,7 +418,7 @@ func (h *handler) Authorize(
 	kc := secp256k1fx.NewKeychain(keys...)
 
 	// Make sure that the operation is valid after a minimum time
-	now := uint64(h.clk.Time().Unix())
+	now := h.clk.Time().Unix()
 
 	// Attempt to prove ownership of the subnet
 	indices, signers, matches := kc.Match(owner, now)
@@ -484,7 +484,7 @@ func (h *handler) VerifySpendUTXOs(
 	}
 
 	// Time this transaction is being verified
-	now := uint64(h.clk.Time().Unix())
+	now := h.clk.Time().Unix()
 
 	// Track the amount of unlocked transfers
 	// assetID -> amount
@@ -492,8 +492,8 @@ func (h *handler) VerifySpendUTXOs(
 
 	// Track the amount of locked transfers and their owners
 	// assetID -> locktime -> ownerID -> amount
-	lockedProduced := make(map[ids.ID]map[uint64]map[ids.ID]uint64)
-	lockedConsumed := make(map[ids.ID]map[uint64]map[ids.ID]uint64)
+	lockedProduced := make(map[ids.ID]map[int64]map[ids.ID]uint64)
+	lockedConsumed := make(map[ids.ID]map[int64]map[ids.ID]uint64)
 
 	for index, input := range ins {
 		utxo := utxos[index] // The UTXO consumed by [input]
@@ -510,7 +510,7 @@ func (h *handler) VerifySpendUTXOs(
 		}
 
 		out := utxo.Out
-		locktime := uint64(0)
+		locktime := int64(0)
 		// Set [locktime] to this UTXO's locktime, if applicable
 		if inner, ok := out.(*stakeable.LockOut); ok {
 			out = inner.TransferableOut
@@ -563,7 +563,7 @@ func (h *handler) VerifySpendUTXOs(
 		}
 		lockedConsumedAsset, ok := lockedConsumed[realAssetID]
 		if !ok {
-			lockedConsumedAsset = make(map[uint64]map[ids.ID]uint64)
+			lockedConsumedAsset = make(map[int64]map[ids.ID]uint64)
 			lockedConsumed[realAssetID] = lockedConsumedAsset
 		}
 		ownerID := hashing.ComputeHash256Array(ownerBytes)
@@ -583,7 +583,7 @@ func (h *handler) VerifySpendUTXOs(
 		assetID := out.AssetID()
 
 		output := out.Output()
-		locktime := uint64(0)
+		locktime := int64(0)
 		// Set [locktime] to this output's locktime, if applicable
 		if inner, ok := output.(*stakeable.LockOut); ok {
 			output = inner.TransferableOut
@@ -612,7 +612,7 @@ func (h *handler) VerifySpendUTXOs(
 		}
 		lockedProducedAsset, ok := lockedProduced[assetID]
 		if !ok {
-			lockedProducedAsset = make(map[uint64]map[ids.ID]uint64)
+			lockedProducedAsset = make(map[int64]map[ids.ID]uint64)
 			lockedProduced[assetID] = lockedProducedAsset
 		}
 		ownerID := hashing.ComputeHash256Array(ownerBytes)

--- a/vms/platformvm/utxo/handler_test.go
+++ b/vms/platformvm/utxo/handler_test.go
@@ -161,7 +161,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 			utxos: []*avax.UTXO{{
 				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 				Out: &stakeable.LockOut{
-					Locktime: uint64(now.Add(time.Second).Unix()),
+					Locktime: now.Add(time.Second).Unix(),
 					TransferableOut: &secp256k1fx.TransferOutput{
 						Amt: 1,
 					},
@@ -185,7 +185,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 			utxos: []*avax.UTXO{{
 				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 				Out: &stakeable.LockOut{
-					Locktime: uint64(now.Add(time.Second).Unix()),
+					Locktime: now.Add(time.Second).Unix(),
 					TransferableOut: &secp256k1fx.TransferOutput{
 						Amt: 1,
 					},
@@ -194,7 +194,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 			ins: []*avax.TransferableInput{{
 				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 				In: &stakeable.LockIn{
-					Locktime: uint64(now.Unix()),
+					Locktime: now.Unix(),
 					TransferableIn: &secp256k1fx.TransferInput{
 						Amt: 1,
 					},
@@ -356,7 +356,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 			utxos: []*avax.UTXO{{
 				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 				Out: &stakeable.LockOut{
-					Locktime: uint64(now.Unix()) + 1,
+					Locktime: now.Unix() + 1,
 					TransferableOut: &secp256k1fx.TransferOutput{
 						Amt: 1,
 					},
@@ -365,7 +365,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 			ins: []*avax.TransferableInput{{
 				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 				In: &stakeable.LockIn{
-					Locktime: uint64(now.Unix()) + 1,
+					Locktime: now.Unix() + 1,
 					TransferableIn: &secp256k1fx.TransferInput{
 						Amt: 1,
 					},
@@ -383,7 +383,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 			utxos: []*avax.UTXO{{
 				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 				Out: &stakeable.LockOut{
-					Locktime: uint64(now.Unix()) + 1,
+					Locktime: now.Unix() + 1,
 					TransferableOut: &secp256k1fx.TransferOutput{
 						Amt: 1,
 					},
@@ -392,7 +392,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 			ins: []*avax.TransferableInput{{
 				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 				In: &stakeable.LockIn{
-					Locktime: uint64(now.Unix()) + 1,
+					Locktime: now.Unix() + 1,
 					TransferableIn: &secp256k1fx.TransferInput{
 						Amt: 1,
 					},
@@ -413,7 +413,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 					Out: &stakeable.LockOut{
-						Locktime: uint64(now.Unix()) + 1,
+						Locktime: now.Unix() + 1,
 						TransferableOut: &secp256k1fx.TransferOutput{
 							Amt: 1,
 						},
@@ -430,7 +430,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 					In: &stakeable.LockIn{
-						Locktime: uint64(now.Unix()) + 1,
+						Locktime: now.Unix() + 1,
 						TransferableIn: &secp256k1fx.TransferInput{
 							Amt: 1,
 						},
@@ -447,7 +447,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 					Out: &stakeable.LockOut{
-						Locktime: uint64(now.Unix()) + 1,
+						Locktime: now.Unix() + 1,
 						TransferableOut: &secp256k1fx.TransferOutput{
 							Amt: 1,
 						},
@@ -469,7 +469,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 					Out: &stakeable.LockOut{
-						Locktime: uint64(now.Unix()) + 1,
+						Locktime: now.Unix() + 1,
 						TransferableOut: &secp256k1fx.TransferOutput{
 							Amt: 1,
 						},
@@ -486,7 +486,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 					In: &stakeable.LockIn{
-						Locktime: uint64(now.Unix()) + 1,
+						Locktime: now.Unix() + 1,
 						TransferableIn: &secp256k1fx.TransferInput{
 							Amt: 1,
 						},
@@ -503,7 +503,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 					Out: &stakeable.LockOut{
-						Locktime: uint64(now.Unix()) + 1,
+						Locktime: now.Unix() + 1,
 						TransferableOut: &secp256k1fx.TransferOutput{
 							Amt: 2,
 						},
@@ -525,7 +525,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 					Out: &stakeable.LockOut{
-						Locktime: uint64(now.Unix()) - 1,
+						Locktime: now.Unix() - 1,
 						TransferableOut: &secp256k1fx.TransferOutput{
 							Amt: 1,
 						},
@@ -807,7 +807,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: customAssetID},
 					Out: &stakeable.LockOut{
-						Locktime: uint64(now.Add(time.Second).Unix()),
+						Locktime: now.Add(time.Second).Unix(),
 						TransferableOut: &secp256k1fx.TransferOutput{
 							Amt: 1,
 						},
@@ -1054,7 +1054,7 @@ func TestVerifySpendUTXOs(t *testing.T) {
 				{
 					Asset: avax.Asset{ID: customAssetID},
 					Out: &stakeable.LockOut{
-						Locktime: uint64(now.Unix()) - 1,
+						Locktime: now.Unix() - 1,
 						TransferableOut: &secp256k1fx.TransferOutput{
 							Amt: 1,
 						},

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -281,8 +281,8 @@ func addSubnetValidator(vm *VM, data *validatorInputData, subnetID ids.ID) (*sta
 	addr := keys[0].PublicKey().Address()
 	signedTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
 		vm.Config.MinValidatorStake,
-		uint64(data.startTime.Unix()),
-		uint64(data.endTime.Unix()),
+		data.startTime.Unix(),
+		data.endTime.Unix(),
 		data.nodeID,
 		subnetID,
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -358,8 +358,8 @@ func addPrimaryValidatorWithoutBLSKey(vm *VM, data *validatorInputData) (*state.
 	addr := keys[0].PublicKey().Address()
 	signedTx, err := vm.txBuilder.NewAddValidatorTx(
 		vm.Config.MinValidatorStake,
-		uint64(data.startTime.Unix()),
-		uint64(data.endTime.Unix()),
+		data.startTime.Unix(),
+		data.endTime.Unix(),
 		data.nodeID,
 		addr,
 		reward.PercentDenominator,

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -321,8 +321,8 @@ func addPrimaryValidatorWithBLSKey(vm *VM, data *validatorInputData) (*state.Sta
 		}},
 		Validator: txs.Validator{
 			NodeID: data.nodeID,
-			Start:  uint64(data.startTime.Unix()),
-			End:    uint64(data.endTime.Unix()),
+			Start:  data.startTime.Unix(),
+			End:    data.endTime.Unix(),
 			Wght:   vm.MinValidatorStake,
 		},
 		Subnet:    constants.PrimaryNetworkID,

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -832,8 +832,8 @@ func buildCustomGenesis() ([]byte, error) {
 	endTime := mockable.MaxTime
 	genesisValidator := api.GenesisPermissionlessValidator{
 		GenesisValidator: api.GenesisValidator{
-			StartTime: json.Uint64(starTime.Unix()),
-			EndTime:   json.Uint64(endTime.Unix()),
+			StartTime: json.Int64(starTime.Unix()),
+			EndTime:   json.Int64(endTime.Unix()),
 			NodeID:    nodeID,
 		},
 		RewardOwner: &api.Owner{
@@ -854,7 +854,7 @@ func buildCustomGenesis() ([]byte, error) {
 		UTXOs:         genesisUTXOs,
 		Validators:    []api.GenesisPermissionlessValidator{genesisValidator},
 		Chains:        nil,
-		Time:          json.Uint64(defaultGenesisTime.Unix()),
+		Time:          json.Int64(defaultGenesisTime.Unix()),
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
 	}
 

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -67,8 +67,8 @@ func BenchmarkGetValidatorSet(b *testing.B) {
 
 	genesisValidators := []api.GenesisPermissionlessValidator{{
 		GenesisValidator: api.GenesisValidator{
-			StartTime: json.Uint64(genesisTime.Unix()),
-			EndTime:   json.Uint64(genesisEndTime.Unix()),
+			StartTime: json.Int64(genesisTime.Unix()),
+			EndTime:   json.Int64(genesisEndTime.Unix()),
 			NodeID:    ids.GenerateTestNodeID(),
 		},
 		RewardOwner: &api.Owner{
@@ -88,7 +88,7 @@ func BenchmarkGetValidatorSet(b *testing.B) {
 		UTXOs:         nil,
 		Validators:    genesisValidators,
 		Chains:        nil,
-		Time:          json.Uint64(genesisTime.Unix()),
+		Time:          json.Int64(genesisTime.Unix()),
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
 		Encoding:      formatting.Hex,
 	}

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -1482,8 +1482,8 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 		}},
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  uint64(primaryStartTime.Unix()),
-			End:    uint64(primaryEndTime.Unix()),
+			Start:  primaryStartTime.Unix(),
+			End:    primaryEndTime.Unix(),
 			Wght:   vm.MinValidatorStake,
 		},
 		Subnet:    constants.PrimaryNetworkID,
@@ -1613,8 +1613,8 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 		}},
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  uint64(primaryReStartTime.Unix()),
-			End:    uint64(primaryReEndTime.Unix()),
+			Start:  primaryReStartTime.Unix(),
+			End:    primaryReEndTime.Unix(),
 			Wght:   vm.MinValidatorStake,
 		},
 		Subnet:    constants.PrimaryNetworkID,
@@ -1812,8 +1812,8 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 		}},
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  uint64(primaryStartTime2.Unix()),
-			End:    uint64(primaryEndTime2.Unix()),
+			Start:  primaryStartTime2.Unix(),
+			End:    primaryEndTime2.Unix(),
 			Wght:   vm.MinValidatorStake,
 		},
 		Subnet:    constants.PrimaryNetworkID,
@@ -2014,8 +2014,8 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 		}},
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  uint64(primaryStartTime2.Unix()),
-			End:    uint64(primaryEndTime2.Unix()),
+			Start:  primaryStartTime2.Unix(),
+			End:    primaryEndTime2.Unix(),
 			Wght:   vm.MinValidatorStake,
 		},
 		Subnet:    constants.PrimaryNetworkID,

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -62,8 +62,8 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	// create valid tx
 	addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		changeAddr,
 		reward.PercentDenominator,
@@ -95,8 +95,8 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	// create valid tx
 	addFirstDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 		4*vm.MinValidatorStake, // maximum amount of stake this delegator can provide
-		uint64(firstDelegatorStartTime.Unix()),
-		uint64(firstDelegatorEndTime.Unix()),
+		firstDelegatorStartTime.Unix(),
+		firstDelegatorEndTime.Unix(),
 		nodeID,
 		changeAddr,
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -129,8 +129,8 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	// create valid tx
 	addSecondDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 		vm.MinDelegatorStake,
-		uint64(secondDelegatorStartTime.Unix()),
-		uint64(secondDelegatorEndTime.Unix()),
+		secondDelegatorStartTime.Unix(),
+		secondDelegatorEndTime.Unix(),
 		nodeID,
 		changeAddr,
 		[]*secp256k1.PrivateKey{keys[0], keys[1], keys[3]},
@@ -153,8 +153,8 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	// create valid tx
 	addThirdDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 		vm.MinDelegatorStake,
-		uint64(thirdDelegatorStartTime.Unix()),
-		uint64(thirdDelegatorEndTime.Unix()),
+		thirdDelegatorStartTime.Unix(),
+		thirdDelegatorEndTime.Unix(),
 		nodeID,
 		changeAddr,
 		[]*secp256k1.PrivateKey{keys[0], keys[1], keys[4]},
@@ -225,8 +225,8 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			// create valid tx
 			addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
 				validatorStake,
-				uint64(validatorStartTime.Unix()),
-				uint64(validatorEndTime.Unix()),
+				validatorStartTime.Unix(),
+				validatorEndTime.Unix(),
 				nodeID,
 				id,
 				reward.PercentDenominator,
@@ -248,8 +248,8 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			// create valid tx
 			addFirstDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 				delegator1Stake,
-				uint64(delegator1StartTime.Unix()),
-				uint64(delegator1EndTime.Unix()),
+				delegator1StartTime.Unix(),
+				delegator1EndTime.Unix(),
 				nodeID,
 				keys[0].PublicKey().Address(),
 				[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -270,8 +270,8 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			// create valid tx
 			addSecondDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 				delegator2Stake,
-				uint64(delegator2StartTime.Unix()),
-				uint64(delegator2EndTime.Unix()),
+				delegator2StartTime.Unix(),
+				delegator2EndTime.Unix(),
 				nodeID,
 				keys[0].PublicKey().Address(),
 				[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -292,8 +292,8 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			// create valid tx
 			addThirdDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 				delegator3Stake,
-				uint64(delegator3StartTime.Unix()),
-				uint64(delegator3EndTime.Unix()),
+				delegator3StartTime.Unix(),
+				delegator3EndTime.Unix(),
 				nodeID,
 				keys[0].PublicKey().Address(),
 				[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -314,8 +314,8 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			// create valid tx
 			addFourthDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 				delegator4Stake,
-				uint64(delegator4StartTime.Unix()),
-				uint64(delegator4EndTime.Unix()),
+				delegator4StartTime.Unix(),
+				delegator4EndTime.Unix(),
 				nodeID,
 				keys[0].PublicKey().Address(),
 				[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -479,8 +479,8 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 	// Create the tx to add a new validator
 	addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(newValidatorStartTime.Unix()),
-		uint64(newValidatorEndTime.Unix()),
+		newValidatorStartTime.Unix(),
+		newValidatorEndTime.Unix(),
 		nodeID,
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -690,8 +690,8 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 	// Create the tx to add the first new validator
 	addValidatorTx0, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MaxValidatorStake,
-		uint64(newValidatorStartTime0.Unix()),
-		uint64(newValidatorEndTime0.Unix()),
+		newValidatorStartTime0.Unix(),
+		newValidatorEndTime0.Unix(),
 		nodeID0,
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -862,8 +862,8 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 	// Create the tx to add the second new validator
 	addValidatorTx1, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MaxValidatorStake,
-		uint64(newValidatorStartTime1.Unix()),
-		uint64(newValidatorEndTime1.Unix()),
+		newValidatorStartTime1.Unix(),
+		newValidatorEndTime1.Unix(),
 		nodeID1,
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -1020,8 +1020,8 @@ func TestValidatorSetAtCacheOverwriteRegression(t *testing.T) {
 	// Create the tx to add the first new validator
 	addValidatorTx0, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MaxValidatorStake,
-		uint64(newValidatorStartTime0.Unix()),
-		uint64(newValidatorEndTime0.Unix()),
+		newValidatorStartTime0.Unix(),
+		newValidatorEndTime0.Unix(),
 		extraNodeID,
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -1146,8 +1146,8 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 	// create valid tx
 	addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
 		validatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		id,
 		reward.PercentDenominator,
@@ -1169,8 +1169,8 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 	// create valid tx
 	addFirstDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 		delegator1Stake,
-		uint64(delegator1StartTime.Unix()),
-		uint64(delegator1EndTime.Unix()),
+		delegator1StartTime.Unix(),
+		delegator1EndTime.Unix(),
 		nodeID,
 		keys[0].PublicKey().Address(),
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -1191,8 +1191,8 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 	// create valid tx
 	addSecondDelegatorTx, err := vm.txBuilder.NewAddDelegatorTx(
 		delegator2Stake,
-		uint64(delegator2StartTime.Unix()),
-		uint64(delegator2EndTime.Unix()),
+		delegator2StartTime.Unix(),
+		delegator2EndTime.Unix(),
 		nodeID,
 		keys[0].PublicKey().Address(),
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -1229,8 +1229,8 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 
 	addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
 		defaultMaxValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		id,
 		reward.PercentDenominator,
@@ -1267,8 +1267,8 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 
 	addSubnetValidatorTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
 		defaultMaxValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		createSubnetTx.ID(),
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -1347,8 +1347,8 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 
 	addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
 		defaultMaxValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		id,
 		reward.PercentDenominator,
@@ -1385,8 +1385,8 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 
 	addSubnetValidatorTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
 		defaultMaxValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		createSubnetTx.ID(),
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
@@ -1526,10 +1526,10 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 
 	// insert the subnet validator
 	subnetTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
-		1,                              // Weight
-		uint64(subnetStartTime.Unix()), // Start time
-		uint64(subnetEndTime.Unix()),   // end time
-		nodeID,                         // Node ID
+		1,                      // Weight
+		subnetStartTime.Unix(), // Start time
+		subnetEndTime.Unix(),   // end time
+		nodeID,                 // Node ID
 		subnetID,
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
 		addr,
@@ -1737,8 +1737,8 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	addr := keys[0].PublicKey().Address()
 	primaryTx1, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(primaryStartTime1.Unix()),
-		uint64(primaryEndTime1.Unix()),
+		primaryStartTime1.Unix(),
+		primaryEndTime1.Unix(),
 		nodeID,
 		addr,
 		reward.PercentDenominator,
@@ -1900,8 +1900,8 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	addr := keys[0].PublicKey().Address()
 	primaryTx1, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(primaryStartTime1.Unix()),
-		uint64(primaryEndTime1.Unix()),
+		primaryStartTime1.Unix(),
+		primaryEndTime1.Unix(),
 		nodeID,
 		addr,
 		reward.PercentDenominator,
@@ -1927,10 +1927,10 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 
 	// insert the subnet validator
 	subnetTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
-		1,                              // Weight
-		uint64(subnetStartTime.Unix()), // Start time
-		uint64(subnetEndTime.Unix()),   // end time
-		nodeID,                         // Node ID
+		1,                      // Weight
+		subnetStartTime.Unix(), // Start time
+		subnetEndTime.Unix(),   // end time
+		nodeID,                 // Node ID
 		subnetID,
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
 		addr,
@@ -2109,8 +2109,8 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 	addr := keys[0].PublicKey().Address()
 	primaryTx1, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(primaryStartTime1.Unix()),
-		uint64(primaryEndTime1.Unix()),
+		primaryStartTime1.Unix(),
+		primaryEndTime1.Unix(),
 		nodeID,
 		addr,
 		reward.PercentDenominator,
@@ -2133,10 +2133,10 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 
 	// insert the subnet validator
 	subnetTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
-		1,                              // Weight
-		uint64(subnetStartTime.Unix()), // Start time
-		uint64(subnetEndTime.Unix()),   // end time
-		nodeID,                         // Node ID
+		1,                      // Weight
+		subnetStartTime.Unix(), // Start time
+		subnetEndTime.Unix(),   // end time
+		nodeID,                 // Node ID
 		subnetID,
 		[]*secp256k1.PrivateKey{keys[0], keys[1]},
 		addr,

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -435,8 +435,8 @@ func TestAddValidatorCommit(t *testing.T) {
 	// create valid tx
 	tx, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		nodeID,
 		rewardAddress,
 		reward.PercentDenominator,
@@ -480,8 +480,8 @@ func TestInvalidAddValidatorCommit(t *testing.T) {
 	// create invalid tx
 	tx, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		nodeID,
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -536,8 +536,8 @@ func TestAddValidatorReject(t *testing.T) {
 	// create valid tx
 	tx, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		nodeID,
 		rewardAddress,
 		reward.PercentDenominator,
@@ -581,8 +581,8 @@ func TestAddValidatorInvalidNotReissued(t *testing.T) {
 	// create valid tx
 	tx, err := vm.txBuilder.NewAddValidatorTx(
 		vm.MinValidatorStake,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		repeatNodeID,
 		ids.GenerateTestShortID(),
 		reward.PercentDenominator,
@@ -617,8 +617,8 @@ func TestAddSubnetValidatorAccept(t *testing.T) {
 	// validates primary network ([defaultValidateStartTime, defaultValidateEndTime])
 	tx, err := vm.txBuilder.NewAddSubnetValidatorTx(
 		defaultWeight,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		nodeID,
 		testSubnet1.ID(),
 		[]*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
@@ -665,8 +665,8 @@ func TestAddSubnetValidatorReject(t *testing.T) {
 	// validates primary network ([defaultValidateStartTime, defaultValidateEndTime])
 	tx, err := vm.txBuilder.NewAddSubnetValidatorTx(
 		defaultWeight,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		nodeID,
 		testSubnet1.ID(),
 		[]*secp256k1.PrivateKey{testSubnet1ControlKeys[1], testSubnet1ControlKeys[2]},
@@ -952,8 +952,8 @@ func TestCreateSubnet(t *testing.T) {
 	// [startTime, endTime] is subset of time keys[0] validates default subnet so tx is valid
 	addValidatorTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
 		defaultWeight,
-		uint64(startTime.Unix()),
-		uint64(endTime.Unix()),
+		startTime.Unix(),
+		endTime.Unix(),
 		nodeID,
 		createSubnetTx.ID(),
 		[]*secp256k1.PrivateKey{keys[0]},
@@ -2054,8 +2054,8 @@ func TestRemovePermissionedValidatorDuringAddPending(t *testing.T) {
 
 	addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
 		defaultMaxValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		id,
 		reward.PercentDenominator,
@@ -2092,8 +2092,8 @@ func TestRemovePermissionedValidatorDuringAddPending(t *testing.T) {
 
 	addSubnetValidatorTx, err := vm.txBuilder.NewAddSubnetValidatorTx(
 		defaultMaxValidatorStake,
-		uint64(validatorStartTime.Unix()),
-		uint64(validatorEndTime.Unix()),
+		validatorStartTime.Unix(),
+		validatorEndTime.Unix(),
 		nodeID,
 		createSubnetTx.ID(),
 		[]*secp256k1.PrivateKey{key, keys[1]},

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -206,8 +206,8 @@ func defaultGenesis(t *testing.T) (*api.BuildGenesisArgs, []byte) {
 		require.NoError(err)
 		genesisValidators[i] = api.GenesisPermissionlessValidator{
 			GenesisValidator: api.GenesisValidator{
-				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
-				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
+				StartTime: json.Int64(defaultValidateStartTime.Unix()),
+				EndTime:   json.Int64(defaultValidateEndTime.Unix()),
 				NodeID:    nodeID,
 			},
 			RewardOwner: &api.Owner{
@@ -229,7 +229,7 @@ func defaultGenesis(t *testing.T) (*api.BuildGenesisArgs, []byte) {
 		UTXOs:         genesisUTXOs,
 		Validators:    genesisValidators,
 		Chains:        nil,
-		Time:          json.Uint64(defaultGenesisTime.Unix()),
+		Time:          json.Int64(defaultGenesisTime.Unix()),
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
 	}
 

--- a/vms/secp256k1fx/fx_test.go
+++ b/vms/secp256k1fx/fx_test.go
@@ -318,7 +318,7 @@ func TestFxVerifyTransferTimelocked(t *testing.T) {
 	out := &TransferOutput{
 		Amt: 1,
 		OutputOwners: OutputOwners{
-			Locktime:  uint64(date.Add(time.Second).Unix()),
+			Locktime:  date.Add(time.Second).Unix(),
 			Threshold: 1,
 			Addrs: []ids.ShortID{
 				addr,
@@ -1122,7 +1122,7 @@ func TestVerifyPermission(t *testing.T) {
 			&Credential{Sigs: [][secp256k1.SignatureLen]byte{sigBytes, sig2Bytes}},
 			&OutputOwners{
 				Threshold: 1,
-				Locktime:  uint64(now.Add(time.Second).Unix()),
+				Locktime:  now.Add(time.Second).Unix(),
 				Addrs:     []ids.ShortID{addr, addr2},
 			},
 			ErrTimelocked,

--- a/vms/secp256k1fx/keychain.go
+++ b/vms/secp256k1fx/keychain.go
@@ -98,7 +98,7 @@ func (kc *Keychain) New() (*secp256k1.PrivateKey, error) {
 }
 
 // Spend attempts to create an input
-func (kc *Keychain) Spend(out verify.Verifiable, time uint64) (verify.Verifiable, []*secp256k1.PrivateKey, error) {
+func (kc *Keychain) Spend(out verify.Verifiable, time int64) (verify.Verifiable, []*secp256k1.PrivateKey, error) {
 	switch out := out.(type) {
 	case *MintOutput:
 		if sigIndices, keys, able := kc.Match(&out.OutputOwners, time); able {
@@ -122,7 +122,7 @@ func (kc *Keychain) Spend(out verify.Verifiable, time uint64) (verify.Verifiable
 }
 
 // Match attempts to match a list of addresses up to the provided threshold
-func (kc *Keychain) Match(owners *OutputOwners, time uint64) ([]uint32, []*secp256k1.PrivateKey, bool) {
+func (kc *Keychain) Match(owners *OutputOwners, time int64) ([]uint32, []*secp256k1.PrivateKey, bool) {
 	if time < owners.Locktime {
 		return nil, nil, false
 	}

--- a/vms/secp256k1fx/output_owners.go
+++ b/vms/secp256k1fx/output_owners.go
@@ -26,7 +26,7 @@ var (
 type OutputOwners struct {
 	verify.IsNotState `json:"-"`
 
-	Locktime  uint64        `serialize:"true" json:"locktime"`
+	Locktime  int64         `serialize:"true" json:"locktime"`
 	Threshold uint32        `serialize:"true" json:"threshold"`
 	Addrs     []ids.ShortID `serialize:"true" json:"addresses"`
 

--- a/wallet/chain/c/builder.go
+++ b/wallet/chain/c/builder.go
@@ -392,7 +392,7 @@ func (b *builder) NewExportTx(
 func getSpendableAmount(
 	utxo *avax.UTXO,
 	addrs set.Set[ids.ShortID],
-	minIssuanceTime uint64,
+	minIssuanceTime int64,
 	avaxAssetID ids.ID,
 ) (uint64, []uint32, bool) {
 	if utxo.Asset.ID != avaxAssetID {

--- a/wallet/subnet/primary/common/options.go
+++ b/wallet/subnet/primary/common/options.go
@@ -35,7 +35,7 @@ type Options struct {
 	baseFee *big.Int
 
 	minIssuanceTimeSet bool
-	minIssuanceTime    uint64
+	minIssuanceTime    int64
 
 	allowStakeableLocked bool
 
@@ -99,11 +99,11 @@ func (o *Options) BaseFee(defaultBaseFee *big.Int) *big.Int {
 	return defaultBaseFee
 }
 
-func (o *Options) MinIssuanceTime() uint64 {
+func (o *Options) MinIssuanceTime() int64 {
 	if o.minIssuanceTimeSet {
 		return o.minIssuanceTime
 	}
-	return uint64(time.Now().Unix())
+	return time.Now().Unix()
 }
 
 func (o *Options) AllowStakeableLocked() bool {
@@ -162,7 +162,7 @@ func WithBaseFee(baseFee *big.Int) Option {
 	}
 }
 
-func WithMinIssuanceTime(minIssuanceTime uint64) Option {
+func WithMinIssuanceTime(minIssuanceTime int64) Option {
 	return func(o *Options) {
 		o.minIssuanceTimeSet = true
 		o.minIssuanceTime = minIssuanceTime

--- a/wallet/subnet/primary/common/spend.go
+++ b/wallet/subnet/primary/common/spend.go
@@ -14,7 +14,7 @@ import (
 func MatchOwners(
 	owners *secp256k1fx.OutputOwners,
 	addrs set.Set[ids.ShortID],
-	minIssuanceTime uint64,
+	minIssuanceTime int64,
 ) ([]uint32, bool) {
 	if owners.Locktime > minIssuanceTime {
 		return nil, false

--- a/wallet/subnet/primary/example_test.go
+++ b/wallet/subnet/primary/example_test.go
@@ -145,8 +145,8 @@ func ExampleWallet() {
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
 				NodeID: genesis.LocalConfig.InitialStakers[0].NodeID,
-				Start:  uint64(startTime.Unix()),
-				End:    uint64(startTime.Add(5 * time.Second).Unix()),
+				Start:  startTime.Unix(),
+				End:    startTime.Add(5 * time.Second).Unix(),
 				Wght:   25 * units.MegaAvax,
 			},
 			Subnet: createSubnetTxID,
@@ -169,8 +169,8 @@ func ExampleWallet() {
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
 				NodeID: genesis.LocalConfig.InitialStakers[0].NodeID,
-				Start:  uint64(startTime.Unix()),
-				End:    uint64(startTime.Add(5 * time.Second).Unix()),
+				Start:  startTime.Unix(),
+				End:    startTime.Add(5 * time.Second).Unix(),
 				Wght:   25 * units.MegaAvax,
 			},
 			Subnet: createSubnetTxID,

--- a/wallet/subnet/primary/examples/add-permissioned-subnet-validator/main.go
+++ b/wallet/subnet/primary/examples/add-permissioned-subnet-validator/main.go
@@ -63,8 +63,8 @@ func main() {
 	addValidatorTx, err := pWallet.IssueAddSubnetValidatorTx(&txs.SubnetValidator{
 		Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  uint64(startTime.Unix()),
-			End:    uint64(startTime.Add(duration).Unix()),
+			Start:  startTime.Unix(),
+			End:    startTime.Add(duration).Unix(),
 			Wght:   weight,
 		},
 		Subnet: subnetID,

--- a/wallet/subnet/primary/examples/add-primary-validator/main.go
+++ b/wallet/subnet/primary/examples/add-primary-validator/main.go
@@ -60,8 +60,8 @@ func main() {
 	addValidatorTx, err := pWallet.IssueAddPermissionlessValidatorTx(
 		&txs.SubnetValidator{Validator: txs.Validator{
 			NodeID: nodeID,
-			Start:  uint64(startTime.Unix()),
-			End:    uint64(startTime.Add(duration).Unix()),
+			Start:  startTime.Unix(),
+			End:    startTime.Add(duration).Unix(),
 			Wght:   weight,
 		}},
 		nodePOP,

--- a/wallet/subnet/primary/examples/create-locked-stakeable/main.go
+++ b/wallet/subnet/primary/examples/create-locked-stakeable/main.go
@@ -23,7 +23,7 @@ func main() {
 	uri := primary.LocalAPIURI
 	kc := secp256k1fx.NewKeychain(key)
 	amount := 500 * units.MilliAvax
-	locktime := uint64(time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC).Unix())
+	locktime := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
 	destAddrStr := "P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
 
 	destAddr, err := address.ParseToID(destAddrStr)


### PR DESCRIPTION
WIP not ready for review.

## Why this should be merged

See https://github.com/ava-labs/avalanchego/issues/2488 

## How this works

uint64 --> int64

## How this was tested

Existing UT
