### PR TITLE
[snow/networking] Enforce `PreferredIDAtHeight` in `Chits` messages

### DIFF
--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -716,9 +716,7 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 				zap.String("field", "PreferredIDAtHeight"),
 				zap.Error(err),
 			)
-			// TODO: Require this field to be populated correctly after v1.11.x
-			// is activated.
-			preferredIDAtHeight = preferredID
+			return engine.QueryFailed(ctx, nodeID, msg.RequestId)
 		}
 
 		acceptedID, err := ids.ToID(msg.AcceptedId)


### PR DESCRIPTION
## Why this should be merged

Durango is live, time to enforce.

## How this works

Return query failed when the field is incorrectly populated.

## How this was tested

CI