### PR TITLE
Replace iterator equality helper

### DIFF
--- a/utils/iterator/slice.go
+++ b/utils/iterator/slice.go
@@ -5,6 +5,18 @@ package iterator
 
 var _ Iterator[any] = (*slice[any])(nil)
 
+// ToSlice returns a slice that contains all of the elements from [it] in order.
+// [it] will be released before returning.
+func ToSlice[T any](it Iterator[T]) []T {
+	defer it.Release()
+
+	var elements []T
+	for it.Next() {
+		elements = append(elements, it.Value())
+	}
+	return elements
+}
+
 type slice[T any] struct {
 	index    int
 	elements []T

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/iterator"
 	"github.com/ava-labs/avalanchego/utils/iterator/iteratormock"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
@@ -530,14 +531,20 @@ func assertChainsEqual(t *testing.T, expected, actual Chain) {
 	actualCurrentStakerIterator, actualErr := actual.GetCurrentStakerIterator()
 	require.Equal(expectedErr, actualErr)
 	if expectedErr == nil {
-		assertIteratorsEqual(t, expectedCurrentStakerIterator, actualCurrentStakerIterator)
+		require.Equal(
+			iterator.ToSlice(expectedCurrentStakerIterator),
+			iterator.ToSlice(actualCurrentStakerIterator),
+		)
 	}
 
 	expectedPendingStakerIterator, expectedErr := expected.GetPendingStakerIterator()
 	actualPendingStakerIterator, actualErr := actual.GetPendingStakerIterator()
 	require.Equal(expectedErr, actualErr)
 	if expectedErr == nil {
-		assertIteratorsEqual(t, expectedPendingStakerIterator, actualPendingStakerIterator)
+		require.Equal(
+			iterator.ToSlice(expectedPendingStakerIterator),
+			iterator.ToSlice(actualPendingStakerIterator),
+		)
 	}
 
 	require.Equal(expected.GetTimestamp(), actual.GetTimestamp())

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -88,18 +88,25 @@ func TestStateSyncGenesis(t *testing.T) {
 
 	delegatorIterator, err := state.GetCurrentDelegatorIterator(constants.PrimaryNetworkID, defaultValidatorNodeID)
 	require.NoError(err)
-	assertIteratorsEqual(t, iterator.Empty[*Staker]{}, delegatorIterator)
+	require.Empty(
+		iterator.ToSlice(delegatorIterator),
+	)
 
 	stakerIterator, err := state.GetCurrentStakerIterator()
 	require.NoError(err)
-	assertIteratorsEqual(t, iterator.FromSlice(staker), stakerIterator)
+	require.Equal(
+		[]*Staker{staker},
+		iterator.ToSlice(stakerIterator),
+	)
 
 	_, err = state.GetPendingValidator(constants.PrimaryNetworkID, defaultValidatorNodeID)
 	require.ErrorIs(err, database.ErrNotFound)
 
 	delegatorIterator, err = state.GetPendingDelegatorIterator(constants.PrimaryNetworkID, defaultValidatorNodeID)
 	require.NoError(err)
-	assertIteratorsEqual(t, iterator.Empty[*Staker]{}, delegatorIterator)
+	require.Empty(
+		iterator.ToSlice(delegatorIterator),
+	)
 }
 
 // Whenever we store a staker, a whole bunch a data structures are updated


### PR DESCRIPTION
## Why this should be merged

ACP-77 will be introducing additional iterators (of different types), this mechanism for checking equality works better as it uses generics.

## How this works

- Added an `iterator.ToSlice` function.
- Removed `assertIteratorsEqual`.

## How this was tested

Existing CI