### PR TITLE
Conditionally allocate WaitGroup memory

### DIFF
--- a/x/merkledb/view.go
+++ b/x/merkledb/view.go
@@ -317,11 +317,6 @@ func (v *view) hashChangedNode(n *node) ids.ID {
 		lastKeyByte byte
 
 		// We use [wg] to wait until all descendants of [n] have been updated.
-		//
-		// We use a pointer to avoid allocating the WaitGroup when no goroutines
-		// are created. Calls to Add and Wait both mark the WaitGroup as
-		// potentially escaping the stack, so the WaitGroup is never able to be
-		// allocated on the stack.
 		wg waitGroup
 	)
 

--- a/x/merkledb/wait_group.go
+++ b/x/merkledb/wait_group.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package merkledb
+
+import "sync"
+
+// waitGroup is a small wrapper of a sync.WaitGroup that avoids performing a
+// memory allocation when Add is never called.
+type waitGroup struct {
+	wg *sync.WaitGroup
+}
+
+func (wg *waitGroup) Add(delta int) {
+	if wg.wg == nil {
+		wg.wg = new(sync.WaitGroup)
+	}
+	wg.wg.Add(delta)
+}
+
+func (wg *waitGroup) Wait() {
+	if wg.wg != nil {
+		wg.wg.Wait()
+	}
+}

--- a/x/merkledb/wait_group_test.go
+++ b/x/merkledb/wait_group_test.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package merkledb
+
+import "testing"
+
+func Benchmark_WaitGroup_Wait(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var wg waitGroup
+		wg.Wait()
+	}
+}
+
+func Benchmark_WaitGroup_Add(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var wg waitGroup
+		wg.Add(1)
+	}
+}
+
+func Benchmark_WaitGroup_AddDoneWait(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var wg waitGroup
+		wg.Add(1)
+		wg.wg.Done()
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
## Why this should be merged

This doesn't show a great improvement in the e2e time in the benchmark. But it does about half the memory allocations.

## Micro Benchmark

Before:
```
Benchmark_WaitGroup_Wait-12           	39920269	        27.86 ns/op	      16 B/op	       1 allocs/op
Benchmark_WaitGroup_Add-12            	38089494	        31.63 ns/op	      16 B/op	       1 allocs/op
Benchmark_WaitGroup_AddDoneWait-12    	29213842	        42.78 ns/op	      16 B/op	       1 allocs/op
```

After:
```
Benchmark_WaitGroup_Wait-12           	1000000000	         0.7141 ns/op	       0 B/op	       0 allocs/op
Benchmark_WaitGroup_Add-12            	36672994	        32.54   ns/op	      16 B/op	       1 allocs/op
Benchmark_WaitGroup_AddDoneWait-12    	26798948	        43.44   ns/op	      16 B/op	       1 allocs/op
```

## E2E

Before:
```
Benchmark_HashChangedNodes/1-12  		 3493987	       341.6 ns/op	     144 B/op	       3 allocs/op
Benchmark_HashChangedNodes/10-12 		  424846	      2914   ns/op	     161 B/op	       5 allocs/op
Benchmark_HashChangedNodes/100-12         	   40664	     29251   ns/op	     280 B/op	      19 allocs/op
Benchmark_HashChangedNodes/1000-12        	    3751	    326273   ns/op	    2746 B/op	     293 allocs/op
Benchmark_HashChangedNodes/10000-12       	     362	   3230055   ns/op	   14263 B/op	    1573 allocs/op
Benchmark_HashChangedNodes/100000-12      	      22	  52736873   ns/op	  355798 B/op	   37157 allocs/op
```

After:
```
Benchmark_HashChangedNodes/1-12  		 3388971	       346.9 ns/op	     144 B/op	       3 allocs/op
Benchmark_HashChangedNodes/10-12 		  424740	      2867   ns/op	     145 B/op	       4 allocs/op
Benchmark_HashChangedNodes/100-12         	   41359	     29432   ns/op	     152 B/op	      11 allocs/op
Benchmark_HashChangedNodes/1000-12        	    3790	    317260   ns/op	     427 B/op	     148 allocs/op
Benchmark_HashChangedNodes/10000-12       	     374	   3199651   ns/op	    1702 B/op	     788 allocs/op
Benchmark_HashChangedNodes/100000-12      	      22	  52643769   ns/op	   58561 B/op	   18580 allocs/op
```


## How this works

calling any of `sync.WaitGroup#Add`, `sync.WaitGroup#Done`, or `sync.WaitGroup#Wait` cause the `sync.WaitGroup` struct to be marked as potentially escaping the stack frame by the compiler (likely due to the `race.Acquire(unsafe.Pointer(wg))` and `race.ReleaseMerge(unsafe.Pointer(wg))` calls.

This PR avoids performing these calls when no goroutines are created.

## How this was tested

- [X] Added benchmark
- [X] CI