### PR TITLE
`merkledb` -- move compressedKey declaration to avoid usage of stale values in loop

### DIFF
--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -789,7 +789,6 @@ func valueOrHashMatches(value maybe.Maybe[[]byte], valueOrHash maybe.Maybe[[]byt
 // Adds each key/value pair in [proofPath] to [t].
 // For each proof node, adds the children that are
 // < [insertChildrenLessThan] or > [insertChildrenGreaterThan].
-// The children have only their ID populated.
 // If [insertChildrenLessThan] is Nothing, no children are < [insertChildrenLessThan].
 // If [insertChildrenGreaterThan] is Nothing, no children are > [insertChildrenGreaterThan].
 // Assumes [v.lock] is held.
@@ -838,12 +837,14 @@ func addPathInfo(
 			childKey := key.Extend(ToToken(index, v.tokenSize), compressedKey)
 			if (shouldInsertLeftChildren && childKey.Less(insertChildrenLessThan.Value())) ||
 				(shouldInsertRightChildren && childKey.Greater(insertChildrenGreaterThan.Value())) {
-				// We don't set all the fields of the child entry but it doesn't matter.
-				// We only need the ID to be correct so that the calculated hash is correct.
+				// We don't set the [hasValue] field of the child but that's OK.
+				// We only need the compressed key and ID to be correct so that the
+				// calculated hash is correct.
 				n.setChildEntry(
 					index,
 					&child{
-						id: childID,
+						id:            childID,
+						compressedKey: compressedKey,
 					})
 			}
 		}

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -789,6 +789,7 @@ func valueOrHashMatches(value maybe.Maybe[[]byte], valueOrHash maybe.Maybe[[]byt
 // Adds each key/value pair in [proofPath] to [t].
 // For each proof node, adds the children that are
 // < [insertChildrenLessThan] or > [insertChildrenGreaterThan].
+// The children have only their ID populated.
 // If [insertChildrenLessThan] is Nothing, no children are < [insertChildrenLessThan].
 // If [insertChildrenGreaterThan] is Nothing, no children are > [insertChildrenGreaterThan].
 // Assumes [v.lock] is held.
@@ -829,21 +830,20 @@ func addPathInfo(
 
 		// Add [proofNode]'s children which are outside the range
 		// [insertChildrenLessThan, insertChildrenGreaterThan].
-		compressedKey := Key{}
 		for index, childID := range proofNode.Children {
+			var compressedKey Key
 			if existingChild, ok := n.children[index]; ok {
 				compressedKey = existingChild.compressedKey
 			}
 			childKey := key.Extend(ToToken(index, v.tokenSize), compressedKey)
 			if (shouldInsertLeftChildren && childKey.Less(insertChildrenLessThan.Value())) ||
 				(shouldInsertRightChildren && childKey.Greater(insertChildrenGreaterThan.Value())) {
-				// We didn't set the other values on the child entry, but it doesn't matter.
-				// We only need the IDs to be correct so that the calculated hash is correct.
+				// We don't set all the fields of the child entry but it doesn't matter.
+				// We only need the ID to be correct so that the calculated hash is correct.
 				n.setChildEntry(
 					index,
 					&child{
-						id:            childID,
-						compressedKey: compressedKey,
+						id: childID,
 					})
 			}
 		}

--- a/x/merkledb/proof_test.go
+++ b/x/merkledb/proof_test.go
@@ -1595,61 +1595,6 @@ func TestChangeProofUnmarshalProtoInvalidMaybe(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidMaybe)
 }
 
-func TestAddPathInfo(t *testing.T) {
-	var (
-		now     = time.Now().UnixNano()
-		rand    = rand.New(rand.NewSource(now)) // #nosec G404
-		require = require.New(t)
-	)
-	t.Logf("seed: %d", now)
-
-	db, err := getBasicDB()
-	require.NoError(err)
-
-	// Insert a bunch of random key values.
-	insertRandomKeyValues(
-		require,
-		rand,
-		[]database.Database{db},
-		100, /* numKeyValues */
-		0,   /* deletePortion */
-	)
-
-	viewIntf, err := db.NewView(context.Background(), ViewChanges{})
-	require.NoError(err)
-
-	view, ok := viewIntf.(*view)
-	require.True(ok)
-
-	// Generate a proof for a random key.
-	key := make([]byte, 32)
-	_, _ = rand.Read(key) // #nosec G404
-	proof, err := db.GetProof(context.Background(), key)
-	require.NoError(err)
-
-	// Add path info to the proof.
-	require.NoError(
-		addPathInfo(
-			view,
-			proof.Path,
-			maybe.Some(proof.Key),
-			maybe.Some(proof.Key),
-		),
-	)
-
-	// Assert that we added the left and right children of each node.
-	for _, proofNode := range proof.Path {
-		node, err := view.getNode(proofNode.Key, false /* hasValue */)
-		require.NoError(err)
-
-		require.Equal(proofNode.ValueOrHash, node.valueDigest)
-
-		for index, childID := range proofNode.Children {
-			require.Equal(childID, node.children[index].id)
-		}
-	}
-}
-
 func FuzzProofProtoMarshalUnmarshal(f *testing.F) {
 	f.Fuzz(func(
 		t *testing.T,


### PR DESCRIPTION
As this code is currently written, we could use a stale value of `compressedKey` from a previous iteration because it is declared outside the loop but may be assigned inside the loop.