### PR TITLE
Remove api namespace

### DIFF
--- a/api/metrics/multi_gatherer.go
+++ b/api/metrics/multi_gatherer.go
@@ -93,3 +93,11 @@ func sortMetrics(m []*dto.MetricFamily) {
 		return cmp.Compare(*i.Name, *j.Name)
 	})
 }
+
+func MakeAndRegister(gatherer MultiGatherer, name string) (*prometheus.Registry, error) {
+	reg := prometheus.NewRegistry()
+	if err := gatherer.Register(name, reg); err != nil {
+		return nil, fmt.Errorf("couldn't register %q metrics: %w", name, err)
+	}
+	return reg, nil
+}

--- a/api/server/metrics.go
+++ b/api/server/metrics.go
@@ -18,29 +18,26 @@ type metrics struct {
 	totalDuration *prometheus.GaugeVec
 }
 
-func newMetrics(namespace string, registerer prometheus.Registerer) (*metrics, error) {
+func newMetrics(registerer prometheus.Registerer) (*metrics, error) {
 	m := &metrics{
 		numProcessing: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace: namespace,
-				Name:      "calls_processing",
-				Help:      "The number of calls this API is currently processing",
+				Name: "calls_processing",
+				Help: "The number of calls this API is currently processing",
 			},
 			[]string{"base"},
 		),
 		numCalls: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "calls",
-				Help:      "The number of calls this API has processed",
+				Name: "calls",
+				Help: "The number of calls this API has processed",
 			},
 			[]string{"base"},
 		),
 		totalDuration: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace: namespace,
-				Name:      "calls_duration",
-				Help:      "The total amount of time, in nanoseconds, spent handling API calls",
+				Name: "calls_duration",
+				Help: "The total amount of time, in nanoseconds, spent handling API calls",
 			},
 			[]string{"base"},
 		),

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -108,12 +108,11 @@ func New(
 	nodeID ids.NodeID,
 	tracingEnabled bool,
 	tracer trace.Tracer,
-	namespace string,
 	registerer prometheus.Registerer,
 	httpConfig HTTPConfig,
 	allowedHosts []string,
 ) (Server, error) {
-	m, err := newMetrics(namespace, registerer)
+	m, err := newMetrics(registerer)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -66,6 +66,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/ips"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/math/meter"
+	"github.com/ava-labs/avalanchego/utils/metric"
 	"github.com/ava-labs/avalanchego/utils/perms"
 	"github.com/ava-labs/avalanchego/utils/profiler"
 	"github.com/ava-labs/avalanchego/utils/resource"
@@ -89,6 +90,8 @@ const (
 	httpPortName    = constants.AppName + "-http"
 
 	ipResolutionTimeout = 30 * time.Second
+
+	apiNamespace = constants.PlatformName + metric.NamespaceSeparator + "api"
 )
 
 var (
@@ -967,6 +970,14 @@ func (n *Node) initAPIServer() error {
 	}
 	n.apiURI = fmt.Sprintf("%s://%s", protocol, listener.Addr())
 
+	apiRegisterer, err := metrics.MakeAndRegister(
+		n.MetricsGatherer,
+		apiNamespace,
+	)
+	if err != nil {
+		return err
+	}
+
 	n.APIServer, err = server.New(
 		n.Log,
 		n.LogFactory,
@@ -976,8 +987,7 @@ func (n *Node) initAPIServer() error {
 		n.ID,
 		n.Config.TraceConfig.Enabled,
 		n.tracer,
-		"api",
-		n.MetricsRegisterer,
+		apiRegisterer,
 		n.Config.HTTPConfig.HTTPConfig,
 		n.Config.HTTPAllowedHosts,
 	)

--- a/utils/metric/namespace.go
+++ b/utils/metric/namespace.go
@@ -5,6 +5,11 @@ package metric
 
 import "strings"
 
+const (
+	NamespaceSeparatorByte = '_'
+	NamespaceSeparator     = string(NamespaceSeparatorByte)
+)
+
 func AppendNamespace(prefix, suffix string) string {
 	switch {
 	case len(prefix) == 0:
@@ -12,6 +17,6 @@ func AppendNamespace(prefix, suffix string) string {
 	case len(suffix) == 0:
 		return prefix
 	default:
-		return strings.Join([]string{prefix, suffix}, "_")
+		return strings.Join([]string{prefix, suffix}, NamespaceSeparator)
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Pulled out of https://github.com/ava-labs/avalanchego/pull/3053.

## How this works

Replaces the passing of a namespace around with registering an additional registerer into the multigatherer.

## How this was tested

- [X] CI
- [x] Verified that metrics were unchanged