### PR TITLE
[MerkleDB] Make intermediate node cache two layered

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -486,17 +486,10 @@ func (db *merkleDB) PrefetchPath(key []byte) error {
 
 func (db *merkleDB) prefetchPath(keyBytes []byte) error {
 	return visitPathToKey(db, ToKey(keyBytes), func(n *node) error {
-		if !n.hasValue() {
-			// if this value is already in the cache, skip writing
-			// to avoid grabbing the cache write lock
-			if _, ok := db.intermediateNodeDB.nodeCache.Get(n.key); !ok {
-				db.intermediateNodeDB.nodeCache.Put(n.key, n)
-			}
-			return nil
-		}
-		// if this value is already in the cache, skip writing
-		if _, ok := db.valueNodeDB.nodeCache.Get(n.key); !ok {
+		if n.hasValue() {
 			db.valueNodeDB.nodeCache.Put(n.key, n)
+		} else {
+			db.intermediateNodeDB.nodeCache.Put(n.key, n)
 		}
 		return nil
 	})

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -259,11 +259,23 @@ func newDatabase(
 			return make([]byte, 0, defaultBufferLength)
 		},
 	}
+	iNodeDB, err := newIntermediateNodeDB(
+		db,
+		bufferPool,
+		metrics,
+		int(config.IntermediateNodeCacheSize),
+		int(config.IntermediateWriteBufferSize),
+		int(config.IntermediateWriteBatchSize),
+		BranchFactorToTokenSize[config.BranchFactor])
+	if err != nil {
+		return nil, err
+	}
+
 	trieDB := &merkleDB{
 		metrics:              metrics,
 		baseDB:               db,
+		intermediateNodeDB:   iNodeDB,
 		valueNodeDB:          newValueNodeDB(db, bufferPool, metrics, int(config.ValueNodeCacheSize)),
-		intermediateNodeDB:   newIntermediateNodeDB(db, bufferPool, metrics, int(config.IntermediateNodeCacheSize), int(config.IntermediateWriteBufferSize), int(config.IntermediateWriteBatchSize), BranchFactorToTokenSize[config.BranchFactor]),
 		history:              newTrieHistory(int(config.HistoryLength)),
 		debugTracer:          getTracerIfEnabled(config.TraceLevel, DebugTrace, config.Tracer),
 		infoTracer:           getTracerIfEnabled(config.TraceLevel, InfoTrace, config.Tracer),

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -161,16 +161,19 @@ type Config struct {
 	//
 	// If 0 is specified, [runtime.NumCPU] will be used.
 	RootGenConcurrency uint
-	// The number of bytes to write to disk when intermediate nodes are evicted
-	// from their cache and written to disk.
-	EvictionBatchSize uint
+
 	// The number of changes to the database that we store in memory in order to
 	// serve change proofs.
 	HistoryLength uint
-	// The number of bytes to cache nodes with values.
+	// The number of bytes used to cache nodes with values.
 	ValueNodeCacheSize uint
-	// The number of bytes to cache nodes without values.
+	// The number of bytes used to cache nodes without values.
 	IntermediateNodeCacheSize uint
+	// The number of bytes used to store nodes without values in memory before forcing them onto disk.
+	IntermediateWriteBufferSize uint
+	// The number of bytes to write to disk when intermediate nodes are evicted
+	// from the write buffer and written to disk.
+	IntermediateWriteBatchSize uint
 	// If [Reg] is nil, metrics are collected locally but not exported through
 	// Prometheus.
 	// This may be useful for testing.
@@ -260,7 +263,7 @@ func newDatabase(
 		metrics:              metrics,
 		baseDB:               db,
 		valueNodeDB:          newValueNodeDB(db, bufferPool, metrics, int(config.ValueNodeCacheSize)),
-		intermediateNodeDB:   newIntermediateNodeDB(db, bufferPool, metrics, int(config.IntermediateNodeCacheSize), int(config.EvictionBatchSize), BranchFactorToTokenSize[config.BranchFactor]),
+		intermediateNodeDB:   newIntermediateNodeDB(db, bufferPool, metrics, int(config.IntermediateNodeCacheSize), int(config.IntermediateWriteBufferSize), int(config.IntermediateWriteBatchSize), BranchFactorToTokenSize[config.BranchFactor]),
 		history:              newTrieHistory(int(config.HistoryLength)),
 		debugTracer:          getTracerIfEnabled(config.TraceLevel, DebugTrace, config.Tracer),
 		infoTracer:           getTracerIfEnabled(config.TraceLevel, InfoTrace, config.Tracer),
@@ -484,18 +487,17 @@ func (db *merkleDB) PrefetchPath(key []byte) error {
 func (db *merkleDB) prefetchPath(keyBytes []byte) error {
 	return visitPathToKey(db, ToKey(keyBytes), func(n *node) error {
 		if !n.hasValue() {
-			// this value is already in the cache, so skip writing
+			// if this value is already in the cache, skip writing
 			// to avoid grabbing the cache write lock
-			if _, ok := db.intermediateNodeDB.nodeCache.Get(n.key); ok {
-				return nil
+			if _, ok := db.intermediateNodeDB.nodeCache.Get(n.key); !ok {
+				db.intermediateNodeDB.nodeCache.Put(n.key, n)
 			}
-			return db.intermediateNodeDB.nodeCache.Put(n.key, n)
-		}
-		// this value is already in the cache, so skip writing
-		if _, ok := db.valueNodeDB.nodeCache.Get(n.key); ok {
 			return nil
 		}
-		db.valueNodeDB.nodeCache.Put(n.key, n)
+		// if this value is already in the cache, skip writing
+		if _, ok := db.valueNodeDB.nodeCache.Get(n.key); !ok {
+			db.valueNodeDB.nodeCache.Put(n.key, n)
+		}
 		return nil
 	})
 }

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -42,13 +42,14 @@ func newDB(ctx context.Context, db database.Database, config Config) (*merkleDB,
 
 func newDefaultConfig() Config {
 	return Config{
-		EvictionBatchSize:         10,
-		HistoryLength:             defaultHistoryLength,
-		ValueNodeCacheSize:        units.MiB,
-		IntermediateNodeCacheSize: units.MiB,
-		Reg:                       prometheus.NewRegistry(),
-		Tracer:                    trace.Noop,
-		BranchFactor:              BranchFactor16,
+		IntermediateWriteBatchSize:  10,
+		HistoryLength:               defaultHistoryLength,
+		ValueNodeCacheSize:          units.MiB,
+		IntermediateNodeCacheSize:   units.MiB,
+		IntermediateWriteBufferSize: units.KiB,
+		Reg:                         prometheus.NewRegistry(),
+		Tracer:                      trace.Noop,
+		BranchFactor:                BranchFactor16,
 	}
 }
 
@@ -807,7 +808,7 @@ func TestMerkleDBClear(t *testing.T) {
 
 	// Assert caches are empty.
 	require.Zero(db.valueNodeDB.nodeCache.Len())
-	require.Zero(db.intermediateNodeDB.nodeCache.currentSize)
+	require.Zero(db.intermediateNodeDB.writeBuffer.currentSize)
 
 	// Assert history has only the clearing change.
 	require.Len(db.history.lastChanges, 1)

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -4,8 +4,9 @@
 package merkledb
 
 import (
-	"github.com/ava-labs/avalanchego/cache"
 	"sync"
+
+	"github.com/ava-labs/avalanchego/cache"
 
 	"github.com/ava-labs/avalanchego/database"
 )

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -24,6 +24,7 @@ type intermediateNodeDB struct {
 	// Keys written to [baseDB] are prefixed with [intermediateNodePrefix].
 	baseDB database.Database
 
+	// The write buffer contains nodes that have been changed but have not been written to disk.
 	// Note that a call to Put may cause a node to be evicted
 	// from the cache, which will call [OnEviction].
 	// A non-nil error returned from Put is considered fatal.

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -4,6 +4,7 @@
 package merkledb
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/ava-labs/avalanchego/cache"
@@ -12,6 +13,8 @@ import (
 )
 
 const defaultBufferLength = 256
+
+var errCacheSizeTooSmall = errors.New("cache size must be larger than or equal to write buffer size")
 
 // Holds intermediate nodes. That is, those without values.
 // Changes to this database aren't written to [baseDB] until
@@ -48,7 +51,10 @@ func newIntermediateNodeDB(
 	writeBufferSize int,
 	evictionBatchSize int,
 	tokenSize int,
-) *intermediateNodeDB {
+) (*intermediateNodeDB, error) {
+	if cacheSize < writeBufferSize {
+		return nil, errCacheSizeTooSmall
+	}
 	result := &intermediateNodeDB{
 		metrics:           metrics,
 		baseDB:            db,
@@ -63,7 +69,7 @@ func newIntermediateNodeDB(
 		result.onEviction,
 	)
 
-	return result
+	return result, nil
 }
 
 // A non-nil error is considered fatal and closes [db.baseDB].

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -28,8 +28,10 @@ func Test_IntermediateNodeDB(t *testing.T) {
 	nodeSize := cacheEntrySize(n.key, n)
 
 	// use exact multiple of node size so require.Equal(1, db.nodeCache.fifo.Len()) is correct later
-	cacheSize := nodeSize * 20
-	evictionBatchSize := cacheSize
+	cacheSize := nodeSize * 100
+	bufferSize := nodeSize * 20
+
+	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(
 		baseDB,
@@ -38,6 +40,7 @@ func Test_IntermediateNodeDB(t *testing.T) {
 		},
 		&mockMetrics{},
 		cacheSize,
+		bufferSize,
 		evictionBatchSize,
 		4,
 	)
@@ -78,7 +81,7 @@ func Test_IntermediateNodeDB(t *testing.T) {
 		node := newNode(Key{})
 		node.setValue(maybe.Some([]byte{byte(added)}))
 		newExpectedSize := expectedSize + cacheEntrySize(key, node)
-		if newExpectedSize > cacheSize {
+		if newExpectedSize > bufferSize {
 			// Don't trigger eviction.
 			break
 		}
@@ -89,7 +92,7 @@ func Test_IntermediateNodeDB(t *testing.T) {
 	}
 
 	// Assert cache has expected number of elements
-	require.Equal(added, db.nodeCache.fifo.Len())
+	require.Equal(added, db.writeBuffer.fifo.Len())
 
 	// Put one more element in the cache, which should trigger an eviction
 	// of all but 2 elements. 2 elements remain rather than 1 element because of
@@ -100,14 +103,14 @@ func Test_IntermediateNodeDB(t *testing.T) {
 	require.NoError(db.Put(key, node))
 
 	// Assert cache has expected number of elements
-	require.Equal(1, db.nodeCache.fifo.Len())
-	gotKey, _, ok := db.nodeCache.fifo.Oldest()
+	require.Equal(1, db.writeBuffer.fifo.Len())
+	gotKey, _, ok := db.writeBuffer.fifo.Oldest()
 	require.True(ok)
 	require.Equal(ToKey([]byte{byte(added)}), gotKey)
 
 	// Get a node from the base database
 	// Use an early key that has been evicted from the cache
-	_, inCache := db.nodeCache.Get(node1Key)
+	_, inCache := db.writeBuffer.Get(node1Key)
 	require.False(inCache)
 	nodeRead, err := db.Get(node1Key)
 	require.NoError(err)
@@ -117,7 +120,7 @@ func Test_IntermediateNodeDB(t *testing.T) {
 	require.NoError(db.Flush())
 
 	// Assert the cache is empty
-	require.Zero(db.nodeCache.fifo.Len())
+	require.Zero(db.writeBuffer.fifo.Len())
 
 	// Assert the evicted cache elements were written to disk with prefix.
 	it := baseDB.NewIteratorWithPrefix(intermediateNodePrefix)
@@ -132,8 +135,9 @@ func Test_IntermediateNodeDB(t *testing.T) {
 }
 
 func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
+	bufferSize := 200
 	cacheSize := 200
-	evictionBatchSize := cacheSize
+	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
 
 	f.Fuzz(func(
@@ -150,6 +154,7 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 				},
 				&mockMetrics{},
 				cacheSize,
+				bufferSize,
 				evictionBatchSize,
 				tokenSize,
 			)
@@ -182,7 +187,8 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 	require := require.New(t)
 	cacheSize := 200
-	evictionBatchSize := cacheSize
+	bufferSize := 200
+	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(
 		baseDB,
@@ -191,6 +197,7 @@ func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 		},
 		&mockMetrics{},
 		cacheSize,
+		bufferSize,
 		evictionBatchSize,
 		4,
 	)
@@ -217,7 +224,8 @@ func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 func TestIntermediateNodeDBClear(t *testing.T) {
 	require := require.New(t)
 	cacheSize := 200
-	evictionBatchSize := cacheSize
+	bufferSize := 200
+	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(
 		baseDB,
@@ -226,6 +234,7 @@ func TestIntermediateNodeDBClear(t *testing.T) {
 		},
 		&mockMetrics{},
 		cacheSize,
+		bufferSize,
 		evictionBatchSize,
 		4,
 	)
@@ -240,7 +249,7 @@ func TestIntermediateNodeDBClear(t *testing.T) {
 	defer iter.Release()
 	require.False(iter.Next())
 
-	require.Zero(db.nodeCache.currentSize)
+	require.Zero(db.writeBuffer.currentSize)
 }
 
 // Test that deleting the empty key and flushing works correctly.
@@ -251,7 +260,8 @@ func TestIntermediateNodeDBClear(t *testing.T) {
 func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 	require := require.New(t)
 	cacheSize := 200
-	evictionBatchSize := cacheSize
+	bufferSize := 200
+	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(
 		baseDB,
@@ -260,6 +270,7 @@ func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 		},
 		&mockMetrics{},
 		cacheSize,
+		bufferSize,
 		evictionBatchSize,
 		4,
 	)

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -33,7 +33,7 @@ func Test_IntermediateNodeDB(t *testing.T) {
 
 	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
-	db := newIntermediateNodeDB(
+	db, err := newIntermediateNodeDB(
 		baseDB,
 		&sync.Pool{
 			New: func() interface{} { return make([]byte, 0) },
@@ -44,6 +44,7 @@ func Test_IntermediateNodeDB(t *testing.T) {
 		evictionBatchSize,
 		4,
 	)
+	require.NoError(err)
 
 	// Put a key-node pair
 	node1Key := ToKey([]byte{0x01})
@@ -147,7 +148,7 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 	) {
 		require := require.New(t)
 		for _, tokenSize := range validTokenSizes {
-			db := newIntermediateNodeDB(
+			db, err := newIntermediateNodeDB(
 				baseDB,
 				&sync.Pool{
 					New: func() interface{} { return make([]byte, 0) },
@@ -158,6 +159,7 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 				evictionBatchSize,
 				tokenSize,
 			)
+			require.NoError(err)
 
 			p := ToKey(key)
 			uBitLength := tokenLength * uint(tokenSize)
@@ -190,7 +192,7 @@ func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 	bufferSize := 200
 	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
-	db := newIntermediateNodeDB(
+	db, err := newIntermediateNodeDB(
 		baseDB,
 		&sync.Pool{
 			New: func() interface{} { return make([]byte, 0) },
@@ -201,6 +203,8 @@ func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 		evictionBatchSize,
 		4,
 	)
+
+	require.NoError(err)
 
 	db.bufferPool.Put([]byte{0xFF, 0xFF, 0xFF})
 	constructedKey := db.constructDBKey(ToKey([]byte{}))
@@ -227,7 +231,7 @@ func TestIntermediateNodeDBClear(t *testing.T) {
 	bufferSize := 200
 	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
-	db := newIntermediateNodeDB(
+	db, err := newIntermediateNodeDB(
 		baseDB,
 		&sync.Pool{
 			New: func() interface{} { return make([]byte, 0) },
@@ -238,6 +242,8 @@ func TestIntermediateNodeDBClear(t *testing.T) {
 		evictionBatchSize,
 		4,
 	)
+
+	require.NoError(err)
 
 	for _, b := range [][]byte{{1}, {2}, {3}} {
 		require.NoError(db.Put(ToKey(b), newNode(ToKey(b))))
@@ -263,7 +269,7 @@ func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 	bufferSize := 200
 	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
-	db := newIntermediateNodeDB(
+	db, err := newIntermediateNodeDB(
 		baseDB,
 		&sync.Pool{
 			New: func() interface{} { return make([]byte, 0) },
@@ -274,6 +280,8 @@ func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 		evictionBatchSize,
 		4,
 	)
+
+	require.NoError(err)
 
 	emptyKey := ToKey([]byte{})
 	require.NoError(db.Put(emptyKey, newNode(emptyKey)))

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -20,9 +20,7 @@ import (
 	pb "github.com/ava-labs/avalanchego/proto/pb/sync"
 )
 
-const (
-	verificationCacheSize = math.MaxUint16
-)
+const verificationCacheSize = math.MaxUint16
 
 var (
 	ErrInvalidProof                = errors.New("proof obtained an invalid root ID")

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	verificationIntermediateWriteBatchSize = 0
-	verificationCacheSize                  = math.MaxInt
+	verificationCacheSize = math.MaxUint16
 )
 
 var (
@@ -861,11 +860,12 @@ func getStandaloneView(ctx context.Context, ops []database.BatchOp, size int) (*
 		ctx,
 		memdb.New(),
 		Config{
-			IntermediateWriteBatchSize: verificationIntermediateWriteBatchSize,
-			Tracer:                     trace.Noop,
-			ValueNodeCacheSize:         verificationCacheSize,
-			IntermediateNodeCacheSize:  verificationCacheSize,
-			BranchFactor:               tokenSizeToBranchFactor[size],
+			BranchFactor:                tokenSizeToBranchFactor[size],
+			Tracer:                      trace.Noop,
+			ValueNodeCacheSize:          verificationCacheSize,
+			IntermediateNodeCacheSize:   verificationCacheSize,
+			IntermediateWriteBufferSize: verificationCacheSize,
+			IntermediateWriteBatchSize:  verificationCacheSize,
 		},
 		&mockMetrics{},
 	)

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	verificationEvictionBatchSize = 0
-	verificationCacheSize         = math.MaxInt
+	verificationIntermediateWriteBatchSize = 0
+	verificationCacheSize                  = math.MaxInt
 )
 
 var (
@@ -861,11 +861,11 @@ func getStandaloneView(ctx context.Context, ops []database.BatchOp, size int) (*
 		ctx,
 		memdb.New(),
 		Config{
-			EvictionBatchSize:         verificationEvictionBatchSize,
-			Tracer:                    trace.Noop,
-			ValueNodeCacheSize:        verificationCacheSize,
-			IntermediateNodeCacheSize: verificationCacheSize,
-			BranchFactor:              tokenSizeToBranchFactor[size],
+			IntermediateWriteBatchSize: verificationIntermediateWriteBatchSize,
+			Tracer:                     trace.Noop,
+			ValueNodeCacheSize:         verificationCacheSize,
+			IntermediateNodeCacheSize:  verificationCacheSize,
+			BranchFactor:               tokenSizeToBranchFactor[size],
 		},
 		&mockMetrics{},
 	)

--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -32,13 +32,14 @@ import (
 
 func newDefaultDBConfig() merkledb.Config {
 	return merkledb.Config{
-		EvictionBatchSize:         100,
-		HistoryLength:             defaultRequestKeyLimit,
-		ValueNodeCacheSize:        defaultRequestKeyLimit,
-		IntermediateNodeCacheSize: defaultRequestKeyLimit,
-		Reg:                       prometheus.NewRegistry(),
-		Tracer:                    trace.Noop,
-		BranchFactor:              merkledb.BranchFactor16,
+		IntermediateWriteBatchSize:  100,
+		HistoryLength:               defaultRequestKeyLimit,
+		ValueNodeCacheSize:          defaultRequestKeyLimit,
+		IntermediateWriteBufferSize: defaultRequestKeyLimit,
+		IntermediateNodeCacheSize:   defaultRequestKeyLimit,
+		Reg:                         prometheus.NewRegistry(),
+		Tracer:                      trace.Noop,
+		BranchFactor:                merkledb.BranchFactor16,
 	}
 }
 


### PR DESCRIPTION
The flushing of the intermediate nodes on db close is taking too long.  Split the cache into two parts, one normal cache that can be large and store nodes in memory and one smaller delayed write cache that will prevent writes, but wont be too large to flush on database close.