### PR TITLE
Improve logging of startup and errors in bootstrapping

### DIFF
--- a/snow/engine/snowman/bootstrap/storage.go
+++ b/snow/engine/snowman/bootstrap/storage.go
@@ -220,16 +220,18 @@ func execute(
 		}
 
 		if err := blk.Verify(ctx); err != nil {
-			return fmt.Errorf("failed to verify block %s (%d) in bootstrapping: %w",
+			return fmt.Errorf("failed to verify block %s (height=%d, parentID=%s) in bootstrapping: %w",
 				blk.ID(),
 				height,
+				blk.Parent(),
 				err,
 			)
 		}
 		if err := blk.Accept(ctx); err != nil {
-			return fmt.Errorf("failed to accept block %s (%d) in bootstrapping: %w",
+			return fmt.Errorf("failed to accept block %s (height=%d, parentID=%s) in bootstrapping: %w",
 				blk.ID(),
 				height,
+				blk.Parent(),
 				err,
 			)
 		}

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -471,7 +471,8 @@ func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 	}
 
 	// initialize consensus to the last accepted blockID
-	if err := t.Consensus.Initialize(t.Ctx, t.Params, lastAcceptedID, lastAccepted.Height(), lastAccepted.Timestamp()); err != nil {
+	lastAcceptedHeight := lastAccepted.Height()
+	if err := t.Consensus.Initialize(t.Ctx, t.Params, lastAcceptedID, lastAcceptedHeight, lastAccepted.Timestamp()); err != nil {
 		return err
 	}
 
@@ -501,8 +502,9 @@ func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 		return err
 	}
 
-	t.Ctx.Log.Info("consensus starting",
-		zap.Stringer("lastAcceptedBlock", lastAcceptedID),
+	t.Ctx.Log.Info("starting consensus",
+		zap.Stringer("lastAcceptedID", lastAcceptedID),
+		zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
 	)
 	t.metrics.bootstrapFinished.Set(1)
 


### PR DESCRIPTION
## Why this should be merged

Improves visibility of the block that caused errors + the last accepted block during startup.

## How this works

Adds additional information to logs.

## How this was tested

- [X] CI