### PR TITLE
Add MerkleDB Snapshots

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1256,7 +1256,8 @@ func (db *merkleDB) maskChangesInSnapshots(changes *changeSummary) error {
 	reversedChanges := &changeSummary{
 		rootID: changes.rootID,
 		values: make(map[Key]*change[maybe.Maybe[[]byte]], len(changes.values)),
-		nodes:  make(map[Key]*change[*node], len(changes.nodes))}
+		nodes:  make(map[Key]*change[*node], len(changes.nodes)),
+	}
 	reversedChanges.rootChange = change[maybe.Maybe[*node]]{before: changes.rootChange.after, after: changes.rootChange.before}
 	for key, currentChange := range changes.values {
 		reversedChanges.values[key] = &change[maybe.Maybe[[]byte]]{before: currentChange.after, after: currentChange.before}

--- a/x/merkledb/mock_db.go
+++ b/x/merkledb/mock_db.go
@@ -346,6 +346,21 @@ func (mr *MockMerkleDBMockRecorder) NewIteratorWithStartAndPrefix(start, prefix 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIteratorWithStartAndPrefix", reflect.TypeOf((*MockMerkleDB)(nil).NewIteratorWithStartAndPrefix), start, prefix)
 }
 
+// NewSnapshot mocks base method.
+func (m *MockMerkleDB) NewSnapshot(revisionsLifetime int) (ReadOnlyTrie, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewSnapshot", revisionsLifetime)
+	ret0, _ := ret[0].(ReadOnlyTrie)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewSnapshot indicates an expected call of NewSnapshot.
+func (mr *MockMerkleDBMockRecorder) NewSnapshot(revisionsLifetime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSnapshot", reflect.TypeOf((*MockMerkleDB)(nil).NewSnapshot), revisionsLifetime)
+}
+
 // NewView mocks base method.
 func (m *MockMerkleDB) NewView(ctx context.Context, changes ViewChanges) (View, error) {
 	m.ctrl.T.Helper()

--- a/x/merkledb/snapshot.go
+++ b/x/merkledb/snapshot.go
@@ -1,0 +1,30 @@
+package merkledb
+
+import "context"
+
+var _ ReadOnlyTrie = (*snapshot)(nil)
+
+type snapshot struct {
+	revisionsLeft   int
+	innerView       *view
+	innermostParent *view
+}
+
+func (s *snapshot) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+	return s.innerView.GetValue(ctx, key)
+}
+
+func (s *snapshot) GetValues(ctx context.Context, keys [][]byte) ([][]byte, []error) {
+	return s.innerView.GetValues(ctx, keys)
+}
+
+// maskingChanges applies the changes in the changeSummary in reverse so that the snapshot stays consistent even though the underlying db has changed
+func (s *snapshot) updateParent(v *view) {
+	s.revisionsLeft--
+	if s.revisionsLeft == 0 {
+		s.innermostParent.invalidate()
+		return
+	}
+	s.innermostParent.updateParent(v)
+	s.innermostParent = v
+}

--- a/x/merkledb/snapshot.go
+++ b/x/merkledb/snapshot.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package merkledb
 
 import "context"

--- a/x/merkledb/snapshot_test.go
+++ b/x/merkledb/snapshot_test.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package merkledb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+)
+
+func Test_Snapshot_Basic(t *testing.T) {
+	require := require.New(t)
+
+	db, err := getBasicDB()
+	require.NoError(err)
+	ctx := context.Background()
+	view, err := db.NewView(
+		ctx,
+		ViewChanges{
+			BatchOps: []database.BatchOp{
+				{Key: []byte{0}, Value: []byte{0}},
+			},
+		},
+	)
+	require.NoError(err)
+	require.NoError(view.CommitToDB(ctx))
+
+	view, err = db.NewView(
+		ctx,
+		ViewChanges{
+			BatchOps: []database.BatchOp{
+				{Key: []byte{1}, Value: []byte{1}},
+			},
+		},
+	)
+	require.NoError(err)
+	require.NoError(view.CommitToDB(ctx))
+
+	snap, err := db.NewSnapshot(3)
+	require.NoError(err)
+
+	// confirm that the snapshot has the expected values
+	val, err := snap.GetValue(ctx, []byte{0})
+	require.NoError(err)
+	require.Equal([]byte{0}, val)
+
+	val, err = snap.GetValue(ctx, []byte{1})
+	require.NoError(err)
+	require.Equal([]byte{1}, val)
+
+	// commit new key/value
+	view, err = db.NewView(
+		ctx,
+		ViewChanges{
+			BatchOps: []database.BatchOp{
+				{Key: []byte{3}, Value: []byte{3}},
+			},
+		},
+	)
+	require.NoError(err)
+	require.NoError(view.CommitToDB(ctx))
+
+	// the snapshot should not contain the new value
+	_, err = snap.GetValue(ctx, []byte{3})
+	require.ErrorIs(err, database.ErrNotFound)
+
+	// write over existing key values
+	view, err = db.NewView(
+		ctx,
+		ViewChanges{
+			BatchOps: []database.BatchOp{
+				{Key: []byte{1}, Value: []byte{4}},
+			},
+		},
+	)
+	require.NoError(err)
+	require.NoError(view.CommitToDB(ctx))
+
+	// should still have the old value
+	val, err = snap.GetValue(ctx, []byte{1})
+	require.NoError(err)
+	require.Equal([]byte{1}, val)
+
+	// commit more to trigger view invalidation
+	view, err = db.NewView(
+		ctx,
+		ViewChanges{
+			BatchOps: []database.BatchOp{
+				{Key: []byte{4}, Value: []byte{4}},
+			},
+		},
+	)
+	require.NoError(err)
+	require.NoError(view.CommitToDB(ctx))
+
+	// too many revisions have passed and now the snapshot is invalid
+	_, err = snap.GetValue(ctx, []byte{1})
+	require.ErrorIs(err, ErrInvalid)
+}

--- a/x/merkledb/trie.go
+++ b/x/merkledb/trie.go
@@ -60,14 +60,7 @@ type Trie interface {
 	MerkleRootGetter
 	ProofGetter
 	database.Iteratee
-
-	// GetValue gets the value associated with the specified key
-	// database.ErrNotFound if the key is not present
-	GetValue(ctx context.Context, key []byte) ([]byte, error)
-
-	// GetValues gets the values associated with the specified keys
-	// database.ErrNotFound if the key is not present
-	GetValues(ctx context.Context, keys [][]byte) ([][]byte, []error)
+	ReadOnlyTrie
 
 	// GetRangeProof returns a proof of up to [maxLength] key-value pairs with
 	// keys in range [start, end].
@@ -82,6 +75,16 @@ type Trie interface {
 		ctx context.Context,
 		changes ViewChanges,
 	) (View, error)
+}
+
+type ReadOnlyTrie interface {
+	// GetValue gets the value associated with the specified key
+	// database.ErrNotFound if the key is not present
+	GetValue(ctx context.Context, key []byte) ([]byte, error)
+
+	// GetValues gets the values associated with the specified keys
+	// database.ErrNotFound if the key is not present
+	GetValues(ctx context.Context, keys [][]byte) ([][]byte, []error)
 }
 
 type View interface {


### PR DESCRIPTION
Creates snapshots in merkledb which creates readonly views of the database which, unlike views, remains valid as new changes are committed to the database.  They only stay valid for a certain number of revisions because otherwise they would live forever and never be cleaned up.