### PR TITLE
Use vectors for message handler metrics

### DIFF
--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -367,7 +367,7 @@ func (h *handler) dispatchSync(ctx context.Context) {
 	for {
 		// Get the next message we should process. If the handler is shutting
 		// down, we may fail to pop a message.
-		ctx, msg, ok := h.popUnexpiredMsg(h.syncMessageQueue, h.metrics.expired)
+		ctx, msg, ok := h.popUnexpiredMsg(h.syncMessageQueue)
 		if !ok {
 			return
 		}
@@ -397,7 +397,7 @@ func (h *handler) dispatchAsync(ctx context.Context) {
 	for {
 		// Get the next message we should process. If the handler is shutting
 		// down, we may fail to pop a message.
-		ctx, msg, ok := h.popUnexpiredMsg(h.asyncMessageQueue, h.metrics.asyncExpired)
+		ctx, msg, ok := h.popUnexpiredMsg(h.asyncMessageQueue)
 		if !ok {
 			return
 		}
@@ -445,7 +445,7 @@ func (h *handler) dispatchChans(ctx context.Context) {
 func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 	var (
 		nodeID    = msg.NodeID()
-		op        = msg.Op()
+		op        = msg.Op().String()
 		body      = msg.Message()
 		startTime = h.clock.Time()
 		// Check if the chain is in normal operation at the start of message
@@ -455,13 +455,13 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 	if h.ctx.Log.Enabled(logging.Verbo) {
 		h.ctx.Log.Verbo("forwarding sync message to consensus",
 			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 			zap.Stringer("message", body),
 		)
 	} else {
 		h.ctx.Log.Debug("forwarding sync message to consensus",
 			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 		)
 	}
 	h.resourceTracker.StartProcessing(nodeID, startTime)
@@ -471,24 +471,28 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 		h.ctx.Lock.Unlock()
 
 		var (
-			endTime           = h.clock.Time()
-			messageHistograms = h.metrics.messages[op]
-			processingTime    = endTime.Sub(startTime)
-			msgHandlingTime   = endTime.Sub(lockAcquiredTime)
+			endTime      = h.clock.Time()
+			lockingTime  = lockAcquiredTime.Sub(startTime)
+			handlingTime = endTime.Sub(lockAcquiredTime)
 		)
 		h.resourceTracker.StopProcessing(nodeID, endTime)
-		messageHistograms.processingTime.Observe(float64(processingTime))
-		messageHistograms.msgHandlingTime.Observe(float64(msgHandlingTime))
+		h.metrics.lockingTime.Add(float64(lockingTime))
+		labels := prometheus.Labels{
+			opLabel: op,
+		}
+		h.metrics.messages.With(labels).Inc()
+		h.metrics.messageHandlingTime.With(labels).Add(float64(handlingTime))
+
 		msg.OnFinishedHandling()
 		h.ctx.Log.Debug("finished handling sync message",
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 		)
-		if processingTime > syncProcessingTimeWarnLimit && isNormalOp {
+		if lockingTime+handlingTime > syncProcessingTimeWarnLimit && isNormalOp {
 			h.ctx.Log.Warn("handling sync message took longer than expected",
-				zap.Duration("processingTime", processingTime),
-				zap.Duration("msgHandlingTime", msgHandlingTime),
+				zap.Duration("lockingTime", lockingTime),
+				zap.Duration("handlingTime", handlingTime),
 				zap.Stringer("nodeID", nodeID),
-				zap.Stringer("messageOp", op),
+				zap.String("messageOp", op),
 				zap.Stringer("message", body),
 			)
 		}
@@ -504,7 +508,7 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 		// drop the message.
 		h.ctx.Log.Debug("dropping sync message",
 			zap.String("reason", "uninitialized engine type"),
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 			zap.Stringer("currentEngineType", currentState.Type),
 			zap.Stringer("requestedEngineType", msg.EngineType),
 		)
@@ -534,7 +538,7 @@ func (h *handler) handleSyncMsg(ctx context.Context, msg Message) error {
 		// requested an Avalanche engine handle the message.
 		h.ctx.Log.Debug("dropping sync message",
 			zap.String("reason", "uninitialized engine state"),
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 			zap.Stringer("currentEngineType", currentState.Type),
 			zap.Stringer("requestedEngineType", msg.EngineType),
 			zap.Stringer("engineState", currentState.State),
@@ -787,36 +791,38 @@ func (h *handler) handleAsyncMsg(ctx context.Context, msg Message) {
 func (h *handler) executeAsyncMsg(ctx context.Context, msg Message) error {
 	var (
 		nodeID    = msg.NodeID()
-		op        = msg.Op()
+		op        = msg.Op().String()
 		body      = msg.Message()
 		startTime = h.clock.Time()
 	)
 	if h.ctx.Log.Enabled(logging.Verbo) {
 		h.ctx.Log.Verbo("forwarding async message to consensus",
 			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 			zap.Stringer("message", body),
 		)
 	} else {
 		h.ctx.Log.Debug("forwarding async message to consensus",
 			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 		)
 	}
 	h.resourceTracker.StartProcessing(nodeID, startTime)
 	defer func() {
 		var (
-			endTime           = h.clock.Time()
-			messageHistograms = h.metrics.messages[op]
-			processingTime    = endTime.Sub(startTime)
+			endTime      = h.clock.Time()
+			handlingTime = endTime.Sub(startTime)
 		)
 		h.resourceTracker.StopProcessing(nodeID, endTime)
-		// There is no lock grabbed here, so both metrics are identical
-		messageHistograms.processingTime.Observe(float64(processingTime))
-		messageHistograms.msgHandlingTime.Observe(float64(processingTime))
+		labels := prometheus.Labels{
+			opLabel: op,
+		}
+		h.metrics.messages.With(labels).Inc()
+		h.metrics.messageHandlingTime.With(labels).Add(float64(handlingTime))
+
 		msg.OnFinishedHandling()
 		h.ctx.Log.Debug("finished handling async message",
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 		)
 	}()
 
@@ -901,7 +907,7 @@ func (h *handler) executeAsyncMsg(ctx context.Context, msg Message) error {
 // Any returned error is treated as fatal
 func (h *handler) handleChanMsg(msg message.InboundMessage) error {
 	var (
-		op        = msg.Op()
+		op        = msg.Op().String()
 		body      = msg.Message()
 		startTime = h.clock.Time()
 		// Check if the chain is in normal operation at the start of message
@@ -910,12 +916,12 @@ func (h *handler) handleChanMsg(msg message.InboundMessage) error {
 	)
 	if h.ctx.Log.Enabled(logging.Verbo) {
 		h.ctx.Log.Verbo("forwarding chan message to consensus",
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 			zap.Stringer("message", body),
 		)
 	} else {
 		h.ctx.Log.Debug("forwarding chan message to consensus",
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 		)
 	}
 	h.ctx.Lock.Lock()
@@ -924,22 +930,26 @@ func (h *handler) handleChanMsg(msg message.InboundMessage) error {
 		h.ctx.Lock.Unlock()
 
 		var (
-			endTime           = h.clock.Time()
-			messageHistograms = h.metrics.messages[op]
-			processingTime    = endTime.Sub(startTime)
-			msgHandlingTime   = endTime.Sub(lockAcquiredTime)
+			endTime      = h.clock.Time()
+			lockingTime  = lockAcquiredTime.Sub(startTime)
+			handlingTime = endTime.Sub(lockAcquiredTime)
 		)
-		messageHistograms.processingTime.Observe(float64(processingTime))
-		messageHistograms.msgHandlingTime.Observe(float64(msgHandlingTime))
+		h.metrics.lockingTime.Add(float64(lockingTime))
+		labels := prometheus.Labels{
+			opLabel: op,
+		}
+		h.metrics.messages.With(labels).Inc()
+		h.metrics.messageHandlingTime.With(labels).Add(float64(handlingTime))
+
 		msg.OnFinishedHandling()
 		h.ctx.Log.Debug("finished handling chan message",
-			zap.Stringer("messageOp", op),
+			zap.String("messageOp", op),
 		)
-		if processingTime > syncProcessingTimeWarnLimit && isNormalOp {
+		if lockingTime+handlingTime > syncProcessingTimeWarnLimit && isNormalOp {
 			h.ctx.Log.Warn("handling chan message took longer than expected",
-				zap.Duration("processingTime", processingTime),
-				zap.Duration("msgHandlingTime", msgHandlingTime),
-				zap.Stringer("messageOp", op),
+				zap.Duration("lockingTime", lockingTime),
+				zap.Duration("handlingTime", handlingTime),
+				zap.String("messageOp", op),
 				zap.Stringer("message", body),
 			)
 		}
@@ -974,10 +984,7 @@ func (h *handler) handleChanMsg(msg message.InboundMessage) error {
 	}
 }
 
-func (h *handler) popUnexpiredMsg(
-	queue MessageQueue,
-	expired prometheus.Counter,
-) (context.Context, Message, bool) {
+func (h *handler) popUnexpiredMsg(queue MessageQueue) (context.Context, Message, bool) {
 	for {
 		// Get the next message we should process. If the handler is shutting
 		// down, we may fail to pop a message.
@@ -988,16 +995,19 @@ func (h *handler) popUnexpiredMsg(
 
 		// If this message's deadline has passed, don't process it.
 		if expiration := msg.Expiration(); h.clock.Time().After(expiration) {
+			op := msg.Op().String()
 			h.ctx.Log.Debug("dropping message",
 				zap.String("reason", "timeout"),
 				zap.Stringer("nodeID", msg.NodeID()),
-				zap.Stringer("messageOp", msg.Op()),
+				zap.String("messageOp", op),
 			)
 			span := trace.SpanFromContext(ctx)
 			span.AddEvent("dropping message", trace.WithAttributes(
 				attribute.String("reason", "timeout"),
 			))
-			expired.Inc()
+			h.metrics.expired.With(prometheus.Labels{
+				opLabel: op,
+			}).Inc()
 			msg.OnFinishedHandling()
 			continue
 		}

--- a/snow/networking/handler/metrics.go
+++ b/snow/networking/handler/metrics.go
@@ -38,14 +38,14 @@ func newMetrics(namespace string, reg prometheus.Registerer) (*metrics, error) {
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "message_handling_time",
-				Help:      "time spent handling a message",
+				Help:      "time spent handling messages",
 			},
 			opLabels,
 		),
 		lockingTime: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "locking_time",
-			Help:      "time spent waiting on acquire the context lock",
+			Help:      "time spent acquiring the context lock",
 		}),
 	}
 	return m, utils.Err(

--- a/snow/networking/handler/metrics.go
+++ b/snow/networking/handler/metrics.go
@@ -4,69 +4,54 @@
 package handler
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/ava-labs/avalanchego/message"
-	"github.com/ava-labs/avalanchego/utils/metric"
-	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/utils"
 )
 
 type metrics struct {
-	expired      prometheus.Counter
-	asyncExpired prometheus.Counter
-	messages     map[message.Op]*messageProcessing
-}
-
-type messageProcessing struct {
-	processingTime  metric.Averager
-	msgHandlingTime metric.Averager
+	expired             *prometheus.CounterVec // op
+	messages            *prometheus.CounterVec // op
+	lockingTime         prometheus.Counter
+	messageHandlingTime *prometheus.CounterVec // op
 }
 
 func newMetrics(namespace string, reg prometheus.Registerer) (*metrics, error) {
-	errs := wrappers.Errs{}
-
-	expired := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "expired",
-		Help:      "Incoming sync messages dropped because the message deadline expired",
-	})
-	asyncExpired := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "async_expired",
-		Help:      "Incoming async messages dropped because the message deadline expired",
-	})
-	errs.Add(
-		reg.Register(expired),
-		reg.Register(asyncExpired),
-	)
-
-	messages := make(map[message.Op]*messageProcessing, len(message.ConsensusOps))
-	for _, op := range message.ConsensusOps {
-		opStr := op.String()
-		messageProcessing := &messageProcessing{
-			processingTime: metric.NewAveragerWithErrs(
-				namespace,
-				opStr,
-				"time (in ns) spent handling a "+opStr,
-				reg,
-				&errs,
-			),
-			msgHandlingTime: metric.NewAveragerWithErrs(
-				namespace,
-				opStr+"_msg_handling",
-				fmt.Sprintf("time (in ns) spent handling a %s after grabbing the lock", opStr),
-				reg,
-				&errs,
-			),
-		}
-		messages[op] = messageProcessing
+	m := &metrics{
+		expired: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "expired",
+				Help:      "messages dropped because the deadline expired",
+			},
+			opLabels,
+		),
+		messages: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "messages",
+				Help:      "messages handled",
+			},
+			opLabels,
+		),
+		messageHandlingTime: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "message_handling_time",
+				Help:      "time spent handling a message",
+			},
+			opLabels,
+		),
+		lockingTime: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "locking_time",
+			Help:      "time spent waiting on acquire the context lock",
+		}),
 	}
-
-	return &metrics{
-		expired:      expired,
-		asyncExpired: asyncExpired,
-		messages:     messages,
-	}, errs.Err
+	return m, utils.Err(
+		reg.Register(m.expired),
+		reg.Register(m.messages),
+		reg.Register(m.messageHandlingTime),
+		reg.Register(m.lockingTime),
+	)
 }


### PR DESCRIPTION
## Why this should be merged

Old:
```
# HELP avalanche_X_handler_accepted_count Total # of observations of time (in ns) spent handling a accepted
# TYPE avalanche_X_handler_accepted_count counter
avalanche_X_handler_accepted_count 619
# HELP avalanche_X_handler_accepted_frontier_count Total # of observations of time (in ns) spent handling a accepted_frontier
# TYPE avalanche_X_handler_accepted_frontier_count counter
avalanche_X_handler_accepted_frontier_count 22
# HELP avalanche_X_handler_accepted_frontier_msg_handling_count Total # of observations of time (in ns) spent handling a accepted_frontier after grabbing the lock
# TYPE avalanche_X_handler_accepted_frontier_msg_handling_count counter
avalanche_X_handler_accepted_frontier_msg_handling_count 22
# HELP avalanche_X_handler_accepted_frontier_msg_handling_sum Sum of time (in ns) spent handling a accepted_frontier after grabbing the lock
# TYPE avalanche_X_handler_accepted_frontier_msg_handling_sum gauge
avalanche_X_handler_accepted_frontier_msg_handling_sum 1.71575e+06
# HELP avalanche_X_handler_accepted_frontier_sum Sum of time (in ns) spent handling a accepted_frontier
# TYPE avalanche_X_handler_accepted_frontier_sum gauge
avalanche_X_handler_accepted_frontier_sum 1.779916e+06
# HELP avalanche_X_handler_accepted_msg_handling_count Total # of observations of time (in ns) spent handling a accepted after grabbing the lock
# TYPE avalanche_X_handler_accepted_msg_handling_count counter
avalanche_X_handler_accepted_msg_handling_count 619
# HELP avalanche_X_handler_accepted_msg_handling_sum Sum of time (in ns) spent handling a accepted after grabbing the lock
# TYPE avalanche_X_handler_accepted_msg_handling_sum gauge
avalanche_X_handler_accepted_msg_handling_sum 6.7524239e+07
# HELP avalanche_X_handler_accepted_state_summary_count Total # of observations of time (in ns) spent handling a accepted_state_summary
# TYPE avalanche_X_handler_accepted_state_summary_count counter
avalanche_X_handler_accepted_state_summary_count 0
# HELP avalanche_X_handler_accepted_state_summary_msg_handling_count Total # of observations of time (in ns) spent handling a accepted_state_summary after grabbing the lock
# TYPE avalanche_X_handler_accepted_state_summary_msg_handling_count counter
avalanche_X_handler_accepted_state_summary_msg_handling_count 0
# HELP avalanche_X_handler_accepted_state_summary_msg_handling_sum Sum of time (in ns) spent handling a accepted_state_summary after grabbing the lock
# TYPE avalanche_X_handler_accepted_state_summary_msg_handling_sum gauge
avalanche_X_handler_accepted_state_summary_msg_handling_sum 0
# HELP avalanche_X_handler_accepted_state_summary_sum Sum of time (in ns) spent handling a accepted_state_summary
# TYPE avalanche_X_handler_accepted_state_summary_sum gauge
avalanche_X_handler_accepted_state_summary_sum 0
# HELP avalanche_X_handler_accepted_sum Sum of time (in ns) spent handling a accepted
# TYPE avalanche_X_handler_accepted_sum gauge
avalanche_X_handler_accepted_sum 6.984471e+07
# HELP avalanche_X_handler_ancestors_count Total # of observations of time (in ns) spent handling a ancestors
# TYPE avalanche_X_handler_ancestors_count counter
avalanche_X_handler_ancestors_count 0
# HELP avalanche_X_handler_ancestors_msg_handling_count Total # of observations of time (in ns) spent handling a ancestors after grabbing the lock
# TYPE avalanche_X_handler_ancestors_msg_handling_count counter
avalanche_X_handler_ancestors_msg_handling_count 0
# HELP avalanche_X_handler_ancestors_msg_handling_sum Sum of time (in ns) spent handling a ancestors after grabbing the lock
# TYPE avalanche_X_handler_ancestors_msg_handling_sum gauge
avalanche_X_handler_ancestors_msg_handling_sum 0
# HELP avalanche_X_handler_ancestors_sum Sum of time (in ns) spent handling a ancestors
# TYPE avalanche_X_handler_ancestors_sum gauge
avalanche_X_handler_ancestors_sum 0
# HELP avalanche_X_handler_app_error_count Total # of observations of time (in ns) spent handling a app_error
# TYPE avalanche_X_handler_app_error_count counter
avalanche_X_handler_app_error_count 7
# HELP avalanche_X_handler_app_error_msg_handling_count Total # of observations of time (in ns) spent handling a app_error after grabbing the lock
# TYPE avalanche_X_handler_app_error_msg_handling_count counter
avalanche_X_handler_app_error_msg_handling_count 7
# HELP avalanche_X_handler_app_error_msg_handling_sum Sum of time (in ns) spent handling a app_error after grabbing the lock
# TYPE avalanche_X_handler_app_error_msg_handling_sum gauge
avalanche_X_handler_app_error_msg_handling_sum 786001
# HELP avalanche_X_handler_app_error_sum Sum of time (in ns) spent handling a app_error
# TYPE avalanche_X_handler_app_error_sum gauge
avalanche_X_handler_app_error_sum 786001
# HELP avalanche_X_handler_app_gossip_count Total # of observations of time (in ns) spent handling a app_gossip
# TYPE avalanche_X_handler_app_gossip_count counter
avalanche_X_handler_app_gossip_count 0
# HELP avalanche_X_handler_app_gossip_msg_handling_count Total # of observations of time (in ns) spent handling a app_gossip after grabbing the lock
# TYPE avalanche_X_handler_app_gossip_msg_handling_count counter
avalanche_X_handler_app_gossip_msg_handling_count 0
# HELP avalanche_X_handler_app_gossip_msg_handling_sum Sum of time (in ns) spent handling a app_gossip after grabbing the lock
# TYPE avalanche_X_handler_app_gossip_msg_handling_sum gauge
avalanche_X_handler_app_gossip_msg_handling_sum 0
# HELP avalanche_X_handler_app_gossip_sum Sum of time (in ns) spent handling a app_gossip
# TYPE avalanche_X_handler_app_gossip_sum gauge
avalanche_X_handler_app_gossip_sum 0
# HELP avalanche_X_handler_app_request_count Total # of observations of time (in ns) spent handling a app_request
# TYPE avalanche_X_handler_app_request_count counter
avalanche_X_handler_app_request_count 16
# HELP avalanche_X_handler_app_request_msg_handling_count Total # of observations of time (in ns) spent handling a app_request after grabbing the lock
# TYPE avalanche_X_handler_app_request_msg_handling_count counter
avalanche_X_handler_app_request_msg_handling_count 16
# HELP avalanche_X_handler_app_request_msg_handling_sum Sum of time (in ns) spent handling a app_request after grabbing the lock
# TYPE avalanche_X_handler_app_request_msg_handling_sum gauge
avalanche_X_handler_app_request_msg_handling_sum 4.178081e+06
# HELP avalanche_X_handler_app_request_sum Sum of time (in ns) spent handling a app_request
# TYPE avalanche_X_handler_app_request_sum gauge
avalanche_X_handler_app_request_sum 4.178081e+06
# HELP avalanche_X_handler_app_response_count Total # of observations of time (in ns) spent handling a app_response
# TYPE avalanche_X_handler_app_response_count counter
avalanche_X_handler_app_response_count 28
# HELP avalanche_X_handler_app_response_msg_handling_count Total # of observations of time (in ns) spent handling a app_response after grabbing the lock
# TYPE avalanche_X_handler_app_response_msg_handling_count counter
avalanche_X_handler_app_response_msg_handling_count 28
# HELP avalanche_X_handler_app_response_msg_handling_sum Sum of time (in ns) spent handling a app_response after grabbing the lock
# TYPE avalanche_X_handler_app_response_msg_handling_sum gauge
avalanche_X_handler_app_response_msg_handling_sum 2.649917e+06
# HELP avalanche_X_handler_app_response_sum Sum of time (in ns) spent handling a app_response
# TYPE avalanche_X_handler_app_response_sum gauge
avalanche_X_handler_app_response_sum 2.649917e+06
# HELP avalanche_X_handler_async_expired Incoming async messages dropped because the message deadline expired
# TYPE avalanche_X_handler_async_expired counter
avalanche_X_handler_async_expired 0
# HELP avalanche_X_handler_chits_count Total # of observations of time (in ns) spent handling a chits
# TYPE avalanche_X_handler_chits_count counter
avalanche_X_handler_chits_count 0
# HELP avalanche_X_handler_chits_msg_handling_count Total # of observations of time (in ns) spent handling a chits after grabbing the lock
# TYPE avalanche_X_handler_chits_msg_handling_count counter
avalanche_X_handler_chits_msg_handling_count 0
# HELP avalanche_X_handler_chits_msg_handling_sum Sum of time (in ns) spent handling a chits after grabbing the lock
# TYPE avalanche_X_handler_chits_msg_handling_sum gauge
avalanche_X_handler_chits_msg_handling_sum 0
# HELP avalanche_X_handler_chits_sum Sum of time (in ns) spent handling a chits
# TYPE avalanche_X_handler_chits_sum gauge
avalanche_X_handler_chits_sum 0
# HELP avalanche_X_handler_connected_count Total # of observations of time (in ns) spent handling a connected
# TYPE avalanche_X_handler_connected_count counter
avalanche_X_handler_connected_count 336
# HELP avalanche_X_handler_connected_msg_handling_count Total # of observations of time (in ns) spent handling a connected after grabbing the lock
# TYPE avalanche_X_handler_connected_msg_handling_count counter
avalanche_X_handler_connected_msg_handling_count 336
# HELP avalanche_X_handler_connected_msg_handling_sum Sum of time (in ns) spent handling a connected after grabbing the lock
# TYPE avalanche_X_handler_connected_msg_handling_sum gauge
avalanche_X_handler_connected_msg_handling_sum 578423
# HELP avalanche_X_handler_connected_subnet_count Total # of observations of time (in ns) spent handling a connected_subnet
# TYPE avalanche_X_handler_connected_subnet_count counter
avalanche_X_handler_connected_subnet_count 0
# HELP avalanche_X_handler_connected_subnet_msg_handling_count Total # of observations of time (in ns) spent handling a connected_subnet after grabbing the lock
# TYPE avalanche_X_handler_connected_subnet_msg_handling_count counter
avalanche_X_handler_connected_subnet_msg_handling_count 0
# HELP avalanche_X_handler_connected_subnet_msg_handling_sum Sum of time (in ns) spent handling a connected_subnet after grabbing the lock
# TYPE avalanche_X_handler_connected_subnet_msg_handling_sum gauge
avalanche_X_handler_connected_subnet_msg_handling_sum 0
# HELP avalanche_X_handler_connected_subnet_sum Sum of time (in ns) spent handling a connected_subnet
# TYPE avalanche_X_handler_connected_subnet_sum gauge
avalanche_X_handler_connected_subnet_sum 0
# HELP avalanche_X_handler_connected_sum Sum of time (in ns) spent handling a connected
# TYPE avalanche_X_handler_connected_sum gauge
avalanche_X_handler_connected_sum 710549
# HELP avalanche_X_handler_cross_chain_app_error_count Total # of observations of time (in ns) spent handling a cross_chain_app_error
# TYPE avalanche_X_handler_cross_chain_app_error_count counter
avalanche_X_handler_cross_chain_app_error_count 0
# HELP avalanche_X_handler_cross_chain_app_error_msg_handling_count Total # of observations of time (in ns) spent handling a cross_chain_app_error after grabbing the lock
# TYPE avalanche_X_handler_cross_chain_app_error_msg_handling_count counter
avalanche_X_handler_cross_chain_app_error_msg_handling_count 0
# HELP avalanche_X_handler_cross_chain_app_error_msg_handling_sum Sum of time (in ns) spent handling a cross_chain_app_error after grabbing the lock
# TYPE avalanche_X_handler_cross_chain_app_error_msg_handling_sum gauge
avalanche_X_handler_cross_chain_app_error_msg_handling_sum 0
# HELP avalanche_X_handler_cross_chain_app_error_sum Sum of time (in ns) spent handling a cross_chain_app_error
# TYPE avalanche_X_handler_cross_chain_app_error_sum gauge
avalanche_X_handler_cross_chain_app_error_sum 0
# HELP avalanche_X_handler_cross_chain_app_request_count Total # of observations of time (in ns) spent handling a cross_chain_app_request
# TYPE avalanche_X_handler_cross_chain_app_request_count counter
avalanche_X_handler_cross_chain_app_request_count 0
# HELP avalanche_X_handler_cross_chain_app_request_msg_handling_count Total # of observations of time (in ns) spent handling a cross_chain_app_request after grabbing the lock
# TYPE avalanche_X_handler_cross_chain_app_request_msg_handling_count counter
avalanche_X_handler_cross_chain_app_request_msg_handling_count 0
# HELP avalanche_X_handler_cross_chain_app_request_msg_handling_sum Sum of time (in ns) spent handling a cross_chain_app_request after grabbing the lock
# TYPE avalanche_X_handler_cross_chain_app_request_msg_handling_sum gauge
avalanche_X_handler_cross_chain_app_request_msg_handling_sum 0
# HELP avalanche_X_handler_cross_chain_app_request_sum Sum of time (in ns) spent handling a cross_chain_app_request
# TYPE avalanche_X_handler_cross_chain_app_request_sum gauge
avalanche_X_handler_cross_chain_app_request_sum 0
# HELP avalanche_X_handler_cross_chain_app_response_count Total # of observations of time (in ns) spent handling a cross_chain_app_response
# TYPE avalanche_X_handler_cross_chain_app_response_count counter
avalanche_X_handler_cross_chain_app_response_count 0
# HELP avalanche_X_handler_cross_chain_app_response_msg_handling_count Total # of observations of time (in ns) spent handling a cross_chain_app_response after grabbing the lock
# TYPE avalanche_X_handler_cross_chain_app_response_msg_handling_count counter
avalanche_X_handler_cross_chain_app_response_msg_handling_count 0
# HELP avalanche_X_handler_cross_chain_app_response_msg_handling_sum Sum of time (in ns) spent handling a cross_chain_app_response after grabbing the lock
# TYPE avalanche_X_handler_cross_chain_app_response_msg_handling_sum gauge
avalanche_X_handler_cross_chain_app_response_msg_handling_sum 0
# HELP avalanche_X_handler_cross_chain_app_response_sum Sum of time (in ns) spent handling a cross_chain_app_response
# TYPE avalanche_X_handler_cross_chain_app_response_sum gauge
avalanche_X_handler_cross_chain_app_response_sum 0
# HELP avalanche_X_handler_disconnected_count Total # of observations of time (in ns) spent handling a disconnected
# TYPE avalanche_X_handler_disconnected_count counter
avalanche_X_handler_disconnected_count 0
# HELP avalanche_X_handler_disconnected_msg_handling_count Total # of observations of time (in ns) spent handling a disconnected after grabbing the lock
# TYPE avalanche_X_handler_disconnected_msg_handling_count counter
avalanche_X_handler_disconnected_msg_handling_count 0
# HELP avalanche_X_handler_disconnected_msg_handling_sum Sum of time (in ns) spent handling a disconnected after grabbing the lock
# TYPE avalanche_X_handler_disconnected_msg_handling_sum gauge
avalanche_X_handler_disconnected_msg_handling_sum 0
# HELP avalanche_X_handler_disconnected_sum Sum of time (in ns) spent handling a disconnected
# TYPE avalanche_X_handler_disconnected_sum gauge
avalanche_X_handler_disconnected_sum 0
# HELP avalanche_X_handler_expired Incoming sync messages dropped because the message deadline expired
# TYPE avalanche_X_handler_expired counter
avalanche_X_handler_expired 0
# HELP avalanche_X_handler_get_accepted_count Total # of observations of time (in ns) spent handling a get_accepted
# TYPE avalanche_X_handler_get_accepted_count counter
avalanche_X_handler_get_accepted_count 2
# HELP avalanche_X_handler_get_accepted_failed_count Total # of observations of time (in ns) spent handling a get_accepted_failed
# TYPE avalanche_X_handler_get_accepted_failed_count counter
avalanche_X_handler_get_accepted_failed_count 859
# HELP avalanche_X_handler_get_accepted_failed_msg_handling_count Total # of observations of time (in ns) spent handling a get_accepted_failed after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_failed_msg_handling_count counter
avalanche_X_handler_get_accepted_failed_msg_handling_count 859
# HELP avalanche_X_handler_get_accepted_failed_msg_handling_sum Sum of time (in ns) spent handling a get_accepted_failed after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_failed_msg_handling_sum gauge
avalanche_X_handler_get_accepted_failed_msg_handling_sum 9.862124e+07
# HELP avalanche_X_handler_get_accepted_failed_sum Sum of time (in ns) spent handling a get_accepted_failed
# TYPE avalanche_X_handler_get_accepted_failed_sum gauge
avalanche_X_handler_get_accepted_failed_sum 1.05752984e+08
# HELP avalanche_X_handler_get_accepted_frontier_count Total # of observations of time (in ns) spent handling a get_accepted_frontier
# TYPE avalanche_X_handler_get_accepted_frontier_count counter
avalanche_X_handler_get_accepted_frontier_count 0
# HELP avalanche_X_handler_get_accepted_frontier_failed_count Total # of observations of time (in ns) spent handling a get_accepted_frontier_failed
# TYPE avalanche_X_handler_get_accepted_frontier_failed_count counter
avalanche_X_handler_get_accepted_frontier_failed_count 0
# HELP avalanche_X_handler_get_accepted_frontier_failed_msg_handling_count Total # of observations of time (in ns) spent handling a get_accepted_frontier_failed after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_frontier_failed_msg_handling_count counter
avalanche_X_handler_get_accepted_frontier_failed_msg_handling_count 0
# HELP avalanche_X_handler_get_accepted_frontier_failed_msg_handling_sum Sum of time (in ns) spent handling a get_accepted_frontier_failed after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_frontier_failed_msg_handling_sum gauge
avalanche_X_handler_get_accepted_frontier_failed_msg_handling_sum 0
# HELP avalanche_X_handler_get_accepted_frontier_failed_sum Sum of time (in ns) spent handling a get_accepted_frontier_failed
# TYPE avalanche_X_handler_get_accepted_frontier_failed_sum gauge
avalanche_X_handler_get_accepted_frontier_failed_sum 0
# HELP avalanche_X_handler_get_accepted_frontier_msg_handling_count Total # of observations of time (in ns) spent handling a get_accepted_frontier after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_frontier_msg_handling_count counter
avalanche_X_handler_get_accepted_frontier_msg_handling_count 0
# HELP avalanche_X_handler_get_accepted_frontier_msg_handling_sum Sum of time (in ns) spent handling a get_accepted_frontier after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_frontier_msg_handling_sum gauge
avalanche_X_handler_get_accepted_frontier_msg_handling_sum 0
# HELP avalanche_X_handler_get_accepted_frontier_sum Sum of time (in ns) spent handling a get_accepted_frontier
# TYPE avalanche_X_handler_get_accepted_frontier_sum gauge
avalanche_X_handler_get_accepted_frontier_sum 0
# HELP avalanche_X_handler_get_accepted_msg_handling_count Total # of observations of time (in ns) spent handling a get_accepted after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_msg_handling_count counter
avalanche_X_handler_get_accepted_msg_handling_count 2
# HELP avalanche_X_handler_get_accepted_msg_handling_sum Sum of time (in ns) spent handling a get_accepted after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_msg_handling_sum gauge
avalanche_X_handler_get_accepted_msg_handling_sum 417792
# HELP avalanche_X_handler_get_accepted_state_summary_count Total # of observations of time (in ns) spent handling a get_accepted_state_summary
# TYPE avalanche_X_handler_get_accepted_state_summary_count counter
avalanche_X_handler_get_accepted_state_summary_count 0
# HELP avalanche_X_handler_get_accepted_state_summary_failed_count Total # of observations of time (in ns) spent handling a get_accepted_state_summary_failed
# TYPE avalanche_X_handler_get_accepted_state_summary_failed_count counter
avalanche_X_handler_get_accepted_state_summary_failed_count 0
# HELP avalanche_X_handler_get_accepted_state_summary_failed_msg_handling_count Total # of observations of time (in ns) spent handling a get_accepted_state_summary_failed after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_state_summary_failed_msg_handling_count counter
avalanche_X_handler_get_accepted_state_summary_failed_msg_handling_count 0
# HELP avalanche_X_handler_get_accepted_state_summary_failed_msg_handling_sum Sum of time (in ns) spent handling a get_accepted_state_summary_failed after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_state_summary_failed_msg_handling_sum gauge
avalanche_X_handler_get_accepted_state_summary_failed_msg_handling_sum 0
# HELP avalanche_X_handler_get_accepted_state_summary_failed_sum Sum of time (in ns) spent handling a get_accepted_state_summary_failed
# TYPE avalanche_X_handler_get_accepted_state_summary_failed_sum gauge
avalanche_X_handler_get_accepted_state_summary_failed_sum 0
# HELP avalanche_X_handler_get_accepted_state_summary_msg_handling_count Total # of observations of time (in ns) spent handling a get_accepted_state_summary after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_state_summary_msg_handling_count counter
avalanche_X_handler_get_accepted_state_summary_msg_handling_count 0
# HELP avalanche_X_handler_get_accepted_state_summary_msg_handling_sum Sum of time (in ns) spent handling a get_accepted_state_summary after grabbing the lock
# TYPE avalanche_X_handler_get_accepted_state_summary_msg_handling_sum gauge
avalanche_X_handler_get_accepted_state_summary_msg_handling_sum 0
# HELP avalanche_X_handler_get_accepted_state_summary_sum Sum of time (in ns) spent handling a get_accepted_state_summary
# TYPE avalanche_X_handler_get_accepted_state_summary_sum gauge
avalanche_X_handler_get_accepted_state_summary_sum 0
# HELP avalanche_X_handler_get_accepted_sum Sum of time (in ns) spent handling a get_accepted
# TYPE avalanche_X_handler_get_accepted_sum gauge
avalanche_X_handler_get_accepted_sum 421124
# HELP avalanche_X_handler_get_ancestors_count Total # of observations of time (in ns) spent handling a get_ancestors
# TYPE avalanche_X_handler_get_ancestors_count counter
avalanche_X_handler_get_ancestors_count 0
# HELP avalanche_X_handler_get_ancestors_failed_count Total # of observations of time (in ns) spent handling a get_ancestors_failed
# TYPE avalanche_X_handler_get_ancestors_failed_count counter
avalanche_X_handler_get_ancestors_failed_count 0
# HELP avalanche_X_handler_get_ancestors_failed_msg_handling_count Total # of observations of time (in ns) spent handling a get_ancestors_failed after grabbing the lock
# TYPE avalanche_X_handler_get_ancestors_failed_msg_handling_count counter
avalanche_X_handler_get_ancestors_failed_msg_handling_count 0
# HELP avalanche_X_handler_get_ancestors_failed_msg_handling_sum Sum of time (in ns) spent handling a get_ancestors_failed after grabbing the lock
# TYPE avalanche_X_handler_get_ancestors_failed_msg_handling_sum gauge
avalanche_X_handler_get_ancestors_failed_msg_handling_sum 0
# HELP avalanche_X_handler_get_ancestors_failed_sum Sum of time (in ns) spent handling a get_ancestors_failed
# TYPE avalanche_X_handler_get_ancestors_failed_sum gauge
avalanche_X_handler_get_ancestors_failed_sum 0
# HELP avalanche_X_handler_get_ancestors_msg_handling_count Total # of observations of time (in ns) spent handling a get_ancestors after grabbing the lock
# TYPE avalanche_X_handler_get_ancestors_msg_handling_count counter
avalanche_X_handler_get_ancestors_msg_handling_count 0
# HELP avalanche_X_handler_get_ancestors_msg_handling_sum Sum of time (in ns) spent handling a get_ancestors after grabbing the lock
# TYPE avalanche_X_handler_get_ancestors_msg_handling_sum gauge
avalanche_X_handler_get_ancestors_msg_handling_sum 0
# HELP avalanche_X_handler_get_ancestors_sum Sum of time (in ns) spent handling a get_ancestors
# TYPE avalanche_X_handler_get_ancestors_sum gauge
avalanche_X_handler_get_ancestors_sum 0
# HELP avalanche_X_handler_get_count Total # of observations of time (in ns) spent handling a get
# TYPE avalanche_X_handler_get_count counter
avalanche_X_handler_get_count 0
# HELP avalanche_X_handler_get_failed_count Total # of observations of time (in ns) spent handling a get_failed
# TYPE avalanche_X_handler_get_failed_count counter
avalanche_X_handler_get_failed_count 0
# HELP avalanche_X_handler_get_failed_msg_handling_count Total # of observations of time (in ns) spent handling a get_failed after grabbing the lock
# TYPE avalanche_X_handler_get_failed_msg_handling_count counter
avalanche_X_handler_get_failed_msg_handling_count 0
# HELP avalanche_X_handler_get_failed_msg_handling_sum Sum of time (in ns) spent handling a get_failed after grabbing the lock
# TYPE avalanche_X_handler_get_failed_msg_handling_sum gauge
avalanche_X_handler_get_failed_msg_handling_sum 0
# HELP avalanche_X_handler_get_failed_sum Sum of time (in ns) spent handling a get_failed
# TYPE avalanche_X_handler_get_failed_sum gauge
avalanche_X_handler_get_failed_sum 0
# HELP avalanche_X_handler_get_msg_handling_count Total # of observations of time (in ns) spent handling a get after grabbing the lock
# TYPE avalanche_X_handler_get_msg_handling_count counter
avalanche_X_handler_get_msg_handling_count 0
# HELP avalanche_X_handler_get_msg_handling_sum Sum of time (in ns) spent handling a get after grabbing the lock
# TYPE avalanche_X_handler_get_msg_handling_sum gauge
avalanche_X_handler_get_msg_handling_sum 0
# HELP avalanche_X_handler_get_state_summary_frontier_count Total # of observations of time (in ns) spent handling a get_state_summary_frontier
# TYPE avalanche_X_handler_get_state_summary_frontier_count counter
avalanche_X_handler_get_state_summary_frontier_count 0
# HELP avalanche_X_handler_get_state_summary_frontier_failed_count Total # of observations of time (in ns) spent handling a get_state_summary_frontier_failed
# TYPE avalanche_X_handler_get_state_summary_frontier_failed_count counter
avalanche_X_handler_get_state_summary_frontier_failed_count 0
# HELP avalanche_X_handler_get_state_summary_frontier_failed_msg_handling_count Total # of observations of time (in ns) spent handling a get_state_summary_frontier_failed after grabbing the lock
# TYPE avalanche_X_handler_get_state_summary_frontier_failed_msg_handling_count counter
avalanche_X_handler_get_state_summary_frontier_failed_msg_handling_count 0
# HELP avalanche_X_handler_get_state_summary_frontier_failed_msg_handling_sum Sum of time (in ns) spent handling a get_state_summary_frontier_failed after grabbing the lock
# TYPE avalanche_X_handler_get_state_summary_frontier_failed_msg_handling_sum gauge
avalanche_X_handler_get_state_summary_frontier_failed_msg_handling_sum 0
# HELP avalanche_X_handler_get_state_summary_frontier_failed_sum Sum of time (in ns) spent handling a get_state_summary_frontier_failed
# TYPE avalanche_X_handler_get_state_summary_frontier_failed_sum gauge
avalanche_X_handler_get_state_summary_frontier_failed_sum 0
# HELP avalanche_X_handler_get_state_summary_frontier_msg_handling_count Total # of observations of time (in ns) spent handling a get_state_summary_frontier after grabbing the lock
# TYPE avalanche_X_handler_get_state_summary_frontier_msg_handling_count counter
avalanche_X_handler_get_state_summary_frontier_msg_handling_count 0
# HELP avalanche_X_handler_get_state_summary_frontier_msg_handling_sum Sum of time (in ns) spent handling a get_state_summary_frontier after grabbing the lock
# TYPE avalanche_X_handler_get_state_summary_frontier_msg_handling_sum gauge
avalanche_X_handler_get_state_summary_frontier_msg_handling_sum 0
# HELP avalanche_X_handler_get_state_summary_frontier_sum Sum of time (in ns) spent handling a get_state_summary_frontier
# TYPE avalanche_X_handler_get_state_summary_frontier_sum gauge
avalanche_X_handler_get_state_summary_frontier_sum 0
# HELP avalanche_X_handler_get_sum Sum of time (in ns) spent handling a get
# TYPE avalanche_X_handler_get_sum gauge
avalanche_X_handler_get_sum 0
# HELP avalanche_X_handler_gossip_request_count Total # of observations of time (in ns) spent handling a gossip_request
# TYPE avalanche_X_handler_gossip_request_count counter
avalanche_X_handler_gossip_request_count 545
# HELP avalanche_X_handler_gossip_request_msg_handling_count Total # of observations of time (in ns) spent handling a gossip_request after grabbing the lock
# TYPE avalanche_X_handler_gossip_request_msg_handling_count counter
avalanche_X_handler_gossip_request_msg_handling_count 545
# HELP avalanche_X_handler_gossip_request_msg_handling_sum Sum of time (in ns) spent handling a gossip_request after grabbing the lock
# TYPE avalanche_X_handler_gossip_request_msg_handling_sum gauge
avalanche_X_handler_gossip_request_msg_handling_sum 890954
# HELP avalanche_X_handler_gossip_request_sum Sum of time (in ns) spent handling a gossip_request
# TYPE avalanche_X_handler_gossip_request_sum gauge
avalanche_X_handler_gossip_request_sum 4.340458e+06
# HELP avalanche_X_handler_notify_count Total # of observations of time (in ns) spent handling a notify
# TYPE avalanche_X_handler_notify_count counter
avalanche_X_handler_notify_count 0
# HELP avalanche_X_handler_notify_msg_handling_count Total # of observations of time (in ns) spent handling a notify after grabbing the lock
# TYPE avalanche_X_handler_notify_msg_handling_count counter
avalanche_X_handler_notify_msg_handling_count 0
# HELP avalanche_X_handler_notify_msg_handling_sum Sum of time (in ns) spent handling a notify after grabbing the lock
# TYPE avalanche_X_handler_notify_msg_handling_sum gauge
avalanche_X_handler_notify_msg_handling_sum 0
# HELP avalanche_X_handler_notify_sum Sum of time (in ns) spent handling a notify
# TYPE avalanche_X_handler_notify_sum gauge
avalanche_X_handler_notify_sum 0
# HELP avalanche_X_handler_pull_query_count Total # of observations of time (in ns) spent handling a pull_query
# TYPE avalanche_X_handler_pull_query_count counter
avalanche_X_handler_pull_query_count 242
# HELP avalanche_X_handler_pull_query_msg_handling_count Total # of observations of time (in ns) spent handling a pull_query after grabbing the lock
# TYPE avalanche_X_handler_pull_query_msg_handling_count counter
avalanche_X_handler_pull_query_msg_handling_count 242
# HELP avalanche_X_handler_pull_query_msg_handling_sum Sum of time (in ns) spent handling a pull_query after grabbing the lock
# TYPE avalanche_X_handler_pull_query_msg_handling_sum gauge
avalanche_X_handler_pull_query_msg_handling_sum 2.524544e+06
# HELP avalanche_X_handler_pull_query_sum Sum of time (in ns) spent handling a pull_query
# TYPE avalanche_X_handler_pull_query_sum gauge
avalanche_X_handler_pull_query_sum 3.87958e+06
# HELP avalanche_X_handler_push_query_count Total # of observations of time (in ns) spent handling a push_query
# TYPE avalanche_X_handler_push_query_count counter
avalanche_X_handler_push_query_count 0
# HELP avalanche_X_handler_push_query_msg_handling_count Total # of observations of time (in ns) spent handling a push_query after grabbing the lock
# TYPE avalanche_X_handler_push_query_msg_handling_count counter
avalanche_X_handler_push_query_msg_handling_count 0
# HELP avalanche_X_handler_push_query_msg_handling_sum Sum of time (in ns) spent handling a push_query after grabbing the lock
# TYPE avalanche_X_handler_push_query_msg_handling_sum gauge
avalanche_X_handler_push_query_msg_handling_sum 0
# HELP avalanche_X_handler_push_query_sum Sum of time (in ns) spent handling a push_query
# TYPE avalanche_X_handler_push_query_sum gauge
avalanche_X_handler_push_query_sum 0
# HELP avalanche_X_handler_put_count Total # of observations of time (in ns) spent handling a put
# TYPE avalanche_X_handler_put_count counter
avalanche_X_handler_put_count 0
# HELP avalanche_X_handler_put_msg_handling_count Total # of observations of time (in ns) spent handling a put after grabbing the lock
# TYPE avalanche_X_handler_put_msg_handling_count counter
avalanche_X_handler_put_msg_handling_count 0
# HELP avalanche_X_handler_put_msg_handling_sum Sum of time (in ns) spent handling a put after grabbing the lock
# TYPE avalanche_X_handler_put_msg_handling_sum gauge
avalanche_X_handler_put_msg_handling_sum 0
# HELP avalanche_X_handler_put_sum Sum of time (in ns) spent handling a put
# TYPE avalanche_X_handler_put_sum gauge
avalanche_X_handler_put_sum 0
# HELP avalanche_X_handler_query_failed_count Total # of observations of time (in ns) spent handling a query_failed
# TYPE avalanche_X_handler_query_failed_count counter
avalanche_X_handler_query_failed_count 0
# HELP avalanche_X_handler_query_failed_msg_handling_count Total # of observations of time (in ns) spent handling a query_failed after grabbing the lock
# TYPE avalanche_X_handler_query_failed_msg_handling_count counter
avalanche_X_handler_query_failed_msg_handling_count 0
# HELP avalanche_X_handler_query_failed_msg_handling_sum Sum of time (in ns) spent handling a query_failed after grabbing the lock
# TYPE avalanche_X_handler_query_failed_msg_handling_sum gauge
avalanche_X_handler_query_failed_msg_handling_sum 0
# HELP avalanche_X_handler_query_failed_sum Sum of time (in ns) spent handling a query_failed
# TYPE avalanche_X_handler_query_failed_sum gauge
avalanche_X_handler_query_failed_sum 0
# HELP avalanche_X_handler_state_summary_frontier_count Total # of observations of time (in ns) spent handling a state_summary_frontier
# TYPE avalanche_X_handler_state_summary_frontier_count counter
avalanche_X_handler_state_summary_frontier_count 0
# HELP avalanche_X_handler_state_summary_frontier_msg_handling_count Total # of observations of time (in ns) spent handling a state_summary_frontier after grabbing the lock
# TYPE avalanche_X_handler_state_summary_frontier_msg_handling_count counter
avalanche_X_handler_state_summary_frontier_msg_handling_count 0
# HELP avalanche_X_handler_state_summary_frontier_msg_handling_sum Sum of time (in ns) spent handling a state_summary_frontier after grabbing the lock
# TYPE avalanche_X_handler_state_summary_frontier_msg_handling_sum gauge
avalanche_X_handler_state_summary_frontier_msg_handling_sum 0
# HELP avalanche_X_handler_state_summary_frontier_sum Sum of time (in ns) spent handling a state_summary_frontier
# TYPE avalanche_X_handler_state_summary_frontier_sum gauge
avalanche_X_handler_state_summary_frontier_sum 0
# HELP avalanche_X_handler_timeout_count Total # of observations of time (in ns) spent handling a timeout
# TYPE avalanche_X_handler_timeout_count counter
avalanche_X_handler_timeout_count 1
# HELP avalanche_X_handler_timeout_msg_handling_count Total # of observations of time (in ns) spent handling a timeout after grabbing the lock
# TYPE avalanche_X_handler_timeout_msg_handling_count counter
avalanche_X_handler_timeout_msg_handling_count 1
# HELP avalanche_X_handler_timeout_msg_handling_sum Sum of time (in ns) spent handling a timeout after grabbing the lock
# TYPE avalanche_X_handler_timeout_msg_handling_sum gauge
avalanche_X_handler_timeout_msg_handling_sum 1.256542e+06
# HELP avalanche_X_handler_timeout_sum Sum of time (in ns) spent handling a timeout
# TYPE avalanche_X_handler_timeout_sum gauge
avalanche_X_handler_timeout_sum 1.262583e+06
```

New:
```
# HELP avalanche_X_handler_locking_time time spent acquiring the context lock
# TYPE avalanche_X_handler_locking_time counter
avalanche_X_handler_locking_time 6.24154e+06
# HELP avalanche_X_handler_message_handling_time time spent handling messages
# TYPE avalanche_X_handler_message_handling_time counter
avalanche_X_handler_message_handling_time{op="accepted"} 1.9717656e+07
avalanche_X_handler_message_handling_time{op="accepted_frontier"} 617001
avalanche_X_handler_message_handling_time{op="app_request"} 5.203083e+06
avalanche_X_handler_message_handling_time{op="app_response"} 944543
avalanche_X_handler_message_handling_time{op="connected"} 539915
avalanche_X_handler_message_handling_time{op="get_accepted_failed"} 2.552337e+07
avalanche_X_handler_message_handling_time{op="gossip_request"} 509242
avalanche_X_handler_message_handling_time{op="pull_query"} 974959
# HELP avalanche_X_handler_messages messages handled
# TYPE avalanche_X_handler_messages counter
avalanche_X_handler_messages{op="accepted"} 276
avalanche_X_handler_messages{op="accepted_frontier"} 12
avalanche_X_handler_messages{op="app_request"} 8
avalanche_X_handler_messages{op="app_response"} 10
avalanche_X_handler_messages{op="connected"} 335
avalanche_X_handler_messages{op="get_accepted_failed"} 350
avalanche_X_handler_messages{op="gossip_request"} 163
avalanche_X_handler_messages{op="pull_query"} 99
```

## How this works

Uses vectors rather than different metric names.

## How this was tested

- [X] CI
- [X] Fuji