### PR TITLE
Add tx complexity helper

### DIFF
--- a/vms/platformvm/txs/fee/complexity.go
+++ b/vms/platformvm/txs/fee/complexity.go
@@ -183,10 +183,24 @@ var (
 	errUnsupportedSigner = errors.New("unsupported signer type")
 )
 
-func TxComplexity(tx txs.UnsignedTx) (gas.Dimensions, error) {
-	c := complexityVisitor{}
-	err := tx.Visit(&c)
-	return c.output, err
+func TxComplexity(txs ...txs.UnsignedTx) (gas.Dimensions, error) {
+	var (
+		c          complexityVisitor
+		complexity gas.Dimensions
+	)
+	for _, tx := range txs {
+		c = complexityVisitor{}
+		err := tx.Visit(&c)
+		if err != nil {
+			return gas.Dimensions{}, err
+		}
+
+		complexity, err = complexity.Add(&c.output)
+		if err != nil {
+			return gas.Dimensions{}, err
+		}
+	}
+	return complexity, nil
 }
 
 // OutputComplexity returns the complexity outputs add to a transaction.


### PR DESCRIPTION
## Why this should be merged

This wasn't originally added because it wasn't expected to be useful for block execution. However, it is useful for tooling around block execution. Also, this pattern aligns with existing behavior of the functions exposed by this file.

## How this works

Allows varargs to be passed into `TxComplexity`. The visitor is re-used to avoid performing additional memory allocations.

## How this was tested

- [X] Added benchmark+unit test.