### PR TITLE
Remove full message from error logs

### DIFF
--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -371,9 +371,10 @@ func (h *handler) dispatchSync(ctx context.Context) {
 		// If there is an error handling the message, shut down the chain
 		if err := h.handleSyncMsg(ctx, msg); err != nil {
 			h.StopWithError(ctx, fmt.Errorf(
-				"%w while processing sync message: %s",
+				"%w while processing sync message: %s from %s",
 				err,
-				msg,
+				msg.Op(),
+				msg.NodeID(),
 			))
 			return
 		}
@@ -429,7 +430,7 @@ func (h *handler) dispatchChans(ctx context.Context) {
 			h.StopWithError(ctx, fmt.Errorf(
 				"%w while processing chan message: %s",
 				err,
-				msg,
+				msg.Op(),
 			))
 			return
 		}
@@ -766,9 +767,10 @@ func (h *handler) handleAsyncMsg(ctx context.Context, msg Message) {
 	h.asyncMessagePool.Go(func() error {
 		if err := h.executeAsyncMsg(ctx, msg); err != nil {
 			h.StopWithError(ctx, fmt.Errorf(
-				"%w while processing async message: %s",
+				"%w while processing async message: %s from %s",
 				err,
-				msg,
+				msg.Op(),
+				msg.NodeID(),
 			))
 		}
 		return nil


### PR DESCRIPTION
## Why this should be merged

The format of these errors are very hard to read... This changes the output to only contain the highly relevant information.

## How this works

Removes the full `msg` from the call to `StopWithError`.

## How this was tested

N/A