### PR TITLE
[tmpnet] Misc cleanup to support xsvm warp test PR

### DIFF
--- a/tests/fixture/tmpnet/flags.go
+++ b/tests/fixture/tmpnet/flags.go
@@ -18,14 +18,30 @@ import (
 type FlagsMap map[string]interface{}
 
 // Utility function simplifying construction of a FlagsMap from a file.
-func ReadFlagsMap(path string, description string) (*FlagsMap, error) {
+func ReadFlagsMap(path string, description string) (FlagsMap, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", description, err)
 	}
-	flagsMap := &FlagsMap{}
-	if err := json.Unmarshal(bytes, flagsMap); err != nil {
+	flagsMap := FlagsMap{}
+	if err := json.Unmarshal(bytes, &flagsMap); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal %s: %w", description, err)
+	}
+	return flagsMap, nil
+}
+
+// Round-trips the provided interface through JSON to convert to a
+// FlagsMap. This allows for a cleaner serialization of embedded types
+// such as chain configuration.
+func InterfaceToFlagsMap(v interface{}) (FlagsMap, error) {
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	flagsMap := FlagsMap{}
+	err = json.Unmarshal(bytes, &flagsMap)
+	if err != nil {
+		return nil, err
 	}
 	return flagsMap, nil
 }

--- a/tests/fixture/tmpnet/flags.go
+++ b/tests/fixture/tmpnet/flags.go
@@ -30,22 +30,6 @@ func ReadFlagsMap(path string, description string) (FlagsMap, error) {
 	return flagsMap, nil
 }
 
-// Round-trips the provided interface through JSON to convert to a
-// FlagsMap. This allows for a cleaner serialization of embedded types
-// such as chain configuration.
-func InterfaceToFlagsMap(v interface{}) (FlagsMap, error) {
-	bytes, err := json.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
-	flagsMap := FlagsMap{}
-	err = json.Unmarshal(bytes, &flagsMap)
-	if err != nil {
-		return nil, err
-	}
-	return flagsMap, nil
-}
-
 // SetDefaults ensures the effectiveness of flag overrides by only
 // setting values supplied in the defaults map that are not already
 // explicitly set.

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -213,7 +213,11 @@ func (n *Network) EnsureDefaultConfig(w io.Writer, avalancheGoPath string, plugi
 
 	// Ensure nodes are created
 	if len(n.Nodes) == 0 {
-		n.Nodes = NewNodes(nodeCount)
+		nodes, err := NewNodes(nodeCount)
+		if err != nil {
+			return err
+		}
+		n.Nodes = nodes
 	}
 
 	// Ensure nodes are configured

--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -140,7 +140,7 @@ func (n *Network) readChainConfigs() error {
 		if err != nil {
 			return err
 		}
-		n.ChainConfigs[chainAlias] = *chainConfig
+		n.ChainConfigs[chainAlias] = chainConfig
 	}
 
 	return nil

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -95,12 +95,16 @@ func NewNode(dataDir string) *Node {
 }
 
 // Initializes the specified number of nodes.
-func NewNodes(count int) []*Node {
+func NewNodes(count int) ([]*Node, error) {
 	nodes := make([]*Node, count)
 	for i := range nodes {
-		nodes[i] = NewNode("")
+		node := NewNode("")
+		if err := node.EnsureKeys(); err != nil {
+			return nil, err
+		}
+		nodes[i] = node
 	}
-	return nodes
+	return nodes, nil
 }
 
 // Reads a node's configuration from the specified directory.

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -30,8 +30,8 @@ const defaultSubnetDirName = "subnets"
 type Chain struct {
 	// Set statically
 	VMID    ids.ID
-	Config  FlagsMap
-	Genesis FlagsMap
+	Config  string
+	Genesis []byte
 
 	// Set at runtime
 	ChainID      ids.ID
@@ -50,12 +50,8 @@ func (c *Chain) WriteConfig(chainDir string) error {
 		return fmt.Errorf("failed to create chain config dir: %w", err)
 	}
 
-	bytes, err := DefaultJSONMarshal(c.Config)
-	if err != nil {
-		return fmt.Errorf("failed to marshal config for chain %s: %w", c.ChainID, err)
-	}
 	path := filepath.Join(chainConfigDir, defaultConfigFilename)
-	if err := os.WriteFile(path, bytes, perms.ReadWrite); err != nil {
+	if err := os.WriteFile(path, []byte(c.Config), perms.ReadWrite); err != nil {
 		return fmt.Errorf("failed to write chain config: %w", err)
 	}
 
@@ -138,13 +134,9 @@ func (s *Subnet) CreateChains(ctx context.Context, w io.Writer, uri string) erro
 	}
 
 	for _, chain := range s.Chains {
-		genesisBytes, err := DefaultJSONMarshal(chain.Genesis)
-		if err != nil {
-			return fmt.Errorf("failed to marshal genesis for chain %s: %w", chain.VMID, err)
-		}
 		createChainTx, err := pWallet.IssueCreateChainTx(
 			s.SubnetID,
-			genesisBytes,
+			chain.Genesis,
 			chain.VMID,
 			nil,
 			"",

--- a/tests/fixture/tmpnet/utils.go
+++ b/tests/fixture/tmpnet/utils.go
@@ -89,9 +89,9 @@ func NewPrivateKeys(keyCount int) ([]*secp256k1.PrivateKey, error) {
 }
 
 func NodesToIDs(nodes ...*Node) []ids.NodeID {
-	validatorIDs := make([]ids.NodeID, len(nodes))
+	nodeIDs := make([]ids.NodeID, len(nodes))
 	for i, node := range nodes {
-		validatorIDs[i] = node.NodeID
+		nodeIDs[i] = node.NodeID
 	}
-	return validatorIDs
+	return nodeIDs
 }

--- a/tests/fixture/tmpnet/utils.go
+++ b/tests/fixture/tmpnet/utils.go
@@ -87,3 +87,11 @@ func NewPrivateKeys(keyCount int) ([]*secp256k1.PrivateKey, error) {
 	}
 	return keys, nil
 }
+
+func NodesToIDs(nodes ...*Node) []ids.NodeID {
+	validatorIDs := make([]ids.NodeID, len(nodes))
+	for i, node := range nodes {
+		validatorIDs[i] = node.NodeID
+	}
+	return validatorIDs
+}


### PR DESCRIPTION
- update tmpnet.ReadFlagsMap to avoid returning an unnecessary pointer

- add tmpnet.InterfaceToFlagsMap helper to simplify conversion of subnet configuration to a FlagsMap for nicer serialization

- update tmpnet.NewNodes to initialize tls and signing keys so that nodes returned by this method can be used to extract the validator IDs for a subnet

- switch tmpnet.Chain.Genesis back to a byte array. A previous attempt to improve the readability of tmpnet subnet configuration by converting to FlagsMap ignored that genesis byte format is VM-specific.

- switch tmpnet.Chain.Config back to a string. A previous attempt to improve the readability of tmpnet subnet configuration by converting to FlagsMap ignored that VMs need to be able to specify their exact configuration.