### PR TITLE
`tmpnet`: Enable collection of logs and metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
         shell: bash
         run: bash -x ./scripts/run_promtail.sh
         env:
-          PROMTAIL_ID: ${{ secrets.PROMTAIL_ID }}
-          PROMTAIL_PASSWORD: ${{ secrets.PROMTAIL_PASSWORD }}
+          LOKI_ID: ${{ secrets.LOKI_ID }}
+          LOKI_PASSWORD: ${{ secrets.LOKI_PASSWORD }}
       - name: Notify of metrics availability
         shell: bash
         run: .github/workflows/notify-metrics-availability.sh
@@ -123,6 +123,12 @@ jobs:
         env:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
+      - name: Start promtail
+        shell: bash
+        run: bash -x ./scripts/run_promtail.sh
+        env:
+          LOKI_ID: ${{ secrets.LOKI_ID }}
+          LOKI_PASSWORD: ${{ secrets.LOKI_PASSWORD }}
       - name: Notify of metrics availability
         shell: bash
         run: .github/workflows/notify-metrics-availability.sh
@@ -147,6 +153,7 @@ jobs:
           path: |
             ~/.tmpnet/networks
             ~/.tmpnet/prometheus/prometheus.log
+            ~/.tmpnet/promtail/promtail.log
           if-no-files-found: error
   Upgrade:
     runs-on: ubuntu-latest
@@ -165,6 +172,12 @@ jobs:
         env:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
+      - name: Start promtail
+        shell: bash
+        run: bash -x ./scripts/run_promtail.sh
+        env:
+          LOKI_ID: ${{ secrets.LOKI_ID }}
+          LOKI_PASSWORD: ${{ secrets.LOKI_PASSWORD }}
       - name: Notify of metrics availability
         shell: bash
         run: .github/workflows/notify-metrics-availability.sh
@@ -189,6 +202,7 @@ jobs:
           path: |
             ~/.tmpnet/networks
             ~/.tmpnet/prometheus/prometheus.log
+            ~/.tmpnet/promtail/promtail.log
           if-no-files-found: error
   Lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,12 @@ jobs:
         env:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
+      - name: Start promtail
+        shell: bash
+        run: bash -x ./scripts/run_promtail.sh
+        env:
+          PROMTAIL_ID: ${{ secrets.PROMTAIL_ID }}
+          PROMTAIL_PASSWORD: ${{ secrets.PROMTAIL_PASSWORD }}
       - name: Notify of metrics availability
         shell: bash
         run: .github/workflows/notify-metrics-availability.sh
@@ -98,6 +104,7 @@ jobs:
           path: |
             ~/.tmpnet/networks
             ~/.tmpnet/prometheus/prometheus.log
+            ~/.tmpnet/promtail/promtail.log
           if-no-files-found: error
   e2e_existing_network:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ concurrency:
 
 env:
   go_version: '~1.21.8'
-  tmpnet_data_path: ~/.tmpnet
   prometheus_url: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-filter=is_ephemeral_node%7C%3D%7Cfalse&var-filter=gh_repo%7C%3D%7Cava-labs%2Favalanchego&var-filter=gh_run_id%7C%3D%7C${{ github.run_id }}&var-filter=gh_run_attempt%7C%3D%7C${{ github.run_attempt }}
 
 jobs:
@@ -83,7 +82,6 @@ jobs:
           FILTER_BY_OWNER: avalanchego-e2e
       - name: Run e2e tests
         shell: bash
-        # TODO(maru) Ensure network stays up for final metrics scrape
         run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
         env:
           GH_REPO: ${{ github.repository }}
@@ -97,7 +95,9 @@ jobs:
         if: always()
         with:
           name: e2e-tmpnet-data
-          path: ${{ env.tmpnet_data_path }}
+          path: |
+            ~/.tmpnet/networks
+            ~/.tmpnet/prometheus/prometheus.log
           if-no-files-found: error
   e2e_existing_network:
     runs-on: ubuntu-latest
@@ -137,7 +137,9 @@ jobs:
         if: always()
         with:
           name: e2e-existing-network-tmpnet-data
-          path: ${{ env.tmpnet_data_path }}
+          path: |
+            ~/.tmpnet/networks
+            ~/.tmpnet/prometheus/prometheus.log
           if-no-files-found: error
   Upgrade:
     runs-on: ubuntu-latest
@@ -177,7 +179,9 @@ jobs:
         if: always()
         with:
           name: upgrade-tmpnet-data
-          path: ${{ env.tmpnet_data_path }}
+          path: |
+            ~/.tmpnet/networks
+            ~/.tmpnet/prometheus/prometheus.log
           if-no-files-found: error
   Lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 
 env:
   go_version: '~1.21.8'
-  tmpnet_data_path: ~/.tmpnet/networks
+  tmpnet_data_path: ~/.tmpnet
 
 jobs:
   Unit:
@@ -67,9 +67,22 @@ jobs:
       - name: Build AvalancheGo Binary
         shell: bash
         run: ./scripts/build.sh -r
+      - name: Start prometheus
+        shell: bash
+        run: bash -x ./scripts/run_prometheus.sh
+        env:
+          PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
+          PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
       - name: Run e2e tests
         shell: bash
+        # TODO(maru) Ensure network stays up for final metrics scrape
         run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_JOB_ID: ${{ github.job }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_NUMBER: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
       - name: Upload tmpnet network dir
         uses: actions/upload-artifact@v4
         if: always()
@@ -88,9 +101,21 @@ jobs:
       - name: Build AvalancheGo Binary
         shell: bash
         run: ./scripts/build.sh -r
+      - name: Start prometheus
+        shell: bash
+        run: bash -x ./scripts/run_prometheus.sh
+        env:
+          PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
+          PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
       - name: Run e2e tests with existing network
         shell: bash
         run: E2E_SERIAL=1 ./scripts/tests.e2e.existing.sh
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_JOB_ID: ${{ github.job }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_NUMBER: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
       - name: Upload tmpnet network dir
         uses: actions/upload-artifact@v4
         if: always()
@@ -109,9 +134,21 @@ jobs:
       - name: Build AvalancheGo Binary
         shell: bash
         run: ./scripts/build.sh
+      - name: Start prometheus
+        shell: bash
+        run: bash -x ./scripts/run_prometheus.sh
+        env:
+          PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
+          PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
       - name: Run e2e tests
         shell: bash
         run: ./scripts/tests.upgrade.sh
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_JOB_ID: ${{ github.job }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_NUMBER: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
       - name: Upload tmpnet network dir
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
         env:
           PROMETHEUS_URL: ${{ env.prometheus_url }}
           GH_JOB_ID: ${{ github.job }}
+          FILTER_BY_OWNER: avalanchego-e2e
       - name: Run e2e tests
         shell: bash
         # TODO(maru) Ensure network stays up for final metrics scrape

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
   go_version: '~1.21.8'
   tmpnet_data_path: ~/.tmpnet
-  prometheus_url: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-adhoc=gh_repo%7C%3D%7Cava-labs%2Favalanchego&var-adhoc=gh_run_id%7C%3D%7C${{ github.run_id }}&var-adhoc=gh_run_attempt%7C%3D%7C${{ github.run_attempt }}
+  prometheus_url: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-filter=is_ephemeral_node%7C%3D%7Cfalse&var-filter=gh_repo%7C%3D%7Cava-labs%2Favalanchego&var-filter=gh_run_id%7C%3D%7C${{ github.run_id }}&var-filter=gh_run_attempt%7C%3D%7C${{ github.run_attempt }}
 
 jobs:
   Unit:
@@ -75,9 +75,8 @@ jobs:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
       - name: Notify of metrics availability
-        run: |
-          msg="Metrics for this job: ${PROMETHEUS_URL}&var-adhoc=gh_job_id%7C%3D%7C${GH_JOB_ID}&from=$(date '+%s')000&to=now"
-          echo "::notice::${msg}"
+        shell: bash
+        run: .github/workflows/notify-metrics-availability.sh
         env:
           PROMETHEUS_URL: ${{ env.prometheus_url }}
           GH_JOB_ID: ${{ github.job }}
@@ -117,9 +116,8 @@ jobs:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
       - name: Notify of metrics availability
-        run: |
-          msg="Metrics for this job: ${PROMETHEUS_URL}&var-gh_job_id=${GH_JOB_ID}"
-          echo "::notice::${msg}"
+        shell: bash
+        run: .github/workflows/notify-metrics-availability.sh
         env:
           PROMETHEUS_URL: ${{ env.prometheus_url }}
           GH_JOB_ID: ${{ github.job }}
@@ -158,9 +156,8 @@ jobs:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
       - name: Notify of metrics availability
-        run: |
-          msg="Metrics for this job: ${PROMETHEUS_URL}&var-gh_job_id=${GH_JOB_ID}"
-          echo "::notice::${msg}"
+        shell: bash
+        run: .github/workflows/notify-metrics-availability.sh
         env:
           PROMETHEUS_URL: ${{ env.prometheus_url }}
           GH_JOB_ID: ${{ github.job }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ concurrency:
 env:
   go_version: '~1.21.8'
   tmpnet_data_path: ~/.tmpnet
+  prometheus_url: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-adhoc=gh_repo%7C%3D%7Cava-labs%2Favalanchego&var-adhoc=gh_run_id%7C%3D%7C${{ github.run_id }}&var-adhoc=gh_run_attempt%7C%3D%7C${{ github.run_attempt }}
 
 jobs:
   Unit:
@@ -73,16 +74,24 @@ jobs:
         env:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
+      - name: Notify of metrics availability
+        run: |
+          msg="Metrics for this job: ${PROMETHEUS_URL}&var-adhoc=gh_job_id%7C%3D%7C${GH_JOB_ID}&from=$(date '+%s')000&to=now"
+          echo "::notice::${msg}"
+        env:
+          PROMETHEUS_URL: ${{ env.prometheus_url }}
+          GH_JOB_ID: ${{ github.job }}
       - name: Run e2e tests
         shell: bash
         # TODO(maru) Ensure network stays up for final metrics scrape
         run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
         env:
           GH_REPO: ${{ github.repository }}
-          GH_JOB_ID: ${{ github.job }}
+          GH_WORKFLOW: ${{ github.workflow }}
           GH_RUN_ID: ${{ github.run_id }}
-          GH_RUN_NUMBER: ${{ github.run_id }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
           GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GH_JOB_ID: ${{ github.job }}
       - name: Upload tmpnet network dir
         uses: actions/upload-artifact@v4
         if: always()
@@ -107,15 +116,23 @@ jobs:
         env:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
+      - name: Notify of metrics availability
+        run: |
+          msg="Metrics for this job: ${PROMETHEUS_URL}&var-gh_job_id=${GH_JOB_ID}"
+          echo "::notice::${msg}"
+        env:
+          PROMETHEUS_URL: ${{ env.prometheus_url }}
+          GH_JOB_ID: ${{ github.job }}
       - name: Run e2e tests with existing network
         shell: bash
         run: E2E_SERIAL=1 ./scripts/tests.e2e.existing.sh
         env:
           GH_REPO: ${{ github.repository }}
-          GH_JOB_ID: ${{ github.job }}
+          GH_WORKFLOW: ${{ github.workflow }}
           GH_RUN_ID: ${{ github.run_id }}
-          GH_RUN_NUMBER: ${{ github.run_id }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
           GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GH_JOB_ID: ${{ github.job }}
       - name: Upload tmpnet network dir
         uses: actions/upload-artifact@v4
         if: always()
@@ -140,15 +157,23 @@ jobs:
         env:
           PROMETHEUS_ID: ${{ secrets.PROMETHEUS_ID }}
           PROMETHEUS_PASSWORD: ${{ secrets.PROMETHEUS_PASSWORD }}
+      - name: Notify of metrics availability
+        run: |
+          msg="Metrics for this job: ${PROMETHEUS_URL}&var-gh_job_id=${GH_JOB_ID}"
+          echo "::notice::${msg}"
+        env:
+          PROMETHEUS_URL: ${{ env.prometheus_url }}
+          GH_JOB_ID: ${{ github.job }}
       - name: Run e2e tests
         shell: bash
         run: ./scripts/tests.upgrade.sh
         env:
           GH_REPO: ${{ github.repository }}
-          GH_JOB_ID: ${{ github.job }}
+          GH_WORKFLOW: ${{ github.workflow }}
           GH_RUN_ID: ${{ github.run_id }}
-          GH_RUN_NUMBER: ${{ github.run_id }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
           GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GH_JOB_ID: ${{ github.job }}
       - name: Upload tmpnet network dir
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 
 env:
   go_version: '~1.21.8'
-  prometheus_url: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-filter=is_ephemeral_node%7C%3D%7Cfalse&var-filter=gh_repo%7C%3D%7Cava-labs%2Favalanchego&var-filter=gh_run_id%7C%3D%7C${{ github.run_id }}&var-filter=gh_run_attempt%7C%3D%7C${{ github.run_attempt }}
+  grafana_url: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-filter=is_ephemeral_node%7C%3D%7Cfalse&var-filter=gh_repo%7C%3D%7Cava-labs%2Favalanchego&var-filter=gh_run_id%7C%3D%7C${{ github.run_id }}&var-filter=gh_run_attempt%7C%3D%7C${{ github.run_attempt }}
 
 jobs:
   Unit:
@@ -83,7 +83,7 @@ jobs:
         shell: bash
         run: .github/workflows/notify-metrics-availability.sh
         env:
-          PROMETHEUS_URL: ${{ env.prometheus_url }}
+          GRAFANA_URL: ${{ env.grafana_url }}
           GH_JOB_ID: ${{ github.job }}
           FILTER_BY_OWNER: avalanchego-e2e
       - name: Run e2e tests
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         run: .github/workflows/notify-metrics-availability.sh
         env:
-          PROMETHEUS_URL: ${{ env.prometheus_url }}
+          GRAFANA_URL: ${{ env.grafana_url }}
           GH_JOB_ID: ${{ github.job }}
       - name: Run e2e tests with existing network
         shell: bash
@@ -169,7 +169,7 @@ jobs:
         shell: bash
         run: .github/workflows/notify-metrics-availability.sh
         env:
-          PROMETHEUS_URL: ${{ env.prometheus_url }}
+          GRAFANA_URL: ${{ env.grafana_url }}
           GH_JOB_ID: ${{ github.job }}
       - name: Run e2e tests
         shell: bash

--- a/.github/workflows/notify-metrics-availability.sh
+++ b/.github/workflows/notify-metrics-availability.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Timestamps are in seconds
 from_timestamp="$(date '+%s')"
 monitoring_period=900 # 15 minutes
-to_timestamp="$((${from_timestamp} + ${monitoring_period}))"
+to_timestamp="$((from_timestamp + monitoring_period))"
 
 # Grafana expects microseconds, so pad timestamps with 3 zeros
 metrics_url="${PROMETHEUS_URL}&var-filter=gh_job_id%7C%3D%7C${GH_JOB_ID}&from=${from_timestamp}000&to=${to_timestamp}000"

--- a/.github/workflows/notify-metrics-availability.sh
+++ b/.github/workflows/notify-metrics-availability.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Timestamps are in seconds
 from_timestamp="$(date '+%s')"
-monitoring_period=600 # 10 minutes
+monitoring_period=900 # 15 minutes
 to_timestamp="$((${from_timestamp} + ${monitoring_period}))"
 
 # Grafana expects microseconds, so pad timestamps with 3 zeros

--- a/.github/workflows/notify-metrics-availability.sh
+++ b/.github/workflows/notify-metrics-availability.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Timestamps are in seconds
+from_timestamp="$(date '+%s')"
+monitoring_period=600 # 10 minutes
+to_timestamp="$((${from_timestamp} + ${monitoring_period}))"
+
+# Grafana expects microseconds, so pad timestamps with 3 zeros
+metrics_url="${PROMETHEUS_URL}&var-filter=gh_job_id%7C%3D%7C${GH_JOB_ID}&from=${from_timestamp}000&to=${to_timestamp}000"
+
+echo "::notice links::metrics ${metrics_url}"

--- a/.github/workflows/notify-metrics-availability.sh
+++ b/.github/workflows/notify-metrics-availability.sh
@@ -10,4 +10,10 @@ to_timestamp="$((${from_timestamp} + ${monitoring_period}))"
 # Grafana expects microseconds, so pad timestamps with 3 zeros
 metrics_url="${PROMETHEUS_URL}&var-filter=gh_job_id%7C%3D%7C${GH_JOB_ID}&from=${from_timestamp}000&to=${to_timestamp}000"
 
+# Optionally ensure that the link displays metrics only for the shared
+# network rather than mixing it with the results for private networks.
+if [[ -n "${FILTER_BY_OWNER:-}" ]]; then
+  metrics_url="${metrics_url}&var-filter=network_owner%7C%3D%7C${FILTER_BY_OWNER}"
+fi
+
 echo "::notice links::metrics ${metrics_url}"

--- a/.github/workflows/notify-metrics-availability.sh
+++ b/.github/workflows/notify-metrics-availability.sh
@@ -8,7 +8,7 @@ monitoring_period=900 # 15 minutes
 to_timestamp="$((from_timestamp + monitoring_period))"
 
 # Grafana expects microseconds, so pad timestamps with 3 zeros
-metrics_url="${PROMETHEUS_URL}&var-filter=gh_job_id%7C%3D%7C${GH_JOB_ID}&from=${from_timestamp}000&to=${to_timestamp}000"
+metrics_url="${GRAFANA_URL}&var-filter=gh_job_id%7C%3D%7C${GH_JOB_ID}&from=${from_timestamp}000&to=${to_timestamp}000"
 
 # Optionally ensure that the link displays metrics only for the shared
 # network rather than mixing it with the results for private networks.

--- a/scripts/run_prometheus.sh
+++ b/scripts/run_prometheus.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Starts a prometheus instance in agent-mode, forwarding to a central
+# instance. Intended to enable metrics collection from temporary networks running
+# locally and in CI.
+#
+# The prometheus instance will remain running in the background and will forward
+# metrics to the central instance for all tmpnet networks.
+#
+# To stop it:
+#
+#   $ kill -9 `cat ~/.tmpnet/prometheus/run.pid` && rm ~/.tmpnet/prometheus/run.pid
+#
+
+# e.g.,
+# PROMETHEUS_ID=<id> PROMETHEUS_PASSWORD=<password> ./scripts/run_prometheus.sh
+if ! [[ "$0" =~ scripts/run_prometheus.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+PROMETHEUS_WORKING_DIR="${HOME}/.tmpnet/prometheus"
+PIDFILE="${PROMETHEUS_WORKING_DIR}"/run.pid
+
+# First check if an agent-mode prometheus is already running. A single instance can collect
+# metrics from all local temporary networks.
+if pgrep --pidfile="${PIDFILE}" -f 'prometheus.*enable-feature=agent' &> /dev/null; then
+  echo "prometheus is already running locally with --enable-feature=agent"
+  exit 0
+fi
+
+PROMETHEUS_URL="${PROMETHEUS_URL:-https://prometheus-experimental.avax-dev.network}"
+if [[ -z "${PROMETHEUS_URL}" ]]; then
+  echo "Please provide a value for PROMETHEUS_URL"
+  exit 1
+fi
+
+PROMETHEUS_ID="${PROMETHEUS_ID:-}"
+if [[ -z "${PROMETHEUS_ID}" ]]; then
+  echo "Please provide a value for PROMETHEUS_ID"
+  exit 1
+fi
+
+PROMETHEUS_PASSWORD="${PROMETHEUS_PASSWORD:-}"
+if [[ -z "${PROMETHEUS_PASSWORD}" ]]; then
+  echo "Plase provide a value for PROMETHEUS_PASSWORD"
+  exit 1
+fi
+
+# This was the LTS version when this script was written. Probably not
+# much reason to update it unless something breaks since the usage
+# here is only to collect metrics from temporary networks.
+VERSION="2.45.3"
+
+# Ensure the prometheus command is locally available
+CMD=prometheus
+if ! command -v "${CMD}" &> /dev/null; then
+  # Try to use a local version
+  CMD="${PWD}/bin/prometheus"
+  if ! command -v "${CMD}" &> /dev/null; then
+    echo "prometheus not found, attempting to install..."
+
+    # Determine the arch
+    if which sw_vers &> /dev/null; then
+      echo "on macos, only amd64 binaries are available so rosetta is required on apple silicon machines."
+      echo "to avoid using rosetta, install via homebrew: brew install prometheus"
+      DIST=darwin
+    else
+      ARCH="$(uname -i)"
+      if [[ "${ARCH}" != "x86_64" ]]; then
+        echo "on linux, only amd64 binaries are available. manual installation of prometheus is required."
+        exit 1
+      else
+        DIST="linux"
+      fi
+    fi
+
+    # Install the specified release
+    PROMETHEUS_FILE="prometheus-${VERSION}.${DIST}-amd64"
+    URL="https://github.com/prometheus/prometheus/releases/download/v${VERSION}/${PROMETHEUS_FILE}.tar.gz"
+    curl -s -L "${URL}" | tar zxv -C /tmp > /dev/null
+    mkdir -p "$(dirname "${CMD}")"
+    cp /tmp/"${PROMETHEUS_FILE}/prometheus" "${CMD}"
+  fi
+fi
+
+# Configure prometheus
+FILE_SD_PATH="${PROMETHEUS_WORKING_DIR}/file_sd_configs"
+mkdir -p "${FILE_SD_PATH}"
+
+echo "writing configuration..."
+cat >"${PROMETHEUS_WORKING_DIR}"/prometheus.yaml <<EOL
+# my global config
+global:
+  scrape_interval: 10s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 10s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  scrape_timeout: 5s # The default is every 10s
+
+scrape_configs:
+  - job_name: "avalanchego"
+    metrics_path: "/ext/metrics"
+    file_sd_configs:
+      - files:
+          - '${FILE_SD_PATH}/*.json'
+
+remote_write:
+  - url: "${PROMETHEUS_URL}/api/v1/write"
+    basic_auth:
+      username: "${PROMETHEUS_ID}"
+      password: "${PROMETHEUS_PASSWORD}"
+EOL
+
+echo "starting prometheus..."
+cd "${PROMETHEUS_WORKING_DIR}"
+nohup "${CMD}" --config.file=prometheus.yaml --web.listen-address=localhost:0 --enable-feature=agent > prometheus.log 2>&1 &
+echo $! > "${PIDFILE}"
+echo "running with pid $(cat "${PIDFILE}")"

--- a/scripts/run_prometheus.sh
+++ b/scripts/run_prometheus.sh
@@ -94,6 +94,7 @@ echo "writing configuration..."
 cat >"${PROMETHEUS_WORKING_DIR}"/prometheus.yaml <<EOL
 # my global config
 global:
+  # Make sure this value takes into account the network-shutdown-delay in tests/fixture/e2e/env.go
   scrape_interval: 10s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 10s # Evaluate rules every 15 seconds. The default is every 1 minute.
   scrape_timeout: 5s # The default is every 10s

--- a/scripts/run_prometheus.sh
+++ b/scripts/run_prometheus.sh
@@ -95,8 +95,8 @@ cat >"${PROMETHEUS_WORKING_DIR}"/prometheus.yaml <<EOL
 # my global config
 global:
   # Make sure this value takes into account the network-shutdown-delay in tests/fixture/e2e/env.go
-  scrape_interval: 10s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 10s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  scrape_interval: 10s # Default is every 1 minute.
+  evaluation_interval: 10s # The default is every 1 minute.
   scrape_timeout: 5s # The default is every 10s
 
 scrape_configs:

--- a/scripts/run_promtail.sh
+++ b/scripts/run_promtail.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Starts a promtail instance to collect logs from temporary networks
+# running locally and in CI.
+#
+# The promtail instance will remain running in the background and will forward
+# metrics to the central instance for all tmpnet networks.
+#
+# To stop it:
+#
+#   $ kill -9 `cat ~/.tmpnet/promtail/run.pid` && rm ~/.tmpnet/promtail/run.pid
+#
+
+# e.g.,
+# LOKI_ID=<id> LOKI_PASSWORD=<password> ./scripts/run_promtail.sh
+if ! [[ "$0" =~ scripts/run_promtail.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+PROMTAIL_WORKING_DIR="${HOME}/.tmpnet/promtail"
+PIDFILE="${PROMTAIL_WORKING_DIR}"/run.pid
+
+# First check if promtail is already running. A single instance can
+# collect logs from all local temporary networks.
+if pgrep --pidfile="${PIDFILE}" &> /dev/null; then
+  echo "promtail is already running"
+  exit 0
+fi
+
+LOKI_URL="${LOKI_URL:-https://loki-experimental.avax-dev.network}"
+if [[ -z "${LOKI_URL}" ]]; then
+  echo "Please provide a value for LOKI_URL"
+  exit 1
+fi
+
+PROMTAIL_ID="${PROMTAIL_ID:-}"
+if [[ -z "${PROMTAIL_ID}" ]]; then
+  echo "Please provide a value for PROMTAIL_ID"
+  exit 1
+fi
+
+PROMTAIL_PASSWORD="${PROMTAIL_PASSWORD:-}"
+if [[ -z "${PROMTAIL_PASSWORD}" ]]; then
+  echo "Plase provide a value for PROMTAIL_PASSWORD"
+  exit 1
+fi
+
+# Version as of this writing
+VERSION="v2.9.5"
+
+# Ensure the promtail command is locally available
+CMD=promtail
+if ! command -v "${CMD}" &> /dev/null; then
+  # Try to use a local version
+  CMD="${PWD}/bin/promtail"
+  if ! command -v "${CMD}" &> /dev/null; then
+    echo "promtail not found, attempting to install..."
+    # Determine the arch
+    if which sw_vers &> /dev/null; then
+      DIST="darwin-$(uname -m)"
+    else
+      ARCH="$(uname -i)"
+      if [[ "${ARCH}" == "aarch64" ]]; then
+        ARCH="arm64"
+      fi
+      DIST="linux-${ARCH}"
+    fi
+
+    # Install the specified release
+    PROMTAIL_FILE="promtail-${DIST}"
+    ZIP_PATH="/tmp/${PROMTAIL_FILE}.zip"
+    BIN_DIR="$(dirname "${CMD}")"
+    URL="https://github.com/grafana/loki/releases/download/VERSION/promtail-${DIST}.zip"
+    curl -L -o "${ZIP_PATH}" "${URL}"
+    unzip "${ZIP_PATH}" -d "${BIN_DIR}"
+    mv "${BIN_DIR}/${PROMTAIL_FILE}" "${CMD}"
+  fi
+fi
+
+# Configure promtail
+FILE_SD_PATH="${PROMTAIL_WORKING_DIR}/file_sd_configs"
+mkdir -p "${FILE_SD_PATH}"
+
+echo "writing configuration..."
+cat >"${PROMTAIL_WORKING_DIR}"/promtail.yaml <<EOL
+server:
+  http_listen_port: 0
+  grpc_listen_port: 0
+
+positions:
+  filename: "${PROMTAIL_WORKING_DIR}/positions.yaml
+
+client:
+  - url: "${LOKI_URL}/api/prom/push"
+    basic_auth:
+      username: "${LOKI_ID}"
+      password: "${LOKI_PASSWORD}"
+
+scrape_configs:
+  - job_name: avalanchego
+    file_sd_configs:
+      - files:
+          - '${FILE_SD_PATH}/*.json'
+EOL
+
+echo "starting promtail..."
+cd "${PROMTAIL_WORKING_DIR}"
+nohup "${CMD}" -config.file=promtail.yaml > promtail.log 2>&1 &
+echo $! > "${PIDFILE}"
+echo "running with pid $(cat "${PIDFILE}")"

--- a/scripts/run_promtail.sh
+++ b/scripts/run_promtail.sh
@@ -65,6 +65,8 @@ if ! command -v "${CMD}" &> /dev/null; then
       ARCH="$(uname -i)"
       if [[ "${ARCH}" == "aarch64" ]]; then
         ARCH="arm64"
+      elif [[ "${ARCH}" == "x86_64" ]]; then
+        ARCH="amd64"
       fi
       DIST="linux-${ARCH}"
     fi

--- a/scripts/run_promtail.sh
+++ b/scripts/run_promtail.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # running locally and in CI.
 #
 # The promtail instance will remain running in the background and will forward
-# metrics to the central instance for all tmpnet networks.
+# logs to the central instance for all tmpnet networks.
 #
 # To stop it:
 #
@@ -36,15 +36,15 @@ if [[ -z "${LOKI_URL}" ]]; then
   exit 1
 fi
 
-PROMTAIL_ID="${PROMTAIL_ID:-}"
-if [[ -z "${PROMTAIL_ID}" ]]; then
-  echo "Please provide a value for PROMTAIL_ID"
+LOKI_ID="${LOKI_ID:-}"
+if [[ -z "${LOKI_ID}" ]]; then
+  echo "Please provide a value for LOKI_ID"
   exit 1
 fi
 
-PROMTAIL_PASSWORD="${PROMTAIL_PASSWORD:-}"
-if [[ -z "${PROMTAIL_PASSWORD}" ]]; then
-  echo "Plase provide a value for PROMTAIL_PASSWORD"
+LOKI_PASSWORD="${LOKI_PASSWORD:-}"
+if [[ -z "${LOKI_PASSWORD}" ]]; then
+  echo "Plase provide a value for LOKI_PASSWORD"
   exit 1
 fi
 
@@ -73,7 +73,7 @@ if ! command -v "${CMD}" &> /dev/null; then
     PROMTAIL_FILE="promtail-${DIST}"
     ZIP_PATH="/tmp/${PROMTAIL_FILE}.zip"
     BIN_DIR="$(dirname "${CMD}")"
-    URL="https://github.com/grafana/loki/releases/download/VERSION/promtail-${DIST}.zip"
+    URL="https://github.com/grafana/loki/releases/download/${VERSION}/promtail-${DIST}.zip"
     curl -L -o "${ZIP_PATH}" "${URL}"
     unzip "${ZIP_PATH}" -d "${BIN_DIR}"
     mv "${BIN_DIR}/${PROMTAIL_FILE}" "${CMD}"
@@ -91,16 +91,16 @@ server:
   grpc_listen_port: 0
 
 positions:
-  filename: "${PROMTAIL_WORKING_DIR}/positions.yaml
+  filename: "${PROMTAIL_WORKING_DIR}/positions.yaml"
 
 client:
-  - url: "${LOKI_URL}/api/prom/push"
-    basic_auth:
-      username: "${LOKI_ID}"
-      password: "${LOKI_PASSWORD}"
+  url: "${LOKI_URL}/api/prom/push"
+  basic_auth:
+    username: "${LOKI_ID}"
+    password: "${LOKI_PASSWORD}"
 
 scrape_configs:
-  - job_name: avalanchego
+  - job_name: "avalanchego"
     file_sd_configs:
       - files:
           - '${FILE_SD_PATH}/*.json'

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -40,6 +40,10 @@ type TestEnvironment struct {
 	URIs []tmpnet.NodeURI
 	// The URI used to access the http server that allocates test data
 	TestDataServerURI string
+	// The number of seconds to wait before shutting down private
+	// networks. A non-zero value may be useful to ensure all metrics
+	// can be scraped before shutdown.
+	PrivateNetworkShutdownDelay uint
 
 	require *require.Assertions
 }
@@ -74,7 +78,7 @@ func NewTestEnvironment(flagVars *FlagVars, desiredNetwork *tmpnet.Network) *Tes
 		}
 	} else {
 		network = desiredNetwork
-		StartNetwork(network, flagVars.AvalancheGoExecPath(), flagVars.PluginDir())
+		StartNetwork(network, flagVars.AvalancheGoExecPath(), flagVars.PluginDir(), flagVars.NetworkShutdownDelay())
 	}
 
 	// A new network will always need subnet creation and an existing
@@ -112,10 +116,11 @@ func NewTestEnvironment(flagVars *FlagVars, desiredNetwork *tmpnet.Network) *Tes
 	require.NoError(err)
 
 	return &TestEnvironment{
-		NetworkDir:        network.Dir,
-		URIs:              uris,
-		TestDataServerURI: testDataServerURI,
-		require:           require,
+		NetworkDir:                  network.Dir,
+		URIs:                        uris,
+		TestDataServerURI:           testDataServerURI,
+		PrivateNetworkShutdownDelay: flagVars.NetworkShutdownDelay(),
+		require:                     require,
 	}
 }
 
@@ -167,5 +172,6 @@ func (te *TestEnvironment) StartPrivateNetwork(network *tmpnet.Network) {
 		network,
 		sharedNetwork.DefaultRuntimeConfig.AvalancheGoPath,
 		pluginDir,
+		te.PrivateNetworkShutdownDelay,
 	)
 }

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -40,10 +40,10 @@ type TestEnvironment struct {
 	URIs []tmpnet.NodeURI
 	// The URI used to access the http server that allocates test data
 	TestDataServerURI string
-	// The number of seconds to wait before shutting down private
-	// networks. A non-zero value may be useful to ensure all metrics
-	// can be scraped before shutdown.
-	PrivateNetworkShutdownDelay uint
+	// The duration to wait before shutting down private networks. A
+	// non-zero value may be useful to ensure all metrics can be
+	// scraped before shutdown.
+	PrivateNetworkShutdownDelay time.Duration
 
 	require *require.Assertions
 }

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -12,10 +12,11 @@ import (
 )
 
 type FlagVars struct {
-	avalancheGoExecPath string
-	pluginDir           string
-	networkDir          string
-	useExistingNetwork  bool
+	avalancheGoExecPath  string
+	pluginDir            string
+	networkDir           string
+	useExistingNetwork   bool
+	networkShutdownDelay uint
 }
 
 func (v *FlagVars) AvalancheGoExecPath() string {
@@ -38,6 +39,10 @@ func (v *FlagVars) NetworkDir() string {
 
 func (v *FlagVars) UseExistingNetwork() bool {
 	return v.useExistingNetwork
+}
+
+func (v *FlagVars) NetworkShutdownDelay() uint {
+	return v.networkShutdownDelay
 }
 
 func RegisterFlags() *FlagVars {
@@ -65,6 +70,12 @@ func RegisterFlags() *FlagVars {
 		"use-existing-network",
 		false,
 		"[optional] whether to target the existing network identified by --network-dir.",
+	)
+	flag.UintVar(
+		&vars.networkShutdownDelay,
+		"network-shutdown-delay",
+		0,
+		"[optional] the number of seconds to wait before shutting down the test network at the end of the test run. If collecting metrics, a value greater than the scrape interval is suggested.",
 	)
 
 	return &vars

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -74,8 +74,8 @@ func RegisterFlags() *FlagVars {
 	flag.UintVar(
 		&vars.networkShutdownDelay,
 		"network-shutdown-delay",
-		0,
-		"[optional] the number of seconds to wait before shutting down the test network at the end of the test run. If collecting metrics, a value greater than the scrape interval is suggested.",
+		12, // Make sure this value takes into account the scrape_interval defined in scripts/run_prometheus.sh
+		"[optional] the number of seconds to wait before shutting down the test network at the end of the test run. A value greater than the scrape interval is suggested. 0 avoids waiting for shutdown.",
 	)
 
 	return &vars

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 )
@@ -16,7 +17,7 @@ type FlagVars struct {
 	pluginDir            string
 	networkDir           string
 	useExistingNetwork   bool
-	networkShutdownDelay uint
+	networkShutdownDelay time.Duration
 }
 
 func (v *FlagVars) AvalancheGoExecPath() string {
@@ -41,7 +42,7 @@ func (v *FlagVars) UseExistingNetwork() bool {
 	return v.useExistingNetwork
 }
 
-func (v *FlagVars) NetworkShutdownDelay() uint {
+func (v *FlagVars) NetworkShutdownDelay() time.Duration {
 	return v.networkShutdownDelay
 }
 
@@ -71,11 +72,11 @@ func RegisterFlags() *FlagVars {
 		false,
 		"[optional] whether to target the existing network identified by --network-dir.",
 	)
-	flag.UintVar(
+	flag.DurationVar(
 		&vars.networkShutdownDelay,
 		"network-shutdown-delay",
-		12, // Make sure this value takes into account the scrape_interval defined in scripts/run_prometheus.sh
-		"[optional] the number of seconds to wait before shutting down the test network at the end of the test run. A value greater than the scrape interval is suggested. 0 avoids waiting for shutdown.",
+		12*time.Second, // Make sure this value takes into account the scrape_interval defined in scripts/run_prometheus.sh
+		"[optional] the duration to wait before shutting down the test network at the end of the test run. A value greater than the scrape interval is suggested. 0 avoids waiting for shutdown.",
 	)
 
 	return &vars

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -216,7 +216,7 @@ func CheckBootstrapIsPossible(network *tmpnet.Network) {
 }
 
 // Start a temporary network with the provided avalanchego binary.
-func StartNetwork(network *tmpnet.Network, avalancheGoExecPath string, pluginDir string) {
+func StartNetwork(network *tmpnet.Network, avalancheGoExecPath string, pluginDir string, shutdownDelay uint) {
 	require := require.New(ginkgo.GinkgoT())
 
 	require.NoError(
@@ -232,6 +232,11 @@ func StartNetwork(network *tmpnet.Network, avalancheGoExecPath string, pluginDir
 	)
 
 	ginkgo.DeferCleanup(func() {
+		if shutdownDelay > 0 {
+			tests.Outf("Waiting %d seconds before network shutdown to ensure final metrics scrape\n", shutdownDelay)
+			time.Sleep(time.Duration(shutdownDelay) * time.Second)
+		}
+
 		tests.Outf("Shutting down network\n")
 		ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 		defer cancel()

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -216,7 +216,7 @@ func CheckBootstrapIsPossible(network *tmpnet.Network) {
 }
 
 // Start a temporary network with the provided avalanchego binary.
-func StartNetwork(network *tmpnet.Network, avalancheGoExecPath string, pluginDir string, shutdownDelay uint) {
+func StartNetwork(network *tmpnet.Network, avalancheGoExecPath string, pluginDir string, shutdownDelay time.Duration) {
 	require := require.New(ginkgo.GinkgoT())
 
 	require.NoError(
@@ -233,8 +233,8 @@ func StartNetwork(network *tmpnet.Network, avalancheGoExecPath string, pluginDir
 
 	ginkgo.DeferCleanup(func() {
 		if shutdownDelay > 0 {
-			tests.Outf("Waiting %d seconds before network shutdown to ensure final metrics scrape\n", shutdownDelay)
-			time.Sleep(time.Duration(shutdownDelay) * time.Second)
+			tests.Outf("Waiting %s before network shutdown to ensure final metrics scrape\n", shutdownDelay)
+			time.Sleep(shutdownDelay)
 		}
 
 		tests.Outf("Shutting down network\n")

--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -130,6 +130,8 @@ HOME
 └── .tmpnet                                              // Root path for the temporary network fixture
     ├── prometheus                                       // Working directory for a metrics-scraping prometheus instance
     │   └── file_sd_configs                              // Directory containing file-based service discovery config for prometheus
+    ├── promtail                                         // Working directory for a log-collecting promtail instance
+    │   └── file_sd_configs                              // Directory containing file-based service discovery config for promtail
     └── networks                                         // Default parent directory for temporary networks
         └── 20240306-152305.924531                       // The timestamp of creation is the name of a network's directory
             ├── NodeID-37E8UK3x2YFsHE3RdALmfWcppcZ1eTuj9 // The ID of a node is the name of its data dir

--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -128,6 +128,8 @@ A temporary network relies on configuration written to disk in the following str
 ```
 HOME
 └── .tmpnet                                              // Root path for the temporary network fixture
+    ├── prometheus                                       // Working directory for a metrics-scraping prometheus instance
+    │   └── file_sd_configs                              // Directory containing file-based service discovery config for prometheus
     └── networks                                         // Default parent directory for temporary networks
         └── 20240306-152305.924531                       // The timestamp of creation is the name of a network's directory
             ├── NodeID-37E8UK3x2YFsHE3RdALmfWcppcZ1eTuj9 // The ID of a node is the name of its data dir

--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -231,3 +231,44 @@ The process details of a node are written by avalanchego to
 `[base-data-dir]/process.json`. The file contains the PID of the node
 process, the URI of the node's API, and the address other nodes can
 use to bootstrap themselves (aka staking address).
+
+## Metrics
+
+### Prometheus configuration
+
+When nodes are started, prometheus configuration for each node is
+written to `~/.tmpnet/prometheus/file_sd_configs/` with a filename of
+`[network uuid]-[node id].json`. Prometheus can be configured to
+scrape the nodes as per the following example:
+
+```yaml
+scrape_configs:
+  - job_name: "avalanchego"
+    metrics_path: "/ext/metrics"
+    file_sd_configs:
+      - files:
+        - '/home/me/.tmpnet/prometheus/file_sd_configs/*.yaml'
+```
+
+### Viewing metrics
+
+When  a network  is  started with  `tmpnet`, a  grafana  link for  the
+network's metrics will be emitted.
+
+The metrics emitted by temporary networks configured with tmpnet will
+have the following labels applied:
+
+ - `network_uuid`
+ - `node_id`
+ - `is_ephemeral_node`
+ - `network_owner`
+
+When a tmpnet network runs as part of github CI, the following
+additional labels will be applied:
+
+ - `gh_repo`
+ - `gh_workflow`
+ - `gh_run_id`
+ - `gh_run_number`
+ - `gh_run_attempt`
+ - `gh_job_id`

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -687,22 +687,21 @@ func (n *Network) getBootstrapIPsAndIDs(skippedNode *Node) ([]string, []string, 
 	return bootstrapIPs, bootstrapIDs, nil
 }
 
+// Retrieves the default path of the given network child dir.
+func getTmpnetPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".tmpnet"), nil
+}
+
 // Retrieves the default root dir for storing networks and their
 // configuration.
 func getDefaultRootNetworkDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
+	tmpnetPath, err := getTmpnetPath()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(homeDir, ".tmpnet", "networks"), nil
-}
-
-// Retrieves the default dir for writing service discovery
-// configuration for prometheus.
-func getPrometheusServiceDiscoveryDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(homeDir, ".tmpnet", "prometheus", "file_sd_configs"), nil
+	return filepath.Join(tmpnetPath, "networks"), nil
 }

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -71,7 +71,9 @@ type Network struct {
 	// unique network ID values across all temporary networks.
 	UUID string
 
-	// A string identifying the entity that started or maintains this network.
+	// A string identifying the entity that started or maintains this
+	// network. Useful for differentiating between networks when a
+	// given CI job uses multiple networks.
 	Owner string
 
 	// Path where network configuration and data is stored
@@ -464,6 +466,9 @@ func (n *Network) EnsureNodeConfig(node *Node) error {
 
 	// Ensure nodes can write include the network uuid in their monitoring configuration
 	node.NetworkUUID = n.UUID
+
+	// Ensure nodes can label metrics with an indication of the shared/private nature of the network
+	node.NetworkOwner = n.Owner
 
 	// Set the network name if available
 	if n.Genesis != nil && n.Genesis.NetworkID > 0 {

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -321,7 +321,8 @@ func (n *Network) Start(ctx context.Context, w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "\nStarted network %s (UUID: %s)\n", n.Dir, n.UUID); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(w, "\nMetrics: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?var-network_uuid=%s\n", n.UUID); err != nil {
+	// Provide a link the main dashboard filtered by the uuid and showing results for now till whenever the link is viewed
+	if _, err := fmt.Fprintf(w, "\nMetrics: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?&var-adhoc=network_uuid%%7C%%3D%%7C%s&from=%d&to=now\n", n.UUID, time.Now().UnixMilli()); err != nil {
 		return err
 	}
 

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -326,7 +326,7 @@ func (n *Network) Start(ctx context.Context, w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "\nStarted network %s (UUID: %s)\n", n.Dir, n.UUID); err != nil {
 		return err
 	}
-	// Provide a link the main dashboard filtered by the uuid and showing results for now till whenever the link is viewed
+	// Provide a link to the main dashboard filtered by the uuid and showing results from now till whenever the link is viewed
 	if _, err := fmt.Fprintf(w, "\nMetrics: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?&var-filter=network_uuid%%7C%%3D%%7C%s&var-filter=is_ephemeral_node%%7C%%3D%%7Cfalse&from=%d&to=now\n", n.UUID, startTime.UnixMilli()); err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func (n *Network) Restart(ctx context.Context, w io.Writer) error {
 func (n *Network) EnsureNodeConfig(node *Node) error {
 	flags := node.Flags
 
-	// Ensure nodes can write include the network uuid in their monitoring configuration
+	// Ensure nodes can label their metrics with the network uuid
 	node.NetworkUUID = n.UUID
 
 	// Ensure nodes can label metrics with an indication of the shared/private nature of the network
@@ -687,7 +687,7 @@ func (n *Network) getBootstrapIPsAndIDs(skippedNode *Node) ([]string, []string, 
 	return bootstrapIPs, bootstrapIDs, nil
 }
 
-// Retrieves the default path of the given network child dir.
+// Retrieves the root dir for tmpnet data.
 func getTmpnetPath() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -305,6 +305,9 @@ func (n *Network) Start(ctx context.Context, w io.Writer) error {
 		return err
 	}
 
+	// Record the time before nodes are started to ensure visibility of subsequently collected metrics via the emitted link
+	startTime := time.Now()
+
 	// Configure the networking for each node and start
 	for _, node := range n.Nodes {
 		if err := n.StartNode(ctx, w, node); err != nil {
@@ -322,7 +325,7 @@ func (n *Network) Start(ctx context.Context, w io.Writer) error {
 		return err
 	}
 	// Provide a link the main dashboard filtered by the uuid and showing results for now till whenever the link is viewed
-	if _, err := fmt.Fprintf(w, "\nMetrics: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?&var-adhoc=network_uuid%%7C%%3D%%7C%s&from=%d&to=now\n", n.UUID, time.Now().UnixMilli()); err != nil {
+	if _, err := fmt.Fprintf(w, "\nMetrics: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?&var-filter=network_uuid%%7C%%3D%%7C%s&var-filter=is_ephemeral_node%%7C%%3D%%7Cfalse&from=%d&to=now\n", n.UUID, startTime.UnixMilli()); err != nil {
 		return err
 	}
 

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -56,6 +56,13 @@ type Node struct {
 	// Uniquely identifies the network the node is part of to enable monitoring.
 	NetworkUUID string
 
+	// Identify the entity associated with this network. This is
+	// intended to be used to label metrics to enable filtering
+	// results for a test run between the primary/shared network used
+	// by the majority of tests and private networks used by
+	// individual tests.
+	NetworkOwner string
+
 	// Set by EnsureNodeID which is also called when the node is read.
 	NodeID ids.NodeID
 

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -53,6 +53,9 @@ type NodeRuntimeConfig struct {
 
 // Node supports configuring and running a node participating in a temporary network.
 type Node struct {
+	// Uniquely identifies the network the node is part of to enable monitoring.
+	NetworkUUID string
+
 	// Set by EnsureNodeID which is also called when the node is read.
 	NodeID ids.NodeID
 

--- a/tests/fixture/tmpnet/node_config.go
+++ b/tests/fixture/tmpnet/node_config.go
@@ -62,6 +62,7 @@ func (n *Node) readConfig() error {
 
 type serializedNodeConfig struct {
 	NetworkUUID   string
+	NetworkOwner  string
 	IsEphemeral   bool
 	RuntimeConfig *NodeRuntimeConfig
 }
@@ -69,6 +70,7 @@ type serializedNodeConfig struct {
 func (n *Node) writeConfig() error {
 	config := serializedNodeConfig{
 		NetworkUUID:   n.NetworkUUID,
+		NetworkOwner:  n.NetworkOwner,
 		IsEphemeral:   n.IsEphemeral,
 		RuntimeConfig: n.RuntimeConfig,
 	}

--- a/tests/fixture/tmpnet/node_config.go
+++ b/tests/fixture/tmpnet/node_config.go
@@ -61,12 +61,14 @@ func (n *Node) readConfig() error {
 }
 
 type serializedNodeConfig struct {
+	NetworkUUID   string
 	IsEphemeral   bool
 	RuntimeConfig *NodeRuntimeConfig
 }
 
 func (n *Node) writeConfig() error {
 	config := serializedNodeConfig{
+		NetworkUUID:   n.NetworkUUID,
 		IsEphemeral:   n.IsEphemeral,
 		RuntimeConfig: n.RuntimeConfig,
 	}

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -304,6 +304,7 @@ func (p *NodeProcess) writePrometheusConfig() error {
 				"network_uuid":      p.node.NetworkUUID,
 				"node_id":           p.node.NodeID,
 				"is_ephemeral_node": strconv.FormatBool(p.node.IsEphemeral),
+				"network_owner":     p.node.NetworkOwner,
 				// Prometheus ignores empty values so running this outside
 				// of a github worker should have no ill-effect.
 				"gh_repo":        os.Getenv("GH_REPO"),

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -301,16 +301,17 @@ func (p *NodeProcess) writePrometheusConfig() error {
 		{
 			"targets": []string{strings.TrimPrefix(p.node.URI, "http://")},
 			"labels": FlagsMap{
-				"network_uuid": p.node.NetworkUUID,
-				"node_id":      p.node.NodeID,
-				"is_ephemeral": strconv.FormatBool(p.node.IsEphemeral),
+				"network_uuid":      p.node.NetworkUUID,
+				"node_id":           p.node.NodeID,
+				"is_ephemeral_node": strconv.FormatBool(p.node.IsEphemeral),
 				// Prometheus ignores empty values so running this outside
-				// of a github worker will have no ill-effect.
+				// of a github worker should have no ill-effect.
 				"gh_repo":        os.Getenv("GH_REPO"),
-				"gh_job_id":      os.Getenv("GH_JOB_ID"),
+				"gh_workflow":    os.Getenv("GH_WORKFLOW"),
 				"gh_run_id":      os.Getenv("GH_RUN_ID"),
 				"gh_run_number":  os.Getenv("GH_RUN_NUMBER"),
 				"gh_run_attempt": os.Getenv("GH_RUN_ATTEMPT"),
+				"gh_job_id":      os.Getenv("GH_JOB_ID"),
 			},
 		},
 	}

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("[Upgrade]", func() {
 		network := &tmpnet.Network{
 			Owner: "avalanchego-upgrade",
 		}
-		e2e.StartNetwork(network, avalancheGoExecPath, "" /* pluginDir */)
+		e2e.StartNetwork(network, avalancheGoExecPath, "" /* pluginDir */, 0 /* shutdownDelay */)
 
 		ginkgo.By(fmt.Sprintf("restarting all nodes with %q binary", avalancheGoExecPathToUpgradeTo))
 		for _, node := range network.Nodes {


### PR DESCRIPTION
## Why this should be merged

Temporary networks used for testing previously lacked an easy way to enable collection of logs and metrics. This PR ensures that prometheus can collect metrics and promtail can collect logs. A separate effort stood up a central monitoring stack that the metrics and logs can be shipped to, and tmpnet and CI jobs will output links to the central grafana instance. 

## How this works

- Writes configuration to `~/.tmpnet/prometheus/file_sd_configs` and `~/tmpnet/promtail/file_sd_configs` for each node on startup and removes it on shutdown. This enables collection from all nodes no matter when they are started.
  - See: https://prometheus.io/docs/guides/file-sd/
- Adds script to run prometheus in agent mode to collect metrics
- Adds script to run promtail to collect logs

Look for metrics links (to grafana-experimental) in the CI logs. 

## How this was tested

Verified that the 'Notify' annotations on a CI summary page link to a populated grafana dashboard.  

## TODO
 - [x] Merge #2763 
 - [x] Add script to collect metrics with promtail
 - [x] Enable experimental loki instance
 - [x] Add dns for experimental loki
 - [x] Integrate loki with experimental grafana