### PR TITLE
Fix typo fix

### DIFF
--- a/snow/README.md
+++ b/snow/README.md
@@ -47,7 +47,7 @@ Currently, Avalanchego implements its own message serialization to communicate. 
 
 ### [Network](https://github.com/ava-labs/avalanchego/blob/master/network/network.go)
 
-The networking interface is shared across all chains. It implements functions from the `ExternalSender` interface. The two functions it implements are `Send` and `Gossip`. `Send` sends a message of type `OutboundMessage` to a specific set of nodes (specified by an array of `NodeIDs`). `Gossip` sends a message of type `OutboundMessage` to a random group of nodes in a subnet (can be a validator or a non-validator). gossiping is used to push transactions across the network. The networking protocol uses TLS to pass messages between peers.
+The networking interface is shared across all chains. It implements functions from the `ExternalSender` interface. The two functions it implements are `Send` and `Gossip`. `Send` sends a message of type `OutboundMessage` to a specific set of nodes (specified by an array of `NodeIDs`). `Gossip` sends a message of type `OutboundMessage` to a random group of nodes in a subnet (can be a validator or a non-validator). Gossiping is used to push transactions across the network. The networking protocol uses TLS to pass messages between peers.
 
 Along with sending and gossiping, the networking library is also responsible for making connections and maintaining connections. Any node whether they are a validator or non-validator will attempt to connect to the primary network.
 


### PR DESCRIPTION
## Why this should be merged

`gossiping` should be capitalized.

## How this works

## How this was tested

N/A