### PR TITLE
Use `ids.GenerateTestID` helper in tests

### DIFF
--- a/cache/lru_cache_test.go
+++ b/cache/lru_cache_test.go
@@ -27,8 +27,8 @@ func TestLRUResize(t *testing.T) {
 	require := require.New(t)
 	cache := LRU[ids.ID, int64]{Size: 2}
 
-	id1 := ids.ID{1}
-	id2 := ids.ID{2}
+	id1 := ids.GenerateTestID()
+	id2 := ids.GenerateTestID()
 
 	expectedVal1 := int64(1)
 	expectedVal2 := int64(2)

--- a/cache/test_cacher.go
+++ b/cache/test_cacher.go
@@ -64,9 +64,9 @@ func TestBasic(t *testing.T, cache Cacher[ids.ID, int64]) {
 func TestEviction(t *testing.T, cache Cacher[ids.ID, int64]) {
 	require := require.New(t)
 
-	id1 := ids.ID{1}
-	id2 := ids.ID{2}
-	id3 := ids.ID{3}
+	id1 := ids.GenerateTestID()
+	id2 := ids.GenerateTestID()
+	id3 := ids.GenerateTestID()
 
 	expectedValue1 := int64(1)
 	expectedValue2 := int64(2)

--- a/cache/unique_cache_test.go
+++ b/cache/unique_cache_test.go
@@ -29,13 +29,13 @@ func TestEvictableLRU(t *testing.T) {
 
 	cache := EvictableLRU[ids.ID, *evictable[ids.ID]]{}
 
-	expectedValue1 := &evictable[ids.ID]{id: ids.ID{1}}
+	expectedValue1 := &evictable[ids.ID]{id: ids.GenerateTestID()}
 	require.Equal(expectedValue1, cache.Deduplicate(expectedValue1))
 	require.Zero(expectedValue1.evicted)
 	require.Equal(expectedValue1, cache.Deduplicate(expectedValue1))
 	require.Zero(expectedValue1.evicted)
 
-	expectedValue2 := &evictable[ids.ID]{id: ids.ID{2}}
+	expectedValue2 := &evictable[ids.ID]{id: ids.GenerateTestID()}
 	returnedValue := cache.Deduplicate(expectedValue2)
 	require.Equal(expectedValue2, returnedValue)
 	require.Equal(1, expectedValue1.evicted)
@@ -43,7 +43,7 @@ func TestEvictableLRU(t *testing.T) {
 
 	cache.Size = 2
 
-	expectedValue3 := &evictable[ids.ID]{id: ids.ID{2}}
+	expectedValue3 := &evictable[ids.ID]{id: ids.GenerateTestID()}
 	returnedValue = cache.Deduplicate(expectedValue3)
 	require.Equal(expectedValue2, returnedValue)
 	require.Equal(1, expectedValue1.evicted)

--- a/snow/engine/avalanche/state/unique_vertex_test.go
+++ b/snow/engine/avalanche/state/unique_vertex_test.go
@@ -76,7 +76,7 @@ func TestUniqueVertexCacheHit(t *testing.T) {
 	})
 
 	id := ids.ID{2}
-	parentID := ids.ID{'p', 'a', 'r', 'e', 'n', 't'}
+	parentID := ids.GenerateTestID()
 	parentIDs := []ids.ID{parentID}
 	chainID := ids.ID{} // Same as chainID of serializer
 	height := uint64(1)

--- a/snow/engine/snowman/syncer/state_syncer_test.go
+++ b/snow/engine/snowman/syncer/state_syncer_test.go
@@ -1262,7 +1262,7 @@ func TestStateSyncIsStoppedIfEnoughVotesAreCastedWithNoClearMajority(t *testing.
 				context.Background(),
 				voterID,
 				reqID,
-				set.Of(ids.ID{'u', 'n', 'k', 'n', 'o', 'w', 'n', 'I', 'D'}),
+				set.Of(ids.GenerateTestID()),
 			))
 			votingWeightStake += beacons.GetWeight(ctx.SubnetID, voterID)
 		}

--- a/snow/engine/snowman/syncer/utils_test.go
+++ b/snow/engine/snowman/syncer/utils_test.go
@@ -30,7 +30,7 @@ var (
 	_ block.ChainVM         = fullVM{}
 	_ block.StateSyncableVM = fullVM{}
 
-	unknownSummaryID = ids.ID{'g', 'a', 'r', 'b', 'a', 'g', 'e'}
+	unknownSummaryID = ids.GenerateTestID()
 
 	summaryBytes = []byte{'s', 'u', 'm', 'm', 'a', 'r', 'y'}
 	summaryID    ids.ID

--- a/vms/avm/block/block_test.go
+++ b/vms/avm/block/block_test.go
@@ -98,7 +98,7 @@ func createTestTxs(cm codec.Manager) ([]*txs.Tx, error) {
 			}},
 			Ins: []*avax.TransferableInput{{
 				UTXOID: avax.UTXOID{
-					TxID:        ids.ID{'t', 'x', 'I', 'D'},
+					TxID:        ids.GenerateTestID(),
 					OutputIndex: 1,
 				},
 				Asset: avax.Asset{ID: assetID},

--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -573,7 +573,7 @@ func createTxs() []*txs.Tx {
 			}},
 			Ins: []*avax.TransferableInput{{
 				UTXOID: avax.UTXOID{
-					TxID:        ids.ID{'t', 'x', 'I', 'D'},
+					TxID:        ids.GenerateTestID(),
 					OutputIndex: 1,
 				},
 				Asset: avax.Asset{ID: ids.GenerateTestID()},
@@ -614,7 +614,7 @@ func createParentTxs(cm codec.Manager) ([]*txs.Tx, error) {
 			}},
 			Ins: []*avax.TransferableInput{{
 				UTXOID: avax.UTXOID{
-					TxID:        ids.ID{'t', 'x', 'p', 'a', 'r', 'e', 'n', 't'},
+					TxID:        ids.GenerateTestID(),
 					OutputIndex: 1,
 				},
 				Asset: avax.Asset{ID: ids.ID{1, 2, 3}},

--- a/vms/avm/txs/mempool/mempool_test.go
+++ b/vms/avm/txs/mempool/mempool_test.go
@@ -55,7 +55,7 @@ func newTx(index uint32, size int) *txs.Tx {
 	tx := &txs.Tx{Unsigned: &txs.BaseTx{BaseTx: avax.BaseTx{
 		Ins: []*avax.TransferableInput{{
 			UTXOID: avax.UTXOID{
-				TxID:        ids.ID{'t', 'x', 'I', 'D'},
+				TxID:        ids.GenerateTestID(),
 				OutputIndex: index,
 			},
 		}},

--- a/vms/platformvm/api/static_service_test.go
+++ b/vms/platformvm/api/static_service_test.go
@@ -210,7 +210,7 @@ func TestBuildGenesisReturnsSortedValidators(t *testing.T) {
 	}
 
 	args := BuildGenesisArgs{
-		AvaxAssetID: ids.ID{'d', 'u', 'm', 'm', 'y', ' ', 'I', 'D'},
+		AvaxAssetID: ids.GenerateTestID(),
 		UTXOs: []UTXO{
 			utxo,
 		},

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -81,7 +81,7 @@ var (
 	defaultMinValidatorStake  = 5 * units.MilliAvax
 	defaultBalance            = 100 * defaultMinValidatorStake
 	preFundedKeys             = secp256k1.TestKeys()
-	avaxAssetID               = ids.ID{'y', 'e', 'e', 't'}
+	avaxAssetID               = ids.GenerateTestID()
 	defaultTxFee              = uint64(100)
 
 	genesisBlkID ids.ID

--- a/vms/platformvm/block/parse_test.go
+++ b/vms/platformvm/block/parse_test.go
@@ -23,7 +23,7 @@ func TestStandardBlocks(t *testing.T) {
 	// check Apricot standard block can be built and parsed
 	require := require.New(t)
 	blkTimestamp := time.Now()
-	parentID := ids.ID{'p', 'a', 'r', 'e', 'n', 't', 'I', 'D'}
+	parentID := ids.GenerateTestID()
 	height := uint64(2022)
 	decisionTxs, err := testDecisionTxs()
 	require.NoError(err)
@@ -75,7 +75,7 @@ func TestProposalBlocks(t *testing.T) {
 	// check Apricot proposal block can be built and parsed
 	require := require.New(t)
 	blkTimestamp := time.Now()
-	parentID := ids.ID{'p', 'a', 'r', 'e', 'n', 't', 'I', 'D'}
+	parentID := ids.GenerateTestID()
 	height := uint64(2022)
 	proposalTx, err := testProposalTx()
 	require.NoError(err)
@@ -170,7 +170,7 @@ func TestCommitBlock(t *testing.T) {
 	// check Apricot commit block can be built and parsed
 	require := require.New(t)
 	blkTimestamp := time.Now()
-	parentID := ids.ID{'p', 'a', 'r', 'e', 'n', 't', 'I', 'D'}
+	parentID := ids.GenerateTestID()
 	height := uint64(2022)
 
 	for _, cdc := range []codec.Manager{Codec, GenesisCodec} {
@@ -213,7 +213,7 @@ func TestAbortBlock(t *testing.T) {
 	// check Apricot abort block can be built and parsed
 	require := require.New(t)
 	blkTimestamp := time.Now()
-	parentID := ids.ID{'p', 'a', 'r', 'e', 'n', 't', 'I', 'D'}
+	parentID := ids.GenerateTestID()
 	height := uint64(2022)
 
 	for _, cdc := range []codec.Manager{Codec, GenesisCodec} {
@@ -255,7 +255,7 @@ func TestAbortBlock(t *testing.T) {
 func TestAtomicBlock(t *testing.T) {
 	// check atomic block can be built and parsed
 	require := require.New(t)
-	parentID := ids.ID{'p', 'a', 'r', 'e', 'n', 't', 'I', 'D'}
+	parentID := ids.GenerateTestID()
 	height := uint64(2022)
 	atomicTx, err := testAtomicTx()
 	require.NoError(err)
@@ -286,12 +286,13 @@ func TestAtomicBlock(t *testing.T) {
 }
 
 func testAtomicTx() (*txs.Tx, error) {
+	assetID := ids.GenerateTestID()
 	utx := &txs.ImportTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    10,
-			BlockchainID: ids.ID{'c', 'h', 'a', 'i', 'n', 'I', 'D'},
+			BlockchainID: ids.GenerateTestID(),
 			Outs: []*avax.TransferableOutput{{
-				Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 'r', 't'}},
+				Asset: avax.Asset{ID: assetID},
 				Out: &secp256k1fx.TransferOutput{
 					Amt: uint64(1234),
 					OutputOwners: secp256k1fx.OutputOwners{
@@ -302,10 +303,10 @@ func testAtomicTx() (*txs.Tx, error) {
 			}},
 			Ins: []*avax.TransferableInput{{
 				UTXOID: avax.UTXOID{
-					TxID:        ids.ID{'t', 'x', 'I', 'D'},
+					TxID:        ids.GenerateTestID(),
 					OutputIndex: 2,
 				},
-				Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 'r', 't'}},
+				Asset: avax.Asset{ID: assetID},
 				In: &secp256k1fx.TransferInput{
 					Amt:   uint64(5678),
 					Input: secp256k1fx.Input{SigIndices: []uint32{0}},
@@ -313,13 +314,13 @@ func testAtomicTx() (*txs.Tx, error) {
 			}},
 			Memo: []byte{1, 2, 3, 4, 5, 6, 7, 8},
 		}},
-		SourceChain: ids.ID{'c', 'h', 'a', 'i', 'n'},
+		SourceChain: ids.GenerateTestID(),
 		ImportedInputs: []*avax.TransferableInput{{
 			UTXOID: avax.UTXOID{
 				TxID:        ids.Empty.Prefix(1),
 				OutputIndex: 1,
 			},
-			Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 'r', 't'}},
+			Asset: avax.Asset{ID: assetID},
 			In: &secp256k1fx.TransferInput{
 				Amt:   50000,
 				Input: secp256k1fx.Input{SigIndices: []uint32{0}},
@@ -331,6 +332,7 @@ func testAtomicTx() (*txs.Tx, error) {
 }
 
 func testDecisionTxs() ([]*txs.Tx, error) {
+	assetID := ids.GenerateTestID()
 	countTxs := 2
 	decisionTxs := make([]*txs.Tx, 0, countTxs)
 	for i := 0; i < countTxs; i++ {
@@ -338,9 +340,9 @@ func testDecisionTxs() ([]*txs.Tx, error) {
 		utx := &txs.CreateChainTx{
 			BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 				NetworkID:    10,
-				BlockchainID: ids.ID{'c', 'h', 'a', 'i', 'n', 'I', 'D'},
+				BlockchainID: ids.GenerateTestID(),
 				Outs: []*avax.TransferableOutput{{
-					Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 'r', 't'}},
+					Asset: avax.Asset{ID: assetID},
 					Out: &secp256k1fx.TransferOutput{
 						Amt: uint64(1234),
 						OutputOwners: secp256k1fx.OutputOwners{
@@ -351,10 +353,10 @@ func testDecisionTxs() ([]*txs.Tx, error) {
 				}},
 				Ins: []*avax.TransferableInput{{
 					UTXOID: avax.UTXOID{
-						TxID:        ids.ID{'t', 'x', 'I', 'D'},
+						TxID:        ids.GenerateTestID(),
 						OutputIndex: 2,
 					},
-					Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 'r', 't'}},
+					Asset: avax.Asset{ID: assetID},
 					In: &secp256k1fx.TransferInput{
 						Amt:   uint64(5678),
 						Input: secp256k1fx.Input{SigIndices: []uint32{0}},
@@ -362,7 +364,7 @@ func testDecisionTxs() ([]*txs.Tx, error) {
 				}},
 				Memo: []byte{1, 2, 3, 4, 5, 6, 7, 8},
 			}},
-			SubnetID:    ids.ID{'s', 'u', 'b', 'n', 'e', 't', 'I', 'D'},
+			SubnetID:    ids.GenerateTestID(),
 			ChainName:   "a chain",
 			VMID:        ids.GenerateTestID(),
 			FxIDs:       []ids.ID{ids.GenerateTestID()},
@@ -382,7 +384,7 @@ func testDecisionTxs() ([]*txs.Tx, error) {
 
 func testProposalTx() (*txs.Tx, error) {
 	utx := &txs.RewardValidatorTx{
-		TxID: ids.ID{'r', 'e', 'w', 'a', 'r', 'd', 'I', 'D'},
+		TxID: ids.GenerateTestID(),
 	}
 
 	signers := [][]*secp256k1.PrivateKey{{preFundedKeys[0]}}

--- a/vms/platformvm/block/serialization_test.go
+++ b/vms/platformvm/block/serialization_test.go
@@ -6,6 +6,7 @@ package block
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -123,13 +124,15 @@ func TestBanffBlockSerialization(t *testing.T) {
 func TestBanffProposalBlockJSON(t *testing.T) {
 	require := require.New(t)
 
+	prntID := ids.GenerateTestID()
+	blockID := ids.GenerateTestID()
 	simpleBanffProposalBlock := &BanffProposalBlock{
 		Time: 123456,
 		ApricotProposalBlock: ApricotProposalBlock{
 			CommonBlock: CommonBlock{
-				PrntID:  ids.ID{'p', 'a', 'r', 'e', 'n', 't', 'I', 'D'},
+				PrntID:  prntID,
 				Hght:    1337,
-				BlockID: ids.ID{'b', 'l', 'o', 'c', 'k', 'I', 'D'},
+				BlockID: blockID,
 			},
 			Tx: &txs.Tx{
 				Unsigned: &txs.AdvanceTimeTx{
@@ -142,12 +145,12 @@ func TestBanffProposalBlockJSON(t *testing.T) {
 	simpleBanffProposalBlockBytes, err := json.MarshalIndent(simpleBanffProposalBlock, "", "\t")
 	require.NoError(err)
 
-	require.Equal(`{
+	expectedSimpleBanffProposalBlockString := `{
 	"time": 123456,
 	"txs": null,
-	"parentID": "rVcYrvnGXdoJBeYQRm5ZNaCGHeVyqcHHJu8Yd89kJcef6V5Eg",
+	"parentID": "EXPECTED_PARENT_ID",
 	"height": 1337,
-	"id": "kM6h4d2UKYEDzQXm7KNqyeBJLjhb42J24m4L4WACB5didf3pk",
+	"id": "EXPECTED_ID",
 	"tx": {
 		"unsignedTx": {
 			"time": 123457
@@ -155,7 +158,10 @@ func TestBanffProposalBlockJSON(t *testing.T) {
 		"credentials": null,
 		"id": "11111111111111111111111111111111LpoYY"
 	}
-}`, string(simpleBanffProposalBlockBytes))
+}`
+	expectedSimpleBanffProposalBlockString = strings.Replace(expectedSimpleBanffProposalBlockString, "EXPECTED_PARENT_ID", prntID.String(), 1)
+	expectedSimpleBanffProposalBlockString = strings.Replace(expectedSimpleBanffProposalBlockString, "EXPECTED_ID", blockID.String(), 1)
+	require.Equal(expectedSimpleBanffProposalBlockString, string(simpleBanffProposalBlockBytes))
 
 	complexBanffProposalBlock := simpleBanffProposalBlock
 	complexBanffProposalBlock.Transactions = []*txs.Tx{
@@ -186,7 +192,7 @@ func TestBanffProposalBlockJSON(t *testing.T) {
 	complexBanffProposalBlockBytes, err := json.MarshalIndent(complexBanffProposalBlock, "", "\t")
 	require.NoError(err)
 
-	require.Equal(`{
+	expectedComplexBanffProposalBlockString := `{
 	"time": 123456,
 	"txs": [
 		{
@@ -212,9 +218,9 @@ func TestBanffProposalBlockJSON(t *testing.T) {
 			"id": "11111111111111111111111111111111LpoYY"
 		}
 	],
-	"parentID": "rVcYrvnGXdoJBeYQRm5ZNaCGHeVyqcHHJu8Yd89kJcef6V5Eg",
+	"parentID": "EXPECTED_PARENT_ID",
 	"height": 1337,
-	"id": "kM6h4d2UKYEDzQXm7KNqyeBJLjhb42J24m4L4WACB5didf3pk",
+	"id": "EXPECTED_ID",
 	"tx": {
 		"unsignedTx": {
 			"time": 123457
@@ -222,5 +228,8 @@ func TestBanffProposalBlockJSON(t *testing.T) {
 		"credentials": null,
 		"id": "11111111111111111111111111111111LpoYY"
 	}
-}`, string(complexBanffProposalBlockBytes))
+}`
+	expectedComplexBanffProposalBlockString = strings.Replace(expectedComplexBanffProposalBlockString, "EXPECTED_PARENT_ID", prntID.String(), 1)
+	expectedComplexBanffProposalBlockString = strings.Replace(expectedComplexBanffProposalBlockString, "EXPECTED_ID", blockID.String(), 1)
+	require.Equal(expectedComplexBanffProposalBlockString, string(complexBanffProposalBlockBytes))
 }

--- a/vms/platformvm/txs/add_delegator_test.go
+++ b/vms/platformvm/txs/add_delegator_test.go
@@ -43,7 +43,7 @@ func TestAddDelegatorTxSyntacticVerify(t *testing.T) {
 	validatorWeight := uint64(2022)
 	inputs := []*avax.TransferableInput{{
 		UTXOID: avax.UTXOID{
-			TxID:        ids.ID{'t', 'x', 'I', 'D'},
+			TxID:        ids.GenerateTestID(),
 			OutputIndex: 2,
 		},
 		Asset: avax.Asset{ID: ctx.AVAXAssetID},
@@ -142,7 +142,7 @@ func TestAddDelegatorTxSyntacticVerifyNotAVAX(t *testing.T) {
 	validatorWeight := uint64(2022)
 	inputs := []*avax.TransferableInput{{
 		UTXOID: avax.UTXOID{
-			TxID:        ids.ID{'t', 'x', 'I', 'D'},
+			TxID:        ids.GenerateTestID(),
 			OutputIndex: 2,
 		},
 		Asset: avax.Asset{ID: assetID},

--- a/vms/platformvm/txs/add_subnet_validator_test.go
+++ b/vms/platformvm/txs/add_subnet_validator_test.go
@@ -40,20 +40,21 @@ func TestAddSubnetValidatorTxSyntacticVerify(t *testing.T) {
 	require.ErrorIs(err, ErrNilTx)
 
 	validatorWeight := uint64(2022)
-	subnetID := ids.ID{'s', 'u', 'b', 'n', 'e', 't', 'I', 'D'}
+	assetID := ids.GenerateTestID()
+	subnetID := ids.GenerateTestID()
 	inputs := []*avax.TransferableInput{{
 		UTXOID: avax.UTXOID{
-			TxID:        ids.ID{'t', 'x', 'I', 'D'},
+			TxID:        ids.GenerateTestID(),
 			OutputIndex: 2,
 		},
-		Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 't'}},
+		Asset: avax.Asset{ID: assetID},
 		In: &secp256k1fx.TransferInput{
 			Amt:   uint64(5678),
 			Input: secp256k1fx.Input{SigIndices: []uint32{0}},
 		},
 	}}
 	outputs := []*avax.TransferableOutput{{
-		Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 't'}},
+		Asset: avax.Asset{ID: assetID},
 		Out: &secp256k1fx.TransferOutput{
 			Amt: uint64(1234),
 			OutputOwners: secp256k1fx.OutputOwners{
@@ -150,21 +151,22 @@ func TestAddSubnetValidatorMarshal(t *testing.T) {
 	)
 
 	// create a valid tx
+	assetID := ids.GenerateTestID()
 	validatorWeight := uint64(2022)
-	subnetID := ids.ID{'s', 'u', 'b', 'n', 'e', 't', 'I', 'D'}
+	subnetID := ids.GenerateTestID()
 	inputs := []*avax.TransferableInput{{
 		UTXOID: avax.UTXOID{
-			TxID:        ids.ID{'t', 'x', 'I', 'D'},
+			TxID:        ids.GenerateTestID(),
 			OutputIndex: 2,
 		},
-		Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 't'}},
+		Asset: avax.Asset{ID: assetID},
 		In: &secp256k1fx.TransferInput{
 			Amt:   uint64(5678),
 			Input: secp256k1fx.Input{SigIndices: []uint32{0}},
 		},
 	}}
 	outputs := []*avax.TransferableOutput{{
-		Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 't'}},
+		Asset: avax.Asset{ID: assetID},
 		Out: &secp256k1fx.TransferOutput{
 			Amt: uint64(1234),
 			OutputOwners: secp256k1fx.OutputOwners{

--- a/vms/platformvm/txs/add_validator_test.go
+++ b/vms/platformvm/txs/add_validator_test.go
@@ -43,7 +43,7 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 	rewardAddress := preFundedKeys[0].PublicKey().Address()
 	inputs := []*avax.TransferableInput{{
 		UTXOID: avax.UTXOID{
-			TxID:        ids.ID{'t', 'x', 'I', 'D'},
+			TxID:        ids.GenerateTestID(),
 			OutputIndex: 2,
 		},
 		Asset: avax.Asset{ID: ctx.AVAXAssetID},
@@ -159,7 +159,7 @@ func TestAddValidatorTxSyntacticVerifyNotAVAX(t *testing.T) {
 	rewardAddress := preFundedKeys[0].PublicKey().Address()
 	inputs := []*avax.TransferableInput{{
 		UTXOID: avax.UTXOID{
-			TxID:        ids.ID{'t', 'x', 'I', 'D'},
+			TxID:        ids.GenerateTestID(),
 			OutputIndex: 2,
 		},
 		Asset: avax.Asset{ID: assetID},

--- a/vms/platformvm/txs/create_chain_test.go
+++ b/vms/platformvm/txs/create_chain_test.go
@@ -126,19 +126,20 @@ func TestUnsignedCreateChainTxVerify(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			require := require.New(t)
 
+			assetID := ids.GenerateTestID()
 			inputs := []*avax.TransferableInput{{
 				UTXOID: avax.UTXOID{
-					TxID:        ids.ID{'t', 'x', 'I', 'D'},
+					TxID:        ids.GenerateTestID(),
 					OutputIndex: 2,
 				},
-				Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 't'}},
+				Asset: avax.Asset{ID: assetID},
 				In: &secp256k1fx.TransferInput{
 					Amt:   uint64(5678),
 					Input: secp256k1fx.Input{SigIndices: []uint32{0}},
 				},
 			}}
 			outputs := []*avax.TransferableOutput{{
-				Asset: avax.Asset{ID: ids.ID{'a', 's', 's', 'e', 't'}},
+				Asset: avax.Asset{ID: assetID},
 				Out: &secp256k1fx.TransferOutput{
 					Amt: uint64(1234),
 					OutputOwners: secp256k1fx.OutputOwners{

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -896,7 +896,7 @@ func TestCreateChain(t *testing.T) {
 	utx, err := builder.NewCreateChainTx(
 		testSubnet1.ID(),
 		nil,
-		ids.ID{'t', 'e', 's', 't', 'v', 'm'},
+		ids.GenerateTestID(),
 		nil,
 		"name",
 	)

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -122,7 +122,7 @@ func TestStateSyncGetOngoingSyncStateSummary(t *testing.T) {
 	}()
 
 	innerSummary := &block.TestStateSummary{
-		IDV:     ids.ID{'s', 'u', 'm', 'm', 'a', 'r', 'y', 'I', 'D'},
+		IDV:     ids.GenerateTestID(),
 		HeightV: uint64(2022),
 		BytesV:  []byte{'i', 'n', 'n', 'e', 'r'},
 	}
@@ -206,7 +206,7 @@ func TestStateSyncGetLastStateSummary(t *testing.T) {
 	}()
 
 	innerSummary := &block.TestStateSummary{
-		IDV:     ids.ID{'s', 'u', 'm', 'm', 'a', 'r', 'y', 'I', 'D'},
+		IDV:     ids.GenerateTestID(),
 		HeightV: uint64(2022),
 		BytesV:  []byte{'i', 'n', 'n', 'e', 'r'},
 	}
@@ -291,7 +291,7 @@ func TestStateSyncGetStateSummary(t *testing.T) {
 	reqHeight := uint64(1969)
 
 	innerSummary := &block.TestStateSummary{
-		IDV:     ids.ID{'s', 'u', 'm', 'm', 'a', 'r', 'y', 'I', 'D'},
+		IDV:     ids.GenerateTestID(),
 		HeightV: reqHeight,
 		BytesV:  []byte{'i', 'n', 'n', 'e', 'r'},
 	}
@@ -377,7 +377,7 @@ func TestParseStateSummary(t *testing.T) {
 	reqHeight := uint64(1969)
 
 	innerSummary := &block.TestStateSummary{
-		IDV:     ids.ID{'s', 'u', 'm', 'm', 'a', 'r', 'y', 'I', 'D'},
+		IDV:     ids.GenerateTestID(),
 		HeightV: reqHeight,
 		BytesV:  []byte{'i', 'n', 'n', 'e', 'r'},
 	}
@@ -455,7 +455,7 @@ func TestStateSummaryAccept(t *testing.T) {
 	reqHeight := uint64(1969)
 
 	innerSummary := &block.TestStateSummary{
-		IDV:     ids.ID{'s', 'u', 'm', 'm', 'a', 'r', 'y', 'I', 'D'},
+		IDV:     ids.GenerateTestID(),
 		HeightV: reqHeight,
 		BytesV:  []byte{'i', 'n', 'n', 'e', 'r'},
 	}
@@ -522,7 +522,7 @@ func TestStateSummaryAcceptOlderBlock(t *testing.T) {
 	reqHeight := uint64(1969)
 
 	innerSummary := &block.TestStateSummary{
-		IDV:     ids.ID{'s', 'u', 'm', 'm', 'a', 'r', 'y', 'I', 'D'},
+		IDV:     ids.GenerateTestID(),
 		HeightV: reqHeight,
 		BytesV:  []byte{'i', 'n', 'n', 'e', 'r'},
 	}

--- a/vms/rpcchainvm/state_syncable_vm_test.go
+++ b/vms/rpcchainvm/state_syncable_vm_test.go
@@ -35,28 +35,30 @@ var (
 
 	// a summary to be returned in some UTs
 	mockedSummary = &block.TestStateSummary{
-		IDV:     ids.ID{'s', 'u', 'm', 'm', 'a', 'r', 'y', 'I', 'D'},
+		IDV:     ids.GenerateTestID(),
 		HeightV: SummaryHeight,
 		BytesV:  []byte("summary"),
 	}
 
+	parentBlkID = ids.GenerateTestID()
+
 	// last accepted blocks data before and after summary is accepted
 	preSummaryBlk = &snowmantest.Block{
 		TestDecidable: choices.TestDecidable{
-			IDV:     ids.ID{'f', 'i', 'r', 's', 't', 'B', 'l', 'K'},
+			IDV:     ids.GenerateTestID(),
 			StatusV: choices.Accepted,
 		},
 		HeightV: preSummaryHeight,
-		ParentV: ids.ID{'p', 'a', 'r', 'e', 'n', 't', 'B', 'l', 'k'},
+		ParentV: parentBlkID,
 	}
 
 	summaryBlk = &snowmantest.Block{
 		TestDecidable: choices.TestDecidable{
-			IDV:     ids.ID{'s', 'u', 'm', 'm', 'a', 'r', 'y', 'B', 'l', 'K'},
+			IDV:     ids.GenerateTestID(),
 			StatusV: choices.Accepted,
 		},
 		HeightV: SummaryHeight,
-		ParentV: ids.ID{'p', 'a', 'r', 'e', 'n', 't', 'B', 'l', 'k'},
+		ParentV: parentBlkID,
 	}
 
 	// a fictitious error unrelated to state sync


### PR DESCRIPTION
## Why this should be merged

We hardcode random byte slices in a lot of the tests. Let's use the helper we have already instead :)

## How this works

Replace hard-coded byte slices with `ids.GenerateTestID()`

## How this was tested

CI