### PR TITLE
Refactor rpcchainvm metrics registration

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -102,6 +102,7 @@ const (
 	requestsNamespace        = constants.PlatformName + metric.NamespaceSeparator + "requests"
 	resourceTrackerNamespace = constants.PlatformName + metric.NamespaceSeparator + "resource_tracker"
 	responsesNamespace       = constants.PlatformName + metric.NamespaceSeparator + "responses"
+	rpcchainvmNamespace      = constants.PlatformName + metric.NamespaceSeparator + "rpcchainvm"
 	systemResourcesNamespace = constants.PlatformName + metric.NamespaceSeparator + "system_resources"
 )
 
@@ -1262,6 +1263,11 @@ func (n *Node) initVMs() error {
 	// initialize vm runtime manager
 	n.runtimeManager = runtime.NewManager()
 
+	rpcchainvmMetricsGatherer := metrics.NewLabelGatherer(chains.ChainLabel)
+	if err := n.MetricsGatherer.Register(rpcchainvmNamespace, rpcchainvmMetricsGatherer); err != nil {
+		return err
+	}
+
 	// initialize the vm registry
 	n.VMRegistry = registry.NewVMRegistry(registry.VMRegistryConfig{
 		VMGetter: registry.NewVMGetter(registry.VMGetterConfig{
@@ -1270,6 +1276,7 @@ func (n *Node) initVMs() error {
 			PluginDirectory: n.Config.PluginDir,
 			CPUTracker:      n.resourceManager,
 			RuntimeTracker:  n.runtimeManager,
+			MetricsGatherer: rpcchainvmMetricsGatherer,
 		}),
 		VMManager: n.VMManager,
 	})

--- a/vms/registry/vm_getter.go
+++ b/vms/registry/vm_getter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/filesystem"
 	"github.com/ava-labs/avalanchego/utils/resource"
@@ -40,6 +41,7 @@ type VMGetterConfig struct {
 	PluginDirectory string
 	CPUTracker      resource.ProcessTracker
 	RuntimeTracker  runtime.Tracker
+	MetricsGatherer metrics.MultiGatherer
 }
 
 type vmGetter struct {
@@ -103,6 +105,7 @@ func (getter *vmGetter) Get() (map[ids.ID]vms.Factory, map[ids.ID]vms.Factory, e
 			filepath.Join(getter.config.PluginDirectory, file.Name()),
 			getter.config.CPUTracker,
 			getter.config.RuntimeTracker,
+			getter.config.MetricsGatherer,
 		)
 	}
 	return registeredVMs, unregisteredVMs, nil

--- a/vms/rpcchainvm/batched_vm_test.go
+++ b/vms/rpcchainvm/batched_vm_test.go
@@ -81,8 +81,8 @@ func TestBatchedParseBlockCaching(t *testing.T) {
 	testKey := batchedParseBlockCachingTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	ctx := snowtest.Context(t, snowtest.CChainID)
 

--- a/vms/rpcchainvm/state_syncable_vm_test.go
+++ b/vms/rpcchainvm/state_syncable_vm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/ids"
@@ -261,7 +262,7 @@ func lastAcceptedBlockPostStateSummaryAcceptTestPlugin(t *testing.T, loadExpecta
 	return ssVM
 }
 
-func buildClientHelper(require *require.Assertions, testKey string) (*VMClient, runtime.Stopper) {
+func buildClientHelper(require *require.Assertions, testKey string) *VMClient {
 	process := helperProcess(testKey)
 
 	log := logging.NewLogger(
@@ -292,7 +293,7 @@ func buildClientHelper(require *require.Assertions, testKey string) (*VMClient, 
 	clientConn, err := grpcutils.Dial(status.Addr)
 	require.NoError(err)
 
-	return NewClient(clientConn), stopper
+	return NewClient(clientConn, stopper, status.Pid, nil, metrics.NewPrefixGatherer())
 }
 
 func TestStateSyncEnabled(t *testing.T) {
@@ -300,8 +301,8 @@ func TestStateSyncEnabled(t *testing.T) {
 	testKey := stateSyncEnabledTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	// test state sync not implemented
 	// Note that enabled == false is returned rather than
@@ -331,8 +332,8 @@ func TestGetOngoingSyncStateSummary(t *testing.T) {
 	testKey := getOngoingSyncStateSummaryTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	// test unimplemented case; this is just a guard
 	_, err := vm.GetOngoingSyncStateSummary(context.Background())
@@ -356,8 +357,8 @@ func TestGetLastStateSummary(t *testing.T) {
 	testKey := getLastStateSummaryTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	// test unimplemented case; this is just a guard
 	_, err := vm.GetLastStateSummary(context.Background())
@@ -381,8 +382,8 @@ func TestParseStateSummary(t *testing.T) {
 	testKey := parseStateSummaryTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	// test unimplemented case; this is just a guard
 	_, err := vm.ParseStateSummary(context.Background(), mockedSummary.Bytes())
@@ -410,8 +411,8 @@ func TestGetStateSummary(t *testing.T) {
 	testKey := getStateSummaryTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	// test unimplemented case; this is just a guard
 	_, err := vm.GetStateSummary(context.Background(), mockedSummary.Height())
@@ -435,8 +436,8 @@ func TestAcceptStateSummary(t *testing.T) {
 	testKey := acceptStateSummaryTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	// retrieve the summary first
 	summary, err := vm.GetStateSummary(context.Background(), mockedSummary.Height())
@@ -465,8 +466,8 @@ func TestLastAcceptedBlockPostStateSummaryAccept(t *testing.T) {
 	testKey := lastAcceptedBlockPostStateSummaryAcceptTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	// Step 1: initialize VM and check initial LastAcceptedBlock
 	ctx := snowtest.Context(t, snowtest.CChainID)

--- a/vms/rpcchainvm/with_context_vm_test.go
+++ b/vms/rpcchainvm/with_context_vm_test.go
@@ -94,8 +94,8 @@ func TestContextVMSummary(t *testing.T) {
 	testKey := contextTestKey
 
 	// Create and start the plugin
-	vm, stopper := buildClientHelper(require, testKey)
-	defer stopper.Stop(context.Background())
+	vm := buildClientHelper(require, testKey)
+	defer vm.runtime.Stop(context.Background())
 
 	ctx := snowtest.Context(t, snowtest.CChainID)
 


### PR DESCRIPTION
## Why this should be merged

Resolves #3169.

## How this works

1. Creates a metrics namespace for the avalanchego side of the rpcchainvm.
2. Removes the `plugin` prefix of metrics served over the grpc interface.

## How this was tested

- [X] CI
- [X] Locally running an `xsvm` subnet:

```
# HELP avalanche_rpcchainvm_bytes_to_id_cache_len number of entries
# TYPE avalanche_rpcchainvm_bytes_to_id_cache_len gauge
avalanche_rpcchainvm_bytes_to_id_cache_len{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_bytes_to_id_cache_portion_filled fraction of cache filled
# TYPE avalanche_rpcchainvm_bytes_to_id_cache_portion_filled gauge
avalanche_rpcchainvm_bytes_to_id_cache_portion_filled{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_bytes_to_id_cache_put_count number of put calls
# TYPE avalanche_rpcchainvm_bytes_to_id_cache_put_count counter
avalanche_rpcchainvm_bytes_to_id_cache_put_count{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_bytes_to_id_cache_put_time time spent (ns) in put calls
# TYPE avalanche_rpcchainvm_bytes_to_id_cache_put_time gauge
avalanche_rpcchainvm_bytes_to_id_cache_put_time{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_decided_cache_get_count number of get calls
# TYPE avalanche_rpcchainvm_decided_cache_get_count counter
avalanche_rpcchainvm_decided_cache_get_count{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",result="hit"} 166
# HELP avalanche_rpcchainvm_decided_cache_get_time time spent (ns) in get calls
# TYPE avalanche_rpcchainvm_decided_cache_get_time gauge
avalanche_rpcchainvm_decided_cache_get_time{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",result="hit"} 229964
# HELP avalanche_rpcchainvm_decided_cache_len number of entries
# TYPE avalanche_rpcchainvm_decided_cache_len gauge
avalanche_rpcchainvm_decided_cache_len{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 1
# HELP avalanche_rpcchainvm_decided_cache_portion_filled fraction of cache filled
# TYPE avalanche_rpcchainvm_decided_cache_portion_filled gauge
avalanche_rpcchainvm_decided_cache_portion_filled{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 1.519918441772461e-06
# HELP avalanche_rpcchainvm_decided_cache_put_count number of put calls
# TYPE avalanche_rpcchainvm_decided_cache_put_count counter
avalanche_rpcchainvm_decided_cache_put_count{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 3
# HELP avalanche_rpcchainvm_decided_cache_put_time time spent (ns) in put calls
# TYPE avalanche_rpcchainvm_decided_cache_put_time gauge
avalanche_rpcchainvm_decided_cache_put_time{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 2083
# HELP avalanche_rpcchainvm_grpc_server_handled_total Total number of RPCs completed on the server, regardless of success or failure.
# TYPE avalanche_rpcchainvm_grpc_server_handled_total counter
avalanche_rpcchainvm_grpc_server_handled_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_code="OK",grpc_method="Get",grpc_service="rpcdb.Database",grpc_type="unary"} 2
avalanche_rpcchainvm_grpc_server_handled_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_code="OK",grpc_method="Has",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_rpcchainvm_grpc_server_handled_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_code="OK",grpc_method="HealthCheck",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_rpcchainvm_grpc_server_handled_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_code="OK",grpc_method="WriteBatch",grpc_service="rpcdb.Database",grpc_type="unary"} 1
# HELP avalanche_rpcchainvm_grpc_server_msg_received_total Total number of RPC stream messages received on the server.
# TYPE avalanche_rpcchainvm_grpc_server_msg_received_total counter
avalanche_rpcchainvm_grpc_server_msg_received_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Get",grpc_service="rpcdb.Database",grpc_type="unary"} 2
avalanche_rpcchainvm_grpc_server_msg_received_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Has",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_rpcchainvm_grpc_server_msg_received_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="HealthCheck",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_rpcchainvm_grpc_server_msg_received_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="WriteBatch",grpc_service="rpcdb.Database",grpc_type="unary"} 1
# HELP avalanche_rpcchainvm_grpc_server_msg_sent_total Total number of gRPC stream messages sent by the server.
# TYPE avalanche_rpcchainvm_grpc_server_msg_sent_total counter
avalanche_rpcchainvm_grpc_server_msg_sent_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Get",grpc_service="rpcdb.Database",grpc_type="unary"} 2
avalanche_rpcchainvm_grpc_server_msg_sent_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Has",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_rpcchainvm_grpc_server_msg_sent_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="HealthCheck",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_rpcchainvm_grpc_server_msg_sent_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="WriteBatch",grpc_service="rpcdb.Database",grpc_type="unary"} 1
# HELP avalanche_rpcchainvm_grpc_server_started_total Total number of RPCs started on the server.
# TYPE avalanche_rpcchainvm_grpc_server_started_total counter
avalanche_rpcchainvm_grpc_server_started_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Get",grpc_service="rpcdb.Database",grpc_type="unary"} 2
avalanche_rpcchainvm_grpc_server_started_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Has",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_rpcchainvm_grpc_server_started_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="HealthCheck",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_rpcchainvm_grpc_server_started_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="WriteBatch",grpc_service="rpcdb.Database",grpc_type="unary"} 1
# HELP avalanche_rpcchainvm_missing_cache_len number of entries
# TYPE avalanche_rpcchainvm_missing_cache_len gauge
avalanche_rpcchainvm_missing_cache_len{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_missing_cache_portion_filled fraction of cache filled
# TYPE avalanche_rpcchainvm_missing_cache_portion_filled gauge
avalanche_rpcchainvm_missing_cache_portion_filled{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_missing_cache_put_count number of put calls
# TYPE avalanche_rpcchainvm_missing_cache_put_count counter
avalanche_rpcchainvm_missing_cache_put_count{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_missing_cache_put_time time spent (ns) in put calls
# TYPE avalanche_rpcchainvm_missing_cache_put_time gauge
avalanche_rpcchainvm_missing_cache_put_time{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_unverified_cache_len number of entries
# TYPE avalanche_rpcchainvm_unverified_cache_len gauge
avalanche_rpcchainvm_unverified_cache_len{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_unverified_cache_portion_filled fraction of cache filled
# TYPE avalanche_rpcchainvm_unverified_cache_portion_filled gauge
avalanche_rpcchainvm_unverified_cache_portion_filled{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_unverified_cache_put_count number of put calls
# TYPE avalanche_rpcchainvm_unverified_cache_put_count counter
avalanche_rpcchainvm_unverified_cache_put_count{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_rpcchainvm_unverified_cache_put_time time spent (ns) in put calls
# TYPE avalanche_rpcchainvm_unverified_cache_put_time gauge
avalanche_rpcchainvm_unverified_cache_put_time{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_xsvm_go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE avalanche_xsvm_go_gc_duration_seconds summary
avalanche_xsvm_go_gc_duration_seconds{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",quantile="0"} 1.1542e-05
avalanche_xsvm_go_gc_duration_seconds{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",quantile="0.25"} 2.9124e-05
avalanche_xsvm_go_gc_duration_seconds{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",quantile="0.5"} 3.4584e-05
avalanche_xsvm_go_gc_duration_seconds{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",quantile="0.75"} 3.7583e-05
avalanche_xsvm_go_gc_duration_seconds{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",quantile="1"} 4.275e-05
avalanche_xsvm_go_gc_duration_seconds_sum{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0.000249625
avalanche_xsvm_go_gc_duration_seconds_count{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 8
# HELP avalanche_xsvm_go_goroutines Number of goroutines that currently exist.
# TYPE avalanche_xsvm_go_goroutines gauge
avalanche_xsvm_go_goroutines{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 31
# HELP avalanche_xsvm_go_info Information about the Go environment.
# TYPE avalanche_xsvm_go_info gauge
avalanche_xsvm_go_info{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",version="go1.22.2"} 1
# HELP avalanche_xsvm_go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE avalanche_xsvm_go_memstats_alloc_bytes gauge
avalanche_xsvm_go_memstats_alloc_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 3.0150248e+07
# HELP avalanche_xsvm_go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE avalanche_xsvm_go_memstats_alloc_bytes_total counter
avalanche_xsvm_go_memstats_alloc_bytes_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 5.7294328e+07
# HELP avalanche_xsvm_go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE avalanche_xsvm_go_memstats_buck_hash_sys_bytes gauge
avalanche_xsvm_go_memstats_buck_hash_sys_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 1.464639e+06
# HELP avalanche_xsvm_go_memstats_frees_total Total number of frees.
# TYPE avalanche_xsvm_go_memstats_frees_total counter
avalanche_xsvm_go_memstats_frees_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 182327
# HELP avalanche_xsvm_go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE avalanche_xsvm_go_memstats_gc_sys_bytes gauge
avalanche_xsvm_go_memstats_gc_sys_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 3.38112e+06
# HELP avalanche_xsvm_go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE avalanche_xsvm_go_memstats_heap_alloc_bytes gauge
avalanche_xsvm_go_memstats_heap_alloc_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 3.0150248e+07
# HELP avalanche_xsvm_go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE avalanche_xsvm_go_memstats_heap_idle_bytes gauge
avalanche_xsvm_go_memstats_heap_idle_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 1.6113664e+07
# HELP avalanche_xsvm_go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE avalanche_xsvm_go_memstats_heap_inuse_bytes gauge
avalanche_xsvm_go_memstats_heap_inuse_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 3.3169408e+07
# HELP avalanche_xsvm_go_memstats_heap_objects Number of allocated objects.
# TYPE avalanche_xsvm_go_memstats_heap_objects gauge
avalanche_xsvm_go_memstats_heap_objects{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 78490
# HELP avalanche_xsvm_go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE avalanche_xsvm_go_memstats_heap_released_bytes gauge
avalanche_xsvm_go_memstats_heap_released_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 1.2853248e+07
# HELP avalanche_xsvm_go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE avalanche_xsvm_go_memstats_heap_sys_bytes gauge
avalanche_xsvm_go_memstats_heap_sys_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 4.9283072e+07
# HELP avalanche_xsvm_go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE avalanche_xsvm_go_memstats_last_gc_time_seconds gauge
avalanche_xsvm_go_memstats_last_gc_time_seconds{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 1.719979656002572e+09
# HELP avalanche_xsvm_go_memstats_lookups_total Total number of pointer lookups.
# TYPE avalanche_xsvm_go_memstats_lookups_total counter
avalanche_xsvm_go_memstats_lookups_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 0
# HELP avalanche_xsvm_go_memstats_mallocs_total Total number of mallocs.
# TYPE avalanche_xsvm_go_memstats_mallocs_total counter
avalanche_xsvm_go_memstats_mallocs_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 260817
# HELP avalanche_xsvm_go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE avalanche_xsvm_go_memstats_mcache_inuse_bytes gauge
avalanche_xsvm_go_memstats_mcache_inuse_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 14400
# HELP avalanche_xsvm_go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE avalanche_xsvm_go_memstats_mcache_sys_bytes gauge
avalanche_xsvm_go_memstats_mcache_sys_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 15600
# HELP avalanche_xsvm_go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE avalanche_xsvm_go_memstats_mspan_inuse_bytes gauge
avalanche_xsvm_go_memstats_mspan_inuse_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 257600
# HELP avalanche_xsvm_go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE avalanche_xsvm_go_memstats_mspan_sys_bytes gauge
avalanche_xsvm_go_memstats_mspan_sys_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 261120
# HELP avalanche_xsvm_go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE avalanche_xsvm_go_memstats_next_gc_bytes gauge
avalanche_xsvm_go_memstats_next_gc_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 5.219408e+07
# HELP avalanche_xsvm_go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE avalanche_xsvm_go_memstats_other_sys_bytes gauge
avalanche_xsvm_go_memstats_other_sys_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 2.628441e+06
# HELP avalanche_xsvm_go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE avalanche_xsvm_go_memstats_stack_inuse_bytes gauge
avalanche_xsvm_go_memstats_stack_inuse_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 1.048576e+06
# HELP avalanche_xsvm_go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE avalanche_xsvm_go_memstats_stack_sys_bytes gauge
avalanche_xsvm_go_memstats_stack_sys_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 1.048576e+06
# HELP avalanche_xsvm_go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE avalanche_xsvm_go_memstats_sys_bytes gauge
avalanche_xsvm_go_memstats_sys_bytes{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 5.8082568e+07
# HELP avalanche_xsvm_go_threads Number of OS threads created.
# TYPE avalanche_xsvm_go_threads gauge
avalanche_xsvm_go_threads{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA"} 16
# HELP avalanche_xsvm_grpc_client_handled_total Total number of RPCs completed by the client, regardless of success or failure.
# TYPE avalanche_xsvm_grpc_client_handled_total counter
avalanche_xsvm_grpc_client_handled_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_code="OK",grpc_method="Get",grpc_service="rpcdb.Database",grpc_type="unary"} 2
avalanche_xsvm_grpc_client_handled_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_code="OK",grpc_method="Has",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_xsvm_grpc_client_handled_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_code="OK",grpc_method="HealthCheck",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_xsvm_grpc_client_handled_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_code="OK",grpc_method="WriteBatch",grpc_service="rpcdb.Database",grpc_type="unary"} 1
# HELP avalanche_xsvm_grpc_client_msg_sent_total Total number of gRPC stream messages sent by the client.
# TYPE avalanche_xsvm_grpc_client_msg_sent_total counter
avalanche_xsvm_grpc_client_msg_sent_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Get",grpc_service="rpcdb.Database",grpc_type="unary"} 2
avalanche_xsvm_grpc_client_msg_sent_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Has",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_xsvm_grpc_client_msg_sent_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="HealthCheck",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_xsvm_grpc_client_msg_sent_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="WriteBatch",grpc_service="rpcdb.Database",grpc_type="unary"} 1
# HELP avalanche_xsvm_grpc_client_started_total Total number of RPCs started on the client.
# TYPE avalanche_xsvm_grpc_client_started_total counter
avalanche_xsvm_grpc_client_started_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Get",grpc_service="rpcdb.Database",grpc_type="unary"} 2
avalanche_xsvm_grpc_client_started_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="Has",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_xsvm_grpc_client_started_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="HealthCheck",grpc_service="rpcdb.Database",grpc_type="unary"} 1
avalanche_xsvm_grpc_client_started_total{chain="2BoYBipXmQCEGexWusiMoAsoaHDJtmiwg1Q2BfbVjsDhvWEJaA",grpc_method="WriteBatch",grpc_service="rpcdb.Database",grpc_type="unary"} 1
```