### PR TITLE
Refactor P-chain Builder

### DIFF
--- a/snow/engine/snowman/engine_test.go
+++ b/snow/engine/snowman/engine_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/getter"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
 )
@@ -3078,7 +3079,7 @@ func TestShouldIssueBlock(t *testing.T) {
 		chain4Through6   = snowmantest.BuildDescendants(chain0Through3[0], 3)
 		chain7Through10  = snowmantest.BuildDescendants(snowmantest.Genesis, 4)
 		chain11Through11 = snowmantest.BuildDescendants(chain7Through10[1], 1)
-		blocks           = join(chain0Through3, chain4Through6, chain7Through10, chain11Through11)
+		blocks           = utils.Join(chain0Through3, chain4Through6, chain7Through10, chain11Through11)
 	)
 
 	require.NoError(t, blocks[0].Accept(context.Background()))
@@ -3180,19 +3181,4 @@ func TestShouldIssueBlock(t *testing.T) {
 			require.Equal(t, test.expectedShouldIssue, shouldIssue)
 		})
 	}
-}
-
-// join the provided slices into a single slice.
-//
-// TODO: Use slices.Concat once the minimum go version is 1.22.
-func join[T any](slices ...[]T) []T {
-	size := 0
-	for _, s := range slices {
-		size += len(s)
-	}
-	newSlice := make([]T, 0, size)
-	for _, s := range slices {
-		newSlice = append(newSlice, s...)
-	}
-	return newSlice
 }

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -3,7 +3,7 @@
 
 package utils
 
-// join the provided slices into a single slice.
+// Join merges the provided slices into a single slice.
 //
 // TODO: Use slices.Concat once the minimum go version is 1.22.
 func Join[T any](slices ...[]T) []T {

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utils
+
+// join the provided slices into a single slice.
+//
+// TODO: Use slices.Concat once the minimum go version is 1.22.
+func Join[T any](slices ...[]T) []T {
+	size := 0
+	for _, s := range slices {
+		size += len(s)
+	}
+	newSlice := make([]T, 0, size)
+	for _, s := range slices {
+		newSlice = append(newSlice, s...)
+	}
+	return newSlice
+}

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -1235,7 +1235,6 @@ func (b *builder) spend(
 	}
 
 	if excessFee > 0 {
-		// It is worth adding the change output
 		newOutput := &avax.TransferableOutput{
 			Asset: avax.Asset{
 				ID: b.context.AVAXAssetID,

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -1010,23 +1010,23 @@ func (b *builder) getBalance(
 
 // spend takes in the requested burn amounts and the requested stake amounts.
 //
-//   - [amountsToBurn] maps assetID to the amount of the asset to spend without
+//   - [toBurn] maps assetID to the amount of the asset to spend without
 //     producing an output. This is typically used for fees. However, it can
 //     also be used to consume some of an asset that will be produced in
 //     separate outputs, such as ExportedOutputs. Only unlocked UTXOs are able
 //     to be burned here.
-//   - [amountsToStake] maps assetID to the amount of the asset to spend and
-//     place into the staked outputs. First locked UTXOs are attempted to be
-//     used for these funds, and then unlocked UTXOs will be attempted to be
-//     used. There is no preferential ordering on the unlock times.
+//   - [toStake] maps assetID to the amount of the asset to spend and place into
+//     the staked outputs. First locked UTXOs are attempted to be used for these
+//     funds, and then unlocked UTXOs will be attempted to be used. There is no
+//     preferential ordering on the unlock times.
 //   - [excessAVAX] contains the amount of extra AVAX that spend can produce in
 //     the change outputs in addition to the consumed and not burned AVAX.
 //   - [ownerOverride] optionally specifies the output owners to use for the
 //     unlocked AVAX change output if no additional AVAX was needed to be
 //     burned. If this value is nil, the default change owner is used.
 func (b *builder) spend(
-	amountsToBurn map[ids.ID]uint64,
-	amountsToStake map[ids.ID]uint64,
+	toBurn map[ids.ID]uint64,
+	toStake map[ids.ID]uint64,
 	excessAVAX uint64,
 	ownerOverride *secp256k1fx.OutputOwners,
 	options *common.Options,
@@ -1057,8 +1057,8 @@ func (b *builder) spend(
 	}
 
 	s := spendHelper{
-		amountsToBurn:  amountsToBurn,
-		amountsToStake: amountsToStake,
+		toBurn:  toBurn,
+		toStake: toStake,
 
 		// Initialize the return values with empty slices to preserve backward
 		// compatibility of the json representation of transactions with no
@@ -1068,8 +1068,8 @@ func (b *builder) spend(
 		stakeOutputs:  make([]*avax.TransferableOutput, 0),
 	}
 
-	unlockedUTXOs, lockedUTXOs := splitUTXOsByLocktime(utxos, minIssuanceTime)
-	for _, utxo := range lockedUTXOs {
+	utxosByLocktime := splitByLocktime(utxos, minIssuanceTime)
+	for _, utxo := range utxosByLocktime.locked {
 		assetID := utxo.AssetID()
 		if !s.shouldConsumeLockedAsset(assetID) {
 			continue
@@ -1130,7 +1130,7 @@ func (b *builder) spend(
 	}
 
 	// Add all the remaining stake amounts assuming unlocked UTXOs.
-	for assetID, amount := range s.amountsToStake {
+	for assetID, amount := range s.toStake {
 		if amount == 0 {
 			continue
 		}
@@ -1147,8 +1147,8 @@ func (b *builder) spend(
 	}
 
 	// AVAX is handled last to account for fees.
-	avaxUTXOs, nonAVAXUTXOs := splitUTXOsByAssetID(unlockedUTXOs, b.context.AVAXAssetID)
-	for _, utxo := range nonAVAXUTXOs {
+	utxosByAVAXAssetID := splitByAssetID(utxosByLocktime.unlocked, b.context.AVAXAssetID)
+	for _, utxo := range utxosByAVAXAssetID.other {
 		assetID := utxo.AssetID()
 		if !s.shouldConsumeAsset(assetID) {
 			continue
@@ -1191,7 +1191,7 @@ func (b *builder) spend(
 		})
 	}
 
-	for _, utxo := range avaxUTXOs {
+	for _, utxo := range utxosByAVAXAssetID.requested {
 		// If we have consumed enough of the asset, then we have no need burn
 		// more.
 		if !s.shouldConsumeAsset(b.context.AVAXAssetID) {
@@ -1291,8 +1291,8 @@ func (b *builder) initCtx(tx txs.UnsignedTx) error {
 }
 
 type spendHelper struct {
-	amountsToBurn  map[ids.ID]uint64
-	amountsToStake map[ids.ID]uint64
+	toBurn  map[ids.ID]uint64
+	toStake map[ids.ID]uint64
 
 	inputs        []*avax.TransferableInput
 	changeOutputs []*avax.TransferableOutput
@@ -1312,40 +1312,37 @@ func (s *spendHelper) addStakedOutput(output *avax.TransferableOutput) {
 }
 
 func (s *spendHelper) shouldConsumeLockedAsset(assetID ids.ID) bool {
-	return s.amountsToStake[assetID] != 0
+	return s.toStake[assetID] != 0
 }
 
 func (s *spendHelper) shouldConsumeAsset(assetID ids.ID) bool {
-	return s.amountsToBurn[assetID] != 0 || s.shouldConsumeLockedAsset(assetID)
+	return s.toBurn[assetID] != 0 || s.shouldConsumeLockedAsset(assetID)
 }
 
 func (s *spendHelper) consumeLockedAsset(assetID ids.ID, amount uint64) uint64 {
-	remainingAmountToStake := s.amountsToStake[assetID]
 	// Stake any value that should be staked
-	amountToStake := min(
-		remainingAmountToStake, // Amount we still need to stake
-		amount,                 // Amount available to stake
+	toStake := min(
+		s.toStake[assetID], // Amount we still need to stake
+		amount,             // Amount available to stake
 	)
-	s.amountsToStake[assetID] -= amountToStake
-	return amount - amountToStake
+	s.toStake[assetID] -= toStake
+	return amount - toStake
 }
 
 func (s *spendHelper) consumeAsset(assetID ids.ID, amount uint64) uint64 {
-	remainingAmountToBurn := s.amountsToBurn[assetID]
-
 	// Burn any value that should be burned
-	amountToBurn := min(
-		remainingAmountToBurn, // Amount we still need to burn
-		amount,                // Amount available to burn
+	toBurn := min(
+		s.toBurn[assetID], // Amount we still need to burn
+		amount,            // Amount available to burn
 	)
-	s.amountsToBurn[assetID] -= amountToBurn
+	s.toBurn[assetID] -= toBurn
 
 	// Stake any remaining value that should be staked
-	return s.consumeLockedAsset(assetID, amount-amountToBurn)
+	return s.consumeLockedAsset(assetID, amount-toBurn)
 }
 
 func (s *spendHelper) verifyAssetsConsumed() error {
-	for assetID, amount := range s.amountsToStake {
+	for assetID, amount := range s.toStake {
 		if amount == 0 {
 			continue
 		}
@@ -1357,7 +1354,7 @@ func (s *spendHelper) verifyAssetsConsumed() error {
 			assetID,
 		)
 	}
-	for assetID, amount := range s.amountsToBurn {
+	for assetID, amount := range s.toBurn {
 		if amount == 0 {
 			continue
 		}
@@ -1372,47 +1369,60 @@ func (s *spendHelper) verifyAssetsConsumed() error {
 	return nil
 }
 
-// splitUTXOsByLocktime separates the provided UTXOs into two slices:
+type utxosByLocktime struct {
+	unlocked []*avax.UTXO
+	locked   []*avax.UTXO
+}
+
+// splitByLocktime separates the provided UTXOs into two slices:
 // 1. UTXOs that are unlocked with the provided issuance time
 // 2. UTXOs that are locked with the provided issuance time
-func splitUTXOsByLocktime(utxos []*avax.UTXO, minIssuanceTime uint64) ([]*avax.UTXO, []*avax.UTXO) {
-	var (
-		unlockedUTXOs = make([]*avax.UTXO, 0, len(utxos))
-		lockedUTXOs   = make([]*avax.UTXO, 0, len(utxos))
-	)
-	for _, utxo := range utxos {
-		lockedOut, ok := utxo.Out.(*stakeable.LockOut)
-		if !ok {
-			unlockedUTXOs = append(unlockedUTXOs, utxo)
-			continue
-		}
-		if minIssuanceTime >= lockedOut.Locktime {
-			unlockedUTXOs = append(unlockedUTXOs, utxo)
-			continue
-		}
-		lockedUTXOs = append(lockedUTXOs, utxo)
+func splitByLocktime(utxos []*avax.UTXO, minIssuanceTime uint64) utxosByLocktime {
+	split := utxosByLocktime{
+		unlocked: make([]*avax.UTXO, 0, len(utxos)),
+		locked:   make([]*avax.UTXO, 0, len(utxos)),
 	}
-	return unlockedUTXOs, lockedUTXOs
+	for _, utxo := range utxos {
+		if lockedOut, ok := utxo.Out.(*stakeable.LockOut); ok && minIssuanceTime < lockedOut.Locktime {
+			split.locked = append(split.locked, utxo)
+		} else {
+			split.unlocked = append(split.unlocked, utxo)
+		}
+	}
+	return split
 }
 
-// splitUTXOsByAssetID separates the provided UTXOs into two slices:
+type utxosByAssetID struct {
+	requested []*avax.UTXO
+	other     []*avax.UTXO
+}
+
+// splitByAssetID separates the provided UTXOs into two slices:
 // 1. UTXOs with the provided assetID
 // 2. UTXOs with a different assetID
-func splitUTXOsByAssetID(utxos []*avax.UTXO, assetID ids.ID) ([]*avax.UTXO, []*avax.UTXO) {
-	var (
-		requestedUTXOs = make([]*avax.UTXO, 0, len(utxos))
-		otherUTXOs     = make([]*avax.UTXO, 0, len(utxos))
-	)
+func splitByAssetID(utxos []*avax.UTXO, assetID ids.ID) utxosByAssetID {
+	split := utxosByAssetID{
+		requested: make([]*avax.UTXO, 0, len(utxos)),
+		other:     make([]*avax.UTXO, 0, len(utxos)),
+	}
 	for _, utxo := range utxos {
 		if utxo.AssetID() == assetID {
-			requestedUTXOs = append(requestedUTXOs, utxo)
+			split.requested = append(split.requested, utxo)
 		} else {
-			otherUTXOs = append(otherUTXOs, utxo)
+			split.other = append(split.other, utxo)
 		}
 	}
-	return requestedUTXOs, otherUTXOs
+	return split
 }
 
+// unwrapOutput returns the *secp256k1fx.TransferOutput that was, potentially,
+// wrapped by a *stakeable.LockOut.
+//
+// If the output was stakeable and locked, the locktime is returned. Otherwise,
+// the locktime returned will be 0.
+//
+// If the output is not a, potentially wrapped, *secp256k1fx.TransferOutput, an
+// error is returned.
 func unwrapOutput(output verify.State) (*secp256k1fx.TransferOutput, uint64, error) {
 	var locktime uint64
 	if lockedOut, ok := output.(*stakeable.LockOut); ok {
@@ -1420,9 +1430,9 @@ func unwrapOutput(output verify.State) (*secp256k1fx.TransferOutput, uint64, err
 		locktime = lockedOut.Locktime
 	}
 
-	out, ok := output.(*secp256k1fx.TransferOutput)
+	unwrappedOutput, ok := output.(*secp256k1fx.TransferOutput)
 	if !ok {
 		return nil, 0, ErrUnknownOutputType
 	}
-	return out, locktime, nil
+	return unwrappedOutput, locktime, nil
 }

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -1311,14 +1311,11 @@ func (s *spendHelper) addStakedOutput(output *avax.TransferableOutput) {
 }
 
 func (s *spendHelper) shouldConsumeLockedAsset(assetID ids.ID) bool {
-	remainingAmountToStake := s.amountsToStake[assetID]
-	return remainingAmountToStake != 0
+	return s.amountsToStake[assetID] != 0
 }
 
 func (s *spendHelper) shouldConsumeAsset(assetID ids.ID) bool {
-	remainingAmountToBurn := s.amountsToBurn[assetID]
-	remainingAmountToStake := s.amountsToStake[assetID]
-	return remainingAmountToBurn != 0 || remainingAmountToStake != 0
+	return s.amountsToBurn[assetID] != 0 || s.shouldConsumeLockedAsset(assetID)
 }
 
 func (s *spendHelper) consumeLockedAsset(assetID ids.ID, amount uint64) uint64 {

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -714,18 +714,14 @@ func (b *builder) NewImportTx(
 	}
 
 	var (
-		toBurn     map[ids.ID]uint64
+		toBurn     = map[ids.ID]uint64{}
 		toStake    = map[ids.ID]uint64{}
 		excessAVAX uint64
 	)
-	if importedAVAX := importedAmounts[avaxAssetID]; importedAVAX > txFee {
-		toBurn = map[ids.ID]uint64{}
-		excessAVAX = importedAVAX - txFee
+	if importedAVAX := importedAmounts[avaxAssetID]; importedAVAX < txFee {
+		toBurn[avaxAssetID] = txFee - importedAVAX
 	} else {
-		toBurn = map[ids.ID]uint64{
-			avaxAssetID: txFee - importedAVAX,
-		}
-		excessAVAX = 0
+		excessAVAX = importedAVAX - txFee
 	}
 
 	inputs, changeOutputs, _, err := b.spend(

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -398,7 +398,13 @@ func (b *builder) NewAddSubnetValidatorTx(
 		b.context.AVAXAssetID: b.context.StaticFeeConfig.AddSubnetValidatorFee,
 	}
 	toStake := map[ids.ID]uint64{}
+
 	ops := common.NewOptions(options)
+	subnetAuth, err := b.authorizeSubnet(vdr.Subnet, ops)
+	if err != nil {
+		return nil, err
+	}
+
 	inputs, outputs, _, err := b.spend(
 		toBurn,
 		toStake,
@@ -406,11 +412,6 @@ func (b *builder) NewAddSubnetValidatorTx(
 		nil,
 		ops,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	subnetAuth, err := b.authorizeSubnet(vdr.Subnet, ops)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +439,13 @@ func (b *builder) NewRemoveSubnetValidatorTx(
 		b.context.AVAXAssetID: b.context.StaticFeeConfig.TxFee,
 	}
 	toStake := map[ids.ID]uint64{}
+
 	ops := common.NewOptions(options)
+	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
+	if err != nil {
+		return nil, err
+	}
+
 	inputs, outputs, _, err := b.spend(
 		toBurn,
 		toStake,
@@ -446,11 +453,6 @@ func (b *builder) NewRemoveSubnetValidatorTx(
 		nil,
 		ops,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
 	if err != nil {
 		return nil, err
 	}
@@ -522,7 +524,13 @@ func (b *builder) NewCreateChainTx(
 		b.context.AVAXAssetID: b.context.StaticFeeConfig.CreateBlockchainTxFee,
 	}
 	toStake := map[ids.ID]uint64{}
+
 	ops := common.NewOptions(options)
+	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
+	if err != nil {
+		return nil, err
+	}
+
 	inputs, outputs, _, err := b.spend(
 		toBurn,
 		toStake,
@@ -530,11 +538,6 @@ func (b *builder) NewCreateChainTx(
 		nil,
 		ops,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +604,13 @@ func (b *builder) NewTransferSubnetOwnershipTx(
 		b.context.AVAXAssetID: b.context.StaticFeeConfig.TxFee,
 	}
 	toStake := map[ids.ID]uint64{}
+
 	ops := common.NewOptions(options)
+	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
+	if err != nil {
+		return nil, err
+	}
+
 	inputs, outputs, _, err := b.spend(
 		toBurn,
 		toStake,
@@ -609,11 +618,6 @@ func (b *builder) NewTransferSubnetOwnershipTx(
 		nil,
 		ops,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
 	if err != nil {
 		return nil, err
 	}
@@ -818,7 +822,13 @@ func (b *builder) NewTransformSubnetTx(
 		assetID:               maxSupply - initialSupply,
 	}
 	toStake := map[ids.ID]uint64{}
+
 	ops := common.NewOptions(options)
+	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
+	if err != nil {
+		return nil, err
+	}
+
 	inputs, outputs, _, err := b.spend(
 		toBurn,
 		toStake,
@@ -826,11 +836,6 @@ func (b *builder) NewTransformSubnetTx(
 		nil,
 		ops,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	subnetAuth, err := b.authorizeSubnet(subnetID, ops)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -1031,10 +1031,10 @@ func (b *builder) spend(
 	ownerOverride *secp256k1fx.OutputOwners,
 	options *common.Options,
 ) (
-	[]*avax.TransferableInput,
-	[]*avax.TransferableOutput,
-	[]*avax.TransferableOutput,
-	error,
+	inputs []*avax.TransferableInput,
+	changeOutputs []*avax.TransferableOutput,
+	stakeOutputs []*avax.TransferableOutput,
+	err error,
 ) {
 	utxos, err := b.backend.UTXOs(options.Context(), constants.PlatformChainID)
 	if err != nil {

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -1067,7 +1067,7 @@ func (b *builder) spend(
 		stakeOutputs:  make([]*avax.TransferableOutput, 0),
 	}
 
-	lockedUTXOs, unlockedUTXOs := splitLockedStakeableUTXOs(utxos, minIssuanceTime)
+	unlockedUTXOs, lockedUTXOs := splitUTXOsByLocktime(utxos, minIssuanceTime)
 	for _, utxo := range lockedUTXOs {
 		assetID := utxo.AssetID()
 		if !s.shouldConsumeLockedAsset(assetID) {
@@ -1146,7 +1146,7 @@ func (b *builder) spend(
 	}
 
 	// AVAX is handled last to account for fees.
-	avaxUTXOs, nonAVAXUTXOs := splitAVAXUTXOs(unlockedUTXOs, b.context.AVAXAssetID)
+	avaxUTXOs, nonAVAXUTXOs := splitUTXOsByAssetID(unlockedUTXOs, b.context.AVAXAssetID)
 	for _, utxo := range nonAVAXUTXOs {
 		assetID := utxo.AssetID()
 		if !s.shouldConsumeAsset(assetID) {
@@ -1367,10 +1367,13 @@ func (s *spendHelper) verifyAssetsConsumed() error {
 	return nil
 }
 
-func splitLockedStakeableUTXOs(utxos []*avax.UTXO, minIssuanceTime uint64) ([]*avax.UTXO, []*avax.UTXO) {
+// splitUTXOsByLocktime separates the provided UTXOs into two slices:
+// 1. UTXOs that are unlocked with the provided issuance time
+// 2. UTXOs that are locked with the provided issuance time
+func splitUTXOsByLocktime(utxos []*avax.UTXO, minIssuanceTime uint64) ([]*avax.UTXO, []*avax.UTXO) {
 	var (
-		lockedUTXOs   = make([]*avax.UTXO, 0, len(utxos))
 		unlockedUTXOs = make([]*avax.UTXO, 0, len(utxos))
+		lockedUTXOs   = make([]*avax.UTXO, 0, len(utxos))
 	)
 	for _, utxo := range utxos {
 		lockedOut, ok := utxo.Out.(*stakeable.LockOut)
@@ -1384,22 +1387,25 @@ func splitLockedStakeableUTXOs(utxos []*avax.UTXO, minIssuanceTime uint64) ([]*a
 		}
 		lockedUTXOs = append(lockedUTXOs, utxo)
 	}
-	return lockedUTXOs, unlockedUTXOs
+	return unlockedUTXOs, lockedUTXOs
 }
 
-func splitAVAXUTXOs(utxos []*avax.UTXO, avaxAssetID ids.ID) ([]*avax.UTXO, []*avax.UTXO) {
+// splitUTXOsByAssetID separates the provided UTXOs into two slices:
+// 1. UTXOs with the provided assetID
+// 2. UTXOs with a different assetID
+func splitUTXOsByAssetID(utxos []*avax.UTXO, assetID ids.ID) ([]*avax.UTXO, []*avax.UTXO) {
 	var (
-		avaxUTXOs    = make([]*avax.UTXO, 0, len(utxos))
-		nonAVAXUTXOs = make([]*avax.UTXO, 0, len(utxos))
+		requestedUTXOs = make([]*avax.UTXO, 0, len(utxos))
+		otherUTXOs     = make([]*avax.UTXO, 0, len(utxos))
 	)
 	for _, utxo := range utxos {
-		if utxo.AssetID() == avaxAssetID {
-			avaxUTXOs = append(avaxUTXOs, utxo)
+		if utxo.AssetID() == assetID {
+			requestedUTXOs = append(requestedUTXOs, utxo)
 		} else {
-			nonAVAXUTXOs = append(nonAVAXUTXOs, utxo)
+			otherUTXOs = append(otherUTXOs, utxo)
 		}
 	}
-	return avaxUTXOs, nonAVAXUTXOs
+	return requestedUTXOs, otherUTXOs
 }
 
 func unwrapOutput(output verify.State) (*secp256k1fx.TransferOutput, uint64, error) {

--- a/wallet/chain/p/builder/builder_test.go
+++ b/wallet/chain/p/builder/builder_test.go
@@ -1,6 +1,7 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//nolint:gosec // This file does not need cryptographically strong randomness
 package builder
 
 import (
@@ -17,7 +18,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
-//nolint:gosec // This does not need cryptographically strong random numbers
 func generateUTXOs(assetID ids.ID, locktime uint64) []*avax.UTXO {
 	utxos := make([]*avax.UTXO, rand.Intn(10))
 	for i := range utxos {
@@ -53,11 +53,12 @@ func TestSplitUTXOsByLocktime(t *testing.T) {
 	var (
 		require = require.New(t)
 
-		expectedUnlockedUTXOsPart0 = generateUTXOs(ids.GenerateTestID(), 0)
-		expectedUnlockedUTXOsPart1 = generateUTXOs(ids.GenerateTestID(), 100)
-		expectedLockedUTXOsPart0   = generateUTXOs(ids.GenerateTestID(), 10000)
-		expectedUnlockedUTXOsPart2 = generateUTXOs(ids.GenerateTestID(), 0)
-		expectedLockedUTXOsPart1   = generateUTXOs(ids.GenerateTestID(), 101)
+		unlockedTime               uint64 = 100
+		expectedUnlockedUTXOsPart0        = generateUTXOs(ids.GenerateTestID(), 0)
+		expectedUnlockedUTXOsPart1        = generateUTXOs(ids.GenerateTestID(), unlockedTime)
+		expectedLockedUTXOsPart0          = generateUTXOs(ids.GenerateTestID(), unlockedTime+100)
+		expectedUnlockedUTXOsPart2        = generateUTXOs(ids.GenerateTestID(), unlockedTime-1)
+		expectedLockedUTXOsPart1          = generateUTXOs(ids.GenerateTestID(), unlockedTime+1)
 
 		utxos = utils.Join(
 			expectedUnlockedUTXOsPart0,
@@ -77,7 +78,7 @@ func TestSplitUTXOsByLocktime(t *testing.T) {
 		)
 	)
 
-	utxosWithAssetID, utxosWithOtherAssetID := splitUTXOsByLocktime(utxos, 100)
+	utxosWithAssetID, utxosWithOtherAssetID := splitUTXOsByLocktime(utxos, unlockedTime)
 	require.Equal(expectedUnlockedUTXOs, utxosWithAssetID)
 	require.Equal(expectedLockedUTXOs, utxosWithOtherAssetID)
 }
@@ -87,11 +88,11 @@ func TestSplitUTXOsByAssetID(t *testing.T) {
 		require = require.New(t)
 
 		assetID                            = ids.GenerateTestID()
-		expectedUTXOsWithAssetIDPart0      = generateUTXOs(assetID, 0)
-		expectedUTXOsWithAssetIDPart1      = generateUTXOs(assetID, 100)
-		expectedUTXOsWithAssetIDPart2      = generateUTXOs(assetID, 10000)
-		expectedUTXOsWithOtherAssetIDPart0 = generateUTXOs(ids.GenerateTestID(), 0)
-		expectedUTXOsWithOtherAssetIDPart1 = generateUTXOs(ids.GenerateTestID(), 100)
+		expectedUTXOsWithAssetIDPart0      = generateUTXOs(assetID, rand.Uint64())
+		expectedUTXOsWithAssetIDPart1      = generateUTXOs(assetID, rand.Uint64())
+		expectedUTXOsWithAssetIDPart2      = generateUTXOs(assetID, rand.Uint64())
+		expectedUTXOsWithOtherAssetIDPart0 = generateUTXOs(ids.GenerateTestID(), rand.Uint64())
+		expectedUTXOsWithOtherAssetIDPart1 = generateUTXOs(ids.GenerateTestID(), rand.Uint64())
 
 		utxos = utils.Join(
 			expectedUTXOsWithAssetIDPart0,

--- a/wallet/chain/p/builder/builder_test.go
+++ b/wallet/chain/p/builder/builder_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+func TestUnwrapOutput(t *testing.T) {
+	normalOutput := &secp256k1fx.TransferOutput{
+		Amt: 123,
+		OutputOwners: secp256k1fx.OutputOwners{
+			Locktime:  456,
+			Threshold: 1,
+			Addrs:     []ids.ShortID{ids.ShortEmpty},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		output           verify.State
+		expectedOutput   *secp256k1fx.TransferOutput
+		expectedLocktime uint64
+		expectedErr      error
+	}{
+		{
+			name:             "normal output",
+			output:           normalOutput,
+			expectedOutput:   normalOutput,
+			expectedLocktime: 0,
+			expectedErr:      nil,
+		},
+		{
+			name: "locked output",
+			output: &stakeable.LockOut{
+				Locktime:        789,
+				TransferableOut: normalOutput,
+			},
+			expectedOutput:   normalOutput,
+			expectedLocktime: 789,
+			expectedErr:      nil,
+		},
+		{
+			name: "locked output with no locktime",
+			output: &stakeable.LockOut{
+				Locktime:        0,
+				TransferableOut: normalOutput,
+			},
+			expectedOutput:   normalOutput,
+			expectedLocktime: 0,
+			expectedErr:      nil,
+		},
+		{
+			name:             "invalid output",
+			output:           nil,
+			expectedOutput:   nil,
+			expectedLocktime: 0,
+			expectedErr:      ErrUnknownOutputType,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			output, locktime, err := unwrapOutput(test.output)
+			require.Equal(test.expectedOutput, output)
+			require.Equal(test.expectedLocktime, locktime)
+			require.ErrorIs(err, test.expectedErr)
+		})
+	}
+}

--- a/wallet/chain/p/builder/builder_test.go
+++ b/wallet/chain/p/builder/builder_test.go
@@ -4,15 +4,117 @@
 package builder
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
+
+//nolint:gosec // This does not need cryptographically strong random numbers
+func generateUTXOs(assetID ids.ID, locktime uint64) []*avax.UTXO {
+	utxos := make([]*avax.UTXO, rand.Intn(10))
+	for i := range utxos {
+		var output avax.TransferableOut = &secp256k1fx.TransferOutput{
+			Amt: rand.Uint64(),
+			OutputOwners: secp256k1fx.OutputOwners{
+				Locktime:  rand.Uint64(),
+				Threshold: 1,
+				Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
+			},
+		}
+		if locktime != 0 {
+			output = &stakeable.LockOut{
+				Locktime:        locktime,
+				TransferableOut: output,
+			}
+		}
+		utxos[i] = &avax.UTXO{
+			UTXOID: avax.UTXOID{
+				TxID:        ids.GenerateTestID(),
+				OutputIndex: rand.Uint32(),
+			},
+			Asset: avax.Asset{
+				ID: assetID,
+			},
+			Out: output,
+		}
+	}
+	return utxos
+}
+
+func TestSplitUTXOsByLocktime(t *testing.T) {
+	var (
+		require = require.New(t)
+
+		expectedUnlockedUTXOsPart0 = generateUTXOs(ids.GenerateTestID(), 0)
+		expectedUnlockedUTXOsPart1 = generateUTXOs(ids.GenerateTestID(), 100)
+		expectedLockedUTXOsPart0   = generateUTXOs(ids.GenerateTestID(), 10000)
+		expectedUnlockedUTXOsPart2 = generateUTXOs(ids.GenerateTestID(), 0)
+		expectedLockedUTXOsPart1   = generateUTXOs(ids.GenerateTestID(), 101)
+
+		utxos = utils.Join(
+			expectedUnlockedUTXOsPart0,
+			expectedUnlockedUTXOsPart1,
+			expectedLockedUTXOsPart0,
+			expectedUnlockedUTXOsPart2,
+			expectedLockedUTXOsPart1,
+		)
+		expectedUnlockedUTXOs = utils.Join(
+			expectedUnlockedUTXOsPart0,
+			expectedUnlockedUTXOsPart1,
+			expectedUnlockedUTXOsPart2,
+		)
+		expectedLockedUTXOs = utils.Join(
+			expectedLockedUTXOsPart0,
+			expectedLockedUTXOsPart1,
+		)
+	)
+
+	utxosWithAssetID, utxosWithOtherAssetID := splitUTXOsByLocktime(utxos, 100)
+	require.Equal(expectedUnlockedUTXOs, utxosWithAssetID)
+	require.Equal(expectedLockedUTXOs, utxosWithOtherAssetID)
+}
+
+func TestSplitUTXOsByAssetID(t *testing.T) {
+	var (
+		require = require.New(t)
+
+		assetID                            = ids.GenerateTestID()
+		expectedUTXOsWithAssetIDPart0      = generateUTXOs(assetID, 0)
+		expectedUTXOsWithAssetIDPart1      = generateUTXOs(assetID, 100)
+		expectedUTXOsWithAssetIDPart2      = generateUTXOs(assetID, 10000)
+		expectedUTXOsWithOtherAssetIDPart0 = generateUTXOs(ids.GenerateTestID(), 0)
+		expectedUTXOsWithOtherAssetIDPart1 = generateUTXOs(ids.GenerateTestID(), 100)
+
+		utxos = utils.Join(
+			expectedUTXOsWithAssetIDPart0,
+			expectedUTXOsWithOtherAssetIDPart0,
+			expectedUTXOsWithAssetIDPart1,
+			expectedUTXOsWithOtherAssetIDPart1,
+			expectedUTXOsWithAssetIDPart2,
+		)
+		expectedUTXOsWithAssetID = utils.Join(
+			expectedUTXOsWithAssetIDPart0,
+			expectedUTXOsWithAssetIDPart1,
+			expectedUTXOsWithAssetIDPart2,
+		)
+		expectedUTXOsWithOtherAssetID = utils.Join(
+			expectedUTXOsWithOtherAssetIDPart0,
+			expectedUTXOsWithOtherAssetIDPart1,
+		)
+	)
+
+	utxosWithAssetID, utxosWithOtherAssetID := splitUTXOsByAssetID(utxos, assetID)
+	require.Equal(expectedUTXOsWithAssetID, utxosWithAssetID)
+	require.Equal(expectedUTXOsWithOtherAssetID, utxosWithOtherAssetID)
+}
 
 func TestUnwrapOutput(t *testing.T) {
 	normalOutput := &secp256k1fx.TransferOutput{


### PR DESCRIPTION
## Why this should be merged

It seems like #3232 is daunting to review - this PR further reduces that diff by refactoring the builder without adding complexity in yet.

## How this works

- This PR refactors `ImportTx` to always call `spend`.
- This PR refactors all the transactions to call `spend` last.
- This PR introduces a `spendHelper` to encapsulate common operations performed in `spend`
- This PR introduces a few helper functions that separate UTXOs into different groups.

## How this was tested

- [X] This PR is a pure refactor and passes existing CI
- [X] Additional helpers are explicitly tested