### PR TITLE
`testing`: Ensure CheckBootstrapIsPossible is safe for teardown

### DIFF
--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -122,9 +122,7 @@ func Eventually(condition func() bool, waitFor time.Duration, tick time.Duration
 func AddEphemeralNode(network *tmpnet.Network, flags tmpnet.FlagsMap) *tmpnet.Node {
 	require := require.New(ginkgo.GinkgoT())
 
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
-	defer cancel()
-	node, err := network.AddEphemeralNode(ctx, ginkgo.GinkgoWriter, flags)
+	node, err := network.AddEphemeralNode(DefaultContext(), ginkgo.GinkgoWriter, flags)
 	require.NoError(err)
 
 	ginkgo.DeferCleanup(func() {
@@ -188,16 +186,34 @@ func WithSuggestedGasPrice(ethClient ethclient.Client) common.Option {
 	return common.WithBaseFee(baseFee)
 }
 
-// Verify that a new node can bootstrap into the network.
+// Verify that a new node can bootstrap into the network. This function is safe to call
+// from `Teardown` by virtue of not depending on ginkgo.DeferCleanup.
 func CheckBootstrapIsPossible(network *tmpnet.Network) {
+	require := require.New(ginkgo.GinkgoT())
+
 	if len(os.Getenv(SkipBootstrapChecksEnvName)) > 0 {
 		tests.Outf("{{yellow}}Skipping bootstrap check due to the %s env var being set", SkipBootstrapChecksEnvName)
 		return
 	}
 	ginkgo.By("checking if bootstrap is possible with the current network state")
 
-	node := AddEphemeralNode(network, tmpnet.FlagsMap{})
-	WaitForHealthy(node)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	// Node stop will be initiated if the node is not started without error.
+	node, err := network.AddEphemeralNode(ctx, ginkgo.GinkgoWriter, tmpnet.FlagsMap{})
+	require.NoError(err)
+
+	err = tmpnet.WaitForHealthy(ctx, node)
+
+	// Ensure the node is stopped regardless of whether bootstrap succeeded. Use a new
+	// context in case the previous one timed out waiting for the node to become healthy.
+	ctx, cancel = context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+	require.NoError(node.Stop(ctx))
+
+	// Check that the node became healthy within timout
+	require.NoError(err)
 }
 
 // Start a temporary network with the provided avalanchego binary.


### PR DESCRIPTION
## Why this should be merged

Supports coreth testing PR https://github.com/ava-labs/coreth/pull/377
## How this works

Previously `CheckBootstrapIsPossible` depended on ginkgo.DeferCleanup which was preventing its use from a Teardown method in coreth integration testing.

## How this was tested

CI both here and for the coreth testing PR
