### PR TITLE
[tmpnet] Avoid calling Stat in advance of Read/Open

### DIFF
--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -77,14 +77,12 @@ func (p *NodeProcess) setProcessContext(processContext node.NodeProcessContext) 
 
 func (p *NodeProcess) readState() error {
 	path := p.getProcessContextPath()
-	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
+	bytes, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
 		// The absence of the process context file indicates the node is not running
 		p.setProcessContext(node.NodeProcessContext{})
 		return nil
-	}
-
-	bytes, err := os.ReadFile(path)
-	if err != nil {
+	} else if err != nil {
 		return fmt.Errorf("failed to read node process context: %w", err)
 	}
 	processContext := node.NodeProcessContext{}

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -339,14 +339,10 @@ func WaitForActiveValidators(
 
 // Reads subnets from [network dir]/subnets/[subnet name].json
 func readSubnets(subnetDir string) ([]*Subnet, error) {
-	if _, err := os.Stat(subnetDir); os.IsNotExist(err) {
+	entries, err := os.ReadDir(subnetDir)
+	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
-		return nil, err
-	}
-
-	entries, err := os.ReadDir(subnetDir)
-	if err != nil {
 		return nil, fmt.Errorf("failed to read subnet dir: %w", err)
 	}
 

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -6,6 +6,7 @@ package tmpnet
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -340,7 +341,7 @@ func WaitForActiveValidators(
 // Reads subnets from [network dir]/subnets/[subnet name].json
 func readSubnets(subnetDir string) ([]*Subnet, error) {
 	entries, err := os.ReadDir(subnetDir)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to read subnet dir: %w", err)


### PR DESCRIPTION
## Why this should be merged

Checking for a file/dir in advance of attempting to open it is redundant and invites race conditions where error handling is not duplicated:

https://github.com/ava-labs/avalanchego/actions/runs/10688505984/job/29628507363

## How this works

Removes calls to Stat in tmpnet code and ensures error handling for ErrNotExist in the calls to read a file or dir. 

## How this was tested

CI
