### PR TITLE
Remove pre-Durango checks in BLS key verification

### DIFF
--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -716,20 +716,12 @@ func (p *peer) shouldDisconnect() bool {
 		return false
 	}
 
-	postDurango := p.Clock.Time().After(version.GetDurangoTime(constants.MainnetID))
-	if postDurango && p.ip.BLSSignature == nil {
+	if p.ip.BLSSignature == nil {
 		p.Log.Debug("disconnecting from peer",
 			zap.String("reason", "missing BLS signature"),
 			zap.Stringer("nodeID", p.id),
 		)
 		return true
-	}
-
-	// If Durango hasn't activated on mainnet yet, we don't require BLS
-	// signatures to be provided. However, if they are provided, verify that
-	// they are correct.
-	if p.ip.BLSSignature == nil {
-		return false
 	}
 
 	validSignature := bls.VerifyProofOfPossession(

--- a/network/peer/peer_test.go
+++ b/network/peer/peer_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/math/meter"
 	"github.com/ava-labs/avalanchego/utils/resource"
 	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/version"
 )
 
@@ -591,14 +590,9 @@ func TestShouldDisconnect(t *testing.T) {
 			expectedShouldDisconnect: false,
 		},
 		{
-			name: "past durango without a signature",
+			name: "peer without signature",
 			initialPeer: &peer{
 				Config: &Config{
-					Clock: func() mockable.Clock {
-						clk := mockable.Clock{}
-						clk.Set(mockable.MaxTime)
-						return clk
-					}(),
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(constants.UnitTestID),
 					Validators: func() validators.Manager {
@@ -619,11 +613,6 @@ func TestShouldDisconnect(t *testing.T) {
 			},
 			expectedPeer: &peer{
 				Config: &Config{
-					Clock: func() mockable.Clock {
-						clk := mockable.Clock{}
-						clk.Set(mockable.MaxTime)
-						return clk
-					}(),
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(constants.UnitTestID),
 					Validators: func() validators.Manager {
@@ -645,68 +634,9 @@ func TestShouldDisconnect(t *testing.T) {
 			expectedShouldDisconnect: true,
 		},
 		{
-			name: "pre durango without a signature",
+			name: "peer with invalid signature",
 			initialPeer: &peer{
 				Config: &Config{
-					Clock: func() mockable.Clock {
-						clk := mockable.Clock{}
-						clk.Set(time.Time{})
-						return clk
-					}(),
-					Log:                  logging.NoLog{},
-					VersionCompatibility: version.GetCompatibility(constants.UnitTestID),
-					Validators: func() validators.Manager {
-						vdrs := validators.NewManager()
-						require.NoError(t, vdrs.AddStaker(
-							constants.PrimaryNetworkID,
-							peerID,
-							bls.PublicFromSecretKey(blsKey),
-							txID,
-							1,
-						))
-						return vdrs
-					}(),
-				},
-				id:      peerID,
-				version: version.CurrentApp,
-				ip:      &SignedIP{},
-			},
-			expectedPeer: &peer{
-				Config: &Config{
-					Clock: func() mockable.Clock {
-						clk := mockable.Clock{}
-						clk.Set(time.Time{})
-						return clk
-					}(),
-					Log:                  logging.NoLog{},
-					VersionCompatibility: version.GetCompatibility(constants.UnitTestID),
-					Validators: func() validators.Manager {
-						vdrs := validators.NewManager()
-						require.NoError(t, vdrs.AddStaker(
-							constants.PrimaryNetworkID,
-							peerID,
-							bls.PublicFromSecretKey(blsKey),
-							txID,
-							1,
-						))
-						return vdrs
-					}(),
-				},
-				id:      peerID,
-				version: version.CurrentApp,
-				ip:      &SignedIP{},
-			},
-			expectedShouldDisconnect: false,
-		},
-		{
-			name: "pre durango with an invalid signature",
-			initialPeer: &peer{
-				Config: &Config{
-					Clock: func() mockable.Clock {
-						clk := mockable.Clock{}
-						clk.Set(time.Time{})
-						return clk
-					}(),
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(constants.UnitTestID),
 					Validators: func() validators.Manager {
@@ -729,11 +659,6 @@ func TestShouldDisconnect(t *testing.T) {
 			},
 			expectedPeer: &peer{
 				Config: &Config{
-					Clock: func() mockable.Clock {
-						clk := mockable.Clock{}
-						clk.Set(time.Time{})
-						return clk
-					}(),
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(constants.UnitTestID),
 					Validators: func() validators.Manager {
@@ -757,14 +682,9 @@ func TestShouldDisconnect(t *testing.T) {
 			expectedShouldDisconnect: true,
 		},
 		{
-			name: "pre durango with a valid signature",
+			name: "peer with valid signature",
 			initialPeer: &peer{
 				Config: &Config{
-					Clock: func() mockable.Clock {
-						clk := mockable.Clock{}
-						clk.Set(time.Time{})
-						return clk
-					}(),
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(constants.UnitTestID),
 					Validators: func() validators.Manager {
@@ -787,11 +707,6 @@ func TestShouldDisconnect(t *testing.T) {
 			},
 			expectedPeer: &peer{
 				Config: &Config{
-					Clock: func() mockable.Clock {
-						clk := mockable.Clock{}
-						clk.Set(time.Time{})
-						return clk
-					}(),
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(constants.UnitTestID),
 					Validators: func() validators.Manager {


### PR DESCRIPTION
## Why this should be merged

Durango is live - this is dead code.

## How this works

Removes dead code.

## How this was tested

- [X] CI