### PR TITLE
Update contributions branch to master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ To start developing on AvalancheGo, you'll need a few things installed.
 
 - Open a new GitHub pull request containing your changes.
 - Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
-- The PR should be opened against the `dev` branch.
+- The PR should be opened against the `master` branch.
 - If your PR isn't ready to be reviewed just yet, you can open it as a draft to collect early feedback on your changes.
 - Once the PR is ready for review, mark it as ready-for-review and request review from one of the maintainers.
 


### PR DESCRIPTION
## Why this should be merged

After `v1.10.18` we'll be merging all PRs into `master` rather than `dev`.

## How this works

`dev` -> `master`

## How this was tested

N/A