### PR TITLE
bump coreth dependency to current master branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/coreth v0.13.6-rc.1.0.20240702201359-ba2ce5367874
+	github.com/ava-labs/coreth v0.13.6-rc.1.0.20240708163958-7684836cb3dc
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20240610153809-9c955cc90a95
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/antithesishq/antithesis-sdk-go v0.3.8 h1:OvGoHxIcOXFJLyn9IJQ5DzByZ3YVAWNBc394ObzDRb8=
 github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.13.6-rc.1.0.20240702201359-ba2ce5367874 h1:aTDg0jvO07EvUvBYebmLO25bffe1DAaZZPPL0ooGhIA=
-github.com/ava-labs/coreth v0.13.6-rc.1.0.20240702201359-ba2ce5367874/go.mod h1:VhNDxZBsqZQQaUTmIkzdyY8UicIsoTDXlRmPaPL9lkA=
+github.com/ava-labs/coreth v0.13.6-rc.1.0.20240708163958-7684836cb3dc h1:ISWP/2fB2E+XpjJc+DZtMJl5V2PVw3kPOlH2zDQW7oM=
+github.com/ava-labs/coreth v0.13.6-rc.1.0.20240708163958-7684836cb3dc/go.mod h1:3JfJLEP3M0ODLbKSawOzRTMmm/MixaIKIQa3/v1Dpm4=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20240610153809-9c955cc90a95 h1:dOVbtdnZL++pENdTCNZ1nu41eYDQkTML4sWebDnnq8c=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20240610153809-9c955cc90a95/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=


### PR DESCRIPTION
this change was produced by doing `go mod edit -require github.com/ava-labs/coreth@master` followed by `go mod tidy`.

## Why this should be merged

prior to this change, running `go mod tidy` in my local environment was giving the errors shown below. I originally discovered this  when trying to build teleporter with a dependency on the latest avalanchego master commit, which resulted in the same error.

It's a mystery to me why the `go mod tidy` check in this repo's CI is passing, but something similar happened to me not too long ago (see https://github.com/ava-labs/avalanchego/pull/3115).

here is the commit that the code was previously referencing, which you can see does not (anymore?) belong to any branch in the repository: https://github.com/ava-labs/coreth/commit/ba2ce53678740a021f2d5b7aa84e5e08b6fd55f5

```bash
gene-dev 07/15 15:06:37 (master) 0 ~/dev/avalanchego$ git status                                                                                                     
On branch master                                                                                                                                                     
Your branch is up to date with 'origin/master'.                                                                                                                      
                                                                                                                                                                     
nothing to commit, working tree clean                                                                                                                                
gene-dev 07/15 15:06:39 (master) 0 ~/dev/avalanchego$ git pull                                                                                                       
Already up to date.                                                                                                                                                  
gene-dev 07/15 15:06:45 (master) 0 ~/dev/avalanchego$ go mod tidy                                                                                                    
go: downloading github.com/ava-labs/coreth v0.13.6-rc.1.0.20240702201359-ba2ce5367874                                                                                
go: github.com/ava-labs/avalanchego/node imports                                                                                                                     
        github.com/ava-labs/coreth/plugin/evm: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874 
go: github.com/ava-labs/avalanchego/tests/e2e/c imports                                                                                                              
        github.com/ava-labs/coreth/core/types: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874 
go: github.com/ava-labs/avalanchego/tests/e2e/c imports                                                                                                              
        github.com/ava-labs/coreth/params: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874     
go: github.com/ava-labs/avalanchego/tests/fixture/e2e imports                                                                                                        
        github.com/ava-labs/coreth/ethclient: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874  
go: github.com/ava-labs/avalanchego/tests/fixture/e2e imports                                                                                                        
        github.com/ava-labs/coreth/interfaces: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874 
go: github.com/ava-labs/avalanchego/tests/fixture/tmpnet imports                                                                                                     
        github.com/ava-labs/coreth/core: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874       
go: github.com/ava-labs/avalanchego/api imports                                                                                                                      
        go.opentelemetry.io/otel/attribute tested by                                                                                                                 
        go.opentelemetry.io/otel/attribute.test imports                                                                                                              
        github.com/google/go-cmp/cmp: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874          
go: github.com/ava-labs/avalanchego/database/leveldb imports                                                                                                         
        github.com/syndtr/goleveldb/leveldb tested by                                                                                                                
        github.com/syndtr/goleveldb/leveldb.test imports                                                                                                             
        github.com/onsi/ginkgo: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                
go: github.com/ava-labs/avalanchego/database/leveldb imports                                                                                                         
        github.com/syndtr/goleveldb/leveldb tested by                                                                                                                
        github.com/syndtr/goleveldb/leveldb.test imports                                                                                                             
        github.com/onsi/gomega: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                
go: github.com/ava-labs/avalanchego/database/pebbledb imports                                                                                                        
        github.com/cockroachdb/pebble tested by                                                                                                                      
        github.com/cockroachdb/pebble.test imports                                                                                                                   
        github.com/cockroachdb/datadriven: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874     
go: github.com/ava-labs/avalanchego/proto/pb/vm imports                                                                                                              
        google.golang.org/protobuf/types/known/timestamppb tested by                                                                                                 
        google.golang.org/protobuf/types/known/timestamppb.test imports                                                                                              
        github.com/google/go-cmp/cmp/cmpopts: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874  
go: github.com/ava-labs/avalanchego/tests/antithesis imports                                                                                                         
        github.com/compose-spec/compose-go/types tested by                                                                                                           
        github.com/compose-spec/compose-go/types.test imports                                                                                                        
        gotest.tools/v3/assert: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                
go: github.com/ava-labs/avalanchego/tests/antithesis imports                                                                                                         
        github.com/compose-spec/compose-go/types tested by                                                                                                           
        github.com/compose-spec/compose-go/types.test imports                                                                                                        
        gotest.tools/v3/assert/cmp: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874            
go: github.com/ava-labs/avalanchego/tests/antithesis imports                                                                                                         
        gopkg.in/yaml.v3 tested by                                                                                                                                   
        gopkg.in/yaml.v3.test imports                                                                                                                                
        gopkg.in/check.v1: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                     
go: github.com/ava-labs/avalanchego/tests/e2e/c imports                                                                                                              
        github.com/ethereum/go-ethereum/accounts/abi tested by                                                                                                       
        github.com/ethereum/go-ethereum/accounts/abi.test imports                                                                                                    
        github.com/google/gofuzz: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874              
go: github.com/ava-labs/avalanchego/utils/crypto/secp256k1 imports                                                                                                   
        github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa tested by                                                                                                    
        github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.test imports                                                                                                 
        github.com/decred/dcrd/crypto/blake256: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874
go: github.com/ava-labs/avalanchego/utils/logging imports                                                                                                            
        gopkg.in/natefinch/lumberjack.v2 tested by                                                                                                                   
        gopkg.in/natefinch/lumberjack.v2.test imports                                                                                                                
        github.com/BurntSushi/toml: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874            
go: github.com/ava-labs/avalanchego/database/leveldb imports                                                                                                         
        github.com/syndtr/goleveldb/leveldb tested by                                                                                                                
        github.com/syndtr/goleveldb/leveldb.test imports                                                                                                             
        github.com/syndtr/goleveldb/leveldb/testutil imports                                                                                                         
        github.com/onsi/ginkgo/config: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874         
go: github.com/ava-labs/avalanchego/tests imports                                                                                                                    
        github.com/onsi/ginkgo/v2 imports                                                                                                                            
        github.com/onsi/ginkgo/v2/internal tested by                                                                                                                 
        github.com/onsi/ginkgo/v2/internal.test imports                                                                                                              
        github.com/onsi/gomega/gbytes: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874         
go: github.com/ava-labs/avalanchego/tests imports                                                                                                                    
        github.com/onsi/ginkgo/v2 imports                                                                                                                            
        github.com/onsi/ginkgo/v2/internal tested by                                                                                                                 
        github.com/onsi/ginkgo/v2/internal.test imports                                                                                                              
        github.com/onsi/gomega/gleak: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874          
go: github.com/ava-labs/avalanchego/tests imports                                                                                                                    
        github.com/onsi/ginkgo/v2 imports                                                                                                                            
        github.com/onsi/ginkgo/v2/internal tested by                                                                                                                 
        github.com/onsi/ginkgo/v2/internal.test imports                                                                                                              
        github.com/onsi/gomega/gmeasure: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874       
go: github.com/ava-labs/avalanchego/tests imports                                                                                                                    
        github.com/onsi/ginkgo/v2 imports                                                                                                                            
        github.com/onsi/ginkgo/v2/reporters tested by                                                                                                                
        github.com/onsi/ginkgo/v2/reporters.test imports                                                                                                             
        github.com/onsi/gomega/format: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874         
go: github.com/ava-labs/avalanchego/tests imports                                                                                                                    
        github.com/onsi/ginkgo/v2 imports                                                                                                                                 
        github.com/onsi/ginkgo/v2/types tested by                                                                                                                         
        github.com/onsi/ginkgo/v2/types.test imports                                                                                                                      
        github.com/onsi/gomega/ghttp: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874               
go: github.com/ava-labs/avalanchego/utils/crypto/ledger imports                                                                                                           
        github.com/ava-labs/ledger-avalanche/go imports                                                                                                                   
        github.com/btcsuite/btcd/btcec/v2/ecdsa tested by                                                                                                                 
        github.com/btcsuite/btcd/btcec/v2/ecdsa.test imports                                                                                                              
        github.com/btcsuite/btcd/chaincfg/chainhash: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874
go: github.com/ava-labs/avalanchego/utils/crypto/ledger imports                                                                                                           
        github.com/tyler-smith/go-bip32 imports                                                                                                                           
        github.com/FactomProject/basen tested by                                                                                                                          
        github.com/FactomProject/basen.test imports                                                                                                                       
        github.com/cmars/basen: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                     
go: github.com/ava-labs/avalanchego/utils/crypto/ledger imports                                                                                                           
        github.com/tyler-smith/go-bip32 imports                                                                                                                           
        github.com/FactomProject/basen tested by                                                                                                                          
        github.com/FactomProject/basen.test imports                                                                                                                       
        launchpad.net/gocheck: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                      
go: github.com/ava-labs/avalanchego/database/pebbledb imports                                                                                                             
        github.com/cockroachdb/pebble imports                                                                                                                             
        github.com/cockroachdb/errors imports                                                                                                                             
        github.com/getsentry/sentry-go tested by                                                                                                                          
        github.com/getsentry/sentry-go.test imports                                                                                                                       
        github.com/go-errors/errors: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                
go: github.com/ava-labs/avalanchego/database/pebbledb imports                                                                                                             
        github.com/cockroachdb/pebble imports                                                                                                                             
        github.com/cockroachdb/errors imports                                                                                                                             
        github.com/getsentry/sentry-go tested by                                                                                                                          
        github.com/getsentry/sentry-go.test imports                                                                                                                       
        github.com/pingcap/errors: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                  
go: github.com/ava-labs/avalanchego/tests imports                                                                                                                         
        github.com/onsi/ginkgo/v2 imports                                                                                                                                 
        github.com/onsi/ginkgo/v2/ginkgo tested by                                                                                                                        
        github.com/onsi/ginkgo/v2/ginkgo.test imports                                                                                                                     
        github.com/onsi/ginkgo/v2/internal/test_helpers imports                                                                                                           
        github.com/onsi/gomega/gcustom: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874             
go: github.com/ava-labs/avalanchego/tests imports                                                                                                                         
        github.com/onsi/ginkgo/v2 imports                                                                                                                                 
        github.com/onsi/ginkgo/v2/ginkgo tested by                                                                                                                        
        github.com/onsi/ginkgo/v2/ginkgo.test imports                                                                                                                     
        github.com/onsi/ginkgo/v2/internal/test_helpers imports                                                                                                           
        github.com/onsi/gomega/gstruct: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874             
go: github.com/ava-labs/avalanchego/tests imports                                                                                                                         
        github.com/onsi/ginkgo/v2 imports                                                                                                                                 
        github.com/onsi/ginkgo/v2/ginkgo tested by                                                                                                                        
        github.com/onsi/ginkgo/v2/ginkgo.test imports                                                                                                                     
        github.com/onsi/ginkgo/v2/internal/test_helpers imports                                                                                                           
        github.com/onsi/gomega/types: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874               
go: github.com/ava-labs/avalanchego/trace imports                                                                                                                         
        go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc imports                                                                                           
        go.opentelemetry.io/proto/otlp/collector/trace/v1 imports                                                                                                         
        github.com/grpc-ecosystem/grpc-gateway/v2/runtime imports                                                                                                         
        github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule tested by                                                                                             
        github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule.test imports                                                                                          
        github.com/golang/glog: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874                     
go: github.com/ava-labs/avalanchego/trace imports                                                                                                                         
        go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc imports                                                                                           
        go.opentelemetry.io/proto/otlp/collector/trace/v1 imports                                                                                                         
        github.com/grpc-ecosystem/grpc-gateway/v2/runtime tested by                                                                                                       
        github.com/grpc-ecosystem/grpc-gateway/v2/runtime.test imports                                                                                                    
        github.com/grpc-ecosystem/grpc-gateway/v2/runtime/internal/examplepb imports                                                                                      
        google.golang.org/genproto/googleapis/api/annotations imports                                                                                                     
        google.golang.org/genproto/googleapis/api imports                                                                                                                 
        google.golang.org/genproto/internal: github.com/ava-labs/coreth@v0.13.6-rc.1.0.20240702201359-ba2ce5367874: invalid version: unknown revision ba2ce5367874        
```