### PR TITLE
Include VM path in plugin version error

### DIFF
--- a/vms/rpcchainvm/runtime/subprocess/initializer.go
+++ b/vms/rpcchainvm/runtime/subprocess/initializer.go
@@ -16,6 +16,8 @@ var _ runtime.Initializer = (*initializer)(nil)
 
 // Subprocess VM Runtime intializer.
 type initializer struct {
+	path string
+
 	once sync.Once
 	// Address of the RPC Chain VM server
 	vmAddr string
@@ -25,8 +27,9 @@ type initializer struct {
 	initialized chan struct{}
 }
 
-func newInitializer() *initializer {
+func newInitializer(path string) *initializer {
 	return &initializer{
+		path:        path,
 		initialized: make(chan struct{}),
 	}
 }
@@ -34,10 +37,11 @@ func newInitializer() *initializer {
 func (i *initializer) Initialize(_ context.Context, protocolVersion uint, vmAddr string) error {
 	i.once.Do(func() {
 		if version.RPCChainVMProtocol != protocolVersion {
-			i.err = fmt.Errorf("%w. AvalancheGo version %s implements RPCChainVM protocol version %d. The VM implements RPCChainVM protocol version %d. Please make sure that there is an exact match of the protocol versions. This can be achieved by updating your VM or running an older/newer version of AvalancheGo. Please be advised that some virtual machines may not yet support the latest RPCChainVM protocol version",
+			i.err = fmt.Errorf("%w. AvalancheGo version %s implements RPCChainVM protocol version %d. The VM (%s) implements RPCChainVM protocol version %d. Please make sure that there is an exact match of the protocol versions. This can be achieved by updating your VM or running an older/newer version of AvalancheGo. Please be advised that some virtual machines may not yet support the latest RPCChainVM protocol version",
 				runtime.ErrProtocolVersionMismatch,
 				version.Current,
 				version.RPCChainVMProtocol,
+				i.path,
 				protocolVersion,
 			)
 		}

--- a/vms/rpcchainvm/runtime/subprocess/initializer.go
+++ b/vms/rpcchainvm/runtime/subprocess/initializer.go
@@ -37,7 +37,7 @@ func newInitializer(path string) *initializer {
 func (i *initializer) Initialize(_ context.Context, protocolVersion uint, vmAddr string) error {
 	i.once.Do(func() {
 		if version.RPCChainVMProtocol != protocolVersion {
-			i.err = fmt.Errorf("%w. AvalancheGo version %s implements RPCChainVM protocol version %d. The VM (%s) implements RPCChainVM protocol version %d. Please make sure that there is an exact match of the protocol versions. This can be achieved by updating your VM or running an older/newer version of AvalancheGo. Please be advised that some virtual machines may not yet support the latest RPCChainVM protocol version",
+			i.err = fmt.Errorf("%w. AvalancheGo version %s implements RPCChainVM protocol version %d. The VM located at %s implements RPCChainVM protocol version %d. Please make sure that there is an exact match of the protocol versions. This can be achieved by updating your VM or running an older/newer version of AvalancheGo. Please be advised that some virtual machines may not yet support the latest RPCChainVM protocol version",
 				runtime.ErrProtocolVersionMismatch,
 				version.Current,
 				version.RPCChainVMProtocol,

--- a/vms/rpcchainvm/runtime/subprocess/runtime.go
+++ b/vms/rpcchainvm/runtime/subprocess/runtime.go
@@ -64,7 +64,7 @@ func Bootstrap(
 		return nil, nil, fmt.Errorf("%w: stderr and stdout required", runtime.ErrInvalidConfig)
 	}
 
-	intitializer := newInitializer()
+	intitializer := newInitializer(cmd.Path)
 
 	server := grpcutils.NewServer()
 	defer server.GracefulStop()


### PR DESCRIPTION
## Why this should be merged

Adds the explicit file that should be updated to the error message.

## How this works

Passes the file path into the initializer.

## How this was tested

- [X] Manually:
```
[07-07|11:26:13.794] ERROR node/node.go:1287 failed to register VM {"vmID": "srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy", "error": "handshake failed: RPCChainVM protocol version mismatch between AvalancheGo and Virtual Machine plugin. AvalancheGo version v1.11.9 implements RPCChainVM protocol version 35. The VM located at /Users/stephen/.avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy implements RPCChainVM protocol version 33. Please make sure that there is an exact match of the protocol versions. This can be achieved by updating your VM or running an older/newer version of AvalancheGo. Please be advised that some virtual machines may not yet support the latest RPCChainVM protocol version"}
```