### PR TITLE
Remove duplicate metrics increment

### DIFF
--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -113,8 +113,6 @@ func (db *intermediateNodeDB) Get(key Key) (*node, error) {
 		}
 		return cachedValue, nil
 	}
-	db.metrics.IntermediateNodeCacheMiss()
-
 	if cachedValue, isCached := db.writeBuffer.Get(key); isCached {
 		db.metrics.IntermediateNodeCacheHit()
 		if cachedValue == nil {


### PR DESCRIPTION
## Why this should be merged

This metric doesn't currently make much sense. We have two intermediate node caches. For the metrics, we should either split the metrics to report the usefulness of the caches independently, or we should treat the caches as a single cache for the metrics.

Specifically, fetching an intermediate node may:
- Register a cache hit
- Register a cache hit and a cache miss
- Register two cache misses and a DB read

This PR takes the (simpler) approach, of just treating the caches as a single cache. Now fetching an intermediate node will either:
- Register a cache hit
- Register a cache miss and a DB read

## How this works

Removes the duplicate cache miss call.

## How this was tested

N/A