### PR TITLE
Update minimum golang version to v1.21.8

### DIFF
--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -11,7 +11,7 @@ on:
       - "*"
 
 env:
-  go_version: '~1.21.7'
+  go_version: '~1.21.8'
 
 jobs:
   build-x86_64-binaries-tarball:

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.8'
           check-latest: true
       - run: go version
 

--- a/.github/workflows/build-public-ami.yml
+++ b/.github/workflows/build-public-ami.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.8'
           check-latest: true
       - run: go version
 

--- a/.github/workflows/build-ubuntu-amd64-release.yml
+++ b/.github/workflows/build-ubuntu-amd64-release.yml
@@ -11,7 +11,7 @@ on:
       - "*"
 
 env:
-  go_version: '~1.21.7'
+  go_version: '~1.21.8'
 
 jobs:
   build-jammy-amd64-package:

--- a/.github/workflows/build-ubuntu-arm64-release.yml
+++ b/.github/workflows/build-ubuntu-arm64-release.yml
@@ -11,7 +11,7 @@ on:
       - "*"
 
 env:
-  go_version: '~1.21.7'
+  go_version: '~1.21.8'
 
 jobs:
   build-jammy-arm64-package:

--- a/.github/workflows/build-win-release.yml
+++ b/.github/workflows/build-win-release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.8'
           check-latest: true
 
       - run: go version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  go_version: '~1.21.7'
+  go_version: '~1.21.8'
   tmpnet_data_path: ~/.tmpnet/networks/1000
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.8'
           check-latest: true
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.8'
           check-latest: true
       - name: Run fuzz tests
         shell: bash

--- a/.github/workflows/fuzz_merkledb.yml
+++ b/.github/workflows/fuzz_merkledb.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.8'
           check-latest: true
       - name: Run merkledb fuzz tests
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 To start developing on AvalancheGo, you'll need a few things installed.
 
-- Golang version >= 1.21.7
+- Golang version >= 1.21.8
 - gcc
 - g++
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # README.md
 # go.mod
 # ============= Compilation Stage ================
-FROM golang:1.21.7-bullseye AS builder
+FROM golang:1.21.8-bullseye AS builder
 
 WORKDIR /build
 # Copy and download avalanche dependencies using go mod

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The minimum recommended hardware specification for nodes connected to Mainnet is
 
 If you plan to build AvalancheGo from source, you will also need the following software:
 
-- [Go](https://golang.org/doc/install) version >= 1.21.7
+- [Go](https://golang.org/doc/install) version >= 1.21.8
 - [gcc](https://gcc.gnu.org/)
 - g++
 

--- a/proto/Dockerfile.buf
+++ b/proto/Dockerfile.buf
@@ -6,7 +6,7 @@ RUN apt-get update && apt -y install bash curl unzip git
 WORKDIR /opt
 
 RUN \
-  curl -L https://go.dev/dl/go1.21.7.linux-amd64.tar.gz > golang.tar.gz && \
+  curl -L https://go.dev/dl/go1.21.8.linux-amd64.tar.gz > golang.tar.gz && \
   mkdir golang && \
   tar -zxvf golang.tar.gz -C golang/
 

--- a/scripts/build_avalanche.sh
+++ b/scripts/build_avalanche.sh
@@ -27,7 +27,7 @@ done
 # Dockerfile
 # README.md
 # go.mod
-go_version_minimum="1.21.7"
+go_version_minimum="1.21.8"
 
 go_version() {
     go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'


### PR DESCRIPTION
## Why this should be merged

Updates the minimum golang version to address.

- [CVE-2024-24783](https://github.com/golang/go/issues/65392)
- [CVE-2023-45290](https://github.com/golang/go/issues/65389)
- [CVE-2023-45289](https://github.com/golang/go/issues/65385)

## How this works

Updates the minimum golang version to [`v1.21.8`](https://github.com/golang/go/issues?q=milestone%3AGo1.21.8+label%3ACherryPickApproved)

## How this was tested

- [X] CI