### PR TITLE
`tmpnet`: Ensure nodes are properly detached from the parent process

### DIFF
--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -7,6 +7,15 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Load the constants
 source "$AVALANCHE_PATH"/scripts/constants.sh
 
-# Ensure execution of fixture unit tests under tests/ but exclude ginkgo tests in tests/e2e and tests/upgrade
-# shellcheck disable=SC2046
-go test -shuffle=on -race -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v /mocks | grep -v proto | grep -v tests/e2e | grep -v tests/upgrade)
+EXCLUDED_TARGETS="| grep -v /mocks | grep -v proto | grep -v tests/e2e | grep -v tests/upgrade"
+
+GOOS=$(go env GOOS)
+if [[ "$GOOS" == "windows" ]]; then
+  # tmpnet is not compatible with windows
+  EXCLUDED_TARGETS="${EXCLUDED_TARGETS} | grep -v tests/fixture"
+fi
+
+TEST_TARGETS="$(eval "go list ./... ${EXCLUDED_TARGETS}")"
+
+# shellcheck disable=SC2086
+go test -shuffle=on -race -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}

--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -46,7 +46,7 @@ func DefaultFlags() FlagsMap {
 		config.HealthCheckFreqKey:               "2s",
 		config.AdminAPIEnabledKey:               true,
 		config.IndexEnabledKey:                  true,
-		config.LogDisplayLevelKey:               "INFO",
+		config.LogDisplayLevelKey:               "off", // Display logging not needed since nodes run headless
 		config.LogLevelKey:                      "DEBUG",
 		config.MinStakeDurationKey:              DefaultMinStakeDuration.String(),
 	}

--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/config"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
 )
 

--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -46,8 +46,8 @@ func DefaultFlags() FlagsMap {
 		config.HealthCheckFreqKey:               "2s",
 		config.AdminAPIEnabledKey:               true,
 		config.IndexEnabledKey:                  true,
-		config.LogDisplayLevelKey:               "off", // Display logging not needed since nodes run headless
-		config.LogLevelKey:                      "DEBUG",
+		config.LogDisplayLevelKey:               logging.Off.String(), // Display logging not needed since nodes run headless
+		config.LogLevelKey:                      logging.Debug.String(),
 		config.MinStakeDurationKey:              DefaultMinStakeDuration.String(),
 	}
 }

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -112,7 +112,7 @@ func (p *NodeProcess) Start(w io.Writer) error {
 		return fmt.Errorf("failed to remove stale process context file: %w", err)
 	}
 
-	// All argument are provided in the flags file
+	// All arguments are provided in the flags file
 	cmd := exec.Command(p.node.RuntimeConfig.AvalancheGoPath, "--config-file", p.node.getFlagsPath()) // #nosec G204
 
 	// Ensure process is detached from the parent process so that an error in the parent will not affect the child

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -120,18 +120,6 @@ func (p *NodeProcess) Start(w io.Writer) error {
 		Setsid: true,
 	}
 
-	// Redirect stdout and stderr to ensure the subprocess is not writing to
-	// the parent's stdout and stderr. Since a node is intended to run
-	// headless and should be logging everything to disk internally, its
-	// direct output can be ignored by sending to /dev/null.
-	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	if err != nil {
-		return fmt.Errorf("failed to open /dev/null: %w", err)
-	}
-	defer devNull.Close()
-	cmd.Stdout = devNull
-	cmd.Stderr = devNull
-
 	if err := cmd.Start(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously tmpnet called `Cmd.Wait` on the node process based on a misreading of the advice of the `Cmd.Start` to ensure that system resources were freed. This ensured that any error in the parent process would result in the node processes being killed.

Now, the child is properly detached by setting `Setsid` and avoiding calling Wait. This ensures that the node restarts required when setting up subnets (e.g. for subnet-evm or hypersdk) do not risk the nodes of an existing network being stopped if the test suite exits non-zero due to a test failure.