### PR TITLE
Cleanup BLS naming and documentation

### DIFF
--- a/snow/validators/gvalidators/validator_state_client.go
+++ b/snow/validators/gvalidators/validator_state_client.go
@@ -76,11 +76,12 @@ func (c *Client) GetValidatorSet(
 		}
 		var publicKey *bls.PublicKey
 		if len(validator.PublicKey) > 0 {
-			// This is a performance optimization to avoid the cost of compression
-			// and key re-verification with PublicKeyFromBytes. We can safely
-			// assume that the BLS Public Keys are verified before being added
-			// to the P-Chain and served by the gRPC server.
-			publicKey = bls.DeserializePublicKey(validator.PublicKey)
+			// This is a performance optimization to avoid the cost of
+			// compression and key re-verification with
+			// PublicKeyFromCompressedBytes. We can safely assume that the BLS
+			// Public Keys are verified before being added to the P-Chain and
+			// served by the gRPC server.
+			publicKey = bls.PublicKeyFromValidUncompressedBytes(validator.PublicKey)
 			if publicKey == nil {
 				return nil, errFailedPublicKeyDeserialize
 			}

--- a/snow/validators/gvalidators/validator_state_server.go
+++ b/snow/validators/gvalidators/validator_state_server.go
@@ -71,8 +71,8 @@ func (s *Server) GetValidatorSet(ctx context.Context, req *pb.GetValidatorSetReq
 		}
 		if vdr.PublicKey != nil {
 			// This is a performance optimization to avoid the cost of compression
-			// from PublicKeyToBytes.
-			vdrPB.PublicKey = bls.SerializePublicKey(vdr.PublicKey)
+			// from PublicKeyToCompressedBytes.
+			vdrPB.PublicKey = bls.PublicKeyToUncompressedBytes(vdr.PublicKey)
 		}
 		resp.Validators[i] = vdrPB
 		i++

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -184,8 +184,8 @@ func TestPublicKeyDeserialize(t *testing.T) {
 	require.NoError(err)
 	pk := bls.PublicFromSecretKey(sk)
 
-	pkBytes := bls.SerializePublicKey(pk)
-	pkDe := bls.DeserializePublicKey(pkBytes)
+	pkBytes := bls.PublicKeyToUncompressedBytes(pk)
+	pkDe := bls.PublicKeyFromValidUncompressedBytes(pkBytes)
 	require.NotNil(pkDe)
 	require.Equal(pk, pkDe)
 }

--- a/snow/validators/logger.go
+++ b/snow/validators/logger.go
@@ -45,7 +45,7 @@ func (l *logger) OnValidatorAdded(
 	if l.nodeIDs.Contains(nodeID) {
 		var pkBytes []byte
 		if pk != nil {
-			pkBytes = bls.PublicKeyToBytes(pk)
+			pkBytes = bls.PublicKeyToCompressedBytes(pk)
 		}
 		l.log.Info("node added to validator set",
 			zap.Stringer("subnetID", l.subnetID),

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -244,7 +244,7 @@ func (n *Node) EnsureBLSSigningKey() error {
 	if err != nil {
 		return fmt.Errorf("failed to generate staking signer key: %w", err)
 	}
-	n.Flags[config.StakingSignerKeyContentKey] = base64.StdEncoding.EncodeToString(bls.SerializeSecretKey(newKey))
+	n.Flags[config.StakingSignerKeyContentKey] = base64.StdEncoding.EncodeToString(bls.SecretKeyToBytes(newKey))
 	return nil
 }
 

--- a/utils/crypto/bls/public.go
+++ b/utils/crypto/bls/public.go
@@ -29,8 +29,8 @@ func PublicKeyToCompressedBytes(pk *PublicKey) []byte {
 	return pk.Compress()
 }
 
-// PublicKeyFromCompressedBytes returns the uncompressed big-endian format of
-// the public key.
+// PublicKeyFromCompressedBytes parses the compressed big-endian format of the
+// public key into a public key.
 func PublicKeyFromCompressedBytes(pkBytes []byte) (*PublicKey, error) {
 	pk := new(PublicKey).Uncompress(pkBytes)
 	if pk == nil {
@@ -42,9 +42,8 @@ func PublicKeyFromCompressedBytes(pkBytes []byte) (*PublicKey, error) {
 	return pk, nil
 }
 
-// PublicKeyToUncompressedBytes parses the uncompressed big-endian format
-// of the public key into a public key. It is assumed that the provided bytes
-// are valid.
+// PublicKeyToUncompressedBytes returns the uncompressed big-endian format of
+// the public key.
 func PublicKeyToUncompressedBytes(key *PublicKey) []byte {
 	return key.Serialize()
 }

--- a/utils/crypto/bls/public.go
+++ b/utils/crypto/bls/public.go
@@ -23,14 +23,15 @@ type (
 	AggregatePublicKey = blst.P1Aggregate
 )
 
-// PublicKeyToBytes returns the compressed big-endian format of the public key.
-func PublicKeyToBytes(pk *PublicKey) []byte {
+// PublicKeyToCompressedBytes returns the compressed big-endian format of the
+// public key.
+func PublicKeyToCompressedBytes(pk *PublicKey) []byte {
 	return pk.Compress()
 }
 
-// PublicKeyFromBytes parses the compressed big-endian format of the public key
-// into a public key.
-func PublicKeyFromBytes(pkBytes []byte) (*PublicKey, error) {
+// PublicKeyFromCompressedBytes returns the uncompressed big-endian format of
+// the public key.
+func PublicKeyFromCompressedBytes(pkBytes []byte) (*PublicKey, error) {
 	pk := new(PublicKey).Uncompress(pkBytes)
 	if pk == nil {
 		return nil, ErrFailedPublicKeyDecompress
@@ -39,6 +40,20 @@ func PublicKeyFromBytes(pkBytes []byte) (*PublicKey, error) {
 		return nil, errInvalidPublicKey
 	}
 	return pk, nil
+}
+
+// PublicKeyToUncompressedBytes parses the uncompressed big-endian format
+// of the public key into a public key. It is assumed that the provided bytes
+// are valid.
+func PublicKeyToUncompressedBytes(key *PublicKey) []byte {
+	return key.Serialize()
+}
+
+// PublicKeyFromValidUncompressedBytes parses the uncompressed big-endian format
+// of the public key into a public key. It is assumed that the provided bytes
+// are valid.
+func PublicKeyFromValidUncompressedBytes(pkBytes []byte) *PublicKey {
+	return new(PublicKey).Deserialize(pkBytes)
 }
 
 // AggregatePublicKeys aggregates a non-zero number of public keys into a single
@@ -69,12 +84,4 @@ func Verify(pk *PublicKey, sig *Signature, msg []byte) bool {
 // Invariant: [pk] and [sig] have both been validated.
 func VerifyProofOfPossession(pk *PublicKey, sig *Signature, msg []byte) bool {
 	return sig.Verify(false, pk, false, msg, ciphersuiteProofOfPossession)
-}
-
-func DeserializePublicKey(pkBytes []byte) *PublicKey {
-	return new(PublicKey).Deserialize(pkBytes)
-}
-
-func SerializePublicKey(key *PublicKey) []byte {
-	return key.Serialize()
 }

--- a/utils/crypto/bls/public_test.go
+++ b/utils/crypto/bls/public_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/ava-labs/avalanchego/utils"
 )
 
-func TestPublicKeyFromBytesWrongSize(t *testing.T) {
+func TestPublicKeyFromCompressedBytesWrongSize(t *testing.T) {
 	require := require.New(t)
 
 	pkBytes := utils.RandomBytes(PublicKeyLen + 1)
-	_, err := PublicKeyFromBytes(pkBytes)
+	_, err := PublicKeyFromCompressedBytes(pkBytes)
 	require.ErrorIs(err, ErrFailedPublicKeyDecompress)
 }
 
@@ -26,11 +26,11 @@ func TestPublicKeyBytes(t *testing.T) {
 	require.NoError(err)
 
 	pk := PublicFromSecretKey(sk)
-	pkBytes := PublicKeyToBytes(pk)
+	pkBytes := PublicKeyToCompressedBytes(pk)
 
-	pk2, err := PublicKeyFromBytes(pkBytes)
+	pk2, err := PublicKeyFromCompressedBytes(pkBytes)
 	require.NoError(err)
-	pk2Bytes := PublicKeyToBytes(pk2)
+	pk2Bytes := PublicKeyToCompressedBytes(pk2)
 
 	require.Equal(pk, pk2)
 	require.Equal(pkBytes, pk2Bytes)
@@ -43,12 +43,12 @@ func TestAggregatePublicKeysNoop(t *testing.T) {
 	require.NoError(err)
 
 	pk := PublicFromSecretKey(sk)
-	pkBytes := PublicKeyToBytes(pk)
+	pkBytes := PublicKeyToCompressedBytes(pk)
 
 	aggPK, err := AggregatePublicKeys([]*PublicKey{pk})
 	require.NoError(err)
 
-	aggPKBytes := PublicKeyToBytes(aggPK)
+	aggPKBytes := PublicKeyToCompressedBytes(aggPK)
 	require.NoError(err)
 
 	require.Equal(pk, aggPK)

--- a/utils/crypto/bls/secret.go
+++ b/utils/crypto/bls/secret.go
@@ -71,11 +71,3 @@ func Sign(sk *SecretKey, msg []byte) *Signature {
 func SignProofOfPossession(sk *SecretKey, msg []byte) *Signature {
 	return new(Signature).Sign(sk, msg, ciphersuiteProofOfPossession)
 }
-
-func DeserializeSecretKey(pkBytes []byte) *SecretKey {
-	return new(SecretKey).Deserialize(pkBytes)
-}
-
-func SerializeSecretKey(key *SecretKey) []byte {
-	return key.Serialize()
-}

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1851,7 +1851,7 @@ func (v *GetValidatorsAtReply) MarshalJSON() ([]byte, error) {
 		}
 
 		if vdr.PublicKey != nil {
-			pk, err := formatting.Encode(formatting.HexNC, bls.PublicKeyToBytes(vdr.PublicKey))
+			pk, err := formatting.Encode(formatting.HexNC, bls.PublicKeyToCompressedBytes(vdr.PublicKey))
 			if err != nil {
 				return nil, err
 			}
@@ -1886,7 +1886,7 @@ func (v *GetValidatorsAtReply) UnmarshalJSON(b []byte) error {
 			if err != nil {
 				return err
 			}
-			vdr.PublicKey, err = bls.PublicKeyFromBytes(pkBytes)
+			vdr.PublicKey, err = bls.PublicKeyFromCompressedBytes(pkBytes)
 			if err != nil {
 				return err
 			}

--- a/vms/platformvm/signer/proof_of_possession.go
+++ b/vms/platformvm/signer/proof_of_possession.go
@@ -30,7 +30,7 @@ type ProofOfPossession struct {
 
 func NewProofOfPossession(sk *bls.SecretKey) *ProofOfPossession {
 	pk := bls.PublicFromSecretKey(sk)
-	pkBytes := bls.PublicKeyToBytes(pk)
+	pkBytes := bls.PublicKeyToCompressedBytes(pk)
 	sig := bls.SignProofOfPossession(sk, pkBytes)
 	sigBytes := bls.SignatureToBytes(sig)
 
@@ -43,7 +43,7 @@ func NewProofOfPossession(sk *bls.SecretKey) *ProofOfPossession {
 }
 
 func (p *ProofOfPossession) Verify() error {
-	publicKey, err := bls.PublicKeyFromBytes(p.PublicKey[:])
+	publicKey, err := bls.PublicKeyFromCompressedBytes(p.PublicKey[:])
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (p *ProofOfPossession) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	pk, err := bls.PublicKeyFromBytes(pkBytes)
+	pk, err := bls.PublicKeyFromCompressedBytes(pkBytes)
 	if err != nil {
 		return err
 	}

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1306,7 +1306,7 @@ func (s *state) ApplyValidatorPublicKeyDiffs(
 			continue
 		}
 
-		vdr.PublicKey = bls.DeserializePublicKey(pkBytes)
+		vdr.PublicKey = bls.PublicKeyFromValidUncompressedBytes(pkBytes)
 	}
 
 	// Note: this does not fallback to the linkeddb index because the linkeddb
@@ -2077,7 +2077,7 @@ func (s *state) writeCurrentStakers(updateValidators bool, height uint64, codecV
 					// diffs.
 					err := s.flatValidatorPublicKeyDiffsDB.Put(
 						marshalDiffKey(constants.PrimaryNetworkID, height, nodeID),
-						bls.SerializePublicKey(staker.PublicKey),
+						bls.PublicKeyToUncompressedBytes(staker.PublicKey),
 					)
 					if err != nil {
 						return err
@@ -2087,7 +2087,7 @@ func (s *state) writeCurrentStakers(updateValidators bool, height uint64, codecV
 					// rollbacks.
 					//
 					// Note: We store the compressed public key here.
-					pkBytes := bls.PublicKeyToBytes(staker.PublicKey)
+					pkBytes := bls.PublicKeyToCompressedBytes(staker.PublicKey)
 					if err := nestedPKDiffDB.Put(nodeID.Bytes(), pkBytes); err != nil {
 						return err
 					}

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -451,7 +451,7 @@ func TestPersistStakers(t *testing.T) {
 				blsDiffBytes, err := s.flatValidatorPublicKeyDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
 				if staker.SubnetID == constants.PrimaryNetworkID {
 					r.NoError(err)
-					r.Equal(bls.DeserializePublicKey(blsDiffBytes), staker.PublicKey)
+					r.Equal(bls.PublicKeyFromValidUncompressedBytes(blsDiffBytes), staker.PublicKey)
 				} else {
 					r.ErrorIs(err, database.ErrNotFound)
 				}

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -2235,7 +2235,7 @@ func checkValidatorBlsKeyIsSet(
 		return errors.New("unexpected BLS key")
 	case expectedBlsKey != nil && val.PublicKey == nil:
 		return errors.New("missing BLS key")
-	case !bytes.Equal(bls.SerializePublicKey(expectedBlsKey), bls.SerializePublicKey(val.PublicKey)):
+	case !bytes.Equal(bls.PublicKeyToUncompressedBytes(expectedBlsKey), bls.PublicKeyToUncompressedBytes(val.PublicKey)):
 		return errors.New("incorrect BLS key")
 	default:
 		return nil

--- a/vms/platformvm/warp/signature_test.go
+++ b/vms/platformvm/warp/signature_test.go
@@ -55,7 +55,7 @@ func newTestValidator() *testValidator {
 		sk:     sk,
 		vdr: &Validator{
 			PublicKey:      pk,
-			PublicKeyBytes: bls.SerializePublicKey(pk),
+			PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk),
 			Weight:         3,
 			NodeIDs:        []ids.NodeID{nodeID},
 		},

--- a/vms/platformvm/warp/validator.go
+++ b/vms/platformvm/warp/validator.go
@@ -72,7 +72,7 @@ func GetCanonicalValidatorSet(
 			continue
 		}
 
-		pkBytes := bls.SerializePublicKey(vdr.PublicKey)
+		pkBytes := bls.PublicKeyToUncompressedBytes(vdr.PublicKey)
 		uniqueVdr, ok := vdrs[string(pkBytes)]
 		if !ok {
 			uniqueVdr = &Validator{

--- a/vms/platformvm/warp/validator_test.go
+++ b/vms/platformvm/warp/validator_test.go
@@ -148,8 +148,8 @@ func TestGetCanonicalValidatorSet(t *testing.T) {
 			require.Len(vdrs, len(tt.expectedVdrs))
 			for i, expectedVdr := range tt.expectedVdrs {
 				gotVdr := vdrs[i]
-				expectedPKBytes := bls.PublicKeyToBytes(expectedVdr.PublicKey)
-				gotPKBytes := bls.PublicKeyToBytes(gotVdr.PublicKey)
+				expectedPKBytes := bls.PublicKeyToCompressedBytes(expectedVdr.PublicKey)
+				gotPKBytes := bls.PublicKeyToCompressedBytes(gotVdr.PublicKey)
 				require.Equal(expectedPKBytes, gotPKBytes)
 				require.Equal(expectedVdr.PublicKeyBytes, gotVdr.PublicKeyBytes)
 				require.Equal(expectedVdr.Weight, gotVdr.Weight)
@@ -165,7 +165,7 @@ func TestFilterValidators(t *testing.T) {
 	pk0 := bls.PublicFromSecretKey(sk0)
 	vdr0 := &Validator{
 		PublicKey:      pk0,
-		PublicKeyBytes: bls.SerializePublicKey(pk0),
+		PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk0),
 		Weight:         1,
 	}
 
@@ -174,7 +174,7 @@ func TestFilterValidators(t *testing.T) {
 	pk1 := bls.PublicFromSecretKey(sk1)
 	vdr1 := &Validator{
 		PublicKey:      pk1,
-		PublicKeyBytes: bls.SerializePublicKey(pk1),
+		PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk1),
 		Weight:         2,
 	}
 

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -185,7 +185,7 @@ func (vm *VMClient) Initialize(
 		SubnetId:     chainCtx.SubnetID[:],
 		ChainId:      chainCtx.ChainID[:],
 		NodeId:       chainCtx.NodeID.Bytes(),
-		PublicKey:    bls.PublicKeyToBytes(chainCtx.PublicKey),
+		PublicKey:    bls.PublicKeyToCompressedBytes(chainCtx.PublicKey),
 		XChainId:     chainCtx.XChainID[:],
 		CChainId:     chainCtx.CChainID[:],
 		AvaxAssetId:  chainCtx.AVAXAssetID[:],

--- a/vms/rpcchainvm/vm_server.go
+++ b/vms/rpcchainvm/vm_server.go
@@ -108,7 +108,7 @@ func (vm *VMServer) Initialize(ctx context.Context, req *vmpb.InitializeRequest)
 	if err != nil {
 		return nil, err
 	}
-	publicKey, err := bls.PublicKeyFromBytes(req.PublicKey)
+	publicKey, err := bls.PublicKeyFromCompressedBytes(req.PublicKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why this should be merged

1. Currently the naming and documentation of the `bls` package is confusing and insufficient.
2. This PR removes duplicate (unsafe) code.

## How this works

- Clearly specifies the format of public keys.
- Removes duplicate (unsafe) secret key handling.

## How this was tested

- [X] CI