### PR TITLE
Chore: fix typos.

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -127,7 +127,7 @@ It is expected for Avalanche nodes to allow inbound connections. If a validator 
 
 Avalanche nodes that have identified the `IP:Port` pair of a node they want to connect to will initiate outbound connections to this `IP:Port` pair. If the connection is not able to complete the [Peer Handshake](#peer-handshake), the connection will be re-attempted with an [Exponential Backoff](https://en.wikipedia.org/wiki/Exponential_backoff).
 
-A node should initiate outbound connections to an `IP:Port` pair that is beleived to belong to a node that is not connected and meets at least one of the following conditions:
+A node should initiate outbound connections to an `IP:Port` pair that is believed to belong to a node that is not connected and meets at least one of the following conditions:
 - The node is in the initial bootstrapper set.
 - The node is in the default bootstrapper set.
 - The node in the current Primary Network validator set.

--- a/vms/platformvm/docs/validators_versioning.md
+++ b/vms/platformvm/docs/validators_versioning.md
@@ -68,7 +68,7 @@ Validator diffs layout is optimized to support iteration. Validator sets are reb
 Note that:
 
 1. `Weight` diffs related to a Subnet are stored contiguously.
-2. Diff height is serialized as `Reverse_Height`. It is stored with big endian format and has its bits flipped too. Big endianess ensures that heights are stored in order, bit flipping ensures that the top-most height is always the first.
+2. Diff height is serialized as `Reverse_Height`. It is stored with big endian format and has its bits flipped too. Big endianness ensures that heights are stored in order, bit flipping ensures that the top-most height is always the first.
 3. `NodeID` is part of the key and `state.ValidatorWeightDiff` is part of the value.
 
 `BLS Public` diffs are stored as follows:


### PR DESCRIPTION
## Why this should be merged
provide better reading experience.

## How this works
by fixing two typos.

## How this was tested
using dictionary.
