### PR TITLE
Fix pebbledb memory corruption

### DIFF
--- a/database/pebble/batch_test.go
+++ b/database/pebble/batch_test.go
@@ -17,7 +17,7 @@ func TestBatch(t *testing.T) {
 	require := require.New(t)
 	dirName := t.TempDir()
 
-	db, err := New(dirName, DefaultConfigBytes, logging.NoLog{}, "", prometheus.NewRegistry())
+	db, err := New(dirName, nil, logging.NoLog{}, "", prometheus.NewRegistry())
 	require.NoError(err)
 
 	batchIntf := db.NewBatch()

--- a/database/pebble/db_test.go
+++ b/database/pebble/db_test.go
@@ -16,7 +16,7 @@ import (
 
 func newDB(t testing.TB) *Database {
 	folder := t.TempDir()
-	db, err := New(folder, DefaultConfigBytes, logging.NoLog{}, "pebble", prometheus.NewRegistry())
+	db, err := New(folder, nil, logging.NoLog{}, "pebble", prometheus.NewRegistry())
 	require.NoError(t, err)
 	return db.(*Database)
 }

--- a/database/pebble/iterator.go
+++ b/database/pebble/iterator.go
@@ -71,8 +71,8 @@ func (it *iter) Next() bool {
 		return false
 	}
 
-	it.nextKey = slices.Clone(key)
-	it.nextVal = slices.Clone(value)
+	it.nextKey = key
+	it.nextVal = value
 	return true
 }
 
@@ -121,6 +121,9 @@ func (it *iter) release() {
 	if it.closed {
 		return
 	}
+
+	it.nextKey = slices.Clone(it.nextKey)
+	it.nextVal = slices.Clone(it.nextVal)
 
 	// Remove the iterator from the list of open iterators.
 	it.db.openIterators.Remove(it)

--- a/database/pebble/iterator.go
+++ b/database/pebble/iterator.go
@@ -122,6 +122,8 @@ func (it *iter) release() {
 		return
 	}
 
+	// Cloning these values ensures that calling it.Key() or it.Value() after
+	// releasing the iterator will not segfault.
 	it.nextKey = slices.Clone(it.nextKey)
 	it.nextVal = slices.Clone(it.nextVal)
 

--- a/database/pebble/iterator.go
+++ b/database/pebble/iterator.go
@@ -17,7 +17,7 @@ import (
 var (
 	_ database.Iterator = (*iter)(nil)
 
-	errCouldntGetValue = errors.New("couldnt get iterator value")
+	errCouldNotGetValue = errors.New("could not get iterator value")
 )
 
 type iter struct {
@@ -63,16 +63,16 @@ func (it *iter) Next() bool {
 		return false
 	}
 
-	it.nextKey = it.iter.Key()
-
-	var err error
-	it.nextVal, err = it.iter.ValueAndErr()
+	key := it.iter.Key()
+	value, err := it.iter.ValueAndErr()
 	if err != nil {
 		it.hasNext = false
-		it.err = fmt.Errorf("%w: %w", errCouldntGetValue, err)
+		it.err = fmt.Errorf("%w: %w", errCouldNotGetValue, err)
 		return false
 	}
 
+	it.nextKey = slices.Clone(key)
+	it.nextVal = slices.Clone(value)
 	return true
 }
 


### PR DESCRIPTION
## Why this should be merged

Should resolve #2885.

## How this works

Currently there are places where we hold a reference to `it.Key()` and `it.Value()` after `it.release` has been called. Pebble frees the memory used for these variables here, so this can cause a segfault.

## How this was tested

I wasn't able to replicate the flake locally, so it's a bit hard to validate the fix.

- [X] CI