### PR TITLE
Update go version to 1.21.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 To start developing on AvalancheGo, you'll need a few things installed.
 
-- Golang version >= 1.21.9
+- Golang version >= 1.21.10
 - gcc
 - g++
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The minimum recommended hardware specification for nodes connected to Mainnet is
 
 If you plan to build AvalancheGo from source, you will also need the following software:
 
-- [Go](https://golang.org/doc/install) version >= 1.21.9
+- [Go](https://golang.org/doc/install) version >= 1.21.10
 - [gcc](https://gcc.gnu.org/)
 - g++
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/ava-labs/avalanchego
 // CONTRIBUTING.md
 // README.md
 // go.mod (here)
-go 1.21.9
+go 1.21.10
 
 require (
 	github.com/DataDog/zstd v1.5.2


### PR DESCRIPTION
## Why this should be merged

govulncheck is blocking merge to master without this: https://github.com/ava-labs/avalanchego/actions/runs/8994685894/job/24708512594?pr=3003