### PR TITLE
Add benchmarks for add and sub fee dimensions

### DIFF
--- a/vms/components/fee/dimensions.go
+++ b/vms/components/fee/dimensions.go
@@ -22,7 +22,7 @@ type (
 // Add returns d + sum(os...).
 //
 // If overflow occurs, an error is returned.
-func (d Dimensions) Add(os ...Dimensions) (Dimensions, error) {
+func (d Dimensions) Add(os ...*Dimensions) (Dimensions, error) {
 	var err error
 	for _, o := range os {
 		for i := range o {
@@ -38,7 +38,7 @@ func (d Dimensions) Add(os ...Dimensions) (Dimensions, error) {
 // Sub returns d - sum(os...).
 //
 // If underflow occurs, an error is returned.
-func (d Dimensions) Sub(os ...Dimensions) (Dimensions, error) {
+func (d Dimensions) Sub(os ...*Dimensions) (Dimensions, error) {
 	var err error
 	for _, o := range os {
 		for i := range o {

--- a/vms/components/fee/dimensions_test.go
+++ b/vms/components/fee/dimensions_test.go
@@ -439,10 +439,17 @@ func Benchmark_Dimensions_Add(b *testing.B) {
 		{10_000, 10_000, 10_000, 10_000},
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = lhs.Add(rhs[0], rhs[1], rhs[2], rhs[3], rhs[4], rhs[5], rhs[6])
-	}
+	b.Run("single", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = lhs.Add(rhs[0])
+		}
+	})
+
+	b.Run("multiple", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = lhs.Add(rhs[0], rhs[1], rhs[2], rhs[3], rhs[4], rhs[5], rhs[6])
+		}
+	})
 }
 
 func Benchmark_Dimensions_Sub(b *testing.B) {
@@ -456,8 +463,15 @@ func Benchmark_Dimensions_Sub(b *testing.B) {
 		{1_000, 1_000, 1_000, 1_000},
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = lhs.Sub(rhs[0], rhs[1], rhs[2], rhs[3], rhs[4], rhs[5])
-	}
+	b.Run("single", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = lhs.Sub(rhs[0])
+		}
+	})
+
+	b.Run("multiple", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = lhs.Sub(rhs[0], rhs[1], rhs[2], rhs[3], rhs[4], rhs[5])
+		}
+	})
 }

--- a/vms/components/fee/dimensions_test.go
+++ b/vms/components/fee/dimensions_test.go
@@ -16,7 +16,7 @@ func Test_Dimensions_Add(t *testing.T) {
 	tests := []struct {
 		name        string
 		lhs         Dimensions
-		rhs         []Dimensions
+		rhs         []*Dimensions
 		expected    Dimensions
 		expectedErr error
 	}{
@@ -28,7 +28,7 @@ func Test_Dimensions_Add(t *testing.T) {
 				DBWrite:   3,
 				Compute:   4,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 10,
 					DBRead:    20,
@@ -52,7 +52,7 @@ func Test_Dimensions_Add(t *testing.T) {
 				DBWrite:   3,
 				Compute:   4,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 10,
 					DBRead:    20,
@@ -82,7 +82,7 @@ func Test_Dimensions_Add(t *testing.T) {
 				DBWrite:   3,
 				Compute:   4,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 10,
 					DBRead:    20,
@@ -106,7 +106,7 @@ func Test_Dimensions_Add(t *testing.T) {
 				DBWrite:   3,
 				Compute:   4,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 10,
 					DBRead:    20,
@@ -130,7 +130,7 @@ func Test_Dimensions_Add(t *testing.T) {
 				DBWrite:   math.MaxUint64,
 				Compute:   4,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 10,
 					DBRead:    20,
@@ -154,7 +154,7 @@ func Test_Dimensions_Add(t *testing.T) {
 				DBWrite:   3,
 				Compute:   math.MaxUint64,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 10,
 					DBRead:    20,
@@ -186,7 +186,7 @@ func Test_Dimensions_Sub(t *testing.T) {
 	tests := []struct {
 		name        string
 		lhs         Dimensions
-		rhs         []Dimensions
+		rhs         []*Dimensions
 		expected    Dimensions
 		expectedErr error
 	}{
@@ -198,7 +198,7 @@ func Test_Dimensions_Sub(t *testing.T) {
 				DBWrite:   33,
 				Compute:   44,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 1,
 					DBRead:    2,
@@ -222,7 +222,7 @@ func Test_Dimensions_Sub(t *testing.T) {
 				DBWrite:   33,
 				Compute:   44,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 1,
 					DBRead:    2,
@@ -252,7 +252,7 @@ func Test_Dimensions_Sub(t *testing.T) {
 				DBWrite:   33,
 				Compute:   44,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: math.MaxUint64,
 					DBRead:    2,
@@ -276,7 +276,7 @@ func Test_Dimensions_Sub(t *testing.T) {
 				DBWrite:   33,
 				Compute:   44,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 1,
 					DBRead:    math.MaxUint64,
@@ -300,7 +300,7 @@ func Test_Dimensions_Sub(t *testing.T) {
 				DBWrite:   33,
 				Compute:   44,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 1,
 					DBRead:    2,
@@ -324,7 +324,7 @@ func Test_Dimensions_Sub(t *testing.T) {
 				DBWrite:   33,
 				Compute:   44,
 			},
-			rhs: []Dimensions{
+			rhs: []*Dimensions{
 				{
 					Bandwidth: 1,
 					DBRead:    2,
@@ -429,7 +429,7 @@ func Test_Dimensions_ToGas(t *testing.T) {
 
 func Benchmark_Dimensions_Add(b *testing.B) {
 	lhs := Dimensions{600, 10, 10, 1000}
-	rhs := []Dimensions{
+	rhs := []*Dimensions{
 		{1, 1, 1, 1},
 		{10, 10, 10, 10},
 		{100, 100, 100, 100},
@@ -441,13 +441,13 @@ func Benchmark_Dimensions_Add(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = lhs.Add(rhs...)
+		_, _ = lhs.Add(rhs[0], rhs[1], rhs[2], rhs[3], rhs[4], rhs[5], rhs[6])
 	}
 }
 
 func Benchmark_Dimensions_Sub(b *testing.B) {
 	lhs := Dimensions{10_000, 10_000, 10_000, 100_000}
-	rhs := []Dimensions{
+	rhs := []*Dimensions{
 		{1, 1, 1, 1},
 		{10, 10, 10, 10},
 		{100, 100, 100, 100},
@@ -458,6 +458,6 @@ func Benchmark_Dimensions_Sub(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = lhs.Sub(rhs...)
+		_, _ = lhs.Sub(rhs[0], rhs[1], rhs[2], rhs[3], rhs[4], rhs[5])
 	}
 }

--- a/vms/components/fee/dimensions_test.go
+++ b/vms/components/fee/dimensions_test.go
@@ -428,8 +428,6 @@ func Test_Dimensions_ToGas(t *testing.T) {
 }
 
 func Benchmark_Dimensions_Add(b *testing.B) {
-	require := require.New(b)
-
 	lhs := Dimensions{600, 10, 10, 1000}
 	rhs := []Dimensions{
 		{1, 1, 1, 1},
@@ -443,14 +441,11 @@ func Benchmark_Dimensions_Add(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := lhs.Add(rhs...)
-		require.NoError(err)
+		_, _ = lhs.Add(rhs...)
 	}
 }
 
 func Benchmark_Dimensions_Sub(b *testing.B) {
-	require := require.New(b)
-
 	lhs := Dimensions{10_000, 10_000, 10_000, 100_000}
 	rhs := []Dimensions{
 		{1, 1, 1, 1},
@@ -463,7 +458,6 @@ func Benchmark_Dimensions_Sub(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := lhs.Sub(rhs...)
-		require.NoError(err)
+		_, _ = lhs.Sub(rhs...)
 	}
 }

--- a/vms/components/fee/dimensions_test.go
+++ b/vms/components/fee/dimensions_test.go
@@ -428,8 +428,6 @@ func Test_Dimensions_ToGas(t *testing.T) {
 }
 
 func Benchmark_Dimensions_Add(b *testing.B) {
-	require := require.New(b)
-
 	lhs := Dimensions{600, 10, 10, 1000}
 	rhs := []Dimensions{
 		{1, 1, 1, 1},
@@ -444,14 +442,13 @@ func Benchmark_Dimensions_Add(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := lhs.Add(rhs...)
-		require.NoError(err)
+		if err != nil {
+			b.Error(err)
+		}
 	}
-	b.StopTimer()
 }
 
 func Benchmark_Dimensions_Sub(b *testing.B) {
-	require := require.New(b)
-
 	lhs := Dimensions{10_000, 10_000, 10_000, 100_000}
 	rhs := []Dimensions{
 		{1, 1, 1, 1},
@@ -465,7 +462,8 @@ func Benchmark_Dimensions_Sub(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := lhs.Sub(rhs...)
-		require.NoError(err)
+		if err != nil {
+			b.Error(err)
+		}
 	}
-	b.StopTimer()
 }

--- a/vms/components/fee/dimensions_test.go
+++ b/vms/components/fee/dimensions_test.go
@@ -426,3 +426,46 @@ func Test_Dimensions_ToGas(t *testing.T) {
 		})
 	}
 }
+
+func Benchmark_Dimensions_Add(b *testing.B) {
+	require := require.New(b)
+
+	lhs := Dimensions{600, 10, 10, 1000}
+	rhs := []Dimensions{
+		{1, 1, 1, 1},
+		{10, 10, 10, 10},
+		{100, 100, 100, 100},
+		{200, 200, 200, 200},
+		{500, 500, 500, 500},
+		{1_000, 1_000, 1_000, 1_000},
+		{10_000, 10_000, 10_000, 10_000},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := lhs.Add(rhs...)
+		require.NoError(err)
+	}
+	b.StopTimer()
+}
+
+func Benchmark_Dimensions_Sub(b *testing.B) {
+	require := require.New(b)
+
+	lhs := Dimensions{10_000, 10_000, 10_000, 100_000}
+	rhs := []Dimensions{
+		{1, 1, 1, 1},
+		{10, 10, 10, 10},
+		{100, 100, 100, 100},
+		{200, 200, 200, 200},
+		{500, 500, 500, 500},
+		{1_000, 1_000, 1_000, 1_000},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := lhs.Sub(rhs...)
+		require.NoError(err)
+	}
+	b.StopTimer()
+}

--- a/vms/components/fee/dimensions_test.go
+++ b/vms/components/fee/dimensions_test.go
@@ -428,6 +428,8 @@ func Test_Dimensions_ToGas(t *testing.T) {
 }
 
 func Benchmark_Dimensions_Add(b *testing.B) {
+	require := require.New(b)
+
 	lhs := Dimensions{600, 10, 10, 1000}
 	rhs := []Dimensions{
 		{1, 1, 1, 1},
@@ -442,13 +444,13 @@ func Benchmark_Dimensions_Add(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := lhs.Add(rhs...)
-		if err != nil {
-			b.Error(err)
-		}
+		require.NoError(err)
 	}
 }
 
 func Benchmark_Dimensions_Sub(b *testing.B) {
+	require := require.New(b)
+
 	lhs := Dimensions{10_000, 10_000, 10_000, 100_000}
 	rhs := []Dimensions{
 		{1, 1, 1, 1},
@@ -462,8 +464,6 @@ func Benchmark_Dimensions_Sub(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := lhs.Sub(rhs...)
-		if err != nil {
-			b.Error(err)
-		}
+		require.NoError(err)
 	}
 }


### PR DESCRIPTION
## Why this should be merged
Dimensions are structured as value objects meaning that Add and Sub methods have a value receiver.
This causes receiver to be copied, but the receiver itself can be reused as the returned value.
On the contrary, if we used a pointer received, we'd avoid copying the receiver but we'd have to allocate the return value.
This PR introduces a couple of small benchmarks to understand what's the fastest alternative.
There seems not to be a significant different among the two alternative

Value receiver:
```
Benchmark_Dimensions_Add-12    	47075594	        25.24 ns/op	       0 B/op	       0 allocs/op
Benchmark_Dimensions_Sub-12    	55160683	        21.76 ns/op	       0 B/op	       0 allocs/op
```

Pointer receiver:
```
Benchmark_Dimensions_Add-12    	46841310	        25.22 ns/op	       0 B/op	       0 allocs/op
Benchmark_Dimensions_Sub-12    	55187002	        21.95 ns/op	       0 B/op	       0 allocs/op
```

## How this works
Just added a couple of benchmarks

## How this was tested
Benchmarks
