### PR TITLE
[vms/platformvm] Miscellaneous testing cleanups

### DIFF
--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -175,7 +175,7 @@ func newEnvironment(t *testing.T, f fork) *environment {
 		backend:        backend,
 	}
 
-	addSubnet(t, env, txBuilder)
+	addSubnet(t, env)
 
 	t.Cleanup(func() {
 		env.ctx.Lock.Lock()
@@ -204,16 +204,12 @@ func newEnvironment(t *testing.T, f fork) *environment {
 	return env
 }
 
-func addSubnet(
-	t *testing.T,
-	env *environment,
-	txBuilder *txstest.Builder,
-) {
+func addSubnet(t *testing.T, env *environment) {
 	require := require.New(t)
 
 	// Create a subnet
 	var err error
-	testSubnet1, err = txBuilder.NewCreateSubnetTx(
+	testSubnet1, err = env.txBuilder.NewCreateSubnetTx(
 		&secp256k1fx.OutputOwners{
 			Threshold: 2,
 			Addrs: []ids.ShortID{


### PR DESCRIPTION
## Why this should be merged

Just some minor cleanups compiled into one PR

## How this works

* Removes `rewardAddress` parameter in table tests since they were always set to the same var
* Removes `txBuilder` param from `addSubnet` since it's included in the `env`

## How this was tested

CI
