### PR TITLE
Refactor chain manager subnets

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -233,6 +233,8 @@ type ManagerConfig struct {
 	StateSyncBeacons []ids.NodeID
 
 	ChainDataDir string
+
+	Subnets *Subnets
 }
 
 type manager struct {
@@ -268,13 +270,12 @@ type manager struct {
 }
 
 // New returns a new Manager
-func New(config *ManagerConfig, subnets *Subnets) Manager {
+func New(config *ManagerConfig) Manager {
 	return &manager{
 		Aliaser:                ids.NewAliaser(),
 		ManagerConfig:          *config,
 		stakingSigner:          config.StakingTLSCert.PrivateKey.(crypto.Signer),
 		stakingCert:            staking.CertificateFromX509(config.StakingTLSCert.Leaf),
-		subnets:                subnets,
 		chains:                 make(map[ids.ID]handler.Handler),
 		chainsQueue:            buffer.NewUnboundedBlockingDeque[ChainParameters](initialQueueSize),
 		unblockChainCreatorCh:  make(chan struct{}),

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -94,11 +94,11 @@ var (
 	// Bootstrapping prefixes for ChainVMs
 	ChainBootstrappingDBPrefix = []byte("bs")
 
-	errUnknownVMType           = errors.New("the vm should have type avalanche.DAGVM or snowman.ChainVM")
-	errCreatePlatformVM        = errors.New("attempted to create a chain running the PlatformVM")
-	errNotBootstrapped         = errors.New("subnets not bootstrapped")
-	errNoPrimaryNetworkConfig  = errors.New("no subnet config for primary network found")
-	errPartialSyncAsAValidator = errors.New("partial sync should not be configured for a validator")
+	errUnknownVMType            = errors.New("the vm should have type avalanche.DAGVM or snowman.ChainVM")
+	errCreatePlatformVM         = errors.New("attempted to create a chain running the PlatformVM")
+	errNotBootstrapped          = errors.New("subnets not bootstrapped")
+	errPrimaryNetworkNotRunning = errors.New("node is not running the primary network")
+	errPartialSyncAsAValidator  = errors.New("partial sync should not be configured for a validator")
 
 	fxs = map[ids.ID]fx.Factory{
 		secp256k1fx.ID: &secp256k1fx.Factory{},
@@ -256,10 +256,7 @@ type manager struct {
 	chainCreatorShutdownCh chan struct{}
 	chainCreatorExited     sync.WaitGroup
 
-	subnetsLock sync.RWMutex
-	// Key: Subnet's ID
-	// Value: Subnet description
-	subnets map[ids.ID]subnets.Subnet
+	subnets *Subnets
 
 	chainsLock sync.Mutex
 	// Key: Chain's ID
@@ -271,13 +268,13 @@ type manager struct {
 }
 
 // New returns a new Manager
-func New(config *ManagerConfig) Manager {
+func New(config *ManagerConfig, subnets *Subnets) Manager {
 	return &manager{
 		Aliaser:                ids.NewAliaser(),
 		ManagerConfig:          *config,
 		stakingSigner:          config.StakingTLSCert.PrivateKey.(crypto.Signer),
 		stakingCert:            staking.CertificateFromX509(config.StakingTLSCert.Leaf),
-		subnets:                make(map[ids.ID]subnets.Subnet),
+		subnets:                subnets,
 		chains:                 make(map[ids.ID]handler.Handler),
 		chainsQueue:            buffer.NewUnboundedBlockingDeque[ChainParameters](initialQueueSize),
 		unblockChainCreatorCh:  make(chan struct{}),
@@ -288,25 +285,11 @@ func New(config *ManagerConfig) Manager {
 // QueueChainCreation queues a chain creation request
 // Invariant: Tracked Subnet must be checked before calling this function
 func (m *manager) QueueChainCreation(chainParams ChainParameters) {
-	m.subnetsLock.Lock()
-	subnetID := chainParams.SubnetID
-	sb, exists := m.subnets[subnetID]
-	if !exists {
-		sbConfig, ok := m.SubnetConfigs[subnetID]
-		if !ok {
-			// default to primary subnet config
-			sbConfig = m.SubnetConfigs[constants.PrimaryNetworkID]
-		}
-		sb = subnets.New(m.NodeID, sbConfig)
-		m.subnets[chainParams.SubnetID] = sb
-	}
-	addedChain := sb.AddChain(chainParams.ID)
-	m.subnetsLock.Unlock()
-
-	if !addedChain {
+	_ = m.subnets.Add(chainParams.SubnetID)
+	if sb, _ := m.subnets.Get(chainParams.SubnetID); !sb.AddChain(chainParams.ID) {
 		m.Log.Debug("skipping chain creation",
 			zap.String("reason", "chain already staged"),
-			zap.Stringer("subnetID", subnetID),
+			zap.Stringer("subnetID", chainParams.SubnetID),
 			zap.Stringer("chainID", chainParams.ID),
 			zap.Stringer("vmID", chainParams.VMID),
 		)
@@ -316,7 +299,7 @@ func (m *manager) QueueChainCreation(chainParams ChainParameters) {
 	if ok := m.chainsQueue.PushRight(chainParams); !ok {
 		m.Log.Warn("skipping chain creation",
 			zap.String("reason", "couldn't enqueue chain"),
-			zap.Stringer("subnetID", subnetID),
+			zap.Stringer("subnetID", chainParams.SubnetID),
 			zap.Stringer("chainID", chainParams.ID),
 			zap.Stringer("vmID", chainParams.VMID),
 		)
@@ -334,9 +317,7 @@ func (m *manager) createChain(chainParams ChainParameters) {
 		zap.Stringer("vmID", chainParams.VMID),
 	)
 
-	m.subnetsLock.RLock()
-	sb := m.subnets[chainParams.SubnetID]
-	m.subnetsLock.RUnlock()
+	sb, _ := m.subnets.Get(chainParams.SubnetID)
 
 	// Note: buildChain builds all chain's relevant objects (notably engine and handler)
 	// but does not start their operations. Starting of the handler (which could potentially
@@ -1307,23 +1288,9 @@ func (m *manager) IsBootstrapped(id ids.ID) bool {
 	return chain.Context().State.Get().State == snow.NormalOp
 }
 
-func (m *manager) subnetsNotBootstrapped() []ids.ID {
-	m.subnetsLock.RLock()
-	defer m.subnetsLock.RUnlock()
-
-	subnetsBootstrapping := make([]ids.ID, 0, len(m.subnets))
-	for subnetID, subnet := range m.subnets {
-		if !subnet.IsBootstrapped() {
-			subnetsBootstrapping = append(subnetsBootstrapping, subnetID)
-		}
-	}
-	return subnetsBootstrapping
-}
-
 func (m *manager) registerBootstrappedHealthChecks() error {
 	bootstrappedCheck := health.CheckerFunc(func(context.Context) (interface{}, error) {
-		subnetIDs := m.subnetsNotBootstrapped()
-		if len(subnetIDs) != 0 {
+		if subnetIDs := m.subnets.Bootstrapping(); len(subnetIDs) != 0 {
 			return subnetIDs, errNotBootstrapped
 		}
 		return []ids.ID{}, nil
@@ -1365,18 +1332,12 @@ func (m *manager) registerBootstrappedHealthChecks() error {
 
 // Starts chain creation loop to process queued chains
 func (m *manager) StartChainCreator(platformParams ChainParameters) error {
-	// Get the Primary Network's subnet config. If it wasn't registered, then we
-	// throw a fatal error.
-	sbConfig, ok := m.SubnetConfigs[constants.PrimaryNetworkID]
+	// Add the P-Chain to the Primary Network
+	sb, ok := m.subnets.Get(constants.PrimaryNetworkID)
 	if !ok {
-		return errNoPrimaryNetworkConfig
+		return errPrimaryNetworkNotRunning
 	}
-
-	sb := subnets.New(m.NodeID, sbConfig)
-	m.subnetsLock.Lock()
-	m.subnets[platformParams.SubnetID] = sb
 	sb.AddChain(platformParams.ID)
-	m.subnetsLock.Unlock()
 
 	// The P-chain is created synchronously to ensure that `VM.Initialize` has
 	// finished before returning from this function. This is required because

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -94,11 +94,10 @@ var (
 	// Bootstrapping prefixes for ChainVMs
 	ChainBootstrappingDBPrefix = []byte("bs")
 
-	errUnknownVMType            = errors.New("the vm should have type avalanche.DAGVM or snowman.ChainVM")
-	errCreatePlatformVM         = errors.New("attempted to create a chain running the PlatformVM")
-	errNotBootstrapped          = errors.New("subnets not bootstrapped")
-	errPrimaryNetworkNotRunning = errors.New("node is not running the primary network")
-	errPartialSyncAsAValidator  = errors.New("partial sync should not be configured for a validator")
+	errUnknownVMType           = errors.New("the vm should have type avalanche.DAGVM or snowman.ChainVM")
+	errCreatePlatformVM        = errors.New("attempted to create a chain running the PlatformVM")
+	errNotBootstrapped         = errors.New("subnets not bootstrapped")
+	errPartialSyncAsAValidator = errors.New("partial sync should not be configured for a validator")
 
 	fxs = map[ids.ID]fx.Factory{
 		secp256k1fx.ID: &secp256k1fx.Factory{},

--- a/chains/subnets.go
+++ b/chains/subnets.go
@@ -14,24 +14,6 @@ import (
 
 var ErrNoPrimaryNetworkConfig = errors.New("no subnet config for primary network found")
 
-func NewSubnets(
-	nodeID ids.NodeID,
-	configs map[ids.ID]subnets.Config,
-) (*Subnets, error) {
-	if _, ok := configs[constants.PrimaryNetworkID]; !ok {
-		return nil, ErrNoPrimaryNetworkConfig
-	}
-
-	s := &Subnets{
-		nodeID:  nodeID,
-		configs: configs,
-		subnets: make(map[ids.ID]subnets.Subnet),
-	}
-
-	_ = s.Add(constants.PrimaryNetworkID)
-	return s, nil
-}
-
 // Subnets holds the currently running subnets on this node
 type Subnets struct {
 	nodeID  ids.NodeID
@@ -41,7 +23,8 @@ type Subnets struct {
 	subnets map[ids.ID]subnets.Subnet
 }
 
-// Add a subnet that is being run on this node
+// Add a subnet that is being run on this node. Returns if the node was added
+// or not.
 func (s *Subnets) Add(subnetID ids.ID) bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -61,7 +44,8 @@ func (s *Subnets) Add(subnetID ids.ID) bool {
 	return true
 }
 
-// Get returns a subnet if it is being run on this node
+// Get returns a subnet if it is being run on this node. Returns the subnet
+// if it was present.
 func (s *Subnets) Get(subnetID ids.ID) (subnets.Subnet, bool) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -84,4 +68,22 @@ func (s *Subnets) Bootstrapping() []ids.ID {
 	}
 
 	return subnetsBootstrapping
+}
+
+func NewSubnets(
+	nodeID ids.NodeID,
+	configs map[ids.ID]subnets.Config,
+) (*Subnets, error) {
+	if _, ok := configs[constants.PrimaryNetworkID]; !ok {
+		return nil, ErrNoPrimaryNetworkConfig
+	}
+
+	s := &Subnets{
+		nodeID:  nodeID,
+		configs: configs,
+		subnets: make(map[ids.ID]subnets.Subnet),
+	}
+
+	_ = s.Add(constants.PrimaryNetworkID)
+	return s, nil
 }

--- a/chains/subnets.go
+++ b/chains/subnets.go
@@ -23,7 +23,7 @@ type Subnets struct {
 	subnets map[ids.ID]subnets.Subnet
 }
 
-// Add a subnet that is being run on this node. Returns if the node was added
+// Add a subnet that is being run on this node. Returns if the subnet was added
 // or not.
 func (s *Subnets) Add(subnetID ids.ID) bool {
 	s.lock.Lock()

--- a/chains/subnets.go
+++ b/chains/subnets.go
@@ -70,7 +70,7 @@ func (s *Subnets) Get(subnetID ids.ID) (subnets.Subnet, bool) {
 	return subnet, ok
 }
 
-// Bootstrapping returns subnets that have any chains that are still
+// Bootstrapping returns the subnetIDs of any chains that are still
 // bootstrapping.
 func (s *Subnets) Bootstrapping() []ids.ID {
 	s.lock.Lock()

--- a/chains/subnets.go
+++ b/chains/subnets.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package chains
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/subnets"
+	"github.com/ava-labs/avalanchego/utils/constants"
+)
+
+var ErrNoPrimaryNetworkConfig = errors.New("no subnet config for primary network found")
+
+func NewSubnets(
+	nodeID ids.NodeID,
+	configs map[ids.ID]subnets.Config,
+) (*Subnets, error) {
+	if _, ok := configs[constants.PrimaryNetworkID]; !ok {
+		return nil, ErrNoPrimaryNetworkConfig
+	}
+
+	s := &Subnets{
+		nodeID:  nodeID,
+		configs: configs,
+		subnets: make(map[ids.ID]subnets.Subnet),
+	}
+
+	_ = s.Add(constants.PrimaryNetworkID)
+	return s, nil
+}
+
+// Subnets holds the currently running subnets on this node
+type Subnets struct {
+	nodeID  ids.NodeID
+	configs map[ids.ID]subnets.Config
+
+	lock    sync.Mutex
+	subnets map[ids.ID]subnets.Subnet
+}
+
+// Add a subnet that is being run on this node
+func (s *Subnets) Add(subnetID ids.ID) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, ok := s.subnets[subnetID]; ok {
+		return false
+	}
+
+	// Default to the primary network config if a subnet config was not
+	// specified
+	config, ok := s.configs[subnetID]
+	if !ok {
+		config = s.configs[constants.PrimaryNetworkID]
+	}
+
+	s.subnets[subnetID] = subnets.New(s.nodeID, config)
+	return true
+}
+
+// Get returns a subnet if it is being run on this node
+func (s *Subnets) Get(subnetID ids.ID) (subnets.Subnet, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	subnet, ok := s.subnets[subnetID]
+	return subnet, ok
+}
+
+// Bootstrapping returns subnets that have any chains that are still
+// bootstrapping.
+func (s *Subnets) Bootstrapping() []ids.ID {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	subnetsBootstrapping := make([]ids.ID, 0, len(s.subnets))
+	for subnetID, subnet := range s.subnets {
+		if !subnet.IsBootstrapped() {
+			subnetsBootstrapping = append(subnetsBootstrapping, subnetID)
+		}
+	}
+
+	return subnetsBootstrapping
+}

--- a/chains/subnets.go
+++ b/chains/subnets.go
@@ -19,7 +19,7 @@ type Subnets struct {
 	nodeID  ids.NodeID
 	configs map[ids.ID]subnets.Config
 
-	lock    sync.Mutex
+	lock    sync.RWMutex
 	subnets map[ids.ID]subnets.Subnet
 }
 
@@ -47,8 +47,8 @@ func (s *Subnets) Add(subnetID ids.ID) bool {
 // Get returns a subnet if it is being run on this node. Returns the subnet
 // if it was present.
 func (s *Subnets) Get(subnetID ids.ID) (subnets.Subnet, bool) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
 	subnet, ok := s.subnets[subnetID]
 	return subnet, ok
@@ -57,8 +57,8 @@ func (s *Subnets) Get(subnetID ids.ID) (subnets.Subnet, bool) {
 // Bootstrapping returns the subnetIDs of any chains that are still
 // bootstrapping.
 func (s *Subnets) Bootstrapping() []ids.ID {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
 	subnetsBootstrapping := make([]ids.ID, 0, len(s.subnets))
 	for subnetID, subnet := range s.subnets {

--- a/chains/subnets.go
+++ b/chains/subnets.go
@@ -70,6 +70,7 @@ func (s *Subnets) Bootstrapping() []ids.ID {
 	return subnetsBootstrapping
 }
 
+// NewSubnets returns an instance of Subnets
 func NewSubnets(
 	nodeID ids.NodeID,
 	configs map[ids.ID]subnets.Config,

--- a/chains/subnets_test.go
+++ b/chains/subnets_test.go
@@ -1,0 +1,177 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package chains
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/subnets"
+	"github.com/ava-labs/avalanchego/utils/constants"
+)
+
+func TestNewSubnets(t *testing.T) {
+	require := require.New(t)
+	config := map[ids.ID]subnets.Config{
+		constants.PrimaryNetworkID: {},
+	}
+
+	subnets, err := NewSubnets(ids.EmptyNodeID, config)
+	require.NoError(err)
+
+	subnet, ok := subnets.Get(constants.PrimaryNetworkID)
+	require.True(ok)
+	require.Equal(subnet.Config(), config[constants.PrimaryNetworkID])
+}
+
+func TestNewSubnets_NoPrimaryNetworkConfig(t *testing.T) {
+	require := require.New(t)
+	config := map[ids.ID]subnets.Config{}
+
+	_, err := NewSubnets(ids.EmptyNodeID, config)
+	require.ErrorIs(err, ErrNoPrimaryNetworkConfig)
+}
+
+func TestSubnetsAdd(t *testing.T) {
+	testSubnetID := ids.GenerateTestID()
+
+	type add struct {
+		subnetID ids.ID
+		want     bool
+	}
+
+	tests := []struct {
+		name string
+		adds []add
+	}{
+		{
+			name: "adding duplicate subnet is a noop",
+			adds: []add{
+				{
+					subnetID: testSubnetID,
+					want:     true,
+				},
+				{
+					subnetID: testSubnetID,
+				},
+			},
+		},
+		{
+			name: "adding unique subnets succeeds",
+			adds: []add{
+				{
+					subnetID: ids.GenerateTestID(),
+					want:     true,
+				},
+				{
+					subnetID: ids.GenerateTestID(),
+					want:     true,
+				},
+				{
+					subnetID: ids.GenerateTestID(),
+					want:     true,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			config := map[ids.ID]subnets.Config{
+				constants.PrimaryNetworkID: {},
+			}
+			subnets, err := NewSubnets(ids.EmptyNodeID, config)
+			require.NoError(err)
+
+			for _, add := range tt.adds {
+				got := subnets.Add(add.subnetID)
+				require.Equal(got, add.want)
+			}
+		})
+	}
+}
+
+func TestSubnetConfigs(t *testing.T) {
+	testSubnetID := ids.GenerateTestID()
+
+	tests := []struct {
+		name     string
+		config   map[ids.ID]subnets.Config
+		subnetID ids.ID
+		want     subnets.Config
+	}{
+		{
+			name: "default to primary network config",
+			config: map[ids.ID]subnets.Config{
+				constants.PrimaryNetworkID: {},
+			},
+			subnetID: testSubnetID,
+			want:     subnets.Config{},
+		},
+		{
+			name: "use subnet config",
+			config: map[ids.ID]subnets.Config{
+				constants.PrimaryNetworkID: {},
+				testSubnetID: {
+					GossipConfig: subnets.GossipConfig{
+						AcceptedFrontierValidatorSize: 123456789,
+					},
+				},
+			},
+			subnetID: testSubnetID,
+			want: subnets.Config{
+				GossipConfig: subnets.GossipConfig{
+					AcceptedFrontierValidatorSize: 123456789,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			subnets, err := NewSubnets(ids.EmptyNodeID, tt.config)
+			require.NoError(err)
+
+			ok := subnets.Add(tt.subnetID)
+			require.True(ok)
+
+			subnet, ok := subnets.Get(tt.subnetID)
+			require.True(ok)
+
+			require.Equal(tt.want, subnet.Config())
+		})
+	}
+}
+
+func TestSubnetsBootstrapping(t *testing.T) {
+	require := require.New(t)
+
+	config := map[ids.ID]subnets.Config{
+		constants.PrimaryNetworkID: {},
+	}
+
+	subnets, err := NewSubnets(ids.EmptyNodeID, config)
+	require.NoError(err)
+
+	subnetID := ids.GenerateTestID()
+	chainID := ids.GenerateTestID()
+
+	subnets.Add(subnetID)
+	subnet, ok := subnets.Get(subnetID)
+	require.True(ok)
+
+	// Start bootstrapping
+	subnet.AddChain(chainID)
+	bootstrapping := subnets.Bootstrapping()
+	require.Contains(bootstrapping, subnetID)
+
+	// Finish bootstrapping
+	subnet.Bootstrapped(chainID)
+	require.Empty(subnets.Bootstrapping())
+}

--- a/node/node.go
+++ b/node/node.go
@@ -1168,8 +1168,8 @@ func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 			TracingEnabled:                          n.Config.TraceConfig.Enabled,
 			Tracer:                                  n.tracer,
 			ChainDataDir:                            n.Config.ChainDataDir,
+			Subnets:                                 n.subnets,
 		},
-		n.subnets,
 	)
 
 	// Notify the API server when new chains are created

--- a/node/node.go
+++ b/node/node.go
@@ -304,6 +304,8 @@ type Node struct {
 	// Manages network timeouts
 	timeoutManager timeout.Manager
 
+	subnets *chains.Subnets
+
 	// Manages creation of blockchains and routing messages to them
 	chainManager chains.Manager
 
@@ -1117,51 +1119,58 @@ func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 		return fmt.Errorf("couldn't initialize chain router: %w", err)
 	}
 
-	n.chainManager = chains.New(&chains.ManagerConfig{
-		SybilProtectionEnabled:                  n.Config.SybilProtectionEnabled,
-		StakingTLSCert:                          n.Config.StakingTLSCert,
-		StakingBLSKey:                           n.Config.StakingSigningKey,
-		Log:                                     n.Log,
-		LogFactory:                              n.LogFactory,
-		VMManager:                               n.VMManager,
-		BlockAcceptorGroup:                      n.BlockAcceptorGroup,
-		TxAcceptorGroup:                         n.TxAcceptorGroup,
-		VertexAcceptorGroup:                     n.VertexAcceptorGroup,
-		DB:                                      n.DB,
-		MsgCreator:                              n.msgCreator,
-		Router:                                  n.chainRouter,
-		Net:                                     n.Net,
-		Validators:                              n.vdrs,
-		PartialSyncPrimaryNetwork:               n.Config.PartialSyncPrimaryNetwork,
-		NodeID:                                  n.ID,
-		NetworkID:                               n.Config.NetworkID,
-		Server:                                  n.APIServer,
-		Keystore:                                n.keystore,
-		AtomicMemory:                            n.sharedMemory,
-		AVAXAssetID:                             avaxAssetID,
-		XChainID:                                xChainID,
-		CChainID:                                cChainID,
-		CriticalChains:                          criticalChains,
-		TimeoutManager:                          n.timeoutManager,
-		Health:                                  n.health,
-		ShutdownNodeFunc:                        n.Shutdown,
-		MeterVMEnabled:                          n.Config.MeterVMEnabled,
-		Metrics:                                 n.MetricsGatherer,
-		SubnetConfigs:                           n.Config.SubnetConfigs,
-		ChainConfigs:                            n.Config.ChainConfigs,
-		FrontierPollFrequency:                   n.Config.FrontierPollFrequency,
-		ConsensusAppConcurrency:                 n.Config.ConsensusAppConcurrency,
-		BootstrapMaxTimeGetAncestors:            n.Config.BootstrapMaxTimeGetAncestors,
-		BootstrapAncestorsMaxContainersSent:     n.Config.BootstrapAncestorsMaxContainersSent,
-		BootstrapAncestorsMaxContainersReceived: n.Config.BootstrapAncestorsMaxContainersReceived,
-		ApricotPhase4Time:                       version.GetApricotPhase4Time(n.Config.NetworkID),
-		ApricotPhase4MinPChainHeight:            version.ApricotPhase4MinPChainHeight[n.Config.NetworkID],
-		ResourceTracker:                         n.resourceTracker,
-		StateSyncBeacons:                        n.Config.StateSyncIDs,
-		TracingEnabled:                          n.Config.TraceConfig.Enabled,
-		Tracer:                                  n.tracer,
-		ChainDataDir:                            n.Config.ChainDataDir,
-	})
+	n.subnets, err = chains.NewSubnets(n.ID, n.Config.SubnetConfigs)
+	if err != nil {
+		return fmt.Errorf("failed to initialize subnets: %w", err)
+	}
+	n.chainManager = chains.New(
+		&chains.ManagerConfig{
+			SybilProtectionEnabled:                  n.Config.SybilProtectionEnabled,
+			StakingTLSCert:                          n.Config.StakingTLSCert,
+			StakingBLSKey:                           n.Config.StakingSigningKey,
+			Log:                                     n.Log,
+			LogFactory:                              n.LogFactory,
+			VMManager:                               n.VMManager,
+			BlockAcceptorGroup:                      n.BlockAcceptorGroup,
+			TxAcceptorGroup:                         n.TxAcceptorGroup,
+			VertexAcceptorGroup:                     n.VertexAcceptorGroup,
+			DB:                                      n.DB,
+			MsgCreator:                              n.msgCreator,
+			Router:                                  n.chainRouter,
+			Net:                                     n.Net,
+			Validators:                              n.vdrs,
+			PartialSyncPrimaryNetwork:               n.Config.PartialSyncPrimaryNetwork,
+			NodeID:                                  n.ID,
+			NetworkID:                               n.Config.NetworkID,
+			Server:                                  n.APIServer,
+			Keystore:                                n.keystore,
+			AtomicMemory:                            n.sharedMemory,
+			AVAXAssetID:                             avaxAssetID,
+			XChainID:                                xChainID,
+			CChainID:                                cChainID,
+			CriticalChains:                          criticalChains,
+			TimeoutManager:                          n.timeoutManager,
+			Health:                                  n.health,
+			ShutdownNodeFunc:                        n.Shutdown,
+			MeterVMEnabled:                          n.Config.MeterVMEnabled,
+			Metrics:                                 n.MetricsGatherer,
+			SubnetConfigs:                           n.Config.SubnetConfigs,
+			ChainConfigs:                            n.Config.ChainConfigs,
+			FrontierPollFrequency:                   n.Config.FrontierPollFrequency,
+			ConsensusAppConcurrency:                 n.Config.ConsensusAppConcurrency,
+			BootstrapMaxTimeGetAncestors:            n.Config.BootstrapMaxTimeGetAncestors,
+			BootstrapAncestorsMaxContainersSent:     n.Config.BootstrapAncestorsMaxContainersSent,
+			BootstrapAncestorsMaxContainersReceived: n.Config.BootstrapAncestorsMaxContainersReceived,
+			ApricotPhase4Time:                       version.GetApricotPhase4Time(n.Config.NetworkID),
+			ApricotPhase4MinPChainHeight:            version.ApricotPhase4MinPChainHeight[n.Config.NetworkID],
+			ResourceTracker:                         n.resourceTracker,
+			StateSyncBeacons:                        n.Config.StateSyncIDs,
+			TracingEnabled:                          n.Config.TraceConfig.Enabled,
+			Tracer:                                  n.tracer,
+			ChainDataDir:                            n.Config.ChainDataDir,
+		},
+		n.subnets,
+	)
 
 	// Notify the API server when new chains are created
 	n.chainManager.AddRegistrant(n.APIServer)

--- a/node/node.go
+++ b/node/node.go
@@ -304,8 +304,6 @@ type Node struct {
 	// Manages network timeouts
 	timeoutManager timeout.Manager
 
-	subnets *chains.Subnets
-
 	// Manages creation of blockchains and routing messages to them
 	chainManager chains.Manager
 
@@ -1119,7 +1117,7 @@ func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 		return fmt.Errorf("couldn't initialize chain router: %w", err)
 	}
 
-	n.subnets, err = chains.NewSubnets(n.ID, n.Config.SubnetConfigs)
+	subnets, err := chains.NewSubnets(n.ID, n.Config.SubnetConfigs)
 	if err != nil {
 		return fmt.Errorf("failed to initialize subnets: %w", err)
 	}
@@ -1168,7 +1166,7 @@ func (n *Node) initChainManager(avaxAssetID ids.ID) error {
 			TracingEnabled:                          n.Config.TraceConfig.Enabled,
 			Tracer:                                  n.tracer,
 			ChainDataDir:                            n.Config.ChainDataDir,
-			Subnets:                                 n.subnets,
+			Subnets:                                 subnets,
 		},
 	)
 


### PR DESCRIPTION
## Why this should be merged

Needed as a pre-requisite to remove `vm.Initialize`. This refactors the currently running subnets into its own struct, so it can be shared with a future `chains.Factory` struct which will be responsible for creating `chain` instances (currently this is created internally in the chain manager). Ideally we'll have a chain factory to create chains and a chain manager that holds the chains that are currently running. This way, the chain manager doesn't need to know about the p-chain at all since the caller can choose arguments passed into the chain factory instead and the p-chain logic can be in the caller instead of in `chains/manager`

## How this works

Refactors currently running subnets into its own struct

## How this was tested

Added unit tests
