### PR TITLE
Use vectors for p2p message metrics

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -225,7 +225,7 @@ func NewNetwork(
 		return nil, fmt.Errorf("initializing outbound message throttler failed with: %w", err)
 	}
 
-	peerMetrics, err := peer.NewMetrics(log, config.Namespace, metricsRegisterer)
+	peerMetrics, err := peer.NewMetrics(config.Namespace, metricsRegisterer)
 	if err != nil {
 		return nil, fmt.Errorf("initializing peer metrics failed with: %w", err)
 	}

--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -478,7 +478,7 @@ func (p *peer) readMessages() {
 				zap.Error(err),
 			)
 
-			p.Metrics.FailedToParse.Inc()
+			p.Metrics.NumFailedToParse.Inc()
 
 			// Couldn't parse the message. Read the next one.
 			onFinishedHandling()
@@ -906,7 +906,8 @@ func (p *peer) handleHandshake(msg *p2p.Handshake) {
 	myTimeUnix := uint64(myTime.Unix())
 	clockDifference := math.Abs(float64(msg.MyTime) - float64(myTimeUnix))
 
-	p.Metrics.ClockSkew.Observe(clockDifference)
+	p.Metrics.ClockSkewCount.Inc()
+	p.Metrics.ClockSkewSum.Add(clockDifference)
 
 	if clockDifference > p.MaxClockDifference.Seconds() {
 		if _, ok := p.Beacons.GetValidator(constants.PrimaryNetworkID, p.id); ok {

--- a/network/peer/peer_test.go
+++ b/network/peer/peer_test.go
@@ -82,7 +82,6 @@ func makeRawTestPeers(t *testing.T, trackedSubnets set.Set[ids.ID]) (*rawTestPee
 	mc := newMessageCreator(t)
 
 	metrics, err := NewMetrics(
-		logging.NoLog{},
 		"",
 		prometheus.NewRegistry(),
 	)

--- a/network/peer/test_peer.go
+++ b/network/peer/test_peer.go
@@ -85,7 +85,6 @@ func StartTestPeer(
 	}
 
 	metrics, err := NewMetrics(
-		logging.NoLog{},
 		"",
 		prometheus.NewRegistry(),
 	)


### PR DESCRIPTION
## Why this should be merged

New:
```
# HELP avalanche_network_msgs number of handled messages
# TYPE avalanche_network_msgs counter
avalanche_network_msgs{compressed="false",io="received",op="accepted"} 1695
avalanche_network_msgs{compressed="false",io="received",op="accepted_frontier"} 124
avalanche_network_msgs{compressed="false",io="received",op="handshake"} 336
avalanche_network_msgs{compressed="false",io="received",op="ping"} 1872
avalanche_network_msgs{compressed="false",io="received",op="pong"} 1872
avalanche_network_msgs{compressed="false",io="sent",op="get_accepted"} 1695
avalanche_network_msgs{compressed="false",io="sent",op="get_accepted_frontier"} 124
avalanche_network_msgs{compressed="false",io="sent",op="get_ancestors"} 410
avalanche_network_msgs{compressed="false",io="sent",op="handshake"} 337
avalanche_network_msgs{compressed="false",io="sent",op="ping"} 1877
avalanche_network_msgs{compressed="false",io="sent",op="pong"} 1872
avalanche_network_msgs{compressed="true",io="received",op="ancestors"} 410
avalanche_network_msgs{compressed="true",io="received",op="peerlist"} 339
avalanche_network_msgs{compressed="true",io="received",op="put"} 146
avalanche_network_msgs{compressed="true",io="sent",op="get_peerlist"} 69
avalanche_network_msgs{compressed="true",io="sent",op="peerlist"} 330
# HELP avalanche_network_msgs_bytes number of message bytes
# TYPE avalanche_network_msgs_bytes counter
avalanche_network_msgs_bytes{io="received",op="accepted"} 123735
avalanche_network_msgs_bytes{io="received",op="accepted_frontier"} 9052
avalanche_network_msgs_bytes{io="received",op="ancestors"} 7.5621533e+07
avalanche_network_msgs_bytes{io="received",op="handshake"} 1.280084e+06
avalanche_network_msgs_bytes{io="received",op="peerlist"} 3.342275e+06
avalanche_network_msgs_bytes{io="received",op="ping"} 3744
avalanche_network_msgs_bytes{io="received",op="pong"} 3744
avalanche_network_msgs_bytes{io="received",op="put"} 403745
avalanche_network_msgs_bytes{io="sent",op="get_accepted"} 133905
avalanche_network_msgs_bytes{io="sent",op="get_accepted_frontier"} 5580
avalanche_network_msgs_bytes{io="sent",op="get_ancestors"} 33492
avalanche_network_msgs_bytes{io="sent",op="get_peerlist"} 151835
avalanche_network_msgs_bytes{io="sent",op="handshake"} 1.231073e+06
avalanche_network_msgs_bytes{io="sent",op="peerlist"} 4290
avalanche_network_msgs_bytes{io="sent",op="ping"} 3754
avalanche_network_msgs_bytes{io="sent",op="pong"} 3744
# HELP avalanche_network_msgs_bytes_saved number of message bytes saved
# TYPE avalanche_network_msgs_bytes_saved gauge
avalanche_network_msgs_bytes_saved{io="received",op="ancestors"} 1.7757768e+08
avalanche_network_msgs_bytes_saved{io="received",op="peerlist"} 370464
avalanche_network_msgs_bytes_saved{io="received",op="put"} 222712
avalanche_network_msgs_bytes_saved{io="sent",op="get_peerlist"} 83166
avalanche_network_msgs_bytes_saved{io="sent",op="peerlist"} -3630
# HELP avalanche_network_msgs_failed_to_parse number of received messages that could not be parsed
# TYPE avalanche_network_msgs_failed_to_parse counter
avalanche_network_msgs_failed_to_parse 0
# HELP avalanche_network_msgs_failed_to_send number of messages that failed to be sent
# TYPE avalanche_network_msgs_failed_to_send counter
avalanche_network_msgs_failed_to_send{op="get_accepted"} 2400
avalanche_network_msgs_failed_to_send{op="get_accepted_frontier"} 1
avalanche_network_msgs_failed_to_send{op="get_ancestors"} 0
```

Old:
```
# HELP avalanche_network_accepted_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of accepted messages
# TYPE avalanche_network_accepted_compression_saved_received_bytes_count counter
avalanche_network_accepted_compression_saved_received_bytes_count 0
# HELP avalanche_network_accepted_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of accepted messages
# TYPE avalanche_network_accepted_compression_saved_received_bytes_sum gauge
avalanche_network_accepted_compression_saved_received_bytes_sum 0
# HELP avalanche_network_accepted_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of accepted messages
# TYPE avalanche_network_accepted_compression_saved_sent_bytes_count counter
avalanche_network_accepted_compression_saved_sent_bytes_count 0
# HELP avalanche_network_accepted_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of accepted messages
# TYPE avalanche_network_accepted_compression_saved_sent_bytes_sum gauge
avalanche_network_accepted_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_accepted_failed Number of accepted messages that failed to be sent over the network
# TYPE avalanche_network_accepted_failed counter
avalanche_network_accepted_failed 0
# HELP avalanche_network_accepted_frontier_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of accepted_frontier messages
# TYPE avalanche_network_accepted_frontier_compression_saved_received_bytes_count counter
avalanche_network_accepted_frontier_compression_saved_received_bytes_count 0
# HELP avalanche_network_accepted_frontier_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of accepted_frontier messages
# TYPE avalanche_network_accepted_frontier_compression_saved_received_bytes_sum gauge
avalanche_network_accepted_frontier_compression_saved_received_bytes_sum 0
# HELP avalanche_network_accepted_frontier_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of accepted_frontier messages
# TYPE avalanche_network_accepted_frontier_compression_saved_sent_bytes_count counter
avalanche_network_accepted_frontier_compression_saved_sent_bytes_count 0
# HELP avalanche_network_accepted_frontier_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of accepted_frontier messages
# TYPE avalanche_network_accepted_frontier_compression_saved_sent_bytes_sum gauge
avalanche_network_accepted_frontier_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_accepted_frontier_failed Number of accepted_frontier messages that failed to be sent over the network
# TYPE avalanche_network_accepted_frontier_failed counter
avalanche_network_accepted_frontier_failed 0
# HELP avalanche_network_accepted_frontier_received Number of accepted_frontier messages received from the network
# TYPE avalanche_network_accepted_frontier_received counter
avalanche_network_accepted_frontier_received 4
# HELP avalanche_network_accepted_frontier_received_bytes Number of bytes of accepted_frontier messages received from the network
# TYPE avalanche_network_accepted_frontier_received_bytes counter
avalanche_network_accepted_frontier_received_bytes 292
# HELP avalanche_network_accepted_frontier_sent Number of accepted_frontier messages sent over the network
# TYPE avalanche_network_accepted_frontier_sent counter
avalanche_network_accepted_frontier_sent 0
# HELP avalanche_network_accepted_frontier_sent_bytes Size of bytes of accepted_frontier messages received from the network
# TYPE avalanche_network_accepted_frontier_sent_bytes counter
avalanche_network_accepted_frontier_sent_bytes 0
# HELP avalanche_network_accepted_received Number of accepted messages received from the network
# TYPE avalanche_network_accepted_received counter
avalanche_network_accepted_received 0
# HELP avalanche_network_accepted_received_bytes Number of bytes of accepted messages received from the network
# TYPE avalanche_network_accepted_received_bytes counter
avalanche_network_accepted_received_bytes 0
# HELP avalanche_network_accepted_sent Number of accepted messages sent over the network
# TYPE avalanche_network_accepted_sent counter
avalanche_network_accepted_sent 0
# HELP avalanche_network_accepted_sent_bytes Size of bytes of accepted messages received from the network
# TYPE avalanche_network_accepted_sent_bytes counter
avalanche_network_accepted_sent_bytes 0
# HELP avalanche_network_accepted_state_summary_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of accepted_state_summary messages
# TYPE avalanche_network_accepted_state_summary_compression_saved_received_bytes_count counter
avalanche_network_accepted_state_summary_compression_saved_received_bytes_count 0
# HELP avalanche_network_accepted_state_summary_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of accepted_state_summary messages
# TYPE avalanche_network_accepted_state_summary_compression_saved_received_bytes_sum gauge
avalanche_network_accepted_state_summary_compression_saved_received_bytes_sum 0
# HELP avalanche_network_accepted_state_summary_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of accepted_state_summary messages
# TYPE avalanche_network_accepted_state_summary_compression_saved_sent_bytes_count counter
avalanche_network_accepted_state_summary_compression_saved_sent_bytes_count 0
# HELP avalanche_network_accepted_state_summary_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of accepted_state_summary messages
# TYPE avalanche_network_accepted_state_summary_compression_saved_sent_bytes_sum gauge
avalanche_network_accepted_state_summary_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_accepted_state_summary_failed Number of accepted_state_summary messages that failed to be sent over the network
# TYPE avalanche_network_accepted_state_summary_failed counter
avalanche_network_accepted_state_summary_failed 0
# HELP avalanche_network_accepted_state_summary_received Number of accepted_state_summary messages received from the network
# TYPE avalanche_network_accepted_state_summary_received counter
avalanche_network_accepted_state_summary_received 0
# HELP avalanche_network_accepted_state_summary_received_bytes Number of bytes of accepted_state_summary messages received from the network
# TYPE avalanche_network_accepted_state_summary_received_bytes counter
avalanche_network_accepted_state_summary_received_bytes 0
# HELP avalanche_network_accepted_state_summary_sent Number of accepted_state_summary messages sent over the network
# TYPE avalanche_network_accepted_state_summary_sent counter
avalanche_network_accepted_state_summary_sent 0
# HELP avalanche_network_accepted_state_summary_sent_bytes Size of bytes of accepted_state_summary messages received from the network
# TYPE avalanche_network_accepted_state_summary_sent_bytes counter
avalanche_network_accepted_state_summary_sent_bytes 0
# HELP avalanche_network_ancestors_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of ancestors messages
# TYPE avalanche_network_ancestors_compression_saved_received_bytes_count counter
avalanche_network_ancestors_compression_saved_received_bytes_count 0
# HELP avalanche_network_ancestors_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of ancestors messages
# TYPE avalanche_network_ancestors_compression_saved_received_bytes_sum gauge
avalanche_network_ancestors_compression_saved_received_bytes_sum 0
# HELP avalanche_network_ancestors_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of ancestors messages
# TYPE avalanche_network_ancestors_compression_saved_sent_bytes_count counter
avalanche_network_ancestors_compression_saved_sent_bytes_count 0
# HELP avalanche_network_ancestors_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of ancestors messages
# TYPE avalanche_network_ancestors_compression_saved_sent_bytes_sum gauge
avalanche_network_ancestors_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_ancestors_failed Number of ancestors messages that failed to be sent over the network
# TYPE avalanche_network_ancestors_failed counter
avalanche_network_ancestors_failed 0
# HELP avalanche_network_ancestors_received Number of ancestors messages received from the network
# TYPE avalanche_network_ancestors_received counter
avalanche_network_ancestors_received 0
# HELP avalanche_network_ancestors_received_bytes Number of bytes of ancestors messages received from the network
# TYPE avalanche_network_ancestors_received_bytes counter
avalanche_network_ancestors_received_bytes 0
# HELP avalanche_network_ancestors_sent Number of ancestors messages sent over the network
# TYPE avalanche_network_ancestors_sent counter
avalanche_network_ancestors_sent 0
# HELP avalanche_network_ancestors_sent_bytes Size of bytes of ancestors messages received from the network
# TYPE avalanche_network_ancestors_sent_bytes counter
avalanche_network_ancestors_sent_bytes 0
# HELP avalanche_network_app_error_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of app_error messages
# TYPE avalanche_network_app_error_compression_saved_received_bytes_count counter
avalanche_network_app_error_compression_saved_received_bytes_count 0
# HELP avalanche_network_app_error_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of app_error messages
# TYPE avalanche_network_app_error_compression_saved_received_bytes_sum gauge
avalanche_network_app_error_compression_saved_received_bytes_sum 0
# HELP avalanche_network_app_error_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of app_error messages
# TYPE avalanche_network_app_error_compression_saved_sent_bytes_count counter
avalanche_network_app_error_compression_saved_sent_bytes_count 0
# HELP avalanche_network_app_error_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of app_error messages
# TYPE avalanche_network_app_error_compression_saved_sent_bytes_sum gauge
avalanche_network_app_error_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_app_error_failed Number of app_error messages that failed to be sent over the network
# TYPE avalanche_network_app_error_failed counter
avalanche_network_app_error_failed 0
# HELP avalanche_network_app_error_received Number of app_error messages received from the network
# TYPE avalanche_network_app_error_received counter
avalanche_network_app_error_received 0
# HELP avalanche_network_app_error_received_bytes Number of bytes of app_error messages received from the network
# TYPE avalanche_network_app_error_received_bytes counter
avalanche_network_app_error_received_bytes 0
# HELP avalanche_network_app_error_sent Number of app_error messages sent over the network
# TYPE avalanche_network_app_error_sent counter
avalanche_network_app_error_sent 0
# HELP avalanche_network_app_error_sent_bytes Size of bytes of app_error messages received from the network
# TYPE avalanche_network_app_error_sent_bytes counter
avalanche_network_app_error_sent_bytes 0
# HELP avalanche_network_app_gossip_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of app_gossip messages
# TYPE avalanche_network_app_gossip_compression_saved_received_bytes_count counter
avalanche_network_app_gossip_compression_saved_received_bytes_count 0
# HELP avalanche_network_app_gossip_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of app_gossip messages
# TYPE avalanche_network_app_gossip_compression_saved_received_bytes_sum gauge
avalanche_network_app_gossip_compression_saved_received_bytes_sum 0
# HELP avalanche_network_app_gossip_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of app_gossip messages
# TYPE avalanche_network_app_gossip_compression_saved_sent_bytes_count counter
avalanche_network_app_gossip_compression_saved_sent_bytes_count 0
# HELP avalanche_network_app_gossip_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of app_gossip messages
# TYPE avalanche_network_app_gossip_compression_saved_sent_bytes_sum gauge
avalanche_network_app_gossip_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_app_gossip_failed Number of app_gossip messages that failed to be sent over the network
# TYPE avalanche_network_app_gossip_failed counter
avalanche_network_app_gossip_failed 0
# HELP avalanche_network_app_gossip_received Number of app_gossip messages received from the network
# TYPE avalanche_network_app_gossip_received counter
avalanche_network_app_gossip_received 0
# HELP avalanche_network_app_gossip_received_bytes Number of bytes of app_gossip messages received from the network
# TYPE avalanche_network_app_gossip_received_bytes counter
avalanche_network_app_gossip_received_bytes 0
# HELP avalanche_network_app_gossip_sent Number of app_gossip messages sent over the network
# TYPE avalanche_network_app_gossip_sent counter
avalanche_network_app_gossip_sent 0
# HELP avalanche_network_app_gossip_sent_bytes Size of bytes of app_gossip messages received from the network
# TYPE avalanche_network_app_gossip_sent_bytes counter
avalanche_network_app_gossip_sent_bytes 0
# HELP avalanche_network_app_request_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of app_request messages
# TYPE avalanche_network_app_request_compression_saved_received_bytes_count counter
avalanche_network_app_request_compression_saved_received_bytes_count 0
# HELP avalanche_network_app_request_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of app_request messages
# TYPE avalanche_network_app_request_compression_saved_received_bytes_sum gauge
avalanche_network_app_request_compression_saved_received_bytes_sum 0
# HELP avalanche_network_app_request_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of app_request messages
# TYPE avalanche_network_app_request_compression_saved_sent_bytes_count counter
avalanche_network_app_request_compression_saved_sent_bytes_count 0
# HELP avalanche_network_app_request_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of app_request messages
# TYPE avalanche_network_app_request_compression_saved_sent_bytes_sum gauge
avalanche_network_app_request_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_app_request_failed Number of app_request messages that failed to be sent over the network
# TYPE avalanche_network_app_request_failed counter
avalanche_network_app_request_failed 0
# HELP avalanche_network_app_request_received Number of app_request messages received from the network
# TYPE avalanche_network_app_request_received counter
avalanche_network_app_request_received 0
# HELP avalanche_network_app_request_received_bytes Number of bytes of app_request messages received from the network
# TYPE avalanche_network_app_request_received_bytes counter
avalanche_network_app_request_received_bytes 0
# HELP avalanche_network_app_request_sent Number of app_request messages sent over the network
# TYPE avalanche_network_app_request_sent counter
avalanche_network_app_request_sent 0
# HELP avalanche_network_app_request_sent_bytes Size of bytes of app_request messages received from the network
# TYPE avalanche_network_app_request_sent_bytes counter
avalanche_network_app_request_sent_bytes 0
# HELP avalanche_network_app_response_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of app_response messages
# TYPE avalanche_network_app_response_compression_saved_received_bytes_count counter
avalanche_network_app_response_compression_saved_received_bytes_count 0
# HELP avalanche_network_app_response_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of app_response messages
# TYPE avalanche_network_app_response_compression_saved_received_bytes_sum gauge
avalanche_network_app_response_compression_saved_received_bytes_sum 0
# HELP avalanche_network_app_response_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of app_response messages
# TYPE avalanche_network_app_response_compression_saved_sent_bytes_count counter
avalanche_network_app_response_compression_saved_sent_bytes_count 0
# HELP avalanche_network_app_response_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of app_response messages
# TYPE avalanche_network_app_response_compression_saved_sent_bytes_sum gauge
avalanche_network_app_response_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_app_response_failed Number of app_response messages that failed to be sent over the network
# TYPE avalanche_network_app_response_failed counter
avalanche_network_app_response_failed 0
# HELP avalanche_network_app_response_received Number of app_response messages received from the network
# TYPE avalanche_network_app_response_received counter
avalanche_network_app_response_received 0
# HELP avalanche_network_app_response_received_bytes Number of bytes of app_response messages received from the network
# TYPE avalanche_network_app_response_received_bytes counter
avalanche_network_app_response_received_bytes 0
# HELP avalanche_network_app_response_sent Number of app_response messages sent over the network
# TYPE avalanche_network_app_response_sent counter
avalanche_network_app_response_sent 0
# HELP avalanche_network_app_response_sent_bytes Size of bytes of app_response messages received from the network
# TYPE avalanche_network_app_response_sent_bytes counter
avalanche_network_app_response_sent_bytes 0
# HELP avalanche_network_bandwidth_throttler_inbound_acquire_latency_count Total # of observations of average time (in ns) to acquire bytes from the inbound bandwidth throttler
# TYPE avalanche_network_bandwidth_throttler_inbound_acquire_latency_count counter
avalanche_network_bandwidth_throttler_inbound_acquire_latency_count 214
# HELP avalanche_network_bandwidth_throttler_inbound_acquire_latency_sum Sum of average time (in ns) to acquire bytes from the inbound bandwidth throttler
# TYPE avalanche_network_bandwidth_throttler_inbound_acquire_latency_sum gauge
avalanche_network_bandwidth_throttler_inbound_acquire_latency_sum 160126
# HELP avalanche_network_bandwidth_throttler_inbound_awaiting_acquire Number of inbound messages waiting to acquire bandwidth from the inbound bandwidth throttler
# TYPE avalanche_network_bandwidth_throttler_inbound_awaiting_acquire gauge
avalanche_network_bandwidth_throttler_inbound_awaiting_acquire 0
# HELP avalanche_network_buffer_throttler_inbound_acquire_latency_count Total # of observations of average time (in ns) to get space on the inbound message buffer
# TYPE avalanche_network_buffer_throttler_inbound_acquire_latency_count counter
avalanche_network_buffer_throttler_inbound_acquire_latency_count 214
# HELP avalanche_network_buffer_throttler_inbound_acquire_latency_sum Sum of average time (in ns) to get space on the inbound message buffer
# TYPE avalanche_network_buffer_throttler_inbound_acquire_latency_sum gauge
avalanche_network_buffer_throttler_inbound_acquire_latency_sum 153420
# HELP avalanche_network_buffer_throttler_inbound_awaiting_acquire Number of inbound messages waiting to take space on the inbound message buffer
# TYPE avalanche_network_buffer_throttler_inbound_awaiting_acquire gauge
avalanche_network_buffer_throttler_inbound_awaiting_acquire 0
# HELP avalanche_network_byte_throttler_inbound_acquire_latency_count Total # of observations of average time (in ns) to get space on the inbound message byte buffer
# TYPE avalanche_network_byte_throttler_inbound_acquire_latency_count counter
avalanche_network_byte_throttler_inbound_acquire_latency_count 214
# HELP avalanche_network_byte_throttler_inbound_acquire_latency_sum Sum of average time (in ns) to get space on the inbound message byte buffer
# TYPE avalanche_network_byte_throttler_inbound_acquire_latency_sum gauge
avalanche_network_byte_throttler_inbound_acquire_latency_sum 87527
# HELP avalanche_network_byte_throttler_inbound_awaiting_acquire Number of inbound messages waiting to acquire space on the inbound message byte buffer
# TYPE avalanche_network_byte_throttler_inbound_awaiting_acquire gauge
avalanche_network_byte_throttler_inbound_awaiting_acquire 0
# HELP avalanche_network_byte_throttler_inbound_awaiting_release Number of messages currently being read/handled
# TYPE avalanche_network_byte_throttler_inbound_awaiting_release gauge
avalanche_network_byte_throttler_inbound_awaiting_release 0
# HELP avalanche_network_byte_throttler_inbound_remaining_at_large_bytes Bytes remaining in the at-large byte buffer
# TYPE avalanche_network_byte_throttler_inbound_remaining_at_large_bytes gauge
avalanche_network_byte_throttler_inbound_remaining_at_large_bytes 6.291456e+06
# HELP avalanche_network_byte_throttler_inbound_remaining_validator_bytes Bytes remaining in the validator byte buffer
# TYPE avalanche_network_byte_throttler_inbound_remaining_validator_bytes gauge
avalanche_network_byte_throttler_inbound_remaining_validator_bytes 3.3554432e+07
# HELP avalanche_network_chits_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of chits messages
# TYPE avalanche_network_chits_compression_saved_received_bytes_count counter
avalanche_network_chits_compression_saved_received_bytes_count 0
# HELP avalanche_network_chits_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of chits messages
# TYPE avalanche_network_chits_compression_saved_received_bytes_sum gauge
avalanche_network_chits_compression_saved_received_bytes_sum 0
# HELP avalanche_network_chits_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of chits messages
# TYPE avalanche_network_chits_compression_saved_sent_bytes_count counter
avalanche_network_chits_compression_saved_sent_bytes_count 0
# HELP avalanche_network_chits_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of chits messages
# TYPE avalanche_network_chits_compression_saved_sent_bytes_sum gauge
avalanche_network_chits_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_chits_failed Number of chits messages that failed to be sent over the network
# TYPE avalanche_network_chits_failed counter
avalanche_network_chits_failed 0
# HELP avalanche_network_chits_received Number of chits messages received from the network
# TYPE avalanche_network_chits_received counter
avalanche_network_chits_received 0
# HELP avalanche_network_chits_received_bytes Number of bytes of chits messages received from the network
# TYPE avalanche_network_chits_received_bytes counter
avalanche_network_chits_received_bytes 0
# HELP avalanche_network_chits_sent Number of chits messages sent over the network
# TYPE avalanche_network_chits_sent counter
avalanche_network_chits_sent 0
# HELP avalanche_network_chits_sent_bytes Size of bytes of chits messages received from the network
# TYPE avalanche_network_chits_sent_bytes counter
avalanche_network_chits_sent_bytes 0
# HELP avalanche_network_clock_skew_count Total # of observations of clock skew during peer handshake
# TYPE avalanche_network_clock_skew_count counter
avalanche_network_clock_skew_count 105
# HELP avalanche_network_clock_skew_sum Sum of clock skew during peer handshake
# TYPE avalanche_network_clock_skew_sum gauge
avalanche_network_clock_skew_sum 2
# HELP avalanche_network_get_accepted_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of get_accepted messages
# TYPE avalanche_network_get_accepted_compression_saved_received_bytes_count counter
avalanche_network_get_accepted_compression_saved_received_bytes_count 0
# HELP avalanche_network_get_accepted_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of get_accepted messages
# TYPE avalanche_network_get_accepted_compression_saved_received_bytes_sum gauge
avalanche_network_get_accepted_compression_saved_received_bytes_sum 0
# HELP avalanche_network_get_accepted_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of get_accepted messages
# TYPE avalanche_network_get_accepted_compression_saved_sent_bytes_count counter
avalanche_network_get_accepted_compression_saved_sent_bytes_count 0
# HELP avalanche_network_get_accepted_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of get_accepted messages
# TYPE avalanche_network_get_accepted_compression_saved_sent_bytes_sum gauge
avalanche_network_get_accepted_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_get_accepted_failed Number of get_accepted messages that failed to be sent over the network
# TYPE avalanche_network_get_accepted_failed counter
avalanche_network_get_accepted_failed 0
# HELP avalanche_network_get_accepted_frontier_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of get_accepted_frontier messages
# TYPE avalanche_network_get_accepted_frontier_compression_saved_received_bytes_count counter
avalanche_network_get_accepted_frontier_compression_saved_received_bytes_count 0
# HELP avalanche_network_get_accepted_frontier_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of get_accepted_frontier messages
# TYPE avalanche_network_get_accepted_frontier_compression_saved_received_bytes_sum gauge
avalanche_network_get_accepted_frontier_compression_saved_received_bytes_sum 0
# HELP avalanche_network_get_accepted_frontier_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of get_accepted_frontier messages
# TYPE avalanche_network_get_accepted_frontier_compression_saved_sent_bytes_count counter
avalanche_network_get_accepted_frontier_compression_saved_sent_bytes_count 0
# HELP avalanche_network_get_accepted_frontier_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of get_accepted_frontier messages
# TYPE avalanche_network_get_accepted_frontier_compression_saved_sent_bytes_sum gauge
avalanche_network_get_accepted_frontier_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_get_accepted_frontier_failed Number of get_accepted_frontier messages that failed to be sent over the network
# TYPE avalanche_network_get_accepted_frontier_failed counter
avalanche_network_get_accepted_frontier_failed 1
# HELP avalanche_network_get_accepted_frontier_received Number of get_accepted_frontier messages received from the network
# TYPE avalanche_network_get_accepted_frontier_received counter
avalanche_network_get_accepted_frontier_received 0
# HELP avalanche_network_get_accepted_frontier_received_bytes Number of bytes of get_accepted_frontier messages received from the network
# TYPE avalanche_network_get_accepted_frontier_received_bytes counter
avalanche_network_get_accepted_frontier_received_bytes 0
# HELP avalanche_network_get_accepted_frontier_sent Number of get_accepted_frontier messages sent over the network
# TYPE avalanche_network_get_accepted_frontier_sent counter
avalanche_network_get_accepted_frontier_sent 4
# HELP avalanche_network_get_accepted_frontier_sent_bytes Size of bytes of get_accepted_frontier messages received from the network
# TYPE avalanche_network_get_accepted_frontier_sent_bytes counter
avalanche_network_get_accepted_frontier_sent_bytes 180
# HELP avalanche_network_get_accepted_received Number of get_accepted messages received from the network
# TYPE avalanche_network_get_accepted_received counter
avalanche_network_get_accepted_received 0
# HELP avalanche_network_get_accepted_received_bytes Number of bytes of get_accepted messages received from the network
# TYPE avalanche_network_get_accepted_received_bytes counter
avalanche_network_get_accepted_received_bytes 0
# HELP avalanche_network_get_accepted_sent Number of get_accepted messages sent over the network
# TYPE avalanche_network_get_accepted_sent counter
avalanche_network_get_accepted_sent 0
# HELP avalanche_network_get_accepted_sent_bytes Size of bytes of get_accepted messages received from the network
# TYPE avalanche_network_get_accepted_sent_bytes counter
avalanche_network_get_accepted_sent_bytes 0
# HELP avalanche_network_get_accepted_state_summary_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of get_accepted_state_summary messages
# TYPE avalanche_network_get_accepted_state_summary_compression_saved_received_bytes_count counter
avalanche_network_get_accepted_state_summary_compression_saved_received_bytes_count 0
# HELP avalanche_network_get_accepted_state_summary_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of get_accepted_state_summary messages
# TYPE avalanche_network_get_accepted_state_summary_compression_saved_received_bytes_sum gauge
avalanche_network_get_accepted_state_summary_compression_saved_received_bytes_sum 0
# HELP avalanche_network_get_accepted_state_summary_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of get_accepted_state_summary messages
# TYPE avalanche_network_get_accepted_state_summary_compression_saved_sent_bytes_count counter
avalanche_network_get_accepted_state_summary_compression_saved_sent_bytes_count 0
# HELP avalanche_network_get_accepted_state_summary_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of get_accepted_state_summary messages
# TYPE avalanche_network_get_accepted_state_summary_compression_saved_sent_bytes_sum gauge
avalanche_network_get_accepted_state_summary_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_get_accepted_state_summary_failed Number of get_accepted_state_summary messages that failed to be sent over the network
# TYPE avalanche_network_get_accepted_state_summary_failed counter
avalanche_network_get_accepted_state_summary_failed 0
# HELP avalanche_network_get_accepted_state_summary_received Number of get_accepted_state_summary messages received from the network
# TYPE avalanche_network_get_accepted_state_summary_received counter
avalanche_network_get_accepted_state_summary_received 0
# HELP avalanche_network_get_accepted_state_summary_received_bytes Number of bytes of get_accepted_state_summary messages received from the network
# TYPE avalanche_network_get_accepted_state_summary_received_bytes counter
avalanche_network_get_accepted_state_summary_received_bytes 0
# HELP avalanche_network_get_accepted_state_summary_sent Number of get_accepted_state_summary messages sent over the network
# TYPE avalanche_network_get_accepted_state_summary_sent counter
avalanche_network_get_accepted_state_summary_sent 0
# HELP avalanche_network_get_accepted_state_summary_sent_bytes Size of bytes of get_accepted_state_summary messages received from the network
# TYPE avalanche_network_get_accepted_state_summary_sent_bytes counter
avalanche_network_get_accepted_state_summary_sent_bytes 0
# HELP avalanche_network_get_ancestors_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of get_ancestors messages
# TYPE avalanche_network_get_ancestors_compression_saved_received_bytes_count counter
avalanche_network_get_ancestors_compression_saved_received_bytes_count 0
# HELP avalanche_network_get_ancestors_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of get_ancestors messages
# TYPE avalanche_network_get_ancestors_compression_saved_received_bytes_sum gauge
avalanche_network_get_ancestors_compression_saved_received_bytes_sum 0
# HELP avalanche_network_get_ancestors_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of get_ancestors messages
# TYPE avalanche_network_get_ancestors_compression_saved_sent_bytes_count counter
avalanche_network_get_ancestors_compression_saved_sent_bytes_count 0
# HELP avalanche_network_get_ancestors_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of get_ancestors messages
# TYPE avalanche_network_get_ancestors_compression_saved_sent_bytes_sum gauge
avalanche_network_get_ancestors_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_get_ancestors_failed Number of get_ancestors messages that failed to be sent over the network
# TYPE avalanche_network_get_ancestors_failed counter
avalanche_network_get_ancestors_failed 0
# HELP avalanche_network_get_ancestors_received Number of get_ancestors messages received from the network
# TYPE avalanche_network_get_ancestors_received counter
avalanche_network_get_ancestors_received 0
# HELP avalanche_network_get_ancestors_received_bytes Number of bytes of get_ancestors messages received from the network
# TYPE avalanche_network_get_ancestors_received_bytes counter
avalanche_network_get_ancestors_received_bytes 0
# HELP avalanche_network_get_ancestors_sent Number of get_ancestors messages sent over the network
# TYPE avalanche_network_get_ancestors_sent counter
avalanche_network_get_ancestors_sent 0
# HELP avalanche_network_get_ancestors_sent_bytes Size of bytes of get_ancestors messages received from the network
# TYPE avalanche_network_get_ancestors_sent_bytes counter
avalanche_network_get_ancestors_sent_bytes 0
# HELP avalanche_network_get_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of get messages
# TYPE avalanche_network_get_compression_saved_received_bytes_count counter
avalanche_network_get_compression_saved_received_bytes_count 0
# HELP avalanche_network_get_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of get messages
# TYPE avalanche_network_get_compression_saved_received_bytes_sum gauge
avalanche_network_get_compression_saved_received_bytes_sum 0
# HELP avalanche_network_get_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of get messages
# TYPE avalanche_network_get_compression_saved_sent_bytes_count counter
avalanche_network_get_compression_saved_sent_bytes_count 0
# HELP avalanche_network_get_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of get messages
# TYPE avalanche_network_get_compression_saved_sent_bytes_sum gauge
avalanche_network_get_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_get_failed Number of get messages that failed to be sent over the network
# TYPE avalanche_network_get_failed counter
avalanche_network_get_failed 0
# HELP avalanche_network_get_peerlist_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of get_peerlist messages
# TYPE avalanche_network_get_peerlist_compression_saved_received_bytes_count counter
avalanche_network_get_peerlist_compression_saved_received_bytes_count 0
# HELP avalanche_network_get_peerlist_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of get_peerlist messages
# TYPE avalanche_network_get_peerlist_compression_saved_received_bytes_sum gauge
avalanche_network_get_peerlist_compression_saved_received_bytes_sum 0
# HELP avalanche_network_get_peerlist_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of get_peerlist messages
# TYPE avalanche_network_get_peerlist_compression_saved_sent_bytes_count counter
avalanche_network_get_peerlist_compression_saved_sent_bytes_count 0
# HELP avalanche_network_get_peerlist_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of get_peerlist messages
# TYPE avalanche_network_get_peerlist_compression_saved_sent_bytes_sum gauge
avalanche_network_get_peerlist_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_get_peerlist_failed Number of get_peerlist messages that failed to be sent over the network
# TYPE avalanche_network_get_peerlist_failed counter
avalanche_network_get_peerlist_failed 0
# HELP avalanche_network_get_peerlist_received Number of get_peerlist messages received from the network
# TYPE avalanche_network_get_peerlist_received counter
avalanche_network_get_peerlist_received 0
# HELP avalanche_network_get_peerlist_received_bytes Number of bytes of get_peerlist messages received from the network
# TYPE avalanche_network_get_peerlist_received_bytes counter
avalanche_network_get_peerlist_received_bytes 0
# HELP avalanche_network_get_peerlist_sent Number of get_peerlist messages sent over the network
# TYPE avalanche_network_get_peerlist_sent counter
avalanche_network_get_peerlist_sent 0
# HELP avalanche_network_get_peerlist_sent_bytes Size of bytes of get_peerlist messages received from the network
# TYPE avalanche_network_get_peerlist_sent_bytes counter
avalanche_network_get_peerlist_sent_bytes 0
# HELP avalanche_network_get_received Number of get messages received from the network
# TYPE avalanche_network_get_received counter
avalanche_network_get_received 0
# HELP avalanche_network_get_received_bytes Number of bytes of get messages received from the network
# TYPE avalanche_network_get_received_bytes counter
avalanche_network_get_received_bytes 0
# HELP avalanche_network_get_sent Number of get messages sent over the network
# TYPE avalanche_network_get_sent counter
avalanche_network_get_sent 0
# HELP avalanche_network_get_sent_bytes Size of bytes of get messages received from the network
# TYPE avalanche_network_get_sent_bytes counter
avalanche_network_get_sent_bytes 0
# HELP avalanche_network_get_state_summary_frontier_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of get_state_summary_frontier messages
# TYPE avalanche_network_get_state_summary_frontier_compression_saved_received_bytes_count counter
avalanche_network_get_state_summary_frontier_compression_saved_received_bytes_count 0
# HELP avalanche_network_get_state_summary_frontier_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of get_state_summary_frontier messages
# TYPE avalanche_network_get_state_summary_frontier_compression_saved_received_bytes_sum gauge
avalanche_network_get_state_summary_frontier_compression_saved_received_bytes_sum 0
# HELP avalanche_network_get_state_summary_frontier_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of get_state_summary_frontier messages
# TYPE avalanche_network_get_state_summary_frontier_compression_saved_sent_bytes_count counter
avalanche_network_get_state_summary_frontier_compression_saved_sent_bytes_count 0
# HELP avalanche_network_get_state_summary_frontier_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of get_state_summary_frontier messages
# TYPE avalanche_network_get_state_summary_frontier_compression_saved_sent_bytes_sum gauge
avalanche_network_get_state_summary_frontier_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_get_state_summary_frontier_failed Number of get_state_summary_frontier messages that failed to be sent over the network
# TYPE avalanche_network_get_state_summary_frontier_failed counter
avalanche_network_get_state_summary_frontier_failed 0
# HELP avalanche_network_get_state_summary_frontier_received Number of get_state_summary_frontier messages received from the network
# TYPE avalanche_network_get_state_summary_frontier_received counter
avalanche_network_get_state_summary_frontier_received 0
# HELP avalanche_network_get_state_summary_frontier_received_bytes Number of bytes of get_state_summary_frontier messages received from the network
# TYPE avalanche_network_get_state_summary_frontier_received_bytes counter
avalanche_network_get_state_summary_frontier_received_bytes 0
# HELP avalanche_network_get_state_summary_frontier_sent Number of get_state_summary_frontier messages sent over the network
# TYPE avalanche_network_get_state_summary_frontier_sent counter
avalanche_network_get_state_summary_frontier_sent 0
# HELP avalanche_network_get_state_summary_frontier_sent_bytes Size of bytes of get_state_summary_frontier messages received from the network
# TYPE avalanche_network_get_state_summary_frontier_sent_bytes counter
avalanche_network_get_state_summary_frontier_sent_bytes 0
# HELP avalanche_network_gossipable_ips Number of IPs this node is willing to gossip
# TYPE avalanche_network_gossipable_ips gauge
avalanche_network_gossipable_ips 105
# HELP avalanche_network_handshake_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of handshake messages
# TYPE avalanche_network_handshake_compression_saved_received_bytes_count counter
avalanche_network_handshake_compression_saved_received_bytes_count 0
# HELP avalanche_network_handshake_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of handshake messages
# TYPE avalanche_network_handshake_compression_saved_received_bytes_sum gauge
avalanche_network_handshake_compression_saved_received_bytes_sum 0
# HELP avalanche_network_handshake_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of handshake messages
# TYPE avalanche_network_handshake_compression_saved_sent_bytes_count counter
avalanche_network_handshake_compression_saved_sent_bytes_count 0
# HELP avalanche_network_handshake_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of handshake messages
# TYPE avalanche_network_handshake_compression_saved_sent_bytes_sum gauge
avalanche_network_handshake_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_handshake_received Number of handshake messages received from the network
# TYPE avalanche_network_handshake_received counter
avalanche_network_handshake_received 105
# HELP avalanche_network_handshake_received_bytes Number of bytes of handshake messages received from the network
# TYPE avalanche_network_handshake_received_bytes counter
avalanche_network_handshake_received_bytes 402454
# HELP avalanche_network_handshake_sent Number of handshake messages sent over the network
# TYPE avalanche_network_handshake_sent counter
avalanche_network_handshake_sent 112
# HELP avalanche_network_handshake_sent_bytes Size of bytes of handshake messages received from the network
# TYPE avalanche_network_handshake_sent_bytes counter
avalanche_network_handshake_sent_bytes 296413
# HELP avalanche_network_msgs_failed_to_parse Number of messages that could not be parsed or were invalidly formed
# TYPE avalanche_network_msgs_failed_to_parse counter
avalanche_network_msgs_failed_to_parse 0
# HELP avalanche_network_peerlist_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of peerlist messages
# TYPE avalanche_network_peerlist_compression_saved_received_bytes_count counter
avalanche_network_peerlist_compression_saved_received_bytes_count 105
# HELP avalanche_network_peerlist_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of peerlist messages
# TYPE avalanche_network_peerlist_compression_saved_received_bytes_sum gauge
avalanche_network_peerlist_compression_saved_received_bytes_sum 177425
# HELP avalanche_network_peerlist_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of peerlist messages
# TYPE avalanche_network_peerlist_compression_saved_sent_bytes_count counter
avalanche_network_peerlist_compression_saved_sent_bytes_count 105
# HELP avalanche_network_peerlist_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of peerlist messages
# TYPE avalanche_network_peerlist_compression_saved_sent_bytes_sum gauge
avalanche_network_peerlist_compression_saved_sent_bytes_sum -1155
# HELP avalanche_network_peerlist_failed Number of peerlist messages that failed to be sent over the network
# TYPE avalanche_network_peerlist_failed counter
avalanche_network_peerlist_failed 0
# HELP avalanche_network_peerlist_received Number of peerlist messages received from the network
# TYPE avalanche_network_peerlist_received counter
avalanche_network_peerlist_received 105
# HELP avalanche_network_peerlist_received_bytes Number of bytes of peerlist messages received from the network
# TYPE avalanche_network_peerlist_received_bytes counter
avalanche_network_peerlist_received_bytes 1.489488e+06
# HELP avalanche_network_peerlist_sent Number of peerlist messages sent over the network
# TYPE avalanche_network_peerlist_sent counter
avalanche_network_peerlist_sent 105
# HELP avalanche_network_peerlist_sent_bytes Size of bytes of peerlist messages received from the network
# TYPE avalanche_network_peerlist_sent_bytes counter
avalanche_network_peerlist_sent_bytes 1365
# HELP avalanche_network_ping_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of ping messages
# TYPE avalanche_network_ping_compression_saved_received_bytes_count counter
avalanche_network_ping_compression_saved_received_bytes_count 0
# HELP avalanche_network_ping_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of ping messages
# TYPE avalanche_network_ping_compression_saved_received_bytes_sum gauge
avalanche_network_ping_compression_saved_received_bytes_sum 0
# HELP avalanche_network_ping_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of ping messages
# TYPE avalanche_network_ping_compression_saved_sent_bytes_count counter
avalanche_network_ping_compression_saved_sent_bytes_count 0
# HELP avalanche_network_ping_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of ping messages
# TYPE avalanche_network_ping_compression_saved_sent_bytes_sum gauge
avalanche_network_ping_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_ping_failed Number of ping messages that failed to be sent over the network
# TYPE avalanche_network_ping_failed counter
avalanche_network_ping_failed 0
# HELP avalanche_network_ping_received Number of ping messages received from the network
# TYPE avalanche_network_ping_received counter
avalanche_network_ping_received 0
# HELP avalanche_network_ping_received_bytes Number of bytes of ping messages received from the network
# TYPE avalanche_network_ping_received_bytes counter
avalanche_network_ping_received_bytes 0
# HELP avalanche_network_ping_sent Number of ping messages sent over the network
# TYPE avalanche_network_ping_sent counter
avalanche_network_ping_sent 0
# HELP avalanche_network_ping_sent_bytes Size of bytes of ping messages received from the network
# TYPE avalanche_network_ping_sent_bytes counter
avalanche_network_ping_sent_bytes 0
# HELP avalanche_network_pong_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of pong messages
# TYPE avalanche_network_pong_compression_saved_received_bytes_count counter
avalanche_network_pong_compression_saved_received_bytes_count 0
# HELP avalanche_network_pong_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of pong messages
# TYPE avalanche_network_pong_compression_saved_received_bytes_sum gauge
avalanche_network_pong_compression_saved_received_bytes_sum 0
# HELP avalanche_network_pong_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of pong messages
# TYPE avalanche_network_pong_compression_saved_sent_bytes_count counter
avalanche_network_pong_compression_saved_sent_bytes_count 0
# HELP avalanche_network_pong_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of pong messages
# TYPE avalanche_network_pong_compression_saved_sent_bytes_sum gauge
avalanche_network_pong_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_pong_failed Number of pong messages that failed to be sent over the network
# TYPE avalanche_network_pong_failed counter
avalanche_network_pong_failed 0
# HELP avalanche_network_pong_received Number of pong messages received from the network
# TYPE avalanche_network_pong_received counter
avalanche_network_pong_received 0
# HELP avalanche_network_pong_received_bytes Number of bytes of pong messages received from the network
# TYPE avalanche_network_pong_received_bytes counter
avalanche_network_pong_received_bytes 0
# HELP avalanche_network_pong_sent Number of pong messages sent over the network
# TYPE avalanche_network_pong_sent counter
avalanche_network_pong_sent 0
# HELP avalanche_network_pong_sent_bytes Size of bytes of pong messages received from the network
# TYPE avalanche_network_pong_sent_bytes counter
avalanche_network_pong_sent_bytes 0
# HELP avalanche_network_pull_query_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of pull_query messages
# TYPE avalanche_network_pull_query_compression_saved_received_bytes_count counter
avalanche_network_pull_query_compression_saved_received_bytes_count 0
# HELP avalanche_network_pull_query_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of pull_query messages
# TYPE avalanche_network_pull_query_compression_saved_received_bytes_sum gauge
avalanche_network_pull_query_compression_saved_received_bytes_sum 0
# HELP avalanche_network_pull_query_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of pull_query messages
# TYPE avalanche_network_pull_query_compression_saved_sent_bytes_count counter
avalanche_network_pull_query_compression_saved_sent_bytes_count 0
# HELP avalanche_network_pull_query_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of pull_query messages
# TYPE avalanche_network_pull_query_compression_saved_sent_bytes_sum gauge
avalanche_network_pull_query_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_pull_query_failed Number of pull_query messages that failed to be sent over the network
# TYPE avalanche_network_pull_query_failed counter
avalanche_network_pull_query_failed 0
# HELP avalanche_network_pull_query_received Number of pull_query messages received from the network
# TYPE avalanche_network_pull_query_received counter
avalanche_network_pull_query_received 0
# HELP avalanche_network_pull_query_received_bytes Number of bytes of pull_query messages received from the network
# TYPE avalanche_network_pull_query_received_bytes counter
avalanche_network_pull_query_received_bytes 0
# HELP avalanche_network_pull_query_sent Number of pull_query messages sent over the network
# TYPE avalanche_network_pull_query_sent counter
avalanche_network_pull_query_sent 0
# HELP avalanche_network_pull_query_sent_bytes Size of bytes of pull_query messages received from the network
# TYPE avalanche_network_pull_query_sent_bytes counter
avalanche_network_pull_query_sent_bytes 0
# HELP avalanche_network_push_query_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of push_query messages
# TYPE avalanche_network_push_query_compression_saved_received_bytes_count counter
avalanche_network_push_query_compression_saved_received_bytes_count 0
# HELP avalanche_network_push_query_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of push_query messages
# TYPE avalanche_network_push_query_compression_saved_received_bytes_sum gauge
avalanche_network_push_query_compression_saved_received_bytes_sum 0
# HELP avalanche_network_push_query_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of push_query messages
# TYPE avalanche_network_push_query_compression_saved_sent_bytes_count counter
avalanche_network_push_query_compression_saved_sent_bytes_count 0
# HELP avalanche_network_push_query_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of push_query messages
# TYPE avalanche_network_push_query_compression_saved_sent_bytes_sum gauge
avalanche_network_push_query_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_push_query_failed Number of push_query messages that failed to be sent over the network
# TYPE avalanche_network_push_query_failed counter
avalanche_network_push_query_failed 0
# HELP avalanche_network_push_query_received Number of push_query messages received from the network
# TYPE avalanche_network_push_query_received counter
avalanche_network_push_query_received 0
# HELP avalanche_network_push_query_received_bytes Number of bytes of push_query messages received from the network
# TYPE avalanche_network_push_query_received_bytes counter
avalanche_network_push_query_received_bytes 0
# HELP avalanche_network_push_query_sent Number of push_query messages sent over the network
# TYPE avalanche_network_push_query_sent counter
avalanche_network_push_query_sent 0
# HELP avalanche_network_push_query_sent_bytes Size of bytes of push_query messages received from the network
# TYPE avalanche_network_push_query_sent_bytes counter
avalanche_network_push_query_sent_bytes 0
# HELP avalanche_network_put_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of put messages
# TYPE avalanche_network_put_compression_saved_received_bytes_count counter
avalanche_network_put_compression_saved_received_bytes_count 0
# HELP avalanche_network_put_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of put messages
# TYPE avalanche_network_put_compression_saved_received_bytes_sum gauge
avalanche_network_put_compression_saved_received_bytes_sum 0
# HELP avalanche_network_put_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of put messages
# TYPE avalanche_network_put_compression_saved_sent_bytes_count counter
avalanche_network_put_compression_saved_sent_bytes_count 0
# HELP avalanche_network_put_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of put messages
# TYPE avalanche_network_put_compression_saved_sent_bytes_sum gauge
avalanche_network_put_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_put_failed Number of put messages that failed to be sent over the network
# TYPE avalanche_network_put_failed counter
avalanche_network_put_failed 0
# HELP avalanche_network_put_received Number of put messages received from the network
# TYPE avalanche_network_put_received counter
avalanche_network_put_received 0
# HELP avalanche_network_put_received_bytes Number of bytes of put messages received from the network
# TYPE avalanche_network_put_received_bytes counter
avalanche_network_put_received_bytes 0
# HELP avalanche_network_put_sent Number of put messages sent over the network
# TYPE avalanche_network_put_sent counter
avalanche_network_put_sent 0
# HELP avalanche_network_put_sent_bytes Size of bytes of put messages received from the network
# TYPE avalanche_network_put_sent_bytes counter
avalanche_network_put_sent_bytes 0
# HELP avalanche_network_send_fail_rate Portion of messages that recently failed to be sent over the network
# TYPE avalanche_network_send_fail_rate gauge
avalanche_network_send_fail_rate 0
# HELP avalanche_network_state_summary_frontier_compression_saved_received_bytes_count Total # of observations of bytes saved (not received) due to compression of state_summary_frontier messages
# TYPE avalanche_network_state_summary_frontier_compression_saved_received_bytes_count counter
avalanche_network_state_summary_frontier_compression_saved_received_bytes_count 0
# HELP avalanche_network_state_summary_frontier_compression_saved_received_bytes_sum Sum of bytes saved (not received) due to compression of state_summary_frontier messages
# TYPE avalanche_network_state_summary_frontier_compression_saved_received_bytes_sum gauge
avalanche_network_state_summary_frontier_compression_saved_received_bytes_sum 0
# HELP avalanche_network_state_summary_frontier_compression_saved_sent_bytes_count Total # of observations of bytes saved (not sent) due to compression of state_summary_frontier messages
# TYPE avalanche_network_state_summary_frontier_compression_saved_sent_bytes_count counter
avalanche_network_state_summary_frontier_compression_saved_sent_bytes_count 0
# HELP avalanche_network_state_summary_frontier_compression_saved_sent_bytes_sum Sum of bytes saved (not sent) due to compression of state_summary_frontier messages
# TYPE avalanche_network_state_summary_frontier_compression_saved_sent_bytes_sum gauge
avalanche_network_state_summary_frontier_compression_saved_sent_bytes_sum 0
# HELP avalanche_network_state_summary_frontier_failed Number of state_summary_frontier messages that failed to be sent over the network
# TYPE avalanche_network_state_summary_frontier_failed counter
avalanche_network_state_summary_frontier_failed 0
# HELP avalanche_network_state_summary_frontier_received Number of state_summary_frontier messages received from the network
# TYPE avalanche_network_state_summary_frontier_received counter
avalanche_network_state_summary_frontier_received 0
# HELP avalanche_network_state_summary_frontier_received_bytes Number of bytes of state_summary_frontier messages received from the network
# TYPE avalanche_network_state_summary_frontier_received_bytes counter
avalanche_network_state_summary_frontier_received_bytes 0
# HELP avalanche_network_state_summary_frontier_sent Number of state_summary_frontier messages sent over the network
# TYPE avalanche_network_state_summary_frontier_sent counter
avalanche_network_state_summary_frontier_sent 0
# HELP avalanche_network_state_summary_frontier_sent_bytes Size of bytes of state_summary_frontier messages received from the network
# TYPE avalanche_network_state_summary_frontier_sent_bytes counter
avalanche_network_state_summary_frontier_sent_bytes 0
```

## How this works

Uses vectors.

## How this was tested

- [X] Fuji
- [X] CI