### PR TITLE
Cleanup ID initialization

### DIFF
--- a/ids/id.go
+++ b/ids/id.go
@@ -46,6 +46,15 @@ func FromString(idStr string) (ID, error) {
 	return ToID(bytes)
 }
 
+// FromStringOrPanic is the same as FromString, but will panic on error
+func FromStringOrPanic(idStr string) ID {
+	id, err := FromString(idStr)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 func (id ID) MarshalJSON() ([]byte, error) {
 	str, err := cb58.Encode(id[:])
 	if err != nil {

--- a/version/constants.go
+++ b/version/constants.go
@@ -123,7 +123,18 @@ var (
 		constants.MainnetID: time.Date(2023, time.April, 25, 15, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2023, time.April, 6, 15, 0, 0, 0, time.UTC),
 	}
-	CortinaXChainStopVertexID map[uint32]ids.ID
+	CortinaXChainStopVertexID = map[uint32]ids.ID{
+		// The mainnet stop vertex is well known. It can be verified on any
+		// fully synced node by looking at the parentID of the genesis block.
+		//
+		// Ref: https://subnets.avax.network/x-chain/block/0
+		constants.MainnetID: ids.FromStringOrPanic("jrGWDh5Po9FMj54depyunNixpia5PN4aAYxfmNzU8n752Rjga"),
+		// The fuji stop vertex is well known. It can be verified on any fully
+		// synced node by looking at the parentID of the genesis block.
+		//
+		// Ref: https://subnets-test.avax.network/x-chain/block/0
+		constants.FujiID: ids.FromStringOrPanic("2D1cmbiG36BqQMRyHt4kFhWarmatA1ighSpND3FeFgz3vFVtCZ"),
+	}
 
 	// TODO: update this before release
 	DurangoTimes = map[uint32]time.Time{
@@ -150,29 +161,6 @@ func init() {
 			versions[i] = version
 		}
 		RPCChainVMProtocolCompatibility[rpcChainVMProtocol] = versions
-	}
-
-	// The mainnet stop vertex is well known. It can be verified on any fully
-	// synced node by looking at the parentID of the genesis block.
-	//
-	// Ref: https://subnets.avax.network/x-chain/block/0
-	mainnetXChainStopVertexID, err := ids.FromString("jrGWDh5Po9FMj54depyunNixpia5PN4aAYxfmNzU8n752Rjga")
-	if err != nil {
-		panic(err)
-	}
-
-	// The fuji stop vertex is well known. It can be verified on any fully
-	// synced node by looking at the parentID of the genesis block.
-	//
-	// Ref: https://subnets-test.avax.network/x-chain/block/0
-	fujiXChainStopVertexID, err := ids.FromString("2D1cmbiG36BqQMRyHt4kFhWarmatA1ighSpND3FeFgz3vFVtCZ")
-	if err != nil {
-		panic(err)
-	}
-
-	CortinaXChainStopVertexID = map[uint32]ids.ID{
-		constants.MainnetID: mainnetXChainStopVertexID,
-		constants.FujiID:    fujiXChainStopVertexID,
 	}
 }
 

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -57,26 +57,13 @@ var (
 	_ block.StateSyncableVM = (*VM)(nil)
 
 	// TODO: remove after the X-chain supports height indexing.
-	mainnetXChainID ids.ID
-	fujiXChainID    ids.ID
+	mainnetXChainID = ids.FromStringOrPanic("2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM")
+	fujiXChainID    = ids.FromStringOrPanic("2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm")
 
 	dbPrefix = []byte("proposervm")
 
 	errHeightIndexInvalidWhilePruning = errors.New("height index invalid while pruning old blocks")
 )
-
-func init() {
-	var err error
-	mainnetXChainID, err = ids.FromString("2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM")
-	if err != nil {
-		panic(err)
-	}
-
-	fujiXChainID, err = ids.FromString("2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm")
-	if err != nil {
-		panic(err)
-	}
-}
 
 func cachedBlockSize(_ ids.ID, blk snowman.Block) int {
 	return ids.IDLen + len(blk.Bytes()) + constants.PointerOverhead


### PR DESCRIPTION
## Why this should be merged

Cleans up ID initialization a bit. Was working on a PR that resulted in encoding a number of IDs and felt that this would make it a lot more clear.

## How this works

Adds a new ID parser that panics on error.

## How this was tested

- [X] CI