### PR TITLE
Update `golangci-lint` to `v1.56.1`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,12 +47,12 @@ linters:
     - errorlint
     - exportloopref
     - forbidigo
+    - gci
     - goconst
     - gocritic
     # - goerr113
     - gofmt
     - gofumpt
-    - goimports
     # - gomnd
     - goprintffuncname
     - gosec
@@ -65,7 +65,7 @@ linters:
     - nakedret
     - noctx
     - nolintlint
-    - perfsprint
+    # - perfsprint
     - prealloc
     - predeclared
     - revive
@@ -105,8 +105,16 @@ linters-settings:
       - '^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the require library should be used instead)?'
     # Exclude godoc examples from forbidigo checks.
     exclude_godoc_examples: false
-  goimports:
-    local-prefixes: github.com/ava-labs/avalanchego
+  gci:
+    sections:
+      - standard
+      - default
+      - blank
+      - dot
+      - prefix(github.com/ava-labs/avalanchego)
+      - alias
+    skip-generated: true
+    custom-order: true
   gosec:
     excludes:
       - G107 # Url provided to HTTP request as taint input https://securego.io/docs/rules/g107

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,7 @@ linters:
     - prealloc
     - predeclared
     - revive
+    - spancheck
     - staticcheck
     - stylecheck
     - tagalign
@@ -170,6 +171,23 @@ linters-settings:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
       - name: useless-break
         disabled: false
+  spancheck:
+    # Checks to enable.
+    # Options include:
+    # - `end`: check that `span.End()` is called
+    # - `record-error`: check that `span.RecordError(err)` is called when an error is returned
+    # - `set-status`: check that `span.SetStatus(codes.Error, msg)` is called when an error is returned
+    # Default: ["end"]
+    checks:
+      - end
+      # - record-error
+      # - set-status
+    # A list of regexes for function signatures that silence `record-error` and `set-status` reports
+    # if found in the call path to a returned error.
+    # https://github.com/jjti/go-spancheck#ignore-check-signatures
+    # Default: []
+    ignore-check-signatures:
+      - "telemetry.RecordError"
   staticcheck:
     # https://staticcheck.io/docs/options#checks
     checks:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,7 @@ linters:
     - nakedret
     - noctx
     - nolintlint
-    # - perfsprint
+    - perfsprint
     - prealloc
     - predeclared
     - revive
@@ -129,6 +129,8 @@ linters-settings:
     alias:
       - pkg: github.com/ava-labs/avalanchego/utils/math
         alias: safemath
+      - pkg: github.com/ava-labs/avalanchego/utils/json
+        alias: avajson
   revive:
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,7 @@ linters:
     - staticcheck
     - stylecheck
     - tagalign
+    - testifylint
     - typecheck
     - unconvert
     - unparam
@@ -181,3 +182,29 @@ linters-settings:
     strict: true
     order:
       - serialize
+  testifylint:
+    # Disable all checkers (https://github.com/Antonboom/testifylint#checkers).
+    # Default: false
+    disable-all: true
+    # Enable checkers by name
+    # (in addition to default
+    #   blank-import, bool-compare, compares, empty, error-is-as, error-nil, expected-actual, go-require, float-compare,
+    #   len, nil-compare, require-error, suite-dont-use-pkg, suite-extra-assert-call, useless-assert
+    # ).
+    enable:
+      - blank-import
+      - bool-compare
+      - compares
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      # - go-require
+      # - float-compare
+      - len
+      - nil-compare
+      - require-error
+      - suite-dont-use-pkg
+      - suite-extra-assert-call
+      - suite-thelper
+      - useless-assert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,22 +174,11 @@ linters-settings:
       - name: useless-break
         disabled: false
   spancheck:
-    # Checks to enable.
-    # Options include:
-    # - `end`: check that `span.End()` is called
-    # - `record-error`: check that `span.RecordError(err)` is called when an error is returned
-    # - `set-status`: check that `span.SetStatus(codes.Error, msg)` is called when an error is returned
-    # Default: ["end"]
+    # https://github.com/jjti/go-spancheck#checks
     checks:
       - end
-      # - record-error
-      # - set-status
-    # A list of regexes for function signatures that silence `record-error` and `set-status` reports
-    # if found in the call path to a returned error.
-    # https://github.com/jjti/go-spancheck#ignore-check-signatures
-    # Default: []
-    ignore-check-signatures:
-      - "telemetry.RecordError"
+      # - record-error # check that `span.RecordError(err)` is called when an error is returned
+      # - set-status   # check that `span.SetStatus(codes.Error, msg)` is called when an error is returned
   staticcheck:
     # https://staticcheck.io/docs/options#checks
     checks:
@@ -203,28 +192,13 @@ linters-settings:
     order:
       - serialize
   testifylint:
-    # Disable all checkers (https://github.com/Antonboom/testifylint#checkers).
+    # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
     # Default: false
-    disable-all: true
-    # Enable checkers by name
+    enable-all: true
+    # Disable checkers by name
     # (in addition to default
-    #   blank-import, bool-compare, compares, empty, error-is-as, error-nil, expected-actual, go-require, float-compare,
-    #   len, nil-compare, require-error, suite-dont-use-pkg, suite-extra-assert-call, useless-assert
+    #   suite-thelper
     # ).
-    enable:
-      - blank-import
-      - bool-compare
-      - compares
-      - empty
-      - error-is-as
-      - error-nil
-      - expected-actual
-      # - go-require
-      # - float-compare
-      - len
-      - nil-compare
-      - require-error
-      - suite-dont-use-pkg
-      - suite-extra-assert-call
-      - suite-thelper
-      - useless-assert
+    disable:
+      - go-require
+      - float-compare

--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/gorilla/rpc/v2"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api"

--- a/api/admin/service_test.go
+++ b/api/admin/service_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database/memdb"

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
-
 	"github.com/gorilla/rpc/v2"
 
 	"github.com/ava-labs/avalanchego/utils/json"
@@ -23,6 +21,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/password"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 const (

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 // Always returns 200 (http.StatusOK)
-var dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+var dummyHandler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
 
 func TestNewTokenWrongPassword(t *testing.T) {
 	require := require.New(t)

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -14,12 +14,12 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/password"
+
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 var (

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -228,7 +228,7 @@ func TestWrapHandlerNoAuthToken(t *testing.T) {
 	endpoints := []string{"/ext/info", "/ext/bc/X", "/ext/metrics"}
 	wrappedHandler := auth.WrapHandler(dummyHandler)
 	for _, endpoint := range endpoints {
-		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:9650%s", endpoint), strings.NewReader(""))
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:9650"+endpoint, strings.NewReader(""))
 		rr := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(rr, req)
 		require.Equal(http.StatusUnauthorized, rr.Code)

--- a/api/common_args_responses.go
+++ b/api/common_args_responses.go
@@ -4,11 +4,11 @@
 package api
 
 import (
-	stdjson "encoding/json"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/json"
+
+	stdjson "encoding/json"
 )
 
 // This file contains structs used in arguments and responses in services

--- a/api/common_args_responses.go
+++ b/api/common_args_responses.go
@@ -4,11 +4,12 @@
 package api
 
 import (
+	"encoding/json"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting"
-	"github.com/ava-labs/avalanchego/utils/json"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 )
 
 // This file contains structs used in arguments and responses in services
@@ -71,13 +72,13 @@ type GetBlockArgs struct {
 
 // GetBlockByHeightArgs is the parameters supplied to the GetBlockByHeight API
 type GetBlockByHeightArgs struct {
-	Height   json.Uint64         `json:"height"`
+	Height   avajson.Uint64      `json:"height"`
 	Encoding formatting.Encoding `json:"encoding"`
 }
 
 // GetBlockResponse is the response object for the GetBlock API.
 type GetBlockResponse struct {
-	Block stdjson.RawMessage `json:"block"`
+	Block json.RawMessage `json:"block"`
 	// If GetBlockResponse.Encoding is formatting.Hex, GetBlockResponse.Block is
 	// the string representation of the block under hex encoding.
 	// If GetBlockResponse.Encoding is formatting.JSON, GetBlockResponse.Block
@@ -86,7 +87,7 @@ type GetBlockResponse struct {
 }
 
 type GetHeightResponse struct {
-	Height json.Uint64 `json:"height"`
+	Height avajson.Uint64 `json:"height"`
 }
 
 // FormattedBlock defines a JSON formatted struct containing a block in Hex
@@ -107,7 +108,7 @@ type GetTxReply struct {
 	// the tx under hex encoding.
 	// If [GetTxArgs.Encoding] is [JSON], [Tx] is the actual tx, which will be
 	// returned as JSON to the caller.
-	Tx       stdjson.RawMessage  `json:"tx"`
+	Tx       json.RawMessage     `json:"tx"`
 	Encoding formatting.Encoding `json:"encoding"`
 }
 
@@ -139,7 +140,7 @@ type Index struct {
 type GetUTXOsArgs struct {
 	Addresses   []string            `json:"addresses"`
 	SourceChain string              `json:"sourceChain"`
-	Limit       json.Uint32         `json:"limit"`
+	Limit       avajson.Uint32      `json:"limit"`
 	StartIndex  Index               `json:"startIndex"`
 	Encoding    formatting.Encoding `json:"encoding"`
 }
@@ -147,7 +148,7 @@ type GetUTXOsArgs struct {
 // GetUTXOsReply defines the GetUTXOs replies returned from the API
 type GetUTXOsReply struct {
 	// Number of UTXOs returned
-	NumFetched json.Uint64 `json:"numFetched"`
+	NumFetched avajson.Uint64 `json:"numFetched"`
 	// The UTXOs
 	UTXOs []string `json:"utxos"`
 	// The last UTXO that was returned, and the address it corresponds to.

--- a/api/health/handler.go
+++ b/api/health/handler.go
@@ -6,12 +6,12 @@ package health
 import (
 	"net/http"
 
-	stdjson "encoding/json"
-
 	"github.com/gorilla/rpc/v2"
 
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
+
+	stdjson "encoding/json"
 )
 
 // NewGetAndPostHandler returns a health handler that supports GET and jsonrpc

--- a/api/health/handler.go
+++ b/api/health/handler.go
@@ -4,21 +4,21 @@
 package health
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/gorilla/rpc/v2"
 
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 )
 
 // NewGetAndPostHandler returns a health handler that supports GET and jsonrpc
 // POST requests.
 func NewGetAndPostHandler(log logging.Logger, reporter Reporter) (http.Handler, error) {
 	newServer := rpc.NewServer()
-	codec := json.NewCodec()
+	codec := avajson.NewCodec()
 	newServer.RegisterCodec(codec, "application/json")
 	newServer.RegisterCodec(codec, "application/json;charset=UTF-8")
 
@@ -60,7 +60,7 @@ func NewGetHandler(reporter func(tags ...string) (map[string]Result, bool)) http
 		}
 		// The encoder will call write on the writer, which will write the
 		// header with a 200.
-		_ = stdjson.NewEncoder(w).Encode(APIReply{
+		_ = json.NewEncoder(w).Encode(APIReply{
 			Checks:  checks,
 			Healthy: healthy,
 		})

--- a/api/health/health.go
+++ b/api/health/health.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/utils/logging"

--- a/api/health/health_test.go
+++ b/api/health/health_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/utils"

--- a/api/health/service_test.go
+++ b/api/health/service_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/api/health/worker.go
+++ b/api/health/worker.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/utils"

--- a/api/info/service.go
+++ b/api/info/service.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/rpc/v2"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/chains"

--- a/api/info/service_test.go
+++ b/api/info/service_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/api/ipcs/service.go
+++ b/api/ipcs/service.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/gorilla/rpc/v2"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api"

--- a/api/metrics/multi_gatherer.go
+++ b/api/metrics/multi_gatherer.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	dto "github.com/prometheus/client_model/go"
-
 	"github.com/ava-labs/avalanchego/utils/metric"
+
+	dto "github.com/prometheus/client_model/go"
 )
 
 var (

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -13,13 +13,9 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
-
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/rs/cors"
-
 	"go.uber.org/zap"
-
 	"golang.org/x/net/http2"
 
 	"github.com/ava-labs/avalanchego/api"

--- a/api/traced_handler.go
+++ b/api/traced_handler.go
@@ -9,9 +9,9 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/trace"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ http.Handler = (*tracedHandler)(nil)

--- a/api/traced_handler.go
+++ b/api/traced_handler.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -25,7 +24,7 @@ type tracedHandler struct {
 func TraceHandler(h http.Handler, name string, tracer trace.Tracer) http.Handler {
 	return &tracedHandler{
 		h:            h,
-		serveHTTPTag: fmt.Sprintf("%s.ServeHTTP", name),
+		serveHTTPTag: name + ".ServeHTTP",
 		tracer:       tracer,
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 
 	"go.uber.org/zap"
-
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ava-labs/avalanchego/node"

--- a/cache/metercacher/cache_test.go
+++ b/cache/metercacher/cache_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/cache"

--- a/cache/metercacher/metrics.go
+++ b/cache/metercacher/metrics.go
@@ -16,7 +16,7 @@ func newAveragerMetric(namespace, name string, reg prometheus.Registerer, errs *
 	return metric.NewAveragerWithErrs(
 		namespace,
 		name,
-		fmt.Sprintf("time (in ns) of a %s", name),
+		"time (in ns) of a "+name,
 		reg,
 		errs,
 	)

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -1338,7 +1338,7 @@ func (m *manager) registerBootstrappedHealthChecks() error {
 		return nil
 	}
 
-	partialSyncCheck := health.CheckerFunc(func(ctx context.Context) (interface{}, error) {
+	partialSyncCheck := health.CheckerFunc(func(context.Context) (interface{}, error) {
 		// Note: The health check is skipped during bootstrapping to allow a
 		// node to sync the network even if it was previously a validator.
 		if !m.IsBootstrapped(constants.PlatformChainID) {

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api/health"
@@ -64,16 +63,14 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/vms/tracedvm"
 
-	timetracker "github.com/ava-labs/avalanchego/snow/networking/tracker"
-
+	smcon "github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	aveng "github.com/ava-labs/avalanchego/snow/engine/avalanche"
 	avbootstrap "github.com/ava-labs/avalanchego/snow/engine/avalanche/bootstrap"
 	avagetter "github.com/ava-labs/avalanchego/snow/engine/avalanche/getter"
-
-	smcon "github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	smeng "github.com/ava-labs/avalanchego/snow/engine/snowman"
 	smbootstrap "github.com/ava-labs/avalanchego/snow/engine/snowman/bootstrap"
 	snowgetter "github.com/ava-labs/avalanchego/snow/engine/snowman/getter"
+	timetracker "github.com/ava-labs/avalanchego/snow/networking/tracker"
 )
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/chains"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -412,7 +412,7 @@ func TestGetSubnetConfigsFromFile(t *testing.T) {
 				config, ok := given[id]
 				require.True(ok)
 
-				require.Equal(true, config.ValidatorOnly)
+				require.True(config.ValidatorOnly)
 				require.Equal(16, config.ConsensusParameters.AlphaConfidence)
 				// must still respect defaults
 				require.Equal(20, config.ConsensusParameters.K)
@@ -522,7 +522,7 @@ func TestGetSubnetConfigsFromFlags(t *testing.T) {
 				id, _ := ids.FromString("2Ctt6eGAeo4MLqTmGa7AdRecuVMPGWEX9wSsCLBYrLhX4a394i")
 				config, ok := given[id]
 				require.True(ok)
-				require.Equal(true, config.ValidatorOnly)
+				require.True(config.ValidatorOnly)
 				require.Equal(16, config.ConsensusParameters.AlphaPreference)
 				require.Equal(20, config.ConsensusParameters.AlphaConfidence)
 				require.Equal(30, config.ConsensusParameters.K)

--- a/database/corruptabledb/db_test.go
+++ b/database/corruptabledb/db_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/database/corruptabledb/db_test.go
+++ b/database/corruptabledb/db_test.go
@@ -100,7 +100,7 @@ func TestIterator(t *testing.T) {
 			name:              "corrupted database; Next",
 			databaseErrBefore: errTest,
 			expectedErr:       errTest,
-			modifyIter:        func(ctrl *gomock.Controller, iter *iterator) {},
+			modifyIter:        func(*gomock.Controller, *iterator) {},
 			op: func(require *require.Assertions, iter *iterator) {
 				require.False(iter.Next())
 			},
@@ -123,7 +123,7 @@ func TestIterator(t *testing.T) {
 			name:              "corrupted database; Error",
 			databaseErrBefore: errTest,
 			expectedErr:       errTest,
-			modifyIter:        func(ctrl *gomock.Controller, iter *iterator) {},
+			modifyIter:        func(*gomock.Controller, *iterator) {},
 			op: func(require *require.Assertions, iter *iterator) {
 				err := iter.Error()
 				require.ErrorIs(err, errTest)
@@ -147,8 +147,8 @@ func TestIterator(t *testing.T) {
 			name:              "corrupted database; Key",
 			databaseErrBefore: errTest,
 			expectedErr:       errTest,
-			modifyIter:        func(ctrl *gomock.Controller, iter *iterator) {},
-			op: func(require *require.Assertions, iter *iterator) {
+			modifyIter:        func(*gomock.Controller, *iterator) {},
+			op: func(_ *require.Assertions, iter *iterator) {
 				_ = iter.Key()
 			},
 		},
@@ -156,8 +156,8 @@ func TestIterator(t *testing.T) {
 			name:              "corrupted database; Value",
 			databaseErrBefore: errTest,
 			expectedErr:       errTest,
-			modifyIter:        func(ctrl *gomock.Controller, iter *iterator) {},
-			op: func(require *require.Assertions, iter *iterator) {
+			modifyIter:        func(*gomock.Controller, *iterator) {},
+			op: func(_ *require.Assertions, iter *iterator) {
 				_ = iter.Value()
 			},
 		},
@@ -165,8 +165,8 @@ func TestIterator(t *testing.T) {
 			name:              "corrupted database; Release",
 			databaseErrBefore: errTest,
 			expectedErr:       errTest,
-			modifyIter:        func(ctrl *gomock.Controller, iter *iterator) {},
-			op: func(require *require.Assertions, iter *iterator) {
+			modifyIter:        func(*gomock.Controller, *iterator) {},
+			op: func(_ *require.Assertions, iter *iterator) {
 				iter.Release()
 			},
 		},

--- a/database/leveldb/db.go
+++ b/database/leveldb/db.go
@@ -14,14 +14,12 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/database/leveldb/db_test.go
+++ b/database/leveldb/db_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/database/leveldb/metrics.go
+++ b/database/leveldb/metrics.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/ava-labs/avalanchego/utils"

--- a/database/meterdb/db_test.go
+++ b/database/meterdb/db_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/database/meterdb/metrics.go
+++ b/database/meterdb/metrics.go
@@ -15,7 +15,7 @@ import (
 func newSizeMetric(namespace, name string, reg prometheus.Registerer, errs *wrappers.Errs) metric.Averager {
 	return metric.NewAveragerWithErrs(
 		namespace,
-		fmt.Sprintf("%s_size", name),
+		name+"_size",
 		fmt.Sprintf("bytes passed in a %s call", name),
 		reg,
 		errs,
@@ -26,7 +26,7 @@ func newTimeMetric(namespace, name string, reg prometheus.Registerer, errs *wrap
 	return metric.NewAveragerWithErrs(
 		namespace,
 		name,
-		fmt.Sprintf("time (in ns) of a %s", name),
+		"time (in ns) of a "+name,
 		reg,
 		errs,
 	)

--- a/database/pebble/batch_test.go
+++ b/database/pebble/batch_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/utils/logging"

--- a/database/pebble/db.go
+++ b/database/pebble/db.go
@@ -12,9 +12,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/pebble"
-
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/database/pebble/db_test.go
+++ b/database/pebble/db_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/database/pebble/db_test.go
+++ b/database/pebble/db_test.go
@@ -63,8 +63,6 @@ func BenchmarkInterface(b *testing.B) {
 }
 
 func TestKeyRange(t *testing.T) {
-	require := require.New(t)
-
 	type test struct {
 		start         []byte
 		prefix        []byte
@@ -149,6 +147,7 @@ func TestKeyRange(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.start)+" "+string(tt.prefix), func(t *testing.T) {
+			require := require.New(t)
 			bounds := keyRange(tt.start, tt.prefix)
 			require.Equal(tt.expectedLower, bounds.LowerBound)
 			require.Equal(tt.expectedUpper, bounds.UpperBound)

--- a/database/test_database.go
+++ b/database/test_database.go
@@ -12,11 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
-
 	"golang.org/x/exp/maps"
-
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ava-labs/avalanchego/utils"

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	_ "embed"
-
 	"github.com/stretchr/testify/require"
+
+	_ "embed"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"

--- a/indexer/examples/p-chain/main.go
+++ b/indexer/examples/p-chain/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -21,7 +20,7 @@ import (
 // and prints the ID of the block and its transactions.
 func main() {
 	var (
-		uri       = fmt.Sprintf("%s/ext/index/P/block", primary.LocalAPIURI)
+		uri       = primary.LocalAPIURI + "/ext/index/P/block"
 		client    = indexer.NewClient(uri)
 		ctx       = context.Background()
 		nextIndex uint64

--- a/indexer/examples/x-chain-blocks/main.go
+++ b/indexer/examples/x-chain-blocks/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -20,7 +19,7 @@ import (
 // and prints the ID of the block and its transactions.
 func main() {
 	var (
-		uri       = fmt.Sprintf("%s/ext/index/X/block", primary.LocalAPIURI)
+		uri       = primary.LocalAPIURI + "/ext/index/X/block"
 		client    = indexer.NewClient(uri)
 		ctx       = context.Background()
 		nextIndex uint64

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/gorilla/rpc/v2"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api/server"

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/api/server"

--- a/ipcs/chainipc.go
+++ b/ipcs/chainipc.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"go.uber.org/zap"
-
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/main/main.go
+++ b/main/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-
 	"golang.org/x/term"
 
 	"github.com/ava-labs/avalanchego/app"

--- a/message/inbound_msg_builder_test.go
+++ b/message/inbound_msg_builder_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/message/messages.go
+++ b/message/messages.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/message/messages_benchmark_test.go
+++ b/message/messages_benchmark_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/message/messages_test.go
+++ b/message/messages_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/message/outbound_msg_builder_test.go
+++ b/message/outbound_msg_builder_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/certs_test.go
+++ b/network/certs_test.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"testing"
 
-	_ "embed"
-
 	"github.com/stretchr/testify/require"
+
+	_ "embed"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/peer"

--- a/network/ip_tracker.go
+++ b/network/ip_tracker.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/ip_tracker_test.go
+++ b/network/ip_tracker_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/network.go
+++ b/network/network.go
@@ -15,9 +15,7 @@ import (
 	"time"
 
 	"github.com/pires/go-proxyproto"
-
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api/health"

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/p2p/gossip/bloom_test.go
+++ b/network/p2p/gossip/bloom_test.go
@@ -7,10 +7,9 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
 )

--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -10,11 +10,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/exp/maps"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/p2p/network_test.go
+++ b/network/p2p/network_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/p2p/network_test.go
+++ b/network/p2p/network_test.go
@@ -540,7 +540,7 @@ func TestNodeSamplerClientOption(t *testing.T) {
 		{
 			name:  "default",
 			peers: []ids.NodeID{nodeID0, nodeID1, nodeID2},
-			option: func(_ *testing.T, n *Network) ClientOption {
+			option: func(*testing.T, *Network) ClientOption {
 				return clientOptionFunc(func(*clientOptions) {})
 			},
 			expected: []ids.NodeID{nodeID0, nodeID1, nodeID2},
@@ -548,7 +548,7 @@ func TestNodeSamplerClientOption(t *testing.T) {
 		{
 			name:  "validator connected",
 			peers: []ids.NodeID{nodeID0, nodeID1},
-			option: func(t *testing.T, n *Network) ClientOption {
+			option: func(_ *testing.T, n *Network) ClientOption {
 				state := &validators.TestState{
 					GetCurrentHeightF: func(context.Context) (uint64, error) {
 						return 0, nil
@@ -568,7 +568,7 @@ func TestNodeSamplerClientOption(t *testing.T) {
 		{
 			name:  "validator disconnected",
 			peers: []ids.NodeID{nodeID0},
-			option: func(t *testing.T, n *Network) ClientOption {
+			option: func(_ *testing.T, n *Network) ClientOption {
 				state := &validators.TestState{
 					GetCurrentHeightF: func(context.Context) (uint64, error) {
 						return 0, nil

--- a/network/p2p/network_test.go
+++ b/network/p2p/network_test.go
@@ -306,9 +306,9 @@ func TestMessageForUnregisteredHandler(t *testing.T) {
 			require.NoError(err)
 			require.NoError(network.AddHandler(handlerID, handler))
 
-			require.Nil(network.AppRequest(ctx, ids.EmptyNodeID, 0, time.Time{}, tt.msg))
-			require.Nil(network.AppGossip(ctx, ids.EmptyNodeID, tt.msg))
-			require.Nil(network.CrossChainAppRequest(ctx, ids.Empty, 0, time.Time{}, tt.msg))
+			require.NoError(network.AppRequest(ctx, ids.EmptyNodeID, 0, time.Time{}, tt.msg))
+			require.NoError(network.AppGossip(ctx, ids.EmptyNodeID, tt.msg))
+			require.NoError(network.CrossChainAppRequest(ctx, ids.Empty, 0, time.Time{}, tt.msg))
 		})
 	}
 }

--- a/network/p2p/peer_tracker.go
+++ b/network/p2p/peer_tracker.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/p2p/peer_tracker_test.go
+++ b/network/p2p/peer_tracker_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/p2p/validators_test.go
+++ b/network/p2p/validators_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/peer/message_queue_test.go
+++ b/network/peer/message_queue_test.go
@@ -20,7 +20,7 @@ func TestMessageQueue(t *testing.T) {
 
 	expectFail := false
 	q := NewBlockingMessageQueue(
-		SendFailedFunc(func(msg message.OutboundMessage) {
+		SendFailedFunc(func(message.OutboundMessage) {
 			require.True(expectFail)
 		}),
 		logging.NoLog{},

--- a/network/peer/metrics.go
+++ b/network/peer/metrics.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/message"

--- a/network/peer/peer_test.go
+++ b/network/peer/peer_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/peer/set_test.go
+++ b/network/peer/set_test.go
@@ -128,10 +128,10 @@ func TestSetSample(t *testing.T) {
 	require.Empty(peers)
 
 	peers = set.Sample(1, NoPrecondition)
-	require.Equal(peers, []Peer{peer1})
+	require.Equal([]Peer{peer1}, peers)
 
 	peers = set.Sample(2, NoPrecondition)
-	require.Equal(peers, []Peer{peer1})
+	require.Equal([]Peer{peer1}, peers)
 
 	// Case: 2 peers
 	set.Add(peer2)

--- a/network/throttling/bandwidth_throttler.go
+++ b/network/throttling/bandwidth_throttler.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
-
 	"golang.org/x/time/rate"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/throttling/bandwidth_throttler_test.go
+++ b/network/throttling/bandwidth_throttler_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/throttling/inbound_msg_buffer_throttler_test.go
+++ b/network/throttling/inbound_msg_buffer_throttler_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/throttling/inbound_msg_byte_throttler.go
+++ b/network/throttling/inbound_msg_byte_throttler.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/throttling/inbound_msg_byte_throttler_test.go
+++ b/network/throttling/inbound_msg_byte_throttler_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/throttling/inbound_resource_throttler_test.go
+++ b/network/throttling/inbound_resource_throttler_test.go
@@ -8,11 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/networking/tracker"

--- a/network/throttling/outbound_msg_throttler.go
+++ b/network/throttling/outbound_msg_throttler.go
@@ -5,7 +5,6 @@ package throttling
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/network/throttling/outbound_msg_throttler_test.go
+++ b/network/throttling/outbound_msg_throttler_test.go
@@ -6,11 +6,9 @@ package throttling
 import (
 	"testing"
 
-	"go.uber.org/mock/gomock"
-
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"

--- a/node/beacon_manager_test.go
+++ b/node/beacon_manager_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/node/node.go
+++ b/node/node.go
@@ -22,10 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"go.uber.org/zap"
-
-	coreth "github.com/ava-labs/coreth/plugin/evm"
 
 	"github.com/ava-labs/avalanchego/api/admin"
 	"github.com/ava-labs/avalanchego/api/auth"
@@ -88,6 +85,7 @@ import (
 	ipcsapi "github.com/ava-labs/avalanchego/api/ipcs"
 	avmconfig "github.com/ava-labs/avalanchego/vms/avm/config"
 	platformconfig "github.com/ava-labs/avalanchego/vms/platformvm/config"
+	coreth "github.com/ava-labs/coreth/plugin/evm"
 )
 
 const (

--- a/pubsub/connection.go
+++ b/pubsub/connection.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/pubsub/bloom"

--- a/pubsub/server.go
+++ b/pubsub/server.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/utils/logging"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -32,7 +32,7 @@ fi
 TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func"}
 
 function test_golangci_lint {
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
+  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
   golangci-lint run --config .golangci.yml
 }
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -32,7 +32,7 @@ fi
 TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_equal_zero require_len_zero require_equal_len require_nil require_no_error_inline_func"}
 
 function test_golangci_lint {
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.1
+  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
   golangci-lint run --config .golangci.yml
 }
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,7 +29,7 @@ fi
 # by default, "./scripts/lint.sh" runs all lint tests
 # to run only "license_header" test
 # TESTS='license_header' ./scripts/lint.sh
-TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_equal_zero require_len_zero require_equal_len require_nil require_no_error_inline_func"}
+TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func"}
 
 function test_golangci_lint {
   go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
@@ -61,74 +61,6 @@ function test_single_import {
 
 function test_require_error_is_no_funcs_as_params {
   if grep -R -zo -P 'require.ErrorIs\(.+?\)[^\n]*\)\n' .; then
-    echo ""
-    return 1
-  fi
-}
-
-function test_require_equal_zero {
-  # check if the first arg, other than t, is 0
-  if grep -R -o -P 'require\.Equal\((t, )?(u?int\d*\(0\)|0)' .; then
-    echo ""
-    echo "Use require.Zero instead of require.Equal when testing for 0."
-    echo ""
-    return 1
-  fi
-
-  # check if the last arg is 0
-  if grep -R -zo -P 'require\.Equal\(.+?, (u?int\d*\(0\)|0)\)\n' .; then
-    echo ""
-    echo "Use require.Zero instead of require.Equal when testing for 0."
-    echo ""
-    return 1
-  fi
-}
-
-function test_require_len_zero {
-  if grep -R -o -P 'require\.Len\((t, )?.+, 0(,|\))' .; then
-    echo ""
-    echo "Use require.Empty instead of require.Len when testing for 0 length."
-    echo ""
-    return 1
-  fi
-}
-
-function test_require_equal_len {
-  # This should only flag if len(foo) is the *actual* val, not the expected val.
-  #
-  # These should *not* match:
-  # - require.Equal(len(foo), 2)
-  # - require.Equal(t, len(foo), 2)
-  #
-  # These should match:
-  # - require.Equal(2, len(foo))
-  # - require.Equal(t, 2, len(foo))
-  if grep -R -o -P --exclude-dir='scripts' 'require\.Equal\((t, )?.*, len\([^,]*$' .; then
-    echo ""
-    echo "Use require.Len instead of require.Equal when testing for length."
-    echo ""
-    return 1
-  fi
-}
-
-function test_require_nil {
-  if grep -R -o -P 'require\..+?!= nil' .; then
-    echo ""
-    echo "Use require.NotNil when testing for nil inequality."
-    echo ""
-    return 1
-  fi
-
-  if grep -R -o -P 'require\..+?== nil' .; then
-    echo ""
-    echo "Use require.Nil when testing for nil equality."
-    echo ""
-    return 1
-  fi
-
-  if grep -R -o -P 'require\.ErrorIs.+?nil\)' .; then
-    echo ""
-    echo "Use require.NoError instead of require.ErrorIs when testing for nil error."
     echo ""
     return 1
   fi

--- a/snow/consensus/snowball/consensus_performance_test.go
+++ b/snow/consensus/snowball/consensus_performance_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"gonum.org/v1/gonum/mathext/prng"
 )
 

--- a/snow/consensus/snowball/consensus_reversibility_test.go
+++ b/snow/consensus/snowball/consensus_reversibility_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"gonum.org/v1/gonum/mathext/prng"
 )
 

--- a/snow/consensus/snowball/tree.go
+++ b/snow/consensus/snowball/tree.go
@@ -173,8 +173,6 @@ func (u *unaryNode) DecidedPrefix() int {
 	return u.decidedPrefix
 }
 
-//nolint:gofmt,gofumpt,goimports // this comment is formatted as intended
-//
 // This is by far the most complicated function in this algorithm.
 // The intuition is that this instance represents a series of consecutive unary
 // snowball instances, and this function's purpose is convert one of these unary
@@ -186,23 +184,23 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "00001" in this node:
 //
-//                       +-------------------+ <-- This node will not be split
-//                       |                   |
-//                       |       0 0 0       |
-//                       |                   |
-//                       +-------------------+ <-- Pass the add to the child
-//                                 ^
-//                                 |
+//     +-------------------+ <-- This node will not be split
+//     |                   |
+//     |       0 0 0       |
+//     |                   |
+//     +-------------------+ <-- Pass the add to the child
+//     ^
+//     |
 //
 //     Results in:
 //
-//                       +-------------------+
-//                       |                   |
-//                       |       0 0 0       |
-//                       |                   |
-//                       +-------------------+ <-- With the modified child
-//                                 ^
-//                                 |
+//     +-------------------+
+//     |                   |
+//     |       0 0 0       |
+//     |                   |
+//     +-------------------+ <-- With the modified child
+//     ^
+//     |
 //
 //  2. This instance represents a series of only one unary instance and it must
 //     be split.
@@ -213,19 +211,19 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "1" in this tree:
 //
-//                       +-------------------+
-//                       |                   |
-//                       |         0         |
-//                       |                   |
-//                       +-------------------+
+//     +-------------------+
+//     |                   |
+//     |         0         |
+//     |                   |
+//     +-------------------+
 //
 //     Results in:
 //
-//                       +-------------------+
-//                       |         |         |
-//                       |    0    |    1    |
-//                       |         |         |
-//                       +-------------------+
+//     +-------------------+
+//     |         |         |
+//     |    0    |    1    |
+//     |         |         |
+//     +-------------------+
 //
 //  3. This instance must be split on the first bit
 //
@@ -235,26 +233,26 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "10" in this tree:
 //
-//                       +-------------------+
-//                       |                   |
-//                       |        0 0        |
-//                       |                   |
-//                       +-------------------+
+//     +-------------------+
+//     |                   |
+//     |        0 0        |
+//     |                   |
+//     +-------------------+
 //
 //     Results in:
 //
-//                       +-------------------+
-//                       |         |         |
-//                       |    0    |    1    |
-//                       |         |         |
-//                       +-------------------+
-//                            ^         ^
-//                           /           \
-//            +-------------------+ +-------------------+
-//            |                   | |                   |
-//            |         0         | |         0         |
-//            |                   | |                   |
-//            +-------------------+ +-------------------+
+//     +-------------------+
+//     |         |         |
+//     |    0    |    1    |
+//     |         |         |
+//     +-------------------+
+//     ^         ^
+//     /           \
+//     +-------------------+ +-------------------+
+//     |                   | |                   |
+//     |         0         | |         0         |
+//     |                   | |                   |
+//     +-------------------+ +-------------------+
 //
 //  4. This instance must be split on the last bit
 //
@@ -265,26 +263,26 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "01" in this tree:
 //
-//                       +-------------------+
-//                       |                   |
-//                       |        0 0        |
-//                       |                   |
-//                       +-------------------+
+//     +-------------------+
+//     |                   |
+//     |        0 0        |
+//     |                   |
+//     +-------------------+
 //
 //     Results in:
 //
-//                       +-------------------+
-//                       |                   |
-//                       |         0         |
-//                       |                   |
-//                       +-------------------+
-//                                 ^
-//                                 |
-//                       +-------------------+
-//                       |         |         |
-//                       |    0    |    1    |
-//                       |         |         |
-//                       +-------------------+
+//     +-------------------+
+//     |                   |
+//     |         0         |
+//     |                   |
+//     +-------------------+
+//     ^
+//     |
+//     +-------------------+
+//     |         |         |
+//     |    0    |    1    |
+//     |         |         |
+//     +-------------------+
 //
 //  5. This instance must be split on an interior bit
 //
@@ -296,33 +294,35 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "010" in this tree:
 //
-//                       +-------------------+
-//                       |                   |
-//                       |       0 0 0       |
-//                       |                   |
-//                       +-------------------+
+//     +-------------------+
+//     |                   |
+//     |       0 0 0       |
+//     |                   |
+//     +-------------------+
 //
 //     Results in:
 //
-//                       +-------------------+
-//                       |                   |
-//                       |         0         |
-//                       |                   |
-//                       +-------------------+
-//                                 ^
-//                                 |
-//                       +-------------------+
-//                       |         |         |
-//                       |    0    |    1    |
-//                       |         |         |
-//                       +-------------------+
-//                            ^         ^
-//                           /           \
-//            +-------------------+ +-------------------+
-//            |                   | |                   |
-//            |         0         | |         0         |
-//            |                   | |                   |
-//            +-------------------+ +-------------------+
+//     +-------------------+
+//     |                   |
+//     |         0         |
+//     |                   |
+//     +-------------------+
+//     ^
+//     |
+//     +-------------------+
+//     |         |         |
+//     |    0    |    1    |
+//     |         |         |
+//     +-------------------+
+//     ^         ^
+//     /           \
+//     +-------------------+ +-------------------+
+//     |                   | |                   |
+//     |         0         | |         0         |
+//     |                   | |                   |
+//     +-------------------+ +-------------------+
+//
+//nolint:gofmt,gofumpt,goimports // this comment is formatted as intended
 func (u *unaryNode) Add(newChoice ids.ID) node {
 	if u.Finalized() {
 		return u // Only happens if the tree is finalized, or it's a leaf node

--- a/snow/consensus/snowball/tree.go
+++ b/snow/consensus/snowball/tree.go
@@ -322,7 +322,7 @@ func (u *unaryNode) DecidedPrefix() int {
 //     |                   | |                   |
 //     +-------------------+ +-------------------+
 //
-//nolint:gofmt,gofumpt,goimports // this comment is formatted as intended
+//nolint:goimports // this comment is formatted as intended
 func (u *unaryNode) Add(newChoice ids.ID) node {
 	if u.Finalized() {
 		return u // Only happens if the tree is finalized, or it's a leaf node

--- a/snow/consensus/snowball/tree.go
+++ b/snow/consensus/snowball/tree.go
@@ -586,4 +586,3 @@ func (b *binaryNode) Printable() (string, []node) {
 	}
 	return s, []node{b.children[1], b.children[0]}
 }
-

--- a/snow/consensus/snowball/tree.go
+++ b/snow/consensus/snowball/tree.go
@@ -173,6 +173,8 @@ func (u *unaryNode) DecidedPrefix() int {
 	return u.decidedPrefix
 }
 
+//nolint:gci,gofmt,gofumpt // this comment is formatted as intended
+//
 // This is by far the most complicated function in this algorithm.
 // The intuition is that this instance represents a series of consecutive unary
 // snowball instances, and this function's purpose is convert one of these unary
@@ -184,23 +186,23 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "00001" in this node:
 //
-//     +-------------------+ <-- This node will not be split
-//     |                   |
-//     |       0 0 0       |
-//     |                   |
-//     +-------------------+ <-- Pass the add to the child
-//     ^
-//     |
+//                       +-------------------+ <-- This node will not be split
+//                       |                   |
+//                       |       0 0 0       |
+//                       |                   |
+//                       +-------------------+ <-- Pass the add to the child
+//                                 ^
+//                                 |
 //
 //     Results in:
 //
-//     +-------------------+
-//     |                   |
-//     |       0 0 0       |
-//     |                   |
-//     +-------------------+ <-- With the modified child
-//     ^
-//     |
+//                       +-------------------+
+//                       |                   |
+//                       |       0 0 0       |
+//                       |                   |
+//                       +-------------------+ <-- With the modified child
+//                                 ^
+//                                 |
 //
 //  2. This instance represents a series of only one unary instance and it must
 //     be split.
@@ -211,19 +213,19 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "1" in this tree:
 //
-//     +-------------------+
-//     |                   |
-//     |         0         |
-//     |                   |
-//     +-------------------+
+//                       +-------------------+
+//                       |                   |
+//                       |         0         |
+//                       |                   |
+//                       +-------------------+
 //
 //     Results in:
 //
-//     +-------------------+
-//     |         |         |
-//     |    0    |    1    |
-//     |         |         |
-//     +-------------------+
+//                       +-------------------+
+//                       |         |         |
+//                       |    0    |    1    |
+//                       |         |         |
+//                       +-------------------+
 //
 //  3. This instance must be split on the first bit
 //
@@ -233,26 +235,26 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "10" in this tree:
 //
-//     +-------------------+
-//     |                   |
-//     |        0 0        |
-//     |                   |
-//     +-------------------+
+//                       +-------------------+
+//                       |                   |
+//                       |        0 0        |
+//                       |                   |
+//                       +-------------------+
 //
 //     Results in:
 //
-//     +-------------------+
-//     |         |         |
-//     |    0    |    1    |
-//     |         |         |
-//     +-------------------+
-//     ^         ^
-//     /           \
-//     +-------------------+ +-------------------+
-//     |                   | |                   |
-//     |         0         | |         0         |
-//     |                   | |                   |
-//     +-------------------+ +-------------------+
+//                       +-------------------+
+//                       |         |         |
+//                       |    0    |    1    |
+//                       |         |         |
+//                       +-------------------+
+//                            ^         ^
+//                           /           \
+//            +-------------------+ +-------------------+
+//            |                   | |                   |
+//            |         0         | |         0         |
+//            |                   | |                   |
+//            +-------------------+ +-------------------+
 //
 //  4. This instance must be split on the last bit
 //
@@ -263,26 +265,26 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "01" in this tree:
 //
-//     +-------------------+
-//     |                   |
-//     |        0 0        |
-//     |                   |
-//     +-------------------+
+//                       +-------------------+
+//                       |                   |
+//                       |        0 0        |
+//                       |                   |
+//                       +-------------------+
 //
 //     Results in:
 //
-//     +-------------------+
-//     |                   |
-//     |         0         |
-//     |                   |
-//     +-------------------+
-//     ^
-//     |
-//     +-------------------+
-//     |         |         |
-//     |    0    |    1    |
-//     |         |         |
-//     +-------------------+
+//                       +-------------------+
+//                       |                   |
+//                       |         0         |
+//                       |                   |
+//                       +-------------------+
+//                                 ^
+//                                 |
+//                       +-------------------+
+//                       |         |         |
+//                       |    0    |    1    |
+//                       |         |         |
+//                       +-------------------+
 //
 //  5. This instance must be split on an interior bit
 //
@@ -294,35 +296,33 @@ func (u *unaryNode) DecidedPrefix() int {
 //
 //     For example, attempting to insert the value "010" in this tree:
 //
-//     +-------------------+
-//     |                   |
-//     |       0 0 0       |
-//     |                   |
-//     +-------------------+
+//                       +-------------------+
+//                       |                   |
+//                       |       0 0 0       |
+//                       |                   |
+//                       +-------------------+
 //
 //     Results in:
 //
-//     +-------------------+
-//     |                   |
-//     |         0         |
-//     |                   |
-//     +-------------------+
-//     ^
-//     |
-//     +-------------------+
-//     |         |         |
-//     |    0    |    1    |
-//     |         |         |
-//     +-------------------+
-//     ^         ^
-//     /           \
-//     +-------------------+ +-------------------+
-//     |                   | |                   |
-//     |         0         | |         0         |
-//     |                   | |                   |
-//     +-------------------+ +-------------------+
-//
-//nolint:goimports // this comment is formatted as intended
+//                       +-------------------+
+//                       |                   |
+//                       |         0         |
+//                       |                   |
+//                       +-------------------+
+//                                 ^
+//                                 |
+//                       +-------------------+
+//                       |         |         |
+//                       |    0    |    1    |
+//                       |         |         |
+//                       +-------------------+
+//                            ^         ^
+//                           /           \
+//            +-------------------+ +-------------------+
+//            |                   | |                   |
+//            |         0         | |         0         |
+//            |                   | |                   |
+//            +-------------------+ +-------------------+
 func (u *unaryNode) Add(newChoice ids.ID) node {
 	if u.Finalized() {
 		return u // Only happens if the tree is finalized, or it's a leaf node
@@ -586,3 +586,4 @@ func (b *binaryNode) Printable() (string, []node) {
 	}
 	return s, []node{b.children[1], b.children[0]}
 }
+

--- a/snow/consensus/snowball/tree_test.go
+++ b/snow/consensus/snowball/tree_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"gonum.org/v1/gonum/mathext/prng"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/consensus/snowman/bootstrapper/majority.go
+++ b/snow/consensus/snowman/bootstrapper/majority.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"go.uber.org/zap"
-
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -14,9 +14,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"gonum.org/v1/gonum/mathext/prng"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/consensus/snowman/metrics.go
+++ b/snow/consensus/snowman/metrics.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/consensus/snowman/poll/set.go
+++ b/snow/consensus/snowman/poll/set.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/consensus/snowman/poll/set_test.go
+++ b/snow/consensus/snowman/poll/set_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/consensus/snowman/poll/set_test.go
+++ b/snow/consensus/snowman/poll/set_test.go
@@ -80,7 +80,7 @@ func TestCreateAndFinishPollOutOfOrder_NewerFinishesFirst(t *testing.T) {
 
 	vdrBag = bag.Of(vdrs...)
 	require.True(s.Add(2, vdrBag))
-	require.Equal(s.Len(), 2)
+	require.Equal(2, s.Len())
 
 	// vote out of order
 	require.Empty(s.Vote(1, vdr1, blkID1))
@@ -117,7 +117,7 @@ func TestCreateAndFinishPollOutOfOrder_OlderFinishesFirst(t *testing.T) {
 
 	vdrBag = bag.Of(vdrs...)
 	require.True(s.Add(2, vdrBag))
-	require.Equal(s.Len(), 2)
+	require.Equal(2, s.Len())
 
 	// vote out of order
 	require.Empty(s.Vote(1, vdr1, blkID1))
@@ -157,7 +157,7 @@ func TestCreateAndFinishPollOutOfOrder_UnfinishedPollsGaps(t *testing.T) {
 
 	vdrBag = bag.Of(vdrs...)
 	require.True(s.Add(3, vdrBag))
-	require.Equal(s.Len(), 3)
+	require.Equal(3, s.Len())
 
 	// vote out of order
 	// 2 finishes first to create a gap of finished poll between two unfinished polls 1 and 3

--- a/snow/consensus/snowman/traced_consensus.go
+++ b/snow/consensus/snowman/traced_consensus.go
@@ -8,11 +8,11 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/bag"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ Consensus = (*tracedConsensus)(nil)

--- a/snow/engine/avalanche/bootstrap/tx_job.go
+++ b/snow/engine/avalanche/bootstrap/tx_job.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/engine/avalanche/bootstrap/vertex_job.go
+++ b/snow/engine/avalanche/bootstrap/vertex_job.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/engine/avalanche/getter/getter.go
+++ b/snow/engine/avalanche/getter/getter.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/engine/avalanche/getter/getter_test.go
+++ b/snow/engine/avalanche/getter/getter_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/engine/avalanche/state/unique_vertex.go
+++ b/snow/engine/avalanche/state/unique_vertex.go
@@ -300,13 +300,13 @@ func (vtx *uniqueVertex) String() string {
 		len(txs),
 	))
 
-	parentFormat := fmt.Sprintf("\n    Parent[%s]: ID = %%s, Status = %%s",
+	parentFormat := fmt.Sprintf("\n    Parent[%s]: ID = %%s, Status = %%s", //nolint:perfsprint
 		formatting.IntFormat(len(parents)-1))
 	for i, parent := range parents {
 		sb.WriteString(fmt.Sprintf(parentFormat, i, parent.ID(), parent.Status()))
 	}
 
-	txFormat := fmt.Sprintf("\n    Transaction[%s]: ID = %%s, Status = %%s",
+	txFormat := fmt.Sprintf("\n    Transaction[%s]: ID = %%s, Status = %%s", //nolint:perfsprint
 		formatting.IntFormat(len(txs)-1))
 	for i, tx := range txs {
 		sb.WriteString(fmt.Sprintf(txFormat, i, tx.ID(), tx.Status()))

--- a/snow/engine/common/queue/jobs.go
+++ b/snow/engine/common/queue/jobs.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/snow/engine/common/queue/jobs_test.go
+++ b/snow/engine/common/queue/jobs_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/snow/engine/common/traced_engine.go
+++ b/snow/engine/common/traced_engine.go
@@ -9,13 +9,13 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ Engine = (*tracedEngine)(nil)

--- a/snow/engine/snowman/bootstrap/block_job.go
+++ b/snow/engine/snowman/bootstrap/block_job.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/engine/snowman/bootstrap/bootstrapper_test.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/snow/engine/snowman/getter/getter.go
+++ b/snow/engine/snowman/getter/getter.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/engine/snowman/getter/getter_test.go
+++ b/snow/engine/snowman/getter/getter_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/engine/snowman/syncer/state_syncer_test.go
+++ b/snow/engine/snowman/syncer/state_syncer_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/snow/engine/snowman/traced_engine.go
+++ b/snow/engine/snowman/traced_engine.go
@@ -8,12 +8,12 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/trace"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ Engine = (*tracedEngine)(nil)

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"

--- a/snow/engine/snowman/transitive_test.go
+++ b/snow/engine/snowman/transitive_test.go
@@ -197,7 +197,7 @@ func TestEngineQuery(t *testing.T) {
 	}
 
 	chitted := new(bool)
-	sender.SendChitsF = func(_ context.Context, inVdr ids.NodeID, requestID uint32, preferredID ids.ID, preferredIDByHeight ids.ID, accepted ids.ID) {
+	sender.SendChitsF = func(_ context.Context, _ ids.NodeID, requestID uint32, preferredID ids.ID, preferredIDByHeight ids.ID, accepted ids.ID) {
 		require.False(*chitted)
 		*chitted = true
 		require.Equal(uint32(15), requestID)
@@ -705,7 +705,7 @@ func TestEngineBuildBlock(t *testing.T) {
 		}
 	}
 
-	sender.SendPullQueryF = func(_ context.Context, inVdrs set.Set[ids.NodeID], _ uint32, _ ids.ID, _ uint64) {
+	sender.SendPullQueryF = func(context.Context, set.Set[ids.NodeID], uint32, ids.ID, uint64) {
 		require.FailNow("should not be sending pulls when we are the block producer")
 	}
 

--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -12,12 +12,9 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-
 	"go.uber.org/zap"
-
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ava-labs/avalanchego/api/health"

--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -176,7 +176,7 @@ func TestHandlerClosesOnError(t *testing.T) {
 	bootstrapper.ContextF = func() *snow.ConsensusContext {
 		return ctx
 	}
-	bootstrapper.GetAcceptedFrontierF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
+	bootstrapper.GetAcceptedFrontierF = func(context.Context, ids.NodeID, uint32) error {
 		return errFatal
 	}
 
@@ -264,7 +264,7 @@ func TestHandlerDropsGossipDuringBootstrapping(t *testing.T) {
 	bootstrapper.ContextF = func() *snow.ConsensusContext {
 		return ctx
 	}
-	bootstrapper.GetFailedF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
+	bootstrapper.GetFailedF = func(context.Context, ids.NodeID, uint32) error {
 		closed <- struct{}{}
 		return nil
 	}

--- a/snow/networking/handler/health_test.go
+++ b/snow/networking/handler/health_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/handler/message_queue_metrics.go
+++ b/snow/networking/handler/message_queue_metrics.go
@@ -49,7 +49,7 @@ func (m *messageQueueMetrics) initialize(
 		opStr := op.String()
 		opMetric := prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("%s_count", opStr),
+			Name:      opStr + "_count",
 			Help:      fmt.Sprintf("Number of %s messages in the message queue.", opStr),
 		})
 		m.ops[op] = opMetric

--- a/snow/networking/handler/message_queue_test.go
+++ b/snow/networking/handler/message_queue_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/handler/metrics.go
+++ b/snow/networking/handler/metrics.go
@@ -49,13 +49,13 @@ func newMetrics(namespace string, reg prometheus.Registerer) (*metrics, error) {
 			processingTime: metric.NewAveragerWithErrs(
 				namespace,
 				opStr,
-				fmt.Sprintf("time (in ns) spent handling a %s", opStr),
+				"time (in ns) spent handling a "+opStr,
 				reg,
 				&errs,
 			),
 			msgHandlingTime: metric.NewAveragerWithErrs(
 				namespace,
-				fmt.Sprintf("%s_msg_handling", opStr),
+				opStr+"_msg_handling",
 				fmt.Sprintf("time (in ns) spent handling a %s after grabbing the lock", opStr),
 				reg,
 				&errs,

--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -417,7 +417,7 @@ func TestRouterTimeout(t *testing.T) {
 		return nil
 	}
 	bootstrapper.HaltF = func(context.Context) {}
-	bootstrapper.ShutdownF = func(ctx context.Context) error { return nil }
+	bootstrapper.ShutdownF = func(context.Context) error { return nil }
 
 	bootstrapper.GetStateSummaryFrontierFailedF = func(context.Context, ids.NodeID, uint32) error {
 		defer wg.Done()
@@ -1405,7 +1405,7 @@ func TestAppRequest(t *testing.T) {
 					return nil
 				}
 			} else if tt.inboundMsg.Op() == message.AppResponseOp {
-				engine.AppResponseF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32, msg []byte) error {
+				engine.AppResponseF = func(_ context.Context, nodeID ids.NodeID, requestID uint32, msg []byte) error {
 					defer wg.Done()
 					require.Zero(chainRouter.timedRequests.Len())
 
@@ -1487,7 +1487,7 @@ func TestCrossChainAppRequest(t *testing.T) {
 					return nil
 				}
 			} else if tt.inboundMsg.Op() == message.CrossChainAppResponseOp {
-				engine.CrossChainAppResponseF = func(ctx context.Context, chainID ids.ID, requestID uint32, msg []byte) error {
+				engine.CrossChainAppResponseF = func(_ context.Context, chainID ids.ID, requestID uint32, msg []byte) error {
 					defer wg.Done()
 					require.Zero(chainRouter.timedRequests.Len())
 

--- a/snow/networking/router/traced_router.go
+++ b/snow/networking/router/traced_router.go
@@ -8,10 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.opentelemetry.io/otel/attribute"
-
-	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"
@@ -22,6 +19,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ Router = (*tracedRouter)(nil)

--- a/snow/networking/sender/sender.go
+++ b/snow/networking/sender/sender.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -201,7 +201,7 @@ func TestTimeout(t *testing.T) {
 	bootstrapper.GetAncestorsFailedF = failed
 	bootstrapper.GetFailedF = failed
 	bootstrapper.QueryFailedF = failed
-	bootstrapper.AppRequestFailedF = func(ctx context.Context, nodeID ids.NodeID, _ uint32, appErr *common.AppError) error {
+	bootstrapper.AppRequestFailedF = func(ctx context.Context, nodeID ids.NodeID, _ uint32, _ *common.AppError) error {
 		require.NoError(ctx.Err())
 
 		failedLock.Lock()
@@ -297,7 +297,7 @@ func TestTimeout(t *testing.T) {
 	}
 
 	// Send messages to disconnected peers
-	externalSender.SendF = func(_ message.OutboundMessage, nodeIDs set.Set[ids.NodeID], _ ids.ID, _ subnets.Allower) set.Set[ids.NodeID] {
+	externalSender.SendF = func(message.OutboundMessage, set.Set[ids.NodeID], ids.ID, subnets.Allower) set.Set[ids.NodeID] {
 		return nil
 	}
 	sendAll()

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/sender/traced_sender.go
+++ b/snow/networking/sender/traced_sender.go
@@ -8,13 +8,13 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/set"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ common.Sender = (*tracedSender)(nil)

--- a/snow/networking/timeout/manager_test.go
+++ b/snow/networking/timeout/manager_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/timeout/metrics.go
+++ b/snow/networking/timeout/metrics.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/tracker/resource_tracker_test.go
+++ b/snow/networking/tracker/resource_tracker_test.go
@@ -8,9 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/networking/tracker/targeter_test.go
+++ b/snow/networking/tracker/targeter_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/snowtest/snowtest.go
+++ b/snow/snowtest/snowtest.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api/metrics"

--- a/snow/uptime/locked_calculator_test.go
+++ b/snow/uptime/locked_calculator_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/snow/validators/traced_state.go
+++ b/snow/validators/traced_state.go
@@ -9,10 +9,10 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ State = (*tracedState)(nil)

--- a/snow/validators/traced_state.go
+++ b/snow/validators/traced_state.go
@@ -5,7 +5,6 @@ package validators
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -29,10 +28,10 @@ type tracedState struct {
 func Trace(s State, name string, tracer trace.Tracer) State {
 	return &tracedState{
 		s:                   s,
-		getMinimumHeightTag: fmt.Sprintf("%s.GetMinimumHeight", name),
-		getCurrentHeightTag: fmt.Sprintf("%s.GetCurrentHeight", name),
-		getSubnetIDTag:      fmt.Sprintf("%s.GetSubnetID", name),
-		getValidatorSetTag:  fmt.Sprintf("%s.GetValidatorSet", name),
+		getMinimumHeightTag: name + ".GetMinimumHeight",
+		getCurrentHeightTag: name + ".GetCurrentHeight",
+		getSubnetIDTag:      name + ".GetSubnetID",
+		getValidatorSetTag:  name + ".GetValidatorSet",
 		tracer:              tracer,
 	}
 }

--- a/staking/parse.go
+++ b/staking/parse.go
@@ -16,9 +16,9 @@ import (
 
 	"golang.org/x/crypto/cryptobyte"
 
-	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
-
 	"github.com/ava-labs/avalanchego/utils/units"
+
+	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
 )
 
 const (

--- a/staking/parse_test.go
+++ b/staking/parse_test.go
@@ -6,9 +6,9 @@ package staking
 import (
 	"testing"
 
-	_ "embed"
-
 	"github.com/stretchr/testify/require"
+
+	_ "embed"
 )
 
 var (

--- a/tests/colors.go
+++ b/tests/colors.go
@@ -4,9 +4,9 @@
 package tests
 
 import (
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/onsi/ginkgo/v2/formatter"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 // Outputs to stdout.

--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -5,8 +5,6 @@
 package banff
 
 import (
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -17,6 +15,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 var _ = ginkgo.Describe("[Banff]", func() {

--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -7,21 +7,19 @@ import (
 	"math/big"
 	"strings"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 // This test uses the compiled bin for `hashing.sol` as

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -6,12 +6,9 @@ package c
 import (
 	"math/big"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
@@ -21,6 +18,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -6,12 +6,7 @@ package e2e_test
 import (
 	"testing"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/onsi/gomega"
-
-	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
-	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 
 	// ensure test packages are scanned by ginkgo
 	_ "github.com/ava-labs/avalanchego/tests/e2e/banff"
@@ -20,6 +15,11 @@ import (
 	_ "github.com/ava-labs/avalanchego/tests/e2e/p"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/x"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/x/transfer"
+
+	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 func TestE2E(t *testing.T) {

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api/info"
@@ -17,6 +15,8 @@ import (
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 	"github.com/ava-labs/avalanchego/utils/set"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 var _ = ginkgo.Describe("Duplicate node handling", func() {

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -7,13 +7,9 @@ import (
 	"math/big"
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
-	"github.com/spf13/cast"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/spf13/cast"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/config"
@@ -29,6 +25,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 var _ = e2e.DescribePChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainLabel), func() {

--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -22,6 +20,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 var _ = e2e.DescribePChain("[Permissionless Subnets]", func() {

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -7,11 +7,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
-
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/spf13/cast"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api/admin"
@@ -28,6 +24,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 const (

--- a/tests/e2e/p/validator_sets.go
+++ b/tests/e2e/p/validator_sets.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/genesis"
@@ -22,6 +20,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 var _ = e2e.DescribePChain("[Validator Sets]", func() {

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -6,8 +6,6 @@ package p
 import (
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api/info"
@@ -23,6 +21,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 // PChainWorkflow is an integration test for normal P-Chain operations

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -6,11 +6,8 @@ package x
 import (
 	"math/big"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
@@ -21,6 +18,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 var _ = e2e.DescribeXChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainLabel), func() {

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -226,14 +226,14 @@ RECEIVER  NEW BALANCE (AFTER) : %21d AVAX
 					xc := avm.NewClient(u, "X")
 					status, err := xc.ConfirmTx(e2e.DefaultContext(), txID, 2*time.Second)
 					require.NoError(err)
-					require.Equal(status, choices.Accepted)
+					require.Equal(choices.Accepted, status)
 				}
 
 				for _, u := range rpcEps {
 					xc := avm.NewClient(u, "X")
 					status, err := xc.ConfirmTx(e2e.DefaultContext(), txID, 2*time.Second)
 					require.NoError(err)
-					require.Equal(status, choices.Accepted)
+					require.Equal(choices.Accepted, status)
 
 					mm, err := tests.GetNodeMetrics(u, allMetrics...)
 					require.NoError(err)

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -9,8 +9,6 @@ import (
 	"math/rand"
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -23,6 +21,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 const (

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api/info"
@@ -22,6 +20,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/perms"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 // Env is used to access shared test fixture. Intended to be

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -163,7 +163,7 @@ func SendEthTransaction(ethClient ethclient.Client, signedTx *types.Transaction)
 		return true
 	}, DefaultTimeout, DefaultPollingInterval, "failed to see transaction acceptance before timeout")
 
-	require.Equal(receipt.Status, types.ReceiptStatusSuccessful)
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 	return receipt
 }
 

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -12,13 +12,10 @@ import (
 	"strings"
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/ethclient"
 	"github.com/ava-labs/coreth/interfaces"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests"
@@ -26,6 +23,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 const (

--- a/tests/fixture/test_data_server_test.go
+++ b/tests/fixture/test_data_server_test.go
@@ -15,19 +15,17 @@ import (
 // Check that funded test keys can be served from an http server to
 // ensure at-most-once allocation when tests are executed in parallel.
 func TestAllocatePreFundedKeys(t *testing.T) {
-	require := require.New(t)
-
 	keys := make([]*secp256k1.PrivateKey, 5)
 	for i := range keys {
 		key, err := secp256k1.NewPrivateKey()
-		require.NoError(err)
+		require.NoError(t, err)
 		keys[i] = key
 	}
 
 	uri, err := ServeTestData(TestData{
 		PreFundedKeys: keys,
 	})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	testCases := []struct {
 		name              string
@@ -63,6 +61,8 @@ func TestAllocatePreFundedKeys(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
 			keys, err := AllocatePreFundedKeys(uri, tc.count)
 			require.ErrorIs(err, tc.expectedError)
 

--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -136,7 +136,7 @@ func (n *Network) readChainConfigs() error {
 			// No config file present
 			continue
 		}
-		chainConfig, err := ReadFlagsMap(configPath, fmt.Sprintf("%s chain config", chainAlias))
+		chainConfig, err := ReadFlagsMap(configPath, chainAlias+" chain config")
 		if err != nil {
 			return err
 		}
@@ -158,7 +158,7 @@ func (n *Network) writeChainConfigs() error {
 
 		// Write the file
 		path := filepath.Join(chainConfigDir, defaultConfigFilename)
-		if err := chainConfig.Write(path, fmt.Sprintf("%s chain config", chainAlias)); err != nil {
+		if err := chainConfig.Write(path, chainAlias+" chain config"); err != nil {
 			return err
 		}
 	}

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -9,9 +9,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-
 	"github.com/onsi/gomega"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"

--- a/trace/noop.go
+++ b/trace/noop.go
@@ -21,7 +21,7 @@ type noOpTracer struct {
 }
 
 func (n noOpTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return n.t.Start(ctx, spanName, opts...)
+	return n.t.Start(ctx, spanName, opts...) //nolint:spancheck
 }
 
 func (noOpTracer) Close() error {

--- a/utils/compression/compressor_test.go
+++ b/utils/compression/compressor_test.go
@@ -9,9 +9,9 @@ import (
 	"runtime"
 	"testing"
 
-	_ "embed"
-
 	"github.com/stretchr/testify/require"
+
+	_ "embed"
 
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/units"

--- a/utils/crypto/keychain/keychain_test.go
+++ b/utils/crypto/keychain/keychain_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/utils/crypto/ledger/ledger.go
+++ b/utils/crypto/ledger/ledger.go
@@ -6,14 +6,13 @@ package ledger
 import (
 	"fmt"
 
-	ledger "github.com/ava-labs/ledger-avalanche/go"
-
-	bip32 "github.com/tyler-smith/go-bip32"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/keychain"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/version"
+
+	ledger "github.com/ava-labs/ledger-avalanche/go"
+	bip32 "github.com/tyler-smith/go-bip32"
 )
 
 const (

--- a/utils/crypto/secp256k1/secp256k1.go
+++ b/utils/crypto/secp256k1/secp256k1.go
@@ -8,16 +8,15 @@ import (
 	"fmt"
 	"strings"
 
-	stdecdsa "crypto/ecdsa"
-
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-
-	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/cb58"
 	"github.com/ava-labs/avalanchego/utils/hashing"
+
+	stdecdsa "crypto/ecdsa"
+	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
 const (

--- a/utils/crypto/secp256k1/secp256k1_test.go
+++ b/utils/crypto/secp256k1/secp256k1_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
-
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/cb58"
 	"github.com/ava-labs/avalanchego/utils/hashing"
+
+	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
 func TestRecover(t *testing.T) {

--- a/utils/formatting/encoding_test.go
+++ b/utils/formatting/encoding_test.go
@@ -39,7 +39,7 @@ func TestEncodingUnmarshalJSON(t *testing.T) {
 
 func TestEncodingString(t *testing.T) {
 	enc := Hex
-	require.Equal(t, enc.String(), "hex")
+	require.Equal(t, "hex", enc.String())
 }
 
 // Test encoding bytes to a string and decoding back to bytes

--- a/utils/hashing/consistent/ring_test.go
+++ b/utils/hashing/consistent/ring_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/utils/hashing"

--- a/utils/logging/factory.go
+++ b/utils/logging/factory.go
@@ -11,9 +11,7 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
 	"golang.org/x/exp/maps"
-
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 

--- a/utils/math/averager_heap_test.go
+++ b/utils/math/averager_heap_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestAveragerHeap(t *testing.T) {
-	require := require.New(t)
-
 	n0 := ids.GenerateTestNodeID()
 	n1 := ids.GenerateTestNodeID()
 	n2 := ids.GenerateTestNodeID()
@@ -37,6 +35,8 @@ func TestAveragerHeap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
 			_, _, ok := test.h.Pop()
 			require.False(ok)
 

--- a/utils/math/meter/meter_test.go
+++ b/utils/math/meter/meter_test.go
@@ -66,17 +66,17 @@ func TimeTravelTest(t *testing.T, factory Factory) {
 
 	now = now.Add(halflife - 1)
 	delta := 0.0001
-	require.InDelta(m.Read(now), .5, delta)
+	require.InDelta(.5, m.Read(now), delta)
 
 	m.Dec(now, 1)
 
 	now = now.Add(-halflife)
-	require.InDelta(m.Read(now), .5, delta)
+	require.InDelta(.5, m.Read(now), delta)
 
 	m.Inc(now, 1)
 
 	now = now.Add(halflife / 2)
-	require.InDelta(m.Read(now), .5, delta)
+	require.InDelta(.5, m.Read(now), delta)
 }
 
 func StandardUsageTest(t *testing.T, factory Factory) {
@@ -89,50 +89,50 @@ func StandardUsageTest(t *testing.T, factory Factory) {
 
 	now = now.Add(halflife - 1)
 	delta := 0.0001
-	require.InDelta(m.Read(now), .5, delta)
+	require.InDelta(.5, m.Read(now), delta)
 
 	m.Inc(now, 1)
-	require.InDelta(m.Read(now), .5, delta)
+	require.InDelta(.5, m.Read(now), delta)
 
 	m.Dec(now, 1)
-	require.InDelta(m.Read(now), .5, delta)
+	require.InDelta(.5, m.Read(now), delta)
 
 	m.Dec(now, 1)
 
-	require.InDelta(m.Read(now), .5, delta)
+	require.InDelta(.5, m.Read(now), delta)
 
 	now = now.Add(halflife)
-	require.InDelta(m.Read(now), .25, delta)
+	require.InDelta(.25, m.Read(now), delta)
 
 	m.Inc(now, 1)
 
 	now = now.Add(halflife)
-	require.InDelta(m.Read(now), .625, delta)
+	require.InDelta(.625, m.Read(now), delta)
 
 	now = now.Add(34 * halflife)
-	require.InDelta(m.Read(now), 1, delta)
+	require.InDelta(1, m.Read(now), delta)
 
 	m.Dec(now, 1)
 
 	now = now.Add(34 * halflife)
-	require.InDelta(m.Read(now), 0, delta)
+	require.InDelta(0, m.Read(now), delta)
 
 	m.Inc(now, 1)
 
 	now = now.Add(2 * halflife)
-	require.InDelta(m.Read(now), .75, delta)
+	require.InDelta(.75, m.Read(now), delta)
 
 	// Second start
 	m.Inc(now, 1)
 
 	now = now.Add(34 * halflife)
-	require.InDelta(m.Read(now), 2, delta)
+	require.InDelta(2, m.Read(now), delta)
 
 	// Stop the second CPU
 	m.Dec(now, 1)
 
 	now = now.Add(34 * halflife)
-	require.InDelta(m.Read(now), 1, delta)
+	require.InDelta(1, m.Read(now), delta)
 }
 
 func TestTimeUntil(t *testing.T) {

--- a/utils/metric/api_interceptor.go
+++ b/utils/metric/api_interceptor.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gorilla/rpc/v2"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/avalanchego/utils"

--- a/utils/metric/averager.go
+++ b/utils/metric/averager.go
@@ -33,13 +33,13 @@ func NewAveragerWithErrs(namespace, name, desc string, reg prometheus.Registerer
 	a := averager{
 		count: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("%s_count", name),
-			Help:      fmt.Sprintf("Total # of observations of %s", desc),
+			Name:      name + "_count",
+			Help:      "Total # of observations of " + desc,
 		}),
 		sum: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("%s_sum", name),
-			Help:      fmt.Sprintf("Sum of %s", desc),
+			Name:      name + "_sum",
+			Help:      "Sum of " + desc,
 		}),
 	}
 

--- a/utils/profiler/continuous.go
+++ b/utils/profiler/continuous.go
@@ -108,7 +108,7 @@ func rotate(name string, maxNumFiles int) error {
 			return err
 		}
 	}
-	destFilename := fmt.Sprintf("%s.1", name)
+	destFilename := name + ".1"
 	_, err := filesystem.RenameIfExists(name, destFilename)
 	return err
 }

--- a/utils/resource/usage.go
+++ b/utils/resource/usage.go
@@ -10,10 +10,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/process"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/utils/logging"

--- a/utils/sampler/rand_test.go
+++ b/utils/sampler/rand_test.go
@@ -10,9 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"github.com/thepudds/fzgen/fuzzer"
-
 	"gonum.org/v1/gonum/mathext/prng"
 )
 

--- a/utils/set/bits_test.go
+++ b/utils/set/bits_test.go
@@ -471,8 +471,6 @@ func Test_Bits_Len(t *testing.T) {
 }
 
 func Test_Bits_Bytes(t *testing.T) {
-	require := require.New(t)
-
 	type test struct {
 		name string
 		elts []int
@@ -495,6 +493,8 @@ func Test_Bits_Bytes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
 			b := NewBits(tt.elts...)
 			bytes := b.Bytes()
 			fromBytes := BitsFromBytes(bytes)

--- a/utils/set/sampleable_set.go
+++ b/utils/set/sampleable_set.go
@@ -7,12 +7,12 @@ import (
 	"bytes"
 	"slices"
 
-	stdjson "encoding/json"
-
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/sampler"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
+
+	stdjson "encoding/json"
 )
 
 var _ stdjson.Marshaler = (*Set[int])(nil)

--- a/utils/set/sampleable_set.go
+++ b/utils/set/sampleable_set.go
@@ -5,17 +5,17 @@ package set
 
 import (
 	"bytes"
+	"encoding/json"
 	"slices"
 
 	"github.com/ava-labs/avalanchego/utils"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/sampler"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 )
 
-var _ stdjson.Marshaler = (*Set[int])(nil)
+var _ json.Marshaler = (*Set[int])(nil)
 
 // SampleableSet is a set of elements that supports sampling.
 type SampleableSet[T comparable] struct {
@@ -149,11 +149,11 @@ func (s SampleableSet[T]) Sample(numToSample int) []T {
 
 func (s *SampleableSet[T]) UnmarshalJSON(b []byte) error {
 	str := string(b)
-	if str == json.Null {
+	if str == avajson.Null {
 		return nil
 	}
 	var elements []T
-	if err := stdjson.Unmarshal(b, &elements); err != nil {
+	if err := json.Unmarshal(b, &elements); err != nil {
 		return err
 	}
 	s.Clear()
@@ -167,7 +167,7 @@ func (s *SampleableSet[_]) MarshalJSON() ([]byte, error) {
 		err          error
 	)
 	for i, e := range s.elements {
-		elementBytes[i], err = stdjson.Marshal(e)
+		elementBytes[i], err = json.Marshal(e)
 		if err != nil {
 			return nil, err
 		}

--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -7,13 +7,13 @@ import (
 	"bytes"
 	"slices"
 
-	stdjson "encoding/json"
-
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
+
+	stdjson "encoding/json"
 )
 
 // The minimum capacity of a set

--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -5,21 +5,21 @@ package set
 
 import (
 	"bytes"
+	"encoding/json"
 	"slices"
 
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/utils"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 )
 
 // The minimum capacity of a set
 const minSetSize = 16
 
-var _ stdjson.Marshaler = (*Set[int])(nil)
+var _ json.Marshaler = (*Set[int])(nil)
 
 // Set is a set of elements.
 type Set[T comparable] map[T]struct{}
@@ -136,11 +136,11 @@ func (s *Set[T]) Pop() (T, bool) {
 
 func (s *Set[T]) UnmarshalJSON(b []byte) error {
 	str := string(b)
-	if str == json.Null {
+	if str == avajson.Null {
 		return nil
 	}
 	var elts []T
-	if err := stdjson.Unmarshal(b, &elts); err != nil {
+	if err := json.Unmarshal(b, &elts); err != nil {
 		return err
 	}
 	s.Clear()
@@ -155,7 +155,7 @@ func (s Set[_]) MarshalJSON() ([]byte, error) {
 		err      error
 	)
 	for elt := range s {
-		eltBytes[i], err = stdjson.Marshal(elt)
+		eltBytes[i], err = json.Marshal(elt)
 		if err != nil {
 			return nil, err
 		}

--- a/utils/timer/adaptive_timeout_manager_test.go
+++ b/utils/timer/adaptive_timeout_manager_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/utils/wrappers/packing_test.go
+++ b/utils/wrappers/packing_test.go
@@ -348,7 +348,7 @@ func TestPackerUnpackBool(t *testing.T) {
 
 	p := Packer{Bytes: []byte{0x01}, Offset: 0}
 
-	require.Equal(true, p.UnpackBool())
+	require.True(p.UnpackBool())
 	require.False(p.Errored())
 	require.NoError(p.Err)
 	require.Equal(BoolLen, p.Offset)
@@ -358,7 +358,7 @@ func TestPackerUnpackBool(t *testing.T) {
 	require.ErrorIs(p.Err, ErrInsufficientLength)
 
 	p = Packer{Bytes: []byte{0x42}, Offset: 0}
-	require.Equal(false, p.UnpackBool())
+	require.False(p.UnpackBool())
 	require.True(p.Errored())
 	require.ErrorIs(p.Err, errBadBool)
 }

--- a/version/parser.go
+++ b/version/parser.go
@@ -36,7 +36,7 @@ func Parse(s string) (*Semantic, error) {
 
 // TODO: Remove after v1.11.x is activated
 func ParseLegacyApplication(s string) (*Application, error) {
-	prefix := fmt.Sprintf("%s/", LegacyAppName)
+	prefix := LegacyAppName + "/"
 	if !strings.HasPrefix(s, prefix) {
 		return nil, fmt.Errorf("%w: %q", errMissingApplicationPrefix, s)
 	}

--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/codec"

--- a/vms/avm/block/executor/block_test.go
+++ b/vms/avm/block/executor/block_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"

--- a/vms/avm/block/executor/block_test.go
+++ b/vms/avm/block/executor/block_test.go
@@ -965,7 +965,7 @@ func TestBlockStatus(t *testing.T) {
 	tests := []test{
 		{
 			name: "block is rejected",
-			blockFunc: func(ctrl *gomock.Controller) *Block {
+			blockFunc: func(*gomock.Controller) *Block {
 				return &Block{
 					rejected: true,
 				}

--- a/vms/avm/block/executor/manager_test.go
+++ b/vms/avm/block/executor/manager_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/avm/block/executor/manager_test.go
+++ b/vms/avm/block/executor/manager_test.go
@@ -121,7 +121,7 @@ func TestManagerVerifyTx(t *testing.T) {
 			txF: func(*gomock.Controller) *txs.Tx {
 				return &txs.Tx{}
 			},
-			managerF: func(ctrl *gomock.Controller) *manager {
+			managerF: func(*gomock.Controller) *manager {
 				return &manager{
 					backend: &executor.Backend{},
 				}

--- a/vms/avm/client_test.go
+++ b/vms/avm/client_test.go
@@ -27,7 +27,7 @@ func (mc *mockClient) SendRequest(
 	_ interface{},
 	_ ...rpc.Option,
 ) error {
-	mc.require.Equal(inData, mc.expectedInData)
+	mc.require.Equal(mc.expectedInData, inData)
 	return nil
 }
 

--- a/vms/avm/environment_test.go
+++ b/vms/avm/environment_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	stdjson "encoding/json"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/api/keystore"
@@ -37,6 +35,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
+	stdjson "encoding/json"
 	keystoreutils "github.com/ava-labs/avalanchego/vms/components/keystore"
 )
 

--- a/vms/avm/environment_test.go
+++ b/vms/avm/environment_test.go
@@ -5,6 +5,7 @@ package avm
 
 import (
 	"context"
+	"encoding/json"
 	"math/rand"
 	"testing"
 	"time"
@@ -23,7 +24,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/linkedhashmap"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/sampler"
@@ -35,7 +35,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 	keystoreutils "github.com/ava-labs/avalanchego/vms/components/keystore"
 )
 
@@ -162,7 +162,7 @@ func setup(tb testing.TB, c *envConfig) *environment {
 	if c.vmDynamicConfig != nil {
 		vmDynamicConfig = *c.vmDynamicConfig
 	}
-	configBytes, err := stdjson.Marshal(vmDynamicConfig)
+	configBytes, err := json.Marshal(vmDynamicConfig)
 	require.NoError(err)
 
 	require.NoError(vm.Initialize(
@@ -354,15 +354,15 @@ func makeDefaultGenesis(tb testing.TB) *BuildGenesisArgs {
 				InitialState: map[string][]interface{}{
 					"fixedCap": {
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr0Str,
 						},
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr1Str,
 						},
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr2Str,
 						},
 					},
@@ -409,11 +409,11 @@ func makeDefaultGenesis(tb testing.TB) *BuildGenesisArgs {
 				InitialState: map[string][]interface{}{
 					"fixedCap": {
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr0Str,
 						},
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr1Str,
 						},
 					},
@@ -444,15 +444,15 @@ func makeCustomAssetGenesis(tb testing.TB) *BuildGenesisArgs {
 				InitialState: map[string][]interface{}{
 					"fixedCap": {
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr0Str,
 						},
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr1Str,
 						},
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr2Str,
 						},
 					},
@@ -464,15 +464,15 @@ func makeCustomAssetGenesis(tb testing.TB) *BuildGenesisArgs {
 				InitialState: map[string][]interface{}{
 					"fixedCap": {
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr0Str,
 						},
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr1Str,
 						},
 						Holder{
-							Amount:  json.Uint64(startBalance),
+							Amount:  avajson.Uint64(startBalance),
 							Address: addr2Str,
 						},
 					},

--- a/vms/avm/index_test.go
+++ b/vms/avm/index_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/avm/metrics/tx_metrics.go
+++ b/vms/avm/metrics/tx_metrics.go
@@ -45,7 +45,7 @@ func newTxMetric(
 ) prometheus.Counter {
 	txMetric := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
-		Name:      fmt.Sprintf("%s_txs_accepted", txName),
+		Name:      txName + "_txs_accepted",
 		Help:      fmt.Sprintf("Number of %s transactions accepted", txName),
 	})
 	errs.Add(registerer.Register(txMetric))

--- a/vms/avm/network/gossip_test.go
+++ b/vms/avm/network/gossip_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/avm/network/network.go
+++ b/vms/avm/network/network.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"

--- a/vms/avm/network/network_test.go
+++ b/vms/avm/network/network_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/avm/service.go
+++ b/vms/avm/service.go
@@ -9,8 +9,6 @@ import (
 	"math"
 	"net/http"
 
-	stdjson "encoding/json"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api"
@@ -30,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
+	stdjson "encoding/json"
 	safemath "github.com/ava-labs/avalanchego/utils/math"
 )
 

--- a/vms/avm/service.go
+++ b/vms/avm/service.go
@@ -4,6 +4,7 @@
 package avm
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -18,7 +19,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
@@ -28,7 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 	safemath "github.com/ava-labs/avalanchego/utils/math"
 )
 
@@ -105,7 +105,7 @@ func (s *Service) GetBlock(_ *http.Request, args *api.GetBlockArgs, reply *api.G
 		}
 	}
 
-	reply.Block, err = stdjson.Marshal(result)
+	reply.Block, err = json.Marshal(result)
 	return err
 }
 
@@ -160,7 +160,7 @@ func (s *Service) GetBlockByHeight(_ *http.Request, args *api.GetBlockByHeightAr
 		}
 	}
 
-	reply.Block, err = stdjson.Marshal(result)
+	reply.Block, err = json.Marshal(result)
 	return err
 }
 
@@ -188,7 +188,7 @@ func (s *Service) GetHeight(_ *http.Request, _ *struct{}, reply *api.GetHeightRe
 		return fmt.Errorf("couldn't get block with id %s: %w", blockID, err)
 	}
 
-	reply.Height = json.Uint64(block.Height())
+	reply.Height = avajson.Uint64(block.Height())
 	return nil
 }
 
@@ -225,9 +225,9 @@ type GetTxStatusReply struct {
 type GetAddressTxsArgs struct {
 	api.JSONAddress
 	// Cursor used as a page index / offset
-	Cursor json.Uint64 `json:"cursor"`
+	Cursor avajson.Uint64 `json:"cursor"`
 	// PageSize num of items per page
-	PageSize json.Uint64 `json:"pageSize"`
+	PageSize avajson.Uint64 `json:"pageSize"`
 	// AssetID defaulted to AVAX if omitted or left blank
 	AssetID string `json:"assetID"`
 }
@@ -235,7 +235,7 @@ type GetAddressTxsArgs struct {
 type GetAddressTxsReply struct {
 	TxIDs []ids.ID `json:"txIDs"`
 	// Cursor used as a page index / offset
-	Cursor json.Uint64 `json:"cursor"`
+	Cursor avajson.Uint64 `json:"cursor"`
 }
 
 // GetAddressTxs returns list of transactions for a given address
@@ -292,7 +292,7 @@ func (s *Service) GetAddressTxs(_ *http.Request, args *GetAddressTxsArgs, reply 
 	// To get the next set of tx IDs, the user should provide this cursor.
 	// e.g. if they provided cursor 5, and read 6 tx IDs, they should start
 	// next time from index (cursor) 11.
-	reply.Cursor = json.Uint64(cursor + uint64(len(reply.TxIDs)))
+	reply.Cursor = avajson.Uint64(cursor + uint64(len(reply.TxIDs)))
 	return nil
 }
 
@@ -363,7 +363,7 @@ func (s *Service) GetTx(_ *http.Request, args *api.GetTxArgs, reply *api.GetTxRe
 		return err
 	}
 
-	reply.Tx, err = stdjson.Marshal(result)
+	reply.Tx, err = json.Marshal(result)
 	return err
 }
 
@@ -465,7 +465,7 @@ func (s *Service) GetUTXOs(_ *http.Request, args *api.GetUTXOsArgs, reply *api.G
 
 	reply.EndIndex.Address = endAddress
 	reply.EndIndex.UTXO = endUTXOID.String()
-	reply.NumFetched = json.Uint64(len(utxos))
+	reply.NumFetched = avajson.Uint64(len(utxos))
 	reply.Encoding = args.Encoding
 	return nil
 }
@@ -478,9 +478,9 @@ type GetAssetDescriptionArgs struct {
 // GetAssetDescriptionReply defines the GetAssetDescription replies returned from the API
 type GetAssetDescriptionReply struct {
 	FormattedAssetID
-	Name         string     `json:"name"`
-	Symbol       string     `json:"symbol"`
-	Denomination json.Uint8 `json:"denomination"`
+	Name         string        `json:"name"`
+	Symbol       string        `json:"symbol"`
+	Denomination avajson.Uint8 `json:"denomination"`
 }
 
 // GetAssetDescription creates an empty account with the name passed in
@@ -511,7 +511,7 @@ func (s *Service) GetAssetDescription(_ *http.Request, args *GetAssetDescription
 	reply.AssetID = assetID
 	reply.Name = createAssetTx.Name
 	reply.Symbol = createAssetTx.Symbol
-	reply.Denomination = json.Uint8(createAssetTx.Denomination)
+	reply.Denomination = avajson.Uint8(createAssetTx.Denomination)
 
 	return nil
 }
@@ -525,8 +525,8 @@ type GetBalanceArgs struct {
 
 // GetBalanceReply defines the GetBalance replies returned from the API
 type GetBalanceReply struct {
-	Balance json.Uint64   `json:"balance"`
-	UTXOIDs []avax.UTXOID `json:"utxoIDs"`
+	Balance avajson.Uint64 `json:"balance"`
+	UTXOIDs []avax.UTXOID  `json:"utxoIDs"`
 }
 
 // GetBalance returns the balance of an asset held by an address.
@@ -581,7 +581,7 @@ func (s *Service) GetBalance(_ *http.Request, args *GetBalanceArgs, reply *GetBa
 		if err != nil {
 			return err
 		}
-		reply.Balance = json.Uint64(amt)
+		reply.Balance = avajson.Uint64(amt)
 		reply.UTXOIDs = append(reply.UTXOIDs, utxo.UTXOID)
 	}
 
@@ -589,8 +589,8 @@ func (s *Service) GetBalance(_ *http.Request, args *GetBalanceArgs, reply *GetBa
 }
 
 type Balance struct {
-	AssetID string      `json:"asset"`
-	Balance json.Uint64 `json:"balance"`
+	AssetID string         `json:"asset"`
+	Balance avajson.Uint64 `json:"balance"`
 }
 
 type GetAllBalancesArgs struct {
@@ -662,7 +662,7 @@ func (s *Service) GetAllBalances(_ *http.Request, args *GetAllBalancesArgs, repl
 		alias := s.vm.PrimaryAliasOrDefault(assetID)
 		reply.Balances[i] = Balance{
 			AssetID: alias,
-			Balance: json.Uint64(balances[assetID]),
+			Balance: avajson.Uint64(balances[assetID]),
 		}
 		i++
 	}
@@ -672,14 +672,14 @@ func (s *Service) GetAllBalances(_ *http.Request, args *GetAllBalancesArgs, repl
 
 // Holder describes how much an address owns of an asset
 type Holder struct {
-	Amount  json.Uint64 `json:"amount"`
-	Address string      `json:"address"`
+	Amount  avajson.Uint64 `json:"amount"`
+	Address string         `json:"address"`
 }
 
 // Owners describes who can perform an action
 type Owners struct {
-	Threshold json.Uint32 `json:"threshold"`
-	Minters   []string    `json:"minters"`
+	Threshold avajson.Uint32 `json:"threshold"`
+	Minters   []string       `json:"minters"`
 }
 
 // CreateAssetArgs are arguments for passing into CreateAsset
@@ -1144,7 +1144,7 @@ func (s *Service) ImportKey(_ *http.Request, args *ImportKeyArgs, reply *api.JSO
 // SendOutput specifies that [Amount] of asset [AssetID] be sent to [To]
 type SendOutput struct {
 	// The amount of funds to send
-	Amount json.Uint64 `json:"amount"`
+	Amount avajson.Uint64 `json:"amount"`
 
 	// ID of the asset being sent
 	AssetID string `json:"assetID"`
@@ -1342,10 +1342,10 @@ func (s *Service) buildSendMultiple(args *SendMultipleArgs) (*txs.Tx, ids.ShortI
 
 // MintArgs are arguments for passing into Mint requests
 type MintArgs struct {
-	api.JSONSpendHeader             // User, password, from addrs, change addr
-	Amount              json.Uint64 `json:"amount"`
-	AssetID             string      `json:"assetID"`
-	To                  string      `json:"to"`
+	api.JSONSpendHeader                // User, password, from addrs, change addr
+	Amount              avajson.Uint64 `json:"amount"`
+	AssetID             string         `json:"assetID"`
+	To                  string         `json:"to"`
 }
 
 // Mint issues a transaction that mints more of the asset
@@ -1475,10 +1475,10 @@ func (s *Service) buildMint(args *MintArgs) (*txs.Tx, ids.ShortID, error) {
 
 // SendNFTArgs are arguments for passing into SendNFT requests
 type SendNFTArgs struct {
-	api.JSONSpendHeader             // User, password, from addrs, change addr
-	AssetID             string      `json:"assetID"`
-	GroupID             json.Uint32 `json:"groupID"`
-	To                  string      `json:"to"`
+	api.JSONSpendHeader                // User, password, from addrs, change addr
+	AssetID             string         `json:"assetID"`
+	GroupID             avajson.Uint32 `json:"groupID"`
+	To                  string         `json:"to"`
 }
 
 // SendNFT sends an NFT
@@ -1858,7 +1858,7 @@ type ExportArgs struct {
 	// User, password, from addrs, change addr
 	api.JSONSpendHeader
 	// Amount of nAVAX to send
-	Amount json.Uint64 `json:"amount"`
+	Amount avajson.Uint64 `json:"amount"`
 
 	// Chain the funds are going to. Optional. Used if To address does not include the chainID.
 	TargetChain string `json:"targetChain"`

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -5,7 +5,7 @@ package avm
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -27,7 +27,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/avm/block"
 	"github.com/ava-labs/avalanchego/vms/avm/block/executor"
@@ -41,7 +40,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/propertyfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 )
 
 func TestServiceIssueTx(t *testing.T) {
@@ -522,7 +521,7 @@ func TestServiceGetTx(t *testing.T) {
 	}, &reply))
 
 	var txStr string
-	require.NoError(stdjson.Unmarshal(reply.Tx, &txStr))
+	require.NoError(json.Unmarshal(reply.Tx, &txStr))
 
 	txBytes, err := formatting.Decode(reply.Encoding, txStr)
 	require.NoError(err)
@@ -551,7 +550,7 @@ func TestServiceGetTxJSON_BaseTx(t *testing.T) {
 
 	require.Equal(formatting.JSON, reply.Encoding)
 
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -633,7 +632,7 @@ func TestServiceGetTxJSON_ExportTx(t *testing.T) {
 	}, &reply))
 
 	require.Equal(formatting.JSON, reply.Encoding)
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -724,7 +723,7 @@ func TestServiceGetTxJSON_CreateAssetTx(t *testing.T) {
 
 	require.Equal(formatting.JSON, reply.Encoding)
 
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -845,7 +844,7 @@ func TestServiceGetTxJSON_OperationTxWithNftxMintOp(t *testing.T) {
 
 	require.Equal(formatting.JSON, reply.Encoding)
 
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -947,7 +946,7 @@ func TestServiceGetTxJSON_OperationTxWithMultipleNftxMintOp(t *testing.T) {
 
 	require.Equal(formatting.JSON, reply.Encoding)
 
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -1082,7 +1081,7 @@ func TestServiceGetTxJSON_OperationTxWithSecpMintOp(t *testing.T) {
 
 	require.Equal(formatting.JSON, reply.Encoding)
 
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -1188,7 +1187,7 @@ func TestServiceGetTxJSON_OperationTxWithMultipleSecpMintOp(t *testing.T) {
 
 	require.Equal(formatting.JSON, reply.Encoding)
 
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -1331,7 +1330,7 @@ func TestServiceGetTxJSON_OperationTxWithPropertyFxMintOp(t *testing.T) {
 
 	require.Equal(formatting.JSON, reply.Encoding)
 
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -1434,7 +1433,7 @@ func TestServiceGetTxJSON_OperationTxWithPropertyFxMintOpMultiple(t *testing.T) 
 
 	require.Equal(formatting.JSON, reply.Encoding)
 
-	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
+	replyTxBytes, err := json.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
 	expectedReplyTxString := `{
@@ -1937,7 +1936,7 @@ func TestServiceGetUTXOs(t *testing.T) {
 			label:       "invalid address: '<ChainID>-'",
 			expectedErr: bech32.ErrInvalidLength(0),
 			args: &api.GetUTXOsArgs{
-				Addresses: []string{fmt.Sprintf("%s-", env.vm.ctx.ChainID.String())},
+				Addresses: []string{env.vm.ctx.ChainID.String() + "-"},
 			},
 		},
 		{
@@ -1978,7 +1977,7 @@ func TestServiceGetUTXOs(t *testing.T) {
 				Addresses: []string{
 					xAddr,
 				},
-				Limit: json.Uint32(numUTXOs + 1),
+				Limit: avajson.Uint32(numUTXOs + 1),
 			},
 		},
 		{
@@ -2848,10 +2847,10 @@ func TestServiceGetBlock(t *testing.T) {
 			}
 			require.Equal(tt.encoding, reply.Encoding)
 
-			expectedJSON, err := stdjson.Marshal(expected)
+			expectedJSON, err := json.Marshal(expected)
 			require.NoError(err)
 
-			require.Equal(stdjson.RawMessage(expectedJSON), reply.Block)
+			require.Equal(json.RawMessage(expectedJSON), reply.Block)
 		})
 	}
 }
@@ -3043,7 +3042,7 @@ func TestServiceGetBlockByHeight(t *testing.T) {
 			service, expected := tt.serviceAndExpectedBlockFunc(t, ctrl)
 
 			args := &api.GetBlockByHeightArgs{
-				Height:   json.Uint64(blockHeight),
+				Height:   avajson.Uint64(blockHeight),
 				Encoding: tt.encoding,
 			}
 			reply := &api.GetBlockResponse{}
@@ -3054,10 +3053,10 @@ func TestServiceGetBlockByHeight(t *testing.T) {
 			}
 			require.Equal(tt.encoding, reply.Encoding)
 
-			expectedJSON, err := stdjson.Marshal(expected)
+			expectedJSON, err := json.Marshal(expected)
 			require.NoError(err)
 
-			require.Equal(stdjson.RawMessage(expectedJSON), reply.Block)
+			require.Equal(json.RawMessage(expectedJSON), reply.Block)
 		})
 	}
 }
@@ -3144,7 +3143,7 @@ func TestServiceGetHeight(t *testing.T) {
 			if tt.expectedErr != nil {
 				return
 			}
-			require.Equal(json.Uint64(blockHeight), reply.Height)
+			require.Equal(avajson.Uint64(blockHeight), reply.Height)
 		})
 	}
 }

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -2705,7 +2705,7 @@ func TestServiceGetBlock(t *testing.T) {
 	tests := []test{
 		{
 			name: "chain not linearized",
-			serviceAndExpectedBlockFunc: func(_ *testing.T, ctrl *gomock.Controller) (*Service, interface{}) {
+			serviceAndExpectedBlockFunc: func(*testing.T, *gomock.Controller) (*Service, interface{}) {
 				return &Service{
 					vm: &VM{
 						ctx: &snow.Context{
@@ -2871,7 +2871,7 @@ func TestServiceGetBlockByHeight(t *testing.T) {
 	tests := []test{
 		{
 			name: "chain not linearized",
-			serviceAndExpectedBlockFunc: func(_ *testing.T, ctrl *gomock.Controller) (*Service, interface{}) {
+			serviceAndExpectedBlockFunc: func(*testing.T, *gomock.Controller) (*Service, interface{}) {
 				return &Service{
 					vm: &VM{
 						ctx: &snow.Context{
@@ -3076,7 +3076,7 @@ func TestServiceGetHeight(t *testing.T) {
 	tests := []test{
 		{
 			name: "chain not linearized",
-			serviceFunc: func(ctrl *gomock.Controller) *Service {
+			serviceFunc: func(*gomock.Controller) *Service {
 				return &Service{
 					vm: &VM{
 						ctx: &snow.Context{

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -549,7 +549,7 @@ func TestServiceGetTxJSON_BaseTx(t *testing.T) {
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
@@ -632,7 +632,7 @@ func TestServiceGetTxJSON_ExportTx(t *testing.T) {
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
 
@@ -722,7 +722,7 @@ func TestServiceGetTxJSON_CreateAssetTx(t *testing.T) {
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
@@ -843,7 +843,7 @@ func TestServiceGetTxJSON_OperationTxWithNftxMintOp(t *testing.T) {
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
@@ -945,7 +945,7 @@ func TestServiceGetTxJSON_OperationTxWithMultipleNftxMintOp(t *testing.T) {
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
@@ -1080,7 +1080,7 @@ func TestServiceGetTxJSON_OperationTxWithSecpMintOp(t *testing.T) {
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
@@ -1186,7 +1186,7 @@ func TestServiceGetTxJSON_OperationTxWithMultipleSecpMintOp(t *testing.T) {
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
@@ -1329,7 +1329,7 @@ func TestServiceGetTxJSON_OperationTxWithPropertyFxMintOp(t *testing.T) {
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)
@@ -1432,7 +1432,7 @@ func TestServiceGetTxJSON_OperationTxWithPropertyFxMintOpMultiple(t *testing.T) 
 		Encoding: formatting.JSON,
 	}, &reply))
 
-	require.Equal(reply.Encoding, formatting.JSON)
+	require.Equal(formatting.JSON, reply.Encoding)
 
 	replyTxBytes, err := stdjson.MarshalIndent(reply.Tx, "", "\t")
 	require.NoError(err)

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -10,14 +10,9 @@ import (
 	"testing"
 	"time"
 
-	stdjson "encoding/json"
-
 	"github.com/btcsuite/btcd/btcutil/bech32"
-
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/api"
@@ -45,6 +40,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/propertyfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	stdjson "encoding/json"
 )
 
 func TestServiceIssueTx(t *testing.T) {

--- a/vms/avm/state/state.go
+++ b/vms/avm/state/state.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"

--- a/vms/avm/state/state_test.go
+++ b/vms/avm/state/state_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/avm/static_service.go
+++ b/vms/avm/static_service.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	stdjson "encoding/json"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/formatting"
@@ -23,6 +21,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/propertyfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	stdjson "encoding/json"
 )
 
 var (

--- a/vms/avm/static_service.go
+++ b/vms/avm/static_service.go
@@ -4,6 +4,7 @@
 package avm
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/vms/avm/fxs"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -22,7 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/propertyfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 )
 
 var (
@@ -56,7 +56,7 @@ func CreateStaticService() *StaticService {
 
 // BuildGenesisArgs are arguments for BuildGenesis
 type BuildGenesisArgs struct {
-	NetworkID   json.Uint32                `json:"networkID"`
+	NetworkID   avajson.Uint32             `json:"networkID"`
 	GenesisData map[string]AssetDefinition `json:"genesisData"`
 	Encoding    formatting.Encoding        `json:"encoding"`
 }
@@ -64,7 +64,7 @@ type BuildGenesisArgs struct {
 type AssetDefinition struct {
 	Name         string                   `json:"name"`
 	Symbol       string                   `json:"symbol"`
-	Denomination json.Uint8               `json:"denomination"`
+	Denomination avajson.Uint8            `json:"denomination"`
 	InitialState map[string][]interface{} `json:"initialState"`
 	Memo         string                   `json:"memo"`
 }
@@ -118,12 +118,12 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 				switch assetType {
 				case "fixedCap":
 					for _, state := range initialStates {
-						b, err := stdjson.Marshal(state)
+						b, err := json.Marshal(state)
 						if err != nil {
 							return fmt.Errorf("problem marshaling state: %w", err)
 						}
 						holder := Holder{}
-						if err := stdjson.Unmarshal(b, &holder); err != nil {
+						if err := json.Unmarshal(b, &holder); err != nil {
 							return fmt.Errorf("problem unmarshaling holder: %w", err)
 						}
 						_, addrbuff, err := address.ParseBech32(holder.Address)
@@ -144,12 +144,12 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 					}
 				case "variableCap":
 					for _, state := range initialStates {
-						b, err := stdjson.Marshal(state)
+						b, err := json.Marshal(state)
 						if err != nil {
 							return fmt.Errorf("problem marshaling state: %w", err)
 						}
 						owners := Owners{}
-						if err := stdjson.Unmarshal(b, &owners); err != nil {
+						if err := json.Unmarshal(b, &owners); err != nil {
 							return fmt.Errorf("problem unmarshaling Owners: %w", err)
 						}
 

--- a/vms/avm/txs/base_tx_test.go
+++ b/vms/avm/txs/base_tx_test.go
@@ -135,7 +135,7 @@ func TestBaseTxSerialization(t *testing.T) {
 	require.NoError(err)
 
 	require.NoError(tx.Initialize(parser.Codec()))
-	require.Equal(tx.ID().String(), "zeqT8FTnRAxes7QQQYkaWhNkHavd9d6aCdH8TQu2Mx5KEydEz")
+	require.Equal("zeqT8FTnRAxes7QQQYkaWhNkHavd9d6aCdH8TQu2Mx5KEydEz", tx.ID().String())
 
 	result := tx.Bytes()
 	require.Equal(expected, result)
@@ -197,7 +197,7 @@ func TestBaseTxSerialization(t *testing.T) {
 			{keys[0], keys[0]},
 		},
 	))
-	require.Equal(tx.ID().String(), "QnTUuie2qe6BKyYrC2jqd73bJ828QNhYnZbdA2HWsnVRPjBfV")
+	require.Equal("QnTUuie2qe6BKyYrC2jqd73bJ828QNhYnZbdA2HWsnVRPjBfV", tx.ID().String())
 
 	// there are two credentials
 	expected[len(expected)-1] = 0x02

--- a/vms/avm/txs/executor/executor_test.go
+++ b/vms/avm/txs/executor/executor_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/avm/txs/executor/semantic_verifier_test.go
+++ b/vms/avm/txs/executor/semantic_verifier_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"

--- a/vms/avm/txs/export_tx_test.go
+++ b/vms/avm/txs/export_tx_test.go
@@ -118,7 +118,7 @@ func TestExportTxSerialization(t *testing.T) {
 	require.NoError(err)
 
 	require.NoError(tx.Initialize(parser.Codec()))
-	require.Equal(tx.ID().String(), "2PKJE4TrKYpgynBFCpNPpV3GHK7d9QTgrL5mpYG6abHKDvNBG3")
+	require.Equal("2PKJE4TrKYpgynBFCpNPpV3GHK7d9QTgrL5mpYG6abHKDvNBG3", tx.ID().String())
 
 	result := tx.Bytes()
 	require.Equal(expected, result)
@@ -179,7 +179,7 @@ func TestExportTxSerialization(t *testing.T) {
 			{keys[0], keys[0]},
 		},
 	))
-	require.Equal(tx.ID().String(), "2oG52e7Cb7XF1yUzv3pRFndAypgbpswWRcSAKD5SH5VgaiTm5D")
+	require.Equal("2oG52e7Cb7XF1yUzv3pRFndAypgbpswWRcSAKD5SH5VgaiTm5D", tx.ID().String())
 
 	// there are two credentials
 	expected[len(expected)-1] = 0x02

--- a/vms/avm/txs/import_tx_test.go
+++ b/vms/avm/txs/import_tx_test.go
@@ -118,7 +118,7 @@ func TestImportTxSerialization(t *testing.T) {
 	require.NoError(err)
 
 	require.NoError(tx.Initialize(parser.Codec()))
-	require.Equal(tx.ID().String(), "9wdPb5rsThXYLX4WxkNeyYrNMfDE5cuWLgifSjxKiA2dCmgCZ")
+	require.Equal("9wdPb5rsThXYLX4WxkNeyYrNMfDE5cuWLgifSjxKiA2dCmgCZ", tx.ID().String())
 
 	result := tx.Bytes()
 	require.Equal(expected, result)
@@ -179,7 +179,7 @@ func TestImportTxSerialization(t *testing.T) {
 			{keys[0], keys[0]},
 		},
 	))
-	require.Equal(tx.ID().String(), "pCW7sVBytzdZ1WrqzGY1DvA2S9UaMr72xpUMxVyx1QHBARNYx")
+	require.Equal("pCW7sVBytzdZ1WrqzGY1DvA2S9UaMr72xpUMxVyx1QHBARNYx", tx.ID().String())
 
 	// there are two credentials
 	expected[len(expected)-1] = 0x02

--- a/vms/avm/txs/mempool/mempool_test.go
+++ b/vms/avm/txs/mempool/mempool_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -12,9 +12,7 @@ import (
 	"sync"
 
 	"github.com/gorilla/rpc/v2"
-
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"

--- a/vms/avm/wallet_service.go
+++ b/vms/avm/wallet_service.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"go.uber.org/zap"
-
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/api"

--- a/vms/components/chain/state_test.go
+++ b/vms/components/chain/state_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/components/index/index.go
+++ b/vms/components/index/index.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/components/message/message_test.go
+++ b/vms/components/message/message_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ava-labs/avalanchego/codec"

--- a/vms/components/verify/subnet_test.go
+++ b/vms/components/verify/subnet_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/example/xsvm/vm.go
+++ b/vms/example/xsvm/vm.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/rpc/v2"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/metervm/metrics.go
+++ b/vms/metervm/metrics.go
@@ -4,8 +4,6 @@
 package metervm
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/avalanchego/utils/metric"
@@ -16,7 +14,7 @@ func newAverager(namespace, name string, reg prometheus.Registerer, errs *wrappe
 	return metric.NewAveragerWithErrs(
 		namespace,
 		name,
-		fmt.Sprintf("time (in ns) of a %s", name),
+		"time (in ns) of a "+name,
 		reg,
 		errs,
 	)

--- a/vms/nftfx/mint_operation.go
+++ b/vms/nftfx/mint_operation.go
@@ -6,11 +6,10 @@ package nftfx
 import (
 	"errors"
 
-	"github.com/ava-labs/avalanchego/vms/types"
-
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/avalanchego/vms/types"
 )
 
 var errNilMintOperation = errors.New("nil mint operation")

--- a/vms/nftfx/transfer_output.go
+++ b/vms/nftfx/transfer_output.go
@@ -7,11 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/ava-labs/avalanchego/vms/types"
-
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/avalanchego/vms/types"
 )
 
 const (

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/chains"

--- a/vms/platformvm/block/builder/standard_block_test.go
+++ b/vms/platformvm/block/builder/standard_block_test.go
@@ -79,5 +79,5 @@ func TestAtomicTxImports(t *testing.T) {
 	_, txStatus, err := env.state.GetTx(tx.ID())
 	require.NoError(err)
 	// Ensure transaction is in the committed state
-	require.Equal(txStatus, status.Committed)
+	require.Equal(status.Committed, txStatus)
 }

--- a/vms/platformvm/block/executor/acceptor_test.go
+++ b/vms/platformvm/block/executor/acceptor_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"

--- a/vms/platformvm/block/executor/backend_test.go
+++ b/vms/platformvm/block/executor/backend_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/block/executor/backend_test.go
+++ b/vms/platformvm/block/executor/backend_test.go
@@ -120,7 +120,7 @@ func TestGetTimestamp(t *testing.T) {
 	tests := []test{
 		{
 			name: "block is in map",
-			backendF: func(ctrl *gomock.Controller) *backend {
+			backendF: func(*gomock.Controller) *backend {
 				return &backend{
 					blkIDToState: map[ids.ID]*blockState{
 						blkID: {

--- a/vms/platformvm/block/executor/block_test.go
+++ b/vms/platformvm/block/executor/block_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains"

--- a/vms/platformvm/block/executor/manager_test.go
+++ b/vms/platformvm/block/executor/manager_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -837,7 +837,7 @@ func TestBanffProposalBlockRemoveSubnetValidator(t *testing.T) {
 
 func TestBanffProposalBlockTrackedSubnet(t *testing.T) {
 	for _, tracked := range []bool{true, false} {
-		t.Run(fmt.Sprintf("tracked %t", tracked), func(ts *testing.T) {
+		t.Run(fmt.Sprintf("tracked %t", tracked), func(t *testing.T) {
 			require := require.New(t)
 			env := newEnvironment(t, nil)
 			env.config.BanffTime = time.Time{} // activate Banff

--- a/vms/platformvm/block/executor/rejector_test.go
+++ b/vms/platformvm/block/executor/rejector_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"

--- a/vms/platformvm/block/parse_test.go
+++ b/vms/platformvm/block/parse_test.go
@@ -199,7 +199,7 @@ func TestCommitBlock(t *testing.T) {
 		// compare content
 		require.Equal(banffCommitBlk.ID(), parsed.ID())
 		require.Equal(banffCommitBlk.Bytes(), parsed.Bytes())
-		require.Equal(banffCommitBlk.Parent(), banffCommitBlk.Parent())
+		require.Equal(banffCommitBlk.Parent(), parsed.Parent())
 		require.Equal(banffCommitBlk.Height(), parsed.Height())
 
 		// timestamp check for banff blocks only
@@ -242,7 +242,7 @@ func TestAbortBlock(t *testing.T) {
 		// compare content
 		require.Equal(banffAbortBlk.ID(), parsed.ID())
 		require.Equal(banffAbortBlk.Bytes(), parsed.Bytes())
-		require.Equal(banffAbortBlk.Parent(), banffAbortBlk.Parent())
+		require.Equal(banffAbortBlk.Parent(), parsed.Parent())
 		require.Equal(banffAbortBlk.Height(), parsed.Height())
 
 		// timestamp check for banff blocks only

--- a/vms/platformvm/block/proposal_block_test.go
+++ b/vms/platformvm/block/proposal_block_test.go
@@ -98,7 +98,7 @@ func TestNewApricotProposalBlock(t *testing.T) {
 	expectedTxs := []*txs.Tx{proposalTx}
 
 	blkTxs := blk.Txs()
-	require.Equal(blkTxs, expectedTxs)
+	require.Equal(expectedTxs, blkTxs)
 	for i, blkTx := range blkTxs {
 		expectedTx := expectedTxs[i]
 		require.NotEmpty(blkTx.Bytes())

--- a/vms/platformvm/metrics/block_metrics.go
+++ b/vms/platformvm/metrics/block_metrics.go
@@ -49,7 +49,7 @@ func newBlockMetric(
 ) prometheus.Counter {
 	blockMetric := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
-		Name:      fmt.Sprintf("%s_blks_accepted", blockName),
+		Name:      blockName + "_blks_accepted",
 		Help:      fmt.Sprintf("Number of %s blocks accepted", blockName),
 	})
 	errs.Add(registerer.Register(blockMetric))

--- a/vms/platformvm/metrics/tx_metrics.go
+++ b/vms/platformvm/metrics/tx_metrics.go
@@ -65,7 +65,7 @@ func newTxMetric(
 ) prometheus.Counter {
 	txMetric := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
-		Name:      fmt.Sprintf("%s_txs_accepted", txName),
+		Name:      txName + "_txs_accepted",
 		Help:      fmt.Sprintf("Number of %s transactions accepted", txName),
 	})
 	errs.Add(registerer.Register(txMetric))

--- a/vms/platformvm/network/gossip_test.go
+++ b/vms/platformvm/network/gossip_test.go
@@ -8,9 +8,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -78,12 +78,10 @@ func TestNetworkAppGossip(t *testing.T) {
 			msgBytesFunc: func() []byte {
 				return []byte{0x00}
 			},
-			mempoolFunc: func(ctrl *gomock.Controller) mempool.Mempool {
-				// Unused in this test
+			mempoolFunc: func(*gomock.Controller) mempool.Mempool {
 				return nil
 			},
-			appSenderFunc: func(ctrl *gomock.Controller) common.AppSender {
-				// Unused in this test
+			appSenderFunc: func(*gomock.Controller) common.AppSender {
 				return nil
 			},
 		},
@@ -99,11 +97,9 @@ func TestNetworkAppGossip(t *testing.T) {
 				return msgBytes
 			},
 			mempoolFunc: func(ctrl *gomock.Controller) mempool.Mempool {
-				// Unused in this test
 				return mempool.NewMockMempool(ctrl)
 			},
 			appSenderFunc: func(ctrl *gomock.Controller) common.AppSender {
-				// Unused in this test
 				return common.NewMockSender(ctrl)
 			},
 		},
@@ -152,7 +148,6 @@ func TestNetworkAppGossip(t *testing.T) {
 				return mempool
 			},
 			appSenderFunc: func(ctrl *gomock.Controller) common.AppSender {
-				// Unused in this test
 				return common.NewMockSender(ctrl)
 			},
 		},

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -12,8 +12,6 @@ import (
 	"net/http"
 	"time"
 
-	stdjson "encoding/json"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api"
@@ -42,6 +40,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
+	stdjson "encoding/json"
 	safemath "github.com/ava-labs/avalanchego/utils/math"
 	platformapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
 )

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -5,6 +5,7 @@ package platformvm
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -24,7 +25,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -40,7 +40,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 	safemath "github.com/ava-labs/avalanchego/utils/math"
 	platformapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
 )
@@ -108,7 +108,7 @@ func (s *Service) GetHeight(r *http.Request, _ *struct{}, response *api.GetHeigh
 
 	ctx := r.Context()
 	height, err := s.vm.GetCurrentHeight(ctx)
-	response.Height = json.Uint64(height)
+	response.Height = avajson.Uint64(height)
 	return err
 }
 
@@ -208,15 +208,15 @@ type GetBalanceRequest struct {
 // compatibility.
 type GetBalanceResponse struct {
 	// Balance, in nAVAX, of the address
-	Balance             json.Uint64            `json:"balance"`
-	Unlocked            json.Uint64            `json:"unlocked"`
-	LockedStakeable     json.Uint64            `json:"lockedStakeable"`
-	LockedNotStakeable  json.Uint64            `json:"lockedNotStakeable"`
-	Balances            map[ids.ID]json.Uint64 `json:"balances"`
-	Unlockeds           map[ids.ID]json.Uint64 `json:"unlockeds"`
-	LockedStakeables    map[ids.ID]json.Uint64 `json:"lockedStakeables"`
-	LockedNotStakeables map[ids.ID]json.Uint64 `json:"lockedNotStakeables"`
-	UTXOIDs             []*avax.UTXOID         `json:"utxoIDs"`
+	Balance             avajson.Uint64            `json:"balance"`
+	Unlocked            avajson.Uint64            `json:"unlocked"`
+	LockedStakeable     avajson.Uint64            `json:"lockedStakeable"`
+	LockedNotStakeable  avajson.Uint64            `json:"lockedNotStakeable"`
+	Balances            map[ids.ID]avajson.Uint64 `json:"balances"`
+	Unlockeds           map[ids.ID]avajson.Uint64 `json:"unlockeds"`
+	LockedStakeables    map[ids.ID]avajson.Uint64 `json:"lockedStakeables"`
+	LockedNotStakeables map[ids.ID]avajson.Uint64 `json:"lockedNotStakeables"`
+	UTXOIDs             []*avax.UTXOID            `json:"utxoIDs"`
 }
 
 // GetBalance gets the balance of an address
@@ -332,10 +332,10 @@ utxoFor:
 	return nil
 }
 
-func newJSONBalanceMap(balanceMap map[ids.ID]uint64) map[ids.ID]json.Uint64 {
-	jsonBalanceMap := make(map[ids.ID]json.Uint64, len(balanceMap))
+func newJSONBalanceMap(balanceMap map[ids.ID]uint64) map[ids.ID]avajson.Uint64 {
+	jsonBalanceMap := make(map[ids.ID]avajson.Uint64, len(balanceMap))
 	for assetID, amount := range balanceMap {
-		jsonBalanceMap[assetID] = json.Uint64(amount)
+		jsonBalanceMap[assetID] = avajson.Uint64(amount)
 	}
 	return jsonBalanceMap
 }
@@ -504,7 +504,7 @@ func (s *Service) GetUTXOs(_ *http.Request, args *api.GetUTXOsArgs, response *ap
 
 	response.EndIndex.Address = endAddress
 	response.EndIndex.UTXO = endUTXOID.String()
-	response.NumFetched = json.Uint64(len(utxos))
+	response.NumFetched = avajson.Uint64(len(utxos))
 	response.Encoding = args.Encoding
 	return nil
 }
@@ -523,8 +523,8 @@ type APISubnet struct {
 	// Each element of [ControlKeys] the address of a public key.
 	// A transaction to add a validator to this subnet requires
 	// signatures from [Threshold] of these keys to be valid.
-	ControlKeys []string    `json:"controlKeys"`
-	Threshold   json.Uint32 `json:"threshold"`
+	ControlKeys []string       `json:"controlKeys"`
+	Threshold   avajson.Uint32 `json:"threshold"`
 }
 
 // GetSubnetsArgs are the arguments to GetSubnet
@@ -566,7 +566,7 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 				response.Subnets[i] = APISubnet{
 					ID:          subnetID,
 					ControlKeys: []string{},
-					Threshold:   json.Uint32(0),
+					Threshold:   avajson.Uint32(0),
 				}
 				continue
 			}
@@ -584,14 +584,14 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 			response.Subnets[i] = APISubnet{
 				ID:          subnetID,
 				ControlKeys: controlAddrs,
-				Threshold:   json.Uint32(owner.Threshold),
+				Threshold:   avajson.Uint32(owner.Threshold),
 			}
 		}
 		// Include primary network
 		response.Subnets[len(subnets)] = APISubnet{
 			ID:          constants.PrimaryNetworkID,
 			ControlKeys: []string{},
-			Threshold:   json.Uint32(0),
+			Threshold:   avajson.Uint32(0),
 		}
 		return nil
 	}
@@ -608,7 +608,7 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 				APISubnet{
 					ID:          constants.PrimaryNetworkID,
 					ControlKeys: []string{},
-					Threshold:   json.Uint32(0),
+					Threshold:   avajson.Uint32(0),
 				},
 			)
 			continue
@@ -618,7 +618,7 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 			response.Subnets = append(response.Subnets, APISubnet{
 				ID:          subnetID,
 				ControlKeys: []string{},
-				Threshold:   json.Uint32(0),
+				Threshold:   avajson.Uint32(0),
 			})
 			continue
 		}
@@ -648,7 +648,7 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 		response.Subnets = append(response.Subnets, APISubnet{
 			ID:          subnetID,
 			ControlKeys: controlAddrs,
-			Threshold:   json.Uint32(owner.Threshold),
+			Threshold:   avajson.Uint32(owner.Threshold),
 		})
 	}
 	return nil
@@ -830,22 +830,22 @@ func (s *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentValidato
 
 	for _, currentStaker := range targetStakers {
 		nodeID := currentStaker.NodeID
-		weight := json.Uint64(currentStaker.Weight)
+		weight := avajson.Uint64(currentStaker.Weight)
 		apiStaker := platformapi.Staker{
 			TxID:        currentStaker.TxID,
-			StartTime:   json.Uint64(currentStaker.StartTime.Unix()),
-			EndTime:     json.Uint64(currentStaker.EndTime.Unix()),
+			StartTime:   avajson.Uint64(currentStaker.StartTime.Unix()),
+			EndTime:     avajson.Uint64(currentStaker.EndTime.Unix()),
 			Weight:      weight,
 			StakeAmount: &weight,
 			NodeID:      nodeID,
 		}
-		potentialReward := json.Uint64(currentStaker.PotentialReward)
+		potentialReward := avajson.Uint64(currentStaker.PotentialReward)
 
 		delegateeReward, err := s.vm.state.GetDelegateeReward(currentStaker.SubnetID, currentStaker.NodeID)
 		if err != nil {
 			return err
 		}
-		jsonDelegateeReward := json.Uint64(delegateeReward)
+		jsonDelegateeReward := avajson.Uint64(delegateeReward)
 
 		switch currentStaker.Priority {
 		case txs.PrimaryNetworkValidatorCurrentPriority, txs.SubnetPermissionlessValidatorCurrentPriority:
@@ -855,7 +855,7 @@ func (s *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentValidato
 			}
 
 			shares := attr.shares
-			delegationFee := json.Float32(100 * float32(shares) / float32(reward.PercentDenominator))
+			delegationFee := avajson.Float32(100 * float32(shares) / float32(reward.PercentDenominator))
 
 			uptime, err := s.getAPIUptime(currentStaker)
 			if err != nil {
@@ -950,8 +950,8 @@ func (s *Service) GetCurrentValidators(_ *http.Request, args *GetCurrentValidato
 			// always return a non-nil value.
 			delegators = []platformapi.PrimaryDelegator{}
 		}
-		delegatorCount := json.Uint64(len(delegators))
-		delegatorWeight := json.Uint64(0)
+		delegatorCount := avajson.Uint64(len(delegators))
+		delegatorWeight := avajson.Uint64(0)
 		for _, d := range delegators {
 			delegatorWeight += d.Weight
 		}
@@ -1045,12 +1045,12 @@ func (s *Service) GetPendingValidators(_ *http.Request, args *GetPendingValidato
 
 	for _, pendingStaker := range targetStakers {
 		nodeID := pendingStaker.NodeID
-		weight := json.Uint64(pendingStaker.Weight)
+		weight := avajson.Uint64(pendingStaker.Weight)
 		apiStaker := platformapi.Staker{
 			TxID:        pendingStaker.TxID,
 			NodeID:      nodeID,
-			StartTime:   json.Uint64(pendingStaker.StartTime.Unix()),
-			EndTime:     json.Uint64(pendingStaker.EndTime.Unix()),
+			StartTime:   avajson.Uint64(pendingStaker.StartTime.Unix()),
+			EndTime:     avajson.Uint64(pendingStaker.EndTime.Unix()),
 			Weight:      weight,
 			StakeAmount: &weight,
 		}
@@ -1063,7 +1063,7 @@ func (s *Service) GetPendingValidators(_ *http.Request, args *GetPendingValidato
 			}
 
 			shares := attr.shares
-			delegationFee := json.Float32(100 * float32(shares) / float32(reward.PercentDenominator))
+			delegationFee := avajson.Float32(100 * float32(shares) / float32(reward.PercentDenominator))
 
 			connected := s.vm.uptimeManager.IsConnected(nodeID, args.SubnetID)
 			vdr := platformapi.PermissionlessValidator{
@@ -1098,8 +1098,8 @@ type GetCurrentSupplyArgs struct {
 
 // GetCurrentSupplyReply are the results from calling GetCurrentSupply
 type GetCurrentSupplyReply struct {
-	Supply json.Uint64 `json:"supply"`
-	Height json.Uint64 `json:"height"`
+	Supply avajson.Uint64 `json:"supply"`
+	Height avajson.Uint64 `json:"height"`
 }
 
 // GetCurrentSupply returns an upper bound on the supply of AVAX in the system
@@ -1116,14 +1116,14 @@ func (s *Service) GetCurrentSupply(r *http.Request, args *GetCurrentSupplyArgs, 
 	if err != nil {
 		return fmt.Errorf("fetching current supply failed: %w", err)
 	}
-	reply.Supply = json.Uint64(supply)
+	reply.Supply = avajson.Uint64(supply)
 
 	ctx := r.Context()
 	height, err := s.vm.GetCurrentHeight(ctx)
 	if err != nil {
 		return fmt.Errorf("fetching current height failed: %w", err)
 	}
-	reply.Height = json.Uint64(height)
+	reply.Height = avajson.Uint64(height)
 
 	return nil
 }
@@ -1131,7 +1131,7 @@ func (s *Service) GetCurrentSupply(r *http.Request, args *GetCurrentSupplyArgs, 
 // SampleValidatorsArgs are the arguments for calling SampleValidators
 type SampleValidatorsArgs struct {
 	// Number of validators in the sample
-	Size json.Uint16 `json:"size"`
+	Size avajson.Uint16 `json:"size"`
 
 	// ID of subnet to sample validators from
 	// If omitted, defaults to the primary network
@@ -1177,8 +1177,8 @@ type AddValidatorArgs struct {
 	api.JSONSpendHeader
 	platformapi.Staker
 	// The address the staking reward, if applicable, will go to
-	RewardAddress     string       `json:"rewardAddress"`
-	DelegationFeeRate json.Float32 `json:"delegationFeeRate"`
+	RewardAddress     string          `json:"rewardAddress"`
+	DelegationFeeRate avajson.Float32 `json:"delegationFeeRate"`
 }
 
 // AddValidator creates and signs and issues a transaction to add a validator to
@@ -1206,9 +1206,9 @@ func (s *Service) AddValidator(req *http.Request, args *AddValidatorArgs, reply 
 func (s *Service) buildAddValidatorTx(args *AddValidatorArgs) (*txs.Tx, ids.ShortID, error) {
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
-	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
+	minAddStakerUnix := avajson.Uint64(minAddStakerTime.Unix())
 	maxAddStakerTime := now.Add(executor.MaxFutureStartTime)
-	maxAddStakerUnix := json.Uint64(maxAddStakerTime.Unix())
+	maxAddStakerUnix := avajson.Uint64(maxAddStakerTime.Unix())
 
 	if args.StartTime == 0 {
 		args.StartTime = minAddStakerUnix
@@ -1328,9 +1328,9 @@ func (s *Service) AddDelegator(req *http.Request, args *AddDelegatorArgs, reply 
 func (s *Service) buildAddDelegatorTx(args *AddDelegatorArgs) (*txs.Tx, ids.ShortID, error) {
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
-	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
+	minAddStakerUnix := avajson.Uint64(minAddStakerTime.Unix())
 	maxAddStakerTime := now.Add(executor.MaxFutureStartTime)
-	maxAddStakerUnix := json.Uint64(maxAddStakerTime.Unix())
+	maxAddStakerUnix := avajson.Uint64(maxAddStakerTime.Unix())
 
 	if args.StartTime == 0 {
 		args.StartTime = minAddStakerUnix
@@ -1447,9 +1447,9 @@ func (s *Service) AddSubnetValidator(req *http.Request, args *AddSubnetValidator
 func (s *Service) buildAddSubnetValidatorTx(args *AddSubnetValidatorArgs) (*txs.Tx, ids.ShortID, error) {
 	now := s.vm.clock.Time()
 	minAddStakerTime := now.Add(minAddStakerDelay)
-	minAddStakerUnix := json.Uint64(minAddStakerTime.Unix())
+	minAddStakerUnix := avajson.Uint64(minAddStakerTime.Unix())
 	maxAddStakerTime := now.Add(executor.MaxFutureStartTime)
-	maxAddStakerUnix := json.Uint64(maxAddStakerTime.Unix())
+	maxAddStakerUnix := avajson.Uint64(maxAddStakerTime.Unix())
 
 	if args.StartTime == 0 {
 		args.StartTime = minAddStakerUnix
@@ -1617,7 +1617,7 @@ type ExportAVAXArgs struct {
 	api.JSONSpendHeader
 
 	// Amount of AVAX to send
-	Amount json.Uint64 `json:"amount"`
+	Amount avajson.Uint64 `json:"amount"`
 
 	// Chain the funds are going to. Optional. Used if To address does not include the chainID.
 	TargetChain string `json:"targetChain"`
@@ -2258,7 +2258,7 @@ func (s *Service) GetTx(_ *http.Request, args *api.GetTxArgs, response *api.GetT
 		}
 	}
 
-	response.Tx, err = stdjson.Marshal(result)
+	response.Tx, err = json.Marshal(result)
 	return err
 }
 
@@ -2339,8 +2339,8 @@ type GetStakeArgs struct {
 
 // GetStakeReply is the response from calling GetStake.
 type GetStakeReply struct {
-	Staked  json.Uint64            `json:"staked"`
-	Stakeds map[ids.ID]json.Uint64 `json:"stakeds"`
+	Staked  avajson.Uint64            `json:"staked"`
+	Stakeds map[ids.ID]avajson.Uint64 `json:"stakeds"`
 	// String representation of staked outputs
 	// Each is of type avax.TransferableOutput
 	Outputs []string `json:"stakedOutputs"`
@@ -2446,9 +2446,9 @@ type GetMinStakeArgs struct {
 // GetMinStakeReply is the response from calling GetMinStake.
 type GetMinStakeReply struct {
 	//  The minimum amount of tokens one must bond to be a validator
-	MinValidatorStake json.Uint64 `json:"minValidatorStake"`
+	MinValidatorStake avajson.Uint64 `json:"minValidatorStake"`
 	// Minimum stake, in nAVAX, that can be delegated on the primary network
-	MinDelegatorStake json.Uint64 `json:"minDelegatorStake"`
+	MinDelegatorStake avajson.Uint64 `json:"minDelegatorStake"`
 }
 
 // GetMinStake returns the minimum staking amount in nAVAX.
@@ -2459,8 +2459,8 @@ func (s *Service) GetMinStake(_ *http.Request, args *GetMinStakeArgs, reply *Get
 	)
 
 	if args.SubnetID == constants.PrimaryNetworkID {
-		reply.MinValidatorStake = json.Uint64(s.vm.MinValidatorStake)
-		reply.MinDelegatorStake = json.Uint64(s.vm.MinDelegatorStake)
+		reply.MinValidatorStake = avajson.Uint64(s.vm.MinValidatorStake)
+		reply.MinDelegatorStake = avajson.Uint64(s.vm.MinDelegatorStake)
 		return nil
 	}
 
@@ -2483,8 +2483,8 @@ func (s *Service) GetMinStake(_ *http.Request, args *GetMinStakeArgs, reply *Get
 		)
 	}
 
-	reply.MinValidatorStake = json.Uint64(transformSubnet.MinValidatorStake)
-	reply.MinDelegatorStake = json.Uint64(transformSubnet.MinDelegatorStake)
+	reply.MinValidatorStake = avajson.Uint64(transformSubnet.MinValidatorStake)
+	reply.MinDelegatorStake = avajson.Uint64(transformSubnet.MinDelegatorStake)
 
 	return nil
 }
@@ -2499,9 +2499,9 @@ type GetTotalStakeArgs struct {
 // GetTotalStakeReply is the response from calling GetTotalStake.
 type GetTotalStakeReply struct {
 	// Deprecated: Use Weight instead.
-	Stake json.Uint64 `json:"stake"`
+	Stake avajson.Uint64 `json:"stake"`
 
-	Weight json.Uint64 `json:"weight"`
+	Weight avajson.Uint64 `json:"weight"`
 }
 
 // GetTotalStake returns the total amount staked on the Primary Network
@@ -2515,7 +2515,7 @@ func (s *Service) GetTotalStake(_ *http.Request, args *GetTotalStakeArgs, reply 
 	if err != nil {
 		return fmt.Errorf("couldn't get total weight: %w", err)
 	}
-	weight := json.Uint64(totalWeight)
+	weight := avajson.Uint64(totalWeight)
 	reply.Weight = weight
 	reply.Stake = weight
 	return nil
@@ -2523,15 +2523,15 @@ func (s *Service) GetTotalStake(_ *http.Request, args *GetTotalStakeArgs, reply 
 
 // GetMaxStakeAmountArgs is the request for calling GetMaxStakeAmount.
 type GetMaxStakeAmountArgs struct {
-	SubnetID  ids.ID      `json:"subnetID"`
-	NodeID    ids.NodeID  `json:"nodeID"`
-	StartTime json.Uint64 `json:"startTime"`
-	EndTime   json.Uint64 `json:"endTime"`
+	SubnetID  ids.ID         `json:"subnetID"`
+	NodeID    ids.NodeID     `json:"nodeID"`
+	StartTime avajson.Uint64 `json:"startTime"`
+	EndTime   avajson.Uint64 `json:"endTime"`
 }
 
 // GetMaxStakeAmountReply is the response from calling GetMaxStakeAmount.
 type GetMaxStakeAmountReply struct {
-	Amount json.Uint64 `json:"amount"`
+	Amount avajson.Uint64 `json:"amount"`
 }
 
 // GetMaxStakeAmount returns the maximum amount of nAVAX staking to the named
@@ -2573,14 +2573,14 @@ func (s *Service) GetMaxStakeAmount(_ *http.Request, args *GetMaxStakeAmountArgs
 	}
 
 	maxStakeAmount, err := executor.GetMaxWeight(s.vm.state, staker, startTime, endTime)
-	reply.Amount = json.Uint64(maxStakeAmount)
+	reply.Amount = avajson.Uint64(maxStakeAmount)
 	return err
 }
 
 // GetRewardUTXOsReply defines the GetRewardUTXOs replies returned from the API
 type GetRewardUTXOsReply struct {
 	// Number of UTXOs returned
-	NumFetched json.Uint64 `json:"numFetched"`
+	NumFetched avajson.Uint64 `json:"numFetched"`
 	// The UTXOs
 	UTXOs []string `json:"utxos"`
 	// Encoding specifies the encoding format the UTXOs are returned in
@@ -2603,7 +2603,7 @@ func (s *Service) GetRewardUTXOs(_ *http.Request, args *api.GetTxArgs, reply *Ge
 		return fmt.Errorf("couldn't get reward UTXOs: %w", err)
 	}
 
-	reply.NumFetched = json.Uint64(len(utxos))
+	reply.NumFetched = avajson.Uint64(len(utxos))
 	reply.UTXOs = make([]string, len(utxos))
 	for i, utxo := range utxos {
 		utxoBytes, err := txs.GenesisCodec.Marshal(txs.CodecVersion, utxo)
@@ -2643,20 +2643,20 @@ func (s *Service) GetTimestamp(_ *http.Request, _ *struct{}, reply *GetTimestamp
 
 // GetValidatorsAtArgs is the response from GetValidatorsAt
 type GetValidatorsAtArgs struct {
-	Height   json.Uint64 `json:"height"`
-	SubnetID ids.ID      `json:"subnetID"`
+	Height   avajson.Uint64 `json:"height"`
+	SubnetID ids.ID         `json:"subnetID"`
 }
 
 type jsonGetValidatorOutput struct {
-	PublicKey *string     `json:"publicKey"`
-	Weight    json.Uint64 `json:"weight"`
+	PublicKey *string        `json:"publicKey"`
+	Weight    avajson.Uint64 `json:"weight"`
 }
 
 func (v *GetValidatorsAtReply) MarshalJSON() ([]byte, error) {
 	m := make(map[ids.NodeID]*jsonGetValidatorOutput, len(v.Validators))
 	for _, vdr := range v.Validators {
 		vdrJSON := &jsonGetValidatorOutput{
-			Weight: json.Uint64(vdr.Weight),
+			Weight: avajson.Uint64(vdr.Weight),
 		}
 
 		if vdr.PublicKey != nil {
@@ -2669,12 +2669,12 @@ func (v *GetValidatorsAtReply) MarshalJSON() ([]byte, error) {
 
 		m[vdr.NodeID] = vdrJSON
 	}
-	return stdjson.Marshal(m)
+	return json.Marshal(m)
 }
 
 func (v *GetValidatorsAtReply) UnmarshalJSON(b []byte) error {
 	var m map[ids.NodeID]*jsonGetValidatorOutput
-	if err := stdjson.Unmarshal(b, &m); err != nil {
+	if err := json.Unmarshal(b, &m); err != nil {
 		return err
 	}
 
@@ -2762,7 +2762,7 @@ func (s *Service) GetBlock(_ *http.Request, args *api.GetBlockArgs, response *ap
 		}
 	}
 
-	response.Block, err = stdjson.Marshal(result)
+	response.Block, err = json.Marshal(result)
 	return err
 }
 
@@ -2804,11 +2804,11 @@ func (s *Service) GetBlockByHeight(_ *http.Request, args *api.GetBlockByHeightAr
 		}
 	}
 
-	response.Block, err = stdjson.Marshal(result)
+	response.Block, err = json.Marshal(result)
 	return err
 }
 
-func (s *Service) getAPIUptime(staker *state.Staker) (*json.Float32, error) {
+func (s *Service) getAPIUptime(staker *state.Staker) (*avajson.Float32, error) {
 	// Only report uptimes that we have been actively tracking.
 	if constants.PrimaryNetworkID != staker.SubnetID && !s.vm.TrackedSubnets.Contains(staker.SubnetID) {
 		return nil, nil
@@ -2820,14 +2820,14 @@ func (s *Service) getAPIUptime(staker *state.Staker) (*json.Float32, error) {
 	}
 	// Transform this to a percentage (0-100) to make it consistent
 	// with observedUptime in info.peers API
-	uptime := json.Float32(rawUptime * 100)
+	uptime := avajson.Float32(rawUptime * 100)
 	return &uptime, nil
 }
 
 func (s *Service) getAPIOwner(owner *secp256k1fx.OutputOwners) (*platformapi.Owner, error) {
 	apiOwner := &platformapi.Owner{
-		Locktime:  json.Uint64(owner.Locktime),
-		Threshold: json.Uint32(owner.Threshold),
+		Locktime:  avajson.Uint64(owner.Locktime),
+		Threshold: avajson.Uint32(owner.Threshold),
 		Addresses: make([]string, 0, len(owner.Addrs)),
 	}
 	for _, addr := range owner.Addrs {

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -824,7 +824,7 @@ func TestGetValidatorsAtReplyMarshalling(t *testing.T) {
 
 	var parsedReply GetValidatorsAtReply
 	require.NoError(parsedReply.UnmarshalJSON(replyJSON))
-	require.Equal(&parsedReply, reply)
+	require.Equal(reply, &parsedReply)
 }
 
 func TestServiceGetBlockByHeight(t *testing.T) {

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -406,7 +406,7 @@ func TestGetStake(t *testing.T) {
 	genesis, _ := defaultGenesis(t, service.vm.ctx.AVAXAssetID)
 	addrsStrs := []string{}
 	for i, validator := range genesis.Validators {
-		addr := "P-%s" + validator.RewardOwner.Addresses[0]
+		addr := "P-" + validator.RewardOwner.Addresses[0]
 		addrsStrs = append(addrsStrs, addr)
 
 		args := GetStakeArgs{

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -5,6 +5,7 @@ package platformvm
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -30,7 +31,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
@@ -41,7 +41,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
-	stdjson "encoding/json"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 	vmkeystore "github.com/ava-labs/avalanchego/vms/components/keystore"
 	pchainapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
 	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/block/executor"
@@ -109,7 +109,7 @@ func TestAddValidator(t *testing.T) {
 
 	expectedJSONString := `{"username":"","password":"","from":null,"changeAddr":"","txID":"11111111111111111111111111111111LpoYY","startTime":"0","endTime":"0","weight":"0","nodeID":"NodeID-111111111111111111116DBWJs","rewardAddress":"","delegationFeeRate":"0.0000"}`
 	args := AddValidatorArgs{}
-	bytes, err := stdjson.Marshal(&args)
+	bytes, err := json.Marshal(&args)
 	require.NoError(err)
 	require.Equal(expectedJSONString, string(bytes))
 }
@@ -119,9 +119,9 @@ func TestCreateBlockchainArgsParsing(t *testing.T) {
 
 	jsonString := `{"vmID":"lol","fxIDs":["secp256k1"], "name":"awesome", "username":"bob loblaw", "password":"yeet", "genesisData":"SkB92YpWm4Q2iPnLGCuDPZPgUQMxajqQQuz91oi3xD984f8r"}`
 	args := CreateBlockchainArgs{}
-	require.NoError(stdjson.Unmarshal([]byte(jsonString), &args))
+	require.NoError(json.Unmarshal([]byte(jsonString), &args))
 
-	_, err := stdjson.Marshal(args.GenesisData)
+	_, err := json.Marshal(args.GenesisData)
 	require.NoError(err)
 }
 
@@ -129,7 +129,7 @@ func TestExportKey(t *testing.T) {
 	require := require.New(t)
 	jsonString := `{"username":"ScoobyUser","password":"ShaggyPassword1Zoinks!","address":"` + testAddress + `"}`
 	args := ExportKeyArgs{}
-	require.NoError(stdjson.Unmarshal([]byte(jsonString), &args))
+	require.NoError(json.Unmarshal([]byte(jsonString), &args))
 
 	service, _ := defaultService(t)
 	defaultAddress(t, service)
@@ -144,7 +144,7 @@ func TestImportKey(t *testing.T) {
 	require := require.New(t)
 	jsonString := `{"username":"ScoobyUser","password":"ShaggyPassword1Zoinks!","privateKey":"PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"}`
 	args := ImportKeyArgs{}
-	require.NoError(stdjson.Unmarshal([]byte(jsonString), &args))
+	require.NoError(json.Unmarshal([]byte(jsonString), &args))
 
 	service, _ := defaultService(t)
 
@@ -352,14 +352,14 @@ func TestGetTx(t *testing.T) {
 				case formatting.Hex:
 					// we're always guaranteed a string for hex encodings.
 					var txStr string
-					require.NoError(stdjson.Unmarshal(response.Tx, &txStr))
+					require.NoError(json.Unmarshal(response.Tx, &txStr))
 					responseTxBytes, err := formatting.Decode(response.Encoding, txStr)
 					require.NoError(err)
 					require.Equal(tx.Bytes(), responseTxBytes)
 
 				case formatting.JSON:
 					tx.Unsigned.InitCtx(service.vm.ctx)
-					expectedTxJSON, err := stdjson.Marshal(tx)
+					expectedTxJSON, err := json.Marshal(tx)
 					require.NoError(err)
 					require.Equal(expectedTxJSON, []byte(response.Tx))
 				}
@@ -378,7 +378,7 @@ func TestGetBalance(t *testing.T) {
 	for idx, utxo := range genesis.UTXOs {
 		request := GetBalanceRequest{
 			Addresses: []string{
-				fmt.Sprintf("P-%s", utxo.Address),
+				"P-" + utxo.Address,
 			},
 		}
 		reply := GetBalanceResponse{}
@@ -390,10 +390,10 @@ func TestGetBalance(t *testing.T) {
 			// As such we need to account for the subnet creation fee
 			balance = defaultBalance - service.vm.Config.GetCreateSubnetTxFee(service.vm.clock.Time())
 		}
-		require.Equal(json.Uint64(balance), reply.Balance)
-		require.Equal(json.Uint64(balance), reply.Unlocked)
-		require.Equal(json.Uint64(0), reply.LockedStakeable)
-		require.Equal(json.Uint64(0), reply.LockedNotStakeable)
+		require.Equal(avajson.Uint64(balance), reply.Balance)
+		require.Equal(avajson.Uint64(balance), reply.Unlocked)
+		require.Equal(avajson.Uint64(0), reply.LockedStakeable)
+		require.Equal(avajson.Uint64(0), reply.LockedNotStakeable)
 	}
 }
 
@@ -406,7 +406,7 @@ func TestGetStake(t *testing.T) {
 	genesis, _ := defaultGenesis(t, service.vm.ctx.AVAXAssetID)
 	addrsStrs := []string{}
 	for i, validator := range genesis.Validators {
-		addr := fmt.Sprintf("P-%s", validator.RewardOwner.Addresses[0])
+		addr := "P-%s" + validator.RewardOwner.Addresses[0]
 		addrsStrs = append(addrsStrs, addr)
 
 		args := GetStakeArgs{
@@ -778,12 +778,12 @@ func TestGetBlock(t *testing.T) {
 			switch {
 			case test.encoding == formatting.JSON:
 				statelessBlock.InitCtx(service.vm.ctx)
-				expectedBlockJSON, err := stdjson.Marshal(statelessBlock)
+				expectedBlockJSON, err := json.Marshal(statelessBlock)
 				require.NoError(err)
 				require.Equal(expectedBlockJSON, []byte(response.Block))
 			default:
 				var blockStr string
-				require.NoError(stdjson.Unmarshal(response.Block, &blockStr))
+				require.NoError(json.Unmarshal(response.Block, &blockStr))
 				responseBlockBytes, err := formatting.Decode(response.Encoding, blockStr)
 				require.NoError(err)
 				require.Equal(blk.Bytes(), responseBlockBytes)
@@ -999,7 +999,7 @@ func TestServiceGetBlockByHeight(t *testing.T) {
 			service, expected := tt.serviceAndExpectedBlockFunc(t, ctrl)
 
 			args := &api.GetBlockByHeightArgs{
-				Height:   json.Uint64(blockHeight),
+				Height:   avajson.Uint64(blockHeight),
 				Encoding: tt.encoding,
 			}
 			reply := &api.GetBlockResponse{}
@@ -1010,10 +1010,10 @@ func TestServiceGetBlockByHeight(t *testing.T) {
 			}
 			require.Equal(tt.encoding, reply.Encoding)
 
-			expectedJSON, err := stdjson.Marshal(expected)
+			expectedJSON, err := json.Marshal(expected)
 			require.NoError(err)
 
-			require.Equal(stdjson.RawMessage(expectedJSON), reply.Block)
+			require.Equal(json.RawMessage(expectedJSON), reply.Block)
 		})
 	}
 }

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -12,10 +12,7 @@ import (
 	"testing"
 	"time"
 
-	stdjson "encoding/json"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/api"
@@ -44,6 +41,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
+	stdjson "encoding/json"
 	vmkeystore "github.com/ava-labs/avalanchego/vms/components/keystore"
 	pchainapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
 	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/block/executor"

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -824,7 +824,7 @@ func TestGetValidatorsAtReplyMarshalling(t *testing.T) {
 
 	var parsedReply GetValidatorsAtReply
 	require.NoError(parsedReply.UnmarshalJSON(replyJSON))
-	require.Equal(reply, &parsedReply)
+	require.Equal(&parsedReply, reply)
 }
 
 func TestServiceGetBlockByHeight(t *testing.T) {

--- a/vms/platformvm/stakeable/stakeable_lock_test.go
+++ b/vms/platformvm/stakeable/stakeable_lock_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/vms/components/avax"

--- a/vms/platformvm/stakeable/stakeable_lock_test.go
+++ b/vms/platformvm/stakeable/stakeable_lock_test.go
@@ -35,7 +35,7 @@ func TestLockOutVerify(t *testing.T) {
 		{
 			name:     "invalid locktime",
 			locktime: 0,
-			transferableOutF: func(ctrl *gomock.Controller) avax.TransferableOut {
+			transferableOutF: func(*gomock.Controller) avax.TransferableOut {
 				return nil
 			},
 			expectedErr: errInvalidLocktime,
@@ -43,7 +43,7 @@ func TestLockOutVerify(t *testing.T) {
 		{
 			name:     "nested",
 			locktime: 1,
-			transferableOutF: func(ctrl *gomock.Controller) avax.TransferableOut {
+			transferableOutF: func(*gomock.Controller) avax.TransferableOut {
 				return &LockOut{}
 			},
 			expectedErr: errNestedStakeableLocks,
@@ -93,7 +93,7 @@ func TestLockInVerify(t *testing.T) {
 		{
 			name:     "invalid locktime",
 			locktime: 0,
-			transferableInF: func(ctrl *gomock.Controller) avax.TransferableIn {
+			transferableInF: func(*gomock.Controller) avax.TransferableIn {
 				return nil
 			},
 			expectedErr: errInvalidLocktime,
@@ -101,7 +101,7 @@ func TestLockInVerify(t *testing.T) {
 		{
 			name:     "nested",
 			locktime: 1,
-			transferableInF: func(ctrl *gomock.Controller) avax.TransferableIn {
+			transferableInF: func(*gomock.Controller) avax.TransferableIn {
 				return &LockIn{}
 			},
 			expectedErr: errNestedStakeableLocks,

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/state/disk_staker_diff_iterator_test.go
+++ b/vms/platformvm/state/disk_staker_diff_iterator_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"github.com/thepudds/fzgen/fuzzer"
 
 	"github.com/ava-labs/avalanchego/database/memdb"

--- a/vms/platformvm/state/staker_test.go
+++ b/vms/platformvm/state/staker_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -12,10 +12,8 @@ import (
 	"time"
 
 	"github.com/google/btree"
-
-	"go.uber.org/zap"
-
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/cache/metercacher"

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -151,11 +151,11 @@ func TestPersistStakers(t *testing.T) {
 				r.Len(valsMap, 1)
 				valOut, found := valsMap[staker.NodeID]
 				r.True(found)
-				r.Equal(valOut, &validators.GetValidatorOutput{
+				r.Equal(&validators.GetValidatorOutput{
 					NodeID:    staker.NodeID,
 					PublicKey: staker.PublicKey,
 					Weight:    staker.Weight,
-				})
+				}, valOut)
 			},
 			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
 				upDuration, lastUpdated, err := s.GetUptime(staker.NodeID, staker.SubnetID)
@@ -168,10 +168,10 @@ func TestPersistStakers(t *testing.T) {
 				r.NoError(err)
 				weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
 				r.NoError(err)
-				r.Equal(weightDiff, &ValidatorWeightDiff{
+				r.Equal(&ValidatorWeightDiff{
 					Decrease: false,
 					Amount:   staker.Weight,
-				})
+				}, weightDiff)
 
 				blsDiffBytes, err := s.flatValidatorPublicKeyDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
 				if staker.SubnetID == constants.PrimaryNetworkID {
@@ -267,10 +267,10 @@ func TestPersistStakers(t *testing.T) {
 				r.NoError(err)
 				weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
 				r.NoError(err)
-				r.Equal(weightDiff, &ValidatorWeightDiff{
+				r.Equal(&ValidatorWeightDiff{
 					Decrease: false,
 					Amount:   staker.Weight,
-				})
+				}, weightDiff)
 			},
 		},
 		"add pending validator": {
@@ -310,7 +310,7 @@ func TestPersistStakers(t *testing.T) {
 			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
 				// pending validators are not showed in validators set
 				valsMap := s.cfg.Validators.GetMap(staker.SubnetID)
-				r.Len(valsMap, 0)
+				r.Empty(valsMap)
 			},
 			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
 				// pending validators uptime is not tracked
@@ -385,7 +385,7 @@ func TestPersistStakers(t *testing.T) {
 			},
 			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
 				valsMap := s.cfg.Validators.GetMap(staker.SubnetID)
-				r.Len(valsMap, 0)
+				r.Empty(valsMap)
 			},
 			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
 				// nothing to do here
@@ -436,7 +436,7 @@ func TestPersistStakers(t *testing.T) {
 			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
 				// deleted validators are not showed in the validators set anymore
 				valsMap := s.cfg.Validators.GetMap(staker.SubnetID)
-				r.Len(valsMap, 0)
+				r.Empty(valsMap)
 			},
 			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
 				// uptimes of delete validators are dropped
@@ -448,10 +448,10 @@ func TestPersistStakers(t *testing.T) {
 				r.NoError(err)
 				weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
 				r.NoError(err)
-				r.Equal(weightDiff, &ValidatorWeightDiff{
+				r.Equal(&ValidatorWeightDiff{
 					Decrease: true,
 					Amount:   staker.Weight,
-				})
+				}, weightDiff)
 
 				blsDiffBytes, err := s.flatValidatorPublicKeyDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
 				if staker.SubnetID == constants.PrimaryNetworkID {
@@ -548,10 +548,10 @@ func TestPersistStakers(t *testing.T) {
 				r.NoError(err)
 				weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
 				r.NoError(err)
-				r.Equal(weightDiff, &ValidatorWeightDiff{
+				r.Equal(&ValidatorWeightDiff{
 					Decrease: true,
 					Amount:   staker.Weight,
-				})
+				}, weightDiff)
 			},
 		},
 		"delete pending validator": {
@@ -593,7 +593,7 @@ func TestPersistStakers(t *testing.T) {
 			},
 			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
 				valsMap := s.cfg.Validators.GetMap(staker.SubnetID)
-				r.Len(valsMap, 0)
+				r.Empty(valsMap)
 			},
 			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
 				_, _, err := s.GetUptime(staker.NodeID, staker.SubnetID)
@@ -664,7 +664,7 @@ func TestPersistStakers(t *testing.T) {
 			},
 			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
 				valsMap := s.cfg.Validators.GetMap(staker.SubnetID)
-				r.Len(valsMap, 0)
+				r.Empty(valsMap)
 			},
 			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
 			},

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -259,8 +259,7 @@ func TestPersistStakers(t *testing.T) {
 				r.Equal(valOut.NodeID, staker.NodeID)
 				r.Equal(valOut.Weight, val.Weight+staker.Weight)
 			},
-			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
-			},
+			checkValidatorUptimes: func(*require.Assertions, *state, *Staker) {},
 			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
 				// validator's weight must increase of delegator's weight amount
 				weightDiffBytes, err := s.flatValidatorWeightDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
@@ -387,12 +386,8 @@ func TestPersistStakers(t *testing.T) {
 				valsMap := s.cfg.Validators.GetMap(staker.SubnetID)
 				r.Empty(valsMap)
 			},
-			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
-				// nothing to do here
-			},
-			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
-				// nothing to do here
-			},
+			checkValidatorUptimes: func(*require.Assertions, *state, *Staker) {},
+			checkDiffs:            func(*require.Assertions, *state, *Staker, uint64) {},
 		},
 		"delete current validator": {
 			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
@@ -539,9 +534,7 @@ func TestPersistStakers(t *testing.T) {
 				r.Equal(valOut.NodeID, staker.NodeID)
 				r.Equal(valOut.Weight, val.Weight)
 			},
-			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
-				// nothing to do here
-			},
+			checkValidatorUptimes: func(*require.Assertions, *state, *Staker) {},
 			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
 				// validator's weight must decrease of delegator's weight amount
 				weightDiffBytes, err := s.flatValidatorWeightDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
@@ -666,10 +659,8 @@ func TestPersistStakers(t *testing.T) {
 				valsMap := s.cfg.Validators.GetMap(staker.SubnetID)
 				r.Empty(valsMap)
 			},
-			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
-			},
-			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
-			},
+			checkValidatorUptimes: func(*require.Assertions, *state, *Staker) {},
+			checkDiffs:            func(*require.Assertions, *state, *Staker, uint64) {},
 		},
 	}
 

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/state/tree_iterator_test.go
+++ b/vms/platformvm/state/tree_iterator_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/btree"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/txs/add_permissionless_validator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/chains"

--- a/vms/platformvm/txs/executor/staker_tx_verification_test.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/txs/remove_subnet_validator_tx_test.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/txs/transfer_subnet_ownership_tx_test.go
+++ b/vms/platformvm/txs/transfer_subnet_ownership_tx_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/txs/transform_subnet_tx_test.go
+++ b/vms/platformvm/txs/transform_subnet_tx_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
-
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/chains"

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -71,7 +71,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 		func(events []uint8) string {
 			vm, subnetID, err := buildVM(t)
 			if err != nil {
-				return fmt.Sprintf("failed building vm: %s", err.Error())
+				return "failed building vm: " + err.Error()
 			}
 			vm.ctx.Lock.Lock()
 			defer func() {
@@ -88,12 +88,12 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 			// random events sequence received as test input
 			validatorsTimes, err := buildTimestampsList(events, currentTime, nodeID)
 			if err != nil {
-				return fmt.Sprintf("failed building events sequence: %s", err.Error())
+				return "failed building events sequence:" + err.Error()
 			}
 
 			validatorSetByHeightAndSubnet := make(map[uint64]map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput)
 			if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-				return fmt.Sprintf("could not take validators snapshot: %s", err.Error())
+				return "could not take validators snapshot: " + err.Error()
 			}
 
 			// insert validator sequence
@@ -106,12 +106,12 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 				if currentSubnetValidator != nil {
 					err := terminateSubnetValidator(vm, currentSubnetValidator)
 					if err != nil {
-						return fmt.Sprintf("could not terminate current subnet validator: %s", err.Error())
+						return "could not terminate current subnet validator: " + err.Error()
 					}
 					currentSubnetValidator = nil
 
 					if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-						return fmt.Sprintf("could not take validators snapshot: %s", err.Error())
+						return "could not take validators snapshot: " + err.Error()
 					}
 				}
 
@@ -119,10 +119,10 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 				case startSubnetValidator:
 					currentSubnetValidator, err = addSubnetValidator(vm, ev, subnetID)
 					if err != nil {
-						return fmt.Sprintf("could not add subnet validator: %s", err.Error())
+						return "could not add subnet validator: " + err.Error()
 					}
 					if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-						return fmt.Sprintf("could not take validators snapshot: %s", err.Error())
+						return "could not take validators snapshot: " + err.Error()
 					}
 
 				case startPrimaryWithBLS:
@@ -131,21 +131,21 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 					if currentPrimaryValidator != nil {
 						err := terminatePrimaryValidator(vm, currentPrimaryValidator)
 						if err != nil {
-							return fmt.Sprintf("could not terminate current primary validator: %s", err.Error())
+							return "could not terminate current primary validator: " + err.Error()
 						}
 						// no need to nil current primary validator, we'll
 						// reassign immediately
 
 						if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-							return fmt.Sprintf("could not take validators snapshot: %s", err.Error())
+							return "could not take validators snapshot: " + err.Error()
 						}
 					}
 					currentPrimaryValidator, err = addPrimaryValidatorWithBLSKey(vm, ev)
 					if err != nil {
-						return fmt.Sprintf("could not add primary validator with BLS key: %s", err.Error())
+						return "could not add primary validator with BLS key: " + err.Error()
 					}
 					if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-						return fmt.Sprintf("could not take validators snapshot: %s", err.Error())
+						return "could not take validators snapshot: " + err.Error()
 					}
 
 				default:
@@ -465,7 +465,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			nodeID := ids.GenerateTestNodeID()
 			validatorsTimes, err := buildTimestampsList(events, currentTime, nodeID)
 			if err != nil {
-				return fmt.Sprintf("failed building events sequence: %s", err.Error())
+				return "failed building events sequence: " + err.Error()
 			}
 
 			if len(validatorsTimes) == 0 {
@@ -516,7 +516,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			nodeID := ids.GenerateTestNodeID()
 			validatorsTimes, err := buildTimestampsList(events, currentTime, nodeID)
 			if err != nil {
-				return fmt.Sprintf("failed building events sequence: %s", err.Error())
+				return "failed building events sequence: " + err.Error()
 			}
 
 			if len(validatorsTimes) == 0 {
@@ -567,7 +567,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			nodeID := ids.GenerateTestNodeID()
 			validatorsTimes, err := buildTimestampsList(events, currentTime, nodeID)
 			if err != nil {
-				return fmt.Sprintf("failed building events sequence: %s", err.Error())
+				return "failed building events sequence: " + err.Error()
 			}
 
 			if len(validatorsTimes) == 0 {

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -51,6 +51,9 @@ import (
 const (
 	startPrimaryWithBLS uint8 = iota
 	startSubnetValidator
+
+	failedValidatorSnapshotString = "could not take validators snapshot: "
+	failedBuildingEventSeqString  = "failed building events sequence: "
 )
 
 var errEmptyEventsList = errors.New("empty events list")
@@ -93,7 +96,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 
 			validatorSetByHeightAndSubnet := make(map[uint64]map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput)
 			if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-				return "could not take validators snapshot: " + err.Error()
+				return failedValidatorSnapshotString + err.Error()
 			}
 
 			// insert validator sequence
@@ -111,7 +114,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 					currentSubnetValidator = nil
 
 					if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-						return "could not take validators snapshot: " + err.Error()
+						return failedValidatorSnapshotString + err.Error()
 					}
 				}
 
@@ -122,7 +125,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 						return "could not add subnet validator: " + err.Error()
 					}
 					if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-						return "could not take validators snapshot: " + err.Error()
+						return failedValidatorSnapshotString + err.Error()
 					}
 
 				case startPrimaryWithBLS:
@@ -137,7 +140,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 						// reassign immediately
 
 						if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-							return "could not take validators snapshot: " + err.Error()
+							return failedValidatorSnapshotString + err.Error()
 						}
 					}
 					currentPrimaryValidator, err = addPrimaryValidatorWithBLSKey(vm, ev)
@@ -145,7 +148,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 						return "could not add primary validator with BLS key: " + err.Error()
 					}
 					if err := takeValidatorsSnapshotAtCurrentHeight(vm, validatorSetByHeightAndSubnet); err != nil {
-						return "could not take validators snapshot: " + err.Error()
+						return failedValidatorSnapshotString + err.Error()
 					}
 
 				default:
@@ -465,7 +468,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			nodeID := ids.GenerateTestNodeID()
 			validatorsTimes, err := buildTimestampsList(events, currentTime, nodeID)
 			if err != nil {
-				return "failed building events sequence: " + err.Error()
+				return failedBuildingEventSeqString + err.Error()
 			}
 
 			if len(validatorsTimes) == 0 {
@@ -516,7 +519,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			nodeID := ids.GenerateTestNodeID()
 			validatorsTimes, err := buildTimestampsList(events, currentTime, nodeID)
 			if err != nil {
-				return "failed building events sequence: " + err.Error()
+				return failedBuildingEventSeqString + err.Error()
 			}
 
 			if len(validatorsTimes) == 0 {
@@ -567,7 +570,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			nodeID := ids.GenerateTestNodeID()
 			validatorsTimes, err := buildTimestampsList(events, currentTime, nodeID)
 			if err != nil {
-				return "failed building events sequence: " + err.Error()
+				return failedBuildingEventSeqString + err.Error()
 			}
 
 			if len(validatorsTimes) == 0 {

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -91,7 +91,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 			// random events sequence received as test input
 			validatorsTimes, err := buildTimestampsList(events, currentTime, nodeID)
 			if err != nil {
-				return "failed building events sequence:" + err.Error()
+				return "failed building events sequence: " + err.Error()
 			}
 
 			validatorSetByHeightAndSubnet := make(map[uint64]map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput)

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database/leveldb"

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -12,9 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/rpc/v2"
-
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ava-labs/avalanchego/chains"

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/chains"

--- a/vms/platformvm/warp/signature_test.go
+++ b/vms/platformvm/warp/signature_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/platformvm/warp/validator_test.go
+++ b/vms/platformvm/warp/validator_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/proposervm/pre_fork_block_test.go
+++ b/vms/proposervm/pre_fork_block_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/proposervm/pre_fork_block_test.go
+++ b/vms/proposervm/pre_fork_block_test.go
@@ -380,7 +380,7 @@ func TestBlockVerify_BlocksBuiltOnPreForkGenesis(t *testing.T) {
 	postActivationTime := activationTime.Add(time.Second)
 	proVM.Set(postActivationTime)
 
-	coreVM.SetPreferenceF = func(_ context.Context, id ids.ID) error {
+	coreVM.SetPreferenceF = func(context.Context, ids.ID) error {
 		return nil
 	}
 	require.NoError(proVM.SetPreference(context.Background(), preForkChild.ID()))

--- a/vms/proposervm/proposer/windower_test.go
+++ b/vms/proposervm/proposer/windower_test.go
@@ -42,7 +42,7 @@ func TestWindowerNoValidators(t *testing.T) {
 
 	expectedProposer, err := w.ExpectedProposer(context.Background(), chainHeight, pChainHeight, slot)
 	require.ErrorIs(err, ErrAnyoneCanPropose)
-	require.Equal(ids.EmptyNodeID, expectedProposer)
+	require.Equal(expectedProposer, ids.EmptyNodeID)
 
 	delay, err = w.MinDelayForProposer(context.Background(), chainHeight, pChainHeight, nodeID, slot)
 	require.ErrorIs(err, ErrAnyoneCanPropose)

--- a/vms/proposervm/proposer/windower_test.go
+++ b/vms/proposervm/proposer/windower_test.go
@@ -40,9 +40,9 @@ func TestWindowerNoValidators(t *testing.T) {
 	require.NoError(err)
 	require.Zero(delay)
 
-	expectedProposer, err := w.ExpectedProposer(context.Background(), chainHeight, pChainHeight, slot)
+	proposer, err := w.ExpectedProposer(context.Background(), chainHeight, pChainHeight, slot)
 	require.ErrorIs(err, ErrAnyoneCanPropose)
-	require.Equal(expectedProposer, ids.EmptyNodeID)
+	require.Equal(ids.EmptyNodeID, proposer)
 
 	delay, err = w.MinDelayForProposer(context.Background(), chainHeight, pChainHeight, nodeID, slot)
 	require.ErrorIs(err, ErrAnyoneCanPropose)

--- a/vms/proposervm/state/block_state_test.go
+++ b/vms/proposervm/state/block_state_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/proposervm/state/state_test.go
+++ b/vms/proposervm/state/state_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database/memdb"

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -501,7 +501,7 @@ func TestStateSummaryAccept(t *testing.T) {
 	statelessSummary, err := summary.Build(innerSummary.Height()-1, slb.Bytes(), innerSummary.Bytes())
 	require.NoError(err)
 
-	innerVM.ParseStateSummaryF = func(ctx context.Context, summaryBytes []byte) (block.StateSummary, error) {
+	innerVM.ParseStateSummaryF = func(_ context.Context, summaryBytes []byte) (block.StateSummary, error) {
 		require.Equal(innerSummary.BytesV, summaryBytes)
 		return innerSummary, nil
 	}

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api/metrics"

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -1379,7 +1379,7 @@ func TestInnerVMRollback(t *testing.T) {
 	// Restart the node and have the inner VM rollback state.
 	require.NoError(proVM.Shutdown(context.Background()))
 	coreBlk.StatusV = choices.Processing
-	coreVM.VerifyHeightIndexF = func(ctx context.Context) error {
+	coreVM.VerifyHeightIndexF = func(context.Context) error {
 		return nil
 	}
 

--- a/vms/registry/vm_getter_test.go
+++ b/vms/registry/vm_getter_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/registry/vm_registry_test.go
+++ b/vms/registry/vm_registry_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/vms/rpcchainvm/batched_vm_test.go
+++ b/vms/rpcchainvm/batched_vm_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database/memdb"

--- a/vms/rpcchainvm/grpcutils/client.go
+++ b/vms/rpcchainvm/grpcutils/client.go
@@ -4,7 +4,6 @@
 package grpcutils
 
 import (
-	"fmt"
 	"math"
 	"time"
 
@@ -62,7 +61,7 @@ var DefaultDialOptions = []grpc.DialOption{
 // Dial returns a gRPC ClientConn with the dial options as defined by
 // DefaultDialOptions. DialOption can also optionally be passed.
 func Dial(addr string, opts ...DialOption) (*grpc.ClientConn, error) {
-	return grpc.Dial(fmt.Sprintf("passthrough:///%s", addr), newDialOpts(opts...)...)
+	return grpc.Dial("passthrough:///"+addr, newDialOpts(opts...)...)
 }
 
 // DialOptions are options which can be applied to a gRPC client in addition to

--- a/vms/rpcchainvm/grpcutils/client_test.go
+++ b/vms/rpcchainvm/grpcutils/client_test.go
@@ -9,19 +9,17 @@ import (
 	"testing"
 	"time"
 
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/rpcdb"
 
 	pb "github.com/ava-labs/avalanchego/proto/pb/rpcdb"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 )
 
 func TestDialOptsSmoke(t *testing.T) {

--- a/vms/rpcchainvm/grpcutils/util.go
+++ b/vms/rpcchainvm/grpcutils/util.go
@@ -12,11 +12,9 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	spb "google.golang.org/genproto/googleapis/rpc/status"
-
-	tspb "google.golang.org/protobuf/types/known/timestamppb"
-
 	httppb "github.com/ava-labs/avalanchego/proto/pb/http"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func Errorf(code int, tmpl string, args ...interface{}) error {

--- a/vms/rpcchainvm/state_syncable_vm_test.go
+++ b/vms/rpcchainvm/state_syncable_vm_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database/memdb"

--- a/vms/rpcchainvm/vm.go
+++ b/vms/rpcchainvm/vm.go
@@ -14,8 +14,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/version"
@@ -25,6 +23,7 @@ import (
 
 	vmpb "github.com/ava-labs/avalanchego/proto/pb/vm"
 	runtimepb "github.com/ava-labs/avalanchego/proto/pb/vm/runtime"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 const defaultRuntimeDialTimeout = 5 * time.Second

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -11,19 +11,11 @@ import (
 	"net/http"
 	"time"
 
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-
 	"github.com/prometheus/client_golang/prometheus"
-
-	dto "github.com/prometheus/client_model/go"
-
 	"go.uber.org/zap"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/protobuf/types/known/emptypb"
-
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/ava-labs/avalanchego/api/keystore/gkeystore"
 	"github.com/ava-labs/avalanchego/api/metrics"
@@ -61,6 +53,9 @@ import (
 	validatorstatepb "github.com/ava-labs/avalanchego/proto/pb/validatorstate"
 	vmpb "github.com/ava-labs/avalanchego/proto/pb/vm"
 	warppb "github.com/ava-labs/avalanchego/proto/pb/warp"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	dto "github.com/prometheus/client_model/go"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // TODO: Enable these to be configured by the user

--- a/vms/rpcchainvm/vm_server.go
+++ b/vms/rpcchainvm/vm_server.go
@@ -11,11 +11,8 @@ import (
 	"os"
 	"time"
 
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/ava-labs/avalanchego/api/keystore/gkeystore"
@@ -52,6 +49,7 @@ import (
 	validatorstatepb "github.com/ava-labs/avalanchego/proto/pb/validatorstate"
 	vmpb "github.com/ava-labs/avalanchego/proto/pb/vm"
 	warppb "github.com/ava-labs/avalanchego/proto/pb/warp"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 )
 
 var (

--- a/vms/rpcchainvm/vm_test.go
+++ b/vms/rpcchainvm/vm_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"

--- a/vms/rpcchainvm/with_context_vm_test.go
+++ b/vms/rpcchainvm/with_context_vm_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database/memdb"

--- a/vms/secp256k1fx/output_owners_test.go
+++ b/vms/secp256k1fx/output_owners_test.go
@@ -163,6 +163,5 @@ func TestMarshalJSONDoesNotRequireCtx(t *testing.T) {
 	b, err := out.MarshalJSON()
 	require.NoError(err)
 
-	jsonData := string(b)
-	require.Equal(jsonData, `{"addresses":["6HgC8KRBEhXYbF4riJyJFLSHt37UNuRt","111111111111111111116DBWJs"],"locktime":2,"threshold":1}`)
+	require.Equal(`{"addresses":["6HgC8KRBEhXYbF4riJyJFLSHt37UNuRt","111111111111111111116DBWJs"],"locktime":2,"threshold":1}`, string(b))
 }

--- a/vms/tracedvm/batched_vm.go
+++ b/vms/tracedvm/batched_vm.go
@@ -9,11 +9,11 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 func (vm *blockVM) GetAncestors(

--- a/vms/tracedvm/block.go
+++ b/vms/tracedvm/block.go
@@ -10,10 +10,10 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var (

--- a/vms/tracedvm/block_vm.go
+++ b/vms/tracedvm/block_vm.go
@@ -9,8 +9,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
@@ -18,6 +16,8 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/trace"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var (

--- a/vms/tracedvm/block_vm.go
+++ b/vms/tracedvm/block_vm.go
@@ -5,7 +5,6 @@ package tracedvm
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -71,28 +70,28 @@ func NewBlockVM(vm block.ChainVM, name string, tracer trace.Tracer) block.ChainV
 		buildBlockVM:                  buildBlockVM,
 		batchedVM:                     batchedVM,
 		ssVM:                          ssVM,
-		initializeTag:                 fmt.Sprintf("%s.initialize", name),
-		buildBlockTag:                 fmt.Sprintf("%s.buildBlock", name),
-		parseBlockTag:                 fmt.Sprintf("%s.parseBlock", name),
-		getBlockTag:                   fmt.Sprintf("%s.getBlock", name),
-		setPreferenceTag:              fmt.Sprintf("%s.setPreference", name),
-		lastAcceptedTag:               fmt.Sprintf("%s.lastAccepted", name),
-		verifyTag:                     fmt.Sprintf("%s.verify", name),
-		acceptTag:                     fmt.Sprintf("%s.accept", name),
-		rejectTag:                     fmt.Sprintf("%s.reject", name),
-		optionsTag:                    fmt.Sprintf("%s.options", name),
-		shouldVerifyWithContextTag:    fmt.Sprintf("%s.shouldVerifyWithContext", name),
-		verifyWithContextTag:          fmt.Sprintf("%s.verifyWithContext", name),
-		buildBlockWithContextTag:      fmt.Sprintf("%s.buildBlockWithContext", name),
-		getAncestorsTag:               fmt.Sprintf("%s.getAncestors", name),
-		batchedParseBlockTag:          fmt.Sprintf("%s.batchedParseBlock", name),
-		verifyHeightIndexTag:          fmt.Sprintf("%s.verifyHeightIndex", name),
-		getBlockIDAtHeightTag:         fmt.Sprintf("%s.getBlockIDAtHeight", name),
-		stateSyncEnabledTag:           fmt.Sprintf("%s.stateSyncEnabled", name),
-		getOngoingSyncStateSummaryTag: fmt.Sprintf("%s.getOngoingSyncStateSummary", name),
-		getLastStateSummaryTag:        fmt.Sprintf("%s.getLastStateSummary", name),
-		parseStateSummaryTag:          fmt.Sprintf("%s.parseStateSummary", name),
-		getStateSummaryTag:            fmt.Sprintf("%s.getStateSummary", name),
+		initializeTag:                 name + ".initialize",
+		buildBlockTag:                 name + ".buildBlock",
+		parseBlockTag:                 name + ".parseBlock",
+		getBlockTag:                   name + ".getBlock",
+		setPreferenceTag:              name + ".setPreference",
+		lastAcceptedTag:               name + ".lastAccepted",
+		verifyTag:                     name + ".verify",
+		acceptTag:                     name + ".accept",
+		rejectTag:                     name + ".reject",
+		optionsTag:                    name + ".options",
+		shouldVerifyWithContextTag:    name + ".shouldVerifyWithContext",
+		verifyWithContextTag:          name + ".verifyWithContext",
+		buildBlockWithContextTag:      name + ".buildBlockWithContext",
+		getAncestorsTag:               name + ".getAncestors",
+		batchedParseBlockTag:          name + ".batchedParseBlock",
+		verifyHeightIndexTag:          name + ".verifyHeightIndex",
+		getBlockIDAtHeightTag:         name + ".getBlockIDAtHeight",
+		stateSyncEnabledTag:           name + ".stateSyncEnabled",
+		getOngoingSyncStateSummaryTag: name + ".getOngoingSyncStateSummary",
+		getLastStateSummaryTag:        name + ".getLastStateSummary",
+		parseStateSummaryTag:          name + ".parseStateSummary",
+		getStateSummaryTag:            name + ".getStateSummary",
 		tracer:                        tracer,
 	}
 }

--- a/vms/tracedvm/build_block_with_context_vm.go
+++ b/vms/tracedvm/build_block_with_context_vm.go
@@ -8,10 +8,10 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 func (vm *blockVM) BuildBlockWithContext(ctx context.Context, blockCtx *block.Context) (snowman.Block, error) {

--- a/vms/tracedvm/state_syncable_vm.go
+++ b/vms/tracedvm/state_syncable_vm.go
@@ -8,9 +8,9 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 func (vm *blockVM) StateSyncEnabled(ctx context.Context) (bool, error) {

--- a/vms/tracedvm/tx.go
+++ b/vms/tracedvm/tx.go
@@ -8,10 +8,10 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/snow/consensus/snowstorm"
 	"github.com/ava-labs/avalanchego/trace"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ snowstorm.Tx = (*tracedTx)(nil)

--- a/vms/tracedvm/vertex_vm.go
+++ b/vms/tracedvm/vertex_vm.go
@@ -8,14 +8,14 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowstorm"
 	"github.com/ava-labs/avalanchego/snow/engine/avalanche/vertex"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/trace"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var _ vertex.LinearizableVMWithEngine = (*vertexVM)(nil)

--- a/wallet/chain/c/backend.go
+++ b/wallet/chain/c/backend.go
@@ -9,16 +9,15 @@ import (
 	"math/big"
 	"sync"
 
-	stdcontext "context"
-
 	"github.com/ava-labs/coreth/plugin/evm"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	stdcontext "context"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var (

--- a/wallet/chain/c/builder.go
+++ b/wallet/chain/c/builder.go
@@ -7,11 +7,7 @@ import (
 	"errors"
 	"math/big"
 
-	stdcontext "context"
-
 	"github.com/ava-labs/coreth/plugin/evm"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
@@ -20,6 +16,9 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	stdcontext "context"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 const avaxConversionRateInt = 1_000_000_000

--- a/wallet/chain/c/builder_with_options.go
+++ b/wallet/chain/c/builder_with_options.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/ava-labs/coreth/plugin/evm"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var _ Builder = (*builderWithOptions)(nil)

--- a/wallet/chain/c/context.go
+++ b/wallet/chain/c/context.go
@@ -4,14 +4,14 @@
 package c
 
 import (
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/avm"
+
+	stdcontext "context"
 )
 
 const Alias = "C"

--- a/wallet/chain/c/signer.go
+++ b/wallet/chain/c/signer.go
@@ -7,11 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	stdcontext "context"
-
 	"github.com/ava-labs/coreth/plugin/evm"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
@@ -22,6 +18,9 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	stdcontext "context"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 const version = 0

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -11,11 +11,11 @@ import (
 	"github.com/ava-labs/coreth/ethclient"
 	"github.com/ava-labs/coreth/plugin/evm"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var (

--- a/wallet/chain/c/wallet_with_options.go
+++ b/wallet/chain/c/wallet_with_options.go
@@ -6,11 +6,11 @@ package c
 import (
 	"github.com/ava-labs/coreth/plugin/evm"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var _ Wallet = (*walletWithOptions)(nil)

--- a/wallet/chain/p/backend.go
+++ b/wallet/chain/p/backend.go
@@ -6,8 +6,6 @@ package p
 import (
 	"sync"
 
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -16,6 +14,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	stdcontext "context"
 )
 
 var _ Backend = (*backend)(nil)

--- a/wallet/chain/p/backend_visitor.go
+++ b/wallet/chain/p/backend_visitor.go
@@ -4,12 +4,12 @@
 package p
 
 import (
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+
+	stdcontext "context"
 )
 
 var _ txs.Visitor = (*backendVisitor)(nil)

--- a/wallet/chain/p/builder.go
+++ b/wallet/chain/p/builder.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -22,6 +20,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	stdcontext "context"
 )
 
 var (

--- a/wallet/chain/p/context.go
+++ b/wallet/chain/p/context.go
@@ -4,14 +4,14 @@
 package p
 
 import (
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/avm"
+
+	stdcontext "context"
 )
 
 const Alias = "P"

--- a/wallet/chain/p/signer.go
+++ b/wallet/chain/p/signer.go
@@ -4,13 +4,13 @@
 package p
 
 import (
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/keychain"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+
+	stdcontext "context"
 )
 
 var _ Signer = (*txSigner)(nil)

--- a/wallet/chain/p/signer_visitor.go
+++ b/wallet/chain/p/signer_visitor.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -20,6 +18,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	stdcontext "context"
 )
 
 var (

--- a/wallet/chain/x/backend.go
+++ b/wallet/chain/x/backend.go
@@ -4,10 +4,10 @@
 package x
 
 import (
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	stdcontext "context"
 )
 
 var _ Backend = (*backend)(nil)

--- a/wallet/chain/x/backend_visitor.go
+++ b/wallet/chain/x/backend_visitor.go
@@ -4,11 +4,11 @@
 package x
 
 import (
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+
+	stdcontext "context"
 )
 
 var _ txs.Visitor = (*backendVisitor)(nil)

--- a/wallet/chain/x/builder.go
+++ b/wallet/chain/x/builder.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/math"
@@ -20,6 +18,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/propertyfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	stdcontext "context"
 )
 
 var (

--- a/wallet/chain/x/context.go
+++ b/wallet/chain/x/context.go
@@ -4,14 +4,14 @@
 package x
 
 import (
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/avm"
+
+	stdcontext "context"
 )
 
 const Alias = "X"

--- a/wallet/chain/x/signer.go
+++ b/wallet/chain/x/signer.go
@@ -4,12 +4,12 @@
 package x
 
 import (
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/keychain"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+
+	stdcontext "context"
 )
 
 var _ Signer = (*signer)(nil)

--- a/wallet/chain/x/signer_visitor.go
+++ b/wallet/chain/x/signer_visitor.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	stdcontext "context"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/keychain"
@@ -20,6 +18,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/propertyfx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	stdcontext "context"
 )
 
 var (

--- a/wallet/subnet/primary/api.go
+++ b/wallet/subnet/primary/api.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ava-labs/coreth/ethclient"
 	"github.com/ava-labs/coreth/plugin/evm"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanchego/api/info"

--- a/wallet/subnet/primary/common/options.go
+++ b/wallet/subnet/primary/common/options.go
@@ -8,11 +8,11 @@ import (
 	"math/big"
 	"time"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 const defaultPollFrequency = 100 * time.Millisecond

--- a/x/merkledb/cache_test.go
+++ b/x/merkledb/cache_test.go
@@ -200,7 +200,7 @@ func TestOnEvictCacheOnEvictionError(t *testing.T) {
 	require.ErrorIs(err, errTest)
 
 	// Cache has [1,2]
-	require.Equal(evicted, []int{0})
+	require.Equal([]int{0}, evicted)
 	require.Equal(maxSize, cache.fifo.Len())
 	_, ok := cache.Get(0)
 	require.False(ok)
@@ -215,7 +215,7 @@ func TestOnEvictCacheOnEvictionError(t *testing.T) {
 
 	// Should still be empty.
 	require.Zero(cache.fifo.Len())
-	require.Equal(evicted, []int{0, 1, 2})
+	require.Equal([]int{0, 1, 2}, evicted)
 	_, ok = cache.Get(0)
 	require.False(ok)
 	_, ok = cache.Get(1)

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -13,13 +13,9 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/semaphore"
-
-	"go.opentelemetry.io/otel/attribute"
-
-	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
@@ -28,6 +24,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/maybe"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 const (

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/ava-labs/avalanchego/cache"
-
 	"github.com/ava-labs/avalanchego/database"
 )
 

--- a/x/merkledb/key_test.go
+++ b/x/merkledb/key_test.go
@@ -164,7 +164,7 @@ func Test_Key_Skip(t *testing.T) {
 func Test_Key_Take(t *testing.T) {
 	require := require.New(t)
 
-	require.Equal(ToKey([]byte{0}).Take(0), Key{})
+	require.Equal(Key{}, ToKey([]byte{0}).Take(0))
 
 	for _, ts := range validTokenSizes {
 		if ts == 8 {

--- a/x/merkledb/key_test.go
+++ b/x/merkledb/key_test.go
@@ -70,14 +70,14 @@ func Test_Key_Has_Prefix(t *testing.T) {
 	tests := []test{
 		{
 			name:           "equal keys",
-			keyA:           func(ts int) Key { return ToKey([]byte(key)) },
-			keyB:           func(ts int) Key { return ToKey([]byte(key)) },
+			keyA:           func(int) Key { return ToKey([]byte(key)) },
+			keyB:           func(int) Key { return ToKey([]byte(key)) },
 			isPrefix:       true,
 			isStrictPrefix: false,
 		},
 		{
 			name: "one key has one fewer token",
-			keyA: func(ts int) Key { return ToKey([]byte(key)) },
+			keyA: func(int) Key { return ToKey([]byte(key)) },
 			keyB: func(ts int) Key {
 				return ToKey([]byte(key)).Take(len(key)*8 - ts)
 			},
@@ -97,8 +97,8 @@ func Test_Key_Has_Prefix(t *testing.T) {
 		},
 		{
 			name:           "different keys",
-			keyA:           func(ts int) Key { return ToKey([]byte{0xF7}) },
-			keyB:           func(ts int) Key { return ToKey([]byte{0xF0}) },
+			keyA:           func(int) Key { return ToKey([]byte{0xF7}) },
+			keyB:           func(int) Key { return ToKey([]byte{0xF0}) },
 			isPrefix:       false,
 			isStrictPrefix: false,
 		},

--- a/x/merkledb/proof_test.go
+++ b/x/merkledb/proof_test.go
@@ -56,7 +56,7 @@ func Test_Proof_Verify_Bad_Data(t *testing.T) {
 	tests := []test{
 		{
 			name:        "happyPath",
-			malform:     func(proof *Proof) {},
+			malform:     func(*Proof) {},
 			expectedErr: nil,
 		},
 		{
@@ -183,7 +183,7 @@ func Test_RangeProof_Verify_Bad_Data(t *testing.T) {
 	tests := []test{
 		{
 			name:        "happyPath",
-			malform:     func(proof *RangeProof) {},
+			malform:     func(*RangeProof) {},
 			expectedErr: nil,
 		},
 		{
@@ -828,7 +828,7 @@ func Test_ChangeProof_Verify_Bad_Data(t *testing.T) {
 	tests := []test{
 		{
 			name:        "happyPath",
-			malform:     func(proof *ChangeProof) {},
+			malform:     func(*ChangeProof) {},
 			expectedErr: nil,
 		},
 		{

--- a/x/merkledb/value_node_db.go
+++ b/x/merkledb/value_node_db.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/ava-labs/avalanchego/cache"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/utils"
 )

--- a/x/merkledb/view.go
+++ b/x/merkledb/view.go
@@ -11,12 +11,12 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/maybe"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 const (

--- a/x/merkledb/view_iterator_test.go
+++ b/x/merkledb/view_iterator_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/x/sync/client.go
+++ b/x/sync/client.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -127,7 +127,7 @@ func sendRangeProofRequest(
 		gomock.Any(), // requestID
 		gomock.Any(), // responseBytes
 	).DoAndReturn(
-		func(_ context.Context, _ ids.NodeID, requestID uint32, responseBytes []byte) error {
+		func(_ context.Context, _ ids.NodeID, _ uint32, responseBytes []byte) error {
 			// deserialize the response so we can modify it if needed.
 			var responseProto pb.RangeProof
 			require.NoError(proto.Unmarshal(responseBytes, &responseProto))
@@ -427,7 +427,7 @@ func sendChangeProofRequest(
 		gomock.Any(), // requestID
 		gomock.Any(), // responseBytes
 	).DoAndReturn(
-		func(_ context.Context, _ ids.NodeID, requestID uint32, responseBytes []byte) error {
+		func(_ context.Context, _ ids.NodeID, _ uint32, responseBytes []byte) error {
 			// deserialize the response so we can modify it if needed.
 			var responseProto pb.SyncGetChangeProofResponse
 			require.NoError(proto.Unmarshal(responseBytes, &responseProto))

--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -10,11 +10,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
-
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/x/sync/network_client.go
+++ b/x/sync/network_client.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"go.uber.org/zap"
-
 	"golang.org/x/sync/semaphore"
 
 	"github.com/ava-labs/avalanchego/ids"

--- a/x/sync/network_server.go
+++ b/x/sync/network_server.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"

--- a/x/sync/network_server_test.go
+++ b/x/sync/network_server_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/x/sync/network_server_test.go
+++ b/x/sync/network_server_test.go
@@ -113,7 +113,7 @@ func Test_Server_GetRangeProof(t *testing.T) {
 				gomock.Any(), // requestID
 				gomock.Any(), // responseBytes
 			).DoAndReturn(
-				func(_ context.Context, _ ids.NodeID, requestID uint32, responseBytes []byte) error {
+				func(_ context.Context, _ ids.NodeID, _ uint32, responseBytes []byte) error {
 					// grab a copy of the proof so we can inspect it later
 					if !test.proofNil {
 						var proofProto pb.RangeProof
@@ -306,7 +306,7 @@ func Test_Server_GetChangeProof(t *testing.T) {
 				gomock.Any(), // requestID
 				gomock.Any(), // responseBytes
 			).DoAndReturn(
-				func(_ context.Context, _ ids.NodeID, requestID uint32, responseBytes []byte) error {
+				func(_ context.Context, _ ids.NodeID, _ uint32, responseBytes []byte) error {
 					if test.proofNil {
 						return nil
 					}

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -939,7 +939,7 @@ func Test_Sync_Error_During_Sync(t *testing.T) {
 
 	client := NewMockClient(ctrl)
 	client.EXPECT().GetRangeProof(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, request *pb.SyncGetRangeProofRequest) (*merkledb.RangeProof, error) {
+		func(context.Context, *pb.SyncGetRangeProofRequest) (*merkledb.RangeProof, error) {
 			return nil, errInvalidRangeProof
 		},
 	).AnyTimes()

--- a/x/sync/workheap.go
+++ b/x/sync/workheap.go
@@ -6,10 +6,10 @@ package sync
 import (
 	"bytes"
 
+	"github.com/google/btree"
+
 	"github.com/ava-labs/avalanchego/utils/heap"
 	"github.com/ava-labs/avalanchego/utils/maybe"
-
-	"github.com/google/btree"
 )
 
 // A priority queue of syncWorkItems.


### PR DESCRIPTION
## Why this should be merged

Linters 🧹 

## How this works

- Updates version
- Enables `gci` and removes `goimports`
- Enables `spancheck`
- Enables `testifylint` and removes some of our bash linters
- Includes this patch: https://github.com/mgechev/revive/issues/965 (filed by @StephenButtolph ;))

## How this was tested

CI
