### PR TITLE
Cleanup Duplicate Transitive Constructor

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -842,7 +842,7 @@ func (m *manager) createAvalancheChain(
 		Consensus:           snowmanConsensus,
 	}
 	var snowmanEngine common.Engine
-	snowmanEngine, err = smeng.NewTransitive(snowmanEngineConfig)
+	snowmanEngine, err = smeng.New(snowmanEngineConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing snowman engine: %w", err)
 	}
@@ -1190,7 +1190,7 @@ func (m *manager) createSnowmanChain(
 		PartialSync:         m.PartialSyncPrimaryNetwork && ctx.ChainID == constants.PlatformChainID,
 	}
 	var engine common.Engine
-	engine, err = smeng.NewTransitive(engineConfig)
+	engine, err = smeng.New(engineConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing snowman engine: %w", err)
 	}

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -841,7 +841,8 @@ func (m *manager) createAvalancheChain(
 		Params:              consensusParams,
 		Consensus:           snowmanConsensus,
 	}
-	snowmanEngine, err := smeng.New(snowmanEngineConfig)
+	var snowmanEngine common.Engine
+	snowmanEngine, err = smeng.NewTransitive(snowmanEngineConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing snowman engine: %w", err)
 	}
@@ -1188,7 +1189,8 @@ func (m *manager) createSnowmanChain(
 		Consensus:           consensus,
 		PartialSync:         m.PartialSyncPrimaryNetwork && ctx.ChainID == constants.PlatformChainID,
 	}
-	engine, err := smeng.New(engineConfig)
+	var engine common.Engine
+	engine, err = smeng.NewTransitive(engineConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing snowman engine: %w", err)
 	}

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -102,7 +102,7 @@ type Transitive struct {
 	errs wrappers.Errs
 }
 
-func NewTransitive(config Config) (*Transitive, error) {
+func New(config Config) (*Transitive, error) {
 	config.Ctx.Log.Info("initializing consensus engine")
 
 	nonVerifiedCache, err := metercacher.New[ids.ID, snowman.Block](

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -44,10 +44,6 @@ const (
 
 var _ common.Engine = (*Transitive)(nil)
 
-func New(config Config) (common.Engine, error) {
-	return newTransitive(config)
-}
-
 func cachedBlockSize(_ ids.ID, blk snowman.Block) int {
 	return ids.IDLen + len(blk.Bytes()) + constants.PointerOverhead
 }
@@ -106,7 +102,7 @@ type Transitive struct {
 	errs wrappers.Errs
 }
 
-func newTransitive(config Config) (*Transitive, error) {
+func NewTransitive(config Config) (*Transitive, error) {
 	config.Ctx.Log.Info("initializing consensus engine")
 
 	nonVerifiedCache, err := metercacher.New[ids.ID, snowman.Block](

--- a/snow/engine/snowman/transitive_test.go
+++ b/snow/engine/snowman/transitive_test.go
@@ -87,7 +87,7 @@ func setup(t *testing.T, engCfg Config) (ids.NodeID, validators.Manager, *common
 		}
 	}
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -377,7 +377,7 @@ func TestEngineMultipleQuery(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -796,7 +796,7 @@ func TestVoteCanceling(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -877,7 +877,7 @@ func TestEngineNoQuery(t *testing.T) {
 
 	engCfg.VM = vm
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -930,7 +930,7 @@ func TestEngineNoRepollQuery(t *testing.T) {
 
 	engCfg.VM = vm
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -1630,7 +1630,7 @@ func TestEngineAggressivePolling(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -1732,7 +1732,7 @@ func TestEngineDoubleChit(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -1831,7 +1831,7 @@ func TestEngineBuildBlockLimit(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -2861,7 +2861,7 @@ func TestEngineApplyAcceptedFrontierInQueryFailed(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 	require.NoError(te.Start(context.Background(), 0))
 
@@ -2969,7 +2969,7 @@ func TestEngineRepollsMisconfiguredSubnet(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := NewTransitive(engCfg)
+	te, err := New(engCfg)
 	require.NoError(err)
 	require.NoError(te.Start(context.Background(), 0))
 

--- a/snow/engine/snowman/transitive_test.go
+++ b/snow/engine/snowman/transitive_test.go
@@ -87,7 +87,7 @@ func setup(t *testing.T, engCfg Config) (ids.NodeID, validators.Manager, *common
 		}
 	}
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -377,7 +377,7 @@ func TestEngineMultipleQuery(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -796,7 +796,7 @@ func TestVoteCanceling(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -877,7 +877,7 @@ func TestEngineNoQuery(t *testing.T) {
 
 	engCfg.VM = vm
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -930,7 +930,7 @@ func TestEngineNoRepollQuery(t *testing.T) {
 
 	engCfg.VM = vm
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -1630,7 +1630,7 @@ func TestEngineAggressivePolling(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -1732,7 +1732,7 @@ func TestEngineDoubleChit(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -1831,7 +1831,7 @@ func TestEngineBuildBlockLimit(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 
 	require.NoError(te.Start(context.Background(), 0))
@@ -2861,7 +2861,7 @@ func TestEngineApplyAcceptedFrontierInQueryFailed(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 	require.NoError(te.Start(context.Background(), 0))
 
@@ -2969,7 +2969,7 @@ func TestEngineRepollsMisconfiguredSubnet(t *testing.T) {
 		return gBlk, nil
 	}
 
-	te, err := newTransitive(engCfg)
+	te, err := NewTransitive(engCfg)
 	require.NoError(err)
 	require.NoError(te.Start(context.Background(), 0))
 


### PR DESCRIPTION
## Why this should be merged

We have a duplicate `New` constructor to return an opaque transitive instance by its interface. We can just let the caller choose how to use the concrete type and remove the extra constructor

## How this works

Removes extra copy of constructor

## How this was tested

CI