### PR TITLE
Notify block builder of txs after reject

### DIFF
--- a/vms/avm/block/executor/block.go
+++ b/vms/avm/block/executor/block.go
@@ -290,6 +290,10 @@ func (b *Block) Reject(context.Context) error {
 		}
 	}
 
+	// If we added transactions to the mempool, we should be willing to build a
+	// block.
+	b.manager.mempool.RequestBuildBlock()
+
 	b.rejected = true
 	return nil
 }

--- a/vms/avm/block/executor/block_test.go
+++ b/vms/avm/block/executor/block_test.go
@@ -857,6 +857,7 @@ func TestBlockReject(t *testing.T) {
 
 				mempool := mempool.NewMockMempool(ctrl)
 				mempool.EXPECT().Add(validTx).Return(nil) // Only add the one that passes verification
+				mempool.EXPECT().RequestBuildBlock()
 
 				preferredID := ids.GenerateTestID()
 				mockPreferredState := state.NewMockDiff(ctrl)
@@ -916,6 +917,7 @@ func TestBlockReject(t *testing.T) {
 				mempool := mempool.NewMockMempool(ctrl)
 				mempool.EXPECT().Add(tx1).Return(nil)
 				mempool.EXPECT().Add(tx2).Return(nil)
+				mempool.EXPECT().RequestBuildBlock()
 
 				preferredID := ids.GenerateTestID()
 				mockPreferredState := state.NewMockDiff(ctrl)


### PR DESCRIPTION
## Why this should be merged

Whenever we have transactions pending in the mempool, we should be willing to build a block. Currently, it's possible for transactions to be added to the mempool while rejecting a block but not notifying the block builder.

## How this works

Notify the block builder after rejecting a block.

## How this was tested

- [X] CI
- [X] Updated tests.