### PR TITLE
Make math.Add64 and math.Mul64 generic

### DIFF
--- a/genesis/config.go
+++ b/genesis/config.go
@@ -143,12 +143,12 @@ func (c Config) Unparse() (UnparsedConfig, error) {
 func (c *Config) InitialSupply() (uint64, error) {
 	initialSupply := uint64(0)
 	for _, allocation := range c.Allocations {
-		newInitialSupply, err := math.Add64(initialSupply, allocation.InitialAmount)
+		newInitialSupply, err := math.Add(initialSupply, allocation.InitialAmount)
 		if err != nil {
 			return 0, err
 		}
 		for _, unlock := range allocation.UnlockSchedule {
-			newInitialSupply, err = math.Add64(newInitialSupply, unlock.Amount)
+			newInitialSupply, err = math.Add(newInitialSupply, unlock.Amount)
 			if err != nil {
 				return 0, err
 			}

--- a/snow/consensus/snowman/bootstrapper/majority.go
+++ b/snow/consensus/snowman/bootstrapper/majority.go
@@ -68,7 +68,7 @@ func (m *Majority) RecordOpinion(_ context.Context, nodeID ids.NodeID, blkIDs se
 
 	weight := m.nodeWeights[nodeID]
 	for blkID := range blkIDs {
-		newWeight, err := math.Add64(m.received[blkID], weight)
+		newWeight, err := math.Add(m.received[blkID], weight)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func (m *Majority) RecordOpinion(_ context.Context, nodeID ids.NodeID, blkIDs se
 		err         error
 	)
 	for _, weight := range m.nodeWeights {
-		totalWeight, err = math.Add64(totalWeight, weight)
+		totalWeight, err = math.Add(totalWeight, weight)
 		if err != nil {
 			return err
 		}

--- a/snow/consensus/snowman/bootstrapper/sampler.go
+++ b/snow/consensus/snowman/bootstrapper/sampler.go
@@ -27,7 +27,7 @@ func Sample[T comparable](elements map[T]uint64, maxSize int) (set.Set[T], error
 	for key, weight := range elements {
 		keys[i] = key
 		weights[i] = weight
-		totalWeight, err = math.Add64(totalWeight, weight)
+		totalWeight, err = math.Add(totalWeight, weight)
 		if err != nil {
 			return nil, err
 		}

--- a/snow/engine/avalanche/state/serializer.go
+++ b/snow/engine/avalanche/state/serializer.go
@@ -86,7 +86,7 @@ func (s *Serializer) BuildStopVtx(
 			return nil, err
 		}
 		parentHeight := parent.v.vtx.Height()
-		childHeight, err := math.Add64(parentHeight, 1)
+		childHeight, err := math.Add(parentHeight, 1)
 		if err != nil {
 			return nil, err
 		}

--- a/snow/engine/snowman/syncer/state_syncer.go
+++ b/snow/engine/snowman/syncer/state_syncer.go
@@ -310,7 +310,7 @@ func (ss *stateSyncer) AcceptedStateSummary(ctx context.Context, nodeID ids.Node
 			continue
 		}
 
-		newWeight, err := safemath.Add64(nodeWeight, ws.weight)
+		newWeight, err := safemath.Add(nodeWeight, ws.weight)
 		if err != nil {
 			ss.Ctx.Log.Error("failed to calculate new summary weight",
 				zap.Stringer("nodeID", nodeID),

--- a/snow/engine/snowman/transitive.go
+++ b/snow/engine/snowman/transitive.go
@@ -179,7 +179,7 @@ func (t *Transitive) Gossip(ctx context.Context) error {
 		return nil
 	}
 
-	nextHeightToAccept, err := math.Add64(lastAcceptedHeight, 1)
+	nextHeightToAccept, err := math.Add(lastAcceptedHeight, 1)
 	if err != nil {
 		t.Ctx.Log.Error("skipping block gossip",
 			zap.String("reason", "block height overflow"),
@@ -886,7 +886,7 @@ func (t *Transitive) sendQuery(
 	}
 
 	_, lastAcceptedHeight := t.Consensus.LastAccepted()
-	nextHeightToAccept, err := math.Add64(lastAcceptedHeight, 1)
+	nextHeightToAccept, err := math.Add(lastAcceptedHeight, 1)
 	if err != nil {
 		t.Ctx.Log.Error("dropped query for block",
 			zap.String("reason", "block height overflow"),

--- a/snow/networking/benchlist/benchlist.go
+++ b/snow/networking/benchlist/benchlist.go
@@ -294,7 +294,7 @@ func (b *benchlist) bench(nodeID ids.NodeID) {
 		return
 	}
 
-	newBenchedStake, err := safemath.Add64(benchedStake, validatorStake)
+	newBenchedStake, err := safemath.Add(benchedStake, validatorStake)
 	if err != nil {
 		// This should never happen
 		b.ctx.Log.Error("overflow calculating new benched stake",

--- a/snow/validators/set.go
+++ b/snow/validators/set.go
@@ -97,7 +97,7 @@ func (s *vdrSet) addWeight(nodeID ids.NodeID, weight uint64) error {
 	}
 
 	oldWeight := vdr.Weight
-	newWeight, err := math.Add64(oldWeight, weight)
+	newWeight, err := math.Add(oldWeight, weight)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (s *vdrSet) subsetWeight(subset set.Set[ids.NodeID]) (uint64, error) {
 		err         error
 	)
 	for nodeID := range subset {
-		totalWeight, err = math.Add64(totalWeight, s.getWeight(nodeID))
+		totalWeight, err = math.Add(totalWeight, s.getWeight(nodeID))
 		if err != nil {
 			return 0, err
 		}

--- a/utils/math/safe_math.go
+++ b/utils/math/safe_math.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 
 	"golang.org/x/exp/constraints"
-
-	"github.com/ava-labs/avalanchego/utils"
 )
 
 var (
@@ -26,9 +24,7 @@ var (
 func MaxUint[T constraints.Unsigned]() T {
 	// Unsigned integers will underflow to their max value.
 	// Ref: https://go.dev/ref/spec#Arithmetic_operators
-	var maxValue T
-	maxValue--
-	return maxValue
+	return T(0) - 1
 }
 
 // Add returns:
@@ -46,7 +42,7 @@ func Add[T constraints.Unsigned](a, b T) (T, error) {
 // 2) If there is underflow, an error
 func Sub[T constraints.Unsigned](a, b T) (T, error) {
 	if a < b {
-		return utils.Zero[T](), ErrUnderflow
+		return 0, ErrUnderflow
 	}
 	return a - b, nil
 }

--- a/utils/math/safe_math.go
+++ b/utils/math/safe_math.go
@@ -5,7 +5,6 @@ package math
 
 import (
 	"errors"
-	"math"
 
 	"golang.org/x/exp/constraints"
 
@@ -15,17 +14,28 @@ import (
 var (
 	ErrOverflow  = errors.New("overflow")
 	ErrUnderflow = errors.New("underflow")
+
+	// Deprecated: Add64 is deprecated. Use Add[uint64] instead.
+	Add64 = Add[uint64]
+
+	// Deprecated: Mul64 is deprecated. Use Mul[uint64] instead.
+	Mul64 = Mul[uint64]
 )
 
-// Add64 returns:
+// MaxUint returns the maximum value of an unsigned integer of type T.
+func MaxUint[T constraints.Unsigned]() T {
+	// Unsigned integers will underflow to their max value.
+	// Ref: https://go.dev/ref/spec#Arithmetic_operators
+	var maxValue T
+	maxValue--
+	return maxValue
+}
+
+// Add returns:
 // 1) a + b
 // 2) If there is overflow, an error
-//
-// Note that we don't have a generic Add function because checking for
-// an overflow requires knowing the max size of a given type, which we
-// don't know if we're adding generic types.
-func Add64(a, b uint64) (uint64, error) {
-	if a > math.MaxUint64-b {
+func Add[T constraints.Unsigned](a, b T) (T, error) {
+	if a > MaxUint[T]()-b {
 		return 0, ErrOverflow
 	}
 	return a + b, nil
@@ -44,12 +54,8 @@ func Sub[T constraints.Unsigned](a, b T) (T, error) {
 // Mul64 returns:
 // 1) a * b
 // 2) If there is overflow, an error
-//
-// Note that we don't have a generic Mul function because checking for
-// an overflow requires knowing the max size of a given type, which we
-// don't know if we're adding generic types.
-func Mul64(a, b uint64) (uint64, error) {
-	if b != 0 && a > math.MaxUint64/b {
+func Mul[T constraints.Unsigned](a, b T) (T, error) {
+	if b != 0 && a > MaxUint[T]()/b {
 		return 0, ErrOverflow
 	}
 	return a * b, nil

--- a/utils/math/safe_math.go
+++ b/utils/math/safe_math.go
@@ -22,9 +22,7 @@ var (
 
 // MaxUint returns the maximum value of an unsigned integer of type T.
 func MaxUint[T constraints.Unsigned]() T {
-	// Unsigned integers will underflow to their max value.
-	// Ref: https://go.dev/ref/spec#Arithmetic_operators
-	return T(0) - 1
+	return ^T(0)
 }
 
 // Add returns:

--- a/utils/math/safe_math.go
+++ b/utils/math/safe_math.go
@@ -45,7 +45,7 @@ func Sub[T constraints.Unsigned](a, b T) (T, error) {
 	return a - b, nil
 }
 
-// Mul64 returns:
+// Mul returns:
 // 1) a * b
 // 2) If there is overflow, an error
 func Mul[T constraints.Unsigned](a, b T) (T, error) {

--- a/utils/math/safe_math_test.go
+++ b/utils/math/safe_math_test.go
@@ -12,28 +12,39 @@ import (
 
 const maxUint64 uint64 = math.MaxUint64
 
-func TestAdd64(t *testing.T) {
+func TestMaxUint(t *testing.T) {
 	require := require.New(t)
 
-	sum, err := Add64(0, maxUint64)
+	require.Equal(uint(math.MaxUint), MaxUint[uint]())
+	require.Equal(uint8(math.MaxUint8), MaxUint[uint8]())
+	require.Equal(uint16(math.MaxUint16), MaxUint[uint16]())
+	require.Equal(uint32(math.MaxUint32), MaxUint[uint32]())
+	require.Equal(uint64(math.MaxUint64), MaxUint[uint64]())
+	require.Equal(uintptr(math.MaxUint), MaxUint[uintptr]())
+}
+
+func TestAdd(t *testing.T) {
+	require := require.New(t)
+
+	sum, err := Add(0, maxUint64)
 	require.NoError(err)
 	require.Equal(maxUint64, sum)
 
-	sum, err = Add64(maxUint64, 0)
+	sum, err = Add(maxUint64, 0)
 	require.NoError(err)
 	require.Equal(maxUint64, sum)
 
-	sum, err = Add64(uint64(1<<62), uint64(1<<62))
+	sum, err = Add(uint64(1<<62), uint64(1<<62))
 	require.NoError(err)
 	require.Equal(uint64(1<<63), sum)
 
-	_, err = Add64(1, maxUint64)
+	_, err = Add(1, maxUint64)
 	require.ErrorIs(err, ErrOverflow)
 
-	_, err = Add64(maxUint64, 1)
+	_, err = Add(maxUint64, 1)
 	require.ErrorIs(err, ErrOverflow)
 
-	_, err = Add64(maxUint64, maxUint64)
+	_, err = Add(maxUint64, maxUint64)
 	require.ErrorIs(err, ErrOverflow)
 }
 
@@ -63,34 +74,34 @@ func TestSub(t *testing.T) {
 	require.ErrorIs(err, ErrUnderflow)
 }
 
-func TestMul64(t *testing.T) {
+func TestMul(t *testing.T) {
 	require := require.New(t)
 
-	got, err := Mul64(0, maxUint64)
+	got, err := Mul(0, maxUint64)
 	require.NoError(err)
 	require.Zero(got)
 
-	got, err = Mul64(maxUint64, 0)
+	got, err = Mul(maxUint64, 0)
 	require.NoError(err)
 	require.Zero(got)
 
-	got, err = Mul64(uint64(1), uint64(3))
+	got, err = Mul(uint64(1), uint64(3))
 	require.NoError(err)
 	require.Equal(uint64(3), got)
 
-	got, err = Mul64(uint64(3), uint64(1))
+	got, err = Mul(uint64(3), uint64(1))
 	require.NoError(err)
 	require.Equal(uint64(3), got)
 
-	got, err = Mul64(uint64(2), uint64(3))
+	got, err = Mul(uint64(2), uint64(3))
 	require.NoError(err)
 	require.Equal(uint64(6), got)
 
-	got, err = Mul64(maxUint64, 0)
+	got, err = Mul(maxUint64, 0)
 	require.NoError(err)
 	require.Zero(got)
 
-	_, err = Mul64(maxUint64-1, 2)
+	_, err = Mul(maxUint64-1, 2)
 	require.ErrorIs(err, ErrOverflow)
 }
 

--- a/utils/sampler/weighted_array.go
+++ b/utils/sampler/weighted_array.go
@@ -67,7 +67,7 @@ func (s *weightedArray) Initialize(weights []uint64) error {
 
 	cumulativeWeight := uint64(0)
 	for i := 0; i < len(s.arr); i++ {
-		newWeight, err := math.Add64(
+		newWeight, err := math.Add(
 			cumulativeWeight,
 			s.arr[i].cumulativeWeight,
 		)

--- a/utils/sampler/weighted_benchmark_test.go
+++ b/utils/sampler/weighted_benchmark_test.go
@@ -88,7 +88,7 @@ func CalcWeightedPoW(exponent float64, size int) (uint64, []uint64, error) {
 		weight := uint64(math.Pow(float64(i+1), exponent))
 		weights[i] = weight
 
-		newWeight, err := safemath.Add64(totalWeight, weight)
+		newWeight, err := safemath.Add(totalWeight, weight)
 		if err != nil {
 			return 0, nil, err
 		}

--- a/utils/sampler/weighted_best.go
+++ b/utils/sampler/weighted_best.go
@@ -34,7 +34,7 @@ type weightedBest struct {
 func (s *weightedBest) Initialize(weights []uint64) error {
 	totalWeight := uint64(0)
 	for _, weight := range weights {
-		newWeight, err := safemath.Add64(totalWeight, weight)
+		newWeight, err := safemath.Add(totalWeight, weight)
 		if err != nil {
 			return err
 		}

--- a/utils/sampler/weighted_heap.go
+++ b/utils/sampler/weighted_heap.go
@@ -67,7 +67,7 @@ func (s *weightedHeap) Initialize(weights []uint64) error {
 		// Explicitly performing a shift here allows the compiler to avoid
 		// checking for negative numbers, which saves a couple cycles
 		parentIndex := (i - 1) >> 1
-		newWeight, err := math.Add64(
+		newWeight, err := math.Add(
 			s.heap[parentIndex].cumulativeWeight,
 			s.heap[i].cumulativeWeight,
 		)

--- a/utils/sampler/weighted_linear.go
+++ b/utils/sampler/weighted_linear.go
@@ -55,7 +55,7 @@ func (s *weightedLinear) Initialize(weights []uint64) error {
 	utils.Sort(s.arr)
 
 	for i := 1; i < len(s.arr); i++ {
-		newWeight, err := math.Add64(
+		newWeight, err := math.Add(
 			s.arr[i-1].cumulativeWeight,
 			s.arr[i].cumulativeWeight,
 		)

--- a/utils/sampler/weighted_uniform.go
+++ b/utils/sampler/weighted_uniform.go
@@ -33,7 +33,7 @@ type weightedUniform struct {
 func (s *weightedUniform) Initialize(weights []uint64) error {
 	totalWeight := uint64(0)
 	for _, weight := range weights {
-		newWeight, err := safemath.Add64(totalWeight, weight)
+		newWeight, err := safemath.Add(totalWeight, weight)
 		if err != nil {
 			return err
 		}

--- a/utils/sampler/weighted_without_replacement_generic.go
+++ b/utils/sampler/weighted_without_replacement_generic.go
@@ -15,7 +15,7 @@ type weightedWithoutReplacementGeneric struct {
 func (s *weightedWithoutReplacementGeneric) Initialize(weights []uint64) error {
 	totalWeight := uint64(0)
 	for _, weight := range weights {
-		newWeight, err := safemath.Add64(totalWeight, weight)
+		newWeight, err := safemath.Add(totalWeight, weight)
 		if err != nil {
 			return err
 		}

--- a/vms/avm/service.go
+++ b/vms/avm/service.go
@@ -579,7 +579,7 @@ func (s *Service) GetBalance(_ *http.Request, args *GetBalanceArgs, reply *GetBa
 		if !args.IncludePartial && (len(owners.Addrs) != 1 || owners.Locktime > now) {
 			continue
 		}
-		amt, err := safemath.Add64(transferable.Amount(), uint64(reply.Balance))
+		amt, err := safemath.Add(transferable.Amount(), uint64(reply.Balance))
 		if err != nil {
 			return err
 		}
@@ -650,7 +650,7 @@ func (s *Service) GetAllBalances(_ *http.Request, args *GetAllBalancesArgs, repl
 		assetID := utxo.AssetID()
 		assetIDs.Add(assetID)
 		balance := balances[assetID] // 0 if key doesn't exist
-		balance, err := safemath.Add64(transferable.Amount(), balance)
+		balance, err := safemath.Add(transferable.Amount(), balance)
 		if err != nil {
 			balances[assetID] = math.MaxUint64
 		} else {
@@ -1264,7 +1264,7 @@ func (s *Service) buildSendMultiple(args *SendMultipleArgs) (*txs.Tx, ids.ShortI
 			assetIDs[output.AssetID] = assetID
 		}
 		currentAmount := amounts[assetID]
-		newAmount, err := safemath.Add64(currentAmount, uint64(output.Amount))
+		newAmount, err := safemath.Add(currentAmount, uint64(output.Amount))
 		if err != nil {
 			return nil, ids.ShortEmpty, fmt.Errorf("problem calculating required spend amount: %w", err)
 		}
@@ -1295,7 +1295,7 @@ func (s *Service) buildSendMultiple(args *SendMultipleArgs) (*txs.Tx, ids.ShortI
 		amountsWithFee[assetID] = amount
 	}
 
-	amountWithFee, err := safemath.Add64(amounts[s.vm.feeAssetID], s.vm.TxFee)
+	amountWithFee, err := safemath.Add(amounts[s.vm.feeAssetID], s.vm.TxFee)
 	if err != nil {
 		return nil, ids.ShortEmpty, fmt.Errorf("problem calculating required spend amount: %w", err)
 	}
@@ -1818,7 +1818,7 @@ func (s *Service) buildImport(args *ImportArgs) (*txs.Tx, error) {
 			return nil, err
 		}
 		for asset, amount := range localAmountsSpent {
-			newAmount, err := safemath.Add64(amountsSpent[asset], amount)
+			newAmount, err := safemath.Add(amountsSpent[asset], amount)
 			if err != nil {
 				return nil, fmt.Errorf("problem calculating required spend amount: %w", err)
 			}
@@ -1955,7 +1955,7 @@ func (s *Service) buildExport(args *ExportArgs) (*txs.Tx, ids.ShortID, error) {
 
 	amounts := map[ids.ID]uint64{}
 	if assetID == s.vm.feeAssetID {
-		amountWithFee, err := safemath.Add64(uint64(args.Amount), s.vm.TxFee)
+		amountWithFee, err := safemath.Add(uint64(args.Amount), s.vm.TxFee)
 		if err != nil {
 			return nil, ids.ShortEmpty, fmt.Errorf("problem calculating required spend amount: %w", err)
 		}

--- a/vms/avm/utxo/spender.go
+++ b/vms/avm/utxo/spender.go
@@ -141,7 +141,7 @@ func (s *spender) Spend(
 			// this input doesn't have an amount, so I don't care about it here
 			continue
 		}
-		newAmountSpent, err := math.Add64(amountSpent, input.Amount())
+		newAmountSpent, err := math.Add(amountSpent, input.Amount())
 		if err != nil {
 			// there was an error calculating the consumed amount, just error
 			return nil, nil, nil, errSpendOverflow
@@ -274,7 +274,7 @@ func (s *spender) SpendAll(
 			// this input doesn't have an amount, so I don't care about it here
 			continue
 		}
-		newAmountSpent, err := math.Add64(amountSpent, input.Amount())
+		newAmountSpent, err := math.Add(amountSpent, input.Amount())
 		if err != nil {
 			// there was an error calculating the consumed amount, just error
 			return nil, nil, nil, errSpendOverflow

--- a/vms/avm/wallet_service.go
+++ b/vms/avm/wallet_service.go
@@ -229,7 +229,7 @@ func (w *WalletService) SendMultiple(_ *http.Request, args *SendMultipleArgs, re
 			assetIDs[output.AssetID] = assetID
 		}
 		currentAmount := amounts[assetID]
-		newAmount, err := math.Add64(currentAmount, uint64(output.Amount))
+		newAmount, err := math.Add(currentAmount, uint64(output.Amount))
 		if err != nil {
 			return fmt.Errorf("problem calculating required spend amount: %w", err)
 		}
@@ -257,7 +257,7 @@ func (w *WalletService) SendMultiple(_ *http.Request, args *SendMultipleArgs, re
 
 	amountsWithFee := maps.Clone(amounts)
 
-	amountWithFee, err := math.Add64(amounts[w.vm.feeAssetID], w.vm.TxFee)
+	amountWithFee, err := math.Add(amounts[w.vm.feeAssetID], w.vm.TxFee)
 	if err != nil {
 		return fmt.Errorf("problem calculating required spend amount: %w", err)
 	}

--- a/vms/components/avax/flow_checker.go
+++ b/vms/components/avax/flow_checker.go
@@ -35,7 +35,7 @@ func (fc *FlowChecker) Produce(assetID ids.ID, amount uint64) {
 
 func (fc *FlowChecker) add(value map[ids.ID]uint64, assetID ids.ID, amount uint64) {
 	var err error
-	value[assetID], err = math.Add64(value[assetID], amount)
+	value[assetID], err = math.Add(value[assetID], amount)
 	fc.errs.Add(err)
 }
 

--- a/vms/components/avax/utxo_fetching.go
+++ b/vms/components/avax/utxo_fetching.go
@@ -24,7 +24,7 @@ func GetBalance(db UTXOReader, addrs set.Set[ids.ShortID]) (uint64, error) {
 	balance := uint64(0)
 	for _, utxo := range utxos {
 		if out, ok := utxo.Out.(Amounter); ok {
-			balance, err = safemath.Add64(out.Amount(), balance)
+			balance, err = safemath.Add(out.Amount(), balance)
 			if err != nil {
 				return 0, err
 			}

--- a/vms/example/xsvm/state/storage.go
+++ b/vms/example/xsvm/state/storage.go
@@ -133,7 +133,7 @@ func IncreaseBalance(db database.KeyValueReaderWriterDeleter, address ids.ShortI
 	if err != nil {
 		return err
 	}
-	balance, err = math.Add64(balance, amount)
+	balance, err = math.Add(balance, amount)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func IncreaseLoan(db database.KeyValueReaderWriterDeleter, chainID ids.ID, amoun
 	if err != nil {
 		return err
 	}
-	balance, err = math.Add64(balance, amount)
+	balance, err = math.Add(balance, amount)
 	if err != nil {
 		return err
 	}

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -280,7 +280,7 @@ func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, repl
 			}
 			stake[i] = utxo
 
-			newWeight, err := math.Add64(weight, uint64(apiUTXO.Amount))
+			newWeight, err := math.Add(weight, uint64(apiUTXO.Amount))
 			if err != nil {
 				return errStakeOverflow
 			}

--- a/vms/platformvm/reward/calculator.go
+++ b/vms/platformvm/reward/calculator.go
@@ -78,7 +78,7 @@ func Split(totalAmount uint64, shares uint32) (uint64, uint64) {
 	remainderAmount := remainderShares * (totalAmount / PercentDenominator)
 
 	// Delay rounding as long as possible for small numbers
-	if optimisticReward, err := math.Mul64(remainderShares, totalAmount); err == nil {
+	if optimisticReward, err := math.Mul(remainderShares, totalAmount); err == nil {
 		remainderAmount = optimisticReward / PercentDenominator
 	}
 

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -192,14 +192,14 @@ utxoFor:
 		switch out := utxo.Out.(type) {
 		case *secp256k1fx.TransferOutput:
 			if out.Locktime <= currentTime {
-				newBalance, err := safemath.Add64(unlockeds[assetID], out.Amount())
+				newBalance, err := safemath.Add(unlockeds[assetID], out.Amount())
 				if err != nil {
 					unlockeds[assetID] = math.MaxUint64
 				} else {
 					unlockeds[assetID] = newBalance
 				}
 			} else {
-				newBalance, err := safemath.Add64(lockedNotStakeables[assetID], out.Amount())
+				newBalance, err := safemath.Add(lockedNotStakeables[assetID], out.Amount())
 				if err != nil {
 					lockedNotStakeables[assetID] = math.MaxUint64
 				} else {
@@ -215,21 +215,21 @@ utxoFor:
 				)
 				continue utxoFor
 			case innerOut.Locktime > currentTime:
-				newBalance, err := safemath.Add64(lockedNotStakeables[assetID], out.Amount())
+				newBalance, err := safemath.Add(lockedNotStakeables[assetID], out.Amount())
 				if err != nil {
 					lockedNotStakeables[assetID] = math.MaxUint64
 				} else {
 					lockedNotStakeables[assetID] = newBalance
 				}
 			case out.Locktime <= currentTime:
-				newBalance, err := safemath.Add64(unlockeds[assetID], out.Amount())
+				newBalance, err := safemath.Add(unlockeds[assetID], out.Amount())
 				if err != nil {
 					unlockeds[assetID] = math.MaxUint64
 				} else {
 					unlockeds[assetID] = newBalance
 				}
 			default:
-				newBalance, err := safemath.Add64(lockedStakeables[assetID], out.Amount())
+				newBalance, err := safemath.Add(lockedStakeables[assetID], out.Amount())
 				if err != nil {
 					lockedStakeables[assetID] = math.MaxUint64
 				} else {
@@ -245,7 +245,7 @@ utxoFor:
 
 	balances := maps.Clone(lockedStakeables)
 	for assetID, amount := range lockedNotStakeables {
-		newBalance, err := safemath.Add64(balances[assetID], amount)
+		newBalance, err := safemath.Add(balances[assetID], amount)
 		if err != nil {
 			balances[assetID] = math.MaxUint64
 		} else {
@@ -253,7 +253,7 @@ utxoFor:
 		}
 	}
 	for assetID, amount := range unlockeds {
-		newBalance, err := safemath.Add64(balances[assetID], amount)
+		newBalance, err := safemath.Add(balances[assetID], amount)
 		if err != nil {
 			balances[assetID] = math.MaxUint64
 		} else {
@@ -1898,7 +1898,7 @@ func getStakeHelper(tx *txs.Tx, addrs set.Set[ids.ShortID], totalAmountStaked ma
 		}
 
 		assetID := output.AssetID()
-		newAmount, err := safemath.Add64(totalAmountStaked[assetID], secpOut.Amt)
+		newAmount, err := safemath.Add(totalAmountStaked[assetID], secpOut.Amt)
 		if err != nil {
 			newAmount = math.MaxUint64
 		}

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -379,7 +379,7 @@ type ValidatorWeightDiff struct {
 func (v *ValidatorWeightDiff) Add(negative bool, amount uint64) error {
 	if v.Decrease == negative {
 		var err error
-		v.Amount, err = safemath.Add64(v.Amount, amount)
+		v.Amount, err = safemath.Add(v.Amount, amount)
 		return err
 	}
 
@@ -1126,7 +1126,7 @@ func applyWeightDiff(
 	if weightDiff.Decrease {
 		// The validator's weight was decreased at this block, so in the
 		// prior block it was higher.
-		vdr.Weight, err = safemath.Add64(vdr.Weight, weightDiff.Amount)
+		vdr.Weight, err = safemath.Add(vdr.Weight, weightDiff.Amount)
 	} else {
 		// The validator's weight was increased at this block, so in the
 		// prior block it was lower.
@@ -1232,7 +1232,7 @@ func (s *state) syncGenesis(genesisBlk block.Block, genesis *genesis.Genesis) er
 			stakeAmount,
 			currentSupply,
 		)
-		newCurrentSupply, err := safemath.Add64(currentSupply, potentialReward)
+		newCurrentSupply, err := safemath.Add(currentSupply, potentialReward)
 		if err != nil {
 			return err
 		}

--- a/vms/platformvm/txs/add_delegator_tx.go
+++ b/vms/platformvm/txs/add_delegator_tx.go
@@ -99,7 +99,7 @@ func (tx *AddDelegatorTx) SyntacticVerify(ctx *snow.Context) error {
 		if err := out.Verify(); err != nil {
 			return fmt.Errorf("output verification failed: %w", err)
 		}
-		newWeight, err := math.Add64(totalStakeWeight, out.Output().Amount())
+		newWeight, err := math.Add(totalStakeWeight, out.Output().Amount())
 		if err != nil {
 			return err
 		}

--- a/vms/platformvm/txs/add_permissionless_delegator_tx.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx.go
@@ -110,7 +110,7 @@ func (tx *AddPermissionlessDelegatorTx) SyntacticVerify(ctx *snow.Context) error
 	stakedAssetID := firstStakeOutput.AssetID()
 	totalStakeWeight := firstStakeOutput.Output().Amount()
 	for _, out := range tx.StakeOuts[1:] {
-		newWeight, err := math.Add64(totalStakeWeight, out.Output().Amount())
+		newWeight, err := math.Add(totalStakeWeight, out.Output().Amount())
 		if err != nil {
 			return err
 		}

--- a/vms/platformvm/txs/add_permissionless_validator_tx.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx.go
@@ -160,7 +160,7 @@ func (tx *AddPermissionlessValidatorTx) SyntacticVerify(ctx *snow.Context) error
 	stakedAssetID := firstStakeOutput.AssetID()
 	totalStakeWeight := firstStakeOutput.Output().Amount()
 	for _, out := range tx.StakeOuts[1:] {
-		newWeight, err := math.Add64(totalStakeWeight, out.Output().Amount())
+		newWeight, err := math.Add(totalStakeWeight, out.Output().Amount())
 		if err != nil {
 			return err
 		}

--- a/vms/platformvm/txs/add_validator_tx.go
+++ b/vms/platformvm/txs/add_validator_tx.go
@@ -112,7 +112,7 @@ func (tx *AddValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 		if err := out.Verify(); err != nil {
 			return fmt.Errorf("failed to verify output: %w", err)
 		}
-		newWeight, err := math.Add64(totalStakeWeight, out.Output().Amount())
+		newWeight, err := math.Add(totalStakeWeight, out.Output().Amount())
 		if err != nil {
 			return err
 		}

--- a/vms/platformvm/txs/executor/staker_tx_verification.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification.go
@@ -425,7 +425,7 @@ func verifyAddDelegatorTx(
 		)
 	}
 
-	maximumWeight, err := safemath.Mul64(MaxValidatorWeightFactor, primaryNetworkValidator.Weight)
+	maximumWeight, err := safemath.Mul(MaxValidatorWeightFactor, primaryNetworkValidator.Weight)
 	if err != nil {
 		return nil, ErrStakeOverflow
 	}
@@ -678,7 +678,7 @@ func verifyAddPermissionlessDelegatorTx(
 		)
 	}
 
-	maximumWeight, err := safemath.Mul64(
+	maximumWeight, err := safemath.Mul(
 		uint64(delegatorRules.maxValidatorWeightFactor),
 		validator.Weight,
 	)

--- a/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
@@ -125,7 +125,7 @@ func overDelegated(
 	if err != nil {
 		return true, err
 	}
-	newMaxWeight, err := math.Add64(maxWeight, delegatorWeight)
+	newMaxWeight, err := math.Add(maxWeight, delegatorWeight)
 	if err != nil {
 		return true, err
 	}
@@ -159,7 +159,7 @@ func GetMaxWeight(
 	for currentDelegatorIterator.Next() {
 		currentDelegator := currentDelegatorIterator.Value()
 
-		currentWeight, err = math.Add64(currentWeight, currentDelegator.Weight)
+		currentWeight, err = math.Add(currentWeight, currentDelegator.Weight)
 		if err != nil {
 			currentDelegatorIterator.Release()
 			return 0, err
@@ -202,7 +202,7 @@ func GetMaxWeight(
 
 		var op func(uint64, uint64) (uint64, error)
 		if isAdded {
-			op = math.Add64
+			op = math.Add
 		} else {
 			op = math.Sub[uint64]
 		}

--- a/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
@@ -204,7 +204,7 @@ func GetMaxWeight(
 		if isAdded {
 			op = math.Add
 		} else {
-			op = math.Sub[uint64]
+			op = math.Sub
 		}
 		currentWeight, err = op(currentWeight, delegator.Weight)
 		if err != nil {

--- a/vms/platformvm/utxo/verifier.go
+++ b/vms/platformvm/utxo/verifier.go
@@ -206,7 +206,7 @@ func (h *verifier) VerifySpendUTXOs(
 		amount := in.Amount()
 
 		if now >= locktime {
-			newUnlockedConsumed, err := math.Add64(unlockedConsumed[realAssetID], amount)
+			newUnlockedConsumed, err := math.Add(unlockedConsumed[realAssetID], amount)
 			if err != nil {
 				return err
 			}
@@ -234,7 +234,7 @@ func (h *verifier) VerifySpendUTXOs(
 			owners = make(map[ids.ID]uint64)
 			lockedConsumedAsset[locktime] = owners
 		}
-		newAmount, err := math.Add64(owners[ownerID], amount)
+		newAmount, err := math.Add(owners[ownerID], amount)
 		if err != nil {
 			return err
 		}
@@ -255,7 +255,7 @@ func (h *verifier) VerifySpendUTXOs(
 		amount := output.Amount()
 
 		if locktime == 0 {
-			newUnlockedProduced, err := math.Add64(unlockedProduced[assetID], amount)
+			newUnlockedProduced, err := math.Add(unlockedProduced[assetID], amount)
 			if err != nil {
 				return err
 			}
@@ -283,7 +283,7 @@ func (h *verifier) VerifySpendUTXOs(
 			owners = make(map[ids.ID]uint64)
 			lockedProducedAsset[locktime] = owners
 		}
-		newAmount, err := math.Add64(owners[ownerID], amount)
+		newAmount, err := math.Add(owners[ownerID], amount)
 		if err != nil {
 			return err
 		}

--- a/vms/platformvm/warp/validator.go
+++ b/vms/platformvm/warp/validator.go
@@ -71,7 +71,7 @@ func FlattenValidatorSet(vdrSet map[ids.NodeID]*validators.GetValidatorOutput) (
 		err         error
 	)
 	for _, vdr := range vdrSet {
-		totalWeight, err = math.Add64(totalWeight, vdr.Weight)
+		totalWeight, err = math.Add(totalWeight, vdr.Weight)
 		if err != nil {
 			return nil, 0, fmt.Errorf("%w: %w", ErrWeightOverflow, err)
 		}
@@ -136,7 +136,7 @@ func SumWeight(vdrs []*Validator) (uint64, error) {
 		err    error
 	)
 	for _, vdr := range vdrs {
-		weight, err = math.Add64(weight, vdr.Weight)
+		weight, err = math.Add(weight, vdr.Weight)
 		if err != nil {
 			return 0, fmt.Errorf("%w: %w", ErrWeightOverflow, err)
 		}

--- a/vms/proposervm/proposer/windower.go
+++ b/vms/proposervm/proposer/windower.go
@@ -123,7 +123,7 @@ func (w *windower) Proposers(ctx context.Context, blockHeight, pChainHeight uint
 
 	var totalWeight uint64
 	for _, validator := range validators {
-		totalWeight, err = math.Add64(totalWeight, validator.weight)
+		totalWeight, err = math.Add(totalWeight, validator.weight)
 		if err != nil {
 			return nil, err
 		}

--- a/vms/secp256k1fx/input.go
+++ b/vms/secp256k1fx/input.go
@@ -28,7 +28,7 @@ type Input struct {
 
 func (in *Input) Cost() (uint64, error) {
 	numSigs := uint64(len(in.SigIndices))
-	return math.Mul64(numSigs, CostPerSignature)
+	return math.Mul(numSigs, CostPerSignature)
 }
 
 // Verify this input is syntactically valid

--- a/wallet/chain/c/backend.go
+++ b/wallet/chain/c/backend.go
@@ -116,7 +116,7 @@ func (b *backend) AcceptAtomicTx(ctx context.Context, tx *evm.Tx) error {
 			}
 			account.Balance.Sub(account.Balance, balance)
 
-			newNonce, err := math.Add64(input.Nonce, 1)
+			newNonce, err := math.Add(input.Nonce, 1)
 			if err != nil {
 				return err
 			}

--- a/wallet/chain/c/builder.go
+++ b/wallet/chain/c/builder.go
@@ -170,7 +170,7 @@ func (b *builder) GetImportableBalance(
 			continue
 		}
 
-		newBalance, err := math.Add64(balance, amount)
+		newBalance, err := math.Add(balance, amount)
 		if err != nil {
 			return 0, err
 		}
@@ -218,7 +218,7 @@ func (b *builder) NewImportTx(
 			},
 		})
 
-		newImportedAmount, err := math.Add64(importedAmount, amount)
+		newImportedAmount, err := math.Add(importedAmount, amount)
 		if err != nil {
 			return nil, err
 		}
@@ -280,7 +280,7 @@ func (b *builder) NewExportTx(
 			Out:   output,
 		}
 
-		newExportedAmount, err := math.Add64(exportedAmount, output.Amt)
+		newExportedAmount, err := math.Add(exportedAmount, output.Amt)
 		if err != nil {
 			return nil, err
 		}
@@ -311,7 +311,7 @@ func (b *builder) NewExportTx(
 		return nil, err
 	}
 
-	amountToConsume, err := math.Add64(exportedAmount, initialFee)
+	amountToConsume, err := math.Add(exportedAmount, initialFee)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (b *builder) NewExportTx(
 		// Update the cost for the next iteration
 		cost = newCost
 
-		amountToConsume, err = math.Add64(amountToConsume, additionalFee)
+		amountToConsume, err = math.Add(amountToConsume, additionalFee)
 		if err != nil {
 			return nil, err
 		}

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -315,7 +315,7 @@ func (b *builder) NewBaseTx(
 	}
 	for _, out := range outputs {
 		assetID := out.AssetID()
-		amountToBurn, err := math.Add64(toBurn[assetID], out.Out.Amount())
+		amountToBurn, err := math.Add(toBurn[assetID], out.Out.Amount())
 		if err != nil {
 			return nil, err
 		}
@@ -630,7 +630,7 @@ func (b *builder) NewImportTx(
 		})
 
 		assetID := utxo.AssetID()
-		newImportedAmount, err := math.Add64(importedAmounts[assetID], out.Amt)
+		newImportedAmount, err := math.Add(importedAmounts[assetID], out.Amt)
 		if err != nil {
 			return nil, err
 		}
@@ -702,7 +702,7 @@ func (b *builder) NewExportTx(
 	}
 	for _, out := range outputs {
 		assetID := out.AssetID()
-		amountToBurn, err := math.Add64(toBurn[assetID], out.Out.Amount())
+		amountToBurn, err := math.Add(toBurn[assetID], out.Out.Amount())
 		if err != nil {
 			return nil, err
 		}
@@ -916,7 +916,7 @@ func (b *builder) getBalance(
 		}
 
 		assetID := utxo.AssetID()
-		balance[assetID], err = math.Add64(balance[assetID], out.Amt)
+		balance[assetID], err = math.Add(balance[assetID], out.Amt)
 		if err != nil {
 			return nil, err
 		}

--- a/wallet/chain/x/builder/builder.go
+++ b/wallet/chain/x/builder/builder.go
@@ -213,7 +213,7 @@ func (b *builder) NewBaseTx(
 	}
 	for _, out := range outputs {
 		assetID := out.AssetID()
-		amountToBurn, err := math.Add64(toBurn[assetID], out.Out.Amount())
+		amountToBurn, err := math.Add(toBurn[assetID], out.Out.Amount())
 		if err != nil {
 			return nil, err
 		}
@@ -408,7 +408,7 @@ func (b *builder) NewImportTx(
 		})
 
 		assetID := utxo.AssetID()
-		newImportedAmount, err := math.Add64(importedAmounts[assetID], out.Amt)
+		newImportedAmount, err := math.Add(importedAmounts[assetID], out.Amt)
 		if err != nil {
 			return nil, err
 		}
@@ -480,7 +480,7 @@ func (b *builder) NewExportTx(
 	}
 	for _, out := range outputs {
 		assetID := out.AssetID()
-		amountToBurn, err := math.Add64(toBurn[assetID], out.Out.Amount())
+		amountToBurn, err := math.Add(toBurn[assetID], out.Out.Amount())
 		if err != nil {
 			return nil, err
 		}
@@ -540,7 +540,7 @@ func (b *builder) getBalance(
 		}
 
 		assetID := utxo.AssetID()
-		balance[assetID], err = math.Add64(balance[assetID], out.Amt)
+		balance[assetID], err = math.Add(balance[assetID], out.Amt)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Why this should be merged

Resolves the asymmetry between `math.Sub` and `math.Add64`/`math.Mul64`.

## How this works

`^uint(0) == maxUint`

## How this was tested

- [X] Added test of wrap-around behavior for all unsigned int types.
- [X] CI