### PR TITLE
Unexport fields from gossip.BloomFilter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/ava-labs/coreth v0.12.9-rc.9.0.20231222191417-2e3f762373e9
+	github.com/ava-labs/coreth v0.12.10-rc.2
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231222191417-2e3f762373e9 h1:DiJBkm2IJ/My4u5DP4gq2wIbdflFRuZJbDm8DbgNDdg=
-github.com/ava-labs/coreth v0.12.9-rc.9.0.20231222191417-2e3f762373e9/go.mod h1:Xftjgk8T46k5/pWSQWcmdPanNl68kTcufd9S4kB58bM=
+github.com/ava-labs/coreth v0.12.10-rc.2 h1:+2YK7PzStcLCHtsBb1VQjw6DyMl1sMZatReZAyIy7w8=
+github.com/ava-labs/coreth v0.12.10-rc.2/go.mod h1:RIbv14KMyWSj4hB1danS+vEPCUsgArZUEo99SaP5nW8=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34 h1:mg9Uw6oZFJKytJxgxnl3uxZOs/SB8CVHg6Io4Tf99Zc=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -71,10 +71,10 @@ func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, req
 	}
 
 	filter := &BloomFilter{
-		Bloom: &bloomfilter.Filter{},
-		Salt:  salt,
+		bloom: &bloomfilter.Filter{},
+		salt:  salt,
 	}
-	if err := filter.Bloom.UnmarshalBinary(request.Filter); err != nil {
+	if err := filter.bloom.UnmarshalBinary(request.Filter); err != nil {
 		return nil, err
 	}
 

--- a/network/p2p/gossip/test_gossip.go
+++ b/network/p2p/gossip/test_gossip.go
@@ -65,6 +65,5 @@ func (t *testSet) Iterate(f func(gossipable *testTx) bool) {
 }
 
 func (t *testSet) GetFilter() ([]byte, []byte, error) {
-	bloom, err := t.bloom.Bloom.MarshalBinary()
-	return bloom, t.bloom.Salt[:], err
+	return t.bloom.Marshal()
 }

--- a/vms/avm/network/gossip.go
+++ b/vms/avm/network/gossip.go
@@ -152,6 +152,5 @@ func (g *gossipMempool) GetFilter() (bloom []byte, salt []byte, err error) {
 	g.lock.RLock()
 	defer g.lock.RUnlock()
 
-	bloomBytes, err := g.bloom.Bloom.MarshalBinary()
-	return bloomBytes, g.bloom.Salt[:], err
+	return g.bloom.Marshal()
 }


### PR DESCRIPTION
## Why this should be merged

This has been introduced multiple times as a bug. Most of the times it was caught before merging... However, it made it through review in #2490. This PR moves the problematic implementation into the SDK and adds a regression test.

## How this works

The `Salt` field is overwritten during `ResetBloomFilterIfNeeded`. So, the binary representation of `Salt` _must_ be copied to be used safely.

## How this was tested

- [X] CI
- [X] Added regression test