### PR TITLE
[vms/proposervm] Set build block time correctly  when anyone can propose

### DIFF
--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -407,7 +407,7 @@ func (vm *VM) getPostDurangoSlotTime(
 		delay = max(delay, vm.MinBlkDelay)
 		return parentTimestamp.Add(delay), nil
 	case errors.Is(err, proposer.ErrAnyoneCanPropose):
-		return parentTimestamp.Add(vm.MinBlkDelay), err
+		return parentTimestamp.Add(vm.MinBlkDelay), nil
 	default:
 		return time.Time{}, err
 	}

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -2388,3 +2388,65 @@ func TestHistoricalBlockDeletion(t *testing.T) {
 	issueBlock()
 	requireNumHeights(newNumHistoricalBlocks)
 }
+
+func TestGetPostDurangoSlotTime(t *testing.T) {
+	require := require.New(t)
+
+	var (
+		activationTime = time.Unix(0, 0)
+		durangoTime    = activationTime
+	)
+	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
+	defer func() {
+		require.NoError(proVM.Shutdown(context.Background()))
+	}()
+
+	valState.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+		return map[ids.NodeID]*validators.GetValidatorOutput{}, nil
+	}
+
+	coreBlk0 := snowmantest.BuildChild(snowmantest.Genesis)
+	statelessBlock0, err := statelessblock.BuildUnsigned(
+		snowmantest.GenesisID,
+		proVM.Time(),
+		0,
+		coreBlk0.Bytes(),
+	)
+	require.NoError(err)
+
+	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
+		switch blkID {
+		case snowmantest.GenesisID:
+			return snowmantest.Genesis, nil
+		case coreBlk0.ID():
+			return coreBlk0, nil
+		default:
+			return nil, errUnknownBlock
+		}
+	}
+	coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
+		switch {
+		case bytes.Equal(b, snowmantest.GenesisBytes):
+			return snowmantest.Genesis, nil
+		case bytes.Equal(b, coreBlk0.Bytes()):
+			return coreBlk0, nil
+		default:
+			return nil, errUnknownBlock
+		}
+	}
+
+	statefulBlock0, err := proVM.ParseBlock(context.Background(), statelessBlock0.Bytes())
+	require.NoError(err)
+
+	require.NoError(statefulBlock0.Verify(context.Background()))
+
+	currentTime := proVM.Clock.Time().Truncate(time.Second)
+	_, err = proVM.getPostDurangoSlotTime(
+		context.Background(),
+		statefulBlock0.Height()+1,
+		statelessBlock0.PChainHeight(),
+		proposer.TimeToSlot(statefulBlock0.Timestamp(), currentTime),
+		statefulBlock0.Timestamp(),
+	)
+	require.NoError(err)
+}


### PR DESCRIPTION
## Why this should be merged

When anyone can propose, the next block build time isn't correctly set since we wrongly return that error. This can cause delays in block building. Block verification is unaffected because this is strictly the build path.

## How this works

Don't return `ErrAnyoneCanPropose`

## How this was tested

Adds a regression test