### PR TITLE
`ci`: Upgrade all workflow actions to versions using Node 20

### DIFF
--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -14,7 +14,7 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.26.1
       - uses: bufbuild/buf-push-action@v1
         with:

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -66,7 +66,7 @@ jobs:
           RELEASE: "focal"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: amd64
           path: /tmp/avalanchego/avalanchego-linux-amd64-${{ env.TAG }}.tar.gz
@@ -80,9 +80,9 @@ jobs:
     runs-on: [self-hosted, linux, ARM64, focal]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -128,7 +128,7 @@ jobs:
           RELEASE: "focal"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: arm64
           path: /tmp/avalanchego/avalanchego-linux-arm64-${{ env.TAG }}.tar.gz

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -23,8 +23,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '~1.20.12'
           check-latest: true
@@ -71,11 +71,11 @@ jobs:
           BUCKET: ${{ secrets.BUCKET }}
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: avalanchego-macos-${{ env.TAG }}.zip
-      
+
       - name: Cleanup
         run: |
           rm -rf ./build

--- a/.github/workflows/build-public-ami.yml
+++ b/.github/workflows/build-public-ami.yml
@@ -16,8 +16,8 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '~1.20.12'
           check-latest: true

--- a/.github/workflows/build-ubuntu-amd64-release.yml
+++ b/.github/workflows/build-ubuntu-amd64-release.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -64,7 +64,7 @@ jobs:
           RELEASE: "jammy"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jammy
           path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
@@ -78,8 +78,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -124,7 +124,7 @@ jobs:
           RELEASE: "focal"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: focal
           path:  /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb

--- a/.github/workflows/build-ubuntu-arm64-release.yml
+++ b/.github/workflows/build-ubuntu-arm64-release.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: [self-hosted, linux, ARM64, jammy]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -64,7 +64,7 @@ jobs:
           RELEASE: "jammy"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jammy
           path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
@@ -78,8 +78,8 @@ jobs:
     runs-on: [self-hosted, linux, ARM64, focal]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -92,7 +92,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt -y install awscli
-      
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -124,7 +124,7 @@ jobs:
           RELEASE: "focal"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: focal
           path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb

--- a/.github/workflows/build-win-release.yml
+++ b/.github/workflows/build-win-release.yml
@@ -22,9 +22,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '~1.20.12'
           check-latest: true
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install awscli
         run: |
-          msiexec.exe /passive /i /n https://awscli.amazonaws.com/AWSCLIV2.msi 
+          msiexec.exe /passive /i /n https://awscli.amazonaws.com/AWSCLIV2.msi
           aws --version
 
       - name: Configure AWS Credentials
@@ -69,9 +69,9 @@ jobs:
 
       - name: Copy to s3
         run: aws s3 cp .\build\avalanchego-win-${{ env.TAG }}-experimental.zip s3://${{ secrets.BUCKET }}/windows/avalanchego-win-${{ env.TAG }}-experimental.zip
-      
+
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: .\build\avalanchego-win-${{ env.TAG }}-experimental.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         os: [macos-12, ubuntu-20.04, ubuntu-22.04, windows-2022, [self-hosted, linux, ARM64, focal], [self-hosted, linux, ARM64, jammy]]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -48,8 +48,8 @@ jobs:
   Fuzz:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -59,8 +59,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -71,7 +71,7 @@ jobs:
         shell: bash
         run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
       - name: Upload tmpnet network dir
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: e2e-tmpnet-data
@@ -80,8 +80,8 @@ jobs:
   e2e_existing_network:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: E2E_SERIAL=1 ./scripts/tests.e2e.existing.sh
       - name: Upload tmpnet network dir
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: e2e-existing-network-tmpnet-data
@@ -101,8 +101,8 @@ jobs:
   Upgrade:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -113,7 +113,7 @@ jobs:
         shell: bash
         run: ./scripts/tests.upgrade.sh
       - name: Upload tmpnet network dir
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: upgrade-tmpnet-data
@@ -122,8 +122,8 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -137,7 +137,7 @@ jobs:
     name: Protobuf Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.26.1
         with:
           github_token: ${{ github.token }}
@@ -148,8 +148,8 @@ jobs:
     name: Up-to-date protobuf
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -162,8 +162,8 @@ jobs:
     name: Up-to-date mocks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -175,8 +175,8 @@ jobs:
     name: Up-to-date go.mod and go.sum
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.go_version }}
           check-latest: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'dev'
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '~1.20.12'
           check-latest: true

--- a/.github/workflows/fuzz_merkledb.yml
+++ b/.github/workflows/fuzz_merkledb.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'dev'
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '~1.20.12'
           check-latest: true

--- a/.github/workflows/net-outage-sim.yml
+++ b/.github/workflows/net-outage-sim.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup docker (avoid conflicts with previous runs)
         shell: bash

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -13,7 +13,7 @@ jobs:
   publish_docker_image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Publish image to DockerHub
         env:
           DOCKER_USERNAME: ${{ secrets.docker_username }}


### PR DESCRIPTION
Node 16 is deprecated and all the actions using 16 are adding warnings to our jobs that risk obscurring more important notifications.
