### PR TITLE
`vms/avm`: Simplify `mempool.Remove` signature

### DIFF
--- a/vms/avm/block/builder/builder.go
+++ b/vms/avm/block/builder/builder.go
@@ -101,7 +101,7 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 		if !exists || len(tx.Bytes()) > remainingSize {
 			break
 		}
-		b.mempool.Remove([]*txs.Tx{tx})
+		b.mempool.Remove(tx)
 
 		// Invariant: [tx] has already been syntactically verified.
 

--- a/vms/avm/block/executor/block.go
+++ b/vms/avm/block/executor/block.go
@@ -200,7 +200,7 @@ func (b *Block) Verify(context.Context) error {
 	stateDiff.AddBlock(b.Block)
 
 	b.manager.blkIDToState[blkID] = blockState
-	b.manager.mempool.Remove(txs)
+	b.manager.mempool.Remove(txs...)
 	return nil
 }
 
@@ -220,7 +220,7 @@ func (b *Block) Accept(context.Context) error {
 	}
 
 	b.manager.lastAccepted = blkID
-	b.manager.mempool.Remove(txs)
+	b.manager.mempool.Remove(txs...)
 
 	blkState, ok := b.manager.blkIDToState[blkID]
 	if !ok {

--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -45,7 +45,7 @@ var (
 type Mempool interface {
 	Add(tx *txs.Tx) error
 	Get(txID ids.ID) (*txs.Tx, bool)
-	Remove(txs []*txs.Tx)
+	Remove(txs ...*txs.Tx)
 
 	// Peek returns the oldest tx in the mempool.
 	Peek() (tx *txs.Tx, exists bool)
@@ -159,11 +159,11 @@ func (m *mempool) Get(txID ids.ID) (*txs.Tx, bool) {
 	return tx, ok
 }
 
-func (m *mempool) Remove(txsToRemove []*txs.Tx) {
+func (m *mempool) Remove(txs ...*txs.Tx) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	for _, tx := range txsToRemove {
+	for _, tx := range txs {
 		txID := tx.ID()
 		if !m.unissuedTxs.Delete(txID) {
 			continue

--- a/vms/avm/txs/mempool/mempool_test.go
+++ b/vms/avm/txs/mempool/mempool_test.go
@@ -101,7 +101,7 @@ func TestGet(t *testing.T) {
 	require.True(exists)
 	require.Equal(tx, returned)
 
-	mempool.Remove([]*txs.Tx{tx})
+	mempool.Remove(tx)
 
 	_, exists = mempool.Get(txID)
 	require.False(exists)
@@ -130,19 +130,19 @@ func TestPeek(t *testing.T) {
 	require.True(exists)
 	require.Equal(tx, tx0)
 
-	mempool.Remove([]*txs.Tx{tx0})
+	mempool.Remove(tx0)
 
 	tx, exists = mempool.Peek()
 	require.True(exists)
 	require.Equal(tx, tx1)
 
-	mempool.Remove([]*txs.Tx{tx0})
+	mempool.Remove(tx0)
 
 	tx, exists = mempool.Peek()
 	require.True(exists)
 	require.Equal(tx, tx1)
 
-	mempool.Remove([]*txs.Tx{tx1})
+	mempool.Remove(tx1)
 
 	_, exists = mempool.Peek()
 	require.False(exists)
@@ -189,7 +189,7 @@ func TestIterate(t *testing.T) {
 	mempool.Iterate(addTxs)
 	require.Equal([]*txs.Tx{tx0, tx1}, iteratedTxs)
 
-	mempool.Remove([]*txs.Tx{tx0, tx2})
+	mempool.Remove(tx0, tx2)
 
 	iteratedTxs = nil
 	mempool.Iterate(addTxs)

--- a/vms/avm/txs/mempool/mock_mempool.go
+++ b/vms/avm/txs/mempool/mock_mempool.go
@@ -121,15 +121,19 @@ func (mr *MockMempoolMockRecorder) Peek() *gomock.Call {
 }
 
 // Remove mocks base method.
-func (m *MockMempool) Remove(arg0 []*txs.Tx) {
+func (m *MockMempool) Remove(arg0 ...*txs.Tx) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Remove", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Remove", varargs...)
 }
 
 // Remove indicates an expected call of Remove.
-func (mr *MockMempoolMockRecorder) Remove(arg0 interface{}) *gomock.Call {
+func (mr *MockMempoolMockRecorder) Remove(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMempool)(nil).Remove), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMempool)(nil).Remove), arg0...)
 }
 
 // RequestBuildBlock mocks base method.


### PR DESCRIPTION
## Why this should be merged

Makes it easier to use

## How this works

pretty straightforward

## How this was tested

CI