### PR TITLE
Move VMAliaser into node from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -985,23 +985,6 @@ func getChainAliases(v *viper.Viper) (map[ids.ID][]string, error) {
 	return getAliases(v, "chain aliases", ChainAliasesContentKey, ChainAliasesFileKey)
 }
 
-func getVMAliaser(v *viper.Viper) (ids.Aliaser, error) {
-	vmAliases, err := getVMAliases(v)
-	if err != nil {
-		return nil, err
-	}
-
-	aliser := ids.NewAliaser()
-	for vmID, aliases := range vmAliases {
-		for _, alias := range aliases {
-			if err := aliser.Alias(vmID, alias); err != nil {
-				return nil, err
-			}
-		}
-	}
-	return aliser, nil
-}
-
 // getPathFromDirKey reads flag value from viper instance and then checks the folder existence
 func getPathFromDirKey(v *viper.Viper, configKey string) (string, error) {
 	configDir := GetExpandedArg(v, configKey)
@@ -1475,7 +1458,7 @@ func GetNodeConfig(v *viper.Viper) (node.Config, error) {
 	}
 
 	// VM Aliases
-	nodeConfig.VMAliaser, err = getVMAliaser(v)
+	nodeConfig.VMAliases, err = getVMAliases(v)
 	if err != nil {
 		return node.Config{}, err
 	}

--- a/genesis/aliases.go
+++ b/genesis/aliases.go
@@ -15,6 +15,20 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
+var (
+	PChainAliases = []string{"P", "platform"}
+	XChainAliases = []string{"X", "avm"}
+	CChainAliases = []string{"C", "evm"}
+	VMAliases     = map[ids.ID][]string{
+		constants.PlatformVMID: {"platform"},
+		constants.AVMID:        {"avm"},
+		constants.EVMID:        {"evm"},
+		secp256k1fx.ID:         {"secp256k1fx"},
+		nftfx.ID:               {"nftfx"},
+		propertyfx.ID:          {"propertyfx"},
+	}
+)
+
 // Aliases returns the default aliases based on the network ID
 func Aliases(genesisBytes []byte) (map[string][]string, map[ids.ID][]string, error) {
 	apiAliases := map[string][]string{
@@ -26,7 +40,7 @@ func Aliases(genesisBytes []byte) (map[string][]string, map[ids.ID][]string, err
 		},
 	}
 	chainAliases := map[ids.ID][]string{
-		constants.PlatformChainID: {"P", "platform"},
+		constants.PlatformChainID: PChainAliases,
 	}
 
 	genesis, err := genesis.Parse(genesisBytes) // TODO let's not re-create genesis to do aliasing
@@ -45,7 +59,7 @@ func Aliases(genesisBytes []byte) (map[string][]string, map[ids.ID][]string, err
 				path.Join(constants.ChainAliasPrefix, "X"),
 				path.Join(constants.ChainAliasPrefix, "avm"),
 			}
-			chainAliases[chainID] = GetXChainAliases()
+			chainAliases[chainID] = XChainAliases
 		case constants.EVMID:
 			apiAliases[endpoint] = []string{
 				"C",
@@ -53,27 +67,8 @@ func Aliases(genesisBytes []byte) (map[string][]string, map[ids.ID][]string, err
 				path.Join(constants.ChainAliasPrefix, "C"),
 				path.Join(constants.ChainAliasPrefix, "evm"),
 			}
-			chainAliases[chainID] = GetCChainAliases()
+			chainAliases[chainID] = CChainAliases
 		}
 	}
 	return apiAliases, chainAliases, nil
-}
-
-func GetCChainAliases() []string {
-	return []string{"C", "evm"}
-}
-
-func GetXChainAliases() []string {
-	return []string{"X", "avm"}
-}
-
-func GetVMAliases() map[ids.ID][]string {
-	return map[ids.ID][]string{
-		constants.PlatformVMID: {"platform"},
-		constants.AVMID:        {"avm"},
-		constants.EVMID:        {"evm"},
-		secp256k1fx.ID:         {"secp256k1fx"},
-		nftfx.ID:               {"nftfx"},
-		propertyfx.ID:          {"propertyfx"},
-	}
 }

--- a/node/config.go
+++ b/node/config.go
@@ -187,7 +187,7 @@ type Config struct {
 	ChainConfigs map[string]chains.ChainConfig `json:"-"`
 	ChainAliases map[ids.ID][]string           `json:"chainAliases"`
 
-	VMAliaser ids.Aliaser `json:"-"`
+	VMAliases map[ids.ID][]string `json:"vmAliases"`
 
 	// Halflife to use for the processing requests tracker.
 	// Larger halflife --> usage metrics change more slowly.


### PR DESCRIPTION
## Why this should be merged

I'm working to try to clean up some of the node package. Currently there is no reason that we initialize the alias manager in the config code. This moves the logic into the node package.

## How this works

Shuffles some code around a bit

## How this was tested

- [X] CI