### PR TITLE
Fix P-chain validator set lookup race condition

### DIFF
--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -75,7 +75,7 @@ func (c *Client) AppRequest(
 	c.router.lock.Lock()
 	defer c.router.lock.Unlock()
 
-	appRequestBytes = c.prefixMessage(appRequestBytes)
+	appRequestBytes = PrefixMessage(c.handlerPrefix, appRequestBytes)
 	for nodeID := range nodeIDs {
 		requestID := c.router.requestID
 		if _, ok := c.router.pendingAppRequests[requestID]; ok {
@@ -112,7 +112,7 @@ func (c *Client) AppGossip(
 ) error {
 	return c.sender.SendAppGossip(
 		ctx,
-		c.prefixMessage(appGossipBytes),
+		PrefixMessage(c.handlerPrefix, appGossipBytes),
 	)
 }
 
@@ -125,7 +125,7 @@ func (c *Client) AppGossipSpecific(
 	return c.sender.SendAppGossipSpecific(
 		ctx,
 		nodeIDs,
-		c.prefixMessage(appGossipBytes),
+		PrefixMessage(c.handlerPrefix, appGossipBytes),
 	)
 }
 
@@ -153,7 +153,7 @@ func (c *Client) CrossChainAppRequest(
 		ctx,
 		chainID,
 		requestID,
-		c.prefixMessage(appRequestBytes),
+		PrefixMessage(c.handlerPrefix, appRequestBytes),
 	); err != nil {
 		return err
 	}
@@ -167,15 +167,14 @@ func (c *Client) CrossChainAppRequest(
 	return nil
 }
 
-// prefixMessage prefixes the original message with the handler identifier
-// corresponding to this client.
+// PrefixMessage prefixes the original message with the protocol identifier.
 //
 // Only gossip and request messages need to be prefixed.
 // Response messages don't need to be prefixed because request ids are tracked
 // which map to the expected response handler.
-func (c *Client) prefixMessage(src []byte) []byte {
-	messageBytes := make([]byte, len(c.handlerPrefix)+len(src))
-	copy(messageBytes, c.handlerPrefix)
-	copy(messageBytes[len(c.handlerPrefix):], src)
+func PrefixMessage(prefix, msg []byte) []byte {
+	messageBytes := make([]byte, len(prefix)+len(msg))
+	copy(messageBytes, prefix)
+	copy(messageBytes[len(prefix):], msg)
 	return messageBytes
 }

--- a/network/p2p/gossip/message.go
+++ b/network/p2p/gossip/message.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package gossip
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/proto/pb/sdk"
+	"github.com/ava-labs/avalanchego/utils/bloom"
+)
+
+func MarshalAppRequest(filter, salt []byte) ([]byte, error) {
+	request := &sdk.PullGossipRequest{
+		Filter: filter,
+		Salt:   salt,
+	}
+	return proto.Marshal(request)
+}
+
+func ParseAppRequest(bytes []byte) (*bloom.ReadFilter, ids.ID, error) {
+	request := &sdk.PullGossipRequest{}
+	if err := proto.Unmarshal(bytes, request); err != nil {
+		return nil, ids.Empty, err
+	}
+
+	salt, err := ids.ToID(request.Salt)
+	if err != nil {
+		return nil, ids.Empty, err
+	}
+
+	filter, err := bloom.Parse(request.Filter)
+	return filter, salt, err
+}
+
+func MarshalAppResponse(gossip [][]byte) ([]byte, error) {
+	return proto.Marshal(&sdk.PullGossipResponse{
+		Gossip: gossip,
+	})
+}
+
+func ParseAppResponse(bytes []byte) ([][]byte, error) {
+	response := &sdk.PullGossipResponse{}
+	err := proto.Unmarshal(bytes, response)
+	return response.Gossip, err
+}
+
+func MarshalAppGossip(gossip [][]byte) ([]byte, error) {
+	return proto.Marshal(&sdk.PushGossip{
+		Gossip: gossip,
+	})
+}
+
+func ParseAppGossip(bytes []byte) ([][]byte, error) {
+	msg := &sdk.PushGossip{}
+	err := proto.Unmarshal(bytes, msg)
+	return msg.Gossip, err
+}

--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -217,7 +217,7 @@ func (n *Network) NewClient(handlerID uint64, options ...ClientOption) *Client {
 	client := &Client{
 		handlerID:     handlerID,
 		handlerIDStr:  strconv.FormatUint(handlerID, 10),
-		handlerPrefix: binary.AppendUvarint(nil, handlerID),
+		handlerPrefix: ProtocolPrefix(handlerID),
 		sender:        n.sender,
 		router:        n.router,
 		options: &clientOptions{
@@ -280,4 +280,8 @@ type peerSampler struct {
 
 func (p peerSampler) Sample(_ context.Context, limit int) []ids.NodeID {
 	return p.peers.Sample(limit)
+}
+
+func ProtocolPrefix(handlerID uint64) []byte {
+	return binary.AppendUvarint(nil, handlerID)
 }

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
 )
 
-const txGossipHandlerID = 0
+const TxGossipHandlerID = 0
 
 type Network interface {
 	common.AppHandler
@@ -80,7 +80,7 @@ func New(
 		config.MaxValidatorSetStaleness,
 	)
 	txGossipClient := p2pNetwork.NewClient(
-		txGossipHandlerID,
+		TxGossipHandlerID,
 		p2p.WithValidatorSampling(validators),
 	)
 	txGossipMetrics, err := gossip.NewMetrics(registerer, "tx")
@@ -154,7 +154,7 @@ func New(
 		appRequestHandler: validatorHandler,
 	}
 
-	if err := p2pNetwork.AddHandler(txGossipHandlerID, txGossipHandler); err != nil {
+	if err := p2pNetwork.AddHandler(TxGossipHandlerID, txGossipHandler); err != nil {
 		return nil, err
 	}
 

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -205,7 +205,10 @@ func (vm *VM) Initialize(
 		chainCtx.Log,
 		chainCtx.NodeID,
 		chainCtx.SubnetID,
-		chainCtx.ValidatorState,
+		validators.NewLockedState(
+			&chainCtx.Lock,
+			validatorManager,
+		),
 		txVerifier,
 		mempool,
 		txExecutorBackend.Config.PartialSyncPrimaryNetwork,

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -14,26 +14,33 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/ava-labs/avalanchego/chains"
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/bloom"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/metrics"
+	"github.com/ava-labs/avalanchego/vms/platformvm/network"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -2216,6 +2223,61 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 	// subnet validator whose primary network validator was also removed.
 	_, err = vm.State.GetValidatorSet(context.Background(), subnetStartHeight, subnetID)
 	require.NoError(err)
+}
+
+func TestValidatorSetRaceCondition(t *testing.T) {
+	require := require.New(t)
+	vm, _, _ := defaultVM(t, cortinaFork)
+	vm.ctx.Lock.Lock()
+	defer vm.ctx.Lock.Unlock()
+
+	nodeID := ids.GenerateTestNodeID()
+	require.NoError(vm.Connected(context.Background(), nodeID, version.CurrentApp))
+
+	protocolAppRequestBytest, err := gossip.MarshalAppRequest(
+		bloom.EmptyFilter.Marshal(),
+		ids.Empty[:],
+	)
+	require.NoError(err)
+
+	appRequestBytes := p2p.PrefixMessage(
+		p2p.ProtocolPrefix(network.TxGossipHandlerID),
+		protocolAppRequestBytest,
+	)
+
+	var eg errgroup.Group
+	for i := 0; i < 100; i++ {
+		eg.Go(func() error {
+			return vm.AppRequest(
+				context.Background(),
+				nodeID,
+				0,
+				time.Now().Add(time.Hour),
+				appRequestBytes,
+			)
+		})
+	}
+
+	// If the validator set lock isn't held, the race detector should fail here.
+	for i := uint64(0); i < 100; i++ {
+		blk, err := block.NewBanffStandardBlock(
+			time.Now(),
+			vm.state.GetLastAccepted(),
+			i,
+			nil,
+		)
+		require.NoError(err)
+
+		vm.state.SetLastAccepted(blk.ID())
+		vm.state.SetHeight(blk.Height())
+		vm.state.AddStatelessBlock(blk)
+	}
+
+	// If the validator set lock is grabbed, we need to make sure to release the
+	// lock to avoid a deadlock.
+	vm.ctx.Lock.Unlock()
+	require.NoError(eg.Wait())
+	vm.ctx.Lock.Lock()
 }
 
 func buildAndAcceptStandardBlock(vm *VM) error {

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -2245,21 +2245,31 @@ func TestValidatorSetRaceCondition(t *testing.T) {
 		protocolAppRequestBytest,
 	)
 
-	var eg errgroup.Group
-	for i := 0; i < 100; i++ {
+	var (
+		eg          errgroup.Group
+		ctx, cancel = context.WithCancel(context.Background())
+	)
+	// keep 10 workers running
+	for i := 0; i < 10; i++ {
 		eg.Go(func() error {
-			return vm.AppRequest(
-				context.Background(),
-				nodeID,
-				0,
-				time.Now().Add(time.Hour),
-				appRequestBytes,
-			)
+			for ctx.Err() == nil {
+				err := vm.AppRequest(
+					context.Background(),
+					nodeID,
+					0,
+					time.Now().Add(time.Hour),
+					appRequestBytes,
+				)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
 		})
 	}
 
 	// If the validator set lock isn't held, the race detector should fail here.
-	for i := uint64(0); i < 100; i++ {
+	for i := uint64(0); i < 1000; i++ {
 		blk, err := block.NewBanffStandardBlock(
 			time.Now(),
 			vm.state.GetLastAccepted(),
@@ -2276,6 +2286,7 @@ func TestValidatorSetRaceCondition(t *testing.T) {
 	// If the validator set lock is grabbed, we need to make sure to release the
 	// lock to avoid a deadlock.
 	vm.ctx.Lock.Unlock()
+	cancel() // stop and wait for workers
 	require.NoError(eg.Wait())
 	vm.ctx.Lock.Lock()
 }

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -277,13 +277,14 @@ func defaultVM(t *testing.T, fork activeFork) (*VM, database.Database, *mutableS
 		return nil
 	}
 
+	dynamicConfigBytes := []byte(`{"network":{"max-validator-set-staleness":0}}`)
 	require.NoError(vm.Initialize(
 		context.Background(),
 		ctx,
 		chainDB,
 		genesisBytes,
 		nil,
-		nil,
+		dynamicConfigBytes,
 		msgChan,
 		nil,
 		appSender,


### PR DESCRIPTION
## Why this should be merged

The P-chain p2p network currently fetches the primary network validator set without first grabbing the P-chain context lock. This can result in racy (incorrect) calculations of the validator set that are cached. This can cause persistently incorrect validator set lookups at P-chain heights where this race occurred.

## How this works

- Wraps the `validators.State` passed into the p2p network with the context lock.
- Exports a number of utility functions from the p2p library to facilitate testing.

## How this was tested

- [X] New unit test (fails on master)
- [X] Ran node on fuji