### PR TITLE
[ci] Configure buf-setup-action for check_generated_protobuf job with token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go-for-project
       - uses: bufbuild/buf-setup-action@v1.31.0
+        with:
+          github_token: ${{ github.token }}
       - shell: bash
         run: scripts/protobuf_codegen.sh
       - shell: bash


### PR DESCRIPTION
As per https://github.com/bufbuild/buf-setup-action?tab=readme-ov-file#github-token, this avoids the potential for jobs flaking from being rate-limited when downloading protobuf. The `buf-lint` job is already so-configured.
