### PR TITLE
`merkledb` -- style nit, remove var name `newView` to reduce shadowing

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -779,7 +779,7 @@ func (db *merkleDB) NewView(
 		return nil, database.ErrClosed
 	}
 
-	newView, err := newView(db, db, changes)
+	view, err := newView(db, db, changes)
 	if err != nil {
 		return nil, err
 	}
@@ -788,8 +788,8 @@ func (db *merkleDB) NewView(
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	db.childViews = append(db.childViews, newView)
-	return newView, nil
+	db.childViews = append(db.childViews, view)
+	return view, nil
 }
 
 func (db *merkleDB) Has(k []byte) (bool, error) {

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -1061,11 +1061,11 @@ func runRandDBTest(require *require.Assertions, r *rand.Rand, rt randTest, token
 				})
 			}
 
-			newView, err := newDB.NewView(context.Background(), ViewChanges{BatchOps: ops})
+			view, err := newDB.NewView(context.Background(), ViewChanges{BatchOps: ops})
 			require.NoError(err)
 
 			// Check that the root of the view is the same as the root of [db]
-			newRoot, err := newView.GetMerkleRoot(context.Background())
+			newRoot, err := view.GetMerkleRoot(context.Background())
 			require.NoError(err)
 
 			dbRoot, err := db.GetMerkleRoot(context.Background())

--- a/x/merkledb/trie_test.go
+++ b/x/merkledb/trie_test.go
@@ -258,7 +258,7 @@ func Test_Trie_ViewOnCommitedView(t *testing.T) {
 
 	require.NoError(committedTrie.CommitToDB(context.Background()))
 
-	newView, err := committedTrie.NewView(
+	view, err := committedTrie.NewView(
 		context.Background(),
 		ViewChanges{
 			BatchOps: []database.BatchOp{
@@ -267,7 +267,7 @@ func Test_Trie_ViewOnCommitedView(t *testing.T) {
 		},
 	)
 	require.NoError(err)
-	require.NoError(newView.CommitToDB(context.Background()))
+	require.NoError(view.CommitToDB(context.Background()))
 
 	val0, err := dbTrie.GetValue(context.Background(), []byte{0})
 	require.NoError(err)
@@ -1235,9 +1235,9 @@ func Test_Trie_ConcurrentNewViewAndCommit(t *testing.T) {
 		require.NoError(newTrie.CommitToDB(context.Background()))
 	}()
 
-	newView, err := newTrie.NewView(context.Background(), ViewChanges{})
+	view, err := newTrie.NewView(context.Background(), ViewChanges{})
 	require.NoError(err)
-	require.NotNil(newView)
+	require.NotNil(view)
 }
 
 // Returns the path of the only child of this node.


### PR DESCRIPTION
## Why this should be merged

A variable `newView` shadows the function of the same name.

## How this works

Self-explanatory

## How this was tested

Existing UT