### PR TITLE
chore: fix some comment

### DIFF
--- a/snow/engine/snowman/bootstrap/interval/state.go
+++ b/snow/engine/snowman/bootstrap/interval/state.go
@@ -78,7 +78,7 @@ func GetBlockIterator(db database.Iteratee) database.Iterator {
 	return db.NewIteratorWithPrefix(blockPrefix)
 }
 
-// GetBlockIterator returns a block iterator that will produce values
+// GetBlockIteratorWithStart returns a block iterator that will produce values
 // corresponding to persisted blocks in order of increasing height starting at
 // [height].
 func GetBlockIteratorWithStart(db database.Iteratee, height uint64) database.Iterator {

--- a/utils/dynamicip/opendns_resolver.go
+++ b/utils/dynamicip/opendns_resolver.go
@@ -20,7 +20,7 @@ var (
 	_ Resolver = (*openDNSResolver)(nil)
 )
 
-// IFConfigResolves resolves our public IP using openDNS
+// openDNSResolver resolves our public IP using openDNS
 type openDNSResolver struct {
 	resolver *net.Resolver
 }

--- a/vms/avm/vm_benchmark_test.go
+++ b/vms/avm/vm_benchmark_test.go
@@ -60,7 +60,7 @@ func BenchmarkLoadUser(b *testing.B) {
 	}
 }
 
-// GetAllUTXOsBenchmark is a helper func to benchmark the GetAllUTXOs depending on the size
+// getAllUTXOsBenchmark is a helper func to benchmark the GetAllUTXOs depending on the size
 func getAllUTXOsBenchmark(b *testing.B, utxoCount int, randSrc rand.Source) {
 	require := require.New(b)
 

--- a/vms/secp256k1fx/tx.go
+++ b/vms/secp256k1fx/tx.go
@@ -13,7 +13,7 @@ var _ UnsignedTx = (*TestTx)(nil)
 // TestTx is a minimal implementation of a Tx
 type TestTx struct{ UnsignedBytes []byte }
 
-// UnsignedBytes returns Bytes
+// Bytes returns UnsignedBytes
 func (tx *TestTx) Bytes() []byte {
 	return tx.UnsignedBytes
 }


### PR DESCRIPTION
## Why this should be merged
This PR enhances readability and maintainability.

## How this works
1. By keeping the function & type names in comment consistent with code.
2. By fixing the description about the utility of type `Bytes`

## How this was tested
No.