### PR TITLE
Add P2P test utility

### DIFF
--- a/network/p2p/p2ptest/client.go
+++ b/network/p2p/p2ptest/client.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package p2ptest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
+)
+
+// NewClient generates a client-server pair and returns the client used to
+// communicate with a server with the specified handler
+func NewClient(t *testing.T, rootCtx context.Context, handler p2p.Handler) *p2p.Client {
+	clientSender := &common.SenderTest{}
+	serverSender := &common.SenderTest{}
+
+	clientNodeID := ids.GenerateTestNodeID()
+	clientNetwork, err := p2p.NewNetwork(logging.NoLog{}, clientSender, prometheus.NewRegistry(), "")
+	require.NoError(t, err)
+
+	serverNodeID := ids.GenerateTestNodeID()
+	serverNetwork, err := p2p.NewNetwork(logging.NoLog{}, serverSender, prometheus.NewRegistry(), "")
+	require.NoError(t, err)
+
+	clientSender.SendAppGossipF = func(ctx context.Context, _ common.SendConfig, gossipBytes []byte) error {
+		go func() {
+			require.NoError(t, serverNetwork.AppGossip(ctx, clientNodeID, gossipBytes))
+		}()
+
+		return nil
+	}
+
+	clientSender.SendAppRequestF = func(ctx context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, requestBytes []byte) error {
+		// Send the request asynchronously to avoid deadlock when the server
+		// sends the response back to the client
+		go func() {
+			require.NoError(t, serverNetwork.AppRequest(ctx, clientNodeID, requestID, time.Time{}, requestBytes))
+		}()
+
+		return nil
+	}
+
+	serverSender.SendAppResponseF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32, responseBytes []byte) error {
+		return clientNetwork.AppResponse(ctx, serverNodeID, requestID, responseBytes)
+	}
+
+	require.NoError(t, clientNetwork.Connected(rootCtx, clientNodeID, nil))
+	require.NoError(t, clientNetwork.Connected(rootCtx, serverNodeID, nil))
+	require.NoError(t, serverNetwork.Connected(rootCtx, clientNodeID, nil))
+	require.NoError(t, serverNetwork.Connected(rootCtx, serverNodeID, nil))
+
+	require.NoError(t, serverNetwork.AddHandler(0, handler))
+	return clientNetwork.NewClient(0)
+}

--- a/network/p2p/p2ptest/client.go
+++ b/network/p2p/p2ptest/client.go
@@ -20,7 +20,7 @@ import (
 
 // NewClient generates a client-server pair and returns the client used to
 // communicate with a server with the specified handler
-// TODO timeouts should fire cilent callback
+// TODO timeouts should fire client callback
 func NewClient(t *testing.T, rootCtx context.Context, handler p2p.Handler) *p2p.Client {
 	clientSender := &common.SenderTest{}
 	serverSender := &common.SenderTest{}

--- a/network/p2p/p2ptest/client.go
+++ b/network/p2p/p2ptest/client.go
@@ -20,6 +20,7 @@ import (
 
 // NewClient generates a client-server pair and returns the client used to
 // communicate with a server with the specified handler
+// TODO timeouts
 func NewClient(t *testing.T, rootCtx context.Context, handler p2p.Handler) *p2p.Client {
 	clientSender := &common.SenderTest{}
 	serverSender := &common.SenderTest{}

--- a/network/p2p/p2ptest/client.go
+++ b/network/p2p/p2ptest/client.go
@@ -20,7 +20,7 @@ import (
 
 // NewClient generates a client-server pair and returns the client used to
 // communicate with a server with the specified handler
-// TODO timeouts
+// TODO timeouts should fire cilent callback
 func NewClient(t *testing.T, rootCtx context.Context, handler p2p.Handler) *p2p.Client {
 	clientSender := &common.SenderTest{}
 	serverSender := &common.SenderTest{}

--- a/network/p2p/p2ptest/client.go
+++ b/network/p2p/p2ptest/client.go
@@ -34,9 +34,7 @@ func NewClient(t *testing.T, rootCtx context.Context, handler p2p.Handler) *p2p.
 	require.NoError(t, err)
 
 	clientSender.SendAppGossipF = func(ctx context.Context, _ common.SendConfig, gossipBytes []byte) error {
-		go func() {
-			require.NoError(t, serverNetwork.AppGossip(ctx, clientNodeID, gossipBytes))
-		}()
+		require.NoError(t, serverNetwork.AppGossip(ctx, clientNodeID, gossipBytes))
 
 		return nil
 	}

--- a/network/p2p/p2ptest/client.go
+++ b/network/p2p/p2ptest/client.go
@@ -40,7 +40,7 @@ func NewClient(t *testing.T, rootCtx context.Context, handler p2p.Handler) *p2p.
 		return nil
 	}
 
-	clientSender.SendAppRequestF = func(ctx context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, requestBytes []byte) error {
+	clientSender.SendAppRequestF = func(ctx context.Context, _ set.Set[ids.NodeID], requestID uint32, requestBytes []byte) error {
 		// Send the request asynchronously to avoid deadlock when the server
 		// sends the response back to the client
 		go func() {
@@ -50,7 +50,7 @@ func NewClient(t *testing.T, rootCtx context.Context, handler p2p.Handler) *p2p.
 		return nil
 	}
 
-	serverSender.SendAppResponseF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32, responseBytes []byte) error {
+	serverSender.SendAppResponseF = func(ctx context.Context, _ ids.NodeID, requestID uint32, responseBytes []byte) error {
 		return clientNetwork.AppResponse(ctx, serverNodeID, requestID, responseBytes)
 	}
 

--- a/network/p2p/p2ptest/client_test.go
+++ b/network/p2p/p2ptest/client_test.go
@@ -5,6 +5,7 @@ package p2ptest
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -32,7 +33,6 @@ func TestNewClient_AppGossip(t *testing.T) {
 	<-appGossipChan
 }
 
-// TODO add error case tests when AppErrors are supported
 func TestNewClient_AppRequest(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -47,13 +47,13 @@ func TestNewClient_AppRequest(t *testing.T) {
 				return client.AppRequest(ctx, set.Of(ids.GenerateTestNodeID()), []byte("foo"), onResponse)
 			},
 		},
-		//{
-		//	name:   "AppRequest - error",
-		//	appErr: errors.New("foobar"),
-		//	appRequestF: func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error {
-		//		return client.AppRequest(ctx, set.Of(ids.GenerateTestNodeID()), []byte("foo"), onResponse)
-		//	},
-		//},
+		{
+			name:   "AppRequest - error",
+			appErr: errors.New("foobar"),
+			appRequestF: func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error {
+				return client.AppRequest(ctx, set.Of(ids.GenerateTestNodeID()), []byte("foo"), onResponse)
+			},
+		},
 		{
 			name:        "AppRequestAny - response",
 			appResponse: []byte("foobar"),
@@ -61,17 +61,22 @@ func TestNewClient_AppRequest(t *testing.T) {
 				return client.AppRequestAny(ctx, []byte("foo"), onResponse)
 			},
 		},
-		//{
-		//	name:   "AppRequestAny - error",
-		//	appErr: errors.New("foobar"),
-		//	appRequestF: func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error {
-		//		return client.AppRequestAny(ctx, []byte("foo"), onResponse)
-		//	},
-		//},
+		{
+			name:   "AppRequestAny - error",
+			appErr: errors.New("foobar"),
+			appRequestF: func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error {
+				return client.AppRequestAny(ctx, []byte("foo"), onResponse)
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// TODO remove when AppErrors are supported
+			if tt.appErr != nil {
+				t.Skip("sending app errors not supported yet")
+			}
+
 			require := require.New(t)
 			ctx := context.Background()
 

--- a/network/p2p/p2ptest/client_test.go
+++ b/network/p2p/p2ptest/client_test.go
@@ -23,7 +23,7 @@ func TestNewClient_AppGossip(t *testing.T) {
 
 	appGossipChan := make(chan struct{})
 	testHandler := p2p.TestHandler{
-		AppGossipF: func(ctx context.Context, nodeID ids.NodeID, gossipBytes []byte) {
+		AppGossipF: func(context.Context, ids.NodeID, []byte) {
 			close(appGossipChan)
 		},
 	}


### PR DESCRIPTION
## Why this should be merged

Currently testing p2p apis is painful and requires mocking the underlying app sender calls to redirect messages to a VM's network handler. This will be used in a future PR when we require testing for the `x/sync` package's migration to use the `p2p` package.

## How this works

Adds a test utility to remove the boiler plate code and provide a cleaner ux.

## How this was tested

Added ut
