### PR TITLE
Remove comment on treating failed sends as FATAL

### DIFF
--- a/snow/engine/common/sender.go
+++ b/snow/engine/common/sender.go
@@ -175,15 +175,12 @@ type NetworkAppSender interface {
 	// * An AppResponse from nodeID with ID [requestID]
 	// * An AppRequestFailed from nodeID with ID [requestID]
 	// Exactly one of the above messages will eventually be received per nodeID.
-	// A non-nil error should be considered fatal.
 	SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, appRequestBytes []byte) error
 	// Send an application-level response to a request.
 	// This response must be in response to an AppRequest that the VM corresponding
 	// to this AppSender received from [nodeID] with ID [requestID].
-	// A non-nil error should be considered fatal.
 	SendAppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, appResponseBytes []byte) error
 	// Gossip an application-level message.
-	// A non-nil error should be considered fatal.
 	SendAppGossip(ctx context.Context, appGossipBytes []byte) error
 	SendAppGossipSpecific(ctx context.Context, nodeIDs set.Set[ids.NodeID], appGossipBytes []byte) error
 }
@@ -199,7 +196,6 @@ type CrossChainAppSender interface {
 	// * A CrossChainAppRequestFailed from [chainID] with ID [requestID]
 	// Exactly one of the above messages will eventually be received from
 	// [chainID].
-	// A non-nil error should be considered fatal.
 	SendCrossChainAppRequest(ctx context.Context, chainID ids.ID, requestID uint32, appRequestBytes []byte) error
 	// SendCrossChainAppResponse sends an application-level response to a
 	// specific chain
@@ -207,7 +203,6 @@ type CrossChainAppSender interface {
 	// This response must be in response to a CrossChainAppRequest that the VM
 	// corresponding to this CrossChainAppSender received from [chainID] with ID
 	// [requestID].
-	// A non-nil error should be considered fatal.
 	SendCrossChainAppResponse(ctx context.Context, chainID ids.ID, requestID uint32, appResponseBytes []byte) error
 }
 


### PR DESCRIPTION
## Why this should be merged

This invariant isn't true, and there's some spots in our code where a failed send is just logged as an error.

## How this works

Removes comment

## How this was tested

CI
