### PR TITLE
Disable Etna by default on local networks

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -70,7 +70,9 @@ var (
 		CortinaTime:                  InitiallyActiveTime,
 		CortinaXChainStopVertexID:    ids.Empty,
 		DurangoTime:                  InitiallyActiveTime,
-		EtnaTime:                     InitiallyActiveTime,
+		// Etna is left unactivated by default on local networks. It can be configured to
+		// activate by overriding the activation time in the upgrade file.
+		EtnaTime: UnscheduledActivationTime,
 	}
 
 	ErrInvalidUpgradeTimes = errors.New("invalid upgrade configuration")


### PR DESCRIPTION
## Why this should be merged
When running a local network, the Etna changes should not be activated by default until they are more stable (i.e. activated on Fuji). Otherwise, the local network may break when updating to future AvalancheGo versions.

## How this works
Self explanatory

## How this was tested
Built and ran `/build/avalanchego --network-id=12345`. Confirmed activation timestamps using
```
curl --location 'http://localhost:9650/ext/info' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc":"2.0",
    "id"     :1,
    "method" :"info.upgrades"
}'
```