### PR TITLE
Select metric by label in e2e tests

### DIFF
--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -55,7 +55,7 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 				require.NoError(err)
 
 				for _, metrics := range allNodeMetrics {
-					xBlksProcessing, ok := tests.GetFirstMetricValue(metrics, xBlksProcessingMetric)
+					xBlksProcessing, ok := tests.GetMetricValue(metrics, xBlksProcessingMetric, nil)
 					if !ok || xBlksProcessing > 0 {
 						return false
 					}
@@ -248,13 +248,13 @@ RECEIVER  NEW BALANCE (AFTER) : %21d AVAX
 
 					// +0 since X-chain tx must have been processed and accepted
 					// by now
-					currentXBlksProcessing, _ := tests.GetFirstMetricValue(mm, xBlksProcessingMetric)
-					previousXBlksProcessing, _ := tests.GetFirstMetricValue(prev, xBlksProcessingMetric)
+					currentXBlksProcessing, _ := tests.GetMetricValue(mm, xBlksProcessingMetric, nil)
+					previousXBlksProcessing, _ := tests.GetMetricValue(prev, xBlksProcessingMetric, nil)
 					require.Equal(currentXBlksProcessing, previousXBlksProcessing)
 
 					// +1 since X-chain tx must have been accepted by now
-					currentXBlksAccepted, _ := tests.GetFirstMetricValue(mm, xBlksAcceptedMetric)
-					previousXBlksAccepted, _ := tests.GetFirstMetricValue(prev, xBlksAcceptedMetric)
+					currentXBlksAccepted, _ := tests.GetMetricValue(mm, xBlksAcceptedMetric, nil)
+					previousXBlksAccepted, _ := tests.GetMetricValue(prev, xBlksAcceptedMetric, nil)
 					require.Equal(currentXBlksAccepted, previousXBlksAccepted+1)
 
 					metricsBeforeTx[u] = mm

--- a/tests/metrics.go
+++ b/tests/metrics.go
@@ -39,6 +39,13 @@ func GetNodesMetrics(ctx context.Context, nodeURIs []string) (NodesMetrics, erro
 	return metrics, nil
 }
 
+// GetMetricValue returns the value of the specified metric which has the
+// required labels.
+//
+// If multiple metrics match the provided labels, the first metric found is
+// returned.
+//
+// Only Counter and Gauge metrics are supported.
 func GetMetricValue(metrics NodeMetrics, name string, labels prometheus.Labels) (float64, bool) {
 	metricFamily, ok := metrics[name]
 	if !ok {

--- a/tests/metrics.go
+++ b/tests/metrics.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/ava-labs/avalanchego/api/metrics"
 
 	dto "github.com/prometheus/client_model/go"
@@ -37,19 +39,38 @@ func GetNodesMetrics(ctx context.Context, nodeURIs []string) (NodesMetrics, erro
 	return metrics, nil
 }
 
-func GetFirstMetricValue(metrics NodeMetrics, name string) (float64, bool) {
+func GetMetricValue(metrics NodeMetrics, name string, labels prometheus.Labels) (float64, bool) {
 	metricFamily, ok := metrics[name]
-	if !ok || len(metricFamily.Metric) < 1 {
+	if !ok {
 		return 0, false
 	}
 
-	metric := metricFamily.Metric[0]
-	switch {
-	case metric.Gauge != nil:
-		return metric.Gauge.GetValue(), true
-	case metric.Counter != nil:
-		return metric.Counter.GetValue(), true
-	default:
-		return 0, false
+	for _, metric := range metricFamily.Metric {
+		if !labelsMatch(metric, labels) {
+			continue
+		}
+
+		switch {
+		case metric.Gauge != nil:
+			return metric.Gauge.GetValue(), true
+		case metric.Counter != nil:
+			return metric.Counter.GetValue(), true
+		}
 	}
+	return 0, false
+}
+
+func labelsMatch(metric *dto.Metric, labels prometheus.Labels) bool {
+	var found int
+	for _, label := range metric.Label {
+		expectedValue, ok := labels[label.GetName()]
+		if !ok {
+			continue
+		}
+		if label.GetValue() != expectedValue {
+			return false
+		}
+		found++
+	}
+	return found == len(labels)
 }


### PR DESCRIPTION
## Why this should be merged

Factored out of #3053.

## How this works

This supports filtering metrics by labels. This will be needed after the metrics refactor.

## How this was tested

- [X] CI