### PR TITLE
Log error if database returns unsorted heights

### DIFF
--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1158,6 +1158,18 @@ func (s *state) ApplyValidatorWeightDiffs(
 		if err != nil {
 			return err
 		}
+
+		if parsedHeight > prevHeight {
+			s.ctx.Log.Error("unexpected parsed height",
+				zap.Stringer("subnetID", subnetID),
+				zap.Uint64("parsedHeight", parsedHeight),
+				zap.Stringer("nodeID", nodeID),
+				zap.Uint64("prevHeight", prevHeight),
+				zap.Uint64("startHeight", startHeight),
+				zap.Uint64("endHeight", endHeight),
+			)
+		}
+
 		// If the parsedHeight is less than our target endHeight, then we have
 		// fully processed the diffs from startHeight through endHeight.
 		if parsedHeight < endHeight {


### PR DESCRIPTION
## Why this should be merged

If triggered, this log would quickly identify that a critical invariant has been broken.

## How this works

`ApplyValidatorWeightDiffs` iterates backwards through the disk applying weight diffs. If the weight diffs were returned out of order, the termination condition wouldn't work properly. This will loudly announce this failure to the node operator.

## How this was tested

N/A