### PR TITLE
Update bug bounty program to immunefi

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,13 +4,13 @@ Avalanche takes the security of the platform and of its users very seriously. We
 
 ## Reporting a Vulnerability
 
-**Please do not file a public ticket** mentioning the vulnerability. To disclose a vulnerability submit it through our [Bug Bounty Program](https://hackenproof.com/avalanche).
+**Please do not file a public ticket** mentioning the vulnerability. To disclose a vulnerability submit it through our [Bug Bounty Program](https://immunefi.com/bounty/avalanche/).
 
 Vulnerabilities must be disclosed to us privately with reasonable time to respond, and avoid compromise of other users and accounts, or loss of funds that are not your own. We do not reward spam or social engineering vulnerabilities. 
 
 Do not test for or validate any security issues in the live Avalanche networks (Mainnet and Fuji testnet), confirm all exploits in a local private testnet.
 
-Please refer to the [Bug Bounty Page](https://hackenproof.com/avalanche) for the most up-to-date program rules and scope.
+Please refer to the [Bug Bounty Page](https://immunefi.com/bounty/avalanche/) for the most up-to-date program rules and scope.
 
 ## Supported Versions
 


### PR DESCRIPTION
## Why this should be merged

The hackenproof bug bounty program is frozen and no longer exists. The bug bounty program has moved to immunefi.

## How this works

Updates links.

## How this was tested

N/A