### PR TITLE
P-chain: updating wallet to use dynamic fee calculator

### DIFF
--- a/vms/components/fee/calculator.go
+++ b/vms/components/fee/calculator.go
@@ -77,7 +77,7 @@ func (c *Calculator) AddFeesFor(complexity Dimensions) (uint64, error) {
 		return 0, fmt.Errorf("%w: %w", errGasBoundBreached, err)
 	}
 	if totalGas > c.gasCap {
-		return 0, fmt.Errorf("%w: %w", errGasBoundBreached, err)
+		return 0, fmt.Errorf("%w: total gas %d, gas cap %d", errGasBoundBreached, totalGas, c.gasCap)
 	}
 
 	return c.GetLatestTxFee()

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -39,13 +39,15 @@ func TestBuildBlockBasic(t *testing.T) {
 	defer env.ctx.Lock.Unlock()
 
 	// Create a valid transaction
-	builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	require.NoError(err)
 	utx, err := builder.NewCreateChainTx(
 		testSubnet1.ID(),
 		nil,
 		constants.AVMID,
 		nil,
 		"chain name",
+		feeCalc,
 	)
 	require.NoError(err)
 	tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -111,7 +113,8 @@ func TestBuildBlockShouldReward(t *testing.T) {
 	require.NoError(err)
 
 	// Create a valid [AddPermissionlessValidatorTx]
-	builder, txSigner := env.factory.NewWallet(preFundedKeys[0])
+	builder, txSigner, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
 	utx, err := builder.NewAddPermissionlessValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -133,6 +136,7 @@ func TestBuildBlockShouldReward(t *testing.T) {
 			Addrs:     []ids.ShortID{preFundedKeys[0].PublicKey().Address()},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		common.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{preFundedKeys[0].PublicKey().Address()},
@@ -251,13 +255,15 @@ func TestBuildBlockForceAdvanceTime(t *testing.T) {
 	defer env.ctx.Lock.Unlock()
 
 	// Create a valid transaction
-	builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	require.NoError(err)
 	utx, err := builder.NewCreateChainTx(
 		testSubnet1.ID(),
 		nil,
 		constants.AVMID,
 		nil,
 		"chain name",
+		feeCalc,
 	)
 	require.NoError(err)
 	tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -320,7 +326,8 @@ func TestBuildBlockInvalidStakingDurations(t *testing.T) {
 	sk, err := bls.NewSecretKey()
 	require.NoError(err)
 
-	builder1, signer1 := env.factory.NewWallet(preFundedKeys[0])
+	builder1, signer1, feeCalc1, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
 	utx1, err := builder1.NewAddPermissionlessValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -342,6 +349,7 @@ func TestBuildBlockInvalidStakingDurations(t *testing.T) {
 			Addrs:     []ids.ShortID{preFundedKeys[0].PublicKey().Address()},
 		},
 		reward.PercentDenominator,
+		feeCalc1,
 		common.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{preFundedKeys[0].PublicKey().Address()},
@@ -361,7 +369,8 @@ func TestBuildBlockInvalidStakingDurations(t *testing.T) {
 	sk, err = bls.NewSecretKey()
 	require.NoError(err)
 
-	builder2, signer2 := env.factory.NewWallet(preFundedKeys[2])
+	builder2, signer2, feeCalc2, err := env.factory.NewWallet(preFundedKeys[2])
+	require.NoError(err)
 	utx2, err := builder2.NewAddPermissionlessValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -383,6 +392,7 @@ func TestBuildBlockInvalidStakingDurations(t *testing.T) {
 			Addrs:     []ids.ShortID{preFundedKeys[2].PublicKey().Address()},
 		},
 		reward.PercentDenominator,
+		feeCalc2,
 		common.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{preFundedKeys[2].PublicKey().Address()},
@@ -426,13 +436,15 @@ func TestPreviouslyDroppedTxsCannotBeReAddedToMempool(t *testing.T) {
 	defer env.ctx.Lock.Unlock()
 
 	// Create a valid transaction
-	builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	require.NoError(err)
 	utx, err := builder.NewCreateChainTx(
 		testSubnet1.ID(),
 		nil,
 		constants.AVMID,
 		nil,
 		"chain name",
+		feeCalc,
 	)
 	require.NoError(err)
 	tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -153,7 +153,7 @@ func newEnvironment(t *testing.T, f fork) *environment { //nolint:unparam
 
 	res.uptimes = uptime.NewManager(res.state, res.clk)
 	res.utxosVerifier = utxo.NewVerifier(res.ctx, res.clk, res.fx)
-	res.factory = txstest.NewWalletFactory(res.ctx, res.config, res.state)
+	res.factory = txstest.NewWalletFactory(res.ctx, res.config, res.clk, res.state)
 
 	genesisID := res.state.GetLastAccepted()
 	res.backend = txexecutor.Backend{
@@ -236,7 +236,9 @@ func newEnvironment(t *testing.T, f fork) *environment { //nolint:unparam
 func addSubnet(t *testing.T, env *environment) {
 	require := require.New(t)
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
+
 	utx, err := builder.NewCreateSubnetTx(
 		&secp256k1fx.OutputOwners{
 			Threshold: 2,
@@ -246,6 +248,7 @@ func addSubnet(t *testing.T, env *environment) {
 				preFundedKeys[2].PublicKey().Address(),
 			},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{preFundedKeys[0].PublicKey().Address()},

--- a/vms/platformvm/block/builder/standard_block_test.go
+++ b/vms/platformvm/block/builder/standard_block_test.go
@@ -63,13 +63,16 @@ func TestAtomicTxImports(t *testing.T) {
 		}}},
 	}))
 
-	builder, signer := env.factory.NewWallet(recipientKey)
+	builder, signer, feeCalc, err := env.factory.NewWallet(recipientKey)
+	require.NoError(err)
+
 	utx, err := builder.NewImportTx(
 		env.ctx.XChainID,
 		&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{recipientKey.PublicKey().Address()},
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -510,7 +510,8 @@ func TestBanffStandardBlockUpdateStakers(t *testing.T) {
 			}
 
 			for _, staker := range test.subnetStakers {
-				builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+				require.NoError(err)
 				utx, err := builder.NewAddSubnetValidatorTx(
 					&txs.SubnetValidator{
 						Validator: txs.Validator{
@@ -521,6 +522,7 @@ func TestBanffStandardBlockUpdateStakers(t *testing.T) {
 						},
 						Subnet: subnetID,
 					},
+					feeCalc,
 				)
 				require.NoError(err)
 				tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -604,7 +606,8 @@ func TestBanffStandardBlockRemoveSubnetValidator(t *testing.T) {
 	subnetValidatorNodeID := genesisNodeIDs[0]
 	subnetVdr1StartTime := defaultValidateStartTime
 	subnetVdr1EndTime := defaultValidateStartTime.Add(defaultMinStakingDuration)
-	builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+	require.NoError(err)
 	utx, err := builder.NewAddSubnetValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -615,6 +618,7 @@ func TestBanffStandardBlockRemoveSubnetValidator(t *testing.T) {
 			},
 			Subnet: subnetID,
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -647,6 +651,7 @@ func TestBanffStandardBlockRemoveSubnetValidator(t *testing.T) {
 			},
 			Subnet: subnetID,
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	tx, err = walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -710,7 +715,8 @@ func TestBanffStandardBlockTrackedSubnet(t *testing.T) {
 			subnetValidatorNodeID := genesisNodeIDs[0]
 			subnetVdr1StartTime := defaultGenesisTime.Add(1 * time.Minute)
 			subnetVdr1EndTime := defaultGenesisTime.Add(10 * defaultMinStakingDuration).Add(1 * time.Minute)
-			builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+			builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+			require.NoError(err)
 			utx, err := builder.NewAddSubnetValidatorTx(
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
@@ -721,6 +727,7 @@ func TestBanffStandardBlockTrackedSubnet(t *testing.T) {
 					},
 					Subnet: subnetID,
 				},
+				feeCalc,
 			)
 			require.NoError(err)
 			tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -805,7 +812,8 @@ func TestBanffStandardBlockDelegatorStakerWeight(t *testing.T) {
 	pendingDelegatorStartTime := pendingValidatorStartTime.Add(1 * time.Second)
 	pendingDelegatorEndTime := pendingDelegatorStartTime.Add(1 * time.Second)
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1], preFundedKeys[4])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1], preFundedKeys[4])
+	require.NoError(err)
 	utx, err := builder.NewAddDelegatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -817,6 +825,7 @@ func TestBanffStandardBlockDelegatorStakerWeight(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{preFundedKeys[0].PublicKey().Address()},
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	addDelegatorTx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/rpc"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
+
+	commonfee "github.com/ava-labs/avalanchego/vms/components/fee"
 )
 
 var _ Client = (*client)(nil)
@@ -121,6 +123,12 @@ type Client interface {
 	GetBlock(ctx context.Context, blockID ids.ID, options ...rpc.Option) ([]byte, error)
 	// GetBlockByHeight returns the block at the given [height].
 	GetBlockByHeight(ctx context.Context, height uint64, options ...rpc.Option) ([]byte, error)
+
+	// GetDynamicFeeConfig returns DynamicFeesConfig
+	GetDynamicFeeConfig(ctx context.Context, options ...rpc.Option) (commonfee.DynamicFeesConfig, error)
+	// GetNextGasData returns the gas price that a transaction must pay to be accepted now
+	// and the gas cap, i.e. the maximum gas a transactions can consume
+	GetNextGasData(ctx context.Context, options ...rpc.Option) (commonfee.GasPrice, commonfee.Gas, error)
 }
 
 // Client implementation for interacting with the P Chain endpoint
@@ -542,4 +550,16 @@ func AwaitTxAccepted(
 			return ctx.Err()
 		}
 	}
+}
+
+func (c *client) GetDynamicFeeConfig(ctx context.Context, options ...rpc.Option) (commonfee.DynamicFeesConfig, error) {
+	res := &DynamicFeesConfigReply{}
+	err := c.requester.SendRequest(ctx, "platform.getDynamicFeeConfig", struct{}{}, res, options...)
+	return res.DynamicFeesConfig, err
+}
+
+func (c *client) GetNextGasData(ctx context.Context, options ...rpc.Option) (commonfee.GasPrice, commonfee.Gas, error) {
+	res := &GetGasPriceReply{}
+	err := c.requester.SendRequest(ctx, "platform.getNextGasData", struct{}{}, res, options...)
+	return res.NextGasPrice, res.NextGasCap, err
 }

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -395,7 +395,9 @@ func TestAdvanceTimeTxUpdateStakers(t *testing.T) {
 			}
 
 			for _, staker := range test.subnetStakers {
-				builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+				require.NoError(err)
+
 				utx, err := builder.NewAddSubnetValidatorTx(
 					&txs.SubnetValidator{
 						Validator: txs.Validator{
@@ -406,6 +408,7 @@ func TestAdvanceTimeTxUpdateStakers(t *testing.T) {
 						},
 						Subnet: subnetID,
 					},
+					feeCalc,
 				)
 				require.NoError(err)
 				tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -499,7 +502,9 @@ func TestAdvanceTimeTxRemoveSubnetValidator(t *testing.T) {
 	subnetVdr1StartTime := defaultValidateStartTime
 	subnetVdr1EndTime := defaultValidateStartTime.Add(defaultMinStakingDuration)
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+	require.NoError(err)
+
 	utx, err := builder.NewAddSubnetValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -510,6 +515,7 @@ func TestAdvanceTimeTxRemoveSubnetValidator(t *testing.T) {
 			},
 			Subnet: subnetID,
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -543,6 +549,7 @@ func TestAdvanceTimeTxRemoveSubnetValidator(t *testing.T) {
 			},
 			Subnet: subnetID,
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	tx, err = walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -617,7 +624,8 @@ func TestTrackedSubnet(t *testing.T) {
 
 			subnetVdr1StartTime := defaultValidateStartTime.Add(1 * time.Minute)
 			subnetVdr1EndTime := defaultValidateStartTime.Add(10 * defaultMinStakingDuration).Add(1 * time.Minute)
-			builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+			builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1])
+			require.NoError(err)
 			utx, err := builder.NewAddSubnetValidatorTx(
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
@@ -628,6 +636,7 @@ func TestTrackedSubnet(t *testing.T) {
 					},
 					Subnet: subnetID,
 				},
+				feeCalc,
 			)
 			require.NoError(err)
 			tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -732,7 +741,9 @@ func TestAdvanceTimeTxDelegatorStakerWeight(t *testing.T) {
 	pendingDelegatorStartTime := pendingValidatorStartTime.Add(1 * time.Second)
 	pendingDelegatorEndTime := pendingDelegatorStartTime.Add(1 * time.Second)
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1], preFundedKeys[4])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1], preFundedKeys[4])
+	require.NoError(err)
+
 	utx, err := builder.NewAddDelegatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -744,6 +755,7 @@ func TestAdvanceTimeTxDelegatorStakerWeight(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{preFundedKeys[0].PublicKey().Address()},
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	addDelegatorTx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -837,7 +849,8 @@ func TestAdvanceTimeTxDelegatorStakers(t *testing.T) {
 	// Add delegator
 	pendingDelegatorStartTime := pendingValidatorStartTime.Add(1 * time.Second)
 	pendingDelegatorEndTime := pendingDelegatorStartTime.Add(defaultMinStakingDuration)
-	builder, signer := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1], preFundedKeys[4])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0], preFundedKeys[1], preFundedKeys[4])
+	require.NoError(err)
 	utx, err := builder.NewAddDelegatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -849,6 +862,7 @@ func TestAdvanceTimeTxDelegatorStakers(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{preFundedKeys[0].PublicKey().Address()},
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	addDelegatorTx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -960,7 +974,11 @@ func addPendingValidator(
 	nodeID ids.NodeID,
 	keys []*secp256k1.PrivateKey,
 ) (*txs.Tx, error) {
-	builder, signer := env.factory.NewWallet(keys...)
+	builder, signer, feeCalc, err := env.factory.NewWallet(keys...)
+	if err != nil {
+		return nil, err
+	}
+
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -973,6 +991,7 @@ func addPendingValidator(
 			Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 	)
 	if err != nil {
 		return nil, err

--- a/vms/platformvm/txs/executor/create_subnet_test.go
+++ b/vms/platformvm/txs/executor/create_subnet_test.go
@@ -66,10 +66,13 @@ func TestCreateSubnetTxAP3FeeChange(t *testing.T) {
 
 			cfg := *env.config
 			cfg.StaticFeeConfig.CreateSubnetTxFee = test.fee
-			factory := txstest.NewWalletFactory(env.ctx, &cfg, env.state)
-			builder, signer := factory.NewWallet(preFundedKeys...)
+			factory := txstest.NewWalletFactory(env.ctx, &cfg, env.clk, env.state)
+			builder, signer, feeCalc, err := factory.NewWallet(preFundedKeys...)
+			require.NoError(err)
+
 			utx, err := builder.NewCreateSubnetTx(
 				&secp256k1fx.OutputOwners{},
+				feeCalc,
 			)
 			require.NoError(err)
 			tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)

--- a/vms/platformvm/txs/executor/import_test.go
+++ b/vms/platformvm/txs/executor/import_test.go
@@ -124,10 +124,13 @@ func TestNewImportTx(t *testing.T) {
 
 			env.msm.SharedMemory = tt.sharedMemory
 
-			builder, signer := env.factory.NewWallet(tt.sourceKeys...)
+			builder, signer, feeCalc, err := env.factory.NewWallet(tt.sourceKeys...)
+			require.NoError(err)
+
 			utx, err := builder.NewImportTx(
 				tt.sourceChainID,
 				to,
+				feeCalc,
 			)
 			require.ErrorIs(err, tt.expectedErr)
 			if tt.expectedErr != nil {

--- a/vms/platformvm/txs/executor/proposal_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor_test.go
@@ -38,7 +38,9 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 	addMinStakeValidator := func(env *environment) {
 		require := require.New(t)
 
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
+
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: newValidatorID,
@@ -51,6 +53,7 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 				Addrs:     []ids.ShortID{rewardAddress},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -76,7 +79,9 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 	addMaxStakeValidator := func(env *environment) {
 		require := require.New(t)
 
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
+
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: newValidatorID,
@@ -89,6 +94,7 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 				Addrs:     []ids.ShortID{rewardAddress},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -244,7 +250,9 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 			env := newEnvironment(t, apricotPhase5)
 			env.config.UpgradeConfig.ApricotPhase3Time = tt.AP3Time
 
-			builder, signer := env.factory.NewWallet(tt.feeKeys...)
+			builder, signer, feeCalc, err := env.factory.NewWallet(tt.feeKeys...)
+			require.NoError(err)
+
 			utx, err := builder.NewAddDelegatorTx(
 				&txs.Validator{
 					NodeID: tt.nodeID,
@@ -256,6 +264,7 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{rewardAddress},
 				},
+				feeCalc,
 			)
 			require.NoError(err)
 			tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -297,7 +306,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// Case: Proposed validator currently validating primary network
 		// but stops validating subnet after stops validating primary network
 		// (note that keys[0] is a genesis validator)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -308,6 +318,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -337,7 +348,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		// and proposed subnet validation period is subset of
 		// primary network validation period
 		// (note that keys[0] is a genesis validator)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -348,6 +360,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -377,7 +390,9 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	dsStartTime := defaultValidateStartTime.Add(10 * time.Second)
 	dsEndTime := dsStartTime.Add(5 * defaultMinStakingDuration)
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
+
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: pendingDSValidatorID,
@@ -390,6 +405,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 			Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 	)
 	require.NoError(err)
 	addDSTx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -397,7 +413,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 
 	{
 		// Case: Proposed validator isn't in pending or current validator sets
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -408,6 +425,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -452,7 +470,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Proposed validator is pending validator of primary network
 		// but starts validating subnet before primary network
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -463,6 +482,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -490,7 +510,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Proposed validator is pending validator of primary network
 		// but stops validating subnet after primary network
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -501,6 +522,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -528,7 +550,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Proposed validator is pending validator of primary network and
 		// period validating subnet is subset of time validating primary network
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -539,6 +562,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -568,7 +592,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	env.state.SetTimestamp(newTimestamp)
 
 	{
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -579,6 +604,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -608,7 +634,9 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 
 	// Case: Proposed validator already validating the subnet
 	// First, add validator as validator of subnet
-	builder, signer = env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	builder, signer, feeCalc, err = env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	require.NoError(err)
+
 	uSubnetTx, err := builder.NewAddSubnetValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -619,6 +647,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 			},
 			Subnet: testSubnet1.ID(),
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	subnetTx, err := walletsigner.SignUnsigned(context.Background(), signer, uSubnetTx)
@@ -640,7 +669,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 
 	{
 		// Node with ID nodeIDKey.PublicKey().Address() now validating subnet with ID testSubnet1.ID
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -651,6 +681,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		duplicateSubnetTx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -681,7 +712,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 
 	{
 		// Case: Too few signatures
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -692,6 +724,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -725,7 +758,9 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 
 	{
 		// Case: Control Signature from invalid key (keys[3] is not a control key)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], preFundedKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], preFundedKeys[1])
+		require.NoError(err)
+
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -736,6 +771,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -768,7 +804,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Proposed validator in pending validator set for subnet
 		// First, add validator to pending validator set of subnet
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -779,6 +816,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -829,7 +867,9 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 
 	{
 		// Case: Validator's start time too early
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
+
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: nodeID,
@@ -842,6 +882,7 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -870,7 +911,9 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 		nodeID := genesisNodeIDs[0]
 
 		// Case: Validator already validating primary network
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
+
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: nodeID,
@@ -883,6 +926,7 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -910,7 +954,9 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 	{
 		// Case: Validator in pending validator set of primary network
 		startTime := defaultValidateStartTime.Add(1 * time.Second)
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
+
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: nodeID,
@@ -923,6 +969,7 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -964,7 +1011,9 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 
 	{
 		// Case: Validator doesn't have enough tokens to cover stake amount
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
+
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: ids.GenerateTestNodeID(),
@@ -977,6 +1026,7 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -251,7 +251,8 @@ func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 	vdrEndTime := uint64(defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix())
 	vdrNodeID := ids.GenerateTestNodeID()
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
 	uVdrTx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: vdrNodeID,
@@ -264,6 +265,7 @@ func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 			Addrs:     []ids.ShortID{vdrRewardAddress},
 		},
 		reward.PercentDenominator/4,
+		feeCalc,
 	)
 	require.NoError(err)
 	vdrTx, err := walletsigner.SignUnsigned(context.Background(), signer, uVdrTx)
@@ -283,6 +285,7 @@ func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{delRewardAddress},
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	delTx, err := walletsigner.SignUnsigned(context.Background(), signer, uDelTx)
@@ -386,7 +389,8 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	vdrEndTime := uint64(defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix())
 	vdrNodeID := ids.GenerateTestNodeID()
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
 	uVdrTx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: vdrNodeID,
@@ -399,6 +403,7 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 			Addrs:     []ids.ShortID{vdrRewardAddress},
 		},
 		reward.PercentDenominator/4,
+		feeCalc,
 	)
 	require.NoError(err)
 	vdrTx, err := walletsigner.SignUnsigned(context.Background(), signer, uVdrTx)
@@ -418,6 +423,7 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{delRewardAddress},
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	delTx, err := walletsigner.SignUnsigned(context.Background(), signer, uDelTx)
@@ -617,7 +623,8 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 	vdrEndTime := uint64(defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix())
 	vdrNodeID := ids.GenerateTestNodeID()
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
 	uVdrTx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: vdrNodeID,
@@ -630,6 +637,7 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 			Addrs:     []ids.ShortID{vdrRewardAddress},
 		},
 		reward.PercentDenominator/4,
+		feeCalc,
 	)
 	require.NoError(err)
 	vdrTx, err := walletsigner.SignUnsigned(context.Background(), signer, uVdrTx)
@@ -649,6 +657,7 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 			Threshold: 1,
 			Addrs:     []ids.ShortID{delRewardAddress},
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	delTx, err := walletsigner.SignUnsigned(context.Background(), signer, uDelTx)
@@ -794,7 +803,8 @@ func TestRewardDelegatorTxExecuteOnAbort(t *testing.T) {
 	vdrEndTime := uint64(defaultValidateStartTime.Add(2 * defaultMinStakingDuration).Unix())
 	vdrNodeID := ids.GenerateTestNodeID()
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
 	uVdrTx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: vdrNodeID,
@@ -807,6 +817,7 @@ func TestRewardDelegatorTxExecuteOnAbort(t *testing.T) {
 			Addrs:     []ids.ShortID{vdrRewardAddress},
 		},
 		reward.PercentDenominator/4,
+		feeCalc,
 	)
 	require.NoError(err)
 	vdrTx, err := walletsigner.SignUnsigned(context.Background(), signer, uVdrTx)
@@ -826,6 +837,7 @@ func TestRewardDelegatorTxExecuteOnAbort(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{delRewardAddress},
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	delTx, err := walletsigner.SignUnsigned(context.Background(), signer, uDelTx)

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -77,7 +77,9 @@ func TestStandardTxExecutorAddValidatorTxEmptyID(t *testing.T) {
 		// Case: Empty validator node ID after banff
 		env.config.UpgradeConfig.BanffTime = test.banffTime
 
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
+
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: ids.EmptyNodeID,
@@ -90,6 +92,7 @@ func TestStandardTxExecutorAddValidatorTxEmptyID(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -125,7 +128,8 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 	addMinStakeValidator := func(env *environment) {
 		require := require.New(t)
 
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: newValidatorID,
@@ -138,6 +142,7 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 				Addrs:     []ids.ShortID{rewardAddress},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -163,7 +168,8 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 	addMaxStakeValidator := func(env *environment) {
 		require := require.New(t)
 
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: newValidatorID,
@@ -176,6 +182,7 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 				Addrs:     []ids.ShortID{rewardAddress},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -331,7 +338,9 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 			env := newEnvironment(t, apricotPhase5)
 			env.config.UpgradeConfig.ApricotPhase3Time = tt.AP3Time
 
-			builder, signer := env.factory.NewWallet(tt.feeKeys...)
+			builder, signer, feeCalc, err := env.factory.NewWallet(tt.feeKeys...)
+			require.NoError(err)
+
 			utx, err := builder.NewAddDelegatorTx(
 				&txs.Validator{
 					NodeID: tt.nodeID,
@@ -343,6 +352,7 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{rewardAddress},
 				},
+				feeCalc,
 			)
 			require.NoError(err)
 			tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -384,7 +394,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// but stops validating subnet after stops validating primary network
 		// (note that keys[0] is a genesis validator)
 		startTime := defaultValidateStartTime.Add(time.Second)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -395,6 +406,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -420,7 +432,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// and proposed subnet validation period is subset of
 		// primary network validation period
 		// (note that keys[0] is a genesis validator)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -431,6 +444,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -456,7 +470,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	dsStartTime := defaultGenesisTime.Add(10 * time.Second)
 	dsEndTime := dsStartTime.Add(5 * defaultMinStakingDuration)
 
-	builder, signer := env.factory.NewWallet(preFundedKeys[0])
+	builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+	require.NoError(err)
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: pendingDSValidatorID,
@@ -469,6 +484,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 			Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 	)
 	require.NoError(err)
 	addDSTx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -476,7 +492,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 
 	{
 		// Case: Proposed validator isn't in pending or current validator sets
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -487,6 +504,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -527,7 +545,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Proposed validator is pending validator of primary network
 		// but starts validating subnet before primary network
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -538,6 +557,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -561,7 +581,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Proposed validator is pending validator of primary network
 		// but stops validating subnet after primary network
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -572,6 +593,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -595,7 +617,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Proposed validator is pending validator of primary network and
 		// period validating subnet is subset of time validating primary network
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -606,6 +629,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -631,7 +655,9 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	env.state.SetTimestamp(newTimestamp)
 
 	{
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
+
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -642,6 +668,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -667,7 +694,9 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 
 	// Case: Proposed validator already validating the subnet
 	// First, add validator as validator of subnet
-	builder, signer = env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	builder, signer, feeCalc, err = env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+	require.NoError(err)
+
 	uSubnetTx, err := builder.NewAddSubnetValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -678,6 +707,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 			},
 			Subnet: testSubnet1.ID(),
 		},
+		feeCalc,
 	)
 	require.NoError(err)
 	subnetTx, err := walletsigner.SignUnsigned(context.Background(), signer, uSubnetTx)
@@ -700,7 +730,9 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	{
 		// Node with ID nodeIDKey.PublicKey().Address() now validating subnet with ID testSubnet1.ID
 		startTime := defaultValidateStartTime.Add(time.Second)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
+
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -711,6 +743,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -738,7 +771,9 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Duplicate signatures
 		startTime := defaultValidateStartTime.Add(time.Second)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1], testSubnet1ControlKeys[2])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1], testSubnet1ControlKeys[2])
+		require.NoError(err)
+
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -749,6 +784,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -779,7 +815,9 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Too few signatures
 		startTime := defaultValidateStartTime.Add(time.Second)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[2])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[2])
+		require.NoError(err)
+
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -790,6 +828,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -820,7 +859,9 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	{
 		// Case: Control Signature from invalid key (keys[3] is not a control key)
 		startTime := defaultValidateStartTime.Add(time.Second)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], preFundedKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], preFundedKeys[1])
+		require.NoError(err)
+
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -831,6 +872,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -860,7 +902,9 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		// Case: Proposed validator in pending validator set for subnet
 		// First, add validator to pending validator set of subnet
 		startTime := defaultValidateStartTime.Add(time.Second)
-		builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+		require.NoError(err)
+
 		utx, err := builder.NewAddSubnetValidatorTx(
 			&txs.SubnetValidator{
 				Validator: txs.Validator{
@@ -871,6 +915,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 				},
 				Subnet: testSubnet1.ID(),
 			},
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -916,7 +961,8 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 
 	{
 		// Case: Validator's start time too early
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: nodeID,
@@ -929,6 +975,7 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.ShortEmpty},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -952,7 +999,8 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 	{
 		// Case: Validator in current validator set of primary network
 		startTime := defaultValidateStartTime.Add(1 * time.Second)
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: nodeID,
@@ -965,6 +1013,7 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.ShortEmpty},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -1000,7 +1049,8 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 	{
 		// Case: Validator in pending validator set of primary network
 		startTime := defaultValidateStartTime.Add(1 * time.Second)
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: nodeID,
@@ -1013,6 +1063,7 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.ShortEmpty},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -1045,7 +1096,8 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 	{
 		// Case: Validator doesn't have enough tokens to cover stake amount
 		startTime := defaultValidateStartTime.Add(1 * time.Second)
-		builder, signer := env.factory.NewWallet(preFundedKeys[0])
+		builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys[0])
+		require.NoError(err)
 		utx, err := builder.NewAddValidatorTx(
 			&txs.Validator{
 				NodeID: nodeID,
@@ -1058,6 +1110,7 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 				Addrs:     []ids.ShortID{ids.ShortEmpty},
 			},
 			reward.PercentDenominator,
+			feeCalc,
 		)
 		require.NoError(err)
 		tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -1105,7 +1158,8 @@ func TestDurangoDisabledTransactions(t *testing.T) {
 					endTime   = chainTime.Add(defaultMaxStakingDuration)
 				)
 
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewAddValidatorTx(
 					&txs.Validator{
 						NodeID: nodeID,
@@ -1118,6 +1172,7 @@ func TestDurangoDisabledTransactions(t *testing.T) {
 						Addrs:     []ids.ShortID{ids.ShortEmpty},
 					},
 					reward.PercentDenominator,
+					feeCalc,
 				)
 				require.NoError(t, err)
 				tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -1143,7 +1198,8 @@ func TestDurangoDisabledTransactions(t *testing.T) {
 				}
 				it.Release()
 
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewAddDelegatorTx(
 					&txs.Validator{
 						NodeID: primaryValidator.NodeID,
@@ -1155,6 +1211,7 @@ func TestDurangoDisabledTransactions(t *testing.T) {
 						Threshold: 1,
 						Addrs:     []ids.ShortID{ids.ShortEmpty},
 					},
+					feeCalc,
 				)
 				require.NoError(t, err)
 				tx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -1216,7 +1273,8 @@ func TestDurangoMemoField(t *testing.T) {
 				}
 				it.Release()
 
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewAddSubnetValidatorTx(
 					&txs.SubnetValidator{
 						Validator: txs.Validator{
@@ -1227,6 +1285,7 @@ func TestDurangoMemoField(t *testing.T) {
 						},
 						Subnet: testSubnet1.TxID,
 					},
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1241,13 +1300,15 @@ func TestDurangoMemoField(t *testing.T) {
 		{
 			name: "CreateChainTx",
 			setupTest: func(env *environment, memoField []byte) (*txs.Tx, state.Diff) {
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewCreateChainTx(
 					testSubnet1.TxID,
 					[]byte{},
 					ids.GenerateTestID(),
 					[]ids.ID{},
 					"aaa",
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1263,12 +1324,14 @@ func TestDurangoMemoField(t *testing.T) {
 		{
 			name: "CreateSubnetTx",
 			setupTest: func(env *environment, memoField []byte) (*txs.Tx, state.Diff) {
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewCreateSubnetTx(
 					&secp256k1fx.OutputOwners{
 						Threshold: 1,
 						Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 					},
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1305,7 +1368,8 @@ func TestDurangoMemoField(t *testing.T) {
 				)
 				env.msm.SharedMemory = sharedMemory
 
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewImportTx(
 					sourceChain,
 					&secp256k1fx.OutputOwners{
@@ -1313,6 +1377,7 @@ func TestDurangoMemoField(t *testing.T) {
 						Threshold: 1,
 						Addrs:     []ids.ShortID{sourceKey.PublicKey().Address()},
 					},
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1328,7 +1393,8 @@ func TestDurangoMemoField(t *testing.T) {
 		{
 			name: "ExportTx",
 			setupTest: func(env *environment, memoField []byte) (*txs.Tx, state.Diff) {
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewExportTx(
 					env.ctx.XChainID,
 					[]*avax.TransferableOutput{{
@@ -1342,6 +1408,7 @@ func TestDurangoMemoField(t *testing.T) {
 							},
 						},
 					}},
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1371,7 +1438,8 @@ func TestDurangoMemoField(t *testing.T) {
 				it.Release()
 
 				endTime := primaryValidator.EndTime
-				builder, signer := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+				builder, signer, feeCalc, err := env.factory.NewWallet(testSubnet1ControlKeys[0], testSubnet1ControlKeys[1])
+				require.NoError(t, err)
 				utx, err := builder.NewAddSubnetValidatorTx(
 					&txs.SubnetValidator{
 						Validator: txs.Validator{
@@ -1382,6 +1450,7 @@ func TestDurangoMemoField(t *testing.T) {
 						},
 						Subnet: testSubnet1.ID(),
 					},
+					feeCalc,
 				)
 				require.NoError(t, err)
 				subnetValTx, err := walletsigner.SignUnsigned(context.Background(), signer, utx)
@@ -1399,10 +1468,12 @@ func TestDurangoMemoField(t *testing.T) {
 					Tx:            subnetValTx,
 				}))
 
-				builder, signer = env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err = env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx2, err := builder.NewRemoveSubnetValidatorTx(
 					primaryValidator.NodeID,
 					testSubnet1.ID(),
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1415,7 +1486,8 @@ func TestDurangoMemoField(t *testing.T) {
 		{
 			name: "TransformSubnetTx",
 			setupTest: func(env *environment, memoField []byte) (*txs.Tx, state.Diff) {
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewTransformSubnetTx(
 					testSubnet1.TxID,          // subnetID
 					ids.GenerateTestID(),      // assetID
@@ -1431,6 +1503,7 @@ func TestDurangoMemoField(t *testing.T) {
 					10,                        // min delegator stake
 					1,                         // max validator weight factor
 					80,                        // uptime requirement
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1454,7 +1527,8 @@ func TestDurangoMemoField(t *testing.T) {
 				sk, err := bls.NewSecretKey()
 				require.NoError(t, err)
 
-				builder, txSigner := env.factory.NewWallet(preFundedKeys...)
+				builder, txSigner, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewAddPermissionlessValidatorTx(
 					&txs.SubnetValidator{
 						Validator: txs.Validator{
@@ -1476,6 +1550,7 @@ func TestDurangoMemoField(t *testing.T) {
 						Addrs:     []ids.ShortID{ids.ShortEmpty},
 					},
 					reward.PercentDenominator,
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1504,7 +1579,8 @@ func TestDurangoMemoField(t *testing.T) {
 				}
 				it.Release()
 
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewAddPermissionlessDelegatorTx(
 					&txs.SubnetValidator{
 						Validator: txs.Validator{
@@ -1520,6 +1596,7 @@ func TestDurangoMemoField(t *testing.T) {
 						Threshold: 1,
 						Addrs:     []ids.ShortID{ids.ShortEmpty},
 					},
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1535,13 +1612,15 @@ func TestDurangoMemoField(t *testing.T) {
 		{
 			name: "TransferSubnetOwnershipTx",
 			setupTest: func(env *environment, memoField []byte) (*txs.Tx, state.Diff) {
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewTransferSubnetOwnershipTx(
 					testSubnet1.TxID,
 					&secp256k1fx.OutputOwners{
 						Threshold: 1,
 						Addrs:     []ids.ShortID{ids.ShortEmpty},
 					},
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)
@@ -1557,7 +1636,8 @@ func TestDurangoMemoField(t *testing.T) {
 		{
 			name: "BaseTx",
 			setupTest: func(env *environment, memoField []byte) (*txs.Tx, state.Diff) {
-				builder, signer := env.factory.NewWallet(preFundedKeys...)
+				builder, signer, feeCalc, err := env.factory.NewWallet(preFundedKeys...)
+				require.NoError(t, err)
 				utx, err := builder.NewBaseTx(
 					[]*avax.TransferableOutput{
 						{
@@ -1571,6 +1651,7 @@ func TestDurangoMemoField(t *testing.T) {
 							},
 						},
 					},
+					feeCalc,
 					common.WithMemo(memoField),
 				)
 				require.NoError(t, err)

--- a/vms/platformvm/txs/fee/dynamic_config.go
+++ b/vms/platformvm/txs/fee/dynamic_config.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	errDynamicFeeConfigNotAvailable = errors.New("dynamic fee config not available")
+	ErrDynamicFeeConfigNotAvailable = errors.New("dynamic fee config not available")
 
 	eUpgradeDynamicFeesConfig = commonfee.DynamicFeesConfig{
 		GasPrice:            commonfee.GasPrice(10 * units.NanoAvax),
@@ -35,7 +35,7 @@ func init() {
 
 func GetDynamicConfig(isEActive bool) (commonfee.DynamicFeesConfig, error) {
 	if !isEActive {
-		return commonfee.DynamicFeesConfig{}, errDynamicFeeConfigNotAvailable
+		return commonfee.DynamicFeesConfig{}, ErrDynamicFeeConfigNotAvailable
 	}
 
 	if customDynamicFeesConfig != nil {

--- a/vms/platformvm/txs/txstest/builder.go
+++ b/vms/platformvm/txs/txstest/builder.go
@@ -6,8 +6,10 @@ package txstest
 import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/fee"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/chain/p/builder"
 	"github.com/ava-labs/avalanchego/wallet/chain/p/signer"
@@ -16,11 +18,13 @@ import (
 func NewWalletFactory(
 	ctx *snow.Context,
 	cfg *config.Config,
+	clk *mockable.Clock,
 	state state.State,
 ) *WalletFactory {
 	return &WalletFactory{
 		ctx:   ctx,
 		cfg:   cfg,
+		clk:   clk,
 		state: state,
 	}
 }
@@ -28,16 +32,25 @@ func NewWalletFactory(
 type WalletFactory struct {
 	ctx   *snow.Context
 	cfg   *config.Config
+	clk   *mockable.Clock
 	state state.State
 }
 
-func (w *WalletFactory) NewWallet(keys ...*secp256k1.PrivateKey) (builder.Builder, signer.Signer) {
+func (w *WalletFactory) NewWallet(keys ...*secp256k1.PrivateKey) (builder.Builder, signer.Signer, fee.Calculator, error) {
 	var (
 		kc      = secp256k1fx.NewKeychain(keys...)
 		addrs   = kc.Addresses()
 		backend = newBackend(addrs, w.state, w.ctx.SharedMemory)
 		context = newContext(w.ctx, w.cfg, w.state.GetTimestamp())
+
+		builder      = builder.New(addrs, context, backend)
+		signer       = signer.New(kc, backend)
+		feeCalc, err = w.FeeCalculator()
 	)
 
-	return builder.New(addrs, context, backend), signer.New(kc, backend)
+	return builder, signer, feeCalc, err
+}
+
+func (w *WalletFactory) FeeCalculator() (fee.Calculator, error) {
+	return state.PickFeeCalculator(w.cfg, w.state)
 }

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -66,7 +66,8 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	changeAddr := keys[0].PublicKey().Address()
 
 	// create valid tx
-	builder, txSigner := factory.NewWallet(keys[0])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0])
+	require.NoError(err)
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -79,6 +80,7 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 			Addrs:     []ids.ShortID{changeAddr},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -111,7 +113,8 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	firstDelegatorEndTime := firstDelegatorStartTime.Add(vm.MinStakeDuration)
 
 	// create valid tx
-	builder, txSigner = factory.NewWallet(keys[0], keys[1])
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys[0], keys[1])
+	require.NoError(err)
 	uDelTx1, err := builder.NewAddDelegatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -123,6 +126,7 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -157,7 +161,9 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	vm.clock.Set(secondDelegatorStartTime.Add(-10 * executor.SyncBound))
 
 	// create valid tx
-	builder, txSigner = factory.NewWallet(keys[0], keys[1], keys[3])
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys[0], keys[1], keys[3])
+	require.NoError(err)
+
 	uDelTx2, err := builder.NewAddDelegatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -169,6 +175,7 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -193,7 +200,9 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	thirdDelegatorEndTime := thirdDelegatorStartTime.Add(vm.MinStakeDuration)
 
 	// create valid tx
-	builder, txSigner = factory.NewWallet(keys[0], keys[1], keys[4])
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys[0], keys[1], keys[4])
+	require.NoError(err)
+
 	uDelTx3, err := builder.NewAddDelegatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -205,6 +214,7 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -274,7 +284,8 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 			changeAddr := keys[0].PublicKey().Address()
 
 			// create valid tx
-			builder, txSigner := factory.NewWallet(keys[0], keys[1])
+			builder, txSigner, feeCalc, err := factory.NewWallet(keys[0], keys[1])
+			require.NoError(err)
 			utx, err := builder.NewAddValidatorTx(
 				&txs.Validator{
 					NodeID: nodeID,
@@ -287,6 +298,7 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 					Addrs:     []ids.ShortID{id},
 				},
 				reward.PercentDenominator,
+				feeCalc,
 				walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 					Threshold: 1,
 					Addrs:     []ids.ShortID{changeAddr},
@@ -320,6 +332,7 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{keys[0].PublicKey().Address()},
 				},
+				feeCalc,
 				walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 					Threshold: 1,
 					Addrs:     []ids.ShortID{changeAddr},
@@ -353,6 +366,7 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{keys[0].PublicKey().Address()},
 				},
+				feeCalc,
 				walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 					Threshold: 1,
 					Addrs:     []ids.ShortID{changeAddr},
@@ -386,6 +400,7 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{keys[0].PublicKey().Address()},
 				},
+				feeCalc,
 				walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 					Threshold: 1,
 					Addrs:     []ids.ShortID{changeAddr},
@@ -419,6 +434,7 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 					Threshold: 1,
 					Addrs:     []ids.ShortID{keys[0].PublicKey().Address()},
 				},
+				feeCalc,
 				walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 					Threshold: 1,
 					Addrs:     []ids.ShortID{changeAddr},
@@ -503,15 +519,19 @@ func TestUnverifiedParentPanicRegression(t *testing.T) {
 	factory := txstest.NewWalletFactory(
 		vm.ctx,
 		&vm.Config,
+		&vm.clock,
 		vm.state,
 	)
 
-	builder, txSigner := factory.NewWallet(key0)
+	builder, txSigner, feeCalc, err := factory.NewWallet(key0)
+	require.NoError(err)
+
 	utx0, err := builder.NewCreateSubnetTx(
 		&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr0},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr0},
@@ -521,12 +541,15 @@ func TestUnverifiedParentPanicRegression(t *testing.T) {
 	addSubnetTx0, err := walletsigner.SignUnsigned(context.Background(), txSigner, utx0)
 	require.NoError(err)
 
-	builder, txSigner = factory.NewWallet(key1)
+	builder, txSigner, feeCalc, err = factory.NewWallet(key1)
+	require.NoError(err)
+
 	utx1, err := builder.NewCreateSubnetTx(
 		&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr1},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr1},
@@ -541,6 +564,7 @@ func TestUnverifiedParentPanicRegression(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr1},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr0},
@@ -611,7 +635,8 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 	newValidatorEndTime := newValidatorStartTime.Add(defaultMinStakingDuration)
 
 	// Create the tx to add a new validator
-	builder, txSigner := factory.NewWallet(keys[0])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0])
+	require.NoError(err)
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -624,6 +649,7 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 			Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 	)
 	require.NoError(err)
 	addValidatorTx, err := walletsigner.SignUnsigned(context.Background(), txSigner, utx)
@@ -825,7 +851,8 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 	nodeID0 := ids.GenerateTestNodeID()
 
 	// Create the tx to add the first new validator
-	builder, txSigner := factory.NewWallet(keys[0])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0])
+	require.NoError(err)
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID0,
@@ -838,6 +865,7 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 			Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 	)
 	require.NoError(err)
 	addValidatorTx0, err := walletsigner.SignUnsigned(context.Background(), txSigner, utx)
@@ -1003,7 +1031,9 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 	nodeID1 := ids.GenerateTestNodeID()
 
 	// Create the tx to add the second new validator
-	builder, txSigner = factory.NewWallet(keys[1])
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys[1])
+	require.NoError(err)
+
 	utx1, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID1,
@@ -1016,6 +1046,7 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 			Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 	)
 	require.NoError(err)
 	addValidatorTx1, err := walletsigner.SignUnsigned(context.Background(), txSigner, utx1)
@@ -1164,7 +1195,8 @@ func TestValidatorSetAtCacheOverwriteRegression(t *testing.T) {
 	extraNodeID := ids.GenerateTestNodeID()
 
 	// Create the tx to add the first new validator
-	builder, txSigner := factory.NewWallet(keys[0])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0])
+	require.NoError(err)
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: extraNodeID,
@@ -1177,6 +1209,7 @@ func TestValidatorSetAtCacheOverwriteRegression(t *testing.T) {
 			Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 	)
 	require.NoError(err)
 	addValidatorTx0, err := walletsigner.SignUnsigned(context.Background(), txSigner, utx)
@@ -1291,7 +1324,9 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 	changeAddr := keys[0].PublicKey().Address()
 
 	// create valid tx
-	builder, txSigner := factory.NewWallet(keys[0], keys[1])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0], keys[1])
+	require.NoError(err)
+
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -1304,6 +1339,7 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 			Addrs:     []ids.ShortID{id},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1337,6 +1373,7 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{keys[0].PublicKey().Address()},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1370,6 +1407,7 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 			Threshold: 1,
 			Addrs:     []ids.ShortID{keys[0].PublicKey().Address()},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1404,7 +1442,8 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 	nodeID := ids.GenerateTestNodeID()
 	changeAddr := keys[0].PublicKey().Address()
 
-	builder, txSigner := factory.NewWallet(keys[0], keys[1])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0], keys[1])
+	require.NoError(err)
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -1417,6 +1456,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 			Addrs:     []ids.ShortID{id},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1442,6 +1482,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1472,6 +1513,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 			},
 			Subnet: createSubnetTx.ID(),
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1503,6 +1545,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 	uRemoveSubnetValTx, err := builder.NewRemoveSubnetValidatorTx(
 		nodeID,
 		createSubnetTx.ID(),
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1553,7 +1596,8 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 	nodeID := ids.GenerateTestNodeID()
 	changeAddr := keys[0].PublicKey().Address()
 
-	builder, txSigner := factory.NewWallet(keys[0], keys[1])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0], keys[1])
+	require.NoError(err)
 	utx, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -1566,6 +1610,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 			Addrs:     []ids.ShortID{id},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1591,6 +1636,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1621,6 +1667,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 			},
 			Subnet: createSubnetTx.ID(),
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1644,6 +1691,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 	uRemoveSubnetValTx, err := builder.NewRemoveSubnetValidatorTx(
 		nodeID,
 		createSubnetTx.ID(),
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{changeAddr},
@@ -1704,7 +1752,9 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 	require.NoError(err)
 
 	// build primary network validator with BLS key
-	builder, txSigner := factory.NewWallet(keys...)
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys...)
+	require.NoError(err)
+
 	uPrimaryTx, err := builder.NewAddPermissionlessValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -1726,6 +1776,7 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 			Addrs:     []ids.ShortID{addr},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -1753,7 +1804,8 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 	require.NoError(err)
 
 	// insert the subnet validator
-	builder, txSigner = factory.NewWallet(keys[0], keys[1])
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys[0], keys[1])
+	require.NoError(err)
 	uAddSubnetValTx, err := builder.NewAddSubnetValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -1764,6 +1816,7 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 			},
 			Subnet: subnetID,
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -1834,7 +1887,8 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 	require.NoError(err)
 	require.NotEqual(sk1, sk2)
 
-	builder, txSigner = factory.NewWallet(keys...)
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys...)
+	require.NoError(err)
 	uPrimaryRestartTx, err := builder.NewAddPermissionlessValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -1856,6 +1910,7 @@ func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 			Addrs:     []ids.ShortID{addr},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -1960,7 +2015,8 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 	addr := keys[0].PublicKey().Address()
 
-	builder, txSigner := factory.NewWallet(keys[0])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0])
+	require.NoError(err)
 	uAddValTx1, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -1973,6 +2029,7 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 			Addrs:     []ids.ShortID{addr},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -2030,7 +2087,8 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	sk2, err := bls.NewSecretKey()
 	require.NoError(err)
 
-	builder, txSigner = factory.NewWallet(keys...)
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys...)
+	require.NoError(err)
 	uPrimaryRestartTx, err := builder.NewAddPermissionlessValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -2052,6 +2110,7 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 			Addrs:     []ids.ShortID{addr},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -2120,7 +2179,9 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 	addr := keys[0].PublicKey().Address()
 
-	builder, txSigner := factory.NewWallet(keys[0])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0])
+	require.NoError(err)
+
 	uPrimaryTx1, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -2133,6 +2194,7 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 			Addrs:     []ids.ShortID{addr},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -2160,7 +2222,8 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	require.NoError(err)
 
 	// insert the subnet validator
-	builder, txSigner = factory.NewWallet(keys[0], keys[1])
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys[0], keys[1])
+	require.NoError(err)
 	uAddSubnetValTx, err := builder.NewAddSubnetValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -2171,6 +2234,7 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 			},
 			Subnet: subnetID,
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -2240,7 +2304,9 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 	sk2, err := bls.NewSecretKey()
 	require.NoError(err)
 
-	builder, txSigner = factory.NewWallet(keys...)
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys...)
+	require.NoError(err)
+
 	uPrimaryRestartTx, err := builder.NewAddPermissionlessValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -2262,6 +2328,7 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 			Addrs:     []ids.ShortID{addr},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -2337,7 +2404,8 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 	addr := keys[0].PublicKey().Address()
 
-	builder, txSigner := factory.NewWallet(keys[0])
+	builder, txSigner, feeCalc, err := factory.NewWallet(keys[0])
+	require.NoError(err)
 	uPrimaryTx1, err := builder.NewAddValidatorTx(
 		&txs.Validator{
 			NodeID: nodeID,
@@ -2350,6 +2418,7 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 			Addrs:     []ids.ShortID{addr},
 		},
 		reward.PercentDenominator,
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},
@@ -2374,7 +2443,9 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 	require.NoError(err)
 
 	// insert the subnet validator
-	builder, txSigner = factory.NewWallet(keys[0], keys[1])
+	builder, txSigner, feeCalc, err = factory.NewWallet(keys[0], keys[1])
+	require.NoError(err)
+
 	uAddSubnetValTx, err := builder.NewAddSubnetValidatorTx(
 		&txs.SubnetValidator{
 			Validator: txs.Validator{
@@ -2385,6 +2456,7 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 			},
 			Subnet: subnetID,
 		},
+		feeCalc,
 		walletcommon.WithChangeOwner(&secp256k1fx.OutputOwners{
 			Threshold: 1,
 			Addrs:     []ids.ShortID{addr},

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -19,6 +20,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/fee"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
@@ -61,6 +63,7 @@ type Builder interface {
 	//   from this transaction.
 	NewBaseTx(
 		outputs []*avax.TransferableOutput,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.BaseTx, error)
 
@@ -77,6 +80,7 @@ type Builder interface {
 		vdr *txs.Validator,
 		rewardsOwner *secp256k1fx.OutputOwners,
 		shares uint32,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.AddValidatorTx, error)
 
@@ -86,6 +90,7 @@ type Builder interface {
 	//   startTime, endTime, sampling weight, nodeID, and subnetID.
 	NewAddSubnetValidatorTx(
 		vdr *txs.SubnetValidator,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.AddSubnetValidatorTx, error)
 
@@ -94,6 +99,7 @@ type Builder interface {
 	NewRemoveSubnetValidatorTx(
 		nodeID ids.NodeID,
 		subnetID ids.ID,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.RemoveSubnetValidatorTx, error)
 
@@ -107,6 +113,7 @@ type Builder interface {
 	NewAddDelegatorTx(
 		vdr *txs.Validator,
 		rewardsOwner *secp256k1fx.OutputOwners,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.AddDelegatorTx, error)
 
@@ -124,6 +131,7 @@ type Builder interface {
 		vmID ids.ID,
 		fxIDs []ids.ID,
 		chainName string,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.CreateChainTx, error)
 
@@ -133,6 +141,7 @@ type Builder interface {
 	//   validators to the subnet.
 	NewCreateSubnetTx(
 		owner *secp256k1fx.OutputOwners,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.CreateSubnetTx, error)
 
@@ -144,6 +153,7 @@ type Builder interface {
 	NewTransferSubnetOwnershipTx(
 		subnetID ids.ID,
 		owner *secp256k1fx.OutputOwners,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.TransferSubnetOwnershipTx, error)
 
@@ -155,6 +165,7 @@ type Builder interface {
 	NewImportTx(
 		chainID ids.ID,
 		to *secp256k1fx.OutputOwners,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.ImportTx, error)
 
@@ -166,6 +177,7 @@ type Builder interface {
 	NewExportTx(
 		chainID ids.ID,
 		outputs []*avax.TransferableOutput,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.ExportTx, error)
 
@@ -214,6 +226,7 @@ type Builder interface {
 		minDelegatorStake uint64,
 		maxValidatorWeightFactor byte,
 		uptimeRequirement uint32,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.TransformSubnetTx, error)
 
@@ -239,6 +252,7 @@ type Builder interface {
 		validationRewardsOwner *secp256k1fx.OutputOwners,
 		delegationRewardsOwner *secp256k1fx.OutputOwners,
 		shares uint32,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.AddPermissionlessValidatorTx, error)
 
@@ -254,6 +268,7 @@ type Builder interface {
 		vdr *txs.SubnetValidator,
 		assetID ids.ID,
 		rewardsOwner *secp256k1fx.OutputOwners,
+		feeCalc fee.Calculator,
 		options ...common.Option,
 	) (*txs.AddPermissionlessDelegatorTx, error)
 }
@@ -308,11 +323,24 @@ func (b *builder) GetImportableBalance(
 
 func (b *builder) NewBaseTx(
 	outputs []*avax.TransferableOutput,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.BaseTx, error) {
-	toBurn := map[ids.ID]uint64{
-		b.context.AVAXAssetID: b.context.BaseTxFee,
+	// 1. Build core transaction without utxos
+	ops := common.NewOptions(options)
+
+	utx := &txs.BaseTx{
+		BaseTx: avax.BaseTx{
+			NetworkID:    b.context.NetworkID,
+			BlockchainID: constants.PlatformChainID,
+			Memo:         ops.Memo(),
+			Outs:         outputs, // not sorted yet, we'll sort later on when we have all the outputs
+		},
 	}
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
 	for _, out := range outputs {
 		assetID := out.AssetID()
 		amountToBurn, err := math.Add64(toBurn[assetID], out.Out.Amount())
@@ -321,162 +349,204 @@ func (b *builder) NewBaseTx(
 		}
 		toBurn[assetID] = amountToBurn
 	}
-	toStake := map[ids.ID]uint64{}
 
-	ops := common.NewOptions(options)
-	inputs, changeOutputs, _, err := b.spend(toBurn, toStake, ops)
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	inputs, changeOuts, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
 	if err != nil {
 		return nil, err
 	}
-	outputs = append(outputs, changeOutputs...)
-	avax.SortTransferableOutputs(outputs, txs.Codec) // sort the outputs
 
-	tx := &txs.BaseTx{BaseTx: avax.BaseTx{
-		NetworkID:    b.context.NetworkID,
-		BlockchainID: constants.PlatformChainID,
-		Ins:          inputs,
-		Outs:         outputs,
-		Memo:         ops.Memo(),
-	}}
-	return tx, b.initCtx(tx)
+	outputs = append(outputs, changeOuts...)
+	avax.SortTransferableOutputs(outputs, txs.Codec)
+	utx.Ins = inputs
+	utx.Outs = outputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewAddValidatorTx(
 	vdr *txs.Validator,
 	rewardsOwner *secp256k1fx.OutputOwners,
 	shares uint32,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddValidatorTx, error) {
-	avaxAssetID := b.context.AVAXAssetID
-	toBurn := map[ids.ID]uint64{
-		avaxAssetID: b.context.AddPrimaryNetworkValidatorFee,
-	}
-	toStake := map[ids.ID]uint64{
-		avaxAssetID: vdr.Wght,
-	}
 	ops := common.NewOptions(options)
-	inputs, baseOutputs, stakeOutputs, err := b.spend(toBurn, toStake, ops)
+	utils.Sort(rewardsOwner.Addrs)
+
+	utx := &txs.AddValidatorTx{
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.context.NetworkID,
+			BlockchainID: constants.PlatformChainID,
+			Memo:         ops.Memo(),
+		}},
+		Validator:        *vdr,
+		RewardsOwner:     rewardsOwner,
+		DelegationShares: shares,
+	}
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{
+		b.context.AVAXAssetID: vdr.Wght,
+	}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	inputs, outputs, stakeOutputs, err := b.financeTx(toBurn, toStake, feeCalc, ops)
 	if err != nil {
 		return nil, err
 	}
 
-	utils.Sort(rewardsOwner.Addrs)
-	tx := &txs.AddValidatorTx{
-		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-			NetworkID:    b.context.NetworkID,
-			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         baseOutputs,
-			Memo:         ops.Memo(),
-		}},
-		Validator:        *vdr,
-		StakeOuts:        stakeOutputs,
-		RewardsOwner:     rewardsOwner,
-		DelegationShares: shares,
-	}
-	return tx, b.initCtx(tx)
+	utx.Ins = inputs
+	utx.Outs = outputs
+	utx.StakeOuts = stakeOutputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewAddSubnetValidatorTx(
 	vdr *txs.SubnetValidator,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddSubnetValidatorTx, error) {
-	toBurn := map[ids.ID]uint64{
-		b.context.AVAXAssetID: b.context.AddSubnetValidatorFee,
-	}
-	toStake := map[ids.ID]uint64{}
 	ops := common.NewOptions(options)
-	inputs, outputs, _, err := b.spend(toBurn, toStake, ops)
-	if err != nil {
-		return nil, err
-	}
 
 	subnetAuth, err := b.authorizeSubnet(vdr.Subnet, ops)
 	if err != nil {
 		return nil, err
 	}
 
-	tx := &txs.AddSubnetValidatorTx{
+	utx := &txs.AddSubnetValidatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.context.NetworkID,
 			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         outputs,
 			Memo:         ops.Memo(),
 		}},
 		SubnetValidator: *vdr,
 		SubnetAuth:      subnetAuth,
 	}
-	return tx, b.initCtx(tx)
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	// update fees to account for the auth credentials to be added upon tx signing
+	if _, err = financeCredential(feeCalc, len(subnetAuth.SigIndices)); err != nil {
+		return nil, fmt.Errorf("account for credential fees: %w", err)
+	}
+
+	inputs, outputs, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	utx.Ins = inputs
+	utx.Outs = outputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewRemoveSubnetValidatorTx(
 	nodeID ids.NodeID,
 	subnetID ids.ID,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.RemoveSubnetValidatorTx, error) {
-	toBurn := map[ids.ID]uint64{
-		b.context.AVAXAssetID: b.context.BaseTxFee,
-	}
-	toStake := map[ids.ID]uint64{}
 	ops := common.NewOptions(options)
-	inputs, outputs, _, err := b.spend(toBurn, toStake, ops)
-	if err != nil {
-		return nil, err
-	}
 
 	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
 	if err != nil {
 		return nil, err
 	}
 
-	tx := &txs.RemoveSubnetValidatorTx{
+	utx := &txs.RemoveSubnetValidatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.context.NetworkID,
 			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         outputs,
 			Memo:         ops.Memo(),
 		}},
 		Subnet:     subnetID,
 		NodeID:     nodeID,
 		SubnetAuth: subnetAuth,
 	}
-	return tx, b.initCtx(tx)
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	// update fees to account for the auth credentials to be added upon tx signing
+	if _, err = financeCredential(feeCalc, len(subnetAuth.SigIndices)); err != nil {
+		return nil, fmt.Errorf("account for credential fees: %w", err)
+	}
+
+	inputs, outputs, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	utx.Ins = inputs
+	utx.Outs = outputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewAddDelegatorTx(
 	vdr *txs.Validator,
 	rewardsOwner *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddDelegatorTx, error) {
-	avaxAssetID := b.context.AVAXAssetID
-	toBurn := map[ids.ID]uint64{
-		avaxAssetID: b.context.AddPrimaryNetworkDelegatorFee,
-	}
-	toStake := map[ids.ID]uint64{
-		avaxAssetID: vdr.Wght,
-	}
 	ops := common.NewOptions(options)
-	inputs, baseOutputs, stakeOutputs, err := b.spend(toBurn, toStake, ops)
+	utils.Sort(rewardsOwner.Addrs)
+
+	utx := &txs.AddDelegatorTx{
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.context.NetworkID,
+			BlockchainID: constants.PlatformChainID,
+			Memo:         ops.Memo(),
+		}},
+		Validator:              *vdr,
+		DelegationRewardsOwner: rewardsOwner,
+	}
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{
+		b.context.AVAXAssetID: vdr.Wght,
+	}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	inputs, outputs, stakeOutputs, err := b.financeTx(toBurn, toStake, feeCalc, ops)
 	if err != nil {
 		return nil, err
 	}
 
-	utils.Sort(rewardsOwner.Addrs)
-	tx := &txs.AddDelegatorTx{
-		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-			NetworkID:    b.context.NetworkID,
-			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         baseOutputs,
-			Memo:         ops.Memo(),
-		}},
-		Validator:              *vdr,
-		StakeOuts:              stakeOutputs,
-		DelegationRewardsOwner: rewardsOwner,
-	}
-	return tx, b.initCtx(tx)
+	utx.Ins = inputs
+	utx.Outs = outputs
+	utx.StakeOuts = stakeOutputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewCreateChainTx(
@@ -485,30 +555,22 @@ func (b *builder) NewCreateChainTx(
 	vmID ids.ID,
 	fxIDs []ids.ID,
 	chainName string,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.CreateChainTx, error) {
-	toBurn := map[ids.ID]uint64{
-		b.context.AVAXAssetID: b.context.CreateBlockchainTxFee,
-	}
-	toStake := map[ids.ID]uint64{}
+	// 1. Build core transaction without utxos
 	ops := common.NewOptions(options)
-	inputs, outputs, _, err := b.spend(toBurn, toStake, ops)
-	if err != nil {
-		return nil, err
-	}
-
 	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
 	if err != nil {
 		return nil, err
 	}
 
 	utils.Sort(fxIDs)
-	tx := &txs.CreateChainTx{
+
+	utx := &txs.CreateChainTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.context.NetworkID,
 			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         outputs,
 			Memo:         ops.Memo(),
 		}},
 		SubnetID:    subnetID,
@@ -518,80 +580,139 @@ func (b *builder) NewCreateChainTx(
 		GenesisData: genesis,
 		SubnetAuth:  subnetAuth,
 	}
-	return tx, b.initCtx(tx)
-}
 
-func (b *builder) NewCreateSubnetTx(
-	owner *secp256k1fx.OutputOwners,
-	options ...common.Option,
-) (*txs.CreateSubnetTx, error) {
-	toBurn := map[ids.ID]uint64{
-		b.context.AVAXAssetID: b.context.CreateSubnetTxFee,
-	}
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
 	toStake := map[ids.ID]uint64{}
-	ops := common.NewOptions(options)
-	inputs, outputs, _, err := b.spend(toBurn, toStake, ops)
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	// update fees to account for the auth credentials to be added upon tx signing
+	if _, err = financeCredential(feeCalc, len(subnetAuth.SigIndices)); err != nil {
+		return nil, fmt.Errorf("account for credential fees: %w", err)
+	}
+
+	inputs, outputs, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
 	if err != nil {
 		return nil, err
 	}
 
+	utx.Ins = inputs
+	utx.Outs = outputs
+
+	return utx, b.initCtx(utx)
+}
+
+func (b *builder) NewCreateSubnetTx(
+	owner *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
+	options ...common.Option,
+) (*txs.CreateSubnetTx, error) {
+	// 1. Build core transaction without utxos
+	ops := common.NewOptions(options)
+
 	utils.Sort(owner.Addrs)
-	tx := &txs.CreateSubnetTx{
+	utx := &txs.CreateSubnetTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.context.NetworkID,
 			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         outputs,
 			Memo:         ops.Memo(),
 		}},
 		Owner: owner,
 	}
-	return tx, b.initCtx(tx)
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	inputs, outputs, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	utx.Ins = inputs
+	utx.Outs = outputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewTransferSubnetOwnershipTx(
 	subnetID ids.ID,
 	owner *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.TransferSubnetOwnershipTx, error) {
-	toBurn := map[ids.ID]uint64{
-		b.context.AVAXAssetID: b.context.BaseTxFee,
-	}
-	toStake := map[ids.ID]uint64{}
+	// 1. Build core transaction without utxos
 	ops := common.NewOptions(options)
-	inputs, outputs, _, err := b.spend(toBurn, toStake, ops)
-	if err != nil {
-		return nil, err
-	}
-
 	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
 	if err != nil {
 		return nil, err
 	}
 
 	utils.Sort(owner.Addrs)
-	tx := &txs.TransferSubnetOwnershipTx{
+	utx := &txs.TransferSubnetOwnershipTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.context.NetworkID,
 			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         outputs,
 			Memo:         ops.Memo(),
 		}},
 		Subnet:     subnetID,
-		Owner:      owner,
 		SubnetAuth: subnetAuth,
+		Owner:      owner,
 	}
-	return tx, b.initCtx(tx)
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	// update fees to account for the auth credentials to be added upon tx signing
+	if _, err = financeCredential(feeCalc, len(subnetAuth.SigIndices)); err != nil {
+		return nil, fmt.Errorf("account for credential fees: %w", err)
+	}
+
+	inputs, outputs, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	utx.Ins = inputs
+	utx.Outs = outputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewImportTx(
 	sourceChainID ids.ID,
 	to *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.ImportTx, error) {
 	ops := common.NewOptions(options)
-	utxos, err := b.backend.UTXOs(ops.Context(), sourceChainID)
+	// 1. Build core transaction
+	utx := &txs.ImportTx{
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.context.NetworkID,
+			BlockchainID: constants.PlatformChainID,
+			Memo:         ops.Memo(),
+		}},
+		SourceChain: sourceChainID,
+	}
+
+	// 2. Add imported inputs first
+	importedUtxos, err := b.backend.UTXOs(ops.Context(), sourceChainID)
 	if err != nil {
 		return nil, err
 	}
@@ -600,13 +721,13 @@ func (b *builder) NewImportTx(
 		addrs           = ops.Addresses(b.addrs)
 		minIssuanceTime = ops.MinIssuanceTime()
 		avaxAssetID     = b.context.AVAXAssetID
-		txFee           = b.context.BaseTxFee
 
-		importedInputs  = make([]*avax.TransferableInput, 0, len(utxos))
-		importedAmounts = make(map[ids.ID]uint64)
+		importedInputs     = make([]*avax.TransferableInput, 0, len(importedUtxos))
+		importedSigIndices = make([][]uint32, 0)
+		importedAmounts    = make(map[ids.ID]uint64)
 	)
-	// Iterate over the unlocked UTXOs
-	for _, utxo := range utxos {
+
+	for _, utxo := range importedUtxos {
 		out, ok := utxo.Out.(*secp256k1fx.TransferOutput)
 		if !ok {
 			continue
@@ -635,9 +756,8 @@ func (b *builder) NewImportTx(
 			return nil, err
 		}
 		importedAmounts[assetID] = newImportedAmount
+		importedSigIndices = append(importedSigIndices, inputSigIndices)
 	}
-	utils.Sort(importedInputs) // sort imported inputs
-
 	if len(importedInputs) == 0 {
 		return nil, fmt.Errorf(
 			"%w: no UTXOs available to import",
@@ -645,61 +765,122 @@ func (b *builder) NewImportTx(
 		)
 	}
 
-	var (
-		inputs       []*avax.TransferableInput
-		outputs      = make([]*avax.TransferableOutput, 0, len(importedAmounts))
-		importedAVAX = importedAmounts[avaxAssetID]
-	)
-	if importedAVAX > txFee {
-		importedAmounts[avaxAssetID] -= txFee
-	} else {
-		if importedAVAX < txFee { // imported amount goes toward paying tx fee
-			toBurn := map[ids.ID]uint64{
-				avaxAssetID: txFee - importedAVAX,
-			}
-			toStake := map[ids.ID]uint64{}
-			var err error
-			inputs, outputs, _, err = b.spend(toBurn, toStake, ops)
-			if err != nil {
-				return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
-			}
-		}
-		delete(importedAmounts, avaxAssetID)
-	}
+	utils.Sort(importedInputs) // sort imported inputs
+	utx.ImportedInputs = importedInputs
 
+	// 3. Add an output for all non-avax denominated inputs.
 	for assetID, amount := range importedAmounts {
-		outputs = append(outputs, &avax.TransferableOutput{
+		if assetID == avaxAssetID {
+			// Avax-denominated inputs may be used to fully or partially pay fees,
+			// so we'll handle them later on.
+			continue
+		}
+
+		utx.Outs = append(utx.Outs, &avax.TransferableOutput{
 			Asset: avax.Asset{ID: assetID},
 			Out: &secp256k1fx.TransferOutput{
 				Amt:          amount,
 				OutputOwners: *to,
 			},
-		})
+		}) // we'll sort them later on
 	}
 
-	avax.SortTransferableOutputs(outputs, txs.Codec) // sort imported outputs
-	tx := &txs.ImportTx{
-		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-			NetworkID:    b.context.NetworkID,
-			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         outputs,
-			Memo:         ops.Memo(),
-		}},
-		SourceChain:    sourceChainID,
-		ImportedInputs: importedInputs,
+	// 3. Finance fees as much as possible with imported, Avax-denominated UTXOs
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
 	}
-	return tx, b.initCtx(tx)
+
+	for _, sigIndices := range importedSigIndices {
+		if _, err = financeCredential(feeCalc, len(sigIndices)); err != nil {
+			return nil, fmt.Errorf("account for credential fees: %w", err)
+		}
+	}
+
+	switch importedAVAX, currentFee := importedAmounts[avaxAssetID], feeCalc.GetFee(); {
+	case importedAVAX == currentFee:
+		// imported inputs match exactly the fees to be paid
+		avax.SortTransferableOutputs(utx.Outs, txs.Codec) // sort imported outputs
+		return utx, b.initCtx(utx)
+
+	case importedAVAX < currentFee:
+		// imported inputs can partially pay fees
+		feeCalc.ResetFee(currentFee - importedAVAX)
+
+	default:
+		// imported inputs may be enough to pay fees by themselves
+		changeOut := &avax.TransferableOutput{
+			Asset: avax.Asset{ID: avaxAssetID},
+			Out: &secp256k1fx.TransferOutput{
+				OutputOwners: *to, // we set amount after considering own fees
+			},
+		}
+
+		// update fees to target given the extra output added
+		_, outDimensions, err := financeOutput(feeCalc, changeOut)
+		if err != nil {
+			return nil, fmt.Errorf("account for output fees: %w", err)
+		}
+
+		switch currentFee := feeCalc.GetFee(); {
+		case currentFee < importedAVAX:
+			changeOut.Out.(*secp256k1fx.TransferOutput).Amt = importedAVAX - currentFee
+			utx.Outs = append(utx.Outs, changeOut)
+			avax.SortTransferableOutputs(utx.Outs, txs.Codec) // sort imported outputs
+			return utx, b.initCtx(utx)
+
+		case currentFee == importedAVAX:
+			// imported fees pays exactly the tx cost. We don't include the outputs
+			avax.SortTransferableOutputs(utx.Outs, txs.Codec) // sort imported outputs
+			return utx, b.initCtx(utx)
+
+		default:
+			// imported avax are not enough to pay fees
+			// Drop the changeOut and finance the tx
+			if _, err := feeCalc.RemoveFeesFor(outDimensions); err != nil {
+				return nil, fmt.Errorf("failed reverting change output: %w", err)
+			}
+			feeCalc.ResetFee(currentFee - importedAVAX)
+		}
+	}
+
+	toStake := map[ids.ID]uint64{}
+	toBurn := map[ids.ID]uint64{}
+	inputs, changeOuts, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	utx.Ins = inputs
+	utx.Outs = append(utx.Outs, changeOuts...)
+	avax.SortTransferableOutputs(utx.Outs, txs.Codec) // sort imported outputs
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewExportTx(
 	chainID ids.ID,
 	outputs []*avax.TransferableOutput,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.ExportTx, error) {
-	toBurn := map[ids.ID]uint64{
-		b.context.AVAXAssetID: b.context.BaseTxFee,
+	// 1. Build core transaction without utxos
+	ops := common.NewOptions(options)
+	avax.SortTransferableOutputs(outputs, txs.Codec) // sort exported outputs
+
+	utx := &txs.ExportTx{
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.context.NetworkID,
+			BlockchainID: constants.PlatformChainID,
+			Memo:         ops.Memo(),
+		}},
+		DestinationChain: chainID,
+		ExportedOutputs:  outputs,
 	}
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
 	for _, out := range outputs {
 		assetID := out.AssetID()
 		amountToBurn, err := math.Add64(toBurn[assetID], out.Out.Amount())
@@ -709,26 +890,20 @@ func (b *builder) NewExportTx(
 		toBurn[assetID] = amountToBurn
 	}
 
-	toStake := map[ids.ID]uint64{}
-	ops := common.NewOptions(options)
-	inputs, changeOutputs, _, err := b.spend(toBurn, toStake, ops)
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	inputs, changeOuts, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
 	if err != nil {
 		return nil, err
 	}
 
-	avax.SortTransferableOutputs(outputs, txs.Codec) // sort exported outputs
-	tx := &txs.ExportTx{
-		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-			NetworkID:    b.context.NetworkID,
-			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         changeOutputs,
-			Memo:         ops.Memo(),
-		}},
-		DestinationChain: chainID,
-		ExportedOutputs:  outputs,
-	}
-	return tx, b.initCtx(tx)
+	utx.Ins = inputs
+	utx.Outs = changeOuts
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewTransformSubnetTx(
@@ -746,30 +921,21 @@ func (b *builder) NewTransformSubnetTx(
 	minDelegatorStake uint64,
 	maxValidatorWeightFactor byte,
 	uptimeRequirement uint32,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.TransformSubnetTx, error) {
-	toBurn := map[ids.ID]uint64{
-		b.context.AVAXAssetID: b.context.TransformSubnetTxFee,
-		assetID:               maxSupply - initialSupply,
-	}
-	toStake := map[ids.ID]uint64{}
+	// 1. Build core transaction without utxos
 	ops := common.NewOptions(options)
-	inputs, outputs, _, err := b.spend(toBurn, toStake, ops)
-	if err != nil {
-		return nil, err
-	}
 
 	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
 	if err != nil {
 		return nil, err
 	}
 
-	tx := &txs.TransformSubnetTx{
+	utx := &txs.TransformSubnetTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.context.NetworkID,
 			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         outputs,
 			Memo:         ops.Memo(),
 		}},
 		Subnet:                   subnetID,
@@ -788,7 +954,32 @@ func (b *builder) NewTransformSubnetTx(
 		UptimeRequirement:        uptimeRequirement,
 		SubnetAuth:               subnetAuth,
 	}
-	return tx, b.initCtx(tx)
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{}
+	toBurn := map[ids.ID]uint64{
+		assetID: maxSupply - initialSupply,
+	} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	// update fees to account for the auth credentials to be added upon tx signing
+	if _, err = financeCredential(feeCalc, len(subnetAuth.SigIndices)); err != nil {
+		return nil, fmt.Errorf("account for credential fees: %w", err)
+	}
+
+	inputs, outputs, _, err := b.financeTx(toBurn, toStake, feeCalc, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	utx.Ins = inputs
+	utx.Outs = outputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewAddPermissionlessValidatorTx(
@@ -798,82 +989,92 @@ func (b *builder) NewAddPermissionlessValidatorTx(
 	validationRewardsOwner *secp256k1fx.OutputOwners,
 	delegationRewardsOwner *secp256k1fx.OutputOwners,
 	shares uint32,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddPermissionlessValidatorTx, error) {
-	avaxAssetID := b.context.AVAXAssetID
-	toBurn := map[ids.ID]uint64{}
-	if vdr.Subnet == constants.PrimaryNetworkID {
-		toBurn[avaxAssetID] = b.context.AddPrimaryNetworkValidatorFee
-	} else {
-		toBurn[avaxAssetID] = b.context.AddSubnetValidatorFee
-	}
-	toStake := map[ids.ID]uint64{
-		assetID: vdr.Wght,
-	}
 	ops := common.NewOptions(options)
-	inputs, baseOutputs, stakeOutputs, err := b.spend(toBurn, toStake, ops)
-	if err != nil {
-		return nil, err
-	}
-
 	utils.Sort(validationRewardsOwner.Addrs)
 	utils.Sort(delegationRewardsOwner.Addrs)
-	tx := &txs.AddPermissionlessValidatorTx{
+
+	utx := &txs.AddPermissionlessValidatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.context.NetworkID,
 			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         baseOutputs,
 			Memo:         ops.Memo(),
 		}},
 		Validator:             vdr.Validator,
 		Subnet:                vdr.Subnet,
 		Signer:                signer,
-		StakeOuts:             stakeOutputs,
 		ValidatorRewardsOwner: validationRewardsOwner,
 		DelegatorRewardsOwner: delegationRewardsOwner,
 		DelegationShares:      shares,
 	}
-	return tx, b.initCtx(tx)
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{
+		assetID: vdr.Wght,
+	}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	inputs, outputs, stakeOutputs, err := b.financeTx(toBurn, toStake, feeCalc, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	utx.Ins = inputs
+	utx.Outs = outputs
+	utx.StakeOuts = stakeOutputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) NewAddPermissionlessDelegatorTx(
 	vdr *txs.SubnetValidator,
 	assetID ids.ID,
 	rewardsOwner *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddPermissionlessDelegatorTx, error) {
-	avaxAssetID := b.context.AVAXAssetID
-	toBurn := map[ids.ID]uint64{}
-	if vdr.Subnet == constants.PrimaryNetworkID {
-		toBurn[avaxAssetID] = b.context.AddPrimaryNetworkDelegatorFee
-	} else {
-		toBurn[avaxAssetID] = b.context.AddSubnetDelegatorFee
-	}
-	toStake := map[ids.ID]uint64{
-		assetID: vdr.Wght,
-	}
 	ops := common.NewOptions(options)
-	inputs, baseOutputs, stakeOutputs, err := b.spend(toBurn, toStake, ops)
-	if err != nil {
-		return nil, err
-	}
-
 	utils.Sort(rewardsOwner.Addrs)
-	tx := &txs.AddPermissionlessDelegatorTx{
+
+	utx := &txs.AddPermissionlessDelegatorTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.context.NetworkID,
 			BlockchainID: constants.PlatformChainID,
-			Ins:          inputs,
-			Outs:         baseOutputs,
 			Memo:         ops.Memo(),
 		}},
 		Validator:              vdr.Validator,
 		Subnet:                 vdr.Subnet,
-		StakeOuts:              stakeOutputs,
 		DelegationRewardsOwner: rewardsOwner,
 	}
-	return tx, b.initCtx(tx)
+
+	// 2. Finance the tx by building the utxos (inputs, outputs and stakes)
+	toStake := map[ids.ID]uint64{
+		assetID: vdr.Wght,
+	}
+	toBurn := map[ids.ID]uint64{} // fees are calculated in financeTx
+
+	// feesMan cumulates complexity. Let's init it with utx filled so far
+	if _, err := feeCalc.CalculateFee(&txs.Tx{Unsigned: utx, Creds: nil}); err != nil {
+		return nil, err
+	}
+
+	inputs, outputs, stakeOutputs, err := b.financeTx(toBurn, toStake, feeCalc, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	utx.Ins = inputs
+	utx.Outs = outputs
+	utx.StakeOuts = stakeOutputs
+
+	return utx, b.initCtx(utx)
 }
 
 func (b *builder) getBalance(
@@ -927,7 +1128,7 @@ func (b *builder) getBalance(
 // spend takes in the requested burn amounts and the requested stake amounts.
 //
 //   - [amountsToBurn] maps assetID to the amount of the asset to spend without
-//     producing an output. This is typically used for fees. However, it can
+//     producing an output. This is typically used for fee. However, it can
 //     also be used to consume some of an asset that will be produced in
 //     separate outputs, such as ExportedOutputs. Only unlocked UTXOs are able
 //     to be burned here.
@@ -935,9 +1136,10 @@ func (b *builder) getBalance(
 //     place into the staked outputs. First locked UTXOs are attempted to be
 //     used for these funds, and then unlocked UTXOs will be attempted to be
 //     used. There is no preferential ordering on the unlock times.
-func (b *builder) spend(
+func (b *builder) financeTx(
 	amountsToBurn map[ids.ID]uint64,
 	amountsToStake map[ids.ID]uint64,
+	feeCalc fee.Calculator,
 	options *common.Options,
 ) (
 	inputs []*avax.TransferableInput,
@@ -945,10 +1147,24 @@ func (b *builder) spend(
 	stakeOutputs []*avax.TransferableOutput,
 	err error,
 ) {
+	avaxAssetID := b.context.AVAXAssetID
 	utxos, err := b.backend.UTXOs(options.Context(), constants.PlatformChainID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	// we can only pay fees in avax, so we sort avax-denominated UTXOs last
+	// to maximize probability of being able to pay fee.
+	slices.SortFunc(utxos, func(lhs, rhs *avax.UTXO) int {
+		switch {
+		case lhs.Asset.AssetID() == avaxAssetID && rhs.Asset.AssetID() != avaxAssetID:
+			return 1
+		case lhs.Asset.AssetID() != avaxAssetID && rhs.Asset.AssetID() == avaxAssetID:
+			return -1
+		default:
+			return 0
+		}
+	})
 
 	addrs := options.Addresses(b.addrs)
 	minIssuanceTime := options.MinIssuanceTime()
@@ -962,6 +1178,8 @@ func (b *builder) spend(
 		Addrs:     []ids.ShortID{addr},
 	})
 
+	amountsToBurn[avaxAssetID] += feeCalc.GetFee()
+
 	// Initialize the return values with empty slices to preserve backward
 	// compatibility of the json representation of transactions with no
 	// inputs or outputs.
@@ -972,11 +1190,10 @@ func (b *builder) spend(
 	// Iterate over the locked UTXOs
 	for _, utxo := range utxos {
 		assetID := utxo.AssetID()
-		remainingAmountToStake := amountsToStake[assetID]
 
 		// If we have staked enough of the asset, then we have no need burn
 		// more.
-		if remainingAmountToStake == 0 {
+		if amountsToStake[assetID] == 0 {
 			continue
 		}
 
@@ -1004,7 +1221,7 @@ func (b *builder) spend(
 			continue
 		}
 
-		inputs = append(inputs, &avax.TransferableInput{
+		input := &avax.TransferableInput{
 			UTXOID: utxo.UTXOID,
 			Asset:  utxo.Asset,
 			In: &stakeable.LockIn{
@@ -1016,16 +1233,30 @@ func (b *builder) spend(
 					},
 				},
 			},
-		})
+		}
+
+		addedFees, err := financeInput(feeCalc, input)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("account for input fees: %w", err)
+		}
+		amountsToBurn[avaxAssetID] += addedFees
+
+		addedFees, err = financeCredential(feeCalc, len(inputSigIndices))
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("account for input fees: %w", err)
+		}
+		amountsToBurn[avaxAssetID] += addedFees
+
+		inputs = append(inputs, input)
 
 		// Stake any value that should be staked
 		amountToStake := min(
-			remainingAmountToStake, // Amount we still need to stake
-			out.Amt,                // Amount available to stake
+			amountsToStake[assetID], // Amount we still need to stake
+			out.Amt,                 // Amount available to stake
 		)
 
 		// Add the output to the staked outputs
-		stakeOutputs = append(stakeOutputs, &avax.TransferableOutput{
+		stakeOut := &avax.TransferableOutput{
 			Asset: utxo.Asset,
 			Out: &stakeable.LockOut{
 				Locktime: lockedOut.Locktime,
@@ -1034,12 +1265,20 @@ func (b *builder) spend(
 					OutputOwners: out.OutputOwners,
 				},
 			},
-		})
+		}
+
+		addedFees, _, err = financeOutput(feeCalc, stakeOut)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("account for output fees: %w", err)
+		}
+		amountsToBurn[avaxAssetID] += addedFees
+
+		stakeOutputs = append(stakeOutputs, stakeOut)
 
 		amountsToStake[assetID] -= amountToStake
 		if remainingAmount := out.Amt - amountToStake; remainingAmount > 0 {
 			// This input had extra value, so some of it must be returned
-			changeOutputs = append(changeOutputs, &avax.TransferableOutput{
+			changeOut := &avax.TransferableOutput{
 				Asset: utxo.Asset,
 				Out: &stakeable.LockOut{
 					Locktime: lockedOut.Locktime,
@@ -1048,19 +1287,26 @@ func (b *builder) spend(
 						OutputOwners: out.OutputOwners,
 					},
 				},
-			})
+			}
+
+			// update fees to account for the change output
+			addedFees, _, err = financeOutput(feeCalc, changeOut)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("account for output fees: %w", err)
+			}
+			amountsToBurn[avaxAssetID] += addedFees
+
+			changeOutputs = append(changeOutputs, changeOut)
 		}
 	}
 
 	// Iterate over the unlocked UTXOs
 	for _, utxo := range utxos {
 		assetID := utxo.AssetID()
-		remainingAmountToStake := amountsToStake[assetID]
-		remainingAmountToBurn := amountsToBurn[assetID]
 
 		// If we have consumed enough of the asset, then we have no need burn
 		// more.
-		if remainingAmountToStake == 0 && remainingAmountToBurn == 0 {
+		if amountsToStake[assetID] == 0 && amountsToBurn[assetID] == 0 {
 			continue
 		}
 
@@ -1085,7 +1331,7 @@ func (b *builder) spend(
 			continue
 		}
 
-		inputs = append(inputs, &avax.TransferableInput{
+		input := &avax.TransferableInput{
 			UTXOID: utxo.UTXOID,
 			Asset:  utxo.Asset,
 			In: &secp256k1fx.TransferInput{
@@ -1094,41 +1340,83 @@ func (b *builder) spend(
 					SigIndices: inputSigIndices,
 				},
 			},
-		})
+		}
 
-		// Burn any value that should be burned
-		amountToBurn := min(
-			remainingAmountToBurn, // Amount we still need to burn
-			out.Amt,               // Amount available to burn
-		)
-		amountsToBurn[assetID] -= amountToBurn
+		addedFees, err := financeInput(feeCalc, input)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("account for input fees: %w", err)
+		}
+		amountsToBurn[avaxAssetID] += addedFees
 
-		amountAvalibleToStake := out.Amt - amountToBurn
-		// Burn any value that should be burned
+		addedFees, err = financeCredential(feeCalc, len(inputSigIndices))
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("account for credential fees: %w", err)
+		}
+		amountsToBurn[avaxAssetID] += addedFees
+
+		inputs = append(inputs, input)
+
+		// Stake any value that should be staked
 		amountToStake := min(
-			remainingAmountToStake, // Amount we still need to stake
-			amountAvalibleToStake,  // Amount available to stake
+			amountsToStake[assetID], // Amount we still need to stake
+			out.Amt,                 // Amount available to stake
 		)
 		amountsToStake[assetID] -= amountToStake
 		if amountToStake > 0 {
 			// Some of this input was put for staking
-			stakeOutputs = append(stakeOutputs, &avax.TransferableOutput{
+			stakeOut := &avax.TransferableOutput{
 				Asset: utxo.Asset,
 				Out: &secp256k1fx.TransferOutput{
 					Amt:          amountToStake,
 					OutputOwners: *changeOwner,
 				},
-			})
+			}
+
+			stakeOutputs = append(stakeOutputs, stakeOut)
+
+			addedFees, _, err = financeOutput(feeCalc, stakeOut)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("account for output fees: %w", err)
+			}
+			amountsToBurn[avaxAssetID] += addedFees
 		}
-		if remainingAmount := amountAvalibleToStake - amountToStake; remainingAmount > 0 {
-			// This input had extra value, so some of it must be returned
-			changeOutputs = append(changeOutputs, &avax.TransferableOutput{
+
+		// Burn any value that should be burned
+		amountAvalibleToBurn := out.Amt - amountToStake
+		amountToBurn := min(
+			amountsToBurn[assetID], // Amount we still need to burn
+			amountAvalibleToBurn,   // Amount available to burn
+		)
+		amountsToBurn[assetID] -= amountToBurn
+		if remainingAmount := amountAvalibleToBurn - amountToBurn; remainingAmount > 0 {
+			// This input had extra value, so some of it must be returned, once fees are removed
+			changeOut := &avax.TransferableOutput{
 				Asset: utxo.Asset,
 				Out: &secp256k1fx.TransferOutput{
-					Amt:          remainingAmount,
 					OutputOwners: *changeOwner,
 				},
-			})
+			}
+
+			// update fees to account for the change output
+			addedFees, _, err = financeOutput(feeCalc, changeOut)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("account for output fees: %w", err)
+			}
+
+			if assetID != avaxAssetID {
+				changeOut.Out.(*secp256k1fx.TransferOutput).Amt = remainingAmount
+				amountsToBurn[avaxAssetID] += addedFees
+				changeOutputs = append(changeOutputs, changeOut)
+			} else {
+				// here assetID == b.context.AVAXAssetID
+				switch {
+				case addedFees < remainingAmount:
+					changeOut.Out.(*secp256k1fx.TransferOutput).Amt = remainingAmount - addedFees
+					changeOutputs = append(changeOutputs, changeOut)
+				case addedFees >= remainingAmount:
+					amountsToBurn[assetID] += addedFees - remainingAmount
+				}
+			}
 		}
 	}
 
@@ -1159,7 +1447,10 @@ func (b *builder) spend(
 	return inputs, changeOutputs, stakeOutputs, nil
 }
 
-func (b *builder) authorizeSubnet(subnetID ids.ID, options *common.Options) (*secp256k1fx.Input, error) {
+func (b *builder) authorizeSubnet(
+	subnetID ids.ID,
+	options *common.Options,
+) (*secp256k1fx.Input, error) {
 	ownerIntf, err := b.backend.GetSubnetOwner(options.Context(), subnetID)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/wallet/chain/p/builder/builder_with_options.go
+++ b/wallet/chain/p/builder/builder_with_options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/fee"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
@@ -59,10 +60,12 @@ func (b *builderWithOptions) GetImportableBalance(
 
 func (b *builderWithOptions) NewBaseTx(
 	outputs []*avax.TransferableOutput,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.BaseTx, error) {
 	return b.builder.NewBaseTx(
 		outputs,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -71,22 +74,26 @@ func (b *builderWithOptions) NewAddValidatorTx(
 	vdr *txs.Validator,
 	rewardsOwner *secp256k1fx.OutputOwners,
 	shares uint32,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddValidatorTx, error) {
 	return b.builder.NewAddValidatorTx(
 		vdr,
 		rewardsOwner,
 		shares,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
 
 func (b *builderWithOptions) NewAddSubnetValidatorTx(
 	vdr *txs.SubnetValidator,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddSubnetValidatorTx, error) {
 	return b.builder.NewAddSubnetValidatorTx(
 		vdr,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -94,11 +101,13 @@ func (b *builderWithOptions) NewAddSubnetValidatorTx(
 func (b *builderWithOptions) NewRemoveSubnetValidatorTx(
 	nodeID ids.NodeID,
 	subnetID ids.ID,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.RemoveSubnetValidatorTx, error) {
 	return b.builder.NewRemoveSubnetValidatorTx(
 		nodeID,
 		subnetID,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -106,11 +115,13 @@ func (b *builderWithOptions) NewRemoveSubnetValidatorTx(
 func (b *builderWithOptions) NewAddDelegatorTx(
 	vdr *txs.Validator,
 	rewardsOwner *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddDelegatorTx, error) {
 	return b.builder.NewAddDelegatorTx(
 		vdr,
 		rewardsOwner,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -121,6 +132,7 @@ func (b *builderWithOptions) NewCreateChainTx(
 	vmID ids.ID,
 	fxIDs []ids.ID,
 	chainName string,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.CreateChainTx, error) {
 	return b.builder.NewCreateChainTx(
@@ -129,16 +141,19 @@ func (b *builderWithOptions) NewCreateChainTx(
 		vmID,
 		fxIDs,
 		chainName,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
 
 func (b *builderWithOptions) NewCreateSubnetTx(
 	owner *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.CreateSubnetTx, error) {
 	return b.builder.NewCreateSubnetTx(
 		owner,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -146,11 +161,13 @@ func (b *builderWithOptions) NewCreateSubnetTx(
 func (b *builderWithOptions) NewTransferSubnetOwnershipTx(
 	subnetID ids.ID,
 	owner *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.TransferSubnetOwnershipTx, error) {
 	return b.builder.NewTransferSubnetOwnershipTx(
 		subnetID,
 		owner,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -158,11 +175,13 @@ func (b *builderWithOptions) NewTransferSubnetOwnershipTx(
 func (b *builderWithOptions) NewImportTx(
 	sourceChainID ids.ID,
 	to *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.ImportTx, error) {
 	return b.builder.NewImportTx(
 		sourceChainID,
 		to,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -170,11 +189,13 @@ func (b *builderWithOptions) NewImportTx(
 func (b *builderWithOptions) NewExportTx(
 	chainID ids.ID,
 	outputs []*avax.TransferableOutput,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.ExportTx, error) {
 	return b.builder.NewExportTx(
 		chainID,
 		outputs,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -194,6 +215,7 @@ func (b *builderWithOptions) NewTransformSubnetTx(
 	minDelegatorStake uint64,
 	maxValidatorWeightFactor byte,
 	uptimeRequirement uint32,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.TransformSubnetTx, error) {
 	return b.builder.NewTransformSubnetTx(
@@ -211,6 +233,7 @@ func (b *builderWithOptions) NewTransformSubnetTx(
 		minDelegatorStake,
 		maxValidatorWeightFactor,
 		uptimeRequirement,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -222,6 +245,7 @@ func (b *builderWithOptions) NewAddPermissionlessValidatorTx(
 	validationRewardsOwner *secp256k1fx.OutputOwners,
 	delegationRewardsOwner *secp256k1fx.OutputOwners,
 	shares uint32,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddPermissionlessValidatorTx, error) {
 	return b.builder.NewAddPermissionlessValidatorTx(
@@ -231,6 +255,7 @@ func (b *builderWithOptions) NewAddPermissionlessValidatorTx(
 		validationRewardsOwner,
 		delegationRewardsOwner,
 		shares,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }
@@ -239,12 +264,14 @@ func (b *builderWithOptions) NewAddPermissionlessDelegatorTx(
 	vdr *txs.SubnetValidator,
 	assetID ids.ID,
 	rewardsOwner *secp256k1fx.OutputOwners,
+	feeCalc fee.Calculator,
 	options ...common.Option,
 ) (*txs.AddPermissionlessDelegatorTx, error) {
 	return b.builder.NewAddPermissionlessDelegatorTx(
 		vdr,
 		assetID,
 		rewardsOwner,
+		feeCalc,
 		common.UnionOptions(b.options, options)...,
 	)
 }

--- a/wallet/chain/p/builder/helpers.go
+++ b/wallet/chain/p/builder/helpers.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package builder
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/fee"
+
+	commonfee "github.com/ava-labs/avalanchego/vms/components/fee"
+)
+
+func financeInput(feeCalc fee.Calculator, input *avax.TransferableInput) (uint64, error) {
+	if !feeCalc.IsEActive() {
+		return 0, nil // pre E-upgrade we have a fixed fee regardless how complex the input is
+	}
+
+	inDimensions, err := commonfee.MeterInput(txs.Codec, txs.CodecVersion, input)
+	if err != nil {
+		return 0, fmt.Errorf("failed calculating input size: %w", err)
+	}
+	addedFees, err := feeCalc.AddFeesFor(inDimensions)
+	if err != nil {
+		return 0, fmt.Errorf("account for input fees: %w", err)
+	}
+	return addedFees, nil
+}
+
+func financeOutput(feeCalc fee.Calculator, output *avax.TransferableOutput) (uint64, commonfee.Dimensions, error) {
+	if !feeCalc.IsEActive() {
+		return 0, commonfee.Empty, nil // pre E-upgrade we have a fixed fee regardless how complex the output is
+	}
+
+	outDimensions, err := commonfee.MeterOutput(txs.Codec, txs.CodecVersion, output)
+	if err != nil {
+		return 0, commonfee.Empty, fmt.Errorf("failed calculating changeOut size: %w", err)
+	}
+	addedFees, err := feeCalc.AddFeesFor(outDimensions)
+	if err != nil {
+		return 0, commonfee.Empty, fmt.Errorf("account for stakedOut fees: %w", err)
+	}
+	return addedFees, outDimensions, nil
+}
+
+func financeCredential(feeCalc fee.Calculator, keysCount int) (uint64, error) {
+	if !feeCalc.IsEActive() {
+		return 0, nil // pre E-upgrade we have a fixed fee regardless how complex the credentials are
+	}
+
+	credDimensions, err := commonfee.MeterCredential(txs.Codec, txs.CodecVersion, keysCount)
+	if err != nil {
+		return 0, fmt.Errorf("failed calculating input size: %w", err)
+	}
+	addedFees, err := feeCalc.AddFeesFor(credDimensions)
+	if err != nil {
+		return 0, fmt.Errorf("account for input fees: %w", err)
+	}
+	return addedFees, nil
+}

--- a/wallet/chain/p/wallet.go
+++ b/wallet/chain/p/wallet.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -308,10 +307,7 @@ func (w *wallet) IssueBaseTx(
 	outputs []*avax.TransferableOutput,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewBaseTx(outputs, feeCalc, options...)
 	if err != nil {
@@ -327,10 +323,7 @@ func (w *wallet) IssueAddValidatorTx(
 	shares uint32,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewAddValidatorTx(vdr, rewardsOwner, shares, feeCalc, options...)
 	if err != nil {
@@ -343,10 +336,7 @@ func (w *wallet) IssueAddSubnetValidatorTx(
 	vdr *txs.SubnetValidator,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewAddSubnetValidatorTx(vdr, feeCalc, options...)
 	if err != nil {
@@ -361,10 +351,7 @@ func (w *wallet) IssueRemoveSubnetValidatorTx(
 	subnetID ids.ID,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewRemoveSubnetValidatorTx(nodeID, subnetID, feeCalc, options...)
 	if err != nil {
@@ -379,10 +366,7 @@ func (w *wallet) IssueAddDelegatorTx(
 	rewardsOwner *secp256k1fx.OutputOwners,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewAddDelegatorTx(vdr, rewardsOwner, feeCalc, options...)
 	if err != nil {
@@ -399,10 +383,7 @@ func (w *wallet) IssueCreateChainTx(
 	chainName string,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewCreateChainTx(subnetID, genesis, vmID, fxIDs, chainName, feeCalc, options...)
 	if err != nil {
@@ -416,10 +397,7 @@ func (w *wallet) IssueCreateSubnetTx(
 	owner *secp256k1fx.OutputOwners,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewCreateSubnetTx(owner, feeCalc, options...)
 	if err != nil {
@@ -433,10 +411,7 @@ func (w *wallet) IssueTransferSubnetOwnershipTx(
 	owner *secp256k1fx.OutputOwners,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewTransferSubnetOwnershipTx(subnetID, owner, feeCalc, options...)
 	if err != nil {
@@ -450,10 +425,7 @@ func (w *wallet) IssueImportTx(
 	to *secp256k1fx.OutputOwners,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewImportTx(sourceChainID, to, feeCalc, options...)
 	if err != nil {
@@ -468,10 +440,7 @@ func (w *wallet) IssueExportTx(
 	outputs []*avax.TransferableOutput,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewExportTx(chainID, outputs, feeCalc, options...)
 	if err != nil {
@@ -498,10 +467,7 @@ func (w *wallet) IssueTransformSubnetTx(
 	uptimeRequirement uint32,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewTransformSubnetTx(
 		subnetID,
@@ -537,10 +503,7 @@ func (w *wallet) IssueAddPermissionlessValidatorTx(
 	shares uint32,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewAddPermissionlessValidatorTx(
 		vdr,
@@ -565,10 +528,7 @@ func (w *wallet) IssueAddPermissionlessDelegatorTx(
 	rewardsOwner *secp256k1fx.OutputOwners,
 	options ...common.Option,
 ) (*txs.Tx, error) {
-	feeCalc, err := w.feeCalculator(w.builder.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	feeCalc := w.feeCalculator(w.builder.Context(), options...)
 
 	utx, err := w.builder.NewAddPermissionlessDelegatorTx(
 		vdr,
@@ -624,49 +584,52 @@ func (w *wallet) IssueTx(
 	return w.Backend.AcceptTx(ctx, tx)
 }
 
-func (w *wallet) feeCalculator(ctx *builder.Context, options ...common.Option) (fee.Calculator, error) {
-	if err := w.refreshFeesData(ctx, options...); err != nil {
-		return nil, err
-	}
+func (w *wallet) feeCalculator(ctx *builder.Context, options ...common.Option) fee.Calculator {
+	w.refreshFeesData(ctx, options...)
 
 	if !w.isEUpgradeActive {
-		return fee.NewStaticCalculator(w.staticFeesConfig, upgrade.Config{}, time.Time{}), nil
+		return fee.NewStaticCalculator(w.staticFeesConfig, upgrade.Config{}, time.Time{})
 	}
 
-	return fee.NewBuildingDynamicCalculator(commonfee.NewCalculator(w.feeCfg.FeeDimensionWeights, w.gasPrice, w.gasCap)), nil
+	return fee.NewBuildingDynamicCalculator(commonfee.NewCalculator(w.feeCfg.FeeDimensionWeights, w.gasPrice, w.gasCap))
 }
 
-func (w *wallet) refreshFeesData(ctx *builder.Context, options ...common.Option) error {
-	var (
-		ops    = common.NewOptions(options)
-		opsCtx = ops.Context()
-	)
+func (w *wallet) refreshFeesData(ctx *builder.Context, _ ...common.Option) {
+	// TODO: until we wire in dynamic fees verification, we should build txs as if all it's static fees
+	// (at least for e2e tests)
 
-	chainTime, err := w.client.GetTimestamp(opsCtx)
-	if err != nil {
-		return err
-	}
-	eUpgradeTime := version.GetEUpgradeTime(w.builder.Context().NetworkID)
-	isEUpgradeActive := !chainTime.Before(eUpgradeTime)
+	// var (
+	// 	ops    = common.NewOptions(options)
+	// 	opsCtx = ops.Context()
+	// )
 
-	// update static and dynamic fees configs if needed
-	switch {
-	case !isEUpgradeActive:
-		w.staticFeesConfig = staticFeesConfigFromContext(ctx)
-		w.isEUpgradeActive = isEUpgradeActive
-		return nil
-	case !w.isEUpgradeActive && isEUpgradeActive:
-		w.feeCfg, err = w.client.GetDynamicFeeConfig(opsCtx)
-		if err != nil {
-			return err
-		}
-		w.isEUpgradeActive = isEUpgradeActive
-	default:
-		// nothing to do
-	}
+	// chainTime, err := w.client.GetTimestamp(opsCtx)
+	// if err != nil {
+	// 	return err
+	// }
+	// eUpgradeTime := version.GetEUpgradeTime(w.builder.Context().NetworkID)
+	// isEUpgradeActive := !chainTime.Before(eUpgradeTime)
 
-	w.gasPrice, w.gasCap, err = w.client.GetNextGasData(opsCtx)
-	return err
+	// // update static and dynamic fees configs if needed
+	// switch {
+	// case !isEUpgradeActive:
+	// 	w.staticFeesConfig = staticFeesConfigFromContext(ctx)
+	// 	w.isEUpgradeActive = isEUpgradeActive
+	// 	return nil
+	// case !w.isEUpgradeActive && isEUpgradeActive:
+	// 	w.feeCfg, err = w.client.GetDynamicFeeConfig(opsCtx)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	w.isEUpgradeActive = isEUpgradeActive
+	// default:
+	// 	// nothing to do
+	// }
+	// w.gasPrice, w.gasCap, err = w.client.GetNextGasData(opsCtx)
+	// return err
+
+	w.staticFeesConfig = staticFeesConfigFromContext(ctx)
+	w.isEUpgradeActive = false
 }
 
 func staticFeesConfigFromContext(ctx *builder.Context) fee.StaticConfig {


### PR DESCRIPTION
## Why this should be merged
Splitting introduction of dynamic fees into 4 PRs:

- [Introduce new dynamic fee calculator](https://github.com/ava-labs/avalanchego/pull/3188)
- Update wallet to build transactions with dynamic fees
- [Wire in new code into blocks/txs verification and building](https://github.com/ava-labs/avalanchego/pull/2703)
- [Update gas prices](https://github.com/ava-labs/avalanchego/pull/2682)

## How this works

- Updated platforvm API to serve dynamic fees related stuff (config and gas cap)
- Updated wallet to use dynamic fee calculator when needed
- Updated UTs to use the new wallet interface (explicitly pass fee calculator)

## How this was tested
Extra UTs. All new code is not wired in yet. Will be done in a sequent PR
