### PR TITLE
Only initialize Txs once

### DIFF
--- a/vms/platformvm/block/abort_block.go
+++ b/vms/platformvm/block/abort_block.go
@@ -4,7 +4,6 @@
 package block
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -44,17 +43,7 @@ func NewBanffAbortBlock(
 			},
 		},
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }
 
 type ApricotAbortBlock struct {
@@ -89,15 +78,5 @@ func NewApricotAbortBlock(
 			Hght:   height,
 		},
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }

--- a/vms/platformvm/block/abort_block.go
+++ b/vms/platformvm/block/abort_block.go
@@ -4,6 +4,7 @@
 package block
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -43,7 +44,17 @@ func NewBanffAbortBlock(
 			},
 		},
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }
 
 type ApricotAbortBlock struct {
@@ -78,5 +89,15 @@ func NewApricotAbortBlock(
 			Hght:   height,
 		},
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }

--- a/vms/platformvm/block/atomic_block.go
+++ b/vms/platformvm/block/atomic_block.go
@@ -52,15 +52,5 @@ func NewApricotAtomicBlock(
 		},
 		Tx: tx,
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }

--- a/vms/platformvm/block/atomic_block.go
+++ b/vms/platformvm/block/atomic_block.go
@@ -52,5 +52,15 @@ func NewApricotAtomicBlock(
 		},
 		Tx: tx,
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }

--- a/vms/platformvm/block/block.go
+++ b/vms/platformvm/block/block.go
@@ -4,7 +4,6 @@
 package block
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -34,14 +33,4 @@ type Block interface {
 type BanffBlock interface {
 	Block
 	Timestamp() time.Time
-}
-
-func initialize(blk Block) error {
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	bytes, err := Codec.Marshal(Version, &blk)
-	if err != nil {
-		return fmt.Errorf("couldn't marshal block: %w", err)
-	}
-	return blk.initialize(bytes)
 }

--- a/vms/platformvm/block/block.go
+++ b/vms/platformvm/block/block.go
@@ -4,6 +4,7 @@
 package block
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -33,4 +34,16 @@ type Block interface {
 type BanffBlock interface {
 	Block
 	Timestamp() time.Time
+}
+
+func initialize(blk Block, commonBlk *CommonBlock) error {
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	bytes, err := Codec.Marshal(Version, &blk)
+	if err != nil {
+		return fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	commonBlk.initialize(bytes)
+	return nil
 }

--- a/vms/platformvm/block/commit_block.go
+++ b/vms/platformvm/block/commit_block.go
@@ -4,6 +4,7 @@
 package block
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -43,7 +44,17 @@ func NewBanffCommitBlock(
 			},
 		},
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }
 
 type ApricotCommitBlock struct {
@@ -75,5 +86,15 @@ func NewApricotCommitBlock(
 			Hght:   height,
 		},
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }

--- a/vms/platformvm/block/commit_block.go
+++ b/vms/platformvm/block/commit_block.go
@@ -4,7 +4,6 @@
 package block
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -44,17 +43,7 @@ func NewBanffCommitBlock(
 			},
 		},
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }
 
 type ApricotCommitBlock struct {
@@ -86,15 +75,5 @@ func NewApricotCommitBlock(
 			Hght:   height,
 		},
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -81,7 +81,17 @@ func NewBanffProposalBlock(
 			Tx: proposalTx,
 		},
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }
 
 type ApricotProposalBlock struct {
@@ -124,5 +134,15 @@ func NewApricotProposalBlock(
 		},
 		Tx: tx,
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -81,17 +81,7 @@ func NewBanffProposalBlock(
 			Tx: proposalTx,
 		},
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }
 
 type ApricotProposalBlock struct {
@@ -134,15 +124,5 @@ func NewApricotProposalBlock(
 		},
 		Tx: tx,
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }

--- a/vms/platformvm/block/serialization_test.go
+++ b/vms/platformvm/block/serialization_test.go
@@ -110,6 +110,10 @@ func TestBanffBlockSerialization(t *testing.T) {
 
 			require.NoError(test.block.initialize(test.bytes))
 			require.Equal(test.bytes, test.block.Bytes())
+
+			got, err := Codec.Marshal(Version, &test.block)
+			require.NoError(err)
+			require.Equal(test.bytes, got)
 		})
 	}
 }

--- a/vms/platformvm/block/serialization_test.go
+++ b/vms/platformvm/block/serialization_test.go
@@ -105,13 +105,11 @@ func TestBanffBlockSerialization(t *testing.T) {
 
 	for _, test := range tests {
 		testName := fmt.Sprintf("%T", test.block)
+		block := test.block
 		t.Run(testName, func(t *testing.T) {
 			require := require.New(t)
 
-			require.NoError(test.block.initialize(test.bytes))
-			require.Equal(test.bytes, test.block.Bytes())
-
-			got, err := Codec.Marshal(Version, &test.block)
+			got, err := Codec.Marshal(Version, &block)
 			require.NoError(err)
 			require.Equal(test.bytes, got)
 		})

--- a/vms/platformvm/block/serialization_test.go
+++ b/vms/platformvm/block/serialization_test.go
@@ -108,7 +108,7 @@ func TestBanffBlockSerialization(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			require := require.New(t)
 
-			require.NoError(initialize(test.block))
+			require.NoError(test.block.initialize(test.bytes))
 			require.Equal(test.bytes, test.block.Bytes())
 		})
 	}

--- a/vms/platformvm/block/standard_block.go
+++ b/vms/platformvm/block/standard_block.go
@@ -46,7 +46,17 @@ func NewBanffStandardBlock(
 			Transactions: txs,
 		},
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }
 
 type ApricotStandardBlock struct {
@@ -93,5 +103,15 @@ func NewApricotStandardBlock(
 		},
 		Transactions: txs,
 	}
-	return blk, initialize(blk)
+
+	// We serialize this block as a pointer so that it can be deserialized into
+	// a Block
+	var blkIntf Block = blk
+	bytes, err := Codec.Marshal(Version, &blkIntf)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal block: %w", err)
+	}
+
+	blk.CommonBlock.initialize(bytes)
+	return blk, nil
 }

--- a/vms/platformvm/block/standard_block.go
+++ b/vms/platformvm/block/standard_block.go
@@ -46,17 +46,7 @@ func NewBanffStandardBlock(
 			Transactions: txs,
 		},
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }
 
 type ApricotStandardBlock struct {
@@ -103,15 +93,5 @@ func NewApricotStandardBlock(
 		},
 		Transactions: txs,
 	}
-
-	// We serialize this block as a pointer so that it can be deserialized into
-	// a Block
-	var blkIntf Block = blk
-	bytes, err := Codec.Marshal(Version, &blkIntf)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal block: %w", err)
-	}
-
-	blk.CommonBlock.initialize(bytes)
-	return blk, nil
+	return blk, initialize(blk, &blk.CommonBlock)
 }

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -557,7 +557,6 @@ func TestParsedStateBlock(t *testing.T) {
 	require := require.New(t)
 
 	var blks []block.Block
-
 	{
 		blk, err := block.NewApricotAbortBlock(ids.GenerateTestID(), 1000)
 		require.NoError(err)
@@ -581,23 +580,25 @@ func TestParsedStateBlock(t *testing.T) {
 	}
 
 	{
-		blk, err := block.NewApricotProposalBlock(ids.GenerateTestID(), 1000, &txs.Tx{
+		tx := &txs.Tx{
 			Unsigned: &txs.RewardValidatorTx{
 				TxID: ids.GenerateTestID(),
 			},
-		})
+		}
+		require.NoError(tx.Initialize(txs.Codec))
+		blk, err := block.NewApricotProposalBlock(ids.GenerateTestID(), 1000, tx)
 		require.NoError(err)
 		blks = append(blks, blk)
 	}
 
 	{
-		blk, err := block.NewApricotStandardBlock(ids.GenerateTestID(), 1000, []*txs.Tx{
-			{
-				Unsigned: &txs.RewardValidatorTx{
-					TxID: ids.GenerateTestID(),
-				},
+		tx := &txs.Tx{
+			Unsigned: &txs.RewardValidatorTx{
+				TxID: ids.GenerateTestID(),
 			},
-		})
+		}
+		require.NoError(tx.Initialize(txs.Codec))
+		blk, err := block.NewApricotStandardBlock(ids.GenerateTestID(), 1000, []*txs.Tx{tx})
 		require.NoError(err)
 		blks = append(blks, blk)
 	}
@@ -615,23 +616,28 @@ func TestParsedStateBlock(t *testing.T) {
 	}
 
 	{
-		blk, err := block.NewBanffProposalBlock(time.Now(), ids.GenerateTestID(), 1000, &txs.Tx{
+
+		tx := &txs.Tx{
 			Unsigned: &txs.RewardValidatorTx{
 				TxID: ids.GenerateTestID(),
 			},
-		}, []*txs.Tx{})
+		}
+		require.NoError(tx.Initialize(txs.Codec))
+
+		blk, err := block.NewBanffProposalBlock(time.Now(), ids.GenerateTestID(), 1000, tx, []*txs.Tx{})
 		require.NoError(err)
 		blks = append(blks, blk)
 	}
 
 	{
-		blk, err := block.NewBanffStandardBlock(time.Now(), ids.GenerateTestID(), 1000, []*txs.Tx{
-			{
-				Unsigned: &txs.RewardValidatorTx{
-					TxID: ids.GenerateTestID(),
-				},
+		tx := &txs.Tx{
+			Unsigned: &txs.RewardValidatorTx{
+				TxID: ids.GenerateTestID(),
 			},
-		})
+		}
+		require.NoError(tx.Initialize(txs.Codec))
+
+		blk, err := block.NewBanffStandardBlock(time.Now(), ids.GenerateTestID(), 1000, []*txs.Tx{tx})
 		require.NoError(err)
 		blks = append(blks, blk)
 	}

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -617,7 +617,6 @@ func TestParsedStateBlock(t *testing.T) {
 	}
 
 	{
-
 		tx := &txs.Tx{
 			Unsigned: &txs.RewardValidatorTx{
 				TxID: ids.GenerateTestID(),

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -557,6 +557,7 @@ func TestParsedStateBlock(t *testing.T) {
 	require := require.New(t)
 
 	var blks []block.Block
+
 	{
 		blk, err := block.NewApricotAbortBlock(ids.GenerateTestID(), 1000)
 		require.NoError(err)

--- a/vms/platformvm/txs/tx.go
+++ b/vms/platformvm/txs/tx.go
@@ -40,8 +40,12 @@ func NewSigned(
 	c codec.Manager,
 	signers [][]*secp256k1.PrivateKey,
 ) (*Tx, error) {
-	res := &Tx{Unsigned: unsigned}
-	return res, res.Sign(c, signers)
+	tx := &Tx{Unsigned: unsigned}
+	if err := tx.Sign(c, signers); err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
+	return tx, tx.Initialize(c)
 }
 
 func (tx *Tx) Initialize(c codec.Manager) error {

--- a/vms/platformvm/txs/tx.go
+++ b/vms/platformvm/txs/tx.go
@@ -40,12 +40,8 @@ func NewSigned(
 	c codec.Manager,
 	signers [][]*secp256k1.PrivateKey,
 ) (*Tx, error) {
-	tx := &Tx{Unsigned: unsigned}
-	if err := tx.Sign(c, signers); err != nil {
-		return nil, fmt.Errorf("failed to sign: %w", err)
-	}
-
-	return tx, tx.Initialize(c)
+	res := &Tx{Unsigned: unsigned}
+	return res, res.Sign(c, signers)
 }
 
 func (tx *Tx) Initialize(c codec.Manager) error {

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1657,7 +1657,7 @@ func TestUnverifiedParent(t *testing.T) {
 	firstAdvanceTimeBlk := vm.manager.NewBlock(statelessBlk)
 	require.NoError(firstAdvanceTimeBlk.Verify(context.Background()))
 
-	// include a tx1 to make the block be accepted
+	// include a tx2 to make the block be accepted
 	tx2 := &txs.Tx{Unsigned: &txs.ImportTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    vm.ctx.NetworkID,
@@ -1675,7 +1675,7 @@ func TestUnverifiedParent(t *testing.T) {
 			},
 		}},
 	}}
-	require.NoError(tx1.Initialize(txs.Codec))
+	require.NoError(tx2.Initialize(txs.Codec))
 	nextChainTime = nextChainTime.Add(time.Second)
 	vm.clock.Set(nextChainTime)
 	statelessSecondAdvanceTimeBlk, err := block.NewBanffStandardBlock(


### PR DESCRIPTION
## Why this should be merged

Currently transactions can be initialized multiple times throughout their lifecycle which can cause data races.

Related: https://github.com/ava-labs/avalanchego/pull/2521

## How this works

We only now initialize a tx upon creation or when parsing a block.

## How this was tested

Unit tests
