### PR TITLE
Use more specific type

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -146,7 +146,7 @@ type network struct {
 	// Cancelled on close
 	onCloseCtx context.Context
 	// Call [onCloseCtxCancel] to cancel [onCloseCtx] during close()
-	onCloseCtxCancel func()
+	onCloseCtxCancel context.CancelFunc
 
 	sendFailRateCalculator safemath.Averager
 


### PR DESCRIPTION
## Why this should be merged

🙅🏾‍♂️ `func()`

## How this works

Replace with `context.CancelFunc`

## How this was tested

CI