### PR TITLE
Initialize transactions once

### DIFF
--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -571,7 +571,7 @@ func AVAXAssetID(avmGenesisBytes []byte) (ids.ID, error) {
 	genesisTx := genesis.Txs[0]
 
 	tx := xchaintxs.Tx{Unsigned: &genesisTx.CreateAssetTx}
-	if err := parser.InitializeGenesisTx(&tx); err != nil {
+	if err := tx.Initialize(genesisCodec); err != nil {
 		return ids.Empty, err
 	}
 	return tx.ID(), nil

--- a/vms/avm/block/parser.go
+++ b/vms/avm/block/parser.go
@@ -4,7 +4,6 @@
 package block
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/ava-labs/avalanchego/codec"
@@ -25,9 +24,6 @@ type Parser interface {
 
 	ParseBlock(bytes []byte) (Block, error)
 	ParseGenesisBlock(bytes []byte) (Block, error)
-
-	InitializeBlock(block Block) error
-	InitializeGenesisBlock(block Block) error
 }
 
 type parser struct {
@@ -87,22 +83,4 @@ func parse(cm codec.Manager, bytes []byte) (Block, error) {
 		return nil, err
 	}
 	return blk, blk.initialize(bytes, cm)
-}
-
-func (p *parser) InitializeBlock(block Block) error {
-	return initialize(block, p.Codec())
-}
-
-func (p *parser) InitializeGenesisBlock(block Block) error {
-	return initialize(block, p.GenesisCodec())
-}
-
-func initialize(blk Block, cm codec.Manager) error {
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	bytes, err := cm.Marshal(CodecVersion, &blk)
-	if err != nil {
-		return fmt.Errorf("couldn't marshal block: %w", err)
-	}
-	return blk.initialize(bytes, cm)
 }

--- a/vms/avm/block/standard_block.go
+++ b/vms/avm/block/standard_block.go
@@ -88,5 +88,16 @@ func NewStandardBlock(
 		Time:         uint64(timestamp.Unix()),
 		Transactions: txs,
 	}
-	return blk, initialize(blk, cm)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := cm.Marshal(CodecVersion, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.BlockID = hashing.ComputeHash256Array(bytes)
+	blk.bytes = bytes
+	return blk, nil
 }

--- a/vms/avm/environment_test.go
+++ b/vms/avm/environment_test.go
@@ -289,7 +289,7 @@ func getCreateTxFromGenesisTest(tb testing.TB, genesisBytes []byte, assetName st
 	tx := &txs.Tx{
 		Unsigned: &assetTx.CreateAssetTx,
 	}
-	require.NoError(parser.InitializeGenesisTx(tx))
+	require.NoError(tx.Initialize(parser.GenesisCodec()))
 	return tx
 }
 

--- a/vms/avm/network/network_test.go
+++ b/vms/avm/network/network_test.go
@@ -45,7 +45,7 @@ func TestNetworkAppGossip(t *testing.T) {
 		&secp256k1fx.Fx{},
 	})
 	require.NoError(t, err)
-	require.NoError(t, parser.InitializeTx(testTx))
+	require.NoError(t, testTx.Initialize(parser.Codec()))
 
 	type test struct {
 		name          string

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -918,7 +918,7 @@ func newAvaxExportTxWithOutputs(t *testing.T, genesisBytes []byte, vm *VM) *txs.
 func newAvaxCreateAssetTxWithOutputs(t *testing.T, vm *VM) *txs.Tx {
 	key := keys[0]
 	tx := buildCreateAssetTx(key)
-	require.NoError(t, vm.parser.InitializeTx(tx))
+	require.NoError(t, tx.Initialize(vm.parser.Codec()))
 	return tx
 }
 

--- a/vms/avm/state/state_test.go
+++ b/vms/avm/state/state_test.go
@@ -61,7 +61,7 @@ func init() {
 	populatedTx = &txs.Tx{Unsigned: &txs.BaseTx{BaseTx: avax.BaseTx{
 		BlockchainID: ids.GenerateTestID(),
 	}}}
-	err = parser.InitializeTx(populatedTx)
+	err = populatedTx.Initialize(parser.Codec())
 	if err != nil {
 		panic(err)
 	}
@@ -197,7 +197,7 @@ func ChainTxTest(t *testing.T, c Chain) {
 	tx := &txs.Tx{Unsigned: &txs.BaseTx{BaseTx: avax.BaseTx{
 		BlockchainID: ids.GenerateTestID(),
 	}}}
-	require.NoError(parser.InitializeTx(tx))
+	require.NoError(tx.Initialize(parser.Codec()))
 	txID := tx.ID()
 
 	_, err = c.GetTx(txID)

--- a/vms/avm/txs/base_tx_test.go
+++ b/vms/avm/txs/base_tx_test.go
@@ -130,7 +130,7 @@ func TestBaseTxSerialization(t *testing.T) {
 	})
 	require.NoError(err)
 
-	require.NoError(parser.InitializeTx(tx))
+	require.NoError(tx.Initialize(parser.Codec()))
 	require.Equal(tx.ID().String(), "zeqT8FTnRAxes7QQQYkaWhNkHavd9d6aCdH8TQu2Mx5KEydEz")
 
 	result := tx.Bytes()

--- a/vms/avm/txs/create_asset_tx_test.go
+++ b/vms/avm/txs/create_asset_tx_test.go
@@ -198,7 +198,7 @@ func TestCreateAssetTxSerialization(t *testing.T) {
 	})
 	require.NoError(err)
 
-	require.NoError(parser.InitializeTx(tx))
+	require.NoError(tx.Initialize(parser.Codec()))
 
 	result := tx.Bytes()
 	require.Equal(expected, result)
@@ -366,7 +366,7 @@ func TestCreateAssetTxSerializationAgain(t *testing.T) {
 		&secp256k1fx.Fx{},
 	})
 	require.NoError(err)
-	require.NoError(parser.InitializeTx(tx))
+	require.NoError(tx.Initialize(parser.Codec()))
 
 	result := tx.Bytes()
 	require.Equal(expected, result)

--- a/vms/avm/txs/export_tx_test.go
+++ b/vms/avm/txs/export_tx_test.go
@@ -113,7 +113,7 @@ func TestExportTxSerialization(t *testing.T) {
 	})
 	require.NoError(err)
 
-	require.NoError(parser.InitializeTx(tx))
+	require.NoError(tx.Initialize(parser.Codec()))
 	require.Equal(tx.ID().String(), "2PKJE4TrKYpgynBFCpNPpV3GHK7d9QTgrL5mpYG6abHKDvNBG3")
 
 	result := tx.Bytes()

--- a/vms/avm/txs/import_tx_test.go
+++ b/vms/avm/txs/import_tx_test.go
@@ -113,7 +113,7 @@ func TestImportTxSerialization(t *testing.T) {
 	})
 	require.NoError(err)
 
-	require.NoError(parser.InitializeTx(tx))
+	require.NoError(tx.Initialize(parser.Codec()))
 	require.Equal(tx.ID().String(), "9wdPb5rsThXYLX4WxkNeyYrNMfDE5cuWLgifSjxKiA2dCmgCZ")
 
 	result := tx.Bytes()

--- a/vms/avm/txs/parser.go
+++ b/vms/avm/txs/parser.go
@@ -31,9 +31,6 @@ type Parser interface {
 
 	ParseTx(bytes []byte) (*Tx, error)
 	ParseGenesisTx(bytes []byte) (*Tx, error)
-
-	InitializeTx(tx *Tx) error
-	InitializeGenesisTx(tx *Tx) error
 }
 
 type parser struct {
@@ -130,14 +127,6 @@ func (p *parser) ParseGenesisTx(bytes []byte) (*Tx, error) {
 	return parse(p.gcm, bytes)
 }
 
-func (p *parser) InitializeTx(tx *Tx) error {
-	return initializeTx(p.cm, tx)
-}
-
-func (p *parser) InitializeGenesisTx(tx *Tx) error {
-	return initializeTx(p.gcm, tx)
-}
-
 func parse(cm codec.Manager, signedBytes []byte) (*Tx, error) {
 	tx := &Tx{}
 	parsedVersion, err := cm.Unmarshal(signedBytes, tx)
@@ -156,20 +145,4 @@ func parse(cm codec.Manager, signedBytes []byte) (*Tx, error) {
 	unsignedBytes := signedBytes[:unsignedBytesLen]
 	tx.SetBytes(unsignedBytes, signedBytes)
 	return tx, nil
-}
-
-func initializeTx(cm codec.Manager, tx *Tx) error {
-	signedBytes, err := cm.Marshal(CodecVersion, tx)
-	if err != nil {
-		return fmt.Errorf("problem creating transaction: %w", err)
-	}
-
-	unsignedBytesLen, err := cm.Size(CodecVersion, &tx.Unsigned)
-	if err != nil {
-		return fmt.Errorf("couldn't calculate UnsignedTx marshal length: %w", err)
-	}
-
-	unsignedBytes := signedBytes[:unsignedBytesLen]
-	tx.SetBytes(unsignedBytes, signedBytes)
-	return nil
 }

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -534,7 +534,7 @@ func (vm *VM) initGenesis(genesisBytes []byte) error {
 		tx := &txs.Tx{
 			Unsigned: &genesisTx.CreateAssetTx,
 		}
-		if err := vm.parser.InitializeGenesisTx(tx); err != nil {
+		if err := tx.Initialize(genesisCodec); err != nil {
 			return err
 		}
 

--- a/vms/avm/vm_regression_test.go
+++ b/vms/avm/vm_regression_test.go
@@ -66,7 +66,7 @@ func TestVerifyFxUsage(t *testing.T) {
 			},
 		},
 	}}
-	require.NoError(env.vm.parser.InitializeTx(createAssetTx))
+	require.NoError(createAssetTx.Initialize(env.vm.parser.Codec()))
 	issueAndAccept(require, env.vm, env.issuer, createAssetTx)
 
 	mintNFTTx := &txs.Tx{Unsigned: &txs.OperationTx{

--- a/vms/avm/vm_test.go
+++ b/vms/avm/vm_test.go
@@ -167,7 +167,7 @@ func TestIssueNFT(t *testing.T) {
 			},
 		}},
 	}}
-	require.NoError(env.vm.parser.InitializeTx(createAssetTx))
+	require.NoError(createAssetTx.Initialize(env.vm.parser.Codec()))
 	issueAndAccept(require, env.vm, env.issuer, createAssetTx)
 
 	mintNFTTx := &txs.Tx{Unsigned: &txs.OperationTx{
@@ -222,7 +222,7 @@ func TestIssueNFT(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(env.vm.parser.InitializeTx(transferNFTTx))
+	require.NoError(transferNFTTx.Initialize(env.vm.parser.Codec()))
 	issueAndAccept(require, env.vm, env.issuer, transferNFTTx)
 }
 
@@ -262,7 +262,7 @@ func TestIssueProperty(t *testing.T) {
 			},
 		}},
 	}}
-	require.NoError(env.vm.parser.InitializeTx(createAssetTx))
+	require.NoError(createAssetTx.Initialize(env.vm.parser.Codec()))
 	issueAndAccept(require, env.vm, env.issuer, createAssetTx)
 
 	mintPropertyTx := &txs.Tx{Unsigned: &txs.OperationTx{


### PR DESCRIPTION
## Why this should be merged

Currently, when creating a block, we re-initialize all transactions being placed into the block. This is inefficient, as the transactions are already initialized. However, this can also introduce racy behavior. In a concurrent setting we generally want to be able to treat transactions as immuable. However calling `.ID` on a transaction that could be re-initialized in a different goroutine would be racy.

## How this works

Ensure that transactions are only initialized once, during creation or parsing.

## How this was tested

- [X] CI