### PR TITLE
Upgrade e2e test cchain

### DIFF
--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -4,8 +4,6 @@
 package upgrade
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"testing"
@@ -13,10 +11,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
-	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 )
 
 func TestUpgrade(t *testing.T) {
@@ -54,16 +50,6 @@ var _ = ginkgo.Describe("[Upgrade]", func() {
 		genesis, err := network.DefaultGenesis()
 		require.NoError(err)
 		network.Genesis = genesis
-
-		// Configure network upgrade flag
-		latestUnscheduled := upgradetest.GetConfig(upgradetest.Latest - 1)
-		upgradeJSON, err := json.Marshal(latestUnscheduled)
-		require.NoError(err)
-		upgradeBase64 := base64.StdEncoding.EncodeToString(upgradeJSON)
-		if network.DefaultFlags == nil {
-			network.DefaultFlags = tmpnet.FlagsMap{}
-		}
-		network.DefaultFlags[config.UpgradeFileContentKey] = upgradeBase64
 
 		e2e.StartNetwork(tc, network, avalancheGoExecPath, "" /* pluginDir */, 0 /* shutdownDelay */, false /* reuseNetwork */)
 


### PR DESCRIPTION
#3364 disables Etna from Default config. We don't need to explicitly disable it in network flags.
