### PR TITLE
ACP-77: Update `SecondsUntil` to prevent under-charging

### DIFF
--- a/vms/platformvm/validators/fee/fee.go
+++ b/vms/platformvm/validators/fee/fee.go
@@ -91,10 +91,10 @@ func (s State) CostOf(c Config, seconds uint64) uint64 {
 	return cost
 }
 
-// SecondsUntil calculates the maximum number of seconds that a validator can
-// pay fees before their [costLimit] would be exceeded based on the dynamic fee
-// mechanism. The result is capped at [maxSeconds].
-func (s State) SecondsUntil(c Config, maxSeconds uint64, costLimit uint64) uint64 {
+// SecondsRemaining calculates the maximum number of seconds that a validator
+// can pay fees before their [costLimit] would be exceeded based on the dynamic
+// fee mechanism. The result is capped at [maxSeconds].
+func (s State) SecondsRemaining(c Config, maxSeconds uint64, costLimit uint64) uint64 {
 	// Because this function can divide by prices, we need to sanity check the
 	// parameters to avoid division by 0.
 	if c.MinPrice == 0 {

--- a/vms/platformvm/validators/fee/fee.go
+++ b/vms/platformvm/validators/fee/fee.go
@@ -43,7 +43,7 @@ func (s State) AdvanceTime(target gas.Gas, seconds uint64) State {
 }
 
 // CostOf calculates how much to charge based on the dynamic fee mechanism for
-// [seconds].
+// seconds.
 //
 // This implements the ACP-77 cost over time formula:
 func (s State) CostOf(c Config, seconds uint64) uint64 {
@@ -92,8 +92,8 @@ func (s State) CostOf(c Config, seconds uint64) uint64 {
 }
 
 // SecondsRemaining calculates the maximum number of seconds that a validator
-// can pay fees before their [costLimit] would be exceeded based on the dynamic
-// fee mechanism. The result is capped at [maxSeconds].
+// can pay fees before their costLimit would be exceeded based on the dynamic
+// fee mechanism. The result is capped at maxSeconds.
 func (s State) SecondsRemaining(c Config, maxSeconds uint64, costLimit uint64) uint64 {
 	// Because this function can divide by prices, we need to sanity check the
 	// parameters to avoid division by 0.

--- a/vms/platformvm/validators/fee/fee.go
+++ b/vms/platformvm/validators/fee/fee.go
@@ -91,35 +91,24 @@ func (s State) CostOf(c Config, seconds uint64) uint64 {
 	return cost
 }
 
-// SecondsUntil calculates the number of seconds that it would take to charge at
-// least [targetCost] based on the dynamic fee mechanism. The result is capped
-// at [maxSeconds].
-func (s State) SecondsUntil(c Config, maxSeconds uint64, targetCost uint64) uint64 {
+// SecondsUntil calculates the maximum number of seconds that a validator can
+// pay fees before their [costLimit] would be exceeded based on the dynamic fee
+// mechanism. The result is capped at [maxSeconds].
+func (s State) SecondsUntil(c Config, maxSeconds uint64, costLimit uint64) uint64 {
 	// Because this function can divide by prices, we need to sanity check the
 	// parameters to avoid division by 0.
 	if c.MinPrice == 0 {
-		if targetCost == 0 {
-			return 0
-		}
 		return maxSeconds
 	}
 
 	// If the current and target are the same, the price is constant.
 	if s.Current == c.Target {
-		price := gas.CalculatePrice(c.MinPrice, s.Excess, c.ExcessConversionConstant)
-		return secondsUntil(
-			uint64(price),
-			maxSeconds,
-			targetCost,
-		)
+		price := uint64(gas.CalculatePrice(c.MinPrice, s.Excess, c.ExcessConversionConstant))
+		seconds := costLimit / price
+		return min(seconds, maxSeconds)
 	}
 
-	var (
-		cost    uint64
-		seconds uint64
-		err     error
-	)
-	for cost < targetCost && seconds < maxSeconds {
+	for seconds := uint64(0); seconds < maxSeconds; seconds++ {
 		s = s.AdvanceTime(c.Target, 1)
 
 		// Advancing the time is going to either hold excess constant,
@@ -127,41 +116,21 @@ func (s State) SecondsUntil(c Config, maxSeconds uint64, targetCost uint64) uint
 		// equal to 0 after performing one of these operations, it is guaranteed
 		// to always remain 0.
 		if s.Excess == 0 {
-			zeroExcessCost := targetCost - cost
-			secondsWithZeroExcess := secondsUntil(
-				uint64(c.MinPrice),
-				maxSeconds,
-				zeroExcessCost,
-			)
-
+			secondsWithZeroExcess := costLimit / uint64(c.MinPrice)
 			totalSeconds, err := safemath.Add(seconds, secondsWithZeroExcess)
-			if err != nil || totalSeconds >= maxSeconds {
+			if err != nil {
+				// This is technically unreachable, but makes the code more
+				// clearly correct.
 				return maxSeconds
 			}
-			return totalSeconds
+			return min(totalSeconds, maxSeconds)
 		}
 
-		seconds++
-		price := gas.CalculatePrice(c.MinPrice, s.Excess, c.ExcessConversionConstant)
-		cost, err = safemath.Add(cost, uint64(price))
-		if err != nil {
+		price := uint64(gas.CalculatePrice(c.MinPrice, s.Excess, c.ExcessConversionConstant))
+		if price > costLimit {
 			return seconds
 		}
+		costLimit -= price
 	}
-	return seconds
-}
-
-// Calculate the number of seconds that it would take to charge at least [cost]
-// at [price] every second. The result is capped at [maxSeconds].
-func secondsUntil(price uint64, maxSeconds uint64, cost uint64) uint64 {
-	// Directly rounding up could cause an overflow. Instead we round down and
-	// then check if we should have rounded up.
-	secondsRoundedDown := cost / price
-	if secondsRoundedDown >= maxSeconds {
-		return maxSeconds
-	}
-	if cost%price == 0 {
-		return secondsRoundedDown
-	}
-	return secondsRoundedDown + 1
+	return maxSeconds
 }

--- a/vms/platformvm/validators/fee/fee.go
+++ b/vms/platformvm/validators/fee/fee.go
@@ -92,9 +92,9 @@ func (s State) CostOf(c Config, seconds uint64) uint64 {
 }
 
 // SecondsRemaining calculates the maximum number of seconds that a validator
-// can pay fees before their costLimit would be exceeded based on the dynamic
-// fee mechanism. The result is capped at maxSeconds.
-func (s State) SecondsRemaining(c Config, maxSeconds uint64, costLimit uint64) uint64 {
+// can pay fees before their fundsRemaining would be exhausted based on the
+// dynamic fee mechanism. The result is capped at maxSeconds.
+func (s State) SecondsRemaining(c Config, maxSeconds uint64, fundsRemaining uint64) uint64 {
 	// Because this function can divide by prices, we need to sanity check the
 	// parameters to avoid division by 0.
 	if c.MinPrice == 0 {
@@ -104,7 +104,7 @@ func (s State) SecondsRemaining(c Config, maxSeconds uint64, costLimit uint64) u
 	// If the current and target are the same, the price is constant.
 	if s.Current == c.Target {
 		price := uint64(gas.CalculatePrice(c.MinPrice, s.Excess, c.ExcessConversionConstant))
-		seconds := costLimit / price
+		seconds := fundsRemaining / price
 		return min(seconds, maxSeconds)
 	}
 
@@ -116,7 +116,7 @@ func (s State) SecondsRemaining(c Config, maxSeconds uint64, costLimit uint64) u
 		// equal to 0 after performing one of these operations, it is guaranteed
 		// to always remain 0.
 		if s.Excess == 0 {
-			secondsWithZeroExcess := costLimit / uint64(c.MinPrice)
+			secondsWithZeroExcess := fundsRemaining / uint64(c.MinPrice)
 			totalSeconds, err := safemath.Add(seconds, secondsWithZeroExcess)
 			if err != nil {
 				// This is technically unreachable, but makes the code more
@@ -127,10 +127,10 @@ func (s State) SecondsRemaining(c Config, maxSeconds uint64, costLimit uint64) u
 		}
 
 		price := uint64(gas.CalculatePrice(c.MinPrice, s.Excess, c.ExcessConversionConstant))
-		if price > costLimit {
+		if price > fundsRemaining {
 			return seconds
 		}
-		costLimit -= price
+		fundsRemaining -= price
 	}
 	return maxSeconds
 }

--- a/vms/platformvm/validators/fee/fee_test.go
+++ b/vms/platformvm/validators/fee/fee_test.go
@@ -551,15 +551,15 @@ func (s State) unoptimizedCostOf(c Config, seconds uint64) uint64 {
 
 // unoptimizedSecondsRemaining is a naive implementation of SecondsRemaining
 // that is used for differential fuzzing.
-func (s State) unoptimizedSecondsRemaining(c Config, maxSeconds uint64, costLimit uint64) uint64 {
+func (s State) unoptimizedSecondsRemaining(c Config, maxSeconds uint64, fundsRemaining uint64) uint64 {
 	for seconds := uint64(0); seconds < maxSeconds; seconds++ {
 		s = s.AdvanceTime(c.Target, 1)
 
 		price := uint64(gas.CalculatePrice(c.MinPrice, s.Excess, c.ExcessConversionConstant))
-		if price > costLimit {
+		if price > fundsRemaining {
 			return seconds
 		}
-		costLimit -= price
+		fundsRemaining -= price
 	}
 	return maxSeconds
 }

--- a/vms/platformvm/validators/fee/fee_test.go
+++ b/vms/platformvm/validators/fee/fee_test.go
@@ -478,7 +478,7 @@ func FuzzStateCostOf(f *testing.F) {
 				MinPrice:                 gas.Price(minPrice),
 				ExcessConversionConstant: gas.Gas(max(excessConversionConstant, 1)),
 			}
-			seconds = min(seconds, week)
+			seconds = min(seconds, hour)
 			require.Equal(
 				t,
 				s.unoptimizedCostOf(c, seconds),
@@ -496,7 +496,7 @@ func FuzzStateSecondsRemaining(f *testing.F) {
 			uint64(test.config.Target),
 			uint64(test.config.MinPrice),
 			uint64(test.config.ExcessConversionConstant),
-			uint64(week),
+			uint64(hour),
 			test.expectedCost,
 		)
 	}
@@ -520,7 +520,7 @@ func FuzzStateSecondsRemaining(f *testing.F) {
 				MinPrice:                 gas.Price(minPrice),
 				ExcessConversionConstant: gas.Gas(max(excessConversionConstant, 1)),
 			}
-			maxSeconds = min(maxSeconds, week)
+			maxSeconds = min(maxSeconds, hour)
 			require.Equal(
 				t,
 				s.unoptimizedSecondsRemaining(c, maxSeconds, targetCost),


### PR DESCRIPTION
## Why this should be merged

Undercharging -> DoS
Overcharging -> Happy

Also limits fuzzing to an hour rather than a year. With race detection enabled, running for a full year can take too long.

## How this works

`SecondsUntil` -> `SecondsRemaining`

The block timestamp must only be able to advance to a point that validators are fully paying for that time.

## How this was tested

- [X] Updated unit tests