### PR TITLE
Fix `tmpnetctl` Restart

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -433,12 +433,16 @@ func (n *Network) Restart(ctx context.Context, w io.Writer) error {
 		if err := n.StartNode(ctx, w, node); err != nil {
 			return fmt.Errorf("failed to start node %s: %w", node.NodeID, err)
 		}
-		if _, err := fmt.Fprintf(w, " waiting for node %s to report healthy\n", node.NodeID); err != nil {
-			return err
-		}
-		if err := WaitForHealthy(ctx, node); err != nil {
-			return err
-		}
+	}
+
+	if _, err := fmt.Fprintf(w, "Waiting for all nodes to report healthy...\n\n"); err != nil {
+		return err
+	}
+	if err := n.WaitForHealthy(ctx, w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "\nRestarted network %d @ %s\n", n.Genesis.NetworkID, n.Dir); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Why this should be merged
Currently `tmpnetctl restart-network` fails to restart the network because it tries and wait for helthness of every single node it launches. This is different from how `tmpnetctl start-network` starts a network, where all nodes are started altogether and only then it waits for all nodes to turn healthy.
This PR fixes the issue by using the same wait logic for both start and restart network

## How this works
Just move the `WaitForHealthy` outside of the loop starting nodes.

## How this was tested
Manual testing