### PR TITLE
Grab iterator at previously executed height

### DIFF
--- a/snow/engine/snowman/bootstrap/interval/state.go
+++ b/snow/engine/snowman/bootstrap/interval/state.go
@@ -78,6 +78,16 @@ func GetBlockIterator(db database.Iteratee) database.Iterator {
 	return db.NewIteratorWithPrefix(blockPrefix)
 }
 
+// GetBlockIterator returns a block iterator that will produce values
+// corresponding to persisted blocks in order of increasing height starting at
+// [height].
+func GetBlockIteratorWithStart(db database.Iteratee, height uint64) database.Iterator {
+	return db.NewIteratorWithStartAndPrefix(
+		makeBlockKey(height),
+		blockPrefix,
+	)
+}
+
 func GetBlock(db database.KeyValueReader, height uint64) ([]byte, error) {
 	return db.Get(makeBlockKey(height))
 }

--- a/snow/engine/snowman/bootstrap/storage.go
+++ b/snow/engine/snowman/bootstrap/storage.go
@@ -139,7 +139,9 @@ func execute(
 		log("compacting database before executing blocks...")
 		if err := db.Compact(nil, nil); err != nil {
 			// Not a fatal error, log and move on.
-			log("failed to compact bootstrap database before executing blocks", zap.Error(err))
+			log("failed to compact bootstrap database before executing blocks",
+				zap.Error(err),
+			)
 		}
 	}
 
@@ -167,6 +169,22 @@ func execute(
 	)
 	defer func() {
 		iterator.Release()
+
+		log("compacting database after executing blocks...")
+		if err := db.Compact(nil, nil); err != nil {
+			// Not a fatal error, log and move on.
+			log("failed to compact bootstrap database after executing blocks",
+				zap.Error(err),
+			)
+		}
+
+		numProcessed := totalNumberToProcess - tree.Len()
+		log("executed blocks",
+			zap.Uint64("numExecuted", numProcessed),
+			zap.Uint64("numToExecute", totalNumberToProcess),
+			zap.Bool("halted", haltable.Halted()),
+			zap.Duration("duration", time.Since(startTime)),
+		)
 	}()
 
 	log("executing blocks",
@@ -208,7 +226,7 @@ func execute(
 
 			processedSinceIteratorRelease = 0
 			iterator.Release()
-			iterator = interval.GetBlockIterator(db)
+			iterator = interval.GetBlockIteratorWithStart(db, height)
 		}
 
 		if now := time.Now(); now.After(timeOfNextLog) {
@@ -248,16 +266,5 @@ func execute(
 	if err := writeBatch(); err != nil {
 		return err
 	}
-	if err := iterator.Error(); err != nil {
-		return err
-	}
-
-	numProcessed := totalNumberToProcess - tree.Len()
-	log("executed blocks",
-		zap.Uint64("numExecuted", numProcessed),
-		zap.Uint64("numToExecute", totalNumberToProcess),
-		zap.Bool("halted", haltable.Halted()),
-		zap.Duration("duration", time.Since(startTime)),
-	)
-	return nil
+	return iterator.Error()
 }


### PR DESCRIPTION
## Why this should be merged

Internally the disk may not have deleted the blocks yet when we grab a new iterator. If that happens, we would previously iterate over all the previously deleted blocks on the first call to `.Next()`.

## How this works

By specifying the start key, we can avoid iterating over deleted (but not garbage collected) entries.

## How this was tested

- [X] CI
- [X] Syncing mainnet P-chain with this code finished execution in ~`6h`. Running master executed `9.1M` of the blocks (out of `13.7M`) in `30h 22m`