### PR TITLE
Remove bitmaskCodec

### DIFF
--- a/network/peer/msg_length.go
+++ b/network/peer/msg_length.go
@@ -12,28 +12,19 @@ import (
 )
 
 var (
-	errInvalidMaxMessageLength  = errors.New("invalid maximum message length")
 	errInvalidMessageLength     = errors.New("invalid message length")
 	errMaxMessageLengthExceeded = errors.New("maximum message length exceeded")
 )
 
-// Used to mask the most significant bit that was used to indicate that the
-// message format uses protocol buffers.
-//
-// TODO: Once the v1.11 is activated, this mask should be removed.
-const bitmaskCodec = uint32(1 << 31)
-
 // Assumes the specified [msgLen] will never >= 1<<31.
 func writeMsgLen(msgLen uint32, maxMsgLen uint32) ([wrappers.IntLen]byte, error) {
-	if maxMsgLen >= bitmaskCodec {
-		return [wrappers.IntLen]byte{}, fmt.Errorf(
-			"%w; maximum message length must be <%d to be able to embed codec information at most significant bit",
-			errInvalidMaxMessageLength,
-			bitmaskCodec,
-		)
-	}
 	if msgLen > maxMsgLen {
-		return [wrappers.IntLen]byte{}, fmt.Errorf("%w; the message length %d exceeds the specified limit %d", errMaxMessageLengthExceeded, msgLen, maxMsgLen)
+		return [wrappers.IntLen]byte{}, fmt.Errorf(
+			"%w; the message length %d exceeds the specified limit %d",
+			errMaxMessageLengthExceeded,
+			msgLen,
+			maxMsgLen,
+		)
 	}
 
 	b := [wrappers.IntLen]byte{}
@@ -44,13 +35,6 @@ func writeMsgLen(msgLen uint32, maxMsgLen uint32) ([wrappers.IntLen]byte, error)
 
 // Assumes the read [msgLen] will never >= 1<<31.
 func readMsgLen(b []byte, maxMsgLen uint32) (uint32, error) {
-	if maxMsgLen >= bitmaskCodec {
-		return 0, fmt.Errorf(
-			"%w; maximum message length must be <%d to be able to embed codec information at most significant bit",
-			errInvalidMaxMessageLength,
-			bitmaskCodec,
-		)
-	}
 	if len(b) != wrappers.IntLen {
 		return 0, fmt.Errorf(
 			"%w; readMsgLen only supports 4 bytes (got %d bytes)",
@@ -61,12 +45,6 @@ func readMsgLen(b []byte, maxMsgLen uint32) (uint32, error) {
 
 	// parse the message length
 	msgLen := binary.BigEndian.Uint32(b)
-
-	// Because we always use proto messages, there's no need to check the most
-	// significant bit to inspect the message format. So, we just zero the proto
-	// flag.
-	msgLen &^= bitmaskCodec
-
 	if msgLen > maxMsgLen {
 		return 0, fmt.Errorf(
 			"%w; the message length %d exceeds the specified limit %d",

--- a/network/peer/msg_length_test.go
+++ b/network/peer/msg_length_test.go
@@ -23,16 +23,6 @@ func TestWriteMsgLen(t *testing.T) {
 		{
 			msgLen:      math.MaxUint32,
 			msgLimit:    math.MaxUint32,
-			expectedErr: errInvalidMaxMessageLength,
-		},
-		{
-			msgLen:      bitmaskCodec,
-			msgLimit:    bitmaskCodec,
-			expectedErr: errInvalidMaxMessageLength,
-		},
-		{
-			msgLen:      bitmaskCodec - 1,
-			msgLimit:    bitmaskCodec - 1,
 			expectedErr: nil,
 		},
 		{
@@ -76,8 +66,8 @@ func TestReadMsgLen(t *testing.T) {
 		{
 			msgLenBytes:    []byte{0xFF, 0xFF, 0xFF, 0xFF},
 			msgLimit:       math.MaxUint32,
-			expectedErr:    errInvalidMaxMessageLength,
-			expectedMsgLen: 0,
+			expectedErr:    nil,
+			expectedMsgLen: math.MaxUint32,
 		},
 		{
 			msgLenBytes:    []byte{0b11111111, 0xFF},
@@ -86,13 +76,13 @@ func TestReadMsgLen(t *testing.T) {
 			expectedMsgLen: 0,
 		},
 		{
-			msgLenBytes:    []byte{0b11111111, 0xFF, 0xFF, 0xFF},
+			msgLenBytes:    []byte{0b01111111, 0xFF, 0xFF, 0xFF},
 			msgLimit:       constants.DefaultMaxMessageSize,
 			expectedErr:    errMaxMessageLengthExceeded,
 			expectedMsgLen: 0,
 		},
 		{
-			msgLenBytes:    []byte{0b11111111, 0xFF, 0xFF, 0xFF},
+			msgLenBytes:    []byte{0b01111111, 0xFF, 0xFF, 0xFF},
 			msgLimit:       math.MaxInt32,
 			expectedErr:    nil,
 			expectedMsgLen: math.MaxInt32,
@@ -100,14 +90,14 @@ func TestReadMsgLen(t *testing.T) {
 		{
 			msgLenBytes:    []byte{0b10000000, 0x00, 0x00, 0x01},
 			msgLimit:       math.MaxInt32,
-			expectedErr:    nil,
-			expectedMsgLen: 1,
+			expectedErr:    errMaxMessageLengthExceeded,
+			expectedMsgLen: 0,
 		},
 		{
 			msgLenBytes:    []byte{0b10000000, 0x00, 0x00, 0x01},
 			msgLimit:       1,
-			expectedErr:    nil,
-			expectedMsgLen: 1,
+			expectedErr:    errMaxMessageLengthExceeded,
+			expectedMsgLen: 0,
 		},
 	}
 	for _, tv := range tt {


### PR DESCRIPTION
## Why this should be merged

This is a remnant from before our usage of proto for p2p messages. Now that all nodes in the network are guaranteed to be sending proto messages without a bit flag, we can remove the masking logic.

## How this works

Deletes dead code.

## How this was tested

- [X] CI