### PR TITLE
Remove `defaultAddress` helper from platformvm service tests

### DIFF
--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -76,10 +76,7 @@ func defaultService(t *testing.T) (*Service, *mutableSharedMemory) {
 	vm, _, mutableSharedMemory := defaultVM(t, latestFork)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
-	ks := keystore.New(logging.NoLog{}, memdb.New())
-	require.NoError(t, ks.CreateUser(testUsername, testPassword))
 
-	vm.ctx.Keystore = ks.NewBlockchainKeyStore(vm.ctx.ChainID)
 	return &Service{
 		vm:          vm,
 		addrManager: avax.NewAddressManager(vm.ctx),
@@ -94,6 +91,10 @@ func TestExportKey(t *testing.T) {
 
 	service, _ := defaultService(t)
 	service.vm.ctx.Lock.Lock()
+
+	ks := keystore.New(logging.NoLog{}, memdb.New())
+	require.NoError(ks.CreateUser(testUsername, testPassword))
+	service.vm.ctx.Keystore = ks.NewBlockchainKeyStore(service.vm.ctx.ChainID)
 
 	user, err := vmkeystore.NewUserFromKeystore(service.vm.ctx.Keystore, testUsername, testPassword)
 	require.NoError(err)

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -94,7 +94,6 @@ func TestExportKey(t *testing.T) {
 
 	service, _ := defaultService(t)
 	service.vm.ctx.Lock.Lock()
-	defer service.vm.ctx.Lock.Unlock()
 
 	user, err := vmkeystore.NewUserFromKeystore(service.vm.ctx.Keystore, testUsername, testPassword)
 	require.NoError(err)
@@ -103,6 +102,8 @@ func TestExportKey(t *testing.T) {
 	require.NoError(err)
 
 	require.NoError(user.PutKeys(pk, keys[0]))
+
+	service.vm.ctx.Lock.Unlock()
 
 	jsonString := `{"username":"` + testUsername + `","password":"` + testPassword + `","address":"` + testAddress + `"}`
 	args := ExportKeyArgs{}

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -89,12 +89,13 @@ func defaultService(t *testing.T) (*Service, *mutableSharedMemory) {
 	}, mutableSharedMemory
 }
 
-// Give user [testUsername] control of [testPrivateKey] and keys[0] (which is funded)
-func defaultAddress(t *testing.T, service *Service) {
+func TestExportKey(t *testing.T) {
 	require := require.New(t)
 
+	service, _ := defaultService(t)
 	service.vm.ctx.Lock.Lock()
 	defer service.vm.ctx.Lock.Unlock()
+
 	user, err := vmkeystore.NewUserFromKeystore(service.vm.ctx.Keystore, testUsername, testPassword)
 	require.NoError(err)
 
@@ -102,16 +103,10 @@ func defaultAddress(t *testing.T, service *Service) {
 	require.NoError(err)
 
 	require.NoError(user.PutKeys(pk, keys[0]))
-}
 
-func TestExportKey(t *testing.T) {
-	require := require.New(t)
-	jsonString := `{"username":"ScoobyUser","password":"ShaggyPassword1Zoinks!","address":"` + testAddress + `"}`
+	jsonString := `{"username":"` + testUsername + `","password":"` + testPassword + `","address":"` + testAddress + `"}`
 	args := ExportKeyArgs{}
 	require.NoError(json.Unmarshal([]byte(jsonString), &args))
-
-	service, _ := defaultService(t)
-	defaultAddress(t, service)
 
 	reply := ExportKeyReply{}
 	require.NoError(service.ExportKey(nil, &args, &reply))
@@ -123,7 +118,6 @@ func TestExportKey(t *testing.T) {
 func TestGetTxStatus(t *testing.T) {
 	require := require.New(t)
 	service, mutableSharedMemory := defaultService(t)
-	defaultAddress(t, service)
 	service.vm.ctx.Lock.Lock()
 
 	recipientKey, err := secp256k1.NewPrivateKey()
@@ -276,7 +270,6 @@ func TestGetTx(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				require := require.New(t)
 				service, _ := defaultService(t)
-				defaultAddress(t, service)
 				service.vm.ctx.Lock.Lock()
 
 				tx, err := test.createTx(service)
@@ -341,7 +334,6 @@ func TestGetTx(t *testing.T) {
 func TestGetBalance(t *testing.T) {
 	require := require.New(t)
 	service, _ := defaultService(t)
-	defaultAddress(t, service)
 
 	// Ensure GetStake is correct for each of the genesis validators
 	genesis, _ := defaultGenesis(t, service.vm.ctx.AVAXAssetID)
@@ -370,7 +362,6 @@ func TestGetBalance(t *testing.T) {
 func TestGetStake(t *testing.T) {
 	require := require.New(t)
 	service, _ := defaultService(t)
-	defaultAddress(t, service)
 
 	// Ensure GetStake is correct for each of the genesis validators
 	genesis, _ := defaultGenesis(t, service.vm.ctx.AVAXAssetID)
@@ -543,7 +534,6 @@ func TestGetStake(t *testing.T) {
 func TestGetCurrentValidators(t *testing.T) {
 	require := require.New(t)
 	service, _ := defaultService(t)
-	defaultAddress(t, service)
 
 	genesis, _ := defaultGenesis(t, service.vm.ctx.AVAXAssetID)
 

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -74,8 +74,6 @@ var (
 
 func defaultService(t *testing.T) (*Service, *mutableSharedMemory) {
 	vm, _, mutableSharedMemory := defaultVM(t, latestFork)
-	vm.ctx.Lock.Lock()
-	defer vm.ctx.Lock.Unlock()
 
 	return &Service{
 		vm:          vm,


### PR DESCRIPTION
## Why this should be merged

This helper function should only be used in `TestExportKey` so we'll in-line it there.

## How this works

moves code around

## How this was tested

cI