### PR TITLE
Align codec interface to exclusively use packers

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -14,7 +14,6 @@ var (
 	ErrMaxSliceLenExceeded       = errors.New("max slice length exceeded")
 	ErrDoesNotImplementInterface = errors.New("does not implement interface")
 	ErrUnexportedField           = errors.New("unexported field")
-	ErrExtraSpace                = errors.New("trailing buffer space")
 	ErrMarshalZeroLength         = errors.New("can't marshal zero length value")
 	ErrUnmarshalZeroLength       = errors.New("can't unmarshal zero length value")
 )
@@ -22,7 +21,6 @@ var (
 // Codec marshals and unmarshals
 type Codec interface {
 	MarshalInto(interface{}, *wrappers.Packer) error
-	Unmarshal([]byte, interface{}) error
 	UnmarshalFrom(*wrappers.Packer, interface{}) error
 
 	// Returns the size, in bytes, of [value] when it's marshaled

--- a/codec/reflectcodec/type_codec.go
+++ b/codec/reflectcodec/type_codec.go
@@ -496,25 +496,6 @@ func (c *genericCodec) marshal(
 	}
 }
 
-// Unmarshal unmarshals [bytes] into [dest], where [dest] must be a pointer or
-// interface
-func (c *genericCodec) Unmarshal(bytes []byte, dest interface{}) error {
-	p := wrappers.Packer{
-		Bytes: bytes,
-	}
-	if err := c.UnmarshalFrom(&p, dest); err != nil {
-		return err
-	}
-	if p.Offset != len(bytes) {
-		return fmt.Errorf("%w: read %d provided %d",
-			codec.ErrExtraSpace,
-			p.Offset,
-			len(bytes),
-		)
-	}
-	return nil
-}
-
 // UnmarshalFrom unmarshals [p.Bytes] into [dest], where [dest] must be a pointer or
 // interface
 func (c *genericCodec) UnmarshalFrom(p *wrappers.Packer, dest interface{}) error {


### PR DESCRIPTION
## Why this should be merged

Because the interface doesn't include a `Marshal` function, it feels very weird to have an `Unmarshal` function.

## How this works

Removes the `Unmarshal` function from the interface.

## How this was tested

- [X] Existing CI