### PR TITLE
x/sync: Remove duplicated call to TrackBandwidth

### DIFF
--- a/x/sync/response_handler.go
+++ b/x/sync/response_handler.go
@@ -20,20 +20,22 @@ func newResponseHandler() *responseHandler {
 
 // Implements [ResponseHandler].
 // Used to wait for a response after making a synchronous request.
-// responseChan may contain response bytes if the original request has not failed.
+// responseChan contains response bytes if the request succeeded.
 // responseChan is closed in either fail or success scenario.
 type responseHandler struct {
 	// If [OnResponse] is called, the response bytes are sent on this channel.
+	// If [OnFailure] is called, the channel is closed without sending bytes.
 	responseChan chan []byte
 }
 
-// OnResponse passes the response bytes to the responseChan and closes the channel
+// OnResponse passes the response bytes to the responseChan and closes the
+// channel.
 func (h *responseHandler) OnResponse(response []byte) {
 	h.responseChan <- response
 	close(h.responseChan)
 }
 
-// OnFailure sets the failed flag to true and closes the channel
+// OnFailure closes the channel.
 func (h *responseHandler) OnFailure() {
 	close(h.responseChan)
 }

--- a/x/sync/response_handler.go
+++ b/x/sync/response_handler.go
@@ -25,8 +25,6 @@ func newResponseHandler() *responseHandler {
 type responseHandler struct {
 	// If [OnResponse] is called, the response bytes are sent on this channel.
 	responseChan chan []byte
-	// Set to true in [OnFailure].
-	failed bool
 }
 
 // OnResponse passes the response bytes to the responseChan and closes the channel
@@ -37,6 +35,5 @@ func (h *responseHandler) OnResponse(response []byte) {
 
 // OnFailure sets the failed flag to true and closes the channel
 func (h *responseHandler) OnFailure() {
-	h.failed = true
 	close(h.responseChan)
 }


### PR DESCRIPTION
## Why this should be merged

Currently a failed request will pass an empty `response` through the `responseChan` when the channel is `close`d. Because `failed` was set to `true` it would then call `TrackBandwidth` again with `0`.

## How this works

Removes the `failed` flag entirely and just uses the channel information.

## How this was tested

This code doesn't seem to be tested 🤔 