### PR TITLE
Remove .Status() from .Accepted()

### DIFF
--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -127,7 +127,7 @@ func (ts *Topological) Initialize(
 	ts.lastAcceptedID = lastAcceptedID
 	ts.lastAcceptedHeight = lastAcceptedHeight
 	ts.blocks = map[ids.ID]*snowmanBlock{
-		lastAcceptedID: {params: ts.params},
+		lastAcceptedID: {t: ts},
 	}
 	ts.preferredHeights = make(map[uint64]ids.ID)
 	ts.preference = lastAcceptedID
@@ -163,8 +163,8 @@ func (ts *Topological) Add(blk Block) error {
 	// add the block as a child of its parent, and add the block to the tree
 	parentNode.AddChild(blk)
 	ts.blocks[blkID] = &snowmanBlock{
-		params: ts.params,
-		blk:    blk,
+		t:   ts,
+		blk: blk,
 	}
 
 	// If we are extending the preference, this is the new preference
@@ -289,7 +289,7 @@ func (ts *Topological) RecordPoll(ctx context.Context, voteBag bag.Bag[ids.ID]) 
 
 	// Runtime = |live set| ; Space = Constant
 	// Traverse from the preferred ID to the last accepted ancestor.
-	for block := startBlock; !block.Accepted(); {
+	for block := startBlock; !block.Decided(); {
 		blkID := block.blk.ID()
 		ts.preferredIDs.Add(blkID)
 		ts.preferredHeights[block.blk.Height()] = blkID
@@ -360,7 +360,7 @@ func (ts *Topological) calculateInDegree(votes bag.Bag[ids.ID]) {
 		}
 
 		// If the vote is for the last accepted block, the vote is dropped
-		if votedBlock.Accepted() {
+		if votedBlock.Decided() {
 			continue
 		}
 
@@ -384,7 +384,7 @@ func (ts *Topological) calculateInDegree(votes bag.Bag[ids.ID]) {
 
 		// iterate through all the block's ancestors and set up the inDegrees of
 		// the blocks
-		for n := ts.blocks[parentID]; !n.Accepted(); n = ts.blocks[parentID] {
+		for n := ts.blocks[parentID]; !n.Decided(); n = ts.blocks[parentID] {
 			parentID = n.blk.Parent()
 
 			// Increase the inDegree by one
@@ -428,7 +428,7 @@ func (ts *Topological) pushVotes() []votes {
 
 		// If the block is accepted, then we don't need to push votes to the
 		// parent block
-		if block.Accepted() {
+		if block.Decided() {
 			continue
 		}
 

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -289,6 +289,11 @@ func (ts *Topological) RecordPoll(ctx context.Context, voteBag bag.Bag[ids.ID]) 
 
 	// Runtime = |live set| ; Space = Constant
 	// Traverse from the preferred ID to the last accepted ancestor.
+	//
+	// It is guaranteed that the first decided block we encounter is the last
+	// accepted block because the startBlock is the preferred block. The
+	// preferred block is guaranteed to either be the last accepted block or
+	// extend the accepted chain.
 	for block := startBlock; !block.Decided(); {
 		blkID := block.blk.ID()
 		ts.preferredIDs.Add(blkID)


### PR DESCRIPTION
## Why this should be merged

Removes the usage of `.Status()` from the consensus code.

## How this works

The blocks map includes both the last accepted block and all the processing blocks. This PR changes how we inspect the last accepted block to use heights rather than checking the status.

We update the last accepted variables immediately after calling `Accept`, so these values are always kept up-to-date.

## How this was tested

- [X] CI