### PR TITLE
Print type of message sent in the verbose log

### DIFF
--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -594,6 +594,7 @@ func (p *peer) writeMessages() {
 func (p *peer) writeMessage(writer io.Writer, msg message.OutboundMessage) {
 	msgBytes := msg.Bytes()
 	p.Log.Verbo("sending message",
+		zap.String("op", msg.Op().String()),
 		zap.Stringer("nodeID", p.id),
 		zap.Binary("messageBytes", msgBytes),
 	)

--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -594,7 +594,7 @@ func (p *peer) writeMessages() {
 func (p *peer) writeMessage(writer io.Writer, msg message.OutboundMessage) {
 	msgBytes := msg.Bytes()
 	p.Log.Verbo("sending message",
-		zap.String("op", msg.Op().String()),
+		zap.Stringer("op", msg.Op()),
 		zap.Stringer("nodeID", p.id),
 		zap.Binary("messageBytes", msgBytes),
 	)


### PR DESCRIPTION
This commit adds the string representation of the message type to the verbose log that notifies about sending a message. Can be useful for troubleshooting issues and it gives better understanding about what the node is doing.

## Why this should be merged

Currently it's not possible to understand what type of messages a node is sending from observing the log, even at verbose level, because the log event doesn't contain the type of message.

## How this works
Just added the type of message to the log.

## How this was tested
No need to test, this is a trivial logging change. 