### PR TITLE
Verify avm mempool txs against the last accepted state

### DIFF
--- a/vms/avm/block/executor/block_test.go
+++ b/vms/avm/block/executor/block_test.go
@@ -859,27 +859,25 @@ func TestBlockReject(t *testing.T) {
 				mempool.EXPECT().Add(validTx).Return(nil) // Only add the one that passes verification
 				mempool.EXPECT().RequestBuildBlock()
 
-				preferredID := ids.GenerateTestID()
-				mockPreferredState := state.NewMockDiff(ctrl)
-				mockPreferredState.EXPECT().GetLastAccepted().Return(ids.GenerateTestID()).AnyTimes()
-				mockPreferredState.EXPECT().GetTimestamp().Return(time.Now()).AnyTimes()
+				lastAcceptedID := ids.GenerateTestID()
+				mockState := state.NewMockState(ctrl)
+				mockState.EXPECT().GetLastAccepted().Return(lastAcceptedID).AnyTimes()
+				mockState.EXPECT().GetTimestamp().Return(time.Now()).AnyTimes()
 
 				return &Block{
 					Block: mockBlock,
 					manager: &manager{
-						preferred: preferredID,
-						mempool:   mempool,
-						metrics:   metrics.NewMockMetrics(ctrl),
+						lastAccepted: lastAcceptedID,
+						mempool:      mempool,
+						metrics:      metrics.NewMockMetrics(ctrl),
 						backend: &executor.Backend{
 							Bootstrapped: true,
 							Ctx: &snow.Context{
 								Log: logging.NoLog{},
 							},
 						},
+						state: mockState,
 						blkIDToState: map[ids.ID]*blockState{
-							preferredID: {
-								onAcceptState: mockPreferredState,
-							},
 							blockID: {},
 						},
 					},
@@ -919,27 +917,25 @@ func TestBlockReject(t *testing.T) {
 				mempool.EXPECT().Add(tx2).Return(nil)
 				mempool.EXPECT().RequestBuildBlock()
 
-				preferredID := ids.GenerateTestID()
-				mockPreferredState := state.NewMockDiff(ctrl)
-				mockPreferredState.EXPECT().GetLastAccepted().Return(ids.GenerateTestID()).AnyTimes()
-				mockPreferredState.EXPECT().GetTimestamp().Return(time.Now()).AnyTimes()
+				lastAcceptedID := ids.GenerateTestID()
+				mockState := state.NewMockState(ctrl)
+				mockState.EXPECT().GetLastAccepted().Return(lastAcceptedID).AnyTimes()
+				mockState.EXPECT().GetTimestamp().Return(time.Now()).AnyTimes()
 
 				return &Block{
 					Block: mockBlock,
 					manager: &manager{
-						preferred: preferredID,
-						mempool:   mempool,
-						metrics:   metrics.NewMockMetrics(ctrl),
+						lastAccepted: lastAcceptedID,
+						mempool:      mempool,
+						metrics:      metrics.NewMockMetrics(ctrl),
 						backend: &executor.Backend{
 							Bootstrapped: true,
 							Ctx: &snow.Context{
 								Log: logging.NoLog{},
 							},
 						},
+						state: mockState,
 						blkIDToState: map[ids.ID]*blockState{
-							preferredID: {
-								onAcceptState: mockPreferredState,
-							},
 							blockID: {},
 						},
 					},

--- a/vms/avm/block/executor/manager.go
+++ b/vms/avm/block/executor/manager.go
@@ -155,7 +155,7 @@ func (m *manager) VerifyTx(tx *txs.Tx) error {
 		return err
 	}
 
-	stateDiff, err := state.NewDiff(m.preferred, m)
+	stateDiff, err := state.NewDiff(m.lastAccepted, m)
 	if err != nil {
 		return err
 	}
@@ -174,12 +174,7 @@ func (m *manager) VerifyTx(tx *txs.Tx) error {
 		State: stateDiff,
 		Tx:    tx,
 	}
-	err = tx.Unsigned.Visit(executor)
-	if err != nil {
-		return err
-	}
-
-	return m.VerifyUniqueInputs(m.preferred, executor.Inputs)
+	return tx.Unsigned.Visit(executor)
 }
 
 func (m *manager) VerifyUniqueInputs(blkID ids.ID, inputs set.Set[ids.ID]) error {

--- a/vms/avm/block/executor/manager_test.go
+++ b/vms/avm/block/executor/manager_test.go
@@ -116,7 +116,6 @@ func TestManagerVerifyTx(t *testing.T) {
 		expectedErr error
 	}
 
-	inputID := ids.GenerateTestID()
 	tests := []test{
 		{
 			name: "not bootstrapped",
@@ -161,11 +160,11 @@ func TestManagerVerifyTx(t *testing.T) {
 				}
 			},
 			managerF: func(ctrl *gomock.Controller) *manager {
-				preferred := ids.GenerateTestID()
+				lastAcceptedID := ids.GenerateTestID()
 
 				// These values don't matter for this test
 				state := state.NewMockState(ctrl)
-				state.EXPECT().GetLastAccepted().Return(preferred)
+				state.EXPECT().GetLastAccepted().Return(lastAcceptedID)
 				state.EXPECT().GetTimestamp().Return(time.Time{})
 
 				return &manager{
@@ -173,8 +172,7 @@ func TestManagerVerifyTx(t *testing.T) {
 						Bootstrapped: true,
 					},
 					state:        state,
-					lastAccepted: preferred,
-					preferred:    preferred,
+					lastAccepted: lastAcceptedID,
 				}
 			},
 			expectedErr: errTestSemanticVerifyFail,
@@ -194,11 +192,11 @@ func TestManagerVerifyTx(t *testing.T) {
 				}
 			},
 			managerF: func(ctrl *gomock.Controller) *manager {
-				preferred := ids.GenerateTestID()
+				lastAcceptedID := ids.GenerateTestID()
 
 				// These values don't matter for this test
 				state := state.NewMockState(ctrl)
-				state.EXPECT().GetLastAccepted().Return(preferred)
+				state.EXPECT().GetLastAccepted().Return(lastAcceptedID)
 				state.EXPECT().GetTimestamp().Return(time.Time{})
 
 				return &manager{
@@ -206,57 +204,10 @@ func TestManagerVerifyTx(t *testing.T) {
 						Bootstrapped: true,
 					},
 					state:        state,
-					lastAccepted: preferred,
-					preferred:    preferred,
+					lastAccepted: lastAcceptedID,
 				}
 			},
 			expectedErr: errTestExecutionFail,
-		},
-		{
-			name: "non-unique inputs",
-			txF: func(ctrl *gomock.Controller) *txs.Tx {
-				unsigned := txs.NewMockUnsignedTx(ctrl)
-				// Syntactic verification passes
-				unsigned.EXPECT().Visit(gomock.Any()).Return(nil)
-				// Semantic verification passes
-				unsigned.EXPECT().Visit(gomock.Any()).Return(nil)
-				// Execution passes
-				unsigned.EXPECT().Visit(gomock.Any()).DoAndReturn(func(e *executor.Executor) error {
-					e.Inputs.Add(inputID)
-					return nil
-				})
-				return &txs.Tx{
-					Unsigned: unsigned,
-				}
-			},
-			managerF: func(ctrl *gomock.Controller) *manager {
-				lastAcceptedID := ids.GenerateTestID()
-
-				preferredID := ids.GenerateTestID()
-				preferred := block.NewMockBlock(ctrl)
-				preferred.EXPECT().Parent().Return(lastAcceptedID).AnyTimes()
-
-				// These values don't matter for this test
-				diffState := state.NewMockDiff(ctrl)
-				diffState.EXPECT().GetLastAccepted().Return(preferredID)
-				diffState.EXPECT().GetTimestamp().Return(time.Time{})
-
-				return &manager{
-					backend: &executor.Backend{
-						Bootstrapped: true,
-					},
-					blkIDToState: map[ids.ID]*blockState{
-						preferredID: {
-							statelessBlock: preferred,
-							onAcceptState:  diffState,
-							importedInputs: set.Of(inputID),
-						},
-					},
-					lastAccepted: lastAcceptedID,
-					preferred:    preferredID,
-				}
-			},
-			expectedErr: ErrConflictingParentTxs,
 		},
 		{
 			name: "happy path",
@@ -273,11 +224,11 @@ func TestManagerVerifyTx(t *testing.T) {
 				}
 			},
 			managerF: func(ctrl *gomock.Controller) *manager {
-				preferred := ids.GenerateTestID()
+				lastAcceptedID := ids.GenerateTestID()
 
 				// These values don't matter for this test
 				state := state.NewMockState(ctrl)
-				state.EXPECT().GetLastAccepted().Return(preferred)
+				state.EXPECT().GetLastAccepted().Return(lastAcceptedID)
 				state.EXPECT().GetTimestamp().Return(time.Time{})
 
 				return &manager{
@@ -285,8 +236,7 @@ func TestManagerVerifyTx(t *testing.T) {
 						Bootstrapped: true,
 					},
 					state:        state,
-					lastAccepted: preferred,
-					preferred:    preferred,
+					lastAccepted: lastAcceptedID,
 				}
 			},
 			expectedErr: nil,


### PR DESCRIPTION
## Why this should be merged

This ensures that the X-chain mempool only contains transactions that are valid to be issued or will be removed from the mempool from transactions that are currently in the processing chain.

## How this works

Verifies transactions against the last accepted state rather than the currently preferred state.

## How this was tested

- [X] CI