### PR TITLE
Log a fatal before exit if node cannot be created

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -71,6 +71,7 @@ func New(config node.Config) (App, error) {
 
 	n, err := node.New(&config, logFactory, log)
 	if err != nil {
+		log.Fatal("failed to initialize node", zap.Error(err))
 		log.Stop()
 		logFactory.Close()
 		return nil, fmt.Errorf("failed to initialize node: %w", err)


### PR DESCRIPTION
## Why this should be merged

Currently, if AvalancheGo runs into a fatal error when initializing the node, it will return that error and propagate it to main. This will print it to stdout, but does not show up in `main.log`, which makes it more difficult to discover the error when using setups like `tmpnet` where stdout may not be collected.

For example, if you run a node and try to listen on a port that's already taken then the error is printed to stdout, but does not show up in `main.log`, which looks like this:

```
scode/.tmpnet/networks/20240909-154939.215011-morpheusvm-e2e-tests/NodeID-D8he6uMyi5bdNADZLtSMJVWao1gyfz4N4/chainData","processContextFilePath":"/home/vscode/.tmpnet/networks/20240909-154939.215011-morpheusvm-e2e-tests/NodeID-D8he6uMyi5bdNADZLtSMJVWao1gyfz4N4/process.json"}}
[09-09|15:49:39.367] INFO node/node.go:952 initializing NAT
[09-09|15:49:39.367] INFO node/node.go:970 initializing API server
```

## How this works

This PR updates AvalancheGo app `Run` to log a fatal error if the node cannot be initialized correctly.

## How this was tested

Tested locally running two nodes trying to listen on the same port correctly adds the error to `main.log`:

```
[09-09|12:06:48.157] INFO node/node.go:970 initializing API server
[09-09|12:06:48.158] FATAL app/app.go:74 failed to initialize node {"error": "couldn't initialize API server: listen tcp 127.0.0.1:9650: bind: address already in use"}
```