### PR TITLE
Fix p2p sdk metric labels

### DIFF
--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -40,6 +40,12 @@ var (
 	_ Accumulator[*testTx] = (*TestAccumulator[*testTx])(nil)
 
 	metricLabels = []string{typeLabel}
+	pushLabels   = prometheus.Labels{
+		typeLabel: pushType,
+	}
+	pullLabels = prometheus.Labels{
+		typeLabel: pullType,
+	}
 )
 
 // Gossiper gossips Gossipables to other nodes
@@ -131,9 +137,6 @@ func NewPullGossiper[T Gossipable](
 		client:     client,
 		metrics:    metrics,
 		pollSize:   pollSize,
-		labels: prometheus.Labels{
-			typeLabel: pullType,
-		},
 	}
 }
 
@@ -144,7 +147,6 @@ type PullGossiper[T Gossipable] struct {
 	client     *p2p.Client
 	metrics    Metrics
 	pollSize   int
-	labels     prometheus.Labels
 }
 
 func (p *PullGossiper[_]) Gossip(ctx context.Context) error {
@@ -223,13 +225,13 @@ func (p *PullGossiper[_]) handleResponse(
 		}
 	}
 
-	receivedCountMetric, err := p.metrics.receivedCount.GetMetricWith(p.labels)
+	receivedCountMetric, err := p.metrics.receivedCount.GetMetricWith(pullLabels)
 	if err != nil {
 		p.log.Error("failed to get received count metric", zap.Error(err))
 		return
 	}
 
-	receivedBytesMetric, err := p.metrics.receivedBytes.GetMetricWith(p.labels)
+	receivedBytesMetric, err := p.metrics.receivedBytes.GetMetricWith(pullLabels)
 	if err != nil {
 		p.log.Error("failed to get received bytes metric", zap.Error(err))
 		return
@@ -246,10 +248,7 @@ func NewPushGossiper[T Gossipable](marshaller Marshaller[T], client *p2p.Client,
 		client:           client,
 		metrics:          metrics,
 		targetGossipSize: targetGossipSize,
-		labels: prometheus.Labels{
-			typeLabel: pushType,
-		},
-		pending: buffer.NewUnboundedDeque[T](0),
+		pending:          buffer.NewUnboundedDeque[T](0),
 	}
 }
 
@@ -259,8 +258,6 @@ type PushGossiper[T Gossipable] struct {
 	client           *p2p.Client
 	metrics          Metrics
 	targetGossipSize int
-
-	labels prometheus.Labels
 
 	lock    sync.Mutex
 	pending buffer.Deque[T]
@@ -303,12 +300,12 @@ func (p *PushGossiper[T]) Gossip(ctx context.Context) error {
 		return err
 	}
 
-	sentCountMetric, err := p.metrics.sentCount.GetMetricWith(p.labels)
+	sentCountMetric, err := p.metrics.sentCount.GetMetricWith(pushLabels)
 	if err != nil {
 		return fmt.Errorf("failed to get sent count metric: %w", err)
 	}
 
-	sentBytesMetric, err := p.metrics.sentBytes.GetMetricWith(p.labels)
+	sentBytesMetric, err := p.metrics.sentBytes.GetMetricWith(pushLabels)
 	if err != nil {
 		return fmt.Errorf("failed to get sent bytes metric: %w", err)
 	}

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -10,8 +10,6 @@ import (
 
 	bloomfilter "github.com/holiman/bloomfilter/v2"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"google.golang.org/protobuf/proto"
@@ -40,9 +38,6 @@ func NewHandler[T Gossipable](
 		set:                set,
 		metrics:            metrics,
 		targetResponseSize: targetResponseSize,
-		pullLabels: prometheus.Labels{
-			typeLabel: pullType,
-		},
 	}
 }
 
@@ -54,9 +49,6 @@ type Handler[T Gossipable] struct {
 	set                Set[T]
 	metrics            Metrics
 	targetResponseSize int
-
-	pullLabels prometheus.Labels
-	pushLabels prometheus.Labels
 }
 
 func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, requestBytes []byte) ([]byte, error) {
@@ -108,12 +100,12 @@ func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, req
 		Gossip: gossipBytes,
 	}
 
-	sentCountMetric, err := h.metrics.sentCount.GetMetricWith(h.pullLabels)
+	sentCountMetric, err := h.metrics.sentCount.GetMetricWith(pullLabels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sent count metric: %w", err)
 	}
 
-	sentBytesMetric, err := h.metrics.sentBytes.GetMetricWith(h.pullLabels)
+	sentBytesMetric, err := h.metrics.sentBytes.GetMetricWith(pullLabels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sent bytes metric: %w", err)
 	}
@@ -162,13 +154,13 @@ func (h Handler[_]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipByte
 		return
 	}
 
-	receivedCountMetric, err := h.metrics.receivedCount.GetMetricWith(h.pushLabels)
+	receivedCountMetric, err := h.metrics.receivedCount.GetMetricWith(pushLabels)
 	if err != nil {
 		h.log.Error("failed to get received count metric", zap.Error(err))
 		return
 	}
 
-	receivedBytesMetric, err := h.metrics.receivedBytes.GetMetricWith(h.pushLabels)
+	receivedBytesMetric, err := h.metrics.receivedBytes.GetMetricWith(pushLabels)
 	if err != nil {
 		h.log.Error("failed to get received bytes metric", zap.Error(err))
 		return


### PR DESCRIPTION
## Why this should be merged

Fixes:
```
ERROR ... gossip/handler.go:167 failed to get received count metric {"error": "inconsistent label cardinality: expected 1 label values but got 0 in prometheus.Labels(nil)"}
```

## How this works

Previously the `pushLabels` was incorrectly left uninitialized. This removes all `labels` from structs and converts them into package private global constants.

## How this was tested

- [X] CI
- [X] Locally using the 5 node network