### PR TITLE
Fix race in test

### DIFF
--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -1085,10 +1085,13 @@ func TestServiceGetSubnets(t *testing.T) {
 	newOwnerIDStr := "P-testing1t73fa4p4dypa4s3kgufuvr6hmprjclw66mgqgm"
 	newOwnerID, err := service.addrManager.ParseLocalAddress(newOwnerIDStr)
 	require.NoError(err)
+
+	service.vm.ctx.Lock.Lock()
 	service.vm.state.SetSubnetOwner(testSubnet1ID, &secp256k1fx.OutputOwners{
 		Addrs:     []ids.ShortID{newOwnerID},
 		Threshold: 1,
 	})
+	service.vm.ctx.Lock.Unlock()
 
 	require.NoError(service.GetSubnets(nil, &GetSubnetsArgs{}, &response))
 	require.Equal([]APISubnet{


### PR DESCRIPTION
## Why this should be merged

This test has a race: https://github.com/ava-labs/avalanchego/actions/runs/9402917779/job/25898166965?pr=3053#step:5:348

## How this works

Correctly locks state before using it.

## How this was tested

- [X] CI