### PR TITLE
Update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,11 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
+# Code owners are the final gate for PR approval to their named section of code.
+# If a single PR involves multiple code owners, every code owner should approve
+# a PR prior to merging.
+
 * @StephenButtolph
-/app/ @danlaine
-/codec/ @danlaine
-/database/corruptabledb/ @ceyonur
-/ids/ @danlaine @joshua-kim
-/indexer/ @danlaine
-/message/ @gyuho
-/network/ @danlaine @joshua-kim @StephenButtolph
-/network/throttling/ @danlaine @dboehm-avalabs @StephenButtolph
-/proto/ @gyuho
-/snow/ @danlaine @StephenButtolph
-/snow/consensus/ @gyuho @StephenButtolph
-/snow/engine/snowman/syncer/ @abi87
-/snow/uptime/ @ceyonur
-/utils/logging/ @ceyonur
-/vms/platformvm/ @abi87 @danlaine @dhrubabasu @StephenButtolph
-/vms/proposervm/ @abi87 @StephenButtolph
-/vms/registry/ @joshua-kim
-/tests/ @abi87 @gyuho @marun
-/x/ @danlaine @darioush @dboehm-avalabs
+/.github/ @marun
+/network/p2p/ @joshua-kim
+/scripts/ @marun
+/tests/ @marun


### PR DESCRIPTION
## Why this should be merged

I have long been the final "Yes/No" for PR review in this repository. The prior CODEOWNERS file was intended to have people grow into this role for some components. The CODEOWNERS will now represent who has the final merge "Yes/No" for a subtree.

This is not a final list, if someone feels that they should own a sub-package please reach out to me to be added to this list.

## How this works

Updates CODEOWNERS

## How this was tested

![image](https://github.com/user-attachments/assets/91d5baca-765d-4e7c-a677-646d0b7167f8)