### PR TITLE
Use math.Ln2 where possible

### DIFF
--- a/utils/math/continuous_averager.go
+++ b/utils/math/continuous_averager.go
@@ -8,8 +8,6 @@ import (
 	"time"
 )
 
-var convertEToBase2 = math.Log(2)
-
 type continuousAverager struct {
 	halflife    float64
 	weightedSum float64
@@ -34,7 +32,7 @@ func NewAverager(
 	currentTime time.Time,
 ) Averager {
 	return &continuousAverager{
-		halflife:    float64(halflife) / convertEToBase2,
+		halflife:    float64(halflife) / math.Ln2,
 		weightedSum: initialPrediction,
 		normalizer:  1,
 		lastUpdated: currentTime,

--- a/utils/math/meter/continuous_meter.go
+++ b/utils/math/meter/continuous_meter.go
@@ -9,8 +9,6 @@ import (
 )
 
 var (
-	convertEToBase2 = math.Log(2)
-
 	_ Factory = (*ContinuousFactory)(nil)
 	_ Meter   = (*continuousMeter)(nil)
 )
@@ -34,7 +32,7 @@ type continuousMeter struct {
 // NewMeter returns a new Meter with the provided halflife
 func NewMeter(halflife time.Duration) Meter {
 	return &continuousMeter{
-		halflife: float64(halflife) / convertEToBase2,
+		halflife: float64(halflife) / math.Ln2,
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

Didn't know there was a constant in the stdlib for this.

Update: I apparently did know this... As we've used it before... But now we can use it everywhere!

## How this works

Use the constant.

## How this was tested

- [X] Existing unit tests