### PR TITLE
Add .String() to Fork testing utility

### DIFF
--- a/upgrade/upgradetest/fork.go
+++ b/upgrade/upgradetest/fork.go
@@ -23,3 +23,36 @@ const (
 
 // Fork is an enum of all the major network upgrades.
 type Fork int
+
+func (f Fork) String() string {
+	switch f {
+	case Etna:
+		return "Etna"
+	case Durango:
+		return "Durango"
+	case Cortina:
+		return "Cortina"
+	case Banff:
+		return "Banff"
+	case ApricotPhasePost6:
+		return "ApricotPhasePost6"
+	case ApricotPhase6:
+		return "ApricotPhase6"
+	case ApricotPhasePre6:
+		return "ApricotPhasePre6"
+	case ApricotPhase5:
+		return "ApricotPhase5"
+	case ApricotPhase4:
+		return "ApricotPhase4"
+	case ApricotPhase3:
+		return "ApricotPhase3"
+	case ApricotPhase2:
+		return "ApricotPhase2"
+	case ApricotPhase1:
+		return "ApricotPhase1"
+	case NoUpgrades:
+		return "NoUpgrades"
+	default:
+		return "Unknown"
+	}
+}


### PR DESCRIPTION
## Why this should be merged

Factored out of #3251.

## How this works

Adds a `String` implementation.

## How this was tested

N/A