### PR TITLE
`gossipping` -> `gossiping`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3018,7 +3018,7 @@ This version is backwards compatible to [v1.7.0](https://github.com/ava-labs/ava
 
 ### Networking
 
-- Reduced default peerlist and accepted frontier gossipping
+- Reduced default peerlist and accepted frontier gossiping
 - Increased the default at-large outbound buffer size to 32 MiB
 
 ### Metrics
@@ -3100,7 +3100,7 @@ This version is backwards compatible to [v1.7.0](https://github.com/ava-labs/ava
 - Added `--snow-mixed-query-num-push-vdr` and `--snow-mixed-query-num-push-non-vdr` to allow parameterization of sending push queries
   - By default, non-validators now send only pull queries, not push queries.
   - By default, validators now send both pull queries and push queries upon inserting a container into consensus. Previously, nodes sent only push queries.
-- Added metrics to track the amount of over gossipping of `peerlist` messages
+- Added metrics to track the amount of over gossiping of `peerlist` messages
 - Added custom message queueing support to outbound `Peer` messages
 - Reused `Ping` messages to avoid needless memory allocations
 

--- a/node/node.go
+++ b/node/node.go
@@ -504,7 +504,7 @@ func (n *Node) initNetworking() error {
 		}
 	}
 	if unknownACPs.Len() > 0 {
-		n.Log.Warn("gossipping unknown ACPs",
+		n.Log.Warn("gossiping unknown ACPs",
 			zap.Reflect("acps", unknownACPs),
 		)
 	}

--- a/snow/README.md
+++ b/snow/README.md
@@ -47,7 +47,7 @@ Currently, Avalanchego implements its own message serialization to communicate. 
 
 ### [Network](https://github.com/ava-labs/avalanchego/blob/master/network/network.go)
 
-The networking interface is shared across all chains. It implements functions from the `ExternalSender` interface. The two functions it implements are `Send` and `Gossip`. `Send` sends a message of type `OutboundMessage` to a specific set of nodes (specified by an array of `NodeIDs`). `Gossip` sends a message of type `OutboundMessage` to a random group of nodes in a subnet (can be a validator or a non-validator). Gossipping is used to push transactions across the network. The networking protocol uses TLS to pass messages between peers.
+The networking interface is shared across all chains. It implements functions from the `ExternalSender` interface. The two functions it implements are `Send` and `Gossip`. `Send` sends a message of type `OutboundMessage` to a specific set of nodes (specified by an array of `NodeIDs`). `Gossip` sends a message of type `OutboundMessage` to a random group of nodes in a subnet (can be a validator or a non-validator). gossiping is used to push transactions across the network. The networking protocol uses TLS to pass messages between peers.
 
 Along with sending and gossiping, the networking library is also responsible for making connections and maintaining connections. Any node whether they are a validator or non-validator will attempt to connect to the primary network.
 


### PR DESCRIPTION
## Why this should be merged

Let's align on `gossiping` :)

## How this works

find + replace

## How this was tested

CI