### PR TITLE
Optimize intermediateNodeDB.constructDBKey

### DIFF
--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -142,11 +142,28 @@ func (db *intermediateNodeDB) Get(key Key) (*node, error) {
 // Additionally, we add a prefix indicating it is part of the intermediateNodeDB.
 func (db *intermediateNodeDB) constructDBKey(key Key) *[]byte {
 	if db.tokenSize == 8 {
-		// For tokens of size byte, no padding is needed since byte length == token length
+		// For tokens of size byte, no padding is needed since byte
+		// length == token length
 		return addPrefixToKey(db.bufferPool, intermediateNodePrefix, key.Bytes())
 	}
 
-	return addPrefixToKey(db.bufferPool, intermediateNodePrefix, key.Extend(ToToken(1, db.tokenSize)).Bytes())
+	var (
+		prefixLen              = len(intermediateNodePrefix)
+		prefixBitLen           = 8 * prefixLen
+		dualIndex              = dualBitIndex(db.tokenSize)
+		paddingByteValue  byte = 1 << dualIndex
+		paddingSliceValue      = []byte{paddingByteValue}
+		paddingKey             = Key{
+			value:  byteSliceToString(paddingSliceValue),
+			length: db.tokenSize,
+		}
+	)
+
+	bufferPtr := db.bufferPool.Get(bytesNeeded(prefixBitLen + key.length + db.tokenSize))
+	copy(*bufferPtr, intermediateNodePrefix)                          // add prefix
+	copy((*bufferPtr)[prefixLen:], key.Bytes())                       // add key
+	extendIntoBuffer(*bufferPtr, paddingKey, prefixBitLen+key.length) // add padding
+	return bufferPtr
 }
 
 func (db *intermediateNodeDB) Put(key Key, n *node) error {


### PR DESCRIPTION
## Why this should be merged

This removes the last memory allocation performed during DB key construction.

This shows between a `~45%` and `~84%` performance improvement (for keys without full bytes, which is already optimal).

Before:
```
Benchmark_IntermediateNodeDB_ConstructDBKey/1/0-12         	25409731	        46.64 ns/op	       1 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/1-12         	25000216	        48.55 ns/op	       1 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/4-12         	25181736	        48.94 ns/op	       1 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/16-12        	24164276	        49.75 ns/op	       3 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/64-12        	20314750	        59.34 ns/op	      16 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/256-12       	14373997	        86.10 ns/op	      48 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/0-12         	25898301	        46.53 ns/op	       1 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/1-12         	24957818	        48.47 ns/op	       1 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/4-12         	25241016	        48.78 ns/op	       2 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/16-12        	23468191	        52.14 ns/op	       5 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/64-12        	17259501	        71.52 ns/op	      24 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/256-12       	10738522	       119.8  ns/op	      80 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/0-12         	26027450	        46.85 ns/op	       1 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/1-12         	25129508	        48.22 ns/op	       1 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/4-12         	24071391	        49.70 ns/op	       3 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/16-12        	20243042	        60.31 ns/op	      16 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/64-12        	13661914	        88.66 ns/op	      48 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/256-12       	 6802599	       175.4  ns/op	     144 B/op	       1 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/0-12         	55742006	        23.24 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/1-12         	54862995	        21.99 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/4-12         	56339461	        21.61 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/16-12        	55833429	        21.28 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/64-12        	56151404	        21.35 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/256-12       	50749971	        23.39 ns/op	       0 B/op	       0 allocs/op
```

After:
```
Benchmark_IntermediateNodeDB_ConstructDBKey/1/0-12         	46500813	        26.04 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/1-12         	38439309	        27.85 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/4-12         	43244282	        27.66 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/16-12        	45858046	        26.26 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/64-12        	46101169	        26.08 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/1/256-12       	44999648	        26.26 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/0-12         	46544250	        25.61 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/1-12         	43411216	        27.72 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/4-12         	45543534	        26.49 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/16-12        	45807792	        26.07 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/64-12        	45994633	        26.35 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/2/256-12       	44242350	        27.10 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/0-12         	46909128	        25.78 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/1-12         	43235452	        27.66 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/4-12         	44799382	        26.40 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/16-12        	45919684	        25.93 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/64-12        	46168495	        26.21 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/4/256-12       	44241736	        28.93 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/0-12         	56356657	        21.26 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/1-12         	53933996	        21.99 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/4-12         	55811896	        21.54 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/16-12        	57010286	        21.30 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/64-12        	54723616	        21.65 ns/op	       0 B/op	       0 allocs/op
Benchmark_IntermediateNodeDB_ConstructDBKey/8/256-12       	51029176	        23.63 ns/op	       0 B/op	       0 allocs/op
```

## How this works

`key.Extend` performs an intermediate memory allocation which can be removed.

## How this was tested

- [X] Added new benchmark
- [X] CI