### PR TITLE
Cleanup codec usage

### DIFF
--- a/api/keystore/codec.go
+++ b/api/keystore/codec.go
@@ -10,18 +10,18 @@ import (
 )
 
 const (
+	CodecVersion = 0
+
 	maxPackerSize  = 1 * units.GiB // max size, in bytes, of something being marshalled by Marshal()
 	maxSliceLength = linearcodec.DefaultMaxSliceLength
-
-	codecVersion = 0
 )
 
-var c codec.Manager
+var Codec codec.Manager
 
 func init() {
 	lc := linearcodec.NewCustomMaxLength(maxSliceLength)
-	c = codec.NewManager(maxPackerSize)
-	if err := c.RegisterCodec(codecVersion, lc); err != nil {
+	Codec = codec.NewManager(maxPackerSize)
+	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
 		panic(err)
 	}
 }

--- a/api/keystore/keystore.go
+++ b/api/keystore/keystore.go
@@ -188,7 +188,7 @@ func (ks *keystore) CreateUser(username, pw string) error {
 		return err
 	}
 
-	passwordBytes, err := c.Marshal(codecVersion, passwordHash)
+	passwordBytes, err := Codec.Marshal(CodecVersion, passwordHash)
 	if err != nil {
 		return err
 	}
@@ -288,14 +288,14 @@ func (ks *keystore) ImportUser(username, pw string, userBytes []byte) error {
 	}
 
 	userData := user{}
-	if _, err := c.Unmarshal(userBytes, &userData); err != nil {
+	if _, err := Codec.Unmarshal(userBytes, &userData); err != nil {
 		return err
 	}
 	if !userData.Hash.Check(pw) {
 		return fmt.Errorf("%w: user %q", errIncorrectPassword, username)
 	}
 
-	usrBytes, err := c.Marshal(codecVersion, &userData.Hash)
+	usrBytes, err := Codec.Marshal(CodecVersion, &userData.Hash)
 	if err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func (ks *keystore) ExportUser(username, pw string) ([]byte, error) {
 	}
 
 	// Return the byte representation of the user
-	return c.Marshal(codecVersion, &userData)
+	return Codec.Marshal(CodecVersion, &userData)
 }
 
 func (ks *keystore) getPassword(username string) (*password.Hash, error) {
@@ -377,6 +377,6 @@ func (ks *keystore) getPassword(username string) (*password.Hash, error) {
 	}
 
 	passwordHash = &password.Hash{}
-	_, err = c.Unmarshal(userBytes, passwordHash)
+	_, err = Codec.Unmarshal(userBytes, passwordHash)
 	return passwordHash, err
 }

--- a/chains/atomic/codec.go
+++ b/chains/atomic/codec.go
@@ -8,15 +8,15 @@ import (
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 )
 
-const codecVersion = 0
+const CodecVersion = 0
 
-// codecManager is used to marshal and unmarshal dbElements and chain IDs.
-var codecManager codec.Manager
+// Codec is used to marshal and unmarshal dbElements and chain IDs.
+var Codec codec.Manager
 
 func init() {
-	linearCodec := linearcodec.NewDefault()
-	codecManager = codec.NewDefaultManager()
-	if err := codecManager.RegisterCodec(codecVersion, linearCodec); err != nil {
+	lc := linearcodec.NewDefault()
+	Codec = codec.NewDefaultManager()
+	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
 		panic(err)
 	}
 }

--- a/chains/atomic/memory.go
+++ b/chains/atomic/memory.go
@@ -107,7 +107,7 @@ func sharedID(id1, id2 ids.ID) ids.ID {
 		id1, id2 = id2, id1
 	}
 
-	combinedBytes, err := codecManager.Marshal(codecVersion, [2]ids.ID{id1, id2})
+	combinedBytes, err := Codec.Marshal(CodecVersion, [2]ids.ID{id1, id2})
 	if err != nil {
 		panic(err)
 	}

--- a/chains/atomic/state.go
+++ b/chains/atomic/state.go
@@ -112,7 +112,7 @@ func (s *state) SetValue(e *Element) error {
 		Traits:  e.Traits,
 	}
 
-	valueBytes, err := codecManager.Marshal(codecVersion, &dbElem)
+	valueBytes, err := Codec.Marshal(CodecVersion, &dbElem)
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func (s *state) RemoveValue(key []byte) error {
 
 		// The value doesn't exist, so we should optimistically delete it
 		dbElem := dbElement{Present: false}
-		valueBytes, err := codecManager.Marshal(codecVersion, &dbElem)
+		valueBytes, err := Codec.Marshal(CodecVersion, &dbElem)
 		if err != nil {
 			return err
 		}
@@ -189,7 +189,7 @@ func (s *state) loadValue(key []byte) (*dbElement, error) {
 
 	// The key was in the database
 	value := &dbElement{}
-	_, err = codecManager.Unmarshal(valueBytes, value)
+	_, err = Codec.Unmarshal(valueBytes, value)
 	return value, err
 }
 

--- a/database/encdb/codec.go
+++ b/database/encdb/codec.go
@@ -1,27 +1,21 @@
 // Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package summary
+package encdb
 
 import (
-	"errors"
-	"math"
-
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 )
 
 const CodecVersion = 0
 
-var (
-	Codec codec.Manager
-
-	errWrongCodecVersion = errors.New("wrong codec version")
-)
+var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
-	Codec = codec.NewManager(math.MaxInt32)
+	lc := linearcodec.NewDefault()
+	Codec = codec.NewDefaultManager()
+
 	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
 		panic(err)
 	}

--- a/database/encdb/db.go
+++ b/database/encdb/db.go
@@ -13,14 +13,8 @@ import (
 
 	"golang.org/x/exp/slices"
 
-	"github.com/ava-labs/avalanchego/codec"
-	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/utils/hashing"
-)
-
-const (
-	codecVersion = 0
 )
 
 var (
@@ -32,7 +26,6 @@ var (
 // Database encrypts all values that are provided
 type Database struct {
 	lock   sync.RWMutex
-	codec  codec.Manager
 	cipher cipher.AEAD
 	db     database.Database
 	closed bool
@@ -42,16 +35,10 @@ type Database struct {
 func New(password []byte, db database.Database) (*Database, error) {
 	h := hashing.ComputeHash256(password)
 	aead, err := chacha20poly1305.NewX(h)
-	if err != nil {
-		return nil, err
-	}
-	c := linearcodec.NewDefault()
-	manager := codec.NewDefaultManager()
 	return &Database{
-		codec:  manager,
 		cipher: aead,
 		db:     db,
-	}, manager.RegisterCodec(codecVersion, c)
+	}, err
 }
 
 func (db *Database) Has(key []byte) (bool, error) {
@@ -297,7 +284,7 @@ func (db *Database) encrypt(plaintext []byte) ([]byte, error) {
 		return nil, err
 	}
 	ciphertext := db.cipher.Seal(nil, nonce, plaintext, nil)
-	return db.codec.Marshal(codecVersion, &encryptedValue{
+	return Codec.Marshal(CodecVersion, &encryptedValue{
 		Ciphertext: ciphertext,
 		Nonce:      nonce,
 	})
@@ -305,7 +292,7 @@ func (db *Database) encrypt(plaintext []byte) ([]byte, error) {
 
 func (db *Database) decrypt(ciphertext []byte) ([]byte, error) {
 	val := encryptedValue{}
-	if _, err := db.codec.Unmarshal(ciphertext, &val); err != nil {
+	if _, err := Codec.Unmarshal(ciphertext, &val); err != nil {
 		return nil, err
 	}
 	return db.cipher.Open(nil, val.Nonce, val.Ciphertext, nil)

--- a/database/linkeddb/codec.go
+++ b/database/linkeddb/codec.go
@@ -10,20 +10,15 @@ import (
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 )
 
-const (
-	codecVersion = 0
-)
+const CodecVersion = 0
 
-// c does serialization and deserialization
-var (
-	c codec.Manager
-)
+var Codec codec.Manager
 
 func init() {
 	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
-	c = codec.NewManager(math.MaxInt32)
+	Codec = codec.NewManager(math.MaxInt32)
 
-	if err := c.RegisterCodec(codecVersion, lc); err != nil {
+	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
 		panic(err)
 	}
 }

--- a/database/linkeddb/linkeddb.go
+++ b/database/linkeddb/linkeddb.go
@@ -316,7 +316,7 @@ func (ldb *linkedDB) getNode(key []byte) (node, error) {
 		return node{}, err
 	}
 	n := node{}
-	_, err = c.Unmarshal(nodeBytes, &n)
+	_, err = Codec.Unmarshal(nodeBytes, &n)
 	if err == nil {
 		ldb.nodeCache.Put(keyStr, &n)
 	}
@@ -325,7 +325,7 @@ func (ldb *linkedDB) getNode(key []byte) (node, error) {
 
 func (ldb *linkedDB) putNode(key []byte, n node) error {
 	ldb.updatedNodes[string(key)] = &n
-	nodeBytes, err := c.Marshal(codecVersion, n)
+	nodeBytes, err := Codec.Marshal(CodecVersion, n)
 	if err != nil {
 		return err
 	}

--- a/indexer/codec.go
+++ b/indexer/codec.go
@@ -1,32 +1,24 @@
 // Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package block
+package indexer
 
 import (
 	"math"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
-	"github.com/ava-labs/avalanchego/utils"
 )
 
 const CodecVersion = 0
 
-// The maximum block size is enforced by the p2p message size limit.
-// See: [constants.DefaultMaxMessageSize]
 var Codec codec.Manager
 
 func init() {
 	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
 	Codec = codec.NewManager(math.MaxInt)
 
-	err := utils.Err(
-		lc.RegisterType(&statelessBlock{}),
-		lc.RegisterType(&option{}),
-		Codec.RegisterCodec(CodecVersion, lc),
-	)
-	if err != nil {
+	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
 		panic(err)
 	}
 }

--- a/indexer/index_test.go
+++ b/indexer/index_test.go
@@ -111,11 +111,7 @@ func TestIndexGetContainerByRangeMaxPageSize(t *testing.T) {
 	db := memdb.New()
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	ctx := snowtest.ConsensusContext(snowCtx)
-<<<<<<< HEAD
-	indexIntf, err := newIndex(db, logging.NoLog{}, mockable.Clock{})
-=======
-	idx, err := newIndex(db, logging.NoLog{},, mockable.Clock{})
->>>>>>> dev
+	idx, err := newIndex(db, logging.NoLog{}, mockable.Clock{})
 	require.NoError(err)
 
 	// Insert [MaxFetchedByRange] + 1 containers

--- a/indexer/index_test.go
+++ b/indexer/index_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/codec"
-	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
@@ -24,14 +22,12 @@ func TestIndex(t *testing.T) {
 	// Setup
 	pageSize := uint64(64)
 	require := require.New(t)
-	codec := codec.NewDefaultManager()
-	require.NoError(codec.RegisterCodec(codecVersion, linearcodec.NewDefault()))
 	baseDB := memdb.New()
 	db := versiondb.New(baseDB)
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	ctx := snowtest.ConsensusContext(snowCtx)
 
-	indexIntf, err := newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
+	indexIntf, err := newIndex(db, logging.NoLog{}, mockable.Clock{})
 	require.NoError(err)
 	idx := indexIntf.(*index)
 
@@ -84,7 +80,7 @@ func TestIndex(t *testing.T) {
 	require.NoError(db.Commit())
 	require.NoError(idx.Close())
 	db = versiondb.New(baseDB)
-	indexIntf, err = newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
+	indexIntf, err = newIndex(db, logging.NoLog{}, mockable.Clock{})
 	require.NoError(err)
 	idx = indexIntf.(*index)
 
@@ -114,12 +110,10 @@ func TestIndex(t *testing.T) {
 func TestIndexGetContainerByRangeMaxPageSize(t *testing.T) {
 	// Setup
 	require := require.New(t)
-	codec := codec.NewDefaultManager()
-	require.NoError(codec.RegisterCodec(codecVersion, linearcodec.NewDefault()))
 	db := memdb.New()
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	ctx := snowtest.ConsensusContext(snowCtx)
-	indexIntf, err := newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
+	indexIntf, err := newIndex(db, logging.NoLog{}, mockable.Clock{})
 	require.NoError(err)
 	idx := indexIntf.(*index)
 
@@ -155,12 +149,10 @@ func TestIndexGetContainerByRangeMaxPageSize(t *testing.T) {
 func TestDontIndexSameContainerTwice(t *testing.T) {
 	// Setup
 	require := require.New(t)
-	codec := codec.NewDefaultManager()
-	require.NoError(codec.RegisterCodec(codecVersion, linearcodec.NewDefault()))
 	db := memdb.New()
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	ctx := snowtest.ConsensusContext(snowCtx)
-	idx, err := newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
+	idx, err := newIndex(db, logging.NoLog{}, mockable.Clock{})
 	require.NoError(err)
 
 	// Accept the same container twice

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -6,7 +6,6 @@ package indexer
 import (
 	"fmt"
 	"io"
-	"math"
 	"sync"
 
 	"github.com/gorilla/rpc/v2"
@@ -15,8 +14,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/server"
 	"github.com/ava-labs/avalanchego/chains"
-	"github.com/ava-labs/avalanchego/codec"
-	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/ids"
@@ -32,26 +29,18 @@ import (
 )
 
 const (
-	indexNamePrefix = "index-"
-	codecVersion    = uint16(0)
-	// Max size, in bytes, of something serialized by this indexer
-	// Assumes no containers are larger than math.MaxUint32
-	// wrappers.IntLen accounts for the size of the container bytes
-	// wrappers.LongLen accounts for the timestamp of the container
-	// ids.IDLen accounts for the container ID
-	// wrappers.ShortLen accounts for the codec version
-	codecMaxSize = int(constants.DefaultMaxMessageSize) + wrappers.IntLen + wrappers.LongLen + ids.IDLen + wrappers.ShortLen
+	indexNamePrefix         = "index-"
+	txPrefix                = 0x01
+	vtxPrefix               = 0x02
+	blockPrefix             = 0x03
+	isIncompletePrefix      = 0x04
+	previouslyIndexedPrefix = 0x05
 )
 
 var (
-	txPrefix                = byte(0x01)
-	vtxPrefix               = byte(0x02)
-	blockPrefix             = byte(0x03)
-	isIncompletePrefix      = byte(0x04)
-	previouslyIndexedPrefix = byte(0x05)
-	hasRunKey               = []byte{0x07}
-
 	_ Indexer = (*indexer)(nil)
+
+	hasRunKey = []byte{0x07}
 )
 
 // Config for an indexer
@@ -80,7 +69,6 @@ type Indexer interface {
 // NewIndexer returns a new Indexer and registers a new endpoint on the given API server.
 func NewIndexer(config Config) (Indexer, error) {
 	indexer := &indexer{
-		codec:                codec.NewManager(codecMaxSize),
 		log:                  config.Log,
 		db:                   config.DB,
 		allowIncompleteIndex: config.AllowIncompleteIndex,
@@ -95,12 +83,6 @@ func NewIndexer(config Config) (Indexer, error) {
 		shutdownF:            config.ShutdownF,
 	}
 
-	if err := indexer.codec.RegisterCodec(
-		codecVersion,
-		linearcodec.NewCustomMaxLength(math.MaxUint32),
-	); err != nil {
-		return nil, fmt.Errorf("couldn't register codec: %w", err)
-	}
 	hasRun, err := indexer.hasRun()
 	if err != nil {
 		return nil, err
@@ -110,7 +92,6 @@ func NewIndexer(config Config) (Indexer, error) {
 }
 
 type indexer struct {
-	codec  codec.Manager
 	clock  mockable.Clock
 	lock   sync.RWMutex
 	log    logging.Logger
@@ -336,7 +317,7 @@ func (i *indexer) registerChainHelper(
 	copy(prefix, chainID[:])
 	prefix[ids.IDLen] = prefixEnd
 	indexDB := prefixdb.New(prefix, i.db)
-	index, err := newIndex(indexDB, i.log, i.codec, i.clock)
+	index, err := newIndex(indexDB, i.log, i.clock)
 	if err != nil {
 		_ = indexDB.Close()
 		return nil, err

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -68,7 +68,6 @@ func TestNewIndexer(t *testing.T) {
 	require.NoError(err)
 	require.IsType(&indexer{}, idxrIntf)
 	idxr := idxrIntf.(*indexer)
-	require.NotNil(idxr.codec)
 	require.NotNil(idxr.log)
 	require.NotNil(idxr.db)
 	require.False(idxr.closed)

--- a/snow/engine/avalanche/vertex/builder.go
+++ b/snow/engine/avalanche/vertex/builder.go
@@ -62,10 +62,10 @@ func buildVtx(
 	utils.Sort(parentIDs)
 	utils.SortByHash(txs)
 
-	codecVer := codecVersion
+	codecVer := CodecVersion
 	if stopVertex {
 		// use new codec version for the "StopVertex"
-		codecVer = codecVersionWithStopVtx
+		codecVer = CodecVersionWithStopVtx
 	}
 
 	innerVtx := innerStatelessVertex{
@@ -80,7 +80,7 @@ func buildVtx(
 		return nil, err
 	}
 
-	vtxBytes, err := c.Marshal(innerVtx.Version, innerVtx)
+	vtxBytes, err := Codec.Marshal(innerVtx.Version, innerVtx)
 	vtx := statelessVertex{
 		innerStatelessVertex: innerVtx,
 		id:                   hashing.ComputeHash256Array(vtxBytes),

--- a/snow/engine/avalanche/vertex/codec.go
+++ b/snow/engine/avalanche/vertex/codec.go
@@ -7,29 +7,30 @@ import (
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/codec/reflectcodec"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/units"
 )
 
 const (
+	CodecVersion            uint16 = 0
+	CodecVersionWithStopVtx uint16 = 1
+
 	// maxSize is the maximum allowed vertex size. It is necessary to deter DoS
 	maxSize = units.MiB
-
-	codecVersion            uint16 = 0
-	codecVersionWithStopVtx uint16 = 1
 )
 
-var c codec.Manager
+var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.New([]string{reflectcodec.DefaultTagName + "V0"}, maxSize)
-	lc2 := linearcodec.New([]string{reflectcodec.DefaultTagName + "V1"}, maxSize)
+	lc0 := linearcodec.New([]string{reflectcodec.DefaultTagName + "V0"}, maxSize)
+	lc1 := linearcodec.New([]string{reflectcodec.DefaultTagName + "V1"}, maxSize)
 
-	c = codec.NewManager(maxSize)
-	// for backward compatibility, still register the initial codec version
-	if err := c.RegisterCodec(codecVersion, lc); err != nil {
-		panic(err)
-	}
-	if err := c.RegisterCodec(codecVersionWithStopVtx, lc2); err != nil {
+	Codec = codec.NewManager(maxSize)
+	err := utils.Err(
+		Codec.RegisterCodec(CodecVersion, lc0),
+		Codec.RegisterCodec(CodecVersionWithStopVtx, lc1),
+	)
+	if err != nil {
 		panic(err)
 	}
 }

--- a/snow/engine/avalanche/vertex/parser.go
+++ b/snow/engine/avalanche/vertex/parser.go
@@ -19,7 +19,7 @@ type Parser interface {
 // Parse parses the provided vertex bytes into a stateless vertex
 func Parse(bytes []byte) (StatelessVertex, error) {
 	vtx := innerStatelessVertex{}
-	version, err := c.Unmarshal(bytes, &vtx)
+	version, err := Codec.Unmarshal(bytes, &vtx)
 	if err != nil {
 		return nil, err
 	}

--- a/snow/engine/avalanche/vertex/stateless_vertex.go
+++ b/snow/engine/avalanche/vertex/stateless_vertex.go
@@ -73,7 +73,7 @@ func (v statelessVertex) ChainID() ids.ID {
 }
 
 func (v statelessVertex) StopVertex() bool {
-	return v.innerStatelessVertex.Version == codecVersionWithStopVtx
+	return v.innerStatelessVertex.Version == CodecVersionWithStopVtx
 }
 
 func (v statelessVertex) Height() uint64 {
@@ -102,7 +102,7 @@ type innerStatelessVertex struct {
 }
 
 func (v innerStatelessVertex) Verify() error {
-	if v.Version == codecVersionWithStopVtx {
+	if v.Version == CodecVersionWithStopVtx {
 		return v.verifyStopVertex()
 	}
 	return v.verify()
@@ -110,7 +110,7 @@ func (v innerStatelessVertex) Verify() error {
 
 func (v innerStatelessVertex) verify() error {
 	switch {
-	case v.Version != codecVersion:
+	case v.Version != CodecVersion:
 		return errBadVersion
 	case v.Epoch != 0:
 		return errBadEpoch
@@ -131,7 +131,7 @@ func (v innerStatelessVertex) verify() error {
 
 func (v innerStatelessVertex) verifyStopVertex() error {
 	switch {
-	case v.Version != codecVersionWithStopVtx:
+	case v.Version != CodecVersionWithStopVtx:
 		return errBadVersion
 	case v.Epoch != 0:
 		return errBadEpoch

--- a/vms/avm/txs/initial_state_test.go
+++ b/vms/avm/txs/initial_state_test.go
@@ -23,10 +23,10 @@ var errTest = errors.New("non-nil error")
 func TestInitialStateVerifySerialization(t *testing.T) {
 	require := require.New(t)
 
-	lc := linearcodec.NewDefault()
-	require.NoError(lc.RegisterType(&secp256k1fx.TransferOutput{}))
-	c := codec.NewDefaultManager()
-	require.NoError(c.RegisterCodec(CodecVersion, lc))
+	c := linearcodec.NewDefault()
+	require.NoError(c.RegisterType(&secp256k1fx.TransferOutput{}))
+	m := codec.NewDefaultManager()
+	require.NoError(m.RegisterCodec(CodecVersion, c))
 
 	expected := []byte{
 		// Codec version:
@@ -72,7 +72,7 @@ func TestInitialStateVerifySerialization(t *testing.T) {
 		},
 	}
 
-	isBytes, err := c.Marshal(CodecVersion, is)
+	isBytes, err := m.Marshal(CodecVersion, is)
 	require.NoError(err)
 	require.Equal(expected, isBytes)
 }

--- a/vms/avm/txs/initial_state_test.go
+++ b/vms/avm/txs/initial_state_test.go
@@ -23,10 +23,10 @@ var errTest = errors.New("non-nil error")
 func TestInitialStateVerifySerialization(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
-	require.NoError(c.RegisterType(&secp256k1fx.TransferOutput{}))
-	m := codec.NewDefaultManager()
-	require.NoError(m.RegisterCodec(CodecVersion, c))
+	lc := linearcodec.NewDefault()
+	require.NoError(lc.RegisterType(&secp256k1fx.TransferOutput{}))
+	c := codec.NewDefaultManager()
+	require.NoError(c.RegisterCodec(CodecVersion, lc))
 
 	expected := []byte{
 		// Codec version:
@@ -72,7 +72,7 @@ func TestInitialStateVerifySerialization(t *testing.T) {
 		},
 	}
 
-	isBytes, err := m.Marshal(CodecVersion, is)
+	isBytes, err := c.Marshal(CodecVersion, is)
 	require.NoError(err)
 	require.Equal(expected, isBytes)
 }

--- a/vms/components/keystore/codec.go
+++ b/vms/components/keystore/codec.go
@@ -11,12 +11,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils"
 )
 
-const (
-	// CodecVersion is the current default codec version
-	CodecVersion = 0
-)
+const CodecVersion = 0
 
-// Codecs do serialization and deserialization
 var (
 	Codec       codec.Manager
 	LegacyCodec codec.Manager

--- a/vms/components/message/codec.go
+++ b/vms/components/message/codec.go
@@ -11,21 +11,21 @@ import (
 )
 
 const (
-	codecVersion   = 0
+	CodecVersion = 0
+
 	maxMessageSize = 512 * units.KiB
 	maxSliceLen    = maxMessageSize
 )
 
-// Codec does serialization and deserialization
-var c codec.Manager
+var Codec codec.Manager
 
 func init() {
-	c = codec.NewManager(maxMessageSize)
+	Codec = codec.NewManager(maxMessageSize)
 	lc := linearcodec.NewCustomMaxLength(maxSliceLen)
 
 	err := utils.Err(
 		lc.RegisterType(&Tx{}),
-		c.RegisterCodec(codecVersion, lc),
+		Codec.RegisterCodec(CodecVersion, lc),
 	)
 	if err != nil {
 		panic(err)

--- a/vms/components/message/message.go
+++ b/vms/components/message/message.go
@@ -65,11 +65,11 @@ func Parse(bytes []byte) (Message, error) {
 		// It must have been encoded with avalanchego's codec.
 		// TODO remove else statement remove once all nodes support proto encoding.
 		// i.e. when all nodes are on v1.11.0 or later.
-		version, err := c.Unmarshal(bytes, &msg)
+		version, err := Codec.Unmarshal(bytes, &msg)
 		if err != nil {
 			return nil, err
 		}
-		if version != codecVersion {
+		if version != CodecVersion {
 			return nil, ErrUnexpectedCodecVersion
 		}
 	}
@@ -78,7 +78,7 @@ func Parse(bytes []byte) (Message, error) {
 }
 
 func Build(msg Message) ([]byte, error) {
-	bytes, err := c.Marshal(codecVersion, &msg)
+	bytes, err := Codec.Marshal(CodecVersion, &msg)
 	msg.initialize(bytes)
 	return bytes, err
 }

--- a/vms/example/xsvm/api/client.go
+++ b/vms/example/xsvm/api/client.go
@@ -170,7 +170,7 @@ func (c *client) IssueTx(
 	newTx *tx.Tx,
 	options ...rpc.Option,
 ) (ids.ID, error) {
-	txBytes, err := tx.Codec.Marshal(tx.Version, newTx)
+	txBytes, err := tx.Codec.Marshal(tx.CodecVersion, newTx)
 	if err != nil {
 		return ids.Empty, err
 	}

--- a/vms/example/xsvm/block/block.go
+++ b/vms/example/xsvm/block/block.go
@@ -26,7 +26,7 @@ func (b *Stateless) Time() time.Time {
 }
 
 func (b *Stateless) ID() (ids.ID, error) {
-	bytes, err := Codec.Marshal(Version, b)
+	bytes, err := Codec.Marshal(CodecVersion, b)
 	return hashing.ComputeHash256Array(bytes), err
 }
 

--- a/vms/example/xsvm/block/codec.go
+++ b/vms/example/xsvm/block/codec.go
@@ -6,6 +6,6 @@ package block
 import "github.com/ava-labs/avalanchego/vms/example/xsvm/tx"
 
 // Version is the current default codec version
-const Version = tx.Version
+const Version = tx.CodecVersion
 
 var Codec = tx.Codec

--- a/vms/example/xsvm/block/codec.go
+++ b/vms/example/xsvm/block/codec.go
@@ -5,7 +5,6 @@ package block
 
 import "github.com/ava-labs/avalanchego/vms/example/xsvm/tx"
 
-// Version is the current default codec version
-const Version = tx.CodecVersion
+const CodecVersion = tx.CodecVersion
 
 var Codec = tx.Codec

--- a/vms/example/xsvm/chain/chain.go
+++ b/vms/example/xsvm/chain/chain.go
@@ -80,7 +80,7 @@ func (c *chain) NewBlock(blk *xsblock.Stateless) (Block, error) {
 		return blk, nil
 	}
 
-	blkBytes, err := xsblock.Codec.Marshal(xsblock.Version, blk)
+	blkBytes, err := xsblock.Codec.Marshal(xsblock.CodecVersion, blk)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/example/xsvm/cmd/chain/create/cmd.go
+++ b/vms/example/xsvm/cmd/chain/create/cmd.go
@@ -55,7 +55,7 @@ func createFunc(c *cobra.Command, args []string) error {
 	// Get the P-chain wallet
 	pWallet := wallet.P()
 
-	genesisBytes, err := genesis.Codec.Marshal(genesis.Version, &genesis.Genesis{
+	genesisBytes, err := genesis.Codec.Marshal(genesis.CodecVersion, &genesis.Genesis{
 		Timestamp: 0,
 		Allocations: []genesis.Allocation{
 			{

--- a/vms/example/xsvm/cmd/chain/genesis/cmd.go
+++ b/vms/example/xsvm/cmd/chain/genesis/cmd.go
@@ -34,7 +34,7 @@ func genesisFunc(c *cobra.Command, args []string) error {
 		return err
 	}
 
-	genesisBytes, err := genesis.Codec.Marshal(genesis.Version, config.Genesis)
+	genesisBytes, err := genesis.Codec.Marshal(genesis.CodecVersion, config.Genesis)
 	if err != nil {
 		return err
 	}

--- a/vms/example/xsvm/execute/block.go
+++ b/vms/example/xsvm/execute/block.go
@@ -62,7 +62,7 @@ func Block(
 		return err
 	}
 
-	blkBytes, err := xsblock.Codec.Marshal(xsblock.Version, blk)
+	blkBytes, err := xsblock.Codec.Marshal(xsblock.CodecVersion, blk)
 	if err != nil {
 		return err
 	}

--- a/vms/example/xsvm/execute/genesis.go
+++ b/vms/example/xsvm/execute/genesis.go
@@ -36,7 +36,7 @@ func Genesis(db database.KeyValueReaderWriterDeleter, chainID ids.ID, g *genesis
 		return err
 	}
 
-	blkBytes, err := block.Codec.Marshal(block.Version, blk)
+	blkBytes, err := block.Codec.Marshal(block.CodecVersion, blk)
 	if err != nil {
 		return err
 	}

--- a/vms/example/xsvm/genesis/codec.go
+++ b/vms/example/xsvm/genesis/codec.go
@@ -5,6 +5,6 @@ package genesis
 
 import "github.com/ava-labs/avalanchego/vms/example/xsvm/block"
 
-const Version = block.CodecVersion
+const CodecVersion = block.CodecVersion
 
 var Codec = block.Codec

--- a/vms/example/xsvm/genesis/codec.go
+++ b/vms/example/xsvm/genesis/codec.go
@@ -5,7 +5,6 @@ package genesis
 
 import "github.com/ava-labs/avalanchego/vms/example/xsvm/block"
 
-// Version is the current default codec version
 const Version = block.CodecVersion
 
 var Codec = block.Codec

--- a/vms/example/xsvm/genesis/codec.go
+++ b/vms/example/xsvm/genesis/codec.go
@@ -6,6 +6,6 @@ package genesis
 import "github.com/ava-labs/avalanchego/vms/example/xsvm/block"
 
 // Version is the current default codec version
-const Version = block.Version
+const Version = block.CodecVersion
 
 var Codec = block.Codec

--- a/vms/example/xsvm/genesis/genesis.go
+++ b/vms/example/xsvm/genesis/genesis.go
@@ -26,7 +26,7 @@ func Parse(bytes []byte) (*Genesis, error) {
 }
 
 func Block(genesis *Genesis) (*block.Stateless, error) {
-	bytes, err := Codec.Marshal(Version, genesis)
+	bytes, err := Codec.Marshal(CodecVersion, genesis)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/example/xsvm/genesis/genesis_test.go
+++ b/vms/example/xsvm/genesis/genesis_test.go
@@ -26,7 +26,7 @@ func TestGenesis(t *testing.T) {
 			{Address: id2, Balance: 3000000000},
 		},
 	}
-	bytes, err := Codec.Marshal(Version, genesis)
+	bytes, err := Codec.Marshal(CodecVersion, genesis)
 	require.NoError(err)
 
 	parsed, err := Parse(bytes)

--- a/vms/example/xsvm/tx/codec.go
+++ b/vms/example/xsvm/tx/codec.go
@@ -11,8 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils"
 )
 
-// Version is the current default codec version
-const Version = 0
+const CodecVersion = 0
 
 var Codec codec.Manager
 
@@ -24,7 +23,7 @@ func init() {
 		c.RegisterType(&Transfer{}),
 		c.RegisterType(&Export{}),
 		c.RegisterType(&Import{}),
-		Codec.RegisterCodec(Version, c),
+		Codec.RegisterCodec(CodecVersion, c),
 	)
 	if err != nil {
 		panic(err)

--- a/vms/example/xsvm/tx/payload.go
+++ b/vms/example/xsvm/tx/payload.go
@@ -34,7 +34,7 @@ func NewPayload(
 		Amount:   amount,
 		To:       to,
 	}
-	bytes, err := Codec.Marshal(Version, p)
+	bytes, err := Codec.Marshal(CodecVersion, p)
 	p.bytes = bytes
 	return p, err
 }

--- a/vms/example/xsvm/tx/tx.go
+++ b/vms/example/xsvm/tx/tx.go
@@ -28,7 +28,7 @@ func Parse(bytes []byte) (*Tx, error) {
 }
 
 func Sign(utx Unsigned, key *secp256k1.PrivateKey) (*Tx, error) {
-	unsignedBytes, err := Codec.Marshal(Version, &utx)
+	unsignedBytes, err := Codec.Marshal(CodecVersion, &utx)
 	if err != nil {
 		return nil, err
 	}
@@ -46,12 +46,12 @@ func Sign(utx Unsigned, key *secp256k1.PrivateKey) (*Tx, error) {
 }
 
 func (tx *Tx) ID() (ids.ID, error) {
-	bytes, err := Codec.Marshal(Version, tx)
+	bytes, err := Codec.Marshal(CodecVersion, tx)
 	return hashing.ComputeHash256Array(bytes), err
 }
 
 func (tx *Tx) SenderID() (ids.ShortID, error) {
-	unsignedBytes, err := Codec.Marshal(Version, &tx.Unsigned)
+	unsignedBytes, err := Codec.Marshal(CodecVersion, &tx.Unsigned)
 	if err != nil {
 		return ids.ShortEmpty, err
 	}

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -390,7 +390,7 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 	}
 
 	// Marshal genesis to bytes
-	bytes, err := genesis.Codec.Marshal(genesis.Version, g)
+	bytes, err := genesis.Codec.Marshal(genesis.CodecVersion, g)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal genesis: %w", err)
 	}

--- a/vms/platformvm/block/block.go
+++ b/vms/platformvm/block/block.go
@@ -39,7 +39,7 @@ type BanffBlock interface {
 func initialize(blk Block, commonBlk *CommonBlock) error {
 	// We serialize this block as a pointer so that it can be deserialized into
 	// a Block
-	bytes, err := Codec.Marshal(Version, &blk)
+	bytes, err := Codec.Marshal(CodecVersion, &blk)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal block: %w", err)
 	}

--- a/vms/platformvm/block/builder/standard_block_test.go
+++ b/vms/platformvm/block/builder/standard_block_test.go
@@ -51,7 +51,7 @@ func TestAtomicTxImports(t *testing.T) {
 			},
 		},
 	}
-	utxoBytes, err := txs.Codec.Marshal(txs.Version, utxo)
+	utxoBytes, err := txs.Codec.Marshal(txs.CodecVersion, utxo)
 	require.NoError(err)
 
 	inputID := utxo.InputID()

--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -13,8 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
-// Version is the current default codec version
-const Version = txs.Version
+const CodecVersion = txs.CodecVersion
 
 // GenesisCode allows blocks of larger than usual size to be parsed.
 // While this gives flexibility in accommodating large genesis blocks
@@ -41,8 +40,8 @@ func init() {
 		)
 	}
 	errs.Add(
-		Codec.RegisterCodec(Version, c),
-		GenesisCodec.RegisterCodec(Version, gc),
+		Codec.RegisterCodec(CodecVersion, c),
+		GenesisCodec.RegisterCodec(CodecVersion, gc),
 	)
 	if errs.Errored() {
 		panic(errs.Err)

--- a/vms/platformvm/block/serialization_test.go
+++ b/vms/platformvm/block/serialization_test.go
@@ -113,7 +113,7 @@ func TestBanffBlockSerialization(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			require := require.New(t)
 
-			got, err := Codec.Marshal(Version, &block)
+			got, err := Codec.Marshal(CodecVersion, &block)
 			require.NoError(err)
 			require.Equal(test.bytes, got)
 		})

--- a/vms/platformvm/genesis/codec.go
+++ b/vms/platformvm/genesis/codec.go
@@ -5,6 +5,6 @@ package genesis
 
 import "github.com/ava-labs/avalanchego/vms/platformvm/block"
 
-const Version = block.Version
+const Version = block.CodecVersion
 
 var Codec = block.GenesisCodec

--- a/vms/platformvm/genesis/codec.go
+++ b/vms/platformvm/genesis/codec.go
@@ -5,6 +5,6 @@ package genesis
 
 import "github.com/ava-labs/avalanchego/vms/platformvm/block"
 
-const Version = block.CodecVersion
+const CodecVersion = block.CodecVersion
 
 var Codec = block.GenesisCodec

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -489,7 +489,7 @@ func (s *Service) GetUTXOs(_ *http.Request, args *api.GetUTXOsArgs, response *ap
 
 	response.UTXOs = make([]string, len(utxos))
 	for i, utxo := range utxos {
-		bytes, err := txs.Codec.Marshal(txs.Version, utxo)
+		bytes, err := txs.Codec.Marshal(txs.CodecVersion, utxo)
 		if err != nil {
 			return fmt.Errorf("couldn't serialize UTXO %q: %w", utxo.InputID(), err)
 		}
@@ -2426,7 +2426,7 @@ func (s *Service) GetStake(_ *http.Request, args *GetStakeArgs, response *GetSta
 	response.Staked = response.Stakeds[s.vm.ctx.AVAXAssetID]
 	response.Outputs = make([]string, len(stakedOuts))
 	for i, output := range stakedOuts {
-		bytes, err := txs.Codec.Marshal(txs.Version, output)
+		bytes, err := txs.Codec.Marshal(txs.CodecVersion, output)
 		if err != nil {
 			return fmt.Errorf("couldn't serialize output %s: %w", output.ID, err)
 		}
@@ -2608,7 +2608,7 @@ func (s *Service) GetRewardUTXOs(_ *http.Request, args *api.GetTxArgs, reply *Ge
 	reply.NumFetched = json.Uint64(len(utxos))
 	reply.UTXOs = make([]string, len(utxos))
 	for i, utxo := range utxos {
-		utxoBytes, err := txs.GenesisCodec.Marshal(txs.Version, utxo)
+		utxoBytes, err := txs.GenesisCodec.Marshal(txs.CodecVersion, utxo)
 		if err != nil {
 			return fmt.Errorf("couldn't encode UTXO to bytes: %w", err)
 		}

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -199,7 +199,7 @@ func TestGetTxStatus(t *testing.T) {
 			},
 		},
 	}
-	utxoBytes, err := txs.Codec.Marshal(txs.Version, utxo)
+	utxoBytes, err := txs.Codec.Marshal(txs.CodecVersion, utxo)
 	require.NoError(err)
 
 	inputID := utxo.InputID()

--- a/vms/platformvm/state/metadata_codec.go
+++ b/vms/platformvm/state/metadata_codec.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	CodecVersion0Tag = "v0"
-	CodecVersion0    = 0
+	CodecVersion0Tag        = "v0"
+	CodecVersion0    uint16 = 0
 
-	CodecVersion1Tag = "v1"
-	CodecVersion1    = 1
+	CodecVersion1Tag        = "v1"
+	CodecVersion1    uint16 = 1
 )
 
 var MetadataCodec codec.Manager

--- a/vms/platformvm/state/metadata_codec.go
+++ b/vms/platformvm/state/metadata_codec.go
@@ -12,23 +12,23 @@ import (
 )
 
 const (
-	v0tag = "v0"
-	v0    = uint16(0)
+	CodecVersion0Tag = "v0"
+	CodecVersion0    = 0
 
-	v1tag = "v1"
-	v1    = uint16(1)
+	CodecVersion1Tag = "v1"
+	CodecVersion1    = 1
 )
 
-var metadataCodec codec.Manager
+var MetadataCodec codec.Manager
 
 func init() {
-	c0 := linearcodec.New([]string{v0tag}, math.MaxInt32)
-	c1 := linearcodec.New([]string{v0tag, v1tag}, math.MaxInt32)
-	metadataCodec = codec.NewManager(math.MaxInt32)
+	c0 := linearcodec.New([]string{CodecVersion0Tag}, math.MaxInt32)
+	c1 := linearcodec.New([]string{CodecVersion0Tag, CodecVersion1Tag}, math.MaxInt32)
+	MetadataCodec = codec.NewManager(math.MaxInt32)
 
 	err := utils.Err(
-		metadataCodec.RegisterCodec(v0, c0),
-		metadataCodec.RegisterCodec(v1, c1),
+		MetadataCodec.RegisterCodec(CodecVersion0, c0),
+		MetadataCodec.RegisterCodec(CodecVersion1, c1),
 	)
 	if err != nil {
 		panic(err)

--- a/vms/platformvm/state/metadata_delegator.go
+++ b/vms/platformvm/state/metadata_delegator.go
@@ -22,7 +22,7 @@ func parseDelegatorMetadata(bytes []byte, metadata *delegatorMetadata) error {
 		// only potential reward was stored
 		metadata.PotentialReward, err = database.ParseUInt64(bytes)
 	default:
-		_, err = metadataCodec.Unmarshal(bytes, metadata)
+		_, err = MetadataCodec.Unmarshal(bytes, metadata)
 	}
 	return err
 }
@@ -36,7 +36,7 @@ func writeDelegatorMetadata(db database.KeyValueWriter, metadata *delegatorMetad
 	if codecVersion == 0 {
 		return database.PutUInt64(db, metadata.txID[:], metadata.PotentialReward)
 	}
-	metadataBytes, err := metadataCodec.Marshal(codecVersion, metadata)
+	metadataBytes, err := MetadataCodec.Marshal(codecVersion, metadata)
 	if err != nil {
 		return err
 	}

--- a/vms/platformvm/state/metadata_delegator_test.go
+++ b/vms/platformvm/state/metadata_delegator_test.go
@@ -100,7 +100,7 @@ func TestWriteDelegatorMetadata(t *testing.T) {
 	tests := []test{
 		{
 			name:    "v0",
-			version: v0,
+			version: CodecVersion0,
 			metadata: &delegatorMetadata{
 				PotentialReward: 123,
 				StakerStartTime: 456,
@@ -112,7 +112,7 @@ func TestWriteDelegatorMetadata(t *testing.T) {
 		},
 		{
 			name:    "v1",
-			version: v1,
+			version: CodecVersion1,
 			metadata: &delegatorMetadata{
 				PotentialReward: 123,
 				StakerStartTime: 456,

--- a/vms/platformvm/state/metadata_delegator_test.go
+++ b/vms/platformvm/state/metadata_delegator_test.go
@@ -99,7 +99,7 @@ func TestWriteDelegatorMetadata(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name:    "v0",
+			name:    CodecVersion0Tag,
 			version: CodecVersion0,
 			metadata: &delegatorMetadata{
 				PotentialReward: 123,
@@ -111,7 +111,7 @@ func TestWriteDelegatorMetadata(t *testing.T) {
 			},
 		},
 		{
-			name:    "v1",
+			name:    CodecVersion1Tag,
 			version: CodecVersion1,
 			metadata: &delegatorMetadata{
 				PotentialReward: 123,

--- a/vms/platformvm/state/metadata_validator.go
+++ b/vms/platformvm/state/metadata_validator.go
@@ -59,7 +59,7 @@ func parseValidatorMetadata(bytes []byte, metadata *validatorMetadata) error {
 		// potential reward and uptime was stored but potential delegatee reward
 		// was not
 		tmp := preDelegateeRewardMetadata{}
-		if _, err := metadataCodec.Unmarshal(bytes, &tmp); err != nil {
+		if _, err := MetadataCodec.Unmarshal(bytes, &tmp); err != nil {
 			return err
 		}
 
@@ -68,7 +68,7 @@ func parseValidatorMetadata(bytes []byte, metadata *validatorMetadata) error {
 		metadata.PotentialReward = tmp.PotentialReward
 	default:
 		// everything was stored
-		if _, err := metadataCodec.Unmarshal(bytes, metadata); err != nil {
+		if _, err := MetadataCodec.Unmarshal(bytes, metadata); err != nil {
 			return err
 		}
 	}
@@ -239,7 +239,7 @@ func (m *metadata) WriteValidatorMetadata(
 			metadata := m.metadata[vdrID][subnetID]
 			metadata.LastUpdated = uint64(metadata.lastUpdated.Unix())
 
-			metadataBytes, err := metadataCodec.Marshal(codecVersion, metadata)
+			metadataBytes, err := MetadataCodec.Marshal(codecVersion, metadata)
 			if err != nil {
 				return err
 			}

--- a/vms/platformvm/state/metadata_validator_test.go
+++ b/vms/platformvm/state/metadata_validator_test.go
@@ -82,9 +82,8 @@ func TestWriteValidatorMetadata(t *testing.T) {
 	primaryDB := memdb.New()
 	subnetDB := memdb.New()
 
-	codecVersion := v1
 	// write empty uptimes
-	require.NoError(state.WriteValidatorMetadata(primaryDB, subnetDB, codecVersion))
+	require.NoError(state.WriteValidatorMetadata(primaryDB, subnetDB, CodecVersion1))
 
 	// load uptime
 	nodeID := ids.GenerateTestNodeID()
@@ -98,7 +97,7 @@ func TestWriteValidatorMetadata(t *testing.T) {
 	state.LoadValidatorMetadata(nodeID, subnetID, testUptimeReward)
 
 	// write state, should not reflect to DB yet
-	require.NoError(state.WriteValidatorMetadata(primaryDB, subnetDB, codecVersion))
+	require.NoError(state.WriteValidatorMetadata(primaryDB, subnetDB, CodecVersion1))
 	require.False(primaryDB.Has(testUptimeReward.txID[:]))
 	require.False(subnetDB.Has(testUptimeReward.txID[:]))
 
@@ -114,7 +113,7 @@ func TestWriteValidatorMetadata(t *testing.T) {
 	require.NoError(state.SetUptime(nodeID, subnetID, newUpDuration, newLastUpdated))
 
 	// write uptimes, should reflect to subnet DB
-	require.NoError(state.WriteValidatorMetadata(primaryDB, subnetDB, codecVersion))
+	require.NoError(state.WriteValidatorMetadata(primaryDB, subnetDB, CodecVersion1))
 	require.False(primaryDB.Has(testUptimeReward.txID[:]))
 	require.True(subnetDB.Has(testUptimeReward.txID[:]))
 }

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1190,7 +1190,7 @@ func (s *state) ApplyValidatorWeightDiffs(
 			Height:   height,
 			SubnetID: subnetID,
 		}
-		prefixBytes, err := block.GenesisCodec.Marshal(block.Version, prefixStruct)
+		prefixBytes, err := block.GenesisCodec.Marshal(block.CodecVersion, prefixStruct)
 		if err != nil {
 			return err
 		}
@@ -1735,9 +1735,9 @@ func (s *state) initValidatorSets() error {
 }
 
 func (s *state) write(updateValidators bool, height uint64) error {
-	codecVersion := v1
+	codecVersion := CodecVersion1
 	if !s.cfg.IsDurangoActivated(s.GetTimestamp()) {
-		codecVersion = v0
+		codecVersion = CodecVersion0
 	}
 
 	return utils.Err(
@@ -1990,7 +1990,7 @@ func (s *state) writeCurrentStakers(updateValidators bool, height uint64, codecV
 			Height:   height,
 			SubnetID: subnetID,
 		}
-		prefixBytes, err := block.GenesisCodec.Marshal(block.Version, prefixStruct)
+		prefixBytes, err := block.GenesisCodec.Marshal(block.CodecVersion, prefixStruct)
 		if err != nil {
 			return fmt.Errorf("failed to create prefix bytes: %w", err)
 		}
@@ -2041,7 +2041,7 @@ func (s *state) writeCurrentStakers(updateValidators bool, height uint64, codecV
 					PotentialDelegateeReward: 0,
 				}
 
-				metadataBytes, err := metadataCodec.Marshal(codecVersion, metadata)
+				metadataBytes, err := MetadataCodec.Marshal(codecVersion, metadata)
 				if err != nil {
 					return fmt.Errorf("failed to serialize current validator: %w", err)
 				}
@@ -2114,7 +2114,7 @@ func (s *state) writeCurrentStakers(updateValidators bool, height uint64, codecV
 			}
 
 			// TODO: Remove this once we no longer support version rollbacks.
-			weightDiffBytes, err := block.GenesisCodec.Marshal(block.Version, weightDiff)
+			weightDiffBytes, err := block.GenesisCodec.Marshal(block.CodecVersion, weightDiff)
 			if err != nil {
 				return fmt.Errorf("failed to serialize validator weight diff: %w", err)
 			}
@@ -2275,7 +2275,7 @@ func (s *state) writeTXs() error {
 
 		// Note that we're serializing a [txBytesAndStatus] here, not a
 		// *txs.Tx, so we don't use [txs.Codec].
-		txBytes, err := txs.GenesisCodec.Marshal(txs.Version, &stx)
+		txBytes, err := txs.GenesisCodec.Marshal(txs.CodecVersion, &stx)
 		if err != nil {
 			return fmt.Errorf("failed to serialize tx: %w", err)
 		}
@@ -2300,7 +2300,7 @@ func (s *state) writeRewardUTXOs() error {
 		txDB := linkeddb.NewDefault(rawTxDB)
 
 		for _, utxo := range utxos {
-			utxoBytes, err := txs.GenesisCodec.Marshal(txs.Version, utxo)
+			utxoBytes, err := txs.GenesisCodec.Marshal(txs.CodecVersion, utxo)
 			if err != nil {
 				return fmt.Errorf("failed to serialize reward UTXO: %w", err)
 			}
@@ -2348,7 +2348,7 @@ func (s *state) writeSubnetOwners() error {
 		owner := owner
 		delete(s.subnetOwners, subnetID)
 
-		ownerBytes, err := block.GenesisCodec.Marshal(block.Version, &owner)
+		ownerBytes, err := block.GenesisCodec.Marshal(block.CodecVersion, &owner)
 		if err != nil {
 			return fmt.Errorf("failed to marshal subnet owner: %w", err)
 		}
@@ -2429,7 +2429,7 @@ func (s *state) writeMetadata() error {
 	}
 
 	if s.indexedHeights != nil {
-		indexedHeightsBytes, err := block.GenesisCodec.Marshal(block.Version, s.indexedHeights)
+		indexedHeightsBytes, err := block.GenesisCodec.Marshal(block.CodecVersion, s.indexedHeights)
 		if err != nil {
 			return err
 		}

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -649,7 +649,7 @@ func TestParsedStateBlock(t *testing.T) {
 			Status: choices.Accepted,
 		}
 
-		stBlkBytes, err := block.GenesisCodec.Marshal(block.Version, &stBlk)
+		stBlkBytes, err := block.GenesisCodec.Marshal(block.CodecVersion, &stBlk)
 		require.NoError(err)
 
 		gotBlk, _, isStateBlk, err := parseStoredBlock(stBlkBytes)

--- a/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
@@ -216,7 +216,7 @@ func TestAddPermissionlessPrimaryDelegatorSerialization(t *testing.T) {
 		0x44, 0x55, 0x66, 0x77,
 	}
 	var unsignedSimpleAddPrimaryTx UnsignedTx = simpleAddPrimaryTx
-	unsignedSimpleAddPrimaryTxBytes, err := Codec.Marshal(Version, &unsignedSimpleAddPrimaryTx)
+	unsignedSimpleAddPrimaryTxBytes, err := Codec.Marshal(CodecVersion, &unsignedSimpleAddPrimaryTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedSimpleAddPrimaryTxBytes, unsignedSimpleAddPrimaryTxBytes)
 
@@ -599,7 +599,7 @@ func TestAddPermissionlessPrimaryDelegatorSerialization(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00,
 	}
 	var unsignedComplexAddPrimaryTx UnsignedTx = complexAddPrimaryTx
-	unsignedComplexAddPrimaryTxBytes, err := Codec.Marshal(Version, &unsignedComplexAddPrimaryTx)
+	unsignedComplexAddPrimaryTxBytes, err := Codec.Marshal(CodecVersion, &unsignedComplexAddPrimaryTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexAddPrimaryTxBytes, unsignedComplexAddPrimaryTxBytes)
 
@@ -972,7 +972,7 @@ func TestAddPermissionlessSubnetDelegatorSerialization(t *testing.T) {
 		0x44, 0x55, 0x66, 0x77,
 	}
 	var unsignedSimpleAddSubnetTx UnsignedTx = simpleAddSubnetTx
-	unsignedSimpleAddSubnetTxBytes, err := Codec.Marshal(Version, &unsignedSimpleAddSubnetTx)
+	unsignedSimpleAddSubnetTxBytes, err := Codec.Marshal(CodecVersion, &unsignedSimpleAddSubnetTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedSimpleAddSubnetTxBytes, unsignedSimpleAddSubnetTxBytes)
 
@@ -1355,7 +1355,7 @@ func TestAddPermissionlessSubnetDelegatorSerialization(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00,
 	}
 	var unsignedComplexAddSubnetTx UnsignedTx = complexAddSubnetTx
-	unsignedComplexAddSubnetTxBytes, err := Codec.Marshal(Version, &unsignedComplexAddSubnetTx)
+	unsignedComplexAddSubnetTxBytes, err := Codec.Marshal(CodecVersion, &unsignedComplexAddSubnetTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexAddSubnetTxBytes, unsignedComplexAddSubnetTxBytes)
 

--- a/vms/platformvm/txs/add_permissionless_validator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx_test.go
@@ -267,7 +267,7 @@ func TestAddPermissionlessPrimaryValidator(t *testing.T) {
 		0x00, 0x0f, 0x42, 0x40,
 	}
 	var unsignedSimpleAddPrimaryTx UnsignedTx = simpleAddPrimaryTx
-	unsignedSimpleAddPrimaryTxBytes, err := Codec.Marshal(Version, &unsignedSimpleAddPrimaryTx)
+	unsignedSimpleAddPrimaryTxBytes, err := Codec.Marshal(CodecVersion, &unsignedSimpleAddPrimaryTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedSimpleAddPrimaryTxBytes, unsignedSimpleAddPrimaryTxBytes)
 
@@ -695,7 +695,7 @@ func TestAddPermissionlessPrimaryValidator(t *testing.T) {
 		0x00, 0x0f, 0x42, 0x40,
 	}
 	var unsignedComplexAddPrimaryTx UnsignedTx = complexAddPrimaryTx
-	unsignedComplexAddPrimaryTxBytes, err := Codec.Marshal(Version, &unsignedComplexAddPrimaryTx)
+	unsignedComplexAddPrimaryTxBytes, err := Codec.Marshal(CodecVersion, &unsignedComplexAddPrimaryTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexAddPrimaryTxBytes, unsignedComplexAddPrimaryTxBytes)
 }
@@ -954,7 +954,7 @@ func TestAddPermissionlessSubnetValidator(t *testing.T) {
 		0x00, 0x0f, 0x42, 0x40,
 	}
 	var unsignedSimpleAddSubnetTx UnsignedTx = simpleAddSubnetTx
-	unsignedSimpleAddSubnetTxBytes, err := Codec.Marshal(Version, &unsignedSimpleAddSubnetTx)
+	unsignedSimpleAddSubnetTxBytes, err := Codec.Marshal(CodecVersion, &unsignedSimpleAddSubnetTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedSimpleAddSubnetTxBytes, unsignedSimpleAddSubnetTxBytes)
 
@@ -1362,7 +1362,7 @@ func TestAddPermissionlessSubnetValidator(t *testing.T) {
 		0x00, 0x0f, 0x42, 0x40,
 	}
 	var unsignedComplexAddSubnetTx UnsignedTx = complexAddSubnetTx
-	unsignedComplexAddSubnetTxBytes, err := Codec.Marshal(Version, &unsignedComplexAddSubnetTx)
+	unsignedComplexAddSubnetTxBytes, err := Codec.Marshal(CodecVersion, &unsignedComplexAddSubnetTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexAddSubnetTxBytes, unsignedComplexAddSubnetTxBytes)
 }

--- a/vms/platformvm/txs/add_subnet_validator_test.go
+++ b/vms/platformvm/txs/add_subnet_validator_test.go
@@ -201,7 +201,7 @@ func TestAddSubnetValidatorMarshal(t *testing.T) {
 	require.NoError(err)
 	require.NoError(stx.SyntacticVerify(ctx))
 
-	txBytes, err := Codec.Marshal(Version, stx)
+	txBytes, err := Codec.Marshal(CodecVersion, stx)
 	require.NoError(err)
 
 	parsedTx, err := Parse(Codec, txBytes)

--- a/vms/platformvm/txs/base_tx_test.go
+++ b/vms/platformvm/txs/base_tx_test.go
@@ -118,7 +118,7 @@ func TestBaseTxSerialization(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00,
 	}
 	var unsignedSimpleBaseTx UnsignedTx = simpleBaseTx
-	unsignedSimpleBaseTxBytes, err := Codec.Marshal(Version, &unsignedSimpleBaseTx)
+	unsignedSimpleBaseTxBytes, err := Codec.Marshal(CodecVersion, &unsignedSimpleBaseTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedSimpleBaseTxBytes, unsignedSimpleBaseTxBytes)
 
@@ -358,7 +358,7 @@ func TestBaseTxSerialization(t *testing.T) {
 		0x01, 0x23, 0x45, 0x21,
 	}
 	var unsignedComplexBaseTx UnsignedTx = complexBaseTx
-	unsignedComplexBaseTxBytes, err := Codec.Marshal(Version, &unsignedComplexBaseTx)
+	unsignedComplexBaseTxBytes, err := Codec.Marshal(CodecVersion, &unsignedComplexBaseTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexBaseTxBytes, unsignedComplexBaseTxBytes)
 

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -15,8 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
-// Version is the current default codec version
-const Version = 0
+const CodecVersion = 0
 
 var (
 	Codec codec.Manager
@@ -48,8 +47,8 @@ func init() {
 		errs.Add(RegisterDUnsignedTxsTypes(c))
 	}
 	errs.Add(
-		Codec.RegisterCodec(Version, c),
-		GenesisCodec.RegisterCodec(Version, gc),
+		Codec.RegisterCodec(CodecVersion, c),
+		GenesisCodec.RegisterCodec(CodecVersion, gc),
 	)
 	if errs.Errored() {
 		panic(errs.Err)

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -909,7 +909,7 @@ func TestAdvanceTimeTxUnmarshal(t *testing.T) {
 	tx, err := env.txBuilder.NewAdvanceTimeTx(chainTime.Add(time.Second))
 	require.NoError(err)
 
-	bytes, err := txs.Codec.Marshal(txs.Version, tx)
+	bytes, err := txs.Codec.Marshal(txs.CodecVersion, tx)
 	require.NoError(err)
 
 	var unmarshaledTx txs.Tx

--- a/vms/platformvm/txs/executor/import_test.go
+++ b/vms/platformvm/txs/executor/import_test.go
@@ -67,7 +67,7 @@ func TestNewImportTx(t *testing.T) {
 					},
 				},
 			}
-			utxoBytes, err := txs.Codec.Marshal(txs.Version, utxo)
+			utxoBytes, err := txs.Codec.Marshal(txs.CodecVersion, utxo)
 			require.NoError(t, err)
 
 			inputID := utxo.InputID()

--- a/vms/platformvm/txs/executor/standard_tx_executor.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor.go
@@ -254,7 +254,7 @@ func (e *StandardTxExecutor) ExportTx(tx *txs.ExportTx) error {
 			Out:   out.Out,
 		}
 
-		utxoBytes, err := txs.Codec.Marshal(txs.Version, utxo)
+		utxoBytes, err := txs.Codec.Marshal(txs.CodecVersion, utxo)
 		if err != nil {
 			return fmt.Errorf("failed to marshal UTXO: %w", err)
 		}

--- a/vms/platformvm/txs/remove_subnet_validator_tx_test.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx_test.go
@@ -157,7 +157,7 @@ func TestRemoveSubnetValidatorTxSerialization(t *testing.T) {
 		0x00, 0x00, 0x00, 0x03,
 	}
 	var unsignedSimpleRemoveValidatorTx UnsignedTx = simpleRemoveValidatorTx
-	unsignedSimpleRemoveValidatorTxBytes, err := Codec.Marshal(Version, &unsignedSimpleRemoveValidatorTx)
+	unsignedSimpleRemoveValidatorTxBytes, err := Codec.Marshal(CodecVersion, &unsignedSimpleRemoveValidatorTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedSimpleRemoveValidatorTxBytes, unsignedSimpleRemoveValidatorTxBytes)
 
@@ -417,7 +417,7 @@ func TestRemoveSubnetValidatorTxSerialization(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00,
 	}
 	var unsignedComplexRemoveValidatorTx UnsignedTx = complexRemoveValidatorTx
-	unsignedComplexRemoveValidatorTxBytes, err := Codec.Marshal(Version, &unsignedComplexRemoveValidatorTx)
+	unsignedComplexRemoveValidatorTxBytes, err := Codec.Marshal(CodecVersion, &unsignedComplexRemoveValidatorTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexRemoveValidatorTxBytes, unsignedComplexRemoveValidatorTxBytes)
 

--- a/vms/platformvm/txs/transfer_subnet_ownership_tx_test.go
+++ b/vms/platformvm/txs/transfer_subnet_ownership_tx_test.go
@@ -164,7 +164,7 @@ func TestTransferSubnetOwnershipTxSerialization(t *testing.T) {
 		0x44, 0x55, 0x66, 0x77,
 	}
 	var unsignedSimpleTransferSubnetOwnershipTx UnsignedTx = simpleTransferSubnetOwnershipTx
-	unsignedSimpleTransferSubnetOwnershipTxBytes, err := Codec.Marshal(Version, &unsignedSimpleTransferSubnetOwnershipTx)
+	unsignedSimpleTransferSubnetOwnershipTxBytes, err := Codec.Marshal(CodecVersion, &unsignedSimpleTransferSubnetOwnershipTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedSimpleTransferSubnetOwnershipTxBytes, unsignedSimpleTransferSubnetOwnershipTxBytes)
 
@@ -438,7 +438,7 @@ func TestTransferSubnetOwnershipTxSerialization(t *testing.T) {
 		0x44, 0x55, 0x66, 0x77,
 	}
 	var unsignedComplexTransferSubnetOwnershipTx UnsignedTx = complexTransferSubnetOwnershipTx
-	unsignedComplexTransferSubnetOwnershipTxBytes, err := Codec.Marshal(Version, &unsignedComplexTransferSubnetOwnershipTx)
+	unsignedComplexTransferSubnetOwnershipTxBytes, err := Codec.Marshal(CodecVersion, &unsignedComplexTransferSubnetOwnershipTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexTransferSubnetOwnershipTxBytes, unsignedComplexTransferSubnetOwnershipTxBytes)
 

--- a/vms/platformvm/txs/transform_subnet_tx_test.go
+++ b/vms/platformvm/txs/transform_subnet_tx_test.go
@@ -223,7 +223,7 @@ func TestTransformSubnetTxSerialization(t *testing.T) {
 		0x00, 0x00, 0x00, 0x03,
 	}
 	var unsignedSimpleTransformTx UnsignedTx = simpleTransformTx
-	unsignedSimpleTransformTxBytes, err := Codec.Marshal(Version, &unsignedSimpleTransformTx)
+	unsignedSimpleTransformTxBytes, err := Codec.Marshal(CodecVersion, &unsignedSimpleTransformTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedSimpleTransformTxBytes, unsignedSimpleTransformTxBytes)
 
@@ -520,7 +520,7 @@ func TestTransformSubnetTxSerialization(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00,
 	}
 	var unsignedComplexTransformTx UnsignedTx = complexTransformTx
-	unsignedComplexTransformTxBytes, err := Codec.Marshal(Version, &unsignedComplexTransformTx)
+	unsignedComplexTransformTxBytes, err := Codec.Marshal(CodecVersion, &unsignedComplexTransformTx)
 	require.NoError(err)
 	require.Equal(expectedUnsignedComplexTransformTxBytes, unsignedComplexTransformTxBytes)
 

--- a/vms/platformvm/txs/tx.go
+++ b/vms/platformvm/txs/tx.go
@@ -48,12 +48,12 @@ func NewSigned(
 }
 
 func (tx *Tx) Initialize(c codec.Manager) error {
-	signedBytes, err := c.Marshal(Version, tx)
+	signedBytes, err := c.Marshal(CodecVersion, tx)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal ProposalTx: %w", err)
 	}
 
-	unsignedBytesLen, err := c.Size(Version, &tx.Unsigned)
+	unsignedBytesLen, err := c.Size(CodecVersion, &tx.Unsigned)
 	if err != nil {
 		return fmt.Errorf("couldn't calculate UnsignedTx marshal length: %w", err)
 	}
@@ -78,7 +78,7 @@ func Parse(c codec.Manager, signedBytes []byte) (*Tx, error) {
 		return nil, fmt.Errorf("couldn't parse tx: %w", err)
 	}
 
-	unsignedBytesLen, err := c.Size(Version, &tx.Unsigned)
+	unsignedBytesLen, err := c.Size(CodecVersion, &tx.Unsigned)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't calculate UnsignedTx marshal length: %w", err)
 	}
@@ -132,7 +132,7 @@ func (tx *Tx) SyntacticVerify(ctx *snow.Context) error {
 // Note: We explicitly pass the codec in Sign since we may need to sign P-Chain
 // genesis txs whose length exceed the max length of txs.Codec.
 func (tx *Tx) Sign(c codec.Manager, signers [][]*secp256k1.PrivateKey) error {
-	unsignedBytes, err := c.Marshal(Version, &tx.Unsigned)
+	unsignedBytes, err := c.Marshal(CodecVersion, &tx.Unsigned)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal UnsignedTx: %w", err)
 	}
@@ -153,7 +153,7 @@ func (tx *Tx) Sign(c codec.Manager, signers [][]*secp256k1.PrivateKey) error {
 		tx.Creds = append(tx.Creds, cred) // Attach credential
 	}
 
-	signedBytes, err := c.Marshal(Version, tx)
+	signedBytes, err := c.Marshal(CodecVersion, tx)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal ProposalTx: %w", err)
 	}

--- a/vms/platformvm/utxo/handler.go
+++ b/vms/platformvm/utxo/handler.go
@@ -557,7 +557,7 @@ func (h *handler) VerifySpendUTXOs(
 			return fmt.Errorf("expected fx.Owned but got %T", out)
 		}
 		owner := owned.Owners()
-		ownerBytes, err := txs.Codec.Marshal(txs.Version, owner)
+		ownerBytes, err := txs.Codec.Marshal(txs.CodecVersion, owner)
 		if err != nil {
 			return fmt.Errorf("couldn't marshal owner: %w", err)
 		}
@@ -606,7 +606,7 @@ func (h *handler) VerifySpendUTXOs(
 			return fmt.Errorf("expected fx.Owned but got %T", out)
 		}
 		owner := owned.Owners()
-		ownerBytes, err := txs.Codec.Marshal(txs.Version, owner)
+		ownerBytes, err := txs.Codec.Marshal(txs.CodecVersion, owner)
 		if err != nil {
 			return fmt.Errorf("couldn't marshal owner: %w", err)
 		}

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -604,7 +604,7 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 	mutableSharedMemory.SharedMemory = m.NewSharedMemory(vm.ctx.ChainID)
 	peerSharedMemory := m.NewSharedMemory(vm.ctx.XChainID)
 
-	utxoBytes, err := txs.Codec.Marshal(txs.Version, utxo)
+	utxoBytes, err := txs.Codec.Marshal(txs.CodecVersion, utxo)
 	require.NoError(err)
 
 	inputID := utxo.InputID()
@@ -849,7 +849,7 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 	mutableSharedMemory.SharedMemory = m.NewSharedMemory(vm.ctx.ChainID)
 	peerSharedMemory := m.NewSharedMemory(vm.ctx.XChainID)
 
-	utxoBytes, err := txs.Codec.Marshal(txs.Version, utxo)
+	utxoBytes, err := txs.Codec.Marshal(txs.CodecVersion, utxo)
 	require.NoError(err)
 
 	inputID := utxo.InputID()

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1013,7 +1013,7 @@ func TestAtomicImport(t *testing.T) {
 			},
 		},
 	}
-	utxoBytes, err := txs.Codec.Marshal(txs.Version, utxo)
+	utxoBytes, err := txs.Codec.Marshal(txs.CodecVersion, utxo)
 	require.NoError(err)
 
 	inputID := utxo.InputID()

--- a/vms/platformvm/warp/codec.go
+++ b/vms/platformvm/warp/codec.go
@@ -11,18 +11,17 @@ import (
 	"github.com/ava-labs/avalanchego/utils"
 )
 
-const codecVersion = 0
+const CodecVersion = 0
 
-// Codec does serialization and deserialization for Warp messages.
-var c codec.Manager
+var Codec codec.Manager
 
 func init() {
-	c = codec.NewManager(math.MaxInt)
+	Codec = codec.NewManager(math.MaxInt)
 	lc := linearcodec.NewCustomMaxLength(math.MaxInt32)
 
 	err := utils.Err(
 		lc.RegisterType(&BitSetSignature{}),
-		c.RegisterCodec(codecVersion, lc),
+		Codec.RegisterCodec(CodecVersion, lc),
 	)
 	if err != nil {
 		panic(err)

--- a/vms/platformvm/warp/message.go
+++ b/vms/platformvm/warp/message.go
@@ -28,7 +28,7 @@ func ParseMessage(b []byte) (*Message, error) {
 	msg := &Message{
 		bytes: b,
 	}
-	_, err := c.Unmarshal(b, msg)
+	_, err := Codec.Unmarshal(b, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func ParseMessage(b []byte) (*Message, error) {
 // Initialize recalculates the result of Bytes(). It does not call Initialize()
 // on the UnsignedMessage.
 func (m *Message) Initialize() error {
-	bytes, err := c.Marshal(codecVersion, m)
+	bytes, err := Codec.Marshal(CodecVersion, m)
 	m.bytes = bytes
 	return err
 }

--- a/vms/platformvm/warp/payload/codec.go
+++ b/vms/platformvm/warp/payload/codec.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	codecVersion = 0
+	CodecVersion = 0
 
 	MaxMessageSize = 24 * units.KiB
 
@@ -20,17 +20,16 @@ const (
 	MaxSliceLen = 24 * 1024
 )
 
-// Codec does serialization and deserialization for Warp messages.
-var c codec.Manager
+var Codec codec.Manager
 
 func init() {
-	c = codec.NewManager(MaxMessageSize)
+	Codec = codec.NewManager(MaxMessageSize)
 	lc := linearcodec.NewCustomMaxLength(MaxSliceLen)
 
 	err := utils.Err(
 		lc.RegisterType(&Hash{}),
 		lc.RegisterType(&AddressedCall{}),
-		c.RegisterCodec(codecVersion, lc),
+		Codec.RegisterCodec(CodecVersion, lc),
 	)
 	if err != nil {
 		panic(err)

--- a/vms/platformvm/warp/payload/payload.go
+++ b/vms/platformvm/warp/payload/payload.go
@@ -22,7 +22,7 @@ type Payload interface {
 
 func Parse(bytes []byte) (Payload, error) {
 	var payload Payload
-	if _, err := c.Unmarshal(bytes, &payload); err != nil {
+	if _, err := Codec.Unmarshal(bytes, &payload); err != nil {
 		return nil, err
 	}
 	payload.initialize(bytes)
@@ -30,7 +30,7 @@ func Parse(bytes []byte) (Payload, error) {
 }
 
 func initialize(p Payload) error {
-	bytes, err := c.Marshal(codecVersion, &p)
+	bytes, err := Codec.Marshal(CodecVersion, &p)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal %T payload: %w", p, err)
 	}

--- a/vms/platformvm/warp/unsigned_message.go
+++ b/vms/platformvm/warp/unsigned_message.go
@@ -41,13 +41,13 @@ func ParseUnsignedMessage(b []byte) (*UnsignedMessage, error) {
 		bytes: b,
 		id:    hashing.ComputeHash256Array(b),
 	}
-	_, err := c.Unmarshal(b, msg)
+	_, err := Codec.Unmarshal(b, msg)
 	return msg, err
 }
 
 // Initialize recalculates the result of Bytes().
 func (m *UnsignedMessage) Initialize() error {
-	bytes, err := c.Marshal(codecVersion, m)
+	bytes, err := Codec.Marshal(CodecVersion, m)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal warp unsigned message: %w", err)
 	}

--- a/vms/proposervm/block/build.go
+++ b/vms/proposervm/block/build.go
@@ -31,7 +31,7 @@ func BuildUnsigned(
 		timestamp: timestamp,
 	}
 
-	bytes, err := c.Marshal(codecVersion, &block)
+	bytes, err := Codec.Marshal(CodecVersion, &block)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func Build(
 	}
 	var blockIntf SignedBlock = block
 
-	unsignedBytesWithEmptySignature, err := c.Marshal(codecVersion, &blockIntf)
+	unsignedBytesWithEmptySignature, err := Codec.Marshal(CodecVersion, &blockIntf)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func Build(
 		return nil, err
 	}
 
-	block.bytes, err = c.Marshal(codecVersion, &blockIntf)
+	block.bytes, err = Codec.Marshal(CodecVersion, &blockIntf)
 	return block, err
 }
 
@@ -100,7 +100,7 @@ func BuildHeader(
 		Body:   bodyID,
 	}
 
-	bytes, err := c.Marshal(codecVersion, &header)
+	bytes, err := Codec.Marshal(CodecVersion, &header)
 	header.bytes = bytes
 	return &header, err
 }
@@ -117,7 +117,7 @@ func BuildOption(
 		InnerBytes: innerBytes,
 	}
 
-	bytes, err := c.Marshal(codecVersion, &block)
+	bytes, err := Codec.Marshal(CodecVersion, &block)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/proposervm/block/codec.go
+++ b/vms/proposervm/block/codec.go
@@ -13,12 +13,12 @@ import (
 
 const CodecVersion = 0
 
-// The maximum block size is enforced by the p2p message size limit.
-// See: [constants.DefaultMaxMessageSize]
 var Codec codec.Manager
 
 func init() {
 	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
+	// The maximum block size is enforced by the p2p message size limit.
+	// See: [constants.DefaultMaxMessageSize]
 	Codec = codec.NewManager(math.MaxInt)
 
 	err := utils.Err(

--- a/vms/proposervm/block/parse.go
+++ b/vms/proposervm/block/parse.go
@@ -7,24 +7,24 @@ import "fmt"
 
 func Parse(bytes []byte) (Block, error) {
 	var block Block
-	parsedVersion, err := c.Unmarshal(bytes, &block)
+	parsedVersion, err := Codec.Unmarshal(bytes, &block)
 	if err != nil {
 		return nil, err
 	}
-	if parsedVersion != codecVersion {
-		return nil, fmt.Errorf("expected codec version %d but got %d", codecVersion, parsedVersion)
+	if parsedVersion != CodecVersion {
+		return nil, fmt.Errorf("expected codec version %d but got %d", CodecVersion, parsedVersion)
 	}
 	return block, block.initialize(bytes)
 }
 
 func ParseHeader(bytes []byte) (Header, error) {
 	header := statelessHeader{}
-	parsedVersion, err := c.Unmarshal(bytes, &header)
+	parsedVersion, err := Codec.Unmarshal(bytes, &header)
 	if err != nil {
 		return nil, err
 	}
-	if parsedVersion != codecVersion {
-		return nil, fmt.Errorf("expected codec version %d but got %d", codecVersion, parsedVersion)
+	if parsedVersion != CodecVersion {
+		return nil, fmt.Errorf("expected codec version %d but got %d", CodecVersion, parsedVersion)
 	}
 	header.bytes = bytes
 	return &header, nil

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -100,11 +100,11 @@ func (s *blockState) GetBlock(blkID ids.ID) (block.Block, choices.Status, error)
 	}
 
 	blkWrapper := blockWrapper{}
-	parsedVersion, err := c.Unmarshal(blkWrapperBytes, &blkWrapper)
+	parsedVersion, err := Codec.Unmarshal(blkWrapperBytes, &blkWrapper)
 	if err != nil {
 		return nil, choices.Unknown, err
 	}
-	if parsedVersion != version {
+	if parsedVersion != CodecVersion {
 		return nil, choices.Unknown, errBlockWrongVersion
 	}
 
@@ -126,7 +126,7 @@ func (s *blockState) PutBlock(blk block.Block, status choices.Status) error {
 		block:  blk,
 	}
 
-	bytes, err := c.Marshal(version, &blkWrapper)
+	bytes, err := Codec.Marshal(CodecVersion, &blkWrapper)
 	if err != nil {
 		return err
 	}

--- a/vms/proposervm/state/codec.go
+++ b/vms/proposervm/state/codec.go
@@ -10,15 +10,15 @@ import (
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 )
 
-const version = 0
+const CodecVersion = 0
 
-var c codec.Manager
+var Codec codec.Manager
 
 func init() {
 	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
-	c = codec.NewManager(math.MaxInt32)
+	Codec = codec.NewManager(math.MaxInt32)
 
-	err := c.RegisterCodec(version, lc)
+	err := Codec.RegisterCodec(CodecVersion, lc)
 	if err != nil {
 		panic(err)
 	}

--- a/vms/proposervm/summary/build.go
+++ b/vms/proposervm/summary/build.go
@@ -20,7 +20,7 @@ func Build(
 		InnerSummary: coreSummary,
 	}
 
-	bytes, err := c.Marshal(codecVersion, &summary)
+	bytes, err := Codec.Marshal(CodecVersion, &summary)
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal proposer summary due to: %w", err)
 	}

--- a/vms/proposervm/summary/parse.go
+++ b/vms/proposervm/summary/parse.go
@@ -14,11 +14,11 @@ func Parse(bytes []byte) (StateSummary, error) {
 		id:    hashing.ComputeHash256Array(bytes),
 		bytes: bytes,
 	}
-	version, err := c.Unmarshal(bytes, &summary)
+	version, err := Codec.Unmarshal(bytes, &summary)
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal summary due to: %w", err)
 	}
-	if version != codecVersion {
+	if version != CodecVersion {
 		return nil, errWrongCodecVersion
 	}
 	return &summary, nil

--- a/wallet/chain/p/signer_visitor.go
+++ b/wallet/chain/p/signer_visitor.go
@@ -284,7 +284,7 @@ func (s *signerVisitor) getSubnetSigners(subnetID ids.ID, subnetAuth verify.Veri
 
 // TODO: remove [signHash] after the ledger supports signing all transactions.
 func sign(tx *txs.Tx, signHash bool, txSigners [][]keychain.Signer) error {
-	unsignedBytes, err := txs.Codec.Marshal(txs.Version, &tx.Unsigned)
+	unsignedBytes, err := txs.Codec.Marshal(txs.CodecVersion, &tx.Unsigned)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal unsigned tx: %w", err)
 	}
@@ -345,7 +345,7 @@ func sign(tx *txs.Tx, signHash bool, txSigners [][]keychain.Signer) error {
 		}
 	}
 
-	signedBytes, err := txs.Codec.Marshal(txs.Version, tx)
+	signedBytes, err := txs.Codec.Marshal(txs.CodecVersion, tx)
 	if err != nil {
 		return fmt.Errorf("couldn't marshal tx: %w", err)
 	}


### PR DESCRIPTION
## Why this should be merged

This standardizes how we use the reflect codec and simplifies some code paths.

## How this works

It's essentially a pure refactor.

## How this was tested

- [X] CI