### PR TITLE
[components/avax] Remove `AtomicUTXOManager` interface

### DIFF
--- a/vms/avm/service.go
+++ b/vms/avm/service.go
@@ -433,7 +433,9 @@ func (s *Service) GetUTXOs(_ *http.Request, args *api.GetUTXOsArgs, reply *api.G
 			limit,
 		)
 	} else {
-		utxos, endAddr, endUTXOID, err = s.vm.GetAtomicUTXOs(
+		utxos, endAddr, endUTXOID, err = avax.GetAtomicUTXOs(
+			s.vm.ctx.SharedMemory,
+			s.vm.parser.Codec(),
 			sourceChain,
 			addrSet,
 			startAddr,
@@ -1782,7 +1784,15 @@ func (s *Service) buildImport(args *ImportArgs) (*txs.Tx, error) {
 		return nil, err
 	}
 
-	atomicUTXOs, _, _, err := s.vm.GetAtomicUTXOs(chainID, kc.Addrs, ids.ShortEmpty, ids.Empty, int(maxPageSize))
+	atomicUTXOs, _, _, err := avax.GetAtomicUTXOs(
+		s.vm.ctx.SharedMemory,
+		s.vm.parser.Codec(),
+		chainID,
+		kc.Addrs,
+		ids.ShortEmpty,
+		ids.Empty,
+		int(maxPageSize),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("problem retrieving user's atomic UTXOs: %w", err)
 	}

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -68,7 +68,6 @@ type VM struct {
 	metrics metrics.Metrics
 
 	avax.AddressManager
-	avax.AtomicUTXOManager
 	ids.Aliaser
 	utxo.Spender
 
@@ -227,7 +226,6 @@ func (vm *VM) Initialize(
 	}
 
 	codec := vm.parser.Codec()
-	vm.AtomicUTXOManager = avax.NewAtomicUTXOManager(ctx.SharedMemory, codec)
 	vm.Spender = utxo.NewSpender(&vm.clock, codec)
 
 	state, err := state.New(

--- a/vms/components/avax/atomic_utxos.go
+++ b/vms/components/avax/atomic_utxos.go
@@ -12,41 +12,19 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 )
 
-var _ AtomicUTXOManager = (*atomicUTXOManager)(nil)
-
-type AtomicUTXOManager interface {
-	// GetAtomicUTXOs returns exported UTXOs such that at least one of the
-	// addresses in [addrs] is referenced.
-	//
-	// Returns at most [limit] UTXOs.
-	//
-	// Returns:
-	// * The fetched UTXOs
-	// * The address associated with the last UTXO fetched
-	// * The ID of the last UTXO fetched
-	// * Any error that may have occurred upstream.
-	GetAtomicUTXOs(
-		chainID ids.ID,
-		addrs set.Set[ids.ShortID],
-		startAddr ids.ShortID,
-		startUTXOID ids.ID,
-		limit int,
-	) ([]*UTXO, ids.ShortID, ids.ID, error)
-}
-
-type atomicUTXOManager struct {
-	sm    atomic.SharedMemory
-	codec codec.Manager
-}
-
-func NewAtomicUTXOManager(sm atomic.SharedMemory, codec codec.Manager) AtomicUTXOManager {
-	return &atomicUTXOManager{
-		sm:    sm,
-		codec: codec,
-	}
-}
-
-func (a *atomicUTXOManager) GetAtomicUTXOs(
+// GetAtomicUTXOs returns exported UTXOs such that at least one of the
+// addresses in [addrs] is referenced.
+//
+// Returns at most [limit] UTXOs.
+//
+// Returns:
+// * The fetched UTXOs
+// * The address associated with the last UTXO fetched
+// * The ID of the last UTXO fetched
+// * Any error that may have occurred upstream.
+func GetAtomicUTXOs(
+	sharedMemory atomic.SharedMemory,
+	codec codec.Manager,
 	chainID ids.ID,
 	addrs set.Set[ids.ShortID],
 	startAddr ids.ShortID,
@@ -61,7 +39,7 @@ func (a *atomicUTXOManager) GetAtomicUTXOs(
 		i++
 	}
 
-	allUTXOBytes, lastAddr, lastUTXO, err := a.sm.Indexed(
+	allUTXOBytes, lastAddr, lastUTXO, err := sharedMemory.Indexed(
 		chainID,
 		addrsList,
 		startAddr.Bytes(),
@@ -84,7 +62,7 @@ func (a *atomicUTXOManager) GetAtomicUTXOs(
 	utxos := make([]*UTXO, len(allUTXOBytes))
 	for i, utxoBytes := range allUTXOBytes {
 		utxo := &UTXO{}
-		if _, err := a.codec.Unmarshal(utxoBytes, utxo); err != nil {
+		if _, err := codec.Unmarshal(utxoBytes, utxo); err != nil {
 			return nil, ids.ShortID{}, ids.ID{}, fmt.Errorf("error parsing UTXO: %w", err)
 		}
 		utxos[i] = utxo

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
-	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
@@ -115,7 +114,6 @@ type environment struct {
 	msm            *mutableSharedMemory
 	fx             fx.Fx
 	state          state.State
-	atomicUTXOs    avax.AtomicUTXOManager
 	uptimes        uptime.Manager
 	utxosVerifier  utxo.Verifier
 	txBuilder      *txstest.Builder
@@ -150,7 +148,6 @@ func newEnvironment(t *testing.T, f fork) *environment { //nolint:unparam
 	rewardsCalc := reward.NewCalculator(res.config.RewardConfig)
 	res.state = defaultState(t, res.config, res.ctx, res.baseDB, rewardsCalc)
 
-	res.atomicUTXOs = avax.NewAtomicUTXOManager(res.ctx.SharedMemory, txs.Codec)
 	res.uptimes = uptime.NewManager(res.state, res.clk)
 	res.utxosVerifier = utxo.NewVerifier(res.ctx, res.clk, res.fx)
 

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
-	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
@@ -127,7 +126,6 @@ type environment struct {
 	fx             fx.Fx
 	state          state.State
 	mockedState    *state.MockState
-	atomicUTXOs    avax.AtomicUTXOManager
 	uptimes        uptime.Manager
 	utxosVerifier  utxo.Verifier
 	txBuilder      *txstest.Builder
@@ -153,7 +151,6 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller, f fork) *environment 
 	res.fx = defaultFx(res.clk, res.ctx.Log, res.isBootstrapped.Get())
 
 	rewardsCalc := reward.NewCalculator(res.config.RewardConfig)
-	res.atomicUTXOs = avax.NewAtomicUTXOManager(res.ctx.SharedMemory, txs.Codec)
 
 	if ctrl == nil {
 		res.state = defaultState(res.config, res.ctx, res.baseDB, rewardsCalc)

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -70,7 +70,6 @@ type Service struct {
 	vm                    *VM
 	addrManager           avax.AddressManager
 	stakerAttributesCache *cache.LRU[ids.ID, *stakerAttributes]
-	atomicUtxosManager    avax.AtomicUTXOManager
 }
 
 // All attributes are optional and may not be filled for each stakerTx.
@@ -384,7 +383,9 @@ func (s *Service) GetUTXOs(_ *http.Request, args *api.GetUTXOsArgs, response *ap
 			limit,
 		)
 	} else {
-		utxos, endAddr, endUTXOID, err = s.atomicUtxosManager.GetAtomicUTXOs(
+		utxos, endAddr, endUTXOID, err = avax.GetAtomicUTXOs(
+			s.vm.ctx.SharedMemory,
+			txs.Codec,
 			sourceChain,
 			addrSet,
 			startAddr,

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -83,7 +83,6 @@ func defaultService(t *testing.T) (*Service, *mutableSharedMemory, *txstest.Buil
 		stakerAttributesCache: &cache.LRU[ids.ID, *stakerAttributes]{
 			Size: stakerAttributesCacheSize,
 		},
-		atomicUtxosManager: avax.NewAtomicUTXOManager(vm.ctx.SharedMemory, txs.Codec),
 	}, mutableSharedMemory, txBuilder
 }
 

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
-	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
@@ -102,7 +101,6 @@ type environment struct {
 	fx             fx.Fx
 	state          state.State
 	states         map[ids.ID]state.Chain
-	atomicUTXOs    avax.AtomicUTXOManager
 	uptimes        uptime.Manager
 	utxosHandler   utxo.Verifier
 	txBuilder      *txstest.Builder
@@ -141,7 +139,6 @@ func newEnvironment(t *testing.T, f fork) *environment {
 	rewards := reward.NewCalculator(config.RewardConfig)
 	baseState := defaultState(config, ctx, baseDB, rewards)
 
-	atomicUTXOs := avax.NewAtomicUTXOManager(ctx.SharedMemory, txs.Codec)
 	uptimes := uptime.NewManager(baseState, clk)
 	utxosVerifier := utxo.NewVerifier(ctx, clk, fx)
 
@@ -172,7 +169,6 @@ func newEnvironment(t *testing.T, f fork) *environment {
 		fx:             fx,
 		state:          baseState,
 		states:         make(map[ids.ID]state.Chain),
-		atomicUTXOs:    atomicUTXOs,
 		uptimes:        uptimes,
 		utxosHandler:   utxosVerifier,
 		txBuilder:      txBuilder,

--- a/vms/platformvm/txs/txstest/backend.go
+++ b/vms/platformvm/txs/txstest/backend.go
@@ -47,8 +47,15 @@ func (b *Backend) UTXOs(_ context.Context, sourceChainID ids.ID) ([]*avax.UTXO, 
 		return avax.GetAllUTXOs(b.state, b.addrs)
 	}
 
-	atomicUTXOManager := avax.NewAtomicUTXOManager(b.sharedMemory, txs.Codec)
-	utxos, _, _, err := atomicUTXOManager.GetAtomicUTXOs(sourceChainID, b.addrs, ids.ShortEmpty, ids.Empty, math.MaxInt)
+	utxos, _, _, err := avax.GetAtomicUTXOs(
+		b.sharedMemory,
+		txs.Codec,
+		sourceChainID,
+		b.addrs,
+		ids.ShortEmpty,
+		ids.Empty,
+		math.MaxInt,
+	)
 	return utxos, err
 }
 

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -464,7 +464,6 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 		stakerAttributesCache: &cache.LRU[ids.ID, *stakerAttributes]{
 			Size: stakerAttributesCacheSize,
 		},
-		atomicUtxosManager: avax.NewAtomicUTXOManager(vm.ctx.SharedMemory, txs.Codec),
 	}
 	err := server.RegisterService(service, "platform")
 	return map[string]http.Handler{


### PR DESCRIPTION
## Why this should be merged

This interface/struct should just be a helper IMO

## How this works

Convert to a helper and use it

## How this was tested

CI