### PR TITLE
[build] Update linter version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,11 +2,6 @@
 run:
   timeout: 10m
 
-  # Enables skipping of directories:
-  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  # Default: true
-  skip-dirs-use-default: false
-
   # If set we pass it to "go list -mod={option}". From "go help modules":
   # If invoked with -mod=readonly, the go command is disallowed from the implicit
   # automatic updating of go.mod described above. Instead, it fails when any changes
@@ -35,6 +30,11 @@ issues:
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 0
+
+  # Enables skipping of directories:
+  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  # Default: true
+  exclude-dirs-use-default: false
 
 linters:
   disable-all: true

--- a/network/peer/tls_config.go
+++ b/network/peer/tls_config.go
@@ -23,7 +23,7 @@ func TLSConfig(cert tls.Certificate, keyLogWriter io.Writer) *tls.Config {
 		//
 		// During our security audit by Quantstamp, this was investigated
 		// and confirmed to be safe and correct.
-		InsecureSkipVerify: true, // #nosec G402
+		InsecureSkipVerify: true, //#nosec G402
 		MinVersion:         tls.VersionTLS13,
 		KeyLogWriter:       keyLogWriter,
 	}

--- a/network/peer/tls_config.go
+++ b/network/peer/tls_config.go
@@ -14,7 +14,6 @@ import (
 // It is safe, and typically expected, for [keyLogWriter] to be [nil].
 // [keyLogWriter] should only be enabled for debugging.
 func TLSConfig(cert tls.Certificate, keyLogWriter io.Writer) *tls.Config {
-	// #nosec G402
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		ClientAuth:   tls.RequireAnyClientCert,
@@ -24,7 +23,7 @@ func TLSConfig(cert tls.Certificate, keyLogWriter io.Writer) *tls.Config {
 		//
 		// During our security audit by Quantstamp, this was investigated
 		// and confirmed to be safe and correct.
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, // #nosec G402
 		MinVersion:         tls.VersionTLS13,
 		KeyLogWriter:       keyLogWriter,
 	}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -32,9 +32,7 @@ fi
 TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func"}
 
 function test_golangci_lint {
-  # We use the commit hash (dc2815312726b4f374f5c69a1c183a85990917a7) to reference the specific version (v1.58.1) used in our build process.
-  # This guarantees a known-good and verifiable version. Unlike releases, commits cannot be altered or deleted after they are made, providing a more reliable reference point for our build system.
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@dc2815312726b4f374f5c69a1c183a85990917a7
+  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.1
   golangci-lint run --config .golangci.yml
 }
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -32,7 +32,9 @@ fi
 TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func"}
 
 function test_golangci_lint {
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
+  # We use the commit hash (dc2815312726b4f374f5c69a1c183a85990917a7) to reference the specific version (v1.58.1) used in our build process.
+  # This guarantees a known-good and verifiable version. Unlike releases, commits cannot be altered or deleted after they are made, providing a more reliable reference point for our build system.
+  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@dc2815312726b4f374f5c69a1c183a85990917a7
   golangci-lint run --config .golangci.yml
 }
 

--- a/vms/platformvm/txs/executor/import_test.go
+++ b/vms/platformvm/txs/executor/import_test.go
@@ -39,7 +39,8 @@ func TestNewImportTx(t *testing.T) {
 	require.NoError(t, err)
 
 	customAssetID := ids.GenerateTestID()
-
+	// generate a constant random source generator.
+	randSrc := rand.NewSource(0)
 	tests := []test{
 		{
 			description:   "can't pay fee",
@@ -52,6 +53,7 @@ func TestNewImportTx(t *testing.T) {
 				map[ids.ID]uint64{
 					env.ctx.AVAXAssetID: env.config.TxFee - 1,
 				},
+				randSrc,
 			),
 			sourceKeys:  []*secp256k1.PrivateKey{sourceKey},
 			expectedErr: builder.ErrInsufficientFunds,
@@ -67,6 +69,7 @@ func TestNewImportTx(t *testing.T) {
 				map[ids.ID]uint64{
 					env.ctx.AVAXAssetID: env.config.TxFee,
 				},
+				randSrc,
 			),
 			sourceKeys:  []*secp256k1.PrivateKey{sourceKey},
 			expectedErr: nil,
@@ -82,6 +85,7 @@ func TestNewImportTx(t *testing.T) {
 				map[ids.ID]uint64{
 					env.ctx.AVAXAssetID: env.config.TxFee,
 				},
+				randSrc,
 			),
 			sourceKeys:  []*secp256k1.PrivateKey{sourceKey},
 			timestamp:   env.config.UpgradeConfig.ApricotPhase5Time,
@@ -99,6 +103,7 @@ func TestNewImportTx(t *testing.T) {
 					env.ctx.AVAXAssetID: env.config.TxFee,
 					customAssetID:       1,
 				},
+				randSrc,
 			),
 			sourceKeys:  []*secp256k1.PrivateKey{sourceKey},
 			timestamp:   env.config.UpgradeConfig.ApricotPhase5Time,
@@ -168,6 +173,7 @@ func fundedSharedMemory(
 	sourceKey *secp256k1.PrivateKey,
 	peerChain ids.ID,
 	assets map[ids.ID]uint64,
+	randSrc rand.Source,
 ) atomic.SharedMemory {
 	fundedSharedMemoryCalls++
 	m := atomic.NewMemory(prefixdb.New([]byte{fundedSharedMemoryCalls}, env.baseDB))
@@ -180,7 +186,7 @@ func fundedSharedMemory(
 		utxo := &avax.UTXO{
 			UTXOID: avax.UTXOID{
 				TxID:        ids.GenerateTestID(),
-				OutputIndex: rand.Uint32(),
+				OutputIndex: uint32(randSrc.Int63()),
 			},
 			Asset: avax.Asset{ID: assetID},
 			Out: &secp256k1fx.TransferOutput{

--- a/vms/platformvm/txs/executor/import_test.go
+++ b/vms/platformvm/txs/executor/import_test.go
@@ -182,7 +182,6 @@ func fundedSharedMemory(
 	peerSharedMemory := m.NewSharedMemory(peerChain)
 
 	for assetID, amt := range assets {
-		// #nosec G404
 		utxo := &avax.UTXO{
 			UTXOID: avax.UTXOID{
 				TxID:        ids.GenerateTestID(),

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"errors"
 	"math"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -1185,6 +1186,7 @@ func TestDurangoMemoField(t *testing.T) {
 					map[ids.ID]uint64{
 						env.ctx.AVAXAssetID: sourceAmount,
 					},
+					rand.NewSource(0),
 				)
 				env.msm.SharedMemory = sharedMemory
 


### PR DESCRIPTION
## Why this should be merged
This PR updates the golangci-lint tool to it's latest release (1.58.1).
In addition it resolves the newly detected issues.

## How this works
Nothing really notable here.
1. The linter configuration file is using `exclude-dirs-use-default` instead of the deprecated `skip-dirs-use-default`.
2. The new gosec requires that the suppress annotation would be on the same line.
3. The fundedSharedMemory used to use a random number. While it's logic is correct, it might randomly fail due to this random number generator. I've switch that to use a fixed-random-source to address this.
4. I've updated the linter version.

## How this was tested

Tested manually as well as using github actions.
