### PR TITLE
Fix minor errors in x/sync tests

### DIFF
--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -441,7 +441,7 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 	// next key at prefix of newly added point
 	nextKey, err := syncer.findNextKey(context.Background(), lastKey, maybe.Nothing[[]byte](), proof.EndProof)
 	require.NoError(err)
-	require.NotNil(nextKey)
+	require.True(nextKey.HasValue())
 
 	require.True(isPrefix(midPointVal, nextKey.Value()))
 
@@ -455,7 +455,7 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 	// next key at prefix of newly added point
 	nextKey, err = syncer.findNextKey(context.Background(), lastKey, maybe.Nothing[[]byte](), proof.EndProof)
 	require.NoError(err)
-	require.NotNil(nextKey)
+	require.True(nextKey.HasValue())
 
 	// deal with odd length key
 	require.True(isPrefix(midPointVal, nextKey.Value()))
@@ -572,7 +572,8 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 
 	nextKey, err := syncer.findNextKey(context.Background(), proof.KeyValues[len(proof.KeyValues)-1].Key, maybe.Nothing[[]byte](), proof.EndProof)
 	require.NoError(err)
-	require.Equal(nextKey.Value(), lastKey)
+	require.True(nextKey.HasValue())
+	require.Equal(lastKey, nextKey.Value())
 }
 
 // Test findNextKey by computing the expected result in a naive, inefficient


### PR DESCRIPTION
## Why this should be merged

- `NotNil` shouldn't be used for `struct`s. As a struct can never be `nil`.
- I feel like we shouldn't be calling `Value` before verifying `HasValue`.

## How this works

Updates tests

## How this was tested

- [X] CI