### PR TITLE
Use vectors in message queue metrics

### DIFF
--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -165,11 +165,11 @@ func New(
 		return nil, fmt.Errorf("initializing handler metrics errored with: %w", err)
 	}
 	cpuTracker := resourceTracker.CPUTracker()
-	h.syncMessageQueue, err = NewMessageQueue(h.ctx, h.validators, cpuTracker, "handler", message.SynchronousOps)
+	h.syncMessageQueue, err = NewMessageQueue(h.ctx, h.validators, cpuTracker, "handler")
 	if err != nil {
 		return nil, fmt.Errorf("initializing sync message queue errored with: %w", err)
 	}
-	h.asyncMessageQueue, err = NewMessageQueue(h.ctx, h.validators, cpuTracker, "handler_async", message.AsynchronousOps)
+	h.asyncMessageQueue, err = NewMessageQueue(h.ctx, h.validators, cpuTracker, "handler_async")
 	if err != nil {
 		return nil, fmt.Errorf("initializing async message queue errored with: %w", err)
 	}

--- a/snow/networking/handler/message_queue_metrics.go
+++ b/snow/networking/handler/message_queue_metrics.go
@@ -4,18 +4,18 @@
 package handler
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/ava-labs/avalanchego/message"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/metric"
-	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
 
+const opLabel = "op"
+
+var opLabels = []string{opLabel}
+
 type messageQueueMetrics struct {
-	ops               map[message.Op]prometheus.Gauge
-	len               prometheus.Gauge
+	count             *prometheus.GaugeVec
 	nodesWithMessages prometheus.Gauge
 	numExcessiveCPU   prometheus.Counter
 }
@@ -23,43 +23,30 @@ type messageQueueMetrics struct {
 func (m *messageQueueMetrics) initialize(
 	metricsNamespace string,
 	metricsRegisterer prometheus.Registerer,
-	ops []message.Op,
 ) error {
 	namespace := metric.AppendNamespace(metricsNamespace, "unprocessed_msgs")
-	m.len = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "len",
-		Help:      "Messages ready to be processed",
-	})
+	m.count = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "count",
+			Help:      "messages in the queue",
+		},
+		opLabels,
+	)
 	m.nodesWithMessages = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "nodes",
-		Help:      "Nodes from which there are at least 1 message ready to be processed",
+		Help:      "nodes with at least 1 message ready to be processed",
 	})
 	m.numExcessiveCPU = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "excessive_cpu",
-		Help:      "Times we deferred handling a message from a node because the node was using excessive CPU",
+		Help:      "times a message has been deferred due to excessive CPU usage",
 	})
 
-	errs := wrappers.Errs{}
-	m.ops = make(map[message.Op]prometheus.Gauge, len(ops))
-
-	for _, op := range ops {
-		opStr := op.String()
-		opMetric := prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      opStr + "_count",
-			Help:      fmt.Sprintf("Number of %s messages in the message queue.", opStr),
-		})
-		m.ops[op] = opMetric
-		errs.Add(metricsRegisterer.Register(opMetric))
-	}
-
-	errs.Add(
-		metricsRegisterer.Register(m.len),
+	return utils.Err(
+		metricsRegisterer.Register(m.count),
 		metricsRegisterer.Register(m.nodesWithMessages),
 		metricsRegisterer.Register(m.numExcessiveCPU),
 	)
-	return errs.Err
 }

--- a/snow/networking/handler/message_queue_test.go
+++ b/snow/networking/handler/message_queue_test.go
@@ -29,7 +29,7 @@ func TestQueue(t *testing.T) {
 	vdr1ID, vdr2ID := ids.GenerateTestNodeID(), ids.GenerateTestNodeID()
 	require.NoError(vdrs.AddStaker(ctx.SubnetID, vdr1ID, nil, ids.Empty, 1))
 	require.NoError(vdrs.AddStaker(ctx.SubnetID, vdr2ID, nil, ids.Empty, 1))
-	mIntf, err := NewMessageQueue(ctx, vdrs, cpuTracker, "", message.SynchronousOps)
+	mIntf, err := NewMessageQueue(ctx, vdrs, cpuTracker, "")
 	require.NoError(err)
 	u := mIntf.(*messageQueue)
 	currentTime := time.Now()


### PR DESCRIPTION
## Why this should be merged

Before:
```
# HELP avalanche_X_handler_unprocessed_msgs_accepted_count Number of accepted messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_accepted_count gauge
avalanche_X_handler_unprocessed_msgs_accepted_count 0
# HELP avalanche_X_handler_unprocessed_msgs_accepted_frontier_count Number of accepted_frontier messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_accepted_frontier_count gauge
avalanche_X_handler_unprocessed_msgs_accepted_frontier_count 0
# HELP avalanche_X_handler_unprocessed_msgs_accepted_state_summary_count Number of accepted_state_summary messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_accepted_state_summary_count gauge
avalanche_X_handler_unprocessed_msgs_accepted_state_summary_count 0
# HELP avalanche_X_handler_unprocessed_msgs_ancestors_count Number of ancestors messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_ancestors_count gauge
avalanche_X_handler_unprocessed_msgs_ancestors_count 0
# HELP avalanche_X_handler_unprocessed_msgs_chits_count Number of chits messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_chits_count gauge
avalanche_X_handler_unprocessed_msgs_chits_count 0
# HELP avalanche_X_handler_unprocessed_msgs_connected_count Number of connected messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_connected_count gauge
avalanche_X_handler_unprocessed_msgs_connected_count 0
# HELP avalanche_X_handler_unprocessed_msgs_connected_subnet_count Number of connected_subnet messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_connected_subnet_count gauge
avalanche_X_handler_unprocessed_msgs_connected_subnet_count 0
# HELP avalanche_X_handler_unprocessed_msgs_disconnected_count Number of disconnected messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_disconnected_count gauge
avalanche_X_handler_unprocessed_msgs_disconnected_count 0
# HELP avalanche_X_handler_unprocessed_msgs_excessive_cpu Times we deferred handling a message from a node because the node was using excessive CPU
# TYPE avalanche_X_handler_unprocessed_msgs_excessive_cpu counter
avalanche_X_handler_unprocessed_msgs_excessive_cpu 0
# HELP avalanche_X_handler_unprocessed_msgs_get_accepted_count Number of get_accepted messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_accepted_count gauge
avalanche_X_handler_unprocessed_msgs_get_accepted_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_accepted_failed_count Number of get_accepted_failed messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_accepted_failed_count gauge
avalanche_X_handler_unprocessed_msgs_get_accepted_failed_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_accepted_frontier_count Number of get_accepted_frontier messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_accepted_frontier_count gauge
avalanche_X_handler_unprocessed_msgs_get_accepted_frontier_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_accepted_frontier_failed_count Number of get_accepted_frontier_failed messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_accepted_frontier_failed_count gauge
avalanche_X_handler_unprocessed_msgs_get_accepted_frontier_failed_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_accepted_state_summary_count Number of get_accepted_state_summary messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_accepted_state_summary_count gauge
avalanche_X_handler_unprocessed_msgs_get_accepted_state_summary_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_accepted_state_summary_failed_count Number of get_accepted_state_summary_failed messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_accepted_state_summary_failed_count gauge
avalanche_X_handler_unprocessed_msgs_get_accepted_state_summary_failed_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_ancestors_count Number of get_ancestors messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_ancestors_count gauge
avalanche_X_handler_unprocessed_msgs_get_ancestors_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_ancestors_failed_count Number of get_ancestors_failed messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_ancestors_failed_count gauge
avalanche_X_handler_unprocessed_msgs_get_ancestors_failed_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_count Number of get messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_count gauge
avalanche_X_handler_unprocessed_msgs_get_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_failed_count Number of get_failed messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_failed_count gauge
avalanche_X_handler_unprocessed_msgs_get_failed_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_state_summary_frontier_count Number of get_state_summary_frontier messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_state_summary_frontier_count gauge
avalanche_X_handler_unprocessed_msgs_get_state_summary_frontier_count 0
# HELP avalanche_X_handler_unprocessed_msgs_get_state_summary_frontier_failed_count Number of get_state_summary_frontier_failed messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_get_state_summary_frontier_failed_count gauge
avalanche_X_handler_unprocessed_msgs_get_state_summary_frontier_failed_count 0
# HELP avalanche_X_handler_unprocessed_msgs_len Messages ready to be processed
# TYPE avalanche_X_handler_unprocessed_msgs_len gauge
avalanche_X_handler_unprocessed_msgs_len 0
# HELP avalanche_X_handler_unprocessed_msgs_nodes Nodes from which there are at least 1 message ready to be processed
# TYPE avalanche_X_handler_unprocessed_msgs_nodes gauge
avalanche_X_handler_unprocessed_msgs_nodes 0
# HELP avalanche_X_handler_unprocessed_msgs_pull_query_count Number of pull_query messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_pull_query_count gauge
avalanche_X_handler_unprocessed_msgs_pull_query_count 0
# HELP avalanche_X_handler_unprocessed_msgs_push_query_count Number of push_query messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_push_query_count gauge
avalanche_X_handler_unprocessed_msgs_push_query_count 0
# HELP avalanche_X_handler_unprocessed_msgs_put_count Number of put messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_put_count gauge
avalanche_X_handler_unprocessed_msgs_put_count 0
# HELP avalanche_X_handler_unprocessed_msgs_query_failed_count Number of query_failed messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_query_failed_count gauge
avalanche_X_handler_unprocessed_msgs_query_failed_count 0
# HELP avalanche_X_handler_unprocessed_msgs_state_summary_frontier_count Number of state_summary_frontier messages in the message queue.
# TYPE avalanche_X_handler_unprocessed_msgs_state_summary_frontier_count gauge
avalanche_X_handler_unprocessed_msgs_state_summary_frontier_count 0
```

After
```
# HELP avalanche_X_handler_unprocessed_msgs_count messages in the queue
# TYPE avalanche_X_handler_unprocessed_msgs_count gauge
avalanche_X_handler_unprocessed_msgs_count{op="accepted"} 0
avalanche_X_handler_unprocessed_msgs_count{op="accepted_frontier"} 0
avalanche_X_handler_unprocessed_msgs_count{op="chits"} 0
avalanche_X_handler_unprocessed_msgs_count{op="connected"} 0
avalanche_X_handler_unprocessed_msgs_count{op="get_accepted"} 0
avalanche_X_handler_unprocessed_msgs_count{op="get_accepted_failed"} 0
avalanche_X_handler_unprocessed_msgs_count{op="pull_query"} 0
# HELP avalanche_X_handler_unprocessed_msgs_excessive_cpu times a message has been deferred due to excessive CPU usage
# TYPE avalanche_X_handler_unprocessed_msgs_excessive_cpu counter
avalanche_X_handler_unprocessed_msgs_excessive_cpu 0
# HELP avalanche_X_handler_unprocessed_msgs_nodes nodes with at least 1 message ready to be processed
# TYPE avalanche_X_handler_unprocessed_msgs_nodes gauge
avalanche_X_handler_unprocessed_msgs_nodes 0
```

## How this works

Uses a vector rather than manually specifying the expected operations.

## How this was tested

- [X] CI
- [X] Fuji sync
