### PR TITLE
[vms/platformvm] Replace `GetSubnets` with `GetSubnetIDs` in `State`

### DIFF
--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -544,15 +544,26 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 				continue
 			}
 
-			unsignedTx := subnet.Unsigned.(*txs.CreateSubnetTx)
-			owner := unsignedTx.Owner.(*secp256k1fx.OutputOwners)
-			controlAddrs := []string{}
-			for _, controlKeyID := range owner.Addrs {
+			subnetOwner, err := s.vm.state.GetSubnetOwner(subnetID)
+			if err == database.ErrNotFound {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+
+			owner, ok := subnetOwner.(*secp256k1fx.OutputOwners)
+			if !ok {
+				return fmt.Errorf("expected *secp256k1fx.OutputOwners but got %T", subnetOwner)
+			}
+
+			controlAddrs := make([]string, len(owner.Addrs))
+			for i, controlKeyID := range owner.Addrs {
 				addr, err := s.addrManager.FormatLocalAddress(controlKeyID)
 				if err != nil {
 					return fmt.Errorf("problem formatting address: %w", err)
 				}
-				controlAddrs = append(controlAddrs, addr)
+				controlAddrs[i] = addr
 			}
 			response.Subnets[i] = APISubnet{
 				ID:          subnetID,

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -527,14 +527,13 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 
 	getAll := len(args.IDs) == 0
 	if getAll {
-		subnets, err := s.vm.state.GetSubnets() // all subnets
+		subnetIDs, err := s.vm.state.GetSubnetIDs() // all subnets
 		if err != nil {
 			return fmt.Errorf("error getting subnets from database: %w", err)
 		}
 
-		response.Subnets = make([]APISubnet, len(subnets)+1)
-		for i, subnet := range subnets {
-			subnetID := subnet.ID()
+		response.Subnets = make([]APISubnet, len(subnetIDs)+1)
+		for i, subnetID := range subnetIDs {
 			if _, err := s.vm.state.GetSubnetTransformation(subnetID); err == nil {
 				response.Subnets[i] = APISubnet{
 					ID:          subnetID,
@@ -572,7 +571,7 @@ func (s *Service) GetSubnets(_ *http.Request, args *GetSubnetsArgs, response *Ge
 			}
 		}
 		// Include primary network
-		response.Subnets[len(subnets)] = APISubnet{
+		response.Subnets[len(subnetIDs)] = APISubnet{
 			ID:          constants.PrimaryNetworkID,
 			ControlKeys: []string{},
 			Threshold:   avajson.Uint32(0),
@@ -1237,14 +1236,13 @@ func (s *Service) GetBlockchains(_ *http.Request, _ *struct{}, response *GetBloc
 	s.vm.ctx.Lock.Lock()
 	defer s.vm.ctx.Lock.Unlock()
 
-	subnets, err := s.vm.state.GetSubnets()
+	subnetIDs, err := s.vm.state.GetSubnetIDs()
 	if err != nil {
 		return fmt.Errorf("couldn't retrieve subnets: %w", err)
 	}
 
 	response.Blockchains = []APIBlockchain{}
-	for _, subnet := range subnets {
-		subnetID := subnet.ID()
+	for _, subnetID := range subnetIDs {
 		chains, err := s.vm.state.GetChains(subnetID)
 		if err != nil {
 			return fmt.Errorf(

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -43,7 +43,7 @@ type diff struct {
 	modifiedDelegateeRewards map[ids.ID]map[ids.NodeID]uint64
 	pendingStakerDiffs       diffStakers
 
-	addedSubnets []*txs.Tx
+	addedSubnetIDs []ids.ID
 	// Subnet ID --> Owner of the subnet
 	subnetOwners map[ids.ID]fx.Owner
 	// Subnet ID --> Tx that transforms the subnet
@@ -272,8 +272,8 @@ func (d *diff) GetPendingStakerIterator() (StakerIterator, error) {
 	return d.pendingStakerDiffs.GetStakerIterator(parentIterator), nil
 }
 
-func (d *diff) AddSubnet(createSubnetTx *txs.Tx) {
-	d.addedSubnets = append(d.addedSubnets, createSubnetTx)
+func (d *diff) AddSubnet(createSubnetTxID ids.ID) {
+	d.addedSubnetIDs = append(d.addedSubnetIDs, createSubnetTxID)
 }
 
 func (d *diff) GetSubnetOwner(subnetID ids.ID) (fx.Owner, error) {
@@ -451,8 +451,8 @@ func (d *diff) Apply(baseState Chain) error {
 			}
 		}
 	}
-	for _, subnet := range d.addedSubnets {
-		baseState.AddSubnet(subnet)
+	for _, subnetID := range d.addedSubnetIDs {
+		baseState.AddSubnet(subnetID)
 	}
 	for _, tx := range d.transformedSubnets {
 		baseState.AddSubnetTransformation(tx)

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -272,8 +272,8 @@ func (d *diff) GetPendingStakerIterator() (StakerIterator, error) {
 	return d.pendingStakerDiffs.GetStakerIterator(parentIterator), nil
 }
 
-func (d *diff) AddSubnet(createSubnetTxID ids.ID) {
-	d.addedSubnetIDs = append(d.addedSubnetIDs, createSubnetTxID)
+func (d *diff) AddSubnet(subnetID ids.ID) {
+	d.addedSubnetIDs = append(d.addedSubnetIDs, subnetID)
 }
 
 func (d *diff) GetSubnetOwner(subnetID ids.ID) (fx.Owner, error) {

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -260,11 +260,11 @@ func TestDiffSubnet(t *testing.T) {
 	state.AddSubnet(parentStateCreateSubnetTx)
 
 	// Verify parent returns one subnet
-	subnets, err := state.GetSubnets()
+	subnetIDs, err := state.GetSubnetIDs()
 	require.NoError(err)
-	require.Equal([]*txs.Tx{
-		parentStateCreateSubnetTx,
-	}, subnets)
+	require.Equal([]ids.ID{
+		parentStateCreateSubnetTx.ID(),
+	}, subnetIDs)
 
 	states := NewMockVersions(ctrl)
 	lastAcceptedID := ids.GenerateTestID()
@@ -285,12 +285,12 @@ func TestDiffSubnet(t *testing.T) {
 	require.NoError(diff.Apply(state))
 
 	// Verify parent now returns two subnets
-	subnets, err = state.GetSubnets()
+	subnetIDs, err = state.GetSubnetIDs()
 	require.NoError(err)
-	require.Equal([]*txs.Tx{
-		parentStateCreateSubnetTx,
-		createSubnetTx,
-	}, subnets)
+	require.Equal([]ids.ID{
+		parentStateCreateSubnetTx.ID(),
+		createSubnetTx.ID(),
+	}, subnetIDs)
 }
 
 func TestDiffChain(t *testing.T) {

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -257,7 +257,7 @@ func TestDiffSubnet(t *testing.T) {
 			Owner: fx.NewMockOwner(ctrl),
 		},
 	}
-	state.AddSubnet(parentStateCreateSubnetTx)
+	state.AddSubnet(parentStateCreateSubnetTx.ID())
 
 	// Verify parent returns one subnet
 	subnetIDs, err := state.GetSubnetIDs()
@@ -279,7 +279,7 @@ func TestDiffSubnet(t *testing.T) {
 			Owner: fx.NewMockOwner(ctrl),
 		},
 	}
-	diff.AddSubnet(createSubnetTx)
+	diff.AddSubnet(createSubnetTx.ID())
 
 	// Apply diff to parent state
 	require.NoError(diff.Apply(state))
@@ -547,7 +547,7 @@ func TestDiffSubnetOwner(t *testing.T) {
 	require.ErrorIs(err, database.ErrNotFound)
 	require.Nil(owner)
 
-	state.AddSubnet(createSubnetTx)
+	state.AddSubnet(subnetID)
 	state.SetSubnetOwner(subnetID, owner1)
 
 	owner, err = state.GetSubnetOwner(subnetID)
@@ -610,7 +610,7 @@ func TestDiffStacking(t *testing.T) {
 	require.ErrorIs(err, database.ErrNotFound)
 	require.Nil(owner)
 
-	state.AddSubnet(createSubnetTx)
+	state.AddSubnet(subnetID)
 	state.SetSubnetOwner(subnetID, owner1)
 
 	owner, err = state.GetSubnetOwner(subnetID)

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -1410,6 +1410,21 @@ func (mr *MockStateMockRecorder) GetStatelessBlock(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatelessBlock", reflect.TypeOf((*MockState)(nil).GetStatelessBlock), arg0)
 }
 
+// GetSubnetIDs mocks base method.
+func (m *MockState) GetSubnetIDs() ([]ids.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubnetIDs")
+	ret0, _ := ret[0].([]ids.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubnetIDs indicates an expected call of GetSubnetIDs.
+func (mr *MockStateMockRecorder) GetSubnetIDs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetIDs", reflect.TypeOf((*MockState)(nil).GetSubnetIDs))
+}
+
 // GetSubnetOwner mocks base method.
 func (m *MockState) GetSubnetOwner(arg0 ids.ID) (fx.Owner, error) {
 	m.ctrl.T.Helper()
@@ -1438,21 +1453,6 @@ func (m *MockState) GetSubnetTransformation(arg0 ids.ID) (*txs.Tx, error) {
 func (mr *MockStateMockRecorder) GetSubnetTransformation(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetTransformation", reflect.TypeOf((*MockState)(nil).GetSubnetTransformation), arg0)
-}
-
-// GetSubnets mocks base method.
-func (m *MockState) GetSubnets() ([]*txs.Tx, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubnets")
-	ret0, _ := ret[0].([]*txs.Tx)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSubnets indicates an expected call of GetSubnets.
-func (mr *MockStateMockRecorder) GetSubnets() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnets", reflect.TypeOf((*MockState)(nil).GetSubnets))
 }
 
 // GetTimestamp mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -75,7 +75,7 @@ func (mr *MockChainMockRecorder) AddRewardUTXO(arg0, arg1 any) *gomock.Call {
 }
 
 // AddSubnet mocks base method.
-func (m *MockChain) AddSubnet(arg0 *txs.Tx) {
+func (m *MockChain) AddSubnet(arg0 ids.ID) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddSubnet", arg0)
 }
@@ -523,7 +523,7 @@ func (mr *MockDiffMockRecorder) AddRewardUTXO(arg0, arg1 any) *gomock.Call {
 }
 
 // AddSubnet mocks base method.
-func (m *MockDiff) AddSubnet(arg0 *txs.Tx) {
+func (m *MockDiff) AddSubnet(arg0 ids.ID) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddSubnet", arg0)
 }
@@ -1009,7 +1009,7 @@ func (mr *MockStateMockRecorder) AddStatelessBlock(arg0 any) *gomock.Call {
 }
 
 // AddSubnet mocks base method.
-func (m *MockState) AddSubnet(arg0 *txs.Tx) {
+func (m *MockState) AddSubnet(arg0 ids.ID) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddSubnet", arg0)
 }

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -104,7 +104,7 @@ type Chain interface {
 
 	AddRewardUTXO(txID ids.ID, utxo *avax.UTXO)
 
-	AddSubnet(createSubnetTx *txs.Tx)
+	AddSubnet(createSubnetTxID ids.ID)
 
 	GetSubnetOwner(subnetID ids.ID) (fx.Owner, error)
 	SetSubnetOwner(subnetID ids.ID, owner fx.Owner)
@@ -753,9 +753,7 @@ func (s *state) GetSubnetIDs() ([]ids.ID, error) {
 	return subnetIDs, nil
 }
 
-func (s *state) AddSubnet(createSubnetTx *txs.Tx) {
-	createSubnetTxID := createSubnetTx.ID()
-
+func (s *state) AddSubnet(createSubnetTxID ids.ID) {
 	s.addedSubnetIDs = append(s.addedSubnetIDs, createSubnetTxID)
 	if s.cachedSubnetIDs != nil {
 		s.cachedSubnetIDs = append(s.cachedSubnetIDs, createSubnetTxID)

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -748,9 +748,7 @@ func (s *state) GetSubnetIDs() ([]ids.ID, error) {
 	if err := subnetDBIt.Error(); err != nil {
 		return nil, err
 	}
-	for _, addedSubnetID := range s.addedSubnetIDs {
-		subnetIDs = append(subnetIDs, addedSubnetID)
-	}
+	subnetIDs = append(subnetIDs, s.addedSubnetIDs...)
 	s.cachedSubnetIDs = subnetIDs
 	return subnetIDs, nil
 }

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -104,7 +104,7 @@ type Chain interface {
 
 	AddRewardUTXO(txID ids.ID, utxo *avax.UTXO)
 
-	AddSubnet(createSubnetTxID ids.ID)
+	AddSubnet(subnetID ids.ID)
 
 	GetSubnetOwner(subnetID ids.ID) (fx.Owner, error)
 	SetSubnetOwner(subnetID ids.ID, owner fx.Owner)
@@ -753,10 +753,10 @@ func (s *state) GetSubnetIDs() ([]ids.ID, error) {
 	return subnetIDs, nil
 }
 
-func (s *state) AddSubnet(createSubnetTxID ids.ID) {
-	s.addedSubnetIDs = append(s.addedSubnetIDs, createSubnetTxID)
+func (s *state) AddSubnet(subnetID ids.ID) {
+	s.addedSubnetIDs = append(s.addedSubnetIDs, subnetID)
 	if s.cachedSubnetIDs != nil {
-		s.cachedSubnetIDs = append(s.cachedSubnetIDs, createSubnetTxID)
+		s.cachedSubnetIDs = append(s.cachedSubnetIDs, subnetID)
 	}
 }
 

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -1388,7 +1388,7 @@ func TestStateSubnetOwner(t *testing.T) {
 	require.ErrorIs(err, database.ErrNotFound)
 	require.Nil(owner)
 
-	state.AddSubnet(createSubnetTx)
+	state.AddSubnet(subnetID)
 	state.SetSubnetOwner(subnetID, owner1)
 
 	owner, err = state.GetSubnetOwner(subnetID)

--- a/vms/platformvm/txs/executor/standard_tx_executor.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor.go
@@ -140,7 +140,7 @@ func (e *StandardTxExecutor) CreateSubnetTx(tx *txs.CreateSubnetTx) error {
 	// Produce the UTXOS
 	avax.Produce(e.State, txID, tx.Outs)
 	// Add the new subnet to the database
-	e.State.AddSubnet(e.Tx)
+	e.State.AddSubnet(txID)
 	e.State.SetSubnetOwner(txID, tx.Owner)
 	return nil
 }

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -302,12 +302,12 @@ func (vm *VM) initBlockchains() error {
 			}
 		}
 	} else {
-		subnets, err := vm.state.GetSubnets()
+		subnetIDs, err := vm.state.GetSubnetIDs()
 		if err != nil {
 			return err
 		}
-		for _, subnet := range subnets {
-			if err := vm.createSubnet(subnet.ID()); err != nil {
+		for _, subnetID := range subnetIDs {
+			if err := vm.createSubnet(subnetID); err != nil {
 				return err
 			}
 		}

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -941,6 +941,7 @@ func TestCreateSubnet(t *testing.T) {
 		}),
 	)
 	require.NoError(err)
+	subnetID := createSubnetTx.ID()
 
 	vm.ctx.Lock.Unlock()
 	require.NoError(vm.issueTxFromRPC(createSubnetTx))
@@ -954,21 +955,13 @@ func TestCreateSubnet(t *testing.T) {
 	require.NoError(blk.Accept(context.Background()))
 	require.NoError(vm.SetPreference(context.Background(), vm.manager.LastAccepted()))
 
-	_, txStatus, err := vm.state.GetTx(createSubnetTx.ID())
+	_, txStatus, err := vm.state.GetTx(subnetID)
 	require.NoError(err)
 	require.Equal(status.Committed, txStatus)
 
 	subnetIDs, err := vm.state.GetSubnetIDs()
 	require.NoError(err)
-
-	found := false
-	for _, subnetID := range subnetIDs {
-		if subnetID == createSubnetTx.ID() {
-			found = true
-			break
-		}
-	}
-	require.True(found)
+	require.Contains(subnetIDs, subnetID)
 
 	// Now that we've created a new subnet, add a validator to that subnet
 	startTime := vm.clock.Time().Add(txexecutor.SyncBound).Add(1 * time.Second)
@@ -982,7 +975,7 @@ func TestCreateSubnet(t *testing.T) {
 				End:    uint64(endTime.Unix()),
 				Wght:   defaultWeight,
 			},
-			Subnet: createSubnetTx.ID(),
+			Subnet: subnetID,
 		},
 		[]*secp256k1.PrivateKey{keys[0]},
 	)
@@ -1004,10 +997,10 @@ func TestCreateSubnet(t *testing.T) {
 	require.NoError(err)
 	require.Equal(status.Committed, txStatus)
 
-	_, err = vm.state.GetPendingValidator(createSubnetTx.ID(), nodeID)
+	_, err = vm.state.GetPendingValidator(subnetID, nodeID)
 	require.ErrorIs(err, database.ErrNotFound)
 
-	_, err = vm.state.GetCurrentValidator(createSubnetTx.ID(), nodeID)
+	_, err = vm.state.GetCurrentValidator(subnetID, nodeID)
 	require.NoError(err)
 
 	// fast forward clock to time validator should stop validating
@@ -1017,10 +1010,10 @@ func TestCreateSubnet(t *testing.T) {
 	require.NoError(blk.Verify(context.Background()))
 	require.NoError(blk.Accept(context.Background())) // remove validator from current validator set
 
-	_, err = vm.state.GetPendingValidator(createSubnetTx.ID(), nodeID)
+	_, err = vm.state.GetPendingValidator(subnetID, nodeID)
 	require.ErrorIs(err, database.ErrNotFound)
 
-	_, err = vm.state.GetCurrentValidator(createSubnetTx.ID(), nodeID)
+	_, err = vm.state.GetCurrentValidator(subnetID, nodeID)
 	require.ErrorIs(err, database.ErrNotFound)
 }
 

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -958,12 +958,12 @@ func TestCreateSubnet(t *testing.T) {
 	require.NoError(err)
 	require.Equal(status.Committed, txStatus)
 
-	subnets, err := vm.state.GetSubnets()
+	subnetIDs, err := vm.state.GetSubnetIDs()
 	require.NoError(err)
 
 	found := false
-	for _, subnet := range subnets {
-		if subnet.ID() == createSubnetTx.ID() {
+	for _, subnetID := range subnetIDs {
+		if subnetID == createSubnetTx.ID() {
 			found = true
 			break
 		}


### PR DESCRIPTION
## Why this should be merged

We don't use the full subnet txs in most places. Let's reduce the amount we store in memory 🧹

## How this works

Modifies `GetSubnets` in the `State` struct to be `GetSubnetIDs`

## How this was tested

CI