### PR TITLE
Wallet get owners from getsubnet call

### DIFF
--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -67,6 +67,8 @@ type Client interface {
 		startUTXOID ids.ID,
 		options ...rpc.Option,
 	) ([][]byte, ids.ShortID, ids.ID, error)
+	// GetSubnet returns information about the specified subnet
+	GetSubnet(ctx context.Context, subnetID ids.ID, options ...rpc.Option) (GetSubnetClientResponse, error)
 	// GetSubnets returns information about the specified subnets
 	//
 	// Deprecated: Subnets should be fetched from a dedicated indexer.

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -530,7 +530,7 @@ type GetSubnetResponse struct {
 	ControlKeys []string    `json:"controlKeys"`
 	Threshold   json.Uint32 `json:"threshold"`
 	// subnet transformation tx ID for a permissionless subnet
-	SubnetTransformationTxID ids.ID `json:"permissionlessTxID"`
+	SubnetTransformationTxID ids.ID `json:"subnetTransformationTxID"`
 }
 
 func (s *Service) GetSubnet(_ *http.Request, args *GetSubnetArgs, response *GetSubnetResponse) error {

--- a/wallet/chain/p/backend.go
+++ b/wallet/chain/p/backend.go
@@ -37,22 +37,7 @@ type backend struct {
 	subnetOwner     map[ids.ID]fx.Owner // subnetID -> owner
 }
 
-func NewBackend(ctx Context, utxos common.ChainUTXOs, subnetTxs map[ids.ID]*txs.Tx) Backend {
-	subnetOwner := make(map[ids.ID]fx.Owner)
-	for txID, tx := range subnetTxs { // first get owners from the CreateSubnetTx
-		createSubnetTx, ok := tx.Unsigned.(*txs.CreateSubnetTx)
-		if !ok {
-			continue
-		}
-		subnetOwner[txID] = createSubnetTx.Owner
-	}
-	for _, tx := range subnetTxs { // then check for TransferSubnetOwnershipTx
-		transferSubnetOwnershipTx, ok := tx.Unsigned.(*txs.TransferSubnetOwnershipTx)
-		if !ok {
-			continue
-		}
-		subnetOwner[transferSubnetOwnershipTx.Subnet] = transferSubnetOwnershipTx.Owner
-	}
+func NewBackend(ctx Context, utxos common.ChainUTXOs, subnetOwner map[ids.ID]fx.Owner) Backend {
 	return &backend{
 		Context:     ctx,
 		ChainUTXOs:  utxos,

--- a/wallet/chain/p/backend.go
+++ b/wallet/chain/p/backend.go
@@ -37,7 +37,22 @@ type backend struct {
 	subnetOwner     map[ids.ID]fx.Owner // subnetID -> owner
 }
 
-func NewBackend(ctx Context, utxos common.ChainUTXOs, subnetOwner map[ids.ID]fx.Owner) Backend {
+func NewBackend(ctx Context, utxos common.ChainUTXOs, subnetTxs map[ids.ID]*txs.Tx) Backend {
+	subnetOwner := make(map[ids.ID]fx.Owner)
+	for txID, tx := range subnetTxs { // first get owners from the CreateSubnetTx
+		createSubnetTx, ok := tx.Unsigned.(*txs.CreateSubnetTx)
+		if !ok {
+			continue
+		}
+		subnetOwner[txID] = createSubnetTx.Owner
+	}
+	for _, tx := range subnetTxs { // then check for TransferSubnetOwnershipTx
+		transferSubnetOwnershipTx, ok := tx.Unsigned.(*txs.TransferSubnetOwnershipTx)
+		if !ok {
+			continue
+		}
+		subnetOwner[transferSubnetOwnershipTx.Subnet] = transferSubnetOwnershipTx.Owner
+	}
 	return &backend{
 		Context:     ctx,
 		ChainUTXOs:  utxos,

--- a/wallet/subnet/primary/wallet.go
+++ b/wallet/subnet/primary/wallet.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/chain/p"
 	"github.com/ava-labs/avalanchego/wallet/chain/x"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
-	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 )
 
 var _ Wallet = (*wallet)(nil)
@@ -117,16 +116,8 @@ func MakeWallet(ctx context.Context, config *WalletConfig) (Wallet, error) {
 		pChainTxs[txID] = tx
 	}
 
-	subnetOwner := map[ids.ID]fx.Owner{}
-	for txID := range config.PChainTxsToFetch {
-		subnetInfo, err := avaxState.PClient.GetSubnet(ctx, txID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	pUTXOs := NewChainUTXOs(constants.PlatformChainID, avaxState.UTXOs)
-	pBackend := p.NewBackend(avaxState.PCTX, pUTXOs, subnetOwner)
+	pBackend := p.NewBackend(avaxState.PCTX, pUTXOs, pChainTxs)
 	pBuilder := p.NewBuilder(avaxAddrs, pBackend)
 	pSigner := p.NewSigner(config.AVAXKeychain, pBackend)
 

--- a/wallet/subnet/primary/wallet.go
+++ b/wallet/subnet/primary/wallet.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/chain/p"
 	"github.com/ava-labs/avalanchego/wallet/chain/x"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 )
 
 var _ Wallet = (*wallet)(nil)
@@ -116,8 +117,16 @@ func MakeWallet(ctx context.Context, config *WalletConfig) (Wallet, error) {
 		pChainTxs[txID] = tx
 	}
 
+	subnetOwner := map[ids.ID]fx.Owner{}
+	for txID := range config.PChainTxsToFetch {
+		subnetInfo, err := avaxState.PClient.GetSubnet(ctx, txID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	pUTXOs := NewChainUTXOs(constants.PlatformChainID, avaxState.UTXOs)
-	pBackend := p.NewBackend(avaxState.PCTX, pUTXOs, pChainTxs)
+	pBackend := p.NewBackend(avaxState.PCTX, pUTXOs, subnetOwner)
 	pBuilder := p.NewBuilder(avaxAddrs, pBackend)
 	pSigner := p.NewSigner(config.AVAXKeychain, pBackend)
 

--- a/wallet/subnet/primary/wallet.go
+++ b/wallet/subnet/primary/wallet.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/chain/p"
 	"github.com/ava-labs/avalanchego/wallet/chain/x"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
 	"golang.org/x/exp/maps"
 )
 


### PR DESCRIPTION
## Why this should be merged
Currently wallet get owner information from given create subnet tx and transfer ownership txs, but that information
can be wrong for partial, of not in sync with db. It also burden client implementations making those to track 
transfer ownership txs. 

## How this works
It uses P-Chain client call GetSubnet to get latest owner directly from database

## How this was tested
CLI test of ownership transfer