### PR TITLE
Export P-Chain Mempool Errors

### DIFF
--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -37,12 +37,12 @@ const (
 var (
 	_ Mempool = (*mempool)(nil)
 
-	errDuplicateTx                = errors.New("duplicate tx")
-	errTxTooLarge                 = errors.New("tx too large")
-	errMempoolFull                = errors.New("mempool is full")
-	errConflictsWithOtherTx       = errors.New("tx conflicts with other tx")
-	errCantIssueAdvanceTimeTx     = errors.New("can not issue an advance time tx")
-	errCantIssueRewardValidatorTx = errors.New("can not issue a reward validator tx")
+	ErrDuplicateTx                = errors.New("duplicate tx")
+	ErrTxTooLarge                 = errors.New("tx too large")
+	ErrMempoolFull                = errors.New("mempool is full")
+	ErrConflictsWithOtherTx       = errors.New("tx conflicts with other tx")
+	ErrCantIssueAdvanceTimeTx     = errors.New("can not issue an advance time tx")
+	ErrCantIssueRewardValidatorTx = errors.New("can not issue a reward validator tx")
 )
 
 type Mempool interface {
@@ -122,22 +122,22 @@ func (m *mempool) Add(tx *txs.Tx) error {
 
 	switch tx.Unsigned.(type) {
 	case *txs.AdvanceTimeTx:
-		return errCantIssueAdvanceTimeTx
+		return ErrCantIssueAdvanceTimeTx
 	case *txs.RewardValidatorTx:
-		return errCantIssueRewardValidatorTx
+		return ErrCantIssueRewardValidatorTx
 	default:
 	}
 
 	// Note: a previously dropped tx can be re-added
 	txID := tx.ID()
 	if _, ok := m.unissuedTxs.Get(txID); ok {
-		return fmt.Errorf("%w: %s", errDuplicateTx, txID)
+		return fmt.Errorf("%w: %s", ErrDuplicateTx, txID)
 	}
 
 	txSize := len(tx.Bytes())
 	if txSize > MaxTxSize {
 		return fmt.Errorf("%w: %s size (%d) > max size (%d)",
-			errTxTooLarge,
+			ErrTxTooLarge,
 			txID,
 			txSize,
 			MaxTxSize,
@@ -145,7 +145,7 @@ func (m *mempool) Add(tx *txs.Tx) error {
 	}
 	if txSize > m.bytesAvailable {
 		return fmt.Errorf("%w: %s size (%d) > available space (%d)",
-			errMempoolFull,
+			ErrMempoolFull,
 			txID,
 			txSize,
 			m.bytesAvailable,
@@ -154,7 +154,7 @@ func (m *mempool) Add(tx *txs.Tx) error {
 
 	inputs := tx.Unsigned.InputIDs()
 	if m.consumedUTXOs.Overlaps(inputs) {
-		return fmt.Errorf("%w: %s", errConflictsWithOtherTx, txID)
+		return fmt.Errorf("%w: %s", ErrConflictsWithOtherTx, txID)
 	}
 
 	m.unissuedTxs.Put(tx.ID(), tx)

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -4,7 +4,6 @@
 package mempool
 
 import (
-	"errors"
 	"testing"
 	"time"
 

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -39,7 +39,7 @@ func TestBlockBuilderMaxMempoolSizeHandling(t *testing.T) {
 	mpool.(*mempool).bytesAvailable = len(tx.Bytes()) - 1
 
 	err = mpool.Add(tx)
-	require.True(errors.Is(err, ErrMempoolFull), err, "max mempool size breached")
+	require.ErrorIs(err, ErrMempoolFull)
 
 	// shortcut to simulated almost filled mempool
 	mpool.(*mempool).bytesAvailable = len(tx.Bytes())

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -39,7 +39,7 @@ func TestBlockBuilderMaxMempoolSizeHandling(t *testing.T) {
 	mpool.(*mempool).bytesAvailable = len(tx.Bytes()) - 1
 
 	err = mpool.Add(tx)
-	require.True(errors.Is(err, errMempoolFull), err, "max mempool size breached")
+	require.True(errors.Is(err, ErrMempoolFull), err, "max mempool size breached")
 
 	// shortcut to simulated almost filled mempool
 	mpool.(*mempool).bytesAvailable = len(tx.Bytes())
@@ -171,7 +171,7 @@ func createTestProposalTxs(count int) ([]*txs.Tx, error) {
 	for i := 0; i < count; i++ {
 		tx, err := generateAddValidatorTx(
 			uint64(now.Add(time.Duration(count-i)*time.Second).Unix()), // startTime
-			0, // endTime
+			0,                                                          // endTime
 		)
 		if err != nil {
 			return nil, err

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -171,7 +171,7 @@ func createTestProposalTxs(count int) ([]*txs.Tx, error) {
 	for i := 0; i < count; i++ {
 		tx, err := generateAddValidatorTx(
 			uint64(now.Add(time.Duration(count-i)*time.Second).Unix()), // startTime
-			0,                                                          // endTime
+			0, // endTime
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Why this should be merged

Export error types, needed because later we'll be wrapping some of these errors (namely duplicate tx error). 

## How this works

Exports errors 

## How this was tested

CI