### PR TITLE
Replace weighted semaphore with channel

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/exp/maps"
-	"golang.org/x/sync/semaphore"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
@@ -218,7 +217,7 @@ type merkleDB struct {
 
 	// calculateNodeIDsSema controls the number of goroutines inside
 	// [calculateNodeIDsHelper] at any given time.
-	calculateNodeIDsSema *semaphore.Weighted
+	calculateNodeIDsSema semaphore
 
 	tokenSize int
 }
@@ -274,7 +273,7 @@ func newDatabase(
 		debugTracer:          getTracerIfEnabled(config.TraceLevel, DebugTrace, config.Tracer),
 		infoTracer:           getTracerIfEnabled(config.TraceLevel, InfoTrace, config.Tracer),
 		childViews:           make([]*view, 0, defaultPreallocationSize),
-		calculateNodeIDsSema: semaphore.NewWeighted(int64(rootGenConcurrency)),
+		calculateNodeIDsSema: make(semaphore, rootGenConcurrency),
 		tokenSize:            BranchFactorToTokenSize[config.BranchFactor],
 	}
 

--- a/x/merkledb/semaphore.go
+++ b/x/merkledb/semaphore.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package merkledb
+
+type semaphore chan struct{}
+
+func (s semaphore) Acquire() {
+	s <- struct{}{}
+}
+
+func (s semaphore) TryAcquire() bool {
+	select {
+	case s <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s semaphore) Release() {
+	select {
+	case <-s:
+	default:
+		panic("release of unacquired semaphore")
+	}
+}

--- a/x/merkledb/semaphore_test.go
+++ b/x/merkledb/semaphore_test.go
@@ -3,9 +3,7 @@
 
 package merkledb
 
-import (
-	"testing"
-)
+import "testing"
 
 func Benchmark_Semaphore_Acquire(b *testing.B) {
 	s := make(semaphore, b.N)

--- a/x/merkledb/semaphore_test.go
+++ b/x/merkledb/semaphore_test.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package merkledb
+
+import (
+	"testing"
+)
+
+func Benchmark_Semaphore_Acquire(b *testing.B) {
+	s := make(semaphore, b.N)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Acquire()
+	}
+}
+
+func Benchmark_Semaphore_Release(b *testing.B) {
+	s := make(semaphore, b.N)
+	for i := 0; i < b.N; i++ {
+		s.Acquire()
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Release()
+	}
+}
+
+func Benchmark_Semaphore_TryAcquire_Success(b *testing.B) {
+	s := make(semaphore, b.N)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.TryAcquire()
+	}
+}
+
+func Benchmark_Semaphore_TryAcquire_Failure(b *testing.B) {
+	s := make(semaphore, 1)
+	s.Acquire()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.TryAcquire()
+	}
+}


### PR DESCRIPTION
## Why this should be merged

Before:
```
Benchmark_Semaphore_Acquire-12                	79965123	        15.26 ns/op	       0 B/op	       0 allocs/op
Benchmark_Semaphore_Release-12                	77948438	        15.40 ns/op	       0 B/op	       0 allocs/op
Benchmark_Semaphore_TryAcquire_Success-12     	78838228	        15.01 ns/op	       0 B/op	       0 allocs/op
Benchmark_Semaphore_TryAcquire_Failure-12     	99081432	        11.77 ns/op	       0 B/op	       0 allocs/op
```

After:
```
Benchmark_Semaphore_Acquire-12               	56607668	        20.70  ns/op	       0 B/op	       0 allocs/op
Benchmark_Semaphore_Release-12               	55961013	        21.51  ns/op	       0 B/op	       0 allocs/op
Benchmark_Semaphore_TryAcquire_Success-12    	56662573	        21.54  ns/op	       0 B/op	       0 allocs/op
Benchmark_Semaphore_TryAcquire_Failure-12    	318408416	         3.779 ns/op	       0 B/op	       0 allocs/op
```

Because `TryAcquire_Failure` is the common case when hashing, we should optimize this path.

## How this works

Replaces the `semaphore` package with a simple wrapper around a channel.

## How this was tested

- [X] New benchmark
- [X] CI