### PR TITLE
Fix `require.ErrorIs` argument order

### DIFF
--- a/network/p2p/network_test.go
+++ b/network/p2p/network_test.go
@@ -614,7 +614,7 @@ func TestNodeSamplerClientOption(t *testing.T) {
 				close(done)
 			}
 
-			require.ErrorIs(tt.expectedErr, err)
+			require.ErrorIs(err, tt.expectedErr)
 			<-done
 		})
 	}

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -336,7 +336,7 @@ func TestPreDurangoNonValidatorNodeBlockBuiltDelaysTests(t *testing.T) {
 		proVM.Set(localTime)
 
 		_, err := proVM.BuildBlock(ctx)
-		require.ErrorIs(errProposerWindowNotStarted, err)
+		require.ErrorIs(err, errProposerWindowNotStarted)
 	}
 
 	{
@@ -346,7 +346,7 @@ func TestPreDurangoNonValidatorNodeBlockBuiltDelaysTests(t *testing.T) {
 		proVM.Set(localTime)
 
 		_, err := proVM.BuildBlock(ctx)
-		require.ErrorIs(errProposerWindowNotStarted, err)
+		require.ErrorIs(err, errProposerWindowNotStarted)
 	}
 
 	{
@@ -356,7 +356,7 @@ func TestPreDurangoNonValidatorNodeBlockBuiltDelaysTests(t *testing.T) {
 		proVM.Set(localTime)
 
 		_, err := proVM.BuildBlock(ctx)
-		require.ErrorIs(errProposerWindowNotStarted, err)
+		require.ErrorIs(err, errProposerWindowNotStarted)
 	}
 
 	{

--- a/vms/proposervm/vm_regression_test.go
+++ b/vms/proposervm/vm_regression_test.go
@@ -77,5 +77,5 @@ func TestProposerVMInitializeShouldFailIfInnerVMCantVerifyItsHeightIndex(t *test
 		nil,
 		nil,
 	)
-	require.ErrorIs(customError, err)
+	require.ErrorIs(err, customError)
 }


### PR DESCRIPTION
## Why this should be merged

`require.ErrorIs` takes in `(err, targetErr)`

## How this works

Reverse the order of the arguments.

## How this was tested

N/A