### PR TITLE
[antithesis] Add tmpnet support to workloads to simplify development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go-for-project
+      - name: Build AvalancheGo Binary
+        shell: bash
+        run: ./scripts/build.sh -r
+      - name: Check that the avalanchego workload is sane
+        shell: bash
+        run: go run ./tests/antithesis/avalanchego --avalanchego-path=./build/avalanchego --duration=60s
       - name: Check image build for avalanchego test setup
         shell: bash
         run: bash -x scripts/tests.build_antithesis_images.sh
@@ -218,26 +224,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go-for-project
-      - name: Check image build for xsvm test setup
-        shell: bash
-        run: bash -x scripts/tests.build_antithesis_images.sh
-        env:
-          TEST_SETUP: xsvm
-  test_antithesis_workloads:
-    name: Check sanity of antithesis workloads
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-go-for-project
       - name: Build AvalancheGo Binary
         shell: bash
         run: ./scripts/build.sh -r
-      - name: Check that the avalanchego workload is sane
-        shell: bash
-        run: go run ./tests/antithesis/avalanchego --avalanchego-path=./build/avalanchego --duration=60s
       - name: Build xsvm binary
         shell: bash
         run: ./scripts/build_xsvm.sh
       - name: Check that the xsvm workload is sane
         shell: bash
         run: go run ./tests/antithesis/xsvm --avalanchego-path=./build/avalanchego --duration=60s
+      - name: Check image build for xsvm test setup
+        shell: bash
+        run: bash -x scripts/tests.build_antithesis_images.sh
+        env:
+          TEST_SETUP: xsvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go-for-project
       - name: Check image build for avalanchego test setup
         shell: bash
         run: bash -x scripts/tests.build_antithesis_images.sh
@@ -216,8 +217,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go-for-project
       - name: Check image build for xsvm test setup
         shell: bash
         run: bash -x scripts/tests.build_antithesis_images.sh
         env:
           TEST_SETUP: xsvm
+  test_antithesis_workloads:
+    name: Check sanity of antithesis workloads
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go-for-project
+      - name: Build AvalancheGo Binary
+        shell: bash
+        run: ./scripts/build.sh -r
+      - name: Check that the avalanchego workload is sane
+        shell: bash
+        run: go run ./tests/antithesis/avalanchego --avalanchego-path=./build/avalanchego --duration=60s
+      - name: Build xsvm binary
+        shell: bash
+        run: ./scripts/build_xsvm.sh
+      - name: Check that the xsvm workload is sane
+        shell: bash
+        run: go run ./tests/antithesis/xsvm --avalanchego-path=./build/avalanchego --duration=60s

--- a/scripts/lib_build_antithesis_images.sh
+++ b/scripts/lib_build_antithesis_images.sh
@@ -108,6 +108,7 @@ function gen_antithesis_compose_config {
     # Ensure the target path is empty before generating the compose config
     rm -r "${target_path:?}"
   fi
+  mkdir -p "${target_path}"
 
   # Define the env vars for the compose config generation
   local compose_env="TARGET_PATH=${target_path} IMAGE_TAG=${image_tag} ${extra_compose_args}"

--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -69,7 +69,7 @@ test setup.
 
 ## Troubleshooting a test setup
 
-### Running a workload directly
+### Running a workload with an existing network
 
 The workload of the 'avalanchego' test setup can be invoked against an
 arbitrary network:
@@ -85,6 +85,20 @@ chain needs to be provided to the workload:
 ```bash
 $ AVAWL_URIS=... CHAIN_IDS="2S9ypz...AzMj9" go run ./tests/antithesis/xsvm
 ```
+
+### Running a workload with a tmpnet network
+
+Just like with e2e tests, running an antithesis workload against a
+tmpnet network requires specifying an avalanchego path (either as an
+argument or an env var):
+
+```bash
+$ go run ./tests/antithesis/avalanchego --avalanchego-path=/path/to/avalanchego
+```
+
+All tmpnet flags are supported (e.g. `--reuse-network`,
+`--stop-network`, `--restart-network`, `--node-count`).  See the
+[tmpnet documentation](../fixture/tmpnet/README.md) for more details.
 
 ### Running a workload with docker compose v2
 

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -8,16 +8,18 @@ import (
 	"crypto/rand"
 	"log"
 	"math/big"
-	"os"
 	"time"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/antithesishq/antithesis-sdk-go/lifecycle"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/antithesis"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -40,15 +42,17 @@ import (
 const NumKeys = 5
 
 func main() {
-	c, err := antithesis.NewConfig(os.Args)
-	if err != nil {
-		log.Fatalf("invalid config: %s", err)
-	}
+	tc := tests.NewTestContext()
+	defer tc.Cleanup()
+	require := require.New(tc)
 
-	ctx := context.Background()
-	if err := antithesis.AwaitHealthyNodes(ctx, c.URIs); err != nil {
-		log.Fatalf("failed to await healthy nodes: %s", err)
-	}
+	c := antithesis.NewConfig(
+		tc,
+		&tmpnet.Network{
+			Owner: "antithesis-avalanchego",
+		},
+	)
+	ctx := tests.DefaultNotifyContext(c.Duration, tc.DeferCleanup)
 
 	kc := secp256k1fx.NewKeychain(genesis.EWOQKey)
 	walletSyncStartTime := time.Now()
@@ -57,9 +61,7 @@ func main() {
 		AVAXKeychain: kc,
 		EthKeychain:  kc,
 	})
-	if err != nil {
-		log.Fatalf("failed to initialize wallet: %s", err)
-	}
+	require.NoError(err, "failed to initialize wallet")
 	log.Printf("synced wallet in %s", time.Since(walletSyncStartTime))
 
 	genesisWorkload := &workload{
@@ -80,9 +82,7 @@ func main() {
 	)
 	for i := 1; i < NumKeys; i++ {
 		key, err := secp256k1.NewPrivateKey()
-		if err != nil {
-			log.Fatalf("failed to generate key: %s", err)
-		}
+		require.NoError(err, "failed to generate key")
 
 		var (
 			addr          = key.Address()
@@ -102,11 +102,10 @@ func main() {
 				},
 			},
 		}})
-		if err != nil {
-			log.Fatalf("failed to issue initial funding X-chain baseTx: %s", err)
-		}
+		require.NoError(err, "failed to issue initial funding X-chain baseTx")
 		log.Printf("issued initial funding X-chain baseTx %s in %s", baseTx.ID(), time.Since(baseStartTime))
 
+		// TODO(marun) Enable cleanup of these contexts
 		genesisWorkload.confirmXChainTx(ctx, baseTx)
 
 		uri := c.URIs[i%len(c.URIs)]
@@ -117,9 +116,7 @@ func main() {
 			AVAXKeychain: kc,
 			EthKeychain:  kc,
 		})
-		if err != nil {
-			log.Fatalf("failed to initialize wallet: %s", err)
-		}
+		require.NoError(err, "failed to initialize wallet")
 		log.Printf("synced wallet in %s", time.Since(walletSyncStartTime))
 
 		workloads[i] = &workload{
@@ -151,6 +148,10 @@ type workload struct {
 func (w *workload) run(ctx context.Context) {
 	timer := timerpkg.StoppedTimer()
 
+	tc := tests.NewTestContext()
+	defer tc.Cleanup()
+	require := require.New(tc)
+
 	var (
 		xWallet  = w.wallet.X()
 		xBuilder = xWallet.Builder()
@@ -158,13 +159,9 @@ func (w *workload) run(ctx context.Context) {
 		pBuilder = pWallet.Builder()
 	)
 	xBalances, err := xBuilder.GetFTBalance()
-	if err != nil {
-		log.Fatalf("failed to fetch X-chain balances: %s", err)
-	}
+	require.NoError(err, "failed to fetch X-chain balances")
 	pBalances, err := pBuilder.GetBalance()
-	if err != nil {
-		log.Fatalf("failed to fetch P-chain balances: %s", err)
-	}
+	require.NoError(err, "failed to fetch P-chain balances")
 	var (
 		xContext    = xBuilder.Context()
 		avaxAssetID = xContext.AVAXAssetID
@@ -180,9 +177,7 @@ func (w *workload) run(ctx context.Context) {
 
 	for {
 		val, err := rand.Int(rand.Reader, big.NewInt(5))
-		if err != nil {
-			log.Fatalf("failed to read randomness: %s", err)
-		}
+		require.NoError(err, "failed to read randomness")
 
 		flowID := val.Int64()
 		log.Printf("wallet %d executing flow %d", w.id, flowID)
@@ -200,9 +195,7 @@ func (w *workload) run(ctx context.Context) {
 		}
 
 		val, err = rand.Int(rand.Reader, big.NewInt(int64(time.Second)))
-		if err != nil {
-			log.Fatalf("failed to read randomness: %s", err)
-		}
+		require.NoError(err, "failed to read randomness")
 
 		timer.Reset(time.Duration(val.Int64()))
 		select {

--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -230,7 +230,7 @@ func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadIm
 	}
 
 	workloadEnv := types.Mapping{
-		"AVAWL_URIS": strings.Join(uris, " "),
+		envVarName(URIsKey): strings.Join(uris, " "),
 	}
 	chainIDs := []string{}
 	for _, subnet := range network.Subnets {
@@ -239,7 +239,7 @@ func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadIm
 		}
 	}
 	if len(chainIDs) > 0 {
-		workloadEnv["AVAWL_CHAIN_IDS"] = strings.Join(chainIDs, " ")
+		workloadEnv[envVarName(ChainIDsKey)] = strings.Join(chainIDs, " ")
 	}
 
 	workloadName := "workload"

--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -47,12 +47,12 @@ func GenerateComposeConfig(network *tmpnet.Network, baseImageName string) error 
 
 	// Subnet testing requires creating an initial db state for the bootstrap node
 	if len(network.Subnets) > 0 {
-		avalancheGoPath := os.Getenv("AVALANCHEGO_PATH")
+		avalancheGoPath := os.Getenv(tmpnet.AvalancheGoPathEnvName)
 		if len(avalancheGoPath) == 0 {
 			return errAvalancheGoEvVarNotSet
 		}
 
-		pluginDir := os.Getenv("AVALANCHEGO_PLUGIN_DIR")
+		pluginDir := os.Getenv(tmpnet.AvalancheGoPluginDirEnvName)
 		if len(pluginDir) == 0 {
 			return errPluginDirEnvVarNotSet
 		}

--- a/tests/antithesis/config.go
+++ b/tests/antithesis/config.go
@@ -127,5 +127,5 @@ func (c *CSV) Set(value string) error {
 }
 
 func envVarName(key string) string {
-	return strings.ToUpper(strings.ToUpper(EnvPrefix + "_" + key))
+	return strings.ToUpper(EnvPrefix + "_" + key)
 }

--- a/tests/antithesis/config.go
+++ b/tests/antithesis/config.go
@@ -30,9 +30,6 @@ type Config struct {
 	Duration time.Duration
 }
 
-// Cleans up resources created by the configuration
-type CleanupFunc func()
-
 type SubnetsForNodesFunc func(nodes ...*tmpnet.Node) []*tmpnet.Subnet
 
 func NewConfig(tc tests.TestContext, defaultNetwork *tmpnet.Network) *Config {
@@ -57,12 +54,12 @@ func NewConfigWithSubnets(tc tests.TestContext, defaultNetwork *tmpnet.Network, 
 	flag.Parse()
 
 	// Env vars take priority over flags
-	envURIs := os.Getenv(strings.ToUpper(EnvPrefix + "_" + URIsKey))
+	envURIs := os.Getenv(envVarName(URIsKey))
 	if len(envURIs) > 0 {
 		// CSV.Set doesn't actually return an error
 		_ = uris.Set(envURIs)
 	}
-	envChainIDs := os.Getenv(strings.ToUpper(EnvPrefix + "_" + ChainIDsKey))
+	envChainIDs := os.Getenv(envVarName(ChainIDsKey))
 	if len(envChainIDs) > 0 {
 		// CSV.Set doesn't actually return an error
 		_ = uris.Set(envChainIDs)
@@ -82,7 +79,7 @@ func NewConfigWithSubnets(tc tests.TestContext, defaultNetwork *tmpnet.Network, 
 	return configForNewNetwork(tc, defaultNetwork, getSubnets, flagVars, duration)
 }
 
-// configForNewNetwork creates a new network and returns the resulting config and cleanup function.
+// configForNewNetwork creates a new network and returns the resulting config.
 func configForNewNetwork(
 	tc tests.TestContext,
 	defaultNetwork *tmpnet.Network,
@@ -127,4 +124,8 @@ func (c *CSV) String() string {
 func (c *CSV) Set(value string) error {
 	*c = strings.Split(value, ",")
 	return nil
+}
+
+func envVarName(key string) string {
+	return strings.ToUpper(strings.ToUpper(EnvPrefix + "_" + key))
 }

--- a/tests/antithesis/node_health.go
+++ b/tests/antithesis/node_health.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Waits for the nodes at the provided URIs to report healthy.
-func AwaitHealthyNodes(ctx context.Context, uris []string) error {
+func awaitHealthyNodes(ctx context.Context, uris []string) error {
 	for _, uri := range uris {
 		if err := awaitHealthyNode(ctx, uri); err != nil {
 			return err

--- a/tests/antithesis/xsvm/main.go
+++ b/tests/antithesis/xsvm/main.go
@@ -74,7 +74,7 @@ func main() {
 	initialAmount := 100 * units.KiloAvax
 	for i := 1; i < NumKeys; i++ {
 		key, err := secp256k1.NewPrivateKey()
-		require.NoError(err, "failed to generate key: %s")
+		require.NoError(err, "failed to generate key")
 
 		var (
 			addr          = key.Address()

--- a/tests/antithesis/xsvm/main.go
+++ b/tests/antithesis/xsvm/main.go
@@ -8,15 +8,18 @@ import (
 	"crypto/rand"
 	"log"
 	"math/big"
-	"os"
 	"time"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/antithesishq/antithesis-sdk-go/lifecycle"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/antithesis"
+	"github.com/ava-labs/avalanchego/tests/fixture/subnet"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
@@ -33,23 +36,29 @@ const (
 )
 
 func main() {
-	c, err := antithesis.NewConfig(os.Args)
-	if err != nil {
-		log.Fatalf("invalid config: %s", err)
-	}
+	tc := tests.NewTestContext()
+	defer tc.Cleanup()
+	require := require.New(tc)
 
-	ctx := context.Background()
-	if err := antithesis.AwaitHealthyNodes(ctx, c.URIs); err != nil {
-		log.Fatalf("failed to await healthy nodes: %s", err)
-	}
+	c := antithesis.NewConfigWithSubnets(
+		tc,
+		&tmpnet.Network{
+			Owner: "antithesis-xsvm",
+		},
+		func(nodes ...*tmpnet.Node) []*tmpnet.Subnet {
+			return []*tmpnet.Subnet{
+				subnet.NewXSVMOrPanic("xsvm", genesis.VMRQKey, nodes...),
+			}
+		},
+	)
+	ctx := tests.DefaultNotifyContext(c.Duration, tc.DeferCleanup)
 
-	if len(c.ChainIDs) != 1 {
-		log.Fatalf("expected 1 chainID, saw %d", len(c.ChainIDs))
-	}
+	require.Len(c.ChainIDs, 1)
+	log.Printf("CHAIN IDS: %v", c.ChainIDs)
 	chainID, err := ids.FromString(c.ChainIDs[0])
-	if err != nil {
-		log.Fatalf("failed to parse chainID: %s", err)
-	}
+	require.NoError(err, "failed to parse chainID")
+
+	log.Printf("Using uris %v and chainID %s", c.URIs, chainID)
 
 	genesisWorkload := &workload{
 		id:      0,
@@ -65,9 +74,7 @@ func main() {
 	initialAmount := 100 * units.KiloAvax
 	for i := 1; i < NumKeys; i++ {
 		key, err := secp256k1.NewPrivateKey()
-		if err != nil {
-			log.Fatalf("failed to generate key: %s", err)
-		}
+		require.NoError(err, "failed to generate key: %s")
 
 		var (
 			addr          = key.Address()
@@ -84,9 +91,7 @@ func main() {
 				PrivateKey: genesisWorkload.key,
 			},
 		)
-		if err != nil {
-			log.Fatalf("failed to issue initial funding transfer: %s", err)
-		}
+		require.NoError(err, "failed to issue initial funding transfer")
 		log.Printf("issued initial funding transfer %s in %s", transferTxStatus.TxID, time.Since(baseStartTime))
 
 		genesisWorkload.confirmTransferTx(ctx, transferTxStatus)
@@ -122,13 +127,15 @@ type workload struct {
 func (w *workload) run(ctx context.Context) {
 	timer := timerpkg.StoppedTimer()
 
+	tc := tests.NewTestContext()
+	defer tc.Cleanup()
+	require := require.New(tc)
+
 	uri := w.uris[w.id%len(w.uris)]
 
 	client := api.NewClient(uri, w.chainID.String())
 	balance, err := client.Balance(ctx, w.key.Address(), w.chainID)
-	if err != nil {
-		log.Fatalf("failed to fetch balance: %s", err)
-	}
+	require.NoError(err, "failed to fetch balance")
 	log.Printf("worker %d starting with a balance of %d", w.id, balance)
 	assert.Reachable("worker starting", map[string]any{
 		"worker":  w.id,
@@ -157,9 +164,7 @@ func (w *workload) run(ctx context.Context) {
 		}
 
 		val, err := rand.Int(rand.Reader, big.NewInt(int64(time.Second)))
-		if err != nil {
-			log.Fatalf("failed to read randomness: %s", err)
-		}
+		require.NoError(err, "failed to read randomness")
 
 		timer.Reset(time.Duration(val.Int64()))
 		select {

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -71,19 +71,33 @@ func (v *FlagVars) ActivateEtna() bool {
 	return v.activateEtna
 }
 
+func getEnvWithDefault(envVar, defaultVal string) string {
+	val := os.Getenv(envVar)
+	if len(val) == 0 {
+		return defaultVal
+	}
+	return val
+}
+
 func RegisterFlags() *FlagVars {
 	vars := FlagVars{}
 	flag.StringVar(
 		&vars.avalancheGoExecPath,
 		"avalanchego-path",
 		os.Getenv(tmpnet.AvalancheGoPathEnvName),
-		fmt.Sprintf("avalanchego executable path (required if not using an existing network). Also possible to configure via the %s env variable.", tmpnet.AvalancheGoPathEnvName),
+		fmt.Sprintf(
+			"[optional] avalanchego executable path if creating a new network. Also possible to configure via the %s env variable.",
+			tmpnet.AvalancheGoPathEnvName,
+		),
 	)
 	flag.StringVar(
 		&vars.pluginDir,
 		"plugin-dir",
-		os.ExpandEnv("$HOME/.avalanchego/plugins"),
-		"[optional] the dir containing VM plugins.",
+		getEnvWithDefault(tmpnet.AvalancheGoPluginDirEnvName, os.ExpandEnv("$HOME/.avalanchego/plugins")),
+		fmt.Sprintf(
+			"[optional] the dir containing VM plugins. Also possible to configure via the %s env variable.",
+			tmpnet.AvalancheGoPluginDirEnvName,
+		),
 	)
 	flag.StringVar(
 		&vars.networkDir,

--- a/tests/fixture/e2e/ginkgo_test_context.go
+++ b/tests/fixture/e2e/ginkgo_test_context.go
@@ -35,8 +35,12 @@ func (*GinkgoTestContext) GetWriter() io.Writer {
 	return ginkgo.GinkgoWriter
 }
 
-func (*GinkgoTestContext) DeferCleanup(args ...interface{}) {
-	ginkgo.DeferCleanup(args...)
+func (*GinkgoTestContext) Cleanup() {
+	// No-op - ginkgo does this automatically
+}
+
+func (*GinkgoTestContext) DeferCleanup(cleanup func()) {
+	ginkgo.DeferCleanup(cleanup)
 }
 
 func (*GinkgoTestContext) By(text string, callback ...func()) {

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	AvalancheGoPathEnvName = "AVALANCHEGO_PATH"
+	AvalancheGoPathEnvName      = "AVALANCHEGO_PATH"
+	AvalancheGoPluginDirEnvName = "AVALANCHEGO_PLUGIN_DIR"
 
 	defaultNodeInitTimeout = 10 * time.Second
 )

--- a/tests/notify_context.go
+++ b/tests/notify_context.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package tests
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// DefaultNotifyContext returns a context that is marked done when signals indicating
+// process termination are received. If a non-zero duration is provided, the parent to the
+// notify context will be a context with a timeout for that duration.
+func DefaultNotifyContext(duration time.Duration, cleanup func(func())) context.Context {
+	parentContext := context.Background()
+	if duration > 0 {
+		var cancel context.CancelFunc
+		parentContext, cancel = context.WithTimeout(parentContext, duration)
+		cleanup(cancel)
+	}
+	ctx, stop := signal.NotifyContext(parentContext, syscall.SIGTERM, syscall.SIGINT)
+	cleanup(stop)
+	return ctx
+}

--- a/tests/other_test_context.go
+++ b/tests/other_test_context.go
@@ -1,0 +1,113 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/onsi/ginkgo/v2/formatter"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+)
+
+const failNowMessage = "OtherTestContext.FailNow called"
+
+// TODO(marun) Consider a more descriptive name for this type
+type OtherTestContext struct {
+	cleanupFuncs  []func()
+	cleanupCalled bool
+}
+
+func NewTestContext() *OtherTestContext {
+	return &OtherTestContext{}
+}
+
+func (*OtherTestContext) Errorf(format string, args ...interface{}) {
+	log.Printf("error: "+format, args...)
+}
+
+func (*OtherTestContext) FailNow() {
+	panic(failNowMessage)
+}
+
+func (*OtherTestContext) GetWriter() io.Writer {
+	return os.Stdout
+}
+
+// Cleanup is intended to be deferred by the caller to ensure cleanup is performed even
+// in the event that a panic occurs.
+func (tc *OtherTestContext) Cleanup() {
+	if tc.cleanupCalled {
+		return
+	}
+	tc.cleanupCalled = true
+
+	// Only exit non-zero if a panic caused cleanup or cleanup caused a panic
+	exitNonZero := false
+
+	if r := recover(); r != nil {
+		exitNonZero = true
+		if r.(string) != failNowMessage {
+			// Only print panic messages not originating from this context
+			fmt.Println(r)
+		}
+	}
+
+	for _, cleanupFunc := range tc.cleanupFuncs {
+		func() {
+			// Ensure a failed cleanup doesn't prevent subsequent cleanup functions from running
+			defer func() {
+				if r := recover(); r != nil {
+					exitNonZero = true
+					fmt.Println("Recovered from in panic during cleanup:", r)
+				}
+			}()
+			cleanupFunc()
+		}()
+	}
+
+	if exitNonZero {
+		os.Exit(1)
+	}
+}
+
+func (tc *OtherTestContext) DeferCleanup(cleanup func()) {
+	tc.cleanupFuncs = append(tc.cleanupFuncs, cleanup)
+}
+
+func (tc *OtherTestContext) By(_ string, _ ...func()) {
+	tc.Errorf("By not yet implemented")
+	tc.FailNow()
+}
+
+// TODO(marun) Enable color output equivalent to GinkgoTestContext.Outf
+func (*OtherTestContext) Outf(format string, args ...interface{}) {
+	s := formatter.F(format, args...)
+	log.Print(s)
+}
+
+// Helper simplifying use of a timed context by canceling the context on ginkgo teardown.
+func (tc *OtherTestContext) ContextWithTimeout(duration time.Duration) context.Context {
+	return ContextWithTimeout(tc, duration)
+}
+
+// Helper simplifying use of a timed context configured with the default timeout.
+func (tc *OtherTestContext) DefaultContext() context.Context {
+	return DefaultContext(tc)
+}
+
+// Helper simplifying use via an option of a timed context configured with the default timeout.
+func (tc *OtherTestContext) WithDefaultContext() common.Option {
+	return WithDefaultContext(tc)
+}
+
+func (tc *OtherTestContext) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msg string) {
+	require.Eventually(tc, condition, waitFor, tick, msg)
+}

--- a/tests/other_test_context.go
+++ b/tests/other_test_context.go
@@ -49,17 +49,20 @@ func (tc *OtherTestContext) Cleanup() {
 	}
 	tc.cleanupCalled = true
 
+	// Only exit non-zero if a cleanup caused a panic
+	exitNonZero := false
+
 	var panicData any
 	if r := recover(); r != nil {
 		errorString, ok := r.(string)
 		if !ok || errorString != failNowMessage {
 			// Retain the panic data to raise after cleanup
 			panicData = r
+		} else {
+			exitNonZero = true
 		}
 	}
 
-	// Only exit non-zero if a cleanup caused a panic
-	exitNonZero := false
 	for _, cleanupFunc := range tc.cleanupFuncs {
 		func() {
 			// Ensure a failed cleanup doesn't prevent subsequent cleanup functions from running

--- a/tests/simple_test_context.go
+++ b/tests/simple_test_context.go
@@ -17,33 +17,32 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
 
-const failNowMessage = "OtherTestContext.FailNow called"
+const failNowMessage = "SimpleTestContext.FailNow called"
 
-// TODO(marun) Consider a more descriptive name for this type
-type OtherTestContext struct {
+type SimpleTestContext struct {
 	cleanupFuncs  []func()
 	cleanupCalled bool
 }
 
-func NewTestContext() *OtherTestContext {
-	return &OtherTestContext{}
+func NewTestContext() *SimpleTestContext {
+	return &SimpleTestContext{}
 }
 
-func (*OtherTestContext) Errorf(format string, args ...interface{}) {
+func (*SimpleTestContext) Errorf(format string, args ...interface{}) {
 	log.Printf("error: "+format, args...)
 }
 
-func (*OtherTestContext) FailNow() {
+func (*SimpleTestContext) FailNow() {
 	panic(failNowMessage)
 }
 
-func (*OtherTestContext) GetWriter() io.Writer {
+func (*SimpleTestContext) GetWriter() io.Writer {
 	return os.Stdout
 }
 
 // Cleanup is intended to be deferred by the caller to ensure cleanup is performed even
 // in the event that a panic occurs.
-func (tc *OtherTestContext) Cleanup() {
+func (tc *SimpleTestContext) Cleanup() {
 	if tc.cleanupCalled {
 		return
 	}
@@ -84,36 +83,36 @@ func (tc *OtherTestContext) Cleanup() {
 	}
 }
 
-func (tc *OtherTestContext) DeferCleanup(cleanup func()) {
+func (tc *SimpleTestContext) DeferCleanup(cleanup func()) {
 	tc.cleanupFuncs = append(tc.cleanupFuncs, cleanup)
 }
 
-func (tc *OtherTestContext) By(_ string, _ ...func()) {
+func (tc *SimpleTestContext) By(_ string, _ ...func()) {
 	tc.Errorf("By not yet implemented")
 	tc.FailNow()
 }
 
 // TODO(marun) Enable color output equivalent to GinkgoTestContext.Outf
-func (*OtherTestContext) Outf(format string, args ...interface{}) {
+func (*SimpleTestContext) Outf(format string, args ...interface{}) {
 	s := formatter.F(format, args...)
 	log.Print(s)
 }
 
 // Helper simplifying use of a timed context by canceling the context on ginkgo teardown.
-func (tc *OtherTestContext) ContextWithTimeout(duration time.Duration) context.Context {
+func (tc *SimpleTestContext) ContextWithTimeout(duration time.Duration) context.Context {
 	return ContextWithTimeout(tc, duration)
 }
 
 // Helper simplifying use of a timed context configured with the default timeout.
-func (tc *OtherTestContext) DefaultContext() context.Context {
+func (tc *SimpleTestContext) DefaultContext() context.Context {
 	return DefaultContext(tc)
 }
 
 // Helper simplifying use via an option of a timed context configured with the default timeout.
-func (tc *OtherTestContext) WithDefaultContext() common.Option {
+func (tc *SimpleTestContext) WithDefaultContext() common.Option {
 	return WithDefaultContext(tc)
 }
 
-func (tc *OtherTestContext) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msg string) {
+func (tc *SimpleTestContext) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msg string) {
 	require.Eventually(tc, condition, waitFor, tick, msg)
 }

--- a/tests/test_context.go
+++ b/tests/test_context.go
@@ -20,11 +20,8 @@ type TestContext interface {
 	// Ensures compatibility with ginkgo.By
 	By(text string, callback ...func())
 
-	// Ensures compatibility with ginkgo.DeferCleanup
-	//
-	// TODO(marun) Ensure registered cleanup functions are called at
-	// the end of the registering test.
-	DeferCleanup(args ...interface{})
+	// Provides a simple alternative to ginkgo.DeferCleanup
+	DeferCleanup(cleanup func())
 
 	// Enables color output to stdout
 	Outf(format string, args ...interface{})


### PR DESCRIPTION
## Why this should be merged

Iterating on the workload for the avalanchego test setup is simple - just launch a local node. Iterating on the tests for any VM is more complicated due to needing to deploy a subnet and chain. This PR adds tmpnet integration to make iterating on an antithesis workload as simple as iterating on an e2e test.

## How this works

 - added support for starting a tmpnet network for a workload when URIs of a running network are not provided
 - implemented non-ginkgo version of TestContext to support reuse of tmpnet test helpers
 - replaced the use of `log.Fatalf` with `require` and a panic-based `require.TestingT` to ensure deferred cleanup functions can execute to enable reliable teardown of tmpnet networks
   - `log.Fatalf` calls `os.Exit` which precludes the execution of deferred functions 
 - replaces the use of `context.Background()` with a context created with `signal.NotifyContext` to support orderly shutdown when `SIGINT` (i.e. Ctrl-C) and `SIGTERM` signals are received

## How this was tested

Existing CI, plus added a new sanity check for workloads running with tmpnet

## TODO

 - [ ] Set new CI job required post-merge 