### PR TITLE
Refactor p-chain edge-cases out of chain manager

### DIFF
--- a/chains/factory.go
+++ b/chains/factory.go
@@ -80,9 +80,6 @@ type Factory struct {
 	resourceTracker       tracker.ResourceTracker
 	subnets               *Subnets
 	unblockChainCreatorCh chan struct{}
-
-	// snowman++ related interface to allow validators retrieval
-	validatorState validators.State
 }
 
 // NewFactory returns an instance of Factory

--- a/vms/platformvm/chaincreator/interface.go
+++ b/vms/platformvm/chaincreator/interface.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package chaincreator
+
+import "github.com/ava-labs/avalanchego/ids"
+
+type Interface interface {
+	// CreateChain creates a blockchain on this node
+	CreateChain(
+		subnetID ids.ID,
+		chainID ids.ID,
+		vmID ids.ID,
+		genesis []byte,
+		fxIDs []ids.ID,
+	)
+}

--- a/vms/platformvm/factory.go
+++ b/vms/platformvm/factory.go
@@ -6,17 +6,16 @@ package platformvm
 import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms"
-	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 )
 
 var _ vms.Factory = (*Factory)(nil)
 
 // Factory can create new instances of the Platform Chain
 type Factory struct {
-	config.Config
+	VM *VM
 }
 
 // New returns a new instance of the Platform Chain
 func (f *Factory) New(logging.Logger) (interface{}, error) {
-	return &VM{Config: f.Config}, nil
+	return f.VM, nil
 }

--- a/vms/platformvm/txs/executor/backend.go
+++ b/vms/platformvm/txs/executor/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+	"github.com/ava-labs/avalanchego/vms/platformvm/chaincreator"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
@@ -16,6 +17,7 @@ import (
 
 type Backend struct {
 	Config       *config.Config
+	ChainCreator chaincreator.Interface
 	Ctx          *snow.Context
 	Clk          *mockable.Clock
 	Fx           fx.Fx

--- a/vms/platformvm/txs/executor/standard_tx_executor.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor.go
@@ -94,7 +94,7 @@ func (e *StandardTxExecutor) CreateChainTx(tx *txs.CreateChainTx) error {
 	// If this proposal is committed and this node is a member of the subnet
 	// that validates the blockchain, create the blockchain
 	e.OnAccept = func() {
-		e.Config.CreateChain(txID, tx)
+		e.ChainCreator.CreateChain(tx.SubnetID, txID, tx.VMID, tx.GenesisData, tx.FxIDs)
 	}
 	return nil
 }


### PR DESCRIPTION
## Why this should be merged

Last piece of the puzzle to remove `vm.Initialize`

## How this works

Refactors all p-chain edge-cases out of the chains/manager and into the parameters of `chains.Factory#New`.

## How this was tested

CI
