### PR TITLE
`tmpnet`: Use AvalancheLocalChainConfig for cchain genesis

### DIFF
--- a/tests/fixture/tmpnet/genesis.go
+++ b/tests/fixture/tmpnet/genesis.go
@@ -148,9 +148,7 @@ func NewTestGenesis(
 
 	// Define C-Chain genesis
 	cChainGenesis := &core.Genesis{
-		Config: &params.ChainConfig{
-			ChainID: big.NewInt(43112), // Arbitrary chain ID is arbitrary
-		},
+		Config:     params.AvalancheLocalChainConfig,
 		Difficulty: big.NewInt(0), // Difficulty is a mandatory field
 		GasLimit:   defaultGasLimit,
 		Alloc:      cChainBalances,


### PR DESCRIPTION
tmpnet has been using an arbitrary cchain genesis configuration that wasn't reflective of desired configuration. Using this new value is intended to ensure consistent behavior in testing.