### PR TITLE
Log critical consensus values during health checks

### DIFF
--- a/snow/engine/common/request.go
+++ b/snow/engine/common/request.go
@@ -3,9 +3,17 @@
 
 package common
 
-import "github.com/ava-labs/avalanchego/ids"
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
 
 type Request struct {
 	NodeID    ids.NodeID
 	RequestID uint32
+}
+
+func (r Request) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("%s:%d", r.NodeID, r.RequestID)), nil
 }

--- a/snow/engine/common/request_test.go
+++ b/snow/engine/common/request_test.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+func TestRequestJSONMarshal(t *testing.T) {
+	requestMap := map[Request]ids.ID{
+		{
+			NodeID:    ids.GenerateTestNodeID(),
+			RequestID: 12345,
+		}: ids.GenerateTestID(),
+	}
+	_, err := json.Marshal(requestMap)
+	require.NoError(t, err)
+}

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -556,6 +556,15 @@ func (t *Transitive) HealthCheck(ctx context.Context) (interface{}, error) {
 	t.Ctx.Lock.Lock()
 	defer t.Ctx.Lock.Unlock()
 
+	t.Ctx.Log.Verbo("running health check",
+		zap.Uint32("requestID", t.requestID),
+		zap.Int("gossipCounter", t.gossipCounter),
+		zap.Stringer("polls", t.polls),
+		zap.Reflect("outstandingBlockRequests", t.blkReqs),
+		zap.Stringer("blockedJobs", &t.blocked),
+		zap.Int("pendingBuildBlocks", t.pendingBuildBlocks),
+	)
+
 	consensusIntf, consensusErr := t.Consensus.HealthCheck(ctx)
 	vmIntf, vmErr := t.VM.HealthCheck(ctx)
 	intf := map[string]interface{}{

--- a/utils/bimap/bimap.go
+++ b/utils/bimap/bimap.go
@@ -3,7 +3,21 @@
 
 package bimap
 
-import "github.com/ava-labs/avalanchego/utils"
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	"github.com/ava-labs/avalanchego/utils"
+)
+
+var (
+	_ json.Marshaler   = (*BiMap[int, int])(nil)
+	_ json.Unmarshaler = (*BiMap[int, int])(nil)
+
+	nullBytes       = []byte("null")
+	errNotBijective = errors.New("map not bijective")
+)
 
 type Entry[K, V any] struct {
 	Key   K
@@ -99,4 +113,29 @@ func (m *BiMap[K, V]) DeleteValue(val V) (K, bool) {
 // Len return the number of entries in this map.
 func (m *BiMap[K, V]) Len() int {
 	return len(m.keyToValue)
+}
+
+func (m *BiMap[K, V]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.keyToValue)
+}
+
+func (m *BiMap[K, V]) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, nullBytes) {
+		return nil
+	}
+	var keyToValue map[K]V
+	if err := json.Unmarshal(b, &keyToValue); err != nil {
+		return err
+	}
+	valueToKey := make(map[V]K, len(keyToValue))
+	for k, v := range keyToValue {
+		valueToKey[v] = k
+	}
+	if len(keyToValue) != len(valueToKey) {
+		return errNotBijective
+	}
+
+	m.keyToValue = keyToValue
+	m.valueToKey = valueToKey
+	return nil
 }

--- a/utils/bimap/bimap_test.go
+++ b/utils/bimap/bimap_test.go
@@ -4,6 +4,7 @@
 package bimap
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -325,4 +326,32 @@ func TestBiMapLen(t *testing.T) {
 
 	m.DeleteKey(1)
 	require.Zero(m.Len())
+}
+
+func TestBiMapJSON(t *testing.T) {
+	require := require.New(t)
+
+	expectedMap := New[int, int]()
+	expectedMap.Put(1, 2)
+	expectedMap.Put(2, 3)
+
+	jsonBytes, err := json.Marshal(expectedMap)
+	require.NoError(err)
+
+	expectedJSONBytes := []byte(`{"1":2,"2":3}`)
+	require.Equal(expectedJSONBytes, jsonBytes)
+
+	var unmarshalledMap BiMap[int, int]
+	err = json.Unmarshal(jsonBytes, &unmarshalledMap)
+	require.NoError(err)
+	require.Equal(expectedMap, &unmarshalledMap)
+}
+
+func TestBiMapInvalidJSON(t *testing.T) {
+	require := require.New(t)
+
+	invalidJSONBytes := []byte(`{"1":2,"2":2}`)
+	var unmarshalledMap BiMap[int, int]
+	err := json.Unmarshal(invalidJSONBytes, &unmarshalledMap)
+	require.ErrorIs(err, errNotBijective)
 }

--- a/utils/bimap/bimap_test.go
+++ b/utils/bimap/bimap_test.go
@@ -342,8 +342,7 @@ func TestBiMapJSON(t *testing.T) {
 	require.Equal(expectedJSONBytes, jsonBytes)
 
 	var unmarshalledMap BiMap[int, int]
-	err = json.Unmarshal(jsonBytes, &unmarshalledMap)
-	require.NoError(err)
+	require.NoError(json.Unmarshal(jsonBytes, &unmarshalledMap))
 	require.Equal(expectedMap, &unmarshalledMap)
 }
 


### PR DESCRIPTION
## Why this should be merged

Adds logging of consensus critical values when performing the health check.

## How this works

When verbose logging is enabled, we'll now log critical values like outstanding polls, blocked blocks, and other critical values.

## How this was tested

Ran a node with verbose logging and made sure the log showed correctly.