### PR TITLE
[antithesis] Fix broken flag handling and improve image testing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -170,16 +170,10 @@ linters-settings:
         disabled: false
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
       - name: unhandled-error
-        disabled: false
-        arguments:
-          - "fmt\\.Fprint"
-          - "fmt\\.Fprintf"
-          - "fmt\\.Fprintln"
-          - "fmt\\.Print"
-          - "fmt\\.Printf"
-          - "fmt\\.Println"
-          - "math/rand\\.Read"
-          - "strings\\.Builder\\.WriteString"
+        # prefer the errcheck linter since it can be disabled directly with nolint directive
+        # but revive's disable directive (e.g. //revive:disable:unhandled-error) is not
+        # supported when run under golangci_lint
+        disabled: true
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
       - name: unused-parameter
         disabled: false

--- a/tests/antithesis/config.go
+++ b/tests/antithesis/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
@@ -54,15 +55,15 @@ func NewConfigWithSubnets(tc tests.TestContext, defaultNetwork *tmpnet.Network, 
 	flag.Parse()
 
 	// Env vars take priority over flags
-	envURIs := os.Getenv(envVarName(URIsKey))
+	envURIs := os.Getenv(envVarName(EnvPrefix, URIsKey))
 	if len(envURIs) > 0 {
 		// CSV.Set doesn't actually return an error
 		_ = uris.Set(envURIs)
 	}
-	envChainIDs := os.Getenv(envVarName(ChainIDsKey))
+	envChainIDs := os.Getenv(envVarName(EnvPrefix, ChainIDsKey))
 	if len(envChainIDs) > 0 {
 		// CSV.Set doesn't actually return an error
-		_ = uris.Set(envChainIDs)
+		_ = chainIDs.Set(envChainIDs)
 	}
 
 	// Use the network configuration provided
@@ -126,6 +127,7 @@ func (c *CSV) Set(value string) error {
 	return nil
 }
 
-func envVarName(key string) string {
-	return strings.ToUpper(EnvPrefix + "_" + key)
+func envVarName(prefix string, key string) string {
+	// e.g. MY_PREFIX, network-id -> MY_PREFIX_NETWORK_ID
+	return strings.ToUpper(prefix + "_" + config.DashesToUnderscores.Replace(key))
 }

--- a/tests/antithesis/config.go
+++ b/tests/antithesis/config.go
@@ -57,12 +57,12 @@ func NewConfigWithSubnets(tc tests.TestContext, defaultNetwork *tmpnet.Network, 
 	// Env vars take priority over flags
 	envURIs := os.Getenv(envVarName(EnvPrefix, URIsKey))
 	if len(envURIs) > 0 {
-		//nolint:errcheck,revive // CSV.Set doesn't actually return an error
+		//nolint:errcheck // CSV.Set doesn't actually return an error
 		uris.Set(envURIs)
 	}
 	envChainIDs := os.Getenv(envVarName(EnvPrefix, ChainIDsKey))
 	if len(envChainIDs) > 0 {
-		//nolint:errcheck,revive // CSV.Set doesn't actually return an error
+		//nolint:errcheck // CSV.Set doesn't actually return an error
 		chainIDs.Set(envChainIDs)
 	}
 

--- a/tests/antithesis/config.go
+++ b/tests/antithesis/config.go
@@ -57,13 +57,13 @@ func NewConfigWithSubnets(tc tests.TestContext, defaultNetwork *tmpnet.Network, 
 	// Env vars take priority over flags
 	envURIs := os.Getenv(envVarName(EnvPrefix, URIsKey))
 	if len(envURIs) > 0 {
-		// CSV.Set doesn't actually return an error
-		_ = uris.Set(envURIs)
+		//nolint:errcheck,revive // CSV.Set doesn't actually return an error
+		uris.Set(envURIs)
 	}
 	envChainIDs := os.Getenv(envVarName(EnvPrefix, ChainIDsKey))
 	if len(envChainIDs) > 0 {
-		// CSV.Set doesn't actually return an error
-		_ = chainIDs.Set(envChainIDs)
+		//nolint:errcheck,revive // CSV.Set doesn't actually return an error
+		chainIDs.Set(envChainIDs)
 	}
 
 	// Use the network configuration provided


### PR DESCRIPTION
## Why this should be merged

The recent addition of tmpnet support for antithesis workloads broke configuration in the actual antithesis environment due to deficiencies in the test of the image build. 

## How this works

This change cleans up the flag configuration that caused the problem and updates the test of image build to directly check the output of the docker compose project for evidence that nodes have reported healthy rather than just waiting for 30s without a non-zero exit.

## How this was tested

- Locally and CI for positive test, locally for negative test.
- Manually ran image publication and test triggering workflows:
  - https://github.com/ava-labs/avalanchego/actions/runs/10400724584
  - https://github.com/ava-labs/avalanchego/actions/runs/10400883250
  - https://github.com/ava-labs/avalanchego/actions/runs/10400897773 
    - Triggered jobs indicated they had run to completion rather than failing due to a configuration issue