### PR TITLE
Publish docker images with race detection

### DIFF
--- a/.github/workflows/publish_image.sh
+++ b/.github/workflows/publish_image.sh
@@ -14,7 +14,7 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd ../.. && pwd )
 source "$AVALANCHE_PATH"/scripts/constants.sh
 
 # Build current avalanchego
-source "$AVALANCHE_PATH"/scripts/build_image.sh -r
+source "$AVALANCHE_PATH"/scripts/build_image.sh
 
 if [[ $current_branch == "master" ]]; then
   echo "Tagging current avalanchego image as $avalanchego_dockerhub_repo:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN go mod download
 COPY . .
 
 # Build avalanchego
-RUN ./scripts/build.sh
+ARG RACE_FLAG=""
+RUN ./scripts/build.sh ${RACE_FLAG}
 
 # ============= Cleanup Stage ================
 FROM debian:11-slim AS execution

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -15,3 +15,7 @@ commit_hash="${full_commit_hash::8}"
 echo "Building Docker Image with tags: $avalanchego_dockerhub_repo:$commit_hash , $avalanchego_dockerhub_repo:$current_branch"
 docker build -t "$avalanchego_dockerhub_repo:$commit_hash" \
         -t "$avalanchego_dockerhub_repo:$current_branch" "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"
+
+echo "Building Docker Image with tags: $avalanchego_dockerhub_repo:$commit_hash-race , $avalanchego_dockerhub_repo:$current_branch-race"
+docker build --build-arg="RACE_FLAG=-r" -t "$avalanchego_dockerhub_repo:$commit_hash-race" \
+        -t "$avalanchego_dockerhub_repo:$current_branch-race" "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -8,6 +8,11 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Load the constants
 source "$AVALANCHE_PATH"/scripts/constants.sh
 
+if [[ $current_branch == *"-race" ]]; then
+  echo "Branch name must not end in '-race'"
+  exit 1
+fi
+
 # WARNING: this will use the most recent commit even if there are un-committed changes present
 full_commit_hash="$(git --git-dir="$AVALANCHE_PATH/.git" rev-parse HEAD)"
 commit_hash="${full_commit_hash::8}"


### PR DESCRIPTION
## Why this should be merged

Enables users to run avalanchego with race detection enabled inside of docker.

## How this works

- Allows passing in the `-r` flag to `scripts/build.sh` from the dockerfile
- Publishes a second docker image with the same name suffixed by `-race`
- Errors if the name of the branch ends in `-race` (to prevent confusion)

## How this was tested

- [X] [Image without race enabled](https://hub.docker.com/layers/avaplatform/avalanchego/v1.10.20-dockerfile-race-test.0/images/sha256-f9fde8ba8a8f50fdb8cc681ff5eb5867def0066a81d29746ef4230b465e99318?context=explore)
- [X] [Image with race enabled](https://hub.docker.com/layers/avaplatform/avalanchego/v1.10.20-dockerfile-race-test.0-race/images/sha256-7dc0367d50e494a543512c0d145736d1ecb4d4f8502d8de23dfa9253457891eb?context=explore)