### PR TITLE
Rename gas price calculation function

### DIFF
--- a/vms/components/fee/gas.go
+++ b/vms/components/fee/gas.go
@@ -55,7 +55,12 @@ func (g Gas) SubPerSecond(gasPerSecond Gas, seconds uint64) Gas {
 	return Gas(totalGas)
 }
 
-// MulExp returns an approximation of g * e^(excess / excessConversionConstant)
+// CalculateGasPrice returns the gas price given the minimum gas price, the
+// excess gas, and the excess conversion constant.
+//
+// It is defined as an approximation of:
+//
+//	minPrice * e^(excess / excessConversionConstant)
 //
 // This implements the EIP-4844 fake exponential formula:
 //
@@ -77,7 +82,8 @@ func (g Gas) SubPerSecond(gasPerSecond Gas, seconds uint64) Gas {
 // This function does not perform any memory allocations.
 //
 //nolint:dupword // The python is copied from the EIP-4844 specification
-func (g GasPrice) MulExp(
+func CalculateGasPrice(
+	minPrice GasPrice,
 	excess Gas,
 	excessConversionConstant Gas,
 ) GasPrice {
@@ -95,7 +101,7 @@ func (g GasPrice) MulExp(
 	denominator.SetUint64(uint64(excessConversionConstant)) // range is [0, MaxUint64]
 
 	i.SetOne()
-	numeratorAccum.SetUint64(uint64(g))               // range is [0, MaxUint64]
+	numeratorAccum.SetUint64(uint64(minPrice))        // range is [0, MaxUint64]
 	numeratorAccum.Mul(&numeratorAccum, &denominator) // range is [0, MaxUint128]
 
 	maxOutput.Mul(&denominator, maxUint64) // range is [0, MaxUint128]

--- a/vms/components/fee/gas_test.go
+++ b/vms/components/fee/gas_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var gasPriceMulExpTests = []struct {
+var calculateGasPriceTests = []struct {
 	minPrice                 GasPrice
 	excess                   Gas
 	excessConversionConstant Gas
@@ -172,20 +172,20 @@ func Test_Gas_SubPerSecond(t *testing.T) {
 	}
 }
 
-func Test_GasPrice_MulExp(t *testing.T) {
-	for _, test := range gasPriceMulExpTests {
+func Test_CalculateGasPrice(t *testing.T) {
+	for _, test := range calculateGasPriceTests {
 		t.Run(fmt.Sprintf("%d*e^(%d/%d)=%d", test.minPrice, test.excess, test.excessConversionConstant, test.expected), func(t *testing.T) {
-			actual := test.minPrice.MulExp(test.excess, test.excessConversionConstant)
+			actual := CalculateGasPrice(test.minPrice, test.excess, test.excessConversionConstant)
 			require.Equal(t, test.expected, actual)
 		})
 	}
 }
 
-func Benchmark_GasPrice_MulExp(b *testing.B) {
-	for _, test := range gasPriceMulExpTests {
+func Benchmark_CalculateGasPrice(b *testing.B) {
+	for _, test := range calculateGasPriceTests {
 		b.Run(fmt.Sprintf("%d*e^(%d/%d)=%d", test.minPrice, test.excess, test.excessConversionConstant, test.expected), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				test.minPrice.MulExp(test.excess, test.excessConversionConstant)
+				CalculateGasPrice(test.minPrice, test.excess, test.excessConversionConstant)
 			}
 		})
 	}

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1863,7 +1863,8 @@ func (s *Service) GetFeeState(_ *http.Request, _ *struct{}, reply *GetFeeStateRe
 	defer s.vm.ctx.Lock.Unlock()
 
 	reply.State = s.vm.state.GetFeeState()
-	reply.Price = s.vm.DynamicFeeConfig.MinGasPrice.MulExp(
+	reply.Price = fee.CalculateGasPrice(
+		s.vm.DynamicFeeConfig.MinGasPrice,
 		reply.State.Excess,
 		s.vm.DynamicFeeConfig.ExcessConversionConstant,
 	)

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -1154,7 +1154,8 @@ func FuzzGetFeeState(f *testing.F) {
 			expectedTime  = time.Now()
 			expectedReply = GetFeeStateReply{
 				State: expectedState,
-				Price: defaultDynamicFeeConfig.MinGasPrice.MulExp(
+				Price: fee.CalculateGasPrice(
+					defaultDynamicFeeConfig.MinGasPrice,
 					expectedState.Excess,
 					defaultDynamicFeeConfig.ExcessConversionConstant,
 				),


### PR DESCRIPTION
## Why this should be merged

Makes using the function more readable.

## How this works

Replaces a method with a function and renames it.

## How this was tested

N/A