### PR TITLE
add upgrade configs to tmpnet

### DIFF
--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -32,7 +32,8 @@ const (
 	// A short minimum stake duration enables testing of staking logic.
 	DefaultMinStakeDuration = time.Second
 
-	defaultConfigFilename = "config.json"
+	defaultConfigFilename  = "config.json"
+	defaultUpgradeFilename = "upgrade.json"
 )
 
 // A set of flags appropriate for testing.

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -648,7 +648,7 @@ func (n *Network) CreateSubnets(ctx context.Context, w io.Writer) error {
 		// If one or more of the subnets chains have explicit configuration, the
 		// subnet's validator nodes will need to be restarted for those nodes to read
 		// the newly written chain configuration and apply it to the chain(s).
-		if subnet.HasChainConfig() {
+		if subnet.HasChainConfig() || subnet.HasUpgradeConfig() {
 			restartRequired = true
 		}
 	}


### PR DESCRIPTION
## Why this should be merged

We can construct e2e tests with later upgrades (precompile-activations, stateupgrades etc in Subnet-EVM) 

## How this works

Adds upgrade config to tmpnet similar to chain configs 

## How this was tested

Locally
