### PR TITLE
[ci] Switch to v2 of docker compose plugin

### DIFF
--- a/scripts/tests.build_antithesis_images.sh
+++ b/scripts/tests.build_antithesis_images.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 #   3. Running the workload and its target network without error for a minute
 #   4. Stopping the workload and its target network
 #
+# `docker compose` is used (docker compose v2 plugin) due to it being installed by default on
+# public github runners. `docker-compose` (the v1 plugin) is not installed by default.
 
 # e.g.,
 # TEST_SETUP=avalanchego ./scripts/tests.build_antithesis_images.sh                 # Test build of images for avalanchego test setup
@@ -31,10 +33,10 @@ docker create --name "${CONTAINER_NAME}" "${IMAGE_NAME}:${TAG}" /bin/true
 
 # Create a temporary directory to write the compose configuration to
 TMPDIR="$(mktemp -d)"
-echo "using temporary directory ${TMPDIR} as the docker-compose path"
+echo "using temporary directory ${TMPDIR} as the docker compose path"
 
 COMPOSE_FILE="${TMPDIR}/docker-compose.yml"
-COMPOSE_CMD="docker-compose -f ${COMPOSE_FILE}"
+COMPOSE_CMD="docker compose -f ${COMPOSE_FILE}"
 
 # Ensure cleanup
 function cleanup {

--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -83,12 +83,12 @@ chain needs to be provided to the workload:
 $ AVAWL_URIS=... CHAIN_IDS="2S9ypz...AzMj9" go run ./tests/antithesis/xsvm
 ```
 
-### Running a workload with docker-compose
+### Running a workload with docker compose v2
 
 Running the test script for a given test setup with the `DEBUG` flag
 set will avoid cleaning up the temporary directory where the
-docker-compose setup is written to. This will allow manual invocation of
-docker-compose to see the log output of the workload.
+docker compose setup is written to. This will allow manual invocation of
+docker compose to see the log output of the workload.
 
 ```bash
 $ DEBUG=1 ./scripts/tests.build_antithesis_images.sh
@@ -99,7 +99,7 @@ directory will appear in the output of the script:
 
 ```
 ...
-using temporary directory /tmp/tmp.E6eHdDr4ln as the docker-compose path"
+using temporary directory /tmp/tmp.E6eHdDr4ln as the docker compose path"
 ...
 ```
 
@@ -110,10 +110,10 @@ output appears on stdout for inspection:
 $ cd [temporary directory]
 
 # Start the compose project
-$ docker-compose up
+$ docker compose up
 
 # Cleanup the compose project
-$ docker-compose down --volumes
+$ docker compose down --volumes
 ```
 
 ## Manually triggering an Antithesis test run

--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -30,7 +30,7 @@ var (
 	errPluginDirEnvVarNotSet  = errors.New("AVALANCHEGO_PLUGIN_DIR environment variable not set")
 )
 
-// Creates docker-compose configuration for an antithesis test
+// Creates docker compose configuration for an antithesis test
 // setup. Configuration is via env vars to simplify usage by main entrypoints. If
 // the provided network includes a subnet, the initial DB state for the subnet
 // will be created and written to the target path.
@@ -77,7 +77,7 @@ func GenerateComposeConfig(network *tmpnet.Network, baseImageName string) error 
 	return nil
 }
 
-// Initialize the given path with the docker-compose configuration (compose file and
+// Initialize the given path with the docker compose configuration (compose file and
 // volumes) needed for an Antithesis test setup.
 func initComposeConfig(
 	network *tmpnet.Network,


### PR DESCRIPTION
## Why this should be merged

As per https://github.com/actions/runner-images/issues/9692, the default runner image no longer includes the docker compose v1 plugin (`docker-compose` command). The v2 plugin (`docker compose` command) is provided, so this change updates the antithesis image build test to use that instead.

## How this was tested

CI