### PR TITLE
Consolidate record poll

### DIFF
--- a/snow/consensus/snowball/binary_snowball.go
+++ b/snow/consensus/snowball/binary_snowball.go
@@ -40,26 +40,10 @@ func (sb *binarySnowball) Preference() int {
 }
 
 func (sb *binarySnowball) RecordPoll(count, choice int) {
-	switch {
-	case count >= sb.alphaConfidence:
-		sb.recordSuccessfulPoll(choice)
-	case count >= sb.alphaPreference:
-		sb.recordPollPreference(choice)
-	default:
-		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
-		// have been called instead.
-		sb.RecordUnsuccessfulPoll()
+	if count >= sb.alphaPreference {
+		sb.increasePreferenceStrength(choice)
 	}
-}
-
-func (sb *binarySnowball) recordSuccessfulPoll(choice int) {
-	sb.increasePreferenceStrength(choice)
-	sb.binarySnowflake.recordSuccessfulPoll(choice)
-}
-
-func (sb *binarySnowball) recordPollPreference(choice int) {
-	sb.increasePreferenceStrength(choice)
-	sb.binarySnowflake.recordPollPreference(choice)
+	sb.binarySnowflake.RecordPoll(count, choice)
 }
 
 func (sb *binarySnowball) String() string {

--- a/snow/consensus/snowball/binary_snowball.go
+++ b/snow/consensus/snowball/binary_snowball.go
@@ -7,9 +7,9 @@ import "fmt"
 
 var _ Binary = (*binarySnowball)(nil)
 
-func newBinarySnowball(beta, choice int) binarySnowball {
+func newBinarySnowball(alphaPreference int, alphaConfidence int, beta int, choice int) binarySnowball {
 	return binarySnowball{
-		binarySnowflake: newBinarySnowflake(beta, choice),
+		binarySnowflake: newBinarySnowflake(alphaPreference, alphaConfidence, beta, choice),
 		preference:      choice,
 	}
 }
@@ -37,6 +37,19 @@ func (sb *binarySnowball) Preference() int {
 		return sb.binarySnowflake.Preference()
 	}
 	return sb.preference
+}
+
+func (sb *binarySnowball) RecordPoll(count, choice int) {
+	switch {
+	case count >= sb.alphaConfidence:
+		sb.RecordSuccessfulPoll(choice)
+	case count >= sb.alphaPreference:
+		sb.RecordPollPreference(choice)
+	default:
+		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
+		// have been called instead.
+		sb.RecordUnsuccessfulPoll()
+	}
 }
 
 func (sb *binarySnowball) RecordSuccessfulPoll(choice int) {

--- a/snow/consensus/snowball/binary_snowball.go
+++ b/snow/consensus/snowball/binary_snowball.go
@@ -41,7 +41,10 @@ func (sb *binarySnowball) Preference() int {
 
 func (sb *binarySnowball) RecordPoll(count, choice int) {
 	if count >= sb.alphaPreference {
-		sb.increasePreferenceStrength(choice)
+		sb.preferenceStrength[choice]++
+		if sb.preferenceStrength[choice] > sb.preferenceStrength[1-choice] {
+			sb.preference = choice
+		}
 	}
 	sb.binarySnowflake.RecordPoll(count, choice)
 }
@@ -53,11 +56,4 @@ func (sb *binarySnowball) String() string {
 		sb.preferenceStrength[0],
 		sb.preferenceStrength[1],
 		&sb.binarySnowflake)
-}
-
-func (sb *binarySnowball) increasePreferenceStrength(choice int) {
-	sb.preferenceStrength[choice]++
-	if sb.preferenceStrength[choice] > sb.preferenceStrength[1-choice] {
-		sb.preference = choice
-	}
 }

--- a/snow/consensus/snowball/binary_snowball.go
+++ b/snow/consensus/snowball/binary_snowball.go
@@ -42,9 +42,9 @@ func (sb *binarySnowball) Preference() int {
 func (sb *binarySnowball) RecordPoll(count, choice int) {
 	switch {
 	case count >= sb.alphaConfidence:
-		sb.RecordSuccessfulPoll(choice)
+		sb.recordSuccessfulPoll(choice)
 	case count >= sb.alphaPreference:
-		sb.RecordPollPreference(choice)
+		sb.recordPollPreference(choice)
 	default:
 		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
 		// have been called instead.
@@ -52,14 +52,14 @@ func (sb *binarySnowball) RecordPoll(count, choice int) {
 	}
 }
 
-func (sb *binarySnowball) RecordSuccessfulPoll(choice int) {
+func (sb *binarySnowball) recordSuccessfulPoll(choice int) {
 	sb.increasePreferenceStrength(choice)
-	sb.binarySnowflake.RecordSuccessfulPoll(choice)
+	sb.binarySnowflake.recordSuccessfulPoll(choice)
 }
 
-func (sb *binarySnowball) RecordPollPreference(choice int) {
+func (sb *binarySnowball) recordPollPreference(choice int) {
 	sb.increasePreferenceStrength(choice)
-	sb.binarySnowflake.RecordPollPreference(choice)
+	sb.binarySnowflake.recordPollPreference(choice)
 }
 
 func (sb *binarySnowball) String() string {

--- a/snow/consensus/snowball/binary_snowball_test.go
+++ b/snow/consensus/snowball/binary_snowball_test.go
@@ -15,9 +15,10 @@ func TestBinarySnowball(t *testing.T) {
 	red := 0
 	blue := 1
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newBinarySnowball(beta, red)
+	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
@@ -44,9 +45,10 @@ func TestBinarySnowballRecordPollPreference(t *testing.T) {
 	red := 0
 	blue := 1
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newBinarySnowball(beta, red)
+	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
@@ -80,9 +82,10 @@ func TestBinarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 	red := 0
 	blue := 1
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newBinarySnowball(beta, red)
+	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
@@ -110,9 +113,10 @@ func TestBinarySnowballAcceptWeirdColor(t *testing.T) {
 	blue := 0
 	red := 1
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newBinarySnowball(beta, red)
+	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
@@ -150,9 +154,10 @@ func TestBinarySnowballLockColor(t *testing.T) {
 	red := 0
 	blue := 1
 
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 1
 
-	sb := newBinarySnowball(beta, red)
+	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 
 	sb.RecordSuccessfulPoll(red)
 

--- a/snow/consensus/snowball/binary_snowball_test.go
+++ b/snow/consensus/snowball/binary_snowball_test.go
@@ -15,26 +15,26 @@ func TestBinarySnowball(t *testing.T) {
 	red := 0
 	blue := 1
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 2, 3
 	beta := 2
 
 	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(red)
+	sb.RecordPoll(alphaConfidence, red)
 	require.Equal(blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sb.Preference())
 	require.True(sb.Finalized())
 }
@@ -45,30 +45,30 @@ func TestBinarySnowballRecordPollPreference(t *testing.T) {
 	red := 0
 	blue := 1
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(red)
+	sb.RecordPoll(alphaConfidence, red)
 	require.Equal(blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordPollPreference(red)
+	sb.RecordPoll(alphaPreference, red)
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(red)
+	sb.RecordPoll(alphaConfidence, red)
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(red)
+	sb.RecordPoll(alphaConfidence, red)
 	require.Equal(red, sb.Preference())
 	require.True(sb.Finalized())
 
@@ -82,24 +82,24 @@ func TestBinarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 	red := 0
 	blue := 1
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sb.Preference())
 	require.False(sb.Finalized())
 
 	sb.RecordUnsuccessfulPoll()
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sb.Preference())
 	require.True(sb.Finalized())
 
@@ -113,7 +113,7 @@ func TestBinarySnowballAcceptWeirdColor(t *testing.T) {
 	blue := 0
 	red := 1
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
@@ -121,25 +121,25 @@ func TestBinarySnowballAcceptWeirdColor(t *testing.T) {
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(red)
+	sb.RecordPoll(alphaConfidence, red)
 	sb.RecordUnsuccessfulPoll()
 
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(red)
+	sb.RecordPoll(alphaConfidence, red)
 
 	sb.RecordUnsuccessfulPoll()
 
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 
 	require.Equal(red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 
 	require.Equal(blue, sb.Preference())
 	require.True(sb.Finalized())
@@ -159,18 +159,18 @@ func TestBinarySnowballLockColor(t *testing.T) {
 
 	sb := newBinarySnowball(alphaPreference, alphaConfidence, beta, red)
 
-	sb.RecordSuccessfulPoll(red)
+	sb.RecordPoll(alphaConfidence, red)
 
 	require.Equal(red, sb.Preference())
 	require.True(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaConfidence, blue)
 
 	require.Equal(red, sb.Preference())
 	require.True(sb.Finalized())
 
-	sb.RecordPollPreference(blue)
-	sb.RecordSuccessfulPoll(blue)
+	sb.RecordPoll(alphaPreference, blue)
+	sb.RecordPoll(alphaConfidence, blue)
 
 	require.Equal(red, sb.Preference())
 	require.True(sb.Finalized())

--- a/snow/consensus/snowball/binary_snowflake.go
+++ b/snow/consensus/snowball/binary_snowflake.go
@@ -47,9 +47,9 @@ func (sf *binarySnowflake) RecordPoll(count, choice int) {
 
 	switch {
 	case count >= sf.alphaConfidence:
-		sf.RecordSuccessfulPoll(choice)
+		sf.recordSuccessfulPoll(choice)
 	case count >= sf.alphaPreference:
-		sf.RecordPollPreference(choice)
+		sf.recordPollPreference(choice)
 	default:
 		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
 		// have been called instead.
@@ -57,7 +57,7 @@ func (sf *binarySnowflake) RecordPoll(count, choice int) {
 	}
 }
 
-func (sf *binarySnowflake) RecordSuccessfulPoll(choice int) {
+func (sf *binarySnowflake) recordSuccessfulPoll(choice int) {
 	if sf.finalized {
 		return // This instance is already decided.
 	}
@@ -74,7 +74,7 @@ func (sf *binarySnowflake) RecordSuccessfulPoll(choice int) {
 	sf.binarySlush.RecordSuccessfulPoll(choice)
 }
 
-func (sf *binarySnowflake) RecordPollPreference(choice int) {
+func (sf *binarySnowflake) recordPollPreference(choice int) {
 	if sf.finalized {
 		return // This instance is already decided.
 	}

--- a/snow/consensus/snowball/binary_snowflake.go
+++ b/snow/consensus/snowball/binary_snowflake.go
@@ -45,21 +45,15 @@ func (sf *binarySnowflake) RecordPoll(count, choice int) {
 		return // This instance is already decided.
 	}
 
-	switch {
-	case count >= sf.alphaConfidence:
-		sf.recordSuccessfulPoll(choice)
-	case count >= sf.alphaPreference:
-		sf.recordPollPreference(choice)
-	default:
-		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
-		// have been called instead.
+	if count < sf.alphaPreference {
 		sf.RecordUnsuccessfulPoll()
+		return
 	}
-}
 
-func (sf *binarySnowflake) recordSuccessfulPoll(choice int) {
-	if sf.finalized {
-		return // This instance is already decided.
+	if count < sf.alphaConfidence {
+		sf.confidence = 0
+		sf.binarySlush.RecordSuccessfulPoll(choice)
+		return
 	}
 
 	if preference := sf.Preference(); preference == choice {
@@ -71,15 +65,6 @@ func (sf *binarySnowflake) recordSuccessfulPoll(choice int) {
 	}
 
 	sf.finalized = sf.confidence >= sf.beta
-	sf.binarySlush.RecordSuccessfulPoll(choice)
-}
-
-func (sf *binarySnowflake) recordPollPreference(choice int) {
-	if sf.finalized {
-		return // This instance is already decided.
-	}
-
-	sf.confidence = 0
 	sf.binarySlush.RecordSuccessfulPoll(choice)
 }
 

--- a/snow/consensus/snowball/binary_snowflake_test.go
+++ b/snow/consensus/snowball/binary_snowflake_test.go
@@ -15,9 +15,10 @@ func TestBinarySnowflake(t *testing.T) {
 	blue := 0
 	red := 1
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sf := newBinarySnowflake(beta, red)
+	sf := newBinarySnowflake(alphaPreference, alphaConfidence, beta, red)
 
 	require.Equal(red, sf.Preference())
 	require.False(sf.Finalized())

--- a/snow/consensus/snowball/binary_snowflake_test.go
+++ b/snow/consensus/snowball/binary_snowflake_test.go
@@ -15,7 +15,7 @@ func TestBinarySnowflake(t *testing.T) {
 	blue := 0
 	red := 1
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sf := newBinarySnowflake(alphaPreference, alphaConfidence, beta, red)
@@ -23,30 +23,30 @@ func TestBinarySnowflake(t *testing.T) {
 	require.Equal(red, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(blue)
+	sf.RecordPoll(alphaConfidence, blue)
 
 	require.Equal(blue, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(red)
+	sf.RecordPoll(alphaConfidence, red)
 
 	require.Equal(red, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(blue)
+	sf.RecordPoll(alphaConfidence, blue)
 
 	require.Equal(blue, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordPollPreference(red)
+	sf.RecordPoll(alphaPreference, red)
 	require.Equal(red, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(blue)
+	sf.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(blue)
+	sf.RecordPoll(alphaConfidence, blue)
 	require.Equal(blue, sf.Preference())
 	require.True(sf.Finalized())
 }

--- a/snow/consensus/snowball/consensus.go
+++ b/snow/consensus/snowball/consensus.go
@@ -48,9 +48,8 @@ type Factory interface {
 
 // Nnary is a snow instance deciding between an unbounded number of values.
 // The caller samples k nodes and then calls
-// 1. RecordSuccessfulPoll if choice collects >= alphaConfidence votes
-// 2. RecordPollPreference if choice collects >= alphaPreference votes
-// 3. RecordUnsuccessfulPoll otherwise
+// 1. RecordPoll if choice collects >= alphaPreference votes
+// 2. RecordUnsuccessfulPoll otherwise
 type Nnary interface {
 	fmt.Stringer
 
@@ -73,9 +72,8 @@ type Nnary interface {
 
 // Binary is a snow instance deciding between two values.
 // The caller samples k nodes and then calls
-// 1. RecordSuccessfulPoll if choice collects >= alphaConfidence votes
-// 2. RecordPollPreference if choice collects >= alphaPreference votes
-// 3. RecordUnsuccessfulPoll otherwise
+// 1. RecordPoll if choice collects >= alphaPreference votes
+// 2. RecordUnsuccessfulPoll otherwise
 type Binary interface {
 	fmt.Stringer
 
@@ -95,9 +93,8 @@ type Binary interface {
 
 // Unary is a snow instance deciding on one value.
 // The caller samples k nodes and then calls
-// 1. RecordSuccessfulPoll if choice collects >= alphaConfidence votes
-// 2. RecordPollPreference if choice collects >= alphaPreference votes
-// 3. RecordUnsuccessfulPoll otherwise
+// 1. RecordPoll if choice collects >= alphaPreference votes
+// 2. RecordUnsuccessfulPoll otherwise
 type Unary interface {
 	fmt.Stringer
 

--- a/snow/consensus/snowball/consensus.go
+++ b/snow/consensus/snowball/consensus.go
@@ -59,8 +59,7 @@ type Nnary interface {
 	// Returns the currently preferred choice to be finalized
 	Preference() ids.ID
 
-	// RecordPoll records a poll that reaches at least an alphaPreference
-	// threshold.
+	// RecordPoll records the results of a network poll
 	RecordPoll(count int, choice ids.ID)
 
 	// RecordUnsuccessfulPoll resets the snowflake counter of this instance
@@ -80,8 +79,7 @@ type Binary interface {
 	// Returns the currently preferred choice to be finalized
 	Preference() int
 
-	// RecordPoll records a poll that reaches at least an alphaPreference
-	// threshold.
+	// RecordPoll records the results of a network poll
 	RecordPoll(count, choice int)
 
 	// RecordUnsuccessfulPoll resets the snowflake counter of this instance
@@ -98,8 +96,7 @@ type Binary interface {
 type Unary interface {
 	fmt.Stringer
 
-	// RecordPoll records a poll that reaches at least an alphaPreference
-	// threshold.
+	// RecordPoll records the results of a network poll
 	RecordPoll(count int)
 
 	// RecordUnsuccessfulPoll resets the snowflake counter of this instance

--- a/snow/consensus/snowball/consensus.go
+++ b/snow/consensus/snowball/consensus.go
@@ -60,14 +60,9 @@ type Nnary interface {
 	// Returns the currently preferred choice to be finalized
 	Preference() ids.ID
 
-	// RecordSuccessfulPoll records a successful poll towards finalizing the
-	// specified choice. Assumes the choice was previously added.
-	RecordSuccessfulPoll(choice ids.ID)
-
-	// RecordPollPreference records a poll that preferred the specified choice
-	// but did not contribute towards finalizing the specified choice. Assumes
-	// the choice was previously added.
-	RecordPollPreference(choice ids.ID)
+	// RecordPoll records a poll that reaches at least an alphaPreference
+	// threshold.
+	RecordPoll(count int, choice ids.ID)
 
 	// RecordUnsuccessfulPoll resets the snowflake counter of this instance
 	RecordUnsuccessfulPoll()
@@ -87,13 +82,9 @@ type Binary interface {
 	// Returns the currently preferred choice to be finalized
 	Preference() int
 
-	// RecordSuccessfulPoll records a successful poll towards finalizing the
-	// specified choice
-	RecordSuccessfulPoll(choice int)
-
-	// RecordPollPreference records a poll that preferred the specified choice
-	// but did not contribute towards finalizing the specified choice
-	RecordPollPreference(choice int)
+	// RecordPoll records a poll that reaches at least an alphaPreference
+	// threshold.
+	RecordPoll(count, choice int)
 
 	// RecordUnsuccessfulPoll resets the snowflake counter of this instance
 	RecordUnsuccessfulPoll()
@@ -110,13 +101,9 @@ type Binary interface {
 type Unary interface {
 	fmt.Stringer
 
-	// RecordSuccessfulPoll records a successful poll that reaches an alpha
-	// confidence threshold.
-	RecordSuccessfulPoll()
-
-	// RecordPollPreference records a poll that receives an alpha preference
-	// threshold, but not an alpha confidence threshold.
-	RecordPollPreference()
+	// RecordPoll records a poll that reaches at least an alphaPreference
+	// threshold.
+	RecordPoll(count int)
 
 	// RecordUnsuccessfulPoll resets the snowflake counter of this instance
 	RecordUnsuccessfulPoll()

--- a/snow/consensus/snowball/consensus.go
+++ b/snow/consensus/snowball/consensus.go
@@ -47,9 +47,9 @@ type Factory interface {
 }
 
 // Nnary is a snow instance deciding between an unbounded number of values.
-// The caller samples k nodes and then calls
-// 1. RecordPoll if choice collects >= alphaPreference votes
-// 2. RecordUnsuccessfulPoll otherwise
+// The caller samples k nodes and calls RecordPoll with the result.
+// RecordUnsuccessfulPoll resets the confidence counters when one or
+// more consecutive polls fail to reach alphaPreference votes.
 type Nnary interface {
 	fmt.Stringer
 
@@ -70,9 +70,9 @@ type Nnary interface {
 }
 
 // Binary is a snow instance deciding between two values.
-// The caller samples k nodes and then calls
-// 1. RecordPoll if choice collects >= alphaPreference votes
-// 2. RecordUnsuccessfulPoll otherwise
+// The caller samples k nodes and calls RecordPoll with the result.
+// RecordUnsuccessfulPoll resets the confidence counters when one or
+// more consecutive polls fail to reach alphaPreference votes.
 type Binary interface {
 	fmt.Stringer
 
@@ -90,9 +90,9 @@ type Binary interface {
 }
 
 // Unary is a snow instance deciding on one value.
-// The caller samples k nodes and then calls
-// 1. RecordPoll if choice collects >= alphaPreference votes
-// 2. RecordUnsuccessfulPoll otherwise
+// The caller samples k nodes and calls RecordPoll with the result.
+// RecordUnsuccessfulPoll resets the confidence counters when one or
+// more consecutive polls fail to reach alphaPreference votes.
 type Unary interface {
 	fmt.Stringer
 

--- a/snow/consensus/snowball/factory.go
+++ b/snow/consensus/snowball/factory.go
@@ -13,23 +13,23 @@ var (
 type snowballFactory struct{}
 
 func (snowballFactory) NewNnary(params Parameters, choice ids.ID) Nnary {
-	sb := newNnarySnowball(params.Beta, choice)
+	sb := newNnarySnowball(params.AlphaPreference, params.AlphaConfidence, params.Beta, choice)
 	return &sb
 }
 
 func (snowballFactory) NewUnary(params Parameters) Unary {
-	sb := newUnarySnowball(params.Beta)
+	sb := newUnarySnowball(params.AlphaPreference, params.AlphaConfidence, params.Beta)
 	return &sb
 }
 
 type snowflakeFactory struct{}
 
 func (snowflakeFactory) NewNnary(params Parameters, choice ids.ID) Nnary {
-	sf := newNnarySnowflake(params.Beta, choice)
+	sf := newNnarySnowflake(params.AlphaPreference, params.AlphaConfidence, params.Beta, choice)
 	return &sf
 }
 
 func (snowflakeFactory) NewUnary(params Parameters) Unary {
-	sf := newUnarySnowflake(params.Beta)
+	sf := newUnarySnowflake(params.AlphaPreference, params.AlphaConfidence, params.Beta)
 	return &sf
 }

--- a/snow/consensus/snowball/flat.go
+++ b/snow/consensus/snowball/flat.go
@@ -28,17 +28,7 @@ type Flat struct {
 
 func (f *Flat) RecordPoll(votes bag.Bag[ids.ID]) bool {
 	pollMode, numVotes := votes.Mode()
-	switch {
-	// AlphaConfidence is guaranteed to be >= AlphaPreference, so we must check
-	// if the poll had enough votes to increase the confidence first.
-	case numVotes >= f.params.AlphaConfidence:
-		f.RecordSuccessfulPoll(pollMode)
-		return true
-	case numVotes >= f.params.AlphaPreference:
-		f.RecordPollPreference(pollMode)
-		return true
-	default:
-		f.RecordUnsuccessfulPoll()
-		return false
-	}
+	f.Nnary.RecordPoll(numVotes, pollMode)
+
+	return numVotes >= f.params.AlphaPreference
 }

--- a/snow/consensus/snowball/flat.go
+++ b/snow/consensus/snowball/flat.go
@@ -28,11 +28,6 @@ type Flat struct {
 
 func (f *Flat) RecordPoll(votes bag.Bag[ids.ID]) bool {
 	pollMode, numVotes := votes.Mode()
-	if numVotes < f.params.AlphaPreference {
-		f.Nnary.RecordUnsuccessfulPoll()
-		return false
-	}
-
 	f.Nnary.RecordPoll(numVotes, pollMode)
-	return true
+	return numVotes >= f.params.AlphaPreference
 }

--- a/snow/consensus/snowball/flat.go
+++ b/snow/consensus/snowball/flat.go
@@ -28,7 +28,11 @@ type Flat struct {
 
 func (f *Flat) RecordPoll(votes bag.Bag[ids.ID]) bool {
 	pollMode, numVotes := votes.Mode()
-	f.Nnary.RecordPoll(numVotes, pollMode)
+	if numVotes < f.params.AlphaPreference {
+		f.Nnary.RecordUnsuccessfulPoll()
+		return false
+	}
 
-	return numVotes >= f.params.AlphaPreference
+	f.Nnary.RecordPoll(numVotes, pollMode)
+	return true
 }

--- a/snow/consensus/snowball/nnary_slush.go
+++ b/snow/consensus/snowball/nnary_slush.go
@@ -28,7 +28,7 @@ func (sl *nnarySlush) Preference() ids.ID {
 	return sl.preference
 }
 
-func (sl *nnarySlush) RecordSuccessfulPoll(choice ids.ID) {
+func (sl *nnarySlush) recordSuccessfulPoll(choice ids.ID) {
 	sl.preference = choice
 }
 

--- a/snow/consensus/snowball/nnary_slush.go
+++ b/snow/consensus/snowball/nnary_slush.go
@@ -28,7 +28,7 @@ func (sl *nnarySlush) Preference() ids.ID {
 	return sl.preference
 }
 
-func (sl *nnarySlush) recordSuccessfulPoll(choice ids.ID) {
+func (sl *nnarySlush) RecordSuccessfulPoll(choice ids.ID) {
 	sl.preference = choice
 }
 

--- a/snow/consensus/snowball/nnary_snowball.go
+++ b/snow/consensus/snowball/nnary_snowball.go
@@ -48,26 +48,10 @@ func (sb *nnarySnowball) Preference() ids.ID {
 }
 
 func (sb *nnarySnowball) RecordPoll(count int, choice ids.ID) {
-	switch {
-	case count >= sb.alphaConfidence:
-		sb.recordSuccessfulPoll(choice)
-	case count >= sb.alphaPreference:
-		sb.recordPollPreference(choice)
-	default:
-		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
-		// have been called instead.
-		sb.RecordUnsuccessfulPoll()
+	if count >= sb.alphaPreference {
+		sb.increasePreferenceStrength(choice)
 	}
-}
-
-func (sb *nnarySnowball) recordSuccessfulPoll(choice ids.ID) {
-	sb.increasePreferenceStrength(choice)
-	sb.nnarySnowflake.recordSuccessfulPoll(choice)
-}
-
-func (sb *nnarySnowball) recordPollPreference(choice ids.ID) {
-	sb.increasePreferenceStrength(choice)
-	sb.nnarySnowflake.recordPollPreference(choice)
+	sb.nnarySnowflake.RecordPoll(count, choice)
 }
 
 func (sb *nnarySnowball) String() string {

--- a/snow/consensus/snowball/nnary_snowball.go
+++ b/snow/consensus/snowball/nnary_snowball.go
@@ -49,7 +49,13 @@ func (sb *nnarySnowball) Preference() ids.ID {
 
 func (sb *nnarySnowball) RecordPoll(count int, choice ids.ID) {
 	if count >= sb.alphaPreference {
-		sb.increasePreferenceStrength(choice)
+		preferenceStrength := sb.preferenceStrength[choice] + 1
+		sb.preferenceStrength[choice] = preferenceStrength
+
+		if preferenceStrength > sb.maxPreferenceStrength {
+			sb.preference = choice
+			sb.maxPreferenceStrength = preferenceStrength
+		}
 	}
 	sb.nnarySnowflake.RecordPoll(count, choice)
 }
@@ -57,14 +63,4 @@ func (sb *nnarySnowball) RecordPoll(count int, choice ids.ID) {
 func (sb *nnarySnowball) String() string {
 	return fmt.Sprintf("SB(Preference = %s, PreferenceStrength = %d, %s)",
 		sb.preference, sb.maxPreferenceStrength, &sb.nnarySnowflake)
-}
-
-func (sb *nnarySnowball) increasePreferenceStrength(choice ids.ID) {
-	preferenceStrength := sb.preferenceStrength[choice] + 1
-	sb.preferenceStrength[choice] = preferenceStrength
-
-	if preferenceStrength > sb.maxPreferenceStrength {
-		sb.preference = choice
-		sb.maxPreferenceStrength = preferenceStrength
-	}
 }

--- a/snow/consensus/snowball/nnary_snowball.go
+++ b/snow/consensus/snowball/nnary_snowball.go
@@ -11,9 +11,9 @@ import (
 
 var _ Nnary = (*nnarySnowball)(nil)
 
-func newNnarySnowball(beta int, choice ids.ID) nnarySnowball {
+func newNnarySnowball(alphaPreference, alphaConfidence, beta int, choice ids.ID) nnarySnowball {
 	return nnarySnowball{
-		nnarySnowflake:     newNnarySnowflake(beta, choice),
+		nnarySnowflake:     newNnarySnowflake(alphaPreference, alphaConfidence, beta, choice),
 		preference:         choice,
 		preferenceStrength: make(map[ids.ID]int),
 	}
@@ -45,6 +45,19 @@ func (sb *nnarySnowball) Preference() ids.ID {
 		return sb.nnarySnowflake.Preference()
 	}
 	return sb.preference
+}
+
+func (sb *nnarySnowball) RecordPoll(count int, choice ids.ID) {
+	switch {
+	case count >= sb.alphaConfidence:
+		sb.RecordSuccessfulPoll(choice)
+	case count >= sb.alphaPreference:
+		sb.RecordPollPreference(choice)
+	default:
+		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
+		// have been called instead.
+		sb.RecordUnsuccessfulPoll()
+	}
 }
 
 func (sb *nnarySnowball) RecordSuccessfulPoll(choice ids.ID) {

--- a/snow/consensus/snowball/nnary_snowball.go
+++ b/snow/consensus/snowball/nnary_snowball.go
@@ -50,9 +50,9 @@ func (sb *nnarySnowball) Preference() ids.ID {
 func (sb *nnarySnowball) RecordPoll(count int, choice ids.ID) {
 	switch {
 	case count >= sb.alphaConfidence:
-		sb.RecordSuccessfulPoll(choice)
+		sb.recordSuccessfulPoll(choice)
 	case count >= sb.alphaPreference:
-		sb.RecordPollPreference(choice)
+		sb.recordPollPreference(choice)
 	default:
 		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
 		// have been called instead.
@@ -60,14 +60,14 @@ func (sb *nnarySnowball) RecordPoll(count int, choice ids.ID) {
 	}
 }
 
-func (sb *nnarySnowball) RecordSuccessfulPoll(choice ids.ID) {
+func (sb *nnarySnowball) recordSuccessfulPoll(choice ids.ID) {
 	sb.increasePreferenceStrength(choice)
-	sb.nnarySnowflake.RecordSuccessfulPoll(choice)
+	sb.nnarySnowflake.recordSuccessfulPoll(choice)
 }
 
-func (sb *nnarySnowball) RecordPollPreference(choice ids.ID) {
+func (sb *nnarySnowball) recordPollPreference(choice ids.ID) {
 	sb.increasePreferenceStrength(choice)
-	sb.nnarySnowflake.RecordPollPreference(choice)
+	sb.nnarySnowflake.recordPollPreference(choice)
 }
 
 func (sb *nnarySnowball) String() string {

--- a/snow/consensus/snowball/nnary_snowball_test.go
+++ b/snow/consensus/snowball/nnary_snowball_test.go
@@ -12,7 +12,7 @@ import (
 func TestNnarySnowball(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sb := newNnarySnowball(alphaPreference, alphaConfidence, beta, Red)
@@ -22,31 +22,31 @@ func TestNnarySnowball(t *testing.T) {
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Blue)
+	sb.RecordPoll(alphaConfidence, Blue)
 	require.Equal(Blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Red)
+	sb.RecordPoll(alphaConfidence, Red)
 	require.Equal(Blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordPollPreference(Red)
+	sb.RecordPoll(alphaPreference, Red)
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Red)
+	sb.RecordPoll(alphaConfidence, Red)
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordPollPreference(Blue)
+	sb.RecordPoll(alphaPreference, Blue)
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Blue)
+	sb.RecordPoll(alphaConfidence, Blue)
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Blue)
+	sb.RecordPoll(alphaConfidence, Blue)
 	require.Equal(Blue, sb.Preference())
 	require.True(sb.Finalized())
 }
@@ -54,7 +54,7 @@ func TestNnarySnowball(t *testing.T) {
 func TestVirtuousNnarySnowball(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 1
 
 	sb := newNnarySnowball(alphaPreference, alphaConfidence, beta, Red)
@@ -62,7 +62,7 @@ func TestVirtuousNnarySnowball(t *testing.T) {
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Red)
+	sb.RecordPoll(alphaConfidence, Red)
 	require.Equal(Red, sb.Preference())
 	require.True(sb.Finalized())
 }
@@ -70,7 +70,7 @@ func TestVirtuousNnarySnowball(t *testing.T) {
 func TestNarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sb := newNnarySnowball(alphaPreference, alphaConfidence, beta, Red)
@@ -79,18 +79,18 @@ func TestNarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Blue)
+	sb.RecordPoll(alphaConfidence, Blue)
 	require.Equal(Blue, sb.Preference())
 	require.False(sb.Finalized())
 
 	sb.RecordUnsuccessfulPoll()
 
-	sb.RecordSuccessfulPoll(Blue)
+	sb.RecordPoll(alphaConfidence, Blue)
 
 	require.Equal(Blue, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Blue)
+	sb.RecordPoll(alphaConfidence, Blue)
 
 	require.Equal(Blue, sb.Preference())
 	require.True(sb.Finalized())
@@ -99,7 +99,7 @@ func TestNarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 	require.Equal(expected, sb.String())
 
 	for i := 0; i < 4; i++ {
-		sb.RecordSuccessfulPoll(Red)
+		sb.RecordPoll(alphaConfidence, Red)
 
 		require.Equal(Blue, sb.Preference())
 		require.True(sb.Finalized())
@@ -109,7 +109,7 @@ func TestNarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 func TestNarySnowballDifferentSnowflakeColor(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sb := newNnarySnowball(alphaPreference, alphaConfidence, beta, Red)
@@ -118,11 +118,11 @@ func TestNarySnowballDifferentSnowflakeColor(t *testing.T) {
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Blue)
+	sb.RecordPoll(alphaConfidence, Blue)
 
 	require.Equal(Blue, sb.nnarySnowflake.Preference())
 
-	sb.RecordSuccessfulPoll(Red)
+	sb.RecordPoll(alphaConfidence, Red)
 
 	require.Equal(Blue, sb.Preference())
 	require.Equal(Red, sb.nnarySnowflake.Preference())

--- a/snow/consensus/snowball/nnary_snowball_test.go
+++ b/snow/consensus/snowball/nnary_snowball_test.go
@@ -12,9 +12,10 @@ import (
 func TestNnarySnowball(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newNnarySnowball(beta, Red)
+	sb := newNnarySnowball(alphaPreference, alphaConfidence, beta, Red)
 	sb.Add(Blue)
 	sb.Add(Green)
 
@@ -53,9 +54,10 @@ func TestNnarySnowball(t *testing.T) {
 func TestVirtuousNnarySnowball(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 1
 
-	sb := newNnarySnowball(beta, Red)
+	sb := newNnarySnowball(alphaPreference, alphaConfidence, beta, Red)
 
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
@@ -68,9 +70,10 @@ func TestVirtuousNnarySnowball(t *testing.T) {
 func TestNarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newNnarySnowball(beta, Red)
+	sb := newNnarySnowball(alphaPreference, alphaConfidence, beta, Red)
 	sb.Add(Blue)
 
 	require.Equal(Red, sb.Preference())
@@ -106,9 +109,10 @@ func TestNarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 func TestNarySnowballDifferentSnowflakeColor(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newNnarySnowball(beta, Red)
+	sb := newNnarySnowball(alphaPreference, alphaConfidence, beta, Red)
 	sb.Add(Blue)
 
 	require.Equal(Red, sb.Preference())

--- a/snow/consensus/snowball/nnary_snowflake.go
+++ b/snow/consensus/snowball/nnary_snowflake.go
@@ -78,7 +78,7 @@ func (sf *nnarySnowflake) recordSuccessfulPoll(choice ids.ID) {
 	}
 
 	sf.finalized = sf.confidence >= sf.beta
-	sf.nnarySlush.recordSuccessfulPoll(choice)
+	sf.nnarySlush.RecordSuccessfulPoll(choice)
 }
 
 func (sf *nnarySnowflake) recordPollPreference(choice ids.ID) {
@@ -87,7 +87,7 @@ func (sf *nnarySnowflake) recordPollPreference(choice ids.ID) {
 	}
 
 	sf.confidence = 0
-	sf.nnarySlush.recordSuccessfulPoll(choice)
+	sf.nnarySlush.RecordSuccessfulPoll(choice)
 }
 
 func (sf *nnarySnowflake) RecordUnsuccessfulPoll() {

--- a/snow/consensus/snowball/nnary_snowflake.go
+++ b/snow/consensus/snowball/nnary_snowflake.go
@@ -54,9 +54,9 @@ func (sf *nnarySnowflake) RecordPoll(count int, choice ids.ID) {
 
 	switch {
 	case count >= sf.alphaConfidence:
-		sf.RecordSuccessfulPoll(choice)
+		sf.recordSuccessfulPoll(choice)
 	case count >= sf.alphaPreference:
-		sf.RecordPollPreference(choice)
+		sf.recordPollPreference(choice)
 	default:
 		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
 		// have been called instead.
@@ -64,7 +64,7 @@ func (sf *nnarySnowflake) RecordPoll(count int, choice ids.ID) {
 	}
 }
 
-func (sf *nnarySnowflake) RecordSuccessfulPoll(choice ids.ID) {
+func (sf *nnarySnowflake) recordSuccessfulPoll(choice ids.ID) {
 	if sf.finalized {
 		return // This instance is already decided.
 	}
@@ -78,16 +78,16 @@ func (sf *nnarySnowflake) RecordSuccessfulPoll(choice ids.ID) {
 	}
 
 	sf.finalized = sf.confidence >= sf.beta
-	sf.nnarySlush.RecordSuccessfulPoll(choice)
+	sf.nnarySlush.recordSuccessfulPoll(choice)
 }
 
-func (sf *nnarySnowflake) RecordPollPreference(choice ids.ID) {
+func (sf *nnarySnowflake) recordPollPreference(choice ids.ID) {
 	if sf.finalized {
 		return // This instance is already decided.
 	}
 
 	sf.confidence = 0
-	sf.nnarySlush.RecordSuccessfulPoll(choice)
+	sf.nnarySlush.recordSuccessfulPoll(choice)
 }
 
 func (sf *nnarySnowflake) RecordUnsuccessfulPoll() {

--- a/snow/consensus/snowball/nnary_snowflake_test.go
+++ b/snow/consensus/snowball/nnary_snowflake_test.go
@@ -12,7 +12,7 @@ import (
 func TestNnarySnowflake(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sf := newNnarySnowflake(alphaPreference, alphaConfidence, beta, Red)
@@ -22,27 +22,27 @@ func TestNnarySnowflake(t *testing.T) {
 	require.Equal(Red, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(Blue)
+	sf.RecordPoll(alphaConfidence, Blue)
 	require.Equal(Blue, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordPollPreference(Red)
+	sf.RecordPoll(alphaPreference, Red)
 	require.Equal(Red, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(Red)
+	sf.RecordPoll(alphaConfidence, Red)
 	require.Equal(Red, sf.Preference())
 	require.False(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(Red)
+	sf.RecordPoll(alphaConfidence, Red)
 	require.Equal(Red, sf.Preference())
 	require.True(sf.Finalized())
 
-	sf.RecordPollPreference(Blue)
+	sf.RecordPoll(alphaPreference, Blue)
 	require.Equal(Red, sf.Preference())
 	require.True(sf.Finalized())
 
-	sf.RecordSuccessfulPoll(Blue)
+	sf.RecordPoll(alphaConfidence, Blue)
 	require.Equal(Red, sf.Preference())
 	require.True(sf.Finalized())
 }
@@ -50,7 +50,7 @@ func TestNnarySnowflake(t *testing.T) {
 func TestNnarySnowflakeConfidenceReset(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 4
 
 	sf := newNnarySnowflake(alphaPreference, alphaConfidence, beta, Red)
@@ -62,20 +62,20 @@ func TestNnarySnowflakeConfidenceReset(t *testing.T) {
 
 	// Increase Blue's confidence without finalizing
 	for i := 0; i < beta-1; i++ {
-		sf.RecordSuccessfulPoll(Blue)
+		sf.RecordPoll(alphaConfidence, Blue)
 		require.Equal(Blue, sf.Preference())
 		require.False(sf.Finalized())
 	}
 
 	// Increase Red's confidence without finalizing
 	for i := 0; i < beta-1; i++ {
-		sf.RecordSuccessfulPoll(Red)
+		sf.RecordPoll(alphaConfidence, Red)
 		require.Equal(Red, sf.Preference())
 		require.False(sf.Finalized())
 	}
 
 	// One more round of voting for Red should accept Red
-	sf.RecordSuccessfulPoll(Red)
+	sf.RecordPoll(alphaConfidence, Red)
 	require.Equal(Red, sf.Preference())
 	require.True(sf.Finalized())
 }
@@ -83,18 +83,18 @@ func TestNnarySnowflakeConfidenceReset(t *testing.T) {
 func TestVirtuousNnarySnowflake(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sb := newNnarySnowflake(alphaPreference, alphaConfidence, beta, Red)
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Red)
+	sb.RecordPoll(alphaConfidence, Red)
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 
-	sb.RecordSuccessfulPoll(Red)
+	sb.RecordPoll(alphaConfidence, Red)
 	require.Equal(Red, sb.Preference())
 	require.True(sb.Finalized())
 }

--- a/snow/consensus/snowball/nnary_snowflake_test.go
+++ b/snow/consensus/snowball/nnary_snowflake_test.go
@@ -12,9 +12,10 @@ import (
 func TestNnarySnowflake(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sf := newNnarySnowflake(beta, Red)
+	sf := newNnarySnowflake(alphaPreference, alphaConfidence, beta, Red)
 	sf.Add(Blue)
 	sf.Add(Green)
 
@@ -49,9 +50,10 @@ func TestNnarySnowflake(t *testing.T) {
 func TestNnarySnowflakeConfidenceReset(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 4
 
-	sf := newNnarySnowflake(beta, Red)
+	sf := newNnarySnowflake(alphaPreference, alphaConfidence, beta, Red)
 	sf.Add(Blue)
 	sf.Add(Green)
 
@@ -81,9 +83,10 @@ func TestNnarySnowflakeConfidenceReset(t *testing.T) {
 func TestVirtuousNnarySnowflake(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newNnarySnowflake(beta, Red)
+	sb := newNnarySnowflake(alphaPreference, alphaConfidence, beta, Red)
 	require.Equal(Red, sb.Preference())
 	require.False(sb.Finalized())
 

--- a/snow/consensus/snowball/unary_snowball.go
+++ b/snow/consensus/snowball/unary_snowball.go
@@ -48,10 +48,12 @@ func (sb *unarySnowball) recordPollPreference() {
 func (sb *unarySnowball) Extend(choice int) Binary {
 	bs := &binarySnowball{
 		binarySnowflake: binarySnowflake{
-			binarySlush: binarySlush{preference: choice},
-			confidence:  sb.confidence,
-			beta:        sb.beta,
-			finalized:   sb.Finalized(),
+			binarySlush:     binarySlush{preference: choice},
+			confidence:      sb.confidence,
+			alphaPreference: sb.alphaPreference,
+			alphaConfidence: sb.alphaConfidence,
+			beta:            sb.beta,
+			finalized:       sb.Finalized(),
 		},
 		preference: choice,
 	}

--- a/snow/consensus/snowball/unary_snowball.go
+++ b/snow/consensus/snowball/unary_snowball.go
@@ -7,9 +7,9 @@ import "fmt"
 
 var _ Unary = (*unarySnowball)(nil)
 
-func newUnarySnowball(beta int) unarySnowball {
+func newUnarySnowball(alphaPreference, alphaConfidence, beta int) unarySnowball {
 	return unarySnowball{
-		unarySnowflake: newUnarySnowflake(beta),
+		unarySnowflake: newUnarySnowflake(alphaPreference, alphaConfidence, beta),
 	}
 }
 
@@ -20,6 +20,19 @@ type unarySnowball struct {
 
 	// preferenceStrength tracks the total number of polls with a preference
 	preferenceStrength int
+}
+
+func (sb *unarySnowball) RecordPoll(count int) {
+	switch {
+	case count >= sb.alphaConfidence:
+		sb.RecordSuccessfulPoll()
+	case count >= sb.alphaPreference:
+		sb.RecordPollPreference()
+	default:
+		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
+		// have been called instead.
+		sb.RecordUnsuccessfulPoll()
+	}
 }
 
 func (sb *unarySnowball) RecordSuccessfulPoll() {

--- a/snow/consensus/snowball/unary_snowball.go
+++ b/snow/consensus/snowball/unary_snowball.go
@@ -23,26 +23,10 @@ type unarySnowball struct {
 }
 
 func (sb *unarySnowball) RecordPoll(count int) {
-	switch {
-	case count >= sb.alphaConfidence:
-		sb.recordSuccessfulPoll()
-	case count >= sb.alphaPreference:
-		sb.recordPollPreference()
-	default:
-		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
-		// have been called instead.
-		sb.RecordUnsuccessfulPoll()
+	if count >= sb.alphaPreference {
+		sb.preferenceStrength++
 	}
-}
-
-func (sb *unarySnowball) recordSuccessfulPoll() {
-	sb.preferenceStrength++
-	sb.unarySnowflake.recordSuccessfulPoll()
-}
-
-func (sb *unarySnowball) recordPollPreference() {
-	sb.preferenceStrength++
-	sb.unarySnowflake.RecordUnsuccessfulPoll()
+	sb.unarySnowflake.RecordPoll(count)
 }
 
 func (sb *unarySnowball) Extend(choice int) Binary {

--- a/snow/consensus/snowball/unary_snowball.go
+++ b/snow/consensus/snowball/unary_snowball.go
@@ -25,9 +25,9 @@ type unarySnowball struct {
 func (sb *unarySnowball) RecordPoll(count int) {
 	switch {
 	case count >= sb.alphaConfidence:
-		sb.RecordSuccessfulPoll()
+		sb.recordSuccessfulPoll()
 	case count >= sb.alphaPreference:
-		sb.RecordPollPreference()
+		sb.recordPollPreference()
 	default:
 		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
 		// have been called instead.
@@ -35,12 +35,12 @@ func (sb *unarySnowball) RecordPoll(count int) {
 	}
 }
 
-func (sb *unarySnowball) RecordSuccessfulPoll() {
+func (sb *unarySnowball) recordSuccessfulPoll() {
 	sb.preferenceStrength++
-	sb.unarySnowflake.RecordSuccessfulPoll()
+	sb.unarySnowflake.recordSuccessfulPoll()
 }
 
-func (sb *unarySnowball) RecordPollPreference() {
+func (sb *unarySnowball) recordPollPreference() {
 	sb.preferenceStrength++
 	sb.unarySnowflake.RecordUnsuccessfulPoll()
 }

--- a/snow/consensus/snowball/unary_snowball_test.go
+++ b/snow/consensus/snowball/unary_snowball_test.go
@@ -20,24 +20,24 @@ func UnarySnowballStateTest(t *testing.T, sb *unarySnowball, expectedPreferenceS
 func TestUnarySnowball(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sb := newUnarySnowball(alphaPreference, alphaConfidence, beta)
 
-	sb.RecordSuccessfulPoll()
+	sb.RecordPoll(alphaConfidence)
 	UnarySnowballStateTest(t, &sb, 1, 1, false)
 
-	sb.RecordPollPreference()
+	sb.RecordPoll(alphaPreference)
 	UnarySnowballStateTest(t, &sb, 2, 0, false)
 
-	sb.RecordSuccessfulPoll()
+	sb.RecordPoll(alphaConfidence)
 	UnarySnowballStateTest(t, &sb, 3, 1, false)
 
 	sb.RecordUnsuccessfulPoll()
 	UnarySnowballStateTest(t, &sb, 3, 0, false)
 
-	sb.RecordSuccessfulPoll()
+	sb.RecordPoll(alphaConfidence)
 	UnarySnowballStateTest(t, &sb, 4, 1, false)
 
 	sbCloneIntf := sb.Clone()

--- a/snow/consensus/snowball/unary_snowball_test.go
+++ b/snow/consensus/snowball/unary_snowball_test.go
@@ -20,9 +20,10 @@ func UnarySnowballStateTest(t *testing.T, sb *unarySnowball, expectedPreferenceS
 func TestUnarySnowball(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sb := newUnarySnowball(beta)
+	sb := newUnarySnowball(alphaPreference, alphaConfidence, beta)
 
 	sb.RecordSuccessfulPoll()
 	UnarySnowballStateTest(t, &sb, 1, 1, false)
@@ -54,18 +55,18 @@ func TestUnarySnowball(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		require.Zero(binarySnowball.Preference())
 		require.False(binarySnowball.Finalized())
-		binarySnowball.RecordSuccessfulPoll(1)
+		binarySnowball.RecordPoll(alphaConfidence, 1)
 		binarySnowball.RecordUnsuccessfulPoll()
 	}
 
 	require.Equal(1, binarySnowball.Preference())
 	require.False(binarySnowball.Finalized())
 
-	binarySnowball.RecordSuccessfulPoll(1)
+	binarySnowball.RecordPoll(alphaConfidence, 1)
 	require.Equal(1, binarySnowball.Preference())
 	require.False(binarySnowball.Finalized())
 
-	binarySnowball.RecordSuccessfulPoll(1)
+	binarySnowball.RecordPoll(alphaConfidence, 1)
 	require.Equal(1, binarySnowball.Preference())
 	require.True(binarySnowball.Finalized())
 

--- a/snow/consensus/snowball/unary_snowflake.go
+++ b/snow/consensus/snowball/unary_snowflake.go
@@ -37,28 +37,13 @@ type unarySnowflake struct {
 }
 
 func (sf *unarySnowflake) RecordPoll(count int) {
-	switch {
-	case count >= sf.alphaConfidence:
-		sf.recordSuccessfulPoll()
-	case count >= sf.alphaPreference:
-		sf.recordPollPreference()
-	default:
-		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
-		// have been called instead.
+	if count < sf.alphaConfidence {
 		sf.RecordUnsuccessfulPoll()
+		return
 	}
-}
 
-func (sf *unarySnowflake) recordSuccessfulPoll() {
 	sf.confidence++
 	sf.finalized = sf.finalized || sf.confidence >= sf.beta
-}
-
-// recordPollPreference fails to reach an alpha threshold to increase our
-// confidence, so this calls RecordUnsuccessfulPoll to reset the confidence
-// counter.
-func (sf *unarySnowflake) recordPollPreference() {
-	sf.RecordUnsuccessfulPoll()
 }
 
 func (sf *unarySnowflake) RecordUnsuccessfulPoll() {

--- a/snow/consensus/snowball/unary_snowflake.go
+++ b/snow/consensus/snowball/unary_snowflake.go
@@ -71,10 +71,12 @@ func (sf *unarySnowflake) Finalized() bool {
 
 func (sf *unarySnowflake) Extend(choice int) Binary {
 	return &binarySnowflake{
-		binarySlush: binarySlush{preference: choice},
-		confidence:  sf.confidence,
-		beta:        sf.beta,
-		finalized:   sf.finalized,
+		binarySlush:     binarySlush{preference: choice},
+		confidence:      sf.confidence,
+		alphaPreference: sf.alphaPreference,
+		alphaConfidence: sf.alphaConfidence,
+		beta:            sf.beta,
+		finalized:       sf.finalized,
 	}
 }
 

--- a/snow/consensus/snowball/unary_snowflake.go
+++ b/snow/consensus/snowball/unary_snowflake.go
@@ -39,9 +39,9 @@ type unarySnowflake struct {
 func (sf *unarySnowflake) RecordPoll(count int) {
 	switch {
 	case count >= sf.alphaConfidence:
-		sf.RecordSuccessfulPoll()
+		sf.recordSuccessfulPoll()
 	case count >= sf.alphaPreference:
-		sf.RecordPollPreference()
+		sf.recordPollPreference()
 	default:
 		// If the poll was unsuccessful, RecordUnsuccessfulPoll should
 		// have been called instead.
@@ -49,15 +49,15 @@ func (sf *unarySnowflake) RecordPoll(count int) {
 	}
 }
 
-func (sf *unarySnowflake) RecordSuccessfulPoll() {
+func (sf *unarySnowflake) recordSuccessfulPoll() {
 	sf.confidence++
 	sf.finalized = sf.finalized || sf.confidence >= sf.beta
 }
 
-// RecordPollPreference fails to reach an alpha threshold to increase our
+// recordPollPreference fails to reach an alpha threshold to increase our
 // confidence, so this calls RecordUnsuccessfulPoll to reset the confidence
 // counter.
-func (sf *unarySnowflake) RecordPollPreference() {
+func (sf *unarySnowflake) recordPollPreference() {
 	sf.RecordUnsuccessfulPoll()
 }
 

--- a/snow/consensus/snowball/unary_snowflake_test.go
+++ b/snow/consensus/snowball/unary_snowflake_test.go
@@ -19,9 +19,10 @@ func UnarySnowflakeStateTest(t *testing.T, sf *unarySnowflake, expectedConfidenc
 func TestUnarySnowflake(t *testing.T) {
 	require := require.New(t)
 
+	alphaPreference, alphaConfidence := 1, 1
 	beta := 2
 
-	sf := newUnarySnowflake(beta)
+	sf := newUnarySnowflake(alphaPreference, alphaConfidence, beta)
 
 	sf.RecordSuccessfulPoll()
 	UnarySnowflakeStateTest(t, &sf, 1, false)
@@ -42,11 +43,11 @@ func TestUnarySnowflake(t *testing.T) {
 
 	binarySnowflake.RecordUnsuccessfulPoll()
 
-	binarySnowflake.RecordSuccessfulPoll(1)
+	binarySnowflake.RecordPoll(alphaConfidence, 1)
 
 	require.False(binarySnowflake.Finalized())
 
-	binarySnowflake.RecordSuccessfulPoll(1)
+	binarySnowflake.RecordPoll(alphaConfidence, 1)
 
 	require.Equal(1, binarySnowflake.Preference())
 	require.True(binarySnowflake.Finalized())

--- a/snow/consensus/snowball/unary_snowflake_test.go
+++ b/snow/consensus/snowball/unary_snowflake_test.go
@@ -19,18 +19,18 @@ func UnarySnowflakeStateTest(t *testing.T, sf *unarySnowflake, expectedConfidenc
 func TestUnarySnowflake(t *testing.T) {
 	require := require.New(t)
 
-	alphaPreference, alphaConfidence := 1, 1
+	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
 
 	sf := newUnarySnowflake(alphaPreference, alphaConfidence, beta)
 
-	sf.RecordSuccessfulPoll()
+	sf.RecordPoll(alphaConfidence)
 	UnarySnowflakeStateTest(t, &sf, 1, false)
 
 	sf.RecordUnsuccessfulPoll()
 	UnarySnowflakeStateTest(t, &sf, 0, false)
 
-	sf.RecordSuccessfulPoll()
+	sf.RecordPoll(alphaConfidence)
 	UnarySnowflakeStateTest(t, &sf, 1, false)
 
 	sfCloneIntf := sf.Clone()
@@ -52,12 +52,12 @@ func TestUnarySnowflake(t *testing.T) {
 	require.Equal(1, binarySnowflake.Preference())
 	require.True(binarySnowflake.Finalized())
 
-	sf.RecordSuccessfulPoll()
+	sf.RecordPoll(alphaConfidence)
 	UnarySnowflakeStateTest(t, &sf, 2, true)
 
 	sf.RecordUnsuccessfulPoll()
 	UnarySnowflakeStateTest(t, &sf, 0, true)
 
-	sf.RecordSuccessfulPoll()
+	sf.RecordPoll(alphaConfidence)
 	UnarySnowflakeStateTest(t, &sf, 1, true)
 }


### PR DESCRIPTION
## Why this should be merged

This PR moves the logic that turns a consensus poll into an action from the consensus implementation in `tree.go` / `flat.go` into the nnary/binary/unary interface.

This change is made in preparation for supporting Flexible Snowflake as described in https://arxiv.org/pdf/2404.14250v1.pdf. Flexible Snowflake uses multiple alpha confidence thresholds instead of a single `AlphaPreference` and `AlphaConfidence` threshold as in the current implementation.

To support this, the nnary/binary/unary implementations need access to the actual count of votes in favor of a given value.

## How this works

This change replaces the `RecordSuccessfulPoll` and `RecordPollPreference` calls on each consensus implementation with a single `RecordPoll` function that checks what threshold was reached and calls the corresponding function internally. The previous functions are un-exported and called from the new `RecordPoll` function.

## How this was tested

Uses the existing unit tests modified so that `RecordSuccessfulPoll(...)` turns into `RecordPoll(alphaConfidence, ...)` and `RecordPollPreference(...)` turns into `RecordPoll(alphaPreference, ...)`. To make sure tests correctly differentiate between recording an alpha preference and alpha confidence majority, the alphaConfidence majority used in existing tests must be strictly greater than the alphaPreference value.