### PR TITLE
setmap nits

### DIFF
--- a/utils/setmap/setmap.go
+++ b/utils/setmap/setmap.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 )
 
-type KeySetPair[K any, V comparable] struct {
+type Entry[K any, V comparable] struct {
 	Key K
 	Set set.Set[V]
 }
@@ -30,10 +30,10 @@ func New[K, V comparable]() *SetMap[K, V] {
 // Put the key-set pair into the map. Removes and returns:
 // * The existing key-set pair for [key].
 // * Existing key-set pairs where the set overlaps with the [set].
-func (m *SetMap[K, V]) Put(key K, set set.Set[V]) []KeySetPair[K, V] {
+func (m *SetMap[K, V]) Put(key K, set set.Set[V]) []Entry[K, V] {
 	removed := m.DeleteOverlapping(set)
 	if removedSet, ok := m.DeleteKey(key); ok {
-		removed = append(removed, KeySetPair[K, V]{
+		removed = append(removed, Entry[K, V]{
 			Key: key,
 			Set: removedSet,
 		})
@@ -102,7 +102,7 @@ func (m *SetMap[K, V]) DeleteKey(key K) (set.Set[V], bool) {
 	return set, true
 }
 
-// DeleteValue removes and returns the key-set pair that contains [val].
+// DeleteValue removes and returns the entry that contained [val].
 func (m *SetMap[K, V]) DeleteValue(val V) (K, set.Set[V], bool) {
 	key, ok := m.valueToKey[val]
 	if !ok {
@@ -112,13 +112,13 @@ func (m *SetMap[K, V]) DeleteValue(val V) (K, set.Set[V], bool) {
 	return key, set, true
 }
 
-// DeleteOverlapping removes and returns all the key-set pairs where the set
-// overlaps with [set].
-func (m *SetMap[K, V]) DeleteOverlapping(set set.Set[V]) []KeySetPair[K, V] {
-	var removed []KeySetPair[K, V]
+// DeleteOverlapping removes and returns all the entries where the set overlaps
+// with [set].
+func (m *SetMap[K, V]) DeleteOverlapping(set set.Set[V]) []Entry[K, V] {
+	var removed []Entry[K, V]
 	for val := range set {
 		if k, removedSet, ok := m.DeleteValue(val); ok {
-			removed = append(removed, KeySetPair[K, V]{
+			removed = append(removed, Entry[K, V]{
 				Key: k,
 				Set: removedSet,
 			})

--- a/utils/setmap/setmap.go
+++ b/utils/setmap/setmap.go
@@ -27,9 +27,9 @@ func New[K, V comparable]() *SetMap[K, V] {
 	}
 }
 
-// Put the key-set pair into the map. Removes and returns:
-// * The existing key-set pair for [key].
-// * Existing key-set pairs where the set overlaps with the [set].
+// Put the key to set entry into the map. Removes and returns:
+// * The existing entry for [key].
+// * Existing entries where the set overlaps with the [set].
 func (m *SetMap[K, V]) Put(key K, set set.Set[V]) []Entry[K, V] {
 	removed := m.DeleteOverlapping(set)
 	if removedSet, ok := m.DeleteKey(key); ok {

--- a/utils/setmap/setmap.go
+++ b/utils/setmap/setmap.go
@@ -27,7 +27,7 @@ func New[K, V comparable]() *SetMap[K, V] {
 	}
 }
 
-// Put the key to set entry into the map. Removes and returns:
+// Put the new entry into the map. Removes and returns:
 // * The existing entry for [key].
 // * Existing entries where the set overlaps with the [set].
 func (m *SetMap[K, V]) Put(key K, set set.Set[V]) []Entry[K, V] {

--- a/utils/setmap/setmap_test.go
+++ b/utils/setmap/setmap_test.go
@@ -17,7 +17,7 @@ func TestSetMapPut(t *testing.T) {
 		state           *SetMap[int, int]
 		key             int
 		value           set.Set[int]
-		expectedRemoved []KeySetPair[int, int]
+		expectedRemoved []Entry[int, int]
 		expectedState   *SetMap[int, int]
 	}{
 		{
@@ -47,7 +47,7 @@ func TestSetMapPut(t *testing.T) {
 			},
 			key:   1,
 			value: set.Of(3),
-			expectedRemoved: []KeySetPair[int, int]{
+			expectedRemoved: []Entry[int, int]{
 				{
 					Key: 1,
 					Set: set.Of(2),
@@ -74,7 +74,7 @@ func TestSetMapPut(t *testing.T) {
 			},
 			key:   3,
 			value: set.Of(2),
-			expectedRemoved: []KeySetPair[int, int]{
+			expectedRemoved: []Entry[int, int]{
 				{
 					Key: 1,
 					Set: set.Of(2),
@@ -103,7 +103,7 @@ func TestSetMapPut(t *testing.T) {
 			},
 			key:   1,
 			value: set.Of(4),
-			expectedRemoved: []KeySetPair[int, int]{
+			expectedRemoved: []Entry[int, int]{
 				{
 					Key: 1,
 					Set: set.Of(2),
@@ -358,7 +358,7 @@ func TestSetMapDeleteOverlapping(t *testing.T) {
 		name            string
 		state           *SetMap[int, int]
 		set             set.Set[int]
-		expectedRemoved []KeySetPair[int, int]
+		expectedRemoved []Entry[int, int]
 		expectedState   *SetMap[int, int]
 	}{
 		{
@@ -379,7 +379,7 @@ func TestSetMapDeleteOverlapping(t *testing.T) {
 				},
 			},
 			set: set.Of(2),
-			expectedRemoved: []KeySetPair[int, int]{
+			expectedRemoved: []Entry[int, int]{
 				{
 					Key: 1,
 					Set: set.Of(2),
@@ -401,7 +401,7 @@ func TestSetMapDeleteOverlapping(t *testing.T) {
 				},
 			},
 			set: set.Of(2, 4),
-			expectedRemoved: []KeySetPair[int, int]{
+			expectedRemoved: []Entry[int, int]{
 				{
 					Key: 1,
 					Set: set.Of(2, 3),

--- a/utils/setmap/setmap_test.go
+++ b/utils/setmap/setmap_test.go
@@ -17,7 +17,7 @@ func TestSetMapPut(t *testing.T) {
 		state           *SetMap[int, int]
 		key             int
 		value           set.Set[int]
-		expectedRemoved []Entry[int, int]
+		expectedRemoved []KeySetPair[int, int]
 		expectedState   *SetMap[int, int]
 	}{
 		{
@@ -47,10 +47,10 @@ func TestSetMapPut(t *testing.T) {
 			},
 			key:   1,
 			value: set.Of(3),
-			expectedRemoved: []Entry[int, int]{
+			expectedRemoved: []KeySetPair[int, int]{
 				{
-					Key:   1,
-					Value: set.Of(2),
+					Key: 1,
+					Set: set.Of(2),
 				},
 			},
 			expectedState: &SetMap[int, int]{
@@ -74,10 +74,10 @@ func TestSetMapPut(t *testing.T) {
 			},
 			key:   3,
 			value: set.Of(2),
-			expectedRemoved: []Entry[int, int]{
+			expectedRemoved: []KeySetPair[int, int]{
 				{
-					Key:   1,
-					Value: set.Of(2),
+					Key: 1,
+					Set: set.Of(2),
 				},
 			},
 			expectedState: &SetMap[int, int]{
@@ -103,14 +103,14 @@ func TestSetMapPut(t *testing.T) {
 			},
 			key:   1,
 			value: set.Of(4),
-			expectedRemoved: []Entry[int, int]{
+			expectedRemoved: []KeySetPair[int, int]{
 				{
-					Key:   1,
-					Value: set.Of(2),
+					Key: 1,
+					Set: set.Of(2),
 				},
 				{
-					Key:   3,
-					Value: set.Of(4),
+					Key: 3,
+					Set: set.Of(4),
 				},
 			},
 			expectedState: &SetMap[int, int]{
@@ -177,7 +177,7 @@ func TestSetMapHasValueAndGetKeyAndSetOverlaps(t *testing.T) {
 	}
 }
 
-func TestSetMapHasValuesOf(t *testing.T) {
+func TestSetMapHasOverlap(t *testing.T) {
 	m := New[int, int]()
 	require.Empty(t, m.Put(1, set.Of(2)))
 	require.Empty(t, m.Put(2, set.Of(3, 4)))
@@ -210,13 +210,13 @@ func TestSetMapHasValuesOf(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			overlaps := m.HasValuesOf(test.set)
+			overlaps := m.HasOverlap(test.set)
 			require.Equal(t, test.expectedOverlaps, overlaps)
 		})
 	}
 }
 
-func TestSetMapHasKeyAndGetValue(t *testing.T) {
+func TestSetMapHasKeyAndGetSet(t *testing.T) {
 	m := New[int, int]()
 	require.Empty(t, m.Put(1, set.Of(2)))
 
@@ -252,7 +252,7 @@ func TestSetMapHasKeyAndGetValue(t *testing.T) {
 			exists := m.HasKey(test.key)
 			require.Equal(test.expectedExists, exists)
 
-			value, exists := m.GetValue(test.key)
+			value, exists := m.GetSet(test.key)
 			require.Equal(test.expectedValue, value)
 			require.Equal(test.expectedExists, exists)
 		})
@@ -353,12 +353,12 @@ func TestSetMapDeleteValue(t *testing.T) {
 	}
 }
 
-func TestSetMapDeleteValuesOf(t *testing.T) {
+func TestSetMapDeleteOverlapping(t *testing.T) {
 	tests := []struct {
 		name            string
 		state           *SetMap[int, int]
 		set             set.Set[int]
-		expectedRemoved []Entry[int, int]
+		expectedRemoved []KeySetPair[int, int]
 		expectedState   *SetMap[int, int]
 	}{
 		{
@@ -379,10 +379,10 @@ func TestSetMapDeleteValuesOf(t *testing.T) {
 				},
 			},
 			set: set.Of(2),
-			expectedRemoved: []Entry[int, int]{
+			expectedRemoved: []KeySetPair[int, int]{
 				{
-					Key:   1,
-					Value: set.Of(2),
+					Key: 1,
+					Set: set.Of(2),
 				},
 			},
 			expectedState: New[int, int](),
@@ -401,14 +401,14 @@ func TestSetMapDeleteValuesOf(t *testing.T) {
 				},
 			},
 			set: set.Of(2, 4),
-			expectedRemoved: []Entry[int, int]{
+			expectedRemoved: []KeySetPair[int, int]{
 				{
-					Key:   1,
-					Value: set.Of(2, 3),
+					Key: 1,
+					Set: set.Of(2, 3),
 				},
 				{
-					Key:   2,
-					Value: set.Of(4),
+					Key: 2,
+					Set: set.Of(4),
 				},
 			},
 			expectedState: New[int, int](),
@@ -418,7 +418,7 @@ func TestSetMapDeleteValuesOf(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
-			removed := test.state.DeleteValuesOf(test.set)
+			removed := test.state.DeleteOverlapping(test.set)
 			require.ElementsMatch(test.expectedRemoved, removed)
 			require.Equal(test.expectedState, test.state)
 		})

--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -138,7 +138,7 @@ func (m *mempool) Add(tx *txs.Tx) error {
 	}
 
 	inputs := tx.Unsigned.InputIDs()
-	if m.consumedUTXOs.HasValuesOf(inputs) {
+	if m.consumedUTXOs.HasOverlap(inputs) {
 		return fmt.Errorf("%w: %s", ErrConflictsWithOtherTx, txID)
 	}
 
@@ -176,7 +176,7 @@ func (m *mempool) Remove(txs ...*txs.Tx) {
 
 		// If the transaction isn't in the mempool, remove any conflicts it has.
 		inputs := tx.Unsigned.InputIDs()
-		for _, removed := range m.consumedUTXOs.DeleteValuesOf(inputs) {
+		for _, removed := range m.consumedUTXOs.DeleteOverlapping(inputs) {
 			tx, _ := m.unissuedTxs.Get(removed.Key)
 			m.unissuedTxs.Delete(removed.Key)
 			m.bytesAvailable += len(tx.Bytes())

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -152,7 +152,7 @@ func (m *mempool) Add(tx *txs.Tx) error {
 	}
 
 	inputs := tx.Unsigned.InputIDs()
-	if m.consumedUTXOs.HasValuesOf(inputs) {
+	if m.consumedUTXOs.HasOverlap(inputs) {
 		return fmt.Errorf("%w: %s", ErrConflictsWithOtherTx, txID)
 	}
 
@@ -189,7 +189,7 @@ func (m *mempool) Remove(txs ...*txs.Tx) {
 
 		// If the transaction isn't in the mempool, remove any conflicts it has.
 		inputs := tx.Unsigned.InputIDs()
-		for _, removed := range m.consumedUTXOs.DeleteValuesOf(inputs) {
+		for _, removed := range m.consumedUTXOs.DeleteOverlapping(inputs) {
 			tx, _ := m.unissuedTxs.Get(removed.Key)
 			m.unissuedTxs.Delete(removed.Key)
 			m.bytesAvailable += len(tx.Bytes())


### PR DESCRIPTION
## Why this should be merged

* Unifies usage of `val` as var name for values (instead of both `v` and `val`)
* Clarifies comments
* Removes usage of "value" when we really mean "set"
* Renames methods / `Entry` to be clearer

Feel free to take or leave whichever of these suggestions. Personally I find things a bit more readable this way. I might also suggest renaming `DeleteValue` to `DeleteSetWith` but I feel less strongly about that.

## How this works

N/A

## How this was tested

N/A