### PR TITLE
Remove cancellation for Send*AppRequest messages

### DIFF
--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -72,6 +72,14 @@ func (c *Client) AppRequest(
 	appRequestBytes []byte,
 	onResponse AppResponseCallback,
 ) error {
+	// Cancellation is removed from this context to avoid erroring unexpectedly.
+	// SendAppRequest should be non-blocking and any error other than context
+	// cancellation is unexpected.
+	//
+	// This guarantees that the router should never receive an unexpected
+	// AppResponse.
+	ctxWithoutCancel := context.WithoutCancel(ctx)
+
 	c.router.lock.Lock()
 	defer c.router.lock.Unlock()
 
@@ -87,7 +95,7 @@ func (c *Client) AppRequest(
 		}
 
 		if err := c.sender.SendAppRequest(
-			ctx,
+			ctxWithoutCancel,
 			set.Of(nodeID),
 			requestID,
 			appRequestBytes,
@@ -126,6 +134,14 @@ func (c *Client) CrossChainAppRequest(
 	appRequestBytes []byte,
 	onResponse CrossChainAppResponseCallback,
 ) error {
+	// Cancellation is removed from this context to avoid erroring unexpectedly.
+	// SendCrossChainAppRequest should be non-blocking and any error other than
+	// context cancellation is unexpected.
+	//
+	// This guarantees that the router should never receive an unexpected
+	// CrossChainAppResponse.
+	ctxWithoutCancel := context.WithoutCancel(ctx)
+
 	c.router.lock.Lock()
 	defer c.router.lock.Unlock()
 
@@ -139,7 +155,7 @@ func (c *Client) CrossChainAppRequest(
 	}
 
 	if err := c.sender.SendCrossChainAppRequest(
-		ctx,
+		ctxWithoutCancel,
 		chainID,
 		requestID,
 		PrefixMessage(c.handlerPrefix, appRequestBytes),

--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -8,7 +8,10 @@ import (
 	"errors"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/message"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
@@ -100,6 +103,12 @@ func (c *Client) AppRequest(
 			requestID,
 			appRequestBytes,
 		); err != nil {
+			c.router.log.Error("unexpected error when sending message",
+				zap.Stringer("op", message.AppRequestOp),
+				zap.Stringer("nodeID", nodeID),
+				zap.Uint32("requestID", requestID),
+				zap.Error(err),
+			)
 			return err
 		}
 
@@ -160,6 +169,12 @@ func (c *Client) CrossChainAppRequest(
 		requestID,
 		PrefixMessage(c.handlerPrefix, appRequestBytes),
 	); err != nil {
+		c.router.log.Error("unexpected error when sending message",
+			zap.Stringer("op", message.CrossChainAppRequestOp),
+			zap.Stringer("chainID", chainID),
+			zap.Uint32("requestID", requestID),
+			zap.Error(err),
+		)
 		return err
 	}
 

--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -128,8 +128,13 @@ func (c *Client) AppGossip(
 	config common.SendConfig,
 	appGossipBytes []byte,
 ) error {
+	// Cancellation is removed from this context to avoid erroring unexpectedly.
+	// SendAppGossip should be non-blocking and any error other than context
+	// cancellation is unexpected.
+	ctxWithoutCancel := context.WithoutCancel(ctx)
+
 	return c.sender.SendAppGossip(
-		ctx,
+		ctxWithoutCancel,
 		config,
 		PrefixMessage(c.handlerPrefix, appGossipBytes),
 	)

--- a/snow/engine/common/sender.go
+++ b/snow/engine/common/sender.go
@@ -167,11 +167,16 @@ type QuerySender interface {
 // NetworkAppSender sends VM-level messages to nodes in the network.
 type NetworkAppSender interface {
 	// Send an application-level request.
-	// A nil return value guarantees that for each nodeID in [nodeIDs],
-	// the VM corresponding to this AppSender eventually receives either:
+	//
+	// The VM corresponding to this AppSender may receive either:
 	// * An AppResponse from nodeID with ID [requestID]
 	// * An AppRequestFailed from nodeID with ID [requestID]
-	// Exactly one of the above messages will eventually be received per nodeID.
+	//
+	// A nil return value guarantees that the VM corresponding to this AppSender
+	// will receive exactly one of the above messages.
+	//
+	// A non-nil return value guarantees that the VM corresponding to this
+	// AppSender will receive at most one of the above messages.
 	SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, appRequestBytes []byte) error
 	// Send an application-level response to a request.
 	// This response must be in response to an AppRequest that the VM corresponding
@@ -192,12 +197,16 @@ type CrossChainAppSender interface {
 	// SendCrossChainAppRequest sends an application-level request to a
 	// specific chain.
 	//
-	// A nil return value guarantees that the VM corresponding to this
-	// CrossChainAppSender eventually receives either:
+	// The VM corresponding to this CrossChainAppSender may receive either:
 	// * A CrossChainAppResponse from [chainID] with ID [requestID]
 	// * A CrossChainAppRequestFailed from [chainID] with ID [requestID]
-	// Exactly one of the above messages will eventually be received from
-	// [chainID].
+	//
+	// A nil return value guarantees that the VM corresponding to this
+	// CrossChainAppSender will eventually receive exactly one of the above
+	// messages.
+	//
+	// A non-nil return value guarantees that the VM corresponding to this
+	// CrossChainAppSender will receive at most one of the above messages.
 	SendCrossChainAppRequest(ctx context.Context, chainID ids.ID, requestID uint32, appRequestBytes []byte) error
 	// SendCrossChainAppResponse sends an application-level response to a
 	// specific chain


### PR DESCRIPTION
## Why this should be merged

Fixes issue that caused unexpected `AppResponse` / `AppRequestFailed` messages to be reported.

## How this works

The `rpcChainVM` does not guarantee that returning an error from these methods implies that the messages was not sent to the peer.

For an error to be reported here:
- Either the `rpcChainVM` is unable to provide a reliable connection (in which case the plugin will FATAL)
- The context was cancelled

## How this was tested

- [x] Added unit test
- [X] CI