### PR TITLE
[antithesis] Enable custom plugin dir for subnet-evm

### DIFF
--- a/tests/antithesis/avalanchego/gencomposeconfig/main.go
+++ b/tests/antithesis/avalanchego/gencomposeconfig/main.go
@@ -15,7 +15,7 @@ const baseImageName = "antithesis-avalanchego"
 // Creates docker-compose.yml and its associated volumes in the target path.
 func main() {
 	network := tmpnet.LocalNetworkOrPanic()
-	if err := antithesis.GenerateComposeConfig(network, baseImageName); err != nil {
+	if err := antithesis.GenerateComposeConfig(network, baseImageName, "" /* runtimePluginDir */); err != nil {
 		log.Fatalf("failed to generate compose config: %v", err)
 	}
 }

--- a/tests/antithesis/xsvm/gencomposeconfig/main.go
+++ b/tests/antithesis/xsvm/gencomposeconfig/main.go
@@ -20,7 +20,7 @@ func main() {
 	network.Subnets = []*tmpnet.Subnet{
 		subnet.NewXSVMOrPanic("xsvm", genesis.VMRQKey, network.Nodes...),
 	}
-	if err := antithesis.GenerateComposeConfig(network, baseImageName); err != nil {
+	if err := antithesis.GenerateComposeConfig(network, baseImageName, "" /* runtimePluginDir */); err != nil {
 		log.Fatalf("failed to generate compose config: %v", err)
 	}
 }

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -289,7 +289,7 @@ func (n *Network) Create(rootDir string) error {
 	n.Dir = canonicalDir
 
 	// Ensure the existence of the plugin directory or nodes won't be able to start.
-	pluginDir, err := n.GetPluginDir()
+	pluginDir, err := n.getPluginDir()
 	if err != nil {
 		return err
 	}
@@ -463,7 +463,7 @@ func (n *Network) Bootstrap(ctx context.Context, w io.Writer) error {
 func (n *Network) StartNode(ctx context.Context, w io.Writer, node *Node) error {
 	// This check is duplicative for a network that is starting, but ensures
 	// that individual node start/restart won't fail due to missing binaries.
-	pluginDir, err := n.GetPluginDir()
+	pluginDir, err := n.getPluginDir()
 	if err != nil {
 		return err
 	}
@@ -877,7 +877,7 @@ func (n *Network) GetNetworkID() uint32 {
 	return n.NetworkID
 }
 
-func (n *Network) GetPluginDir() (string, error) {
+func (n *Network) getPluginDir() (string, error) {
 	return n.DefaultFlags.GetStringVal(config.PluginDirKey)
 }
 

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -289,7 +289,7 @@ func (n *Network) Create(rootDir string) error {
 	n.Dir = canonicalDir
 
 	// Ensure the existence of the plugin directory or nodes won't be able to start.
-	pluginDir, err := n.getPluginDir()
+	pluginDir, err := n.GetPluginDir()
 	if err != nil {
 		return err
 	}
@@ -463,7 +463,7 @@ func (n *Network) Bootstrap(ctx context.Context, w io.Writer) error {
 func (n *Network) StartNode(ctx context.Context, w io.Writer, node *Node) error {
 	// This check is duplicative for a network that is starting, but ensures
 	// that individual node start/restart won't fail due to missing binaries.
-	pluginDir, err := n.getPluginDir()
+	pluginDir, err := n.GetPluginDir()
 	if err != nil {
 		return err
 	}
@@ -877,7 +877,7 @@ func (n *Network) GetNetworkID() uint32 {
 	return n.NetworkID
 }
 
-func (n *Network) getPluginDir() (string, error) {
+func (n *Network) GetPluginDir() (string, error) {
 	return n.DefaultFlags.GetStringVal(config.PluginDirKey)
 }
 


### PR DESCRIPTION
## Why this should be merged

subnet-evm's docker image uses a non-default plugin dir and it needs to be possible to set it for nodes that will run under the antithesis docker compose project.

## How this works

- support setting the plugin dir for the compose project while still using the default plugin dir when initializing the db 

## How this was tested

- CI workflows testing image build in this repo and the workflow testing image build in https://github.com/ava-labs/subnet-evm/pull/1166
