### PR TITLE
Refactor Transitive Config

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -803,17 +803,19 @@ func (m *manager) createAvalancheChain(
 	// Create engine, bootstrapper and state-syncer in this order,
 	// to make sure start callbacks are duly initialized
 	snowmanEngineConfig := smeng.Config{
-		Ctx:                 ctx,
-		AllGetsServer:       snowGetHandler,
-		VM:                  vmWrappingProposerVM,
-		Sender:              snowmanMessageSender,
-		Validators:          vdrs,
-		ConnectedValidators: connectedValidators,
-		Params:              consensusParams,
-		Consensus:           snowmanConsensus,
+		Parameters: consensusParams,
 	}
 	var snowmanEngine common.Engine
-	snowmanEngine, err = smeng.New(snowmanEngineConfig)
+	snowmanEngine, err = smeng.New(
+		snowmanEngineConfig,
+		ctx,
+		snowGetHandler,
+		vmWrappingProposerVM,
+		snowmanMessageSender,
+		vdrs,
+		connectedValidators,
+		snowmanConsensus,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing snowman engine: %w", err)
 	}
@@ -1135,18 +1137,20 @@ func (m *manager) createSnowmanChain(
 	// Create engine, bootstrapper and state-syncer in this order,
 	// to make sure start callbacks are duly initialized
 	engineConfig := smeng.Config{
-		Ctx:                 ctx,
-		AllGetsServer:       snowGetHandler,
-		VM:                  vm,
-		Sender:              messageSender,
-		Validators:          vdrs,
-		ConnectedValidators: connectedValidators,
-		Params:              consensusParams,
-		Consensus:           consensus,
-		PartialSync:         m.PartialSyncPrimaryNetwork && ctx.ChainID == constants.PlatformChainID,
+		Parameters:  consensusParams,
+		PartialSync: m.PartialSyncPrimaryNetwork && ctx.ChainID == constants.PlatformChainID,
 	}
 	var engine common.Engine
-	engine, err = smeng.New(engineConfig)
+	engine, err = smeng.New(
+		engineConfig,
+		ctx,
+		snowGetHandler,
+		vm,
+		messageSender,
+		vdrs,
+		connectedValidators,
+		consensus,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing snowman engine: %w", err)
 	}

--- a/snow/engine/snowman/config.go
+++ b/snow/engine/snowman/config.go
@@ -3,26 +3,10 @@
 
 package snowman
 
-import (
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/consensus/snowball"
-	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
-	"github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/snow/engine/common/tracker"
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/snow/validators"
-)
+import "github.com/ava-labs/avalanchego/snow/consensus/snowball"
 
 // Config wraps all the parameters needed for a snowman engine
 type Config struct {
-	common.AllGetsServer
-
-	Ctx                 *snow.ConsensusContext
-	VM                  block.ChainVM
-	Sender              common.Sender
-	Validators          validators.Manager
-	ConnectedValidators tracker.Peers
-	Params              snowball.Parameters
-	Consensus           snowman.Consensus
-	PartialSync         bool
+	snowball.Parameters
+	PartialSync bool
 }

--- a/snow/engine/snowman/config_test.go
+++ b/snow/engine/snowman/config_test.go
@@ -3,28 +3,11 @@
 
 package snowman
 
-import (
-	"testing"
+import "github.com/ava-labs/avalanchego/snow/consensus/snowball"
 
-	"github.com/ava-labs/avalanchego/snow/consensus/snowball"
-	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
-	"github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/snow/engine/common/tracker"
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/snow/snowtest"
-	"github.com/ava-labs/avalanchego/snow/validators"
-)
-
-func DefaultConfig(t testing.TB) Config {
-	ctx := snowtest.Context(t, snowtest.PChainID)
-
+func DefaultConfig() Config {
 	return Config{
-		Ctx:                 snowtest.ConsensusContext(ctx),
-		VM:                  &block.TestVM{},
-		Sender:              &common.SenderTest{},
-		Validators:          validators.NewManager(),
-		ConnectedValidators: tracker.NewPeers(),
-		Params: snowball.Parameters{
+		Parameters: snowball.Parameters{
 			K:                     1,
 			AlphaPreference:       1,
 			AlphaConfidence:       1,
@@ -35,6 +18,6 @@ func DefaultConfig(t testing.TB) Config {
 			MaxOutstandingItems:   1,
 			MaxItemProcessingTime: 1,
 		},
-		Consensus: &snowman.Topological{},
+		PartialSync: false,
 	}
 }

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -63,30 +63,40 @@ type Transitive struct {
 	validators          validators.Manager
 	connectedValidators tracker.Peers
 	consensus           snowman.Consensus
-	requestID           uint32
+
+	requestID uint32
+
 	// track outstanding preference requests
 	polls poll.Set
+
 	// blocks that have we have sent get requests for but haven't yet received
 	blkReqs            *bimap.BiMap[common.Request, ids.ID]
 	blkReqSourceMetric map[common.Request]prometheus.Counter
+
 	// blocks that are queued to be issued to consensus once missing dependencies are fetched
 	// Block ID --> Block
 	pending map[ids.ID]snowman.Block
+
 	// Block ID --> Parent ID
 	nonVerifieds ancestor.Tree
+
 	// Block ID --> Block.
 	// A block is put into this cache if it was not able to be issued. A block
 	// fails to be issued if verification on the block or one of its ancestors
 	// occurs.
 	nonVerifiedCache cache.Cacher[ids.ID, snowman.Block]
+
 	// acceptedFrontiers of the other validators of this chain
 	acceptedFrontiers tracker.Accepted
+
 	// operations that are blocked on a block being issued. This could be
 	// issuing another block, responding to a query, or applying votes to consensus
 	blocked event.Blocker
+
 	// number of times build block needs to be called once the number of
 	// processing blocks has gone below the optimal number.
 	pendingBuildBlocks int
+
 	// errs tracks if an error has occurred in a callback
 	errs wrappers.Errs
 }

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/common/tracker"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/ancestor"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/event"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/bag"
@@ -44,9 +45,7 @@ func cachedBlockSize(_ ids.ID, blk snowman.Block) int {
 // Transitive implements the Engine interface by attempting to fetch all
 // Transitive dependencies.
 type Transitive struct {
-	Config
-	metrics
-
+	common.AllGetsServer
 	// list of NoOpsHandler for messages dropped by engine
 	common.StateSummaryFrontierHandler
 	common.AcceptedStateSummaryHandler
@@ -55,50 +54,58 @@ type Transitive struct {
 	common.AncestorsHandler
 	common.AppHandler
 	validators.Connector
+	metrics
 
-	requestID uint32
-
+	config              Config
+	ctx                 *snow.ConsensusContext
+	vm                  block.ChainVM
+	sender              common.Sender
+	validators          validators.Manager
+	connectedValidators tracker.Peers
+	consensus           snowman.Consensus
+	requestID           uint32
 	// track outstanding preference requests
 	polls poll.Set
-
 	// blocks that have we have sent get requests for but haven't yet received
 	blkReqs            *bimap.BiMap[common.Request, ids.ID]
 	blkReqSourceMetric map[common.Request]prometheus.Counter
-
 	// blocks that are queued to be issued to consensus once missing dependencies are fetched
 	// Block ID --> Block
 	pending map[ids.ID]snowman.Block
-
 	// Block ID --> Parent ID
 	nonVerifieds ancestor.Tree
-
 	// Block ID --> Block.
 	// A block is put into this cache if it was not able to be issued. A block
 	// fails to be issued if verification on the block or one of its ancestors
 	// occurs.
 	nonVerifiedCache cache.Cacher[ids.ID, snowman.Block]
-
 	// acceptedFrontiers of the other validators of this chain
 	acceptedFrontiers tracker.Accepted
-
 	// operations that are blocked on a block being issued. This could be
 	// issuing another block, responding to a query, or applying votes to consensus
 	blocked event.Blocker
-
 	// number of times build block needs to be called once the number of
 	// processing blocks has gone below the optimal number.
 	pendingBuildBlocks int
-
 	// errs tracks if an error has occurred in a callback
 	errs wrappers.Errs
 }
 
-func New(config Config) (*Transitive, error) {
-	config.Ctx.Log.Info("initializing consensus engine")
+func New(
+	config Config,
+	ctx *snow.ConsensusContext,
+	server common.AllGetsServer,
+	vm block.ChainVM,
+	sender common.Sender,
+	validators validators.Manager,
+	connectedValidators tracker.Peers,
+	consensus snowman.Consensus,
+) (*Transitive, error) {
+	ctx.Log.Info("initializing consensus engine")
 
 	nonVerifiedCache, err := metercacher.New[ids.ID, snowman.Block](
 		"non_verified_cache",
-		config.Ctx.Registerer,
+		ctx.Registerer,
 		cache.NewSizedLRU[ids.ID, snowman.Block](
 			nonVerifiedCacheSize,
 			cachedBlockSize,
@@ -109,31 +116,38 @@ func New(config Config) (*Transitive, error) {
 	}
 
 	acceptedFrontiers := tracker.NewAccepted()
-	config.Validators.RegisterCallbackListener(config.Ctx.SubnetID, acceptedFrontiers)
+	validators.RegisterCallbackListener(ctx.SubnetID, acceptedFrontiers)
 
 	factory := poll.NewEarlyTermNoTraversalFactory(
-		config.Params.AlphaPreference,
-		config.Params.AlphaConfidence,
+		config.AlphaPreference,
+		config.AlphaConfidence,
 	)
 	polls, err := poll.NewSet(
 		factory,
-		config.Ctx.Log,
+		ctx.Log,
 		"",
-		config.Ctx.Registerer,
+		ctx.Registerer,
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	t := &Transitive{
-		Config:                      config,
-		StateSummaryFrontierHandler: common.NewNoOpStateSummaryFrontierHandler(config.Ctx.Log),
-		AcceptedStateSummaryHandler: common.NewNoOpAcceptedStateSummaryHandler(config.Ctx.Log),
-		AcceptedFrontierHandler:     common.NewNoOpAcceptedFrontierHandler(config.Ctx.Log),
-		AcceptedHandler:             common.NewNoOpAcceptedHandler(config.Ctx.Log),
-		AncestorsHandler:            common.NewNoOpAncestorsHandler(config.Ctx.Log),
-		AppHandler:                  config.VM,
-		Connector:                   config.VM,
+		AllGetsServer:               server,
+		StateSummaryFrontierHandler: common.NewNoOpStateSummaryFrontierHandler(ctx.Log),
+		AcceptedStateSummaryHandler: common.NewNoOpAcceptedStateSummaryHandler(ctx.Log),
+		AcceptedFrontierHandler:     common.NewNoOpAcceptedFrontierHandler(ctx.Log),
+		AcceptedHandler:             common.NewNoOpAcceptedHandler(ctx.Log),
+		AncestorsHandler:            common.NewNoOpAncestorsHandler(ctx.Log),
+		AppHandler:                  vm,
+		Connector:                   vm,
+		config:                      config,
+		ctx:                         ctx,
+		vm:                          vm,
+		sender:                      sender,
+		validators:                  validators,
+		connectedValidators:         connectedValidators,
+		consensus:                   consensus,
 		pending:                     make(map[ids.ID]snowman.Block),
 		nonVerifieds:                ancestor.NewTree(),
 		nonVerifiedCache:            nonVerifiedCache,
@@ -143,13 +157,13 @@ func New(config Config) (*Transitive, error) {
 		blkReqSourceMetric:          make(map[common.Request]prometheus.Counter),
 	}
 
-	return t, t.metrics.Initialize("", config.Ctx.Registerer)
+	return t, t.metrics.Initialize("", ctx.Registerer)
 }
 
 func (t *Transitive) Gossip(ctx context.Context) error {
-	lastAcceptedID, lastAcceptedHeight := t.Consensus.LastAccepted()
-	if numProcessing := t.Consensus.NumProcessing(); numProcessing != 0 {
-		t.Ctx.Log.Debug("skipping block gossip",
+	lastAcceptedID, lastAcceptedHeight := t.consensus.LastAccepted()
+	if numProcessing := t.consensus.NumProcessing(); numProcessing != 0 {
+		t.ctx.Log.Debug("skipping block gossip",
 			zap.String("reason", "blocks currently processing"),
 			zap.Int("numProcessing", numProcessing),
 		)
@@ -161,15 +175,15 @@ func (t *Transitive) Gossip(ctx context.Context) error {
 		return nil
 	}
 
-	t.Ctx.Log.Verbo("sampling from validators",
-		zap.Stringer("validators", t.Validators),
+	t.ctx.Log.Verbo("sampling from validators",
+		zap.Stringer("validators", t.validators),
 	)
 
 	// Uniform sampling is used here to reduce bandwidth requirements of
 	// nodes with a large amount of stake weight.
-	vdrID, ok := t.ConnectedValidators.SampleValidator()
+	vdrID, ok := t.connectedValidators.SampleValidator()
 	if !ok {
-		t.Ctx.Log.Warn("skipping block gossip",
+		t.ctx.Log.Warn("skipping block gossip",
 			zap.String("reason", "no connected validators"),
 		)
 		return nil
@@ -177,7 +191,7 @@ func (t *Transitive) Gossip(ctx context.Context) error {
 
 	nextHeightToAccept, err := math.Add64(lastAcceptedHeight, 1)
 	if err != nil {
-		t.Ctx.Log.Error("skipping block gossip",
+		t.ctx.Log.Error("skipping block gossip",
 			zap.String("reason", "block height overflow"),
 			zap.Stringer("blkID", lastAcceptedID),
 			zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -187,28 +201,28 @@ func (t *Transitive) Gossip(ctx context.Context) error {
 	}
 
 	t.requestID++
-	t.Sender.SendPullQuery(
+	t.sender.SendPullQuery(
 		ctx,
 		set.Of(vdrID),
 		t.requestID,
-		t.Consensus.Preference(),
+		t.consensus.Preference(),
 		nextHeightToAccept,
 	)
 	return nil
 }
 
 func (t *Transitive) Put(ctx context.Context, nodeID ids.NodeID, requestID uint32, blkBytes []byte) error {
-	blk, err := t.VM.ParseBlock(ctx, blkBytes)
+	blk, err := t.vm.ParseBlock(ctx, blkBytes)
 	if err != nil {
-		if t.Ctx.Log.Enabled(logging.Verbo) {
-			t.Ctx.Log.Verbo("failed to parse block",
+		if t.ctx.Log.Enabled(logging.Verbo) {
+			t.ctx.Log.Verbo("failed to parse block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Binary("block", blkBytes),
 				zap.Error(err),
 			)
 		} else {
-			t.Ctx.Log.Debug("failed to parse block",
+			t.ctx.Log.Debug("failed to parse block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Error(err),
@@ -231,7 +245,7 @@ func (t *Transitive) Put(ctx context.Context, nodeID ids.NodeID, requestID uint3
 	case ok:
 		actualBlkID := blk.ID()
 		if actualBlkID != expectedBlkID {
-			t.Ctx.Log.Debug("incorrect block returned in Put",
+			t.ctx.Log.Debug("incorrect block returned in Put",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Stringer("blkID", actualBlkID),
@@ -278,7 +292,7 @@ func (t *Transitive) GetFailed(ctx context.Context, nodeID ids.NodeID, requestID
 	}
 	blkID, ok := t.blkReqs.DeleteKey(req)
 	if !ok {
-		t.Ctx.Log.Debug("unexpected GetFailed",
+		t.ctx.Log.Debug("unexpected GetFailed",
 			zap.Stringer("nodeID", nodeID),
 			zap.Uint32("requestID", requestID),
 		)
@@ -308,18 +322,18 @@ func (t *Transitive) PullQuery(ctx context.Context, nodeID ids.NodeID, requestID
 func (t *Transitive) PushQuery(ctx context.Context, nodeID ids.NodeID, requestID uint32, blkBytes []byte, requestedHeight uint64) error {
 	t.sendChits(ctx, nodeID, requestID, requestedHeight)
 
-	blk, err := t.VM.ParseBlock(ctx, blkBytes)
+	blk, err := t.vm.ParseBlock(ctx, blkBytes)
 	// If parsing fails, we just drop the request, as we didn't ask for it
 	if err != nil {
-		if t.Ctx.Log.Enabled(logging.Verbo) {
-			t.Ctx.Log.Verbo("failed to parse block",
+		if t.ctx.Log.Enabled(logging.Verbo) {
+			t.ctx.Log.Verbo("failed to parse block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Binary("block", blkBytes),
 				zap.Error(err),
 			)
 		} else {
-			t.Ctx.Log.Debug("failed to parse block",
+			t.ctx.Log.Debug("failed to parse block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Error(err),
@@ -349,7 +363,7 @@ func (t *Transitive) PushQuery(ctx context.Context, nodeID ids.NodeID, requestID
 func (t *Transitive) Chits(ctx context.Context, nodeID ids.NodeID, requestID uint32, preferredID ids.ID, preferredIDAtHeight ids.ID, acceptedID ids.ID) error {
 	t.acceptedFrontiers.SetLastAccepted(nodeID, acceptedID)
 
-	t.Ctx.Log.Verbo("called Chits for the block",
+	t.ctx.Log.Verbo("called Chits for the block",
 		zap.Stringer("nodeID", nodeID),
 		zap.Uint32("requestID", requestID),
 		zap.Stringer("preferredID", preferredID),
@@ -426,12 +440,12 @@ func (*Transitive) Timeout(context.Context) error {
 func (*Transitive) Halt(context.Context) {}
 
 func (t *Transitive) Shutdown(ctx context.Context) error {
-	t.Ctx.Log.Info("shutting down consensus engine")
+	t.ctx.Log.Info("shutting down consensus engine")
 
-	t.Ctx.Lock.Lock()
-	defer t.Ctx.Lock.Unlock()
+	t.ctx.Lock.Lock()
+	defer t.ctx.Lock.Unlock()
 
-	return t.VM.Shutdown(ctx)
+	return t.vm.Shutdown(ctx)
 }
 
 func (t *Transitive) Notify(ctx context.Context, msg common.Message) error {
@@ -441,10 +455,10 @@ func (t *Transitive) Notify(ctx context.Context, msg common.Message) error {
 		t.pendingBuildBlocks++
 		return t.executeDeferredWork(ctx)
 	case common.StateSyncDone:
-		t.Ctx.StateSyncing.Set(false)
+		t.ctx.StateSyncing.Set(false)
 		return nil
 	default:
-		t.Ctx.Log.Warn("received an unexpected message from the VM",
+		t.ctx.Log.Warn("received an unexpected message from the vm",
 			zap.Stringer("messageString", msg),
 		)
 		return nil
@@ -452,26 +466,32 @@ func (t *Transitive) Notify(ctx context.Context, msg common.Message) error {
 }
 
 func (t *Transitive) Context() *snow.ConsensusContext {
-	return t.Ctx
+	return t.ctx
 }
 
 func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 	t.requestID = startReqID
-	lastAcceptedID, err := t.VM.LastAccepted(ctx)
+	lastAcceptedID, err := t.vm.LastAccepted(ctx)
 	if err != nil {
 		return err
 	}
 
 	lastAccepted, err := t.getBlock(ctx, lastAcceptedID)
 	if err != nil {
-		t.Ctx.Log.Error("failed to get last accepted block",
+		t.ctx.Log.Error("failed to get last accepted block",
 			zap.Error(err),
 		)
 		return err
 	}
 
 	// initialize consensus to the last accepted blockID
-	if err := t.Consensus.Initialize(t.Ctx, t.Params, lastAcceptedID, lastAccepted.Height(), lastAccepted.Timestamp()); err != nil {
+	if err := t.consensus.Initialize(
+		t.ctx,
+		t.config.Parameters,
+		lastAcceptedID,
+		lastAccepted.Height(),
+		lastAccepted.Timestamp(),
+	); err != nil {
 		return err
 	}
 
@@ -483,7 +503,7 @@ func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 		case err == snowman.ErrNotOracle:
 			// if there aren't blocks we need to deliver on startup, we need to set
 			// the preference to the last accepted block
-			if err := t.VM.SetPreference(ctx, lastAcceptedID); err != nil {
+			if err := t.vm.SetPreference(ctx, lastAcceptedID); err != nil {
 				return err
 			}
 		case err != nil:
@@ -492,36 +512,36 @@ func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 			issuedMetric := t.metrics.issued.WithLabelValues(builtSource)
 			for _, blk := range options {
 				// note that deliver will set the VM's preference
-				if err := t.deliver(ctx, t.Ctx.NodeID, blk, false, issuedMetric); err != nil {
+				if err := t.deliver(ctx, t.ctx.NodeID, blk, false, issuedMetric); err != nil {
 					return err
 				}
 			}
 		}
-	} else if err := t.VM.SetPreference(ctx, lastAcceptedID); err != nil {
+	} else if err := t.vm.SetPreference(ctx, lastAcceptedID); err != nil {
 		return err
 	}
 
-	t.Ctx.Log.Info("consensus starting",
+	t.ctx.Log.Info("consensus starting",
 		zap.Stringer("lastAcceptedBlock", lastAcceptedID),
 	)
 	t.metrics.bootstrapFinished.Set(1)
 
-	t.Ctx.State.Set(snow.EngineState{
+	t.ctx.State.Set(snow.EngineState{
 		Type:  p2p.EngineType_ENGINE_TYPE_SNOWMAN,
 		State: snow.NormalOp,
 	})
-	if err := t.VM.SetState(ctx, snow.NormalOp); err != nil {
-		return fmt.Errorf("failed to notify VM that consensus is starting: %w",
+	if err := t.vm.SetState(ctx, snow.NormalOp); err != nil {
+		return fmt.Errorf("failed to notify vm that consensus is starting: %w",
 			err)
 	}
 	return t.executeDeferredWork(ctx)
 }
 
 func (t *Transitive) HealthCheck(ctx context.Context) (interface{}, error) {
-	t.Ctx.Lock.Lock()
-	defer t.Ctx.Lock.Unlock()
+	t.ctx.Lock.Lock()
+	defer t.ctx.Lock.Unlock()
 
-	t.Ctx.Log.Verbo("running health check",
+	t.ctx.Log.Verbo("running health check",
 		zap.Uint32("requestID", t.requestID),
 		zap.Stringer("polls", t.polls),
 		zap.Reflect("outstandingBlockRequests", t.blkReqs),
@@ -529,8 +549,8 @@ func (t *Transitive) HealthCheck(ctx context.Context) (interface{}, error) {
 		zap.Int("pendingBuildBlocks", t.pendingBuildBlocks),
 	)
 
-	consensusIntf, consensusErr := t.Consensus.HealthCheck(ctx)
-	vmIntf, vmErr := t.VM.HealthCheck(ctx)
+	consensusIntf, consensusErr := t.consensus.HealthCheck(ctx)
+	vmIntf, vmErr := t.vm.HealthCheck(ctx)
 	intf := map[string]interface{}{
 		"consensus": consensusIntf,
 		"vm":        vmIntf,
@@ -564,20 +584,20 @@ func (t *Transitive) getBlock(ctx context.Context, blkID ids.ID) (snowman.Block,
 		return blk, nil
 	}
 
-	return t.VM.GetBlock(ctx, blkID)
+	return t.vm.GetBlock(ctx, blkID)
 }
 
 func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID uint32, requestedHeight uint64) {
-	lastAcceptedID, lastAcceptedHeight := t.Consensus.LastAccepted()
+	lastAcceptedID, lastAcceptedHeight := t.consensus.LastAccepted()
 	// If we aren't fully verifying blocks, only vote for blocks that are widely
 	// preferred by the validator set.
-	if t.Ctx.StateSyncing.Get() || t.Config.PartialSync {
-		acceptedAtHeight, err := t.VM.GetBlockIDAtHeight(ctx, requestedHeight)
+	if t.ctx.StateSyncing.Get() || t.config.PartialSync {
+		acceptedAtHeight, err := t.vm.GetBlockIDAtHeight(ctx, requestedHeight)
 		if err != nil {
 			// Because we only return accepted state here, it's fairly likely
 			// that the requested height is higher than the last accepted block.
 			// That means that this code path is actually quite common.
-			t.Ctx.Log.Debug("failed fetching accepted block",
+			t.ctx.Log.Debug("failed fetching accepted block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -586,17 +606,17 @@ func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID
 			)
 			acceptedAtHeight = lastAcceptedID
 		}
-		t.Sender.SendChits(ctx, nodeID, requestID, lastAcceptedID, acceptedAtHeight, lastAcceptedID)
+		t.sender.SendChits(ctx, nodeID, requestID, lastAcceptedID, acceptedAtHeight, lastAcceptedID)
 		return
 	}
 
 	var (
-		preference         = t.Consensus.Preference()
+		preference         = t.consensus.Preference()
 		preferenceAtHeight ids.ID
 	)
 	if requestedHeight < lastAcceptedHeight {
 		var err error
-		preferenceAtHeight, err = t.VM.GetBlockIDAtHeight(ctx, requestedHeight)
+		preferenceAtHeight, err = t.vm.GetBlockIDAtHeight(ctx, requestedHeight)
 		if err != nil {
 			// If this chain is pruning historical blocks, it's expected for a
 			// node to be unable to fetch some block IDs. In this case, we fall
@@ -605,7 +625,7 @@ func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID
 			// Because it is possible for a byzantine node to spam requests at
 			// old heights on a pruning network, we log this as debug. However,
 			// this case is unexpected to be hit by correct peers.
-			t.Ctx.Log.Debug("failed fetching accepted block",
+			t.ctx.Log.Debug("failed fetching accepted block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -618,9 +638,9 @@ func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID
 		}
 	} else {
 		var ok bool
-		preferenceAtHeight, ok = t.Consensus.PreferenceAtHeight(requestedHeight)
+		preferenceAtHeight, ok = t.consensus.PreferenceAtHeight(requestedHeight)
 		if !ok {
-			t.Ctx.Log.Debug("failed fetching processing block",
+			t.ctx.Log.Debug("failed fetching processing block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -631,7 +651,7 @@ func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID
 			preferenceAtHeight = preference
 		}
 	}
-	t.Sender.SendChits(ctx, nodeID, requestID, preference, preferenceAtHeight, lastAcceptedID)
+	t.sender.SendChits(ctx, nodeID, requestID, preference, preferenceAtHeight, lastAcceptedID)
 }
 
 // Build blocks if they have been requested and the number of processing blocks
@@ -640,12 +660,12 @@ func (t *Transitive) buildBlocks(ctx context.Context) error {
 	if err := t.errs.Err; err != nil {
 		return err
 	}
-	for t.pendingBuildBlocks > 0 && t.Consensus.NumProcessing() < t.Params.OptimalProcessing {
+	for t.pendingBuildBlocks > 0 && t.consensus.NumProcessing() < t.config.OptimalProcessing {
 		t.pendingBuildBlocks--
 
-		blk, err := t.VM.BuildBlock(ctx)
+		blk, err := t.vm.BuildBlock(ctx)
 		if err != nil {
-			t.Ctx.Log.Debug("failed building block",
+			t.ctx.Log.Debug("failed building block",
 				zap.Error(err),
 			)
 			t.numBuildsFailed.Inc()
@@ -656,7 +676,7 @@ func (t *Transitive) buildBlocks(ctx context.Context) error {
 		// a newly created block is expected to be processing. If this check
 		// fails, there is potentially an error in the VM this engine is running
 		if status := blk.Status(); status != choices.Processing {
-			t.Ctx.Log.Warn("attempting to issue block with unexpected status",
+			t.ctx.Log.Warn("attempting to issue block with unexpected status",
 				zap.Stringer("expectedStatus", choices.Processing),
 				zap.Stringer("status", status),
 			)
@@ -665,8 +685,8 @@ func (t *Transitive) buildBlocks(ctx context.Context) error {
 		// The newly created block should be built on top of the preferred block.
 		// Otherwise, the new block doesn't have the best chance of being confirmed.
 		parentID := blk.Parent()
-		if pref := t.Consensus.Preference(); parentID != pref {
-			t.Ctx.Log.Warn("built block with unexpected parent",
+		if pref := t.consensus.Preference(); parentID != pref {
+			t.ctx.Log.Warn("built block with unexpected parent",
 				zap.Stringer("expectedParentID", pref),
 				zap.Stringer("parentID", parentID),
 			)
@@ -680,9 +700,9 @@ func (t *Transitive) buildBlocks(ctx context.Context) error {
 
 		// issuing the block shouldn't have any missing dependencies
 		if added {
-			t.Ctx.Log.Verbo("successfully issued new block from the VM")
+			t.ctx.Log.Verbo("successfully issued new block from the vm")
 		} else {
-			t.Ctx.Log.Warn("built block with unissued ancestors")
+			t.ctx.Log.Warn("built block with unissued ancestors")
 		}
 	}
 	return nil
@@ -693,9 +713,9 @@ func (t *Transitive) buildBlocks(ctx context.Context) error {
 func (t *Transitive) repoll(ctx context.Context) {
 	// if we are issuing a repoll, we should gossip our current preferences to
 	// propagate the most likely branch as quickly as possible
-	prefID := t.Consensus.Preference()
+	prefID := t.consensus.Preference()
 
-	for i := t.polls.Len(); i < t.Params.ConcurrentRepolls; i++ {
+	for i := t.polls.Len(); i < t.config.ConcurrentRepolls; i++ {
 		t.sendQuery(ctx, prefID, nil, false)
 	}
 }
@@ -749,7 +769,7 @@ func (t *Transitive) issueFrom(
 		delete(t.blkReqSourceMetric, req)
 	}
 
-	issued := t.Consensus.Decided(blk) || t.Consensus.Processing(blkID)
+	issued := t.consensus.Decided(blk) || t.consensus.Processing(blkID)
 	if issued {
 		// A dependency should never be waiting on a decided or processing
 		// block. However, if the block was marked as rejected by the VM, the
@@ -771,7 +791,7 @@ func (t *Transitive) issueWithAncestors(
 	// issue [blk] and its ancestors into consensus
 	status := blk.Status()
 	for status.Fetched() && !t.wasIssued(blk) {
-		err := t.issue(ctx, t.Ctx.NodeID, blk, true, issuedMetric)
+		err := t.issue(ctx, t.ctx.NodeID, blk, true, issuedMetric)
 		if err != nil {
 			return false, err
 		}
@@ -785,7 +805,7 @@ func (t *Transitive) issueWithAncestors(
 	}
 
 	// The block was issued into consensus. This is the happy path.
-	if status != choices.Unknown && (t.Consensus.Decided(blk) || t.Consensus.Processing(blkID)) {
+	if status != choices.Unknown && (t.consensus.Decided(blk) || t.consensus.Processing(blkID)) {
 		return true, nil
 	}
 
@@ -806,7 +826,7 @@ func (t *Transitive) issueWithAncestors(
 // If the block is queued to be added to consensus, then it was issued.
 func (t *Transitive) wasIssued(blk snowman.Block) bool {
 	blkID := blk.ID()
-	return t.Consensus.Decided(blk) || t.Consensus.Processing(blkID) || t.pendingContains(blkID)
+	return t.consensus.Decided(blk) || t.consensus.Processing(blkID) || t.pendingContains(blkID)
 }
 
 // Issue [blk] to consensus once its ancestors have been issued.
@@ -840,8 +860,8 @@ func (t *Transitive) issue(
 
 	// block on the parent if needed
 	parentID := blk.Parent()
-	if parent, err := t.getBlock(ctx, parentID); err != nil || !(t.Consensus.Decided(parent) || t.Consensus.Processing(parentID)) {
-		t.Ctx.Log.Verbo("block waiting for parent to be issued",
+	if parent, err := t.getBlock(ctx, parentID); err != nil || !(t.consensus.Decided(parent) || t.consensus.Processing(parentID)) {
+		t.ctx.Log.Verbo("block waiting for parent to be issued",
 			zap.Stringer("blkID", blkID),
 			zap.Stringer("parentID", parentID),
 		)
@@ -872,12 +892,12 @@ func (t *Transitive) sendRequest(
 	t.blkReqs.Put(req, blkID)
 	t.blkReqSourceMetric[req] = issuedMetric
 
-	t.Ctx.Log.Verbo("sending Get request",
+	t.ctx.Log.Verbo("sending Get request",
 		zap.Stringer("nodeID", nodeID),
 		zap.Uint32("requestID", t.requestID),
 		zap.Stringer("blkID", blkID),
 	)
-	t.Sender.SendGet(ctx, nodeID, t.requestID, blkID)
+	t.sender.SendGet(ctx, nodeID, t.requestID, blkID)
 }
 
 // Send a query for this block. If push is set to true, blkBytes will be used to
@@ -889,24 +909,24 @@ func (t *Transitive) sendQuery(
 	blkBytes []byte,
 	push bool,
 ) {
-	t.Ctx.Log.Verbo("sampling from validators",
-		zap.Stringer("validators", t.Validators),
+	t.ctx.Log.Verbo("sampling from validators",
+		zap.Stringer("validators", t.validators),
 	)
 
-	vdrIDs, err := t.Validators.Sample(t.Ctx.SubnetID, t.Params.K)
+	vdrIDs, err := t.validators.Sample(t.ctx.SubnetID, t.config.K)
 	if err != nil {
-		t.Ctx.Log.Warn("dropped query for block",
+		t.ctx.Log.Warn("dropped query for block",
 			zap.String("reason", "insufficient number of validators"),
 			zap.Stringer("blkID", blkID),
-			zap.Int("size", t.Params.K),
+			zap.Int("size", t.config.K),
 		)
 		return
 	}
 
-	_, lastAcceptedHeight := t.Consensus.LastAccepted()
+	_, lastAcceptedHeight := t.consensus.LastAccepted()
 	nextHeightToAccept, err := math.Add64(lastAcceptedHeight, 1)
 	if err != nil {
-		t.Ctx.Log.Error("dropped query for block",
+		t.ctx.Log.Error("dropped query for block",
 			zap.String("reason", "block height overflow"),
 			zap.Stringer("blkID", blkID),
 			zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -918,7 +938,7 @@ func (t *Transitive) sendQuery(
 	vdrBag := bag.Of(vdrIDs...)
 	t.requestID++
 	if !t.polls.Add(t.requestID, vdrBag) {
-		t.Ctx.Log.Error("dropped query for block",
+		t.ctx.Log.Error("dropped query for block",
 			zap.String("reason", "failed to add poll"),
 			zap.Stringer("blkID", blkID),
 			zap.Uint32("requestID", t.requestID),
@@ -928,9 +948,9 @@ func (t *Transitive) sendQuery(
 
 	vdrSet := set.Of(vdrIDs...)
 	if push {
-		t.Sender.SendPushQuery(ctx, vdrSet, t.requestID, blkBytes, nextHeightToAccept)
+		t.sender.SendPushQuery(ctx, vdrSet, t.requestID, blkBytes, nextHeightToAccept)
 	} else {
-		t.Sender.SendPullQuery(ctx, vdrSet, t.requestID, blkID, nextHeightToAccept)
+		t.sender.SendPullQuery(ctx, vdrSet, t.requestID, blkID, nextHeightToAccept)
 	}
 }
 
@@ -945,7 +965,7 @@ func (t *Transitive) deliver(
 	issuedMetric prometheus.Counter,
 ) error {
 	blkID := blk.ID()
-	if t.Consensus.Decided(blk) || t.Consensus.Processing(blkID) {
+	if t.consensus.Decided(blk) || t.consensus.Processing(blkID) {
 		return nil
 	}
 
@@ -957,7 +977,7 @@ func (t *Transitive) deliver(
 	// Because the dependency must have been fulfilled by the time this function
 	// is called - we don't expect [err] to be non-nil. But it is handled for
 	// completness and future proofing.
-	if err != nil || !(parent.Status() == choices.Accepted || t.Consensus.Processing(parentID)) {
+	if err != nil || !(parent.Status() == choices.Accepted || t.consensus.Processing(parentID)) {
 		// if the parent isn't processing or the last accepted block, then this
 		// block is effectively rejected
 		t.blocked.Abandon(ctx, blkID)
@@ -1002,20 +1022,20 @@ func (t *Transitive) deliver(
 		}
 	}
 
-	if err := t.VM.SetPreference(ctx, t.Consensus.Preference()); err != nil {
+	if err := t.vm.SetPreference(ctx, t.consensus.Preference()); err != nil {
 		return err
 	}
 
 	// If the block is now preferred, query the network for its preferences
 	// with this new block.
-	if t.Consensus.IsPreferred(blk) {
+	if t.consensus.IsPreferred(blk) {
 		t.sendQuery(ctx, blkID, blk.Bytes(), push)
 	}
 
 	t.blocked.Fulfill(ctx, blkID)
 	for _, blk := range added {
 		blkID := blk.ID()
-		if t.Consensus.IsPreferred(blk) {
+		if t.consensus.IsPreferred(blk) {
 			t.sendQuery(ctx, blkID, blk.Bytes(), push)
 		}
 
@@ -1052,14 +1072,14 @@ func (t *Transitive) removeFromPending(blk snowman.Block) {
 func (t *Transitive) addToNonVerifieds(blk snowman.Block) {
 	// don't add this blk if it's decided or processing.
 	blkID := blk.ID()
-	if t.Consensus.Decided(blk) || t.Consensus.Processing(blkID) {
+	if t.consensus.Decided(blk) || t.consensus.Processing(blkID) {
 		return
 	}
 	parentID := blk.Parent()
 	// we might still need this block so we can bubble votes to the parent
 	// only add blocks with parent already in the tree or processing.
 	// decided parents should not be in this map.
-	if t.nonVerifieds.Has(parentID) || t.Consensus.Processing(parentID) {
+	if t.nonVerifieds.Has(parentID) || t.consensus.Processing(parentID) {
 		t.nonVerifieds.Add(blkID, parentID)
 		t.nonVerifiedCache.Put(blkID, blk)
 	}
@@ -1078,7 +1098,7 @@ func (t *Transitive) addUnverifiedBlockToConsensus(
 
 	// make sure this block is valid
 	if err := blk.Verify(ctx); err != nil {
-		t.Ctx.Log.Debug("block verification failed",
+		t.ctx.Log.Debug("block verification failed",
 			zap.Stringer("nodeID", nodeID),
 			zap.Stringer("blkID", blkID),
 			zap.Uint64("height", blkHeight),
@@ -1093,13 +1113,13 @@ func (t *Transitive) addUnverifiedBlockToConsensus(
 	issuedMetric.Inc()
 	t.nonVerifieds.Remove(blkID)
 	t.nonVerifiedCache.Evict(blkID)
-	t.metrics.issuerStake.Observe(float64(t.Validators.GetWeight(t.Ctx.SubnetID, nodeID)))
-	t.Ctx.Log.Verbo("adding block to consensus",
+	t.metrics.issuerStake.Observe(float64(t.validators.GetWeight(t.ctx.SubnetID, nodeID)))
+	t.ctx.Log.Verbo("adding block to consensus",
 		zap.Stringer("nodeID", nodeID),
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", blkHeight),
 	)
-	return true, t.Consensus.Add(ctx, &memoryBlock{
+	return true, t.consensus.Add(ctx, &memoryBlock{
 		Block:   blk,
 		metrics: &t.metrics,
 		tree:    t.nonVerifieds,

--- a/snow/engine/snowman/transitive_test.go
+++ b/snow/engine/snowman/transitive_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/getter"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
 )

--- a/snow/engine/snowman/voter.go
+++ b/snow/engine/snowman/voter.go
@@ -71,10 +71,10 @@ func (v *voter) Update(ctx context.Context) {
 
 	for _, result := range results {
 		result := result
-		v.t.Ctx.Log.Debug("finishing poll",
+		v.t.ctx.Log.Debug("finishing poll",
 			zap.Stringer("result", &result),
 		)
-		if err := v.t.Consensus.RecordPoll(ctx, result); err != nil {
+		if err := v.t.consensus.RecordPoll(ctx, result); err != nil {
 			v.t.errs.Add(err)
 		}
 	}
@@ -83,17 +83,17 @@ func (v *voter) Update(ctx context.Context) {
 		return
 	}
 
-	if err := v.t.VM.SetPreference(ctx, v.t.Consensus.Preference()); err != nil {
+	if err := v.t.vm.SetPreference(ctx, v.t.consensus.Preference()); err != nil {
 		v.t.errs.Add(err)
 		return
 	}
 
-	if v.t.Consensus.NumProcessing() == 0 {
-		v.t.Ctx.Log.Debug("Snowman engine can quiesce")
+	if v.t.consensus.NumProcessing() == 0 {
+		v.t.ctx.Log.Debug("Snowman engine can quiesce")
 		return
 	}
 
-	v.t.Ctx.Log.Debug("Snowman engine can't quiesce")
+	v.t.ctx.Log.Debug("Snowman engine can't quiesce")
 	v.t.repoll(ctx)
 }
 
@@ -110,7 +110,7 @@ func (v *voter) getProcessingAncestor(ctx context.Context, initialVote ids.ID) (
 		blk, err := v.t.getBlock(ctx, bubbledVote)
 		// If we cannot retrieve the block, drop [vote]
 		if err != nil {
-			v.t.Ctx.Log.Debug("dropping vote",
+			v.t.ctx.Log.Debug("dropping vote",
 				zap.String("reason", "ancestor couldn't be fetched"),
 				zap.Stringer("initialVoteID", initialVote),
 				zap.Stringer("bubbledVoteID", bubbledVote),
@@ -120,8 +120,8 @@ func (v *voter) getProcessingAncestor(ctx context.Context, initialVote ids.ID) (
 			return ids.Empty, false
 		}
 
-		if v.t.Consensus.Decided(blk) {
-			v.t.Ctx.Log.Debug("dropping vote",
+		if v.t.consensus.Decided(blk) {
+			v.t.ctx.Log.Debug("dropping vote",
 				zap.String("reason", "bubbled vote already decided"),
 				zap.Stringer("initialVoteID", initialVote),
 				zap.Stringer("bubbledVoteID", bubbledVote),
@@ -132,8 +132,8 @@ func (v *voter) getProcessingAncestor(ctx context.Context, initialVote ids.ID) (
 			return ids.Empty, false
 		}
 
-		if v.t.Consensus.Processing(bubbledVote) {
-			v.t.Ctx.Log.Verbo("applying vote",
+		if v.t.consensus.Processing(bubbledVote) {
+			v.t.ctx.Log.Verbo("applying vote",
 				zap.Stringer("initialVoteID", initialVote),
 				zap.Stringer("bubbledVoteID", bubbledVote),
 				zap.Uint64("height", blk.Height()),

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1508,12 +1508,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 	require.NoError(err)
 
 	engineConfig := smeng.Config{
-		Ctx:           bootstrapConfig.Ctx,
-		AllGetsServer: snowGetHandler,
-		VM:            bootstrapConfig.VM,
-		Sender:        bootstrapConfig.Sender,
-		Validators:    beacons,
-		Params: snowball.Parameters{
+		Parameters: snowball.Parameters{
 			K:                     1,
 			AlphaPreference:       1,
 			AlphaConfidence:       1,
@@ -1524,9 +1519,17 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 			MaxOutstandingItems:   1,
 			MaxItemProcessingTime: 1,
 		},
-		Consensus: &smcon.Topological{},
 	}
-	engine, err := smeng.New(engineConfig)
+	engine, err := smeng.New(
+		engineConfig,
+		bootstrapConfig.Ctx,
+		snowGetHandler,
+		bootstrapConfig.VM,
+		bootstrapConfig.Sender,
+		beacons,
+		nil,
+		&smcon.Topological{},
+	)
 	require.NoError(err)
 
 	bootstrapper, err := bootstrap.New(


### PR DESCRIPTION
## Why this should be merged

Refactors non-config values out of the consensus config struct + unexposes a lot of random fields in the struct.

## How this works

Refactors code

## How this was tested

CI