### PR TITLE
Remove averager metrics namespace

### DIFF
--- a/network/throttling/bandwidth_throttler.go
+++ b/network/throttling/bandwidth_throttler.go
@@ -68,7 +68,6 @@ func newBandwidthThrottler(
 		limiters:                 make(map[ids.NodeID]*rate.Limiter),
 		metrics: bandwidthThrottlerMetrics{
 			acquireLatency: metric.NewAveragerWithErrs(
-				"",
 				"bandwidth_throttler_inbound_acquire_latency",
 				"average time (in ns) to acquire bytes from the inbound bandwidth throttler",
 				registerer,

--- a/network/throttling/inbound_msg_buffer_throttler.go
+++ b/network/throttling/inbound_msg_buffer_throttler.go
@@ -132,7 +132,6 @@ type inboundMsgBufferThrottlerMetrics struct {
 func (m *inboundMsgBufferThrottlerMetrics) initialize(reg prometheus.Registerer) error {
 	errs := wrappers.Errs{}
 	m.acquireLatency = metric.NewAveragerWithErrs(
-		"",
 		"buffer_throttler_inbound_acquire_latency",
 		"average time (in ns) to get space on the inbound message buffer",
 		reg,

--- a/network/throttling/inbound_msg_byte_throttler.go
+++ b/network/throttling/inbound_msg_byte_throttler.go
@@ -308,7 +308,6 @@ type inboundMsgByteThrottlerMetrics struct {
 func (m *inboundMsgByteThrottlerMetrics) initialize(reg prometheus.Registerer) error {
 	errs := wrappers.Errs{}
 	m.acquireLatency = metric.NewAveragerWithErrs(
-		"",
 		"byte_throttler_inbound_acquire_latency",
 		"average time (in ns) to get space on the inbound message byte buffer",
 		reg,

--- a/snow/consensus/snowman/metrics.go
+++ b/snow/consensus/snowman/metrics.go
@@ -98,14 +98,12 @@ func newMetrics(
 			Help: "cumulative size of all accepted blocks",
 		}),
 		pollsAccepted: metric.NewAveragerWithErrs(
-			"",
 			"blks_polls_accepted",
 			"number of polls from the issuance of a block to its acceptance",
 			reg,
 			&errs,
 		),
 		latAccepted: metric.NewAveragerWithErrs(
-			"",
 			"blks_accepted",
 			"time (in ns) from the issuance of a block to its acceptance",
 			reg,
@@ -121,14 +119,12 @@ func newMetrics(
 			Help: "cumulative size of all rejected blocks",
 		}),
 		pollsRejected: metric.NewAveragerWithErrs(
-			"",
 			"blks_polls_rejected",
 			"number of polls from the issuance of a block to its rejection",
 			reg,
 			&errs,
 		),
 		latRejected: metric.NewAveragerWithErrs(
-			"",
 			"blks_rejected",
 			"time (in ns) from the issuance of a block to its rejection",
 			reg,

--- a/snow/consensus/snowman/poll/set.go
+++ b/snow/consensus/snowman/poll/set.go
@@ -66,7 +66,6 @@ func NewSet(
 	}
 
 	durPolls, err := metric.NewAverager(
-		"",
 		"poll_duration",
 		"time (in ns) this poll took to complete",
 		reg,

--- a/snow/engine/avalanche/getter/getter.go
+++ b/snow/engine/avalanche/getter/getter.go
@@ -44,7 +44,6 @@ func New(
 
 	var err error
 	gh.getAncestorsVtxs, err = metric.NewAverager(
-		"",
 		"bs_get_ancestors_vtxs",
 		"vertices fetched in a call to GetAncestors",
 		reg,

--- a/snow/engine/snowman/getter/getter.go
+++ b/snow/engine/snowman/getter/getter.go
@@ -43,7 +43,6 @@ func New(
 
 	var err error
 	gh.getAncestorsBlks, err = metric.NewAverager(
-		"",
 		"bs_get_ancestors_blks",
 		"blocks fetched in a call to GetAncestors",
 		reg,

--- a/snow/engine/snowman/metrics.go
+++ b/snow/engine/snowman/metrics.go
@@ -98,21 +98,18 @@ func newMetrics(reg prometheus.Registerer) (*metrics, error) {
 			Help: "Number of votes that were directly applied to blocks",
 		}),
 		getAncestorsBlks: metric.NewAveragerWithErrs(
-			"",
 			"get_ancestors_blks",
 			"blocks fetched in a call to GetAncestors",
 			reg,
 			&errs,
 		),
 		selectedVoteIndex: metric.NewAveragerWithErrs(
-			"",
 			"selected_vote_index",
 			"index of the voteID that was passed into consensus",
 			reg,
 			&errs,
 		),
 		issuerStake: metric.NewAveragerWithErrs(
-			"",
 			"issuer_stake",
 			"stake weight of the peer who provided a block that was issued into consensus",
 			reg,

--- a/utils/metric/averager.go
+++ b/utils/metric/averager.go
@@ -23,23 +23,21 @@ type averager struct {
 	sum   prometheus.Gauge
 }
 
-func NewAverager(namespace, name, desc string, reg prometheus.Registerer) (Averager, error) {
+func NewAverager(name, desc string, reg prometheus.Registerer) (Averager, error) {
 	errs := wrappers.Errs{}
-	a := NewAveragerWithErrs(namespace, name, desc, reg, &errs)
+	a := NewAveragerWithErrs(name, desc, reg, &errs)
 	return a, errs.Err
 }
 
-func NewAveragerWithErrs(namespace, name, desc string, reg prometheus.Registerer, errs *wrappers.Errs) Averager {
+func NewAveragerWithErrs(name, desc string, reg prometheus.Registerer, errs *wrappers.Errs) Averager {
 	a := averager{
 		count: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      name + "_count",
-			Help:      "Total # of observations of " + desc,
+			Name: AppendNamespace(name, "count"),
+			Help: "Total # of observations of " + desc,
 		}),
 		sum: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      name + "_sum",
-			Help:      "Sum of " + desc,
+			Name: AppendNamespace(name, "sum"),
+			Help: "Sum of " + desc,
 		}),
 	}
 

--- a/vms/metervm/metrics.go
+++ b/vms/metervm/metrics.go
@@ -12,7 +12,6 @@ import (
 
 func newAverager(name string, reg prometheus.Registerer, errs *wrappers.Errs) metric.Averager {
 	return metric.NewAveragerWithErrs(
-		"",
 		name,
 		"time (in ns) of a "+name,
 		reg,


### PR DESCRIPTION
## Why this should be merged

Factored out of #3053.

## How this works

We no longer use the `namespace` for these functions, so we can remove it.

## How this was tested

- [X] CI