### PR TITLE
Separate e2e tests by etna activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: fuzz_test
         shell: bash
         run: ./scripts/build_fuzz.sh 10 # Run each fuzz test 10 seconds
-  e2e:
+  e2e_pre_etna:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +68,28 @@ jobs:
         uses: ./.github/actions/upload-tmpnet-artifact
         if: always()
         with:
-          name: e2e-tmpnet-data
+          name: e2e-pre-etna-tmpnet-data
+  e2e_post_etna:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go-for-project
+      - name: Build AvalancheGo Binary
+        shell: bash
+        run: ./scripts/build.sh -r
+      - name: Run e2e tests
+        uses: ./.github/actions/run-monitored-tmpnet-cmd
+        with:
+          run: E2E_SERIAL=1 ./scripts/tests.e2e.sh --delay-network-shutdown --activate-etna
+          prometheus_id: ${{ secrets.PROMETHEUS_ID || '' }}
+          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          loki_id: ${{ secrets.LOKI_ID || '' }}
+          loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
+      - name: Upload tmpnet network dir
+        uses: ./.github/actions/upload-tmpnet-artifact
+        if: always()
+        with:
+          name: e2e-post-etna-tmpnet-data
   e2e_existing_network:
     runs-on: ubuntu-latest
     steps:

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -4,19 +4,24 @@
 package e2e_test
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	// ensure test packages are scanned by ginkgo
 	_ "github.com/ava-labs/avalanchego/tests/e2e/banff"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/c"
+	_ "github.com/ava-labs/avalanchego/tests/e2e/etna"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/faultinjection"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/p"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/x"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/x/transfer"
 
+	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/tests/e2e/vms"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/upgrade"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 )
@@ -36,11 +41,28 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 	nodes := tmpnet.NewNodesOrPanic(flagVars.NodeCount())
 	subnets := vms.XSVMSubnetsOrPanic(nodes...)
+
+	upgrades := upgrade.Default
+	if flagVars.ActivateEtna() {
+		upgrades.EtnaTime = upgrade.InitiallyActiveTime
+	} else {
+		upgrades.EtnaTime = upgrade.UnscheduledActivationTime
+	}
+
+	upgradeJSON, err := json.Marshal(upgrades)
+	if err != nil {
+		panic(err)
+	}
+
+	upgradeBase64 := base64.StdEncoding.EncodeToString(upgradeJSON)
 	return e2e.NewTestEnvironment(
 		e2e.NewTestContext(),
 		flagVars,
 		&tmpnet.Network{
-			Owner:   "avalanchego-e2e",
+			Owner: "avalanchego-e2e",
+			DefaultFlags: tmpnet.FlagsMap{
+				config.UpgradeFileContentKey: upgradeBase64,
+			},
 			Nodes:   nodes,
 			Subnets: subnets,
 		},

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	// ensure test packages are scanned by ginkgo
 	_ "github.com/ava-labs/avalanchego/tests/e2e/banff"
 	_ "github.com/ava-labs/avalanchego/tests/e2e/c"
@@ -39,6 +41,8 @@ func init() {
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// Run only once in the first ginkgo process
 
+	tc := e2e.NewTestContext()
+
 	nodes := tmpnet.NewNodesOrPanic(flagVars.NodeCount())
 	subnets := vms.XSVMSubnetsOrPanic(nodes...)
 
@@ -50,13 +54,11 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	}
 
 	upgradeJSON, err := json.Marshal(upgrades)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(tc, err)
 
 	upgradeBase64 := base64.StdEncoding.EncodeToString(upgradeJSON)
 	return e2e.NewTestEnvironment(
-		e2e.NewTestContext(),
+		tc,
 		flagVars,
 		&tmpnet.Network{
 			Owner: "avalanchego-e2e",

--- a/tests/e2e/etna/suites.go
+++ b/tests/e2e/etna/suites.go
@@ -1,8 +1,8 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// Implements tests for the banff network upgrade.
-package banff
+// Implements tests for the etna network upgrade.
+package etna
 
 import (
 	"time"
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
-	"github.com/ava-labs/avalanchego/upgrade"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 )
@@ -25,12 +24,9 @@ var _ = ginkgo.Describe("[Etna]", func() {
 			env := e2e.GetEnv(tc)
 			infoClient := info.NewClient(env.GetRandomNodeURI().URI)
 
-			var upgrades *upgrade.Config
-			tc.By("get upgrade config", func() {
-				var err error
-				upgrades, err = infoClient.Upgrades(tc.DefaultContext())
-				require.NoError(err)
-			})
+			tc.By("get upgrade config")
+			upgrades, err := infoClient.Upgrades(tc.DefaultContext())
+			require.NoError(err)
 
 			now := time.Now()
 			if !upgrades.IsEtnaActivated(now) {

--- a/tests/e2e/etna/suites.go
+++ b/tests/e2e/etna/suites.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// Implements tests for the banff network upgrade.
+package banff
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/ava-labs/avalanchego/upgrade"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+)
+
+var _ = ginkgo.Describe("[Etna]", func() {
+	tc := e2e.NewTestContext()
+	require := require.New(tc)
+
+	ginkgo.It("can detect if Etna is activated",
+		func() {
+			env := e2e.GetEnv(tc)
+			infoClient := info.NewClient(env.GetRandomNodeURI().URI)
+
+			var upgrades *upgrade.Config
+			tc.By("get upgrade config", func() {
+				var err error
+				upgrades, err = infoClient.Upgrades(tc.DefaultContext())
+				require.NoError(err)
+			})
+
+			now := time.Now()
+			if !upgrades.IsEtnaActivated(now) {
+				tc.Outf("{{green}}Etna is not activated{{/}}: %s (now) < %s (EtnaTime)\n", now, upgrades.EtnaTime)
+				return
+			}
+
+			tc.Outf("{{green}}Etna is activated{{/}}: %s (now) >= %s (EtnaTime)\n", now, upgrades.EtnaTime)
+		})
+})

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -20,6 +20,7 @@ type FlagVars struct {
 	delayNetworkShutdown bool
 	stopNetwork          bool
 	nodeCount            int
+	activateEtna         bool
 }
 
 func (v *FlagVars) AvalancheGoExecPath() string {
@@ -59,6 +60,10 @@ func (v *FlagVars) StopNetwork() bool {
 
 func (v *FlagVars) NodeCount() int {
 	return v.nodeCount
+}
+
+func (v *FlagVars) ActivateEtna() bool {
+	return v.activateEtna
 }
 
 func RegisterFlags() *FlagVars {
@@ -104,6 +109,12 @@ func RegisterFlags() *FlagVars {
 		"node-count",
 		tmpnet.DefaultNodeCount,
 		"number of nodes the network should initially consist of",
+	)
+	flag.BoolVar(
+		&vars.activateEtna,
+		"activate-etna",
+		false,
+		"[optional] activate the etna upgrade",
 	)
 
 	return &vars


### PR DESCRIPTION
## Why this should be merged

This converts the single e2e test network (which currently runs with the Etna upgrade activated) into two e2e test networks:
1. e2e tests with Etna activated
2. e2e tests without Etna activated
All the tests run on each network - if a test is upgrade dependent, then it should check the network setup internally.

## How this works

- Adds `--activate-etna` to the tmpnet flags.
- Adds a new test with `--activate-etna` provided.

## How this was tested

- [X] CI
  - https://github.com/ava-labs/avalanchego/actions/runs/10239550091/job/28325281174?pr=3268#step:5:605
  - https://github.com/ava-labs/avalanchego/actions/runs/10239550091/job/28325280991?pr=3268#step:5:2982