### PR TITLE
check router is closing in requests

### DIFF
--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -191,6 +191,117 @@ func TestShutdown(t *testing.T) {
 	require.Less(shutdownDuration, 250*time.Millisecond)
 }
 
+func TestConnectedAfterShutdownErrorLogRegression(t *testing.T) {
+	require := require.New(t)
+
+	snowCtx := snowtest.Context(t, snowtest.PChainID)
+	chainCtx := snowtest.ConsensusContext(snowCtx)
+
+	chainRouter := ChainRouter{}
+	require.NoError(chainRouter.Initialize(
+		ids.EmptyNodeID,
+		logging.NoWarn{}, // If an error log is emitted, the test will fail
+		nil,
+		time.Second,
+		set.Set[ids.ID]{},
+		true,
+		set.Set[ids.ID]{},
+		nil,
+		HealthConfig{},
+		prometheus.NewRegistry(),
+	))
+
+	resourceTracker, err := tracker.NewResourceTracker(
+		prometheus.NewRegistry(),
+		resource.NoUsage,
+		meter.ContinuousFactory{},
+		time.Second,
+	)
+	require.NoError(err)
+
+	p2pTracker, err := p2p.NewPeerTracker(
+		logging.NoLog{},
+		"",
+		prometheus.NewRegistry(),
+		nil,
+		version.CurrentApp,
+	)
+	require.NoError(err)
+
+	h, err := handler.New(
+		chainCtx,
+		nil,
+		nil,
+		time.Second,
+		testThreadPoolSize,
+		resourceTracker,
+		validators.UnhandledSubnetConnector,
+		subnets.New(chainCtx.NodeID, subnets.Config{}),
+		commontracker.NewPeers(),
+		p2pTracker,
+		prometheus.NewRegistry(),
+	)
+	require.NoError(err)
+
+	engine := common.EngineTest{
+		T: t,
+		StartF: func(context.Context, uint32) error {
+			return nil
+		},
+		ContextF: func() *snow.ConsensusContext {
+			return chainCtx
+		},
+		HaltF: func(context.Context) {},
+		ShutdownF: func(context.Context) error {
+			return nil
+		},
+		ConnectedF: func(context.Context, ids.NodeID, *version.Application) error {
+			return nil
+		},
+	}
+	engine.Default(true)
+	engine.CantGossip = false
+
+	bootstrapper := &common.BootstrapperTest{
+		EngineTest: engine,
+		CantClear:  true,
+	}
+
+	h.SetEngineManager(&handler.EngineManager{
+		Avalanche: &handler.Engine{
+			StateSyncer:  nil,
+			Bootstrapper: bootstrapper,
+			Consensus:    &engine,
+		},
+		Snowman: &handler.Engine{
+			StateSyncer:  nil,
+			Bootstrapper: bootstrapper,
+			Consensus:    &engine,
+		},
+	})
+	chainCtx.State.Set(snow.EngineState{
+		Type:  engineType,
+		State: snow.NormalOp, // assumed bootstrapping is done
+	})
+
+	chainRouter.AddChain(context.Background(), h)
+
+	h.Start(context.Background(), false)
+
+	chainRouter.Shutdown(context.Background())
+
+	shutdownDuration, err := h.AwaitStopped(context.Background())
+	require.NoError(err)
+	require.GreaterOrEqual(shutdownDuration, time.Duration(0))
+
+	// Calling connected after shutdown should result in an error log.
+	chainRouter.Connected(
+		ids.GenerateTestNodeID(),
+		version.CurrentApp,
+		ids.GenerateTestID(),
+	)
+}
+
 func TestShutdownTimesOut(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
## Why this should be merged

Fixes #3155 

## How this works

This pull request primarily focuses on introducing a closing mechanism to the `ChainRouter` structure in the `snow/networking/router/chain_router.go` file. This mechanism prevents the router from processing requests and messages once it's in the process of shutting down. The most significant changes include the addition of the `closing` boolean field to the `ChainRouter` struct, a new error type `errClosing` to signal the router is closing, and modifications to several methods to check the `closing` field before proceeding with their operations.

### Added closing mechanism:

* [`snow/networking/router/chain_router.go`](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R67): Added `closing` boolean field to `ChainRouter` struct to indicate whether the router is in the process of shutting down.
* [`snow/networking/router/chain_router.go`](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R34): Introduced `errClosing` error type to signal that the router is closing.

### Modified methods to check `closing` field:

* [`snow/networking/router/chain_router.go`](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R159-R170): Modified `RegisterRequest`, `HandleInbound`, `Shutdown`, `AddChain`, `Connected`, `Disconnected`, `Benched`, and `Unbenched` methods to check the `closing` field before proceeding. If the router is closing, these methods log a debug message and return early. [[1]](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R159-R170) [[2]](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R261-R271) [[3]](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R384) [[4]](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R417-R423) [[5]](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R482-R489) [[6]](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R537-R544) [[7]](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R574-R582) [[8]](diffhunk://#diff-c2531a5dcd3ad1ff091a235c9b0a4f60064ab41e8f1317466ce0eb4ad2a798e4R615-R623)

## How this was tested

Added unit test
