### PR TITLE
[tmpnet] Add check for vm binaries to network and node start

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -941,7 +941,7 @@ func checkVMBinariesExist(subnets []*Subnet, pluginDir string) error {
 		for _, chain := range subnet.Chains {
 			pluginPath := filepath.Join(pluginDir, chain.VMID.String())
 			if _, err := os.Stat(pluginPath); err != nil {
-				errs = append(errs, fmt.Errorf("failed to check VM binary for subnet %q: %w ", subnet.Name, err))
+				errs = append(errs, fmt.Errorf("failed to check VM binary for subnet %q: %w", subnet.Name, err))
 			}
 		}
 	}


### PR DESCRIPTION
## Why this should be merged

Previously, a missing VM binary could fail network start with diagnosis requiring manually reviewing node logs. Now the failure should be obvious.  

## How this works

- Adds checks to network and node start for the presence of VM binaries for configured chains

## How this was tested

CI for regression, manually for usage:

```
[SynchronizedBeforeSuite] [FAILED] [0.006 seconds]
[SynchronizedBeforeSuite]
/home/me/src/avalanchego/master/tests/e2e/e2e_test.go:41

  [FAILED]
        Error Trace:    /home/me/src/avalanchego/master/tests/fixture/e2e/helpers.go:197
                                                /home/me/src/avalanchego/master/tests/fixture/e2e/env.go:119
                                                /home/me/src/avalanchego/master/tests/e2e/e2e_test.go:60
                                                /home/me/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.12.linux-arm64/src/reflect/value.go:596
                                                /home/me/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.12.linux-arm64/src/reflect/value.go:380
                                                /home/me/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/node.go:486
                                                /home/me/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/suite.go:642
                                                /home/me/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/suite.go:889
                                                /home/me/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.12.linux-arm64/src/runtime/asm_arm64.s:1197
        Error:          Received unexpected error:
                        failed to check VM binary for subnet "xsvm-a": stat /home/me/.avalanchego/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH: no such file or directory
                        failed to check VM binary for subnet "xsvm-b": stat /home/me/.avalanchego/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH: no such file or directory

  In [SynchronizedBeforeSuite] at: /home/me/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1495 @ 08/06/24 11:30:34.18
```