### PR TITLE
`tmpnet`: Improve subnet configuration

### DIFF
--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -154,9 +154,11 @@ HOME
             ├── config.json                              // Common configuration (including defaults and pre-funded keys)
             ├── genesis.json                             // Genesis for all nodes
             ├── network.env                              // Sets network dir env var to simplify network usage
-            └── subnets                                  // Parent directory for subnet definitions
-                ├─ subnet-a.json                         // Configuration for subnet-a and its chain(s)
-                └─ subnet-b.json                         // Configuration for subnet-b and its chain(s)
+            └── subnets                                  // Directory containing subnet config for both avalanchego and tmpnet
+                ├── subnet-a.json                        // tmpnet configuration for subnet-a and its chain(s)
+                ├── subnet-b.json                        // tmpnet configuration for subnet-b and its chain(s)
+                └── 2jRbWtaonb2RP8DEM5DBsd7o2o8d...RqNs9 // The ID of a subnet is the name of its configuration dir
+                    └── config.json                      // avalanchego configuration for subnet
 ```
 
 ### Common networking configuration

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -370,6 +370,37 @@ func (n *Network) StartNode(ctx context.Context, w io.Writer, node *Node) error 
 	return nil
 }
 
+// Restart a single node.
+func (n *Network) RestartNode(ctx context.Context, w io.Writer, node *Node) error {
+	// Ensure the node reuses the same API port across restarts to ensure
+	// consistent labeling of metrics. Otherwise prometheus's automatic
+	// addition of the `instance` label (host:port) results in
+	// segmentation of results for a given node every time the port
+	// changes on restart. This segmentation causes graphs on the grafana
+	// dashboards to display multiple series per graph for a given node,
+	// one for each port that the node used.
+	//
+	// There is a non-zero chance of the port being allocatted to a
+	// different process and the node subsequently being unable to start,
+	// but the alternative is having to update the grafana dashboards
+	// query-by-query to ensure that node metrics ignore the instance
+	// label.
+	if err := node.SaveAPIPort(); err != nil {
+		return err
+	}
+
+	if err := node.Stop(ctx); err != nil {
+		return fmt.Errorf("failed to stop node %s: %w", node.NodeID, err)
+	}
+	if err := n.StartNode(ctx, w, node); err != nil {
+		return fmt.Errorf("failed to start node %s: %w", node.NodeID, err)
+	}
+	if _, err := fmt.Fprintf(w, " waiting for node %s to report healthy\n", node.NodeID); err != nil {
+		return err
+	}
+	return WaitForHealthy(ctx, node)
+}
+
 // Waits until all nodes in the network are healthy.
 func (n *Network) WaitForHealthy(ctx context.Context, w io.Writer) error {
 	ticker := time.NewTicker(networkHealthCheckInterval)
@@ -441,33 +472,7 @@ func (n *Network) Restart(ctx context.Context, w io.Writer) error {
 		return err
 	}
 	for _, node := range n.Nodes {
-		// Ensure the node reuses the same API port across restarts to ensure
-		// consistent labeling of metrics. Otherwise prometheus's automatic
-		// addition of the `instance` label (host:port) results in
-		// segmentation of results for a given node every time the port
-		// changes on restart. This segmentation causes graphs on the grafana
-		// dashboards to display multiple series per graph for a given node,
-		// one for each port that the node used.
-		//
-		// There is a non-zero chance of the port being allocatted to a
-		// different process and the node subsequently being unable to start,
-		// but the alternative is having to update the grafana dashboards
-		// query-by-query to ensure that node metrics ignore the instance
-		// label.
-		if err := node.SaveAPIPort(); err != nil {
-			return err
-		}
-
-		if err := node.Stop(ctx); err != nil {
-			return fmt.Errorf("failed to stop node %s: %w", node.NodeID, err)
-		}
-		if err := n.StartNode(ctx, w, node); err != nil {
-			return fmt.Errorf("failed to start node %s: %w", node.NodeID, err)
-		}
-		if _, err := fmt.Fprintf(w, " waiting for node %s to report healthy\n", node.NodeID); err != nil {
-			return err
-		}
-		if err := WaitForHealthy(ctx, node); err != nil {
+		if err := n.RestartNode(ctx, w, node); err != nil {
 			return err
 		}
 	}
@@ -501,10 +506,20 @@ func (n *Network) EnsureNodeConfig(node *Node) error {
 
 	// Set fields including the network path
 	if len(n.Dir) > 0 {
-		node.Flags.SetDefaults(FlagsMap{
+		defaultFlags := FlagsMap{
 			config.GenesisFileKey:    n.getGenesisPath(),
 			config.ChainConfigDirKey: n.getChainConfigDir(),
-		})
+		}
+
+		// Only set the subnet dir if it exists or the node won't start.
+		subnetDir := n.getSubnetDir()
+		if _, err := os.Stat(subnetDir); err == nil {
+			defaultFlags[config.SubnetConfigDirKey] = subnetDir
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		node.Flags.SetDefaults(defaultFlags)
 
 		// Ensure the node's data dir is configured
 		dataDir := node.getDataDir()
@@ -522,17 +537,26 @@ func (n *Network) EnsureNodeConfig(node *Node) error {
 		}
 	}
 
-	// Ensure available subnets are tracked
+	return nil
+}
+
+// TrackedSubnetsForNode returns the subnet IDs for the given node
+func (n *Network) TrackedSubnetsForNode(nodeID ids.NodeID) string {
 	subnetIDs := make([]string, 0, len(n.Subnets))
 	for _, subnet := range n.Subnets {
 		if subnet.SubnetID == ids.Empty {
+			// Subnet has not yet been created
 			continue
 		}
-		subnetIDs = append(subnetIDs, subnet.SubnetID.String())
+		// Only track subnets that this node validates
+		for _, validatorID := range subnet.ValidatorIDs {
+			if validatorID == nodeID {
+				subnetIDs = append(subnetIDs, subnet.SubnetID.String())
+				break
+			}
+		}
 	}
-	flags[config.TrackSubnetsKey] = strings.Join(subnetIDs, ",")
-
-	return nil
+	return strings.Join(subnetIDs, ",")
 }
 
 func (n *Network) GetSubnet(name string) *Subnet {
@@ -544,16 +568,20 @@ func (n *Network) GetSubnet(name string) *Subnet {
 	return nil
 }
 
-// Ensure that each subnet on the network is created and that it is validated by all non-ephemeral nodes.
+// Ensure that each subnet on the network is created.
 func (n *Network) CreateSubnets(ctx context.Context, w io.Writer) error {
 	createdSubnets := make([]*Subnet, 0, len(n.Subnets))
 	for _, subnet := range n.Subnets {
-		if _, err := fmt.Fprintf(w, "Creating subnet %q\n", subnet.Name); err != nil {
-			return err
+		if len(subnet.ValidatorIDs) == 0 {
+			return fmt.Errorf("subnet %s needs at least one validator", subnet.SubnetID)
 		}
 		if subnet.SubnetID != ids.Empty {
 			// The subnet already exists
 			continue
+		}
+
+		if _, err := fmt.Fprintf(w, "Creating subnet %q\n", subnet.Name); err != nil {
+			return err
 		}
 
 		if subnet.OwningKey == nil {
@@ -599,34 +627,53 @@ func (n *Network) CreateSubnets(ctx context.Context, w io.Writer) error {
 		return err
 	}
 
-	// Reconfigure nodes for the new subnets
-	if _, err := fmt.Fprintf(w, "Configured nodes to track new subnet(s). Restart is required.\n"); err != nil {
+	if _, err := fmt.Fprintf(w, "Restarting node(s) to enable them to track the new subnet(s)\n"); err != nil {
 		return err
 	}
+	reconfiguredNodes := []*Node{}
 	for _, node := range n.Nodes {
-		if err := n.EnsureNodeConfig(node); err != nil {
+		existingTrackedSubnets, err := node.Flags.GetStringVal(config.TrackSubnetsKey)
+		if err != nil {
+			return err
+		}
+		trackedSubnets := n.TrackedSubnetsForNode(node.NodeID)
+		if existingTrackedSubnets == trackedSubnets {
+			continue
+		}
+		node.Flags[config.TrackSubnetsKey] = trackedSubnets
+		reconfiguredNodes = append(reconfiguredNodes, node)
+	}
+	for _, node := range reconfiguredNodes {
+		if err := n.RestartNode(ctx, w, node); err != nil {
 			return err
 		}
 	}
-	// Restart nodes to allow new configuration to take effect
-	// TODO(marun) Only restart the validator nodes of newly-created subnets
-	if err := n.Restart(ctx, w); err != nil {
-		return err
-	}
 
-	// Add each node as a subnet validator
+	// Add validators for the subnet
 	for _, subnet := range createdSubnets {
 		if _, err := fmt.Fprintf(w, "Adding validators for subnet %q\n", subnet.Name); err != nil {
 			return err
 		}
-		if err := subnet.AddValidators(ctx, w, n.Nodes); err != nil {
+
+		// Collect the nodes intended to validate the subnet
+		validatorIDs := set.NewSet[ids.NodeID](len(subnet.ValidatorIDs))
+		validatorIDs.Add(subnet.ValidatorIDs...)
+		validatorNodes := []*Node{}
+		for _, node := range n.Nodes {
+			if !validatorIDs.Contains(node.NodeID) {
+				continue
+			}
+			validatorNodes = append(validatorNodes, node)
+		}
+
+		if err := subnet.AddValidators(ctx, w, validatorNodes...); err != nil {
 			return err
 		}
 	}
 
 	// Wait for nodes to become subnet validators
 	pChainClient := platformvm.NewClient(n.Nodes[0].URI)
-	restartRequired := false
+	validatorsToRestart := set.Set[ids.NodeID]{}
 	for _, subnet := range createdSubnets {
 		if err := waitForActiveValidators(ctx, w, pChainClient, subnet); err != nil {
 			return err
@@ -649,17 +696,29 @@ func (n *Network) CreateSubnets(ctx context.Context, w io.Writer) error {
 		// subnet's validator nodes will need to be restarted for those nodes to read
 		// the newly written chain configuration and apply it to the chain(s).
 		if subnet.HasChainConfig() {
-			restartRequired = true
+			validatorsToRestart.Add(subnet.ValidatorIDs...)
 		}
 	}
 
-	if !restartRequired {
+	if len(validatorsToRestart) == 0 {
 		return nil
 	}
 
+	if _, err := fmt.Fprintf(w, "Restarting node(s) to pick up chain configuration\n"); err != nil {
+		return err
+	}
+
 	// Restart nodes to allow configuration for the new chains to take effect
-	// TODO(marun) Only restart the validator nodes of subnets that have chains that need configuring
-	return n.Restart(ctx, w)
+	for _, node := range n.Nodes {
+		if !validatorsToRestart.Contains(node.NodeID) {
+			continue
+		}
+		if err := n.RestartNode(ctx, w, node); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (n *Network) GetURIForNodeID(nodeID ids.NodeID) (string, error) {

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -515,7 +515,7 @@ func (n *Network) EnsureNodeConfig(node *Node) error {
 		subnetDir := n.getSubnetDir()
 		if _, err := os.Stat(subnetDir); err == nil {
 			defaultFlags[config.SubnetConfigDirKey] = subnetDir
-		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		} else if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -30,8 +30,8 @@ const defaultSubnetDirName = "subnets"
 type Chain struct {
 	// Set statically
 	VMID    ids.ID
-	Config  string
-	Genesis []byte
+	Config  FlagsMap
+	Genesis FlagsMap
 
 	// Set at runtime
 	ChainID      ids.ID
@@ -40,6 +40,7 @@ type Chain struct {
 
 // Write the chain configuration to the specified directory.
 func (c *Chain) WriteConfig(chainDir string) error {
+	// TODO(marun) Ensure removal of an existing file if no configuration should be provided
 	if len(c.Config) == 0 {
 		return nil
 	}
@@ -49,8 +50,12 @@ func (c *Chain) WriteConfig(chainDir string) error {
 		return fmt.Errorf("failed to create chain config dir: %w", err)
 	}
 
+	bytes, err := DefaultJSONMarshal(c.Config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config for chain %s: %w", c.ChainID, err)
+	}
 	path := filepath.Join(chainConfigDir, defaultConfigFilename)
-	if err := os.WriteFile(path, []byte(c.Config), perms.ReadWrite); err != nil {
+	if err := os.WriteFile(path, bytes, perms.ReadWrite); err != nil {
 		return fmt.Errorf("failed to write chain config: %w", err)
 	}
 
@@ -61,6 +66,8 @@ type Subnet struct {
 	// A unique string that can be used to refer to the subnet across different temporary
 	// networks (since the SubnetID will be different every time the subnet is created)
 	Name string
+
+	Config FlagsMap
 
 	// The ID of the transaction that created the subnet
 	SubnetID ids.ID
@@ -131,9 +138,13 @@ func (s *Subnet) CreateChains(ctx context.Context, w io.Writer, uri string) erro
 	}
 
 	for _, chain := range s.Chains {
+		genesisBytes, err := DefaultJSONMarshal(chain.Genesis)
+		if err != nil {
+			return fmt.Errorf("failed to marshal genesis for chain %s: %w", chain.VMID, err)
+		}
 		createChainTx, err := pWallet.IssueCreateChainTx(
 			s.SubnetID,
-			chain.Genesis,
+			genesisBytes,
 			chain.VMID,
 			nil,
 			"",
@@ -152,7 +163,7 @@ func (s *Subnet) CreateChains(ctx context.Context, w io.Writer, uri string) erro
 }
 
 // Add validators to the subnet
-func (s *Subnet) AddValidators(ctx context.Context, w io.Writer, nodes []*Node) error {
+func (s *Subnet) AddValidators(ctx context.Context, w io.Writer, nodes ...*Node) error {
 	apiURI := nodes[0].URI
 
 	wallet, err := s.GetWallet(ctx, apiURI)
@@ -198,8 +209,6 @@ func (s *Subnet) AddValidators(ctx context.Context, w io.Writer, nodes []*Node) 
 		if _, err := fmt.Fprintf(w, " added %s as validator for subnet `%s`\n", node.NodeID, s.Name); err != nil {
 			return err
 		}
-
-		s.ValidatorIDs = append(s.ValidatorIDs, node.NodeID)
 	}
 
 	return nil
@@ -210,14 +219,14 @@ func (s *Subnet) Write(subnetDir string, chainDir string) error {
 	if err := os.MkdirAll(subnetDir, perms.ReadWriteExecute); err != nil {
 		return fmt.Errorf("failed to create subnet dir: %w", err)
 	}
-	path := filepath.Join(subnetDir, s.Name+".json")
+	tmpnetConfigPath := filepath.Join(subnetDir, s.Name+".json")
 
 	// Since subnets are expected to be serialized for the first time
 	// without their chains having been created (i.e. chains will have
 	// empty IDs), use the absence of chain IDs as a prompt for a
-	// subnet name uniquness check.
+	// subnet name uniqueness check.
 	if len(s.Chains) > 0 && s.Chains[0].ChainID == ids.Empty {
-		_, err := os.Stat(path)
+		_, err := os.Stat(tmpnetConfigPath)
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -226,12 +235,39 @@ func (s *Subnet) Write(subnetDir string, chainDir string) error {
 		}
 	}
 
+	// Write subnet configuration for tmpnet
 	bytes, err := DefaultJSONMarshal(s)
 	if err != nil {
-		return fmt.Errorf("failed to marshal subnet %s: %w", s.Name, err)
+		return fmt.Errorf("failed to marshal tmpnet subnet %s: %w", s.Name, err)
 	}
-	if err := os.WriteFile(path, bytes, perms.ReadWrite); err != nil {
-		return fmt.Errorf("failed to write subnet %s: %w", s.Name, err)
+	if err := os.WriteFile(tmpnetConfigPath, bytes, perms.ReadWrite); err != nil {
+		return fmt.Errorf("failed to write tmpnet subnet config %s: %w", s.Name, err)
+	}
+
+	// The subnet and chain configurations for avalanchego can only be written once
+	// they have been created since the id of the creating transaction must be
+	// included in the path.
+	if s.SubnetID == ids.Empty {
+		return nil
+	}
+
+	// TODO(marun) Ensure removal of an existing file if no configuration should be provided
+	if len(s.Config) > 0 {
+		// Write subnet configuration for avalanchego
+		bytes, err = DefaultJSONMarshal(s.Config)
+		if err != nil {
+			return fmt.Errorf("failed to marshal avalanchego subnet config %s: %w", s.Name, err)
+		}
+
+		avgoConfigDir := filepath.Join(subnetDir, s.SubnetID.String())
+		if err := os.MkdirAll(avgoConfigDir, perms.ReadWriteExecute); err != nil {
+			return fmt.Errorf("failed to create avalanchego subnet config dir: %w", err)
+		}
+
+		avgoConfigPath := filepath.Join(avgoConfigDir, defaultConfigFilename)
+		if err := os.WriteFile(avgoConfigPath, bytes, perms.ReadWrite); err != nil {
+			return fmt.Errorf("failed to write avalanchego subnet config %s: %w", s.Name, err)
+		}
 	}
 
 	for _, chain := range s.Chains {


### PR DESCRIPTION
## Why this should be merged

- Enable subnet validators to be a subnet of available validators. Previously tmpnet expected all validators to validate all subnets.

- Enable setting of non-default subnet configuration. Previously tmpnet did not support setting per-subnet configuration.

## How this was tested

- CI to validate that existing behavior isn't broken


## TODO

- [ ] Validate both changes with hypersdk PR

