### PR TITLE
Reduce dynamic fees variability to ease testing

### DIFF
--- a/genesis/genesis_fuji.go
+++ b/genesis/genesis_fuji.go
@@ -45,7 +45,7 @@ var (
 				MaxGasPerSecond:          1_000,
 				TargetGasPerSecond:       500,
 				MinGasPrice:              1,
-				ExcessConversionConstant: 1,
+				ExcessConversionConstant: 5_000,
 			},
 		},
 		StakingConfig: StakingConfig{

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -63,7 +63,7 @@ var (
 				MaxGasPerSecond:          1_000,
 				TargetGasPerSecond:       500,
 				MinGasPrice:              1,
-				ExcessConversionConstant: 1,
+				ExcessConversionConstant: 5_000,
 			},
 		},
 		StakingConfig: StakingConfig{

--- a/genesis/genesis_mainnet.go
+++ b/genesis/genesis_mainnet.go
@@ -45,7 +45,7 @@ var (
 				MaxGasPerSecond:          1_000,
 				TargetGasPerSecond:       500,
 				MinGasPrice:              1,
-				ExcessConversionConstant: 1,
+				ExcessConversionConstant: 5_000,
 			},
 		},
 		StakingConfig: StakingConfig{


### PR DESCRIPTION
## Why this should be merged

Currently, the gas price can change as much as a factor of `e^500` every second. This causes the fees to be so volatile that even simple usage is unworkable.

This changes the factor to `e^(1/10)` every second. Which is stable enough for reasonable usage.

This is not the final parameterization (by any means). Just making the defaults possible to use.

## How this works

`1` -> `5000`.

## How this was tested

These values aren't currently used, but when they are used this change is required for CI to pass.