### PR TITLE
Rename race condition image tags

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -28,8 +28,8 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Load the constants
 source "$AVALANCHE_PATH"/scripts/constants.sh
 
-if [[ $image_tag == *"-race" ]]; then
-  echo "Branch name must not end in '-race'"
+if [[ $image_tag == *"-r" ]]; then
+  echo "Branch name must not end in '-r'"
   exit 1
 fi
 
@@ -84,8 +84,8 @@ echo "Building Docker Image with tags: $DOCKER_IMAGE:$commit_hash , $DOCKER_IMAG
 ${DOCKER_CMD} -t "$DOCKER_IMAGE:$commit_hash" -t "$DOCKER_IMAGE:$image_tag" \
               "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"
 
-echo "Building Docker Image with tags: $DOCKER_IMAGE:$commit_hash-race , $DOCKER_IMAGE:$image_tag-race"
-${DOCKER_CMD} --build-arg="RACE_FLAG=-r" -t "$DOCKER_IMAGE:$commit_hash-race" -t "$DOCKER_IMAGE:$image_tag-race" \
+echo "Building Docker Image with tags: $DOCKER_IMAGE:$commit_hash-r , $DOCKER_IMAGE:$image_tag-r"
+${DOCKER_CMD} --build-arg="RACE_FLAG=-r" -t "$DOCKER_IMAGE:$commit_hash-r" -t "$DOCKER_IMAGE:$image_tag-r" \
               "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"
 
 # Only tag the latest image for the master branch when images are pushed to a registry

--- a/scripts/tests.build_image.sh
+++ b/scripts/tests.build_image.sh
@@ -36,13 +36,13 @@ build_and_test() {
   local target_images=(
     "$image_name:$commit_hash"
     "$image_name:$image_tag"
-    "$image_name:$commit_hash-race"
-    "$image_name:$image_tag-race"
+    "$image_name:$commit_hash-r"
+    "$image_name:$image_tag-r"
   )
 
   for arch in "${arches[@]}"; do
     for target_image in "${target_images[@]}"; do
-      if [[ "$host_arch" == "amd64" && "$arch" == "arm64" && "$target_image" =~ "-race" ]]; then
+      if [[ "$host_arch" == "amd64" && "$arch" == "arm64" && "$target_image" =~ "-r" ]]; then
         # Error reported when trying to sanity check this configuration in github ci:
         #
         #   FATAL: ThreadSanitizer: unsupported VMA range


### PR DESCRIPTION
## Why this should be merged
Replace `-race` with `-r` as the suffix for image tags to prevent unfortunate fully-formed tag names.

## How this works
See above

## How this was tested
CI