### PR TITLE
Remove useless bootstrapping metric

### DIFF
--- a/snow/engine/avalanche/bootstrap/bootstrapper.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper.go
@@ -325,7 +325,6 @@ func (b *bootstrapper) Start(ctx context.Context, startReqID uint32) error {
 	if err := b.VtxBlocked.SetParser(ctx, &vtxParser{
 		log:         b.Ctx.Log,
 		numAccepted: b.numAcceptedVts,
-		numDropped:  b.numDroppedVts,
 		manager:     b.Manager,
 	}); err != nil {
 		return err
@@ -334,7 +333,6 @@ func (b *bootstrapper) Start(ctx context.Context, startReqID uint32) error {
 	if err := b.TxBlocked.SetParser(&txParser{
 		log:         b.Ctx.Log,
 		numAccepted: b.numAcceptedTxs,
-		numDropped:  b.numDroppedTxs,
 		vm:          b.VM,
 	}); err != nil {
 		return err
@@ -475,7 +473,6 @@ func (b *bootstrapper) process(ctx context.Context, vtxs ...avalanche.Vertex) er
 			pushed, err := b.VtxBlocked.Push(ctx, &vertexJob{
 				log:         b.Ctx.Log,
 				numAccepted: b.numAcceptedVts,
-				numDropped:  b.numDroppedVts,
 				vtx:         vtx,
 			})
 			if err != nil {
@@ -497,7 +494,6 @@ func (b *bootstrapper) process(ctx context.Context, vtxs ...avalanche.Vertex) er
 				pushed, err := b.TxBlocked.Push(ctx, &txJob{
 					log:         b.Ctx.Log,
 					numAccepted: b.numAcceptedTxs,
-					numDropped:  b.numDroppedTxs,
 					tx:          tx,
 				})
 				if err != nil {

--- a/snow/engine/avalanche/bootstrap/metrics.go
+++ b/snow/engine/avalanche/bootstrap/metrics.go
@@ -10,8 +10,8 @@ import (
 )
 
 type metrics struct {
-	numFetchedVts, numDroppedVts, numAcceptedVts,
-	numFetchedTxs, numDroppedTxs, numAcceptedTxs prometheus.Counter
+	numFetchedVts, numAcceptedVts,
+	numFetchedTxs, numAcceptedTxs prometheus.Counter
 }
 
 func (m *metrics) Initialize(
@@ -22,11 +22,6 @@ func (m *metrics) Initialize(
 		Namespace: namespace,
 		Name:      "fetched_vts",
 		Help:      "Number of vertices fetched during bootstrapping",
-	})
-	m.numDroppedVts = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "dropped_vts",
-		Help:      "Number of vertices dropped during bootstrapping",
 	})
 	m.numAcceptedVts = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
@@ -39,11 +34,6 @@ func (m *metrics) Initialize(
 		Name:      "fetched_txs",
 		Help:      "Number of transactions fetched during bootstrapping",
 	})
-	m.numDroppedTxs = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "dropped_txs",
-		Help:      "Number of transactions dropped during bootstrapping",
-	})
 	m.numAcceptedTxs = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "accepted_txs",
@@ -52,10 +42,8 @@ func (m *metrics) Initialize(
 
 	return utils.Err(
 		registerer.Register(m.numFetchedVts),
-		registerer.Register(m.numDroppedVts),
 		registerer.Register(m.numAcceptedVts),
 		registerer.Register(m.numFetchedTxs),
-		registerer.Register(m.numDroppedTxs),
 		registerer.Register(m.numAcceptedTxs),
 	)
 }

--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -170,7 +170,6 @@ func (b *Bootstrapper) Start(ctx context.Context, startReqID uint32) error {
 	b.parser = &parser{
 		log:         b.Ctx.Log,
 		numAccepted: b.numAccepted,
-		numDropped:  b.numDropped,
 		vm:          b.VM,
 	}
 	if err := b.Blocked.SetParser(ctx, b.parser); err != nil {
@@ -616,7 +615,6 @@ func (b *Bootstrapper) process(ctx context.Context, blk snowman.Block, processin
 		pushed, err := b.Blocked.Push(ctx, &blockJob{
 			log:         b.Ctx.Log,
 			numAccepted: b.numAccepted,
-			numDropped:  b.numDropped,
 			blk:         blk,
 			vm:          b.VM,
 		})

--- a/snow/engine/snowman/bootstrap/bootstrapper_test.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper_test.go
@@ -1386,7 +1386,6 @@ func TestBootstrapNoParseOnNew(t *testing.T) {
 	pushed, err := blocker.Push(context.Background(), &blockJob{
 		log:         logging.NoLog{},
 		numAccepted: prometheus.NewCounter(prometheus.CounterOpts{}),
-		numDropped:  prometheus.NewCounter(prometheus.CounterOpts{}),
 		blk:         blk1,
 		vm:          vm,
 	})

--- a/snow/engine/snowman/bootstrap/metrics.go
+++ b/snow/engine/snowman/bootstrap/metrics.go
@@ -10,8 +10,8 @@ import (
 )
 
 type metrics struct {
-	numFetched, numDropped, numAccepted prometheus.Counter
-	fetchETA                            prometheus.Gauge
+	numFetched, numAccepted prometheus.Counter
+	fetchETA                prometheus.Gauge
 }
 
 func newMetrics(namespace string, registerer prometheus.Registerer) (*metrics, error) {
@@ -20,11 +20,6 @@ func newMetrics(namespace string, registerer prometheus.Registerer) (*metrics, e
 			Namespace: namespace,
 			Name:      "fetched",
 			Help:      "Number of blocks fetched during bootstrapping",
-		}),
-		numDropped: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "dropped",
-			Help:      "Number of blocks dropped during bootstrapping",
 		}),
 		numAccepted: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
@@ -40,7 +35,6 @@ func newMetrics(namespace string, registerer prometheus.Registerer) (*metrics, e
 
 	err := utils.Err(
 		registerer.Register(m.numFetched),
-		registerer.Register(m.numDropped),
 		registerer.Register(m.numAccepted),
 		registerer.Register(m.fetchETA),
 	)


### PR DESCRIPTION
## Why this should be merged

This metric is only incremented prior to FATALing - so we should just remove it.

## How this works

1. Delete
2. Require that bootstrapping always is able to execute every transaction. This is guaranteed to be the case because the X-chain has been linearized.

## How this was tested

- [x] CI