### PR TITLE
[vms/proposervm] Remove `getForkHeight()`

### DIFF
--- a/vms/proposervm/pre_fork_block.go
+++ b/vms/proposervm/pre_fork_block.go
@@ -39,7 +39,7 @@ func (b *preForkBlock) acceptInnerBlk(ctx context.Context) error {
 }
 
 func (b *preForkBlock) Status() choices.Status {
-	forkHeight, err := b.vm.getForkHeight()
+	forkHeight, err := b.vm.GetForkHeight()
 	if err == database.ErrNotFound {
 		return b.Block.Status()
 	}

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -53,10 +53,6 @@ var (
 	_ block.BatchedChainVM  = (*VM)(nil)
 	_ block.StateSyncableVM = (*VM)(nil)
 
-	// TODO: remove after the X-chain supports height indexing.
-	mainnetXChainID = ids.FromStringOrPanic("2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM")
-	fujiXChainID    = ids.FromStringOrPanic("2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm")
-
 	dbPrefix = []byte("proposervm")
 )
 
@@ -214,7 +210,7 @@ func (vm *VM) Initialize(
 		return err
 	}
 
-	forkHeight, err := vm.getForkHeight()
+	forkHeight, err := vm.GetForkHeight()
 	switch err {
 	case nil:
 		chainCtx.Log.Info("initialized proposervm",
@@ -573,26 +569,6 @@ func (vm *VM) getBlock(ctx context.Context, id ids.ID) (Block, error) {
 		return blk, nil
 	}
 	return vm.getPreForkBlock(ctx, id)
-}
-
-// TODO: remove after the P-chain and X-chain support height indexing.
-func (vm *VM) getForkHeight() (uint64, error) {
-	// The fork block can be easily identified with the provided links because
-	// the `Parent Hash` is equal to the `Proposer Parent ID`.
-	switch vm.ctx.ChainID {
-	case constants.PlatformChainID:
-		switch vm.ctx.NetworkID {
-		case constants.MainnetID:
-			return 805732, nil // https://subnets.avax.network/p-chain/block/805732
-		case constants.FujiID:
-			return 47529, nil // https://subnets-test.avax.network/p-chain/block/47529
-		}
-	case mainnetXChainID:
-		return 1, nil // https://subnets.avax.network/x-chain/block/1
-	case fujiXChainID:
-		return 1, nil // https://subnets-test.avax.network/x-chain/block/1
-	}
-	return vm.GetForkHeight()
 }
 
 func (vm *VM) getPostForkBlock(ctx context.Context, blkID ids.ID) (PostForkBlock, error) {


### PR DESCRIPTION
## Why this should be merged

The P-Chain and X-Chain both support height indexing:
- https://github.com/ava-labs/avalanchego/pull/1699
- https://github.com/ava-labs/avalanchego/pull/1746

We can now remove this method and use `GetForkHeight()` directly.

## How this works

🧹 

## How this was tested

CI