### PR TITLE
chore: allow test-only imports in `*test` and `/tests/**` packages

### DIFF
--- a/snow/consensus/snowman/snowmantest/block.go
+++ b/snow/consensus/snowman/snowmantest/block.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package snowmantest
 
 import (

--- a/snow/consensus/snowman/snowmantest/engine.go
+++ b/snow/consensus/snowman/snowmantest/engine.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package snowmantest
 
 import (

--- a/snow/consensus/snowman/snowmantest/require.go
+++ b/snow/consensus/snowman/snowmantest/require.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package snowmantest
 
 import (

--- a/snow/snowtest/context.go
+++ b/snow/snowtest/context.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package snowtest
 
 import (

--- a/snow/snowtest/decidable.go
+++ b/snow/snowtest/decidable.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package snowtest
 
 import (

--- a/snow/snowtest/status.go
+++ b/snow/snowtest/status.go
@@ -1,8 +1,6 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-//go:build test
-
 package snowtest
 
 type Status int


### PR DESCRIPTION
## Why this should be merged

The requirement for `//go:build test` tags was proving too onerous.

## How this works

The files _excluded_ by the linter are expanded to those in the `/tests/` directory and those in a package named `*test`. The files _included_ by the linter are also expanded to include those that import the former sets.

## How this was tested

Manually by removal of the build constraints from files in `snowmantest` and `snowtest`, demonstrating lint failure, and then clearing the failure by adding the `$IN_TEST_PKG` exclusion.