### PR TITLE
Fix bootstrapping warn log

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -411,11 +411,6 @@ type Node struct {
  ******************************************************************************
  */
 
-func (n *Node) getRequiredConns() int {
-	numBootstrappers := n.bootstrappers.Count(constants.PrimaryNetworkID)
-	return (3*numBootstrappers + 3) / 4
-}
-
 // Initialize the networking layer.
 // Assumes [n.vdrs], [n.CPUTracker], and [n.CPUTargeter] have been initialized.
 func (n *Node) initNetworking(reg prometheus.Registerer) error {
@@ -605,7 +600,10 @@ func (n *Node) initNetworking(reg prometheus.Registerer) error {
 	}
 
 	n.onSufficientlyConnected = make(chan struct{})
-	if requiredConns := n.getRequiredConns(); requiredConns > 0 {
+	numBootstrappers := n.bootstrappers.Count(constants.PrimaryNetworkID)
+	requiredConns := (3*numBootstrappers + 3) / 4
+
+	if requiredConns > 0 {
 		consensusRouter = &beaconManager{
 			Router:                  consensusRouter,
 			beacons:                 n.bootstrappers,

--- a/node/node.go
+++ b/node/node.go
@@ -81,10 +81,10 @@ import (
 	"github.com/ava-labs/avalanchego/vms/registry"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime"
 
-	coreth "github.com/ava-labs/coreth/plugin/evm"
-
 	avmconfig "github.com/ava-labs/avalanchego/vms/avm/config"
 	platformconfig "github.com/ava-labs/avalanchego/vms/platformvm/config"
+
+	coreth "github.com/ava-labs/coreth/plugin/evm"
 )
 
 const (

--- a/node/node.go
+++ b/node/node.go
@@ -81,9 +81,10 @@ import (
 	"github.com/ava-labs/avalanchego/vms/registry"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime"
 
+	coreth "github.com/ava-labs/coreth/plugin/evm"
+
 	avmconfig "github.com/ava-labs/avalanchego/vms/avm/config"
 	platformconfig "github.com/ava-labs/avalanchego/vms/platformvm/config"
-	coreth "github.com/ava-labs/coreth/plugin/evm"
 )
 
 const (
@@ -604,14 +605,16 @@ func (n *Node) initNetworking(reg prometheus.Registerer) error {
 		}
 	}
 
+	n.onSufficientlyConnected = make(chan struct{})
 	if requiredConns := n.getRequiredConns(); requiredConns > 0 {
-		n.onSufficientlyConnected = make(chan struct{})
 		consensusRouter = &beaconManager{
 			Router:                  consensusRouter,
 			beacons:                 n.bootstrappers,
 			requiredConns:           int64(requiredConns),
 			onSufficientlyConnected: n.onSufficientlyConnected,
 		}
+	} else {
+		close(n.onSufficientlyConnected)
 	}
 
 	// add node configs to network config
@@ -701,26 +704,24 @@ func (n *Node) Dispatch() error {
 		n.Shutdown(1)
 	})
 
-	if requiredConns := n.getRequiredConns(); requiredConns > 0 {
-		// Log a warning if we aren't able to connect to a sufficient portion of
-		// nodes.
-		go func() {
-			timer := time.NewTimer(n.Config.BootstrapBeaconConnectionTimeout)
-			defer timer.Stop()
+	// Log a warning if we aren't able to connect to a sufficient portion of
+	// nodes.
+	go func() {
+		timer := time.NewTimer(n.Config.BootstrapBeaconConnectionTimeout)
+		defer timer.Stop()
 
-			select {
-			case <-timer.C:
-				if n.shuttingDown.Get() {
-					return
-				}
-				n.Log.Warn("failed to connect to bootstrap nodes",
-					zap.Stringer("bootstrappers", n.bootstrappers),
-					zap.Duration("duration", n.Config.BootstrapBeaconConnectionTimeout),
-				)
-			case <-n.onSufficientlyConnected:
+		select {
+		case <-timer.C:
+			if n.shuttingDown.Get() {
+				return
 			}
-		}()
-	}
+			n.Log.Warn("failed to connect to bootstrap nodes",
+				zap.Stringer("bootstrappers", n.bootstrappers),
+				zap.Duration("duration", n.Config.BootstrapBeaconConnectionTimeout),
+			)
+		case <-n.onSufficientlyConnected:
+		}
+	}()
 
 	// Add state sync nodes to the peer network
 	for i, peerIP := range n.Config.StateSyncIPs {

--- a/node/node.go
+++ b/node/node.go
@@ -401,7 +401,7 @@ type Node struct {
 	// we rate-limit them.
 	diskTargeter tracker.Targeter
 
-	// Fired when a sufficient amount of bootstrapper nodes are connected to
+	// Closed when a sufficient amount of bootstrap nodes are connected to
 	onSufficientlyConnected chan struct{}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -83,7 +83,6 @@ import (
 
 	avmconfig "github.com/ava-labs/avalanchego/vms/avm/config"
 	platformconfig "github.com/ava-labs/avalanchego/vms/platformvm/config"
-
 	coreth "github.com/ava-labs/coreth/plugin/evm"
 )
 


### PR DESCRIPTION
## Why this should be merged

Fixes https://github.com/ava-labs/avalanchego/issues/3109

## How this works

Starts timeout goroutine before starting the networking stack, instead of during network initialization where other long-running processes may falsely call this to time out.

## How this was tested

Tested manually
