### PR TITLE
Activate Error Driven Snowflake

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -304,6 +304,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Uint(BootstrapAncestorsMaxContainersReceivedKey, 2000, "This node reads at most this many containers from an incoming Ancestors message")
 
 	// Consensus
+	fs.String(SnowTerminationCriteriaJSONKey, "", "Termination criteria for poll")
 	fs.Int(SnowSampleSizeKey, snowball.DefaultParameters.K, "Number of nodes to query for each network poll")
 	fs.Int(SnowQuorumSizeKey, snowball.DefaultParameters.AlphaConfidence, "Threshold of nodes required to update this node's preference and increase its confidence in a network poll")
 	fs.Int(SnowPreferenceQuorumSizeKey, snowball.DefaultParameters.AlphaPreference, fmt.Sprintf("Threshold of nodes required to update this node's preference in a network poll. Ignored if %s is provided", SnowQuorumSizeKey))

--- a/config/keys.go
+++ b/config/keys.go
@@ -135,6 +135,7 @@ const (
 	LogRotaterMaxAgeKey                                = "log-rotater-max-age"
 	LogRotaterCompressEnabledKey                       = "log-rotater-compress-enabled"
 	LogDisableDisplayPluginLogsKey                     = "log-disable-display-plugin-logs"
+	SnowTerminationCriteriaJSONKey                     = "snow-termination-criteria"
 	SnowSampleSizeKey                                  = "snow-sample-size"
 	SnowQuorumSizeKey                                  = "snow-quorum-size"
 	SnowPreferenceQuorumSizeKey                        = "snow-preference-quorum-size"

--- a/snow/consensus/snowball/binary_snowball_test.go
+++ b/snow/consensus/snowball/binary_snowball_test.go
@@ -17,7 +17,7 @@ func TestBinarySnowball(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 2, 3
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newBinarySnowball(alphaPreference, terminationConditions, red)
 	require.Equal(red, sb.Preference())
@@ -48,7 +48,7 @@ func TestBinarySnowballRecordPollPreference(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newBinarySnowball(alphaPreference, terminationConditions, red)
 	require.Equal(red, sb.Preference())
@@ -86,7 +86,7 @@ func TestBinarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newBinarySnowball(alphaPreference, terminationConditions, red)
 	require.Equal(red, sb.Preference())
@@ -118,7 +118,7 @@ func TestBinarySnowballAcceptWeirdColor(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newBinarySnowball(alphaPreference, terminationConditions, red)
 
@@ -160,7 +160,7 @@ func TestBinarySnowballLockColor(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 1
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newBinarySnowball(alphaPreference, terminationConditions, red)
 

--- a/snow/consensus/snowball/binary_snowflake_test.go
+++ b/snow/consensus/snowball/binary_snowflake_test.go
@@ -17,7 +17,7 @@ func TestBinarySnowflake(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sf := newBinarySnowflake(alphaPreference, terminationConditions, red)
 

--- a/snow/consensus/snowball/factory.go
+++ b/snow/consensus/snowball/factory.go
@@ -13,23 +13,23 @@ var (
 type snowballFactory struct{}
 
 func (snowballFactory) NewNnary(params Parameters, choice ids.ID) Nnary {
-	sb := newNnarySnowball(params.AlphaPreference, newSingleTerminationCondition(params.AlphaConfidence, params.Beta), choice)
+	sb := newNnarySnowball(params.AlphaPreference, params.terminationConditions(), choice)
 	return &sb
 }
 
 func (snowballFactory) NewUnary(params Parameters) Unary {
-	sb := newUnarySnowball(params.AlphaPreference, newSingleTerminationCondition(params.AlphaConfidence, params.Beta))
+	sb := newUnarySnowball(params.AlphaPreference, params.terminationConditions())
 	return &sb
 }
 
 type snowflakeFactory struct{}
 
 func (snowflakeFactory) NewNnary(params Parameters, choice ids.ID) Nnary {
-	sf := newNnarySnowflake(params.AlphaPreference, newSingleTerminationCondition(params.AlphaConfidence, params.Beta), choice)
+	sf := newNnarySnowflake(params.AlphaPreference, params.terminationConditions(), choice)
 	return &sf
 }
 
 func (snowflakeFactory) NewUnary(params Parameters) Unary {
-	sf := newUnarySnowflake(params.AlphaPreference, newSingleTerminationCondition(params.AlphaConfidence, params.Beta))
+	sf := newUnarySnowflake(params.AlphaPreference, params.terminationConditions())
 	return &sf
 }

--- a/snow/consensus/snowball/nnary_snowball_test.go
+++ b/snow/consensus/snowball/nnary_snowball_test.go
@@ -14,7 +14,7 @@ func TestNnarySnowball(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newNnarySnowball(alphaPreference, terminationConditions, Red)
 	sb.Add(Blue)
@@ -57,7 +57,7 @@ func TestVirtuousNnarySnowball(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 1
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newNnarySnowball(alphaPreference, terminationConditions, Red)
 
@@ -74,7 +74,7 @@ func TestNarySnowballRecordUnsuccessfulPoll(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newNnarySnowball(alphaPreference, terminationConditions, Red)
 	sb.Add(Blue)
@@ -114,7 +114,7 @@ func TestNarySnowballDifferentSnowflakeColor(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newNnarySnowball(alphaPreference, terminationConditions, Red)
 	sb.Add(Blue)

--- a/snow/consensus/snowball/nnary_snowflake_test.go
+++ b/snow/consensus/snowball/nnary_snowflake_test.go
@@ -16,7 +16,8 @@ func TestNnarySnowflake(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sf := newNnarySnowflake(alphaPreference, terminationConditions, Red)
 	sf.Add(Blue)
@@ -55,7 +56,7 @@ func TestNnarySnowflakeConfidenceReset(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 4
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sf := newNnarySnowflake(alphaPreference, terminationConditions, Red)
 	sf.Add(Blue)
@@ -89,7 +90,7 @@ func TestVirtuousNnarySnowflake(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newNnarySnowflake(alphaPreference, terminationConditions, Red)
 	require.Equal(Red, sb.Preference())

--- a/snow/consensus/snowball/parameters_test.go
+++ b/snow/consensus/snowball/parameters_test.go
@@ -211,6 +211,68 @@ func TestParametersVerify(t *testing.T) {
 			},
 			expectedError: ErrParametersInvalid,
 		},
+		{
+			name: "termination criteria same vote threshold",
+			params: Parameters{
+				TerminationCriteria: []TerminationCriteria{
+					{VoteThreshold: 10, ConsecutiveSuccesses: 5},
+					{VoteThreshold: 10, ConsecutiveSuccesses: 4},
+				},
+			},
+			expectedError: ErrParametersInvalid,
+		},
+		{
+			name: "termination criteria descending vote threshold",
+			params: Parameters{
+				TerminationCriteria: []TerminationCriteria{
+					{VoteThreshold: 10, ConsecutiveSuccesses: 5},
+					{VoteThreshold: 9, ConsecutiveSuccesses: 4},
+				},
+			},
+			expectedError: ErrParametersInvalid,
+		},
+		{
+			name: "termination criteria ascending consecutive successes",
+			params: Parameters{
+				TerminationCriteria: []TerminationCriteria{
+					{VoteThreshold: 10, ConsecutiveSuccesses: 5},
+					{VoteThreshold: 11, ConsecutiveSuccesses: 6},
+				},
+			},
+			expectedError: ErrParametersInvalid,
+		},
+		{
+			name: "termination criteria single criteria",
+			params: Parameters{
+				K:                     1,
+				AlphaPreference:       1,
+				Beta:                  1,
+				ConcurrentRepolls:     1,
+				OptimalProcessing:     1,
+				MaxOutstandingItems:   1,
+				MaxItemProcessingTime: 1,
+				TerminationCriteria: []TerminationCriteria{
+					{VoteThreshold: 10, ConsecutiveSuccesses: 5},
+				},
+			},
+		},
+		{
+			name: "termination criteria multiple criteria",
+			params: Parameters{
+				K:                     1,
+				AlphaPreference:       1,
+				Beta:                  1,
+				ConcurrentRepolls:     1,
+				OptimalProcessing:     1,
+				MaxOutstandingItems:   1,
+				MaxItemProcessingTime: 1,
+				TerminationCriteria: []TerminationCriteria{
+					{VoteThreshold: 10, ConsecutiveSuccesses: 5},
+					{VoteThreshold: 11, ConsecutiveSuccesses: 5},
+					{VoteThreshold: 12, ConsecutiveSuccesses: 4},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/snow/consensus/snowball/unary_snowball_test.go
+++ b/snow/consensus/snowball/unary_snowball_test.go
@@ -22,7 +22,7 @@ func TestUnarySnowball(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sb := newUnarySnowball(alphaPreference, terminationConditions)
 

--- a/snow/consensus/snowball/unary_snowflake_test.go
+++ b/snow/consensus/snowball/unary_snowflake_test.go
@@ -21,7 +21,7 @@ func TestUnarySnowflake(t *testing.T) {
 
 	alphaPreference, alphaConfidence := 1, 2
 	beta := 2
-	terminationConditions := newSingleTerminationCondition(alphaConfidence, beta)
+	terminationConditions := newTerminationCondition([]TerminationCriteria{{VoteThreshold: alphaConfidence, ConsecutiveSuccesses: beta}})
 
 	sf := newUnarySnowflake(alphaPreference, terminationConditions)
 

--- a/snow/engine/snowman/engine.go
+++ b/snow/engine/snowman/engine.go
@@ -107,10 +107,16 @@ func New(config Config) (*Engine, error) {
 	acceptedFrontiers := tracker.NewAccepted()
 	config.Validators.RegisterSetCallbackListener(config.Ctx.SubnetID, acceptedFrontiers)
 
+	confidences := make([]int, 0, len(config.Params.TerminationCriteria))
+	for _, confidence := range config.Params.TerminationCriteria {
+		confidences = append(confidences, confidence.VoteThreshold)
+	}
+
 	factory, err := poll.NewEarlyTermNoTraversalFactory(
 		config.Params.AlphaPreference,
 		config.Params.AlphaConfidence,
 		config.Ctx.Registerer,
+		confidences,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Why this should be merged and how was this tested

This commit enables error driven snowflake. 

I deployed on the Fuji network two nodes with the same spec (8 CPU, 32GB RAM), and collected metrics for 12 hours.

The measurement of the average time to finalize a block on the latest version of Avalanche is as follows:

<img width="1376" alt="Screenshot 2024-08-09 at 15 25 46" src="https://github.com/user-attachments/assets/b44e69d9-1c1f-4596-8625-36d12563736f">


In contrast, with this commit, the time to finalize a block is now cut by ~ 35%:

<img width="1377" alt="Screenshot 2024-08-09 at 15 26 35" src="https://github.com/user-attachments/assets/f6a02913-a37b-4fdd-a74f-a9f4f9682de5">

When 5% of the stake is unreachable, the current snowflake finalization time increases: 

<img width="1376" alt="Screenshot 2024-08-09 at 21 33 33" src="https://github.com/user-attachments/assets/eb7d09b5-3f12-483e-a6da-05573318c30d">


The error driven snowflake finalization time increases more, but it seems it is still slightly faster than the current snowflake:

<img width="1378" alt="Screenshot 2024-08-09 at 21 32 48" src="https://github.com/user-attachments/assets/b7133c7b-f77e-4699-9d93-2e33c7cec881">


The time measurements for block finalizations were collected via the metric `avalanche_snowman_blks_accepted_sum` which is the metric which measures the duration from the time the block is seen for the first time and enters consensus, to the time the block is finalized. 




## How this works

In the classical snowflake protocol, a node issues a sequence of polls, and every poll yields a certain confidence score which is based on the number of nodes that responded and the content of the response.

If the poll contains enough responses that amplify the confidence score above a certain threshold, the poll is considered a success, and the criteria to finalize a block is collecting enough successive successful polls. 

In the error driven snowflake which is described in Section 4.1 in the [Frosty paper](https://arxiv.org/abs/2404.14250), a poll can succeed in various degrees of success: The higher the confidence score that the poll concludes, the more successful the poll is considered. In contrast to the classical snowflake protocol, the criteria for how many successful polls are required to finalize a block is now determined by the confidence score of the polls - successive polls with a higher confidence score require fewer of them to finalize, and vice versa. 

Each poll consists of sending queries to a number of nodes, and collecting responses. Since nodes may be offline, slow or malicious, they might not return responses in a timely manner. In order for the polls to be efficient, there exists logic which terminates a poll early once it has reached a required level of confidence, or if enough nodes timed out such that it is evident that the required confidence level cannot be reached by waiting for further nodes.

The current snowflake code already supports the error driven variant. However, the logic that terminates the polls early currently only supports the classical snowflake with a single confidence score. 
In addition, there is no way to express in the configuration the threshold for the error driven snowflake, as there is only a single confidence configuration in the configuration. 

This commit introduces new configuration flags to the avalanche node which express the error driven snowflake various confidence criteria, and also changes the early termination logic to accommodate the error driven snowflake. 
