### PR TITLE
Move context lock into `network.issueTx`

### DIFF
--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -52,7 +52,9 @@ func TestBuildBlockBasic(t *testing.T) {
 	txID := tx.ID()
 
 	// Issue the transaction
+	env.ctx.Lock.Unlock()
 	require.NoError(env.network.IssueTx(context.Background(), tx))
+	env.ctx.Lock.Lock()
 	_, ok := env.mempool.Get(txID)
 	require.True(ok)
 
@@ -125,7 +127,9 @@ func TestBuildBlockShouldReward(t *testing.T) {
 	txID := tx.ID()
 
 	// Issue the transaction
+	env.ctx.Lock.Unlock()
 	require.NoError(env.network.IssueTx(context.Background(), tx))
+	env.ctx.Lock.Lock()
 	_, ok := env.mempool.Get(txID)
 	require.True(ok)
 
@@ -249,7 +253,9 @@ func TestBuildBlockForceAdvanceTime(t *testing.T) {
 	txID := tx.ID()
 
 	// Issue the transaction
+	env.ctx.Lock.Unlock()
 	require.NoError(env.network.IssueTx(context.Background(), tx))
+	env.ctx.Lock.Lock()
 	_, ok := env.mempool.Get(txID)
 	require.True(ok)
 
@@ -471,6 +477,7 @@ func TestPreviouslyDroppedTxsCanBeReAddedToMempool(t *testing.T) {
 	env := newEnvironment(t)
 	env.ctx.Lock.Lock()
 	defer func() {
+		env.ctx.Lock.Lock()
 		require.NoError(shutdownEnvironment(env))
 		env.ctx.Lock.Unlock()
 	}()
@@ -500,6 +507,7 @@ func TestPreviouslyDroppedTxsCanBeReAddedToMempool(t *testing.T) {
 	require.ErrorIs(reason, errTestingDropped)
 
 	// Issue the transaction
+	env.ctx.Lock.Unlock()
 	require.NoError(env.network.IssueTx(context.Background(), tx))
 	_, ok := env.mempool.Get(txID)
 	require.True(ok)

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -148,9 +148,6 @@ func (n *network) issueTx(tx *txs.Tx) error {
 	//
 	// We need to grab the context lock here to avoid racy behavior with
 	// transaction verification + mempool modifications.
-	//
-	// Invariant: tx should not be referenced again without the context lock
-	// held to avoid any data races.
 	n.ctx.Lock.Lock()
 	err := n.manager.VerifyTx(tx)
 	n.ctx.Lock.Unlock()

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -30,8 +30,6 @@ type Network interface {
 
 	// IssueTx verifies the transaction at the currently preferred state, adds
 	// it to the mempool, and gossips it to the network.
-	//
-	// Invariant: Assumes the context lock is held.
 	IssueTx(context.Context, *txs.Tx) error
 }
 
@@ -109,14 +107,6 @@ func (n *network) AppGossip(ctx context.Context, nodeID ids.NodeID, msgBytes []b
 	}
 	txID := tx.ID()
 
-	// We need to grab the context lock here to avoid racy behavior with
-	// transaction verification + mempool modifications.
-	//
-	// Invariant: tx should not be referenced again without the context lock
-	// held to avoid any data races.
-	n.ctx.Lock.Lock()
-	defer n.ctx.Lock.Unlock()
-
 	if reason := n.mempool.GetDropReason(txID); reason != nil {
 		// If the tx is being dropped - just ignore it
 		return nil
@@ -155,7 +145,16 @@ func (n *network) issueTx(tx *txs.Tx) error {
 	}
 
 	// Verify the tx at the currently preferred state
-	if err := n.manager.VerifyTx(tx); err != nil {
+	//
+	// We need to grab the context lock here to avoid racy behavior with
+	// transaction verification + mempool modifications.
+	//
+	// Invariant: tx should not be referenced again without the context lock
+	// held to avoid any data races.
+	n.ctx.Lock.Lock()
+	err := n.manager.VerifyTx(tx)
+	n.ctx.Lock.Unlock()
+	if err != nil {
 		n.ctx.Log.Debug("tx failed verification",
 			zap.Stringer("txID", txID),
 			zap.Error(err),

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1291,10 +1291,10 @@ func (s *Service) buildAddValidatorTx(args *AddValidatorArgs) (*txs.Tx, ids.Shor
 		changeAddr,
 	)
 	if err != nil {
-		return nil, ids.ShortEmpty, fmt.Errorf("couldn't create tx: %w", err)
+		return nil, ids.ShortEmpty, err
 	}
 
-	return tx, changeAddr, nil
+	return tx, changeAddr, user.Close()
 }
 
 // AddDelegatorArgs are the arguments to AddDelegator
@@ -1408,8 +1408,11 @@ func (s *Service) buildAddDelegatorTx(args *AddDelegatorArgs) (*txs.Tx, ids.Shor
 		privKeys.Keys,          // Private keys
 		changeAddr,             // Change address
 	)
+	if err != nil {
+		return nil, ids.ShortEmpty, err
+	}
 
-	return tx, changeAddr, err
+	return tx, changeAddr, user.Close()
 }
 
 // AddSubnetValidatorArgs are the arguments to AddSubnetValidator
@@ -1519,8 +1522,11 @@ func (s *Service) buildAddSubnetValidatorTx(args *AddSubnetValidatorArgs) (*txs.
 		keys.Keys,
 		changeAddr,
 	)
+	if err != nil {
+		return nil, ids.ShortEmpty, err
+	}
 
-	return tx, changeAddr, err
+	return tx, changeAddr, user.Close()
 }
 
 // CreateSubnetArgs are the arguments to CreateSubnet
@@ -1600,8 +1606,11 @@ func (s *Service) buildCreateSubnetTx(args *CreateSubnetArgs) (*txs.Tx, ids.Shor
 		privKeys.Keys,          // Private keys
 		changeAddr,
 	)
+	if err != nil {
+		return nil, ids.ShortEmpty, err
+	}
 
-	return tx, changeAddr, err
+	return tx, changeAddr, user.Close()
 }
 
 // ExportAVAXArgs are the arguments to ExportAVAX
@@ -1701,8 +1710,11 @@ func (s *Service) buildExportAVAX(args *ExportAVAXArgs) (*txs.Tx, ids.ShortID, e
 		privKeys.Keys,       // Private keys
 		changeAddr,          // Change address
 	)
+	if err != nil {
+		return nil, ids.ShortEmpty, err
+	}
 
-	return tx, changeAddr, err
+	return tx, changeAddr, user.Close()
 }
 
 // ImportAVAXArgs are the arguments to ImportAVAX
@@ -1791,8 +1803,11 @@ func (s *Service) buildImportAVAXTx(args *ImportAVAXArgs) (*txs.Tx, ids.ShortID,
 		privKeys.Keys,
 		changeAddr,
 	)
+	if err != nil {
+		return nil, ids.ShortEmpty, err
+	}
 
-	return tx, changeAddr, err
+	return tx, changeAddr, user.Close()
 }
 
 /*
@@ -1920,8 +1935,11 @@ func (s *Service) buildCreateBlockchainTx(args *CreateBlockchainArgs) (*txs.Tx, 
 		keys.Keys,
 		changeAddr, // Change address
 	)
+	if err != nil {
+		return nil, ids.ShortEmpty, err
+	}
 
-	return tx, changeAddr, err
+	return tx, changeAddr, user.Close()
 }
 
 // GetBlockchainStatusArgs is the arguments for calling GetBlockchainStatus

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -5,13 +5,12 @@ package platformvm
 
 import (
 	"context"
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"net/http"
 	"time"
-
-	stdjson "encoding/json"
 
 	"go.uber.org/zap"
 
@@ -1191,6 +1190,21 @@ func (s *Service) AddValidator(req *http.Request, args *AddValidatorArgs, reply 
 		zap.String("method", "addValidator"),
 	)
 
+	tx, changeAddr, err := s.buildAddValidatorTx(args)
+	if err != nil {
+		return fmt.Errorf("couldn't create tx: %w", err)
+	}
+
+	reply.TxID = tx.ID()
+	reply.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+	if err != nil {
+		return fmt.Errorf("couldn't format address: %w", err)
+	}
+
+	return s.vm.issueTx(req.Context(), tx)
+}
+
+func (s *Service) buildAddValidatorTx(args *AddValidatorArgs) (*txs.Tx, ids.ShortID, error) {
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
 	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
@@ -1203,13 +1217,13 @@ func (s *Service) AddValidator(req *http.Request, args *AddValidatorArgs, reply 
 
 	switch {
 	case args.RewardAddress == "":
-		return errNoRewardAddress
+		return nil, ids.ShortEmpty, errNoRewardAddress
 	case args.StartTime < minAddStakerUnix:
-		return errStartTimeTooSoon
+		return nil, ids.ShortEmpty, errStartTimeTooSoon
 	case args.StartTime > maxAddStakerUnix:
-		return errStartTimeTooLate
+		return nil, ids.ShortEmpty, errStartTimeTooLate
 	case args.DelegationFeeRate < 0 || args.DelegationFeeRate > 100:
-		return errInvalidDelegationRate
+		return nil, ids.ShortEmpty, errInvalidDelegationRate
 	}
 
 	// Parse the node ID
@@ -1223,13 +1237,13 @@ func (s *Service) AddValidator(req *http.Request, args *AddValidatorArgs, reply 
 	// Parse the from addresses
 	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, args.From)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 
 	// Parse the reward address
 	rewardAddress, err := avax.ParseServiceAddress(s.addrManager, args.RewardAddress)
 	if err != nil {
-		return fmt.Errorf("problem while parsing reward address: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("problem while parsing reward address: %w", err)
 	}
 
 	s.vm.ctx.Lock.Lock()
@@ -1237,25 +1251,25 @@ func (s *Service) AddValidator(req *http.Request, args *AddValidatorArgs, reply 
 
 	user, err := keystore.NewUserFromKeystore(s.vm.ctx.Keystore, args.Username, args.Password)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 	defer user.Close()
 
 	// Get the user's keys
 	privKeys, err := keystore.GetKeychain(user, fromAddrs)
 	if err != nil {
-		return fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
 	}
 
 	// Parse the change address.
 	if len(privKeys.Keys) == 0 {
-		return errNoKeys
+		return nil, ids.ShortEmpty, errNoKeys
 	}
 	changeAddr := privKeys.Keys[0].PublicKey().Address() // By default, use a key controlled by the user
 	if args.ChangeAddr != "" {
 		changeAddr, err = avax.ParseServiceAddress(s.addrManager, args.ChangeAddr)
 		if err != nil {
-			return fmt.Errorf("couldn't parse changeAddr: %w", err)
+			return nil, ids.ShortEmpty, fmt.Errorf("couldn't parse changeAddr: %w", err)
 		}
 	}
 
@@ -1276,17 +1290,10 @@ func (s *Service) AddValidator(req *http.Request, args *AddValidatorArgs, reply 
 		changeAddr,
 	)
 	if err != nil {
-		return fmt.Errorf("couldn't create tx: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't create tx: %w", err)
 	}
 
-	reply.TxID = tx.ID()
-	reply.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
-
-	return utils.Err(
-		err,
-		s.vm.Network.IssueTx(req.Context(), tx),
-		user.Close(),
-	)
+	return tx, changeAddr, nil
 }
 
 // AddDelegatorArgs are the arguments to AddDelegator
@@ -1305,6 +1312,21 @@ func (s *Service) AddDelegator(req *http.Request, args *AddDelegatorArgs, reply 
 		zap.String("method", "addDelegator"),
 	)
 
+	tx, changeAddr, err := s.buildAddDelegatorTx(args)
+	if err != nil {
+		return fmt.Errorf("couldn't create tx: %w", err)
+	}
+
+	reply.TxID = tx.ID()
+	reply.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+	if err != nil {
+		return fmt.Errorf("couldn't format address: %w", err)
+	}
+
+	return s.vm.issueTx(req.Context(), tx)
+}
+
+func (s *Service) buildAddDelegatorTx(args *AddDelegatorArgs) (*txs.Tx, ids.ShortID, error) {
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
 	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
@@ -1317,11 +1339,11 @@ func (s *Service) AddDelegator(req *http.Request, args *AddDelegatorArgs, reply 
 
 	switch {
 	case args.RewardAddress == "":
-		return errNoRewardAddress
+		return nil, ids.ShortEmpty, errNoRewardAddress
 	case args.StartTime < minAddStakerUnix:
-		return errStartTimeTooSoon
+		return nil, ids.ShortEmpty, errStartTimeTooSoon
 	case args.StartTime > maxAddStakerUnix:
-		return errStartTimeTooLate
+		return nil, ids.ShortEmpty, errStartTimeTooLate
 	}
 
 	var nodeID ids.NodeID
@@ -1334,13 +1356,13 @@ func (s *Service) AddDelegator(req *http.Request, args *AddDelegatorArgs, reply 
 	// Parse the reward address
 	rewardAddress, err := avax.ParseServiceAddress(s.addrManager, args.RewardAddress)
 	if err != nil {
-		return fmt.Errorf("problem parsing 'rewardAddress': %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("problem parsing 'rewardAddress': %w", err)
 	}
 
 	// Parse the from addresses
 	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, args.From)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 
 	s.vm.ctx.Lock.Lock()
@@ -1348,25 +1370,25 @@ func (s *Service) AddDelegator(req *http.Request, args *AddDelegatorArgs, reply 
 
 	user, err := keystore.NewUserFromKeystore(s.vm.ctx.Keystore, args.Username, args.Password)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 	defer user.Close()
 
 	privKeys, err := keystore.GetKeychain(user, fromAddrs)
 	if err != nil {
-		return fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
 	}
 
 	// Parse the change address. Assumes that if the user has no keys,
 	// this operation will fail so the change address can be anything.
 	if len(privKeys.Keys) == 0 {
-		return errNoKeys
+		return nil, ids.ShortEmpty, errNoKeys
 	}
 	changeAddr := privKeys.Keys[0].PublicKey().Address() // By default, use a key controlled by the user
 	if args.ChangeAddr != "" {
 		changeAddr, err = avax.ParseServiceAddress(s.addrManager, args.ChangeAddr)
 		if err != nil {
-			return fmt.Errorf("couldn't parse changeAddr: %w", err)
+			return nil, ids.ShortEmpty, fmt.Errorf("couldn't parse changeAddr: %w", err)
 		}
 	}
 
@@ -1386,17 +1408,10 @@ func (s *Service) AddDelegator(req *http.Request, args *AddDelegatorArgs, reply 
 		changeAddr,             // Change address
 	)
 	if err != nil {
-		return fmt.Errorf("couldn't create tx: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't create tx: %w", err)
 	}
 
-	reply.TxID = tx.ID()
-	reply.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
-
-	return utils.Err(
-		err,
-		s.vm.Network.IssueTx(req.Context(), tx),
-		user.Close(),
-	)
+	return tx, changeAddr, err
 }
 
 // AddSubnetValidatorArgs are the arguments to AddSubnetValidator
@@ -1416,6 +1431,21 @@ func (s *Service) AddSubnetValidator(req *http.Request, args *AddSubnetValidator
 		zap.String("method", "addSubnetValidator"),
 	)
 
+	tx, changeAddr, err := s.buildAddSubnetValidatorTx(args)
+	if err != nil {
+		return fmt.Errorf("couldn't create tx: %w", err)
+	}
+
+	response.TxID = tx.ID()
+	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+	if err != nil {
+		return fmt.Errorf("couldn't format address: %w", err)
+	}
+
+	return s.vm.issueTx(req.Context(), tx)
+}
+
+func (s *Service) buildAddSubnetValidatorTx(args *AddSubnetValidatorArgs) (*txs.Tx, ids.ShortID, error) {
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
 	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
@@ -1428,26 +1458,26 @@ func (s *Service) AddSubnetValidator(req *http.Request, args *AddSubnetValidator
 
 	switch {
 	case args.SubnetID == "":
-		return errNoSubnetID
+		return nil, ids.ShortEmpty, errNoSubnetID
 	case args.StartTime < minAddStakerUnix:
-		return errStartTimeTooSoon
+		return nil, ids.ShortEmpty, errStartTimeTooSoon
 	case args.StartTime > maxAddStakerUnix:
-		return errStartTimeTooLate
+		return nil, ids.ShortEmpty, errStartTimeTooLate
 	}
 
 	// Parse the subnet ID
 	subnetID, err := ids.FromString(args.SubnetID)
 	if err != nil {
-		return fmt.Errorf("problem parsing subnetID %q: %w", args.SubnetID, err)
+		return nil, ids.ShortEmpty, fmt.Errorf("problem parsing subnetID %q: %w", args.SubnetID, err)
 	}
 	if subnetID == constants.PrimaryNetworkID {
-		return errNamedSubnetCantBePrimary
+		return nil, ids.ShortEmpty, errNamedSubnetCantBePrimary
 	}
 
 	// Parse the from addresses
 	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, args.From)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 
 	s.vm.ctx.Lock.Lock()
@@ -1455,24 +1485,24 @@ func (s *Service) AddSubnetValidator(req *http.Request, args *AddSubnetValidator
 
 	user, err := keystore.NewUserFromKeystore(s.vm.ctx.Keystore, args.Username, args.Password)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 	defer user.Close()
 
 	keys, err := keystore.GetKeychain(user, fromAddrs)
 	if err != nil {
-		return fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
 	}
 
 	// Parse the change address.
 	if len(keys.Keys) == 0 {
-		return errNoKeys
+		return nil, ids.ShortEmpty, errNoKeys
 	}
 	changeAddr := keys.Keys[0].PublicKey().Address() // By default, use a key controlled by the user
 	if args.ChangeAddr != "" {
 		changeAddr, err = avax.ParseServiceAddress(s.addrManager, args.ChangeAddr)
 		if err != nil {
-			return fmt.Errorf("couldn't parse changeAddr: %w", err)
+			return nil, ids.ShortEmpty, fmt.Errorf("couldn't parse changeAddr: %w", err)
 		}
 	}
 
@@ -1491,18 +1521,8 @@ func (s *Service) AddSubnetValidator(req *http.Request, args *AddSubnetValidator
 		keys.Keys,
 		changeAddr,
 	)
-	if err != nil {
-		return fmt.Errorf("couldn't create tx: %w", err)
-	}
 
-	response.TxID = tx.ID()
-	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
-
-	return utils.Err(
-		err,
-		s.vm.Network.IssueTx(req.Context(), tx),
-		user.Close(),
-	)
+	return tx, changeAddr, err
 }
 
 // CreateSubnetArgs are the arguments to CreateSubnet
@@ -1521,16 +1541,31 @@ func (s *Service) CreateSubnet(req *http.Request, args *CreateSubnetArgs, respon
 		zap.String("method", "createSubnet"),
 	)
 
+	tx, changeAddr, err := s.buildCreateSubnetTx(args)
+	if err != nil {
+		return fmt.Errorf("couldn't create tx: %w", err)
+	}
+
+	response.TxID = tx.ID()
+	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+	if err != nil {
+		return fmt.Errorf("couldn't format address: %w", err)
+	}
+
+	return s.vm.issueTx(req.Context(), tx)
+}
+
+func (s *Service) buildCreateSubnetTx(args *CreateSubnetArgs) (*txs.Tx, ids.ShortID, error) {
 	// Parse the control keys
 	controlKeys, err := avax.ParseServiceAddresses(s.addrManager, args.ControlKeys)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 
 	// Parse the from addresses
 	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, args.From)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 
 	s.vm.ctx.Lock.Lock()
@@ -1538,25 +1573,25 @@ func (s *Service) CreateSubnet(req *http.Request, args *CreateSubnetArgs, respon
 
 	user, err := keystore.NewUserFromKeystore(s.vm.ctx.Keystore, args.Username, args.Password)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 	defer user.Close()
 
 	privKeys, err := keystore.GetKeychain(user, fromAddrs)
 	if err != nil {
-		return fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
 	}
 
 	// Parse the change address. Assumes that if the user has no keys,
 	// this operation will fail so the change address can be anything.
 	if len(privKeys.Keys) == 0 {
-		return errNoKeys
+		return nil, ids.ShortEmpty, errNoKeys
 	}
 	changeAddr := privKeys.Keys[0].PublicKey().Address() // By default, use a key controlled by the user
 	if args.ChangeAddr != "" {
 		changeAddr, err = avax.ParseServiceAddress(s.addrManager, args.ChangeAddr)
 		if err != nil {
-			return fmt.Errorf("couldn't parse changeAddr: %w", err)
+			return nil, ids.ShortEmpty, fmt.Errorf("couldn't parse changeAddr: %w", err)
 		}
 	}
 
@@ -1567,18 +1602,8 @@ func (s *Service) CreateSubnet(req *http.Request, args *CreateSubnetArgs, respon
 		privKeys.Keys,          // Private keys
 		changeAddr,
 	)
-	if err != nil {
-		return fmt.Errorf("couldn't create tx: %w", err)
-	}
 
-	response.TxID = tx.ID()
-	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
-
-	return utils.Err(
-		err,
-		s.vm.Network.IssueTx(req.Context(), tx),
-		user.Close(),
-	)
+	return tx, changeAddr, err
 }
 
 // ExportAVAXArgs are the arguments to ExportAVAX
@@ -1605,8 +1630,23 @@ func (s *Service) ExportAVAX(req *http.Request, args *ExportAVAXArgs, response *
 		zap.String("method", "exportAVAX"),
 	)
 
+	tx, changeAddr, err := s.buildExportAVAX(args)
+	if err != nil {
+		return fmt.Errorf("couldn't create tx: %w", err)
+	}
+
+	response.TxID = tx.ID()
+	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+	if err != nil {
+		return fmt.Errorf("couldn't format address: %w", err)
+	}
+
+	return s.vm.issueTx(req.Context(), tx)
+}
+
+func (s *Service) buildExportAVAX(args *ExportAVAXArgs) (*txs.Tx, ids.ShortID, error) {
 	if args.Amount == 0 {
-		return errNoAmount
+		return nil, ids.ShortEmpty, errNoAmount
 	}
 
 	// Get the chainID and parse the to address
@@ -1614,18 +1654,18 @@ func (s *Service) ExportAVAX(req *http.Request, args *ExportAVAXArgs, response *
 	if err != nil {
 		chainID, err = s.vm.ctx.BCLookup.Lookup(args.TargetChain)
 		if err != nil {
-			return err
+			return nil, ids.ShortEmpty, err
 		}
 		to, err = ids.ShortFromString(args.To)
 		if err != nil {
-			return err
+			return nil, ids.ShortEmpty, err
 		}
 	}
 
 	// Parse the from addresses
 	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, args.From)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 
 	s.vm.ctx.Lock.Lock()
@@ -1633,25 +1673,25 @@ func (s *Service) ExportAVAX(req *http.Request, args *ExportAVAXArgs, response *
 
 	user, err := keystore.NewUserFromKeystore(s.vm.ctx.Keystore, args.Username, args.Password)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 	defer user.Close()
 
 	privKeys, err := keystore.GetKeychain(user, fromAddrs)
 	if err != nil {
-		return fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
 	}
 
 	// Parse the change address. Assumes that if the user has no keys,
 	// this operation will fail so the change address can be anything.
 	if len(privKeys.Keys) == 0 {
-		return errNoKeys
+		return nil, ids.ShortEmpty, errNoKeys
 	}
 	changeAddr := privKeys.Keys[0].PublicKey().Address() // By default, use a key controlled by the user
 	if args.ChangeAddr != "" {
 		changeAddr, err = avax.ParseServiceAddress(s.addrManager, args.ChangeAddr)
 		if err != nil {
-			return fmt.Errorf("couldn't parse changeAddr: %w", err)
+			return nil, ids.ShortEmpty, fmt.Errorf("couldn't parse changeAddr: %w", err)
 		}
 	}
 
@@ -1663,18 +1703,8 @@ func (s *Service) ExportAVAX(req *http.Request, args *ExportAVAXArgs, response *
 		privKeys.Keys,       // Private keys
 		changeAddr,          // Change address
 	)
-	if err != nil {
-		return fmt.Errorf("couldn't create tx: %w", err)
-	}
 
-	response.TxID = tx.ID()
-	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
-
-	return utils.Err(
-		err,
-		s.vm.Network.IssueTx(req.Context(), tx),
-		user.Close(),
-	)
+	return tx, changeAddr, err
 }
 
 // ImportAVAXArgs are the arguments to ImportAVAX
@@ -1697,22 +1727,34 @@ func (s *Service) ImportAVAX(req *http.Request, args *ImportAVAXArgs, response *
 		zap.String("method", "importAVAX"),
 	)
 
+	tx, changeAddr, err := s.buildImportAVAXTx(args)
+	if err != nil {
+		return fmt.Errorf("couldn't create tx: %w", err)
+	}
+
+	response.TxID = tx.ID()
+	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+
+	return s.vm.issueTx(req.Context(), tx)
+}
+
+func (s *Service) buildImportAVAXTx(args *ImportAVAXArgs) (*txs.Tx, ids.ShortID, error) {
 	// Parse the sourceCHain
 	chainID, err := s.vm.ctx.BCLookup.Lookup(args.SourceChain)
 	if err != nil {
-		return fmt.Errorf("problem parsing chainID %q: %w", args.SourceChain, err)
+		return nil, ids.ShortEmpty, fmt.Errorf("problem parsing chainID %q: %w", args.SourceChain, err)
 	}
 
 	// Parse the to address
 	to, err := avax.ParseServiceAddress(s.addrManager, args.To)
 	if err != nil { // Parse address
-		return fmt.Errorf("couldn't parse argument 'to' to an address: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't parse argument 'to' to an address: %w", err)
 	}
 
 	// Parse the from addresses
 	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, args.From)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 
 	s.vm.ctx.Lock.Lock()
@@ -1720,25 +1762,25 @@ func (s *Service) ImportAVAX(req *http.Request, args *ImportAVAXArgs, response *
 
 	user, err := keystore.NewUserFromKeystore(s.vm.ctx.Keystore, args.Username, args.Password)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 	defer user.Close()
 
 	privKeys, err := keystore.GetKeychain(user, fromAddrs)
 	if err != nil { // Get keys
-		return fmt.Errorf("couldn't get keys controlled by the user: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't get keys controlled by the user: %w", err)
 	}
 
 	// Parse the change address. Assumes that if the user has no keys,
 	// this operation will fail so the change address can be anything.
 	if len(privKeys.Keys) == 0 {
-		return errNoKeys
+		return nil, ids.ShortEmpty, errNoKeys
 	}
 	changeAddr := privKeys.Keys[0].PublicKey().Address() // By default, use a key controlled by the user
 	if args.ChangeAddr != "" {
 		changeAddr, err = avax.ParseServiceAddress(s.addrManager, args.ChangeAddr)
 		if err != nil {
-			return fmt.Errorf("couldn't parse changeAddr: %w", err)
+			return nil, ids.ShortEmpty, fmt.Errorf("couldn't parse changeAddr: %w", err)
 		}
 	}
 
@@ -1748,18 +1790,8 @@ func (s *Service) ImportAVAX(req *http.Request, args *ImportAVAXArgs, response *
 		privKeys.Keys,
 		changeAddr,
 	)
-	if err != nil {
-		return err
-	}
 
-	response.TxID = tx.ID()
-	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
-
-	return utils.Err(
-		err,
-		s.vm.Network.IssueTx(req.Context(), tx),
-		user.Close(),
-	)
+	return tx, changeAddr, err
 }
 
 /*
@@ -1793,28 +1825,40 @@ func (s *Service) CreateBlockchain(req *http.Request, args *CreateBlockchainArgs
 		zap.String("method", "createBlockchain"),
 	)
 
+	tx, changeAddr, err := s.buildCreateBlockchainTx(args)
+	if err != nil {
+		return fmt.Errorf("couldn't create tx: %w", err)
+	}
+
+	response.TxID = tx.ID()
+	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+
+	return s.vm.issueTx(req.Context(), tx)
+}
+
+func (s *Service) buildCreateBlockchainTx(args *CreateBlockchainArgs) (*txs.Tx, ids.ShortID, error) {
 	switch {
 	case args.Name == "":
-		return errMissingName
+		return nil, ids.ShortEmpty, errMissingName
 	case args.VMID == "":
-		return errMissingVMID
+		return nil, ids.ShortEmpty, errMissingVMID
 	}
 
 	genesisBytes, err := formatting.Decode(args.Encoding, args.GenesisData)
 	if err != nil {
-		return fmt.Errorf("problem parsing genesis data: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("problem parsing genesis data: %w", err)
 	}
 
 	vmID, err := s.vm.Chains.LookupVM(args.VMID)
 	if err != nil {
-		return fmt.Errorf("no VM with ID '%s' found", args.VMID)
+		return nil, ids.ShortEmpty, fmt.Errorf("no VM with ID '%s' found", args.VMID)
 	}
 
 	fxIDs := []ids.ID(nil)
 	for _, fxIDStr := range args.FxIDs {
 		fxID, err := s.vm.Chains.LookupVM(fxIDStr)
 		if err != nil {
-			return fmt.Errorf("no FX with ID '%s' found", fxIDStr)
+			return nil, ids.ShortEmpty, fmt.Errorf("no FX with ID '%s' found", fxIDStr)
 		}
 		fxIDs = append(fxIDs, fxID)
 	}
@@ -1826,13 +1870,13 @@ func (s *Service) CreateBlockchain(req *http.Request, args *CreateBlockchainArgs
 	}
 
 	if args.SubnetID == constants.PrimaryNetworkID {
-		return txs.ErrCantValidatePrimaryNetwork
+		return nil, ids.ShortEmpty, txs.ErrCantValidatePrimaryNetwork
 	}
 
 	// Parse the from addresses
 	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, args.From)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 
 	s.vm.ctx.Lock.Lock()
@@ -1840,25 +1884,25 @@ func (s *Service) CreateBlockchain(req *http.Request, args *CreateBlockchainArgs
 
 	user, err := keystore.NewUserFromKeystore(s.vm.ctx.Keystore, args.Username, args.Password)
 	if err != nil {
-		return err
+		return nil, ids.ShortEmpty, err
 	}
 	defer user.Close()
 
 	keys, err := keystore.GetKeychain(user, fromAddrs)
 	if err != nil {
-		return fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
+		return nil, ids.ShortEmpty, fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
 	}
 
 	// Parse the change address. Assumes that if the user has no keys,
 	// this operation will fail so the change address can be anything.
 	if len(keys.Keys) == 0 {
-		return errNoKeys
+		return nil, ids.ShortEmpty, errNoKeys
 	}
 	changeAddr := keys.Keys[0].PublicKey().Address() // By default, use a key controlled by the user
 	if args.ChangeAddr != "" {
 		changeAddr, err = avax.ParseServiceAddress(s.addrManager, args.ChangeAddr)
 		if err != nil {
-			return fmt.Errorf("couldn't parse changeAddr: %w", err)
+			return nil, ids.ShortEmpty, fmt.Errorf("couldn't parse changeAddr: %w", err)
 		}
 	}
 
@@ -1872,18 +1916,8 @@ func (s *Service) CreateBlockchain(req *http.Request, args *CreateBlockchainArgs
 		keys.Keys,
 		changeAddr, // Change address
 	)
-	if err != nil {
-		return fmt.Errorf("couldn't create tx: %w", err)
-	}
 
-	response.TxID = tx.ID()
-	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
-
-	return utils.Err(
-		err,
-		s.vm.Network.IssueTx(req.Context(), tx),
-		user.Close(),
-	)
+	return tx, changeAddr, err
 }
 
 // GetBlockchainStatusArgs is the arguments for calling GetBlockchainStatus
@@ -2170,10 +2204,7 @@ func (s *Service) IssueTx(req *http.Request, args *api.FormattedTx, response *ap
 		return fmt.Errorf("couldn't parse tx: %w", err)
 	}
 
-	s.vm.ctx.Lock.Lock()
-	defer s.vm.ctx.Lock.Unlock()
-
-	if err := s.vm.Network.IssueTx(req.Context(), tx); err != nil {
+	if err := s.vm.issueTx(req.Context(), tx); err != nil {
 		return fmt.Errorf("couldn't issue tx: %w", err)
 	}
 
@@ -2557,7 +2588,7 @@ func (s *Service) GetRewardUTXOs(_ *http.Request, args *api.GetTxArgs, reply *Ge
 	for i, utxo := range utxos {
 		utxoBytes, err := txs.GenesisCodec.Marshal(txs.Version, utxo)
 		if err != nil {
-			return fmt.Errorf("failed to encode UTXO to bytes: %w", err)
+			return fmt.Errorf("couldn't encode UTXO to bytes: %w", err)
 		}
 
 		utxoStr, err := formatting.Encode(args.Encoding, utxoBytes)

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1735,6 +1735,9 @@ func (s *Service) ImportAVAX(req *http.Request, args *ImportAVAXArgs, response *
 
 	response.TxID = tx.ID()
 	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+	if err != nil {
+		return fmt.Errorf("problem formatting address: %w", err)
+	}
 
 	return s.vm.issueTx(req.Context(), tx)
 }
@@ -1833,6 +1836,9 @@ func (s *Service) CreateBlockchain(req *http.Request, args *CreateBlockchainArgs
 
 	response.TxID = tx.ID()
 	response.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
+	if err != nil {
+		return fmt.Errorf("problem formatting address: %w", err)
+	}
 
 	return s.vm.issueTx(req.Context(), tx)
 }

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1408,9 +1408,6 @@ func (s *Service) buildAddDelegatorTx(args *AddDelegatorArgs) (*txs.Tx, ids.Shor
 		privKeys.Keys,          // Private keys
 		changeAddr,             // Change address
 	)
-	if err != nil {
-		return nil, ids.ShortEmpty, fmt.Errorf("couldn't create tx: %w", err)
-	}
 
 	return tx, changeAddr, err
 }

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -5,12 +5,13 @@ package platformvm
 
 import (
 	"context"
-	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"net/http"
 	"time"
+
+	stdjson "encoding/json"
 
 	"go.uber.org/zap"
 

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -5,13 +5,14 @@ package platformvm
 
 import (
 	"context"
-	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"math/rand"
 	"testing"
 	"time"
+
+	stdjson "encoding/json"
 
 	"github.com/stretchr/testify/require"
 

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -5,14 +5,13 @@ package platformvm
 
 import (
 	"context"
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"math/rand"
 	"testing"
 	"time"
-
-	stdjson "encoding/json"
 
 	"github.com/stretchr/testify/require"
 
@@ -240,8 +239,6 @@ func TestGetTxStatus(t *testing.T) {
 	require.Equal(status.Unknown, resp.Status)
 	require.Zero(resp.Reason)
 
-	service.vm.ctx.Lock.Lock()
-
 	// put the chain in existing chain list
 	err = service.vm.Network.IssueTx(context.Background(), tx)
 	require.ErrorIs(err, database.ErrNotFound) // Missing shared memory UTXO
@@ -249,6 +246,7 @@ func TestGetTxStatus(t *testing.T) {
 	mutableSharedMemory.SharedMemory = sm
 
 	require.NoError(service.vm.Network.IssueTx(context.Background(), tx))
+	service.vm.ctx.Lock.Lock()
 
 	block, err := service.vm.BuildBlock(context.Background())
 	require.NoError(err)
@@ -342,9 +340,8 @@ func TestGetTx(t *testing.T) {
 				err = service.GetTx(nil, arg, &response)
 				require.ErrorIs(err, database.ErrNotFound) // We haven't issued the tx yet
 
-				service.vm.ctx.Lock.Lock()
-
 				require.NoError(service.vm.Network.IssueTx(context.Background(), tx))
+				service.vm.ctx.Lock.Lock()
 
 				blk, err := service.vm.BuildBlock(context.Background())
 				require.NoError(err)

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -170,7 +170,7 @@ func createTestProposalTxs(count int) ([]*txs.Tx, error) {
 	for i := 0; i < count; i++ {
 		tx, err := generateAddValidatorTx(
 			uint64(now.Add(time.Duration(count-i)*time.Second).Unix()), // startTime
-			0,                                                          // endTime
+			0, // endTime
 		)
 		if err != nil {
 			return nil, err

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -170,7 +170,7 @@ func createTestProposalTxs(count int) ([]*txs.Tx, error) {
 	for i := 0; i < count; i++ {
 		tx, err := generateAddValidatorTx(
 			uint64(now.Add(time.Duration(count-i)*time.Second).Unix()), // startTime
-			0, // endTime
+			0,                                                          // endTime
 		)
 		if err != nil {
 			return nil, err

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -374,7 +374,11 @@ func addPrimaryValidatorWithoutBLSKey(vm *VM, data *validatorInputData) (*state.
 }
 
 func internalAddValidator(vm *VM, signedTx *txs.Tx) (*state.Staker, error) {
-	if err := vm.Network.IssueTx(context.Background(), signedTx); err != nil {
+	vm.ctx.Lock.Unlock()
+	err := vm.issueTx(context.Background(), signedTx)
+	vm.ctx.Lock.Lock()
+
+	if err != nil {
 		return nil, fmt.Errorf("could not add tx to mempool: %w", err)
 	}
 
@@ -784,7 +788,10 @@ func buildVM(t *testing.T) (*VM, ids.ID, error) {
 	if err != nil {
 		return nil, ids.Empty, err
 	}
-	if err := vm.Network.IssueTx(context.Background(), testSubnet1); err != nil {
+	vm.ctx.Lock.Unlock()
+	err = vm.issueTx(context.Background(), testSubnet1)
+	vm.ctx.Lock.Lock()
+	if err != nil {
 		return nil, ids.Empty, err
 	}
 

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -5,6 +5,7 @@ package platformvm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -487,6 +488,14 @@ func (vm *VM) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, erro
 // Invariant: tx should not be referenced again without the context lock
 // held to avoid any data races.
 func (vm *VM) issueTx(ctx context.Context, tx *txs.Tx) error {
-	//TODO check duplicate tx error
-	return vm.Network.IssueTx(ctx, tx)
+	err := vm.Network.IssueTx(ctx, tx)
+	if err != nil && !errors.Is(err, mempool.ErrDuplicateTx) {
+		vm.ctx.Log.Debug("failed to add tx to mempool",
+			zap.Stringer("txID", tx.ID()),
+			zap.Error(err),
+		)
+		return err
+	}
+
+	return nil
 }

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -482,11 +482,6 @@ func (vm *VM) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, erro
 	return vm.state.GetBlockIDAtHeight(height)
 }
 
-// We need to grab the context lock here to avoid racy behavior with
-// transaction verification + mempool modifications.
-//
-// Invariant: tx should not be referenced again without the context lock
-// held to avoid any data races.
 func (vm *VM) issueTx(ctx context.Context, tx *txs.Tx) error {
 	err := vm.Network.IssueTx(ctx, tx)
 	if err != nil && !errors.Is(err, mempool.ErrDuplicateTx) {

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -480,3 +480,13 @@ func (vm *VM) VerifyHeightIndex(_ context.Context) error {
 func (vm *VM) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, error) {
 	return vm.state.GetBlockIDAtHeight(height)
 }
+
+// We need to grab the context lock here to avoid racy behavior with
+// transaction verification + mempool modifications.
+//
+// Invariant: tx should not be referenced again without the context lock
+// held to avoid any data races.
+func (vm *VM) issueTx(ctx context.Context, tx *txs.Tx) error {
+	//TODO check duplicate tx error
+	return vm.Network.IssueTx(ctx, tx)
+}

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -50,6 +50,7 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	vm, _, _ := defaultVM(t, cortinaFork)
 	vm.ctx.Lock.Lock()
 	defer func() {
+		vm.ctx.Lock.Lock()
 		require.NoError(vm.Shutdown(context.Background()))
 		vm.ctx.Lock.Unlock()
 	}()
@@ -74,7 +75,9 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	require.NoError(vm.Network.IssueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	addValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
@@ -106,7 +109,9 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	require.NoError(vm.Network.IssueTx(context.Background(), addFirstDelegatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addFirstDelegatorTx))
+	vm.ctx.Lock.Lock()
 
 	addFirstDelegatorBlock, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
@@ -140,7 +145,9 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	require.NoError(vm.Network.IssueTx(context.Background(), addSecondDelegatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addSecondDelegatorTx))
+	vm.ctx.Lock.Lock()
 
 	addSecondDelegatorBlock, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
@@ -164,7 +171,8 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	err = vm.Network.IssueTx(context.Background(), addThirdDelegatorTx)
+	vm.ctx.Lock.Unlock()
+	err = vm.issueTx(context.Background(), addThirdDelegatorTx)
 	require.ErrorIs(err, executor.ErrOverDelegated)
 }
 
@@ -237,7 +245,9 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			require.NoError(err)
 
 			// issue the add validator tx
-			require.NoError(vm.Network.IssueTx(context.Background(), addValidatorTx))
+			vm.ctx.Lock.Unlock()
+			require.NoError(vm.issueTx(context.Background(), addValidatorTx))
+			vm.ctx.Lock.Lock()
 
 			// trigger block creation for the validator tx
 			addValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -259,7 +269,9 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			require.NoError(err)
 
 			// issue the first add delegator tx
-			require.NoError(vm.Network.IssueTx(context.Background(), addFirstDelegatorTx))
+			vm.ctx.Lock.Unlock()
+			require.NoError(vm.issueTx(context.Background(), addFirstDelegatorTx))
+			vm.ctx.Lock.Lock()
 
 			// trigger block creation for the first add delegator tx
 			addFirstDelegatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -281,7 +293,9 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			require.NoError(err)
 
 			// issue the second add delegator tx
-			require.NoError(vm.Network.IssueTx(context.Background(), addSecondDelegatorTx))
+			vm.ctx.Lock.Unlock()
+			require.NoError(vm.issueTx(context.Background(), addSecondDelegatorTx))
+			vm.ctx.Lock.Lock()
 
 			// trigger block creation for the second add delegator tx
 			addSecondDelegatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -303,7 +317,9 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			require.NoError(err)
 
 			// issue the third add delegator tx
-			require.NoError(vm.Network.IssueTx(context.Background(), addThirdDelegatorTx))
+			vm.ctx.Lock.Unlock()
+			require.NoError(vm.issueTx(context.Background(), addThirdDelegatorTx))
+			vm.ctx.Lock.Lock()
 
 			// trigger block creation for the third add delegator tx
 			addThirdDelegatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -325,7 +341,9 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			require.NoError(err)
 
 			// issue the fourth add delegator tx
-			require.NoError(vm.Network.IssueTx(context.Background(), addFourthDelegatorTx))
+			vm.ctx.Lock.Unlock()
+			require.NoError(vm.issueTx(context.Background(), addFourthDelegatorTx))
+			vm.ctx.Lock.Lock()
 
 			// trigger block creation for the fourth add delegator tx
 			addFourthDelegatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1133,6 +1151,7 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 
 	vm.ctx.Lock.Lock()
 	defer func() {
+		vm.ctx.Lock.Lock()
 		require.NoError(vm.Shutdown(context.Background()))
 
 		vm.ctx.Lock.Unlock()
@@ -1159,7 +1178,9 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 	require.NoError(err)
 
 	// issue the add validator tx
-	require.NoError(vm.Network.IssueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the validator tx
 	addValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1181,7 +1202,9 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 	require.NoError(err)
 
 	// issue the first add delegator tx
-	require.NoError(vm.Network.IssueTx(context.Background(), addFirstDelegatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addFirstDelegatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the first add delegator tx
 	addFirstDelegatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1204,7 +1227,8 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 
 	// attempting to issue the second add delegator tx should fail because the
 	// total stake weight would go over the limit.
-	err = vm.Network.IssueTx(context.Background(), addSecondDelegatorTx)
+	vm.ctx.Lock.Unlock()
+	err = vm.issueTx(context.Background(), addSecondDelegatorTx)
 	require.ErrorIs(err, executor.ErrOverDelegated)
 }
 
@@ -1241,7 +1265,9 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the validator tx
 	addValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1258,7 +1284,9 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the subnet tx
 	createSubnetBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1278,7 +1306,9 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), addSubnetValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addSubnetValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the validator tx
 	addSubnetValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1307,7 +1337,9 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 	// validator set into the current validator set.
 	vm.clock.Set(validatorStartTime)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), removeSubnetValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), removeSubnetValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the validator tx
 	removeSubnetValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1359,7 +1391,9 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the validator tx
 	addValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1376,7 +1410,9 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the subnet tx
 	createSubnetBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1396,7 +1432,9 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), addSubnetValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addSubnetValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the validator tx
 	addSubnetValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1417,7 +1455,9 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 	// validator set into the current validator set.
 	vm.clock.Set(validatorStartTime)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), removeSubnetValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), removeSubnetValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the validator tx
 	removeSubnetValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -1511,7 +1551,9 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 	require.NoError(err)
 	require.NoError(primaryTx.SyntacticVerify(vm.ctx))
 
-	require.NoError(vm.Network.IssueTx(context.Background(), primaryTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), primaryTx))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting primary validator to current
@@ -1538,7 +1580,9 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), subnetTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), subnetTx))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting the subnet validator to current
@@ -1642,7 +1686,9 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 	require.NoError(err)
 	require.NoError(uPrimaryRestartTx.SyntacticVerify(vm.ctx))
 
-	require.NoError(vm.Network.IssueTx(context.Background(), primaryRestartTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), primaryRestartTx))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting restarted primary validator to current
@@ -1749,7 +1795,9 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), primaryTx1))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), primaryTx1))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting primary validator to current
@@ -1841,7 +1889,9 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	require.NoError(err)
 	require.NoError(uPrimaryRestartTx.SyntacticVerify(vm.ctx))
 
-	require.NoError(vm.Network.IssueTx(context.Background(), primaryRestartTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), primaryRestartTx))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting restarted primary validator to current
@@ -1912,7 +1962,9 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), primaryTx1))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), primaryTx1))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting primary validator to current
@@ -1939,7 +1991,9 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), subnetTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), subnetTx))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting the subnet validator to current
@@ -2043,7 +2097,9 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	require.NoError(err)
 	require.NoError(uPrimaryRestartTx.SyntacticVerify(vm.ctx))
 
-	require.NoError(vm.Network.IssueTx(context.Background(), primaryRestartTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), primaryRestartTx))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting restarted primary validator to current
@@ -2121,7 +2177,9 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), primaryTx1))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), primaryTx1))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting primary validator to current
@@ -2145,7 +2203,9 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), subnetTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), subnetTx))
+	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
 	// move time ahead, promoting the subnet validator to current

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -306,7 +306,9 @@ func defaultVM(t *testing.T, fork activeFork) (*VM, database.Database, *mutableS
 		keys[0].PublicKey().Address(),    // change addr
 	)
 	require.NoError(err)
-	require.NoError(vm.Network.IssueTx(context.Background(), testSubnet1))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), testSubnet1))
+	vm.ctx.Lock.Lock()
 	blk, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
 	require.NoError(blk.Verify(context.Background()))
@@ -403,7 +405,9 @@ func TestAddValidatorCommit(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	require.NoError(vm.Network.IssueTx(context.Background(), tx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), tx))
+	vm.ctx.Lock.Lock()
 
 	blk, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
@@ -504,7 +508,9 @@ func TestAddValidatorReject(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	require.NoError(vm.Network.IssueTx(context.Background(), tx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), tx))
+	vm.ctx.Lock.Lock()
 
 	blk, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
@@ -525,6 +531,7 @@ func TestAddValidatorInvalidNotReissued(t *testing.T) {
 	vm, _, _ := defaultVM(t, latestFork)
 	vm.ctx.Lock.Lock()
 	defer func() {
+		vm.ctx.Lock.Lock()
 		require.NoError(vm.Shutdown(context.Background()))
 		vm.ctx.Lock.Unlock()
 	}()
@@ -549,7 +556,8 @@ func TestAddValidatorInvalidNotReissued(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	err = vm.Network.IssueTx(context.Background(), tx)
+	vm.ctx.Lock.Unlock()
+	err = vm.issueTx(context.Background(), tx)
 	require.ErrorIs(err, txexecutor.ErrAlreadyValidator)
 }
 
@@ -584,7 +592,9 @@ func TestAddSubnetValidatorAccept(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	require.NoError(vm.Network.IssueTx(context.Background(), tx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), tx))
+	vm.ctx.Lock.Lock()
 
 	blk, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
@@ -632,7 +642,9 @@ func TestAddSubnetValidatorReject(t *testing.T) {
 	require.NoError(err)
 
 	// trigger block creation
-	require.NoError(vm.Network.IssueTx(context.Background(), tx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), tx))
+	vm.ctx.Lock.Lock()
 
 	blk, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
@@ -826,7 +838,9 @@ func TestCreateChain(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), tx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), tx))
+	vm.ctx.Lock.Lock()
 
 	blk, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err) // should contain proposal to create chain
@@ -877,7 +891,9 @@ func TestCreateSubnet(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Lock()
 
 	// should contain the CreateSubnetTx
 	blk, err := vm.Builder.BuildBlock(context.Background())
@@ -918,7 +934,9 @@ func TestCreateSubnet(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	blk, err = vm.Builder.BuildBlock(context.Background()) // should add validator to the new subnet
 	require.NoError(err)
@@ -1021,7 +1039,9 @@ func TestAtomicImport(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), tx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), tx))
+	vm.ctx.Lock.Lock()
 
 	blk, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
@@ -2026,7 +2046,9 @@ func TestRemovePermissionedValidatorDuringAddPending(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), addValidatorTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the validator tx
 	addValidatorBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -2043,7 +2065,9 @@ func TestRemovePermissionedValidatorDuringAddPending(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Lock()
 
 	// trigger block creation for the subnet tx
 	createSubnetBlock, err := vm.Builder.BuildBlock(context.Background())
@@ -2112,7 +2136,9 @@ func TestTransferSubnetOwnershipTx(t *testing.T) {
 	require.NoError(err)
 	subnetID := createSubnetTx.ID()
 
-	require.NoError(vm.Network.IssueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), createSubnetTx))
+	vm.ctx.Lock.Lock()
 	createSubnetBlock, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
 
@@ -2144,7 +2170,9 @@ func TestTransferSubnetOwnershipTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), transferSubnetOwnershipTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), transferSubnetOwnershipTx))
+	vm.ctx.Lock.Lock()
 	transferSubnetOwnershipBlock, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
 
@@ -2230,7 +2258,10 @@ func TestBaseTx(t *testing.T) {
 	require.Equal(vm.TxFee, totalInputAmt-totalOutputAmt)
 	require.Equal(sendAmt, key1OutputAmt)
 
-	require.NoError(vm.Network.IssueTx(context.Background(), baseTx))
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTx(context.Background(), baseTx))
+	require.NoError(vm.issueTx(context.Background(), baseTx))
+	vm.ctx.Lock.Lock()
 	baseTxBlock, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)
 

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -2260,7 +2260,6 @@ func TestBaseTx(t *testing.T) {
 
 	vm.ctx.Lock.Unlock()
 	require.NoError(vm.issueTx(context.Background(), baseTx))
-	require.NoError(vm.issueTx(context.Background(), baseTx))
 	vm.ctx.Lock.Lock()
 	baseTxBlock, err := vm.Builder.BuildBlock(context.Background())
 	require.NoError(err)


### PR DESCRIPTION
## Why this should be merged

P-chain counterpart to https://github.com/ava-labs/avalanchego/pull/2524
## How this works

Moves the context lock grab into `issueTx` to be held while verification is being done

## How this was tested

UTs
