### PR TITLE
Remove .Status() from .IsPreferred()

### DIFF
--- a/snow/consensus/snowman/consensus.go
+++ b/snow/consensus/snowman/consensus.go
@@ -45,9 +45,9 @@ type Consensus interface {
 	// Processing returns true if the block ID is currently processing.
 	Processing(ids.ID) bool
 
-	// IsPreferred returns true if the block is currently on the preferred
-	// chain.
-	IsPreferred(Block) bool
+	// IsPreferred returns true if the block ID is preferred. Only the last
+	// accepted decision and processing decisions are considered preferred.
+	IsPreferred(ids.ID) bool
 
 	// Returns the ID and height of the last accepted decision.
 	LastAccepted() (ids.ID, uint64)

--- a/snow/consensus/snowman/consensus.go
+++ b/snow/consensus/snowman/consensus.go
@@ -46,7 +46,7 @@ type Consensus interface {
 	Processing(ids.ID) bool
 
 	// IsPreferred returns true if the block ID is preferred. Only the last
-	// accepted decision and processing decisions are considered preferred.
+	// accepted block and processing blocks are considered preferred.
 	IsPreferred(ids.ID) bool
 
 	// Returns the ID and height of the last accepted decision.

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -177,7 +177,7 @@ func AddToTailTest(t *testing.T, factory Factory) {
 	// Adding to the previous preference will update the preference
 	require.NoError(sm.Add(block))
 	require.Equal(block.ID(), sm.Preference())
-	require.True(sm.IsPreferred(block))
+	require.True(sm.IsPreferred(block.ID()))
 
 	pref, ok := sm.PreferenceAtHeight(block.Height())
 	require.True(ok)
@@ -292,7 +292,7 @@ func StatusOrProcessingPreviouslyAcceptedTest(t *testing.T, factory Factory) {
 	require.Equal(choices.Accepted, snowmantest.Genesis.Status())
 	require.False(sm.Processing(snowmantest.Genesis.ID()))
 	require.True(sm.Decided(snowmantest.Genesis))
-	require.True(sm.IsPreferred(snowmantest.Genesis))
+	require.True(sm.IsPreferred(snowmantest.Genesis.ID()))
 
 	pref, ok := sm.PreferenceAtHeight(snowmantest.Genesis.Height())
 	require.True(ok)
@@ -330,7 +330,7 @@ func StatusOrProcessingPreviouslyRejectedTest(t *testing.T, factory Factory) {
 	require.Equal(choices.Rejected, block.Status())
 	require.False(sm.Processing(block.ID()))
 	require.True(sm.Decided(block))
-	require.False(sm.IsPreferred(block))
+	require.False(sm.IsPreferred(block.ID()))
 
 	_, ok := sm.PreferenceAtHeight(block.Height())
 	require.False(ok)
@@ -366,7 +366,7 @@ func StatusOrProcessingUnissuedTest(t *testing.T, factory Factory) {
 	require.Equal(choices.Processing, block.Status())
 	require.False(sm.Processing(block.ID()))
 	require.False(sm.Decided(block))
-	require.False(sm.IsPreferred(block))
+	require.False(sm.IsPreferred(block.ID()))
 
 	_, ok := sm.PreferenceAtHeight(block.Height())
 	require.False(ok)
@@ -403,7 +403,7 @@ func StatusOrProcessingIssuedTest(t *testing.T, factory Factory) {
 	require.Equal(choices.Processing, block.Status())
 	require.True(sm.Processing(block.ID()))
 	require.False(sm.Decided(block))
-	require.True(sm.IsPreferred(block))
+	require.True(sm.IsPreferred(block.ID()))
 
 	pref, ok := sm.PreferenceAtHeight(block.Height())
 	require.True(ok)
@@ -968,10 +968,10 @@ func RecordPollChangePreferredChainTest(t *testing.T, factory Factory) {
 
 	require.Equal(a2Block.ID(), sm.Preference())
 
-	require.True(sm.IsPreferred(a1Block))
-	require.True(sm.IsPreferred(a2Block))
-	require.False(sm.IsPreferred(b1Block))
-	require.False(sm.IsPreferred(b2Block))
+	require.True(sm.IsPreferred(a1Block.ID()))
+	require.True(sm.IsPreferred(a2Block.ID()))
+	require.False(sm.IsPreferred(b1Block.ID()))
+	require.False(sm.IsPreferred(b2Block.ID()))
 
 	pref, ok := sm.PreferenceAtHeight(a1Block.Height())
 	require.True(ok)
@@ -985,10 +985,10 @@ func RecordPollChangePreferredChainTest(t *testing.T, factory Factory) {
 	require.NoError(sm.RecordPoll(context.Background(), b2Votes))
 
 	require.Equal(b2Block.ID(), sm.Preference())
-	require.False(sm.IsPreferred(a1Block))
-	require.False(sm.IsPreferred(a2Block))
-	require.True(sm.IsPreferred(b1Block))
-	require.True(sm.IsPreferred(b2Block))
+	require.False(sm.IsPreferred(a1Block.ID()))
+	require.False(sm.IsPreferred(a2Block.ID()))
+	require.True(sm.IsPreferred(b1Block.ID()))
+	require.True(sm.IsPreferred(b2Block.ID()))
 
 	pref, ok = sm.PreferenceAtHeight(b1Block.Height())
 	require.True(ok)
@@ -1003,10 +1003,10 @@ func RecordPollChangePreferredChainTest(t *testing.T, factory Factory) {
 	require.NoError(sm.RecordPoll(context.Background(), a1Votes))
 
 	require.Equal(a2Block.ID(), sm.Preference())
-	require.True(sm.IsPreferred(a1Block))
-	require.True(sm.IsPreferred(a2Block))
-	require.False(sm.IsPreferred(b1Block))
-	require.False(sm.IsPreferred(b2Block))
+	require.True(sm.IsPreferred(a1Block.ID()))
+	require.True(sm.IsPreferred(a2Block.ID()))
+	require.False(sm.IsPreferred(b1Block.ID()))
+	require.False(sm.IsPreferred(b2Block.ID()))
 
 	pref, ok = sm.PreferenceAtHeight(a1Block.Height())
 	require.True(ok)

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -204,12 +204,8 @@ func (ts *Topological) Processing(blkID ids.ID) bool {
 	return ok
 }
 
-func (ts *Topological) IsPreferred(blk Block) bool {
-	// If the block is accepted, then it must be transitively preferred.
-	if blk.Status() == choices.Accepted {
-		return true
-	}
-	return ts.preferredIDs.Contains(blk.ID())
+func (ts *Topological) IsPreferred(blkID ids.ID) bool {
+	return blkID == ts.lastAcceptedID || ts.preferredIDs.Contains(blkID)
 }
 
 func (ts *Topological) LastAccepted() (ids.ID, uint64) {

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -1018,14 +1018,14 @@ func (t *Transitive) deliver(
 
 	// If the block is now preferred, query the network for its preferences
 	// with this new block.
-	if t.Consensus.IsPreferred(blk) {
+	if t.Consensus.IsPreferred(blkID) {
 		t.sendQuery(ctx, blkID, blk.Bytes(), push)
 	}
 
 	t.blocked.Fulfill(ctx, blkID)
 	for _, blk := range added {
 		blkID := blk.ID()
-		if t.Consensus.IsPreferred(blk) {
+		if t.Consensus.IsPreferred(blkID) {
 			t.sendQuery(ctx, blkID, blk.Bytes(), push)
 		}
 


### PR DESCRIPTION
## Why this should be merged

This PR is part of the work to remove calls to `.Status()` in the consensus code.

## How this works

The purposes to query for these blocks are:
1. to immediately start disseminating them.
2. to support `push`ing the block to disseminate even faster.

If the blocks are deeper than the last accepted block, this node shouldn't need to quickly disseminate them (as they are already sufficiently disseminated to be accepted).

## How this was tested

- [X] Existing unit tests.