### PR TITLE
Fix P-chain Shutdown deadlock

### DIFF
--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/gorilla/rpc/v2"
@@ -95,7 +94,6 @@ type VM struct {
 	onShutdownCtx context.Context
 	// Call [onShutdownCtxCancel] to cancel [onShutdownCtx] during Shutdown()
 	onShutdownCtxCancel context.CancelFunc
-	awaitShutdown       sync.WaitGroup
 
 	// TODO: Remove after v1.11.x is activated
 	pruned utils.Atomic[bool]
@@ -221,13 +219,9 @@ func (vm *VM) Initialize(
 	}
 
 	vm.onShutdownCtx, vm.onShutdownCtxCancel = context.WithCancel(context.Background())
-	vm.awaitShutdown.Add(1)
-	go func() {
-		defer vm.awaitShutdown.Done()
-
-		// Invariant: Gossip must never grab the context lock.
-		vm.Network.Gossip(vm.onShutdownCtx)
-	}()
+	// TODO: Wait for this goroutine to exit during Shutdown once the platformvm
+	// has better control of the context lock.
+	go vm.Network.Gossip(vm.onShutdownCtx)
 
 	vm.Builder = blockbuilder.New(
 		mempool,
@@ -431,8 +425,6 @@ func (vm *VM) Shutdown(context.Context) error {
 	}
 
 	vm.onShutdownCtxCancel()
-	vm.awaitShutdown.Wait()
-
 	vm.Builder.ShutdownBlockTimer()
 
 	if vm.bootstrapped.Get() {


### PR DESCRIPTION
## Why this should be merged

Fixes deadlock observed [here](https://github.com/ava-labs/avalanchego/actions/runs/7730161615/job/21074952870?pr=2684#step:5:221).

Currently it's possible that:
1. `Shutdown` is called with the context lock held
2. `Gossip` is called
3. Inside `Gossip` the validator set needs to be recalculated
4. Recalculating the validator set blocks until it can grab the context lock
5. `Shutdown` blocks until `Gossip` returns

## How this works

The options here are:

1. Release the lock in `Shutdown` prior to waiting and then re-grabbing it
2. Not blocking on `Gossip` in `Shutdown`.

This PR takes approach 2. Technically this could cause unexpected warnings to be logged... I felt like this was better than releasing the context lock in `Shutdown`. Hopefully all of this will be cleaned up once we push the context lock into the VMs.

## How this was tested

- [X] CI