### PR TITLE
Include disconnected validators in health message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go-for-project
       - uses: bufbuild/buf-setup-action@v1.31.0
+        with:
+          github_token: ${{ github.token }}
       - shell: bash
         run: scripts/protobuf_codegen.sh
       - shell: bash

--- a/snow/engine/common/tracker/peers.go
+++ b/snow/engine/common/tracker/peers.go
@@ -38,7 +38,7 @@ type Peers interface {
 	// GetValidators returns the set of all validators
 	// known to this peer manager
 	GetValidators() set.Set[ids.NodeID]
-	// GetConnectedValidators returns the set of all validators
+	// ConnectedValidators returns the set of all validators
 	// that are currently connected
 	ConnectedValidators() set.Set[ids.NodeID]
 }

--- a/snow/engine/common/tracker/peers.go
+++ b/snow/engine/common/tracker/peers.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"
@@ -34,6 +35,12 @@ type Peers interface {
 	// SampleValidator returns a randomly selected connected validator. If there
 	// are no currently connected validators then it will return false.
 	SampleValidator() (ids.NodeID, bool)
+	// GetValidators returns the set of all validators
+	// known to this peer manager
+	GetValidators() set.Set[ids.NodeID]
+	// GetConnectedValidators returns the set of all validators
+	// that are currently connected
+	ConnectedValidators() set.Set[ids.NodeID]
 }
 
 type lockedPeers struct {
@@ -103,6 +110,20 @@ func (p *lockedPeers) SampleValidator() (ids.NodeID, bool) {
 	defer p.lock.RUnlock()
 
 	return p.peers.SampleValidator()
+}
+
+func (p *lockedPeers) GetValidators() set.Set[ids.NodeID] {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.peers.GetValidators()
+}
+
+func (p *lockedPeers) ConnectedValidators() set.Set[ids.NodeID] {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.peers.ConnectedValidators()
 }
 
 type meteredPeers struct {
@@ -249,4 +270,15 @@ func (p *peerData) ConnectedPercent() float64 {
 
 func (p *peerData) SampleValidator() (ids.NodeID, bool) {
 	return p.connectedValidators.Peek()
+}
+
+func (p *peerData) GetValidators() set.Set[ids.NodeID] {
+	vdrs := set.Of(maps.Keys(p.validators)...)
+	return vdrs
+}
+
+func (p *peerData) ConnectedValidators() set.Set[ids.NodeID] {
+	// copy in case
+	vdrs := set.Of(p.connectedValidators.List()...)
+	return vdrs
 }

--- a/snow/engine/common/tracker/peers.go
+++ b/snow/engine/common/tracker/peers.go
@@ -273,8 +273,7 @@ func (p *peerData) SampleValidator() (ids.NodeID, bool) {
 }
 
 func (p *peerData) GetValidators() set.Set[ids.NodeID] {
-	vdrs := set.Of(maps.Keys(p.validators)...)
-	return vdrs
+	return set.Of(maps.Keys(p.validators)...)
 }
 
 func (p *peerData) ConnectedValidators() set.Set[ids.NodeID] {

--- a/snow/networking/handler/health.go
+++ b/snow/networking/handler/health.go
@@ -43,7 +43,8 @@ func (h *handler) HealthCheck(ctx context.Context) (interface{}, error) {
 func (h *handler) networkHealthCheck() (interface{}, error) {
 	percentConnected := h.peerTracker.ConnectedPercent()
 	details := map[string]interface{}{
-		"percentConnected": percentConnected,
+		"percentConnected":       percentConnected,
+		"disconnectedValidators": h.getDisconnectedValidators(),
 	}
 
 	var err error
@@ -55,11 +56,6 @@ func (h *handler) networkHealthCheck() (interface{}, error) {
 			percentConnected*100,
 			minPercentConnected*100,
 		)
-	}
-
-	disconnectedVdrs := h.getDisconnectedValidators()
-	if disconnectedVdrs.Len() > 0 {
-		details["disconnectedValidators"] = disconnectedVdrs
 	}
 
 	return details, err

--- a/snow/networking/handler/health.go
+++ b/snow/networking/handler/health.go
@@ -57,7 +57,10 @@ func (h *handler) networkHealthCheck() (interface{}, error) {
 		)
 	}
 
-	details["disconnectedValidators"] = h.getDisconnectedValidators()
+	disconnectedVdrs := h.getDisconnectedValidators()
+	if disconnectedVdrs.Len() > 0 {
+		details["disconnectedValidators"] = disconnectedVdrs
+	}
 
 	return details, err
 }
@@ -65,13 +68,13 @@ func (h *handler) networkHealthCheck() (interface{}, error) {
 func (h *handler) getDisconnectedValidators() set.Set[ids.NodeID] {
 	allVdrs := h.peerTracker.GetValidators()
 	if allVdrs.Len() == 0 {
-		return set.NewSet[ids.NodeID](0)
+		return nil
 	}
 	connectedVdrs := h.peerTracker.ConnectedValidators()
 	if connectedVdrs.Len() == 0 {
 		return allVdrs
 	} else if connectedVdrs.Len() == allVdrs.Len() {
-		return set.NewSet[ids.NodeID](0)
+		return nil
 	}
 	// difference is disconnected validator
 	allVdrs.Difference(connectedVdrs)

--- a/snow/networking/handler/health.go
+++ b/snow/networking/handler/health.go
@@ -66,18 +66,9 @@ func (h *handler) networkHealthCheck() (interface{}, error) {
 }
 
 func (h *handler) getDisconnectedValidators() set.Set[ids.NodeID] {
-	allVdrs := h.peerTracker.GetValidators()
-	if allVdrs.Len() == 0 {
-		return nil
-	}
+	vdrs := h.peerTracker.GetValidators()
 	connectedVdrs := h.peerTracker.ConnectedValidators()
-	if connectedVdrs.Len() == 0 {
-		return allVdrs
-	} else if connectedVdrs.Len() == allVdrs.Len() {
-		return nil
-	}
-	// difference is disconnected validator
-	allVdrs.Difference(connectedVdrs)
-
-	return allVdrs
+	// vdrs - connectedVdrs is equal to the disconnectedVdrs
+	vdrs.Difference(connectedVdrs)
+	return vdrs
 }

--- a/snow/networking/handler/health_test.go
+++ b/snow/networking/handler/health_test.go
@@ -154,11 +154,16 @@ func TestHealthCheckSubnet(t *testing.T) {
 				require.True(ok)
 				networkingMap, ok := detailsMap["networking"]
 				require.True(ok)
-				networkingDetails, ok := networkingMap.(map[string]float64)
+				networkingDetails, ok := networkingMap.(map[string]interface{})
 				require.True(ok)
 				percentConnected, ok := networkingDetails["percentConnected"]
 				require.True(ok)
 				require.Equal(expectedPercentConnected, percentConnected)
+				disconnectedValidators, ok := networkingDetails["disconnectedValidators"]
+				require.True(ok)
+				vdrSet, ok := disconnectedValidators.(set.Set[ids.NodeID])
+				require.True(ok)
+				require.Equal(vdrSet.Len(), testVdrCount-index-1)
 			}
 		})
 	}


### PR DESCRIPTION
## Why this should be merged

Adds disconnected validators to the networking health message details. NodeIDs are sorted.

 Example:
```json
 "networking": {
    "disconnectedValidators": [
        "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
        "NodeID-GWPcbFJZFfZreETSoWjPimr846mXEKCtu",
        "NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ",
        "NodeID-P7oB2McjBGgW2NXXWVYjV8JEDFoW9xDE5"
    ],
    "percentConnected": 0.2
}
```

## How this works

adds a new field to the health check details and expand the peer Tracker interface.

## How this was tested

* added unit test
* tested in local network
