### PR TITLE
`tmpnet`: Ensure restart after chain creation

### DIFF
--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -243,6 +243,19 @@ func (s *Subnet) Write(subnetDir string, chainDir string) error {
 	return nil
 }
 
+// HasChainConfig indicates whether at least one of the subnet's
+// chains have explicit configuration. This can be used to determine
+// whether validator restart is required after chain creation to
+// ensure that chains are configured correctly.
+func (s *Subnet) HasChainConfig() bool {
+	for _, chain := range s.Chains {
+		if len(chain.Config) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func waitForActiveValidators(
 	ctx context.Context,
 	w io.Writer,


### PR DESCRIPTION
A previous iteration of tmpnet created subnets and chains, restarted nodes, and then added validators. This was changed to create subnets, restart nodes, add validators, and create chains. This prevented the correct configuration of any chain that had explicit configuration since the configuration would only be written after the chain was created and nodes need to be restarted to see the new configuration.

So, nodes are now restarted if any chains have explicit configuration.

Restart will be tested in https://github.com/ava-labs/subnet-evm/pull/1027