### PR TITLE
[antithesis] Remove assertions incompatible with fault injection

### DIFF
--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -263,10 +263,6 @@ func (w *workload) issueXChainBaseTx(ctx context.Context) {
 	)
 	if err != nil {
 		log.Printf("failed to issue X-chain baseTx: %s", err)
-		assert.Unreachable("failed to issue X-chain baseTx", map[string]any{
-			"worker": w.id,
-			"err":    err,
-		})
 		return
 	}
 	log.Printf("issued new X-chain baseTx %s in %s", baseTx.ID(), time.Since(baseStartTime))
@@ -320,10 +316,6 @@ func (w *workload) issueXChainCreateAssetTx(ctx context.Context) {
 	)
 	if err != nil {
 		log.Printf("failed to issue X-chain create asset transaction: %s", err)
-		assert.Unreachable("failed to issue X-chain create asset transaction", map[string]any{
-			"worker": w.id,
-			"err":    err,
-		})
 		return
 	}
 	log.Printf("created new X-chain asset %s in %s", createAssetTx.ID(), time.Since(createAssetStartTime))
@@ -378,10 +370,6 @@ func (w *workload) issueXChainOperationTx(ctx context.Context) {
 	)
 	if err != nil {
 		log.Printf("failed to issue X-chain create asset transaction: %s", err)
-		assert.Unreachable("failed to issue X-chain create asset transaction", map[string]any{
-			"worker": w.id,
-			"err":    err,
-		})
 		return
 	}
 	log.Printf("created new X-chain asset %s in %s", createAssetTx.ID(), time.Since(createAssetStartTime))
@@ -393,10 +381,6 @@ func (w *workload) issueXChainOperationTx(ctx context.Context) {
 	)
 	if err != nil {
 		log.Printf("failed to issue X-chain operation transaction: %s", err)
-		assert.Unreachable("failed to issue X-chain operation transaction", map[string]any{
-			"worker": w.id,
-			"err":    err,
-		})
 		return
 	}
 	log.Printf("issued X-chain operation tx %s in %s", operationTx.ID(), time.Since(operationStartTime))
@@ -456,10 +440,6 @@ func (w *workload) issueXToPTransfer(ctx context.Context) {
 	)
 	if err != nil {
 		log.Printf("failed to issue X-chain export transaction: %s", err)
-		assert.Unreachable("failed to issue X-chain export transaction", map[string]any{
-			"worker": w.id,
-			"err":    err,
-		})
 		return
 	}
 	log.Printf("created X-chain export transaction %s in %s", exportTx.ID(), time.Since(exportStartTime))
@@ -474,10 +454,6 @@ func (w *workload) issueXToPTransfer(ctx context.Context) {
 	)
 	if err != nil {
 		log.Printf("failed to issue P-chain import transaction: %s", err)
-		assert.Unreachable("failed to issue P-chain import transaction", map[string]any{
-			"worker": w.id,
-			"err":    err,
-		})
 		return
 	}
 	log.Printf("created P-chain import transaction %s in %s", importTx.ID(), time.Since(importStartTime))
@@ -538,10 +514,6 @@ func (w *workload) issuePToXTransfer(ctx context.Context) {
 	)
 	if err != nil {
 		log.Printf("failed to issue P-chain export transaction: %s", err)
-		assert.Unreachable("failed to issue P-chain export transaction", map[string]any{
-			"worker": w.id,
-			"err":    err,
-		})
 		return
 	}
 	log.Printf("created P-chain export transaction %s in %s", exportTx.ID(), time.Since(exportStartTime))
@@ -553,10 +525,6 @@ func (w *workload) issuePToXTransfer(ctx context.Context) {
 	)
 	if err != nil {
 		log.Printf("failed to issue X-chain import transaction: %s", err)
-		assert.Unreachable("failed to issue X-chain import transaction", map[string]any{
-			"worker": w.id,
-			"err":    err,
-		})
 		return
 	}
 	log.Printf("created X-chain import transaction %s in %s", importTx.ID(), time.Since(importStartTime))
@@ -584,22 +552,10 @@ func (w *workload) confirmXChainTx(ctx context.Context, tx *xtxs.Tx) {
 		status, err := client.ConfirmTx(ctx, txID, 100*time.Millisecond)
 		if err != nil {
 			log.Printf("failed to confirm X-chain transaction %s on %s: %s", txID, uri, err)
-			assert.Unreachable("failed to determine the status of an X-chain transaction", map[string]any{
-				"worker": w.id,
-				"txID":   txID,
-				"uri":    uri,
-				"err":    err,
-			})
 			return
 		}
 		if status != choices.Accepted {
 			log.Printf("failed to confirm X-chain transaction %s on %s: status == %s", txID, uri, status)
-			assert.Unreachable("failed to confirm an X-chain transaction", map[string]any{
-				"worker": w.id,
-				"txID":   txID,
-				"uri":    uri,
-				"status": status,
-			})
 			return
 		}
 		log.Printf("confirmed X-chain transaction %s on %s", txID, uri)
@@ -614,22 +570,10 @@ func (w *workload) confirmPChainTx(ctx context.Context, tx *ptxs.Tx) {
 		s, err := client.AwaitTxDecided(ctx, txID, 100*time.Millisecond)
 		if err != nil {
 			log.Printf("failed to determine the status of a P-chain transaction %s on %s: %s", txID, uri, err)
-			assert.Unreachable("failed to determine the status of a P-chain transaction", map[string]any{
-				"worker": w.id,
-				"txID":   txID,
-				"uri":    uri,
-				"err":    err,
-			})
 			return
 		}
 		if s.Status != status.Committed {
 			log.Printf("failed to confirm P-chain transaction %s on %s: status == %s", txID, uri, s.Status)
-			assert.Unreachable("failed to confirm a P-chain transaction", map[string]any{
-				"worker": w.id,
-				"txID":   txID,
-				"uri":    uri,
-				"status": s.Status,
-			})
 			return
 		}
 		log.Printf("confirmed P-chain transaction %s on %s", txID, uri)
@@ -655,19 +599,13 @@ func (w *workload) verifyXChainTxConsumedUTXOs(ctx context.Context, tx *xtxs.Tx)
 		)
 		if err != nil {
 			log.Printf("failed to fetch X-chain UTXOs on %s: %s", uri, err)
-			assert.Unreachable("failed to fetch X-chain UTXOs", map[string]any{
-				"worker": w.id,
-				"txID":   txID,
-				"uri":    uri,
-				"err":    err,
-			})
 			return
 		}
 
 		inputs := tx.Unsigned.InputIDs()
 		for input := range inputs {
 			_, err := utxos.GetUTXO(ctx, chainID, chainID, input)
-			if err != database.ErrNotFound {
+			if err != nil && err != database.ErrNotFound {
 				log.Printf("failed to verify that X-chain UTXO %s was deleted on %s after %s", input, uri, txID)
 				assert.Unreachable("failed to verify that X-chain UTXO was deleted", map[string]any{
 					"worker": w.id,
@@ -701,19 +639,13 @@ func (w *workload) verifyPChainTxConsumedUTXOs(ctx context.Context, tx *ptxs.Tx)
 		)
 		if err != nil {
 			log.Printf("failed to fetch P-chain UTXOs on %s: %s", uri, err)
-			assert.Unreachable("failed to fetch P-chain UTXOs", map[string]any{
-				"worker": w.id,
-				"uri":    uri,
-				"txID":   txID,
-				"err":    err,
-			})
 			return
 		}
 
 		inputs := tx.Unsigned.InputIDs()
 		for input := range inputs {
 			_, err := utxos.GetUTXO(ctx, constants.PlatformChainID, constants.PlatformChainID, input)
-			if err != database.ErrNotFound {
+			if err != nil && err != database.ErrNotFound {
 				log.Printf("failed to verify that P-chain UTXO %s was deleted on %s after %s", input, uri, txID)
 				assert.Unreachable("failed to verify that P-chain UTXO was deleted", map[string]any{
 					"worker": w.id,

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -605,7 +605,7 @@ func (w *workload) verifyXChainTxConsumedUTXOs(ctx context.Context, tx *xtxs.Tx)
 		inputs := tx.Unsigned.InputIDs()
 		for input := range inputs {
 			_, err := utxos.GetUTXO(ctx, chainID, chainID, input)
-			if err != nil && err != database.ErrNotFound {
+			if err != database.ErrNotFound {
 				log.Printf("failed to verify that X-chain UTXO %s was deleted on %s after %s", input, uri, txID)
 				assert.Unreachable("failed to verify that X-chain UTXO was deleted", map[string]any{
 					"worker": w.id,
@@ -645,7 +645,7 @@ func (w *workload) verifyPChainTxConsumedUTXOs(ctx context.Context, tx *ptxs.Tx)
 		inputs := tx.Unsigned.InputIDs()
 		for input := range inputs {
 			_, err := utxos.GetUTXO(ctx, constants.PlatformChainID, constants.PlatformChainID, input)
-			if err != nil && err != database.ErrNotFound {
+			if err != database.ErrNotFound {
 				log.Printf("failed to verify that P-chain UTXO %s was deleted on %s after %s", input, uri, txID)
 				assert.Unreachable("failed to verify that P-chain UTXO was deleted", map[string]any{
 					"worker": w.id,

--- a/tests/antithesis/xsvm/main.go
+++ b/tests/antithesis/xsvm/main.go
@@ -173,12 +173,6 @@ func (w *workload) confirmTransferTx(ctx context.Context, tx *status.TxIssuance)
 		client := api.NewClient(uri, w.chainID.String())
 		if err := api.WaitForAcceptance(ctx, client, w.key.Address(), tx.Nonce); err != nil {
 			log.Printf("worker %d failed to confirm transaction %s on %s: %s", w.id, tx.TxID, uri, err)
-			assert.Unreachable("failed to confirm transaction", map[string]any{
-				"worker": w.id,
-				"txID":   tx.TxID,
-				"uri":    uri,
-				"err":    err,
-			})
 			return
 		}
 	}


### PR DESCRIPTION
## Why this should be merged

The antithesis test runs are currently reporting errors due to the recent addition of assertions that cannot be guaranteed to succeed in the face of injected faults. 

Future effort will ensure the addition of more reliable assertions and/or add retries to account for the possibility of temporary error conditions induced by injected faults.

## How this works

As per @StephenButtolph:

Remove assertions for network calls: 

- client calls
- wallet.Issue calls
- primary.AddAllUTXOs calls

Retain assertions for local calls:

 - utxos.GetUTXO
- status checks
- balance checks

## How this was tested
 
- [x] Manually triggered publication of images from this branch: 
  - https://github.com/ava-labs/avalanchego/actions/runs/9467893563
- [x] Manually triggered a run for avalanchego images
   - [x] Passed?
- [x] Manually triggered a run for xsvm images
   - [x] Passed?