### PR TITLE
Remove duplicate IP length constant

### DIFF
--- a/network/peer/ip.go
+++ b/network/peer/ip.go
@@ -44,7 +44,7 @@ func (ip *UnsignedIP) Sign(signer crypto.Signer) (*SignedIP, error) {
 
 func (ip *UnsignedIP) bytes() []byte {
 	p := wrappers.Packer{
-		Bytes: make([]byte, wrappers.IPLen+wrappers.LongLen),
+		Bytes: make([]byte, ips.IPPortLen+wrappers.LongLen),
 	}
 	ips.PackIP(&p, ip.IPPort)
 	p.PackLong(ip.Timestamp)

--- a/utils/ips/ip_port.go
+++ b/utils/ips/ip_port.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	IPPortLen = 16 + wrappers.ShortLen
+	IPPortLen = net.IPv6len + wrappers.ShortLen
 	nullStr   = "null"
 )
 

--- a/utils/wrappers/packing.go
+++ b/utils/wrappers/packing.go
@@ -22,8 +22,6 @@ const (
 	LongLen = 8
 	// BoolLen is the number of bytes per bool
 	BoolLen = 1
-	// IPLen is the number of bytes per IP
-	IPLen = 16 + ShortLen
 )
 
 func StringLen(str string) int {


### PR DESCRIPTION
## Why this should be merged

This constant was defined twice (with a magic number).

## How this works

Removes one of the definitions and both of the magic numbers

## How this was tested

- [X] CI