### PR TITLE
[ci] Increase Fuzz Time in Periodic Runs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,4 +22,4 @@ jobs:
           check-latest: true
       - name: Run fuzz tests
         shell: bash
-        run: ./scripts/build_fuzz.sh 300 # Run each fuzz test 300 seconds
+        run: ./scripts/build_fuzz.sh 180 # Run each fuzz test 180 seconds

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,4 +22,4 @@ jobs:
           check-latest: true
       - name: Run fuzz tests
         shell: bash
-        run: ./scripts/build_fuzz.sh 30 # Run each fuzz test 30 seconds
+        run: ./scripts/build_fuzz.sh 300 # Run each fuzz test 300 seconds


### PR DESCRIPTION
## Why this should be merged

Fuzz tests currently take ~32-35 minutes. This PR multiplies the runtime by ~6x to target 3 hours (max is 6 hours): https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration
 
<img width="1300" alt="image" src="https://github.com/ava-labs/avalanchego/assets/13023275/2d2feaf2-9108-4fbe-b501-07cc207b3035">


## How this works
Increase fuzz time per test

## How this was tested
CI
