### PR TITLE
Reintroduce the upgrade test against v1.10.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,17 +109,16 @@ jobs:
       - name: Build AvalancheGo Binary
         shell: bash
         run: ./scripts/build.sh
-      # TODO: re-activate this test after there is a compatible tag to use
-      # - name: Run e2e tests
-      #   shell: bash
-      #   run: ./scripts/tests.upgrade.sh
-      # - name: Upload tmpnet network dir
-      #   uses: actions/upload-artifact@v3
-      #   if: always()
-      #   with:
-      #     name: upgrade-tmpnet-data
-      #     path: ${{ env.tmpnet_data_path }}
-      #     if-no-files-found: error
+      - name: Run e2e tests
+        shell: bash
+        run: ./scripts/tests.upgrade.sh
+      - name: Upload tmpnet network dir
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: upgrade-tmpnet-data
+          path: ${{ env.tmpnet_data_path }}
+          if-no-files-found: error
   Lint:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -16,7 +16,7 @@ fi
 # local network, this flag must be updated to the last compatible
 # version with the latest code.
 #
-# v1.10.18 includes restrictions on ports sent over the p2p network, along with
+# v1.10.18 includes restrictions on ports sent over the p2p network along with
 # proposervm and P-chain rule changes on the local network.
 DEFAULT_VERSION="1.10.18"
 

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -16,9 +16,9 @@ fi
 # local network, this flag must be updated to the last compatible
 # version with the latest code.
 #
-# v1.10.17 includes the AWM activation on the C-Chain local network
-# and the inclusion of BLS Public Keys in the network genesis.
-DEFAULT_VERSION="1.10.17"
+# v1.10.18 includes restrictions on ports sent over the p2p network, along with
+# proposervm and P-chain rule changes on the local network.
+DEFAULT_VERSION="1.10.18"
 
 VERSION="${1:-${DEFAULT_VERSION}}"
 if [[ -z "${VERSION}" ]]; then


### PR DESCRIPTION
## Why this should be merged

This was deactivated because of rule changes included in v1.10.18. Now that v1.10.18 is released, we can reintroduce this test.

## How this works

Sets the default version to 1.10.18.

## How this was tested

- [X] CI