### PR TITLE
Reduce p2p sdk metrics

### DIFF
--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -26,8 +26,9 @@ var (
 	_ common.AppHandler    = (*Network)(nil)
 	_ NodeSampler          = (*peerSampler)(nil)
 
+	opLabel      = "op"
 	handlerLabel = "handlerID"
-	labelNames   = []string{handlerLabel}
+	labelNames   = []string{opLabel, handlerLabel}
 )
 
 // ClientOption configures Client
@@ -62,93 +63,27 @@ func NewNetwork(
 	namespace string,
 ) (*Network, error) {
 	metrics := metrics{
-		appRequestTime: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "app_request_time",
-			Help:      "app request time (ns)",
-		}, labelNames),
-		appRequestCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "app_request_count",
-			Help:      "app request count (n)",
-		}, labelNames),
-		appResponseTime: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "app_response_time",
-			Help:      "app response time (ns)",
-		}, labelNames),
-		appResponseCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "app_response_count",
-			Help:      "app response count (n)",
-		}, labelNames),
-		appRequestFailedTime: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "app_request_failed_time",
-			Help:      "app request failed time (ns)",
-		}, labelNames),
-		appRequestFailedCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "app_request_failed_count",
-			Help:      "app request failed count (ns)",
-		}, labelNames),
-		appGossipTime: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "app_gossip_time",
-			Help:      "app gossip time (ns)",
-		}, labelNames),
-		appGossipCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "app_gossip_count",
-			Help:      "app gossip count (n)",
-		}, labelNames),
-		crossChainAppRequestTime: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "cross_chain_app_request_time",
-			Help:      "cross chain app request time (ns)",
-		}, labelNames),
-		crossChainAppRequestCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "cross_chain_app_request_count",
-			Help:      "cross chain app request count (n)",
-		}, labelNames),
-		crossChainAppResponseTime: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "cross_chain_app_response_time",
-			Help:      "cross chain app response time (ns)",
-		}, labelNames),
-		crossChainAppResponseCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "cross_chain_app_response_count",
-			Help:      "cross chain app response count (n)",
-		}, labelNames),
-		crossChainAppRequestFailedTime: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "cross_chain_app_request_failed_time",
-			Help:      "cross chain app request failed time (ns)",
-		}, labelNames),
-		crossChainAppRequestFailedCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "cross_chain_app_request_failed_count",
-			Help:      "cross chain app request failed count (n)",
-		}, labelNames),
+		msgTime: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "msg_time",
+				Help:      "message handling time (ns)",
+			},
+			labelNames,
+		),
+		msgCount: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "msg_count",
+				Help:      "message count (n)",
+			},
+			labelNames,
+		),
 	}
 
 	err := utils.Err(
-		registerer.Register(metrics.appRequestTime),
-		registerer.Register(metrics.appRequestCount),
-		registerer.Register(metrics.appResponseTime),
-		registerer.Register(metrics.appResponseCount),
-		registerer.Register(metrics.appRequestFailedTime),
-		registerer.Register(metrics.appRequestFailedCount),
-		registerer.Register(metrics.appGossipTime),
-		registerer.Register(metrics.appGossipCount),
-		registerer.Register(metrics.crossChainAppRequestTime),
-		registerer.Register(metrics.crossChainAppRequestCount),
-		registerer.Register(metrics.crossChainAppResponseTime),
-		registerer.Register(metrics.crossChainAppResponseCount),
-		registerer.Register(metrics.crossChainAppRequestFailedTime),
-		registerer.Register(metrics.crossChainAppRequestFailedCount),
+		registerer.Register(metrics.msgTime),
+		registerer.Register(metrics.msgCount),
 	)
 	if err != nil {
 		return nil, err

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -45,20 +45,8 @@ type meteredHandler struct {
 }
 
 type metrics struct {
-	appRequestTime                  *prometheus.CounterVec
-	appRequestCount                 *prometheus.CounterVec
-	appResponseTime                 *prometheus.CounterVec
-	appResponseCount                *prometheus.CounterVec
-	appRequestFailedTime            *prometheus.CounterVec
-	appRequestFailedCount           *prometheus.CounterVec
-	appGossipTime                   *prometheus.CounterVec
-	appGossipCount                  *prometheus.CounterVec
-	crossChainAppRequestTime        *prometheus.CounterVec
-	crossChainAppRequestCount       *prometheus.CounterVec
-	crossChainAppResponseTime       *prometheus.CounterVec
-	crossChainAppResponseCount      *prometheus.CounterVec
-	crossChainAppRequestFailedTime  *prometheus.CounterVec
-	crossChainAppRequestFailedCount *prometheus.CounterVec
+	msgTime  *prometheus.CounterVec
+	msgCount *prometheus.CounterVec
 }
 
 // router routes incoming application messages to the corresponding registered
@@ -140,15 +128,16 @@ func (r *router) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID ui
 	}
 
 	labels := prometheus.Labels{
+		opLabel:      message.AppRequestOp.String(),
 		handlerLabel: handlerID,
 	}
 
-	metricCount, err := r.metrics.appRequestCount.GetMetricWith(labels)
+	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
 
-	metricTime, err := r.metrics.appRequestTime.GetMetricWith(labels)
+	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
@@ -175,15 +164,16 @@ func (r *router) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reques
 	pending.callback(ctx, nodeID, nil, appErr)
 
 	labels := prometheus.Labels{
+		opLabel:      message.AppErrorOp.String(),
 		handlerLabel: pending.handlerID,
 	}
 
-	metricCount, err := r.metrics.appRequestFailedCount.GetMetricWith(labels)
+	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
 
-	metricTime, err := r.metrics.appRequestFailedTime.GetMetricWith(labels)
+	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
@@ -210,15 +200,16 @@ func (r *router) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID u
 	pending.callback(ctx, nodeID, response, nil)
 
 	labels := prometheus.Labels{
+		opLabel:      message.AppResponseOp.String(),
 		handlerLabel: pending.handlerID,
 	}
 
-	metricCount, err := r.metrics.appResponseCount.GetMetricWith(labels)
+	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
 
-	metricTime, err := r.metrics.appResponseTime.GetMetricWith(labels)
+	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
@@ -249,15 +240,16 @@ func (r *router) AppGossip(ctx context.Context, nodeID ids.NodeID, gossip []byte
 	handler.AppGossip(ctx, nodeID, parsedMsg)
 
 	labels := prometheus.Labels{
+		opLabel:      message.AppGossipOp.String(),
 		handlerLabel: handlerID,
 	}
 
-	metricCount, err := r.metrics.appGossipCount.GetMetricWith(labels)
+	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
 
-	metricTime, err := r.metrics.appGossipTime.GetMetricWith(labels)
+	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
@@ -299,15 +291,16 @@ func (r *router) CrossChainAppRequest(
 	}
 
 	labels := prometheus.Labels{
+		opLabel:      message.CrossChainAppRequestOp.String(),
 		handlerLabel: handlerID,
 	}
 
-	metricCount, err := r.metrics.crossChainAppRequestCount.GetMetricWith(labels)
+	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
 
-	metricTime, err := r.metrics.crossChainAppRequestTime.GetMetricWith(labels)
+	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
@@ -334,15 +327,16 @@ func (r *router) CrossChainAppRequestFailed(ctx context.Context, chainID ids.ID,
 	pending.callback(ctx, chainID, nil, appErr)
 
 	labels := prometheus.Labels{
+		opLabel:      message.CrossChainAppErrorOp.String(),
 		handlerLabel: pending.handlerID,
 	}
 
-	metricCount, err := r.metrics.crossChainAppRequestFailedCount.GetMetricWith(labels)
+	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
 
-	metricTime, err := r.metrics.crossChainAppRequestFailedTime.GetMetricWith(labels)
+	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
@@ -369,15 +363,16 @@ func (r *router) CrossChainAppResponse(ctx context.Context, chainID ids.ID, requ
 	pending.callback(ctx, chainID, response, nil)
 
 	labels := prometheus.Labels{
+		opLabel:      message.CrossChainAppResponseOp.String(),
 		handlerLabel: pending.handlerID,
 	}
 
-	metricCount, err := r.metrics.crossChainAppResponseCount.GetMetricWith(labels)
+	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}
 
-	metricTime, err := r.metrics.crossChainAppResponseTime.GetMetricWith(labels)
+	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
 	if err != nil {
 		return err
 	}

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -49,6 +49,22 @@ type metrics struct {
 	msgCount *prometheus.CounterVec
 }
 
+func (m *metrics) observe(labels prometheus.Labels, start time.Time) error {
+	metricTime, err := m.msgTime.GetMetricWith(labels)
+	if err != nil {
+		return err
+	}
+
+	metricCount, err := m.msgCount.GetMetricWith(labels)
+	if err != nil {
+		return err
+	}
+
+	metricTime.Add(float64(time.Since(start)))
+	metricCount.Inc()
+	return nil
+}
+
 // router routes incoming application messages to the corresponding registered
 // app handler. App messages must be made using the registered handler's
 // corresponding Client.
@@ -127,25 +143,13 @@ func (r *router) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID ui
 		return err
 	}
 
-	labels := prometheus.Labels{
-		opLabel:      message.AppRequestOp.String(),
-		handlerLabel: handlerID,
-	}
-
-	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricCount.Inc()
-	metricTime.Add(float64(time.Since(start)))
-
-	return nil
+	return r.metrics.observe(
+		prometheus.Labels{
+			opLabel:      message.AppRequestOp.String(),
+			handlerLabel: handlerID,
+		},
+		start,
+	)
 }
 
 // AppRequestFailed routes an AppRequestFailed message to the callback
@@ -163,25 +167,13 @@ func (r *router) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reques
 
 	pending.callback(ctx, nodeID, nil, appErr)
 
-	labels := prometheus.Labels{
-		opLabel:      message.AppErrorOp.String(),
-		handlerLabel: pending.handlerID,
-	}
-
-	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricCount.Inc()
-	metricTime.Add(float64(time.Since(start)))
-
-	return nil
+	return r.metrics.observe(
+		prometheus.Labels{
+			opLabel:      message.AppErrorOp.String(),
+			handlerLabel: pending.handlerID,
+		},
+		start,
+	)
 }
 
 // AppResponse routes an AppResponse message to the callback corresponding to
@@ -199,25 +191,13 @@ func (r *router) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	pending.callback(ctx, nodeID, response, nil)
 
-	labels := prometheus.Labels{
-		opLabel:      message.AppResponseOp.String(),
-		handlerLabel: pending.handlerID,
-	}
-
-	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricCount.Inc()
-	metricTime.Add(float64(time.Since(start)))
-
-	return nil
+	return r.metrics.observe(
+		prometheus.Labels{
+			opLabel:      message.AppResponseOp.String(),
+			handlerLabel: pending.handlerID,
+		},
+		start,
+	)
 }
 
 // AppGossip routes an AppGossip message to a Handler based on the handler
@@ -239,25 +219,13 @@ func (r *router) AppGossip(ctx context.Context, nodeID ids.NodeID, gossip []byte
 
 	handler.AppGossip(ctx, nodeID, parsedMsg)
 
-	labels := prometheus.Labels{
-		opLabel:      message.AppGossipOp.String(),
-		handlerLabel: handlerID,
-	}
-
-	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricCount.Inc()
-	metricTime.Add(float64(time.Since(start)))
-
-	return nil
+	return r.metrics.observe(
+		prometheus.Labels{
+			opLabel:      message.AppGossipOp.String(),
+			handlerLabel: handlerID,
+		},
+		start,
+	)
 }
 
 // CrossChainAppRequest routes a CrossChainAppRequest message to a Handler
@@ -290,25 +258,13 @@ func (r *router) CrossChainAppRequest(
 		return err
 	}
 
-	labels := prometheus.Labels{
-		opLabel:      message.CrossChainAppRequestOp.String(),
-		handlerLabel: handlerID,
-	}
-
-	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricCount.Inc()
-	metricTime.Add(float64(time.Since(start)))
-
-	return nil
+	return r.metrics.observe(
+		prometheus.Labels{
+			opLabel:      message.CrossChainAppRequestOp.String(),
+			handlerLabel: handlerID,
+		},
+		start,
+	)
 }
 
 // CrossChainAppRequestFailed routes a CrossChainAppRequestFailed message to
@@ -326,25 +282,13 @@ func (r *router) CrossChainAppRequestFailed(ctx context.Context, chainID ids.ID,
 
 	pending.callback(ctx, chainID, nil, appErr)
 
-	labels := prometheus.Labels{
-		opLabel:      message.CrossChainAppErrorOp.String(),
-		handlerLabel: pending.handlerID,
-	}
-
-	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricCount.Inc()
-	metricTime.Add(float64(time.Since(start)))
-
-	return nil
+	return r.metrics.observe(
+		prometheus.Labels{
+			opLabel:      message.CrossChainAppErrorOp.String(),
+			handlerLabel: pending.handlerID,
+		},
+		start,
+	)
 }
 
 // CrossChainAppResponse routes a CrossChainAppResponse message to the callback
@@ -362,25 +306,13 @@ func (r *router) CrossChainAppResponse(ctx context.Context, chainID ids.ID, requ
 
 	pending.callback(ctx, chainID, response, nil)
 
-	labels := prometheus.Labels{
-		opLabel:      message.CrossChainAppResponseOp.String(),
-		handlerLabel: pending.handlerID,
-	}
-
-	metricCount, err := r.metrics.msgCount.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricTime, err := r.metrics.msgTime.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	metricCount.Inc()
-	metricTime.Add(float64(time.Since(start)))
-
-	return nil
+	return r.metrics.observe(
+		prometheus.Labels{
+			opLabel:      message.CrossChainAppResponseOp.String(),
+			handlerLabel: pending.handlerID,
+		},
+		start,
+	)
 }
 
 // Parse parses a gossip or request message and maps it to a corresponding


### PR DESCRIPTION
## Why this should be merged

Improves UX for monitoring metrics.

## How this works

Removes a bunch of duplicate metrics and replaces them with vectors.

## How this was tested

- [X] CI