### PR TITLE
Add keys values to bimap

### DIFF
--- a/utils/bimap/bimap.go
+++ b/utils/bimap/bimap.go
@@ -120,7 +120,7 @@ func (m *BiMap[K, _]) Keys() []K {
 // Values returns the values of the map. The values will be in an indeterminate
 // order.
 func (m *BiMap[_, V]) Values() []V {
-	return maps.Keys(m.valueToKey)
+	return maps.Values(m.keyToValue)
 }
 
 // Len return the number of entries in this map.

--- a/utils/bimap/bimap.go
+++ b/utils/bimap/bimap.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"errors"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/ava-labs/avalanchego/utils"
 )
 
@@ -108,6 +110,17 @@ func (m *BiMap[K, V]) DeleteValue(val V) (K, bool) {
 	delete(m.keyToValue, key)
 	delete(m.valueToKey, val)
 	return key, true
+}
+
+// Keys returns the keys of the map. The keys will be in an indeterminate order.
+func (m *BiMap[K, _]) Keys() []K {
+	return maps.Keys(m.keyToValue)
+}
+
+// Values returns the values of the map. The values will be in an indeterminate
+// order.
+func (m *BiMap[_, V]) Values() []V {
+	return maps.Keys(m.valueToKey)
 }
 
 // Len return the number of entries in this map.

--- a/utils/bimap/bimap_test.go
+++ b/utils/bimap/bimap_test.go
@@ -309,23 +309,33 @@ func TestBiMapDeleteValue(t *testing.T) {
 	}
 }
 
-func TestBiMapLen(t *testing.T) {
+func TestBiMapLenAndLists(t *testing.T) {
 	require := require.New(t)
 
 	m := New[int, int]()
 	require.Zero(m.Len())
+	require.Empty(m.Keys())
+	require.Empty(m.Values())
 
 	m.Put(1, 2)
 	require.Equal(1, m.Len())
+	require.ElementsMatch([]int{1}, m.Keys())
+	require.ElementsMatch([]int{2}, m.Values())
 
 	m.Put(2, 3)
 	require.Equal(2, m.Len())
+	require.ElementsMatch([]int{1, 2}, m.Keys())
+	require.ElementsMatch([]int{2, 3}, m.Values())
 
 	m.Put(1, 3)
 	require.Equal(1, m.Len())
+	require.ElementsMatch([]int{1}, m.Keys())
+	require.ElementsMatch([]int{3}, m.Values())
 
 	m.DeleteKey(1)
 	require.Zero(m.Len())
+	require.Empty(m.Keys())
+	require.Empty(m.Values())
 }
 
 func TestBiMapJSON(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

I wanted to iterate over the map, but found that it wasn't currently supported.

## How this works

Adds `.Keys()` and `.Values()` to the map.

## How this was tested

- [X] Extended unit test