### PR TITLE
Revert setup-go to v3 on all arm actions

### DIFF
--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go_version }}
           check-latest: true

--- a/.github/workflows/build-ubuntu-arm64-release.yml
+++ b/.github/workflows/build-ubuntu-arm64-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go_version }}
           check-latest: true
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go_version }}
           check-latest: true


### PR DESCRIPTION
## Why this should be merged

Some jobs are still taking a very long time. This should speed them back up. This blocks faster actions running on arm64 because the arm runners are self-hosted.

## How this works

Reverts all instances of `setup-go` to `v3` when running `arm`.

## How this was tested

N/A