### PR TITLE
Use vector for router latency metrics

### DIFF
--- a/snow/networking/timeout/manager.go
+++ b/snow/networking/timeout/manager.go
@@ -149,7 +149,7 @@ func (m *manager) RegisterResponse(
 	op message.Op,
 	latency time.Duration,
 ) {
-	m.metrics.Observe(nodeID, chainID, op, latency)
+	m.metrics.Observe(chainID, op, latency)
 	m.benchlistMgr.RegisterResponse(chainID, nodeID)
 	m.tm.Remove(requestID)
 }


### PR DESCRIPTION
## Why this should be merged

Old:
```
# HELP avalanche_C_lat_accepted_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_accepted_count counter
avalanche_C_lat_accepted_count 576
# HELP avalanche_C_lat_accepted_frontier_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_accepted_frontier_count counter
avalanche_C_lat_accepted_frontier_count 22
# HELP avalanche_C_lat_accepted_frontier_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_accepted_frontier_sum gauge
avalanche_C_lat_accepted_frontier_sum 3.194490957e+09
# HELP avalanche_C_lat_accepted_state_summary_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_accepted_state_summary_count counter
avalanche_C_lat_accepted_state_summary_count 0
# HELP avalanche_C_lat_accepted_state_summary_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_accepted_state_summary_sum gauge
avalanche_C_lat_accepted_state_summary_sum 0
# HELP avalanche_C_lat_accepted_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_accepted_sum gauge
avalanche_C_lat_accepted_sum 5.2717695834e+10
# HELP avalanche_C_lat_ancestors_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_ancestors_count counter
avalanche_C_lat_ancestors_count 113
# HELP avalanche_C_lat_ancestors_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_ancestors_sum gauge
avalanche_C_lat_ancestors_sum 2.8194641961e+10
# HELP avalanche_C_lat_app_error_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_app_error_count counter
avalanche_C_lat_app_error_count 0
# HELP avalanche_C_lat_app_error_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_app_error_sum gauge
avalanche_C_lat_app_error_sum 0
# HELP avalanche_C_lat_app_response_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_app_response_count counter
avalanche_C_lat_app_response_count 0
# HELP avalanche_C_lat_app_response_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_app_response_sum gauge
avalanche_C_lat_app_response_sum 0
# HELP avalanche_C_lat_chits_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_chits_count counter
avalanche_C_lat_chits_count 0
# HELP avalanche_C_lat_chits_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_chits_sum gauge
avalanche_C_lat_chits_sum 0
# HELP avalanche_C_lat_put_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_put_count counter
avalanche_C_lat_put_count 0
# HELP avalanche_C_lat_put_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_put_sum gauge
avalanche_C_lat_put_sum 0
# HELP avalanche_C_lat_state_summary_frontier_count Total # of observations of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_state_summary_frontier_count counter
avalanche_C_lat_state_summary_frontier_count 0
# HELP avalanche_C_lat_state_summary_frontier_sum Sum of time (in ns) spent waiting for a response to this message
# TYPE avalanche_C_lat_state_summary_frontier_sum gauge
avalanche_C_lat_state_summary_frontier_sum 0
```

New:
```
# HELP avalanche_C_response_message_latencies message latencies (ns)
# TYPE avalanche_C_response_message_latencies counter
avalanche_C_response_message_latencies{op="accepted"} 6.1356957746e+10
avalanche_C_response_message_latencies{op="accepted_frontier"} 2.167703459e+09
avalanche_C_response_message_latencies{op="ancestors"} 4.8915896584e+10
avalanche_C_response_message_latencies{op="chits"} 2.71066716631e+11
avalanche_C_response_message_latencies{op="put"} 1.654034876e+09
# HELP avalanche_C_response_messages number of responses
# TYPE avalanche_C_response_messages counter
avalanche_C_response_messages{op="accepted"} 663
avalanche_C_response_messages{op="accepted_frontier"} 19
avalanche_C_response_messages{op="ancestors"} 177
avalanche_C_response_messages{op="chits"} 1940
avalanche_C_response_messages{op="put"} 19
```

## How this works

Uses labels.
Removes dead code.

## How this was tested

- [X] CI
- [X] Fuji