### PR TITLE
Remove avalanche metrics registerer from consensus context

### DIFF
--- a/snow/context.go
+++ b/snow/context.go
@@ -65,15 +65,8 @@ type Registerer interface {
 type ConsensusContext struct {
 	*Context
 
-	// Registers all common and snowman consensus metrics. Unlike the avalanche
-	// consensus engine metrics, we do not prefix the name with the engine name,
-	// as snowman is used for all chains by default.
+	// Registers all consensus metrics.
 	Registerer Registerer
-	// Only used to register Avalanche consensus metrics. Previously, all
-	// metrics were prefixed with "avalanche_{chainID}_". Now we add avalanche
-	// to the prefix, "avalanche_{chainID}_avalanche_", to differentiate
-	// consensus operations after the DAG linearization.
-	AvalancheRegisterer Registerer
 
 	// BlockAcceptor is the callback that will be fired whenever a VM is
 	// notified that their block was accepted.

--- a/snow/engine/avalanche/bootstrap/bootstrapper.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"
@@ -47,6 +48,7 @@ var _ common.BootstrapableEngine = (*bootstrapper)(nil)
 func New(
 	config Config,
 	onFinished func(ctx context.Context, lastReqID uint32) error,
+	reg prometheus.Registerer,
 ) (common.BootstrapableEngine, error) {
 	b := &bootstrapper{
 		Config: config,
@@ -66,7 +68,7 @@ func New(
 		processedCache: &cache.LRU[ids.ID, struct{}]{Size: cacheSize},
 		onFinished:     onFinished,
 	}
-	return b, b.metrics.Initialize(config.Ctx.AvalancheRegisterer)
+	return b, b.metrics.Initialize(reg)
 }
 
 // Note: To align with the Snowman invariant, it should be guaranteed the VM is

--- a/snow/engine/avalanche/bootstrap/bootstrapper_test.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper_test.go
@@ -76,10 +76,10 @@ func newConfig(t *testing.T) (Config, ids.NodeID, *common.SenderTest, *vertex.Te
 	peer := ids.GenerateTestNodeID()
 	require.NoError(vdrs.AddStaker(constants.PrimaryNetworkID, peer, nil, ids.Empty, 1))
 
-	vtxBlocker, err := queue.NewWithMissing(prefixdb.New([]byte("vtx"), db), "vtx", ctx.AvalancheRegisterer)
+	vtxBlocker, err := queue.NewWithMissing(prefixdb.New([]byte("vtx"), db), "vtx", prometheus.NewRegistry())
 	require.NoError(err)
 
-	txBlocker, err := queue.New(prefixdb.New([]byte("tx"), db), "tx", ctx.AvalancheRegisterer)
+	txBlocker, err := queue.New(prefixdb.New([]byte("tx"), db), "tx", prometheus.NewRegistry())
 	require.NoError(err)
 
 	peerTracker := tracker.NewPeers()
@@ -88,7 +88,7 @@ func newConfig(t *testing.T) (Config, ids.NodeID, *common.SenderTest, *vertex.Te
 	startupTracker := tracker.NewStartup(peerTracker, totalWeight/2+1)
 	vdrs.RegisterSetCallbackListener(constants.PrimaryNetworkID, startupTracker)
 
-	avaGetHandler, err := getter.New(manager, sender, ctx.Log, time.Second, 2000, ctx.AvalancheRegisterer)
+	avaGetHandler, err := getter.New(manager, sender, ctx.Log, time.Second, 2000, prometheus.NewRegistry())
 	require.NoError(err)
 
 	p2pTracker, err := p2p.NewPeerTracker(
@@ -172,6 +172,7 @@ func TestBootstrapperSingleFrontier(t *testing.T) {
 			})
 			return nil
 		},
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 
@@ -278,6 +279,7 @@ func TestBootstrapperByzantineResponses(t *testing.T) {
 			})
 			return nil
 		},
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 
@@ -444,6 +446,7 @@ func TestBootstrapperTxDependencies(t *testing.T) {
 			})
 			return nil
 		},
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 
@@ -567,6 +570,7 @@ func TestBootstrapperIncompleteAncestors(t *testing.T) {
 			})
 			return nil
 		},
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 

--- a/snow/networking/sender/sender.go
+++ b/snow/networking/sender/sender.go
@@ -5,7 +5,6 @@ package sender
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -58,6 +57,7 @@ func New(
 	timeouts timeout.Manager,
 	engineType p2p.EngineType,
 	subnet subnets.Subnet,
+	reg prometheus.Registerer,
 ) (common.Sender, error) {
 	s := &sender{
 		ctx:        ctx,
@@ -74,16 +74,6 @@ func New(
 		),
 		engineType: engineType,
 		subnet:     subnet,
-	}
-
-	var reg prometheus.Registerer
-	switch engineType {
-	case p2p.EngineType_ENGINE_TYPE_SNOWMAN:
-		reg = ctx.Registerer
-	case p2p.EngineType_ENGINE_TYPE_AVALANCHE:
-		reg = ctx.AvalancheRegisterer
-	default:
-		return nil, fmt.Errorf("unknown engine type %s", engineType)
 	}
 	return s, reg.Register(s.failedDueToBench)
 }

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -100,6 +100,7 @@ func TestTimeout(t *testing.T) {
 		tm,
 		p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
 		subnets.New(ctx.NodeID, subnets.Config{}),
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 
@@ -376,6 +377,7 @@ func TestReliableMessages(t *testing.T) {
 		tm,
 		p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
 		subnets.New(ctx.NodeID, subnets.Config{}),
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 
@@ -532,6 +534,7 @@ func TestReliableMessagesToMyself(t *testing.T) {
 		tm,
 		p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
 		subnets.New(ctx.NodeID, subnets.Config{}),
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 
@@ -843,6 +846,7 @@ func TestSender_Bootstrap_Requests(t *testing.T) {
 				timeoutManager,
 				p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
 				subnets.New(ctx.NodeID, subnets.Config{}),
+				prometheus.NewRegistry(),
 			)
 			require.NoError(err)
 
@@ -1049,11 +1053,6 @@ func TestSender_Bootstrap_Responses(t *testing.T) {
 				router         = router.NewMockRouter(ctrl)
 			)
 
-			// Instantiate new registerers to avoid duplicate metrics
-			// registration
-			ctx.Registerer = prometheus.NewRegistry()
-			ctx.AvalancheRegisterer = prometheus.NewRegistry()
-
 			sender, err := New(
 				ctx,
 				msgCreator,
@@ -1062,6 +1061,7 @@ func TestSender_Bootstrap_Responses(t *testing.T) {
 				timeoutManager,
 				p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
 				subnets.New(ctx.NodeID, subnets.Config{}),
+				prometheus.NewRegistry(),
 			)
 			require.NoError(err)
 
@@ -1228,6 +1228,7 @@ func TestSender_Single_Request(t *testing.T) {
 				timeoutManager,
 				engineType,
 				subnets.New(ctx.NodeID, subnets.Config{}),
+				prometheus.NewRegistry(),
 			)
 			require.NoError(err)
 

--- a/snow/snowtest/snowtest.go
+++ b/snow/snowtest/snowtest.go
@@ -39,12 +39,11 @@ func (noOpAcceptor) Accept(*snow.ConsensusContext, ids.ID, []byte) error {
 
 func ConsensusContext(ctx *snow.Context) *snow.ConsensusContext {
 	return &snow.ConsensusContext{
-		Context:             ctx,
-		Registerer:          prometheus.NewRegistry(),
-		AvalancheRegisterer: prometheus.NewRegistry(),
-		BlockAcceptor:       noOpAcceptor{},
-		TxAcceptor:          noOpAcceptor{},
-		VertexAcceptor:      noOpAcceptor{},
+		Context:        ctx,
+		Registerer:     prometheus.NewRegistry(),
+		BlockAcceptor:  noOpAcceptor{},
+		TxAcceptor:     noOpAcceptor{},
+		VertexAcceptor: noOpAcceptor{},
 	}
 }
 

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1447,6 +1447,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		timeoutManager,
 		p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
 		subnets.New(consensusCtx.NodeID, subnets.Config{}),
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 


### PR DESCRIPTION
## Why this should be merged

Reduces the diff in #3053.

## How this works

Explicitly passes the avalanche context rather than specifying it in the `snow.ConsensusContext`.

## How this was tested

- [X] CI
- [x] Diffed the metrics against master on fuji.