### PR TITLE
Implement `utils.BytesPool` to replace `sync.Pool` for byte slices

### DIFF
--- a/utils/bytes.go
+++ b/utils/bytes.go
@@ -43,14 +43,14 @@ const intSize = 32 << (^uint(0) >> 63) // 32 or 64
 // required to represent 20 (5). And therefore place the slice into bucket 4,
 // which has length 15. This is the bucket which produces the largest slices
 // that a length 19 slice can be used for.
-type BytesPool [intSize]*sync.Pool
+type BytesPool [intSize]sync.Pool
 
 func NewBytesPool() *BytesPool {
 	var p BytesPool
 	for i := range p {
 		// uint is used here to avoid overflowing int during the shift
 		size := uint(1)<<i - 1
-		p[i] = &sync.Pool{
+		p[i] = sync.Pool{
 			New: func() interface{} {
 				// Sync pool needs to return pointer-like values to avoid memory
 				// allocations.

--- a/utils/bytes.go
+++ b/utils/bytes.go
@@ -78,6 +78,6 @@ func (p *BytesPool) Get(length int) *[]byte {
 // of the provided slice is ignored and only its capacity is used.
 func (p *BytesPool) Put(bytes *[]byte) {
 	size := cap(*bytes)
-	index := bits.Len(uint(size+1)) - 1 // Round down
+	index := bits.Len(uint(size)+1) - 1 // Round down
 	p[index].Put(bytes)
 }

--- a/utils/bytes.go
+++ b/utils/bytes.go
@@ -23,6 +23,7 @@ const intSize = 32 << (^uint(0) >> 63) // 32 or 64
 // BytesPool tracks buckets of available buffers to be allocated. Each bucket
 // allocates buffers of the following length:
 //
+// 0
 // 1
 // 3
 // 7
@@ -35,44 +36,48 @@ const intSize = 32 << (^uint(0) >> 63) // 32 or 64
 //
 // In order to allocate a buffer of length 19 (for example), we calculate the
 // number of bits required to represent 19 (5). And therefore allocate a slice
-// from bucket 4, which has length 31. This is the bucket which produces the
+// from bucket 5, which has length 31. This is the bucket which produces the
 // smallest slices that are at least length 19.
 //
 // When replacing a buffer of length 19, we calculate the number of bits
-// required to represent 20 (5). And therefore place the slice into bucket 3,
+// required to represent 20 (5). And therefore place the slice into bucket 4,
 // which has length 15. This is the bucket which produces the largest slices
-// that are at most length 19.
-type BytesPool [intSize - 1]*sync.Pool
+// that a length 19 slice can be used for.
+type BytesPool [intSize]*sync.Pool
 
 func NewBytesPool() *BytesPool {
 	var p BytesPool
 	for i := range p {
-		size := uint64(1)<<(i+1) - 1
+		// uint is used here to avoid overflowing int during the shift
+		size := uint(1)<<i - 1
 		p[i] = &sync.Pool{
 			New: func() interface{} {
-				return make([]byte, size)
+				// Sync pool needs to return pointer-like values to avoid memory
+				// allocations.
+				b := make([]byte, size)
+				return &b
 			},
 		}
 	}
 	return &p
 }
 
-func (p *BytesPool) Get(length int) []byte {
-	if length <= 0 {
-		return nil
-	}
-
-	index := bits.Len(uint(length)) - 1 // Round up
-	bytes := p[index].Get().([]byte)
-	return bytes[:length]
+// Get returns a non-nil pointer to a slice with the requested length.
+//
+// It is not guaranteed for the returned bytes to have been zeroed.
+func (p *BytesPool) Get(length int) *[]byte {
+	index := bits.Len(uint(length)) // Round up
+	bytes := p[index].Get().(*[]byte)
+	*bytes = (*bytes)[:length] // Set the length to be the expected value
+	return bytes
 }
 
-func (p *BytesPool) Put(bytes []byte) {
-	size := cap(bytes)
-	if size == 0 {
-		return
-	}
-
-	index := bits.Len(uint(size+1)) - 2 // Round down
+// Put takes ownership of a non-nil pointer to a slice of bytes.
+//
+// Note: this function takes ownership of the underlying array. So, the length
+// of the provided slice is ignored and only its capacity is used.
+func (p *BytesPool) Put(bytes *[]byte) {
+	size := cap(*bytes)
+	index := bits.Len(uint(size+1)) - 1 // Round down
 	p[index].Put(bytes)
 }

--- a/utils/bytes.go
+++ b/utils/bytes.go
@@ -3,7 +3,11 @@
 
 package utils
 
-import "crypto/rand"
+import (
+	"crypto/rand"
+	"math/bits"
+	"sync"
+)
 
 // RandomBytes returns a slice of n random bytes
 // Intended for use in testing
@@ -11,4 +15,64 @@ func RandomBytes(n int) []byte {
 	b := make([]byte, n)
 	_, _ = rand.Read(b)
 	return b
+}
+
+// Constant taken from the "math" package
+const intSize = 32 << (^uint(0) >> 63) // 32 or 64
+
+// BytesPool tracks buckets of available buffers to be allocated. Each bucket
+// allocates buffers of the following length:
+//
+// 1
+// 3
+// 7
+// 15
+// 31
+// 63
+// 127
+// ...
+// MaxInt
+//
+// In order to allocate a buffer of length 19 (for example), we calculate the
+// number of bits required to represent 19 (5). And therefore allocate a slice
+// from bucket 4, which has length 31. This is the bucket which produces the
+// smallest slices that are at least length 19.
+//
+// When replacing a buffer of length 19, we calculate the number of bits
+// required to represent 20 (5). And therefore place the slice into bucket 3,
+// which has length 15. This is the bucket which produces the largest slices
+// that are at most length 19.
+type BytesPool [intSize - 1]*sync.Pool
+
+func NewBytesPool() *BytesPool {
+	var p BytesPool
+	for i := range p {
+		size := uint64(1)<<(i+1) - 1
+		p[i] = &sync.Pool{
+			New: func() interface{} {
+				return make([]byte, size)
+			},
+		}
+	}
+	return &p
+}
+
+func (p *BytesPool) Get(length int) []byte {
+	if length <= 0 {
+		return nil
+	}
+
+	index := bits.Len(uint(length)) - 1 // Round up
+	bytes := p[index].Get().([]byte)
+	return bytes[:length]
+}
+
+func (p *BytesPool) Put(bytes []byte) {
+	size := cap(bytes)
+	if size == 0 {
+		return
+	}
+
+	index := bits.Len(uint(size+1)) - 2 // Round down
+	p[index].Put(bytes)
 }

--- a/utils/bytes_test.go
+++ b/utils/bytes_test.go
@@ -7,11 +7,21 @@ import (
 	"math"
 	"math/rand"
 	"strconv"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestIntSize(t *testing.T) {
+	require := require.New(t)
+
+	require.Contains([]int{32, 64}, intSize)
+	if intSize == 32 {
+		require.Equal(math.MaxInt32, math.MaxInt)
+	} else {
+		require.Equal(math.MaxInt64, math.MaxInt)
+	}
+}
 
 func TestBytesPool(t *testing.T) {
 	require := require.New(t)
@@ -19,6 +29,7 @@ func TestBytesPool(t *testing.T) {
 	p := NewBytesPool()
 	for i := 0; i < 128; i++ {
 		bytes := p.Get(i)
+		require.NotNil(bytes)
 		require.Len(*bytes, i)
 		p.Put(bytes)
 	}
@@ -29,84 +40,9 @@ func TestBytesPoolMaxInt(t *testing.T) {
 
 	p := NewBytesPool()
 	bytes := p.Get(math.MaxInt32)
+	require.NotNil(bytes)
 	require.Len(*bytes, math.MaxInt32)
 	p.Put(bytes)
-}
-
-func getBufferFromPool(bufferPool *sync.Pool, size int) *[]byte {
-	buffer := bufferPool.Get().(*[]byte)
-	if cap(*buffer) >= size {
-		// The [] byte we got from the pool is big enough to hold the prefixed key
-		*buffer = (*buffer)[:size]
-	} else {
-		// The []byte from the pool wasn't big enough.
-		// Put it back and allocate a new, bigger one
-		bufferPool.Put(buffer)
-		b := make([]byte, size)
-		buffer = &b
-	}
-	return buffer
-}
-
-func BenchmarkOldBytesPool_Constant(b *testing.B) {
-	sizes := []int{
-		0,
-		8,
-		16,
-		32,
-		64,
-		256,
-		2048,
-	}
-	for _, size := range sizes {
-		b.Run(strconv.Itoa(size), func(b *testing.B) {
-			p := &sync.Pool{
-				New: func() interface{} {
-					b := make([]byte, 0, 256)
-					return &b
-				},
-			}
-			for i := 0; i < b.N; i++ {
-				p.Put(getBufferFromPool(p, size))
-			}
-		})
-	}
-}
-
-func BenchmarkOldBytesPool_Decending(b *testing.B) {
-	p := &sync.Pool{
-		New: func() interface{} {
-			b := make([]byte, 0, 256)
-			return &b
-		},
-	}
-	for i := b.N; i > 0; i-- {
-		p.Put(getBufferFromPool(p, i))
-	}
-}
-
-func BenchmarkOldBytesPool_Ascending(b *testing.B) {
-	p := &sync.Pool{
-		New: func() interface{} {
-			b := make([]byte, 0, 256)
-			return &b
-		},
-	}
-	for i := 0; i < b.N; i++ {
-		p.Put(getBufferFromPool(p, i))
-	}
-}
-
-func BenchmarkOldBytesPool_Random(b *testing.B) {
-	p := &sync.Pool{
-		New: func() interface{} {
-			b := make([]byte, 0, 256)
-			return &b
-		},
-	}
-	for i := 0; i < b.N; i++ {
-		p.Put(getBufferFromPool(p, rand.Intn(100_000))) //#nosec G404
-	}
 }
 
 func BenchmarkBytesPool_Constant(b *testing.B) {
@@ -147,42 +83,5 @@ func BenchmarkBytesPool_Random(b *testing.B) {
 	p := NewBytesPool()
 	for i := 0; i < b.N; i++ {
 		p.Put(p.Get(rand.Intn(100_000))) //#nosec G404
-	}
-}
-
-func BenchmarkAllocBytes_Constant(b *testing.B) {
-	sizes := []int{
-		0,
-		8,
-		16,
-		32,
-		64,
-		256,
-		2048,
-	}
-	for _, size := range sizes {
-		b.Run(strconv.Itoa(size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = make([]byte, size)
-			}
-		})
-	}
-}
-
-func BenchmarkAllocBytes_Decending(b *testing.B) {
-	for i := b.N; i > 0; i-- {
-		_ = make([]byte, i)
-	}
-}
-
-func BenchmarkAllocBytes_Ascending(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_ = make([]byte, i)
-	}
-}
-
-func BenchmarkAllocBytes_Random(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_ = make([]byte, rand.Intn(100_000)) //#nosec G404
 	}
 }

--- a/utils/bytes_test.go
+++ b/utils/bytes_test.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytesPool(t *testing.T) {
+	require := require.New(t)
+
+	p := NewBytesPool()
+	for i := 127; i < 128; i++ {
+		p.Put(make([]byte, i))
+	}
+	// for j := 0; j < 256; j++ {
+	for i := 127; i < 128; i++ {
+		bytes := p.Get(i)
+		require.Len(bytes, i)
+		p.Put(bytes)
+	}
+	// }
+}

--- a/utils/bytes_test.go
+++ b/utils/bytes_test.go
@@ -4,6 +4,10 @@
 package utils
 
 import (
+	"math"
+	"math/rand"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,14 +17,172 @@ func TestBytesPool(t *testing.T) {
 	require := require.New(t)
 
 	p := NewBytesPool()
-	for i := 127; i < 128; i++ {
-		p.Put(make([]byte, i))
-	}
-	// for j := 0; j < 256; j++ {
-	for i := 127; i < 128; i++ {
+	for i := 0; i < 128; i++ {
 		bytes := p.Get(i)
-		require.Len(bytes, i)
+		require.Len(*bytes, i)
 		p.Put(bytes)
 	}
-	// }
+}
+
+func TestBytesPoolMaxInt(t *testing.T) {
+	require := require.New(t)
+
+	p := NewBytesPool()
+	bytes := p.Get(math.MaxInt32)
+	require.Len(*bytes, math.MaxInt32)
+	p.Put(bytes)
+}
+
+func getBufferFromPool(bufferPool *sync.Pool, size int) *[]byte {
+	buffer := bufferPool.Get().(*[]byte)
+	if cap(*buffer) >= size {
+		// The [] byte we got from the pool is big enough to hold the prefixed key
+		*buffer = (*buffer)[:size]
+	} else {
+		// The []byte from the pool wasn't big enough.
+		// Put it back and allocate a new, bigger one
+		bufferPool.Put(buffer)
+		b := make([]byte, size)
+		buffer = &b
+	}
+	return buffer
+}
+
+func BenchmarkOldBytesPool_Constant(b *testing.B) {
+	sizes := []int{
+		0,
+		8,
+		16,
+		32,
+		64,
+		256,
+		2048,
+	}
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			p := &sync.Pool{
+				New: func() interface{} {
+					b := make([]byte, 0, 256)
+					return &b
+				},
+			}
+			for i := 0; i < b.N; i++ {
+				p.Put(getBufferFromPool(p, size))
+			}
+		})
+	}
+}
+
+func BenchmarkOldBytesPool_Decending(b *testing.B) {
+	p := &sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 0, 256)
+			return &b
+		},
+	}
+	for i := b.N; i > 0; i-- {
+		p.Put(getBufferFromPool(p, i))
+	}
+}
+
+func BenchmarkOldBytesPool_Ascending(b *testing.B) {
+	p := &sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 0, 256)
+			return &b
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		p.Put(getBufferFromPool(p, i))
+	}
+}
+
+func BenchmarkOldBytesPool_Random(b *testing.B) {
+	p := &sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 0, 256)
+			return &b
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		p.Put(getBufferFromPool(p, rand.Intn(100_000))) //#nosec G404
+	}
+}
+
+func BenchmarkBytesPool_Constant(b *testing.B) {
+	sizes := []int{
+		0,
+		8,
+		16,
+		32,
+		64,
+		256,
+		2048,
+	}
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			p := NewBytesPool()
+			for i := 0; i < b.N; i++ {
+				p.Put(p.Get(size))
+			}
+		})
+	}
+}
+
+func BenchmarkBytesPool_Decending(b *testing.B) {
+	p := NewBytesPool()
+	for i := b.N; i > 0; i-- {
+		p.Put(p.Get(i))
+	}
+}
+
+func BenchmarkBytesPool_Ascending(b *testing.B) {
+	p := NewBytesPool()
+	for i := 0; i < b.N; i++ {
+		p.Put(p.Get(i))
+	}
+}
+
+func BenchmarkBytesPool_Random(b *testing.B) {
+	p := NewBytesPool()
+	for i := 0; i < b.N; i++ {
+		p.Put(p.Get(rand.Intn(100_000))) //#nosec G404
+	}
+}
+
+func BenchmarkAllocBytes_Constant(b *testing.B) {
+	sizes := []int{
+		0,
+		8,
+		16,
+		32,
+		64,
+		256,
+		2048,
+	}
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = make([]byte, size)
+			}
+		})
+	}
+}
+
+func BenchmarkAllocBytes_Decending(b *testing.B) {
+	for i := b.N; i > 0; i-- {
+		_ = make([]byte, i)
+	}
+}
+
+func BenchmarkAllocBytes_Ascending(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = make([]byte, i)
+	}
+}
+
+func BenchmarkAllocBytes_Random(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = make([]byte, rand.Intn(100_000)) //#nosec G404
+	}
 }

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -260,7 +260,7 @@ func newDatabase(
 		rootGenConcurrency = int(config.RootGenConcurrency)
 	}
 
-	// Share a bytes poolbetween the intermediateNodeDB and valueNodeDB to
+	// Share a bytes pool between the intermediateNodeDB and valueNodeDB to
 	// reduce memory allocations.
 	bufferPool := utils.NewBytesPool()
 

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -260,13 +260,9 @@ func newDatabase(
 		rootGenConcurrency = int(config.RootGenConcurrency)
 	}
 
-	// Share a sync.Pool of []byte between the intermediateNodeDB and valueNodeDB
-	// to reduce memory allocations.
-	bufferPool := &sync.Pool{
-		New: func() interface{} {
-			return make([]byte, 0, defaultBufferLength)
-		},
-	}
+	// Share a bytes poolbetween the intermediateNodeDB and valueNodeDB to
+	// reduce memory allocations.
+	bufferPool := utils.NewBytesPool()
 
 	trieDB := &merkleDB{
 		metrics: metrics,
@@ -1341,31 +1337,15 @@ func (db *merkleDB) getTokenSize() int {
 }
 
 // Returns [key] prefixed by [prefix].
-// The returned []byte is taken from [bufferPool] and
-// should be returned to it when the caller is done with it.
-func addPrefixToKey(bufferPool *sync.Pool, prefix []byte, key []byte) []byte {
+// The returned *[]byte is taken from [bufferPool] and should be returned to it
+// when the caller is done with it.
+func addPrefixToKey(bufferPool *utils.BytesPool, prefix []byte, key []byte) *[]byte {
 	prefixLen := len(prefix)
 	keyLen := prefixLen + len(key)
-	prefixedKey := getBufferFromPool(bufferPool, keyLen)
-	copy(prefixedKey, prefix)
-	copy(prefixedKey[prefixLen:], key)
+	prefixedKey := bufferPool.Get(keyLen)
+	copy(*prefixedKey, prefix)
+	copy((*prefixedKey)[prefixLen:], key)
 	return prefixedKey
-}
-
-// Returns a []byte from [bufferPool] with length exactly [size].
-// The []byte is not guaranteed to be zeroed.
-func getBufferFromPool(bufferPool *sync.Pool, size int) []byte {
-	buffer := bufferPool.Get().([]byte)
-	if cap(buffer) >= size {
-		// The [] byte we got from the pool is big enough to hold the prefixed key
-		buffer = buffer[:size]
-	} else {
-		// The []byte from the pool wasn't big enough.
-		// Put it back and allocate a new, bigger one
-		bufferPool.Put(buffer)
-		buffer = make([]byte, size)
-	}
-	return buffer
 }
 
 // cacheEntrySize returns a rough approximation of the memory consumed by storing the key and node.

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -4,20 +4,16 @@
 package merkledb
 
 import (
-	"sync"
-
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils"
 )
-
-const defaultBufferLength = 256
 
 // Holds intermediate nodes. That is, those without values.
 // Changes to this database aren't written to [baseDB] until
 // they're evicted from the [nodeCache] or Flush is called.
 type intermediateNodeDB struct {
-	// Holds unused []byte
-	bufferPool *sync.Pool
+	bufferPool *utils.BytesPool
 
 	// The underlying storage.
 	// Keys written to [baseDB] are prefixed with [intermediateNodePrefix].
@@ -41,7 +37,7 @@ type intermediateNodeDB struct {
 
 func newIntermediateNodeDB(
 	db database.Database,
-	bufferPool *sync.Pool,
+	bufferPool *utils.BytesPool,
 	metrics merkleMetrics,
 	cacheSize int,
 	writeBufferSize int,
@@ -98,14 +94,15 @@ func (db *intermediateNodeDB) onEviction(key Key, n *node) error {
 	return nil
 }
 
-func (db *intermediateNodeDB) addToBatch(b database.Batch, key Key, n *node) error {
+func (db *intermediateNodeDB) addToBatch(b database.KeyValueWriterDeleter, key Key, n *node) error {
 	dbKey := db.constructDBKey(key)
 	defer db.bufferPool.Put(dbKey)
+
 	db.metrics.DatabaseNodeWrite()
 	if n == nil {
-		return b.Delete(dbKey)
+		return b.Delete(*dbKey)
 	}
-	return b.Put(dbKey, n.bytes())
+	return b.Put(*dbKey, n.bytes())
 }
 
 func (db *intermediateNodeDB) Get(key Key) (*node, error) {
@@ -128,12 +125,13 @@ func (db *intermediateNodeDB) Get(key Key) (*node, error) {
 	db.metrics.IntermediateNodeCacheMiss()
 
 	dbKey := db.constructDBKey(key)
+	defer db.bufferPool.Put(dbKey)
+
 	db.metrics.DatabaseNodeRead()
-	nodeBytes, err := db.baseDB.Get(dbKey)
+	nodeBytes, err := db.baseDB.Get(*dbKey)
 	if err != nil {
 		return nil, err
 	}
-	db.bufferPool.Put(dbKey)
 
 	return parseNode(key, nodeBytes)
 }
@@ -142,7 +140,7 @@ func (db *intermediateNodeDB) Get(key Key) (*node, error) {
 // We need to be able to differentiate between two keys of equal
 // byte length but different bit length, so we add padding to differentiate.
 // Additionally, we add a prefix indicating it is part of the intermediateNodeDB.
-func (db *intermediateNodeDB) constructDBKey(key Key) []byte {
+func (db *intermediateNodeDB) constructDBKey(key Key) *[]byte {
 	if db.tokenSize == 8 {
 		// For tokens of size byte, no padding is needed since byte length == token length
 		return addPrefixToKey(db.bufferPool, intermediateNodePrefix, key.Bytes())

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -169,11 +169,11 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 				// for keys with tokens of size byte, no padding is added
 				require.Equal(p.Bytes(), (*constructedKey)[len(intermediateNodePrefix):])
 			case p.hasPartialByte():
-				require.Len(constructedKey, baseLength)
+				require.Len(*constructedKey, baseLength)
 				require.Equal(p.Extend(ToToken(1, tokenSize)).Bytes(), (*constructedKey)[len(intermediateNodePrefix):])
 			default:
 				// when a whole number of bytes, there is an extra padding byte
-				require.Len(constructedKey, baseLength+1)
+				require.Len(*constructedKey, baseLength+1)
 				require.Equal(p.Extend(ToToken(1, tokenSize)).Bytes(), (*constructedKey)[len(intermediateNodePrefix):])
 			}
 		}

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -4,13 +4,13 @@
 package merkledb
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/maybe"
 )
 
@@ -35,9 +35,7 @@ func Test_IntermediateNodeDB(t *testing.T) {
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(
 		baseDB,
-		&sync.Pool{
-			New: func() interface{} { return make([]byte, 0) },
-		},
+		utils.NewBytesPool(),
 		&mockMetrics{},
 		cacheSize,
 		bufferSize,
@@ -149,9 +147,7 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 		for _, tokenSize := range validTokenSizes {
 			db := newIntermediateNodeDB(
 				baseDB,
-				&sync.Pool{
-					New: func() interface{} { return make([]byte, 0) },
-				},
+				utils.NewBytesPool(),
 				&mockMetrics{},
 				cacheSize,
 				bufferSize,
@@ -167,18 +163,18 @@ func FuzzIntermediateNodeDBConstructDBKey(f *testing.F) {
 			p = p.Take(int(uBitLength))
 			constructedKey := db.constructDBKey(p)
 			baseLength := len(p.value) + len(intermediateNodePrefix)
-			require.Equal(intermediateNodePrefix, constructedKey[:len(intermediateNodePrefix)])
+			require.Equal(intermediateNodePrefix, (*constructedKey)[:len(intermediateNodePrefix)])
 			switch {
 			case tokenSize == 8:
 				// for keys with tokens of size byte, no padding is added
-				require.Equal(p.Bytes(), constructedKey[len(intermediateNodePrefix):])
+				require.Equal(p.Bytes(), (*constructedKey)[len(intermediateNodePrefix):])
 			case p.hasPartialByte():
 				require.Len(constructedKey, baseLength)
-				require.Equal(p.Extend(ToToken(1, tokenSize)).Bytes(), constructedKey[len(intermediateNodePrefix):])
+				require.Equal(p.Extend(ToToken(1, tokenSize)).Bytes(), (*constructedKey)[len(intermediateNodePrefix):])
 			default:
 				// when a whole number of bytes, there is an extra padding byte
 				require.Len(constructedKey, baseLength+1)
-				require.Equal(p.Extend(ToToken(1, tokenSize)).Bytes(), constructedKey[len(intermediateNodePrefix):])
+				require.Equal(p.Extend(ToToken(1, tokenSize)).Bytes(), (*constructedKey)[len(intermediateNodePrefix):])
 			}
 		}
 	})
@@ -192,9 +188,7 @@ func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(
 		baseDB,
-		&sync.Pool{
-			New: func() interface{} { return make([]byte, 0) },
-		},
+		utils.NewBytesPool(),
 		&mockMetrics{},
 		cacheSize,
 		bufferSize,
@@ -202,23 +196,19 @@ func Test_IntermediateNodeDB_ConstructDBKey_DirtyBuffer(t *testing.T) {
 		4,
 	)
 
-	db.bufferPool.Put([]byte{0xFF, 0xFF, 0xFF})
+	db.bufferPool.Put(&[]byte{0xFF, 0xFF, 0xFF})
 	constructedKey := db.constructDBKey(ToKey([]byte{}))
-	require.Len(constructedKey, 2)
-	require.Equal(intermediateNodePrefix, constructedKey[:len(intermediateNodePrefix)])
-	require.Equal(byte(16), constructedKey[len(constructedKey)-1])
+	require.Len(*constructedKey, 2)
+	require.Equal(intermediateNodePrefix, (*constructedKey)[:len(intermediateNodePrefix)])
+	require.Equal(byte(16), (*constructedKey)[len(*constructedKey)-1])
 
-	db.bufferPool = &sync.Pool{
-		New: func() interface{} {
-			return make([]byte, 0, defaultBufferLength)
-		},
-	}
-	db.bufferPool.Put([]byte{0xFF, 0xFF, 0xFF})
+	db.bufferPool = utils.NewBytesPool()
+	db.bufferPool.Put(&[]byte{0xFF, 0xFF, 0xFF})
 	p := ToKey([]byte{0xF0}).Take(4)
 	constructedKey = db.constructDBKey(p)
-	require.Len(constructedKey, 2)
-	require.Equal(intermediateNodePrefix, constructedKey[:len(intermediateNodePrefix)])
-	require.Equal(p.Extend(ToToken(1, 4)).Bytes(), constructedKey[len(intermediateNodePrefix):])
+	require.Len(*constructedKey, 2)
+	require.Equal(intermediateNodePrefix, (*constructedKey)[:len(intermediateNodePrefix)])
+	require.Equal(p.Extend(ToToken(1, 4)).Bytes(), (*constructedKey)[len(intermediateNodePrefix):])
 }
 
 func TestIntermediateNodeDBClear(t *testing.T) {
@@ -229,9 +219,7 @@ func TestIntermediateNodeDBClear(t *testing.T) {
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(
 		baseDB,
-		&sync.Pool{
-			New: func() interface{} { return make([]byte, 0) },
-		},
+		utils.NewBytesPool(),
 		&mockMetrics{},
 		cacheSize,
 		bufferSize,
@@ -265,9 +253,7 @@ func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 	baseDB := memdb.New()
 	db := newIntermediateNodeDB(
 		baseDB,
-		&sync.Pool{
-			New: func() interface{} { return make([]byte, 0) },
-		},
+		utils.NewBytesPool(),
 		&mockMetrics{},
 		cacheSize,
 		bufferSize,
@@ -280,7 +266,7 @@ func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 	require.NoError(db.Flush())
 
 	emptyDBKey := db.constructDBKey(emptyKey)
-	has, err := baseDB.Has(emptyDBKey)
+	has, err := baseDB.Has(*emptyDBKey)
 	require.NoError(err)
 	require.True(has)
 
@@ -288,7 +274,7 @@ func TestIntermediateNodeDBDeleteEmptyKey(t *testing.T) {
 	require.NoError(db.Flush())
 
 	emptyDBKey = db.constructDBKey(emptyKey)
-	has, err = baseDB.Has(emptyDBKey)
+	has, err = baseDB.Has(*emptyDBKey)
 	require.NoError(err)
 	require.False(has)
 }

--- a/x/merkledb/value_node_db_test.go
+++ b/x/merkledb/value_node_db_test.go
@@ -4,13 +4,13 @@
 package merkledb
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/maybe"
 )
 
@@ -23,9 +23,7 @@ func TestValueNodeDB(t *testing.T) {
 	cacheSize := 10_000
 	db := newValueNodeDB(
 		baseDB,
-		&sync.Pool{
-			New: func() interface{} { return make([]byte, 0) },
-		},
+		utils.NewBytesPool(),
 		&mockMetrics{},
 		cacheSize,
 	)
@@ -118,9 +116,7 @@ func TestValueNodeDBIterator(t *testing.T) {
 	cacheSize := 10
 	db := newValueNodeDB(
 		baseDB,
-		&sync.Pool{
-			New: func() interface{} { return make([]byte, 0) },
-		},
+		utils.NewBytesPool(),
 		&mockMetrics{},
 		cacheSize,
 	)
@@ -225,9 +221,7 @@ func TestValueNodeDBClear(t *testing.T) {
 	baseDB := memdb.New()
 	db := newValueNodeDB(
 		baseDB,
-		&sync.Pool{
-			New: func() interface{} { return make([]byte, 0) },
-		},
+		utils.NewBytesPool(),
 		&mockMetrics{},
 		cacheSize,
 	)


### PR DESCRIPTION
## Why this should be merged

This PR improves the average workload allocation speed by `~70%`. 
This PR improves the worst case workload allocation speed by `~91%`

This PR implements a bucketed `sync.Pool` for byte slices. It has comparable performance than the (fixed) approach used in the prefixdb/merkledb for most workloads. However, the performance is workload independent. The prefixdb/merkledb approach does not handle the ascending workload efficiently. 

Performance of just allocating the requested bytes:
```
BenchmarkBytesPool_Constant/0-12    	305457604	         4.158 ns/op	         0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/8-12    	76623870	        15.83  ns/op	         8 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/16-12   	44998242	        25.46  ns/op	        16 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/32-12   	49072311	        25.67  ns/op	        32 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/64-12   	37186384	        33.22  ns/op	        64 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/256-12  	 9332716	       134.0   ns/op	       256 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/2048-12 	 2156217	       569.7   ns/op	      2048 B/op	       1 allocs/op
BenchmarkBytesPool_Descending-12    	       2	 973057916     ns/op	5309609360 B/op	  100507 allocs/op
BenchmarkBytesPool_Ascending-12     	       3	 498653917     ns/op	5309465072 B/op	  100112 allocs/op
BenchmarkBytesPool_Random-12        	     224	   5282923     ns/op	  51456611 B/op	    1001 allocs/op
```

Using the prefixdb/merkledb `sync.Pool` approach:
```
BenchmarkBytesPool_Constant/0-12    	23733140	        46.89 ns/op	      24 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/8-12    	25610904	        47.00 ns/op	      24 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/16-12   	25540450	        48.19 ns/op	      24 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/32-12   	25697008	        47.32 ns/op	      24 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/64-12   	24564198	        47.91 ns/op	      24 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/256-12  	25694967	        47.75 ns/op	      24 B/op	       1 allocs/op
BenchmarkBytesPool_Constant/2048-12 	24311798	        49.26 ns/op	      26 B/op	       1 allocs/op
BenchmarkBytesPool_Descending-12    	     235	      5059765 ns/op	 3244221 B/op	  100041 allocs/op
BenchmarkBytesPool_Ascending-12     	      79	     15944859 ns/op    203357893 B/op	  106367 allocs/op
BenchmarkBytesPool_Random-12        	   21878	        58405 ns/op	   57793 B/op	    1000 allocs/op
```

Using the prefixdb/merkledb `sync.Pool` approach (with `*[]byte`):
```
BenchmarkBytesPool_Constant/0-12    	80639740	        16.84 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/8-12    	83390275	        14.50 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/16-12   	84568580	        14.32 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/32-12   	83906548	        14.48 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/64-12   	84178773	        14.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/256-12  	82249292	        14.39 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/2048-12 	73301838	        14.35 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Descending-12    	     818	      1455992 ns/op	    9124 B/op	       0 allocs/op
BenchmarkBytesPool_Ascending-12     	     565	      2135166 ns/op	 9619777 B/op	     365 allocs/op
BenchmarkBytesPool_Random-12        	   76890	        15618 ns/op	     530 B/op	       0 allocs/op
```

Using the bucketed `sync.Pool` approach:
```
BenchmarkBytesPool_Constant/0-12    	85004992	        14.09 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/8-12    	84486711	        14.18 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/16-12   	86129293	        14.03 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/32-12   	89044167	        13.99 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/64-12   	87703000	        13.98 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/256-12  	88138891	        13.90 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Constant/2048-12 	85855333	        14.04 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesPool_Descending-12    	     835	      1411102 ns/op	     670 B/op	       0 allocs/op
BenchmarkBytesPool_Ascending-12     	     855	      1404976 ns/op	     349 B/op	       0 allocs/op
BenchmarkBytesPool_Random-12        	   85389	        14161 ns/op	       3 B/op	       0 allocs/op
```

## How this works

This PR implements buckets of `sync.Pool`s that return byte slices that are of size `2^n -1`. This allows us to allocate slices that are always sufficient size. This isn't too memory inefficient, it'll allocate slices that are at most 2x larger than requested.

## How this was tested

- [X] Added unit tests
- [X] Added benchmarks
- [X] CI