### PR TITLE
[vms/platformvm] Cleanup execution config tests

### DIFF
--- a/vms/platformvm/config/execution_config_test.go
+++ b/vms/platformvm/config/execution_config_test.go
@@ -31,7 +31,6 @@ func VerifyInitializedStruct(s interface{}) error {
 		if !isSet {
 			log = fmt.Sprintf("%v%s not set; ", log, structType.Field(i).Name)
 		}
-
 	}
 
 	if len(log) > 0 {

--- a/vms/platformvm/config/execution_config_test.go
+++ b/vms/platformvm/config/execution_config_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/network"
 )
 
-// Errors if all values in a struct are not initialized
+// Requires all values in a struct to be initialized
 func verifyInitializedStruct(tb testing.TB, s interface{}) {
 	tb.Helper()
 

--- a/vms/platformvm/config/execution_config_test.go
+++ b/vms/platformvm/config/execution_config_test.go
@@ -16,6 +16,8 @@ import (
 
 // Errors if all values in a struct are not initialized
 func verifyInitializedStruct(tb testing.TB, s interface{}) {
+	tb.Helper()
+
 	require := require.New(tb)
 
 	structType := reflect.TypeOf(s)

--- a/vms/platformvm/config/execution_config_test.go
+++ b/vms/platformvm/config/execution_config_test.go
@@ -86,6 +86,7 @@ func TestExecutionConfigUnmarshal(t *testing.T) {
 				PullGossipPollSize:                          11,
 				PullGossipFrequency:                         12,
 				PullGossipThrottlingPeriod:                  13,
+				PullGossipThrottlingLimit:                   14,
 				ExpectedBloomFilterElements:                 15,
 				ExpectedBloomFilterFalsePositiveProbability: 16,
 				MaxBloomFilterFalsePositiveProbability:      17,


### PR DESCRIPTION
## Why this should be merged

@marun had a good suggestion that this test should just do a round-trip for maintainability and clarity

## How this works

struct1 -> marshal to json -> unmarshall to struct2, call Equal on the 2 structs

## How this was tested

CI