### PR TITLE
Update metercacher to use vectors

### DIFF
--- a/cache/metercacher/cache.go
+++ b/cache/metercacher/cache.go
@@ -4,19 +4,19 @@
 package metercacher
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/avalanchego/cache"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 )
 
 var _ cache.Cacher[struct{}, struct{}] = (*Cache[struct{}, struct{}])(nil)
 
 type Cache[K comparable, V any] struct {
-	metrics
 	cache.Cacher[K, V]
 
-	clock mockable.Clock
+	metrics *metrics
 }
 
 func New[K comparable, V any](
@@ -24,28 +24,35 @@ func New[K comparable, V any](
 	registerer prometheus.Registerer,
 	cache cache.Cacher[K, V],
 ) (cache.Cacher[K, V], error) {
-	meterCache := &Cache[K, V]{Cacher: cache}
-	return meterCache, meterCache.metrics.Initialize(namespace, registerer)
+	metrics, err := newMetrics(namespace, registerer)
+	return &Cache[K, V]{
+		Cacher:  cache,
+		metrics: metrics,
+	}, err
 }
 
 func (c *Cache[K, V]) Put(key K, value V) {
-	start := c.clock.Time()
+	start := time.Now()
 	c.Cacher.Put(key, value)
-	end := c.clock.Time()
-	c.put.Observe(float64(end.Sub(start)))
-	c.len.Set(float64(c.Cacher.Len()))
-	c.portionFilled.Set(c.Cacher.PortionFilled())
+	putDuration := time.Since(start)
+
+	c.metrics.putCount.Inc()
+	c.metrics.putTime.Add(float64(putDuration))
+	c.metrics.len.Set(float64(c.Cacher.Len()))
+	c.metrics.portionFilled.Set(c.Cacher.PortionFilled())
 }
 
 func (c *Cache[K, V]) Get(key K) (V, bool) {
-	start := c.clock.Time()
+	start := time.Now()
 	value, has := c.Cacher.Get(key)
-	end := c.clock.Time()
-	c.get.Observe(float64(end.Sub(start)))
+	getDuration := time.Since(start)
+
 	if has {
-		c.hit.Inc()
+		c.metrics.getCount.With(hitLabels).Inc()
+		c.metrics.getTime.With(hitLabels).Add(float64(getDuration))
 	} else {
-		c.miss.Inc()
+		c.metrics.getCount.With(missLabels).Inc()
+		c.metrics.getTime.With(missLabels).Add(float64(getDuration))
 	}
 
 	return value, has
@@ -53,12 +60,14 @@ func (c *Cache[K, V]) Get(key K) (V, bool) {
 
 func (c *Cache[K, _]) Evict(key K) {
 	c.Cacher.Evict(key)
-	c.len.Set(float64(c.Cacher.Len()))
-	c.portionFilled.Set(c.Cacher.PortionFilled())
+
+	c.metrics.len.Set(float64(c.Cacher.Len()))
+	c.metrics.portionFilled.Set(c.Cacher.PortionFilled())
 }
 
 func (c *Cache[_, _]) Flush() {
 	c.Cacher.Flush()
-	c.len.Set(float64(c.Cacher.Len()))
-	c.portionFilled.Set(c.Cacher.PortionFilled())
+
+	c.metrics.len.Set(float64(c.Cacher.Len()))
+	c.metrics.portionFilled.Set(c.Cacher.PortionFilled())
 }

--- a/cache/metercacher/cache.go
+++ b/cache/metercacher/cache.go
@@ -23,7 +23,7 @@ func New[K comparable, V any](
 	namespace string,
 	registerer prometheus.Registerer,
 	cache cache.Cacher[K, V],
-) (cache.Cacher[K, V], error) {
+) (*Cache[K, V], error) {
 	metrics, err := newMetrics(namespace, registerer)
 	return &Cache[K, V]{
 		Cacher:  cache,

--- a/cache/metercacher/metrics.go
+++ b/cache/metercacher/metrics.go
@@ -4,67 +4,86 @@
 package metercacher
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/ava-labs/avalanchego/utils/metric"
-	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/utils"
 )
 
-func newAveragerMetric(namespace, name string, reg prometheus.Registerer, errs *wrappers.Errs) metric.Averager {
-	return metric.NewAveragerWithErrs(
-		namespace,
-		name,
-		"time (in ns) of a "+name,
-		reg,
-		errs,
-	)
-}
+const (
+	resultLabel = "result"
+	hitResult   = "hit"
+	missResult  = "miss"
+)
 
-func newCounterMetric(namespace, name string, reg prometheus.Registerer, errs *wrappers.Errs) prometheus.Counter {
-	c := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      name,
-		Help:      fmt.Sprintf("# of times a %s occurred", name),
-	})
-	errs.Add(reg.Register(c))
-	return c
-}
+var (
+	resultLabels = []string{resultLabel}
+	hitLabels    = prometheus.Labels{
+		resultLabel: hitResult,
+	}
+	missLabels = prometheus.Labels{
+		resultLabel: missResult,
+	}
+)
 
 type metrics struct {
-	get           metric.Averager
-	put           metric.Averager
+	getCount *prometheus.CounterVec
+	getTime  *prometheus.CounterVec
+
+	putCount prometheus.Counter
+	putTime  prometheus.Counter
+
 	len           prometheus.Gauge
 	portionFilled prometheus.Gauge
-	hit           prometheus.Counter
-	miss          prometheus.Counter
 }
 
-func (m *metrics) Initialize(
+func newMetrics(
 	namespace string,
 	reg prometheus.Registerer,
-) error {
-	errs := wrappers.Errs{}
-	m.get = newAveragerMetric(namespace, "get", reg, &errs)
-	m.put = newAveragerMetric(namespace, "put", reg, &errs)
-	m.len = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+) (*metrics, error) {
+	m := &metrics{
+		getCount: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "get_count",
+				Help:      "number of get calls",
+			},
+			resultLabels,
+		),
+		getTime: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "get_time",
+				Help:      "time spent (ns) in get calls",
+			},
+			resultLabels,
+		),
+		putCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "put_count",
+			Help:      "number of put calls",
+		}),
+		putTime: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "put_time",
+			Help:      "time spent (ns) in put calls",
+		}),
+		len: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "len",
 			Help:      "number of entries",
-		},
-	)
-	errs.Add(reg.Register(m.len))
-	m.portionFilled = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+		}),
+		portionFilled: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "portion_filled",
 			Help:      "fraction of cache filled",
-		},
+		}),
+	}
+	return m, utils.Err(
+		reg.Register(m.getCount),
+		reg.Register(m.getTime),
+		reg.Register(m.putCount),
+		reg.Register(m.putTime),
+		reg.Register(m.len),
+		reg.Register(m.portionFilled),
 	)
-	errs.Add(reg.Register(m.portionFilled))
-	m.hit = newCounterMetric(namespace, "hit", reg, &errs)
-	m.miss = newCounterMetric(namespace, "miss", reg, &errs)
-	return errs.Err
 }


### PR DESCRIPTION
## Why this should be merged

We originally avoided using `.*Vec` due to a misunderstanding in how the library worked. Integrations treat metrics and labels separately. Do it is cheaper and easier to group related metrics together and separate values by labels.

## How this works

Previously `hit`, `miss`, and `get_count` were essentially duplicates (as `get_count = hit + miss`). This replaces `hit` and `miss` with `get_count{result:hit}` and `get_count{result:miss}`. This also renames `get_sum` to `get_time` and adds the `hit` and `miss` labels to it.

## How this was tested

- [X] CI
- [X] Running on fuji:

```
# HELP avalanche_C_vm_chain_state_decided_cache_get_count number of get calls
# TYPE avalanche_C_vm_chain_state_decided_cache_get_count counter
avalanche_C_vm_chain_state_decided_cache_get_count{result="hit"} 49
avalanche_C_vm_chain_state_decided_cache_get_count{result="miss"} 5603
# HELP avalanche_C_vm_chain_state_decided_cache_get_time time spent (ns) in get calls
# TYPE avalanche_C_vm_chain_state_decided_cache_get_time counter
avalanche_C_vm_chain_state_decided_cache_get_time{result="hit"} 64164
avalanche_C_vm_chain_state_decided_cache_get_time{result="miss"} 976083
# HELP avalanche_C_vm_chain_state_decided_cache_len number of entries
# TYPE avalanche_C_vm_chain_state_decided_cache_len gauge
avalanche_C_vm_chain_state_decided_cache_len 298
# HELP avalanche_C_vm_chain_state_decided_cache_portion_filled fraction of cache filled
# TYPE avalanche_C_vm_chain_state_decided_cache_portion_filled gauge
avalanche_C_vm_chain_state_decided_cache_portion_filled 0.1472013473510742
# HELP avalanche_C_vm_chain_state_decided_cache_put_count number of put calls
# TYPE avalanche_C_vm_chain_state_decided_cache_put_count counter
avalanche_C_vm_chain_state_decided_cache_put_count 298
# HELP avalanche_C_vm_chain_state_decided_cache_put_time time spent (ns) in put calls
# TYPE avalanche_C_vm_chain_state_decided_cache_put_time counter
avalanche_C_vm_chain_state_decided_cache_put_time 2.800428e+06
```