### PR TITLE
`tmpnet`: Save metrics snapshot to disk before node shutdown

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -299,7 +299,7 @@ func (n *Network) Stop(ctx context.Context) error {
 
 	// Initiate stop on all nodes
 	for _, node := range nodes {
-		if err := node.InitiateStop(); err != nil {
+		if err := node.InitiateStop(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("failed to stop node %s: %w", node.NodeID, err))
 		}
 	}

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -163,6 +163,10 @@ func (n *Node) getDataDir() string {
 
 // Writes the current state of the metrics endpoint to disk
 func (n *Node) SaveMetricsSnapshot(ctx context.Context) error {
+	if len(n.URI) == 0 {
+		// No URI to request metrics from
+		return nil
+	}
 	uri := n.URI + "/ext/metrics"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -141,7 +142,10 @@ func (n *Node) Start(w io.Writer) error {
 	return n.getRuntime().Start(w)
 }
 
-func (n *Node) InitiateStop() error {
+func (n *Node) InitiateStop(ctx context.Context) error {
+	if err := n.SaveMetricsSnapshot(ctx); err != nil {
+		return err
+	}
 	return n.getRuntime().InitiateStop()
 }
 
@@ -157,9 +161,28 @@ func (n *Node) getDataDir() string {
 	return cast.ToString(n.Flags[config.DataDirKey])
 }
 
+// Writes the current state of the metrics endpoint to disk
+func (n *Node) SaveMetricsSnapshot(ctx context.Context) error {
+	uri := n.URI + "/ext/metrics"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	return n.writeMetricsSnapshot(body)
+}
+
 // Initiates node shutdown and waits for the node to stop.
 func (n *Node) Stop(ctx context.Context) error {
-	if err := n.InitiateStop(); err != nil {
+	if err := n.InitiateStop(ctx); err != nil {
 		return err
 	}
 	return n.WaitForStopped(ctx)

--- a/tests/fixture/tmpnet/node_config.go
+++ b/tests/fixture/tmpnet/node_config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/ava-labs/avalanchego/utils/perms"
 )
@@ -97,4 +98,13 @@ func (n *Node) Write() error {
 		return nil
 	}
 	return n.writeConfig()
+}
+
+func (n *Node) writeMetricsSnapshot(data []byte) error {
+	metricsDir := filepath.Join(n.getDataDir(), "metrics")
+	if err := os.MkdirAll(metricsDir, perms.ReadWriteExecute); err != nil {
+		return fmt.Errorf("failed to create metrics dir: %w", err)
+	}
+	metricsPath := filepath.Join(metricsDir, time.Now().Format(time.RFC3339))
+	return os.WriteFile(metricsPath, data, perms.ReadWrite)
 }

--- a/tests/fixture/tmpnet/node_config.go
+++ b/tests/fixture/tmpnet/node_config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ava-labs/avalanchego/utils/perms"
@@ -105,6 +106,9 @@ func (n *Node) writeMetricsSnapshot(data []byte) error {
 	if err := os.MkdirAll(metricsDir, perms.ReadWriteExecute); err != nil {
 		return fmt.Errorf("failed to create metrics dir: %w", err)
 	}
-	metricsPath := filepath.Join(metricsDir, time.Now().Format(time.RFC3339))
+	// Create a compatible filesystem from the current timestamp
+	ts := time.Now().UTC().Format(time.RFC3339)
+	ts = strings.Replace(strings.Replace(ts, ":", "", -1), "-", "", -1)
+	metricsPath := filepath.Join(metricsDir, ts)
 	return os.WriteFile(metricsPath, data, perms.ReadWrite)
 }

--- a/tests/fixture/tmpnet/node_config.go
+++ b/tests/fixture/tmpnet/node_config.go
@@ -108,7 +108,7 @@ func (n *Node) writeMetricsSnapshot(data []byte) error {
 	}
 	// Create a compatible filesystem from the current timestamp
 	ts := time.Now().UTC().Format(time.RFC3339)
-	ts = strings.Replace(strings.Replace(ts, ":", "", -1), "-", "", -1)
+	ts = strings.ReplaceAll(strings.ReplaceAll(ts, ":", ""), "-", "")
 	metricsPath := filepath.Join(metricsDir, ts)
 	return os.WriteFile(metricsPath, data, perms.ReadWrite)
 }


### PR DESCRIPTION
## Why this should be merged

As per a request from @StephenButtolph 

## How this works

Whenever node shutdown is initiated, retrieves `/ext/metrics` and writes it to the `[data dir]/metrics/[timestamp]`.

## How this was tested

Locally started and stopped a network, checked `~/.tmpnet/networks/latest/[node id]/metrics` for a timestamped metrics snapshot. 