### PR TITLE
Expose upgrade config in the info API

### DIFF
--- a/api/info/client.go
+++ b/api/info/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils/rpc"
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 )
@@ -27,6 +28,7 @@ type Client interface {
 	Peers(context.Context, ...rpc.Option) ([]Peer, error)
 	IsBootstrapped(context.Context, string, ...rpc.Option) (bool, error)
 	GetTxFee(context.Context, ...rpc.Option) (*GetTxFeeResponse, error)
+	Upgrades(context.Context, ...rpc.Option) (*upgrade.Config, error)
 	Uptime(context.Context, ids.ID, ...rpc.Option) (*UptimeResponse, error)
 	GetVMs(context.Context, ...rpc.Option) (map[ids.ID][]string, error)
 }
@@ -98,6 +100,12 @@ func (c *client) IsBootstrapped(ctx context.Context, chainID string, options ...
 func (c *client) GetTxFee(ctx context.Context, options ...rpc.Option) (*GetTxFeeResponse, error) {
 	res := &GetTxFeeResponse{}
 	err := c.requester.SendRequest(ctx, "info.getTxFee", struct{}{}, res, options...)
+	return res, err
+}
+
+func (c *client) Upgrades(ctx context.Context, options ...rpc.Option) (*upgrade.Config, error) {
+	res := &upgrade.Config{}
+	err := c.requester.SendRequest(ctx, "info.upgrades", struct{}{}, res, options...)
 	return res, err
 }
 

--- a/api/info/service.go
+++ b/api/info/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/network/peer"
 	"github.com/ava-labs/avalanchego/snow/networking/benchlist"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/json"
@@ -53,6 +54,7 @@ type Parameters struct {
 	NetworkID   uint32
 	TxFeeConfig genesis.TxFeeConfig
 	VMManager   vms.Manager
+	Upgrades    upgrade.Config
 }
 
 func NewService(
@@ -280,6 +282,17 @@ func (i *Info) IsBootstrapped(_ *http.Request, args *IsBootstrappedArgs, reply *
 		return fmt.Errorf("there is no chain with alias/ID '%s'", args.Chain)
 	}
 	reply.IsBootstrapped = i.chainManager.IsBootstrapped(chainID)
+	return nil
+}
+
+// Upgrades returns the upgrade schedule this node is running.
+func (i *Info) Upgrades(_ *http.Request, _ *struct{}, reply *upgrade.Config) error {
+	i.log.Debug("API called",
+		zap.String("service", "info"),
+		zap.String("method", "upgrades"),
+	)
+
+	*reply = i.Parameters.Upgrades
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -1420,6 +1420,7 @@ func (n *Node) initInfoAPI() error {
 			NetworkID:   n.Config.NetworkID,
 			TxFeeConfig: n.Config.TxFeeConfig,
 			VMManager:   n.VMManager,
+			Upgrades:    n.Config.UpgradeConfig,
 		},
 		n.Log,
 		n.vdrs,

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	InitiallyActiveTime       = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
-	UnscheduledActivationTime = time.Date(10000, time.December, 1, 0, 0, 0, 0, time.UTC)
+	UnscheduledActivationTime = time.Date(9999, time.December, 1, 0, 0, 0, 0, time.UTC)
 
 	Mainnet = Config{
 		ApricotPhase1Time:            time.Date(2021, time.March, 31, 14, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## Why this should be merged

This will be used in the E2E testing to determine which ruleset should be used when executing tests.

## How this works

Exposes the `upgrade.Config` through a new `info.upgrades` API.

## How this was tested

- Manually