### PR TITLE
[ci] Ensure monitoring action compatibility for other repos

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -54,7 +54,7 @@ runs:
     - name: Notify of metrics availability
       if: (inputs.prometheus_id != '')
       shell: bash
-      run: .github/actions/run-monitored-tmpnet-cmd/notify-metrics-availability.sh
+      run: ${{ github.action_path }}/notify-metrics-availability.sh
       env:
         GRAFANA_URL: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-filter=is_ephemeral_node%7C%3D%7Cfalse&var-filter=gh_repo%7C%3D%7C${{ inputs.repository_owner }}%2F${{ inputs.repository_name }}&var-filter=gh_run_id%7C%3D%7C${{ inputs.run_id }}&var-filter=gh_run_attempt%7C%3D%7C${{ inputs.run_attempt }}
         GH_JOB_ID: ${{ inputs.job }}


### PR DESCRIPTION
The path to the notification script needs to be constructed with `github.action_path` to be compatible with other repos.