### PR TITLE
`ci`: Update shellcheck.sh to pass all args to shellcheck

### DIFF
--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -17,8 +17,8 @@ SYSTEM_VERSION="$(get_version shellcheck)"
 if [[ "${SYSTEM_VERSION}" == "${VERSION}" ]]; then
   SHELLCHECK=shellcheck
 else
-  SHELLCHECK="${REPO_ROOT}/build/shellcheck"
   # Try to install a local version
+  SHELLCHECK="${REPO_ROOT}/bin/shellcheck"
   LOCAL_VERSION="$(get_version "${SHELLCHECK}")"
   if [[ -z "${LOCAL_VERSION}" || "${LOCAL_VERSION}" != "${VERSION}" ]]; then
     if which sw_vers &> /dev/null; then
@@ -31,9 +31,9 @@ else
       DIST="linux.${arch}"
     fi
     curl -s -L "https://github.com/koalaman/shellcheck/releases/download/${VERSION}/shellcheck-${VERSION}.${DIST}.tar.xz" | tar Jxv -C /tmp > /dev/null
-    mkdir -p "${REPO_ROOT}"/build
+    mkdir -p "$(dirname "${SHELLCHECK}")"
     cp /tmp/shellcheck-"${VERSION}"/shellcheck "${SHELLCHECK}"
   fi
 fi
 
-find "${REPO_ROOT}" -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}"
+find "${REPO_ROOT}" -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}" "${@}"


### PR DESCRIPTION
This is useful to vary the output format (e.g. `-f gcc`) for local execution (the default is more detailed but not as machine-consumable e.g. for editor consumption).