### PR TITLE
Set dependabot target branch to `dev`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    target-branch: "dev"


### PR DESCRIPTION
## Why this should be merged

We currently stage all changes to `dev` and push to `master`. Dependabot should be targeting `dev` with this workflow.

## How this works

pretty straightforward

## How this was tested

it wasn't :) - can't test it until merged all the way through to master