### PR TITLE
[anitithesis] increase number of keys from 5 to 6

### DIFF
--- a/tests/antithesis/avalanchego/gencomposeconfig/main.go
+++ b/tests/antithesis/avalanchego/gencomposeconfig/main.go
@@ -7,14 +7,16 @@ import (
 	"log"
 
 	"github.com/ava-labs/avalanchego/tests/antithesis"
-	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 )
 
-const baseImageName = "antithesis-avalanchego"
+const (
+	baseImageName = "antithesis-avalanchego"
+	NumNodes      = 6
+)
 
 // Creates docker-compose.yml and its associated volumes in the target path.
 func main() {
-	network := tmpnet.LocalNetworkOrPanic()
+	network := antithesis.CreateNetwork(NumNodes)
 	if err := antithesis.GenerateComposeConfig(network, baseImageName, "" /* runtimePluginDir */); err != nil {
 		log.Fatalf("failed to generate compose config: %v", err)
 	}

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -39,7 +39,7 @@ import (
 	xbuilder "github.com/ava-labs/avalanchego/wallet/chain/x/builder"
 )
 
-const NumKeys = 5
+const NumKeys = 6
 
 func main() {
 	tc := tests.NewTestContext()

--- a/tests/antithesis/network.go
+++ b/tests/antithesis/network.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package antithesis
+
+import (
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+)
+
+// Creates a network with the given number of nodes.
+func CreateNetwork(nodesCount int) *tmpnet.Network {
+	network := tmpnet.NewDefaultNetwork("antithesis-network")
+	network.Nodes = tmpnet.NewNodesOrPanic(nodesCount)
+	return network
+}

--- a/tests/antithesis/xsvm/gencomposeconfig/main.go
+++ b/tests/antithesis/xsvm/gencomposeconfig/main.go
@@ -12,11 +12,14 @@ import (
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 )
 
-const baseImageName = "antithesis-xsvm"
+const (
+	baseImageName = "antithesis-xsvm"
+	NumNodes      = 6
+)
 
 // Creates docker-compose.yml and its associated volumes in the target path.
 func main() {
-	network := tmpnet.LocalNetworkOrPanic()
+	network := antithesis.CreateNetwork(NumNodes)
 	network.Subnets = []*tmpnet.Subnet{
 		subnet.NewXSVMOrPanic("xsvm", genesis.VMRQKey, network.Nodes...),
 	}

--- a/tests/antithesis/xsvm/main.go
+++ b/tests/antithesis/xsvm/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	NumKeys         = 5
+	NumKeys         = 6
 	PollingInterval = 50 * time.Millisecond
 )
 


### PR DESCRIPTION
## Why this should be merged

Increasing the number of nodes from 5 to 6 would allow us to test the 50% case and it's recovery.

## How this works

trivial

## How this was tested

CI.