### PR TITLE
Add suggestions to update `Local.StartTime`

### DIFF
--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -343,28 +343,27 @@ func TestGenesisFromFlag(t *testing.T) {
 
 func TestGenesis(t *testing.T) {
 	tests := []struct {
-		networkID  uint32
+		config     *Config
 		expectedID string
 	}{
 		{
-			networkID:  constants.MainnetID,
+			config:     &MainnetConfig,
 			expectedID: "UUvXi6j7QhVvgpbKM89MP5HdrxKm9CaJeHc187TsDNf8nZdLk",
 		},
 		{
-			networkID:  constants.FujiID,
+			config:     &FujiConfig,
 			expectedID: "MSj6o9TpezwsQx4Tv7SHqpVvCbJ8of1ikjsqPZ1bKRjc9zBy3",
 		},
 		{
-			networkID:  constants.LocalID,
+			config:     &unmodifiedLocalConfig,
 			expectedID: "23DnViuN2kgePiBN4JxZXh1VrfXca2rwUp6XrKgNGdj3TSQjiN",
 		},
 	}
 	for _, test := range tests {
-		t.Run(constants.NetworkIDToNetworkName[test.networkID], func(t *testing.T) {
+		t.Run(constants.NetworkIDToNetworkName[test.config.NetworkID], func(t *testing.T) {
 			require := require.New(t)
 
-			config := GetConfig(test.networkID)
-			genesisBytes, _, err := FromConfig(config)
+			genesisBytes, _, err := FromConfig(test.config)
 			require.NoError(err)
 
 			var genesisID ids.ID = hashing.ComputeHash256Array(genesisBytes)


### PR DESCRIPTION
## Why this should be merged

- Modifies a test so that it won't fail in 9 months.
- Uses `time.Date` rather than `time.Unix` for readability
- Renames some vars

## How this works

- Just a refactor / suggestions

## How this was tested

- [X] CI