### PR TITLE
[ci] Lint on non-test code importing packages from /tests

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -92,8 +92,8 @@ function test_import_testing_only_in_tests {
 
   IMPORT_TESTING=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '^\s*(import\s+)?"testing"');
   IMPORT_TESTIFY=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/stretchr/testify');
-  IMPORT_FROM_TESTS=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/ava-labs/tests/');
-  IMPORT_TEST_PKG=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '"github.com/ava-labs/.*?test"');
+  IMPORT_FROM_TESTS=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/ava-labs/avalanchego/tests/');
+  IMPORT_TEST_PKG=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '"github.com/ava-labs/avalanchego/.*?test');
 
   # TODO(arr4n): send a PR to add support for build tags in `mockgen` and then enable this.
   # IMPORT_GOMOCK=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"go.uber.org/mock');

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -93,7 +93,7 @@ function test_import_testing_only_in_tests {
   IMPORT_TESTING=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '^\s*(import\s+)?"testing"');
   IMPORT_TESTIFY=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/stretchr/testify');
   IMPORT_FROM_TESTS=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/ava-labs/avalanchego/tests/');
-  IMPORT_TEST_PKG=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '"github.com/ava-labs/avalanchego/.*?test');
+  IMPORT_TEST_PKG=$( echo "${NON_TEST_GO_FILES}" | xargs grep -lP '"github.com/ava-labs/avalanchego/.*?test"');
 
   # TODO(arr4n): send a PR to add support for build tags in `mockgen` and then enable this.
   # IMPORT_GOMOCK=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"go.uber.org/mock');

--- a/scripts/tests.e2e.existing.sh
+++ b/scripts/tests.e2e.existing.sh
@@ -22,7 +22,7 @@ function print_separator {
 function cleanup {
   print_separator
   echo "cleaning up reusable network"
-  ginkgo -v --tags test ./tests/e2e/e2e.test -- --stop-network
+  ginkgo -v ./tests/e2e/e2e.test -- --stop-network
 }
 trap cleanup EXIT
 

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -23,7 +23,7 @@ source ./scripts/constants.sh
 echo "building e2e.test"
 # to install the ginkgo binary (required for test build and run)
 go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
-ACK_GINKGO_RC=true ginkgo build --tags test ./tests/e2e
+ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 ./tests/e2e/e2e.test --help
 
 # Enable subnet testing by building xsvm
@@ -57,4 +57,4 @@ fi
 
 #################################
 # - Execute in random order to identify unwanted dependency
-ginkgo ${GINKGO_ARGS} -v --tags test --randomize-all ./tests/e2e/e2e.test -- "${E2E_ARGS[@]}" "${@}"
+ginkgo ${GINKGO_ARGS} -v --randomize-all ./tests/e2e/e2e.test -- "${E2E_ARGS[@]}" "${@}"

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -66,7 +66,7 @@ source ./scripts/constants.sh
 echo "building upgrade.test"
 # to install the ginkgo binary (required for test build and run)
 go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
-ACK_GINKGO_RC=true ginkgo build --tags test ./tests/upgrade
+ACK_GINKGO_RC=true ginkgo build ./tests/upgrade
 ./tests/upgrade/upgrade.test --help
 
 #################################

--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 // Implements tests for the banff network upgrade.
 package banff
 

--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package c
 
 import (

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package c
 
 import (

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package faultinjection
 
 import (

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package p
 
 import (

--- a/tests/e2e/p/permissionless_subnets.go
+++ b/tests/e2e/p/permissionless_subnets.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package p
 
 import (

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package p
 
 import (

--- a/tests/e2e/p/validator_sets.go
+++ b/tests/e2e/p/validator_sets.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package p
 
 import (

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package p
 
 import (

--- a/tests/e2e/vms/xsvm.go
+++ b/tests/e2e/vms/xsvm.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package vms
 
 import (

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package x
 
 import (

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 // Implements X-chain transfer tests.
 package transfer
 

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package e2e
 
 import (

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package e2e
 
 import (


### PR DESCRIPTION
This avoids having to redundantly tag test code in `/tests` with `go:build test` or supply `--tags test` on every ginkgo invocation.

## How was this tested

- Negative case validated in CI
- Positive case manually validated by adding a reference to a package under `/tests` to non-test code and witnessing a failure:

```bash
Non-test Go files importing test-only packages MUST have '//go:build test' tag:
/home/me/src/avalanchego/master/main/main.go
```