### PR TITLE
Fix comparison comment in snowflake algorithms

### DIFF
--- a/snow/consensus/snowball/binary_snowflake.go
+++ b/snow/consensus/snowball/binary_snowflake.go
@@ -20,7 +20,7 @@ func newBinarySnowflake(alphaPreference int, terminationConditions []termination
 // Invariant:
 // len(terminationConditions) == len(confidence)
 // terminationConditions[i].alphaConfidence < terminationConditions[i+1].alphaConfidence
-// terminationConditions[i].beta <= terminationConditions[i+1].beta
+// terminationConditions[i].beta >= terminationConditions[i+1].beta
 // confidence[i] >= confidence[i+1] (except after finalizing due to early termination)
 type binarySnowflake struct {
 	// wrap the binary slush logic

--- a/snow/consensus/snowball/nnary_snowflake.go
+++ b/snow/consensus/snowball/nnary_snowflake.go
@@ -25,7 +25,7 @@ func newNnarySnowflake(alphaPreference int, terminationConditions []terminationC
 // Invariant:
 // len(terminationConditions) == len(confidence)
 // terminationConditions[i].alphaConfidence < terminationConditions[i+1].alphaConfidence
-// terminationConditions[i].beta <= terminationConditions[i+1].beta
+// terminationConditions[i].beta >= terminationConditions[i+1].beta
 // confidence[i] >= confidence[i+1] (except after finalizing due to early termination)
 type nnarySnowflake struct {
 	// wrap the n-nary slush logic

--- a/snow/consensus/snowball/unary_snowflake.go
+++ b/snow/consensus/snowball/unary_snowflake.go
@@ -22,7 +22,7 @@ func newUnarySnowflake(alphaPreference int, terminationConditions []terminationC
 // Invariant:
 // len(terminationConditions) == len(confidence)
 // terminationConditions[i].alphaConfidence < terminationConditions[i+1].alphaConfidence
-// terminationConditions[i].beta <= terminationConditions[i+1].beta
+// terminationConditions[i].beta >= terminationConditions[i+1].beta
 // confidence[i] >= confidence[i+1] (except after finalizing due to early termination)
 type unarySnowflake struct {
 	// alphaPreference is the threshold required to update the preference


### PR DESCRIPTION
## Why this should be merged

In the snowflake algorithms, there is the following comment:

```
// terminationConditions[i].alphaConfidence < terminationConditions[i+1].alphaConfidence 
// terminationConditions[i].beta <= terminationConditions[i+1].beta
```
However, the two lines contradict, as if alpha confidence grows with i, then beta should decrease and not increase. The reason is that the higher our confidence, the less consecutive polls we need to finalize.

## How this works

Just a comment fix

## How this was tested

No need to test, it's a comment fix. 