### PR TITLE
Remove unused index interface

### DIFF
--- a/indexer/index_test.go
+++ b/indexer/index_test.go
@@ -31,9 +31,8 @@ func TestIndex(t *testing.T) {
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	ctx := snowtest.ConsensusContext(snowCtx)
 
-	indexIntf, err := newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
+	idx, err := newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
 	require.NoError(err)
-	idx := indexIntf.(*index)
 
 	// Populate "containers" with random IDs/bytes
 	containers := map[ids.ID][]byte{}
@@ -84,9 +83,8 @@ func TestIndex(t *testing.T) {
 	require.NoError(db.Commit())
 	require.NoError(idx.Close())
 	db = versiondb.New(baseDB)
-	indexIntf, err = newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
+	idx, err = newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
 	require.NoError(err)
-	idx = indexIntf.(*index)
 
 	// Get all of the containers
 	containersList, err := idx.GetContainerRange(0, pageSize)
@@ -119,9 +117,8 @@ func TestIndexGetContainerByRangeMaxPageSize(t *testing.T) {
 	db := memdb.New()
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	ctx := snowtest.ConsensusContext(snowCtx)
-	indexIntf, err := newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
+	idx, err := newIndex(db, logging.NoLog{}, codec, mockable.Clock{})
 	require.NoError(err)
-	idx := indexIntf.(*index)
 
 	// Insert [MaxFetchedByRange] + 1 containers
 	for i := uint64(0); i < MaxFetchedByRange+1; i++ {

--- a/indexer/service.go
+++ b/indexer/service.go
@@ -15,7 +15,7 @@ import (
 )
 
 type service struct {
-	Index
+	index *index
 }
 
 type FormattedContainer struct {
@@ -46,11 +46,11 @@ type GetLastAcceptedArgs struct {
 }
 
 func (s *service) GetLastAccepted(_ *http.Request, args *GetLastAcceptedArgs, reply *FormattedContainer) error {
-	container, err := s.Index.GetLastAccepted()
+	container, err := s.index.GetLastAccepted()
 	if err != nil {
 		return err
 	}
-	index, err := s.Index.GetIndex(container.ID)
+	index, err := s.index.GetIndex(container.ID)
 	if err != nil {
 		return fmt.Errorf("couldn't get index: %w", err)
 	}
@@ -64,11 +64,11 @@ type GetContainerByIndexArgs struct {
 }
 
 func (s *service) GetContainerByIndex(_ *http.Request, args *GetContainerByIndexArgs, reply *FormattedContainer) error {
-	container, err := s.Index.GetContainerByIndex(uint64(args.Index))
+	container, err := s.index.GetContainerByIndex(uint64(args.Index))
 	if err != nil {
 		return err
 	}
-	index, err := s.Index.GetIndex(container.ID)
+	index, err := s.index.GetIndex(container.ID)
 	if err != nil {
 		return fmt.Errorf("couldn't get index: %w", err)
 	}
@@ -92,14 +92,14 @@ type GetContainerRangeResponse struct {
 // If [n] > [MaxFetchedByRange], returns an error.
 // If we run out of transactions, returns the ones fetched before running out.
 func (s *service) GetContainerRange(_ *http.Request, args *GetContainerRangeArgs, reply *GetContainerRangeResponse) error {
-	containers, err := s.Index.GetContainerRange(uint64(args.StartIndex), uint64(args.NumToFetch))
+	containers, err := s.index.GetContainerRange(uint64(args.StartIndex), uint64(args.NumToFetch))
 	if err != nil {
 		return err
 	}
 
 	reply.Containers = make([]FormattedContainer, len(containers))
 	for i, container := range containers {
-		index, err := s.Index.GetIndex(container.ID)
+		index, err := s.index.GetIndex(container.ID)
 		if err != nil {
 			return fmt.Errorf("couldn't get index: %w", err)
 		}
@@ -120,7 +120,7 @@ type GetIndexResponse struct {
 }
 
 func (s *service) GetIndex(_ *http.Request, args *GetIndexArgs, reply *GetIndexResponse) error {
-	index, err := s.Index.GetIndex(args.ID)
+	index, err := s.index.GetIndex(args.ID)
 	reply.Index = json.Uint64(index)
 	return err
 }
@@ -134,7 +134,7 @@ type IsAcceptedResponse struct {
 }
 
 func (s *service) IsAccepted(_ *http.Request, args *IsAcceptedArgs, reply *IsAcceptedResponse) error {
-	_, err := s.Index.GetIndex(args.ID)
+	_, err := s.index.GetIndex(args.ID)
 	if err == nil {
 		reply.IsAccepted = true
 		return nil
@@ -152,11 +152,11 @@ type GetContainerByIDArgs struct {
 }
 
 func (s *service) GetContainerByID(_ *http.Request, args *GetContainerByIDArgs, reply *FormattedContainer) error {
-	container, err := s.Index.GetContainerByID(args.ID)
+	container, err := s.index.GetContainerByID(args.ID)
 	if err != nil {
 		return err
 	}
-	index, err := s.Index.GetIndex(container.ID)
+	index, err := s.index.GetIndex(container.ID)
 	if err != nil {
 		return fmt.Errorf("couldn't get index: %w", err)
 	}


### PR DESCRIPTION
## Why this should be merged

`Index` is never provided outside of the `indexer` package, so we can just remove the interface entirely.

## How this works

Replaces `Index` with `*index`.

## How this was tested

- [X] CI