### PR TITLE
Add metrics client

### DIFF
--- a/api/metrics/client.go
+++ b/api/metrics/client.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Client for requesting metrics from a remote AvalancheGo instance Info API Client
+type Client struct {
+	uri string
+}
+
+// NewClient returns a new Metrics API Client
+func NewClient(uri string) *Client {
+	return &Client{
+		uri: uri + "/ext/metrics",
+	}
+}
+
+// GetMetrics returns the metrics from the connected node. The metrics are
+// returned as a map of metric family name to the metric family.
+func (c *Client) GetMetrics(ctx context.Context) (map[string]*dto.MetricFamily, error) {
+	uri, err := url.Parse(c.uri)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		uri.String(),
+		bytes.NewReader(nil),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to issue request: %w", err)
+	}
+
+	// Return an error for any non successful status code
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// Drop any error during close to report the original error
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("received status code: %d", resp.StatusCode)
+	}
+
+	var parser expfmt.TextParser
+	metrics, err := parser.TextToMetricFamilies(resp.Body)
+	if err != nil {
+		// Drop any error during close to report the original error
+		_ = resp.Body.Close()
+		return nil, err
+	}
+	return metrics, resp.Body.Close()
+}

--- a/api/metrics/client.go
+++ b/api/metrics/client.go
@@ -15,7 +15,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-// Client for requesting metrics from a remote AvalancheGo instance Info API Client
+// Client for requesting metrics from a remote AvalancheGo instance
 type Client struct {
 	uri string
 }

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/pires/go-proxyproto v0.6.2
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
+	github.com/prometheus/common v0.42.0
 	github.com/rs/cors v1.7.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cast v1.5.0
@@ -136,7 +137,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -246,23 +246,15 @@ RECEIVER  NEW BALANCE (AFTER) : %21d AVAX
 
 					prev := metricsBeforeTx[u]
 
-					currentXBlksProcessing, ok := tests.GetFirstMetricValue(mm, xBlksProcessingMetric)
-					require.True(ok)
-
-					previousXBlksProcessing, ok := tests.GetFirstMetricValue(prev, xBlksProcessingMetric)
-					require.True(ok)
-
 					// +0 since X-chain tx must have been processed and accepted
 					// by now
+					currentXBlksProcessing, _ := tests.GetFirstMetricValue(mm, xBlksProcessingMetric)
+					previousXBlksProcessing, _ := tests.GetFirstMetricValue(prev, xBlksProcessingMetric)
 					require.Equal(currentXBlksProcessing, previousXBlksProcessing)
 
-					currentXBlksAccepted, ok := tests.GetFirstMetricValue(mm, xBlksAcceptedMetric)
-					require.True(ok)
-
-					previousXBlksAccepted, ok := tests.GetFirstMetricValue(prev, xBlksAcceptedMetric)
-					require.True(ok)
-
 					// +1 since X-chain tx must have been accepted by now
+					currentXBlksAccepted, _ := tests.GetFirstMetricValue(mm, xBlksAcceptedMetric)
+					previousXBlksAccepted, _ := tests.GetFirstMetricValue(prev, xBlksAcceptedMetric)
 					require.Equal(currentXBlksAccepted, previousXBlksAccepted+1)
 
 					metricsBeforeTx[u] = mm

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -28,8 +28,8 @@ import (
 const (
 	totalRounds = 50
 
-	metricBlksProcessing = "avalanche_X_blks_processing"
-	metricBlksAccepted   = "avalanche_X_blks_accepted_count"
+	xBlksProcessingMetric = "avalanche_X_blks_processing"
+	xBlksAcceptedMetric   = "avalanche_X_blks_accepted_count"
 )
 
 // This test requires that the network not have ongoing blocks and
@@ -48,10 +48,15 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 			// test avoids the case of a previous test having initiated block
 			// processing but not having completed it.
 			e2e.Eventually(func() bool {
-				allNodeMetrics, err := tests.GetNodesMetrics(rpcEps, metricBlksProcessing)
+				allNodeMetrics, err := tests.GetNodesMetrics(
+					e2e.DefaultContext(),
+					rpcEps,
+				)
 				require.NoError(err)
+
 				for _, metrics := range allNodeMetrics {
-					if metrics[metricBlksProcessing] > 0 {
+					xBlksProcessing, ok := tests.GetFirstMetricValue(metrics, xBlksProcessingMetric)
+					if !ok || xBlksProcessing > 0 {
 						return false
 					}
 				}
@@ -61,11 +66,6 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 				e2e.DefaultPollingInterval,
 				"The cluster is generating ongoing blocks. Is this test being run in parallel?",
 			)
-
-			allMetrics := []string{
-				metricBlksProcessing,
-				metricBlksAccepted,
-			}
 
 			// Ensure the same set of 10 keys is used for all tests
 			// by retrieving them outside of runFunc.
@@ -102,7 +102,10 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 					)
 				}
 
-				metricsBeforeTx, err := tests.GetNodesMetrics(rpcEps, allMetrics...)
+				metricsBeforeTx, err := tests.GetNodesMetrics(
+					e2e.DefaultContext(),
+					rpcEps,
+				)
 				require.NoError(err)
 				for _, uri := range rpcEps {
 					tests.Outf("{{green}}metrics at %q:{{/}} %v\n", uri, metricsBeforeTx[uri])
@@ -238,17 +241,29 @@ RECEIVER  NEW BALANCE (AFTER) : %21d AVAX
 					require.NoError(err)
 					require.Equal(choices.Accepted, status)
 
-					mm, err := tests.GetNodeMetrics(u, allMetrics...)
+					mm, err := tests.GetNodeMetrics(e2e.DefaultContext(), u)
 					require.NoError(err)
 
 					prev := metricsBeforeTx[u]
 
+					currentXBlksProcessing, ok := tests.GetFirstMetricValue(mm, xBlksProcessingMetric)
+					require.True(ok)
+
+					previousXBlksProcessing, ok := tests.GetFirstMetricValue(prev, xBlksProcessingMetric)
+					require.True(ok)
+
 					// +0 since X-chain tx must have been processed and accepted
 					// by now
-					require.Equal(mm[metricBlksProcessing], prev[metricBlksProcessing])
+					require.Equal(currentXBlksProcessing, previousXBlksProcessing)
+
+					currentXBlksAccepted, ok := tests.GetFirstMetricValue(mm, xBlksAcceptedMetric)
+					require.True(ok)
+
+					previousXBlksAccepted, ok := tests.GetFirstMetricValue(prev, xBlksAcceptedMetric)
+					require.True(ok)
 
 					// +1 since X-chain tx must have been accepted by now
-					require.Equal(mm[metricBlksAccepted], prev[metricBlksAccepted]+1)
+					require.Equal(currentXBlksAccepted, previousXBlksAccepted+1)
 
 					metricsBeforeTx[u] = mm
 				}

--- a/tests/http.go
+++ b/tests/http.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"fmt"
 
-	dto "github.com/prometheus/client_model/go"
-
 	"github.com/ava-labs/avalanchego/api/metrics"
+
+	dto "github.com/prometheus/client_model/go"
 )
 
 // "metric name" -> "metric value"

--- a/tests/http.go
+++ b/tests/http.go
@@ -4,33 +4,32 @@
 package tests
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"strconv"
-	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/ava-labs/avalanchego/api/metrics"
 )
 
 // "metric name" -> "metric value"
-type NodeMetrics map[string]float64
+type NodeMetrics map[string]*dto.MetricFamily
 
 // URI -> "metric name" -> "metric value"
 type NodesMetrics map[string]NodeMetrics
 
 // GetNodeMetrics retrieves the specified metrics the provided node URI.
-func GetNodeMetrics(nodeURI string, metricNames ...string) (NodeMetrics, error) {
-	uri := nodeURI + "/ext/metrics"
-	return GetMetricsValue(uri, metricNames...)
+func GetNodeMetrics(ctx context.Context, nodeURI string) (NodeMetrics, error) {
+	client := metrics.NewClient(nodeURI)
+	return client.GetMetrics(ctx)
 }
 
 // GetNodesMetrics retrieves the specified metrics for the provided node URIs.
-func GetNodesMetrics(nodeURIs []string, metricNames ...string) (NodesMetrics, error) {
+func GetNodesMetrics(ctx context.Context, nodeURIs []string) (NodesMetrics, error) {
 	metrics := make(NodesMetrics, len(nodeURIs))
 	for _, u := range nodeURIs {
 		var err error
-		metrics[u], err = GetNodeMetrics(u, metricNames...)
+		metrics[u], err = GetNodeMetrics(ctx, u)
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve metrics for %s: %w", u, err)
 		}
@@ -38,63 +37,19 @@ func GetNodesMetrics(nodeURIs []string, metricNames ...string) (NodesMetrics, er
 	return metrics, nil
 }
 
-func GetMetricsValue(url string, metrics ...string) (map[string]float64, error) {
-	lines, err := getHTTPLines(url)
-	if err != nil {
-		return nil, err
-	}
-	mm := make(map[string]float64, len(metrics))
-	for _, line := range lines {
-		if strings.HasPrefix(line, "# ") {
-			continue
-		}
-		found, name := false, ""
-		for _, name = range metrics {
-			if !strings.HasPrefix(line, name) {
-				continue
-			}
-			found = true
-			break
-		}
-		if !found || name == "" { // no matched metric found
-			continue
-		}
-		ll := strings.Split(line, " ")
-		if len(ll) != 2 {
-			continue
-		}
-		fv, err := strconv.ParseFloat(ll[1], 64)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse %q (%w)", ll, err)
-		}
-		mm[name] = fv
-	}
-	return mm, nil
-}
-
-func getHTTPLines(url string) ([]string, error) {
-	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
+func GetFirstMetricValue(metrics NodeMetrics, name string) (float64, bool) {
+	metricFamily, ok := metrics[name]
+	if !ok || len(metricFamily.Metric) < 1 {
+		return 0, false
 	}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
+	metric := metricFamily.Metric[0]
+	switch {
+	case metric.Gauge != nil:
+		return metric.Gauge.GetValue(), true
+	case metric.Counter != nil:
+		return metric.Counter.GetValue(), true
+	default:
+		return 0, false
 	}
-
-	rd := bufio.NewReader(resp.Body)
-	lines := []string{}
-	for {
-		line, err := rd.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			_ = resp.Body.Close()
-			return nil, err
-		}
-		lines = append(lines, strings.TrimSpace(line))
-	}
-	return lines, resp.Body.Close()
 }


### PR DESCRIPTION
## Why this should be merged

Currently our metrics parsing in the e2e tests is ad-hoc and incomplete. This implements a metrics client for anyone to use and uses it in the e2e tests.

## How this works

^

## How this was tested

- [x] CI