### PR TITLE
build(tests): require `//go:build test` tag if importing test packages outside of `_test.go` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ tmp/
 
 *logs/
 
+.vscode*
+
 *.pb*
 
 db*

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,6 @@ tmp/
 
 *logs/
 
-.vscode*
-
 *.pb*
 
 db*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,11 @@ run:
   # By default, it isn't set.
   modules-download-mode: readonly
 
+  # Include non-test files tagged as test-only.
+  # Context: https://github.com/ava-labs/avalanchego/pull/3173
+  build-tags:
+    - test
+
 output:
   # Make issues output unique by line.
   # Default: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "gopls": {
+        "build.buildFlags": [
+            // Context: https://github.com/ava-labs/avalanchego/pull/3173
+            // Without this tag, the language server won't build the test-only
+            // code in non-_test.go files.
+            "--tags='test'",
+        ],
+    },
+    "go.testTags": "test",
+}

--- a/cache/test_cacher.go
+++ b/cache/test_cacher.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package cache
 
 import (

--- a/chains/atomic/test_shared_memory.go
+++ b/chains/atomic/test_shared_memory.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package atomic
 
 import (

--- a/codec/test_codec.go
+++ b/codec/test_codec.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package codec
 
 import (

--- a/database/benchmark_database.go
+++ b/database/benchmark_database.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package database
 
 import (

--- a/database/test_database.go
+++ b/database/test_database.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package database
 
 import (

--- a/ids/test_aliases.go
+++ b/ids/test_aliases.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package ids
 
 import "github.com/stretchr/testify/require"

--- a/scripts/build_fuzz.sh
+++ b/scripts/build_fuzz.sh
@@ -28,7 +28,7 @@ do
         echo "Fuzzing $func in $file"
         parentDir=$(dirname "$file")
         # If any of the fuzz tests fail, return exit code 1
-        if ! go test "$parentDir" -run="$func" -fuzz="$func" -fuzztime="${fuzzTime}"s; then
+        if ! go test -tags test "$parentDir" -run="$func" -fuzz="$func" -fuzztime="${fuzzTime}"s; then
             failed=true
         fi
     done

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -18,4 +18,4 @@ fi
 TEST_TARGETS="$(eval "go list ./... ${EXCLUDED_TARGETS}")"
 
 # shellcheck disable=SC2086
-go test -shuffle=on -race -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}
+go test -tags test -shuffle=on -race -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -94,7 +94,7 @@ function test_import_testing_only_in_tests {
   IMPORT_TESTIFY=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/stretchr/testify');
   # TODO(arr4n): send a PR to add support for build tags in `mockgen` and then enable this.
   # IMPORT_GOMOCK=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"go.uber.org/mock');
-  HAVE_TEST_LOGIC=$( printf "${IMPORT_TESTING}\n${IMPORT_TESTIFY}" );
+  HAVE_TEST_LOGIC=$( printf "%s\n%s" "${IMPORT_TESTING}" "${IMPORT_TESTIFY}" );
 
   TAGGED_AS_TEST=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '^\/\/go:build\s+(.+(,|\s+))?test[,\s]?');
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,7 +29,7 @@ fi
 # by default, "./scripts/lint.sh" runs all lint tests
 # to run only "license_header" test
 # TESTS='license_header' ./scripts/lint.sh
-TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func"}
+TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func import_testing_only_in_tests"}
 
 function test_golangci_lint {
   go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.1

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -88,19 +88,25 @@ function test_interface_compliance_nil {
 
 function test_import_testing_only_in_tests {
   ROOT=$( git rev-parse --show-toplevel )
-  NON_TEST_GO_FILES=$( find "${ROOT}" -iname '*.go' ! -iname '*_test.go' | sort );
+  NON_TEST_GO_FILES=$( find "${ROOT}" -iname '*.go' ! -iname '*_test.go');
+
   IMPORT_TESTING=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '^\s*(import\s+)?"testing"');
+  IMPORT_TESTIFY=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/stretchr/testify');
+  # TODO(arr4n): send a PR to add support for build tags in `mockgen` and then enable this.
+  # IMPORT_GOMOCK=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"go.uber.org/mock');
+  HAVE_TEST_LOGIC=$( printf "${IMPORT_TESTING}\n${IMPORT_TESTIFY}" );
+
   TAGGED_AS_TEST=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '^\/\/go:build\s+(.+(,|\s+))?test[,\s]?');
 
-  # -3 suppresses files that import "testing" and have the "test" build tag
-  # -2 suppresses files that are tagged despite not importing "testing"
-  UNTAGGED=$( comm -23 <( echo "${IMPORT_TESTING}" ) <( echo "${TAGGED_AS_TEST}" ) );
+  # -3 suppresses files that have test logic and have the "test" build tag
+  # -2 suppresses files that are tagged despite not having detectable test logic
+  UNTAGGED=$( comm -23 <( echo "${HAVE_TEST_LOGIC}" | sort -u ) <( echo "${TAGGED_AS_TEST}" | sort -u ) );
   if [ -z "${UNTAGGED}" ];
   then
     return 0;
   fi
 
-  echo "Non-test Go files importing \"testing\" MUST have '//go:build test' tag:";
+  echo "Non-test Go files importing test-only packages MUST have '//go:build test' tag:";
   echo "${UNTAGGED}";
   return 1;
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -87,7 +87,8 @@ function test_interface_compliance_nil {
 }
 
 function test_import_testing_only_in_tests {
-  NON_TEST_GO_FILES=$( find -iname '*.go' ! -iname '*_test.go' | sort );
+  ROOT=$( git rev-parse --show-toplevel )
+  NON_TEST_GO_FILES=$( find "${ROOT}" -iname '*.go' ! -iname '*_test.go' | sort );
   IMPORT_TESTING=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '^\s*(import\s+)?"testing"');
   TAGGED_AS_TEST=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '^\/\/go:build\s+(.+(,|\s+))?test[,\s]?');
 

--- a/scripts/tests.e2e.existing.sh
+++ b/scripts/tests.e2e.existing.sh
@@ -22,7 +22,7 @@ function print_separator {
 function cleanup {
   print_separator
   echo "cleaning up reusable network"
-  ginkgo -v ./tests/e2e/e2e.test -- --stop-network
+  ginkgo -v --tags test ./tests/e2e/e2e.test -- --stop-network
 }
 trap cleanup EXIT
 

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -23,7 +23,7 @@ source ./scripts/constants.sh
 echo "building e2e.test"
 # to install the ginkgo binary (required for test build and run)
 go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
-ACK_GINKGO_RC=true ginkgo build ./tests/e2e
+ACK_GINKGO_RC=true ginkgo build --tags test ./tests/e2e
 ./tests/e2e/e2e.test --help
 
 # Enable subnet testing by building xsvm
@@ -57,4 +57,4 @@ fi
 
 #################################
 # - Execute in random order to identify unwanted dependency
-ginkgo ${GINKGO_ARGS} -v --randomize-all ./tests/e2e/e2e.test -- "${E2E_ARGS[@]}" "${@}"
+ginkgo ${GINKGO_ARGS} -v --tags test --randomize-all ./tests/e2e/e2e.test -- "${E2E_ARGS[@]}" "${@}"

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -66,7 +66,7 @@ source ./scripts/constants.sh
 echo "building upgrade.test"
 # to install the ginkgo binary (required for test build and run)
 go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
-ACK_GINKGO_RC=true ginkgo build ./tests/upgrade
+ACK_GINKGO_RC=true ginkgo build --tags test ./tests/upgrade
 ./tests/upgrade/upgrade.test --help
 
 #################################

--- a/snow/consensus/snowball/test_snowflake.go
+++ b/snow/consensus/snowball/test_snowflake.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package snowball
 
 import "testing"

--- a/snow/engine/avalanche/bootstrap/queue/test_job.go
+++ b/snow/engine/avalanche/bootstrap/queue/test_job.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package queue
 
 import (

--- a/snow/engine/avalanche/bootstrap/queue/test_parser.go
+++ b/snow/engine/avalanche/bootstrap/queue/test_parser.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package queue
 
 import (

--- a/snow/engine/avalanche/vertex/test_builder.go
+++ b/snow/engine/avalanche/vertex/test_builder.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package vertex
 
 import (

--- a/snow/engine/avalanche/vertex/test_manager.go
+++ b/snow/engine/avalanche/vertex/test_manager.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package vertex
 
 import "testing"

--- a/snow/engine/avalanche/vertex/test_parser.go
+++ b/snow/engine/avalanche/vertex/test_parser.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package vertex
 
 import (

--- a/snow/engine/avalanche/vertex/test_parser.go
+++ b/snow/engine/avalanche/vertex/test_parser.go
@@ -1,7 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
+// TODO: https://github.com/ava-labs/avalanchego/issues/3174
+//go:build test || !test
 
 package vertex
 

--- a/snow/engine/avalanche/vertex/test_parser.go
+++ b/snow/engine/avalanche/vertex/test_parser.go
@@ -1,8 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// TODO: https://github.com/ava-labs/avalanchego/issues/3174
-//go:build test || !test
+//go:build test
 
 package vertex
 

--- a/snow/engine/avalanche/vertex/test_storage.go
+++ b/snow/engine/avalanche/vertex/test_storage.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package vertex
 
 import (

--- a/snow/engine/avalanche/vertex/test_vm.go
+++ b/snow/engine/avalanche/vertex/test_vm.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package vertex
 
 import (

--- a/snow/engine/common/test_bootstrap_tracker.go
+++ b/snow/engine/common/test_bootstrap_tracker.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package common
 
 import (

--- a/snow/engine/common/test_bootstrap_tracker.go
+++ b/snow/engine/common/test_bootstrap_tracker.go
@@ -1,7 +1,10 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
+// TODO(arr4n) this file needs to be built along with the avalanchego binary
+// so temporarily trick the linter into thinking we've tagged it as a test.
+// Tracking issue: https://github.com/ava-labs/avalanchego/issues/3174
+//go:build test || !test
 
 package common
 

--- a/snow/engine/common/test_bootstrap_tracker.go
+++ b/snow/engine/common/test_bootstrap_tracker.go
@@ -1,8 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// TODO: https://github.com/ava-labs/avalanchego/issues/3174
-//go:build test || !test
+//go:build test
 
 package common
 

--- a/snow/engine/common/test_bootstrap_tracker.go
+++ b/snow/engine/common/test_bootstrap_tracker.go
@@ -1,9 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// TODO(arr4n) this file needs to be built along with the avalanchego binary
-// so temporarily trick the linter into thinking we've tagged it as a test.
-// Tracking issue: https://github.com/ava-labs/avalanchego/issues/3174
+// TODO: https://github.com/ava-labs/avalanchego/issues/3174
 //go:build test || !test
 
 package common

--- a/snow/engine/common/test_bootstrapper.go
+++ b/snow/engine/common/test_bootstrapper.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package common
 
 import (

--- a/snow/engine/common/test_engine.go
+++ b/snow/engine/common/test_engine.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package common
 
 import (

--- a/snow/engine/common/test_engine.go
+++ b/snow/engine/common/test_engine.go
@@ -1,7 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
+// TODO: https://github.com/ava-labs/avalanchego/issues/3174
+//go:build test || !test
 
 package common
 

--- a/snow/engine/common/test_engine.go
+++ b/snow/engine/common/test_engine.go
@@ -1,8 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// TODO: https://github.com/ava-labs/avalanchego/issues/3174
-//go:build test || !test
+//go:build test
 
 package common
 

--- a/snow/engine/common/test_sender.go
+++ b/snow/engine/common/test_sender.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package common
 
 import (

--- a/snow/engine/common/test_timer.go
+++ b/snow/engine/common/test_timer.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package common
 
 import (

--- a/snow/engine/common/test_vm.go
+++ b/snow/engine/common/test_vm.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package common
 
 import (

--- a/snow/engine/common/test_vm.go
+++ b/snow/engine/common/test_vm.go
@@ -1,7 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
+// TODO: https://github.com/ava-labs/avalanchego/issues/3174
+//go:build test || !test
 
 package common
 

--- a/snow/engine/common/test_vm.go
+++ b/snow/engine/common/test_vm.go
@@ -1,8 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// TODO: https://github.com/ava-labs/avalanchego/issues/3174
-//go:build test || !test
+//go:build test
 
 package common
 

--- a/snow/engine/snowman/block/test_batched_vm.go
+++ b/snow/engine/snowman/block/test_batched_vm.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package block
 
 import (

--- a/snow/engine/snowman/block/test_batched_vm.go
+++ b/snow/engine/snowman/block/test_batched_vm.go
@@ -1,7 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
+// TODO: https://github.com/ava-labs/avalanchego/issues/3174
+//go:build test || !test
 
 package block
 

--- a/snow/engine/snowman/block/test_batched_vm.go
+++ b/snow/engine/snowman/block/test_batched_vm.go
@@ -1,8 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// TODO: https://github.com/ava-labs/avalanchego/issues/3174
-//go:build test || !test
+//go:build test
 
 package block
 

--- a/snow/engine/snowman/block/test_state_summary.go
+++ b/snow/engine/snowman/block/test_state_summary.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package block
 
 import (

--- a/snow/engine/snowman/block/test_state_syncable_vm.go
+++ b/snow/engine/snowman/block/test_state_syncable_vm.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package block
 
 import (

--- a/snow/engine/snowman/block/test_vm.go
+++ b/snow/engine/snowman/block/test_vm.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package block
 
 import (

--- a/snow/networking/benchlist/test_benchable.go
+++ b/snow/networking/benchlist/test_benchable.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package benchlist
 
 import (

--- a/snow/networking/sender/test_external_sender.go
+++ b/snow/networking/sender/test_external_sender.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package sender
 
 import (

--- a/snow/snowtest/snowtest.go
+++ b/snow/snowtest/snowtest.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package snowtest
 
 import (

--- a/snow/validators/test_state.go
+++ b/snow/validators/test_state.go
@@ -1,8 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// TODO: https://github.com/ava-labs/avalanchego/issues/3174
-//go:build test || !test
+//go:build test
 
 package validators
 

--- a/snow/validators/test_state.go
+++ b/snow/validators/test_state.go
@@ -1,7 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
+// TODO: https://github.com/ava-labs/avalanchego/issues/3174
+//go:build test || !test
 
 package validators
 

--- a/snow/validators/test_state.go
+++ b/snow/validators/test_state.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package validators
 
 import (

--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 // Implements tests for the banff network upgrade.
 package banff
 

--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package c
 
 import (

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package c
 
 import (

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package faultinjection
 
 import (

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package p
 
 import (

--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package p
 
 import (

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package p
 
 import (

--- a/tests/e2e/p/validator_sets.go
+++ b/tests/e2e/p/validator_sets.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package p
 
 import (

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package p
 
 import (

--- a/tests/e2e/vms/xsvm.go
+++ b/tests/e2e/vms/xsvm.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package vms
 
 import (

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package x
 
 import (

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 // Implements X-chain transfer tests.
 package transfer
 

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package e2e
 
 import (

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package e2e
 
 import (

--- a/vms/platformvm/warp/test_signer.go
+++ b/vms/platformvm/warp/test_signer.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package warp
 
 import (

--- a/wallet/subnet/primary/common/test_utxos.go
+++ b/wallet/subnet/primary/common/test_utxos.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build test
+
 package common
 
 import (


### PR DESCRIPTION
## Why this should be merged

Including test-only code in non-test files risks leaking said functionality into production.

## How this works

A new linter finds all `*.go` files that (i) aren't `_test.go`; and (ii) import test packages[^1]. If any of these files don't include a build-constraint tag of `test` then the linter fails. To the best of my knowledge, there's no native tag that's set when running tests, so all runs of `go test` and `ginkgo` now need to include `-tags test`.

[^1]: Currently detects `testing` and `stretchr/testify/*` packages. As `mockgen` doesn't add build tags, detection of mocks is disabled pending a [PR](https://github.com/uber-go/mock/pull/191) to them.

## How this was tested

Manually: I wrote the linter first as a way to find the offending files.

## Future work

See #3174 for files flagged by the linter that have been temporarily ignored.