### PR TITLE
Unblock misconfigured subnets

### DIFF
--- a/snow/engine/snowman/transitive_test.go
+++ b/snow/engine/snowman/transitive_test.go
@@ -3031,7 +3031,7 @@ func TestEngineRepollsMisconfiguredSubnet(t *testing.T) {
 	}
 
 	// Voting for the block that was issued during the period when the validator
-	// set was misconfigured should result in it being accepted succesfully.
+	// set was misconfigured should result in it being accepted successfully.
 	require.NoError(te.Chits(context.Background(), vdr, queryRequestID, blk.ID(), blk.ID(), blk.ID()))
 	require.Equal(choices.Accepted, blk.Status())
 }


### PR DESCRIPTION
## Why this should be merged

Resolves #2594. While this is an unsafe/undesirable configuration. This error has occurred enough that we should probably make it at least recoverable. Especially for users that have no control over the validator set (which can occur on permissioned subnets)

## How this works

If there a blocks processing, we now trigger repolls during the periodic `Gossip` call. This gets the node out of the (generally unexpected) state where there are blocks processing but there are no outstanding polls.

## How this was tested

- [X] Locally on an intentionally misconfigured subnet
- [X] Added regression unit test
- [X] CI