### PR TITLE
chore: remove redundant symbol in tests/antithesis/README.md

### DIFF
--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -116,7 +116,7 @@ directory will appear in the output of the script:
 
 ```
 ...
-using temporary directory /tmp/tmp.E6eHdDr4ln as the docker compose path"
+using temporary directory /tmp/tmp.E6eHdDr4ln as the docker compose path
 ...
 ```
 


### PR DESCRIPTION
## Why this should be merged

remove redundant symbol in tests/antithesis/README.md

## How this works

## How this was tested
