### PR TITLE
Enable gossiping of newer IPs when connected to an older IP

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -173,7 +173,6 @@ A `GetPeerList` message contains the Bloom Filter of the currently known peers a
 `PeerList` messages are expected to contain `IP:Port` pairs that satisfy all of the following constraints:
 - The Bloom Filter sent when requesting the `PeerList` message does not contain the node claiming the `IP:Port` pair.
 - The node claiming the `IP:Port` pair is currently connected.
-- The `IP:Port` pair the node shared during the `Handshake` message is the node's most recently known `IP:Port` pair.
 - The node claiming the `IP:Port` pair is either in the default bootstrapper set, is a current Primary Network validator, is a validator of a tracked Subnet, or is a validator of a Subnet and the peer is a Primary Network validator.
 
 #### Example PeerList Gossip

--- a/network/ip_tracker.go
+++ b/network/ip_tracker.go
@@ -477,11 +477,9 @@ func (i *ipTracker) addGossipableID(nodeID ids.NodeID, subnetID ids.ID, manually
 		return
 	}
 
-	if trackedNode, ok := i.tracked[nodeID]; !ok || trackedNode.ip == nil || trackedNode.ip.Timestamp != node.ip.Timestamp {
-		return
+	if trackedNode, ok := i.tracked[nodeID]; ok {
+		subnet.setGossipableIP(trackedNode.ip)
 	}
-
-	subnet.setGossipableIP(node.ip)
 }
 
 func (*ipTracker) OnValidatorWeightChanged(ids.ID, ids.NodeID, uint64, uint64) {}

--- a/network/ip_tracker_test.go
+++ b/network/ip_tracker_test.go
@@ -544,13 +544,9 @@ func TestIPTracker_AddIP(t *testing.T) {
 			ip:                        newerIP,
 			expectedUpdatedAndDesired: true,
 			expectedChange: func(tracker *ipTracker) {
-				tracker.numGossipableIPs.Dec()
 				tracker.tracked[newerIP.NodeID].ip = newerIP
 				tracker.bloomAdditions[newerIP.NodeID] = 2
-
-				subnet := tracker.subnet[constants.PrimaryNetworkID]
-				delete(subnet.gossipableIndices, newerIP.NodeID)
-				subnet.gossipableIPs = subnet.gossipableIPs[:0]
+				tracker.subnet[constants.PrimaryNetworkID].gossipableIPs[0] = newerIP
 			},
 		},
 		{
@@ -566,10 +562,6 @@ func TestIPTracker_AddIP(t *testing.T) {
 			expectedChange: func(tracker *ipTracker) {
 				tracker.tracked[newerIP.NodeID].ip = newerIP
 				tracker.bloomAdditions[newerIP.NodeID] = 2
-
-				subnet := tracker.subnet[subnetID]
-				delete(subnet.gossipableIndices, newerIP.NodeID)
-				subnet.gossipableIPs = subnet.gossipableIPs[:0]
 			},
 		},
 	}
@@ -659,9 +651,16 @@ func TestIPTracker_Connected(t *testing.T) {
 			},
 			ip: ip,
 			expectedChange: func(tracker *ipTracker) {
+				tracker.numGossipableIPs.Inc()
 				tracker.connected[ip.NodeID] = &connectedNode{
 					trackedSubnets: set.Of(constants.PrimaryNetworkID),
 					ip:             ip,
+				}
+
+				subnet := tracker.subnet[constants.PrimaryNetworkID]
+				subnet.gossipableIndices[newerIP.NodeID] = 0
+				subnet.gossipableIPs = []*ips.ClaimedIPPort{
+					newerIP,
 				}
 			},
 		},

--- a/network/ip_tracker_test.go
+++ b/network/ip_tracker_test.go
@@ -933,12 +933,18 @@ func TestIPTracker_OnValidatorAdded(t *testing.T) {
 			},
 			subnetID: constants.PrimaryNetworkID,
 			expectedChange: func(tracker *ipTracker) {
+				tracker.numGossipableIPs.Inc()
 				tracker.tracked[ip.NodeID].subnets.Add(constants.PrimaryNetworkID)
 				tracker.tracked[ip.NodeID].trackedSubnets.Add(constants.PrimaryNetworkID)
 				tracker.subnet[constants.PrimaryNetworkID] = &gossipableSubnet{
-					numGossipableIPs:  tracker.numGossipableIPs,
-					gossipableIDs:     set.Of(ip.NodeID),
-					gossipableIndices: make(map[ids.NodeID]int),
+					numGossipableIPs: tracker.numGossipableIPs,
+					gossipableIDs:    set.Of(ip.NodeID),
+					gossipableIndices: map[ids.NodeID]int{
+						ip.NodeID: 0,
+					},
+					gossipableIPs: []*ips.ClaimedIPPort{
+						newerIP,
+					},
 				}
 			},
 		},


### PR DESCRIPTION
## Why this should be merged

Simplifies the restrictions on IP gossip.

Fixes a logical race where a peer may connect and claim an IP that doesn't match their actual IP because they haven't noticed that it changed yet.

## How this works

Remove the restriction that in order to gossip an IP the node must be connected with that IP (and that that IP is the most recent IP).

## How this was tested

- [X] Updated unit tests