### PR TITLE
CI: ensure image build job is compatible with merge queue

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -28,7 +28,7 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Load the constants
 source "$AVALANCHE_PATH"/scripts/constants.sh
 
-if [[ $current_branch == *"-race" ]]; then
+if [[ $image_tag == *"-race" ]]; then
   echo "Branch name must not end in '-race'"
   exit 1
 fi
@@ -74,16 +74,16 @@ else
   DOCKER_CMD="${DOCKER_CMD} --load"
 fi
 
-echo "Building Docker Image with tags: $DOCKER_IMAGE:$commit_hash , $DOCKER_IMAGE:$current_branch"
-${DOCKER_CMD} -t "$DOCKER_IMAGE:$commit_hash" -t "$DOCKER_IMAGE:$current_branch" \
+echo "Building Docker Image with tags: $DOCKER_IMAGE:$commit_hash , $DOCKER_IMAGE:$image_tag"
+${DOCKER_CMD} -t "$DOCKER_IMAGE:$commit_hash" -t "$DOCKER_IMAGE:$image_tag" \
               "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"
 
-echo "Building Docker Image with tags: $DOCKER_IMAGE:$commit_hash-race , $DOCKER_IMAGE:$current_branch-race"
-${DOCKER_CMD} --build-arg="RACE_FLAG=-r" -t "$DOCKER_IMAGE:$commit_hash-race" -t "$DOCKER_IMAGE:$current_branch-race" \
+echo "Building Docker Image with tags: $DOCKER_IMAGE:$commit_hash-race , $DOCKER_IMAGE:$image_tag-race"
+${DOCKER_CMD} --build-arg="RACE_FLAG=-r" -t "$DOCKER_IMAGE:$commit_hash-race" -t "$DOCKER_IMAGE:$image_tag-race" \
               "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"
 
 # Only tag the latest image for the master branch when images are pushed to a registry
-if [[ "${DOCKER_IMAGE}" == *"/"* && $current_branch == "master" ]]; then
+if [[ "${DOCKER_IMAGE}" == *"/"* && $image_tag == "master" ]]; then
   echo "Tagging current avalanchego images as $DOCKER_IMAGE:latest"
   docker buildx imagetools create -t "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$commit_hash"
 fi

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -13,12 +13,15 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd ) # Direct
 # Where AvalancheGo binary goes
 avalanchego_path="$AVALANCHE_PATH/build/avalanchego"
 
-# Current branch  (shared between image build and its test script)
+# Image tag based on current branch  (shared between image build and its test script)
 # TODO: fix "fatal: No names found, cannot describe anything" in github CI
-current_branch=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match || true)
-# Supply a default branch when one is not discovered
-if [[ -z $current_branch ]]; then
-  current_branch=ci_dummy
+image_tag=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match || true)
+if [[ -z $image_tag ]]; then
+  # Supply a default tag when one is not discovered
+  image_tag=ci_dummy
+elif [[ "$image_tag" == */* ]]; then
+  # Slashes are not legal for docker image tags - replace with dashes
+  image_tag=$(echo "$image_tag" | tr '/' '-')
 fi
 
 # Current commit (shared between image build and its test script)

--- a/scripts/tests.build_image.sh
+++ b/scripts/tests.build_image.sh
@@ -35,9 +35,9 @@ build_and_test() {
   # Check all of the images expected to have been built
   local target_images=(
     "$image_name:$commit_hash"
-    "$image_name:$current_branch"
+    "$image_name:$image_tag"
     "$image_name:$commit_hash-race"
-    "$image_name:$current_branch-race"
+    "$image_name:$image_tag-race"
   )
 
   for arch in "${arches[@]}"; do


### PR DESCRIPTION
The name of the branches used for the merge queue contain slashes, and since docker image tags cannot include slashes, the merge queue branch names are not valid for use as docker image tags.

To fix this, convert a branch name to an image tag by replacing any slashes with dashes (which are allowed).