### PR TITLE
Implement snowflake+ consensus

### DIFF
--- a/snow/consensus/snowball/snowflake_plus.go
+++ b/snow/consensus/snowball/snowflake_plus.go
@@ -1,0 +1,116 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package snowball
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/bag"
+)
+
+var _ Consensus = (*snowflakePlus)(nil)
+
+// snowflakePlus implements Consensus using Snowflake with multiple
+// alpha thresholds and corresponding beta values.
+type snowflakePlus struct {
+	// alpha1 is the threshold of votes required to update the preference
+	// of the consensus instance.
+	alpha1 int
+
+	// alpha2Cutoff is the lowest alpha threshold that can be used to find
+	// the termination point.
+	alpha2Cutoff int
+
+	// betas are the number of required successful polls corresponding to
+	// each alpha threshold required to finalize.
+	// The ith element of betas is the number of consecutive polls that
+	// received >= alpha2Cutoff + i votes required to finalize.
+	betas []int
+
+	// confidence tracks the number of successful polls in a row for each
+	// corresponding alpha threshold.
+	// The ith element of confidence is the number of consecutive polls
+	// that received >= alpha2Cutoff + i votes.
+	confidence []int
+
+	finalized bool
+
+	choice ids.ID
+}
+
+func newSnowflakePlus(alpha1 int, alpha2Cutoff int, betas []int, choice ids.ID) *snowflakePlus {
+	return &snowflakePlus{
+		alpha1:       alpha1,
+		alpha2Cutoff: alpha2Cutoff,
+		betas:        betas,
+		confidence:   make([]int, len(betas)),
+		choice:       choice,
+	}
+}
+
+// Add is a no-op for snowflakePlus because it has no notion of beta rogue.
+func (s *snowflakePlus) Add(ids.ID) {}
+
+// Returns the currently preferred choice to be finalized
+func (s *snowflakePlus) Preference() ids.ID {
+	return s.choice
+}
+
+// RecordPoll records the results of a network poll. Assumes all choices
+// have been previously added.
+//
+// If the consensus instance was not previously finalized, this function
+// will return true if the poll was successful and false if the poll was
+// unsuccessful.
+//
+// If the consensus instance was previously finalized, the function may
+// return true or false.
+func (s *snowflakePlus) RecordPoll(votes bag.Bag[ids.ID]) bool {
+	choice, count := votes.Mode()
+
+	// If a new choice received an alpha1 threshold of votes,
+	// update my preference and zero out my confidence counters.
+	if choice != s.choice && count >= s.alpha1 {
+		s.choice = choice
+		s.RecordUnsuccessfulPoll()
+	}
+
+	// If my choice received an alpha2 threshold, increment the
+	// corresponding confidence counter. Otherwise, zero out
+	// the confidence counter.
+	for i := 0; i < len(s.confidence); i++ {
+		if count >= s.alpha2Cutoff+i {
+			s.confidence[i]++
+			if s.confidence[i] >= s.betas[i] {
+				s.finalized = true
+			}
+		} else {
+			s.confidence[i] = 0
+		}
+	}
+	return s.finalized
+}
+
+// RecordUnsuccessfulPoll resets the snowflake counters of this consensus
+// instance
+func (s *snowflakePlus) RecordUnsuccessfulPoll() {
+	for i := 0; i < len(s.confidence); i++ {
+		s.confidence[i] = 0
+	}
+}
+
+// Return whether a choice has been finalized
+func (s *snowflakePlus) Finalized() bool {
+	return s.finalized
+}
+
+func (s *snowflakePlus) String() string {
+	return fmt.Sprintf(
+		"SFP(Choice = %s, Confidence = %v, Finalized = %v)",
+		s.choice,
+		s.confidence,
+		s.finalized,
+	)
+}

--- a/snow/consensus/snowball/snowflake_plus.go
+++ b/snow/consensus/snowball/snowflake_plus.go
@@ -51,7 +51,7 @@ func newSnowflakePlus(alpha1 int, alpha2Cutoff int, betas []int, choice ids.ID) 
 }
 
 // Add is a no-op for snowflakePlus because it has no notion of beta rogue.
-func (s *snowflakePlus) Add(ids.ID) {}
+func (*snowflakePlus) Add(ids.ID) {}
 
 // Returns the currently preferred choice to be finalized
 func (s *snowflakePlus) Preference() ids.ID {

--- a/snow/consensus/snowball/snowflake_plus_test.go
+++ b/snow/consensus/snowball/snowflake_plus_test.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package snowball
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/bag"
+	"github.com/stretchr/testify/require"
+)
+
+type step struct {
+	votes            bag.Bag[ids.ID]
+	expectFinalized  bool
+	expectPreference ids.ID
+}
+
+func consensusTest(require *require.Assertions, sf Consensus, steps []step) {
+	for _, step := range steps {
+		// Note: it would be nice to switch from using a bag to a "Moder" interface, so that specifying only
+		// the mode in a given "step" does not hide any information.
+		// Leaving this to call only RecordPoll for snowflake+ tests for now.
+		sf.RecordPoll(step.votes)
+		require.Equal(step.expectFinalized, sf.Finalized())
+		require.Equal(step.expectPreference, sf.Preference())
+	}
+}
+
+func TestSnowflakePlusLowestAlphaThreshold(t *testing.T) {
+	k := 3
+	alpha1 := k/2 + 1
+	alpha2Cutoff := alpha1
+	betas := []int{2, 1}
+	// Create a new snowflake+ instance
+	sf := newSnowflakePlus(alpha1, alpha2Cutoff, betas, Red)
+	consensusTest(require.New(t), sf, []step{
+		{
+			votes:            bag.Of(Red, Red, Blue),
+			expectFinalized:  false,
+			expectPreference: Red,
+		},
+		{
+			votes:            bag.Of(Red, Red, Blue),
+			expectFinalized:  true,
+			expectPreference: Red,
+		},
+	})
+}
+
+func TestSnowflakePlusHighestAlphaThreshold(t *testing.T) {
+	k := 3
+	alpha1 := k/2 + 1
+	alpha2Cutoff := alpha1
+	betas := []int{2, 1}
+	// Create a new snowflake+ instance
+	sf := newSnowflakePlus(alpha1, alpha2Cutoff, betas, Red)
+	consensusTest(require.New(t), sf, []step{
+		{
+			votes:            bag.Of(Red, Red, Red),
+			expectFinalized:  true,
+			expectPreference: Red,
+		},
+	})
+}
+
+func TestSnowflakePlusFlips(t *testing.T) {
+	k := 3
+	alpha1 := k/2 + 1
+	alpha2Cutoff := alpha1
+	betas := []int{2, 1}
+	// Create a new snowflake+ instance
+	sf := newSnowflakePlus(alpha1, alpha2Cutoff, betas, Red)
+	consensusTest(require.New(t), sf, []step{
+		{
+			votes:            bag.Of(Red, Red, Blue),
+			expectFinalized:  false,
+			expectPreference: Red,
+		},
+		{
+			votes:            bag.Of(Red, Blue, Blue),
+			expectFinalized:  false,
+			expectPreference: Blue,
+		},
+		{
+			votes:            bag.Of(Red, Red, Blue),
+			expectFinalized:  false,
+			expectPreference: Red,
+		},
+		{
+			votes:            bag.Of(Red, Red, Blue),
+			expectFinalized:  true,
+			expectPreference: Red,
+		},
+	})
+}

--- a/snow/consensus/snowball/snowflake_plus_test.go
+++ b/snow/consensus/snowball/snowflake_plus_test.go
@@ -6,9 +6,10 @@ package snowball
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/bag"
-	"github.com/stretchr/testify/require"
 )
 
 type step struct {


### PR DESCRIPTION
## Why this should be merged

This PR adds a new consensus implementation to the Snowball package called Snowflake+.

## How this works

Snowflake+ is a modification of Snowflake that utilizes multiple alpha threshold/beta confidence counter pairs for finalization detection.

Rather than using a single alpha/beta pair that requires beta consecutive alpha thresholds to finalize, Snowflake+ pre-calculates beta values for each possible alpha threshold in the range [k/2 + 1, k].

This provides a significant improvement in finalization detection by using more detailed information in the full voting history. For example, if Snowflake receives 10 consecutive polls K votes for blue (100% voting blue), it treats this identically to receiving AlphaConfidence votes for blue 10 times in a row, which may be less than K.

Snowflake+ implements the Consensus interface rather than the Unary/Binary/Nnary interfaces because it needs access to the mode/frequency returned by the sample. Snowflake and Snowball use either the Tree or Flat implementations to convert from an actual sample to calling a corresponding function depending on the highest threshold reached by the sample.

## How this was tested

Basic unit tests added in the PR to test finalizing after different beta values and flipping correctly between preferences.
