### PR TITLE
Fix node initialization in snowman test

### DIFF
--- a/snow/consensus/snowman/network_test.go
+++ b/snow/consensus/snowman/network_test.go
@@ -74,26 +74,11 @@ func (n *Network) AddNode(t testing.TB, sm Consensus) error {
 	}
 
 	n.shuffleColors()
-	deps := map[ids.ID]ids.ID{}
 	for _, blk := range n.colors {
-		myDep, found := deps[blk.ParentV]
-		if !found {
-			myDep = blk.Parent()
-		}
-		myBlock := &snowmantest.Block{
-			Decidable: snowtest.Decidable{
-				IDV:    blk.ID(),
-				Status: blk.Status,
-			},
-			ParentV: myDep,
-			HeightV: blk.Height(),
-			VerifyV: blk.Verify(context.Background()),
-			BytesV:  blk.Bytes(),
-		}
-		if err := sm.Add(myBlock); err != nil {
+		copiedBlk := *blk
+		if err := sm.Add(&copiedBlk); err != nil {
 			return err
 		}
-		deps[myBlock.ID()] = myDep
 	}
 	n.nodes = append(n.nodes, sm)
 	n.running = append(n.running, sm)


### PR DESCRIPTION
## Why this should be merged

The topological consensus tests were supposed to have the instances initialized with a random tree of blocks, where each block points to a random set of descendants.

Instead, because of a bug that influenced the parent reference, the blocks were added to the consensus instance as a single block with the rest of the blocks as descendants.

That's not what we want to test, so this commit fixes this and further simplifies the initialization logic.

## How this works

Properly sets the parent of the block.


