### PR TITLE
remove state commit on disconnect

### DIFF
--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -487,9 +487,6 @@ func (vm *VM) Disconnected(ctx context.Context, nodeID ids.NodeID) error {
 	if err := vm.uptimeManager.Disconnect(nodeID); err != nil {
 		return err
 	}
-	if err := vm.state.Commit(); err != nil {
-		return err
-	}
 	return vm.Network.Disconnected(ctx, nodeID)
 }
 


### PR DESCRIPTION
## Why this should be merged

Committing state adds an overhead on peer disconnects

## How this works

Removes state commit from disconnect. Block acceptance/Shutdown should be sufficient for writing disk to the state.

## How this was tested

existing UTs should cover this
