### PR TITLE
Separate codec registries by upgrade

### DIFF
--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -32,10 +32,11 @@ func init() {
 	errs := wrappers.Errs{}
 	for _, c := range []linearcodec.Codec{c, gc} {
 		errs.Add(
-			RegisterApricotBlockTypes(c),
-			txs.RegisterUnsignedTxsTypes(c),
-			RegisterBanffBlockTypes(c),
-			txs.RegisterDurangoUnsignedTxsTypes(c),
+			RegisterApricotTypes(c),
+			txs.RegisterApricotTypes(c),
+			txs.RegisterBanffTypes(c),
+			RegisterBanffTypes(c),
+			txs.RegisterDurangoTypes(c),
 		)
 	}
 
@@ -50,11 +51,9 @@ func init() {
 	}
 }
 
-// RegisterApricotBlockTypes allows registering relevant type of blocks package
-// in the right sequence. Following repackaging of platformvm package, a few
-// subpackage-level codecs were introduced, each handling serialization of
-// specific types.
-func RegisterApricotBlockTypes(targetCodec codec.Registry) error {
+// RegisterApricotTypes registers the type information for blocks that were
+// valid during the Apricot series of upgrades.
+func RegisterApricotTypes(targetCodec codec.Registry) error {
 	return errors.Join(
 		targetCodec.RegisterType(&ApricotProposalBlock{}),
 		targetCodec.RegisterType(&ApricotAbortBlock{}),
@@ -64,7 +63,9 @@ func RegisterApricotBlockTypes(targetCodec codec.Registry) error {
 	)
 }
 
-func RegisterBanffBlockTypes(targetCodec codec.Registry) error {
+// RegisterBanffTypes registers the type information for blocks that were valid
+// during the Banff series of upgrades.
+func RegisterBanffTypes(targetCodec codec.Registry) error {
 	return errors.Join(
 		targetCodec.RegisterType(&BanffProposalBlock{}),
 		targetCodec.RegisterType(&BanffAbortBlock{}),

--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -33,10 +33,8 @@ func init() {
 	for _, c := range []linearcodec.Codec{c, gc} {
 		errs.Add(
 			RegisterApricotTypes(c),
-			txs.RegisterApricotTypes(c),
-			txs.RegisterBanffTypes(c),
 			RegisterBanffTypes(c),
-			txs.RegisterDurangoTypes(c),
+			RegisterDurangoTypes(c),
 		)
 	}
 
@@ -53,23 +51,31 @@ func init() {
 
 // RegisterApricotTypes registers the type information for blocks that were
 // valid during the Apricot series of upgrades.
-func RegisterApricotTypes(targetCodec codec.Registry) error {
+func RegisterApricotTypes(targetCodec linearcodec.Codec) error {
 	return errors.Join(
 		targetCodec.RegisterType(&ApricotProposalBlock{}),
 		targetCodec.RegisterType(&ApricotAbortBlock{}),
 		targetCodec.RegisterType(&ApricotCommitBlock{}),
 		targetCodec.RegisterType(&ApricotStandardBlock{}),
 		targetCodec.RegisterType(&ApricotAtomicBlock{}),
+		txs.RegisterApricotTypes(targetCodec),
 	)
 }
 
 // RegisterBanffTypes registers the type information for blocks that were valid
 // during the Banff series of upgrades.
-func RegisterBanffTypes(targetCodec codec.Registry) error {
+func RegisterBanffTypes(targetCodec linearcodec.Codec) error {
 	return errors.Join(
+		txs.RegisterBanffTypes(targetCodec),
 		targetCodec.RegisterType(&BanffProposalBlock{}),
 		targetCodec.RegisterType(&BanffAbortBlock{}),
 		targetCodec.RegisterType(&BanffCommitBlock{}),
 		targetCodec.RegisterType(&BanffStandardBlock{}),
 	)
+}
+
+// RegisterDurangoTypes registers the type information for blocks that were
+// valid during the Durango series of upgrades.
+func RegisterDurangoTypes(targetCodec linearcodec.Codec) error {
+	return txs.RegisterDurangoTypes(targetCodec)
 }

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -38,11 +38,12 @@ func init() {
 		// we skip positions for the blocks.
 		c.SkipRegistrations(5)
 
-		errs.Add(RegisterUnsignedTxsTypes(c))
+		errs.Add(RegisterApricotTypes(c))
+		errs.Add(RegisterBanffTypes(c))
 
 		c.SkipRegistrations(4)
 
-		errs.Add(RegisterDurangoUnsignedTxsTypes(c))
+		errs.Add(RegisterDurangoTypes(c))
 	}
 
 	Codec = codec.NewDefaultManager()
@@ -56,14 +57,9 @@ func init() {
 	}
 }
 
-// RegisterUnsignedTxsTypes allows registering relevant type of unsigned package
-// in the right sequence. Following repackaging of platformvm package, a few
-// subpackage-level codecs were introduced, each handling serialization of
-// specific types.
-//
-// RegisterUnsignedTxsTypes is made exportable so to guarantee that other codecs
-// are coherent with components one.
-func RegisterUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
+// RegisterApricotTypes registers the type information for transactions that
+// were valid during the Apricot series of upgrades.
+func RegisterApricotTypes(targetCodec linearcodec.Codec) error {
 	errs := wrappers.Errs{}
 
 	// The secp256k1fx is registered here because this is the same place it is
@@ -90,8 +86,14 @@ func RegisterUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
 
 		targetCodec.RegisterType(&stakeable.LockIn{}),
 		targetCodec.RegisterType(&stakeable.LockOut{}),
+	)
+	return errs.Err
+}
 
-		// Banff additions:
+// RegisterBanffTypes registers the type information for transactions that were
+// valid during the Banff series of upgrades.
+func RegisterBanffTypes(targetCodec linearcodec.Codec) error {
+	return errors.Join(
 		targetCodec.RegisterType(&RemoveSubnetValidatorTx{}),
 		targetCodec.RegisterType(&TransformSubnetTx{}),
 		targetCodec.RegisterType(&AddPermissionlessValidatorTx{}),
@@ -100,10 +102,11 @@ func RegisterUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
 		targetCodec.RegisterType(&signer.Empty{}),
 		targetCodec.RegisterType(&signer.ProofOfPossession{}),
 	)
-	return errs.Err
 }
 
-func RegisterDurangoUnsignedTxsTypes(targetCodec linearcodec.Codec) error {
+// RegisterDurangoTypes registers the type information for transactions that
+// were valid during the Durango series of upgrades.
+func RegisterDurangoTypes(targetCodec linearcodec.Codec) error {
 	return errors.Join(
 		targetCodec.RegisterType(&TransferSubnetOwnershipTx{}),
 		targetCodec.RegisterType(&BaseTx{}),

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -38,8 +38,10 @@ func init() {
 		// we skip positions for the blocks.
 		c.SkipRegistrations(5)
 
-		errs.Add(RegisterApricotTypes(c))
-		errs.Add(RegisterBanffTypes(c))
+		errs.Add(
+			RegisterApricotTypes(c),
+			RegisterBanffTypes(c),
+		)
 
 		c.SkipRegistrations(4)
 


### PR DESCRIPTION
## Why this should be merged

The naming of `RegisterUnsignedTxsTypes` seemed misleading as it didn't register all transaction types, only the Aprioct and Banff tx types (not the Durango types). This PR separates this function into `RegisterApricotTypes` and `RegisterBanffTypes`.

Additionally the duplicate naming `block.Register.*BlockTypes` and `txs.Register.*UnsignedTxTypes` was simplified to `block.Register.*Types` and `txs.Register.*Types`

## How this works

This is a pure refactor.

## How this was tested

- [X] Existing CI