### PR TITLE
Remove duplicate fork definitions

### DIFF
--- a/upgrade/upgradetest/config.go
+++ b/upgrade/upgradetest/config.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package upgradetest
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade"
+)
+
+func GetConfig(fork Fork) upgrade.Config {
+	c := upgrade.Config{
+		ApricotPhase1Time:            upgrade.UnscheduledActivationTime,
+		ApricotPhase2Time:            upgrade.UnscheduledActivationTime,
+		ApricotPhase3Time:            upgrade.UnscheduledActivationTime,
+		ApricotPhase4Time:            upgrade.UnscheduledActivationTime,
+		ApricotPhase4MinPChainHeight: 0,
+		ApricotPhase5Time:            upgrade.UnscheduledActivationTime,
+		ApricotPhasePre6Time:         upgrade.UnscheduledActivationTime,
+		ApricotPhase6Time:            upgrade.UnscheduledActivationTime,
+		ApricotPhasePost6Time:        upgrade.UnscheduledActivationTime,
+		BanffTime:                    upgrade.UnscheduledActivationTime,
+		CortinaTime:                  upgrade.UnscheduledActivationTime,
+		CortinaXChainStopVertexID:    ids.Empty,
+		DurangoTime:                  upgrade.UnscheduledActivationTime,
+		EtnaTime:                     upgrade.UnscheduledActivationTime,
+	}
+
+	switch fork {
+	case Etna:
+		c.EtnaTime = upgrade.InitiallyActiveTime
+		fallthrough
+	case Durango:
+		c.DurangoTime = upgrade.InitiallyActiveTime
+		fallthrough
+	case Cortina:
+		c.CortinaTime = upgrade.InitiallyActiveTime
+		fallthrough
+	case Banff:
+		c.BanffTime = upgrade.InitiallyActiveTime
+		fallthrough
+	case ApricotPhasePost6:
+		c.ApricotPhasePost6Time = upgrade.InitiallyActiveTime
+		fallthrough
+	case ApricotPhase6:
+		c.ApricotPhase6Time = upgrade.InitiallyActiveTime
+		fallthrough
+	case ApricotPhasePre6:
+		c.ApricotPhasePre6Time = upgrade.InitiallyActiveTime
+		fallthrough
+	case ApricotPhase5:
+		c.ApricotPhase5Time = upgrade.InitiallyActiveTime
+		fallthrough
+	case ApricotPhase4:
+		c.ApricotPhase4Time = upgrade.InitiallyActiveTime
+		fallthrough
+	case ApricotPhase3:
+		c.ApricotPhase3Time = upgrade.InitiallyActiveTime
+		fallthrough
+	case ApricotPhase2:
+		c.ApricotPhase2Time = upgrade.InitiallyActiveTime
+		fallthrough
+	case ApricotPhase1:
+		c.ApricotPhase1Time = upgrade.InitiallyActiveTime
+	}
+	return c
+}

--- a/upgrade/upgradetest/config.go
+++ b/upgrade/upgradetest/config.go
@@ -16,8 +16,9 @@ func GetConfig(fork Fork) upgrade.Config {
 	return GetConfigWithUpgradeTime(fork, upgrade.InitiallyActiveTime)
 }
 
-// GetConfig returns an upgrade config with the provided fork scheduled to be
-// activated at the provided upgradeTime and all other forks to be unscheduled.
+// GetConfigWithUpgradeTime returns an upgrade config with the provided fork
+// scheduled to be activated at the provided upgradeTime and all other forks to
+// be unscheduled.
 func GetConfigWithUpgradeTime(fork Fork, upgradeTime time.Time) upgrade.Config {
 	c := upgrade.Config{
 		ApricotPhase4MinPChainHeight: 0,

--- a/upgrade/upgradetest/config.go
+++ b/upgrade/upgradetest/config.go
@@ -6,7 +6,6 @@ package upgradetest
 import (
 	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/upgrade"
 )
 
@@ -20,10 +19,7 @@ func GetConfig(fork Fork) upgrade.Config {
 // scheduled to be activated at the provided upgradeTime and all other forks to
 // be unscheduled.
 func GetConfigWithUpgradeTime(fork Fork, upgradeTime time.Time) upgrade.Config {
-	c := upgrade.Config{
-		ApricotPhase4MinPChainHeight: 0,
-		CortinaXChainStopVertexID:    ids.Empty,
-	}
+	c := upgrade.Config{}
 	// Initialize all forks to be unscheduled
 	SetTimesTo(&c, Latest, upgrade.UnscheduledActivationTime)
 	// Schedule the requested forks at the provided upgrade time

--- a/upgrade/upgradetest/config.go
+++ b/upgrade/upgradetest/config.go
@@ -24,15 +24,15 @@ func GetConfigWithUpgradeTime(fork Fork, upgradeTime time.Time) upgrade.Config {
 		CortinaXChainStopVertexID:    ids.Empty,
 	}
 	// Initialize all forks to be unscheduled
-	SetConfigTimesTo(&c, Latest, upgrade.UnscheduledActivationTime)
+	SetTimesTo(&c, Latest, upgrade.UnscheduledActivationTime)
 	// Schedule the requested forks at the provided upgrade time
-	SetConfigTimesTo(&c, fork, upgradeTime)
+	SetTimesTo(&c, fork, upgradeTime)
 	return c
 }
 
-// SetConfigTimesTo sets the upgrade time of the provided fork, and all prior
-// forks, to the provided upgradeTime.
-func SetConfigTimesTo(c *upgrade.Config, fork Fork, upgradeTime time.Time) {
+// SetTimesTo sets the upgrade time of the provided fork, and all prior forks,
+// to the provided upgradeTime.
+func SetTimesTo(c *upgrade.Config, fork Fork, upgradeTime time.Time) {
 	switch fork {
 	case Etna:
 		c.EtnaTime = upgradeTime

--- a/upgrade/upgradetest/config.go
+++ b/upgrade/upgradetest/config.go
@@ -16,22 +16,15 @@ func GetConfig(fork Fork) upgrade.Config {
 
 func GetConfigWithUpgradeTime(fork Fork, upgradeTime time.Time) upgrade.Config {
 	c := upgrade.Config{
-		ApricotPhase1Time:            upgrade.UnscheduledActivationTime,
-		ApricotPhase2Time:            upgrade.UnscheduledActivationTime,
-		ApricotPhase3Time:            upgrade.UnscheduledActivationTime,
-		ApricotPhase4Time:            upgrade.UnscheduledActivationTime,
 		ApricotPhase4MinPChainHeight: 0,
-		ApricotPhase5Time:            upgrade.UnscheduledActivationTime,
-		ApricotPhasePre6Time:         upgrade.UnscheduledActivationTime,
-		ApricotPhase6Time:            upgrade.UnscheduledActivationTime,
-		ApricotPhasePost6Time:        upgrade.UnscheduledActivationTime,
-		BanffTime:                    upgrade.UnscheduledActivationTime,
-		CortinaTime:                  upgrade.UnscheduledActivationTime,
 		CortinaXChainStopVertexID:    ids.Empty,
-		DurangoTime:                  upgrade.UnscheduledActivationTime,
-		EtnaTime:                     upgrade.UnscheduledActivationTime,
 	}
+	SetConfigTimesTo(&c, Latest, upgrade.UnscheduledActivationTime)
+	SetConfigTimesTo(&c, fork, upgradeTime)
+	return c
+}
 
+func SetConfigTimesTo(c *upgrade.Config, fork Fork, upgradeTime time.Time) {
 	switch fork {
 	case Etna:
 		c.EtnaTime = upgradeTime
@@ -69,5 +62,4 @@ func GetConfigWithUpgradeTime(fork Fork, upgradeTime time.Time) upgrade.Config {
 	case ApricotPhase1:
 		c.ApricotPhase1Time = upgradeTime
 	}
-	return c
 }

--- a/upgrade/upgradetest/config.go
+++ b/upgrade/upgradetest/config.go
@@ -10,20 +10,28 @@ import (
 	"github.com/ava-labs/avalanchego/upgrade"
 )
 
+// GetConfig returns an upgrade config with the provided fork scheduled to have
+// been initially activated and all other forks to be unscheduled.
 func GetConfig(fork Fork) upgrade.Config {
 	return GetConfigWithUpgradeTime(fork, upgrade.InitiallyActiveTime)
 }
 
+// GetConfig returns an upgrade config with the provided fork scheduled to be
+// activated at the provided upgradeTime and all other forks to be unscheduled.
 func GetConfigWithUpgradeTime(fork Fork, upgradeTime time.Time) upgrade.Config {
 	c := upgrade.Config{
 		ApricotPhase4MinPChainHeight: 0,
 		CortinaXChainStopVertexID:    ids.Empty,
 	}
+	// Initialize all forks to be unscheduled
 	SetConfigTimesTo(&c, Latest, upgrade.UnscheduledActivationTime)
+	// Schedule the requested forks at the provided upgrade time
 	SetConfigTimesTo(&c, fork, upgradeTime)
 	return c
 }
 
+// SetConfigTimesTo sets the upgrade time of the provided fork, and all prior
+// forks, to the provided upgradeTime.
 func SetConfigTimesTo(c *upgrade.Config, fork Fork, upgradeTime time.Time) {
 	switch fork {
 	case Etna:

--- a/upgrade/upgradetest/config.go
+++ b/upgrade/upgradetest/config.go
@@ -4,11 +4,17 @@
 package upgradetest
 
 import (
+	"time"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/upgrade"
 )
 
 func GetConfig(fork Fork) upgrade.Config {
+	return GetConfigWithUpgradeTime(fork, upgrade.InitiallyActiveTime)
+}
+
+func GetConfigWithUpgradeTime(fork Fork, upgradeTime time.Time) upgrade.Config {
 	c := upgrade.Config{
 		ApricotPhase1Time:            upgrade.UnscheduledActivationTime,
 		ApricotPhase2Time:            upgrade.UnscheduledActivationTime,
@@ -28,40 +34,40 @@ func GetConfig(fork Fork) upgrade.Config {
 
 	switch fork {
 	case Etna:
-		c.EtnaTime = upgrade.InitiallyActiveTime
+		c.EtnaTime = upgradeTime
 		fallthrough
 	case Durango:
-		c.DurangoTime = upgrade.InitiallyActiveTime
+		c.DurangoTime = upgradeTime
 		fallthrough
 	case Cortina:
-		c.CortinaTime = upgrade.InitiallyActiveTime
+		c.CortinaTime = upgradeTime
 		fallthrough
 	case Banff:
-		c.BanffTime = upgrade.InitiallyActiveTime
+		c.BanffTime = upgradeTime
 		fallthrough
 	case ApricotPhasePost6:
-		c.ApricotPhasePost6Time = upgrade.InitiallyActiveTime
+		c.ApricotPhasePost6Time = upgradeTime
 		fallthrough
 	case ApricotPhase6:
-		c.ApricotPhase6Time = upgrade.InitiallyActiveTime
+		c.ApricotPhase6Time = upgradeTime
 		fallthrough
 	case ApricotPhasePre6:
-		c.ApricotPhasePre6Time = upgrade.InitiallyActiveTime
+		c.ApricotPhasePre6Time = upgradeTime
 		fallthrough
 	case ApricotPhase5:
-		c.ApricotPhase5Time = upgrade.InitiallyActiveTime
+		c.ApricotPhase5Time = upgradeTime
 		fallthrough
 	case ApricotPhase4:
-		c.ApricotPhase4Time = upgrade.InitiallyActiveTime
+		c.ApricotPhase4Time = upgradeTime
 		fallthrough
 	case ApricotPhase3:
-		c.ApricotPhase3Time = upgrade.InitiallyActiveTime
+		c.ApricotPhase3Time = upgradeTime
 		fallthrough
 	case ApricotPhase2:
-		c.ApricotPhase2Time = upgrade.InitiallyActiveTime
+		c.ApricotPhase2Time = upgradeTime
 		fallthrough
 	case ApricotPhase1:
-		c.ApricotPhase1Time = upgrade.InitiallyActiveTime
+		c.ApricotPhase1Time = upgradeTime
 	}
 	return c
 }

--- a/upgrade/upgradetest/fork.go
+++ b/upgrade/upgradetest/fork.go
@@ -21,4 +21,5 @@ const (
 	Latest = Etna
 )
 
+// Fork is an enum of all the major network upgrades.
 type Fork int

--- a/upgrade/upgradetest/fork.go
+++ b/upgrade/upgradetest/fork.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package upgradetest
+
+const (
+	NoUpgrades Fork = iota
+	ApricotPhase1
+	ApricotPhase2
+	ApricotPhase3
+	ApricotPhase4
+	ApricotPhase5
+	ApricotPhasePre6
+	ApricotPhase6
+	ApricotPhasePost6
+	Banff
+	Cortina
+	Durango
+	Etna
+
+	Latest = Etna
+)
+
+type Fork int

--- a/vms/avm/block/executor/block_test.go
+++ b/vms/avm/block/executor/block_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -940,9 +940,7 @@ func defaultTestBackend(bootstrapped bool, sharedMemory atomic.SharedMemory) *ex
 			Log:          logging.NoLog{},
 		},
 		Config: &config.Config{
-			Upgrades: upgrade.Config{
-				EtnaTime: mockable.MaxTime,
-			},
+			Upgrades:         upgradetest.GetConfig(upgradetest.Durango),
 			TxFee:            0,
 			CreateAssetTxFee: 0,
 		},

--- a/vms/avm/index_test.go
+++ b/vms/avm/index_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
@@ -27,7 +28,7 @@ import (
 func TestIndexTransaction_Ordered(t *testing.T) {
 	require := require.New(t)
 
-	env := setup(t, &envConfig{fork: durango})
+	env := setup(t, &envConfig{fork: upgradetest.Durango})
 	defer env.vm.ctx.Lock.Unlock()
 
 	key := keys[0]
@@ -66,7 +67,7 @@ func TestIndexTransaction_Ordered(t *testing.T) {
 func TestIndexTransaction_MultipleTransactions(t *testing.T) {
 	require := require.New(t)
 
-	env := setup(t, &envConfig{fork: durango})
+	env := setup(t, &envConfig{fork: upgradetest.Durango})
 	defer env.vm.ctx.Lock.Unlock()
 
 	addressTxMap := map[ids.ShortID]*txs.Tx{}
@@ -109,7 +110,7 @@ func TestIndexTransaction_MultipleTransactions(t *testing.T) {
 func TestIndexTransaction_MultipleAddresses(t *testing.T) {
 	require := require.New(t)
 
-	env := setup(t, &envConfig{fork: durango})
+	env := setup(t, &envConfig{fork: upgradetest.Durango})
 	defer env.vm.ctx.Lock.Unlock()
 
 	addrs := make([]ids.ShortID, len(keys))
@@ -147,7 +148,7 @@ func TestIndexTransaction_MultipleAddresses(t *testing.T) {
 func TestIndexer_Read(t *testing.T) {
 	require := require.New(t)
 
-	env := setup(t, &envConfig{fork: durango})
+	env := setup(t, &envConfig{fork: upgradetest.Durango})
 	defer env.vm.ctx.Lock.Unlock()
 
 	// generate test address and asset IDs

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -22,14 +22,12 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/avm/block"
 	"github.com/ava-labs/avalanchego/vms/avm/block/executor"
@@ -2721,7 +2719,6 @@ func TestSendMultiple(t *testing.T) {
 			require := require.New(t)
 
 			env := setup(t, &envConfig{
-				fork:             upgradetest.Durango,
 				isCustomFeeAsset: !tc.avaxAsset,
 				keystoreUsers: []*user{{
 					username:    username,
@@ -2729,9 +2726,7 @@ func TestSendMultiple(t *testing.T) {
 					initialKeys: keys,
 				}},
 				vmStaticConfig: &config.Config{
-					Upgrades: upgrade.Config{
-						EtnaTime: mockable.MaxTime,
-					},
+					Upgrades: upgradetest.GetConfig(upgradetest.Durango),
 				},
 			})
 			service := &Service{vm: env.vm}

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting"
@@ -49,7 +50,7 @@ func TestServiceIssueTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -72,7 +73,7 @@ func TestServiceGetTxStatus(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -104,7 +105,7 @@ func TestServiceGetBalanceStrict(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 
@@ -258,7 +259,7 @@ func TestServiceGetBalanceStrict(t *testing.T) {
 func TestServiceGetTxs(t *testing.T) {
 	require := require.New(t)
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 
@@ -299,7 +300,7 @@ func TestServiceGetAllBalances(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 
@@ -495,7 +496,7 @@ func TestServiceGetTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -520,7 +521,7 @@ func TestServiceGetTxJSON_BaseTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -608,7 +609,7 @@ func TestServiceGetTxJSON_ExportTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -698,7 +699,7 @@ func TestServiceGetTxJSON_CreateAssetTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: propertyfx.ID,
 			Fx: &propertyfx.Fx{},
@@ -891,7 +892,7 @@ func TestServiceGetTxJSON_OperationTxWithNftxMintOp(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: propertyfx.ID,
 			Fx: &propertyfx.Fx{},
@@ -1033,7 +1034,7 @@ func TestServiceGetTxJSON_OperationTxWithMultipleNftxMintOp(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: propertyfx.ID,
 			Fx: &propertyfx.Fx{},
@@ -1214,7 +1215,7 @@ func TestServiceGetTxJSON_OperationTxWithSecpMintOp(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: propertyfx.ID,
 			Fx: &propertyfx.Fx{},
@@ -1357,7 +1358,7 @@ func TestServiceGetTxJSON_OperationTxWithMultipleSecpMintOp(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: durango,
+		fork: upgradetest.Durango,
 		additionalFxs: []*common.Fx{{
 			ID: propertyfx.ID,
 			Fx: &propertyfx.Fx{},
@@ -1544,7 +1545,7 @@ func TestServiceGetTxJSON_OperationTxWithPropertyFxMintOp(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: propertyfx.ID,
 			Fx: &propertyfx.Fx{},
@@ -1679,7 +1680,7 @@ func TestServiceGetTxJSON_OperationTxWithPropertyFxMintOpMultiple(t *testing.T) 
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: propertyfx.ID,
 			Fx: &propertyfx.Fx{},
@@ -2010,7 +2011,7 @@ func TestServiceGetNilTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -2024,7 +2025,7 @@ func TestServiceGetUnknownTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -2036,7 +2037,7 @@ func TestServiceGetUnknownTx(t *testing.T) {
 
 func TestServiceGetUTXOs(t *testing.T) {
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -2288,7 +2289,7 @@ func TestGetAssetDescription(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -2308,7 +2309,7 @@ func TestGetBalance(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	service := &Service{vm: env.vm}
 	env.vm.ctx.Lock.Unlock()
@@ -2332,6 +2333,7 @@ func TestCreateFixedCapAsset(t *testing.T) {
 			require := require.New(t)
 
 			env := setup(t, &envConfig{
+				fork:             upgradetest.Durango,
 				isCustomFeeAsset: !tc.avaxAsset,
 				keystoreUsers: []*user{{
 					username:    username,
@@ -2378,6 +2380,7 @@ func TestCreateVariableCapAsset(t *testing.T) {
 			require := require.New(t)
 
 			env := setup(t, &envConfig{
+				fork:             upgradetest.Durango,
 				isCustomFeeAsset: !tc.avaxAsset,
 				keystoreUsers: []*user{{
 					username:    username,
@@ -2466,6 +2469,7 @@ func TestNFTWorkflow(t *testing.T) {
 			require := require.New(t)
 
 			env := setup(t, &envConfig{
+				fork:             upgradetest.Durango,
 				isCustomFeeAsset: !tc.avaxAsset,
 				keystoreUsers: []*user{{
 					username:    username,
@@ -2584,6 +2588,7 @@ func TestImportExportKey(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
+		fork: upgradetest.Durango,
 		keystoreUsers: []*user{{
 			username: username,
 			password: password,
@@ -2623,6 +2628,7 @@ func TestImportAVMKeyNoDuplicates(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
+		fork: upgradetest.Durango,
 		keystoreUsers: []*user{{
 			username: username,
 			password: password,
@@ -2668,6 +2674,7 @@ func TestSend(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
+		fork: upgradetest.Durango,
 		keystoreUsers: []*user{{
 			username:    username,
 			password:    password,
@@ -2714,6 +2721,7 @@ func TestSendMultiple(t *testing.T) {
 			require := require.New(t)
 
 			env := setup(t, &envConfig{
+				fork:             upgradetest.Durango,
 				isCustomFeeAsset: !tc.avaxAsset,
 				keystoreUsers: []*user{{
 					username:    username,
@@ -2773,6 +2781,7 @@ func TestCreateAndListAddresses(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
+		fork: upgradetest.Durango,
 		keystoreUsers: []*user{{
 			username: username,
 			password: password,
@@ -2807,6 +2816,7 @@ func TestImport(t *testing.T) {
 			require := require.New(t)
 
 			env := setup(t, &envConfig{
+				fork:             upgradetest.Durango,
 				isCustomFeeAsset: !tc.avaxAsset,
 				keystoreUsers: []*user{{
 					username:    username,

--- a/vms/avm/state_test.go
+++ b/vms/avm/state_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/units"
@@ -23,7 +24,7 @@ func TestSetsAndGets(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: ids.GenerateTestID(),
 			Fx: &FxTest{
@@ -83,7 +84,7 @@ func TestSetsAndGets(t *testing.T) {
 
 func TestFundingNoAddresses(t *testing.T) {
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: ids.GenerateTestID(),
 			Fx: &FxTest{
@@ -113,7 +114,7 @@ func TestFundingAddresses(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: ids.GenerateTestID(),
 			Fx: &FxTest{

--- a/vms/avm/txs/executor/syntactic_verifier_test.go
+++ b/vms/avm/txs/executor/syntactic_verifier_test.go
@@ -12,10 +12,9 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
-	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/avm/config"
 	"github.com/ava-labs/avalanchego/vms/avm/fxs"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
@@ -29,9 +28,7 @@ import (
 var (
 	keys      = secp256k1.TestKeys()
 	feeConfig = config.Config{
-		Upgrades: upgrade.Config{
-			EtnaTime: mockable.MaxTime,
-		},
+		Upgrades:         upgradetest.GetConfig(upgradetest.Durango),
 		TxFee:            2,
 		CreateAssetTxFee: 3,
 	}

--- a/vms/avm/vm_benchmark_test.go
+++ b/vms/avm/vm_benchmark_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/keystore"
@@ -22,7 +23,7 @@ func BenchmarkLoadUser(b *testing.B) {
 		require := require.New(b)
 
 		env := setup(b, &envConfig{
-			fork: latest,
+			fork: upgradetest.Latest,
 			keystoreUsers: []*user{{
 				username: username,
 				password: password,
@@ -64,7 +65,7 @@ func BenchmarkLoadUser(b *testing.B) {
 func getAllUTXOsBenchmark(b *testing.B, utxoCount int, randSrc rand.Source) {
 	require := require.New(b)
 
-	env := setup(b, &envConfig{fork: latest})
+	env := setup(b, &envConfig{fork: upgradetest.Latest})
 	defer env.vm.ctx.Lock.Unlock()
 
 	addr := ids.GenerateTestShortID()

--- a/vms/avm/vm_regression_test.go
+++ b/vms/avm/vm_regression_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/nftfx"
@@ -18,7 +19,7 @@ import (
 func TestVerifyFxUsage(t *testing.T) {
 	require := require.New(t)
 
-	env := setup(t, &envConfig{fork: latest})
+	env := setup(t, &envConfig{fork: upgradetest.Latest})
 	env.vm.ctx.Lock.Unlock()
 
 	var (

--- a/vms/avm/vm_test.go
+++ b/vms/avm/vm_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
@@ -114,7 +115,7 @@ func TestIssueTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	env.vm.ctx.Lock.Unlock()
 
@@ -127,7 +128,7 @@ func TestIssueNFT(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	env.vm.ctx.Lock.Unlock()
 
@@ -200,7 +201,7 @@ func TestIssueProperty(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 		additionalFxs: []*common.Fx{{
 			ID: propertyfx.ID,
 			Fx: &propertyfx.Fx{},
@@ -288,7 +289,7 @@ func TestIssueTxWithFeeAsset(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork:             latest,
+		fork:             upgradetest.Latest,
 		isCustomFeeAsset: true,
 	})
 	env.vm.ctx.Lock.Unlock()
@@ -302,7 +303,7 @@ func TestIssueTxWithAnotherAsset(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork:             latest,
+		fork:             upgradetest.Latest,
 		isCustomFeeAsset: true,
 	})
 	env.vm.ctx.Lock.Unlock()
@@ -349,7 +350,7 @@ func TestIssueTxWithAnotherAsset(t *testing.T) {
 
 func TestVMFormat(t *testing.T) {
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	defer env.vm.ctx.Lock.Unlock()
 
@@ -376,7 +377,7 @@ func TestTxAcceptAfterParseTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork:          latest,
+		fork:          upgradetest.Latest,
 		notLinearized: true,
 	})
 	defer env.vm.ctx.Lock.Unlock()
@@ -451,7 +452,7 @@ func TestIssueImportTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: durango,
+		fork: upgradetest.Durango,
 	})
 	defer env.vm.ctx.Lock.Unlock()
 
@@ -529,7 +530,7 @@ func TestForceAcceptImportTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork:          durango,
+		fork:          upgradetest.Durango,
 		notLinearized: true,
 	})
 	defer env.vm.ctx.Lock.Unlock()
@@ -603,7 +604,7 @@ func TestImportTxNotState(t *testing.T) {
 func TestIssueExportTx(t *testing.T) {
 	require := require.New(t)
 
-	env := setup(t, &envConfig{fork: durango})
+	env := setup(t, &envConfig{fork: upgradetest.Durango})
 	defer env.vm.ctx.Lock.Unlock()
 
 	genesisTx := getCreateTxFromGenesisTest(t, env.genesisBytes, "AVAX")
@@ -662,7 +663,7 @@ func TestClearForceAcceptedExportTx(t *testing.T) {
 	require := require.New(t)
 
 	env := setup(t, &envConfig{
-		fork: latest,
+		fork: upgradetest.Latest,
 	})
 	defer env.vm.ctx.Lock.Unlock()
 

--- a/vms/avm/wallet_service_test.go
+++ b/vms/avm/wallet_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/linked"
 	"github.com/ava-labs/avalanchego/vms/avm/txs"
 )
@@ -20,7 +21,7 @@ func TestWalletService_SendMultiple(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			env := setup(t, &envConfig{
-				fork:             latest,
+				fork:             upgradetest.Latest,
 				isCustomFeeAsset: !tc.avaxAsset,
 				keystoreUsers: []*user{{
 					username:    username,

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -34,7 +35,7 @@ import (
 func TestBuildBlockBasic(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -77,7 +78,7 @@ func TestBuildBlockBasic(t *testing.T) {
 func TestBuildBlockDoesNotBuildWithEmptyMempool(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -94,7 +95,7 @@ func TestBuildBlockDoesNotBuildWithEmptyMempool(t *testing.T) {
 func TestBuildBlockShouldReward(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -213,7 +214,7 @@ func TestBuildBlockShouldReward(t *testing.T) {
 func TestBuildBlockAdvanceTime(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -246,7 +247,7 @@ func TestBuildBlockAdvanceTime(t *testing.T) {
 func TestBuildBlockForceAdvanceTime(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -301,7 +302,7 @@ func TestBuildBlockForceAdvanceTime(t *testing.T) {
 func TestBuildBlockInvalidStakingDurations(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -421,7 +422,7 @@ func TestBuildBlockInvalidStakingDurations(t *testing.T) {
 func TestPreviouslyDroppedTxsCannotBeReAddedToMempool(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -465,7 +466,7 @@ func TestPreviouslyDroppedTxsCannotBeReAddedToMempool(t *testing.T) {
 func TestNoErrorOnUnexpectedSetPreferenceDuringBootstrapping(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
@@ -61,15 +62,6 @@ import (
 const (
 	defaultWeight = 10000
 	trackChecksum = false
-
-	apricotPhase3 fork = iota
-	apricotPhase5
-	banff
-	cortina
-	durango
-	etna
-
-	latestFork = durango
 )
 
 var (
@@ -97,8 +89,6 @@ func init() {
 	}
 }
 
-type fork uint8
-
 type mutableSharedMemory struct {
 	atomic.SharedMemory
 }
@@ -124,7 +114,7 @@ type environment struct {
 	backend        txexecutor.Backend
 }
 
-func newEnvironment(t *testing.T, f fork) *environment { //nolint:unparam
+func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:unparam
 	require := require.New(t)
 
 	res := &environment{
@@ -303,7 +293,7 @@ func defaultState(
 	return state
 }
 
-func defaultConfig(t *testing.T, f fork) *config.Config {
+func defaultConfig(t *testing.T, f upgradetest.Fork) *config.Config {
 	c := &config.Config{
 		Chains:                 chains.TestManager,
 		UptimeLockedCalculator: uptime.NewLockedCalculator(),
@@ -335,22 +325,22 @@ func defaultConfig(t *testing.T, f fork) *config.Config {
 	}
 
 	switch f {
-	case etna:
+	case upgradetest.Etna:
 		c.UpgradeConfig.EtnaTime = time.Time{} // neglecting fork ordering this for package tests
 		fallthrough
-	case durango:
+	case upgradetest.Durango:
 		c.UpgradeConfig.DurangoTime = time.Time{} // neglecting fork ordering for this package's tests
 		fallthrough
-	case cortina:
+	case upgradetest.Cortina:
 		c.UpgradeConfig.CortinaTime = time.Time{} // neglecting fork ordering for this package's tests
 		fallthrough
-	case banff:
+	case upgradetest.Banff:
 		c.UpgradeConfig.BanffTime = time.Time{} // neglecting fork ordering for this package's tests
 		fallthrough
-	case apricotPhase5:
+	case upgradetest.ApricotPhase5:
 		c.UpgradeConfig.ApricotPhase5Time = defaultValidateEndTime
 		fallthrough
-	case apricotPhase3:
+	case upgradetest.ApricotPhase3:
 		c.UpgradeConfig.ApricotPhase3Time = defaultValidateEndTime
 	default:
 		require.FailNow(t, "unhandled fork", f)

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -119,7 +118,7 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 
 	res := &environment{
 		isBootstrapped: &utils.Atomic[bool]{},
-		config:         defaultConfig(t, f),
+		config:         defaultConfig(f),
 		clk:            defaultClock(),
 	}
 	res.isBootstrapped.Set(true)
@@ -293,8 +292,16 @@ func defaultState(
 	return state
 }
 
-func defaultConfig(t *testing.T, f upgradetest.Fork) *config.Config {
-	c := &config.Config{
+func defaultConfig(f upgradetest.Fork) *config.Config {
+	upgrades := upgradetest.GetConfigWithUpgradeTime(f, time.Time{})
+	// This package neglects fork ordering
+	upgradetest.SetConfigTimesTo(
+		&upgrades,
+		min(f, upgradetest.ApricotPhase5),
+		defaultValidateEndTime,
+	)
+
+	return &config.Config{
 		Chains:                 chains.TestManager,
 		UptimeLockedCalculator: uptime.NewLockedCalculator(),
 		Validators:             validators.NewManager(),
@@ -314,39 +321,8 @@ func defaultConfig(t *testing.T, f upgradetest.Fork) *config.Config {
 			MintingPeriod:      365 * 24 * time.Hour,
 			SupplyCap:          720 * units.MegaAvax,
 		},
-		UpgradeConfig: upgrade.Config{
-			ApricotPhase3Time: mockable.MaxTime,
-			ApricotPhase5Time: mockable.MaxTime,
-			BanffTime:         mockable.MaxTime,
-			CortinaTime:       mockable.MaxTime,
-			DurangoTime:       mockable.MaxTime,
-			EtnaTime:          mockable.MaxTime,
-		},
+		UpgradeConfig: upgrades,
 	}
-
-	switch f {
-	case upgradetest.Etna:
-		c.UpgradeConfig.EtnaTime = time.Time{} // neglecting fork ordering this for package tests
-		fallthrough
-	case upgradetest.Durango:
-		c.UpgradeConfig.DurangoTime = time.Time{} // neglecting fork ordering for this package's tests
-		fallthrough
-	case upgradetest.Cortina:
-		c.UpgradeConfig.CortinaTime = time.Time{} // neglecting fork ordering for this package's tests
-		fallthrough
-	case upgradetest.Banff:
-		c.UpgradeConfig.BanffTime = time.Time{} // neglecting fork ordering for this package's tests
-		fallthrough
-	case upgradetest.ApricotPhase5:
-		c.UpgradeConfig.ApricotPhase5Time = defaultValidateEndTime
-		fallthrough
-	case upgradetest.ApricotPhase3:
-		c.UpgradeConfig.ApricotPhase3Time = defaultValidateEndTime
-	default:
-		require.FailNow(t, "unhandled fork", f)
-	}
-
-	return c
 }
 
 func defaultClock() *mockable.Clock {

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -295,7 +295,7 @@ func defaultState(
 func defaultConfig(f upgradetest.Fork) *config.Config {
 	upgrades := upgradetest.GetConfigWithUpgradeTime(f, time.Time{})
 	// This package neglects fork ordering
-	upgradetest.SetConfigTimesTo(
+	upgradetest.SetTimesTo(
 		&upgrades,
 		min(f, upgradetest.ApricotPhase5),
 		defaultValidateEndTime,

--- a/vms/platformvm/block/builder/standard_block_test.go
+++ b/vms/platformvm/block/builder/standard_block_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -23,7 +24,7 @@ import (
 func TestAtomicTxImports(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, latestFork)
+	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
@@ -63,13 +64,6 @@ const (
 
 	defaultWeight = 10000
 	trackChecksum = false
-
-	apricotPhase3 fork = iota
-	apricotPhase5
-	banff
-	cortina
-	durango
-	etna
 )
 
 var (
@@ -99,8 +93,6 @@ func init() {
 }
 
 type stakerStatus uint
-
-type fork uint8
 
 type staker struct {
 	nodeID             ids.NodeID
@@ -136,7 +128,7 @@ type environment struct {
 	backend        *executor.Backend
 }
 
-func newEnvironment(t *testing.T, ctrl *gomock.Controller, f fork) *environment {
+func newEnvironment(t *testing.T, ctrl *gomock.Controller, f upgradetest.Fork) *environment {
 	res := &environment{
 		isBootstrapped: &utils.Atomic[bool]{},
 		config:         defaultConfig(t, f),
@@ -332,7 +324,7 @@ func defaultState(
 	return state
 }
 
-func defaultConfig(t *testing.T, f fork) *config.Config {
+func defaultConfig(t *testing.T, f upgradetest.Fork) *config.Config {
 	c := &config.Config{
 		Chains:                 chains.TestManager,
 		UptimeLockedCalculator: uptime.NewLockedCalculator(),
@@ -364,22 +356,22 @@ func defaultConfig(t *testing.T, f fork) *config.Config {
 	}
 
 	switch f {
-	case etna:
+	case upgradetest.Etna:
 		c.UpgradeConfig.EtnaTime = time.Time{} // neglecting fork ordering this for package tests
 		fallthrough
-	case durango:
+	case upgradetest.Durango:
 		c.UpgradeConfig.DurangoTime = time.Time{} // neglecting fork ordering for this package's tests
 		fallthrough
-	case cortina:
+	case upgradetest.Cortina:
 		c.UpgradeConfig.CortinaTime = time.Time{} // neglecting fork ordering for this package's tests
 		fallthrough
-	case banff:
+	case upgradetest.Banff:
 		c.UpgradeConfig.BanffTime = time.Time{} // neglecting fork ordering for this package's tests
 		fallthrough
-	case apricotPhase5:
+	case upgradetest.ApricotPhase5:
 		c.UpgradeConfig.ApricotPhase5Time = defaultValidateEndTime
 		fallthrough
-	case apricotPhase3:
+	case upgradetest.ApricotPhase3:
 		c.UpgradeConfig.ApricotPhase3Time = defaultValidateEndTime
 	default:
 		require.FailNow(t, "unhandled fork", f)

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -326,7 +326,7 @@ func defaultState(
 func defaultConfig(f upgradetest.Fork) *config.Config {
 	upgrades := upgradetest.GetConfigWithUpgradeTime(f, time.Time{})
 	// This package neglects fork ordering
-	upgradetest.SetConfigTimesTo(
+	upgradetest.SetTimesTo(
 		&upgrades,
 		min(f, upgradetest.ApricotPhase5),
 		defaultValidateEndTime,

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
@@ -38,7 +39,7 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	env := newEnvironment(t, ctrl, apricotPhase5)
+	env := newEnvironment(t, ctrl, upgradetest.ApricotPhase5)
 
 	// create apricotParentBlk. It's a standard one for simplicity
 	parentHeight := uint64(2022)
@@ -140,7 +141,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	env := newEnvironment(t, ctrl, banff)
+	env := newEnvironment(t, ctrl, upgradetest.Banff)
 
 	// create parentBlock. It's a standard one for simplicity
 	parentTime := defaultGenesisTime
@@ -531,7 +532,7 @@ func TestBanffProposalBlockUpdateStakers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			require := require.New(t)
-			env := newEnvironment(t, nil, banff)
+			env := newEnvironment(t, nil, upgradetest.Banff)
 
 			subnetID := testSubnet1.ID()
 			env.config.TrackedSubnets.Add(subnetID)
@@ -709,7 +710,7 @@ func TestBanffProposalBlockUpdateStakers(t *testing.T) {
 
 func TestBanffProposalBlockRemoveSubnetValidator(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, nil, banff)
+	env := newEnvironment(t, nil, upgradetest.Banff)
 
 	subnetID := testSubnet1.ID()
 	env.config.TrackedSubnets.Add(subnetID)
@@ -866,7 +867,7 @@ func TestBanffProposalBlockTrackedSubnet(t *testing.T) {
 	for _, tracked := range []bool{true, false} {
 		t.Run(fmt.Sprintf("tracked %t", tracked), func(t *testing.T) {
 			require := require.New(t)
-			env := newEnvironment(t, nil, banff)
+			env := newEnvironment(t, nil, upgradetest.Banff)
 
 			subnetID := testSubnet1.ID()
 			if tracked {
@@ -980,7 +981,7 @@ func TestBanffProposalBlockTrackedSubnet(t *testing.T) {
 
 func TestBanffProposalBlockDelegatorStakerWeight(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, nil, banff)
+	env := newEnvironment(t, nil, upgradetest.Banff)
 
 	// Case: Timestamp is after next validator start time
 	// Add a pending validator
@@ -1175,7 +1176,7 @@ func TestBanffProposalBlockDelegatorStakerWeight(t *testing.T) {
 
 func TestBanffProposalBlockDelegatorStakers(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, nil, banff)
+	env := newEnvironment(t, nil, upgradetest.Banff)
 
 	// Case: Timestamp is after next validator start time
 	// Add a pending validator
@@ -1370,7 +1371,7 @@ func TestBanffProposalBlockDelegatorStakers(t *testing.T) {
 
 func TestAddValidatorProposalBlock(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, nil, durango)
+	env := newEnvironment(t, nil, upgradetest.Durango)
 
 	now := env.clk.Time()
 

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -32,7 +33,7 @@ func TestApricotStandardBlockTimeVerification(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	env := newEnvironment(t, ctrl, apricotPhase5)
+	env := newEnvironment(t, ctrl, upgradetest.ApricotPhase5)
 
 	// setup and store parent block
 	// it's a standard block for simplicity
@@ -84,7 +85,7 @@ func TestBanffStandardBlockTimeVerification(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	env := newEnvironment(t, ctrl, banff)
+	env := newEnvironment(t, ctrl, upgradetest.Banff)
 	now := env.clk.Time()
 	env.clk.Set(now)
 
@@ -290,7 +291,7 @@ func TestBanffStandardBlockTimeVerification(t *testing.T) {
 func TestBanffStandardBlockUpdatePrimaryNetworkStakers(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, nil, banff)
+	env := newEnvironment(t, nil, upgradetest.Banff)
 
 	// Case: Timestamp is after next validator start time
 	// Add a pending validator
@@ -491,7 +492,7 @@ func TestBanffStandardBlockUpdateStakers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			require := require.New(t)
-			env := newEnvironment(t, nil, banff)
+			env := newEnvironment(t, nil, upgradetest.Banff)
 
 			subnetID := testSubnet1.ID()
 			env.config.TrackedSubnets.Add(subnetID)
@@ -594,7 +595,7 @@ func TestBanffStandardBlockUpdateStakers(t *testing.T) {
 // is after the new timestamp
 func TestBanffStandardBlockRemoveSubnetValidator(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, nil, banff)
+	env := newEnvironment(t, nil, upgradetest.Banff)
 
 	subnetID := testSubnet1.ID()
 	env.config.TrackedSubnets.Add(subnetID)
@@ -698,7 +699,7 @@ func TestBanffStandardBlockTrackedSubnet(t *testing.T) {
 	for _, tracked := range []bool{true, false} {
 		t.Run(fmt.Sprintf("tracked %t", tracked), func(t *testing.T) {
 			require := require.New(t)
-			env := newEnvironment(t, nil, banff)
+			env := newEnvironment(t, nil, upgradetest.Banff)
 
 			subnetID := testSubnet1.ID()
 			if tracked {
@@ -762,7 +763,7 @@ func TestBanffStandardBlockTrackedSubnet(t *testing.T) {
 
 func TestBanffStandardBlockDelegatorStakerWeight(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, nil, banff)
+	env := newEnvironment(t, nil, upgradetest.Banff)
 
 	// Case: Timestamp is after next validator start time
 	// Add a pending validator

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -61,9 +61,7 @@ func TestVerifierVisitProposalBlock(t *testing.T) {
 	manager := &manager{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -143,10 +141,7 @@ func TestVerifierVisitAtomicBlock(t *testing.T) {
 	manager := &manager{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					ApricotPhase5Time: time.Now().Add(time.Hour),
-					BanffTime:         mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -228,10 +223,7 @@ func TestVerifierVisitStandardBlock(t *testing.T) {
 	manager := &manager{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					ApricotPhase5Time: time.Now().Add(time.Hour),
-					BanffTime:         mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -332,9 +324,7 @@ func TestVerifierVisitCommitBlock(t *testing.T) {
 	manager := &manager{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -401,9 +391,7 @@ func TestVerifierVisitAbortBlock(t *testing.T) {
 	manager := &manager{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -458,9 +446,7 @@ func TestVerifyUnverifiedParent(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -532,9 +518,7 @@ func TestBanffAbortBlockTimestampChecks(t *testing.T) {
 			verifier := &verifier{
 				txExecutorBackend: &executor.Backend{
 					Config: &config.Config{
-						UpgradeConfig: upgrade.Config{
-							BanffTime: time.Time{}, // banff is activated
-						},
+						UpgradeConfig: upgradetest.GetConfig(upgradetest.Banff),
 					},
 					Clk: &mockable.Clock{},
 				},
@@ -631,9 +615,7 @@ func TestBanffCommitBlockTimestampChecks(t *testing.T) {
 			verifier := &verifier{
 				txExecutorBackend: &executor.Backend{
 					Config: &config.Config{
-						UpgradeConfig: upgrade.Config{
-							BanffTime: time.Time{}, // banff is activated
-						},
+						UpgradeConfig: upgradetest.GetConfig(upgradetest.Banff),
 					},
 					Clk: &mockable.Clock{},
 				},
@@ -713,10 +695,7 @@ func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					ApricotPhase5Time: time.Now().Add(time.Hour),
-					BanffTime:         mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -805,9 +784,7 @@ func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) 
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -864,9 +841,7 @@ func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: time.Time{}, // banff is activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.Banff),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -903,9 +878,7 @@ func TestVerifierVisitApricotCommitBlockUnexpectedParentState(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -948,9 +921,7 @@ func TestVerifierVisitBanffCommitBlockUnexpectedParentState(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: time.Time{}, // banff is activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.Banff),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -994,9 +965,7 @@ func TestVerifierVisitApricotAbortBlockUnexpectedParentState(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: mockable.MaxTime, // banff is not activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.ApricotPhasePost6),
 			},
 			Clk: &mockable.Clock{},
 		},
@@ -1039,9 +1008,7 @@ func TestVerifierVisitBanffAbortBlockUnexpectedParentState(t *testing.T) {
 	verifier := &verifier{
 		txExecutorBackend: &executor.Backend{
 			Config: &config.Config{
-				UpgradeConfig: upgrade.Config{
-					BanffTime: time.Time{}, // banff is activated
-				},
+				UpgradeConfig: upgradetest.GetConfig(upgradetest.Banff),
 			},
 			Clk: &mockable.Clock{},
 		},

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
@@ -77,7 +78,7 @@ var (
 )
 
 func defaultService(t *testing.T) (*Service, *mutableSharedMemory, *txstest.WalletFactory) {
-	vm, factory, _, mutableSharedMemory := defaultVM(t, latestFork)
+	vm, factory, _, mutableSharedMemory := defaultVM(t, upgradetest.Latest)
 
 	return &Service{
 		vm:          vm,

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
@@ -38,7 +39,7 @@ func newAdvanceTimeTx(t testing.TB, timestamp time.Time) (*txs.Tx, error) {
 // for the primary network
 func TestAdvanceTimeTxUpdatePrimaryNetworkStakers(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 	dummyHeight := uint64(1)
@@ -103,7 +104,7 @@ func TestAdvanceTimeTxUpdatePrimaryNetworkStakers(t *testing.T) {
 // Ensure semantic verification fails when proposed timestamp is at or before current timestamp
 func TestAdvanceTimeTxTimestampTooEarly(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 
 	tx, err := newAdvanceTimeTx(t, env.state.GetTimestamp())
 	require.NoError(err)
@@ -129,7 +130,7 @@ func TestAdvanceTimeTxTimestampTooEarly(t *testing.T) {
 // Ensure semantic verification fails when proposed timestamp is after next validator set change time
 func TestAdvanceTimeTxTimestampTooLate(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -164,7 +165,7 @@ func TestAdvanceTimeTxTimestampTooLate(t *testing.T) {
 	}
 
 	// Case: Timestamp is after next validator end time
-	env = newEnvironment(t, apricotPhase5)
+	env = newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -366,7 +367,7 @@ func TestAdvanceTimeTxUpdateStakers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			require := require.New(t)
-			env := newEnvironment(t, apricotPhase5)
+			env := newEnvironment(t, upgradetest.ApricotPhase5)
 			env.ctx.Lock.Lock()
 			defer env.ctx.Lock.Unlock()
 
@@ -476,7 +477,7 @@ func TestAdvanceTimeTxUpdateStakers(t *testing.T) {
 // is after the new timestamp
 func TestAdvanceTimeTxRemoveSubnetValidator(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -590,7 +591,7 @@ func TestTrackedSubnet(t *testing.T) {
 	for _, tracked := range []bool{true, false} {
 		t.Run(fmt.Sprintf("tracked %t", tracked), func(t *testing.T) {
 			require := require.New(t)
-			env := newEnvironment(t, apricotPhase5)
+			env := newEnvironment(t, upgradetest.ApricotPhase5)
 			env.ctx.Lock.Lock()
 			defer env.ctx.Lock.Unlock()
 			dummyHeight := uint64(1)
@@ -665,7 +666,7 @@ func TestTrackedSubnet(t *testing.T) {
 
 func TestAdvanceTimeTxDelegatorStakerWeight(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 	dummyHeight := uint64(1)
@@ -775,7 +776,7 @@ func TestAdvanceTimeTxDelegatorStakerWeight(t *testing.T) {
 
 func TestAdvanceTimeTxDelegatorStakers(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 	dummyHeight := uint64(1)
@@ -878,7 +879,7 @@ func TestAdvanceTimeTxDelegatorStakers(t *testing.T) {
 
 func TestAdvanceTimeTxAfterBanff(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, durango)
+	env := newEnvironment(t, upgradetest.Durango)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 	env.clk.Set(defaultGenesisTime) // VM's clock reads the genesis time
@@ -912,7 +913,7 @@ func TestAdvanceTimeTxAfterBanff(t *testing.T) {
 // Ensure marshaling/unmarshaling works
 func TestAdvanceTimeTxUnmarshal(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 

--- a/vms/platformvm/txs/executor/create_chain_test.go
+++ b/vms/platformvm/txs/executor/create_chain_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/hashing"
@@ -29,7 +30,7 @@ import (
 // Ensure Execute fails when there are not enough control sigs
 func TestCreateChainTxInsufficientControlSigs(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, banff)
+	env := newEnvironment(t, upgradetest.Banff)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -65,7 +66,7 @@ func TestCreateChainTxInsufficientControlSigs(t *testing.T) {
 // Ensure Execute fails when an incorrect control signature is given
 func TestCreateChainTxWrongControlSig(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, banff)
+	env := newEnvironment(t, upgradetest.Banff)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -108,7 +109,7 @@ func TestCreateChainTxWrongControlSig(t *testing.T) {
 // its validator set doesn't exist
 func TestCreateChainTxNoSuchSubnet(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, banff)
+	env := newEnvironment(t, upgradetest.Banff)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -146,7 +147,7 @@ func TestCreateChainTxNoSuchSubnet(t *testing.T) {
 // Ensure valid tx passes semanticVerify
 func TestCreateChainTxValid(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, banff)
+	env := newEnvironment(t, upgradetest.Banff)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -209,7 +210,7 @@ func TestCreateChainTxAP3FeeChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
-			env := newEnvironment(t, banff)
+			env := newEnvironment(t, upgradetest.Banff)
 			env.config.UpgradeConfig.ApricotPhase3Time = ap3Time
 
 			addrs := set.NewSet[ids.ShortID](len(preFundedKeys))

--- a/vms/platformvm/txs/executor/create_subnet_test.go
+++ b/vms/platformvm/txs/executor/create_subnet_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -52,7 +53,7 @@ func TestCreateSubnetTxAP3FeeChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
-			env := newEnvironment(t, apricotPhase3)
+			env := newEnvironment(t, upgradetest.ApricotPhase3)
 			env.config.UpgradeConfig.ApricotPhase3Time = ap3Time
 			env.ctx.Lock.Lock()
 			defer env.ctx.Lock.Unlock()

--- a/vms/platformvm/txs/executor/export_test.go
+++ b/vms/platformvm/txs/executor/export_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -20,7 +21,7 @@ import (
 )
 
 func TestNewExportTx(t *testing.T) {
-	env := newEnvironment(t, banff)
+	env := newEnvironment(t, upgradetest.Banff)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -271,7 +271,7 @@ func defaultConfig(f upgradetest.Fork) *config.Config {
 		f,
 		defaultValidateStartTime.Add(-2*time.Second),
 	)
-	upgradetest.SetConfigTimesTo(
+	upgradetest.SetTimesTo(
 		&upgrades,
 		min(f, upgradetest.ApricotPhase5),
 		defaultValidateEndTime,

--- a/vms/platformvm/txs/executor/import_test.go
+++ b/vms/platformvm/txs/executor/import_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -27,7 +28,7 @@ import (
 var fundedSharedMemoryCalls byte
 
 func TestNewImportTx(t *testing.T) {
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 
 	type test struct {
 		description   string

--- a/vms/platformvm/txs/executor/proposal_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
@@ -109,7 +110,7 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 		require.NoError(env.state.Commit())
 	}
 
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	currentTimestamp := env.state.GetTimestamp()
 
 	type test struct {
@@ -241,7 +242,7 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			require := require.New(t)
-			env := newEnvironment(t, apricotPhase5)
+			env := newEnvironment(t, upgradetest.ApricotPhase5)
 			env.config.UpgradeConfig.ApricotPhase3Time = tt.AP3Time
 
 			builder, signer := env.factory.NewWallet(tt.feeKeys...)
@@ -287,7 +288,7 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 
 func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -808,7 +809,7 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 
 func TestProposalTxExecuteAddValidator(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -37,7 +38,7 @@ func newRewardValidatorTx(t testing.TB, txID ids.ID) (*txs.Tx, error) {
 
 func TestRewardValidatorTxExecuteOnCommit(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	dummyHeight := uint64(1)
 
 	currentStakerIterator, err := env.state.GetCurrentStakerIterator()
@@ -141,7 +142,7 @@ func TestRewardValidatorTxExecuteOnCommit(t *testing.T) {
 
 func TestRewardValidatorTxExecuteOnAbort(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	dummyHeight := uint64(1)
 
 	currentStakerIterator, err := env.state.GetCurrentStakerIterator()
@@ -239,7 +240,7 @@ func TestRewardValidatorTxExecuteOnAbort(t *testing.T) {
 
 func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	dummyHeight := uint64(1)
 
 	vdrRewardAddress := ids.GenerateTestShortID()
@@ -373,7 +374,7 @@ func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 
 func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, cortina)
+	env := newEnvironment(t, upgradetest.Cortina)
 	dummyHeight := uint64(1)
 
 	vdrRewardAddress := ids.GenerateTestShortID()
@@ -603,7 +604,7 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 
 func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, cortina)
+	env := newEnvironment(t, upgradetest.Cortina)
 	dummyHeight := uint64(1)
 
 	vdrRewardAddress := ids.GenerateTestShortID()
@@ -776,7 +777,7 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 
 func TestRewardDelegatorTxExecuteOnAbort(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	dummyHeight := uint64(1)
 
 	initialSupply, err := env.state.GetCurrentSupply(constants.PrimaryNetworkID)

--- a/vms/platformvm/txs/executor/staker_tx_verification_test.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -110,7 +111,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 			backendF: func(*gomock.Controller) *Backend {
 				return &Backend{
 					Ctx:    ctx,
-					Config: defaultTestConfig(t, durango, activeForkTime),
+					Config: defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 				}
 			},
 			stateF: func(ctrl *gomock.Controller) state.Chain {
@@ -131,7 +132,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 			backendF: func(*gomock.Controller) *Backend {
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: &utils.Atomic[bool]{},
 				}
 			},
@@ -155,7 +156,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, cortina, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Cortina, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -179,7 +180,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -206,7 +207,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -233,7 +234,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -261,7 +262,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -292,7 +293,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -323,7 +324,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -356,7 +357,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -383,7 +384,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped.Set(true)
 				return &Backend{
 					Ctx:          ctx,
-					Config:       defaultTestConfig(t, durango, activeForkTime),
+					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -424,7 +425,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 					gomock.Any(),
 				).Return(ErrFlowCheckFailed)
 
-				cfg := defaultTestConfig(t, durango, activeForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, activeForkTime)
 				cfg.StaticFeeConfig.AddSubnetValidatorFee = 1
 
 				return &Backend{
@@ -470,7 +471,7 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 					gomock.Any(),
 				).Return(nil)
 
-				cfg := defaultTestConfig(t, durango, activeForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, activeForkTime)
 				cfg.StaticFeeConfig.AddSubnetValidatorFee = 1
 
 				return &Backend{

--- a/vms/platformvm/txs/executor/staker_tx_verification_test.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/fee"
 	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
@@ -110,10 +111,13 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 			name: "fail syntactic verification",
 			backendF: func(*gomock.Controller) *Backend {
 				return &Backend{
-					Ctx:    ctx,
-					Config: defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 				}
 			},
+
 			stateF: func(ctrl *gomock.Controller) state.Chain {
 				mockState := state.NewMockChain(ctrl)
 				mockState.EXPECT().GetTimestamp().Return(now)
@@ -131,8 +135,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 			name: "not bootstrapped",
 			backendF: func(*gomock.Controller) *Backend {
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: &utils.Atomic[bool]{},
 				}
 			},
@@ -155,8 +161,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Cortina, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Cortina, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -179,8 +187,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -206,8 +216,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -233,8 +245,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -261,8 +275,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -292,8 +308,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -323,8 +341,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -356,8 +376,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -383,8 +405,10 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				bootstrapped := &utils.Atomic[bool]{}
 				bootstrapped.Set(true)
 				return &Backend{
-					Ctx:          ctx,
-					Config:       defaultTestConfig(t, upgradetest.Durango, activeForkTime),
+					Ctx: ctx,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+					},
 					Bootstrapped: bootstrapped,
 				}
 			},
@@ -425,12 +449,14 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 					gomock.Any(),
 				).Return(ErrFlowCheckFailed)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, activeForkTime)
-				cfg.StaticFeeConfig.AddSubnetValidatorFee = 1
-
 				return &Backend{
-					FlowChecker:  flowChecker,
-					Config:       cfg,
+					FlowChecker: flowChecker,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+						StaticFeeConfig: fee.StaticConfig{
+							AddSubnetValidatorFee: 1,
+						},
+					},
 					Ctx:          ctx,
 					Bootstrapped: bootstrapped,
 				}
@@ -471,12 +497,14 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 					gomock.Any(),
 				).Return(nil)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, activeForkTime)
-				cfg.StaticFeeConfig.AddSubnetValidatorFee = 1
-
 				return &Backend{
-					FlowChecker:  flowChecker,
-					Config:       cfg,
+					FlowChecker: flowChecker,
+					Config: &config.Config{
+						UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, activeForkTime),
+						StaticFeeConfig: fee.StaticConfig{
+							AddSubnetValidatorFee: 1,
+						},
+					},
 					Ctx:          ctx,
 					Bootstrapped: bootstrapped,
 				}

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
@@ -49,7 +50,7 @@ var errTest = errors.New("non-nil error")
 
 func TestStandardTxExecutorAddValidatorTxEmptyID(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -195,7 +196,7 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 		require.NoError(env.state.Commit())
 	}
 
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	currentTimestamp := env.state.GetTimestamp()
 
 	type test struct {
@@ -327,7 +328,7 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			require := require.New(t)
-			env := newEnvironment(t, apricotPhase5)
+			env := newEnvironment(t, upgradetest.ApricotPhase5)
 			env.config.UpgradeConfig.ApricotPhase3Time = tt.AP3Time
 
 			builder, signer := env.factory.NewWallet(tt.feeKeys...)
@@ -371,7 +372,7 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 
 func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, apricotPhase5)
+	env := newEnvironment(t, upgradetest.ApricotPhase5)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -894,7 +895,7 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 
 func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 	require := require.New(t)
-	env := newEnvironment(t, banff)
+	env := newEnvironment(t, upgradetest.Banff)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -1152,7 +1153,7 @@ func TestDurangoDisabledTransactions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			env := newEnvironment(t, durango)
+			env := newEnvironment(t, upgradetest.Durango)
 			env.ctx.Lock.Lock()
 			defer env.ctx.Lock.Unlock()
 
@@ -1569,7 +1570,7 @@ func TestDurangoMemoField(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			env := newEnvironment(t, durango)
+			env := newEnvironment(t, upgradetest.Durango)
 			env.ctx.Lock.Lock()
 			defer env.ctx.Lock.Unlock()
 
@@ -1601,7 +1602,7 @@ func TestDurangoMemoField(t *testing.T) {
 func TestEtnaDisabledTransactions(t *testing.T) {
 	require := require.New(t)
 
-	env := newEnvironment(t, etna)
+	env := newEnvironment(t, upgradetest.Etna)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
@@ -1743,7 +1744,7 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().DeleteUTXO(gomock.Any()).Times(len(env.unsignedTx.Ins))
 				env.state.EXPECT().AddUTXO(gomock.Any()).Times(len(env.unsignedTx.Outs))
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1771,7 +1772,7 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state = state.NewMockDiff(ctrl)
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1799,7 +1800,7 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetCurrentValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(nil, database.ErrNotFound)
 				env.state.EXPECT().GetPendingValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(nil, database.ErrNotFound)
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1830,7 +1831,7 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 				env.state.EXPECT().GetCurrentValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(&staker, nil).Times(1)
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1859,7 +1860,7 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 				env.state.EXPECT().GetCurrentValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(env.staker, nil)
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1887,7 +1888,7 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetCurrentValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(env.staker, nil)
 				env.state.EXPECT().GetSubnetOwner(env.unsignedTx.Subnet).Return(nil, database.ErrNotFound)
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1917,7 +1918,7 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetSubnetOwner(env.unsignedTx.Subnet).Return(subnetOwner, nil)
 				env.fx.EXPECT().VerifyPermission(gomock.Any(), env.unsignedTx.SubnetAuth, env.tx.Creds[len(env.tx.Creds)-1], subnetOwner).Return(errTest)
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1950,7 +1951,7 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(errTest)
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -2108,7 +2109,7 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				env.state = state.NewMockDiff(ctrl)
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -2135,7 +2136,7 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				env.state = state.NewMockDiff(ctrl)
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -2163,7 +2164,7 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				env.state = state.NewMockDiff(ctrl)
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				cfg.MaxStakeDuration = math.MaxInt64
 
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
@@ -2198,7 +2199,7 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(ErrFlowCheckFailed)
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				cfg.MaxStakeDuration = math.MaxInt64
 
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
@@ -2238,7 +2239,7 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				env.state.EXPECT().DeleteUTXO(gomock.Any()).Times(len(env.unsignedTx.Ins))
 				env.state.EXPECT().AddUTXO(gomock.Any()).Times(len(env.unsignedTx.Outs))
 
-				cfg := defaultTestConfig(t, durango, env.latestForkTime)
+				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
 				cfg.MaxStakeDuration = math.MaxInt64
 
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
@@ -2272,7 +2273,7 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 	}
 }
 
-func defaultTestConfig(t *testing.T, f fork, tm time.Time) *config.Config {
+func defaultTestConfig(t *testing.T, f upgradetest.Fork, tm time.Time) *config.Config {
 	c := &config.Config{
 		UpgradeConfig: upgrade.Config{
 			ApricotPhase3Time: mockable.MaxTime,
@@ -2285,22 +2286,22 @@ func defaultTestConfig(t *testing.T, f fork, tm time.Time) *config.Config {
 	}
 
 	switch f {
-	case etna:
+	case upgradetest.Etna:
 		c.UpgradeConfig.EtnaTime = tm
 		fallthrough
-	case durango:
+	case upgradetest.Durango:
 		c.UpgradeConfig.DurangoTime = tm
 		fallthrough
-	case cortina:
+	case upgradetest.Cortina:
 		c.UpgradeConfig.CortinaTime = tm
 		fallthrough
-	case banff:
+	case upgradetest.Banff:
 		c.UpgradeConfig.BanffTime = tm
 		fallthrough
-	case apricotPhase5:
+	case upgradetest.ApricotPhase5:
 		c.UpgradeConfig.ApricotPhase5Time = tm
 		fallthrough
-	case apricotPhase3:
+	case upgradetest.ApricotPhase3:
 		c.UpgradeConfig.ApricotPhase3Time = tm
 	default:
 		require.FailNow(t, "unhandled fork", f)

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -17,14 +17,12 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/hashing"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
@@ -1744,7 +1742,9 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().DeleteUTXO(gomock.Any()).Times(len(env.unsignedTx.Ins))
 				env.state.EXPECT().AddUTXO(gomock.Any()).Times(len(env.unsignedTx.Outs))
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1772,7 +1772,9 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state = state.NewMockDiff(ctrl)
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1800,7 +1802,9 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetCurrentValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(nil, database.ErrNotFound)
 				env.state.EXPECT().GetPendingValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(nil, database.ErrNotFound)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1831,7 +1835,9 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 				env.state.EXPECT().GetCurrentValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(&staker, nil).Times(1)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1860,7 +1866,9 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 				env.state.EXPECT().GetCurrentValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(env.staker, nil)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1888,7 +1896,9 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetCurrentValidator(env.unsignedTx.Subnet, env.unsignedTx.NodeID).Return(env.staker, nil)
 				env.state.EXPECT().GetSubnetOwner(env.unsignedTx.Subnet).Return(nil, database.ErrNotFound)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1918,7 +1928,9 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 				env.state.EXPECT().GetSubnetOwner(env.unsignedTx.Subnet).Return(subnetOwner, nil)
 				env.fx.EXPECT().VerifyPermission(gomock.Any(), env.unsignedTx.SubnetAuth, env.tx.Creds[len(env.tx.Creds)-1], subnetOwner).Return(errTest)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -1951,7 +1963,9 @@ func TestStandardExecutorRemoveSubnetValidatorTx(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(errTest)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -2109,7 +2123,9 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				env.state = state.NewMockDiff(ctrl)
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -2136,7 +2152,9 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				env.state = state.NewMockDiff(ctrl)
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
+				cfg := &config.Config{
+					UpgradeConfig: upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+				}
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
 					Backend: &Backend{
@@ -2164,8 +2182,10 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				env.state = state.NewMockDiff(ctrl)
 				env.state.EXPECT().GetTimestamp().Return(env.latestForkTime).AnyTimes()
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
-				cfg.MaxStakeDuration = math.MaxInt64
+				cfg := &config.Config{
+					UpgradeConfig:    upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+					MaxStakeDuration: math.MaxInt64,
+				}
 
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
@@ -2199,8 +2219,10 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(ErrFlowCheckFailed)
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
-				cfg.MaxStakeDuration = math.MaxInt64
+				cfg := &config.Config{
+					UpgradeConfig:    upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+					MaxStakeDuration: math.MaxInt64,
+				}
 
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
@@ -2239,8 +2261,10 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				env.state.EXPECT().DeleteUTXO(gomock.Any()).Times(len(env.unsignedTx.Ins))
 				env.state.EXPECT().AddUTXO(gomock.Any()).Times(len(env.unsignedTx.Outs))
 
-				cfg := defaultTestConfig(t, upgradetest.Durango, env.latestForkTime)
-				cfg.MaxStakeDuration = math.MaxInt64
+				cfg := &config.Config{
+					UpgradeConfig:    upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, env.latestForkTime),
+					MaxStakeDuration: math.MaxInt64,
+				}
 
 				feeCalculator := state.PickFeeCalculator(cfg, env.state)
 				e := &StandardTxExecutor{
@@ -2271,41 +2295,4 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 			require.ErrorIs(t, err, tt.err)
 		})
 	}
-}
-
-func defaultTestConfig(t *testing.T, f upgradetest.Fork, tm time.Time) *config.Config {
-	c := &config.Config{
-		UpgradeConfig: upgrade.Config{
-			ApricotPhase3Time: mockable.MaxTime,
-			ApricotPhase5Time: mockable.MaxTime,
-			BanffTime:         mockable.MaxTime,
-			CortinaTime:       mockable.MaxTime,
-			DurangoTime:       mockable.MaxTime,
-			EtnaTime:          mockable.MaxTime,
-		},
-	}
-
-	switch f {
-	case upgradetest.Etna:
-		c.UpgradeConfig.EtnaTime = tm
-		fallthrough
-	case upgradetest.Durango:
-		c.UpgradeConfig.DurangoTime = tm
-		fallthrough
-	case upgradetest.Cortina:
-		c.UpgradeConfig.CortinaTime = tm
-		fallthrough
-	case upgradetest.Banff:
-		c.UpgradeConfig.BanffTime = tm
-		fallthrough
-	case upgradetest.ApricotPhase5:
-		c.UpgradeConfig.ApricotPhase5Time = tm
-		fallthrough
-	case upgradetest.ApricotPhase3:
-		c.UpgradeConfig.ApricotPhase3Time = tm
-	default:
-		require.FailNow(t, "unhandled fork", f)
-	}
-
-	return c
 }

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/formatting"
@@ -645,7 +645,6 @@ func TestTimestampListGenerator(t *testing.T) {
 // add a single validator at the end of times,
 // to make sure it won't pollute our tests
 func buildVM(t *testing.T) (*VM, ids.ID, error) {
-	forkTime := defaultGenesisTime
 	vm := &VM{Config: config.Config{
 		Chains:                 chains.TestManager,
 		UptimeLockedCalculator: uptime.NewLockedCalculator(),
@@ -663,15 +662,9 @@ func buildVM(t *testing.T) (*VM, ids.ID, error) {
 		MinStakeDuration:  defaultMinStakingDuration,
 		MaxStakeDuration:  defaultMaxStakingDuration,
 		RewardConfig:      defaultRewardConfig,
-		UpgradeConfig: upgrade.Config{
-			ApricotPhase3Time: forkTime,
-			ApricotPhase5Time: forkTime,
-			BanffTime:         forkTime,
-			CortinaTime:       forkTime,
-			EtnaTime:          mockable.MaxTime,
-		},
+		UpgradeConfig:     upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, defaultGenesisTime),
 	}}
-	vm.clock.Set(forkTime.Add(time.Second))
+	vm.clock.Set(defaultGenesisTime.Add(time.Second))
 
 	baseDB := memdb.New()
 	chainDB := prefixdb.New([]byte{0}, baseDB)

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -27,13 +27,11 @@ import (
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/bloom"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
@@ -457,12 +455,7 @@ func TestUnverifiedParentPanicRegression(t *testing.T) {
 		MinStakeDuration:       defaultMinStakingDuration,
 		MaxStakeDuration:       defaultMaxStakingDuration,
 		RewardConfig:           defaultRewardConfig,
-		UpgradeConfig: upgrade.Config{
-			BanffTime:   latestForkTime,
-			CortinaTime: mockable.MaxTime,
-			DurangoTime: mockable.MaxTime,
-			EtnaTime:    mockable.MaxTime,
-		},
+		UpgradeConfig:          upgradetest.GetConfigWithUpgradeTime(upgradetest.Banff, latestForkTime),
 	}}
 
 	ctx := snowtest.Context(t, snowtest.PChainID)

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/bloom"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
@@ -53,7 +54,7 @@ import (
 
 func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 	require := require.New(t)
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -258,7 +259,7 @@ func TestAddDelegatorTxHeapCorruption(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
-			vm, factory, _, _ := defaultVM(t, apricotPhase3)
+			vm, factory, _, _ := defaultVM(t, upgradetest.ApricotPhase3)
 			vm.UpgradeConfig.ApricotPhase3Time = test.ap3Time
 
 			vm.ctx.Lock.Lock()
@@ -600,7 +601,7 @@ func TestUnverifiedParentPanicRegression(t *testing.T) {
 func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 	require := require.New(t)
 
-	vm, factory, baseDB, mutableSharedMemory := defaultVM(t, cortina)
+	vm, factory, baseDB, mutableSharedMemory := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -799,7 +800,7 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 	require := require.New(t)
 
-	vm, factory, baseDB, mutableSharedMemory := defaultVM(t, cortina)
+	vm, factory, baseDB, mutableSharedMemory := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -1111,7 +1112,7 @@ func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 func TestValidatorSetAtCacheOverwriteRegression(t *testing.T) {
 	require := require.New(t)
 
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -1253,7 +1254,7 @@ func TestAddDelegatorTxAddBeforeRemove(t *testing.T) {
 	delegator2EndTime := delegator2StartTime.Add(3 * defaultMinStakingDuration)
 	delegator2Stake := defaultMaxValidatorStake - validatorStake
 
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -1367,7 +1368,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionNotTracked(t
 	validatorStartTime := latestForkTime.Add(executor.SyncBound).Add(1 * time.Second)
 	validatorEndTime := validatorStartTime.Add(360 * 24 * time.Hour)
 
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -1516,7 +1517,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 	validatorStartTime := latestForkTime.Add(executor.SyncBound).Add(1 * time.Second)
 	validatorEndTime := validatorStartTime.Add(360 * 24 * time.Hour)
 
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -1648,7 +1649,7 @@ func TestRemovePermissionedValidatorDuringPendingToCurrentTransitionTracked(t *t
 func TestSubnetValidatorBLSKeyDiffAfterExpiry(t *testing.T) {
 	// setup
 	require := require.New(t)
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -1913,7 +1914,7 @@ func TestPrimaryNetworkValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 
 	// setup
 	require := require.New(t)
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -2069,7 +2070,7 @@ func TestSubnetValidatorPopulatedToEmptyBLSKeyDiff(t *testing.T) {
 
 	// setup
 	require := require.New(t)
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -2288,7 +2289,7 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 
 	// setup
 	require := require.New(t)
-	vm, factory, _, _ := defaultVM(t, cortina)
+	vm, factory, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -2426,7 +2427,7 @@ func TestSubnetValidatorSetAfterPrimaryNetworkValidatorRemoval(t *testing.T) {
 
 func TestValidatorSetRaceCondition(t *testing.T) {
 	require := require.New(t)
-	vm, _, _, _ := defaultVM(t, cortina)
+	vm, _, _, _ := defaultVM(t, upgradetest.Cortina)
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/staking"
-	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/proposervm/proposer"
@@ -72,11 +72,7 @@ func TestPostForkCommonComponents_buildChild(t *testing.T) {
 	require.NoError(err)
 	vm := &VM{
 		Config: Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  time.Unix(0, 0),
-			},
+			Upgrades:          upgradetest.GetConfig(upgradetest.Latest),
 			StakingCertLeaf:   &staking.Certificate{},
 			StakingLeafSigner: pk,
 			Registerer:        prometheus.NewRegistry(),
@@ -388,11 +384,7 @@ func TestPostDurangoBuildChildResetScheduler(t *testing.T) {
 	require.NoError(err)
 	vm := &VM{
 		Config: Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  time.Unix(0, 0),
-			},
+			Upgrades:          upgradetest.GetConfig(upgradetest.Latest),
 			StakingCertLeaf:   &staking.Certificate{},
 			StakingLeafSigner: pk,
 			Registerer:        prometheus.NewRegistry(),

--- a/vms/proposervm/post_fork_option_test.go
+++ b/vms/proposervm/post_fork_option_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman/snowmantest"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
-	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/vms/proposervm/block"
 )
 
@@ -528,11 +528,7 @@ func TestOptionTimestampValidity(t *testing.T) {
 	proVM = New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  time.Unix(0, 0),
-			},
+			Upgrades:            upgradetest.GetConfig(upgradetest.Latest),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -6,7 +6,6 @@ package proposervm
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -23,7 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block/blocktest"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
-	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/vms/proposervm/summary"
 
 	statelessblock "github.com/ava-labs/avalanchego/vms/proposervm/block"
@@ -61,11 +60,7 @@ func helperBuildStateSyncTestObjects(t *testing.T) (*fullVM, *VM) {
 	vm := New(
 		innerVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  time.Unix(0, 0),
-			},
+			Upgrades:            upgradetest.GetConfig(upgradetest.Latest),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -1910,11 +1911,7 @@ func TestVMInnerBlkCache(t *testing.T) {
 	vm := New(
 		innerVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  time.Unix(0, 0),
-			},
+			Upgrades:            upgradetest.GetConfig(upgradetest.Latest),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -2022,11 +2019,7 @@ func TestVM_VerifyBlockWithContext(t *testing.T) {
 	vm := New(
 		innerVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  time.Unix(0, 0),
-			},
+			Upgrades:            upgradetest.GetConfig(upgradetest.Latest),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -809,11 +809,7 @@ func TestExpiredBuildBlock(t *testing.T) {
 	proVM := New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Time{},
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  mockable.MaxTime,
-			},
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Time{}),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -1129,11 +1125,7 @@ func TestInnerVMRollback(t *testing.T) {
 	proVM := New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Time{},
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  mockable.MaxTime,
-			},
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Time{}),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -1211,11 +1203,7 @@ func TestInnerVMRollback(t *testing.T) {
 	proVM = New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Time{},
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  mockable.MaxTime,
-			},
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Time{}),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -1601,11 +1589,7 @@ func TestRejectedHeightNotIndexed(t *testing.T) {
 	proVM := New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  time.Unix(0, 0),
-			},
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.Latest, time.Unix(0, 0)),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -1774,11 +1758,7 @@ func TestRejectedOptionHeightNotIndexed(t *testing.T) {
 	proVM := New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  time.Unix(0, 0),
-			},
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.Latest, time.Unix(0, 0)),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -2219,11 +2199,7 @@ func TestHistoricalBlockDeletion(t *testing.T) {
 	proVM := New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Unix(0, 0),
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  mockable.MaxTime,
-			},
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Unix(0, 0)),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -2313,11 +2289,7 @@ func TestHistoricalBlockDeletion(t *testing.T) {
 	proVM = New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Time{},
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  mockable.MaxTime,
-			},
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Time{}),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: numHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -2360,11 +2332,7 @@ func TestHistoricalBlockDeletion(t *testing.T) {
 	proVM = New(
 		coreVM,
 		Config{
-			Upgrades: upgrade.Config{
-				ApricotPhase4Time:            time.Time{},
-				ApricotPhase4MinPChainHeight: 0,
-				DurangoTime:                  mockable.MaxTime,
-			},
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Time{}),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: newNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -1589,7 +1589,7 @@ func TestRejectedHeightNotIndexed(t *testing.T) {
 	proVM := New(
 		coreVM,
 		Config{
-			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.Latest, time.Unix(0, 0)),
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.Latest, time.Time{}),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -1758,7 +1758,7 @@ func TestRejectedOptionHeightNotIndexed(t *testing.T) {
 	proVM := New(
 		coreVM,
 		Config{
-			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.Latest, time.Unix(0, 0)),
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.Latest, time.Time{}),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,
@@ -2199,7 +2199,7 @@ func TestHistoricalBlockDeletion(t *testing.T) {
 	proVM := New(
 		coreVM,
 		Config{
-			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Unix(0, 0)),
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Time{}),
 			MinBlkDelay:         DefaultMinBlockDelay,
 			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
 			StakingLeafSigner:   pTestSigner,


### PR DESCRIPTION
## Why this should be merged

`type fork uint8` seems to be very popular... Moving this into a common package and sharing where possible.

## How this works

Adds an `upgradetest` package and exposes common functionality that existing VMs re-implement multiple times.

## How this was tested

- [X] CI