### PR TITLE
Disable non-security related dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0 # Disable non-security version updates


### PR DESCRIPTION
## Why this should be merged

We very rarely merge dependabot PRs (unless they are security related). They just clutter the open PRs.

## How this works

Restricts the number of open non-security PRs to 0.

This does _not_ impact security related PRs ([ref](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit)).
> This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.

## How this was tested

N/A