### PR TITLE
chore: remove deprecated `validatorstest.TestState` after bumping `coreth` version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/coreth v0.13.8-0.20240802110637-b3e5088d062d
+	github.com/ava-labs/coreth v0.13.8-0.20240806125756-7cdd29947a17
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20240610153809-9c955cc90a95
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/coreth v0.13.8-0.20240802110637-b3e5088d062d h1:klPTcKVvqfA2KSKaRvQAO56Pd4XAqGhwgMTQ6/W+w7w=
 github.com/ava-labs/coreth v0.13.8-0.20240802110637-b3e5088d062d/go.mod h1:tXDujonxXFOF6oK5HS2EmgtSXJK3Gy6RpZxb5WzR9rM=
+github.com/ava-labs/coreth v0.13.8-0.20240806125756-7cdd29947a17 h1:A1XwzC0LcHSqPDu2mzXjn3qNZbfcq/ERvjQ3/ZIj6fQ=
+github.com/ava-labs/coreth v0.13.8-0.20240806125756-7cdd29947a17/go.mod h1:Ckp7Lf5h7sOEJzNVCcMwpDe/3oamljcVHkEPhTsZgu0=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20240610153809-9c955cc90a95 h1:dOVbtdnZL++pENdTCNZ1nu41eYDQkTML4sWebDnnq8c=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20240610153809-9c955cc90a95/go.mod h1:pJxaT9bUgeRNVmNRgtCHb7sFDIRKy7CzTQVi8gGNT6g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/antithesishq/antithesis-sdk-go v0.3.8 h1:OvGoHxIcOXFJLyn9IJQ5DzByZ3YVAWNBc394ObzDRb8=
 github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/coreth v0.13.8-0.20240802110637-b3e5088d062d h1:klPTcKVvqfA2KSKaRvQAO56Pd4XAqGhwgMTQ6/W+w7w=
-github.com/ava-labs/coreth v0.13.8-0.20240802110637-b3e5088d062d/go.mod h1:tXDujonxXFOF6oK5HS2EmgtSXJK3Gy6RpZxb5WzR9rM=
 github.com/ava-labs/coreth v0.13.8-0.20240806125756-7cdd29947a17 h1:A1XwzC0LcHSqPDu2mzXjn3qNZbfcq/ERvjQ3/ZIj6fQ=
 github.com/ava-labs/coreth v0.13.8-0.20240806125756-7cdd29947a17/go.mod h1:Ckp7Lf5h7sOEJzNVCcMwpDe/3oamljcVHkEPhTsZgu0=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20240610153809-9c955cc90a95 h1:dOVbtdnZL++pENdTCNZ1nu41eYDQkTML4sWebDnnq8c=

--- a/snow/validators/validatorstest/state.go
+++ b/snow/validators/validatorstest/state.go
@@ -23,12 +23,6 @@ var (
 
 var _ validators.State = (*State)(nil)
 
-// TestState is an alias for State because ava-labs/coreth uses the original
-// identifier and this change would otherwise break the build.
-//
-// Deprecated: use [State].
-type TestState = State
-
 type State struct {
 	T testing.TB
 


### PR DESCRIPTION
## Why this should be merged

To merge #3260 we had to depend on a commit from `coreth` that wasn't merged to `master`. Said branch has now been merged as https://github.com/ava-labs/coreth/pull/620 so this PR updates the dep. It also removes the deprecated `validatorstest.TestState` that is no longer used by `coreth`.

Closes #3174 

## How this works

1. Two parallel changes were made locally in `avalanchego` and `coreth`.
2. A local `go.work` file was introduced to confirm that they were compatible.
3. The `coreth` changes were pushed to a branch but not merged because that would break `coreth` CI.
4. The changes in #3260 depended on the branch in (3) to avoid breaking `avalanchego` CI.
5. The branch in (3) was merged as https://github.com/ava-labs/coreth/pull/620.
6. This PR depends on the commit merged in (5).
7. Type this out just so I can use the Pepe SIlvia meme.

![image](https://github.com/user-attachments/assets/e821666d-7780-4fde-8312-e93dd9323f05)

## How this was tested

CI
