### PR TITLE
Revert "Set dependabot target branch to `dev` (#2553)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    target-branch: "dev"


### PR DESCRIPTION
This reverts commit 1bc0378202d8c8cc6fef7543544e19f6f8cbea98.

## Why this should be merged

We'll be switching to working off of `master` after `v1.10.18` is released.

## How this works

pretty straightforward

## How this was tested

CI