### PR TITLE
Remove targetBlockSize arg

### DIFF
--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -61,12 +62,12 @@ type Builder interface {
 	// BuildBlock can be called to attempt to create a new block
 	BuildBlock(context.Context) (snowman.Block, error)
 
-	// PackBlockTxs returns an array of txs that can fit into a valid block of
-	// size [targetBlockSize]. The returned txs are all verified against the
-	// preferred state.
+	// PackAllBlockTxs returns an array of all txs that could be packed into a
+	// valid block of infinite size. The returned txs are all verified against
+	// the preferred state.
 	//
 	// Note: This function does not call the consensus engine.
-	PackBlockTxs(targetBlockSize int) ([]*txs.Tx, error)
+	PackAllBlockTxs() ([]*txs.Tx, error)
 }
 
 // builder implements a simple builder to convert txs into valid blocks
@@ -236,7 +237,7 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 	return b.blkManager.NewBlock(statelessBlk), nil
 }
 
-func (b *builder) PackBlockTxs(targetBlockSize int) ([]*txs.Tx, error) {
+func (b *builder) PackAllBlockTxs() ([]*txs.Tx, error) {
 	preferredID := b.blkManager.Preferred()
 	preferredState, ok := b.blkManager.GetState(preferredID)
 	if !ok {
@@ -250,7 +251,7 @@ func (b *builder) PackBlockTxs(targetBlockSize int) ([]*txs.Tx, error) {
 		b.txExecutorBackend,
 		b.blkManager,
 		b.txExecutorBackend.Clk.Time(),
-		targetBlockSize,
+		math.MaxInt,
 	)
 }
 

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"time"
 
@@ -269,7 +268,7 @@ func (vm *VM) pruneMempool() error {
 	// Packing all of the transactions in order performs additional checks that
 	// the MempoolTxVerifier doesn't include. So, evicting transactions from
 	// here is expected to happen occasionally.
-	blockTxs, err := vm.Builder.PackBlockTxs(math.MaxInt)
+	blockTxs, err := vm.Builder.PackAllBlockTxs()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why this should be merged

After Etna, the block size is limited by complexity, not by bytes. This change allows the pre-Etna/post-Etna logic to be completely owned by the block builder.

## How this works

Hardcodes the single argument in the function body.

## How this was tested

- [X] CI