### PR TITLE
Exit topological sort earlier

### DIFF
--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -409,20 +409,17 @@ func (ts *Topological) calculateInDegree(votes bag.Bag[ids.ID]) {
 			parentID = n.blk.Parent()
 
 			// Increase the inDegree by one
-			kahn := ts.kahnNodes[parentID]
+			kahn, previouslySeen := ts.kahnNodes[parentID]
 			kahn.inDegree++
 			ts.kahnNodes[parentID] = kahn
 
 			// If we have already seen this block, then we shouldn't increase
 			// the inDegree of the ancestors through this block again.
-			if kahn.inDegree != 1 {
+			if previouslySeen {
+				// Nodes are only leaves if they have no inbound edges.
+				ts.leaves.Remove(parentID)
 				break
 			}
-
-			// If I am transitively seeing this block for the first time, either
-			// the block was previously unknown or it was previously a leaf.
-			// Regardless, it shouldn't be tracked as a leaf.
-			ts.leaves.Remove(parentID)
 		}
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Previously the consensus logic may have marked a node as having more inbound edges than it actually had because the traversal would not exit after hitting a node that was already seen.

This could cause some votes to be dropped which could increase time-to-finality.

## How this works

Exits the topological sort as soon as a node that has been previously touched is seen (rather than waiting for a node that previously had inbound edges).

## How this was tested

- [X] Added a new unit test (which previously would fail non-deterministically)
- [X] CI