### PR TITLE
chore: fix function names in comment

### DIFF
--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -292,7 +292,7 @@ type GetLoggerLevelArgs struct {
 	LoggerName string `json:"loggerName"`
 }
 
-// GetLogLevel returns the log level and display level of all loggers.
+// GetLoggerLevel returns the log level and display level of all loggers.
 func (a *Admin) GetLoggerLevel(_ *http.Request, args *GetLoggerLevelArgs, reply *LoggerLevelReply) error {
 	a.Log.Debug("API called",
 		zap.String("service", "admin"),

--- a/config/config.go
+++ b/config/config.go
@@ -949,7 +949,7 @@ func getChainConfigs(v *viper.Viper) (map[string]chains.ChainConfig, error) {
 	return getChainConfigsFromDir(v)
 }
 
-// ReadsChainConfigs reads chain config files from static directories and returns map with contents,
+// readChainConfigPath reads chain config files from static directories and returns map with contents,
 // if successful.
 func readChainConfigPath(chainConfigPath string) (map[string]chains.ChainConfig, error) {
 	chainDirs, err := filepath.Glob(filepath.Join(chainConfigPath, "*"))
@@ -987,7 +987,7 @@ func readChainConfigPath(chainConfigPath string) (map[string]chains.ChainConfig,
 	return chainConfigMap, nil
 }
 
-// getSubnetConfigsFromFlags reads subnet configs from the correct place
+// getSubnetConfigs reads subnet configs from the correct place
 // (flag or file) and returns a non-nil map.
 func getSubnetConfigs(v *viper.Viper, subnetIDs []ids.ID) (map[ids.ID]subnets.Config, error) {
 	if v.IsSet(SubnetConfigContentKey) {

--- a/database/test_database.go
+++ b/database/test_database.go
@@ -307,7 +307,7 @@ func TestBatchDelete(t *testing.T, db Database) {
 	require.NoError(db.Delete(key))
 }
 
-// TestMemorySafetyDatabase ensures it is safe to modify a key after passing it
+// TestMemorySafetyBatch ensures it is safe to modify a key after passing it
 // to Batch.Put.
 func TestMemorySafetyBatch(t *testing.T, db Database) {
 	require := require.New(t)


### PR DESCRIPTION
## Why this should be merged

 fix function names in comment

## How this works

## How this was tested
