### PR TITLE
Move division by 0 check out of the bloom loops

### DIFF
--- a/utils/bloom/filter.go
+++ b/utils/bloom/filter.go
@@ -63,6 +63,7 @@ func (f *Filter) Add(hash uint64) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	_ = 1 % f.numBits // hint to the compiler that numBits is not 0
 	for _, seed := range f.hashSeeds {
 		hash = bits.RotateLeft64(hash, hashRotation) ^ seed
 		index := hash % f.numBits
@@ -119,6 +120,7 @@ func newHashSeeds(count int) ([]uint64, error) {
 func contains(hashSeeds []uint64, entries []byte, hash uint64) bool {
 	var (
 		numBits          = bitsPerByte * uint64(len(entries))
+		_                = 1 % numBits // hint to the compiler that numBits is not 0
 		accumulator byte = 1
 	)
 	for seedIndex := 0; seedIndex < len(hashSeeds) && accumulator != 0; seedIndex++ {


### PR DESCRIPTION
## Why this should be merged

This PR provides hints to the compiler that `numBits` can be assumed to be non-zero when iterating over the bloom filter hashes.

The compiler requires these hints because there is a subtle change in behavior of the function if `len(hashSeeds) == 0`.

![image](https://github.com/ava-labs/avalanchego/assets/22109487/93ef45e7-2974-491a-aa98-a0371503309f)

## How this works

By including `_ = 1 % numBits // hint to the compiler that numBits is not 0` outside of the loop we move the `numBits == 0` division by 0 panic check outside of the loop.

We can see the difference in the compiled code of `contains` here (from `go tool compile -S`):
```diff
...
	FUNCDATA	$5, main.contains.arginfo1(SB)
	FUNCDATA	$6, main.contains.argliveinfo(SB)
	PCDATA	$3, $1
	LSL	$3, R4, R2
+	CBZ	R2, $PANICDIVIDE
	MOVD	ZR, R5
	MOVD	$1, R7
	JMP	$LOOPCMP
UPDATEHASH:
	AND	$7, R8, R8
	MOVBU	(R3)(R9), R9
	LSR	R8, R9, R8
	ADD	$1, R5, R5
	AND	R8, R7, R7
LOOPCMP:
	CMP	R5, R1
	BLE	$EXIT
	MOVBU	R7, R8
	CBZW	R8, $EXIT
	MOVD	(R0)(R5<<3), R8
	EOR	R6@>47, R8, R6
-	CBZ	R2, $PANICDIVIDE
	UDIV	R2, R6, R8
	MSUB	R2, R6, R8, R8
	LSR	$3, R8, R9
	CMP	R8>>3, R4
	BHI	$UPDATEHASH
	JMP$PANICOOB
EXIT:
	MOVBU	R7, R1
	CMPW	$0, R1
	CSET	NE, R0
	LDP	-8(RSP), (R29, R30)
	ADD	$32, RSP
	RET	(R30)
PANICOOB:
	MOVD	R9, R0
	MOVD	R4, R1
	PCDATA	$1, $1
	CALL	runtime.panicIndexU(SB)
PANICDIVIDE:
	CALL	runtime.panicdivide(SB)
...
```

I wasn't able to figure out how to get the compiler to move the `PANICOOB` call out of the loop, which would further optimize the check.

## How this was tested

Before:
```
BenchmarkAdd-12    		43385254	        27.47 ns/op	       0 B/op	       0 allocs/op
BenchmarkContains-12    	52014932	        22.85 ns/op	       0 B/op	       0 allocs/op
```
After:
```
BenchmarkAdd-12    		43245295	        27.08 ns/op	       0 B/op	       0 allocs/op
BenchmarkContains-12    	53046825	        22.50 ns/op	       0 B/op	       0 allocs/op
```
🚀 