### PR TITLE
Emit version in JSON format for --json-version

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -69,6 +69,7 @@ func deprecateFlags(fs *pflag.FlagSet) error {
 func addProcessFlags(fs *pflag.FlagSet) {
 	// If true, print the version and quit.
 	fs.Bool(VersionKey, false, "If true, print version and quit")
+	fs.Bool(JSONVersionKey, false, "If true, print version in JSON format and quit")
 }
 
 func addNodeFlags(fs *pflag.FlagSet) {

--- a/config/flags.go
+++ b/config/flags.go
@@ -69,7 +69,7 @@ func deprecateFlags(fs *pflag.FlagSet) error {
 func addProcessFlags(fs *pflag.FlagSet) {
 	// If true, print the version and quit.
 	fs.Bool(VersionKey, false, "If true, print version and quit")
-	fs.Bool(JSONVersionKey, false, "If true, print version in JSON format and quit")
+	fs.Bool(VersionJSONKey, false, "If true, print version in JSON format and quit")
 }
 
 func addNodeFlags(fs *pflag.FlagSet) {

--- a/config/keys.go
+++ b/config/keys.go
@@ -13,7 +13,7 @@ const (
 	ConfigContentKey                 = "config-file-content"
 	ConfigContentTypeKey             = "config-file-content-type"
 	VersionKey                       = "version"
-	JSONVersionKey                   = "json-version"
+	VersionJSONKey                   = "version-json"
 	GenesisFileKey                   = "genesis-file"
 	GenesisFileContentKey            = "genesis-file-content"
 	NetworkNameKey                   = "network-id"

--- a/config/keys.go
+++ b/config/keys.go
@@ -13,6 +13,7 @@ const (
 	ConfigContentKey                 = "config-file-content"
 	ConfigContentTypeKey             = "config-file-content-type"
 	VersionKey                       = "version"
+	JSONVersionKey                   = "json-version"
 	GenesisFileKey                   = "genesis-file"
 	GenesisFileContentKey            = "genesis-file-content"
 	NetworkNameKey                   = "network-id"

--- a/main/main.go
+++ b/main/main.go
@@ -29,13 +29,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if v.GetBool(config.JSONVersionKey) && v.GetBool(config.VersionKey) {
+	if v.GetBool(config.VersionJSONKey) && v.GetBool(config.VersionKey) {
 		fmt.Println("can't print both JSON and human readable versions")
 		os.Exit(1)
 	}
 
-	if v.GetBool(config.JSONVersionKey) {
 		fmt.Println(version.GetVersions().JSON())
+	if v.GetBool(config.VersionJSONKey) {
 		os.Exit(0)
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -29,6 +29,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if v.GetBool(config.JSONVersionKey) {
+		fmt.Print(version.JSONString)
+		os.Exit(0)
+	}
+
 	if v.GetBool(config.VersionKey) {
 		fmt.Print(version.String)
 		os.Exit(0)

--- a/main/main.go
+++ b/main/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	if v.GetBool(config.JSONVersionKey) && v.GetBool(config.VersionKey) {
-		fmt.Printf("can't print both JSON and human readable versions\n")
+		fmt.Println("can't print both JSON and human readable versions")
 		os.Exit(1)
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -34,8 +35,14 @@ func main() {
 		os.Exit(1)
 	}
 
-		fmt.Println(version.GetVersions().JSON())
 	if v.GetBool(config.VersionJSONKey) {
+		versions := version.GetVersions()
+		jsonBytes, err := json.MarshalIndent(versions, "", "  ")
+		if err != nil {
+			fmt.Printf("couldn't marshal versions: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(jsonBytes))
 		os.Exit(0)
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -29,13 +29,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	if v.GetBool(config.JSONVersionKey) && v.GetBool(config.VersionKey) {
+		fmt.Printf("can't print both JSON and human readable versions\n")
+		os.Exit(1)
+	}
+
 	if v.GetBool(config.JSONVersionKey) {
-		fmt.Print(version.JSONString)
+		fmt.Println(version.GetVersions().JSON())
 		os.Exit(0)
 	}
 
 	if v.GetBool(config.VersionKey) {
-		fmt.Print(version.String)
+		fmt.Println(version.GetVersions().String())
 		os.Exit(0)
 	}
 

--- a/version/string.go
+++ b/version/string.go
@@ -16,8 +16,8 @@ var GitCommit string
 
 // Versions contains the versions relevant to a build of avalanchego. In
 // addition to supporting construction of the strings displayed by
-// --version and --json-version, it can be used to unmarshal the output
-// of --json-version.
+// --version and --version-json, it can be used to unmarshal the output
+// of --version-json.
 type Versions struct {
 	Application string `json:"application"`
 	Database    string `json:"database"`

--- a/version/string.go
+++ b/version/string.go
@@ -6,7 +6,6 @@ package version
 import (
 	"fmt"
 	"runtime"
-	"strconv"
 	"strings"
 )
 
@@ -20,7 +19,7 @@ var GitCommit string
 type Versions struct {
 	Application string `json:"application"`
 	Database    string `json:"database"`
-	RPCChainVM  string `json:"rpcchainvm"`
+	RPCChainVM  uint64 `json:"rpcchainvm"`
 	// Commit may be empty if GitCommit was not set at compile time
 	Commit string `json:"commit"`
 	Go     string `json:"go"`
@@ -30,7 +29,7 @@ func GetVersions() *Versions {
 	versions := &Versions{
 		Application: CurrentApp.String(),
 		Database:    CurrentDatabase.String(),
-		RPCChainVM:  strconv.FormatUint(uint64(RPCChainVMProtocol), 10),
+		RPCChainVM:  uint64(RPCChainVMProtocol),
 		Go:          strings.TrimPrefix(runtime.Version(), "go"),
 	}
 	if GitCommit != "" {
@@ -41,7 +40,7 @@ func GetVersions() *Versions {
 
 func (v *Versions) String() string {
 	// This format maintains consistency with previous --version output
-	versionString := fmt.Sprintf("%s [database=%s, rpcchainvm=%s, ", v.Application, v.Database, v.RPCChainVM)
+	versionString := fmt.Sprintf("%s [database=%s, rpcchainvm=%d, ", v.Application, v.Database, v.RPCChainVM)
 	if len(v.Commit) > 0 {
 		versionString += fmt.Sprintf("commit=%s, ", v.Commit)
 	}

--- a/version/string.go
+++ b/version/string.go
@@ -22,8 +22,9 @@ type Versions struct {
 	Application string `json:"application"`
 	Database    string `json:"database"`
 	RPCChainVM  string `json:"rpcchainvm"`
-	Commit      string `json:"commit"`
-	Go          string `json:"go"`
+	// Commit may be empty if GitCommit was not set at compile time
+	Commit string `json:"commit"`
+	Go     string `json:"go"`
 }
 
 func GetVersions() *Versions {

--- a/version/string.go
+++ b/version/string.go
@@ -13,9 +13,9 @@ import (
 var GitCommit string
 
 // Versions contains the versions relevant to a build of avalanchego. In
-// addition to supporting construction of the strings displayed by
-// --version and --version-json, it can be used to unmarshal the output
-// of --version-json.
+// addition to supporting construction of the string displayed by
+// --version, it is used to produce the output of --version-json and can
+// be used to unmarshal that output.
 type Versions struct {
 	Application string `json:"application"`
 	Database    string `json:"database"`

--- a/version/string.go
+++ b/version/string.go
@@ -4,7 +4,6 @@
 package version
 
 import (
-	"encoding/json"
 	"fmt"
 	"runtime"
 	"strconv"
@@ -47,12 +46,4 @@ func (v *Versions) String() string {
 		versionString += fmt.Sprintf("commit=%s, ", v.Commit)
 	}
 	return versionString + fmt.Sprintf("go=%s]", v.Go)
-}
-
-func (v *Versions) JSON() string {
-	jsonBytes, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		panic(err)
-	}
-	return string(jsonBytes)
 }

--- a/version/string.go
+++ b/version/string.go
@@ -4,8 +4,10 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -13,28 +15,57 @@ var (
 	// String is displayed when CLI arg --version is used
 	String string
 
+	// String is displayed when CLI arg --json-version is used
+	JSONString string
+
 	// GitCommit is set in the build script at compile time
 	GitCommit string
 )
 
+type namedVersion struct {
+	name    string
+	version string
+}
+
 func init() {
-	format := "%s [database=%s, rpcchainvm=%d"
-	args := []interface{}{
-		CurrentApp,
-		CurrentDatabase,
-		RPCChainVMProtocol,
-	}
-	if GitCommit != "" {
-		format += ", commit=%s"
-		args = append(args, GitCommit)
+	// Define the ordered set of versions that are common to regular and JSON
+	// output. The order is maintained to ensure consistency with previous
+	// --version output.
+	versions := []namedVersion{
+		{name: "database", version: CurrentDatabase.String()},
+		{name: "rpcchainvm", version: strconv.FormatUint(uint64(RPCChainVMProtocol), 10)},
 	}
 
-	// add golang version
+	// Add git commit if available
+	if GitCommit != "" {
+		versions = append(versions, namedVersion{name: "commit", version: GitCommit})
+	}
+
+	// Add golang version
 	goVersion := runtime.Version()
 	goVersionNumber := strings.TrimPrefix(goVersion, "go")
-	format += ", go=%s"
-	args = append(args, goVersionNumber)
+	versions = append(versions, namedVersion{name: "go", version: goVersionNumber})
 
-	format += "]\n"
-	String = fmt.Sprintf(format, args...)
+	// Set the value of the regular version string
+	versionPairs := make([]string, len(versions))
+	for i, v := range versions {
+		versionPairs[i] = fmt.Sprintf("%s=%s", v.name, v.version)
+	}
+	// This format maintains consistency with previous --version output
+	String = fmt.Sprintf("%s [%s]\n", CurrentApp, strings.Join(versionPairs, ", "))
+
+	// Include the app version as a regular value in the JSON output
+	versions = append(versions, namedVersion{name: "app", version: CurrentApp.String()})
+
+	// Convert versions to a map for more compact JSON output
+	versionMap := make(map[string]string, len(versions))
+	for _, v := range versions {
+		versionMap[v.name] = v.version
+	}
+
+	jsonBytes, err := json.MarshalIndent(versionMap, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	JSONString = string(jsonBytes) + "\n"
 }

--- a/version/string.go
+++ b/version/string.go
@@ -26,16 +26,13 @@ type Versions struct {
 }
 
 func GetVersions() *Versions {
-	versions := &Versions{
+	return &Versions{
 		Application: CurrentApp.String(),
 		Database:    CurrentDatabase.String(),
 		RPCChainVM:  uint64(RPCChainVMProtocol),
+		Commit:      GitCommit,
 		Go:          strings.TrimPrefix(runtime.Version(), "go"),
 	}
-	if GitCommit != "" {
-		versions.Commit = GitCommit
-	}
-	return versions
 }
 
 func (v *Versions) String() string {

--- a/version/string_test.go
+++ b/version/string_test.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionsGetString(t *testing.T) {
+	versions := Versions{
+		Application: "1",
+		Database:    "2",
+		RPCChainVM:  "3",
+		Go:          "5",
+	}
+	expectedVersions := fmt.Sprintf(
+		"%s [database=%s, rpcchainvm=%s, go=%s]",
+		versions.Application,
+		versions.Database,
+		versions.RPCChainVM,
+		versions.Go,
+	)
+	require.Equal(t, expectedVersions, versions.String())
+
+	versions.Commit = "eafd"
+	expectedVersions = fmt.Sprintf(
+		"%s [database=%s, rpcchainvm=%s, commit=%s, go=%s]",
+		versions.Application,
+		versions.Database,
+		versions.RPCChainVM,
+		versions.Commit,
+		versions.Go,
+	)
+	require.Equal(t, expectedVersions, versions.String())
+}
+
+func TestVersionsJSON(t *testing.T) {
+	versions := GetVersions()
+	jsonString := versions.JSON()
+	unmarshalledVersions := &Versions{}
+	require.NoError(t, json.Unmarshal([]byte(jsonString), unmarshalledVersions))
+	require.Equal(t, versions, unmarshalledVersions)
+}

--- a/version/string_test.go
+++ b/version/string_test.go
@@ -4,7 +4,6 @@
 package version
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -15,11 +14,11 @@ func TestVersionsGetString(t *testing.T) {
 	versions := Versions{
 		Application: "1",
 		Database:    "2",
-		RPCChainVM:  "3",
+		RPCChainVM:  3,
 		Go:          "5",
 	}
 	expectedVersions := fmt.Sprintf(
-		"%s [database=%s, rpcchainvm=%s, go=%s]",
+		"%s [database=%s, rpcchainvm=%d, go=%s]",
 		versions.Application,
 		versions.Database,
 		versions.RPCChainVM,
@@ -29,7 +28,7 @@ func TestVersionsGetString(t *testing.T) {
 
 	versions.Commit = "eafd"
 	expectedVersions = fmt.Sprintf(
-		"%s [database=%s, rpcchainvm=%s, commit=%s, go=%s]",
+		"%s [database=%s, rpcchainvm=%d, commit=%s, go=%s]",
 		versions.Application,
 		versions.Database,
 		versions.RPCChainVM,

--- a/version/string_test.go
+++ b/version/string_test.go
@@ -14,9 +14,10 @@ func TestVersionsGetString(t *testing.T) {
 		Application: "1",
 		Database:    "2",
 		RPCChainVM:  3,
+		Commit:      "4",
 		Go:          "5",
 	}
-	require.Equal(t, "1 [database=2, rpcchainvm=3, go=5]", versions.String())
-	versions.Commit = "4"
 	require.Equal(t, "1 [database=2, rpcchainvm=3, commit=4, go=5]", versions.String())
+	versions.Commit = ""
+	require.Equal(t, "1 [database=2, rpcchainvm=3, go=5]", versions.String())
 }

--- a/version/string_test.go
+++ b/version/string_test.go
@@ -38,11 +38,3 @@ func TestVersionsGetString(t *testing.T) {
 	)
 	require.Equal(t, expectedVersions, versions.String())
 }
-
-func TestVersionsJSON(t *testing.T) {
-	versions := GetVersions()
-	jsonString := versions.JSON()
-	unmarshalledVersions := &Versions{}
-	require.NoError(t, json.Unmarshal([]byte(jsonString), unmarshalledVersions))
-	require.Equal(t, versions, unmarshalledVersions)
-}

--- a/version/string_test.go
+++ b/version/string_test.go
@@ -4,7 +4,6 @@
 package version
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,23 +16,7 @@ func TestVersionsGetString(t *testing.T) {
 		RPCChainVM:  3,
 		Go:          "5",
 	}
-	expectedVersions := fmt.Sprintf(
-		"%s [database=%s, rpcchainvm=%d, go=%s]",
-		versions.Application,
-		versions.Database,
-		versions.RPCChainVM,
-		versions.Go,
-	)
-	require.Equal(t, expectedVersions, versions.String())
-
-	versions.Commit = "eafd"
-	expectedVersions = fmt.Sprintf(
-		"%s [database=%s, rpcchainvm=%d, commit=%s, go=%s]",
-		versions.Application,
-		versions.Database,
-		versions.RPCChainVM,
-		versions.Commit,
-		versions.Go,
-	)
-	require.Equal(t, expectedVersions, versions.String())
+	require.Equal(t, "1 [database=2, rpcchainvm=3, go=5]", versions.String())
+	versions.Commit = "4"
+	require.Equal(t, "1 [database=2, rpcchainvm=3, commit=4, go=5]", versions.String())
 }


### PR DESCRIPTION
## Why this should be merged

Simplifies determination of the version of avalanchego by providing machine-readable version output when `--version-json` is specified. This is intended to allow a test controller to easily determine the versions for a given image published with the `latest` tag. 

## How this works

 - Create a JSON equivalent to the version string
 - Output JSON version string in response to `--version-json`

Alternate additive-only implementation: https://github.com/ava-labs/avalanchego/compare/json-version-additive?expand=1

## How this was tested

Locally confirmed output consistency:

`--version`
```
avalanchego/1.11.8 [database=v1.4.5, rpcchainvm=35, commit=eff4dc65a9073554000edace407a181df40c2857, go=1.21.11]
```

`--version-json`
```json
{
  "app": "avalanchego/1.11.8",
  "commit": "eff4dc65a9073554000edace407a181df40c2857",
  "database": "v1.4.5",
  "go": "1.21.11",
  "rpcchainvm": 35
}
```