### PR TITLE
Update local validator start time

### DIFF
--- a/genesis/config_test.go
+++ b/genesis/config_test.go
@@ -5,6 +5,7 @@ package genesis
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -48,6 +49,61 @@ func TestAllocationCompare(t *testing.T) {
 
 			require.Equal(tt.expected, tt.alloc1.Compare(tt.alloc2))
 			require.Equal(-tt.expected, tt.alloc2.Compare(tt.alloc1))
+		})
+	}
+}
+
+func TestRenewPeriod(t *testing.T) {
+	localConfigStartTime := time.Unix(int64(LocalConfig.StartTime), 0)
+	type test struct {
+		name     string
+		current  time.Time
+		expected uint64
+	}
+	tests := []test{
+		{
+			name:     "1 sec before local config",
+			expected: 1721016000, // Mon Jul 15 2024 04:00:00 GMT+0000
+			current:  localConfigStartTime.Add(-1 * time.Second),
+		},
+		{
+			name:     "1 sec after local config",
+			expected: 1721016000, // Mon Jul 15 2024 04:00:00 GMT+0000
+			current:  localConfigStartTime.Add(1 * time.Second),
+		},
+		{
+			name:     "after less than period",
+			expected: 1721016000, // Mon Jul 15 2024 04:00:00 GMT+0000
+			current:  localConfigStartTime.Add(renewPeriod).Add(-1 * time.Second),
+		},
+		{
+			name:     "after exactly 1 period",
+			expected: 1721016000, // Mon Jul 15 2024 04:00:00 GMT+0000
+			current:  localConfigStartTime.Add(renewPeriod),
+		},
+		{
+			name:     "after 1 period and 1 second",
+			expected: 1744344000, // Fri Apr 11 2025 04:00:00 GMT+0000
+			current:  localConfigStartTime.Add(renewPeriod).Add(1 * time.Second),
+		},
+		{
+			name:     "after 2 periods",
+			expected: 1744344000, // Fri Apr 11 2025 04:00:00 GMT+0000
+			current:  localConfigStartTime.Add(renewPeriod * 2),
+		},
+		{
+			name:     "after 2 periods and 1 second",
+			expected: 1767672000, // Tue Jan 06 2026 04:00:00 GMT+0000
+			current:  localConfigStartTime.Add(renewPeriod * 2).Add(1 * time.Second),
+		}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// to avoud modifying the global LocalConfig
+			testLocalConfig := Config{
+				StartTime: LocalConfig.StartTime,
+			}
+			testLocalConfig.renewStartTime(tt.current)
+			require.Equalf(t, tt.expected, testLocalConfig.StartTime, "expected %d, got %d", tt.expected, testLocalConfig.StartTime)
 		})
 	}
 }

--- a/genesis/genesis_local.json
+++ b/genesis/genesis_local.json
@@ -38,7 +38,7 @@
 			]
 		}
 	],
-	"startTime": 1690862400,
+	"startTime": 1721016000,
 	"initialStakeDuration": 31536000,
 	"initialStakeDurationOffset": 5400,
 	"initialStakedFunds": [

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -356,7 +356,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.LocalID,
-			expectedID: "S4BvHv1XyihF9gXkJKXWWwQuuDWZqesRXz6wnqavQ9FrjGfAa",
+			expectedID: "23DnViuN2kgePiBN4JxZXh1VrfXca2rwUp6XrKgNGdj3TSQjiN",
 		},
 	}
 	for _, test := range tests {

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -343,28 +343,27 @@ func TestGenesisFromFlag(t *testing.T) {
 
 func TestGenesis(t *testing.T) {
 	tests := []struct {
-		networkID  uint32
+		config     *Config
 		expectedID string
 	}{
 		{
-			networkID:  constants.MainnetID,
+			config:     &MainnetConfig,
 			expectedID: "UUvXi6j7QhVvgpbKM89MP5HdrxKm9CaJeHc187TsDNf8nZdLk",
 		},
 		{
-			networkID:  constants.FujiID,
+			config:     &FujiConfig,
 			expectedID: "MSj6o9TpezwsQx4Tv7SHqpVvCbJ8of1ikjsqPZ1bKRjc9zBy3",
 		},
 		{
-			networkID:  constants.LocalID,
+			config:     &unmodifiedLocalConfig,
 			expectedID: "23DnViuN2kgePiBN4JxZXh1VrfXca2rwUp6XrKgNGdj3TSQjiN",
 		},
 	}
 	for _, test := range tests {
-		t.Run(constants.NetworkIDToNetworkName[test.networkID], func(t *testing.T) {
+		t.Run(constants.NetworkIDToNetworkName[test.config.NetworkID], func(t *testing.T) {
 			require := require.New(t)
 
-			config := GetConfig(test.networkID)
-			genesisBytes, _, err := FromConfig(config)
+			genesisBytes, _, err := FromConfig(test.config)
 			require.NoError(err)
 
 			var genesisID ids.ID = hashing.ComputeHash256Array(genesisBytes)


### PR DESCRIPTION
## Why this should be merged

* Updates local genesis validator start times to Mon Jul 15 2024 04:00:00 GMT+0000

* Adds a periodic start time generation for every 9 months

Fixes: #3223 

## How this works

modifies local genesis file

## How this was tested

locally tested + UT
