### PR TITLE
`merkledb` -- generalize error case to check state that should never occur

### DIFF
--- a/x/merkledb/view.go
+++ b/x/merkledb/view.go
@@ -793,7 +793,7 @@ func (v *view) recordKeyChange(key Key, after *node, hadValue bool, newNode bool
 	}
 
 	before, err := v.getParentTrie().getEditableNode(key, hadValue)
-	if err != nil && !errors.Is(err, database.ErrNotFound) {
+	if err != nil {
 		return err
 	}
 	v.changes.nodes[key] = &change[*node]{


### PR DESCRIPTION
## Why this should be merged

If we are at this point in execution then `v.getParentTrie().getEditableNode(key, hadValue)` should always return a `nil` error.

## How this works

Return an error if we can't get a node that we expect exists.

## How this was tested

Existing UT.