### PR TITLE
Remove `len` tag parsing from the reflect codec

### DIFF
--- a/codec/reflectcodec/struct_fielder.go
+++ b/codec/reflectcodec/struct_fielder.go
@@ -6,44 +6,31 @@ package reflectcodec
 import (
 	"fmt"
 	"reflect"
-	"strconv"
 	"sync"
 
 	"github.com/ava-labs/avalanchego/codec"
 )
 
-const (
-	// SliceLenTagName that specifies the length of a slice.
-	SliceLenTagName = "len"
-
-	// TagValue is the value the tag must have to be serialized.
-	TagValue = "true"
-)
+// TagValue is the value the tag must have to be serialized.
+const TagValue = "true"
 
 var _ StructFielder = (*structFielder)(nil)
-
-type FieldDesc struct {
-	Index       int
-	MaxSliceLen uint32
-}
 
 // StructFielder handles discovery of serializable fields in a struct.
 type StructFielder interface {
 	// Returns the fields that have been marked as serializable in [t], which is
-	// a struct type. Additionally, returns the custom maximum length slice that
-	// may be serialized into the field, if any.
+	// a struct type.
 	// Returns an error if a field has tag "[tagName]: [TagValue]" but the field
 	// is un-exported.
 	// GetSerializedField(Foo) --> [1,5,8] means Foo.Field(1), Foo.Field(5),
 	// Foo.Field(8) are to be serialized/deserialized.
-	GetSerializedFields(t reflect.Type) ([]FieldDesc, error)
+	GetSerializedFields(t reflect.Type) ([]int, error)
 }
 
-func NewStructFielder(tagNames []string, maxSliceLen uint32) StructFielder {
+func NewStructFielder(tagNames []string) StructFielder {
 	return &structFielder{
 		tags:                   tagNames,
-		maxSliceLen:            maxSliceLen,
-		serializedFieldIndices: make(map[reflect.Type][]FieldDesc),
+		serializedFieldIndices: make(map[reflect.Type][]int),
 	}
 }
 
@@ -54,28 +41,26 @@ type structFielder struct {
 	// if it has at least one of the specified tags.
 	tags []string
 
-	maxSliceLen uint32
-
 	// Key: a struct type
 	// Value: Slice where each element is index in the struct type of a field
 	// that is serialized/deserialized e.g. Foo --> [1,5,8] means Foo.Field(1),
 	// etc. are to be serialized/deserialized. We assume this cache is pretty
 	// small (a few hundred keys at most) and doesn't take up much memory.
-	serializedFieldIndices map[reflect.Type][]FieldDesc
+	serializedFieldIndices map[reflect.Type][]int
 }
 
-func (s *structFielder) GetSerializedFields(t reflect.Type) ([]FieldDesc, error) {
+func (s *structFielder) GetSerializedFields(t reflect.Type) ([]int, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	if s.serializedFieldIndices == nil {
-		s.serializedFieldIndices = make(map[reflect.Type][]FieldDesc)
+		s.serializedFieldIndices = make(map[reflect.Type][]int)
 	}
 	if serializedFields, ok := s.serializedFieldIndices[t]; ok { // use pre-computed result
 		return serializedFields, nil
 	}
 	numFields := t.NumField()
-	serializedFields := make([]FieldDesc, 0, numFields)
+	serializedFields := make([]int, 0, numFields)
 	for i := 0; i < numFields; i++ { // Go through all fields of this struct
 		field := t.Field(i)
 
@@ -100,16 +85,7 @@ func (s *structFielder) GetSerializedFields(t reflect.Type) ([]FieldDesc, error)
 				field.Name,
 			)
 		}
-		sliceLenField := field.Tag.Get(SliceLenTagName)
-		maxSliceLen := s.maxSliceLen
-
-		if newLen, err := strconv.ParseUint(sliceLenField, 10, 31); err == nil {
-			maxSliceLen = uint32(newLen)
-		}
-		serializedFields = append(serializedFields, FieldDesc{
-			Index:       i,
-			MaxSliceLen: maxSliceLen,
-		})
+		serializedFields = append(serializedFields, i)
 	}
 	s.serializedFieldIndices[t] = serializedFields // cache result
 	return serializedFields, nil

--- a/snow/engine/avalanche/vertex/stateless_vertex.go
+++ b/snow/engine/avalanche/vertex/stateless_vertex.go
@@ -94,11 +94,11 @@ func (v statelessVertex) Txs() [][]byte {
 
 type innerStatelessVertex struct {
 	Version   uint16   `json:"version"`
-	ChainID   ids.ID   `json:"chainID"             serializeV0:"true" serializeV1:"true"`
-	Height    uint64   `json:"height"              serializeV0:"true" serializeV1:"true"`
-	Epoch     uint32   `json:"epoch"               serializeV0:"true"`
-	ParentIDs []ids.ID `json:"parentIDs" len:"128" serializeV0:"true" serializeV1:"true"`
-	Txs       [][]byte `json:"txs"       len:"128" serializeV0:"true"`
+	ChainID   ids.ID   `json:"chainID"   serializeV0:"true" serializeV1:"true"`
+	Height    uint64   `json:"height"    serializeV0:"true" serializeV1:"true"`
+	Epoch     uint32   `json:"epoch"     serializeV0:"true"`
+	ParentIDs []ids.ID `json:"parentIDs" serializeV0:"true" serializeV1:"true"`
+	Txs       [][]byte `json:"txs"       serializeV0:"true"`
 }
 
 func (v innerStatelessVertex) Verify() error {


### PR DESCRIPTION
## Why this should be merged

This PR is the first in an attempt to remove slice length parsing restrictions from the reflect codec.

## How this works

This PR shouldn't impact any validity rules. The only place the `len` tag was used in either coreth or avalanchego was vertex parsing. However, vertex verification also enforces this restriction. This means that we may be willing to parse vertices we were previously unwilling to parse, but those new vertices would fail verification. Regardless, because the X-chain was linearized, all vertices already exist and no new vertices will be issued.

## How this was tested

- [X] CI