### PR TITLE
[tmpnet] Enable network restart to simplify iteration

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -77,6 +77,17 @@ If a network is not already running the first time the suite runs with
 `--reuse-network`, one will be started automatically and configured
 for reuse by subsequent test runs also supplying `--reuse-network`.
 
+### Restarting temporary networks
+
+When iterating on a change to avalanchego and/or a VM, it may be
+useful to restart a running network to ensure the network is using the
+latest binary state. Supplying `--restart-network` in addition to
+`--reuse-network` will ensure that all nodes are restarted before
+tests are run. `--restart-network` is ignored if a network is not
+running or if `--stop-network` is supplied.
+
+### Stopping temporary networks
+
 To stop a network configured for reuse, invoke the test suite with the
 `--stop-network` argument. This will stop the network and exit
 immediately without executing any tests:

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -110,6 +110,9 @@ func NewTestEnvironment(tc tests.TestContext, flagVars *FlagVars, desiredNetwork
 				tc.Outf("No network to stop\n")
 			}
 			os.Exit(0)
+		} else if network != nil && flagVars.RestartNetwork() {
+			// A network is only restarted if it is already running and stop was not requested
+			require.NoError(network.Restart(tc.DefaultContext(), tc.GetWriter()))
 		}
 	}
 

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -19,6 +19,7 @@ type FlagVars struct {
 	reuseNetwork         bool
 	delayNetworkShutdown bool
 	stopNetwork          bool
+	restartNetwork       bool
 	nodeCount            int
 	activateEtna         bool
 }
@@ -43,6 +44,10 @@ func (v *FlagVars) NetworkDir() string {
 
 func (v *FlagVars) ReuseNetwork() bool {
 	return v.reuseNetwork
+}
+
+func (v *FlagVars) RestartNetwork() bool {
+	return v.restartNetwork
 }
 
 func (v *FlagVars) NetworkShutdownDelay() time.Duration {
@@ -91,6 +96,12 @@ func RegisterFlags() *FlagVars {
 		"reuse-network",
 		false,
 		"[optional] reuse an existing network. If an existing network is not already running, create a new one and leave it running for subsequent usage.",
+	)
+	flag.BoolVar(
+		&vars.restartNetwork,
+		"restart-network",
+		false,
+		"[optional] restarts an existing network. Useful for ensuring a network is running with the current state of binaries on disk. Ignored if a network is not already running or --stop-network is provided.",
 	)
 	flag.BoolVar(
 		&vars.delayNetworkShutdown,


### PR DESCRIPTION
## Why this should be merged

When making changes to avalanchego or VM binaries as part of e2e iteration, it may be useful to restart a running network instead of having to start a new one.

## How this works

Adds `--restart-network` flag for e2e test suite.

## How this was tested

CI against regression, manually for usage:

```
[SynchronizedBeforeSuite]
/home/me/src/avalanchego/master/tests/e2e/e2e_test.go:41
  Loaded a network configured at /home/me/.tmpnet/networks/20240806-105414.807586-avalanchego-e2e
   restarting network
  Started node "NodeID-5drktRkarrPqdHhKKRpcP6iM94ckg5Xhy"
   waiting for node NodeID-5drktRkarrPqdHhKKRpcP6iM94ckg5Xhy to report healthy
  Started node "NodeID-8kXEqbVv9vZMNyUtUTnVcmXJtQvuEPS9X"
   waiting for node NodeID-8kXEqbVv9vZMNyUtUTnVcmXJtQvuEPS9X to report healthy
  network URIs:  [{NodeID:NodeID-5drktRkarrPqdHhKKRpcP6iM94ckg5Xhy URI:http://127.0.0.1:44575} {NodeID:NodeID-8kXEqbVv9vZMNyUtUTnVcmXJtQvuEPS9X URI:http://127.0.0.1:42131}]
  test data server URI:  http://127.0.0.1:40503
[SynchronizedBeforeSuite] PASSED [12.919 seconds]
```
