### PR TITLE
Remove network context

### DIFF
--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -183,7 +183,7 @@ func newEnvironment(t *testing.T) *environment {
 
 	txVerifier := network.NewLockedTxVerifier(&res.ctx.Lock, res.blkManager)
 	res.network = network.New(
-		res.backend.Ctx,
+		logging.NoLog{},
 		txVerifier,
 		res.mempool,
 		res.backend.Config.PartialSyncPrimaryNetwork,

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -166,9 +165,7 @@ func TestNetworkAppGossip(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			n := New(
-				&snow.Context{
-					Log: logging.NoLog{},
-				},
+				logging.NoLog{},
 				testTxVerifier{},
 				tt.mempoolFunc(ctrl),
 				tt.partialSyncPrimaryNetwork,
@@ -293,9 +290,7 @@ func TestNetworkIssueTx(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			n := New(
-				&snow.Context{
-					Log: logging.NoLog{},
-				},
+				logging.NoLog{},
 				tt.txVerifier,
 				tt.mempoolFunc(ctrl),
 				tt.partialSyncPrimaryNetwork,
@@ -314,9 +309,7 @@ func TestNetworkGossipTx(t *testing.T) {
 	appSender := common.NewMockSender(ctrl)
 
 	nIntf := New(
-		&snow.Context{
-			Log: logging.NoLog{},
-		},
+		logging.NoLog{},
 		testTxVerifier{},
 		mempool.NewMockMempool(ctrl),
 		false,

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -193,7 +193,7 @@ func (vm *VM) Initialize(
 
 	txVerifier := network.NewLockedTxVerifier(&txExecutorBackend.Ctx.Lock, vm.manager)
 	vm.Network = network.New(
-		txExecutorBackend.Ctx,
+		chainCtx.Log,
 		txVerifier,
 		mempool,
 		txExecutorBackend.Config.PartialSyncPrimaryNetwork,


### PR DESCRIPTION
## Why this should be merged

This field is only used for the log

## How this works

Replaces the context field with a log

## How this was tested

CI
