### PR TITLE
fix broken link.

### DIFF
--- a/api/admin/service.md
+++ b/api/admin/service.md
@@ -75,7 +75,7 @@ Now, calls to the X-Chain can be made to either `/ext/bc/X` or, equivalently, to
 
 Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used.
 
-:::note Aliasing a chain can also be done via the [Node API](https://docs.avax.network/nodes/configure/avalanchego-config-flags.md#--chain-aliases-file-string).
+:::note Aliasing a chain can also be done via the [Node API](/nodes/configure/avalanchego-config-flags.md#--chain-aliases-file-string).
 Note that the alias is set for each chain on each node individually. In a multi-node Subnet, the
 same alias should be configured on each node to use an alias across a Subnet successfully. Setting
 an alias for a chain on one node does not register that alias with other nodes automatically.


### PR DESCRIPTION
Note: the original link breaks because of additional ".md" in its path. As communicated [here](https://github.com/ava-labs/avalanchego/pull/3027#pullrequestreview-2065099431), the paths in the service.md file is set intentionally to local paths, so I replaced the original link with a local path. 

if any changes need to be made, kindly tell me.

## Why this should be merged
one broken link was fixed.

## How this works
by replacing the broken link with the right link.

## How this was tested
by manually checking if the replaced link works.