### PR TITLE
Repackaged NextBlockTime and GetNextStakerChangeTime

### DIFF
--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -171,7 +171,7 @@ func (b *builder) durationToSleep() (time.Duration, error) {
 		return 0, fmt.Errorf("%w: %s", errMissingPreferredState, preferredID)
 	}
 
-	nextStakerChangeTime, err := txexecutor.GetNextStakerChangeTime(preferredState)
+	nextStakerChangeTime, err := state.GetNextStakerChangeTime(preferredState)
 	if err != nil {
 		return 0, fmt.Errorf("%w of %s: %w", errCalculatingNextStakerTime, preferredID, err)
 	}
@@ -216,7 +216,7 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 		return nil, fmt.Errorf("%w: %s", state.ErrMissingParentState, preferredID)
 	}
 
-	timestamp, timeWasCapped, err := txexecutor.NextBlockTime(preferredState, b.txExecutorBackend.Clk)
+	timestamp, timeWasCapped, err := state.NextBlockTime(preferredState, b.txExecutorBackend.Clk)
 	if err != nil {
 		return nil, fmt.Errorf("could not calculate next staker change time: %w", err)
 	}

--- a/vms/platformvm/block/executor/manager.go
+++ b/vms/platformvm/block/executor/manager.go
@@ -132,7 +132,7 @@ func (m *manager) VerifyTx(tx *txs.Tx) error {
 		return err
 	}
 
-	nextBlkTime, _, err := executor.NextBlockTime(stateDiff, m.txExecutorBackend.Clk)
+	nextBlkTime, _, err := state.NextBlockTime(stateDiff, m.txExecutorBackend.Clk)
 	if err != nil {
 		return err
 	}

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -1436,7 +1436,7 @@ func TestAddValidatorProposalBlock(t *testing.T) {
 
 	// Advance time until next staker change time is [validatorEndTime]
 	for {
-		nextStakerChangeTime, err := executor.GetNextStakerChangeTime(env.state)
+		nextStakerChangeTime, err := state.GetNextStakerChangeTime(env.state)
 		require.NoError(err)
 		if nextStakerChangeTime.Equal(validatorEndTime) {
 			break

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -266,7 +266,7 @@ func (v *verifier) banffNonOptionBlock(b block.BanffBlock) error {
 		)
 	}
 
-	nextStakerChangeTime, err := executor.GetNextStakerChangeTime(parentState)
+	nextStakerChangeTime, err := state.GetNextStakerChangeTime(parentState)
 	if err != nil {
 		return fmt.Errorf("could not verify block timestamp: %w", err)
 	}

--- a/vms/platformvm/state/chain_time_helpers.go
+++ b/vms/platformvm/state/chain_time_helpers.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+)
+
+func NextBlockTime(state Chain, clk *mockable.Clock) (time.Time, bool, error) {
+	var (
+		timestamp  = clk.Time()
+		parentTime = state.GetTimestamp()
+	)
+	if parentTime.After(timestamp) {
+		timestamp = parentTime
+	}
+	// [timestamp] = max(now, parentTime)
+
+	nextStakerChangeTime, err := GetNextStakerChangeTime(state)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("failed getting next staker change time: %w", err)
+	}
+
+	// timeWasCapped means that [timestamp] was reduced to [nextStakerChangeTime]
+	timeWasCapped := !timestamp.Before(nextStakerChangeTime)
+	if timeWasCapped {
+		timestamp = nextStakerChangeTime
+	}
+	// [timestamp] = min(max(now, parentTime), nextStakerChangeTime)
+	return timestamp, timeWasCapped, nil
+}
+
+// GetNextStakerChangeTime returns the next time a staker will be either added
+// or removed to/from the current validator set.
+func GetNextStakerChangeTime(state Chain) (time.Time, error) {
+	currentStakerIterator, err := state.GetCurrentStakerIterator()
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer currentStakerIterator.Release()
+
+	pendingStakerIterator, err := state.GetPendingStakerIterator()
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer pendingStakerIterator.Release()
+
+	hasCurrentStaker := currentStakerIterator.Next()
+	hasPendingStaker := pendingStakerIterator.Next()
+	switch {
+	case hasCurrentStaker && hasPendingStaker:
+		nextCurrentTime := currentStakerIterator.Value().NextTime
+		nextPendingTime := pendingStakerIterator.Value().NextTime
+		if nextCurrentTime.Before(nextPendingTime) {
+			return nextCurrentTime, nil
+		}
+		return nextPendingTime, nil
+	case hasCurrentStaker:
+		return currentStakerIterator.Value().NextTime, nil
+	case hasPendingStaker:
+		return pendingStakerIterator.Value().NextTime, nil
+	default:
+		return time.Time{}, database.ErrNotFound
+	}
+}

--- a/vms/platformvm/txs/executor/proposal_tx_executor.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor.go
@@ -269,7 +269,7 @@ func (e *ProposalTxExecutor) AdvanceTimeTx(tx *txs.AdvanceTimeTx) error {
 
 	// Only allow timestamp to move forward as far as the time of next staker
 	// set change time
-	nextStakerChangeTime, err := GetNextStakerChangeTime(e.OnCommitState)
+	nextStakerChangeTime, err := state.GetNextStakerChangeTime(e.OnCommitState)
 	if err != nil {
 		return err
 	}

--- a/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
@@ -94,40 +94,6 @@ func getDelegatorRules(
 	}, nil
 }
 
-// GetNextStakerChangeTime returns the next time a staker will be either added
-// or removed to/from the current validator set.
-func GetNextStakerChangeTime(state state.Chain) (time.Time, error) {
-	currentStakerIterator, err := state.GetCurrentStakerIterator()
-	if err != nil {
-		return time.Time{}, err
-	}
-	defer currentStakerIterator.Release()
-
-	pendingStakerIterator, err := state.GetPendingStakerIterator()
-	if err != nil {
-		return time.Time{}, err
-	}
-	defer pendingStakerIterator.Release()
-
-	hasCurrentStaker := currentStakerIterator.Next()
-	hasPendingStaker := pendingStakerIterator.Next()
-	switch {
-	case hasCurrentStaker && hasPendingStaker:
-		nextCurrentTime := currentStakerIterator.Value().NextTime
-		nextPendingTime := pendingStakerIterator.Value().NextTime
-		if nextCurrentTime.Before(nextPendingTime) {
-			return nextCurrentTime, nil
-		}
-		return nextPendingTime, nil
-	case hasCurrentStaker:
-		return currentStakerIterator.Value().NextTime, nil
-	case hasPendingStaker:
-		return pendingStakerIterator.Value().NextTime, nil
-	default:
-		return time.Time{}, database.ErrNotFound
-	}
-}
-
 // GetValidator returns information about the given validator, which may be a
 // current validator or pending validator.
 func GetValidator(state state.Chain, subnetID ids.ID, nodeID ids.NodeID) (*state.Staker, error) {

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -56,30 +55,6 @@ func VerifyNewChainTime(
 		)
 	}
 	return nil
-}
-
-func NextBlockTime(state state.Chain, clk *mockable.Clock) (time.Time, bool, error) {
-	var (
-		timestamp  = clk.Time()
-		parentTime = state.GetTimestamp()
-	)
-	if parentTime.After(timestamp) {
-		timestamp = parentTime
-	}
-	// [timestamp] = max(now, parentTime)
-
-	nextStakerChangeTime, err := GetNextStakerChangeTime(state)
-	if err != nil {
-		return time.Time{}, false, fmt.Errorf("failed getting next staker change time: %w", err)
-	}
-
-	// timeWasCapped means that [timestamp] was reduced to [nextStakerChangeTime]
-	timeWasCapped := !timestamp.Before(nextStakerChangeTime)
-	if timeWasCapped {
-		timestamp = nextStakerChangeTime
-	}
-	// [timestamp] = min(max(now, parentTime), nextStakerChangeTime)
-	return timestamp, timeWasCapped, nil
 }
 
 // AdvanceTimeTo applies all state changes to [parentState] resulting from


### PR DESCRIPTION
## Why this should be merged
With dynamic fees, a bunch of `platformvm` packages will need to calculate block time in order to pick the right gas price.
In anticipation for it, this PR moves  `NextBlockTime` and its dependencies to `state` package, in order to avoid import cycles.

## How this works
Just move `NextBlockTime` and `GetNextStakerChangeTime`  from `txexecutor` package to `state` package, where they won't cause import cycles.

## How this was tested
CI (it's pure refactoring