### PR TITLE
Revert setup-go during unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         os: [macos-12, ubuntu-20.04, ubuntu-22.04, windows-2022, [self-hosted, linux, ARM64, focal], [self-hosted, linux, ARM64, jammy]]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go_version }}
           check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         os: [macos-12, ubuntu-20.04, ubuntu-22.04, windows-2022, [self-hosted, linux, ARM64, focal], [self-hosted, linux, ARM64, jammy]]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.go_version }}
           check-latest: true


### PR DESCRIPTION
## Why this should be merged

It seems that there was an unexpected regression when using `setup-go` `v4` and `v5` that causes the `Post Run actions` to take an _extremely_ long time (`> 20m`) on arm. This reverts the version back to `v3` which finishes in `0s`.

## How this works

`5 -> 3`

## How this was tested

- [X] CI