### PR TITLE
Implement `constants.VMName`

### DIFF
--- a/tests/fixture/subnet/xsvm.go
+++ b/tests/fixture/subnet/xsvm.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
-	"github.com/ava-labs/avalanchego/vms/example/xsvm"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/genesis"
 )
 
@@ -35,7 +35,7 @@ func NewXSVMOrPanic(name string, key *secp256k1.PrivateKey, nodes ...*tmpnet.Nod
 		Name: name,
 		Chains: []*tmpnet.Chain{
 			{
-				VMID:         xsvm.ID,
+				VMID:         constants.XSVMID,
 				Genesis:      genesisBytes,
 				PreFundedKey: key,
 			},

--- a/utils/constants/vm_ids.go
+++ b/utils/constants/vm_ids.go
@@ -5,8 +5,37 @@ package constants
 
 import "github.com/ava-labs/avalanchego/ids"
 
+const (
+	PlatformVMName = "platformvm"
+	AVMName        = "avm"
+	EVMName        = "evm"
+	SubnetEVMName  = "subnetevm"
+	XSVMName       = "xsvm"
+)
+
 var (
 	PlatformVMID = ids.ID{'p', 'l', 'a', 't', 'f', 'o', 'r', 'm', 'v', 'm'}
 	AVMID        = ids.ID{'a', 'v', 'm'}
 	EVMID        = ids.ID{'e', 'v', 'm'}
+	SubnetEVMID  = ids.ID{'s', 'u', 'b', 'n', 'e', 't', 'e', 'v', 'm'}
+	XSVMID       = ids.ID{'x', 's', 'v', 'm'}
 )
+
+// VMName returns the name of the VM with the provided ID. If a human readable
+// name isn't known, then the formatted ID is returned.
+func VMName(vmID ids.ID) string {
+	switch vmID {
+	case PlatformVMID:
+		return PlatformVMName
+	case AVMID:
+		return AVMName
+	case EVMID:
+		return EVMName
+	case SubnetEVMID:
+		return SubnetEVMName
+	case XSVMID:
+		return XSVMName
+	default:
+		return vmID.String()
+	}
+}

--- a/vms/example/xsvm/cmd/chain/create/cmd.go
+++ b/vms/example/xsvm/cmd/chain/create/cmd.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/avalanchego/vms/example/xsvm"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
@@ -72,7 +72,7 @@ func createFunc(c *cobra.Command, args []string) error {
 	createChainTxID, err := pWallet.IssueCreateChainTx(
 		config.SubnetID,
 		genesisBytes,
-		xsvm.ID,
+		constants.XSVMID,
 		nil,
 		config.Name,
 		common.WithContext(ctx),

--- a/vms/example/xsvm/cmd/version/cmd.go
+++ b/vms/example/xsvm/cmd/version/cmd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm"
 )
@@ -29,8 +30,8 @@ func Command() *cobra.Command {
 func versionFunc(*cobra.Command, []string) error {
 	fmt.Printf(
 		format,
-		xsvm.Name,
-		xsvm.ID,
+		constants.XSVMName,
+		constants.XSVMID,
 		xsvm.Version,
 		version.RPCChainVMProtocol,
 	)

--- a/vms/example/xsvm/constants.go
+++ b/vms/example/xsvm/constants.go
@@ -3,19 +3,10 @@
 
 package xsvm
 
-import (
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/version"
-)
+import "github.com/ava-labs/avalanchego/version"
 
-const Name = "xsvm"
-
-var (
-	ID = ids.ID{'x', 's', 'v', 'm'}
-
-	Version = &version.Semantic{
-		Major: 1,
-		Minor: 0,
-		Patch: 4,
-	}
-)
+var Version = &version.Semantic{
+	Major: 1,
+	Minor: 0,
+	Patch: 4,
+}

--- a/vms/example/xsvm/vm.go
+++ b/vms/example/xsvm/vm.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/api"
@@ -124,7 +125,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	)
 	return map[string]http.Handler{
 		"": server,
-	}, server.RegisterService(api, Name)
+	}, server.RegisterService(api, constants.XSVMName)
 }
 
 func (*VM) HealthCheck(context.Context) (interface{}, error) {

--- a/wallet/subnet/primary/examples/create-chain/main.go
+++ b/wallet/subnet/primary/examples/create-chain/main.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/avalanchego/vms/example/xsvm"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
 
@@ -33,7 +33,7 @@ func main() {
 			},
 		},
 	}
-	vmID := xsvm.ID
+	vmID := constants.XSVMID
 	name := "let there"
 
 	subnetID, err := ids.FromString(subnetIDStr)


### PR DESCRIPTION
## Why this should be merged

This is factored out of #3053. This function will be used to improve the readability of VM specific metrics.

## How this works

Implements a map from `vmID` to `vmName`.

## How this was tested

N/A