### PR TITLE
Fix intermediate node caching

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -259,23 +259,22 @@ func newDatabase(
 			return make([]byte, 0, defaultBufferLength)
 		},
 	}
-	iNodeDB, err := newIntermediateNodeDB(
-		db,
-		bufferPool,
-		metrics,
-		int(config.IntermediateNodeCacheSize),
-		int(config.IntermediateWriteBufferSize),
-		int(config.IntermediateWriteBatchSize),
-		BranchFactorToTokenSize[config.BranchFactor])
-	if err != nil {
-		return nil, err
-	}
 
 	trieDB := &merkleDB{
-		metrics:              metrics,
-		baseDB:               db,
-		intermediateNodeDB:   iNodeDB,
-		valueNodeDB:          newValueNodeDB(db, bufferPool, metrics, int(config.ValueNodeCacheSize)),
+		metrics: metrics,
+		baseDB:  db,
+		intermediateNodeDB: newIntermediateNodeDB(
+			db,
+			bufferPool,
+			metrics,
+			int(config.IntermediateNodeCacheSize),
+			int(config.IntermediateWriteBufferSize),
+			int(config.IntermediateWriteBatchSize),
+			BranchFactorToTokenSize[config.BranchFactor]),
+		valueNodeDB: newValueNodeDB(db,
+			bufferPool,
+			metrics,
+			int(config.ValueNodeCacheSize)),
 		history:              newTrieHistory(int(config.HistoryLength)),
 		debugTracer:          getTracerIfEnabled(config.TraceLevel, DebugTrace, config.Tracer),
 		infoTracer:           getTracerIfEnabled(config.TraceLevel, InfoTrace, config.Tracer),

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -4,7 +4,6 @@
 package merkledb
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/ava-labs/avalanchego/cache"
@@ -13,8 +12,6 @@ import (
 )
 
 const defaultBufferLength = 256
-
-var errCacheSizeTooSmall = errors.New("cache size must be larger than or equal to write buffer size")
 
 // Holds intermediate nodes. That is, those without values.
 // Changes to this database aren't written to [baseDB] until
@@ -51,10 +48,7 @@ func newIntermediateNodeDB(
 	writeBufferSize int,
 	evictionBatchSize int,
 	tokenSize int,
-) (*intermediateNodeDB, error) {
-	if cacheSize < writeBufferSize {
-		return nil, errCacheSizeTooSmall
-	}
+) *intermediateNodeDB {
 	result := &intermediateNodeDB{
 		metrics:           metrics,
 		baseDB:            db,
@@ -69,7 +63,7 @@ func newIntermediateNodeDB(
 		result.onEviction,
 	)
 
-	return result, nil
+	return result
 }
 
 // A non-nil error is considered fatal and closes [db.baseDB].
@@ -116,7 +110,7 @@ func (db *intermediateNodeDB) addToBatch(b database.Batch, key Key, n *node) err
 }
 
 func (db *intermediateNodeDB) Get(key Key) (*node, error) {
-	if cachedValue, isCached := db.writeBuffer.Get(key); isCached {
+	if cachedValue, isCached := db.nodeCache.Get(key); isCached {
 		db.metrics.IntermediateNodeCacheHit()
 		if cachedValue == nil {
 			return nil, database.ErrNotFound
@@ -125,7 +119,7 @@ func (db *intermediateNodeDB) Get(key Key) (*node, error) {
 	}
 	db.metrics.IntermediateNodeCacheMiss()
 
-	if cachedValue, isCached := db.nodeCache.Get(key); isCached {
+	if cachedValue, isCached := db.writeBuffer.Get(key); isCached {
 		db.metrics.IntermediateNodeCacheHit()
 		if cachedValue == nil {
 			return nil, database.ErrNotFound

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -116,6 +116,15 @@ func (db *intermediateNodeDB) addToBatch(b database.Batch, key Key, n *node) err
 }
 
 func (db *intermediateNodeDB) Get(key Key) (*node, error) {
+	if cachedValue, isCached := db.writeBuffer.Get(key); isCached {
+		db.metrics.IntermediateNodeCacheHit()
+		if cachedValue == nil {
+			return nil, database.ErrNotFound
+		}
+		return cachedValue, nil
+	}
+	db.metrics.IntermediateNodeCacheMiss()
+
 	if cachedValue, isCached := db.nodeCache.Get(key); isCached {
 		db.metrics.IntermediateNodeCacheHit()
 		if cachedValue == nil {

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -33,7 +33,7 @@ func Test_IntermediateNodeDB(t *testing.T) {
 
 	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
-	db, err := newIntermediateNodeDB(
+	db := newIntermediateNodeDB(
 		baseDB,
 		&sync.Pool{
 			New: func() interface{} { return make([]byte, 0) },
@@ -44,7 +44,6 @@ func Test_IntermediateNodeDB(t *testing.T) {
 		evictionBatchSize,
 		4,
 	)
-	require.NoError(err)
 
 	// Put a key-node pair
 	node1Key := ToKey([]byte{0x01})
@@ -148,7 +147,7 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 	) {
 		require := require.New(t)
 		for _, tokenSize := range validTokenSizes {
-			db, err := newIntermediateNodeDB(
+			db := newIntermediateNodeDB(
 				baseDB,
 				&sync.Pool{
 					New: func() interface{} { return make([]byte, 0) },
@@ -159,7 +158,6 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 				evictionBatchSize,
 				tokenSize,
 			)
-			require.NoError(err)
 
 			p := ToKey(key)
 			uBitLength := tokenLength * uint(tokenSize)
@@ -192,7 +190,7 @@ func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 	bufferSize := 200
 	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
-	db, err := newIntermediateNodeDB(
+	db := newIntermediateNodeDB(
 		baseDB,
 		&sync.Pool{
 			New: func() interface{} { return make([]byte, 0) },
@@ -203,8 +201,6 @@ func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 		evictionBatchSize,
 		4,
 	)
-
-	require.NoError(err)
 
 	db.bufferPool.Put([]byte{0xFF, 0xFF, 0xFF})
 	constructedKey := db.constructDBKey(ToKey([]byte{}))
@@ -231,7 +227,7 @@ func TestIntermediateNodeDBClear(t *testing.T) {
 	bufferSize := 200
 	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
-	db, err := newIntermediateNodeDB(
+	db := newIntermediateNodeDB(
 		baseDB,
 		&sync.Pool{
 			New: func() interface{} { return make([]byte, 0) },
@@ -242,8 +238,6 @@ func TestIntermediateNodeDBClear(t *testing.T) {
 		evictionBatchSize,
 		4,
 	)
-
-	require.NoError(err)
 
 	for _, b := range [][]byte{{1}, {2}, {3}} {
 		require.NoError(db.Put(ToKey(b), newNode(ToKey(b))))
@@ -269,7 +263,7 @@ func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 	bufferSize := 200
 	evictionBatchSize := bufferSize
 	baseDB := memdb.New()
-	db, err := newIntermediateNodeDB(
+	db := newIntermediateNodeDB(
 		baseDB,
 		&sync.Pool{
 			New: func() interface{} { return make([]byte, 0) },
@@ -280,8 +274,6 @@ func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 		evictionBatchSize,
 		4,
 	)
-
-	require.NoError(err)
 
 	emptyKey := ToKey([]byte{})
 	require.NoError(db.Put(emptyKey, newNode(emptyKey)))

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -580,7 +580,7 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 func TestFindNextKeyRandom(t *testing.T) {
 	now := time.Now().UnixNano()
 	t.Logf("seed: %d", now)
-	r := rand.New(rand.NewSource(1704383220955266000)) // #nosec G404
+	rand := rand.New(rand.NewSource(now)) // #nosec G404
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -614,10 +614,10 @@ func TestFindNextKeyRandom(t *testing.T) {
 	// Put random keys into the databases
 	for _, db := range []database.Database{remoteDB, localDB} {
 		for i := 0; i < numKeyValues; i++ {
-			key := make([]byte, r.Intn(maxKeyLen))
-			_, _ = r.Read(key)
-			val := make([]byte, r.Intn(maxValLen))
-			_, _ = r.Read(val)
+			key := make([]byte, rand.Intn(maxKeyLen))
+			_, _ = rand.Read(key)
+			val := make([]byte, rand.Intn(maxValLen))
+			_, _ = rand.Read(val)
 			require.NoError(db.Put(key, val))
 		}
 	}
@@ -632,10 +632,10 @@ func TestFindNextKeyRandom(t *testing.T) {
 		)
 		// Generate a valid range start and end
 		for rangeStart == nil || bytes.Compare(rangeStart, rangeEnd) == 1 {
-			rangeStart = make([]byte, r.Intn(maxRangeStartLen)+1)
-			_, _ = r.Read(rangeStart)
-			rangeEnd = make([]byte, r.Intn(maxRangeEndLen)+1)
-			_, _ = r.Read(rangeEnd)
+			rangeStart = make([]byte, rand.Intn(maxRangeStartLen)+1)
+			_, _ = rand.Read(rangeStart)
+			rangeEnd = make([]byte, rand.Intn(maxRangeEndLen)+1)
+			_, _ = rand.Read(rangeEnd)
 		}
 
 		startKey := maybe.Nothing[[]byte]()

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -580,7 +580,7 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 func TestFindNextKeyRandom(t *testing.T) {
 	now := time.Now().UnixNano()
 	t.Logf("seed: %d", now)
-	rand := rand.New(rand.NewSource(now)) // #nosec G404
+	r := rand.New(rand.NewSource(1704383220955266000)) // #nosec G404
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -614,10 +614,10 @@ func TestFindNextKeyRandom(t *testing.T) {
 	// Put random keys into the databases
 	for _, db := range []database.Database{remoteDB, localDB} {
 		for i := 0; i < numKeyValues; i++ {
-			key := make([]byte, rand.Intn(maxKeyLen))
-			_, _ = rand.Read(key)
-			val := make([]byte, rand.Intn(maxValLen))
-			_, _ = rand.Read(val)
+			key := make([]byte, r.Intn(maxKeyLen))
+			_, _ = r.Read(key)
+			val := make([]byte, r.Intn(maxValLen))
+			_, _ = r.Read(val)
 			require.NoError(db.Put(key, val))
 		}
 	}
@@ -632,10 +632,10 @@ func TestFindNextKeyRandom(t *testing.T) {
 		)
 		// Generate a valid range start and end
 		for rangeStart == nil || bytes.Compare(rangeStart, rangeEnd) == 1 {
-			rangeStart = make([]byte, rand.Intn(maxRangeStartLen)+1)
-			_, _ = rand.Read(rangeStart)
-			rangeEnd = make([]byte, rand.Intn(maxRangeEndLen)+1)
-			_, _ = rand.Read(rangeEnd)
+			rangeStart = make([]byte, r.Intn(maxRangeStartLen)+1)
+			_, _ = r.Read(rangeStart)
+			rangeEnd = make([]byte, r.Intn(maxRangeEndLen)+1)
+			_, _ = r.Read(rangeEnd)
 		}
 
 		startKey := maybe.Nothing[[]byte]()


### PR DESCRIPTION
I thought that if the node cache was always larger then the write buffer, than the items in the buffer would always be in the cache.  This was an incorrect assumption.  Check both the write buffer and the node cache when retrieving nodes from the intermediate node db.  The error that enforced the size constraints is no longer needed, so cleaned that up.