### PR TITLE
Add pebbledb to docs

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -272,7 +272,7 @@ Specifies the directory to which the database is persisted. Defaults to `"$HOME/
 
 ##### `--db-type` (string)
 
-Specifies the type of database to use. Must be one of `LevelDB` or `memdb`.
+Specifies the type of database to use. Must be one of `leveldb`, `memdb`, or `pebbledb`.
 `memdb` is an in-memory, non-persisted database.
 
 :::note

--- a/config/flags.go
+++ b/config/flags.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database/leveldb"
 	"github.com/ava-labs/avalanchego/database/memdb"
-	"github.com/ava-labs/avalanchego/database/pebble"
+	"github.com/ava-labs/avalanchego/database/pebbledb"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowball"
 	"github.com/ava-labs/avalanchego/trace"
@@ -109,7 +109,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Uint64(AddSubnetDelegatorFeeKey, genesis.LocalParams.AddSubnetDelegatorFee, "Transaction fee, in nAVAX, for transactions that add new subnet delegators")
 
 	// Database
-	fs.String(DBTypeKey, leveldb.Name, fmt.Sprintf("Database type to use. Must be one of {%s, %s, %s}", leveldb.Name, memdb.Name, pebble.Name))
+	fs.String(DBTypeKey, leveldb.Name, fmt.Sprintf("Database type to use. Must be one of {%s, %s, %s}", leveldb.Name, memdb.Name, pebbledb.Name))
 	fs.Bool(DBReadOnlyKey, false, "If true, database writes are to memory and never persisted. May still initialize database directory/files on disk if they don't exist")
 	fs.String(DBPathKey, defaultDBDir, "Path to database directory")
 	fs.String(DBConfigFileKey, "", fmt.Sprintf("Path to database config file. Ignored if %s is specified", DBConfigContentKey))

--- a/database/pebbledb/batch.go
+++ b/database/pebbledb/batch.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package pebble
+package pebbledb
 
 import (
 	"fmt"

--- a/database/pebbledb/batch_test.go
+++ b/database/pebbledb/batch_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package pebble
+package pebbledb
 
 import (
 	"testing"

--- a/database/pebbledb/db.go
+++ b/database/pebbledb/db.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package pebble
+package pebbledb
 
 import (
 	"context"
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	Name = "pebble"
+	Name = "pebbledb"
 
 	// pebbleByteOverHead is the number of bytes of constant overhead that
 	// should be added to a batch size per operation.

--- a/database/pebbledb/db_test.go
+++ b/database/pebbledb/db_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package pebble
+package pebbledb
 
 import (
 	"fmt"

--- a/database/pebbledb/iterator.go
+++ b/database/pebbledb/iterator.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package pebble
+package pebbledb
 
 import (
 	"errors"

--- a/node/node.go
+++ b/node/node.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ava-labs/avalanchego/database/leveldb"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/meterdb"
-	"github.com/ava-labs/avalanchego/database/pebble"
+	"github.com/ava-labs/avalanchego/database/pebbledb"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/genesis"
@@ -729,16 +729,16 @@ func (n *Node) initDatabase() error {
 		var err error
 		n.DB, err = leveldb.New(dbPath, n.Config.DatabaseConfig.Config, n.Log, "db_internal", n.MetricsRegisterer)
 		if err != nil {
-			return fmt.Errorf("couldn't create leveldb at %s: %w", dbPath, err)
+			return fmt.Errorf("couldn't create %s at %s: %w", leveldb.Name, dbPath, err)
 		}
 	case memdb.Name:
 		n.DB = memdb.New()
-	case pebble.Name:
-		dbPath := filepath.Join(n.Config.DatabaseConfig.Path, pebble.Name)
+	case pebbledb.Name:
+		dbPath := filepath.Join(n.Config.DatabaseConfig.Path, "pebble")
 		var err error
-		n.DB, err = pebble.New(dbPath, n.Config.DatabaseConfig.Config, n.Log, "db_internal", n.MetricsRegisterer)
+		n.DB, err = pebbledb.New(dbPath, n.Config.DatabaseConfig.Config, n.Log, "db_internal", n.MetricsRegisterer)
 		if err != nil {
-			return fmt.Errorf("couldn't create pebbledb at %s: %w", dbPath, err)
+			return fmt.Errorf("couldn't create %s at %s: %w", pebbledb.Name, dbPath, err)
 		}
 	default:
 		return fmt.Errorf(
@@ -746,7 +746,7 @@ func (n *Node) initDatabase() error {
 			n.Config.DatabaseConfig.Name,
 			leveldb.Name,
 			memdb.Name,
-			pebble.Name,
+			pebbledb.Name,
 		)
 	}
 


### PR DESCRIPTION
## Why this should be merged

Currently `pebbledb` isn't documented as a `db-type`. This adds this documentation and standardizes the name from `pebble` to `pebbledb`.

## How this works

- Updates docs
- Updates some names
- Hardcodes `pebble` as the file path to avoid breaking anyone using the undocumented flag.

## How this was tested

