### PR TITLE
[e2e] Fix excessively verbose output from virtuous test

### DIFF
--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -114,7 +114,9 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 				)
 				require.NoError(err)
 				for _, uri := range rpcEps {
-					tests.Outf("{{green}}metrics at %q:{{/}} %v\n", uri, metricsBeforeTx[uri])
+					for _, metric := range []string{blksProcessingMetric, blksAcceptedMetric} {
+						tests.Outf("{{green}}%s at %q:{{/}} %v\n", metric, uri, metricsBeforeTx[uri][metric])
+					}
 				}
 
 				testBalances := make([]uint64, 0)


### PR DESCRIPTION
## Why this should be merged

PR #3057 added a metrics client and switched the virtuous test to use it. The virtuous test was previously selecting only the 2 metrics it was interested in and printing them out on each of its 50 rounds, but after the switch to the new client it was printing all metrics rather than just 2, resulting in so much log output that it was no longer possible to view a complete e2e log in github's UI without downloading it. 

## How this works

This change ensures that only the 2 metrics of interest are output.

## How this was tested

Local verification that only the 2 metrics of interest for each node are output.