### PR TITLE
Add tests for inefficient string formatting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,6 +166,7 @@ linters-settings:
         arguments:
           - "fmt\\.Fprint"
           - "fmt\\.Fprintf"
+          - "fmt\\.Fprintln"
           - "fmt\\.Print"
           - "fmt\\.Printf"
           - "fmt\\.Println"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,7 +146,14 @@ linters-settings:
       - name: string-format
         disabled: false
         arguments:
+        - ["b.Logf[0]", "/.*%.*/", "no format directive, use b.Log instead"]
         - ["fmt.Errorf[0]", "/.*%.*/", "no format directive, use errors.New instead"]
+        - ["fmt.Fprintf[1]", "/.*%.*/", "no format directive, use fmt.Fprint instead"]
+        - ["fmt.Printf[0]", "/.*%.*/", "no format directive, use fmt.Print instead"]
+        - ["fmt.Sprintf[0]", "/.*%.*/", "no format directive, use fmt.Sprint instead"]
+        - ["log.Fatalf[0]", "/.*%.*/", "no format directive, use log.Fatal instead"]
+        - ["log.Printf[0]", "/.*%.*/", "no format directive, use log.Print instead"]
+        - ["t.Logf[0]", "/.*%.*/", "no format directive, use t.Log instead"]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
       - name: struct-tag
         disabled: false

--- a/indexer/examples/p-chain/main.go
+++ b/indexer/examples/p-chain/main.go
@@ -28,7 +28,7 @@ func main() {
 		container, err := client.GetContainerByIndex(ctx, nextIndex)
 		if err != nil {
 			time.Sleep(time.Second)
-			log.Printf("polling for next accepted block\n")
+			log.Println("polling for next accepted block")
 			continue
 		}
 

--- a/indexer/examples/x-chain-blocks/main.go
+++ b/indexer/examples/x-chain-blocks/main.go
@@ -27,7 +27,7 @@ func main() {
 		container, err := client.GetContainerByIndex(ctx, nextIndex)
 		if err != nil {
 			time.Sleep(time.Second)
-			log.Printf("polling for next accepted block\n")
+			log.Println("polling for next accepted block")
 			continue
 		}
 

--- a/tests/fixture/tmpnet/cmd/main.go
+++ b/tests/fixture/tmpnet/cmd/main.go
@@ -97,7 +97,7 @@ func main() {
 				return err
 			}
 
-			fmt.Fprintf(os.Stdout, "\nConfigure tmpnetctl to target this network by default with one of the following statements:\n")
+			fmt.Fprintln(os.Stdout, "\nConfigure tmpnetctl to target this network by default with one of the following statements:")
 			fmt.Fprintf(os.Stdout, " - source %s\n", network.EnvFilePath())
 			fmt.Fprintf(os.Stdout, " - %s\n", network.EnvFileContents())
 			fmt.Fprintf(os.Stdout, " - export %s=%s\n", tmpnet.NetworkDirEnvName, latestSymlinkPath)

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -317,7 +317,7 @@ func (n *Network) Start(ctx context.Context, w io.Writer) error {
 		}
 	}
 
-	if _, err := fmt.Fprintf(w, "Waiting for all nodes to report healthy...\n\n"); err != nil {
+	if _, err := fmt.Fprint(w, "Waiting for all nodes to report healthy...\n\n"); err != nil {
 		return err
 	}
 	if err := n.WaitForHealthy(ctx, w); err != nil {
@@ -437,7 +437,7 @@ func (n *Network) Stop(ctx context.Context) error {
 
 // Restarts all non-ephemeral nodes in the network.
 func (n *Network) Restart(ctx context.Context, w io.Writer) error {
-	if _, err := fmt.Fprintf(w, " restarting network\n"); err != nil {
+	if _, err := fmt.Fprintln(w, " restarting network"); err != nil {
 		return err
 	}
 	for _, node := range n.Nodes {
@@ -600,7 +600,7 @@ func (n *Network) CreateSubnets(ctx context.Context, w io.Writer) error {
 	}
 
 	// Reconfigure nodes for the new subnets
-	if _, err := fmt.Fprintf(w, "Configured nodes to track new subnet(s). Restart is required.\n"); err != nil {
+	if _, err := fmt.Fprintln(w, "Configured nodes to track new subnet(s). Restart is required."); err != nil {
 		return err
 	}
 	for _, node := range n.Nodes {

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -704,7 +704,7 @@ func (n *Network) CreateSubnets(ctx context.Context, w io.Writer) error {
 		return nil
 	}
 
-	if _, err := fmt.Fprintf(w, "Restarting node(s) to pick up chain configuration\n"); err != nil {
+	if _, err := fmt.Fprintln(w, "Restarting node(s) to pick up chain configuration"); err != nil {
 		return err
 	}
 

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -269,12 +269,12 @@ func waitForActiveValidators(
 		return err
 	}
 
-	if _, err := fmt.Fprintf(w, " "); err != nil {
+	if _, err := fmt.Fprint(w, " "); err != nil {
 		return err
 	}
 
 	for {
-		if _, err := fmt.Fprintf(w, "."); err != nil {
+		if _, err := fmt.Fprint(w, "."); err != nil {
 			return err
 		}
 		validators, err := pChainClient.GetCurrentValidators(ctx, subnet.SubnetID, nil)

--- a/vms/rpcchainvm/vm_test.go
+++ b/vms/rpcchainvm/vm_test.go
@@ -79,7 +79,7 @@ func TestHelperProcess(t *testing.T) {
 	}
 
 	if len(args) == 0 {
-		fmt.Fprintf(os.Stderr, "failed to receive testKey\n")
+		fmt.Fprintln(os.Stderr, "failed to receive testKey")
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
## Why this should be merged

Calling formatting functions results in processing the format string. If the format string doesn't include any format directives, we shouldn't be using a formatting function.

## How this works

Bans usage of formatting functions without a formatting directive.

## How this was tested

- [x] CI