### PR TITLE
Bloomfilter metrics union

### DIFF
--- a/network/ip_tracker.go
+++ b/network/ip_tracker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/ips"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/avalanchego/utils/metric"
 	"github.com/ava-labs/avalanchego/utils/sampler"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
@@ -42,7 +43,8 @@ func newIPTracker(
 	namespace string,
 	registerer prometheus.Registerer,
 ) (*ipTracker, error) {
-	bloomMetrics, err := bloom.NewMetrics(namespace+"_ip_bloom", registerer)
+	bloomNamespace := metric.AppendNamespace(namespace, "ip_bloom")
+	bloomMetrics, err := bloom.NewMetrics(bloomNamespace, registerer)
 	if err != nil {
 		return nil, err
 	}

--- a/network/ip_tracker.go
+++ b/network/ip_tracker.go
@@ -42,6 +42,10 @@ func newIPTracker(
 	namespace string,
 	registerer prometheus.Registerer,
 ) (*ipTracker, error) {
+	bloomMetrics, err := bloom.NewMetrics(namespace+"_ip_bloom", registerer)
+	if err != nil {
+		return nil, err
+	}
 	tracker := &ipTracker{
 		log: log,
 		numValidatorIPs: prometheus.NewGauge(prometheus.GaugeOpts{
@@ -54,44 +58,15 @@ func newIPTracker(
 			Name:      "gossipable_ips",
 			Help:      "Number of IPs this node is willing to gossip",
 		}),
-		bloomCount: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "ip_bloom_count",
-			Help:      "Number of IP entries added to the bloom",
-		}),
-		bloomNumHashes: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "ip_bloom_hashes",
-			Help:      "Number of hashes in the IP bloom",
-		}),
-		bloomNumEntries: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "ip_bloom_entries",
-			Help:      "Number of entry slots in the IP bloom",
-		}),
-		bloomMaxCount: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "ip_bloom_max_count",
-			Help:      "Maximum number of IP entries that can be added to the bloom before resetting",
-		}),
-		bloomResetCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "ip_bloom_reset_count",
-			Help:      "Number times the IP bloom has been reset",
-		}),
+		bloomMetrics:           bloomMetrics,
 		connected:              make(map[ids.NodeID]*ips.ClaimedIPPort),
 		mostRecentValidatorIPs: make(map[ids.NodeID]*ips.ClaimedIPPort),
 		gossipableIndicies:     make(map[ids.NodeID]int),
 		bloomAdditions:         make(map[ids.NodeID]int),
 	}
-	err := utils.Err(
+	err = utils.Err(
 		registerer.Register(tracker.numValidatorIPs),
 		registerer.Register(tracker.numGossipable),
-		registerer.Register(tracker.bloomCount),
-		registerer.Register(tracker.bloomNumHashes),
-		registerer.Register(tracker.bloomNumEntries),
-		registerer.Register(tracker.bloomMaxCount),
-		registerer.Register(tracker.bloomResetCount),
 	)
 	if err != nil {
 		return nil, err
@@ -103,11 +78,7 @@ type ipTracker struct {
 	log             logging.Logger
 	numValidatorIPs prometheus.Gauge
 	numGossipable   prometheus.Gauge
-	bloomCount      prometheus.Gauge
-	bloomNumHashes  prometheus.Gauge
-	bloomNumEntries prometheus.Gauge
-	bloomMaxCount   prometheus.Gauge
-	bloomResetCount prometheus.Counter
+	bloomMetrics    *bloom.Metrics
 
 	lock sync.RWMutex
 	// Manually tracked nodes are always treated like validators
@@ -315,7 +286,7 @@ func (i *ipTracker) updateMostRecentValidatorIP(ip *ips.ClaimedIPPort) {
 
 	i.bloomAdditions[ip.NodeID] = oldCount + 1
 	bloom.Add(i.bloom, ip.GossipID[:], i.bloomSalt)
-	i.bloomCount.Inc()
+	i.bloomMetrics.Count.Inc()
 }
 
 func (i *ipTracker) addGossipableIP(ip *ips.ClaimedIPPort) {
@@ -428,10 +399,6 @@ func (i *ipTracker) resetBloom() error {
 		bloom.Add(newFilter, ip.GossipID[:], newSalt)
 		i.bloomAdditions[nodeID] = 1
 	}
-	i.bloomCount.Set(float64(len(i.mostRecentValidatorIPs)))
-	i.bloomNumHashes.Set(float64(numHashes))
-	i.bloomNumEntries.Set(float64(numEntries))
-	i.bloomMaxCount.Set(float64(i.maxBloomCount))
-	i.bloomResetCount.Inc()
+	i.bloomMetrics.Reset(newFilter, i.maxBloomCount)
 	return nil
 }

--- a/network/ip_tracker_test.go
+++ b/network/ip_tracker_test.go
@@ -48,8 +48,8 @@ func requireMetricsConsistent(t *testing.T, tracker *ipTracker) {
 	require := require.New(t)
 	require.Equal(float64(len(tracker.mostRecentValidatorIPs)), testutil.ToFloat64(tracker.numValidatorIPs))
 	require.Equal(float64(len(tracker.gossipableIPs)), testutil.ToFloat64(tracker.numGossipable))
-	require.Equal(float64(tracker.bloom.Count()), testutil.ToFloat64(tracker.bloomCount))
-	require.Equal(float64(tracker.maxBloomCount), testutil.ToFloat64(tracker.bloomMaxCount))
+	require.Equal(float64(tracker.bloom.Count()), testutil.ToFloat64(tracker.bloomMetrics.Count))
+	require.Equal(float64(tracker.maxBloomCount), testutil.ToFloat64(tracker.bloomMetrics.MaxCount))
 }
 
 func TestIPTracker_ManuallyTrack(t *testing.T) {

--- a/network/p2p/gossip/bloom.go
+++ b/network/p2p/gossip/bloom.go
@@ -113,17 +113,16 @@ func resetBloomFilter(
 	targetFalsePositiveProbability,
 	resetFalsePositiveProbability float64,
 ) error {
-	var newSalt ids.ID
-	if _, err := rand.Read(newSalt[:]); err != nil {
-		return err
-	}
-
 	numHashes, numEntries := bloom.OptimalParameters(
 		targetElements,
 		targetFalsePositiveProbability,
 	)
 	newBloom, err := bloom.New(numHashes, numEntries)
 	if err != nil {
+		return err
+	}
+	var newSalt ids.ID
+	if _, err := rand.Read(newSalt[:]); err != nil {
 		return err
 	}
 

--- a/network/p2p/gossip/bloom.go
+++ b/network/p2p/gossip/bloom.go
@@ -101,10 +101,7 @@ func ResetBloomFilterIfNeeded(
 		bloomFilter.targetFalsePositiveProbability,
 		bloomFilter.resetFalsePositiveProbability,
 	)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return err == nil, err
 }
 
 func resetBloomFilter(

--- a/network/p2p/gossip/bloom.go
+++ b/network/p2p/gossip/bloom.go
@@ -9,32 +9,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/bloom"
 	"github.com/ava-labs/avalanchego/utils/math"
 )
-
-type bloomFilterMetrics struct {
-	resetCount prometheus.Counter
-}
-
-// newBloomFilterMetrics returns a common set of metrics
-func newBloomFilterMetrics(
-	registerer prometheus.Registerer,
-	namespace string,
-) (bloomFilterMetrics, error) {
-	m := bloomFilterMetrics{
-		resetCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "reset_count",
-			Help:      "reset count of bloom filter (n)",
-		}),
-	}
-	err := utils.Err(
-		registerer.Register(m.resetCount),
-	)
-	return m, err
-}
 
 // NewBloomFilter returns a new instance of a bloom filter with at least [minTargetElements] elements
 // anticipated at any moment, and a false positive probability of [targetFalsePositiveProbability]. If the
@@ -49,32 +26,24 @@ func NewBloomFilter(
 	targetFalsePositiveProbability,
 	resetFalsePositiveProbability float64,
 ) (*BloomFilter, error) {
-	numHashes, numEntries := bloom.OptimalParameters(
-		minTargetElements,
-		targetFalsePositiveProbability,
-	)
-	b, err := bloom.New(numHashes, numEntries)
+	metrics, err := bloom.NewMetrics(namespace, registerer)
 	if err != nil {
 		return nil, err
 	}
-
-	metrics, err := newBloomFilterMetrics(registerer, namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	salt, err := randomSalt()
-	return &BloomFilter{
+	filter := &BloomFilter{
 		minTargetElements:              minTargetElements,
 		targetFalsePositiveProbability: targetFalsePositiveProbability,
 		resetFalsePositiveProbability:  resetFalsePositiveProbability,
 
 		metrics: metrics,
-
-		maxCount: bloom.EstimateCount(numHashes, numEntries, resetFalsePositiveProbability),
-		bloom:    b,
-		salt:     salt,
-	}, err
+	}
+	err = resetBloomFilter(
+		filter,
+		minTargetElements,
+		targetFalsePositiveProbability,
+		resetFalsePositiveProbability,
+	)
+	return filter, err
 }
 
 type BloomFilter struct {
@@ -82,7 +51,7 @@ type BloomFilter struct {
 	targetFalsePositiveProbability float64
 	resetFalsePositiveProbability  float64
 
-	metrics bloomFilterMetrics
+	metrics *bloom.Metrics
 
 	maxCount int
 	bloom    *bloom.Filter
@@ -95,6 +64,7 @@ type BloomFilter struct {
 func (b *BloomFilter) Add(gossipable Gossipable) {
 	h := gossipable.GossipID()
 	bloom.Add(b.bloom, h[:], b.salt[:])
+	b.metrics.Count.Inc()
 }
 
 func (b *BloomFilter) Has(gossipable Gossipable) bool {
@@ -124,28 +94,43 @@ func ResetBloomFilterIfNeeded(
 		return false, nil
 	}
 
-	numHashes, numEntries := bloom.OptimalParameters(
-		math.Max(bloomFilter.minTargetElements, targetElements),
+	targetElements = math.Max(bloomFilter.minTargetElements, targetElements)
+	err := resetBloomFilter(
+		bloomFilter,
+		targetElements,
 		bloomFilter.targetFalsePositiveProbability,
+		bloomFilter.resetFalsePositiveProbability,
 	)
-	newBloom, err := bloom.New(numHashes, numEntries)
 	if err != nil {
 		return false, err
 	}
-	salt, err := randomSalt()
-	if err != nil {
-		return false, err
-	}
-	bloomFilter.maxCount = bloom.EstimateCount(numHashes, numEntries, bloomFilter.resetFalsePositiveProbability)
-	bloomFilter.bloom = newBloom
-	bloomFilter.salt = salt
-
-	bloomFilter.metrics.resetCount.Inc()
 	return true, nil
 }
 
-func randomSalt() (ids.ID, error) {
-	salt := ids.ID{}
-	_, err := rand.Read(salt[:])
-	return salt, err
+func resetBloomFilter(
+	bloomFilter *BloomFilter,
+	targetElements int,
+	targetFalsePositiveProbability,
+	resetFalsePositiveProbability float64,
+) error {
+	var newSalt ids.ID
+	if _, err := rand.Read(newSalt[:]); err != nil {
+		return err
+	}
+
+	numHashes, numEntries := bloom.OptimalParameters(
+		targetElements,
+		targetFalsePositiveProbability,
+	)
+	newBloom, err := bloom.New(numHashes, numEntries)
+	if err != nil {
+		return err
+	}
+
+	bloomFilter.maxCount = bloom.EstimateCount(numHashes, numEntries, resetFalsePositiveProbability)
+	bloomFilter.bloom = newBloom
+	bloomFilter.salt = newSalt
+
+	bloomFilter.metrics.Reset(newBloom, bloomFilter.maxCount)
+	return nil
 }

--- a/network/p2p/gossip/bloom_test.go
+++ b/network/p2p/gossip/bloom_test.go
@@ -101,7 +101,7 @@ func TestBloomFilterRefresh(t *testing.T) {
 			}
 
 			require.Equal(tt.resetCount, resetCount)
-			require.Equal(float64(tt.resetCount), testutil.ToFloat64(bloom.metrics.resetCount))
+			require.Equal(float64(tt.resetCount), testutil.ToFloat64(bloom.metrics.ResetCount))
 			for _, expected := range tt.expected {
 				require.True(bloom.Has(expected))
 			}

--- a/network/p2p/gossip/bloom_test.go
+++ b/network/p2p/gossip/bloom_test.go
@@ -83,7 +83,7 @@ func TestBloomFilterRefresh(t *testing.T) {
 			bloom, err := NewBloomFilter(prometheus.NewRegistry(), "", tt.minTargetElements, tt.targetFalsePositiveProbability, tt.resetFalsePositiveProbability)
 			require.NoError(err)
 
-			var resetCount uint64 = 1
+			var resetCount uint64
 			for _, item := range tt.add {
 				bloomBytes, saltBytes := bloom.Marshal()
 				initialBloomBytes := slices.Clone(bloomBytes)
@@ -101,7 +101,7 @@ func TestBloomFilterRefresh(t *testing.T) {
 			}
 
 			require.Equal(tt.resetCount, resetCount)
-			require.Equal(float64(tt.resetCount), testutil.ToFloat64(bloom.metrics.ResetCount))
+			require.Equal(float64(tt.resetCount+1), testutil.ToFloat64(bloom.metrics.ResetCount))
 			for _, expected := range tt.expected {
 				require.True(bloom.Has(expected))
 			}

--- a/network/p2p/gossip/bloom_test.go
+++ b/network/p2p/gossip/bloom_test.go
@@ -83,7 +83,7 @@ func TestBloomFilterRefresh(t *testing.T) {
 			bloom, err := NewBloomFilter(prometheus.NewRegistry(), "", tt.minTargetElements, tt.targetFalsePositiveProbability, tt.resetFalsePositiveProbability)
 			require.NoError(err)
 
-			var resetCount uint64
+			var resetCount uint64 = 1
 			for _, item := range tt.add {
 				bloomBytes, saltBytes := bloom.Marshal()
 				initialBloomBytes := slices.Clone(bloomBytes)

--- a/utils/bloom/metrics.go
+++ b/utils/bloom/metrics.go
@@ -60,8 +60,7 @@ func NewMetrics(
 	return m, err
 }
 
-// New creates a new bloom filter with the specified values and updates the
-// reported metrics.
+// Reset the metrics to align with the provided bloom filter and max count.
 func (m *Metrics) Reset(newFilter *Filter, maxCount int) {
 	m.Count.Set(float64(newFilter.Count()))
 	m.NumHashes.Set(float64(len(newFilter.hashSeeds)))

--- a/utils/bloom/metrics.go
+++ b/utils/bloom/metrics.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package bloom
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ava-labs/avalanchego/utils"
+)
+
+// Metrics is a collection of commonly useful metrics when using a long-lived
+// bloom filter.
+type Metrics struct {
+	Count      prometheus.Gauge
+	NumHashes  prometheus.Gauge
+	NumEntries prometheus.Gauge
+	MaxCount   prometheus.Gauge
+	ResetCount prometheus.Counter
+}
+
+func NewMetrics(
+	namespace string,
+	registerer prometheus.Registerer,
+) (*Metrics, error) {
+	m := &Metrics{
+		Count: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "count",
+			Help:      "Number of additions that have been performed to the bloom",
+		}),
+		NumHashes: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "hashes",
+			Help:      "Number of hashes in the bloom",
+		}),
+		NumEntries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "entries",
+			Help:      "Number of entry slots in the bloom",
+		}),
+		MaxCount: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "max_count",
+			Help:      "Maximum number of additions that should be performed to the bloom before resetting",
+		}),
+		ResetCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "reset_count",
+			Help:      "Number times the bloom has been reset",
+		}),
+	}
+	err := utils.Err(
+		registerer.Register(m.Count),
+		registerer.Register(m.NumHashes),
+		registerer.Register(m.NumEntries),
+		registerer.Register(m.MaxCount),
+		registerer.Register(m.ResetCount),
+	)
+	return m, err
+}
+
+// New creates a new bloom filter with the specified values and updates the
+// reported metrics.
+func (m *Metrics) Reset(newFilter *Filter, maxCount int) {
+	m.Count.Set(float64(newFilter.Count()))
+	m.NumHashes.Set(float64(len(newFilter.hashSeeds)))
+	m.NumEntries.Set(float64(len(newFilter.entries)))
+	m.MaxCount.Set(float64(maxCount))
+	m.ResetCount.Inc()
+}


### PR DESCRIPTION
## Why this should be merged

This moved the bloom filter metrics to a common location and shares them between the p2p sdk and networking packages.

- [x] TODO: Rebase on top of #2632 to avoid the potentially incorrect `namespace+"_ip_bloom"` usage.

## How this works

- Adds a new `bloom.Metrics` struct

## How this was tested

- [X] CI