### PR TITLE
Optimize encodeUint

### DIFF
--- a/x/merkledb/codec_test.go
+++ b/x/merkledb/codec_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -264,5 +265,21 @@ func TestUintSize(t *testing.T) {
 		expectedSize := c.uintSize(n)
 		actualSize := binary.PutUvarint(make([]byte, binary.MaxVarintLen64), n)
 		require.Equal(t, expectedSize, actualSize, power)
+	}
+}
+
+func Benchmark_EncodeUint(b *testing.B) {
+	c := codec.(*codecImpl)
+
+	var dst bytes.Buffer
+	dst.Grow(binary.MaxVarintLen64)
+
+	for _, v := range []uint64{0, 1, 2, 32, 1024, 32768} {
+		b.Run(strconv.FormatUint(v, 10), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.encodeUint(&dst, v)
+				dst.Reset()
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged

This code is simpler and faster.

Before:
```
Benchmark_EncodeUint/1-12  		19007980	        60.29 ns/op	      24 B/op	       1 allocs/op
Benchmark_EncodeUint/2-12  		20342215	        60.37 ns/op	      24 B/op	       1 allocs/op
Benchmark_EncodeUint/32-12 		20273323	        60.40 ns/op	      24 B/op	       1 allocs/op
Benchmark_EncodeUint/1024-12         	19789828	        60.73 ns/op	      24 B/op	       1 allocs/op
Benchmark_EncodeUint/32768-12        	19555718	        61.48 ns/op	      24 B/op	       1 allocs/op
```

After:
```
Benchmark_EncodeUint/1-12  		179371581	         6.680 ns/op	       0 B/op	       0 allocs/op
Benchmark_EncodeUint/2-12  		179073162	         7.116 ns/op	       0 B/op	       0 allocs/op
Benchmark_EncodeUint/32-12 		181321675	         6.617 ns/op	       0 B/op	       0 allocs/op
Benchmark_EncodeUint/1024-12         	180010732	         6.657 ns/op	       0 B/op	       0 allocs/op
Benchmark_EncodeUint/32768-12        	163931486	         7.240 ns/op	       0 B/op	       0 allocs/op
```

## How this works

This allows the intermediate buffer to be allocated on the stack rather than the heap. This completely removes the memory allocation and doesn't require the sync pool.

## How this was tested

- [X] Added benchmark
- [X] CI