### PR TITLE
Avoid including 'failed' in debug log messages

### DIFF
--- a/snow/engine/snowman/engine.go
+++ b/snow/engine/snowman/engine.go
@@ -587,7 +587,7 @@ func (e *Engine) sendChits(ctx context.Context, nodeID ids.NodeID, requestID uin
 			// Because we only return accepted state here, it's fairly likely
 			// that the requested height is higher than the last accepted block.
 			// That means that this code path is actually quite common.
-			e.Ctx.Log.Debug("failed fetching accepted block",
+			e.Ctx.Log.Debug("unable to retrieve accepted block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
@@ -615,7 +615,7 @@ func (e *Engine) sendChits(ctx context.Context, nodeID ids.NodeID, requestID uin
 			// Because it is possible for a byzantine node to spam requests at
 			// old heights on a pruning network, we log this as debug. However,
 			// this case is unexpected to be hit by correct peers.
-			e.Ctx.Log.Debug("failed fetching accepted block",
+			e.Ctx.Log.Debug("unable to retrieve accepted block",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),

--- a/snow/engine/snowman/engine.go
+++ b/snow/engine/snowman/engine.go
@@ -630,7 +630,7 @@ func (e *Engine) sendChits(ctx context.Context, nodeID ids.NodeID, requestID uin
 		var ok bool
 		preferenceAtHeight, ok = e.Consensus.PreferenceAtHeight(requestedHeight)
 		if !ok {
-			e.Ctx.Log.Debug("failed fetching processing block",
+			e.Ctx.Log.Debug("processing block not found",
 				zap.Stringer("nodeID", nodeID),
 				zap.Uint64("requestedHeight", requestedHeight),
 				zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),


### PR DESCRIPTION
When using logs to diagnose a problem, 'failed' would ideally be reserved for a serious problem rather than something that occurs commonly.