### PR TITLE
[vms/platformvm] `RegisterDUnsignedTxsTypes` -> `RegisterDurangoUnsignedTxsTypes`

### DIFF
--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -35,7 +35,7 @@ func init() {
 			RegisterApricotBlockTypes(c),
 			txs.RegisterUnsignedTxsTypes(c),
 			RegisterBanffBlockTypes(c),
-			txs.RegisterDUnsignedTxsTypes(c),
+			txs.RegisterDurangoUnsignedTxsTypes(c),
 		)
 	}
 

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -42,7 +42,7 @@ func init() {
 
 		c.SkipRegistrations(4)
 
-		errs.Add(RegisterDUnsignedTxsTypes(c))
+		errs.Add(RegisterDurangoUnsignedTxsTypes(c))
 	}
 
 	Codec = codec.NewDefaultManager()
@@ -103,7 +103,7 @@ func RegisterUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
 	return errs.Err
 }
 
-func RegisterDUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
+func RegisterDurangoUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
 	return errors.Join(
 		targetCodec.RegisterType(&TransferSubnetOwnershipTx{}),
 		targetCodec.RegisterType(&BaseTx{}),


### PR DESCRIPTION
## Why this should be merged

Should be `Durango` not `D`.

## How this works

Rename

## How this was tested

CI