### PR TITLE
[vms/platformvm] Return the correct owner in `platform.GetSubnets` after transfer

### DIFF
--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -545,9 +545,6 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 			}
 
 			subnetOwner, err := s.vm.state.GetSubnetOwner(subnetID)
-			if err == database.ErrNotFound {
-				continue
-			}
 			if err != nil {
 				return err
 			}

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -544,15 +544,26 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 				continue
 			}
 
-			unsignedTx := subnet.Unsigned.(*txs.CreateSubnetTx)
-			owner := unsignedTx.Owner.(*secp256k1fx.OutputOwners)
-			controlAddrs := []string{}
-			for _, controlKeyID := range owner.Addrs {
+			subnetOwner, err := s.vm.state.GetSubnetOwner(subnetID)
+			if err == database.ErrNotFound {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+
+			owner, ok := subnetOwner.(*secp256k1fx.OutputOwners)
+			if !ok {
+				return fmt.Errorf("expected *secp256k1fx.OutputOwners but got %T", subnetOwner)
+			}
+
+			controlAddrs := make([]string, len(owner.Addrs))
+			for i, controlKeyID := range owner.Addrs {
 				addr, err := s.addrManager.FormatLocalAddress(controlKeyID)
 				if err != nil {
 					return fmt.Errorf("problem formatting address: %w", err)
 				}
-				controlAddrs = append(controlAddrs, addr)
+				controlAddrs[i] = addr
 			}
 			response.Subnets[i] = APISubnet{
 				ID:          subnetID,


### PR DESCRIPTION
## Why this should be merged

Fixes #3012 

## How this works

Uses `GetSubnetOwner` like we do when a single subnetID is passed in

## How this was tested

Added a UT that fails on master