### PR TITLE
Do not mark txs as dropped when mempool is full

### DIFF
--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -215,7 +215,9 @@ func (m *mempool) MarkDropped(txID ids.ID, reason error) {
 		return
 	}
 
-	m.droppedTxIDs.Put(txID, reason)
+	if !errors.Is(reason, ErrMempoolFull) {
+		m.droppedTxIDs.Put(txID, reason)
+	}
 }
 
 func (m *mempool) GetDropReason(txID ids.ID) error {

--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -208,6 +208,10 @@ func (m *mempool) RequestBuildBlock() {
 }
 
 func (m *mempool) MarkDropped(txID ids.ID, reason error) {
+	if errors.Is(reason, ErrMempoolFull) {
+		return
+	}
+
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
@@ -215,9 +219,7 @@ func (m *mempool) MarkDropped(txID ids.ID, reason error) {
 		return
 	}
 
-	if !errors.Is(reason, ErrMempoolFull) {
-		m.droppedTxIDs.Put(txID, reason)
-	}
+	m.droppedTxIDs.Put(txID, reason)
 }
 
 func (m *mempool) GetDropReason(txID ids.ID) error {

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -219,7 +219,9 @@ func (m *mempool) MarkDropped(txID ids.ID, reason error) {
 		return
 	}
 
-	m.droppedTxIDs.Put(txID, reason)
+	if !errors.Is(reason, ErrMempoolFull) {
+		m.droppedTxIDs.Put(txID, reason)
+	}
 }
 
 func (m *mempool) GetDropReason(txID ids.ID) error {

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -212,6 +212,10 @@ func (m *mempool) Iterate(f func(tx *txs.Tx) bool) {
 }
 
 func (m *mempool) MarkDropped(txID ids.ID, reason error) {
+	if errors.Is(reason, ErrMempoolFull) {
+		return
+	}
+
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
@@ -219,9 +223,7 @@ func (m *mempool) MarkDropped(txID ids.ID, reason error) {
 		return
 	}
 
-	if !errors.Is(reason, ErrMempoolFull) {
-		m.droppedTxIDs.Put(txID, reason)
-	}
+	m.droppedTxIDs.Put(txID, reason)
 }
 
 func (m *mempool) GetDropReason(txID ids.ID) error {

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -43,7 +43,7 @@ func TestBlockBuilderMaxMempoolSizeHandling(t *testing.T) {
 	// tx should not be marked as dropped if the mempool is full
 	txID := tx.ID()
 	mpool.MarkDropped(txID, err)
-	require.NoError(mpool.GetDropReason(tx.ID()))
+	require.NoError(mpool.GetDropReason(txID))
 
 	// shortcut to simulated almost filled mempool
 	mpool.(*mempool).bytesAvailable = len(tx.Bytes())

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -40,6 +40,11 @@ func TestBlockBuilderMaxMempoolSizeHandling(t *testing.T) {
 	err = mpool.Add(tx)
 	require.ErrorIs(err, ErrMempoolFull)
 
+	// tx should not be marked as dropped if the mempool is full
+	txID := tx.ID()
+	mpool.MarkDropped(txID, err)
+	require.NoError(mpool.GetDropReason(tx.ID()))
+
 	// shortcut to simulated almost filled mempool
 	mpool.(*mempool).bytesAvailable = len(tx.Bytes())
 


### PR DESCRIPTION
## Why this should be merged

When the mempool is full, we can cache txs as dropped and prevent re-adding them (ref: https://github.com/ava-labs/avalanchego/blob/dev/vms/platformvm/network/gossip.go#L94-L100)

## How this works

Modify `MarkDropped` to only store a tx in `droppedTxIDs` if the error is not `ErrMempoolFull`

## How this was tested

CI + added UT
