### PR TITLE
Deprecate the auth API

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ const (
 	chainUpgradeFileName = "upgrade"
 	subnetConfigFileExt  = ".json"
 
+	authDeprecationMsg                   = "Auth API is deprecated"
 	ipcDeprecationMsg                    = "IPC API is deprecated"
 	keystoreDeprecationMsg               = "keystore API is deprecated"
 	acceptedFrontierGossipDeprecationMsg = "push-based accepted frontier gossip is deprecated"
@@ -66,6 +67,10 @@ var (
 	// TODO: deprecate "BootstrapIDsKey" and "BootstrapIPsKey"
 	commitThresholdDeprecationMsg = fmt.Sprintf("use --%s instead", SnowCommitThresholdKey)
 	deprecatedKeys                = map[string]string{
+		APIAuthRequiredKey:     authDeprecationMsg,
+		APIAuthPasswordKey:     authDeprecationMsg,
+		APIAuthPasswordFileKey: authDeprecationMsg,
+
 		IpcAPIEnabledKey: ipcDeprecationMsg,
 		IpcsChainIDsKey:  ipcDeprecationMsg,
 		IpcsPathKey:      ipcDeprecationMsg,


### PR DESCRIPTION
## Why this should be merged

The Auth API is really a hammer looking for a nail. In reality it is almost never recommended to use the Auth API. Avalanchego should never expose its APIs publicly, so it should never need to authenticate its callers. If caller identification is required, then it should almost certainly be done at a higher level than the end server (like by a load balancer).

## How this works

Notifies any (I doubt there are any) users of the Auth API that it may be removed in a future release.

## How this was tested

N/A