### PR TITLE
Specify golang patch version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ module github.com/ava-labs/avalanchego
 // tests/antithesis/Dockerfile.workload
 // Dockerfile
 // README.md
-// go.mod (here, only major.minor can be specified)
-go 1.21
+// go.mod (here)
+go 1.21.9
 
 require (
 	github.com/DataDog/zstd v1.5.2


### PR DESCRIPTION
## Why this should be merged

As of `go.1.21` - the `go.mod` file supports enforcing a minimum patch version.

## How this works

`+ .9`.

## How this was tested

- [X] CI