### PR TITLE
[tmpnet] Fail node health check if node is not running

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -865,7 +865,7 @@ func waitForHealthy(ctx context.Context, w io.Writer, nodes []*Node) error {
 	for {
 		for node := range unhealthyNodes {
 			healthy, err := node.IsHealthy(ctx)
-			if err != nil && !errors.Is(err, ErrNotRunning) {
+			if err != nil {
 				return err
 			}
 			if !healthy {

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -31,7 +31,10 @@ const (
 	defaultNodeInitTimeout = 10 * time.Second
 )
 
-var errNodeAlreadyRunning = errors.New("failed to start node: node is already running")
+var (
+	errNodeAlreadyRunning = errors.New("failed to start node: node is already running")
+	errNotRunning         = errors.New("node is not running")
+)
 
 func checkNodeHealth(ctx context.Context, uri string) (bool, error) {
 	// Check that the node is reporting healthy
@@ -194,7 +197,7 @@ func (p *NodeProcess) IsHealthy(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to determine process status: %w", err)
 	}
 	if proc == nil {
-		return false, ErrNotRunning
+		return false, errNotRunning
 	}
 
 	return checkNodeHealth(ctx, p.node.URI)

--- a/tests/fixture/tmpnet/utils.go
+++ b/tests/fixture/tmpnet/utils.go
@@ -6,7 +6,6 @@ package tmpnet
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -18,8 +17,6 @@ const (
 	DefaultNodeTickerInterval = 50 * time.Millisecond
 )
 
-var ErrNotRunning = errors.New("not running")
-
 // WaitForHealthy blocks until Node.IsHealthy returns true or an error (including context timeout) is observed.
 func WaitForHealthy(ctx context.Context, node *Node) error {
 	if _, ok := ctx.Deadline(); !ok {
@@ -30,7 +27,7 @@ func WaitForHealthy(ctx context.Context, node *Node) error {
 
 	for {
 		healthy, err := node.IsHealthy(ctx)
-		if err != nil && !errors.Is(err, ErrNotRunning) {
+		if err != nil {
 			return fmt.Errorf("failed to wait for health of node %q: %w", node.NodeID, err)
 		}
 		if healthy {


### PR DESCRIPTION
## Why this should be merged

Ignoring the error indicating that a node wasn't running in the context of checking the health of that node seems like an accident. A node can never be healthy if it is not running.

## How this works

Ensures health checks fail if they see an error indicating that a node is not running.

## How this was tested

CI