### PR TITLE
Enforce network config not including `PrimaryNetworkID` in `trackedSubnets`

### DIFF
--- a/network/config.go
+++ b/network/config.go
@@ -131,6 +131,7 @@ type Config struct {
 	BLSKey *bls.SecretKey `json:"-"`
 
 	// TrackedSubnets of the node.
+	// It must not include the primary network ID.
 	TrackedSubnets set.Set[ids.ID]    `json:"-"`
 	Beacons        validators.Manager `json:"-"`
 

--- a/network/network.go
+++ b/network/network.go
@@ -202,6 +202,10 @@ func NewNetwork(
 		}
 	}
 
+	if config.TrackedSubnets.Contains(constants.PrimaryNetworkID) {
+		return nil, fmt.Errorf("tracked subnets must not contain the primary network ID")
+	}
+
 	inboundMsgThrottler, err := throttling.NewInboundMsgThrottler(
 		log,
 		metricsRegisterer,

--- a/network/network.go
+++ b/network/network.go
@@ -51,10 +51,11 @@ const (
 var (
 	_ Network = (*network)(nil)
 
-	errNotValidator        = errors.New("node is not a validator")
-	errNotTracked          = errors.New("subnet is not tracked")
-	errExpectedProxy       = errors.New("expected proxy")
-	errExpectedTCPProtocol = errors.New("expected TCP protocol")
+	errNotValidator           = errors.New("node is not a validator")
+	errNotTracked             = errors.New("subnet is not tracked")
+	errExpectedProxy          = errors.New("expected proxy")
+	errExpectedTCPProtocol    = errors.New("expected TCP protocol")
+	errTrackingPrimaryNetwork = errors.New("cannot track primary network")
 )
 
 // Network defines the functionality of the networking library.
@@ -203,7 +204,7 @@ func NewNetwork(
 	}
 
 	if config.TrackedSubnets.Contains(constants.PrimaryNetworkID) {
-		return nil, fmt.Errorf("tracked subnets must not contain the primary network ID")
+		return nil, errTrackingPrimaryNetwork
 	}
 
 	inboundMsgThrottler, err := throttling.NewInboundMsgThrottler(


### PR DESCRIPTION
## Why this should be merged
`TrackedSubnets` should not include `constants.PrimaryNetworkID` this was previously just documented on `MySubnets` field of the [peer config](https://github.com/ava-labs/avalanchego/blob/4647158bffbb0134ea5677473587a767f24ee521/network/peer/config.go#L37). This makes the check explicit at network start and documents it on the network config. 

## How this works

- Makes `NewNetwork` return an error if network config contains `constants.PrimaryNetworkID`
- Adds a comment to the network config

## How this was tested
CI
