### PR TITLE
Use `ids.Empty` instead of `ids.ID{}`

### DIFF
--- a/chains/test_manager.go
+++ b/chains/test_manager.go
@@ -42,7 +42,7 @@ func (testManager) StartChainCreator(ChainParameters) error {
 }
 
 func (testManager) SubnetID(ids.ID) (ids.ID, error) {
-	return ids.ID{}, nil
+	return ids.Empty, nil
 }
 
 func (testManager) IsBootstrapped(ids.ID) bool {

--- a/database/helpers.go
+++ b/database/helpers.go
@@ -36,7 +36,7 @@ func PutID(db KeyValueWriter, key []byte, val ids.ID) error {
 func GetID(db KeyValueReader, key []byte) (ids.ID, error) {
 	b, err := db.Get(key)
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 	return ids.ToID(b)
 }

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -203,7 +203,7 @@ func validateConfig(networkID uint32, config *Config, stakingCfg *StakingConfig)
 func FromFile(networkID uint32, filepath string, stakingCfg *StakingConfig) ([]byte, ids.ID, error) {
 	switch networkID {
 	case constants.MainnetID, constants.TestnetID, constants.LocalID:
-		return nil, ids.ID{}, fmt.Errorf(
+		return nil, ids.Empty, fmt.Errorf(
 			"%w: %s",
 			errOverridesStandardNetworkConfig,
 			constants.NetworkName(networkID),
@@ -212,11 +212,11 @@ func FromFile(networkID uint32, filepath string, stakingCfg *StakingConfig) ([]b
 
 	config, err := GetConfigFile(filepath)
 	if err != nil {
-		return nil, ids.ID{}, fmt.Errorf("unable to load provided genesis config at %s: %w", filepath, err)
+		return nil, ids.Empty, fmt.Errorf("unable to load provided genesis config at %s: %w", filepath, err)
 	}
 
 	if err := validateConfig(networkID, config, stakingCfg); err != nil {
-		return nil, ids.ID{}, fmt.Errorf("genesis config validation failed: %w", err)
+		return nil, ids.Empty, fmt.Errorf("genesis config validation failed: %w", err)
 	}
 
 	return FromConfig(config)
@@ -245,7 +245,7 @@ func FromFile(networkID uint32, filepath string, stakingCfg *StakingConfig) ([]b
 func FromFlag(networkID uint32, genesisContent string, stakingCfg *StakingConfig) ([]byte, ids.ID, error) {
 	switch networkID {
 	case constants.MainnetID, constants.TestnetID, constants.LocalID:
-		return nil, ids.ID{}, fmt.Errorf(
+		return nil, ids.Empty, fmt.Errorf(
 			"%w: %s",
 			errOverridesStandardNetworkConfig,
 			constants.NetworkName(networkID),
@@ -254,11 +254,11 @@ func FromFlag(networkID uint32, genesisContent string, stakingCfg *StakingConfig
 
 	customConfig, err := GetConfigContent(genesisContent)
 	if err != nil {
-		return nil, ids.ID{}, fmt.Errorf("unable to load genesis content from flag: %w", err)
+		return nil, ids.Empty, fmt.Errorf("unable to load genesis content from flag: %w", err)
 	}
 
 	if err := validateConfig(networkID, customConfig, stakingCfg); err != nil {
-		return nil, ids.ID{}, fmt.Errorf("genesis config validation failed: %w", err)
+		return nil, ids.Empty, fmt.Errorf("genesis config validation failed: %w", err)
 	}
 
 	return FromConfig(customConfig)
@@ -298,7 +298,7 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 		for _, allocation := range xAllocations {
 			addr, err := address.FormatBech32(hrp, allocation.AVAXAddr.Bytes())
 			if err != nil {
-				return nil, ids.ID{}, err
+				return nil, ids.Empty, err
 			}
 
 			avax.InitialState["fixedCap"] = append(avax.InitialState["fixedCap"], avm.Holder{
@@ -323,22 +323,22 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 	avmSS := avm.CreateStaticService()
 	err := avmSS.BuildGenesis(nil, &avmArgs, &avmReply)
 	if err != nil {
-		return nil, ids.ID{}, err
+		return nil, ids.Empty, err
 	}
 
 	bytes, err := formatting.Decode(defaultEncoding, avmReply.Bytes)
 	if err != nil {
-		return nil, ids.ID{}, fmt.Errorf("couldn't parse avm genesis reply: %w", err)
+		return nil, ids.Empty, fmt.Errorf("couldn't parse avm genesis reply: %w", err)
 	}
 	avaxAssetID, err := AVAXAssetID(bytes)
 	if err != nil {
-		return nil, ids.ID{}, fmt.Errorf("couldn't generate AVAX asset ID: %w", err)
+		return nil, ids.Empty, fmt.Errorf("couldn't generate AVAX asset ID: %w", err)
 	}
 
 	genesisTime := time.Unix(int64(config.StartTime), 0)
 	initialSupply, err := config.InitialSupply()
 	if err != nil {
-		return nil, ids.ID{}, fmt.Errorf("couldn't calculate the initial supply: %w", err)
+		return nil, ids.Empty, fmt.Errorf("couldn't calculate the initial supply: %w", err)
 	}
 
 	initiallyStaked := set.Of(config.InitialStakedFunds...)
@@ -360,7 +360,7 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 		}
 		addr, err := address.FormatBech32(hrp, allocation.AVAXAddr.Bytes())
 		if err != nil {
-			return nil, ids.ID{}, err
+			return nil, ids.Empty, err
 		}
 		for _, unlock := range allocation.UnlockSchedule {
 			if unlock.Amount > 0 {
@@ -391,14 +391,14 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 
 		destAddrStr, err := address.FormatBech32(hrp, staker.RewardAddress.Bytes())
 		if err != nil {
-			return nil, ids.ID{}, err
+			return nil, ids.Empty, err
 		}
 
 		utxos := []api.UTXO(nil)
 		for _, allocation := range nodeAllocations {
 			addr, err := address.FormatBech32(hrp, allocation.AVAXAddr.Bytes())
 			if err != nil {
-				return nil, ids.ID{}, err
+				return nil, ids.Empty, err
 			}
 			for _, unlock := range allocation.UnlockSchedule {
 				msgStr, err := formatting.Encode(defaultEncoding, allocation.ETHAddr.Bytes())
@@ -463,12 +463,12 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 	platformvmReply := api.BuildGenesisReply{}
 	platformvmSS := api.StaticService{}
 	if err := platformvmSS.BuildGenesis(nil, &platformvmArgs, &platformvmReply); err != nil {
-		return nil, ids.ID{}, fmt.Errorf("problem while building platform chain's genesis state: %w", err)
+		return nil, ids.Empty, fmt.Errorf("problem while building platform chain's genesis state: %w", err)
 	}
 
 	genesisBytes, err := formatting.Decode(platformvmReply.Encoding, platformvmReply.Bytes)
 	if err != nil {
-		return nil, ids.ID{}, fmt.Errorf("problem parsing platformvm genesis bytes: %w", err)
+		return nil, ids.Empty, fmt.Errorf("problem parsing platformvm genesis bytes: %w", err)
 	}
 
 	return genesisBytes, avaxAssetID, nil

--- a/ids/galiasreader/alias_reader_client.go
+++ b/ids/galiasreader/alias_reader_client.go
@@ -29,7 +29,7 @@ func (c *Client) Lookup(alias string) (ids.ID, error) {
 		Alias: alias,
 	})
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 	return ids.ToID(resp.Id)
 }

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -502,7 +502,7 @@ func (ts *Topological) vote(ctx context.Context, voteStack []votes) (ids.ID, err
 		// block.
 		if parentBlock.sb.Finalized() && ts.lastAcceptedID == vote.parentID {
 			if err := ts.acceptPreferredChild(ctx, parentBlock); err != nil {
-				return ids.ID{}, err
+				return ids.Empty, err
 			}
 
 			// by accepting the child of parentBlock, the last accepted block is
@@ -522,7 +522,7 @@ func (ts *Topological) vote(ctx context.Context, voteStack []votes) (ids.ID, err
 		// children will need to have their confidence reset. If there isn't a
 		// child having RecordPoll called, then the nextID will default to the
 		// nil ID.
-		nextID := ids.ID{}
+		nextID := ids.Empty
 		if len(voteStack) > 0 {
 			nextID = voteStack[newStackSize-1].parentID
 		}

--- a/snow/engine/avalanche/bootstrap/queue/test_job.go
+++ b/snow/engine/avalanche/bootstrap/queue/test_job.go
@@ -51,7 +51,7 @@ func (j *TestJob) ID() ids.ID {
 	if j.CantID && j.T != nil {
 		require.FailNow(j.T, "Unexpectedly called ID")
 	}
-	return ids.ID{}
+	return ids.Empty
 }
 
 func (j *TestJob) MissingDependencies(ctx context.Context) (set.Set[ids.ID], error) {

--- a/snow/engine/avalanche/state/unique_vertex_test.go
+++ b/snow/engine/avalanche/state/unique_vertex_test.go
@@ -47,7 +47,7 @@ func TestUnknownUniqueVertexErrors(t *testing.T) {
 
 	uVtx := &uniqueVertex{
 		serializer: s,
-		id:         ids.ID{},
+		id:         ids.Empty,
 	}
 
 	status := uVtx.Status()
@@ -78,7 +78,7 @@ func TestUniqueVertexCacheHit(t *testing.T) {
 	id := ids.ID{2}
 	parentID := ids.ID{'p', 'a', 'r', 'e', 'n', 't'}
 	parentIDs := []ids.ID{parentID}
-	chainID := ids.ID{} // Same as chainID of serializer
+	chainID := ids.Empty // Same as chainID of serializer
 	height := uint64(1)
 	vtx, err := vertex.Build( // regular, non-stop vertex
 		chainID,
@@ -153,7 +153,7 @@ func TestUniqueVertexCacheMiss(t *testing.T) {
 
 	parentID := uvtxParent.ID()
 	parentIDs := []ids.ID{parentID}
-	chainID := ids.ID{}
+	chainID := ids.Empty
 	height := uint64(1)
 	innerVertex, err := vertex.Build( // regular, non-stop vertex
 		chainID,
@@ -323,14 +323,14 @@ func newTestUniqueVertex(
 	)
 	if !stopVertex {
 		vtx, err = vertex.Build(
-			ids.ID{},
+			ids.Empty,
 			uint64(1),
 			parentIDs,
 			txs,
 		)
 	} else {
 		vtx, err = vertex.BuildStopVertex(
-			ids.ID{},
+			ids.Empty,
 			uint64(1),
 			parentIDs,
 		)

--- a/snow/engine/avalanche/state/unique_vertex_test.go
+++ b/snow/engine/avalanche/state/unique_vertex_test.go
@@ -78,10 +78,9 @@ func TestUniqueVertexCacheHit(t *testing.T) {
 	id := ids.ID{2}
 	parentID := ids.ID{'p', 'a', 'r', 'e', 'n', 't'}
 	parentIDs := []ids.ID{parentID}
-	chainID := ids.Empty // Same as chainID of serializer
 	height := uint64(1)
 	vtx, err := vertex.Build( // regular, non-stop vertex
-		chainID,
+		s.ChainID,
 		height,
 		parentIDs,
 		[][]byte{{0}},
@@ -153,10 +152,9 @@ func TestUniqueVertexCacheMiss(t *testing.T) {
 
 	parentID := uvtxParent.ID()
 	parentIDs := []ids.ID{parentID}
-	chainID := ids.Empty
 	height := uint64(1)
 	innerVertex, err := vertex.Build( // regular, non-stop vertex
-		chainID,
+		s.ChainID,
 		height,
 		parentIDs,
 		[][]byte{txBytes},
@@ -259,16 +257,6 @@ func TestParseVertexWithIncorrectChainID(t *testing.T) {
 func TestParseVertexWithInvalidTxs(t *testing.T) {
 	require := require.New(t)
 
-	chainID := ids.Empty
-	statelessVertex, err := vertex.Build( // regular, non-stop vertex
-		chainID,
-		0,
-		nil,
-		[][]byte{{1}},
-	)
-	require.NoError(err)
-	vtxBytes := statelessVertex.Bytes()
-
 	s := newTestSerializer(t, func(_ context.Context, b []byte) (snowstorm.Tx, error) {
 		switch {
 		case bytes.Equal(b, []byte{2}):
@@ -277,6 +265,15 @@ func TestParseVertexWithInvalidTxs(t *testing.T) {
 			return nil, errUnknownTx
 		}
 	})
+
+	statelessVertex, err := vertex.Build( // regular, non-stop vertex
+		s.ChainID,
+		0,
+		nil,
+		[][]byte{{1}},
+	)
+	require.NoError(err)
+	vtxBytes := statelessVertex.Bytes()
 
 	_, err = s.ParseVtx(context.Background(), vtxBytes)
 	require.ErrorIs(err, errUnknownTx)
@@ -289,7 +286,7 @@ func TestParseVertexWithInvalidTxs(t *testing.T) {
 	require.ErrorIs(err, errUnknownVertex)
 
 	childStatelessVertex, err := vertex.Build( // regular, non-stop vertex
-		chainID,
+		s.ChainID,
 		1,
 		[]ids.ID{id},
 		[][]byte{{2}},
@@ -323,14 +320,14 @@ func newTestUniqueVertex(
 	)
 	if !stopVertex {
 		vtx, err = vertex.Build(
-			ids.Empty,
+			s.ChainID,
 			uint64(1),
 			parentIDs,
 			txs,
 		)
 	} else {
 		vtx, err = vertex.BuildStopVertex(
-			ids.Empty,
+			s.ChainID,
 			uint64(1),
 			parentIDs,
 		)

--- a/snow/engine/avalanche/vertex/stateless_vertex_test.go
+++ b/snow/engine/avalanche/vertex/stateless_vertex_test.go
@@ -39,7 +39,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "valid vertex",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     0,
 				ParentIDs: []ids.ID{},
@@ -51,7 +51,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "invalid vertex epoch",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     1,
 				ParentIDs: []ids.ID{},
@@ -63,7 +63,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "too many vertex parents",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     0,
 				ParentIDs: tooManyParents,
@@ -75,7 +75,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "no vertex txs",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     0,
 				ParentIDs: []ids.ID{},
@@ -87,7 +87,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "too many vertex txs",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     0,
 				ParentIDs: []ids.ID{},
@@ -99,7 +99,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "unsorted vertex parents",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     0,
 				ParentIDs: []ids.ID{{1}, {0}},
@@ -111,7 +111,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "unsorted vertex txs",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     0,
 				ParentIDs: []ids.ID{},
@@ -123,7 +123,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "duplicate vertex parents",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     0,
 				ParentIDs: []ids.ID{{0}, {0}},
@@ -135,7 +135,7 @@ func TestVertexVerify(t *testing.T) {
 			name: "duplicate vertex txs",
 			vertex: statelessVertex{innerStatelessVertex: innerStatelessVertex{
 				Version:   0,
-				ChainID:   ids.ID{},
+				ChainID:   ids.Empty,
 				Height:    0,
 				Epoch:     0,
 				ParentIDs: []ids.ID{},

--- a/snow/engine/snowman/block/test_vm.go
+++ b/snow/engine/snowman/block/test_vm.go
@@ -100,7 +100,7 @@ func (vm *TestVM) LastAccepted(ctx context.Context) (ids.ID, error) {
 	if vm.CantLastAccepted && vm.T != nil {
 		require.FailNow(vm.T, errLastAccepted.Error())
 	}
-	return ids.ID{}, errLastAccepted
+	return ids.Empty, errLastAccepted
 }
 
 func (vm *TestVM) GetBlockIDAtHeight(ctx context.Context, height uint64) (ids.ID, error) {

--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -114,7 +114,7 @@ func TestHandlerDropsTimedOutMessages(t *testing.T) {
 
 	nodeID := ids.EmptyNodeID
 	reqID := uint32(1)
-	chainID := ids.ID{}
+	chainID := ids.Empty
 	msg := Message{
 		InboundMessage: message.InboundGetAcceptedFrontier(chainID, reqID, 0*time.Second, nodeID),
 		EngineType:     p2ppb.EngineType_ENGINE_TYPE_UNSPECIFIED,
@@ -237,7 +237,7 @@ func TestHandlerClosesOnError(t *testing.T) {
 	reqID := uint32(1)
 	deadline := time.Nanosecond
 	msg := Message{
-		InboundMessage: message.InboundGetAcceptedFrontier(ids.ID{}, reqID, deadline, nodeID),
+		InboundMessage: message.InboundGetAcceptedFrontier(ids.Empty, reqID, deadline, nodeID),
 		EngineType:     p2ppb.EngineType_ENGINE_TYPE_UNSPECIFIED,
 	}
 	handler.Push(context.Background(), msg)

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -435,7 +435,7 @@ func TestShutdownTimesOut(t *testing.T) {
 	shutdownFinished := make(chan struct{}, 1)
 
 	go func() {
-		chainID := ids.ID{}
+		chainID := ids.Empty
 		msg := handler.Message{
 			InboundMessage: message.InboundPullQuery(chainID, 1, time.Hour, ids.GenerateTestID(), 0, nodeID),
 			EngineType:     p2ppb.EngineType_ENGINE_TYPE_UNSPECIFIED,

--- a/snow/networking/timeout/manager_test.go
+++ b/snow/networking/timeout/manager_test.go
@@ -39,7 +39,7 @@ func TestManagerFire(t *testing.T) {
 
 	manager.RegisterRequest(
 		ids.EmptyNodeID,
-		ids.ID{},
+		ids.Empty,
 		true,
 		ids.RequestID{},
 		wg.Done,

--- a/vms/avm/client.go
+++ b/vms/avm/client.go
@@ -266,7 +266,7 @@ func (c *client) GetHeight(ctx context.Context, options ...rpc.Option) (uint64, 
 func (c *client) IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error) {
 	txStr, err := formatting.Encode(formatting.Hex, txBytes)
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 	res := &api.JSONTxID{}
 	err = c.requester.SendRequest(ctx, "avm.issueTx", &api.FormattedTx{
@@ -693,7 +693,7 @@ func (c *client) MintNFT(
 ) (ids.ID, error) {
 	payloadStr, err := formatting.Encode(formatting.Hex, payload)
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 	res := &api.JSONTxID{}
 	err = c.requester.SendRequest(ctx, "avm.mintNFT", &MintNFTArgs{

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -641,7 +641,7 @@ func (vm *VM) lookupAssetID(asset string) (ids.ID, error) {
 	if assetID, err := ids.FromString(asset); err == nil {
 		return assetID, nil
 	}
-	return ids.ID{}, fmt.Errorf("asset '%s' not found", asset)
+	return ids.Empty, fmt.Errorf("asset '%s' not found", asset)
 }
 
 // Invariant: onAccept is called when [tx] is being marked as accepted, but

--- a/vms/avm/wallet_client.go
+++ b/vms/avm/wallet_client.go
@@ -75,7 +75,7 @@ func NewWalletClient(uri, chain string) WalletClient {
 func (c *walletClient) IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error) {
 	txStr, err := formatting.Encode(formatting.Hex, txBytes)
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 	res := &api.JSONTxID{}
 	err = c.requester.SendRequest(ctx, "wallet.issueTx", &api.FormattedTx{

--- a/vms/components/avax/addresses.go
+++ b/vms/components/avax/addresses.go
@@ -66,17 +66,17 @@ func (a *addressManager) ParseLocalAddress(addrStr string) (ids.ShortID, error) 
 func (a *addressManager) ParseAddress(addrStr string) (ids.ID, ids.ShortID, error) {
 	chainIDAlias, hrp, addrBytes, err := address.Parse(addrStr)
 	if err != nil {
-		return ids.ID{}, ids.ShortID{}, err
+		return ids.Empty, ids.ShortID{}, err
 	}
 
 	chainID, err := a.ctx.BCLookup.Lookup(chainIDAlias)
 	if err != nil {
-		return ids.ID{}, ids.ShortID{}, err
+		return ids.Empty, ids.ShortID{}, err
 	}
 
 	expectedHRP := constants.GetHRP(a.ctx.NetworkID)
 	if hrp != expectedHRP {
-		return ids.ID{}, ids.ShortID{}, fmt.Errorf(
+		return ids.Empty, ids.ShortID{}, fmt.Errorf(
 			"expected hrp %q but got %q",
 			expectedHRP,
 			hrp,
@@ -85,7 +85,7 @@ func (a *addressManager) ParseAddress(addrStr string) (ids.ID, ids.ShortID, erro
 
 	addr, err := ids.ToShortID(addrBytes)
 	if err != nil {
-		return ids.ID{}, ids.ShortID{}, err
+		return ids.Empty, ids.ShortID{}, err
 	}
 	return chainID, addr, nil
 }

--- a/vms/components/avax/atomic_utxos.go
+++ b/vms/components/avax/atomic_utxos.go
@@ -47,7 +47,7 @@ func GetAtomicUTXOs(
 		limit,
 	)
 	if err != nil {
-		return nil, ids.ShortID{}, ids.ID{}, fmt.Errorf("error fetching atomic UTXOs: %w", err)
+		return nil, ids.ShortID{}, ids.Empty, fmt.Errorf("error fetching atomic UTXOs: %w", err)
 	}
 
 	lastAddrID, err := ids.ToShortID(lastAddr)
@@ -63,7 +63,7 @@ func GetAtomicUTXOs(
 	for i, utxoBytes := range allUTXOBytes {
 		utxo := &UTXO{}
 		if _, err := codec.Unmarshal(utxoBytes, utxo); err != nil {
-			return nil, ids.ShortID{}, ids.ID{}, fmt.Errorf("error parsing UTXO: %w", err)
+			return nil, ids.ShortID{}, ids.Empty, fmt.Errorf("error parsing UTXO: %w", err)
 		}
 		utxos[i] = utxo
 	}

--- a/vms/components/avax/utxo_fetching.go
+++ b/vms/components/avax/utxo_fetching.go
@@ -84,7 +84,7 @@ func GetPaginatedUTXOs(
 
 		utxoIDs, err := db.UTXOIDs(addr.Bytes(), start, searchSize) // Get UTXOs associated with [addr]
 		if err != nil {
-			return nil, ids.ShortID{}, ids.ID{}, fmt.Errorf("couldn't get UTXOs for address %s: %w", addr, err)
+			return nil, ids.ShortID{}, ids.Empty, fmt.Errorf("couldn't get UTXOs for address %s: %w", addr, err)
 		}
 		for _, utxoID := range utxoIDs {
 			lastUTXOID = utxoID // The last searched UTXO - not the last found
@@ -95,7 +95,7 @@ func GetPaginatedUTXOs(
 
 			utxo, err := db.GetUTXO(utxoID)
 			if err != nil {
-				return nil, ids.ShortID{}, ids.ID{}, fmt.Errorf("couldn't get UTXO %s: %w", utxoID, err)
+				return nil, ids.ShortID{}, ids.Empty, fmt.Errorf("couldn't get UTXO %s: %w", utxoID, err)
 			}
 
 			utxos = append(utxos, utxo)

--- a/vms/components/chain/state_test.go
+++ b/vms/components/chain/state_test.go
@@ -102,7 +102,7 @@ func createInternalBlockFuncs(blks []*snowmantest.Block) (
 			}
 		}
 
-		return ids.ID{}, database.ErrNotFound
+		return ids.Empty, database.ErrNotFound
 	}
 
 	return getBlock, parseBlk, getAcceptedBlockIDAtHeight

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -362,7 +362,7 @@ func (c *client) GetBlockchains(ctx context.Context, options ...rpc.Option) ([]A
 func (c *client) IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error) {
 	txStr, err := formatting.Encode(formatting.Hex, txBytes)
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 
 	res := &api.JSONTxID{}

--- a/vms/platformvm/txs/create_chain_test.go
+++ b/vms/platformvm/txs/create_chain_test.go
@@ -59,7 +59,7 @@ func TestUnsignedCreateChainTxVerify(t *testing.T) {
 			chainName:   "yeet",
 			keys:        []*secp256k1.PrivateKey{testSubnet1ControlKeys[0], testSubnet1ControlKeys[1]},
 			setup: func(tx *CreateChainTx) *CreateChainTx {
-				tx.VMID = ids.ID{}
+				tx.VMID = ids.Empty
 				return tx
 			},
 			expectedErr: errInvalidVMID,

--- a/vms/proposervm/proposer/windower_test.go
+++ b/vms/proposervm/proposer/windower_test.go
@@ -123,11 +123,11 @@ func TestDelayChangeByChain(t *testing.T) {
 	source := rand.NewSource(int64(0))
 	rng := rand.New(source) // #nosec G404
 
-	chainID0 := ids.ID{}
+	chainID0 := ids.Empty
 	_, err := rng.Read(chainID0[:])
 	require.NoError(err)
 
-	chainID1 := ids.ID{}
+	chainID1 := ids.Empty
 	_, err = rng.Read(chainID1[:])
 	require.NoError(err)
 
@@ -196,11 +196,11 @@ func TestExpectedProposerChangeByChain(t *testing.T) {
 	source := rand.NewSource(int64(0))
 	rng := rand.New(source) // #nosec G404
 
-	chainID0 := ids.ID{}
+	chainID0 := ids.Empty
 	_, err := rng.Read(chainID0[:])
 	require.NoError(err)
 
-	chainID1 := ids.ID{}
+	chainID1 := ids.Empty
 	_, err = rng.Read(chainID1[:])
 	require.NoError(err)
 

--- a/vms/proposervm/state/chain_state.go
+++ b/vms/proposervm/state/chain_state.go
@@ -52,11 +52,11 @@ func (s *chainState) GetLastAccepted() (ids.ID, error) {
 	}
 	lastAcceptedBytes, err := s.db.Get(lastAcceptedKey)
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 	lastAccepted, err := ids.ToID(lastAcceptedBytes)
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 	s.lastAccepted = lastAccepted
 	return lastAccepted, nil

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -1571,7 +1571,7 @@ func TestRejectedHeightNotIndexed(t *testing.T) {
 		},
 		GetBlockIDAtHeightF: func(_ context.Context, height uint64) (ids.ID, error) {
 			if height >= uint64(len(coreHeights)) {
-				return ids.ID{}, errTooHigh
+				return ids.Empty, errTooHigh
 			}
 			return coreHeights[height], nil
 		},
@@ -1743,7 +1743,7 @@ func TestRejectedOptionHeightNotIndexed(t *testing.T) {
 		},
 		GetBlockIDAtHeightF: func(_ context.Context, height uint64) (ids.ID, error) {
 			if height >= uint64(len(coreHeights)) {
-				return ids.ID{}, errTooHigh
+				return ids.Empty, errTooHigh
 			}
 			return coreHeights[height], nil
 		},
@@ -2299,7 +2299,7 @@ func TestHistoricalBlockDeletion(t *testing.T) {
 		},
 		GetBlockIDAtHeightF: func(_ context.Context, height uint64) (ids.ID, error) {
 			if height >= uint64(len(acceptedBlocks)) {
-				return ids.ID{}, errTooHigh
+				return ids.Empty, errTooHigh
 			}
 			return acceptedBlocks[height].ID(), nil
 		},

--- a/x/sync/g_db/db_client.go
+++ b/x/sync/g_db/db_client.go
@@ -32,7 +32,7 @@ type DBClient struct {
 func (c *DBClient) GetMerkleRoot(ctx context.Context) (ids.ID, error) {
 	resp, err := c.client.GetMerkleRoot(ctx, &emptypb.Empty{})
 	if err != nil {
-		return ids.ID{}, err
+		return ids.Empty, err
 	}
 	return ids.ToID(resp.RootHash)
 }


### PR DESCRIPTION
## Why this should be merged

We should be consistent on which one we use

## How this works

Aligns on `ids.Empty`

## How this was tested

CI