### PR TITLE
Fix race in timer stoppage

### DIFF
--- a/network/throttling/inbound_resource_throttler.go
+++ b/network/throttling/inbound_resource_throttler.go
@@ -164,28 +164,21 @@ func (t *systemThrottler) Acquire(ctx context.Context, nodeID ids.NodeID) {
 			waitDuration = t.MaxRecheckDelay
 		}
 
-		// Reset [timer].
 		if timer == nil {
 			// Note this is called at most once.
 			t.metrics.awaitingAcquire.Inc()
 
 			timer = t.timerPool.Get().(*time.Timer)
-			defer func() {
-				// Satisfy [t.timerPool] invariant.
-				if !timer.Stop() {
-					// The default ensures we don't wait forever in the case
-					// that the channel was already drained.
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				t.timerPool.Put(timer)
-			}()
+			defer t.timerPool.Put(timer)
 		}
+
 		timer.Reset(waitDuration)
 		select {
 		case <-ctx.Done():
+			// Satisfy [t.timerPool] invariant.
+			if !timer.Stop() {
+				<-timer.C
+			}
 			return
 		case <-timer.C:
 		}


### PR DESCRIPTION
## Why this should be merged

It is possible for:
1. `Stop` to return `false`
2. have the select statement run before the event is pushed to the `timer.C` channel.
3. Have the select statement run the default case
4. Have the timer then push the event onto the `timer.C` channel
5. The `timerPool` will then include a timer that has already fired (breaking the documented invariant)

## How this works

Rather than draining the channel in the `defer` (which doesn't have enough information to safely drain the channel) - the channel is drained in the `for` loop.

## How this was tested

Open to feedback on how to test this, It seems like any test for this would be inherently racy... But open to suggestions.