### PR TITLE
Minimize Signer interface and document Sign

### DIFF
--- a/wallet/chain/c/signer.go
+++ b/wallet/chain/c/signer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
@@ -20,8 +21,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
 	stdcontext "context"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 const version = 0
@@ -51,10 +50,10 @@ type Signer interface {
 
 type EthKeychain interface {
 	// The returned Signer can provide a signature for [addr]
-	GetEth(addr ethcommon.Address) (keychain.Signer, bool)
+	GetEth(addr common.Address) (keychain.Signer, bool)
 	// Returns the set of addresses for which the accessor keeps an associated
 	// signer
-	EthAddresses() set.Set[ethcommon.Address]
+	EthAddresses() set.Set[common.Address]
 }
 
 type SignerBackend interface {

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -140,7 +140,7 @@ func (w *wallet) IssueUnsignedAtomicTx(
 ) (*evm.Tx, error) {
 	ops := common.NewOptions(options)
 	ctx := ops.Context()
-	tx, err := w.signer.SignUnsignedAtomic(ctx, utx)
+	tx, err := SignUnsignedAtomic(ctx, w.signer, utx)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/chain/p/signer.go
+++ b/wallet/chain/p/signer.go
@@ -16,7 +16,14 @@ import (
 var _ Signer = (*txSigner)(nil)
 
 type Signer interface {
-	SignUnsigned(ctx stdcontext.Context, tx txs.UnsignedTx) (*txs.Tx, error)
+	// Sign adds as many missing signatures as possible to the provided
+	// transaction.
+	//
+	// If there are already some signatures on the transaction, those signatures
+	// will not be removed.
+	//
+	// If the signer doesn't have the ability to provide a required signature,
+	// the signature slot will be skipped without reporting an error.
 	Sign(ctx stdcontext.Context, tx *txs.Tx) error
 }
 
@@ -37,11 +44,6 @@ func NewSigner(kc keychain.Keychain, backend SignerBackend) Signer {
 	}
 }
 
-func (s *txSigner) SignUnsigned(ctx stdcontext.Context, utx txs.UnsignedTx) (*txs.Tx, error) {
-	tx := &txs.Tx{Unsigned: utx}
-	return tx, s.Sign(ctx, tx)
-}
-
 func (s *txSigner) Sign(ctx stdcontext.Context, tx *txs.Tx) error {
 	return tx.Unsigned.Visit(&signerVisitor{
 		kc:      s.kc,
@@ -49,4 +51,13 @@ func (s *txSigner) Sign(ctx stdcontext.Context, tx *txs.Tx) error {
 		ctx:     ctx,
 		tx:      tx,
 	})
+}
+
+func SignUnsigned(
+	ctx stdcontext.Context,
+	signer Signer,
+	utx txs.UnsignedTx,
+) (*txs.Tx, error) {
+	tx := &txs.Tx{Unsigned: utx}
+	return tx, signer.Sign(ctx, tx)
 }

--- a/wallet/chain/p/wallet.go
+++ b/wallet/chain/p/wallet.go
@@ -495,7 +495,7 @@ func (w *wallet) IssueUnsignedTx(
 ) (*txs.Tx, error) {
 	ops := common.NewOptions(options)
 	ctx := ops.Context()
-	tx, err := w.signer.SignUnsigned(ctx, utx)
+	tx, err := SignUnsigned(ctx, w.signer, utx)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/chain/x/signer.go
+++ b/wallet/chain/x/signer.go
@@ -15,7 +15,14 @@ import (
 var _ Signer = (*signer)(nil)
 
 type Signer interface {
-	SignUnsigned(ctx stdcontext.Context, tx txs.UnsignedTx) (*txs.Tx, error)
+	// Sign adds as many missing signatures as possible to the provided
+	// transaction.
+	//
+	// If there are already some signatures on the transaction, those signatures
+	// will not be removed.
+	//
+	// If the signer doesn't have the ability to provide a required signature,
+	// the signature slot will be skipped without reporting an error.
 	Sign(ctx stdcontext.Context, tx *txs.Tx) error
 }
 
@@ -35,11 +42,6 @@ func NewSigner(kc keychain.Keychain, backend SignerBackend) Signer {
 	}
 }
 
-func (s *signer) SignUnsigned(ctx stdcontext.Context, utx txs.UnsignedTx) (*txs.Tx, error) {
-	tx := &txs.Tx{Unsigned: utx}
-	return tx, s.Sign(ctx, tx)
-}
-
 func (s *signer) Sign(ctx stdcontext.Context, tx *txs.Tx) error {
 	return tx.Unsigned.Visit(&signerVisitor{
 		kc:      s.kc,
@@ -47,4 +49,13 @@ func (s *signer) Sign(ctx stdcontext.Context, tx *txs.Tx) error {
 		ctx:     ctx,
 		tx:      tx,
 	})
+}
+
+func SignUnsigned(
+	ctx stdcontext.Context,
+	signer Signer,
+	utx txs.UnsignedTx,
+) (*txs.Tx, error) {
+	tx := &txs.Tx{Unsigned: utx}
+	return tx, signer.Sign(ctx, tx)
 }

--- a/wallet/chain/x/wallet.go
+++ b/wallet/chain/x/wallet.go
@@ -286,7 +286,7 @@ func (w *wallet) IssueUnsignedTx(
 ) (*txs.Tx, error) {
 	ops := common.NewOptions(options)
 	ctx := ops.Context()
-	tx, err := w.signer.SignUnsigned(ctx, utx)
+	tx, err := SignUnsigned(ctx, w.signer, utx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why this should be merged

1. There is really no reason to have `SignUnsigned` on the interface, it just makes it more annoying to implement.
2. Wanted to document this function better because it seems like partial signing is unexpected for some users: ref: #2734

## How this works

Moves `SignUnsigned` into a static function rather than on the struct.

## How this was tested

N/A