### PR TITLE
Add packing for varint/uvarint types

### DIFF
--- a/utils/wrappers/packing.go
+++ b/utils/wrappers/packing.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	MaxStringLen  = math.MaxUint16
+	MaxStringLen = math.MaxUint16
 	MinVarintLen = 1
 	MaxVarintLen = 10
 

--- a/utils/wrappers/packing_test.go
+++ b/utils/wrappers/packing_test.go
@@ -362,3 +362,31 @@ func TestPackerUnpackBool(t *testing.T) {
 	require.True(p.Errored())
 	require.ErrorIs(p.Err, errBadBool)
 }
+
+func TestPackerPackVarInt(t *testing.T) {
+	require := require.New(t)
+
+	p := Packer{MaxSize: 2}
+	p.PackVarInt(-1784)
+	require.False(p.Errored())
+	require.NoError(p.Err)
+	require.Equal([]byte{0xef, 0x1b}, p.Bytes)
+
+	p.PackVarInt(-1784)
+	require.True(p.Errored())
+	require.ErrorIs(p.Err, ErrInsufficientLength)
+}
+
+func TestPackerPackUvarInt(t *testing.T) {
+	require := require.New(t)
+
+	p := Packer{MaxSize: 2}
+	p.PackVarInt(1784)
+	require.False(p.Errored())
+	require.NoError(p.Err)
+	require.Equal([]byte{0xf0, 0x1b}, p.Bytes)
+
+	p.PackVarInt(1784)
+	require.True(p.Errored())
+	require.ErrorIs(p.Err, ErrInsufficientLength)
+}


### PR DESCRIPTION
## Why this should be merged

This PR adds capabilities of packing / unpacking varint/uvarint types in the packer. We wanted this in the hypersdk (https://github.com/ava-labs/hypersdk/pull/989) and @patrick-ogrady figured that we should not handle low-level packer operations in the high-level code but rather in avalanchego since that's the package we are importing.

## How this works

Create the varint in a temporary slice as we don't know the size before, and append it as a fixed bytes slice in the packer.
The unpacking is also pretty self-explanatory

## How this was tested

Adding two unit test that does the packing/unpacking and making sure that the number matches in `utils/wrappers/packing_test.go`