### PR TITLE
Add ip bloom metrics

### DIFF
--- a/network/ip_tracker_test.go
+++ b/network/ip_tracker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/stretchr/testify/require"
 
@@ -41,6 +42,14 @@ func requireEqual(t *testing.T, expected, actual *ipTracker) {
 	require.Equal(expected.gossipableIPs, actual.gossipableIPs)
 	require.Equal(expected.bloomAdditions, actual.bloomAdditions)
 	require.Equal(expected.maxBloomCount, actual.maxBloomCount)
+}
+
+func requireMetricsConsistent(t *testing.T, tracker *ipTracker) {
+	require := require.New(t)
+	require.Equal(float64(len(tracker.mostRecentValidatorIPs)), testutil.ToFloat64(tracker.numValidatorIPs))
+	require.Equal(float64(len(tracker.gossipableIPs)), testutil.ToFloat64(tracker.numGossipable))
+	require.Equal(float64(tracker.bloom.Count()), testutil.ToFloat64(tracker.bloomCount))
+	require.Equal(float64(tracker.maxBloomCount), testutil.ToFloat64(tracker.bloomMaxCount))
 }
 
 func TestIPTracker_ManuallyTrack(t *testing.T) {
@@ -120,6 +129,7 @@ func TestIPTracker_ManuallyTrack(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.initialState.ManuallyTrack(test.nodeID)
 			requireEqual(t, test.expectedState, test.initialState)
+			requireMetricsConsistent(t, test.initialState)
 		})
 	}
 }
@@ -237,6 +247,7 @@ func TestIPTracker_AddIP(t *testing.T) {
 			updated := test.initialState.AddIP(test.ip)
 			require.Equal(t, test.expectedUpdated, updated)
 			requireEqual(t, test.expectedState, test.initialState)
+			requireMetricsConsistent(t, test.initialState)
 		})
 	}
 }
@@ -346,6 +357,7 @@ func TestIPTracker_Connected(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.initialState.Connected(test.ip)
 			requireEqual(t, test.expectedState, test.initialState)
+			requireMetricsConsistent(t, test.initialState)
 		})
 	}
 }
@@ -418,6 +430,7 @@ func TestIPTracker_Disconnected(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.initialState.Disconnected(test.nodeID)
 			requireEqual(t, test.expectedState, test.initialState)
+			requireMetricsConsistent(t, test.initialState)
 		})
 	}
 }
@@ -479,6 +492,7 @@ func TestIPTracker_OnValidatorAdded(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.initialState.OnValidatorAdded(test.nodeID, nil, ids.Empty, 0)
 			requireEqual(t, test.expectedState, test.initialState)
+			requireMetricsConsistent(t, test.initialState)
 		})
 	}
 }
@@ -579,6 +593,7 @@ func TestIPTracker_OnValidatorRemoved(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.initialState.OnValidatorRemoved(test.nodeID, 0)
 			requireEqual(t, test.expectedState, test.initialState)
+			requireMetricsConsistent(t, test.initialState)
 		})
 	}
 }
@@ -639,9 +654,11 @@ func TestIPTracker_BloomGrowsWithValidatorSet(t *testing.T) {
 	for i := 0; i < 2048; i++ {
 		tracker.onValidatorAdded(ids.GenerateTestNodeID())
 	}
+	requireMetricsConsistent(t, tracker)
 
 	require.NoError(tracker.ResetBloom())
 	require.Greater(tracker.maxBloomCount, initialMaxBloomCount)
+	requireMetricsConsistent(t, tracker)
 }
 
 func TestIPTracker_BloomResetsDynamically(t *testing.T) {
@@ -654,6 +671,7 @@ func TestIPTracker_BloomResetsDynamically(t *testing.T) {
 	tracker.maxBloomCount = 1
 	tracker.Connected(otherIP)
 	tracker.onValidatorAdded(otherIP.NodeID)
+	requireMetricsConsistent(t, tracker)
 
 	bloomBytes, salt := tracker.Bloom()
 	readFilter, err := bloom.Parse(bloomBytes)
@@ -675,6 +693,7 @@ func TestIPTracker_PreventBloomFilterAddition(t *testing.T) {
 	require.True(tracker.AddIP(newerIP))
 	require.True(tracker.AddIP(newestIP))
 	require.Equal(maxIPEntriesPerValidator, tracker.bloomAdditions[ip.NodeID])
+	requireMetricsConsistent(t, tracker)
 }
 
 func TestIPTracker_ShouldVerifyIP(t *testing.T) {

--- a/network/ip_tracker_test.go
+++ b/network/ip_tracker_test.go
@@ -6,6 +6,8 @@ package network
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -15,7 +17,7 @@ import (
 )
 
 func newTestIPTracker(t *testing.T) *ipTracker {
-	tracker, err := newIPTracker(logging.NoLog{})
+	tracker, err := newIPTracker(logging.NoLog{}, "", prometheus.NewRegistry())
 	require.NoError(t, err)
 	return tracker
 }

--- a/network/network.go
+++ b/network/network.go
@@ -237,7 +237,7 @@ func NewNetwork(
 		return nil, fmt.Errorf("initializing network metrics failed with: %w", err)
 	}
 
-	ipTracker, err := newIPTracker(log)
+	ipTracker, err := newIPTracker(log, config.Namespace, metricsRegisterer)
 	if err != nil {
 		return nil, fmt.Errorf("initializing ip tracker failed with: %w", err)
 	}


### PR DESCRIPTION
## Why this should be merged

Adds observability into the efficiency of the new IP bloom tracking.

## How this works

Adds various metrics.

## How this was tested

- [X] Fuji:
```
# HELP avalanche_network_validator_ips Number of known validator IPs
# TYPE avalanche_network_validator_ips gauge
avalanche_network_validator_ips 305
# HELP avalanche_network_gossipable_ips Number of IPs this node is willing to gossip
# TYPE avalanche_network_gossipable_ips gauge
avalanche_network_gossipable_ips 280
# HELP avalanche_network_ip_bloom_count Number of IP entries added to the bloom
# TYPE avalanche_network_ip_bloom_count gauge
avalanche_network_ip_bloom_count 305
# HELP avalanche_network_ip_bloom_entries Number of entry slots in the IP bloom
# TYPE avalanche_network_ip_bloom_entries gauge
avalanche_network_ip_bloom_entries 2247
# HELP avalanche_network_ip_bloom_hashes Number of hashes in the IP bloom
# TYPE avalanche_network_ip_bloom_hashes gauge
avalanche_network_ip_bloom_hashes 10
# HELP avalanche_network_ip_bloom_max_count Maximum number of IP entries that can be added to the bloom before resetting
# TYPE avalanche_network_ip_bloom_max_count gauge
avalanche_network_ip_bloom_max_count 1792
# HELP avalanche_network_ip_bloom_reset_count Number times the IP bloom has been reset
# TYPE avalanche_network_ip_bloom_reset_count counter
avalanche_network_ip_bloom_reset_count 4
```
with:
```
# HELP avalanche_network_peers Number of network peers
# TYPE avalanche_network_peers gauge
avalanche_network_peers 280
```