### PR TITLE
[tmpnet] Enable bootstrap of subnets with disjoint validator sets

### DIFF
--- a/tests/e2e/vms/xsvm.go
+++ b/tests/e2e/vms/xsvm.go
@@ -58,7 +58,6 @@ var _ = ginkgo.Describe("[XSVM]", func() {
 
 		sourceSubnet := network.GetSubnet(subnetAName)
 		require.NotNil(sourceSubnet)
-
 		destinationSubnet := network.GetSubnet(subnetBName)
 		require.NotNil(destinationSubnet)
 

--- a/tests/e2e/vms/xsvm.go
+++ b/tests/e2e/vms/xsvm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/subnet"
@@ -35,9 +36,17 @@ func XSVMSubnetsOrPanic(nodes ...*tmpnet.Node) []*tmpnet.Subnet {
 	if err != nil {
 		panic(err)
 	}
+	subnetANodes := nodes
+	subnetBNodes := nodes
+	if len(nodes) > 1 {
+		// Validate tmpnet bootstrap of a disjoint validator set
+		midpoint := len(nodes) / 2
+		subnetANodes = nodes[:midpoint]
+		subnetBNodes = nodes[midpoint:]
+	}
 	return []*tmpnet.Subnet{
-		subnet.NewXSVMOrPanic(subnetAName, key, nodes...),
-		subnet.NewXSVMOrPanic(subnetBName, key, nodes...),
+		subnet.NewXSVMOrPanic(subnetAName, key, subnetANodes...),
+		subnet.NewXSVMOrPanic(subnetBName, key, subnetBNodes...),
 	}
 }
 
@@ -49,20 +58,28 @@ var _ = ginkgo.Describe("[XSVM]", func() {
 
 		sourceSubnet := network.GetSubnet(subnetAName)
 		require.NotNil(sourceSubnet)
+
 		destinationSubnet := network.GetSubnet(subnetBName)
 		require.NotNil(destinationSubnet)
 
 		sourceChain := sourceSubnet.Chains[0]
 		destinationChain := destinationSubnet.Chains[0]
 
-		apiNode := network.Nodes[0]
-		tests.Outf(" issuing transactions on %s (%s)\n", apiNode.NodeID, apiNode.URI)
+		sourceValidators := getNodesForIDs(network.Nodes, sourceSubnet.ValidatorIDs)
+		require.NotEmpty(sourceValidators)
+		sourceAPINode := sourceValidators[0]
+		tests.Outf(" issuing transactions for source subnet on %s (%s)\n", sourceAPINode.NodeID, sourceAPINode.URI)
+
+		destinationValidators := getNodesForIDs(network.Nodes, destinationSubnet.ValidatorIDs)
+		require.NotEmpty(destinationValidators)
+		destinationAPINode := destinationValidators[0]
+		tests.Outf(" issuing transactions for destination subnet on %s (%s)\n", destinationAPINode.NodeID, destinationAPINode.URI)
 
 		destinationKey, err := secp256k1.NewPrivateKey()
 		require.NoError(err)
 
 		ginkgo.By("checking that the funded key has sufficient funds for the export")
-		sourceClient := api.NewClient(apiNode.URI, sourceChain.ChainID.String())
+		sourceClient := api.NewClient(sourceAPINode.URI, sourceChain.ChainID.String())
 		initialSourcedBalance, err := sourceClient.Balance(
 			e2e.DefaultContext(),
 			sourceChain.PreFundedKey.Address(),
@@ -75,7 +92,7 @@ var _ = ginkgo.Describe("[XSVM]", func() {
 		exportTxStatus, err := export.Export(
 			e2e.DefaultContext(),
 			&export.Config{
-				URI:                apiNode.URI,
+				URI:                sourceAPINode.URI,
 				SourceChainID:      sourceChain.ChainID,
 				DestinationChainID: destinationChain.ChainID,
 				Amount:             units.Schmeckle,
@@ -87,7 +104,7 @@ var _ = ginkgo.Describe("[XSVM]", func() {
 		tests.Outf(" issued transaction with ID: %s\n", exportTxStatus.TxID)
 
 		ginkgo.By("checking that the export transaction has been accepted on all nodes")
-		for _, node := range network.Nodes[1:] {
+		for _, node := range sourceValidators[1:] {
 			require.NoError(api.AwaitTxAccepted(
 				e2e.DefaultContext(),
 				api.NewClient(node.URI, sourceChain.ChainID.String()),
@@ -104,7 +121,7 @@ var _ = ginkgo.Describe("[XSVM]", func() {
 		transferTxStatus, err := transfer.Transfer(
 			e2e.DefaultContext(),
 			&transfer.Config{
-				URI:        apiNode.URI,
+				URI:        destinationAPINode.URI,
 				ChainID:    destinationChain.ChainID,
 				AssetID:    destinationChain.ChainID,
 				Amount:     units.Schmeckle,
@@ -116,14 +133,14 @@ var _ = ginkgo.Describe("[XSVM]", func() {
 		tests.Outf(" issued transaction with ID: %s\n", transferTxStatus.TxID)
 
 		ginkgo.By(fmt.Sprintf("importing to blockchain %s on subnet %s", destinationChain.ChainID, destinationSubnet.SubnetID))
-		sourceURIs := make([]string, len(network.Nodes))
-		for i, node := range network.Nodes {
+		sourceURIs := make([]string, len(sourceValidators))
+		for i, node := range sourceValidators {
 			sourceURIs[i] = node.URI
 		}
 		importTxStatus, err := importtx.Import(
 			e2e.DefaultContext(),
 			&importtx.Config{
-				URI:                apiNode.URI,
+				URI:                destinationAPINode.URI,
 				SourceURIs:         sourceURIs,
 				SourceChainID:      sourceChain.ChainID.String(),
 				DestinationChainID: destinationChain.ChainID.String(),
@@ -140,9 +157,22 @@ var _ = ginkgo.Describe("[XSVM]", func() {
 		require.GreaterOrEqual(initialSourcedBalance-units.Schmeckle, sourceBalance)
 
 		ginkgo.By("checking that the balance of the destination key is non-zero")
-		destinationClient := api.NewClient(apiNode.URI, destinationChain.ChainID.String())
+		destinationClient := api.NewClient(destinationAPINode.URI, destinationChain.ChainID.String())
 		destinationBalance, err := destinationClient.Balance(e2e.DefaultContext(), destinationKey.Address(), sourceChain.ChainID)
 		require.NoError(err)
 		require.Equal(units.Schmeckle, destinationBalance)
 	})
 })
+
+// Retrieve the nodes corresponding to the provided IDs
+func getNodesForIDs(nodes []*tmpnet.Node, nodeIDs []ids.NodeID) []*tmpnet.Node {
+	desiredNodes := make([]*tmpnet.Node, 0, len(nodeIDs))
+	for _, node := range nodes {
+		for _, nodeID := range nodeIDs {
+			if node.NodeID == nodeID {
+				desiredNodes = append(desiredNodes, node)
+			}
+		}
+	}
+	return desiredNodes
+}

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -409,7 +409,7 @@ func (n *Network) Bootstrap(ctx context.Context, w io.Writer) error {
 	}
 
 	// Don't restart the node during subnet creation since it will always be restarted afterwards.
-	if err := n.CreateSubnets(ctx, w, false /* restartRequired */); err != nil {
+	if err := n.CreateSubnets(ctx, w, bootstrapNode.URI, false /* restartRequired */); err != nil {
 		return err
 	}
 
@@ -646,7 +646,7 @@ func (n *Network) GetSubnet(name string) *Subnet {
 
 // Ensure that each subnet on the network is created. If restartRequired is false, node restart
 // to pick up configuration changes becomes the responsibility of the caller.
-func (n *Network) CreateSubnets(ctx context.Context, w io.Writer, restartRequired bool) error {
+func (n *Network) CreateSubnets(ctx context.Context, w io.Writer, apiURI string, restartRequired bool) error {
 	createdSubnets := make([]*Subnet, 0, len(n.Subnets))
 	for _, subnet := range n.Subnets {
 		if len(subnet.ValidatorIDs) == 0 {
@@ -748,7 +748,7 @@ func (n *Network) CreateSubnets(ctx context.Context, w io.Writer, restartRequire
 			validatorNodes = append(validatorNodes, node)
 		}
 
-		if err := subnet.AddValidators(ctx, w, validatorNodes...); err != nil {
+		if err := subnet.AddValidators(ctx, w, apiURI, validatorNodes...); err != nil {
 			return err
 		}
 	}

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -155,9 +155,7 @@ func (s *Subnet) CreateChains(ctx context.Context, w io.Writer, uri string) erro
 }
 
 // Add validators to the subnet
-func (s *Subnet) AddValidators(ctx context.Context, w io.Writer, nodes ...*Node) error {
-	apiURI := nodes[0].URI
-
+func (s *Subnet) AddValidators(ctx context.Context, w io.Writer, apiURI string, nodes ...*Node) error {
 	wallet, err := s.GetWallet(ctx, apiURI)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Why this should be merged

Previously, tmpnet required that the node used for subnet bootstrap be a validator for all subnets. This was by virtue of attempting to perform API operations to bootstrap a given subnet against the first validator for that subnet. That validator would only be running if it was the one node selected for bootstrapping all subnets.

This change ensures the support of disjoint validator sets by always using the URI of the node used for subnet bootstrap.

## How this works

 - pass around the URI of the node used for subnet bootstrap 

## How this was tested

- update the 2 subnets of the xsvm e2e test to use disjoint validator sets 
