### PR TITLE
Refactor state tests to always use initialized state

### DIFF
--- a/vms/platformvm/genesis/genesistest/genesis.go
+++ b/vms/platformvm/genesis/genesistest/genesis.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesistest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+var (
+	AVAXAssetID = ids.GenerateTestID()
+	AVAXAsset   = avax.Asset{ID: AVAXAssetID}
+
+	ValidatorNodeID                  = ids.GenerateTestNodeID()
+	Time                             = time.Now().Round(time.Second)
+	TimeUnix                         = uint64(Time.Unix())
+	ValidatorDuration                = 28 * 24 * time.Hour
+	ValidatorEndTime                 = Time.Add(ValidatorDuration)
+	ValidatorEndTimeUnix             = uint64(ValidatorEndTime.Unix())
+	ValidatorWeight                  = units.Avax
+	ValidatorRewardsOwner            = &secp256k1fx.OutputOwners{}
+	ValidatorDelegationShares uint32 = reward.PercentDenominator
+
+	XChainName = "x"
+
+	InitialBalance = units.Schmeckle
+	InitialSupply  = ValidatorWeight + InitialBalance
+)
+
+func New(t testing.TB) *genesis.Genesis {
+	require := require.New(t)
+
+	genesisValidator := &txs.AddValidatorTx{
+		Validator: txs.Validator{
+			NodeID: ValidatorNodeID,
+			Start:  TimeUnix,
+			End:    ValidatorEndTimeUnix,
+			Wght:   ValidatorWeight,
+		},
+		StakeOuts: []*avax.TransferableOutput{
+			{
+				Asset: AVAXAsset,
+				Out: &secp256k1fx.TransferOutput{
+					Amt: ValidatorWeight,
+				},
+			},
+		},
+		RewardsOwner:     ValidatorRewardsOwner,
+		DelegationShares: ValidatorDelegationShares,
+	}
+	genesisValidatorTx := &txs.Tx{Unsigned: genesisValidator}
+	require.NoError(genesisValidatorTx.Initialize(txs.Codec))
+
+	genesisChain := &txs.CreateChainTx{
+		SubnetID:   constants.PrimaryNetworkID,
+		ChainName:  XChainName,
+		VMID:       constants.AVMID,
+		SubnetAuth: &secp256k1fx.Input{},
+	}
+	genesisChainTx := &txs.Tx{Unsigned: genesisChain}
+	require.NoError(genesisChainTx.Initialize(txs.Codec))
+
+	return &genesis.Genesis{
+		UTXOs: []*genesis.UTXO{
+			{
+				UTXO: avax.UTXO{
+					UTXOID: avax.UTXOID{
+						TxID:        AVAXAssetID,
+						OutputIndex: 0,
+					},
+					Asset: AVAXAsset,
+					Out: &secp256k1fx.TransferOutput{
+						Amt: InitialBalance,
+					},
+				},
+				Message: nil,
+			},
+		},
+		Validators: []*txs.Tx{
+			genesisValidatorTx,
+		},
+		Chains: []*txs.Tx{
+			genesisChainTx,
+		},
+		Timestamp:     TimeUnix,
+		InitialSupply: InitialSupply,
+	}
+}
+
+func NewBytes(t testing.TB) []byte {
+	g := New(t)
+	genesisBytes, err := genesis.Codec.Marshal(genesis.CodecVersion, g)
+	require.NoError(t, err)
+	return genesisBytes
+}

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -37,7 +37,7 @@ func TestDiffMissingState(t *testing.T) {
 func TestNewDiffOn(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 
 	d, err := NewDiffOn(state)
 	require.NoError(err)
@@ -48,7 +48,7 @@ func TestNewDiffOn(t *testing.T) {
 func TestDiffFeeState(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 
 	d, err := NewDiffOn(state)
 	require.NoError(err)
@@ -69,7 +69,7 @@ func TestDiffFeeState(t *testing.T) {
 func TestDiffCurrentSupply(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 
 	d, err := NewDiffOn(state)
 	require.NoError(err)
@@ -257,7 +257,7 @@ func TestDiffSubnet(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 
 	// Initialize parent with one subnet
 	parentStateCreateSubnetTx := &txs.Tx{
@@ -306,7 +306,7 @@ func TestDiffSubnet(t *testing.T) {
 func TestDiffChain(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 	subnetID := ids.GenerateTestID()
 
 	// Initialize parent with one chain
@@ -403,7 +403,7 @@ func TestDiffTx(t *testing.T) {
 func TestDiffRewardUTXO(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 
 	// Initialize parent with one reward UTXO
 	var (
@@ -532,7 +532,7 @@ func TestDiffSubnetOwner(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 
 	var (
 		owner1 = fx.NewMockOwner(ctrl)
@@ -590,7 +590,7 @@ func TestDiffSubnetManager(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 
 	states := NewMockVersions(ctrl)
 	lastAcceptedID := ids.GenerateTestID()
@@ -639,7 +639,7 @@ func TestDiffStacking(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	state := newInitializedStateFromDB(t, memdb.New())
+	state := newTestState(t, memdb.New())
 
 	var (
 		owner1 = fx.NewMockOwner(ctrl)

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -36,7 +37,7 @@ func TestDiffMissingState(t *testing.T) {
 func TestNewDiffOn(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 
 	d, err := NewDiffOn(state)
 	require.NoError(err)
@@ -47,7 +48,7 @@ func TestNewDiffOn(t *testing.T) {
 func TestDiffFeeState(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 
 	d, err := NewDiffOn(state)
 	require.NoError(err)
@@ -68,7 +69,7 @@ func TestDiffFeeState(t *testing.T) {
 func TestDiffCurrentSupply(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 
 	d, err := NewDiffOn(state)
 	require.NoError(err)
@@ -256,7 +257,7 @@ func TestDiffSubnet(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 
 	// Initialize parent with one subnet
 	parentStateCreateSubnetTx := &txs.Tx{
@@ -305,7 +306,7 @@ func TestDiffSubnet(t *testing.T) {
 func TestDiffChain(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 	subnetID := ids.GenerateTestID()
 
 	// Initialize parent with one chain
@@ -402,7 +403,7 @@ func TestDiffTx(t *testing.T) {
 func TestDiffRewardUTXO(t *testing.T) {
 	require := require.New(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 
 	// Initialize parent with one reward UTXO
 	var (
@@ -531,7 +532,7 @@ func TestDiffSubnetOwner(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 
 	var (
 		owner1 = fx.NewMockOwner(ctrl)
@@ -589,7 +590,7 @@ func TestDiffSubnetManager(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 
 	states := NewMockVersions(ctrl)
 	lastAcceptedID := ids.GenerateTestID()
@@ -638,7 +639,7 @@ func TestDiffStacking(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	state := newInitializedState(require)
+	state := newInitializedStateFromDB(t, memdb.New())
 
 	var (
 		owner1 = fx.NewMockOwner(ctrl)

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis/genesistest"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
@@ -219,7 +220,7 @@ func TestDiffStakersDelegator(t *testing.T) {
 
 func newTestStaker() *Staker {
 	startTime := time.Now().Round(time.Second)
-	endTime := startTime.Add(28 * 24 * time.Hour)
+	endTime := startTime.Add(genesistest.ValidatorDuration)
 	return &Staker{
 		TxID:            ids.GenerateTestID(),
 		NodeID:          ids.GenerateTestNodeID(),

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -52,24 +52,6 @@ var (
 	initialValidatorEndTime = initialTime.Add(28 * 24 * time.Hour)
 )
 
-func TestStateInitialization(t *testing.T) {
-	require := require.New(t)
-	s, db := newUninitializedState(require)
-
-	shouldInit, err := s.shouldInit()
-	require.NoError(err)
-	require.True(shouldInit)
-
-	require.NoError(s.doneInit())
-	require.NoError(s.Commit())
-
-	s = newStateFromDB(require, db)
-
-	shouldInit, err = s.shouldInit()
-	require.NoError(err)
-	require.False(shouldInit)
-}
-
 func TestStateSyncGenesis(t *testing.T) {
 	require := require.New(t)
 	state := newInitializedState(require)
@@ -1562,6 +1544,21 @@ func TestStateFeeStateCommitAndLoad(t *testing.T) {
 	s = newStateFromDB(require, db)
 	require.NoError(s.load())
 	require.Equal(expectedFeeState, s.GetFeeState())
+}
+
+func TestMarkAndIsInitialized(t *testing.T) {
+	require := require.New(t)
+
+	db := memdb.New()
+	defaultIsInitialized, err := isInitialized(db)
+	require.NoError(err)
+	require.False(defaultIsInitialized)
+
+	require.NoError(markInitialized(db))
+
+	isInitializedAfterMarking, err := isInitialized(db)
+	require.NoError(err)
+	require.True(isInitializedAfterMarking)
 }
 
 // Verify that reading from the database returns the same value that was written

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -671,10 +671,10 @@ func TestPersistStakers(t *testing.T) {
 				require.NoError(rebuiltState.initValidatorSets())
 
 				// check again that all relevant data are still available in rebuilt state
-				test.checkStakerInState(require, state, staker)
-				test.checkValidatorsSet(require, state, staker)
-				test.checkValidatorUptimes(require, state, staker)
-				test.checkDiffs(require, state, staker, 0 /*height*/)
+				test.checkStakerInState(require, rebuiltState, staker)
+				test.checkValidatorsSet(require, rebuiltState, staker)
+				test.checkValidatorUptimes(require, rebuiltState, staker)
+				test.checkDiffs(require, rebuiltState, staker, 0 /*height*/)
 			})
 		}
 	}

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -160,7 +160,8 @@ func TestPersistStakers(t *testing.T) {
 						PublicKey: staker.PublicKey,
 						Weight:    staker.Weight,
 					},
-					valsMap[staker.NodeID])
+					valsMap[staker.NodeID],
+				)
 			},
 			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
 				upDuration, lastUpdated, err := s.GetUptime(staker.NodeID, staker.SubnetID)

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -687,12 +687,8 @@ func newInitializedStateFromDB(t testing.TB, db database.Database) *state {
 }
 
 func initializeState(t testing.TB, s *state) {
-	genesisBlkID := ids.GenerateTestID()
-	genesisBlk, err := block.NewApricotCommitBlock(genesisBlkID, 0)
-	require.NoError(t, err)
-
-	genesis := genesistest.New(t)
-	require.NoError(t, s.syncGenesis(genesisBlk, genesis))
+	genesis := genesistest.NewBytes(t)
+	require.NoError(t, s.sync(genesis))
 }
 
 func newStateFromDB(t testing.TB, db database.Database) *state {


### PR DESCRIPTION
## Why this should be merged

Previously some tests relied on using an uninitialized testing struct.

## How this works

- Update the tests that relied on uninitialized structs to use initialized structs.
- Remove support for creating partially initialized structs.
- Introduce a `genesistest` package so that constructing a simple `State` instance is easier for external packages.

## How this was tested

- [X] CI