### PR TITLE
Remove chain router from node.Config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1387,7 +1387,6 @@ func GetNodeConfig(v *viper.Viper) (node.Config, error) {
 	}
 
 	// Router
-	nodeConfig.ConsensusRouter = &router.ChainRouter{}
 	nodeConfig.RouterHealthConfig, err = getRouterHealthConfig(v, healthCheckAveragerHalflife)
 	if err != nil {
 		return node.Config{}, err

--- a/node/config.go
+++ b/node/config.go
@@ -172,8 +172,6 @@ type Config struct {
 	// Metrics
 	MeterVMEnabled bool `json:"meterVMEnabled"`
 
-	// Router that is used to handle incoming consensus messages
-	ConsensusRouter          router.Router       `json:"-"`
 	RouterHealthConfig       router.HealthConfig `json:"routerHealthConfig"`
 	ConsensusShutdownTimeout time.Duration       `json:"consensusShutdownTimeout"`
 	// Poll for new frontiers every [FrontierPollFrequency]


### PR DESCRIPTION
## Why this should be merged

We used to use this to inject custom chain routers into node instances. We no longer do this, so we can cleanup the router initialization (a bit). I was hoping we could also replace `Initialize` with a constructor... But currently there is a circular dependency between the benchlist manager and the router.

## How this works

- Moves the chain router from the config struct to the node struct.

## How this was tested

- [X] CI