### PR TITLE
Specify configs in caller for `TestNetwork`

### DIFF
--- a/network/example_test.go
+++ b/network/example_test.go
@@ -129,8 +129,8 @@ func ExampleNewTestNetwork() {
 		)
 		return
 	}
-	dialerConfig := NewTestDialerConfig()
 
+	dialerConfig := NewTestDialerConfig()
 	network, err := NewTestNetwork(
 		log,
 		config,

--- a/network/example_test.go
+++ b/network/example_test.go
@@ -95,7 +95,11 @@ func ExampleNewTestNetwork() {
 
 	tlsCert, err := staking.NewTLSCert()
 	if err != nil {
-		panic(err)
+		log.Fatal(
+			"failed to create tls cert",
+			zap.Error(err),
+		)
+		return
 	}
 
 	blsKey, err := bls.NewSecretKey()

--- a/network/example_test.go
+++ b/network/example_test.go
@@ -104,12 +104,12 @@ func ExampleNewTestNetwork() {
 	}
 
 	metrics := prometheus.NewRegistry()
-	config, err := NewTestNetworkConfig(constants.FujiID, tlsCert, blsKey, validators, trackedSubnets, metrics)
+	config, err := NewTestNetworkConfig(log, constants.FujiID, tlsCert, blsKey, validators, trackedSubnets, metrics)
 	if err != nil {
 		panic(err)
 	}
 
-	messageCreator, err := NewTestMessageCreator(metrics)
+	messageCreator, err := NewTestMessageCreator(log, metrics)
 	if err != nil {
 		panic(err)
 	}

--- a/network/example_test.go
+++ b/network/example_test.go
@@ -100,18 +100,30 @@ func ExampleNewTestNetwork() {
 
 	blsKey, err := bls.NewSecretKey()
 	if err != nil {
-		panic(err)
+		log.Fatal(
+			"failed to create bls key",
+			zap.Error(err),
+		)
+		return
 	}
 
 	metrics := prometheus.NewRegistry()
 	config, err := NewTestNetworkConfig(log, constants.FujiID, tlsCert, blsKey, validators, trackedSubnets, metrics)
 	if err != nil {
-		panic(err)
+		log.Fatal(
+			"failed to create network config",
+			zap.Error(err),
+		)
+		return
 	}
 
 	messageCreator, err := NewTestMessageCreator(log, metrics)
 	if err != nil {
-		panic(err)
+		log.Fatal(
+			"failed to create message creator",
+			zap.Error(err),
+		)
+		return
 	}
 	dialerConfig := NewTestDialerConfig()
 
@@ -124,7 +136,11 @@ func ExampleNewTestNetwork() {
 		metrics,
 	)
 	if err != nil {
-		panic(err)
+		log.Fatal(
+			"failed to create test network",
+			zap.Error(err),
+		)
+		return
 	}
 
 	// We need to initially connect to some nodes in the network before peer
@@ -147,7 +163,8 @@ func ExampleNewTestNetwork() {
 	// Calling network.Dispatch() will block until a fatal error occurs or
 	// network.StartClose() is called.
 	err = network.Dispatch()
-	if err != nil {
-		panic(err)
-	}
+	log.Info(
+		"network exited",
+		zap.Error(err),
+	)
 }

--- a/network/test_network.go
+++ b/network/test_network.go
@@ -73,6 +73,7 @@ func (*noopListener) Addr() net.Addr {
 }
 
 func NewTestNetworkConfig(
+	log logging.Logger,
 	networkID uint32,
 	tlsCert *tls.Certificate,
 	blsKey *bls.SecretKey,
@@ -175,7 +176,7 @@ func NewTestNetworkConfig(
 		PeerWriteBufferSize:          constants.DefaultNetworkPeerWriteBufferSize,
 		ResourceTracker:              resourceTracker,
 		CPUTargeter: tracker.NewTargeter(
-			logging.NoLog{},
+			log,
 			&tracker.TargeterConfig{
 				VdrAlloc:           float64(runtime.NumCPU()),
 				MaxNonVdrUsage:     .8 * float64(runtime.NumCPU()),
@@ -185,7 +186,7 @@ func NewTestNetworkConfig(
 			resourceTracker.CPUTracker(),
 		),
 		DiskTargeter: tracker.NewTargeter(
-			logging.NoLog{},
+			log,
 			&tracker.TargeterConfig{
 				VdrAlloc:           1000 * units.GiB,
 				MaxNonVdrUsage:     1000 * units.GiB,
@@ -197,9 +198,9 @@ func NewTestNetworkConfig(
 	}, nil
 }
 
-func NewTestMessageCreator(metrics prometheus.Registerer) (message.Creator, error) {
+func NewTestMessageCreator(log logging.Logger, metrics prometheus.Registerer) (message.Creator, error) {
 	return message.NewCreator(
-		logging.NoLog{},
+		log,
 		metrics,
 		constants.DefaultNetworkCompressionType,
 		constants.DefaultNetworkMaximumInboundTimeout,

--- a/network/test_network.go
+++ b/network/test_network.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"crypto"
+	"crypto/tls"
 	"errors"
 	"math"
 	"net"
@@ -23,7 +24,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/networking/tracker"
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -72,34 +72,14 @@ func (*noopListener) Addr() net.Addr {
 	}
 }
 
-func NewTestNetwork(
-	log logging.Logger,
+func NewTestNetworkConfig(
 	networkID uint32,
+	tlsCert *tls.Certificate,
+	blsKey *bls.SecretKey,
 	currentValidators validators.Manager,
 	trackedSubnets set.Set[ids.ID],
-	router router.ExternalHandler,
-) (Network, error) {
-	metrics := prometheus.NewRegistry()
-	msgCreator, err := message.NewCreator(
-		logging.NoLog{},
-		metrics,
-		constants.DefaultNetworkCompressionType,
-		constants.DefaultNetworkMaximumInboundTimeout,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsCert, err := staking.NewTLSCert()
-	if err != nil {
-		return nil, err
-	}
-
-	blsKey, err := bls.NewSecretKey()
-	if err != nil {
-		return nil, err
-	}
-
+	metrics prometheus.Registerer,
+) (*Config, error) {
 	// TODO actually monitor usage
 	// TestNetwork doesn't use disk so we don't need to track it, but we should
 	// still have guardrails around cpu/memory usage.
@@ -113,119 +93,143 @@ func NewTestNetwork(
 		return nil, err
 	}
 
-	return NewNetwork(
-		&Config{
-			HealthConfig: HealthConfig{
-				Enabled:                      true,
-				MinConnectedPeers:            constants.DefaultNetworkHealthMinPeers,
-				MaxTimeSinceMsgReceived:      constants.DefaultNetworkHealthMaxTimeSinceMsgReceived,
-				MaxTimeSinceMsgSent:          constants.DefaultNetworkHealthMaxTimeSinceMsgSent,
-				MaxPortionSendQueueBytesFull: constants.DefaultNetworkHealthMaxPortionSendQueueFill,
-				MaxSendFailRate:              constants.DefaultNetworkHealthMaxSendFailRate,
-				SendFailRateHalflife:         constants.DefaultHealthCheckAveragerHalflife,
-			},
-			PeerListGossipConfig: PeerListGossipConfig{
-				PeerListNumValidatorIPs: constants.DefaultNetworkPeerListNumValidatorIPs,
-				PeerListPullGossipFreq:  constants.DefaultNetworkPeerListPullGossipFreq,
-				PeerListBloomResetFreq:  constants.DefaultNetworkPeerListBloomResetFreq,
-			},
-			TimeoutConfig: TimeoutConfig{
-				PingPongTimeout:      constants.DefaultPingPongTimeout,
-				ReadHandshakeTimeout: constants.DefaultNetworkReadHandshakeTimeout,
-			},
-			DelayConfig: DelayConfig{
-				InitialReconnectDelay: constants.DefaultNetworkInitialReconnectDelay,
-				MaxReconnectDelay:     constants.DefaultNetworkMaxReconnectDelay,
-			},
-			ThrottlerConfig: ThrottlerConfig{
-				InboundConnUpgradeThrottlerConfig: throttling.InboundConnUpgradeThrottlerConfig{
-					UpgradeCooldown:        constants.DefaultInboundConnUpgradeThrottlerCooldown,
-					MaxRecentConnsUpgraded: int(math.Ceil(constants.DefaultInboundThrottlerMaxConnsPerSec * constants.DefaultInboundConnUpgradeThrottlerCooldown.Seconds())),
-				},
-				InboundMsgThrottlerConfig: throttling.InboundMsgThrottlerConfig{
-					MsgByteThrottlerConfig: throttling.MsgByteThrottlerConfig{
-						VdrAllocSize:        constants.DefaultInboundThrottlerVdrAllocSize,
-						AtLargeAllocSize:    constants.DefaultInboundThrottlerAtLargeAllocSize,
-						NodeMaxAtLargeBytes: constants.DefaultInboundThrottlerNodeMaxAtLargeBytes,
-					},
-					BandwidthThrottlerConfig: throttling.BandwidthThrottlerConfig{
-						RefillRate:   constants.DefaultInboundThrottlerBandwidthRefillRate,
-						MaxBurstSize: constants.DefaultInboundThrottlerBandwidthMaxBurstSize,
-					},
-					CPUThrottlerConfig: throttling.SystemThrottlerConfig{
-						MaxRecheckDelay: constants.DefaultInboundThrottlerCPUMaxRecheckDelay,
-					},
-					DiskThrottlerConfig: throttling.SystemThrottlerConfig{
-						MaxRecheckDelay: constants.DefaultInboundThrottlerDiskMaxRecheckDelay,
-					},
-					MaxProcessingMsgsPerNode: constants.DefaultInboundThrottlerMaxProcessingMsgsPerNode,
-				},
-				OutboundMsgThrottlerConfig: throttling.MsgByteThrottlerConfig{
-					VdrAllocSize:        constants.DefaultOutboundThrottlerVdrAllocSize,
-					AtLargeAllocSize:    constants.DefaultOutboundThrottlerAtLargeAllocSize,
-					NodeMaxAtLargeBytes: constants.DefaultOutboundThrottlerNodeMaxAtLargeBytes,
-				},
-				MaxInboundConnsPerSec: constants.DefaultInboundThrottlerMaxConnsPerSec,
-			},
-			ProxyEnabled:           constants.DefaultNetworkTCPProxyEnabled,
-			ProxyReadHeaderTimeout: constants.DefaultNetworkTCPProxyReadTimeout,
-			DialerConfig: dialer.Config{
-				ThrottleRps:       constants.DefaultOutboundConnectionThrottlingRps,
-				ConnectionTimeout: constants.DefaultOutboundConnectionTimeout,
-			},
-			TLSConfig: peer.TLSConfig(*tlsCert, nil),
-			MyIPPort: utils.NewAtomic(netip.AddrPortFrom(
-				netip.IPv4Unspecified(),
-				1,
-			)),
-			NetworkID:                    networkID,
-			MaxClockDifference:           constants.DefaultNetworkMaxClockDifference,
-			PingFrequency:                constants.DefaultPingFrequency,
-			AllowPrivateIPs:              !constants.ProductionNetworkIDs.Contains(networkID),
-			CompressionType:              constants.DefaultNetworkCompressionType,
-			TLSKey:                       tlsCert.PrivateKey.(crypto.Signer),
-			BLSKey:                       blsKey,
-			TrackedSubnets:               trackedSubnets,
-			Beacons:                      validators.NewManager(),
-			Validators:                   currentValidators,
-			UptimeCalculator:             uptime.NoOpCalculator,
-			UptimeMetricFreq:             constants.DefaultUptimeMetricFreq,
-			RequireValidatorToConnect:    constants.DefaultNetworkRequireValidatorToConnect,
-			MaximumInboundMessageTimeout: constants.DefaultNetworkMaximumInboundTimeout,
-			PeerReadBufferSize:           constants.DefaultNetworkPeerReadBufferSize,
-			PeerWriteBufferSize:          constants.DefaultNetworkPeerWriteBufferSize,
-			ResourceTracker:              resourceTracker,
-			CPUTargeter: tracker.NewTargeter(
-				logging.NoLog{},
-				&tracker.TargeterConfig{
-					VdrAlloc:           float64(runtime.NumCPU()),
-					MaxNonVdrUsage:     .8 * float64(runtime.NumCPU()),
-					MaxNonVdrNodeUsage: float64(runtime.NumCPU()) / 8,
-				},
-				currentValidators,
-				resourceTracker.CPUTracker(),
-			),
-			DiskTargeter: tracker.NewTargeter(
-				logging.NoLog{},
-				&tracker.TargeterConfig{
-					VdrAlloc:           1000 * units.GiB,
-					MaxNonVdrUsage:     1000 * units.GiB,
-					MaxNonVdrNodeUsage: 1000 * units.GiB,
-				},
-				currentValidators,
-				resourceTracker.DiskTracker(),
-			),
+	return &Config{
+		HealthConfig: HealthConfig{
+			Enabled:                      true,
+			MinConnectedPeers:            constants.DefaultNetworkHealthMinPeers,
+			MaxTimeSinceMsgReceived:      constants.DefaultNetworkHealthMaxTimeSinceMsgReceived,
+			MaxTimeSinceMsgSent:          constants.DefaultNetworkHealthMaxTimeSinceMsgSent,
+			MaxPortionSendQueueBytesFull: constants.DefaultNetworkHealthMaxPortionSendQueueFill,
+			MaxSendFailRate:              constants.DefaultNetworkHealthMaxSendFailRate,
+			SendFailRateHalflife:         constants.DefaultHealthCheckAveragerHalflife,
 		},
-		msgCreator,
+		PeerListGossipConfig: PeerListGossipConfig{
+			PeerListNumValidatorIPs: constants.DefaultNetworkPeerListNumValidatorIPs,
+			PeerListPullGossipFreq:  constants.DefaultNetworkPeerListPullGossipFreq,
+			PeerListBloomResetFreq:  constants.DefaultNetworkPeerListBloomResetFreq,
+		},
+		TimeoutConfig: TimeoutConfig{
+			PingPongTimeout:      constants.DefaultPingPongTimeout,
+			ReadHandshakeTimeout: constants.DefaultNetworkReadHandshakeTimeout,
+		},
+		DelayConfig: DelayConfig{
+			InitialReconnectDelay: constants.DefaultNetworkInitialReconnectDelay,
+			MaxReconnectDelay:     constants.DefaultNetworkMaxReconnectDelay,
+		},
+		ThrottlerConfig: ThrottlerConfig{
+			InboundConnUpgradeThrottlerConfig: throttling.InboundConnUpgradeThrottlerConfig{
+				UpgradeCooldown:        constants.DefaultInboundConnUpgradeThrottlerCooldown,
+				MaxRecentConnsUpgraded: int(math.Ceil(constants.DefaultInboundThrottlerMaxConnsPerSec * constants.DefaultInboundConnUpgradeThrottlerCooldown.Seconds())),
+			},
+			InboundMsgThrottlerConfig: throttling.InboundMsgThrottlerConfig{
+				MsgByteThrottlerConfig: throttling.MsgByteThrottlerConfig{
+					VdrAllocSize:        constants.DefaultInboundThrottlerVdrAllocSize,
+					AtLargeAllocSize:    constants.DefaultInboundThrottlerAtLargeAllocSize,
+					NodeMaxAtLargeBytes: constants.DefaultInboundThrottlerNodeMaxAtLargeBytes,
+				},
+				BandwidthThrottlerConfig: throttling.BandwidthThrottlerConfig{
+					RefillRate:   constants.DefaultInboundThrottlerBandwidthRefillRate,
+					MaxBurstSize: constants.DefaultInboundThrottlerBandwidthMaxBurstSize,
+				},
+				CPUThrottlerConfig: throttling.SystemThrottlerConfig{
+					MaxRecheckDelay: constants.DefaultInboundThrottlerCPUMaxRecheckDelay,
+				},
+				DiskThrottlerConfig: throttling.SystemThrottlerConfig{
+					MaxRecheckDelay: constants.DefaultInboundThrottlerDiskMaxRecheckDelay,
+				},
+				MaxProcessingMsgsPerNode: constants.DefaultInboundThrottlerMaxProcessingMsgsPerNode,
+			},
+			OutboundMsgThrottlerConfig: throttling.MsgByteThrottlerConfig{
+				VdrAllocSize:        constants.DefaultOutboundThrottlerVdrAllocSize,
+				AtLargeAllocSize:    constants.DefaultOutboundThrottlerAtLargeAllocSize,
+				NodeMaxAtLargeBytes: constants.DefaultOutboundThrottlerNodeMaxAtLargeBytes,
+			},
+			MaxInboundConnsPerSec: constants.DefaultInboundThrottlerMaxConnsPerSec,
+		},
+		ProxyEnabled:           constants.DefaultNetworkTCPProxyEnabled,
+		ProxyReadHeaderTimeout: constants.DefaultNetworkTCPProxyReadTimeout,
+		DialerConfig: dialer.Config{
+			ThrottleRps:       constants.DefaultOutboundConnectionThrottlingRps,
+			ConnectionTimeout: constants.DefaultOutboundConnectionTimeout,
+		},
+		TLSConfig: peer.TLSConfig(*tlsCert, nil),
+		MyIPPort: utils.NewAtomic(netip.AddrPortFrom(
+			netip.IPv4Unspecified(),
+			1,
+		)),
+		NetworkID:                    networkID,
+		MaxClockDifference:           constants.DefaultNetworkMaxClockDifference,
+		PingFrequency:                constants.DefaultPingFrequency,
+		AllowPrivateIPs:              !constants.ProductionNetworkIDs.Contains(networkID),
+		CompressionType:              constants.DefaultNetworkCompressionType,
+		TLSKey:                       tlsCert.PrivateKey.(crypto.Signer),
+		BLSKey:                       blsKey,
+		TrackedSubnets:               trackedSubnets,
+		Beacons:                      validators.NewManager(),
+		Validators:                   currentValidators,
+		UptimeCalculator:             uptime.NoOpCalculator,
+		UptimeMetricFreq:             constants.DefaultUptimeMetricFreq,
+		RequireValidatorToConnect:    constants.DefaultNetworkRequireValidatorToConnect,
+		MaximumInboundMessageTimeout: constants.DefaultNetworkMaximumInboundTimeout,
+		PeerReadBufferSize:           constants.DefaultNetworkPeerReadBufferSize,
+		PeerWriteBufferSize:          constants.DefaultNetworkPeerWriteBufferSize,
+		ResourceTracker:              resourceTracker,
+		CPUTargeter: tracker.NewTargeter(
+			logging.NoLog{},
+			&tracker.TargeterConfig{
+				VdrAlloc:           float64(runtime.NumCPU()),
+				MaxNonVdrUsage:     .8 * float64(runtime.NumCPU()),
+				MaxNonVdrNodeUsage: float64(runtime.NumCPU()) / 8,
+			},
+			currentValidators,
+			resourceTracker.CPUTracker(),
+		),
+		DiskTargeter: tracker.NewTargeter(
+			logging.NoLog{},
+			&tracker.TargeterConfig{
+				VdrAlloc:           1000 * units.GiB,
+				MaxNonVdrUsage:     1000 * units.GiB,
+				MaxNonVdrNodeUsage: 1000 * units.GiB,
+			},
+			currentValidators,
+			resourceTracker.DiskTracker(),
+		),
+	}, nil
+}
+
+func NewTestMessageCreator(metrics prometheus.Registerer) (message.Creator, error) {
+	return message.NewCreator(
+		logging.NoLog{},
+		metrics,
+		constants.DefaultNetworkCompressionType,
+		constants.DefaultNetworkMaximumInboundTimeout,
+	)
+}
+
+func NewTestDialerConfig() dialer.Config {
+	return dialer.Config{
+		ThrottleRps:       constants.DefaultOutboundConnectionThrottlingRps,
+		ConnectionTimeout: constants.DefaultOutboundConnectionTimeout,
+	}
+}
+
+func NewTestNetwork(
+	log logging.Logger,
+	config *Config,
+	messageCreator message.Creator,
+	dialerConfig dialer.Config,
+	router router.ExternalHandler,
+	metrics prometheus.Registerer,
+) (Network, error) {
+	return NewNetwork(
+		config,
+		messageCreator,
 		metrics,
 		log,
 		newNoopListener(),
 		dialer.NewDialer(
 			constants.NetworkType,
-			dialer.Config{
-				ThrottleRps:       constants.DefaultOutboundConnectionThrottlingRps,
-				ConnectionTimeout: constants.DefaultOutboundConnectionTimeout,
-			},
+			dialerConfig,
 			log,
 		),
 		router,


### PR DESCRIPTION
## Why this should be merged

Lets callers specify parameters for p2p network creation. Specifically useful if we want to re-use a tls cert to have a pre-determined node id.

## How this works

Refactors code + helpers to specify configs in caller code

## How this was tested

Updated example
