### PR TITLE
Add scaffolding for warp verifier

### DIFF
--- a/vms/platformvm/block/executor/block.go
+++ b/vms/platformvm/block/executor/block.go
@@ -38,7 +38,7 @@ func (b *Block) VerifyWithContext(_ context.Context, ctx *smblock.Context) error
 	blkID := b.ID()
 	if blkState, ok := b.manager.blkIDToState[blkID]; ok {
 		if !blkState.verifiedHeights.Contains(pChainHeight) {
-			if err := b.Visit(&warpVerifier{}); err != nil {
+			if err := b.Visit(&warpBlockVerifier{}); err != nil {
 				return err
 			}
 
@@ -49,7 +49,7 @@ func (b *Block) VerifyWithContext(_ context.Context, ctx *smblock.Context) error
 		return nil
 	}
 
-	if err := b.Visit(&warpVerifier{}); err != nil {
+	if err := b.Visit(&warpBlockVerifier{}); err != nil {
 		return err
 	}
 

--- a/vms/platformvm/block/executor/block.go
+++ b/vms/platformvm/block/executor/block.go
@@ -38,14 +38,19 @@ func (b *Block) VerifyWithContext(_ context.Context, ctx *smblock.Context) error
 	blkID := b.ID()
 	if blkState, ok := b.manager.blkIDToState[blkID]; ok {
 		if !blkState.verifiedHeights.Contains(pChainHeight) {
-			// PlatformVM blocks are currently valid regardless of the ProposerVM's
-			// PChainHeight. If this changes, those validity checks should be done prior
-			// to adding [pChainHeight] to [verifiedHeights].
+			if err := b.Visit(&warpVerifier{}); err != nil {
+				return err
+			}
+
 			blkState.verifiedHeights.Add(pChainHeight)
 		}
 
 		// This block has already been verified.
 		return nil
+	}
+
+	if err := b.Visit(&warpVerifier{}); err != nil {
+		return err
 	}
 
 	return b.Visit(&verifier{

--- a/vms/platformvm/block/executor/warp_verifier.go
+++ b/vms/platformvm/block/executor/warp_verifier.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package executor
+
+import (
+	"github.com/ava-labs/avalanchego/vms/platformvm/block"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+)
+
+var _ block.Visitor = (*warpVerifier)(nil)
+
+// warpVerifier handles the logic for verifying the warp signatures in P-Chain txs.
+type warpVerifier struct{}
+
+func (*warpVerifier) BanffAbortBlock(*block.BanffAbortBlock) error           { return nil }
+func (*warpVerifier) BanffCommitBlock(*block.BanffCommitBlock) error         { return nil }
+func (*warpVerifier) ApricotAbortBlock(*block.ApricotAbortBlock) error       { return nil }
+func (*warpVerifier) ApricotCommitBlock(*block.ApricotCommitBlock) error     { return nil }
+func (*warpVerifier) ApricotProposalBlock(*block.ApricotProposalBlock) error { return nil }
+func (*warpVerifier) ApricotStandardBlock(*block.ApricotStandardBlock) error { return nil }
+func (*warpVerifier) ApricotAtomicBlock(*block.ApricotAtomicBlock) error     { return nil }
+
+func (v *warpVerifier) BanffProposalBlock(b *block.BanffProposalBlock) error {
+	return v.verifyStandardTxs(b.Transactions)
+}
+
+func (v *warpVerifier) BanffStandardBlock(b *block.BanffStandardBlock) error {
+	return v.verifyStandardTxs(b.Transactions)
+}
+
+func (*warpVerifier) verifyStandardTxs([]*txs.Tx) error {
+	// If any tx contains a warp message, that must be checked here.
+	return nil
+}

--- a/vms/platformvm/block/executor/warp_verifier.go
+++ b/vms/platformvm/block/executor/warp_verifier.go
@@ -10,16 +10,20 @@ import (
 
 var _ block.Visitor = (*warpVerifier)(nil)
 
-// warpVerifier handles the logic for verifying the warp signatures in P-Chain txs.
+// warpVerifier handles the logic for verifying the signatures in the warp
+// messages contained in transactions.
 type warpVerifier struct{}
 
-func (*warpVerifier) BanffAbortBlock(*block.BanffAbortBlock) error           { return nil }
-func (*warpVerifier) BanffCommitBlock(*block.BanffCommitBlock) error         { return nil }
+// Pre-Banff did not contain any transactions with warp messages.
 func (*warpVerifier) ApricotAbortBlock(*block.ApricotAbortBlock) error       { return nil }
 func (*warpVerifier) ApricotCommitBlock(*block.ApricotCommitBlock) error     { return nil }
 func (*warpVerifier) ApricotProposalBlock(*block.ApricotProposalBlock) error { return nil }
 func (*warpVerifier) ApricotStandardBlock(*block.ApricotStandardBlock) error { return nil }
 func (*warpVerifier) ApricotAtomicBlock(*block.ApricotAtomicBlock) error     { return nil }
+
+// No transactions in these blocks.
+func (*warpVerifier) BanffAbortBlock(*block.BanffAbortBlock) error   { return nil }
+func (*warpVerifier) BanffCommitBlock(*block.BanffCommitBlock) error { return nil }
 
 func (v *warpVerifier) BanffProposalBlock(b *block.BanffProposalBlock) error {
 	return v.verifyStandardTxs(b.Transactions)

--- a/vms/platformvm/block/executor/warp_verifier.go
+++ b/vms/platformvm/block/executor/warp_verifier.go
@@ -8,32 +8,63 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
-var _ block.Visitor = (*warpVerifier)(nil)
+var (
+	_ block.Visitor = (*warpBlockVerifier)(nil)
+	_ txs.Visitor   = (*warpTxVerifier)(nil)
+)
 
-// warpVerifier handles the logic for verifying the signatures in the warp
-// messages contained in transactions.
-type warpVerifier struct{}
+// warpBlockVerifier handles the logic for verifying all the warp message
+// signatures in a block's transactions.
+type warpBlockVerifier struct{}
 
 // Pre-Banff did not contain any transactions with warp messages.
-func (*warpVerifier) ApricotAbortBlock(*block.ApricotAbortBlock) error       { return nil }
-func (*warpVerifier) ApricotCommitBlock(*block.ApricotCommitBlock) error     { return nil }
-func (*warpVerifier) ApricotProposalBlock(*block.ApricotProposalBlock) error { return nil }
-func (*warpVerifier) ApricotStandardBlock(*block.ApricotStandardBlock) error { return nil }
-func (*warpVerifier) ApricotAtomicBlock(*block.ApricotAtomicBlock) error     { return nil }
+func (*warpBlockVerifier) ApricotAbortBlock(*block.ApricotAbortBlock) error       { return nil }
+func (*warpBlockVerifier) ApricotCommitBlock(*block.ApricotCommitBlock) error     { return nil }
+func (*warpBlockVerifier) ApricotProposalBlock(*block.ApricotProposalBlock) error { return nil }
+func (*warpBlockVerifier) ApricotStandardBlock(*block.ApricotStandardBlock) error { return nil }
+func (*warpBlockVerifier) ApricotAtomicBlock(*block.ApricotAtomicBlock) error     { return nil }
 
 // No transactions in these blocks.
-func (*warpVerifier) BanffAbortBlock(*block.BanffAbortBlock) error   { return nil }
-func (*warpVerifier) BanffCommitBlock(*block.BanffCommitBlock) error { return nil }
+func (*warpBlockVerifier) BanffAbortBlock(*block.BanffAbortBlock) error   { return nil }
+func (*warpBlockVerifier) BanffCommitBlock(*block.BanffCommitBlock) error { return nil }
 
-func (v *warpVerifier) BanffProposalBlock(b *block.BanffProposalBlock) error {
+func (v *warpBlockVerifier) BanffProposalBlock(b *block.BanffProposalBlock) error {
 	return v.verifyStandardTxs(b.Transactions)
 }
 
-func (v *warpVerifier) BanffStandardBlock(b *block.BanffStandardBlock) error {
+func (v *warpBlockVerifier) BanffStandardBlock(b *block.BanffStandardBlock) error {
 	return v.verifyStandardTxs(b.Transactions)
 }
 
-func (*warpVerifier) verifyStandardTxs([]*txs.Tx) error {
-	// If any tx contains a warp message, that must be checked here.
+func (*warpBlockVerifier) verifyStandardTxs(txs []*txs.Tx) error {
+	for _, tx := range txs {
+		if err := tx.Unsigned.Visit(&warpTxVerifier{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// warpBlockVerifier handles the logic for verifying the warp message
+// signature in a transaction.
+type warpTxVerifier struct{}
+
+func (*warpTxVerifier) AddDelegatorTx(*txs.AddDelegatorTx) error                       { return nil }
+func (*warpTxVerifier) AddSubnetValidatorTx(*txs.AddSubnetValidatorTx) error           { return nil }
+func (*warpTxVerifier) AddValidatorTx(*txs.AddValidatorTx) error                       { return nil }
+func (*warpTxVerifier) AdvanceTimeTx(*txs.AdvanceTimeTx) error                         { return nil }
+func (*warpTxVerifier) BaseTx(*txs.BaseTx) error                                       { return nil }
+func (*warpTxVerifier) CreateChainTx(*txs.CreateChainTx) error                         { return nil }
+func (*warpTxVerifier) CreateSubnetTx(*txs.CreateSubnetTx) error                       { return nil }
+func (*warpTxVerifier) ExportTx(*txs.ExportTx) error                                   { return nil }
+func (*warpTxVerifier) ImportTx(*txs.ImportTx) error                                   { return nil }
+func (*warpTxVerifier) RemoveSubnetValidatorTx(*txs.RemoveSubnetValidatorTx) error     { return nil }
+func (*warpTxVerifier) RewardValidatorTx(*txs.RewardValidatorTx) error                 { return nil }
+func (*warpTxVerifier) TransferSubnetOwnershipTx(*txs.TransferSubnetOwnershipTx) error { return nil }
+func (*warpTxVerifier) TransformSubnetTx(*txs.TransformSubnetTx) error                 { return nil }
+func (*warpTxVerifier) AddPermissionlessDelegatorTx(*txs.AddPermissionlessDelegatorTx) error {
+	return nil
+}
+func (*warpTxVerifier) AddPermissionlessValidatorTx(*txs.AddPermissionlessValidatorTx) error {
 	return nil
 }

--- a/vms/platformvm/block/executor/warp_verifier.go
+++ b/vms/platformvm/block/executor/warp_verifier.go
@@ -65,6 +65,7 @@ func (*warpTxVerifier) TransformSubnetTx(*txs.TransformSubnetTx) error          
 func (*warpTxVerifier) AddPermissionlessDelegatorTx(*txs.AddPermissionlessDelegatorTx) error {
 	return nil
 }
+
 func (*warpTxVerifier) AddPermissionlessValidatorTx(*txs.AddPermissionlessValidatorTx) error {
 	return nil
 }


### PR DESCRIPTION
## Why this should be merged

Preparatory work for when we verify warp messages as specified in ACP-77. Currently, it does nothing since no txs with warp messages have been introduced into the codebase.

## How this works

pretty straightforward

## How this was tested

existing UTs. Will add UTs for the verifier itself once we add txs.