### PR TITLE
Cleanup warp signer tests

### DIFF
--- a/vms/platformvm/warp/gwarp/signer_test.go
+++ b/vms/platformvm/warp/gwarp/signer_test.go
@@ -64,9 +64,11 @@ func setupSigner(t testing.TB) *testSigner {
 }
 
 func TestInterface(t *testing.T) {
-	for _, test := range warp.SignerTests {
-		s := setupSigner(t)
-		test(t, s.client, s.sk, s.networkID, s.chainID)
-		s.closeFn()
+	for name, test := range warp.SignerTests {
+		t.Run(name, func(t *testing.T) {
+			s := setupSigner(t)
+			test(t, s.client, s.sk, s.networkID, s.chainID)
+			s.closeFn()
+		})
 	}
 }

--- a/vms/platformvm/warp/signer_test.go
+++ b/vms/platformvm/warp/signer_test.go
@@ -14,13 +14,15 @@ import (
 )
 
 func TestSigner(t *testing.T) {
-	for _, test := range SignerTests {
-		sk, err := bls.NewSecretKey()
-		require.NoError(t, err)
+	for name, test := range SignerTests {
+		t.Run(name, func(t *testing.T) {
+			sk, err := bls.NewSecretKey()
+			require.NoError(t, err)
 
-		chainID := ids.GenerateTestID()
-		s := NewSigner(sk, constants.UnitTestID, chainID)
+			chainID := ids.GenerateTestID()
+			s := NewSigner(sk, constants.UnitTestID, chainID)
 
-		test(t, s, sk, constants.UnitTestID, chainID)
+			test(t, s, sk, constants.UnitTestID, chainID)
+		})
 	}
 }

--- a/vms/platformvm/warp/test_signer.go
+++ b/vms/platformvm/warp/test_signer.go
@@ -14,13 +14,14 @@ import (
 )
 
 // SignerTests is a list of all signer tests
-var SignerTests = []func(t *testing.T, s Signer, sk *bls.SecretKey, networkID uint32, chainID ids.ID){
-	TestSignerWrongChainID,
-	TestSignerVerifies,
+var SignerTests = map[string]func(t *testing.T, s Signer, sk *bls.SecretKey, networkID uint32, chainID ids.ID){
+	"WrongChainID":   TestWrongChainID,
+	"WrongNetworkID": TestWrongNetworkID,
+	"Verifies":       TestVerifies,
 }
 
 // Test that using a random SourceChainID results in an error
-func TestSignerWrongChainID(t *testing.T, s Signer, _ *bls.SecretKey, _ uint32, _ ids.ID) {
+func TestWrongChainID(t *testing.T, s Signer, _ *bls.SecretKey, _ uint32, _ ids.ID) {
 	require := require.New(t)
 
 	msg, err := NewUnsignedMessage(
@@ -36,7 +37,7 @@ func TestSignerWrongChainID(t *testing.T, s Signer, _ *bls.SecretKey, _ uint32, 
 }
 
 // Test that using a different networkID results in an error
-func TestSignerWrongNetworkID(t *testing.T, s Signer, _ *bls.SecretKey, networkID uint32, blockchainID ids.ID) {
+func TestWrongNetworkID(t *testing.T, s Signer, _ *bls.SecretKey, networkID uint32, blockchainID ids.ID) {
 	require := require.New(t)
 
 	msg, err := NewUnsignedMessage(
@@ -52,7 +53,7 @@ func TestSignerWrongNetworkID(t *testing.T, s Signer, _ *bls.SecretKey, networkI
 }
 
 // Test that a signature generated with the signer verifies correctly
-func TestSignerVerifies(t *testing.T, s Signer, sk *bls.SecretKey, networkID uint32, chainID ids.ID) {
+func TestVerifies(t *testing.T, s Signer, sk *bls.SecretKey, networkID uint32, chainID ids.ID) {
 	require := require.New(t)
 
 	msg, err := NewUnsignedMessage(


### PR DESCRIPTION
## Why this should be merged

It's difficult to tell which sub-test fails if we run them sequentially.

## How this works

Uses `t.Run` for each individual test.

## How this was tested

CI