### PR TITLE
Remove subnet filter from Peer.TrackedSubnets()

### DIFF
--- a/network/metrics.go
+++ b/network/metrics.go
@@ -12,11 +12,12 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/peer"
 	"github.com/ava-labs/avalanchego/utils"
-	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 type metrics struct {
+	trackedSubnets set.Set[ids.ID]
+
 	numTracked                      prometheus.Gauge
 	numPeers                        prometheus.Gauge
 	numSubnetPeers                  *prometheus.GaugeVec
@@ -41,8 +42,9 @@ type metrics struct {
 	peerConnectedStartTimesSum float64
 }
 
-func newMetrics(namespace string, registerer prometheus.Registerer, initialSubnetIDs set.Set[ids.ID]) (*metrics, error) {
+func newMetrics(namespace string, registerer prometheus.Registerer, trackedSubnets set.Set[ids.ID]) (*metrics, error) {
 	m := &metrics{
+		trackedSubnets: trackedSubnets,
 		numPeers: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "peers",
@@ -169,11 +171,7 @@ func newMetrics(namespace string, registerer prometheus.Registerer, initialSubne
 	)
 
 	// init subnet tracker metrics with tracked subnets
-	for subnetID := range initialSubnetIDs {
-		// no need to track primary network ID
-		if subnetID == constants.PrimaryNetworkID {
-			continue
-		}
+	for subnetID := range trackedSubnets {
 		// initialize to 0
 		subnetIDStr := subnetID.String()
 		m.numSubnetPeers.WithLabelValues(subnetIDStr).Set(0)
@@ -189,8 +187,10 @@ func (m *metrics) markConnected(peer peer.Peer) {
 	m.connected.Inc()
 
 	trackedSubnets := peer.TrackedSubnets()
-	for subnetID := range trackedSubnets {
-		m.numSubnetPeers.WithLabelValues(subnetID.String()).Inc()
+	for subnetID := range m.trackedSubnets {
+		if trackedSubnets.Contains(subnetID) {
+			m.numSubnetPeers.WithLabelValues(subnetID.String()).Inc()
+		}
 	}
 
 	m.lock.Lock()
@@ -206,8 +206,10 @@ func (m *metrics) markDisconnected(peer peer.Peer) {
 	m.disconnected.Inc()
 
 	trackedSubnets := peer.TrackedSubnets()
-	for subnetID := range trackedSubnets {
-		m.numSubnetPeers.WithLabelValues(subnetID.String()).Dec()
+	for subnetID := range m.trackedSubnets {
+		if trackedSubnets.Contains(subnetID) {
+			m.numSubnetPeers.WithLabelValues(subnetID.String()).Dec()
+		}
 	}
 
 	m.lock.Lock()

--- a/network/network.go
+++ b/network/network.go
@@ -460,8 +460,12 @@ func (n *network) Connected(nodeID ids.NodeID) {
 
 	peerVersion := peer.Version()
 	n.router.Connected(nodeID, peerVersion, constants.PrimaryNetworkID)
-	for subnetID := range peer.TrackedSubnets() {
-		n.router.Connected(nodeID, peerVersion, subnetID)
+
+	trackedSubnets := peer.TrackedSubnets()
+	for subnetID := range n.peerConfig.MySubnets {
+		if trackedSubnets.Contains(subnetID) {
+			n.router.Connected(nodeID, peerVersion, subnetID)
+		}
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

For Sov networking, we must track which subnets the peer is attempting to connect to. Rather than including this information in every `GetPeerList` message, we can use the information provided during the `Handshake`. However, currently we limit the memory usage of a peer by filtering the provided subnets to be the subset of subnets that the local node also tracks.

This PR removes the filtering of tracked subnets and replaces it with a maximum number of tracked subnets.

## How this works

- Removes `if p.MySubnets.Contains(subnetID) {` from the handling of `subnetIDs` in the `Handshake` message.
- Updates the usage of `trackedSubnets` to filter with the local `trackedSubnets` (if needed).

## How this was tested

- [X] CI
- [X] Running on Fuji seems to report non-tracked subnets from `info.Peers` now.
```json
{
    "ip": "54.163.96.167:9651",
    "publicIP": "54.163.96.167:9651",
    "nodeID": "NodeID-GPc1Si7SQ6oAEfP8MzQ3cFN3fsAtkwC6i",
    "version": "avalanchego/1.11.3",
    "lastSent": "2024-04-29T15:06:39-04:00",
    "lastReceived": "2024-04-29T15:06:39-04:00",
    "observedUptime": "0",
    "observedSubnetUptimes": {},
    "trackedSubnets": [
        "25BsTBm8GQZirHUUKoRSjed8NxjTxtnXP1FvGNanV3QRuizkdt",
        "2J8TLHUDfWuGnEuKKG6n47rkU9YcocEtpxCAaFg447doVBYLEH",
        "Ck7LqxbQX5wzqy6w6UHRoy6EDB1jeEb8AMa6V6vXyn4csc8Mu",
        "SEerb4ZQYMPFiSaekS1LqnJqPgYR5uPYBR9ggPjfxc1SaeBSj",
        "dLyxcugrVZarrCSREN4B7idVwoRzEbP3kzyJN2BTsoRqYggN5"
    ],
    "supportedACPs": [
        23,
        24,
        25,
        30,
        31,
        41,
        62
    ],
    "objectedACPs": [],
    "benched": []
}
```