### PR TITLE
[antithesis] Ensure node image is pushed

### DIFF
--- a/scripts/build_antithesis_images.sh
+++ b/scripts/build_antithesis_images.sh
@@ -61,12 +61,16 @@ function build_images {
     docker_cmd="${docker_cmd} --build-arg AVALANCHEGO_NODE_IMAGE=antithesis-avalanchego-node:${TAG}"
   fi
 
-  # Build node image first to allow the workload image to use it.
-  ${docker_cmd} -t "${node_image_name}" -f "${node_dockerfile}" "${AVALANCHE_PATH}"
-  if [[ -n "${image_prefix}" ]]; then
-    # Push images with an image prefix since the prefix defines a registry location
+  if [[ -n "${image_prefix}" && -z "${node_only}" ]]; then
+    # Push images with an image prefix since the prefix defines a
+    # registry location, and only if building all images. When
+    # building just the node image the image is only intended to be
+    # used locally.
     docker_cmd="${docker_cmd} --push"
   fi
+
+  # Build node image first to allow the workload image to use it.
+  ${docker_cmd} -t "${node_image_name}" -f "${node_dockerfile}" "${AVALANCHE_PATH}"
 
   if [[ -n "${node_only}" ]]; then
     # Skip building the config and workload images. Supports building the avalanchego


### PR DESCRIPTION
## Why this should be merged

The recent [xsvm test setup PR](https://github.com/ava-labs/avalanchego/pull/2982) configured push after building the node image, which prevented push of node images for either setup. 

## How this works

This PR enables push when building images with an image prefix and when building all images. When building only the node image - to support xsvm and subnet-evm - the image is only used locally and doesn't need to be pushed.

## How this was tested

CI passes, but this PR will need to merge to validate push. Not sure its worth adding a local registry to validate the push itself.