### PR TITLE
[ci] Update fuzz workflows to target master branch

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,7 +2,7 @@ name: Run fuzz tests
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * *" # Once a day at midnight UTC
 
 permissions:
   contents: read
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
-        with:
-          ref: 'dev'
       - name: Set up Go
         uses: ./.github/actions/setup-go-for-project
       - name: Run fuzz tests

--- a/.github/workflows/fuzz_merkledb.yml
+++ b/.github/workflows/fuzz_merkledb.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
-        with:
-          ref: 'dev'
       - name: Set up Go
         uses: ./.github/actions/setup-go-for-project
       - name: Run merkledb fuzz tests


### PR DESCRIPTION
## Why this should be merged

When the active branch changed from `dev` to `master` 5 months ago, these jobs appear to have been overlooked because nobody was seeing the notifications of their failure.

## How this works

Update the jobs to target the `master` branch instead of `dev`.

## How this was tested

Notifications will be received if this job continues to fail.