### PR TITLE
[ci] Remove perpetually failing govulncheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,13 +285,3 @@ jobs:
         run: bash -x scripts/tests.build_antithesis_images.sh
         env:
           TEST_SETUP: xsvm
-  govulncheck:
-    runs-on: ubuntu-latest
-    name: govulncheck
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-go-version-in-env
-      - id: govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: ${{ env.GO_VERSION }}


### PR DESCRIPTION
Getting everyone used to seeing failures on every single CI run is harmful. If/when govulncheck can be made to pass the job can be added back.