### PR TITLE
Cleanup database benchmarks

### DIFF
--- a/database/benchmark_database.go
+++ b/database/benchmark_database.go
@@ -119,7 +119,7 @@ func BenchmarkBatchPut(b *testing.B, db Database, keys, values [][]byte) {
 }
 
 // BenchmarkBatchDelete measures the time it takes to batch delete.
-func BenchmarkBatchDelete(b *testing.B, db Database, keys, values [][]byte) {
+func BenchmarkBatchDelete(b *testing.B, db Database, keys, _ [][]byte) {
 	require.NotEmpty(b, keys)
 	count := len(keys)
 

--- a/database/benchmark_database.go
+++ b/database/benchmark_database.go
@@ -4,7 +4,6 @@
 package database
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -15,16 +14,16 @@ import (
 
 var (
 	// Benchmarks is a list of all database benchmarks
-	Benchmarks = []func(b *testing.B, db Database, name string, keys, values [][]byte){
-		BenchmarkGet,
-		BenchmarkPut,
-		BenchmarkDelete,
-		BenchmarkBatchPut,
-		BenchmarkBatchDelete,
-		BenchmarkBatchWrite,
-		BenchmarkParallelGet,
-		BenchmarkParallelPut,
-		BenchmarkParallelDelete,
+	Benchmarks = map[string]func(b *testing.B, db Database, keys, values [][]byte){
+		"Get":            BenchmarkGet,
+		"Put":            BenchmarkPut,
+		"Delete":         BenchmarkDelete,
+		"BatchPut":       BenchmarkBatchPut,
+		"BatchDelete":    BenchmarkBatchDelete,
+		"BatchWrite":     BenchmarkBatchWrite,
+		"ParallelGet":    BenchmarkParallelGet,
+		"ParallelPut":    BenchmarkParallelPut,
+		"ParallelDelete": BenchmarkParallelDelete,
 	}
 	// BenchmarkSizes to use with each benchmark
 	BenchmarkSizes = [][]int{
@@ -56,169 +55,150 @@ func SetupBenchmark(b *testing.B, count int, keySize, valueSize int) ([][]byte, 
 }
 
 // BenchmarkGet measures the time it takes to get an operation from a database.
-func BenchmarkGet(b *testing.B, db Database, name string, keys, values [][]byte) {
+func BenchmarkGet(b *testing.B, db Database, keys, values [][]byte) {
 	require.NotEmpty(b, keys)
 	count := len(keys)
 
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_db.get", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		require := require.New(b)
+	require := require.New(b)
 
-		for i, key := range keys {
-			value := values[i]
-			require.NoError(db.Put(key, value))
-		}
+	for i, key := range keys {
+		value := values[i]
+		require.NoError(db.Put(key, value))
+	}
 
-		b.ResetTimer()
+	b.ResetTimer()
 
-		// Reads b.N values from the db
-		for i := 0; i < b.N; i++ {
+	// Reads b.N values from the db
+	for i := 0; i < b.N; i++ {
+		_, err := db.Get(keys[i%count])
+		require.NoError(err)
+	}
+}
+
+// BenchmarkPut measures the time it takes to write an operation to a database.
+func BenchmarkPut(b *testing.B, db Database, keys, values [][]byte) {
+	require.NotEmpty(b, keys)
+	count := len(keys)
+
+	// Writes b.N values to the db
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, db.Put(keys[i%count], values[i%count]))
+	}
+}
+
+// BenchmarkDelete measures the time it takes to delete a (k, v) from a database.
+func BenchmarkDelete(b *testing.B, db Database, keys, values [][]byte) {
+	require.NotEmpty(b, keys)
+	count := len(keys)
+
+	require := require.New(b)
+
+	// Writes random values of size _size_ to the database
+	for i, key := range keys {
+		value := values[i]
+		require.NoError(db.Put(key, value))
+	}
+
+	b.ResetTimer()
+
+	// Deletes b.N values from the db
+	for i := 0; i < b.N; i++ {
+		require.NoError(db.Delete(keys[i%count]))
+	}
+}
+
+// BenchmarkBatchPut measures the time it takes to batch put.
+func BenchmarkBatchPut(b *testing.B, db Database, keys, values [][]byte) {
+	require.NotEmpty(b, keys)
+	count := len(keys)
+
+	batch := db.NewBatch()
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, batch.Put(keys[i%count], values[i%count]))
+	}
+}
+
+// BenchmarkBatchDelete measures the time it takes to batch delete.
+func BenchmarkBatchDelete(b *testing.B, db Database, keys, values [][]byte) {
+	require.NotEmpty(b, keys)
+	count := len(keys)
+
+	batch := db.NewBatch()
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, batch.Delete(keys[i%count]))
+	}
+}
+
+// BenchmarkBatchWrite measures the time it takes to batch write.
+func BenchmarkBatchWrite(b *testing.B, db Database, keys, values [][]byte) {
+	require.NotEmpty(b, keys)
+
+	require := require.New(b)
+
+	batch := db.NewBatch()
+	for i, key := range keys {
+		value := values[i]
+		require.NoError(batch.Put(key, value))
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		require.NoError(batch.Write())
+	}
+}
+
+// BenchmarkParallelGet measures the time it takes to read in parallel.
+func BenchmarkParallelGet(b *testing.B, db Database, keys, values [][]byte) {
+	require.NotEmpty(b, keys)
+	count := len(keys)
+
+	require := require.New(b)
+
+	for i, key := range keys {
+		value := values[i]
+		require.NoError(db.Put(key, value))
+	}
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for i := 0; pb.Next(); i++ {
 			_, err := db.Get(keys[i%count])
 			require.NoError(err)
 		}
 	})
 }
 
-// BenchmarkPut measures the time it takes to write an operation to a database.
-func BenchmarkPut(b *testing.B, db Database, name string, keys, values [][]byte) {
+// BenchmarkParallelPut measures the time it takes to write to the db in parallel.
+func BenchmarkParallelPut(b *testing.B, db Database, keys, values [][]byte) {
 	require.NotEmpty(b, keys)
 	count := len(keys)
 
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_db.put", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		// Writes b.N values to the db
-		for i := 0; i < b.N; i++ {
+	b.RunParallel(func(pb *testing.PB) {
+		// Write N values to the db
+		for i := 0; pb.Next(); i++ {
 			require.NoError(b, db.Put(keys[i%count], values[i%count]))
 		}
 	})
 }
 
-// BenchmarkDelete measures the time it takes to delete a (k, v) from a database.
-func BenchmarkDelete(b *testing.B, db Database, name string, keys, values [][]byte) {
+// BenchmarkParallelDelete measures the time it takes to delete a (k, v) from the db.
+func BenchmarkParallelDelete(b *testing.B, db Database, keys, values [][]byte) {
 	require.NotEmpty(b, keys)
 	count := len(keys)
 
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_db.delete", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		require := require.New(b)
+	require := require.New(b)
+	for i, key := range keys {
+		value := values[i]
+		require.NoError(db.Put(key, value))
+	}
+	b.ResetTimer()
 
-		// Writes random values of size _size_ to the database
-		for i, key := range keys {
-			value := values[i]
-			require.NoError(db.Put(key, value))
-		}
-
-		b.ResetTimer()
-
+	b.RunParallel(func(pb *testing.PB) {
 		// Deletes b.N values from the db
-		for i := 0; i < b.N; i++ {
+		for i := 0; pb.Next(); i++ {
 			require.NoError(db.Delete(keys[i%count]))
 		}
-	})
-}
-
-// BenchmarkBatchPut measures the time it takes to batch put.
-func BenchmarkBatchPut(b *testing.B, db Database, name string, keys, values [][]byte) {
-	require.NotEmpty(b, keys)
-	count := len(keys)
-
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_batch.put", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		batch := db.NewBatch()
-		for i := 0; i < b.N; i++ {
-			require.NoError(b, batch.Put(keys[i%count], values[i%count]))
-		}
-	})
-}
-
-// BenchmarkBatchDelete measures the time it takes to batch delete.
-func BenchmarkBatchDelete(b *testing.B, db Database, name string, keys, values [][]byte) {
-	require.NotEmpty(b, keys)
-	count := len(keys)
-
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_batch.delete", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		batch := db.NewBatch()
-		for i := 0; i < b.N; i++ {
-			require.NoError(b, batch.Delete(keys[i%count]))
-		}
-	})
-}
-
-// BenchmarkBatchWrite measures the time it takes to batch write.
-func BenchmarkBatchWrite(b *testing.B, db Database, name string, keys, values [][]byte) {
-	require.NotEmpty(b, keys)
-	count := len(keys)
-
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_batch.write", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		require := require.New(b)
-
-		batch := db.NewBatch()
-		for i, key := range keys {
-			value := values[i]
-			require.NoError(batch.Put(key, value))
-		}
-
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			require.NoError(batch.Write())
-		}
-	})
-}
-
-// BenchmarkParallelGet measures the time it takes to read in parallel.
-func BenchmarkParallelGet(b *testing.B, db Database, name string, keys, values [][]byte) {
-	require.NotEmpty(b, keys)
-	count := len(keys)
-
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_db.get_parallel", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		require := require.New(b)
-
-		for i, key := range keys {
-			value := values[i]
-			require.NoError(db.Put(key, value))
-		}
-
-		b.ResetTimer()
-
-		b.RunParallel(func(pb *testing.PB) {
-			for i := 0; pb.Next(); i++ {
-				_, err := db.Get(keys[i%count])
-				require.NoError(err)
-			}
-		})
-	})
-}
-
-// BenchmarkParallelPut measures the time it takes to write to the db in parallel.
-func BenchmarkParallelPut(b *testing.B, db Database, name string, keys, values [][]byte) {
-	require.NotEmpty(b, keys)
-	count := len(keys)
-
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_db.put_parallel", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		b.RunParallel(func(pb *testing.PB) {
-			// Write N values to the db
-			for i := 0; pb.Next(); i++ {
-				require.NoError(b, db.Put(keys[i%count], values[i%count]))
-			}
-		})
-	})
-}
-
-// BenchmarkParallelDelete measures the time it takes to delete a (k, v) from the db.
-func BenchmarkParallelDelete(b *testing.B, db Database, name string, keys, values [][]byte) {
-	require.NotEmpty(b, keys)
-	count := len(keys)
-
-	b.Run(fmt.Sprintf("%s_%d_pairs_%d_keys_%d_values_db.delete_parallel", name, count, len(keys[0]), len(values[0])), func(b *testing.B) {
-		require := require.New(b)
-		for i, key := range keys {
-			value := values[i]
-			require.NoError(db.Put(key, value))
-		}
-		b.ResetTimer()
-
-		b.RunParallel(func(pb *testing.PB) {
-			// Deletes b.N values from the db
-			for i := 0; pb.Next(); i++ {
-				require.NoError(db.Delete(keys[i%count]))
-			}
-		})
 	})
 }

--- a/database/encdb/db_test.go
+++ b/database/encdb/db_test.go
@@ -4,6 +4,7 @@
 package encdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -46,8 +47,10 @@ func FuzzNewIteratorWithStartAndPrefix(f *testing.F) {
 func BenchmarkInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
-		for _, bench := range database.Benchmarks {
-			bench(b, newDB(b), "encdb", keys, values)
+		for name, bench := range database.Benchmarks {
+			b.Run(fmt.Sprintf("encdb_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				bench(b, newDB(b), keys, values)
+			})
 		}
 	}
 }

--- a/database/leveldb/db_test.go
+++ b/database/leveldb/db_test.go
@@ -4,6 +4,7 @@
 package leveldb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -57,14 +58,16 @@ func FuzzNewIteratorWithStartAndPrefix(f *testing.F) {
 func BenchmarkInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
-		for _, bench := range database.Benchmarks {
-			db := newDB(b)
+		for name, bench := range database.Benchmarks {
+			b.Run(fmt.Sprintf("leveldb_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				db := newDB(b)
 
-			bench(b, db, "leveldb", keys, values)
+				bench(b, db, keys, values)
 
-			// The database may have been closed by the test, so we don't care if it
-			// errors here.
-			_ = db.Close()
+				// The database may have been closed by the test, so we don't care if it
+				// errors here.
+				_ = db.Close()
+			})
 		}
 	}
 }

--- a/database/memdb/db_test.go
+++ b/database/memdb/db_test.go
@@ -4,6 +4,7 @@
 package memdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -30,9 +31,11 @@ func FuzzNewIteratorWithStartAndPrefix(f *testing.F) {
 func BenchmarkInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
-		for _, bench := range database.Benchmarks {
-			db := New()
-			bench(b, db, "memdb", keys, values)
+		for name, bench := range database.Benchmarks {
+			b.Run(fmt.Sprintf("memdb_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				db := New()
+				bench(b, db, keys, values)
+			})
 		}
 	}
 }

--- a/database/meterdb/db_test.go
+++ b/database/meterdb/db_test.go
@@ -4,6 +4,7 @@
 package meterdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,8 +47,10 @@ func FuzzNewIteratorWithStartAndPrefix(f *testing.F) {
 func BenchmarkInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
-		for _, bench := range database.Benchmarks {
-			bench(b, newDB(b), "meterdb", keys, values)
+		for name, bench := range database.Benchmarks {
+			b.Run(fmt.Sprintf("meterdb_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				bench(b, newDB(b), keys, values)
+			})
 		}
 	}
 }

--- a/database/pebble/db_test.go
+++ b/database/pebble/db_test.go
@@ -4,6 +4,7 @@
 package pebble
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,10 +51,12 @@ func FuzzNewIteratorWithStartAndPrefix(f *testing.F) {
 func BenchmarkInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
-		for _, bench := range database.Benchmarks {
-			db := newDB(b)
-			bench(b, db, "pebble", keys, values)
-			_ = db.Close()
+		for name, bench := range database.Benchmarks {
+			b.Run(fmt.Sprintf("pebble_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				db := newDB(b)
+				bench(b, db, keys, values)
+				_ = db.Close()
+			})
 		}
 	}
 }

--- a/database/prefixdb/db_test.go
+++ b/database/prefixdb/db_test.go
@@ -4,6 +4,7 @@
 package prefixdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -37,9 +38,11 @@ func FuzzNewIteratorWithStartAndPrefix(f *testing.F) {
 func BenchmarkInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
-		for _, bench := range database.Benchmarks {
-			db := New([]byte("hello"), memdb.New())
-			bench(b, db, "prefixdb", keys, values)
+		for name, bench := range database.Benchmarks {
+			b.Run(fmt.Sprintf("prefixdb_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				db := New([]byte("hello"), memdb.New())
+				bench(b, db, keys, values)
+			})
 		}
 	}
 }

--- a/database/rpcdb/db_test.go
+++ b/database/rpcdb/db_test.go
@@ -5,6 +5,7 @@ package rpcdb
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -85,10 +86,12 @@ func FuzzNewIteratorWithStartAndPrefix(f *testing.F) {
 func BenchmarkInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
-		for _, bench := range database.Benchmarks {
-			db := setupDB(b)
-			bench(b, db.client, "rpcdb", keys, values)
-			db.closeFn()
+		for name, bench := range database.Benchmarks {
+			b.Run(fmt.Sprintf("rpcdb_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				db := setupDB(b)
+				bench(b, db.client, keys, values)
+				db.closeFn()
+			})
 		}
 	}
 }

--- a/database/versiondb/db_test.go
+++ b/database/versiondb/db_test.go
@@ -4,6 +4,7 @@
 package versiondb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -299,11 +300,13 @@ func TestSetDatabaseClosed(t *testing.T) {
 func BenchmarkInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
-		for _, bench := range database.Benchmarks {
-			baseDB := memdb.New()
-			db := New(baseDB)
-			bench(b, db, "versiondb", keys, values)
-			_ = db.Close()
+		for name, bench := range database.Benchmarks {
+			b.Run(fmt.Sprintf("versiondb_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				baseDB := memdb.New()
+				db := New(baseDB)
+				bench(b, db, keys, values)
+				_ = db.Close()
+			})
 		}
 	}
 }

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -111,10 +111,12 @@ func Benchmark_MerkleDB_DBInterface(b *testing.B) {
 	for _, size := range database.BenchmarkSizes {
 		keys, values := database.SetupBenchmark(b, size[0], size[1], size[2])
 		for _, bf := range validBranchFactors {
-			for _, bench := range database.Benchmarks {
-				db, err := getBasicDBWithBranchFactor(bf)
-				require.NoError(b, err)
-				bench(b, db, fmt.Sprintf("merkledb_%d", bf), keys, values)
+			for name, bench := range database.Benchmarks {
+				b.Run(fmt.Sprintf("merkledb_%d_%d_pairs_%d_keys_%d_values_%s", bf, size[0], size[1], size[2], name), func(b *testing.B) {
+					db, err := getBasicDBWithBranchFactor(bf)
+					require.NoError(b, err)
+					bench(b, db, keys, values)
+				})
 			}
 		}
 	}


### PR DESCRIPTION
## Why this should be merged

The naming structure for database benchmarks was a bit convoluted. This PR simplifies it.

## How this works

They are now standardized to look like this:
`pebble_1024_pairs_32_keys_32_values_BatchWrite`

## How this was tested

manually
