### PR TITLE
[tmpnet] Add support for checking rpcchainvm version compatibility

### DIFF
--- a/tests/fixture/subnet/xsvm.go
+++ b/tests/fixture/subnet/xsvm.go
@@ -38,6 +38,7 @@ func NewXSVMOrPanic(name string, key *secp256k1.PrivateKey, nodes ...*tmpnet.Nod
 				VMID:         constants.XSVMID,
 				Genesis:      genesisBytes,
 				PreFundedKey: key,
+				VersionArgs:  []string{"version-json"},
 			},
 		},
 		ValidatorIDs: tmpnet.NodesToIDs(nodes...),

--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -93,9 +93,14 @@ network := &tmpnet.Network{                   // Configure non-default values fo
             Name: "xsvm-a",                   // User-defined name used to reference subnet in code and on disk
             Chains: []*tmpnet.Chain{
                 {
-                    VMName: "xsvm",           // Name of the VM the chain will run, will be used to derive the name of the VM binary
-                    Genesis: <genesis bytes>, // Genesis bytes used to initialize the custom chain
-                    PreFundedKey: <key>,      // (Optional) A private key that is funded in the genesis bytes
+                    VMName: "xsvm",              // Name of the VM the chain will run, will be used to derive the name of the VM binary
+                    Genesis: <genesis bytes>,    // Genesis bytes used to initialize the custom chain
+                    PreFundedKey: <key>,         // (Optional) A private key that is funded in the genesis bytes
+                    VersionArgs: "version-json", // (Optional) Arguments that prompt the VM binary to output version details in json format.
+                                                 // If one or more arguments are provided, the resulting json output should include a field
+                                                 // named `rpcchainvm` of type uint64 containing the rpc version supported by the VM binary.
+                                                 // The version will be checked against the version reported by the configured avalanchego
+                                                 // binary before network and node start.
                 },
             },
             ValidatorIDs: <node ids>,         // The IDs of nodes that validate the subnet

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -943,8 +943,8 @@ func GetReusableNetworkPathForOwner(owner string) (string, error) {
 	return filepath.Join(networkPath, "latest_"+owner), nil
 }
 
-// Checks that VM binaries for the given subnets exist and optionally checks that VM binaries have the
-// same rpcchainvm version as the indicated avalanchego binary.
+// checkVMBinaries checks that VM binaries for the given subnets exist and optionally checks that VM
+// binaries have the same rpcchainvm version as the indicated avalanchego binary.
 func checkVMBinaries(w io.Writer, subnets []*Subnet, avalanchegoPath string, pluginDir string) error {
 	if len(subnets) == 0 {
 		return nil

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -468,11 +468,12 @@ func (n *Network) StartNode(ctx context.Context, w io.Writer, node *Node) error 
 		return err
 	}
 
-	if err := checkVMBinaries(w, n.Subnets, node.RuntimeConfig.AvalancheGoPath, pluginDir); err != nil {
+	if err := n.EnsureNodeConfig(node); err != nil {
 		return err
 	}
 
-	if err := n.EnsureNodeConfig(node); err != nil {
+	// Check the VM binaries after EnsureNodeConfig to ensure node.RuntimeConfig is non-nil
+	if err := checkVMBinaries(w, n.Subnets, node.RuntimeConfig.AvalancheGoPath, pluginDir); err != nil {
 		return err
 	}
 

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -994,7 +994,7 @@ type RPCChainVMVersion struct {
 }
 
 // getRPCVersion attempts to invoke the given command with the specified version arguments and
-// retrieve the rpcchainvm version from its output.
+// retrieve an rpcchainvm version from its output.
 func getRPCVersion(command string, versionArgs ...string) (uint64, error) {
 	cmd := exec.Command(command, versionArgs...)
 	output, err := cmd.CombinedOutput()

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -36,6 +36,12 @@ type Chain struct {
 	VMID    ids.ID
 	Config  string
 	Genesis []byte
+	// VersionArgs are the argument(s) to pass to the VM binary to receive
+	// version details in json format (e.g. `--version-json`). This
+	// supports checking that the rpcchainvm version of the VM binary
+	// matches the version used by the configured avalanchego binary. If
+	// empty, the version check will be skipped.
+	VersionArgs []string
 
 	// Set at runtime
 	ChainID      ids.ID

--- a/vms/example/xsvm/README.md
+++ b/vms/example/xsvm/README.md
@@ -66,6 +66,7 @@ Available Commands:
   help        Help about any command
   issue       Issues transactions
   version     Prints out the version
+  versionjson Prints out the version in json format
 
 Flags:
   -h, --help   help for xsvm

--- a/vms/example/xsvm/cmd/versionjson/cmd.go
+++ b/vms/example/xsvm/cmd/versionjson/cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm"
@@ -16,7 +17,7 @@ import (
 
 type vmVersions struct {
 	Name       string            `json:"name"`
-	VMID       string            `json:"vmid"`
+	VMID       ids.ID            `json:"vmid"`
 	Version    *version.Semantic `json:"version"`
 	RPCChainVM uint64            `json:"rpcchainvm"`
 }
@@ -32,7 +33,7 @@ func Command() *cobra.Command {
 func versionFunc(*cobra.Command, []string) error {
 	versions := vmVersions{
 		Name:       constants.XSVMName,
-		VMID:       constants.XSVMID.String(),
+		VMID:       constants.XSVMID,
 		Version:    xsvm.Version,
 		RPCChainVM: uint64(version.RPCChainVMProtocol),
 	}

--- a/vms/example/xsvm/cmd/versionjson/cmd.go
+++ b/vms/example/xsvm/cmd/versionjson/cmd.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package versionjson
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/example/xsvm"
+)
+
+type vmVersions struct {
+	Name       string            `json:"name"`
+	VMID       string            `json:"vmid"`
+	Version    *version.Semantic `json:"version"`
+	RPCChainVM uint64            `json:"rpcchainvm"`
+}
+
+func Command() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version-json",
+		Short: "Prints out the version in json format",
+		RunE:  versionFunc,
+	}
+}
+
+func versionFunc(*cobra.Command, []string) error {
+	versions := vmVersions{
+		Name:       constants.XSVMName,
+		VMID:       constants.XSVMID.String(),
+		Version:    xsvm.Version,
+		RPCChainVM: uint64(version.RPCChainVMProtocol),
+	}
+	jsonBytes, err := json.MarshalIndent(versions, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal versions: %w", err)
+	}
+	fmt.Println(string(jsonBytes))
+	return nil
+}

--- a/vms/example/xsvm/cmd/xsvm/main.go
+++ b/vms/example/xsvm/cmd/xsvm/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/cmd/issue"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/cmd/run"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/cmd/version"
+	"github.com/ava-labs/avalanchego/vms/example/xsvm/cmd/versionjson"
 )
 
 func init() {
@@ -28,6 +29,7 @@ func main() {
 		chain.Command(),
 		issue.Command(),
 		version.Command(),
+		versionjson.Command(),
 	)
 	ctx := context.Background()
 	if err := cmd.ExecuteContext(ctx); err != nil {


### PR DESCRIPTION
## Why this should be merged

Previously, if the rpcchainvm version differed between avalanchego and a VM that a node was configured to support, the node would never become healthy and discovering this would require examining log output. This PR adds support for optionally checking the rpcchainvm version of a VM against the version supported by the configured avalanchego binary.

## How this works

- enables configuring `VersionArgs` for each chain to specify arguments that output version info in json format from a vm binary
- updates the vm binary check to use a chain's version args to retrieve the rpcchain version and compare against that reported by avalanchego
- adds a json-capable version command to xsvm and configures its use in e2e

## How this was tested

Positive coverage: CI, negative coverage: manual:

```
/home/me/src/avalanchego/master/tests/e2e/e2e_test.go:41

  [FAILED]
        Error Trace:    /home/me/src/avalanchego/master/tests/fixture/e2e/helpers.go:197
                                                /home/me/src/avalanchego/master/tests/fixture/e2e/env.go:119
                                                /home/me/src/avalanchego/master/tests/e2e/e2e_test.go:60
                                                /home/me/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.12.linux-arm64/src/reflect/value.go:596
                                                /home/me/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.12.linux-arm64/src/reflect/value.go:380
                                                /home/me/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/node.go:486
                                                /home/me/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/suite.go:642
                                                /home/me/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/suite.go:889
                                                /home/me/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.12.linux-arm64/src/runtime/asm_arm64.s:1197
        Error:          Received unexpected error:
                        unexpected rpcchainvm version for VM binary of subnet "xsvm-a": "/home/me/src/avalanchego/master/build/avalanchego" reports 35, but "/home/me/.avalanchego/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH" reports 36
                        unexpected rpcchainvm version for VM binary of subnet "xsvm-b": "/home/me/src/avalanchego/master/build/avalanchego" reports 35, but "/home/me/.avalanchego/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH" reports 36

  In [SynchronizedBeforeSuite] at: /home/me/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1495 @ 08/06/24 13:31:05.61
```

## TODO

 - [x] Merge parent #3273 