### PR TITLE
Rename Transitive snowman to Engine snowman

### DIFF
--- a/snow/engine/snowman/engine.go
+++ b/snow/engine/snowman/engine.go
@@ -33,15 +33,15 @@ import (
 
 const nonVerifiedCacheSize = 64 * units.MiB
 
-var _ common.Engine = (*Transitive)(nil)
+var _ common.Engine = (*Engine)(nil)
 
 func cachedBlockSize(_ ids.ID, blk snowman.Block) int {
 	return ids.IDLen + len(blk.Bytes()) + constants.PointerOverhead
 }
 
-// Transitive implements the Engine interface by attempting to fetch all
-// Transitive dependencies.
-type Transitive struct {
+// Engine implements the Engine interface by attempting to fetch all
+// Engine dependencies.
+type Engine struct {
 	Config
 	*metrics
 
@@ -89,7 +89,7 @@ type Transitive struct {
 	pendingBuildBlocks int
 }
 
-func New(config Config) (*Transitive, error) {
+func New(config Config) (*Engine, error) {
 	config.Ctx.Log.Info("initializing consensus engine")
 
 	nonVerifiedCache, err := metercacher.New[ids.ID, snowman.Block](
@@ -129,7 +129,7 @@ func New(config Config) (*Transitive, error) {
 		return nil, err
 	}
 
-	return &Transitive{
+	return &Engine{
 		Config:                      config,
 		metrics:                     metrics,
 		StateSummaryFrontierHandler: common.NewNoOpStateSummaryFrontierHandler(config.Ctx.Log),
@@ -150,10 +150,10 @@ func New(config Config) (*Transitive, error) {
 	}, nil
 }
 
-func (t *Transitive) Gossip(ctx context.Context) error {
-	lastAcceptedID, lastAcceptedHeight := t.Consensus.LastAccepted()
-	if numProcessing := t.Consensus.NumProcessing(); numProcessing != 0 {
-		t.Ctx.Log.Debug("skipping block gossip",
+func (e *Engine) Gossip(ctx context.Context) error {
+	lastAcceptedID, lastAcceptedHeight := e.Consensus.LastAccepted()
+	if numProcessing := e.Consensus.NumProcessing(); numProcessing != 0 {
+		e.Ctx.Log.Debug("skipping block gossip",
 			zap.String("reason", "blocks currently processing"),
 			zap.Int("numProcessing", numProcessing),
 		)
@@ -161,19 +161,19 @@ func (t *Transitive) Gossip(ctx context.Context) error {
 		// repoll is called here to unblock the engine if it previously errored
 		// when attempting to issue a query. This can happen if a subnet was
 		// temporarily misconfigured and there were no validators.
-		t.repoll(ctx)
+		e.repoll(ctx)
 		return nil
 	}
 
-	t.Ctx.Log.Verbo("sampling from validators",
-		zap.Stringer("validators", t.Validators),
+	e.Ctx.Log.Verbo("sampling from validators",
+		zap.Stringer("validators", e.Validators),
 	)
 
 	// Uniform sampling is used here to reduce bandwidth requirements of
 	// nodes with a large amount of stake weight.
-	vdrID, ok := t.ConnectedValidators.SampleValidator()
+	vdrID, ok := e.ConnectedValidators.SampleValidator()
 	if !ok {
-		t.Ctx.Log.Warn("skipping block gossip",
+		e.Ctx.Log.Warn("skipping block gossip",
 			zap.String("reason", "no connected validators"),
 		)
 		return nil
@@ -181,7 +181,7 @@ func (t *Transitive) Gossip(ctx context.Context) error {
 
 	nextHeightToAccept, err := math.Add(lastAcceptedHeight, 1)
 	if err != nil {
-		t.Ctx.Log.Error("skipping block gossip",
+		e.Ctx.Log.Error("skipping block gossip",
 			zap.String("reason", "block height overflow"),
 			zap.Stringer("blkID", lastAcceptedID),
 			zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -190,29 +190,29 @@ func (t *Transitive) Gossip(ctx context.Context) error {
 		return nil
 	}
 
-	t.requestID++
-	t.Sender.SendPullQuery(
+	e.requestID++
+	e.Sender.SendPullQuery(
 		ctx,
 		set.Of(vdrID),
-		t.requestID,
-		t.Consensus.Preference(),
+		e.requestID,
+		e.Consensus.Preference(),
 		nextHeightToAccept,
 	)
 	return nil
 }
 
-func (t *Transitive) Put(ctx context.Context, nodeID ids.NodeID, requestID uint32, blkBytes []byte) error {
-	blk, err := t.VM.ParseBlock(ctx, blkBytes)
+func (e *Engine) Put(ctx context.Context, nodeID ids.NodeID, requestID uint32, blkBytes []byte) error {
+	blk, err := e.VM.ParseBlock(ctx, blkBytes)
 	if err != nil {
-		if t.Ctx.Log.Enabled(logging.Verbo) {
-			t.Ctx.Log.Verbo("failed to parse block",
+		if e.Ctx.Log.Enabled(logging.Verbo) {
+			e.Ctx.Log.Verbo("failed to parse block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Binary("block", blkBytes),
 				zap.Error(err),
 			)
 		} else {
-			t.Ctx.Log.Debug("failed to parse block",
+			e.Ctx.Log.Debug("failed to parse block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Error(err),
@@ -221,7 +221,7 @@ func (t *Transitive) Put(ctx context.Context, nodeID ids.NodeID, requestID uint3
 		// because GetFailed doesn't utilize the assumption that we actually
 		// sent a Get message, we can safely call GetFailed here to potentially
 		// abandon the request.
-		return t.GetFailed(ctx, nodeID, requestID)
+		return e.GetFailed(ctx, nodeID, requestID)
 	}
 
 	var (
@@ -231,11 +231,11 @@ func (t *Transitive) Put(ctx context.Context, nodeID ids.NodeID, requestID uint3
 		}
 		issuedMetric prometheus.Counter
 	)
-	switch expectedBlkID, ok := t.blkReqs.GetValue(req); {
+	switch expectedBlkID, ok := e.blkReqs.GetValue(req); {
 	case ok:
 		actualBlkID := blk.ID()
 		if actualBlkID != expectedBlkID {
-			t.Ctx.Log.Debug("incorrect block returned in Put",
+			e.Ctx.Log.Debug("incorrect block returned in Put",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Stringer("blkID", actualBlkID),
@@ -243,10 +243,10 @@ func (t *Transitive) Put(ctx context.Context, nodeID ids.NodeID, requestID uint3
 			)
 			// We assume that [blk] is useless because it doesn't match what we
 			// expected.
-			return t.GetFailed(ctx, nodeID, requestID)
+			return e.GetFailed(ctx, nodeID, requestID)
 		}
 
-		issuedMetric = t.blkReqSourceMetric[req]
+		issuedMetric = e.blkReqSourceMetric[req]
 	default:
 		// This can happen if this block was provided to this engine while a Get
 		// request was outstanding. For example, the block may have been locally
@@ -254,11 +254,11 @@ func (t *Transitive) Put(ctx context.Context, nodeID ids.NodeID, requestID uint3
 		//
 		// Note: It is still possible this block will be issued here, because
 		// the block may have previously failed verification.
-		issuedMetric = t.metrics.issued.WithLabelValues(unknownSource)
+		issuedMetric = e.metrics.issued.WithLabelValues(unknownSource)
 	}
 
-	if !t.shouldIssueBlock(blk) {
-		t.metrics.numUselessPutBytes.Add(float64(len(blkBytes)))
+	if !e.shouldIssueBlock(blk) {
+		e.metrics.numUselessPutBytes.Add(float64(len(blkBytes)))
 	}
 
 	// issue the block into consensus. If the block has already been issued,
@@ -266,13 +266,13 @@ func (t *Transitive) Put(ctx context.Context, nodeID ids.NodeID, requestID uint3
 	// receive requests to fill the ancestry. dependencies that have already
 	// been fetched, but with missing dependencies themselves won't be requested
 	// from the vdr.
-	if err := t.issueFrom(ctx, nodeID, blk, issuedMetric); err != nil {
+	if err := e.issueFrom(ctx, nodeID, blk, issuedMetric); err != nil {
 		return err
 	}
-	return t.executeDeferredWork(ctx)
+	return e.executeDeferredWork(ctx)
 }
 
-func (t *Transitive) GetFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
+func (e *Engine) GetFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
 	// We don't assume that this function is called after a failed Get message.
 	// Check to see if we have an outstanding request and also get what the
 	// request was for if it exists.
@@ -280,53 +280,53 @@ func (t *Transitive) GetFailed(ctx context.Context, nodeID ids.NodeID, requestID
 		NodeID:    nodeID,
 		RequestID: requestID,
 	}
-	blkID, ok := t.blkReqs.DeleteKey(req)
+	blkID, ok := e.blkReqs.DeleteKey(req)
 	if !ok {
-		t.Ctx.Log.Debug("unexpected GetFailed",
+		e.Ctx.Log.Debug("unexpected GetFailed",
 			zap.Stringer("nodeID", nodeID),
 			zap.Uint32("requestID", requestID),
 		)
 		return nil
 	}
-	delete(t.blkReqSourceMetric, req)
+	delete(e.blkReqSourceMetric, req)
 
 	// Because the get request was dropped, we no longer expect blkID to be
 	// issued.
-	if err := t.blocked.Abandon(ctx, blkID); err != nil {
+	if err := e.blocked.Abandon(ctx, blkID); err != nil {
 		return err
 	}
-	return t.executeDeferredWork(ctx)
+	return e.executeDeferredWork(ctx)
 }
 
-func (t *Transitive) PullQuery(ctx context.Context, nodeID ids.NodeID, requestID uint32, blkID ids.ID, requestedHeight uint64) error {
-	t.sendChits(ctx, nodeID, requestID, requestedHeight)
+func (e *Engine) PullQuery(ctx context.Context, nodeID ids.NodeID, requestID uint32, blkID ids.ID, requestedHeight uint64) error {
+	e.sendChits(ctx, nodeID, requestID, requestedHeight)
 
-	issuedMetric := t.metrics.issued.WithLabelValues(pushGossipSource)
+	issuedMetric := e.metrics.issued.WithLabelValues(pushGossipSource)
 
 	// Try to issue [blkID] to consensus.
 	// If we're missing an ancestor, request it from [vdr]
-	if err := t.issueFromByID(ctx, nodeID, blkID, issuedMetric); err != nil {
+	if err := e.issueFromByID(ctx, nodeID, blkID, issuedMetric); err != nil {
 		return err
 	}
 
-	return t.executeDeferredWork(ctx)
+	return e.executeDeferredWork(ctx)
 }
 
-func (t *Transitive) PushQuery(ctx context.Context, nodeID ids.NodeID, requestID uint32, blkBytes []byte, requestedHeight uint64) error {
-	t.sendChits(ctx, nodeID, requestID, requestedHeight)
+func (e *Engine) PushQuery(ctx context.Context, nodeID ids.NodeID, requestID uint32, blkBytes []byte, requestedHeight uint64) error {
+	e.sendChits(ctx, nodeID, requestID, requestedHeight)
 
-	blk, err := t.VM.ParseBlock(ctx, blkBytes)
+	blk, err := e.VM.ParseBlock(ctx, blkBytes)
 	// If parsing fails, we just drop the request, as we didn't ask for it
 	if err != nil {
-		if t.Ctx.Log.Enabled(logging.Verbo) {
-			t.Ctx.Log.Verbo("failed to parse block",
+		if e.Ctx.Log.Enabled(logging.Verbo) {
+			e.Ctx.Log.Verbo("failed to parse block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Binary("block", blkBytes),
 				zap.Error(err),
 			)
 		} else {
-			t.Ctx.Log.Debug("failed to parse block",
+			e.Ctx.Log.Debug("failed to parse block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint32("requestID", requestID),
 				zap.Error(err),
@@ -335,28 +335,28 @@ func (t *Transitive) PushQuery(ctx context.Context, nodeID ids.NodeID, requestID
 		return nil
 	}
 
-	if !t.shouldIssueBlock(blk) {
-		t.metrics.numUselessPushQueryBytes.Add(float64(len(blkBytes)))
+	if !e.shouldIssueBlock(blk) {
+		e.metrics.numUselessPushQueryBytes.Add(float64(len(blkBytes)))
 	}
 
-	issuedMetric := t.metrics.issued.WithLabelValues(pushGossipSource)
+	issuedMetric := e.metrics.issued.WithLabelValues(pushGossipSource)
 
 	// issue the block into consensus. If the block has already been issued,
 	// this will be a noop. If this block has missing dependencies, nodeID will
 	// receive requests to fill the ancestry. dependencies that have already
 	// been fetched, but with missing dependencies themselves won't be requested
 	// from the vdr.
-	if err := t.issueFrom(ctx, nodeID, blk, issuedMetric); err != nil {
+	if err := e.issueFrom(ctx, nodeID, blk, issuedMetric); err != nil {
 		return err
 	}
 
-	return t.executeDeferredWork(ctx)
+	return e.executeDeferredWork(ctx)
 }
 
-func (t *Transitive) Chits(ctx context.Context, nodeID ids.NodeID, requestID uint32, preferredID ids.ID, preferredIDAtHeight ids.ID, acceptedID ids.ID) error {
-	t.acceptedFrontiers.SetLastAccepted(nodeID, acceptedID)
+func (e *Engine) Chits(ctx context.Context, nodeID ids.NodeID, requestID uint32, preferredID ids.ID, preferredIDAtHeight ids.ID, acceptedID ids.ID) error {
+	e.acceptedFrontiers.SetLastAccepted(nodeID, acceptedID)
 
-	t.Ctx.Log.Verbo("called Chits for the block",
+	e.Ctx.Log.Verbo("called Chits for the block",
 		zap.Stringer("nodeID", nodeID),
 		zap.Uint32("requestID", requestID),
 		zap.Stringer("preferredID", preferredID),
@@ -364,8 +364,8 @@ func (t *Transitive) Chits(ctx context.Context, nodeID ids.NodeID, requestID uin
 		zap.Stringer("acceptedID", acceptedID),
 	)
 
-	issuedMetric := t.metrics.issued.WithLabelValues(pullGossipSource)
-	if err := t.issueFromByID(ctx, nodeID, preferredID, issuedMetric); err != nil {
+	issuedMetric := e.metrics.issued.WithLabelValues(pullGossipSource)
+	if err := e.issueFromByID(ctx, nodeID, preferredID, issuedMetric); err != nil {
 		return err
 	}
 
@@ -378,17 +378,17 @@ func (t *Transitive) Chits(ctx context.Context, nodeID ids.NodeID, requestID uin
 		responseOptions = []ids.ID{preferredID}
 	)
 	if preferredID != preferredIDAtHeight {
-		if err := t.issueFromByID(ctx, nodeID, preferredIDAtHeight, issuedMetric); err != nil {
+		if err := e.issueFromByID(ctx, nodeID, preferredIDAtHeight, issuedMetric); err != nil {
 			return err
 		}
-		preferredIDAtHeightShouldBlock = t.canDependOn(preferredIDAtHeight)
+		preferredIDAtHeightShouldBlock = e.canDependOn(preferredIDAtHeight)
 		responseOptions = append(responseOptions, preferredIDAtHeight)
 	}
 
 	// Will record chits once [preferredID] and [preferredIDAtHeight] have been
 	// issued into consensus
 	v := &voter{
-		t:               t,
+		e:               e,
 		nodeID:          nodeID,
 		requestID:       requestID,
 		responseOptions: responseOptions,
@@ -397,82 +397,82 @@ func (t *Transitive) Chits(ctx context.Context, nodeID ids.NodeID, requestID uin
 	// Wait until [preferredID] and [preferredIDAtHeight] have been issued to
 	// consensus before applying this chit.
 	var deps []ids.ID
-	if t.canDependOn(preferredID) {
+	if e.canDependOn(preferredID) {
 		deps = append(deps, preferredID)
 	}
 	if preferredIDAtHeightShouldBlock {
 		deps = append(deps, preferredIDAtHeight)
 	}
 
-	if err := t.blocked.Schedule(ctx, v, deps...); err != nil {
+	if err := e.blocked.Schedule(ctx, v, deps...); err != nil {
 		return err
 	}
-	return t.executeDeferredWork(ctx)
+	return e.executeDeferredWork(ctx)
 }
 
-func (t *Transitive) QueryFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
-	lastAccepted, ok := t.acceptedFrontiers.LastAccepted(nodeID)
+func (e *Engine) QueryFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
+	lastAccepted, ok := e.acceptedFrontiers.LastAccepted(nodeID)
 	if ok {
-		return t.Chits(ctx, nodeID, requestID, lastAccepted, lastAccepted, lastAccepted)
+		return e.Chits(ctx, nodeID, requestID, lastAccepted, lastAccepted, lastAccepted)
 	}
 
 	v := &voter{
-		t:         t,
+		e:         e,
 		nodeID:    nodeID,
 		requestID: requestID,
 	}
-	if err := t.blocked.Schedule(ctx, v); err != nil {
+	if err := e.blocked.Schedule(ctx, v); err != nil {
 		return err
 	}
-	return t.executeDeferredWork(ctx)
+	return e.executeDeferredWork(ctx)
 }
 
-func (*Transitive) Timeout(context.Context) error {
+func (*Engine) Timeout(context.Context) error {
 	return nil
 }
 
-func (*Transitive) Halt(context.Context) {}
+func (*Engine) Halt(context.Context) {}
 
-func (t *Transitive) Shutdown(ctx context.Context) error {
-	t.Ctx.Log.Info("shutting down consensus engine")
+func (e *Engine) Shutdown(ctx context.Context) error {
+	e.Ctx.Log.Info("shutting down consensus engine")
 
-	t.Ctx.Lock.Lock()
-	defer t.Ctx.Lock.Unlock()
+	e.Ctx.Lock.Lock()
+	defer e.Ctx.Lock.Unlock()
 
-	return t.VM.Shutdown(ctx)
+	return e.VM.Shutdown(ctx)
 }
 
-func (t *Transitive) Notify(ctx context.Context, msg common.Message) error {
+func (e *Engine) Notify(ctx context.Context, msg common.Message) error {
 	switch msg {
 	case common.PendingTxs:
 		// the pending txs message means we should attempt to build a block.
-		t.pendingBuildBlocks++
-		return t.executeDeferredWork(ctx)
+		e.pendingBuildBlocks++
+		return e.executeDeferredWork(ctx)
 	case common.StateSyncDone:
-		t.Ctx.StateSyncing.Set(false)
+		e.Ctx.StateSyncing.Set(false)
 		return nil
 	default:
-		t.Ctx.Log.Warn("received an unexpected message from the VM",
+		e.Ctx.Log.Warn("received an unexpected message from the VM",
 			zap.Stringer("messageString", msg),
 		)
 		return nil
 	}
 }
 
-func (t *Transitive) Context() *snow.ConsensusContext {
-	return t.Ctx
+func (e *Engine) Context() *snow.ConsensusContext {
+	return e.Ctx
 }
 
-func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
-	t.requestID = startReqID
-	lastAcceptedID, err := t.VM.LastAccepted(ctx)
+func (e *Engine) Start(ctx context.Context, startReqID uint32) error {
+	e.requestID = startReqID
+	lastAcceptedID, err := e.VM.LastAccepted(ctx)
 	if err != nil {
 		return err
 	}
 
-	lastAccepted, err := t.VM.GetBlock(ctx, lastAcceptedID)
+	lastAccepted, err := e.VM.GetBlock(ctx, lastAcceptedID)
 	if err != nil {
-		t.Ctx.Log.Error("failed to get last accepted block",
+		e.Ctx.Log.Error("failed to get last accepted block",
 			zap.Error(err),
 		)
 		return err
@@ -480,7 +480,7 @@ func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 
 	// initialize consensus to the last accepted blockID
 	lastAcceptedHeight := lastAccepted.Height()
-	if err := t.Consensus.Initialize(t.Ctx, t.Params, lastAcceptedID, lastAcceptedHeight, lastAccepted.Timestamp()); err != nil {
+	if err := e.Consensus.Initialize(e.Ctx, e.Params, lastAcceptedID, lastAcceptedHeight, lastAccepted.Timestamp()); err != nil {
 		return err
 	}
 
@@ -492,55 +492,55 @@ func (t *Transitive) Start(ctx context.Context, startReqID uint32) error {
 		case err == snowman.ErrNotOracle:
 			// if there aren't blocks we need to deliver on startup, we need to set
 			// the preference to the last accepted block
-			if err := t.VM.SetPreference(ctx, lastAcceptedID); err != nil {
+			if err := e.VM.SetPreference(ctx, lastAcceptedID); err != nil {
 				return err
 			}
 		case err != nil:
 			return err
 		default:
-			issuedMetric := t.metrics.issued.WithLabelValues(builtSource)
+			issuedMetric := e.metrics.issued.WithLabelValues(builtSource)
 			for _, blk := range options {
 				// note that deliver will set the VM's preference
-				if err := t.deliver(ctx, t.Ctx.NodeID, blk, false, issuedMetric); err != nil {
+				if err := e.deliver(ctx, e.Ctx.NodeID, blk, false, issuedMetric); err != nil {
 					return err
 				}
 			}
 		}
-	} else if err := t.VM.SetPreference(ctx, lastAcceptedID); err != nil {
+	} else if err := e.VM.SetPreference(ctx, lastAcceptedID); err != nil {
 		return err
 	}
 
-	t.Ctx.Log.Info("starting consensus",
+	e.Ctx.Log.Info("starting consensus",
 		zap.Stringer("lastAcceptedID", lastAcceptedID),
 		zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
 	)
-	t.metrics.bootstrapFinished.Set(1)
+	e.metrics.bootstrapFinished.Set(1)
 
-	t.Ctx.State.Set(snow.EngineState{
+	e.Ctx.State.Set(snow.EngineState{
 		Type:  p2p.EngineType_ENGINE_TYPE_SNOWMAN,
 		State: snow.NormalOp,
 	})
-	if err := t.VM.SetState(ctx, snow.NormalOp); err != nil {
+	if err := e.VM.SetState(ctx, snow.NormalOp); err != nil {
 		return fmt.Errorf("failed to notify VM that consensus is starting: %w",
 			err)
 	}
-	return t.executeDeferredWork(ctx)
+	return e.executeDeferredWork(ctx)
 }
 
-func (t *Transitive) HealthCheck(ctx context.Context) (interface{}, error) {
-	t.Ctx.Lock.Lock()
-	defer t.Ctx.Lock.Unlock()
+func (e *Engine) HealthCheck(ctx context.Context) (interface{}, error) {
+	e.Ctx.Lock.Lock()
+	defer e.Ctx.Lock.Unlock()
 
-	t.Ctx.Log.Verbo("running health check",
-		zap.Uint32("requestID", t.requestID),
-		zap.Stringer("polls", t.polls),
-		zap.Reflect("outstandingBlockRequests", t.blkReqs),
-		zap.Int("numMissingDependencies", t.blocked.NumDependencies()),
-		zap.Int("pendingBuildBlocks", t.pendingBuildBlocks),
+	e.Ctx.Log.Verbo("running health check",
+		zap.Uint32("requestID", e.requestID),
+		zap.Stringer("polls", e.polls),
+		zap.Reflect("outstandingBlockRequests", e.blkReqs),
+		zap.Int("numMissingDependencies", e.blocked.NumDependencies()),
+		zap.Int("pendingBuildBlocks", e.pendingBuildBlocks),
 	)
 
-	consensusIntf, consensusErr := t.Consensus.HealthCheck(ctx)
-	vmIntf, vmErr := t.VM.HealthCheck(ctx)
+	consensusIntf, consensusErr := e.Consensus.HealthCheck(ctx)
+	vmIntf, vmErr := e.VM.HealthCheck(ctx)
 	intf := map[string]interface{}{
 		"consensus": consensusIntf,
 		"vm":        vmIntf,
@@ -554,40 +554,40 @@ func (t *Transitive) HealthCheck(ctx context.Context) (interface{}, error) {
 	return intf, fmt.Errorf("vm: %w ; consensus: %w", vmErr, consensusErr)
 }
 
-func (t *Transitive) executeDeferredWork(ctx context.Context) error {
-	if err := t.buildBlocks(ctx); err != nil {
+func (e *Engine) executeDeferredWork(ctx context.Context) error {
+	if err := e.buildBlocks(ctx); err != nil {
 		return err
 	}
 
-	t.metrics.numRequests.Set(float64(t.blkReqs.Len()))
-	t.metrics.numBlocked.Set(float64(len(t.pending)))
-	t.metrics.numBlockers.Set(float64(t.blocked.NumDependencies()))
-	t.metrics.numNonVerifieds.Set(float64(t.unverifiedIDToAncestor.Len()))
+	e.metrics.numRequests.Set(float64(e.blkReqs.Len()))
+	e.metrics.numBlocked.Set(float64(len(e.pending)))
+	e.metrics.numBlockers.Set(float64(e.blocked.NumDependencies()))
+	e.metrics.numNonVerifieds.Set(float64(e.unverifiedIDToAncestor.Len()))
 	return nil
 }
 
-func (t *Transitive) getBlock(ctx context.Context, blkID ids.ID) (snowman.Block, error) {
-	if blk, ok := t.pending[blkID]; ok {
+func (e *Engine) getBlock(ctx context.Context, blkID ids.ID) (snowman.Block, error) {
+	if blk, ok := e.pending[blkID]; ok {
 		return blk, nil
 	}
-	if blk, ok := t.unverifiedBlockCache.Get(blkID); ok {
+	if blk, ok := e.unverifiedBlockCache.Get(blkID); ok {
 		return blk, nil
 	}
 
-	return t.VM.GetBlock(ctx, blkID)
+	return e.VM.GetBlock(ctx, blkID)
 }
 
-func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID uint32, requestedHeight uint64) {
-	lastAcceptedID, lastAcceptedHeight := t.Consensus.LastAccepted()
+func (e *Engine) sendChits(ctx context.Context, nodeID ids.NodeID, requestID uint32, requestedHeight uint64) {
+	lastAcceptedID, lastAcceptedHeight := e.Consensus.LastAccepted()
 	// If we aren't fully verifying blocks, only vote for blocks that are widely
 	// preferred by the validator set.
-	if t.Ctx.StateSyncing.Get() || t.Config.PartialSync {
-		acceptedAtHeight, err := t.VM.GetBlockIDAtHeight(ctx, requestedHeight)
+	if e.Ctx.StateSyncing.Get() || e.Config.PartialSync {
+		acceptedAtHeight, err := e.VM.GetBlockIDAtHeight(ctx, requestedHeight)
 		if err != nil {
 			// Because we only return accepted state here, it's fairly likely
 			// that the requested height is higher than the last accepted block.
 			// That means that this code path is actually quite common.
-			t.Ctx.Log.Debug("failed fetching accepted block",
+			e.Ctx.Log.Debug("failed fetching accepted block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -596,17 +596,17 @@ func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID
 			)
 			acceptedAtHeight = lastAcceptedID
 		}
-		t.Sender.SendChits(ctx, nodeID, requestID, lastAcceptedID, acceptedAtHeight, lastAcceptedID)
+		e.Sender.SendChits(ctx, nodeID, requestID, lastAcceptedID, acceptedAtHeight, lastAcceptedID)
 		return
 	}
 
 	var (
-		preference         = t.Consensus.Preference()
+		preference         = e.Consensus.Preference()
 		preferenceAtHeight ids.ID
 	)
 	if requestedHeight < lastAcceptedHeight {
 		var err error
-		preferenceAtHeight, err = t.VM.GetBlockIDAtHeight(ctx, requestedHeight)
+		preferenceAtHeight, err = e.VM.GetBlockIDAtHeight(ctx, requestedHeight)
 		if err != nil {
 			// If this chain is pruning historical blocks, it's expected for a
 			// node to be unable to fetch some block IDs. In this case, we fall
@@ -615,22 +615,22 @@ func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID
 			// Because it is possible for a byzantine node to spam requests at
 			// old heights on a pruning network, we log this as debug. However,
 			// this case is unexpected to be hit by correct peers.
-			t.Ctx.Log.Debug("failed fetching accepted block",
+			e.Ctx.Log.Debug("failed fetching accepted block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
 				zap.Stringer("lastAcceptedID", lastAcceptedID),
 				zap.Error(err),
 			)
-			t.numMissingAcceptedBlocks.Inc()
+			e.numMissingAcceptedBlocks.Inc()
 
 			preferenceAtHeight = lastAcceptedID
 		}
 	} else {
 		var ok bool
-		preferenceAtHeight, ok = t.Consensus.PreferenceAtHeight(requestedHeight)
+		preferenceAtHeight, ok = e.Consensus.PreferenceAtHeight(requestedHeight)
 		if !ok {
-			t.Ctx.Log.Debug("failed fetching processing block",
+			e.Ctx.Log.Debug("failed fetching processing block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -641,37 +641,37 @@ func (t *Transitive) sendChits(ctx context.Context, nodeID ids.NodeID, requestID
 			preferenceAtHeight = preference
 		}
 	}
-	t.Sender.SendChits(ctx, nodeID, requestID, preference, preferenceAtHeight, lastAcceptedID)
+	e.Sender.SendChits(ctx, nodeID, requestID, preference, preferenceAtHeight, lastAcceptedID)
 }
 
 // Build blocks if they have been requested and the number of processing blocks
 // is less than optimal.
-func (t *Transitive) buildBlocks(ctx context.Context) error {
-	for t.pendingBuildBlocks > 0 && t.Consensus.NumProcessing() < t.Params.OptimalProcessing {
-		t.pendingBuildBlocks--
+func (e *Engine) buildBlocks(ctx context.Context) error {
+	for e.pendingBuildBlocks > 0 && e.Consensus.NumProcessing() < e.Params.OptimalProcessing {
+		e.pendingBuildBlocks--
 
-		blk, err := t.VM.BuildBlock(ctx)
+		blk, err := e.VM.BuildBlock(ctx)
 		if err != nil {
-			t.Ctx.Log.Debug("failed building block",
+			e.Ctx.Log.Debug("failed building block",
 				zap.Error(err),
 			)
-			t.numBuildsFailed.Inc()
+			e.numBuildsFailed.Inc()
 			return nil
 		}
-		t.numBuilt.Inc()
+		e.numBuilt.Inc()
 
 		// The newly created block should be built on top of the preferred block.
 		// Otherwise, the new block doesn't have the best chance of being confirmed.
 		parentID := blk.Parent()
-		if pref := t.Consensus.Preference(); parentID != pref {
-			t.Ctx.Log.Warn("built block with unexpected parent",
+		if pref := e.Consensus.Preference(); parentID != pref {
+			e.Ctx.Log.Warn("built block with unexpected parent",
 				zap.Stringer("expectedParentID", pref),
 				zap.Stringer("parentID", parentID),
 			)
 		}
 
-		issuedMetric := t.metrics.issued.WithLabelValues(builtSource)
-		if err := t.issueWithAncestors(ctx, blk, issuedMetric); err != nil {
+		issuedMetric := e.metrics.issued.WithLabelValues(builtSource)
+		if err := e.issueWithAncestors(ctx, blk, issuedMetric); err != nil {
 			return err
 		}
 
@@ -679,10 +679,10 @@ func (t *Transitive) buildBlocks(ctx context.Context) error {
 		// that was just built caused votes to be applied such that the block
 		// was rejected or was accepted along with one of its children. This
 		// should be cleaned up to never produce an invalid warning.
-		if t.canIssueChildOn(blk.ID()) {
-			t.Ctx.Log.Verbo("successfully issued new block from the VM")
+		if e.canIssueChildOn(blk.ID()) {
+			e.Ctx.Log.Verbo("successfully issued new block from the VM")
 		} else {
-			t.Ctx.Log.Warn("block that was just built is not extendable")
+			e.Ctx.Log.Warn("block that was just built is not extendable")
 		}
 	}
 	return nil
@@ -690,38 +690,38 @@ func (t *Transitive) buildBlocks(ctx context.Context) error {
 
 // Issue another poll to the network, asking what it prefers given the block we prefer.
 // Helps move consensus along.
-func (t *Transitive) repoll(ctx context.Context) {
+func (e *Engine) repoll(ctx context.Context) {
 	// if we are issuing a repoll, we should gossip our current preferences to
 	// propagate the most likely branch as quickly as possible
-	prefID := t.Consensus.Preference()
+	prefID := e.Consensus.Preference()
 
-	for i := t.polls.Len(); i < t.Params.ConcurrentRepolls; i++ {
-		t.sendQuery(ctx, prefID, nil, false)
+	for i := e.polls.Len(); i < e.Params.ConcurrentRepolls; i++ {
+		e.sendQuery(ctx, prefID, nil, false)
 	}
 }
 
 // issueFromByID attempts to issue the branch ending with a block [blkID] into
 // consensus.
 // If we do not have [blkID], request it.
-func (t *Transitive) issueFromByID(
+func (e *Engine) issueFromByID(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	blkID ids.ID,
 	issuedMetric prometheus.Counter,
 ) error {
-	blk, err := t.getBlock(ctx, blkID)
+	blk, err := e.getBlock(ctx, blkID)
 	if err != nil {
 		// If the block is not locally available, request it from the peer.
-		t.sendRequest(ctx, nodeID, blkID, issuedMetric)
+		e.sendRequest(ctx, nodeID, blkID, issuedMetric)
 		return nil //nolint:nilerr
 	}
-	return t.issueFrom(ctx, nodeID, blk, issuedMetric)
+	return e.issueFrom(ctx, nodeID, blk, issuedMetric)
 }
 
 // issueFrom attempts to issue the branch ending with block [blkID] to
 // consensus.
 // If a dependency is missing, it will be requested it from [nodeID].
-func (t *Transitive) issueFrom(
+func (e *Engine) issueFrom(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	blk snowman.Block,
@@ -729,30 +729,30 @@ func (t *Transitive) issueFrom(
 ) error {
 	// issue [blk] and its ancestors to consensus.
 	blkID := blk.ID()
-	for t.shouldIssueBlock(blk) {
-		err := t.issue(ctx, nodeID, blk, false, issuedMetric)
+	for e.shouldIssueBlock(blk) {
+		err := e.issue(ctx, nodeID, blk, false, issuedMetric)
 		if err != nil {
 			return err
 		}
 
 		// If we don't have this ancestor, request it from [nodeID]
 		blkID = blk.Parent()
-		blk, err = t.getBlock(ctx, blkID)
+		blk, err = e.getBlock(ctx, blkID)
 		if err != nil {
 			// If the block is not locally available, request it from the peer.
-			t.sendRequest(ctx, nodeID, blkID, issuedMetric)
+			e.sendRequest(ctx, nodeID, blkID, issuedMetric)
 			return nil //nolint:nilerr
 		}
 	}
 
 	// Remove any outstanding requests for this block
-	if req, ok := t.blkReqs.DeleteValue(blkID); ok {
-		delete(t.blkReqSourceMetric, req)
+	if req, ok := e.blkReqs.DeleteValue(blkID); ok {
+		delete(e.blkReqSourceMetric, req)
 	}
 
 	// If this block isn't pending, make sure nothing is blocked on it.
-	if _, isPending := t.pending[blkID]; !isPending {
-		return t.blocked.Abandon(ctx, blkID)
+	if _, isPending := e.pending[blkID]; !isPending {
+		return e.blocked.Abandon(ctx, blkID)
 	}
 	return nil
 }
@@ -761,20 +761,20 @@ func (t *Transitive) issueFrom(
 // consensus.
 // If a dependency is missing and the dependency hasn't been requested, the
 // issuance will be abandoned.
-func (t *Transitive) issueWithAncestors(
+func (e *Engine) issueWithAncestors(
 	ctx context.Context,
 	blk snowman.Block,
 	issuedMetric prometheus.Counter,
 ) error {
 	blkID := blk.ID()
 	// issue [blk] and its ancestors into consensus
-	for t.shouldIssueBlock(blk) {
-		err := t.issue(ctx, t.Ctx.NodeID, blk, true, issuedMetric)
+	for e.shouldIssueBlock(blk) {
+		err := e.issue(ctx, e.Ctx.NodeID, blk, true, issuedMetric)
 		if err != nil {
 			return err
 		}
 		blkID = blk.Parent()
-		blk, err = t.getBlock(ctx, blkID)
+		blk, err = e.getBlock(ctx, blkID)
 		if err != nil {
 			break
 		}
@@ -782,19 +782,19 @@ func (t *Transitive) issueWithAncestors(
 
 	// There's an outstanding request for this block. We can wait for that
 	// request to succeed or fail.
-	if t.blkReqs.HasValue(blkID) {
+	if e.blkReqs.HasValue(blkID) {
 		return nil
 	}
 
 	// If the block wasn't already issued, we have no reason to expect that it
 	// will be able to be issued.
-	return t.blocked.Abandon(ctx, blkID)
+	return e.blocked.Abandon(ctx, blkID)
 }
 
 // Issue [blk] to consensus once its ancestors have been issued.
 // If [push] is true, a push query will be used. Otherwise, a pull query will be
 // used.
-func (t *Transitive) issue(
+func (e *Engine) issue(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	blk snowman.Block,
@@ -804,16 +804,16 @@ func (t *Transitive) issue(
 	blkID := blk.ID()
 
 	// mark that the block is queued to be added to consensus once its ancestors have been
-	t.pending[blkID] = blk
+	e.pending[blkID] = blk
 
 	// Remove any outstanding requests for this block
-	if req, ok := t.blkReqs.DeleteValue(blkID); ok {
-		delete(t.blkReqSourceMetric, req)
+	if req, ok := e.blkReqs.DeleteValue(blkID); ok {
+		delete(e.blkReqSourceMetric, req)
 	}
 
 	// Will add [blk] to consensus once its ancestors have been
 	i := &issuer{
-		t:            t,
+		e:            e,
 		nodeID:       nodeID,
 		blk:          blk,
 		push:         push,
@@ -823,72 +823,72 @@ func (t *Transitive) issue(
 	// We know that shouldIssueBlock(blk) is true. This means that parent is
 	// either the last accepted block or is not decided.
 	var deps []ids.ID
-	if parentID := blk.Parent(); !t.canIssueChildOn(parentID) {
-		t.Ctx.Log.Verbo("block waiting for parent to be issued",
+	if parentID := blk.Parent(); !e.canIssueChildOn(parentID) {
+		e.Ctx.Log.Verbo("block waiting for parent to be issued",
 			zap.Stringer("blkID", blkID),
 			zap.Stringer("parentID", parentID),
 		)
 		deps = append(deps, parentID)
 	}
 
-	return t.blocked.Schedule(ctx, i, deps...)
+	return e.blocked.Schedule(ctx, i, deps...)
 }
 
 // Request that [vdr] send us block [blkID]
-func (t *Transitive) sendRequest(
+func (e *Engine) sendRequest(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	blkID ids.ID,
 	issuedMetric prometheus.Counter,
 ) {
 	// There is already an outstanding request for this block
-	if t.blkReqs.HasValue(blkID) {
+	if e.blkReqs.HasValue(blkID) {
 		return
 	}
 
-	t.requestID++
+	e.requestID++
 	req := common.Request{
 		NodeID:    nodeID,
-		RequestID: t.requestID,
+		RequestID: e.requestID,
 	}
-	t.blkReqs.Put(req, blkID)
-	t.blkReqSourceMetric[req] = issuedMetric
+	e.blkReqs.Put(req, blkID)
+	e.blkReqSourceMetric[req] = issuedMetric
 
-	t.Ctx.Log.Verbo("sending Get request",
+	e.Ctx.Log.Verbo("sending Get request",
 		zap.Stringer("nodeID", nodeID),
-		zap.Uint32("requestID", t.requestID),
+		zap.Uint32("requestID", e.requestID),
 		zap.Stringer("blkID", blkID),
 	)
-	t.Sender.SendGet(ctx, nodeID, t.requestID, blkID)
+	e.Sender.SendGet(ctx, nodeID, e.requestID, blkID)
 }
 
 // Send a query for this block. If push is set to true, blkBytes will be used to
 // send a PushQuery. Otherwise, blkBytes will be ignored and a PullQuery will be
 // sent.
-func (t *Transitive) sendQuery(
+func (e *Engine) sendQuery(
 	ctx context.Context,
 	blkID ids.ID,
 	blkBytes []byte,
 	push bool,
 ) {
-	t.Ctx.Log.Verbo("sampling from validators",
-		zap.Stringer("validators", t.Validators),
+	e.Ctx.Log.Verbo("sampling from validators",
+		zap.Stringer("validators", e.Validators),
 	)
 
-	vdrIDs, err := t.Validators.Sample(t.Ctx.SubnetID, t.Params.K)
+	vdrIDs, err := e.Validators.Sample(e.Ctx.SubnetID, e.Params.K)
 	if err != nil {
-		t.Ctx.Log.Warn("dropped query for block",
+		e.Ctx.Log.Warn("dropped query for block",
 			zap.String("reason", "insufficient number of validators"),
 			zap.Stringer("blkID", blkID),
-			zap.Int("size", t.Params.K),
+			zap.Int("size", e.Params.K),
 		)
 		return
 	}
 
-	_, lastAcceptedHeight := t.Consensus.LastAccepted()
+	_, lastAcceptedHeight := e.Consensus.LastAccepted()
 	nextHeightToAccept, err := math.Add(lastAcceptedHeight, 1)
 	if err != nil {
-		t.Ctx.Log.Error("dropped query for block",
+		e.Ctx.Log.Error("dropped query for block",
 			zap.String("reason", "block height overflow"),
 			zap.Stringer("blkID", blkID),
 			zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -898,28 +898,28 @@ func (t *Transitive) sendQuery(
 	}
 
 	vdrBag := bag.Of(vdrIDs...)
-	t.requestID++
-	if !t.polls.Add(t.requestID, vdrBag) {
-		t.Ctx.Log.Error("dropped query for block",
+	e.requestID++
+	if !e.polls.Add(e.requestID, vdrBag) {
+		e.Ctx.Log.Error("dropped query for block",
 			zap.String("reason", "failed to add poll"),
 			zap.Stringer("blkID", blkID),
-			zap.Uint32("requestID", t.requestID),
+			zap.Uint32("requestID", e.requestID),
 		)
 		return
 	}
 
 	vdrSet := set.Of(vdrIDs...)
 	if push {
-		t.Sender.SendPushQuery(ctx, vdrSet, t.requestID, blkBytes, nextHeightToAccept)
+		e.Sender.SendPushQuery(ctx, vdrSet, e.requestID, blkBytes, nextHeightToAccept)
 	} else {
-		t.Sender.SendPullQuery(ctx, vdrSet, t.requestID, blkID, nextHeightToAccept)
+		e.Sender.SendPullQuery(ctx, vdrSet, e.requestID, blkID, nextHeightToAccept)
 	}
 }
 
 // issue [blk] to consensus
 // If [push] is true, a push query will be used. Otherwise, a pull query will be
 // used.
-func (t *Transitive) deliver(
+func (e *Engine) deliver(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	blk snowman.Block,
@@ -929,26 +929,26 @@ func (t *Transitive) deliver(
 	// we are no longer waiting on adding the block to consensus, so it is no
 	// longer pending
 	blkID := blk.ID()
-	delete(t.pending, blkID)
+	delete(e.pending, blkID)
 
 	parentID := blk.Parent()
-	if !t.canIssueChildOn(parentID) || t.Consensus.Processing(blkID) {
+	if !e.canIssueChildOn(parentID) || e.Consensus.Processing(blkID) {
 		// If the parent isn't processing or the last accepted block, then this
 		// block is effectively rejected.
 		// Additionally, if [blkID] is already in the processing set, it
 		// shouldn't be added to consensus again.
-		return t.blocked.Abandon(ctx, blkID)
+		return e.blocked.Abandon(ctx, blkID)
 	}
 
 	// By ensuring that the parent is either processing or accepted, it is
 	// guaranteed that the parent was successfully verified. This means that
 	// calling Verify on this block is allowed.
-	blkAdded, err := t.addUnverifiedBlockToConsensus(ctx, nodeID, blk, issuedMetric)
+	blkAdded, err := e.addUnverifiedBlockToConsensus(ctx, nodeID, blk, issuedMetric)
 	if err != nil {
 		return err
 	}
 	if !blkAdded {
-		return t.blocked.Abandon(ctx, blkID)
+		return e.blocked.Abandon(ctx, blkID)
 	}
 
 	// Add all the oracle blocks if they exist. We call verify on all the blocks
@@ -964,7 +964,7 @@ func (t *Transitive) deliver(
 			}
 
 			for _, blk := range options {
-				blkAdded, err := t.addUnverifiedBlockToConsensus(ctx, nodeID, blk, issuedMetric)
+				blkAdded, err := e.addUnverifiedBlockToConsensus(ctx, nodeID, blk, issuedMetric)
 				if err != nil {
 					return err
 				}
@@ -977,60 +977,60 @@ func (t *Transitive) deliver(
 		}
 	}
 
-	if err := t.VM.SetPreference(ctx, t.Consensus.Preference()); err != nil {
+	if err := e.VM.SetPreference(ctx, e.Consensus.Preference()); err != nil {
 		return err
 	}
 
 	// If the block is now preferred, query the network for its preferences
 	// with this new block.
-	if t.Consensus.IsPreferred(blkID) {
-		t.sendQuery(ctx, blkID, blk.Bytes(), push)
+	if e.Consensus.IsPreferred(blkID) {
+		e.sendQuery(ctx, blkID, blk.Bytes(), push)
 	}
 
-	if err := t.blocked.Fulfill(ctx, blkID); err != nil {
+	if err := e.blocked.Fulfill(ctx, blkID); err != nil {
 		return err
 	}
 	for _, blk := range added {
 		blkID := blk.ID()
-		if t.Consensus.IsPreferred(blkID) {
-			t.sendQuery(ctx, blkID, blk.Bytes(), push)
+		if e.Consensus.IsPreferred(blkID) {
+			e.sendQuery(ctx, blkID, blk.Bytes(), push)
 		}
 
-		delete(t.pending, blkID)
-		if err := t.blocked.Fulfill(ctx, blkID); err != nil {
+		delete(e.pending, blkID)
+		if err := e.blocked.Fulfill(ctx, blkID); err != nil {
 			return err
 		}
-		if req, ok := t.blkReqs.DeleteValue(blkID); ok {
-			delete(t.blkReqSourceMetric, req)
+		if req, ok := e.blkReqs.DeleteValue(blkID); ok {
+			delete(e.blkReqSourceMetric, req)
 		}
 	}
 	for _, blk := range dropped {
 		blkID := blk.ID()
-		delete(t.pending, blkID)
-		if err := t.blocked.Abandon(ctx, blkID); err != nil {
+		delete(e.pending, blkID)
+		if err := e.blocked.Abandon(ctx, blkID); err != nil {
 			return err
 		}
-		if req, ok := t.blkReqs.DeleteValue(blkID); ok {
-			delete(t.blkReqSourceMetric, req)
+		if req, ok := e.blkReqs.DeleteValue(blkID); ok {
+			delete(e.blkReqSourceMetric, req)
 		}
 	}
 
 	// It's possible that the blocks we just added to consensus were decided
 	// immediately by votes that were pending their issuance. If this is the
 	// case, we should not be requesting any chits.
-	if t.Consensus.NumProcessing() == 0 {
+	if e.Consensus.NumProcessing() == 0 {
 		return nil
 	}
 
 	// If we should issue multiple queries at the same time, we need to repoll
-	t.repoll(ctx)
+	e.repoll(ctx)
 	return nil
 }
 
-func (t *Transitive) markAsUnverified(blk snowman.Block) {
+func (e *Engine) markAsUnverified(blk snowman.Block) {
 	// If this block is processing, we don't need to add it to non-verifieds.
 	blkID := blk.ID()
-	if t.Consensus.Processing(blkID) {
+	if e.Consensus.Processing(blkID) {
 		return
 	}
 	parentID := blk.Parent()
@@ -1040,15 +1040,15 @@ func (t *Transitive) markAsUnverified(blk snowman.Block) {
 	// parent is not decided and therefore blk is not decided.
 	// Similarly, if the parent is processing, then the parent is not decided
 	// and therefore blk is not decided.
-	if t.unverifiedIDToAncestor.Has(parentID) || t.Consensus.Processing(parentID) {
-		t.unverifiedIDToAncestor.Add(blkID, parentID)
-		t.unverifiedBlockCache.Put(blkID, blk)
+	if e.unverifiedIDToAncestor.Has(parentID) || e.Consensus.Processing(parentID) {
+		e.unverifiedIDToAncestor.Add(blkID, parentID)
+		e.unverifiedBlockCache.Put(blkID, blk)
 	}
 }
 
 // addUnverifiedBlockToConsensus returns whether the block was added and an
 // error if one occurred while adding it to consensus.
-func (t *Transitive) addUnverifiedBlockToConsensus(
+func (e *Engine) addUnverifiedBlockToConsensus(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	blk snowman.Block,
@@ -1059,7 +1059,7 @@ func (t *Transitive) addUnverifiedBlockToConsensus(
 
 	// make sure this block is valid
 	if err := blk.Verify(ctx); err != nil {
-		t.Ctx.Log.Debug("block verification failed",
+		e.Ctx.Log.Debug("block verification failed",
 			zap.Stringer("nodeID", nodeID),
 			zap.Stringer("blkID", blkID),
 			zap.Uint64("height", blkHeight),
@@ -1067,23 +1067,23 @@ func (t *Transitive) addUnverifiedBlockToConsensus(
 		)
 
 		// if verify fails, then all descendants are also invalid
-		t.markAsUnverified(blk)
+		e.markAsUnverified(blk)
 		return false, nil
 	}
 
 	issuedMetric.Inc()
-	t.unverifiedIDToAncestor.Remove(blkID)
-	t.unverifiedBlockCache.Evict(blkID)
-	t.metrics.issuerStake.Observe(float64(t.Validators.GetWeight(t.Ctx.SubnetID, nodeID)))
-	t.Ctx.Log.Verbo("adding block to consensus",
+	e.unverifiedIDToAncestor.Remove(blkID)
+	e.unverifiedBlockCache.Evict(blkID)
+	e.metrics.issuerStake.Observe(float64(e.Validators.GetWeight(e.Ctx.SubnetID, nodeID)))
+	e.Ctx.Log.Verbo("adding block to consensus",
 		zap.Stringer("nodeID", nodeID),
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", blkHeight),
 	)
-	return true, t.Consensus.Add(&memoryBlock{
+	return true, e.Consensus.Add(&memoryBlock{
 		Block:   blk,
-		metrics: t.metrics,
-		tree:    t.unverifiedIDToAncestor,
+		metrics: e.metrics,
+		tree:    e.unverifiedIDToAncestor,
 	})
 }
 
@@ -1091,45 +1091,45 @@ func (t *Transitive) addUnverifiedBlockToConsensus(
 // processing in consensus. If no ancestor could be found, false is returned.
 //
 // Note: If [initialVote] is processing, then [initialVote] will be returned.
-func (t *Transitive) getProcessingAncestor(initialVote ids.ID) (ids.ID, bool) {
+func (e *Engine) getProcessingAncestor(initialVote ids.ID) (ids.ID, bool) {
 	// If [bubbledVote] != [initialVote], it is guaranteed that [bubbledVote] is
 	// in processing. Otherwise, we attempt to iterate through any blocks we
 	// have at our disposal as a best-effort mechanism to find a valid ancestor.
-	bubbledVote := t.unverifiedIDToAncestor.GetAncestor(initialVote)
+	bubbledVote := e.unverifiedIDToAncestor.GetAncestor(initialVote)
 	for {
-		if t.Consensus.Processing(bubbledVote) {
-			t.Ctx.Log.Verbo("applying vote",
+		if e.Consensus.Processing(bubbledVote) {
+			e.Ctx.Log.Verbo("applying vote",
 				zap.Stringer("initialVoteID", initialVote),
 				zap.Stringer("bubbledVoteID", bubbledVote),
 			)
 			if bubbledVote != initialVote {
-				t.numProcessingAncestorFetchesSucceeded.Inc()
+				e.numProcessingAncestorFetchesSucceeded.Inc()
 			} else {
-				t.numProcessingAncestorFetchesUnneeded.Inc()
+				e.numProcessingAncestorFetchesUnneeded.Inc()
 			}
 			return bubbledVote, true
 		}
 
 		// If we haven't cached the block, drop [vote].
-		blk, ok := t.unverifiedBlockCache.Get(bubbledVote)
+		blk, ok := e.unverifiedBlockCache.Get(bubbledVote)
 		if !ok {
-			t.Ctx.Log.Debug("dropping vote",
+			e.Ctx.Log.Debug("dropping vote",
 				zap.String("reason", "ancestor isn't cached"),
 				zap.Stringer("initialVoteID", initialVote),
 				zap.Stringer("bubbledVoteID", bubbledVote),
 			)
-			t.numProcessingAncestorFetchesFailed.Inc()
+			e.numProcessingAncestorFetchesFailed.Inc()
 			return ids.Empty, false
 		}
 
-		if t.isDecided(blk) {
-			t.Ctx.Log.Debug("dropping vote",
+		if e.isDecided(blk) {
+			e.Ctx.Log.Debug("dropping vote",
 				zap.String("reason", "bubbled vote already decided"),
 				zap.Stringer("initialVoteID", initialVote),
 				zap.Stringer("bubbledVoteID", bubbledVote),
 				zap.Uint64("height", blk.Height()),
 			)
-			t.numProcessingAncestorFetchesDropped.Inc()
+			e.numProcessingAncestorFetchesDropped.Inc()
 			return ids.Empty, false
 		}
 
@@ -1140,36 +1140,36 @@ func (t *Transitive) getProcessingAncestor(initialVote ids.ID) (ids.ID, bool) {
 // shouldIssueBlock returns true if the provided block should be enqueued for
 // issuance. If the block is already decided, already enqueued, or has already
 // been issued, this function will return false.
-func (t *Transitive) shouldIssueBlock(blk snowman.Block) bool {
-	if t.isDecided(blk) {
+func (e *Engine) shouldIssueBlock(blk snowman.Block) bool {
+	if e.isDecided(blk) {
 		return false
 	}
 
 	blkID := blk.ID()
-	_, isPending := t.pending[blkID]
+	_, isPending := e.pending[blkID]
 	return !isPending && // If the block is already pending, don't issue it again.
-		!t.Consensus.Processing(blkID) // If the block was previously issued, don't issue it again.
+		!e.Consensus.Processing(blkID) // If the block was previously issued, don't issue it again.
 }
 
 // canDependOn reports true if it is guaranteed for the provided block ID to
 // eventually either be fulfilled or abandoned.
-func (t *Transitive) canDependOn(blkID ids.ID) bool {
-	_, isPending := t.pending[blkID]
-	return isPending || t.blkReqs.HasValue(blkID)
+func (e *Engine) canDependOn(blkID ids.ID) bool {
+	_, isPending := e.pending[blkID]
+	return isPending || e.blkReqs.HasValue(blkID)
 }
 
 // canIssueChildOn reports true if it is valid for a child of parentID to be
 // verified and added to consensus.
-func (t *Transitive) canIssueChildOn(parentID ids.ID) bool {
-	lastAcceptedID, _ := t.Consensus.LastAccepted()
-	return parentID == lastAcceptedID || t.Consensus.Processing(parentID)
+func (e *Engine) canIssueChildOn(parentID ids.ID) bool {
+	lastAcceptedID, _ := e.Consensus.LastAccepted()
+	return parentID == lastAcceptedID || e.Consensus.Processing(parentID)
 }
 
 // isDecided reports true if the provided block's height implies that the block
 // is either Accepted or Rejected.
-func (t *Transitive) isDecided(blk snowman.Block) bool {
+func (e *Engine) isDecided(blk snowman.Block) bool {
 	height := blk.Height()
-	lastAcceptedID, lastAcceptedHeight := t.Consensus.LastAccepted()
+	lastAcceptedID, lastAcceptedHeight := e.Consensus.LastAccepted()
 	if height <= lastAcceptedHeight {
 		return true // block is either accepted or rejected
 	}

--- a/snow/engine/snowman/engine_test.go
+++ b/snow/engine/snowman/engine_test.go
@@ -64,7 +64,7 @@ func MakeParseBlockF(blks ...[]*snowmantest.Block) func(context.Context, []byte)
 	}
 }
 
-func setup(t *testing.T, config Config) (ids.NodeID, validators.Manager, *common.SenderTest, *block.TestVM, *Transitive) {
+func setup(t *testing.T, config Config) (ids.NodeID, validators.Manager, *common.SenderTest, *block.TestVM, *Engine) {
 	require := require.New(t)
 
 	vdr := ids.GenerateTestNodeID()
@@ -3023,7 +3023,7 @@ func TestGetProcessingAncestor(t *testing.T) {
 			metrics, err := newMetrics(prometheus.NewRegistry())
 			require.NoError(err)
 
-			engine := &Transitive{
+			engine := &Engine{
 				Config: Config{
 					Ctx:       ctx,
 					Consensus: consensus,
@@ -3092,7 +3092,7 @@ func TestShouldIssueBlock(t *testing.T) {
 	))
 	require.NoError(t, c.Add(blocks[1]))
 
-	engine := &Transitive{
+	engine := &Engine{
 		Config: Config{
 			Consensus: c,
 		},

--- a/snow/engine/snowman/issuer.go
+++ b/snow/engine/snowman/issuer.go
@@ -17,7 +17,7 @@ var _ job.Job[ids.ID] = (*issuer)(nil)
 
 // issuer issues [blk] into to consensus after its dependencies are met.
 type issuer struct {
-	t            *Transitive
+	e            *Engine
 	nodeID       ids.NodeID // nodeID of the peer that provided this block
 	blk          snowman.Block
 	push         bool
@@ -27,13 +27,13 @@ type issuer struct {
 func (i *issuer) Execute(ctx context.Context, _ []ids.ID, abandoned []ids.ID) error {
 	if len(abandoned) == 0 {
 		// If the parent block wasn't abandoned, this block can be issued.
-		return i.t.deliver(ctx, i.nodeID, i.blk, i.push, i.issuedMetric)
+		return i.e.deliver(ctx, i.nodeID, i.blk, i.push, i.issuedMetric)
 	}
 
 	// If the parent block was abandoned, this block should be abandoned as
 	// well.
 	blkID := i.blk.ID()
-	delete(i.t.pending, blkID)
-	i.t.markAsUnverified(i.blk)
-	return i.t.blocked.Abandon(ctx, blkID)
+	delete(i.e.pending, blkID)
+	i.e.markAsUnverified(i.blk)
+	return i.e.blocked.Abandon(ctx, blkID)
 }


### PR DESCRIPTION
## Why this should be merged

In the package snow/engine/snowman, the engine is called Transitive, and resides in transitive.go. while in the package snow/engine/avalanche it's respectively Engine and engine.go.

Moreover, in the tests of snow/engine/snowman/, the bespoken object is referred to as engine.

I therefore rename the transitive to engine to better fit the rest of the code.

## How this works

Just a file and struct renaming

## How this was tested

If the unit tests pass, this should be good to go.
