### PR TITLE
[antithesis] Enable image build for multi-module repos

### DIFF
--- a/scripts/lib_build_antithesis_images.sh
+++ b/scripts/lib_build_antithesis_images.sh
@@ -26,8 +26,14 @@ function build_antithesis_builder_image {
     builder_dockerfile="${base_dockerfile}.builder-uninstrumented"
   fi
 
-  docker buildx build --build-arg GO_VERSION="${go_version}" --build-arg=MODULE_PATH="${module_path}" \
-         -t "${image_name}" -f "${builder_dockerfile}" "${target_path}"
+  BUILD_ARGS="--build-arg GO_VERSION=${go_version}"
+  if [[ -n "${module_path}" ]]; then
+    # Only set the module path if it is provided
+    BUILD_ARGS="${BUILD_ARGS} --build-arg MODULE_PATH=${module_path}"
+  fi
+
+  # shellcheck disable=SC2086
+  docker buildx build ${BUILD_ARGS} -t "${image_name}" -f "${builder_dockerfile}" "${target_path}"
 }
 
 # Build the antithesis node, workload, and config images.

--- a/tests/antithesis/Dockerfile.builder-instrumented
+++ b/tests/antithesis/Dockerfile.builder-instrumented
@@ -9,13 +9,18 @@ FROM docker.io/antithesishq/go-instrumentor AS instrumentor
 FROM golang:$GO_VERSION-bullseye
 
 WORKDIR /build
-# Copy and download dependencies using go mod
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
 
 # Copy the code into the container
 COPY . .
+
+# Providing a non-empty MODULE_PATH supports the case where the target module is
+# not at the root of the repo but its go.mod references other modules in the repo
+# (including the root).
+ARG MODULE_PATH=.
+
+# Download dependencies for the specified go module if a path was provided,
+# otherwise download dependencies for the current directory.
+RUN cd $MODULE_PATH && go mod download
 
 # Ensure pre-existing builds are not available for inclusion in the final image
 RUN [ -d ./build ] && rm -rf ./build/* || true
@@ -38,7 +43,7 @@ RUN cp -r .git /opt/tmp/
 RUN /opt/antithesis/bin/goinstrumentor \
     -stderrthreshold=INFO \
     -antithesis /opt/antithesis/instrumentation \
-    . \
+    $MODULE_PATH \
     /instrumented
 
 WORKDIR /instrumented/customer

--- a/tests/antithesis/Dockerfile.builder-uninstrumented
+++ b/tests/antithesis/Dockerfile.builder-uninstrumented
@@ -9,16 +9,14 @@ WORKDIR /build
 # Copy the code into the container
 COPY . .
 
-# Download dependencies of the main go module
-RUN go mod download
-
 # Providing a non-empty MODULE_PATH supports the case where the target module is
 # not at the root of the repo but its go.mod references other modules in the repo
 # (including the root).
-ARG MODULE_PATH
+ARG MODULE_PATH=.
 
-# Download dependencies for the specified go module if a path was provided
-RUN [ -n $MODULE_PATH ] && (cd $MODULE_PATH && go mod download) || true
+# Download dependencies for the specified go module if a path was provided,
+# otherwise download dependencies for the current directory.
+RUN cd $MODULE_PATH && go mod download
 
 # Ensure pre-existing builds are not available for inclusion in the final image
 RUN [ -d ./build ] && rm -rf ./build/* || true


### PR DESCRIPTION
## Why this should be merged

The proposed subnet-evm refactor requires that construction of the builder image support providing the path to the go module whose dependencies will be downloaded.

## How this works

- Update build_antithesis_builder_image helper to optionally accept the path to a non-root go module
- Download dependencies for that go module

## How this was tested

CI on this PR and the related subnet-evm PR (https://github.com/ava-labs/subnet-evm/pull/1314)