### PR TITLE
[antithesis] Update schedule to make room for subnet-evm

### DIFF
--- a/.github/workflows/trigger-antithesis-avalanchego.yml
+++ b/.github/workflows/trigger-antithesis-avalanchego.yml
@@ -37,5 +37,5 @@ jobs:
           email_recipients: ${{ github.event.inputs.recipients || secrets.ANTITHESIS_RECIPIENTS }}
           # Duration is in hours
           additional_parameters: |-
-            custom.duration=${{ github.event.inputs.duration || '11.25' }}
+            custom.duration=${{ github.event.inputs.duration || '7.5' }}
             custom.workload=avalanchego

--- a/.github/workflows/trigger-antithesis-xsvm.yml
+++ b/.github/workflows/trigger-antithesis-xsvm.yml
@@ -2,7 +2,7 @@ name: Trigger Antithesis XSVM Setup
 
 on:
   schedule:
-    - cron: '0 10 * * *' # Every day at 10AM UTC
+    - cron: '0 6 * * *' # Every day at 6AM UTC
   workflow_dispatch:
     inputs:
       duration:
@@ -37,5 +37,5 @@ jobs:
           email_recipients: ${{ github.event.inputs.recipients || secrets.ANTITHESIS_RECIPIENTS }}
           # Duration is in hours
           additional_parameters: |-
-            custom.duration=${{ github.event.inputs.duration || '11.25' }}
+            custom.duration=${{ github.event.inputs.duration || '7.5' }}
             custom.workload=xsvm


### PR DESCRIPTION
## Why this should be merged

With the merge of https://github.com/ava-labs/subnet-evm/pull/1166 there is a test setup for subnet-evm that needs to be scheduled. 
## How this works

Update the runtime of the existing jobs from 11.25h to 7.5h.

## How this was tested

CI