### PR TITLE
Suppress gossip warnings due to no sampled peers

### DIFF
--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -5,6 +5,7 @@ package gossip
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -163,7 +164,8 @@ func (p *PullGossiper[_]) Gossip(ctx context.Context) error {
 	}
 
 	for i := 0; i < p.pollSize; i++ {
-		if err := p.client.AppRequestAny(ctx, msgBytes, p.handleResponse); err != nil {
+		err := p.client.AppRequestAny(ctx, msgBytes, p.handleResponse)
+		if err != nil && !errors.Is(err, p2p.ErrNoPeers) {
 			return err
 		}
 	}

--- a/network/p2p/validators.go
+++ b/network/p2p/validators.go
@@ -86,6 +86,8 @@ func (v *Validators) Sample(ctx context.Context, limit int) []ids.NodeID {
 
 	v.refresh(ctx)
 
+	// TODO: Account for peer connectivity during the sampling of validators
+	// rather than filtering sampled validators.
 	validatorIDs := v.validatorIDs.Sample(limit)
 	sampled := validatorIDs[:0]
 


### PR DESCRIPTION
## Why this should be merged

Suppresses:
```
WARN ... gossip/gossip.go:337 failed to gossip {"error": "no peers"}
```
As the error is currently expected.

## How this works

- Checks for `ErrNoPeers` before reporting an error from `PullGossiper.Gossip`.
- Adds a TODO to more accurately sample the requested number of validators.

## How this was tested

- [X] CI
- [X] Running a local 5-node network