### PR TITLE
Fix antithesis image publication

### DIFF
--- a/.github/workflows/publish_antithesis_images.yml
+++ b/.github/workflows/publish_antithesis_images.yml
@@ -30,7 +30,9 @@ jobs:
         password: ${{ secrets.ANTITHESIS_GAR_JSON_KEY }}
 
     - name: Set the Go version in the environment
-      uses: ./.github/actions/set-go-version-in-env
+      # Need an exact version vs the range (~x.x.x) provided by set-go-version-in-env action
+      run: echo GO_VERSION="$(go list -m -f '{{.GoVersion}}')" >> $GITHUB_ENV
+      shell: bash
 
     - name: Build node
       id: build-node-image


### PR DESCRIPTION
## Why this should be merged

The docker commands need an exact version (x.x.x) rather than the range (~x.x.x) provided by the action.

## How this works

Replaced use of an action with the go command to get the version.

## How this was tested

Used the same command to configure [the govulncheck job](https://github.com/ava-labs/avalanchego/actions/runs/8972478820/job/24640566821?pr=2998).