### PR TITLE
add chainID to "consensus starting" log

### DIFF
--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -542,6 +542,7 @@ func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 
 	t.Ctx.Log.Info("consensus starting",
 		zap.Stringer("lastAcceptedBlock", lastAcceptedID),
+		zap.Stringer("chainID", t.Ctx.ChainID),
 	)
 	t.metrics.bootstrapFinished.Set(1)
 


### PR DESCRIPTION
## Why this should be merged
Seems it would be helpful to have this information in the logs

## How this works
Adds a field to the logger

## How this was tested
N/A
