### PR TITLE
Remove `Decided` from the `Consensus` interface

### DIFF
--- a/snow/consensus/snowman/consensus.go
+++ b/snow/consensus/snowman/consensus.go
@@ -39,9 +39,6 @@ type Consensus interface {
 	// Returns if a critical error has occurred.
 	Add(Block) error
 
-	// Decided returns true if the block has been decided.
-	Decided(Block) bool
-
 	// Processing returns true if the block ID is currently processing.
 	Processing(ids.ID) bool
 

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -291,7 +291,6 @@ func StatusOrProcessingPreviouslyAcceptedTest(t *testing.T, factory Factory) {
 
 	require.Equal(choices.Accepted, snowmantest.Genesis.Status())
 	require.False(sm.Processing(snowmantest.Genesis.ID()))
-	require.True(sm.Decided(snowmantest.Genesis))
 	require.True(sm.IsPreferred(snowmantest.Genesis.ID()))
 
 	pref, ok := sm.PreferenceAtHeight(snowmantest.Genesis.Height())
@@ -329,7 +328,6 @@ func StatusOrProcessingPreviouslyRejectedTest(t *testing.T, factory Factory) {
 
 	require.Equal(choices.Rejected, block.Status())
 	require.False(sm.Processing(block.ID()))
-	require.True(sm.Decided(block))
 	require.False(sm.IsPreferred(block.ID()))
 
 	_, ok := sm.PreferenceAtHeight(block.Height())
@@ -365,7 +363,6 @@ func StatusOrProcessingUnissuedTest(t *testing.T, factory Factory) {
 
 	require.Equal(choices.Processing, block.Status())
 	require.False(sm.Processing(block.ID()))
-	require.False(sm.Decided(block))
 	require.False(sm.IsPreferred(block.ID()))
 
 	_, ok := sm.PreferenceAtHeight(block.Height())
@@ -402,7 +399,6 @@ func StatusOrProcessingIssuedTest(t *testing.T, factory Factory) {
 	require.NoError(sm.Add(block))
 	require.Equal(choices.Processing, block.Status())
 	require.True(sm.Processing(block.ID()))
-	require.False(sm.Decided(block))
 	require.True(sm.IsPreferred(block.ID()))
 
 	pref, ok := sm.PreferenceAtHeight(block.Height())

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowball"
 	"github.com/ava-labs/avalanchego/utils/bag"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -180,16 +179,6 @@ func (ts *Topological) Add(blk Block) error {
 		zap.Stringer("parentID", parentID),
 	)
 	return nil
-}
-
-func (ts *Topological) Decided(blk Block) bool {
-	// If the block is decided, then it must have been previously issued.
-	if blk.Status().Decided() {
-		return true
-	}
-	// If the block is marked as fetched, we can check if it has been
-	// transitively rejected.
-	return blk.Status() == choices.Processing && blk.Height() <= ts.lastAcceptedHeight
 }
 
 func (ts *Topological) Processing(blkID ids.ID) bool {


### PR DESCRIPTION
## Why this should be merged

This PR simplifies the `snowman.Consensus` interface to not expose the `Decided` method.

## How this works

The `Decided` method can be implemented directly on top of the existing `snowman.Consensus` interface.

## How this was tested

- [X] CI