### PR TITLE
Use vectors for accepted tx and block metrics

### DIFF
--- a/vms/avm/metrics/tx_metrics.go
+++ b/vms/avm/metrics/tx_metrics.go
@@ -4,75 +4,71 @@
 package metrics
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
 )
 
-var _ txs.Visitor = (*txMetrics)(nil)
+const txLabel = "tx"
+
+var (
+	_ txs.Visitor = (*txMetrics)(nil)
+
+	txLabels = []string{txLabel}
+)
 
 type txMetrics struct {
-	numBaseTxs,
-	numCreateAssetTxs,
-	numOperationTxs,
-	numImportTxs,
-	numExportTxs prometheus.Counter
+	numTxs *prometheus.CounterVec
 }
 
 func newTxMetrics(
 	namespace string,
 	registerer prometheus.Registerer,
 ) (*txMetrics, error) {
-	errs := wrappers.Errs{}
 	m := &txMetrics{
-		numBaseTxs:        newTxMetric(namespace, "base", registerer, &errs),
-		numCreateAssetTxs: newTxMetric(namespace, "create_asset", registerer, &errs),
-		numOperationTxs:   newTxMetric(namespace, "operation", registerer, &errs),
-		numImportTxs:      newTxMetric(namespace, "import", registerer, &errs),
-		numExportTxs:      newTxMetric(namespace, "export", registerer, &errs),
+		numTxs: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "txs_accepted",
+				Help:      "number of transactions accepted",
+			},
+			txLabels,
+		),
 	}
-	return m, errs.Err
-}
-
-func newTxMetric(
-	namespace string,
-	txName string,
-	registerer prometheus.Registerer,
-	errs *wrappers.Errs,
-) prometheus.Counter {
-	txMetric := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      txName + "_txs_accepted",
-		Help:      fmt.Sprintf("Number of %s transactions accepted", txName),
-	})
-	errs.Add(registerer.Register(txMetric))
-	return txMetric
+	return m, registerer.Register(m.numTxs)
 }
 
 func (m *txMetrics) BaseTx(*txs.BaseTx) error {
-	m.numBaseTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "base",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) CreateAssetTx(*txs.CreateAssetTx) error {
-	m.numCreateAssetTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "create_asset",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) OperationTx(*txs.OperationTx) error {
-	m.numOperationTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "operation",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) ImportTx(*txs.ImportTx) error {
-	m.numImportTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "import",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) ExportTx(*txs.ExportTx) error {
-	m.numExportTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "export",
+	}).Inc()
 	return nil
 }

--- a/vms/platformvm/metrics/tx_metrics.go
+++ b/vms/platformvm/metrics/tx_metrics.go
@@ -4,145 +4,141 @@
 package metrics
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
-var _ txs.Visitor = (*txMetrics)(nil)
+const txLabel = "tx"
+
+var (
+	_ txs.Visitor = (*txMetrics)(nil)
+
+	txLabels = []string{txLabel}
+)
 
 type txMetrics struct {
-	numAddDelegatorTxs,
-	numAddSubnetValidatorTxs,
-	numAddValidatorTxs,
-	numAdvanceTimeTxs,
-	numCreateChainTxs,
-	numCreateSubnetTxs,
-	numExportTxs,
-	numImportTxs,
-	numRewardValidatorTxs,
-	numRemoveSubnetValidatorTxs,
-	numTransformSubnetTxs,
-	numAddPermissionlessValidatorTxs,
-	numAddPermissionlessDelegatorTxs,
-	numTransferSubnetOwnershipTxs,
-	numBaseTxs prometheus.Counter
+	numTxs *prometheus.CounterVec
 }
 
 func newTxMetrics(
 	namespace string,
 	registerer prometheus.Registerer,
 ) (*txMetrics, error) {
-	errs := wrappers.Errs{}
 	m := &txMetrics{
-		numAddDelegatorTxs:               newTxMetric(namespace, "add_delegator", registerer, &errs),
-		numAddSubnetValidatorTxs:         newTxMetric(namespace, "add_subnet_validator", registerer, &errs),
-		numAddValidatorTxs:               newTxMetric(namespace, "add_validator", registerer, &errs),
-		numAdvanceTimeTxs:                newTxMetric(namespace, "advance_time", registerer, &errs),
-		numCreateChainTxs:                newTxMetric(namespace, "create_chain", registerer, &errs),
-		numCreateSubnetTxs:               newTxMetric(namespace, "create_subnet", registerer, &errs),
-		numExportTxs:                     newTxMetric(namespace, "export", registerer, &errs),
-		numImportTxs:                     newTxMetric(namespace, "import", registerer, &errs),
-		numRewardValidatorTxs:            newTxMetric(namespace, "reward_validator", registerer, &errs),
-		numRemoveSubnetValidatorTxs:      newTxMetric(namespace, "remove_subnet_validator", registerer, &errs),
-		numTransformSubnetTxs:            newTxMetric(namespace, "transform_subnet", registerer, &errs),
-		numAddPermissionlessValidatorTxs: newTxMetric(namespace, "add_permissionless_validator", registerer, &errs),
-		numAddPermissionlessDelegatorTxs: newTxMetric(namespace, "add_permissionless_delegator", registerer, &errs),
-		numTransferSubnetOwnershipTxs:    newTxMetric(namespace, "transfer_subnet_ownership", registerer, &errs),
-		numBaseTxs:                       newTxMetric(namespace, "base", registerer, &errs),
+		numTxs: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "txs_accepted",
+				Help:      "number of transactions accepted",
+			},
+			txLabels,
+		),
 	}
-	return m, errs.Err
-}
-
-func newTxMetric(
-	namespace string,
-	txName string,
-	registerer prometheus.Registerer,
-	errs *wrappers.Errs,
-) prometheus.Counter {
-	txMetric := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      txName + "_txs_accepted",
-		Help:      fmt.Sprintf("Number of %s transactions accepted", txName),
-	})
-	errs.Add(registerer.Register(txMetric))
-	return txMetric
+	return m, registerer.Register(m.numTxs)
 }
 
 func (m *txMetrics) AddValidatorTx(*txs.AddValidatorTx) error {
-	m.numAddValidatorTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "add_validator",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) AddSubnetValidatorTx(*txs.AddSubnetValidatorTx) error {
-	m.numAddSubnetValidatorTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "add_subnet_validator",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) AddDelegatorTx(*txs.AddDelegatorTx) error {
-	m.numAddDelegatorTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "add_delegator",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) CreateChainTx(*txs.CreateChainTx) error {
-	m.numCreateChainTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "create_chain",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) CreateSubnetTx(*txs.CreateSubnetTx) error {
-	m.numCreateSubnetTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "create_subnet",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) ImportTx(*txs.ImportTx) error {
-	m.numImportTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "import",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) ExportTx(*txs.ExportTx) error {
-	m.numExportTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "export",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) AdvanceTimeTx(*txs.AdvanceTimeTx) error {
-	m.numAdvanceTimeTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "advance_time",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) RewardValidatorTx(*txs.RewardValidatorTx) error {
-	m.numRewardValidatorTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "reward_validator",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) RemoveSubnetValidatorTx(*txs.RemoveSubnetValidatorTx) error {
-	m.numRemoveSubnetValidatorTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "remove_subnet_validator",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) TransformSubnetTx(*txs.TransformSubnetTx) error {
-	m.numTransformSubnetTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "transform_subnet",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) AddPermissionlessValidatorTx(*txs.AddPermissionlessValidatorTx) error {
-	m.numAddPermissionlessValidatorTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "add_permissionless_validator",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) AddPermissionlessDelegatorTx(*txs.AddPermissionlessDelegatorTx) error {
-	m.numAddPermissionlessDelegatorTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "add_permissionless_delegator",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) TransferSubnetOwnershipTx(*txs.TransferSubnetOwnershipTx) error {
-	m.numTransferSubnetOwnershipTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "transfer_subnet_ownership",
+	}).Inc()
 	return nil
 }
 
 func (m *txMetrics) BaseTx(*txs.BaseTx) error {
-	m.numBaseTxs.Inc()
+	m.numTxs.With(prometheus.Labels{
+		txLabel: "base",
+	}).Inc()
 	return nil
 }


### PR DESCRIPTION
## Why this should be merged

Old:
```
# HELP avalanche_P_vm_abort_blks_accepted Number of abort blocks accepted
# TYPE avalanche_P_vm_abort_blks_accepted counter
avalanche_P_vm_abort_blks_accepted 0
# HELP avalanche_P_vm_atomic_blks_accepted Number of atomic blocks accepted
# TYPE avalanche_P_vm_atomic_blks_accepted counter
avalanche_P_vm_atomic_blks_accepted 0
# HELP avalanche_P_vm_commit_blks_accepted Number of commit blocks accepted
# TYPE avalanche_P_vm_commit_blks_accepted counter
avalanche_P_vm_commit_blks_accepted 0
# HELP avalanche_P_vm_proposal_blks_accepted Number of proposal blocks accepted
# TYPE avalanche_P_vm_proposal_blks_accepted counter
avalanche_P_vm_proposal_blks_accepted 0
# HELP avalanche_P_vm_standard_blks_accepted Number of standard blocks accepted
# TYPE avalanche_P_vm_standard_blks_accepted counter
avalanche_P_vm_standard_blks_accepted 1
# HELP avalanche_P_vm_add_delegator_txs_accepted Number of add_delegator transactions accepted
# TYPE avalanche_P_vm_add_delegator_txs_accepted counter
avalanche_P_vm_add_delegator_txs_accepted 0
# HELP avalanche_P_vm_add_permissionless_delegator_txs_accepted Number of add_permissionless_delegator transactions accepted
# TYPE avalanche_P_vm_add_permissionless_delegator_txs_accepted counter
avalanche_P_vm_add_permissionless_delegator_txs_accepted 0
# HELP avalanche_P_vm_add_permissionless_validator_txs_accepted Number of add_permissionless_validator transactions accepted
# TYPE avalanche_P_vm_add_permissionless_validator_txs_accepted counter
avalanche_P_vm_add_permissionless_validator_txs_accepted 0
# HELP avalanche_P_vm_add_subnet_validator_txs_accepted Number of add_subnet_validator transactions accepted
# TYPE avalanche_P_vm_add_subnet_validator_txs_accepted counter
avalanche_P_vm_add_subnet_validator_txs_accepted 0
# HELP avalanche_P_vm_add_validator_txs_accepted Number of add_validator transactions accepted
# TYPE avalanche_P_vm_add_validator_txs_accepted counter
avalanche_P_vm_add_validator_txs_accepted 0
# HELP avalanche_P_vm_advance_time_txs_accepted Number of advance_time transactions accepted
# TYPE avalanche_P_vm_advance_time_txs_accepted counter
avalanche_P_vm_advance_time_txs_accepted 0
# HELP avalanche_P_vm_base_txs_accepted Number of base transactions accepted
# TYPE avalanche_P_vm_base_txs_accepted counter
avalanche_P_vm_base_txs_accepted 0
# HELP avalanche_P_vm_create_chain_txs_accepted Number of create_chain transactions accepted
# TYPE avalanche_P_vm_create_chain_txs_accepted counter
avalanche_P_vm_create_chain_txs_accepted 0
# HELP avalanche_P_vm_create_subnet_txs_accepted Number of create_subnet transactions accepted
# TYPE avalanche_P_vm_create_subnet_txs_accepted counter
avalanche_P_vm_create_subnet_txs_accepted 0
# HELP avalanche_P_vm_export_txs_accepted Number of export transactions accepted
# TYPE avalanche_P_vm_export_txs_accepted counter
avalanche_P_vm_export_txs_accepted 1
# HELP avalanche_P_vm_import_txs_accepted Number of import transactions accepted
# TYPE avalanche_P_vm_import_txs_accepted counter
avalanche_P_vm_import_txs_accepted 0
# HELP avalanche_P_vm_remove_subnet_validator_txs_accepted Number of remove_subnet_validator transactions accepted
# TYPE avalanche_P_vm_remove_subnet_validator_txs_accepted counter
avalanche_P_vm_remove_subnet_validator_txs_accepted 0
# HELP avalanche_P_vm_reward_validator_txs_accepted Number of reward_validator transactions accepted
# TYPE avalanche_P_vm_reward_validator_txs_accepted counter
avalanche_P_vm_reward_validator_txs_accepted 0
# HELP avalanche_P_vm_transfer_subnet_ownership_txs_accepted Number of transfer_subnet_ownership transactions accepted
# TYPE avalanche_P_vm_transfer_subnet_ownership_txs_accepted counter
avalanche_P_vm_transfer_subnet_ownership_txs_accepted 0
# HELP avalanche_P_vm_transform_subnet_txs_accepted Number of transform_subnet transactions accepted
# TYPE avalanche_P_vm_transform_subnet_txs_accepted counter
avalanche_P_vm_transform_subnet_txs_accepted 0
# HELP avalanche_X_vm_avalanche_base_txs_accepted Number of base transactions accepted
# TYPE avalanche_X_vm_avalanche_base_txs_accepted counter
avalanche_X_vm_avalanche_base_txs_accepted 0
# HELP avalanche_X_vm_avalanche_create_asset_txs_accepted Number of create_asset transactions accepted
# TYPE avalanche_X_vm_avalanche_create_asset_txs_accepted counter
avalanche_X_vm_avalanche_create_asset_txs_accepted 0
# HELP avalanche_X_vm_avalanche_export_txs_accepted Number of export transactions accepted
# TYPE avalanche_X_vm_avalanche_export_txs_accepted counter
avalanche_X_vm_avalanche_export_txs_accepted 0
# HELP avalanche_X_vm_avalanche_import_txs_accepted Number of import transactions accepted
# TYPE avalanche_X_vm_avalanche_import_txs_accepted counter
avalanche_X_vm_avalanche_import_txs_accepted 0
# HELP avalanche_X_vm_avalanche_operation_txs_accepted Number of operation transactions accepted
# TYPE avalanche_X_vm_avalanche_operation_txs_accepted counter
avalanche_X_vm_avalanche_operation_txs_accepted 0
```

New:
```
# HELP avalanche_P_vm_blks_accepted number of blocks accepted
# TYPE avalanche_P_vm_blks_accepted counter
avalanche_P_vm_blks_accepted{blk="standard"} 1
# HELP avalanche_P_vm_txs_accepted number of transactions accepted
# TYPE avalanche_P_vm_txs_accepted counter
avalanche_P_vm_txs_accepted{tx="export"} 1
# HELP avalanche_X_vm_avalanche_txs_accepted number of transactions accepted
# TYPE avalanche_X_vm_avalanche_txs_accepted counter
avalanche_X_vm_avalanche_txs_accepted{tx="import"} 1
```

## How this works

Uses labels rather than custom metrics

## How this was tested

- [X] CI
- [X] Fuji