### PR TITLE
Remove codec length check after Durango

### DIFF
--- a/api/keystore/codec.go
+++ b/api/keystore/codec.go
@@ -4,6 +4,8 @@
 package keystore
 
 import (
+	"time"
+
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/utils/units"
@@ -12,14 +14,13 @@ import (
 const (
 	CodecVersion = 0
 
-	maxPackerSize  = 1 * units.GiB // max size, in bytes, of something being marshalled by Marshal()
-	maxSliceLength = linearcodec.DefaultMaxSliceLength
+	maxPackerSize = 1 * units.GiB // max size, in bytes, of something being marshalled by Marshal()
 )
 
 var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.NewCustomMaxLength(maxSliceLength)
+	lc := linearcodec.NewDefault(time.Time{})
 	Codec = codec.NewManager(maxPackerSize)
 	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
 		panic(err)

--- a/chains/atomic/codec.go
+++ b/chains/atomic/codec.go
@@ -4,6 +4,9 @@
 package atomic
 
 import (
+	"math"
+	"time"
+
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 )
@@ -14,8 +17,8 @@ const CodecVersion = 0
 var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.NewDefault()
-	Codec = codec.NewDefaultManager()
+	lc := linearcodec.NewDefault(time.Time{})
+	Codec = codec.NewManager(math.MaxInt)
 	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
 		panic(err)
 	}

--- a/codec/hierarchycodec/codec.go
+++ b/codec/hierarchycodec/codec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/reflectcodec"
@@ -50,19 +51,19 @@ type hierarchyCodec struct {
 }
 
 // New returns a new, concurrency-safe codec
-func New(tagNames []string, maxSliceLen uint32) Codec {
+func New(durangoTime time.Time, tagNames []string, maxSliceLen uint32) Codec {
 	hCodec := &hierarchyCodec{
 		currentGroupID:  0,
 		nextTypeID:      0,
 		registeredTypes: bimap.New[typeID, reflect.Type](),
 	}
-	hCodec.Codec = reflectcodec.New(hCodec, tagNames, maxSliceLen)
+	hCodec.Codec = reflectcodec.New(hCodec, tagNames, durangoTime, maxSliceLen)
 	return hCodec
 }
 
 // NewDefault returns a new codec with reasonable default values
-func NewDefault() Codec {
-	return New([]string{reflectcodec.DefaultTagName}, defaultMaxSliceLength)
+func NewDefault(durangoTime time.Time) Codec {
+	return New(durangoTime, []string{reflectcodec.DefaultTagName}, defaultMaxSliceLength)
 }
 
 // SkipRegistrations some number of type IDs

--- a/codec/hierarchycodec/codec_test.go
+++ b/codec/hierarchycodec/codec_test.go
@@ -7,23 +7,24 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 )
 
 func TestVectors(t *testing.T) {
 	for _, test := range codec.Tests {
-		c := NewDefault()
+		c := NewDefault(mockable.MaxTime)
 		test(c, t)
 	}
 }
 
 func TestMultipleTags(t *testing.T) {
 	for _, test := range codec.MultipleTagsTests {
-		c := New([]string{"tag1", "tag2"}, defaultMaxSliceLength)
+		c := New(mockable.MaxTime, []string{"tag1", "tag2"}, defaultMaxSliceLength)
 		test(c, t)
 	}
 }
 
 func FuzzStructUnmarshalHierarchyCodec(f *testing.F) {
-	c := NewDefault()
+	c := NewDefault(mockable.MaxTime)
 	codec.FuzzStructUnmarshal(c, f)
 }

--- a/codec/hierarchycodec/codec_test.go
+++ b/codec/hierarchycodec/codec_test.go
@@ -5,6 +5,7 @@ package hierarchycodec
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -20,6 +21,20 @@ func TestVectors(t *testing.T) {
 func TestMultipleTags(t *testing.T) {
 	for _, test := range codec.MultipleTagsTests {
 		c := New(mockable.MaxTime, []string{"tag1", "tag2"}, defaultMaxSliceLength)
+		test(c, t)
+	}
+}
+
+func TestEnforceSliceLen(t *testing.T) {
+	for _, test := range codec.EnforceSliceLenTests {
+		c := NewDefault(mockable.MaxTime)
+		test(c, t)
+	}
+}
+
+func TestIgnoreSliceLen(t *testing.T) {
+	for _, test := range codec.IgnoreSliceLenTests {
+		c := NewDefault(time.Time{})
 		test(c, t)
 	}
 }

--- a/codec/linearcodec/codec.go
+++ b/codec/linearcodec/codec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/reflectcodec"
@@ -44,23 +45,23 @@ type linearCodec struct {
 
 // New returns a new, concurrency-safe codec; it allow to specify
 // both tagNames and maxSlicelenght
-func New(tagNames []string, maxSliceLen uint32) Codec {
+func New(durangoTime time.Time, tagNames []string, maxSliceLen uint32) Codec {
 	hCodec := &linearCodec{
 		nextTypeID:      0,
 		registeredTypes: bimap.New[uint32, reflect.Type](),
 	}
-	hCodec.Codec = reflectcodec.New(hCodec, tagNames, maxSliceLen)
+	hCodec.Codec = reflectcodec.New(hCodec, tagNames, durangoTime, maxSliceLen)
 	return hCodec
 }
 
 // NewDefault is a convenience constructor; it returns a new codec with reasonable default values
-func NewDefault() Codec {
-	return New([]string{reflectcodec.DefaultTagName}, DefaultMaxSliceLength)
+func NewDefault(durangoTime time.Time) Codec {
+	return New(durangoTime, []string{reflectcodec.DefaultTagName}, DefaultMaxSliceLength)
 }
 
 // NewCustomMaxLength is a convenience constructor; it returns a new codec with custom max length and default tags
-func NewCustomMaxLength(maxSliceLen uint32) Codec {
-	return New([]string{reflectcodec.DefaultTagName}, maxSliceLen)
+func NewCustomMaxLength(durangoTime time.Time, maxSliceLen uint32) Codec {
+	return New(durangoTime, []string{reflectcodec.DefaultTagName}, maxSliceLen)
 }
 
 // Skip some number of type IDs

--- a/codec/linearcodec/codec_test.go
+++ b/codec/linearcodec/codec_test.go
@@ -7,23 +7,24 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 )
 
 func TestVectors(t *testing.T) {
 	for _, test := range codec.Tests {
-		c := NewDefault()
+		c := NewDefault(mockable.MaxTime)
 		test(c, t)
 	}
 }
 
 func TestMultipleTags(t *testing.T) {
 	for _, test := range codec.MultipleTagsTests {
-		c := New([]string{"tag1", "tag2"}, DefaultMaxSliceLength)
+		c := New(mockable.MaxTime, []string{"tag1", "tag2"}, DefaultMaxSliceLength)
 		test(c, t)
 	}
 }
 
 func FuzzStructUnmarshalLinearCodec(f *testing.F) {
-	c := NewDefault()
+	c := NewDefault(mockable.MaxTime)
 	codec.FuzzStructUnmarshal(c, f)
 }

--- a/codec/linearcodec/codec_test.go
+++ b/codec/linearcodec/codec_test.go
@@ -5,6 +5,7 @@ package linearcodec
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -20,6 +21,20 @@ func TestVectors(t *testing.T) {
 func TestMultipleTags(t *testing.T) {
 	for _, test := range codec.MultipleTagsTests {
 		c := New(mockable.MaxTime, []string{"tag1", "tag2"}, DefaultMaxSliceLength)
+		test(c, t)
+	}
+}
+
+func TestEnforceSliceLen(t *testing.T) {
+	for _, test := range codec.EnforceSliceLenTests {
+		c := NewDefault(mockable.MaxTime)
+		test(c, t)
+	}
+}
+
+func TestIgnoreSliceLen(t *testing.T) {
+	for _, test := range codec.IgnoreSliceLenTests {
+		c := NewDefault(time.Time{})
 		test(c, t)
 	}
 }

--- a/codec/test_codec.go
+++ b/codec/test_codec.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +47,15 @@ var (
 
 	MultipleTagsTests = []func(c GeneralCodec, t testing.TB){
 		TestMultipleTags,
+	}
+
+	EnforceSliceLenTests = []func(c GeneralCodec, t testing.TB){
+		TestCanNotMarshalLargeSlices,
+		TestCanNotUnmarshalLargeSlices,
+	}
+
+	IgnoreSliceLenTests = []func(c GeneralCodec, t testing.TB){
+		TestCanMarshalLargeSlices,
 	}
 )
 
@@ -1018,6 +1028,52 @@ func TestMap(codec GeneralCodec, t testing.TB) {
 	outerArraySize, err := manager.Size(0, outerArray)
 	require.NoError(err)
 	require.Len(outerArrayBytes, outerArraySize)
+}
+
+func TestCanNotMarshalLargeSlices(codec GeneralCodec, t testing.TB) {
+	require := require.New(t)
+
+	data := make([]uint16, 1_000_000)
+
+	manager := NewManager(math.MaxInt)
+	require.NoError(manager.RegisterCodec(0, codec))
+
+	_, err := manager.Marshal(0, data)
+	require.ErrorIs(err, ErrMaxSliceLenExceeded)
+}
+
+func TestCanNotUnmarshalLargeSlices(codec GeneralCodec, t testing.TB) {
+	require := require.New(t)
+
+	writer := wrappers.Packer{
+		Bytes: make([]byte, 2+4+2_000_000),
+	}
+	writer.PackShort(0)
+	writer.PackInt(1_000_000)
+
+	manager := NewManager(math.MaxInt)
+	require.NoError(manager.RegisterCodec(0, codec))
+
+	var data []uint16
+	_, err := manager.Unmarshal(writer.Bytes, &data)
+	require.ErrorIs(err, ErrMaxSliceLenExceeded)
+}
+
+func TestCanMarshalLargeSlices(codec GeneralCodec, t testing.TB) {
+	require := require.New(t)
+
+	data := make([]uint16, 1_000_000)
+
+	manager := NewManager(math.MaxInt)
+	require.NoError(manager.RegisterCodec(0, codec))
+
+	bytes, err := manager.Marshal(0, data)
+	require.NoError(err)
+
+	var unmarshalledData []uint16
+	_, err = manager.Unmarshal(bytes, &unmarshalledData)
+	require.NoError(err)
+	require.Equal(data, unmarshalledData)
 }
 
 func FuzzStructUnmarshal(codec GeneralCodec, f *testing.F) {

--- a/codec/test_codec.go
+++ b/codec/test_codec.go
@@ -7,8 +7,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
 
 var (

--- a/database/encdb/codec.go
+++ b/database/encdb/codec.go
@@ -4,6 +4,8 @@
 package encdb
 
 import (
+	"time"
+
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 )
@@ -13,7 +15,7 @@ const CodecVersion = 0
 var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.NewDefault()
+	lc := linearcodec.NewDefault(time.Time{})
 	Codec = codec.NewDefaultManager()
 
 	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {

--- a/database/linkeddb/codec.go
+++ b/database/linkeddb/codec.go
@@ -5,6 +5,7 @@ package linkeddb
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -15,7 +16,7 @@ const CodecVersion = 0
 var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
+	lc := linearcodec.NewDefault(time.Time{})
 	Codec = codec.NewManager(math.MaxInt32)
 
 	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -552,9 +552,12 @@ func VMGenesis(genesisBytes []byte, vmID ids.ID) (*pchaintxs.Tx, error) {
 }
 
 func AVAXAssetID(avmGenesisBytes []byte) (ids.ID, error) {
-	parser, err := xchaintxs.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := xchaintxs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	if err != nil {
 		return ids.Empty, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/ava-labs/coreth v0.12.10-rc.2
+	github.com/ava-labs/coreth v0.12.10-rc.4
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.12.10-rc.2 h1:+2YK7PzStcLCHtsBb1VQjw6DyMl1sMZatReZAyIy7w8=
-github.com/ava-labs/coreth v0.12.10-rc.2/go.mod h1:RIbv14KMyWSj4hB1danS+vEPCUsgArZUEo99SaP5nW8=
+github.com/ava-labs/coreth v0.12.10-rc.4 h1:+Ll3cpi3tZbw37lTa+1a/VnPa7xZktpbAFiuKtDKnIE=
+github.com/ava-labs/coreth v0.12.10-rc.4/go.mod h1:8pt5LW6MP/luIdhQA+gvs8LobKE8tP/5APXUiFbfb2c=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34 h1:mg9Uw6oZFJKytJxgxnl3uxZOs/SB8CVHg6Io4Tf99Zc=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20231102202641-ae2ebdaeac34/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/indexer/codec.go
+++ b/indexer/codec.go
@@ -5,6 +5,7 @@ package indexer
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -15,7 +16,7 @@ const CodecVersion = 0
 var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
+	lc := linearcodec.NewDefault(time.Time{})
 	Codec = codec.NewManager(math.MaxInt)
 
 	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -78,7 +78,9 @@ import (
 	"github.com/ava-labs/avalanchego/vms/avm"
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
+	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/propertyfx"
 	"github.com/ava-labs/avalanchego/vms/registry"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime"
@@ -1075,6 +1077,14 @@ func (n *Node) initVMs() error {
 		VMManager:    n.VMManager,
 	})
 
+	durangoTime := version.GetDurangoTime(n.Config.NetworkID)
+	if err := txs.InitCodec(durangoTime); err != nil {
+		return err
+	}
+	if err := block.InitCodec(durangoTime); err != nil {
+		return err
+	}
+
 	// Register the VMs that Avalanche supports
 	err := utils.Err(
 		vmRegisterer.Register(context.TODO(), constants.PlatformVMID, &platformvm.Factory{
@@ -1106,7 +1116,7 @@ func (n *Node) initVMs() error {
 				ApricotPhase5Time:             version.GetApricotPhase5Time(n.Config.NetworkID),
 				BanffTime:                     version.GetBanffTime(n.Config.NetworkID),
 				CortinaTime:                   version.GetCortinaTime(n.Config.NetworkID),
-				DurangoTime:                   version.GetDurangoTime(n.Config.NetworkID),
+				DurangoTime:                   durangoTime,
 				UseCurrentHeight:              n.Config.UseCurrentHeight,
 			},
 		}),
@@ -1114,6 +1124,7 @@ func (n *Node) initVMs() error {
 			Config: avmconfig.Config{
 				TxFee:            n.Config.TxFee,
 				CreateAssetTxFee: n.Config.CreateAssetTxFee,
+				DurangoTime:      durangoTime,
 			},
 		}),
 		vmRegisterer.Register(context.TODO(), constants.EVMID, &coreth.Factory{}),

--- a/node/node.go
+++ b/node/node.go
@@ -1084,6 +1084,9 @@ func (n *Node) initVMs() error {
 	if err := block.InitCodec(durangoTime); err != nil {
 		return err
 	}
+	if err := coreth.InitCodec(durangoTime); err != nil {
+		return err
+	}
 
 	// Register the VMs that Avalanche supports
 	err := utils.Err(

--- a/snow/engine/avalanche/vertex/codec.go
+++ b/snow/engine/avalanche/vertex/codec.go
@@ -4,6 +4,8 @@
 package vertex
 
 import (
+	"time"
+
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/codec/reflectcodec"
@@ -22,8 +24,8 @@ const (
 var Codec codec.Manager
 
 func init() {
-	lc0 := linearcodec.New([]string{reflectcodec.DefaultTagName + "V0"}, maxSize)
-	lc1 := linearcodec.New([]string{reflectcodec.DefaultTagName + "V1"}, maxSize)
+	lc0 := linearcodec.New(time.Time{}, []string{reflectcodec.DefaultTagName + "V0"}, maxSize)
+	lc1 := linearcodec.New(time.Time{}, []string{reflectcodec.DefaultTagName + "V1"}, maxSize)
 
 	Codec = codec.NewManager(maxSize)
 	err := utils.Err(

--- a/vms/avm/block/block_test.go
+++ b/vms/avm/block/block_test.go
@@ -28,9 +28,12 @@ var (
 func TestInvalidBlock(t *testing.T) {
 	require := require.New(t)
 
-	parser, err := NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	_, err = parser.ParseBlock(nil)
@@ -41,9 +44,12 @@ func TestStandardBlocks(t *testing.T) {
 	// check standard block can be built and parsed
 	require := require.New(t)
 
-	parser, err := NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	blkTimestamp := time.Now()

--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -514,9 +514,12 @@ func TestBlockBuilderAddLocalTx(t *testing.T) {
 	_, ok := mempool.Get(txID)
 	require.True(ok)
 
-	parser, err := block.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := block.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	backend := &txexecutor.Backend{

--- a/vms/avm/block/parser.go
+++ b/vms/avm/block/parser.go
@@ -5,6 +5,7 @@ package block
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/utils"
@@ -30,8 +31,8 @@ type parser struct {
 	txs.Parser
 }
 
-func NewParser(fxs []fxs.Fx) (Parser, error) {
-	p, err := txs.NewParser(fxs)
+func NewParser(durangoTime time.Time, fxs []fxs.Fx) (Parser, error) {
+	p, err := txs.NewParser(durangoTime, fxs)
 	if err != nil {
 		return nil, err
 	}
@@ -48,12 +49,13 @@ func NewParser(fxs []fxs.Fx) (Parser, error) {
 }
 
 func NewCustomParser(
+	durangoTime time.Time,
 	typeToFxIndex map[reflect.Type]int,
 	clock *mockable.Clock,
 	log logging.Logger,
 	fxs []fxs.Fx,
 ) (Parser, error) {
-	p, err := txs.NewCustomParser(typeToFxIndex, clock, log, fxs)
+	p, err := txs.NewCustomParser(durangoTime, typeToFxIndex, clock, log, fxs)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/avm/config/config.go
+++ b/vms/avm/config/config.go
@@ -3,6 +3,8 @@
 
 package config
 
+import "time"
+
 // Struct collecting all the foundational parameters of the AVM
 type Config struct {
 	// Fee that is burned by every non-asset creating transaction
@@ -10,4 +12,7 @@ type Config struct {
 
 	// Fee that must be burned by every asset creating transaction
 	CreateAssetTxFee uint64
+
+	// Time of the Durango network upgrade
+	DurangoTime time.Time
 }

--- a/vms/avm/environment_test.go
+++ b/vms/avm/environment_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math/rand"
 	"testing"
+	"time"
 
 	stdjson "encoding/json"
 
@@ -228,9 +229,12 @@ func setup(tb testing.TB, c *envConfig) *environment {
 func getCreateTxFromGenesisTest(tb testing.TB, genesisBytes []byte, assetName string) *txs.Tx {
 	require := require.New(tb)
 
-	parser, err := txs.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	cm := parser.GenesisCodec()

--- a/vms/avm/network/gossip_test.go
+++ b/vms/avm/network/gossip_test.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -33,9 +34,12 @@ func (v testVerifier) VerifyTx(*txs.Tx) error {
 func TestMarshaller(t *testing.T) {
 	require := require.New(t)
 
-	parser, err := txs.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	marhsaller := txParser{
@@ -62,7 +66,7 @@ func TestGossipMempoolAdd(t *testing.T) {
 	baseMempool, err := mempool.New("", metrics, toEngine)
 	require.NoError(err)
 
-	parser, err := txs.NewParser(nil)
+	parser, err := txs.NewParser(time.Time{}, nil)
 	require.NoError(err)
 
 	mempool, err := newGossipMempool(
@@ -98,7 +102,7 @@ func TestGossipMempoolAddVerified(t *testing.T) {
 	baseMempool, err := mempool.New("", metrics, toEngine)
 	require.NoError(err)
 
-	parser, err := txs.NewParser(nil)
+	parser, err := txs.NewParser(time.Time{}, nil)
 	require.NoError(err)
 
 	mempool, err := newGossipMempool(

--- a/vms/avm/network/network_test.go
+++ b/vms/avm/network/network_test.go
@@ -59,9 +59,12 @@ func TestNetworkAppGossip(t *testing.T) {
 		},
 	}
 
-	parser, err := txs.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(t, err)
 	require.NoError(t, testTx.Initialize(parser.Codec()))
 
@@ -183,11 +186,14 @@ func TestNetworkAppGossip(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
 
-			parser, err := txs.NewParser([]fxs.Fx{
-				&secp256k1fx.Fx{},
-				&nftfx.Fx{},
-				&propertyfx.Fx{},
-			})
+			parser, err := txs.NewParser(
+				time.Time{},
+				[]fxs.Fx{
+					&secp256k1fx.Fx{},
+					&nftfx.Fx{},
+					&propertyfx.Fx{},
+				},
+			)
 			require.NoError(err)
 
 			mempoolFunc := func(ctrl *gomock.Controller) mempool.Mempool {
@@ -319,11 +325,14 @@ func TestNetworkIssueTx(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
 
-			parser, err := txs.NewParser([]fxs.Fx{
-				&secp256k1fx.Fx{},
-				&nftfx.Fx{},
-				&propertyfx.Fx{},
-			})
+			parser, err := txs.NewParser(
+				time.Time{},
+				[]fxs.Fx{
+					&secp256k1fx.Fx{},
+					&nftfx.Fx{},
+					&propertyfx.Fx{},
+				},
+			)
 			require.NoError(err)
 
 			mempoolFunc := func(ctrl *gomock.Controller) mempool.Mempool {
@@ -406,11 +415,14 @@ func TestNetworkIssueVerifiedTx(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
 
-			parser, err := txs.NewParser([]fxs.Fx{
-				&secp256k1fx.Fx{},
-				&nftfx.Fx{},
-				&propertyfx.Fx{},
-			})
+			parser, err := txs.NewParser(
+				time.Time{},
+				[]fxs.Fx{
+					&secp256k1fx.Fx{},
+					&nftfx.Fx{},
+					&propertyfx.Fx{},
+				},
+			)
 			require.NoError(err)
 
 			mempoolFunc := func(ctrl *gomock.Controller) mempool.Mempool {
@@ -449,9 +461,12 @@ func TestNetworkGossipTx(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	parser, err := txs.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	appSender := common.NewMockSender(ctrl)

--- a/vms/avm/state/state_test.go
+++ b/vms/avm/state/state_test.go
@@ -38,9 +38,12 @@ var (
 
 func init() {
 	var err error
-	parser, err = block.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err = block.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/vms/avm/static_service.go
+++ b/vms/avm/static_service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	stdjson "encoding/json"
 
@@ -77,11 +78,14 @@ type BuildGenesisReply struct {
 // BuildGenesis returns the UTXOs such that at least one address in [args.Addresses] is
 // referenced in the UTXO.
 func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, reply *BuildGenesisReply) error {
-	parser, err := txs.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-		&nftfx.Fx{},
-		&propertyfx.Fx{},
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+			&nftfx.Fx{},
+			&propertyfx.Fx{},
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/vms/avm/txs/base_tx_test.go
+++ b/vms/avm/txs/base_tx_test.go
@@ -5,6 +5,7 @@ package txs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -125,9 +126,12 @@ func TestBaseTxSerialization(t *testing.T) {
 		Memo: []byte{0x00, 0x01, 0x02, 0x03},
 	}}}
 
-	parser, err := NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	require.NoError(tx.Initialize(parser.Codec()))

--- a/vms/avm/txs/create_asset_tx_test.go
+++ b/vms/avm/txs/create_asset_tx_test.go
@@ -5,6 +5,7 @@ package txs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -193,9 +194,12 @@ func TestCreateAssetTxSerialization(t *testing.T) {
 		},
 	}}
 
-	parser, err := NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	require.NoError(tx.Initialize(parser.Codec()))
@@ -362,9 +366,12 @@ func TestCreateAssetTxSerializationAgain(t *testing.T) {
 		})
 	}
 
-	parser, err := NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 	require.NoError(tx.Initialize(parser.Codec()))
 

--- a/vms/avm/txs/executor/executor_test.go
+++ b/vms/avm/txs/executor/executor_test.go
@@ -5,6 +5,7 @@ package executor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -37,7 +38,10 @@ func TestBaseTxExecutor(t *testing.T) {
 	require := require.New(t)
 
 	secpFx := &secp256k1fx.Fx{}
-	parser, err := block.NewParser([]fxs.Fx{secpFx})
+	parser, err := block.NewParser(
+		time.Time{},
+		[]fxs.Fx{secpFx},
+	)
 	require.NoError(err)
 	codec := parser.Codec()
 
@@ -142,7 +146,10 @@ func TestCreateAssetTxExecutor(t *testing.T) {
 	require := require.New(t)
 
 	secpFx := &secp256k1fx.Fx{}
-	parser, err := block.NewParser([]fxs.Fx{secpFx})
+	parser, err := block.NewParser(
+		time.Time{},
+		[]fxs.Fx{secpFx},
+	)
 	require.NoError(err)
 	codec := parser.Codec()
 
@@ -285,7 +292,10 @@ func TestOperationTxExecutor(t *testing.T) {
 	require := require.New(t)
 
 	secpFx := &secp256k1fx.Fx{}
-	parser, err := block.NewParser([]fxs.Fx{secpFx})
+	parser, err := block.NewParser(
+		time.Time{},
+		[]fxs.Fx{secpFx},
+	)
 	require.NoError(err)
 	codec := parser.Codec()
 

--- a/vms/avm/txs/executor/semantic_verifier_test.go
+++ b/vms/avm/txs/executor/semantic_verifier_test.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -36,6 +37,7 @@ func TestSemanticVerifierBaseTx(t *testing.T) {
 	typeToFxIndex := make(map[reflect.Type]int)
 	secpFx := &secp256k1fx.Fx{}
 	parser, err := txs.NewCustomParser(
+		time.Time{},
 		typeToFxIndex,
 		new(mockable.Clock),
 		logging.NoWarn{},
@@ -393,6 +395,7 @@ func TestSemanticVerifierExportTx(t *testing.T) {
 	typeToFxIndex := make(map[reflect.Type]int)
 	secpFx := &secp256k1fx.Fx{}
 	parser, err := txs.NewCustomParser(
+		time.Time{},
 		typeToFxIndex,
 		new(mockable.Clock),
 		logging.NoWarn{},
@@ -761,6 +764,7 @@ func TestSemanticVerifierExportTxDifferentSubnet(t *testing.T) {
 	typeToFxIndex := make(map[reflect.Type]int)
 	secpFx := &secp256k1fx.Fx{}
 	parser, err := txs.NewCustomParser(
+		time.Time{},
 		typeToFxIndex,
 		new(mockable.Clock),
 		logging.NoWarn{},
@@ -877,6 +881,7 @@ func TestSemanticVerifierImportTx(t *testing.T) {
 	typeToFxIndex := make(map[reflect.Type]int)
 	fx := &secp256k1fx.Fx{}
 	parser, err := txs.NewCustomParser(
+		time.Time{},
 		typeToFxIndex,
 		new(mockable.Clock),
 		logging.NoWarn{},

--- a/vms/avm/txs/executor/syntactic_verifier_test.go
+++ b/vms/avm/txs/executor/syntactic_verifier_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -36,9 +37,12 @@ func TestSyntacticVerifierBaseTx(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.XChainID)
 
 	fx := &secp256k1fx.Fx{}
-	parser, err := txs.NewParser([]fxs.Fx{
-		fx,
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			fx,
+		},
+	)
 	require.NoError(t, err)
 
 	feeAssetID := ids.GenerateTestID()
@@ -406,9 +410,12 @@ func TestSyntacticVerifierCreateAssetTx(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.XChainID)
 
 	fx := &secp256k1fx.Fx{}
-	parser, err := txs.NewParser([]fxs.Fx{
-		fx,
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			fx,
+		},
+	)
 	require.NoError(t, err)
 
 	feeAssetID := ids.GenerateTestID()
@@ -1013,9 +1020,12 @@ func TestSyntacticVerifierOperationTx(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.XChainID)
 
 	fx := &secp256k1fx.Fx{}
-	parser, err := txs.NewParser([]fxs.Fx{
-		fx,
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			fx,
+		},
+	)
 	require.NoError(t, err)
 
 	feeAssetID := ids.GenerateTestID()
@@ -1500,9 +1510,12 @@ func TestSyntacticVerifierImportTx(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.XChainID)
 
 	fx := &secp256k1fx.Fx{}
-	parser, err := txs.NewParser([]fxs.Fx{
-		fx,
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			fx,
+		},
+	)
 	require.NoError(t, err)
 
 	feeAssetID := ids.GenerateTestID()
@@ -1898,9 +1911,12 @@ func TestSyntacticVerifierExportTx(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.XChainID)
 
 	fx := &secp256k1fx.Fx{}
-	parser, err := txs.NewParser([]fxs.Fx{
-		fx,
-	})
+	parser, err := txs.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			fx,
+		},
+	)
 	require.NoError(t, err)
 
 	feeAssetID := ids.GenerateTestID()

--- a/vms/avm/txs/export_tx_test.go
+++ b/vms/avm/txs/export_tx_test.go
@@ -5,6 +5,7 @@ package txs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -108,9 +109,12 @@ func TestExportTxSerialization(t *testing.T) {
 		},
 	}}
 
-	parser, err := NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	require.NoError(tx.Initialize(parser.Codec()))

--- a/vms/avm/txs/import_tx_test.go
+++ b/vms/avm/txs/import_tx_test.go
@@ -5,6 +5,7 @@ package txs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -108,9 +109,12 @@ func TestImportTxSerialization(t *testing.T) {
 		}},
 	}}
 
-	parser, err := NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-	})
+	parser, err := NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+		},
+	)
 	require.NoError(err)
 
 	require.NoError(tx.Initialize(parser.Codec()))

--- a/vms/avm/txs/initial_state_test.go
+++ b/vms/avm/txs/initial_state_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -23,7 +24,7 @@ var errTest = errors.New("non-nil error")
 func TestInitialStateVerifySerialization(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	require.NoError(c.RegisterType(&secp256k1fx.TransferOutput{}))
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(CodecVersion, c))
@@ -80,7 +81,7 @@ func TestInitialStateVerifySerialization(t *testing.T) {
 func TestInitialStateVerifyNil(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(CodecVersion, c))
 	numFxs := 1
@@ -93,7 +94,7 @@ func TestInitialStateVerifyNil(t *testing.T) {
 func TestInitialStateVerifyUnknownFxID(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(CodecVersion, c))
 	numFxs := 1
@@ -108,7 +109,7 @@ func TestInitialStateVerifyUnknownFxID(t *testing.T) {
 func TestInitialStateVerifyNilOutput(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(CodecVersion, c))
 	numFxs := 1
@@ -124,7 +125,7 @@ func TestInitialStateVerifyNilOutput(t *testing.T) {
 func TestInitialStateVerifyInvalidOutput(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	require.NoError(c.RegisterType(&avax.TestState{}))
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(CodecVersion, c))
@@ -141,7 +142,7 @@ func TestInitialStateVerifyInvalidOutput(t *testing.T) {
 func TestInitialStateVerifyUnsortedOutputs(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	require.NoError(c.RegisterType(&avax.TestTransferable{}))
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(CodecVersion, c))

--- a/vms/avm/txs/operation_test.go
+++ b/vms/avm/txs/operation_test.go
@@ -5,6 +5,7 @@ package txs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -79,7 +80,7 @@ func TestOperationVerify(t *testing.T) {
 func TestOperationSorting(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	require.NoError(c.RegisterType(&testOperable{}))
 
 	m := codec.NewDefaultManager()

--- a/vms/avm/txs/parser.go
+++ b/vms/avm/txs/parser.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
-	"github.com/ava-labs/avalanchego/codec/reflectcodec"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -40,8 +40,9 @@ type parser struct {
 	gc  linearcodec.Codec
 }
 
-func NewParser(fxs []fxs.Fx) (Parser, error) {
+func NewParser(durangoTime time.Time, fxs []fxs.Fx) (Parser, error) {
 	return NewCustomParser(
+		durangoTime,
 		make(map[reflect.Type]int),
 		&mockable.Clock{},
 		logging.NoLog{},
@@ -50,13 +51,14 @@ func NewParser(fxs []fxs.Fx) (Parser, error) {
 }
 
 func NewCustomParser(
+	durangoTime time.Time,
 	typeToFxIndex map[reflect.Type]int,
 	clock *mockable.Clock,
 	log logging.Logger,
 	fxs []fxs.Fx,
 ) (Parser, error) {
-	gc := linearcodec.New([]string{reflectcodec.DefaultTagName}, 1<<20)
-	c := linearcodec.NewDefault()
+	gc := linearcodec.NewDefault(time.Time{})
+	c := linearcodec.NewDefault(durangoTime)
 
 	gcm := codec.NewManager(math.MaxInt32)
 	cm := codec.NewDefaultManager()

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -219,6 +219,7 @@ func (vm *VM) Initialize(
 
 	vm.typeToFxIndex = map[reflect.Type]int{}
 	vm.parser, err = block.NewCustomParser(
+		vm.DurangoTime,
 		vm.typeToFxIndex,
 		&vm.clock,
 		ctx.Log,

--- a/vms/components/avax/asset_test.go
+++ b/vms/components/avax/asset_test.go
@@ -5,6 +5,7 @@ package avax
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -28,7 +29,7 @@ func TestAssetVerifyEmpty(t *testing.T) {
 func TestAssetID(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	manager := codec.NewDefaultManager()
 	require.NoError(manager.RegisterCodec(codecVersion, c))
 

--- a/vms/components/avax/transferables_test.go
+++ b/vms/components/avax/transferables_test.go
@@ -5,6 +5,7 @@ package avax
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -42,7 +43,7 @@ func TestTransferableOutputVerify(t *testing.T) {
 func TestTransferableOutputSorting(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	require.NoError(c.RegisterType(&TestTransferable{}))
 	manager := codec.NewDefaultManager()
 	require.NoError(manager.RegisterCodec(codecVersion, c))
@@ -84,7 +85,7 @@ func TestTransferableOutputSorting(t *testing.T) {
 func TestTransferableOutputSerialization(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	require.NoError(c.RegisterType(&secp256k1fx.TransferOutput{}))
 	manager := codec.NewDefaultManager()
 	require.NoError(manager.RegisterCodec(codecVersion, c))
@@ -175,7 +176,7 @@ func TestTransferableInputVerify(t *testing.T) {
 func TestTransferableInputSorting(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	require.NoError(c.RegisterType(&TestTransferable{}))
 
 	ins := []*TransferableInput{
@@ -232,7 +233,7 @@ func TestTransferableInputSorting(t *testing.T) {
 func TestTransferableInputSerialization(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	require.NoError(c.RegisterType(&secp256k1fx.TransferInput{}))
 	manager := codec.NewDefaultManager()
 	require.NoError(manager.RegisterCodec(codecVersion, c))

--- a/vms/components/avax/utxo_fetching_test.go
+++ b/vms/components/avax/utxo_fetching_test.go
@@ -5,6 +5,7 @@ package avax
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -39,7 +40,7 @@ func TestFetchUTXOs(t *testing.T) {
 		},
 	}
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	manager := codec.NewDefaultManager()
 
 	require.NoError(c.RegisterType(&secp256k1fx.TransferOutput{}))
@@ -72,7 +73,7 @@ func TestGetPaginatedUTXOs(t *testing.T) {
 	addr2 := ids.GenerateTestShortID()
 	addrs := set.Of(addr0, addr1)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	manager := codec.NewDefaultManager()
 
 	require.NoError(c.RegisterType(&secp256k1fx.TransferOutput{}))

--- a/vms/components/avax/utxo_id_test.go
+++ b/vms/components/avax/utxo_id_test.go
@@ -6,6 +6,7 @@ package avax
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -23,7 +24,7 @@ func TestUTXOIDVerifyNil(t *testing.T) {
 func TestUTXOID(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	manager := codec.NewDefaultManager()
 	require.NoError(manager.RegisterCodec(codecVersion, c))
 

--- a/vms/components/avax/utxo_state_test.go
+++ b/vms/components/avax/utxo_state_test.go
@@ -5,6 +5,7 @@ package avax
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -41,7 +42,7 @@ func TestUTXOState(t *testing.T) {
 	}
 	utxoID := utxo.InputID()
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	manager := codec.NewDefaultManager()
 
 	require.NoError(c.RegisterType(&secp256k1fx.MintOutput{}))

--- a/vms/components/avax/utxo_test.go
+++ b/vms/components/avax/utxo_test.go
@@ -5,6 +5,7 @@ package avax
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -32,7 +33,7 @@ func TestUTXOVerifyEmpty(t *testing.T) {
 func TestUTXOSerialize(t *testing.T) {
 	require := require.New(t)
 
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	manager := codec.NewDefaultManager()
 
 	require.NoError(c.RegisterType(&secp256k1fx.MintOutput{}))

--- a/vms/components/keystore/codec.go
+++ b/vms/components/keystore/codec.go
@@ -5,6 +5,7 @@ package keystore
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -19,9 +20,9 @@ var (
 )
 
 func init() {
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	Codec = codec.NewDefaultManager()
-	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
+	lc := linearcodec.NewDefault(time.Time{})
 	LegacyCodec = codec.NewManager(math.MaxInt32)
 
 	err := utils.Err(

--- a/vms/components/message/codec.go
+++ b/vms/components/message/codec.go
@@ -4,6 +4,8 @@
 package message
 
 import (
+	"time"
+
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/utils"
@@ -14,14 +16,13 @@ const (
 	CodecVersion = 0
 
 	maxMessageSize = 512 * units.KiB
-	maxSliceLen    = maxMessageSize
 )
 
 var Codec codec.Manager
 
 func init() {
 	Codec = codec.NewManager(maxMessageSize)
-	lc := linearcodec.NewCustomMaxLength(maxSliceLen)
+	lc := linearcodec.NewDefault(time.Time{})
 
 	err := utils.Err(
 		lc.RegisterType(&Tx{}),

--- a/vms/example/xsvm/tx/codec.go
+++ b/vms/example/xsvm/tx/codec.go
@@ -5,6 +5,7 @@ package tx
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -16,7 +17,7 @@ const CodecVersion = 0
 var Codec codec.Manager
 
 func init() {
-	c := linearcodec.NewCustomMaxLength(math.MaxInt32)
+	c := linearcodec.NewDefault(time.Time{})
 	Codec = codec.NewManager(math.MaxInt32)
 
 	err := utils.Err(

--- a/vms/nftfx/fx_test.go
+++ b/vms/nftfx/fx_test.go
@@ -39,7 +39,7 @@ var (
 
 func TestFxInitialize(t *testing.T) {
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	fx := Fx{}
@@ -56,7 +56,7 @@ func TestFxVerifyMintOperation(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -92,7 +92,7 @@ func TestFxVerifyMintOperationWrongTx(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -126,7 +126,7 @@ func TestFxVerifyMintOperationWrongNumberUTXOs(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -157,7 +157,7 @@ func TestFxVerifyMintOperationWrongCredential(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -189,7 +189,7 @@ func TestFxVerifyMintOperationInvalidUTXO(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -220,7 +220,7 @@ func TestFxVerifyMintOperationFailingVerification(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -258,7 +258,7 @@ func TestFxVerifyMintOperationInvalidGroupID(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -296,7 +296,7 @@ func TestFxVerifyTransferOperation(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -346,7 +346,7 @@ func TestFxVerifyTransferOperationWrongUTXO(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -387,7 +387,7 @@ func TestFxVerifyTransferOperationFailedVerify(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -435,7 +435,7 @@ func TestFxVerifyTransferOperationWrongGroupID(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -486,7 +486,7 @@ func TestFxVerifyTransferOperationWrongBytes(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -537,7 +537,7 @@ func TestFxVerifyTransferOperationTooSoon(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -589,7 +589,7 @@ func TestFxVerifyOperationUnknownOperation(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -625,7 +625,7 @@ func TestFxVerifyTransfer(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -330,7 +330,7 @@ func defaultFx(t *testing.T, clk *mockable.Clock, log logging.Logger, isBootstra
 	require := require.New(t)
 
 	fxVMInt := &fxVMInt{
-		registry: linearcodec.NewDefault(),
+		registry: linearcodec.NewDefault(time.Time{}),
 		clk:      clk,
 		log:      log,
 	}

--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -5,6 +5,7 @@ package block
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -15,20 +16,23 @@ import (
 
 const CodecVersion = txs.CodecVersion
 
-// GenesisCode allows blocks of larger than usual size to be parsed.
-// While this gives flexibility in accommodating large genesis blocks
-// it must not be used to parse new, unverified blocks which instead
-// must be processed by Codec
 var (
-	Codec        codec.Manager
+	Codec codec.Manager
+
+	// GenesisCode allows blocks of larger than usual size to be parsed.
+	// While this gives flexibility in accommodating large genesis blocks
+	// it must not be used to parse new, unverified blocks which instead
+	// must be processed by Codec
 	GenesisCodec codec.Manager
 )
 
-func init() {
-	c := linearcodec.NewDefault()
-	Codec = codec.NewDefaultManager()
-	gc := linearcodec.NewCustomMaxLength(math.MaxInt32)
-	GenesisCodec = codec.NewManager(math.MaxInt32)
+// TODO: Remove after v1.11.x has activated
+//
+// Invariant: InitCodec, Codec, and GenesisCodec must not be accessed
+// concurrently
+func InitCodec(durangoTime time.Time) error {
+	c := linearcodec.NewDefault(durangoTime)
+	gc := linearcodec.NewDefault(time.Time{})
 
 	errs := wrappers.Errs{}
 	for _, c := range []linearcodec.Codec{c, gc} {
@@ -39,12 +43,25 @@ func init() {
 			txs.RegisterDUnsignedTxsTypes(c),
 		)
 	}
+
+	newCodec := codec.NewDefaultManager()
+	newGenesisCodec := codec.NewManager(math.MaxInt32)
 	errs.Add(
-		Codec.RegisterCodec(CodecVersion, c),
-		GenesisCodec.RegisterCodec(CodecVersion, gc),
+		newCodec.RegisterCodec(CodecVersion, c),
+		newGenesisCodec.RegisterCodec(CodecVersion, gc),
 	)
 	if errs.Errored() {
-		panic(errs.Err)
+		return errs.Err
+	}
+
+	Codec = newCodec
+	GenesisCodec = newGenesisCodec
+	return nil
+}
+
+func init() {
+	if err := InitCodec(time.Time{}); err != nil {
+		panic(err)
 	}
 }
 

--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -17,7 +17,7 @@ import (
 const CodecVersion = txs.CodecVersion
 
 var (
-	// GenesisCode allows blocks of larger than usual size to be parsed.
+	// GenesisCodec allows blocks of larger than usual size to be parsed.
 	// While this gives flexibility in accommodating large genesis blocks
 	// it must not be used to parse new, unverified blocks which instead
 	// must be processed by Codec

--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -17,13 +17,13 @@ import (
 const CodecVersion = txs.CodecVersion
 
 var (
-	Codec codec.Manager
-
 	// GenesisCode allows blocks of larger than usual size to be parsed.
 	// While this gives flexibility in accommodating large genesis blocks
 	// it must not be used to parse new, unverified blocks which instead
 	// must be processed by Codec
 	GenesisCodec codec.Manager
+
+	Codec codec.Manager
 )
 
 // TODO: Remove after v1.11.x has activated

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -345,7 +345,7 @@ func (fvi *fxVMInt) Logger() logging.Logger {
 
 func defaultFx(clk *mockable.Clock, log logging.Logger, isBootstrapped bool) fx.Fx {
 	fxVMInt := &fxVMInt{
-		registry: linearcodec.NewDefault(),
+		registry: linearcodec.NewDefault(time.Time{}),
 		clk:      clk,
 		log:      log,
 	}

--- a/vms/platformvm/state/metadata_codec.go
+++ b/vms/platformvm/state/metadata_codec.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -22,8 +23,8 @@ const (
 var MetadataCodec codec.Manager
 
 func init() {
-	c0 := linearcodec.New([]string{CodecVersion0Tag}, math.MaxInt32)
-	c1 := linearcodec.New([]string{CodecVersion0Tag, CodecVersion1Tag}, math.MaxInt32)
+	c0 := linearcodec.New(time.Time{}, []string{CodecVersion0Tag}, math.MaxInt32)
+	c1 := linearcodec.New(time.Time{}, []string{CodecVersion0Tag, CodecVersion1Tag}, math.MaxInt32)
 	MetadataCodec = codec.NewManager(math.MaxInt32)
 
 	err := utils.Err(

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -5,6 +5,7 @@ package txs
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -27,11 +28,13 @@ var (
 	GenesisCodec codec.Manager
 )
 
-func init() {
-	c := linearcodec.NewDefault()
-	Codec = codec.NewDefaultManager()
-	gc := linearcodec.NewCustomMaxLength(math.MaxInt32)
-	GenesisCodec = codec.NewManager(math.MaxInt32)
+// TODO: Remove after v1.11.x has activated
+//
+// Invariant: InitCodec, Codec, and GenesisCodec must not be accessed
+// concurrently
+func InitCodec(durangoTime time.Time) error {
+	c := linearcodec.NewDefault(durangoTime)
+	gc := linearcodec.NewDefault(time.Time{})
 
 	errs := wrappers.Errs{}
 	for _, c := range []linearcodec.Codec{c, gc} {
@@ -46,12 +49,25 @@ func init() {
 
 		errs.Add(RegisterDUnsignedTxsTypes(c))
 	}
+
+	newCodec := codec.NewDefaultManager()
+	newGenesisCodec := codec.NewManager(math.MaxInt32)
 	errs.Add(
-		Codec.RegisterCodec(CodecVersion, c),
-		GenesisCodec.RegisterCodec(CodecVersion, gc),
+		newCodec.RegisterCodec(CodecVersion, c),
+		newGenesisCodec.RegisterCodec(CodecVersion, gc),
 	)
 	if errs.Errored() {
-		panic(errs.Err)
+		return errs.Err
+	}
+
+	Codec = newCodec
+	GenesisCodec = newGenesisCodec
+	return nil
+}
+
+func init() {
+	if err := InitCodec(time.Time{}); err != nil {
+		panic(err)
 	}
 }
 

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -318,7 +318,7 @@ func (fvi *fxVMInt) Logger() logging.Logger {
 
 func defaultFx(clk *mockable.Clock, log logging.Logger, isBootstrapped bool) fx.Fx {
 	fxVMInt := &fxVMInt{
-		registry: linearcodec.NewDefault(),
+		registry: linearcodec.NewDefault(time.Time{}),
 		clk:      clk,
 		log:      log,
 	}

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -137,7 +137,8 @@ func (vm *VM) Initialize(
 	vm.ctx = chainCtx
 	vm.db = db
 
-	vm.codecRegistry = linearcodec.NewDefault()
+	// Note: this codec is never used to serialize anything
+	vm.codecRegistry = linearcodec.NewDefault(time.Time{})
 	vm.fx = &secp256k1fx.Fx{}
 	if err := vm.fx.Initialize(vm); err != nil {
 		return err

--- a/vms/platformvm/warp/codec.go
+++ b/vms/platformvm/warp/codec.go
@@ -5,6 +5,7 @@ package warp
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -17,7 +18,7 @@ var Codec codec.Manager
 
 func init() {
 	Codec = codec.NewManager(math.MaxInt)
-	lc := linearcodec.NewCustomMaxLength(math.MaxInt32)
+	lc := linearcodec.NewDefault(time.Time{})
 
 	err := utils.Err(
 		lc.RegisterType(&BitSetSignature{}),

--- a/vms/platformvm/warp/payload/codec.go
+++ b/vms/platformvm/warp/payload/codec.go
@@ -4,6 +4,8 @@
 package payload
 
 import (
+	"time"
+
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/utils"
@@ -14,17 +16,13 @@ const (
 	CodecVersion = 0
 
 	MaxMessageSize = 24 * units.KiB
-
-	// Note: Modifying this variable can have subtle implications on memory
-	// usage when parsing malformed payloads.
-	MaxSliceLen = 24 * 1024
 )
 
 var Codec codec.Manager
 
 func init() {
 	Codec = codec.NewManager(MaxMessageSize)
-	lc := linearcodec.NewCustomMaxLength(MaxSliceLen)
+	lc := linearcodec.NewDefault(time.Time{})
 
 	err := utils.Err(
 		lc.RegisterType(&Hash{}),

--- a/vms/propertyfx/fx_test.go
+++ b/vms/propertyfx/fx_test.go
@@ -39,7 +39,7 @@ var (
 
 func TestFxInitialize(t *testing.T) {
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	fx := Fx{}
@@ -56,7 +56,7 @@ func TestFxVerifyMintOperation(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -98,7 +98,7 @@ func TestFxVerifyMintOperationWrongTx(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -132,7 +132,7 @@ func TestFxVerifyMintOperationWrongNumberUTXOs(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -163,7 +163,7 @@ func TestFxVerifyMintOperationWrongCredential(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -195,7 +195,7 @@ func TestFxVerifyMintOperationInvalidUTXO(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -226,7 +226,7 @@ func TestFxVerifyMintOperationFailingVerification(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -264,7 +264,7 @@ func TestFxVerifyMintOperationInvalidGroupID(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -301,7 +301,7 @@ func TestFxVerifyTransferOperation(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -335,7 +335,7 @@ func TestFxVerifyTransferOperationWrongUTXO(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -364,7 +364,7 @@ func TestFxVerifyTransferOperationFailedVerify(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -399,7 +399,7 @@ func TestFxVerifyOperationUnknownOperation(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -431,7 +431,7 @@ func TestFxVerifyTransfer(t *testing.T) {
 	require := require.New(t)
 
 	vm := secp256k1fx.TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)

--- a/vms/proposervm/block/codec.go
+++ b/vms/proposervm/block/codec.go
@@ -5,6 +5,7 @@ package block
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -16,7 +17,7 @@ const CodecVersion = 0
 var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
+	lc := linearcodec.NewDefault(time.Time{})
 	// The maximum block size is enforced by the p2p message size limit.
 	// See: [constants.DefaultMaxMessageSize]
 	Codec = codec.NewManager(math.MaxInt)

--- a/vms/proposervm/state/codec.go
+++ b/vms/proposervm/state/codec.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -15,7 +16,7 @@ const CodecVersion = 0
 var Codec codec.Manager
 
 func init() {
-	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
+	lc := linearcodec.NewDefault(time.Time{})
 	Codec = codec.NewManager(math.MaxInt32)
 
 	err := Codec.RegisterCodec(CodecVersion, lc)

--- a/vms/proposervm/summary/codec.go
+++ b/vms/proposervm/summary/codec.go
@@ -6,6 +6,7 @@ package summary
 import (
 	"errors"
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -20,7 +21,7 @@ var (
 )
 
 func init() {
-	lc := linearcodec.NewCustomMaxLength(math.MaxUint32)
+	lc := linearcodec.NewDefault(time.Time{})
 	Codec = codec.NewManager(math.MaxInt32)
 	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
 		panic(err)

--- a/vms/secp256k1fx/credential_test.go
+++ b/vms/secp256k1fx/credential_test.go
@@ -5,6 +5,7 @@ package secp256k1fx
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +28,7 @@ func TestCredentialVerifyNil(t *testing.T) {
 
 func TestCredentialSerialize(t *testing.T) {
 	require := require.New(t)
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(0, c))
 

--- a/vms/secp256k1fx/fx_test.go
+++ b/vms/secp256k1fx/fx_test.go
@@ -53,7 +53,7 @@ func init() {
 
 func TestFxInitialize(t *testing.T) {
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	fx := Fx{}
@@ -69,7 +69,7 @@ func TestFxInitializeInvalid(t *testing.T) {
 func TestFxVerifyTransfer(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -107,7 +107,7 @@ func TestFxVerifyTransfer(t *testing.T) {
 func TestFxVerifyTransferNilTx(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -143,7 +143,7 @@ func TestFxVerifyTransferNilTx(t *testing.T) {
 func TestFxVerifyTransferNilOutput(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -170,7 +170,7 @@ func TestFxVerifyTransferNilOutput(t *testing.T) {
 func TestFxVerifyTransferNilInput(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -201,7 +201,7 @@ func TestFxVerifyTransferNilInput(t *testing.T) {
 func TestFxVerifyTransferNilCredential(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -233,7 +233,7 @@ func TestFxVerifyTransferNilCredential(t *testing.T) {
 func TestFxVerifyTransferInvalidOutput(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -270,7 +270,7 @@ func TestFxVerifyTransferInvalidOutput(t *testing.T) {
 func TestFxVerifyTransferWrongAmounts(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -307,7 +307,7 @@ func TestFxVerifyTransferWrongAmounts(t *testing.T) {
 func TestFxVerifyTransferTimelocked(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -344,7 +344,7 @@ func TestFxVerifyTransferTimelocked(t *testing.T) {
 func TestFxVerifyTransferTooManySigners(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -382,7 +382,7 @@ func TestFxVerifyTransferTooManySigners(t *testing.T) {
 func TestFxVerifyTransferTooFewSigners(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -417,7 +417,7 @@ func TestFxVerifyTransferTooFewSigners(t *testing.T) {
 func TestFxVerifyTransferMismatchedSigners(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -455,7 +455,7 @@ func TestFxVerifyTransferMismatchedSigners(t *testing.T) {
 func TestFxVerifyTransferInvalidSignature(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -495,7 +495,7 @@ func TestFxVerifyTransferInvalidSignature(t *testing.T) {
 func TestFxVerifyTransferWrongSigner(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -535,7 +535,7 @@ func TestFxVerifyTransferWrongSigner(t *testing.T) {
 func TestFxVerifyTransferSigIndexOOB(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -575,7 +575,7 @@ func TestFxVerifyTransferSigIndexOOB(t *testing.T) {
 func TestFxVerifyOperation(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -627,7 +627,7 @@ func TestFxVerifyOperation(t *testing.T) {
 func TestFxVerifyOperationUnknownTx(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -679,7 +679,7 @@ func TestFxVerifyOperationUnknownTx(t *testing.T) {
 func TestFxVerifyOperationUnknownOperation(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -709,7 +709,7 @@ func TestFxVerifyOperationUnknownOperation(t *testing.T) {
 func TestFxVerifyOperationUnknownCredential(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -757,7 +757,7 @@ func TestFxVerifyOperationUnknownCredential(t *testing.T) {
 func TestFxVerifyOperationWrongNumberOfUTXOs(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -810,7 +810,7 @@ func TestFxVerifyOperationWrongNumberOfUTXOs(t *testing.T) {
 func TestFxVerifyOperationUnknownUTXOType(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -855,7 +855,7 @@ func TestFxVerifyOperationUnknownUTXOType(t *testing.T) {
 func TestFxVerifyOperationInvalidOperationVerify(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -905,7 +905,7 @@ func TestFxVerifyOperationInvalidOperationVerify(t *testing.T) {
 func TestFxVerifyOperationMismatchedMintOutputs(t *testing.T) {
 	require := require.New(t)
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
@@ -952,7 +952,7 @@ func TestFxVerifyOperationMismatchedMintOutputs(t *testing.T) {
 
 func TestVerifyPermission(t *testing.T) {
 	vm := TestVM{
-		Codec: linearcodec.NewDefault(),
+		Codec: linearcodec.NewDefault(time.Time{}),
 		Log:   logging.NoLog{},
 	}
 	fx := Fx{}

--- a/vms/secp256k1fx/transfer_input_test.go
+++ b/vms/secp256k1fx/transfer_input_test.go
@@ -5,6 +5,7 @@ package secp256k1fx
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -80,7 +81,7 @@ func TestTransferInputVerifyUnsorted(t *testing.T) {
 
 func TestTransferInputSerialize(t *testing.T) {
 	require := require.New(t)
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(0, c))
 

--- a/vms/secp256k1fx/transfer_output_test.go
+++ b/vms/secp256k1fx/transfer_output_test.go
@@ -5,6 +5,7 @@ package secp256k1fx
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -135,7 +136,7 @@ func TestOutputVerifyDuplicated(t *testing.T) {
 
 func TestOutputSerialize(t *testing.T) {
 	require := require.New(t)
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewDefault(time.Time{})
 	m := codec.NewDefaultManager()
 	require.NoError(m.RegisterCodec(0, c))
 

--- a/wallet/chain/x/constants.go
+++ b/wallet/chain/x/constants.go
@@ -4,6 +4,8 @@
 package x
 
 import (
+	"time"
+
 	"github.com/ava-labs/avalanchego/vms/avm/block"
 	"github.com/ava-labs/avalanchego/vms/avm/fxs"
 	"github.com/ava-labs/avalanchego/vms/nftfx"
@@ -22,11 +24,14 @@ var Parser block.Parser
 
 func init() {
 	var err error
-	Parser, err = block.NewParser([]fxs.Fx{
-		&secp256k1fx.Fx{},
-		&nftfx.Fx{},
-		&propertyfx.Fx{},
-	})
+	Parser, err = block.NewParser(
+		time.Time{},
+		[]fxs.Fx{
+			&secp256k1fx.Fx{},
+			&nftfx.Fx{},
+			&propertyfx.Fx{},
+		},
+	)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Why this should be merged

Since the preallocation logic was removed from the codec, there is no reason to have explicit (and brittle) additional length checks.

## How this works

Allow deserialization of messages without enforcing slice length checks after the Durango timestamp.

## How this was tested

- [x] CI
- [x] Fuji