### PR TITLE
Reenable the upgrade tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,17 +109,16 @@ jobs:
       - name: Build AvalancheGo Binary
         shell: bash
         run: ./scripts/build.sh
-      # TODO: Reactivate test once v1.11.0 is published
-      # - name: Run e2e tests
-      #   shell: bash
-      #   run: ./scripts/tests.upgrade.sh
-      # - name: Upload tmpnet network dir
-      #   uses: actions/upload-artifact@v4
-      #   if: always()
-      #   with:
-      #     name: upgrade-tmpnet-data
-      #     path: ${{ env.tmpnet_data_path }}
-      #     if-no-files-found: error
+      - name: Run e2e tests
+        shell: bash
+        run: ./scripts/tests.upgrade.sh
+      - name: Upload tmpnet network dir
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: upgrade-tmpnet-data
+          path: ${{ env.tmpnet_data_path }}
+          if-no-files-found: error
   Lint:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # e.g.,
-# ./scripts/tests.upgrade.sh                                                # Use default version
-# ./scripts/tests.upgrade.sh 1.10.18                                        # Specify a version
-# AVALANCHEGO_PATH=./path/to/avalanchego ./scripts/tests.upgrade.sh 1.10.18 # Customization of avalanchego path
+# ./scripts/tests.upgrade.sh                                               # Use default version
+# ./scripts/tests.upgrade.sh 1.11.0                                        # Specify a version
+# AVALANCHEGO_PATH=./path/to/avalanchego ./scripts/tests.upgrade.sh 1.11.0 # Customization of avalanchego path
 if ! [[ "$0" =~ scripts/tests.upgrade.sh ]]; then
   echo "must be run from repository root"
   exit 255
@@ -16,9 +16,8 @@ fi
 # local network, this flag must be updated to the last compatible
 # version with the latest code.
 #
-# v1.10.18 includes restrictions on ports sent over the p2p network along with
-# proposervm and P-chain rule changes on the local network.
-DEFAULT_VERSION="1.10.18"
+# v1.11.0 activates Durango.
+DEFAULT_VERSION="1.11.0"
 
 VERSION="${1:-${DEFAULT_VERSION}}"
 if [[ -z "${VERSION}" ]]; then


### PR DESCRIPTION
## Why this should be merged

`v1.11.0` was released - time to re-activate the upgrade test.

## How this works

Uncomments code and `v1.10.18` -> `v1.11.0`.

## How this was tested

- [X] CI