### PR TITLE
Manually compact during bootstrapping iteration

### DIFF
--- a/snow/engine/snowman/bootstrap/storage.go
+++ b/snow/engine/snowman/bootstrap/storage.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	batchWritePeriod      = 64
-	iteratorReleasePeriod = 25_000
+	iteratorReleasePeriod = 50_000
 	logPeriod             = 5 * time.Second
 	minBlocksToCompact    = 5000
 )

--- a/snow/engine/snowman/bootstrap/storage.go
+++ b/snow/engine/snowman/bootstrap/storage.go
@@ -139,7 +139,9 @@ func execute(
 		log("compacting database before executing blocks...")
 		if err := db.Compact(nil, nil); err != nil {
 			// Not a fatal error, log and move on.
-			log("failed to compact bootstrap database before executing blocks", zap.Error(err))
+			log("failed to compact bootstrap database before executing blocks",
+				zap.Error(err),
+			)
 		}
 	}
 
@@ -206,8 +208,17 @@ func execute(
 				return err
 			}
 
+			lastProcessedKey := iterator.Key()
 			processedSinceIteratorRelease = 0
 			iterator.Release()
+
+			if err := db.Compact(nil, lastProcessedKey); err != nil {
+				// Not a fatal error, log and move on.
+				log("failed to compact bootstrap database before grabbing new iterator",
+					zap.Error(err),
+				)
+			}
+
 			iterator = interval.GetBlockIterator(db)
 		}
 

--- a/snow/engine/snowman/bootstrap/storage.go
+++ b/snow/engine/snowman/bootstrap/storage.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	batchWritePeriod      = 64
-	iteratorReleasePeriod = 50_000
+	iteratorReleasePeriod = 100_000
 	logPeriod             = 5 * time.Second
 	minBlocksToCompact    = 5000
 )

--- a/snow/engine/snowman/bootstrap/storage.go
+++ b/snow/engine/snowman/bootstrap/storage.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	batchWritePeriod      = 64
-	iteratorReleasePeriod = 1024
+	iteratorReleasePeriod = 25_000
 	logPeriod             = 5 * time.Second
 	minBlocksToCompact    = 5000
 )


### PR DESCRIPTION
## Why this should be merged

When introducing the interval tree into bootstrapping, the database was designed to support iteration rather than random reads to improve querying performance. However, it appears that holding the the iterator prevents compaction from occurring in a timely manner. Over time (after executing > 1M blocks) the iteration starts to slow down significantly. By manually compacting the database periodically, we manage to avoid this slowdown.

## How this works

Periodically calls `Compact` every 128 iterator releases.

## How this was tested

- [X] CI
- [X] Syncing mainnet P-chain with this code finished execution in ~`6h`. Running master executed `9.1M` of the blocks (out of `13.7M`) in `30h 22m`