### PR TITLE
Cleanup wallet tests

### DIFF
--- a/wallet/chain/p/builder_test.go
+++ b/wallet/chain/p/builder_test.go
@@ -83,14 +83,17 @@ func TestBaseTx(t *testing.T) {
 	require.NoError(err)
 
 	// check UTXOs selection and fee financing
-	ins := utx.Ins
 	outs := utx.Outs
-	require.Len(ins, 2)
 	require.Len(outs, 2)
-
-	expectedConsumed := testContext.BaseTxFee + outputsToMove[0].Out.Amount()
-	consumed := ins[0].In.Amount() + ins[1].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(outs),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.BaseTxFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 	require.Equal(outputsToMove[0], outs[1])
 }
 
@@ -140,15 +143,16 @@ func TestAddSubnetValidatorTx(t *testing.T) {
 	utx, err := builder.NewAddSubnetValidatorTx(subnetValidator)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	outs := utx.Outs
-	require.Len(ins, 2)
-	require.Len(outs, 1)
-
-	expectedConsumed := testContext.AddSubnetValidatorFee
-	consumed := ins[0].In.Amount() + ins[1].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.AddSubnetValidatorFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func TestRemoveSubnetValidatorTx(t *testing.T) {
@@ -191,15 +195,16 @@ func TestRemoveSubnetValidatorTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	outs := utx.Outs
-	require.Len(ins, 1)
-	require.Len(outs, 1)
-
-	expectedConsumed := testContext.BaseTxFee
-	consumed := ins[0].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.BaseTxFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func TestCreateChainTx(t *testing.T) {
@@ -250,15 +255,16 @@ func TestCreateChainTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	outs := utx.Outs
-	require.Len(ins, 1)
-	require.Len(outs, 1)
-
-	expectedConsumed := testContext.CreateBlockchainTxFee
-	consumed := ins[0].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.CreateBlockchainTxFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func TestCreateSubnetTx(t *testing.T) {
@@ -298,15 +304,16 @@ func TestCreateSubnetTx(t *testing.T) {
 	utx, err := builder.NewCreateSubnetTx(subnetOwner)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	outs := utx.Outs
-	require.Len(ins, 1)
-	require.Len(outs, 1)
-
-	expectedConsumed := testContext.CreateSubnetTxFee
-	consumed := ins[0].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.CreateSubnetTxFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func TestTransferSubnetOwnershipTx(t *testing.T) {
@@ -349,15 +356,16 @@ func TestTransferSubnetOwnershipTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	outs := utx.Outs
-	require.Len(ins, 1)
-	require.Len(outs, 1)
-
-	expectedConsumed := testContext.BaseTxFee
-	consumed := ins[0].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.BaseTxFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func TestImportTx(t *testing.T) {
@@ -397,17 +405,18 @@ func TestImportTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	outs := utx.Outs
-	importedIns := utx.ImportedInputs
-	require.Empty(ins) // we spend the imported input (at least partially)
-	require.Len(importedIns, 1)
-	require.Len(outs, 1)
+	require.Empty(utx.Ins) // we spend the imported input (at least partially)
 
-	expectedConsumed := testContext.BaseTxFee
-	consumed := importedIns[0].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.BaseTxFee,
+			},
+		),
+		addInputAmounts(utx.Ins, utx.ImportedInputs),
+	)
 }
 
 func TestExportTx(t *testing.T) {
@@ -447,16 +456,18 @@ func TestExportTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	outs := utx.Outs
-	require.Len(ins, 2)
-	require.Len(outs, 1)
-
-	expectedConsumed := testContext.BaseTxFee + exportedOutputs[0].Out.Amount()
-	consumed := ins[0].In.Amount() + ins[1].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
 	require.Equal(utx.ExportedOutputs, exportedOutputs)
+
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs, utx.ExportedOutputs),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.BaseTxFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func TestTransformSubnetTx(t *testing.T) {
@@ -515,18 +526,17 @@ func TestTransformSubnetTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	outs := utx.Outs
-	require.Len(ins, 2)
-	require.Len(outs, 2)
-
-	expectedConsumedSubnetAsset := maxSupply - initialSupply
-	consumedSubnetAsset := ins[0].In.Amount() - outs[1].Out.Amount()
-	require.Equal(expectedConsumedSubnetAsset, consumedSubnetAsset)
-	expectedConsumed := testContext.TransformSubnetTxFee
-	consumed := ins[1].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs),
+			map[ids.ID]uint64{
+				avaxAssetID:   testContext.TransformSubnetTxFee,
+				subnetAssetID: maxSupply - initialSupply,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func TestAddPermissionlessValidatorTx(t *testing.T) {
@@ -583,20 +593,24 @@ func TestAddPermissionlessValidatorTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	staked := utx.StakeOuts
-	outs := utx.Outs
-	require.Len(ins, 4)
-	require.Len(staked, 2)
-	require.Len(outs, 2)
+	// check stake amount
+	require.Equal(
+		map[ids.ID]uint64{
+			avaxAssetID: 2 * units.Avax,
+		},
+		addOutputAmounts(utx.StakeOuts),
+	)
 
-	expectedConsumedSubnetAsset := utx.Validator.Weight()
-	consumedSubnetAsset := staked[0].Out.Amount() + staked[1].Out.Amount()
-	require.Equal(expectedConsumedSubnetAsset, consumedSubnetAsset)
-	expectedConsumed := testContext.AddPrimaryNetworkValidatorFee
-	consumed := ins[1].In.Amount() + ins[3].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs, utx.StakeOuts),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.AddPrimaryNetworkValidatorFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func TestAddPermissionlessDelegatorTx(t *testing.T) {
@@ -641,20 +655,24 @@ func TestAddPermissionlessDelegatorTx(t *testing.T) {
 	)
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	ins := utx.Ins
-	staked := utx.StakeOuts
-	outs := utx.Outs
-	require.Len(ins, 4)
-	require.Len(staked, 2)
-	require.Len(outs, 2)
+	// check stake amount
+	require.Equal(
+		map[ids.ID]uint64{
+			avaxAssetID: 2 * units.Avax,
+		},
+		addOutputAmounts(utx.StakeOuts),
+	)
 
-	expectedConsumedSubnetAsset := utx.Validator.Weight()
-	consumedSubnetAsset := staked[0].Out.Amount() + staked[1].Out.Amount()
-	require.Equal(expectedConsumedSubnetAsset, consumedSubnetAsset)
-	expectedConsumed := testContext.AddPrimaryNetworkDelegatorFee
-	consumed := ins[1].In.Amount() + ins[3].In.Amount() - outs[0].Out.Amount()
-	require.Equal(expectedConsumed, consumed)
+	// check fee calculation
+	require.Equal(
+		addAmounts(
+			addOutputAmounts(utx.Outs, utx.StakeOuts),
+			map[ids.ID]uint64{
+				avaxAssetID: testContext.AddPrimaryNetworkDelegatorFee,
+			},
+		),
+		addInputAmounts(utx.Ins),
+	)
 }
 
 func makeTestUTXOs(utxosKey *secp256k1.PrivateKey) []*avax.UTXO {
@@ -744,4 +762,34 @@ func makeTestUTXOs(utxosKey *secp256k1.PrivateKey) []*avax.UTXO {
 			},
 		},
 	}
+}
+
+func addAmounts(allAmounts ...map[ids.ID]uint64) map[ids.ID]uint64 {
+	amounts := make(map[ids.ID]uint64)
+	for _, amountsToAdd := range allAmounts {
+		for assetID, amount := range amountsToAdd {
+			amounts[assetID] += amount
+		}
+	}
+	return amounts
+}
+
+func addInputAmounts(inputSlices ...[]*avax.TransferableInput) map[ids.ID]uint64 {
+	consumed := make(map[ids.ID]uint64)
+	for _, inputs := range inputSlices {
+		for _, in := range inputs {
+			consumed[in.AssetID()] += in.In.Amount()
+		}
+	}
+	return consumed
+}
+
+func addOutputAmounts(outputSlices ...[]*avax.TransferableOutput) map[ids.ID]uint64 {
+	produced := make(map[ids.ID]uint64)
+	for _, outputs := range outputSlices {
+		for _, out := range outputs {
+			produced[out.AssetID()] += out.Out.Amount()
+		}
+	}
+	return produced
 }

--- a/wallet/chain/p/builder_test.go
+++ b/wallet/chain/p/builder_test.go
@@ -67,7 +67,7 @@ func TestBaseTx(t *testing.T) {
 		builder  = builder.New(set.Of(utxoAddr), testContext, backend)
 
 		// data to build the transaction
-		outputsToMove = []*avax.TransferableOutput{{
+		outputToMove = &avax.TransferableOutput{
 			Asset: avax.Asset{ID: avaxAssetID},
 			Out: &secp256k1fx.TransferOutput{
 				Amt: 7 * units.Avax,
@@ -76,25 +76,25 @@ func TestBaseTx(t *testing.T) {
 					Addrs:     []ids.ShortID{utxoAddr},
 				},
 			},
-		}}
+		}
 	)
 
-	utx, err := builder.NewBaseTx(outputsToMove)
+	utx, err := builder.NewBaseTx([]*avax.TransferableOutput{outputToMove})
 	require.NoError(err)
 
-	// check UTXOs selection and fee financing
-	outs := utx.Outs
-	require.Len(outs, 2)
+	// check that the output is included in the transaction
+	require.Contains(utx.Outs, outputToMove)
+
+	// check fee calculation
 	require.Equal(
 		addAmounts(
-			addOutputAmounts(outs),
+			addOutputAmounts(utx.Outs),
 			map[ids.ID]uint64{
 				avaxAssetID: testContext.BaseTxFee,
 			},
 		),
 		addInputAmounts(utx.Ins),
 	)
-	require.Equal(outputsToMove[0], outs[1])
 }
 
 func TestAddSubnetValidatorTx(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

Currently the wallet tests manually add and subtract different input/output amounts to calculate the expected fees. This PR replaces this with a few helpers that can ensure that the fees are paid correctly.

## How this works

Improves readability of the tests.

## How this was tested

- [X] CI