### PR TITLE
Introduce TxVerifier interface to network

### DIFF
--- a/vms/avm/network/network.go
+++ b/vms/avm/network/network.go
@@ -40,9 +40,9 @@ type Network interface {
 	// Invariant: The context lock is not held
 	IssueTx(context.Context, *txs.Tx) error
 
-	// IssueTx attempts to add a tx to the mempool, after verifying it against
-	// the preferred state. If the tx is added to the mempool, it will attempt
-	// to push gossip the tx to random peers in the network.
+	// IssueTx attempts to add a tx to the mempool. If the tx is added to the
+	// mempool, it will attempt to push gossip the tx to random peers in the
+	// network.
 	//
 	// If the tx is already in the mempool, mempool.ErrDuplicateTx will be
 	// returned.

--- a/vms/avm/network/network.go
+++ b/vms/avm/network/network.go
@@ -35,8 +35,6 @@ type Network interface {
 	// If the tx is already in the mempool, mempool.ErrDuplicateTx will be
 	// returned.
 	// If the tx is not added to the mempool, an error will be returned.
-	//
-	// Invariant: The context lock is not held
 	IssueTx(context.Context, *txs.Tx) error
 
 	// IssueVerifiedTx attempts to add a tx to the mempool. If the tx is added

--- a/vms/avm/network/network.go
+++ b/vms/avm/network/network.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/vms/avm/block/executor"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
 	"github.com/ava-labs/avalanchego/vms/avm/txs/mempool"
 	"github.com/ava-labs/avalanchego/vms/components/message"
@@ -54,11 +53,11 @@ type network struct {
 	// We embed a noop handler for all unhandled messages
 	common.AppHandler
 
-	ctx       *snow.Context
-	parser    txs.Parser
-	manager   executor.Manager
-	mempool   mempool.Mempool
-	appSender common.AppSender
+	ctx        *snow.Context
+	parser     txs.Parser
+	txVerifier TxVerifier
+	mempool    mempool.Mempool
+	appSender  common.AppSender
 
 	// gossip related attributes
 	recentTxsLock sync.Mutex
@@ -68,18 +67,18 @@ type network struct {
 func New(
 	ctx *snow.Context,
 	parser txs.Parser,
-	manager executor.Manager,
+	txVerifier TxVerifier,
 	mempool mempool.Mempool,
 	appSender common.AppSender,
 ) Network {
 	return &network{
 		AppHandler: common.NewNoOpAppHandler(ctx.Log),
 
-		ctx:       ctx,
-		parser:    parser,
-		manager:   manager,
-		mempool:   mempool,
-		appSender: appSender,
+		ctx:        ctx,
+		parser:     parser,
+		txVerifier: txVerifier,
+		mempool:    mempool,
+		appSender:  appSender,
 
 		recentTxs: &cache.LRU[ids.ID, struct{}]{
 			Size: recentTxsCacheSize,
@@ -154,11 +153,7 @@ func (n *network) issueTx(tx *txs.Tx) error {
 		return reason
 	}
 
-	// Verify the tx at the currently preferred state
-	n.ctx.Lock.Lock()
-	err := n.manager.VerifyTx(tx)
-	n.ctx.Lock.Unlock()
-	if err != nil {
+	if err := n.txVerifier.VerifyTx(tx); err != nil {
 		n.ctx.Log.Debug("tx failed verification",
 			zap.Stringer("txID", txID),
 			zap.Error(err),

--- a/vms/avm/network/network.go
+++ b/vms/avm/network/network.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"go.uber.org/zap"
@@ -28,11 +29,25 @@ var _ Network = (*network)(nil)
 type Network interface {
 	common.AppHandler
 
-	// IssueTx verifies the transaction at the currently preferred state, adds
-	// it to the mempool, and gossips it to the network.
+	// IssueTx attempts to add a tx to the mempool, after verifying it against
+	// the preferred state. If the tx is added to the mempool, it will attempt
+	// to push gossip the tx to random peers in the network.
 	//
-	// Invariant: Assumes the context lock is held.
+	// If the tx is already in the mempool, mempool.ErrDuplicateTx will be
+	// returned.
+	// If the tx is not added to the mempool, an error will be returned.
+	//
+	// Invariant: The context lock is not held
 	IssueTx(context.Context, *txs.Tx) error
+
+	// IssueTx attempts to add a tx to the mempool, after verifying it against
+	// the preferred state. If the tx is added to the mempool, it will attempt
+	// to push gossip the tx to random peers in the network.
+	//
+	// If the tx is already in the mempool, mempool.ErrDuplicateTx will be
+	// returned.
+	// If the tx is not added to the mempool, an error will be returned.
+	IssueVerifiedTx(context.Context, *txs.Tx) error
 }
 
 type network struct {
@@ -103,18 +118,10 @@ func (n *network) AppGossip(ctx context.Context, nodeID ids.NodeID, msgBytes []b
 		)
 		return nil
 	}
-	txID := tx.ID()
 
-	// We need to grab the context lock here to avoid racy behavior with
-	// transaction verification + mempool modifications.
-	//
-	// Invariant: tx should not be referenced again without the context lock
-	// held to avoid any data races.
-	n.ctx.Lock.Lock()
-	err = n.issueTx(tx)
-	n.ctx.Lock.Unlock()
-	if err == nil {
-		n.gossipTx(ctx, txID, msgBytes)
+	if err := n.issueTx(tx); err == nil {
+		txID := tx.ID()
+		n.gossipTxMessage(ctx, txID, msgBytes)
 	}
 	return nil
 }
@@ -123,27 +130,20 @@ func (n *network) IssueTx(ctx context.Context, tx *txs.Tx) error {
 	if err := n.issueTx(tx); err != nil {
 		return err
 	}
-
-	txBytes := tx.Bytes()
-	msg := &message.Tx{
-		Tx: txBytes,
-	}
-	msgBytes, err := message.Build(msg)
-	if err != nil {
-		return err
-	}
-
-	txID := tx.ID()
-	n.gossipTx(ctx, txID, msgBytes)
-	return nil
+	return n.gossipTx(ctx, tx)
 }
 
-// returns nil if the tx is in the mempool
+func (n *network) IssueVerifiedTx(ctx context.Context, tx *txs.Tx) error {
+	if err := n.issueVerifiedTx(tx); err != nil {
+		return err
+	}
+	return n.gossipTx(ctx, tx)
+}
+
 func (n *network) issueTx(tx *txs.Tx) error {
 	txID := tx.ID()
 	if _, ok := n.mempool.Get(txID); ok {
-		// The tx is already in the mempool
-		return nil
+		return fmt.Errorf("attempted to issue %w: %s ", mempool.ErrDuplicateTx, txID)
 	}
 
 	if reason := n.mempool.GetDropReason(txID); reason != nil {
@@ -155,7 +155,10 @@ func (n *network) issueTx(tx *txs.Tx) error {
 	}
 
 	// Verify the tx at the currently preferred state
-	if err := n.manager.VerifyTx(tx); err != nil {
+	n.ctx.Lock.Lock()
+	err := n.manager.VerifyTx(tx)
+	n.ctx.Lock.Unlock()
+	if err != nil {
 		n.ctx.Log.Debug("tx failed verification",
 			zap.Stringer("txID", txID),
 			zap.Error(err),
@@ -165,7 +168,12 @@ func (n *network) issueTx(tx *txs.Tx) error {
 		return err
 	}
 
+	return n.issueVerifiedTx(tx)
+}
+
+func (n *network) issueVerifiedTx(tx *txs.Tx) error {
 	if err := n.mempool.Add(tx); err != nil {
+		txID := tx.ID()
 		n.ctx.Log.Debug("tx failed to be added to the mempool",
 			zap.Stringer("txID", txID),
 			zap.Error(err),
@@ -179,7 +187,22 @@ func (n *network) issueTx(tx *txs.Tx) error {
 	return nil
 }
 
-func (n *network) gossipTx(ctx context.Context, txID ids.ID, msgBytes []byte) {
+func (n *network) gossipTx(ctx context.Context, tx *txs.Tx) error {
+	txBytes := tx.Bytes()
+	msg := &message.Tx{
+		Tx: txBytes,
+	}
+	msgBytes, err := message.Build(msg)
+	if err != nil {
+		return err
+	}
+
+	txID := tx.ID()
+	n.gossipTxMessage(ctx, txID, msgBytes)
+	return nil
+}
+
+func (n *network) gossipTxMessage(ctx context.Context, txID ids.ID, msgBytes []byte) {
 	n.recentTxsLock.Lock()
 	_, has := n.recentTxs.Get(txID)
 	n.recentTxs.Put(txID, struct{}{})

--- a/vms/avm/network/network.go
+++ b/vms/avm/network/network.go
@@ -40,9 +40,9 @@ type Network interface {
 	// Invariant: The context lock is not held
 	IssueTx(context.Context, *txs.Tx) error
 
-	// IssueTx attempts to add a tx to the mempool. If the tx is added to the
-	// mempool, it will attempt to push gossip the tx to random peers in the
-	// network.
+	// IssueVerifiedTx attempts to add a tx to the mempool. If the tx is added
+	// to the mempool, it will attempt to push gossip the tx to random peers in
+	// the network.
 	//
 	// If the tx is already in the mempool, mempool.ErrDuplicateTx will be
 	// returned.

--- a/vms/avm/network/tx_verifier.go
+++ b/vms/avm/network/tx_verifier.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package network
+
+import (
+	"sync"
+
+	"github.com/ava-labs/avalanchego/vms/avm/txs"
+)
+
+var _ TxVerifier = (*LockedTxVerifier)(nil)
+
+type TxVerifier interface {
+	// VerifyTx verifies that the transaction should be issued into the mempool.
+	VerifyTx(tx *txs.Tx) error
+}
+
+type LockedTxVerifier struct {
+	lock       sync.Locker
+	txVerifier TxVerifier
+}
+
+func (l *LockedTxVerifier) VerifyTx(tx *txs.Tx) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	return l.txVerifier.VerifyTx(tx)
+}
+
+func NewLockedTxVerifier(lock sync.Locker, txVerifier TxVerifier) *LockedTxVerifier {
+	return &LockedTxVerifier{
+		lock:       lock,
+		txVerifier: txVerifier,
+	}
+}

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -427,7 +427,10 @@ func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- 
 	vm.network = network.New(
 		vm.ctx,
 		vm.parser,
-		vm.chainManager,
+		network.NewLockedTxVerifier(
+			&vm.ctx.Lock,
+			vm.chainManager,
+		),
 		vm.mempool,
 		vm.appSender,
 	)

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -483,7 +483,8 @@ func (vm *VM) ParseTx(_ context.Context, bytes []byte) (snowstorm.Tx, error) {
 // Invariant: This function is only called after Linearize has been called.
 func (vm *VM) issueTx(tx *txs.Tx) (ids.ID, error) {
 	txID := tx.ID()
-	if err := vm.network.IssueTx(context.TODO(), tx); err != nil && !errors.Is(err, mempool.ErrDuplicateTx) {
+	err := vm.network.IssueTx(context.TODO(), tx)
+	if err != nil && !errors.Is(err, mempool.ErrDuplicateTx) {
 		vm.ctx.Log.Debug("failed to add tx to mempool",
 			zap.Stringer("txID", txID),
 			zap.Error(err),

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -424,6 +424,7 @@ func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- 
 		vm.mempool,
 	)
 
+	// Invariant: The context lock is not held when calling network.IssueTx.
 	vm.network = network.New(
 		vm.ctx,
 		vm.parser,

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -482,16 +482,15 @@ func (vm *VM) ParseTx(_ context.Context, bytes []byte) (snowstorm.Tx, error) {
 // Invariant: The context lock is not held
 // Invariant: This function is only called after Linearize has been called.
 func (vm *VM) issueTx(tx *txs.Tx) (ids.ID, error) {
-	vm.ctx.Lock.Lock()
-	defer vm.ctx.Lock.Unlock()
-
-	err := vm.network.IssueTx(context.TODO(), tx)
-	if err != nil {
+	txID := tx.ID()
+	if err := vm.network.IssueTx(context.TODO(), tx); err != nil && !errors.Is(err, mempool.ErrDuplicateTx) {
 		vm.ctx.Log.Debug("failed to add tx to mempool",
+			zap.Stringer("txID", txID),
 			zap.Error(err),
 		)
+		return txID, err
 	}
-	return tx.ID(), err
+	return txID, nil
 }
 
 /*


### PR DESCRIPTION
## Why this should be merged

Factored out of #2490.

## How this works

- Rather than having the network manage locking, this pulls the locking knowledge out into the VM.
- Reduces the interface required to be provided to the network code.

## How this was tested

- [X] CI