### PR TITLE
Simplify common.Engine API

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -888,6 +888,8 @@ func (m *manager) createAvalancheChain(
 		return nil, err
 	}
 
+	var halter common.Halter
+
 	// Asynchronously passes messages from the network to the consensus engine
 	h, err := handler.New(
 		ctx,
@@ -900,6 +902,7 @@ func (m *manager) createAvalancheChain(
 		connectedValidators,
 		peerTracker,
 		handlerReg,
+		halter.Halt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing network handler: %w", err)
@@ -950,6 +953,7 @@ func (m *manager) createAvalancheChain(
 
 	// create bootstrap gear
 	bootstrapCfg := smbootstrap.Config{
+		ShouldHalt:                     halter.Halted,
 		NonVerifyingParse:              block.ParseFunc(proposerVM.ParseLocalBlock),
 		AllGetsServer:                  snowGetHandler,
 		Ctx:                            ctx,
@@ -1012,7 +1016,8 @@ func (m *manager) createAvalancheChain(
 		avalancheBootstrapperConfig.StopVertexID = m.Upgrades.CortinaXChainStopVertexID
 	}
 
-	avalancheBootstrapper, err := avbootstrap.New(
+	var avalancheBootstrapper common.BootstrapableEngine
+	avalancheBootstrapper, err = avbootstrap.New(
 		avalancheBootstrapperConfig,
 		snowmanBootstrapper.Start,
 		avalancheMetrics,
@@ -1277,6 +1282,8 @@ func (m *manager) createSnowmanChain(
 		return nil, err
 	}
 
+	var halter common.Halter
+
 	// Asynchronously passes messages from the network to the consensus engine
 	h, err := handler.New(
 		ctx,
@@ -1289,6 +1296,7 @@ func (m *manager) createSnowmanChain(
 		connectedValidators,
 		peerTracker,
 		handlerReg,
+		halter.Halt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't initialize message handler: %w", err)
@@ -1340,6 +1348,7 @@ func (m *manager) createSnowmanChain(
 
 	// create bootstrap gear
 	bootstrapCfg := smbootstrap.Config{
+		ShouldHalt:                     halter.Halted,
 		NonVerifyingParse:              block.ParseFunc(proposerVM.ParseLocalBlock),
 		AllGetsServer:                  snowGetHandler,
 		Ctx:                            ctx,

--- a/snow/engine/common/engine.go
+++ b/snow/engine/common/engine.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/health"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
@@ -22,9 +21,6 @@ import (
 // required.
 type Engine interface {
 	Handler
-
-	// Return the context of the chain this engine is working on
-	Context() *snow.ConsensusContext
 
 	// Start engine operations from given request ID
 	Start(ctx context.Context, startReqID uint32) error
@@ -424,14 +420,6 @@ type InternalHandler interface {
 
 	// Gossip to the network a container on the accepted frontier
 	Gossip(context.Context) error
-
-	// Halt this engine.
-	//
-	// This function will be called before the environment starts exiting. This
-	// function is special, in that it does not expect the chain's context lock
-	// to be held before calling this function. This function also does not
-	// require the engine to have been started.
-	Halt(context.Context)
 
 	// Shutdown this engine.
 	//

--- a/snow/engine/common/halter.go
+++ b/snow/engine/common/halter.go
@@ -3,15 +3,12 @@
 
 package common
 
-import (
-	"context"
-	"sync/atomic"
-)
+import "sync/atomic"
 
 var _ Haltable = (*Halter)(nil)
 
 type Haltable interface {
-	Halt(context.Context)
+	Halt()
 	Halted() bool
 }
 
@@ -19,7 +16,7 @@ type Halter struct {
 	halted uint32
 }
 
-func (h *Halter) Halt(context.Context) {
+func (h *Halter) Halt() {
 	atomic.StoreUint32(&h.halted, 1)
 }
 

--- a/snow/engine/common/no_ops_handlers.go
+++ b/snow/engine/common/no_ops_handlers.go
@@ -355,13 +355,6 @@ func (nop *noOpInternalHandler) Gossip(context.Context) error {
 	return nil
 }
 
-func (nop *noOpInternalHandler) Halt(context.Context) {
-	nop.log.Debug("dropping request",
-		zap.String("reason", "unhandled by this gear"),
-		zap.String("messageOp", "halt"),
-	)
-}
-
 func (nop *noOpInternalHandler) Shutdown(context.Context) error {
 	nop.log.Debug("dropping request",
 		zap.String("reason", "unhandled by this gear"),

--- a/snow/engine/common/traced_engine.go
+++ b/snow/engine/common/traced_engine.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
@@ -344,13 +343,6 @@ func (e *tracedEngine) Gossip(ctx context.Context) error {
 	return e.engine.Gossip(ctx)
 }
 
-func (e *tracedEngine) Halt(ctx context.Context) {
-	ctx, span := e.tracer.Start(ctx, "tracedEngine.Halt")
-	defer span.End()
-
-	e.engine.Halt(ctx)
-}
-
 func (e *tracedEngine) Shutdown(ctx context.Context) error {
 	ctx, span := e.tracer.Start(ctx, "tracedEngine.Shutdown")
 	defer span.End()
@@ -365,10 +357,6 @@ func (e *tracedEngine) Notify(ctx context.Context, msg Message) error {
 	defer span.End()
 
 	return e.engine.Notify(ctx, msg)
-}
-
-func (e *tracedEngine) Context() *snow.ConsensusContext {
-	return e.engine.Context()
 }
 
 func (e *tracedEngine) Start(ctx context.Context, startReqID uint32) error {

--- a/snow/engine/enginetest/engine.go
+++ b/snow/engine/enginetest/engine.go
@@ -189,19 +189,6 @@ func (e *Engine) Start(ctx context.Context, startReqID uint32) error {
 	return errStart
 }
 
-func (e *Engine) Context() *snow.ConsensusContext {
-	if e.ContextF != nil {
-		return e.ContextF()
-	}
-	if !e.CantContext {
-		return nil
-	}
-	if e.T != nil {
-		require.FailNow(e.T, "Unexpectedly called Context")
-	}
-	return nil
-}
-
 func (e *Engine) Timeout(ctx context.Context) error {
 	if e.TimeoutF != nil {
 		return e.TimeoutF(ctx)
@@ -226,19 +213,6 @@ func (e *Engine) Gossip(ctx context.Context) error {
 		require.FailNow(e.T, errGossip.Error())
 	}
 	return errGossip
-}
-
-func (e *Engine) Halt(ctx context.Context) {
-	if e.HaltF != nil {
-		e.HaltF(ctx)
-		return
-	}
-	if !e.CantHalt {
-		return
-	}
-	if e.T != nil {
-		require.FailNow(e.T, "Unexpectedly called Halt")
-	}
 }
 
 func (e *Engine) Shutdown(ctx context.Context) error {

--- a/snow/engine/snowman/bootstrap/config.go
+++ b/snow/engine/snowman/bootstrap/config.go
@@ -42,4 +42,6 @@ type Config struct {
 	NonVerifyingParse block.ParseFunc
 
 	Bootstrapped func()
+
+	ShouldHalt func() bool
 }

--- a/snow/engine/snowman/bootstrap/storage_test.go
+++ b/snow/engine/snowman/bootstrap/storage_test.go
@@ -221,7 +221,7 @@ func TestExecute(t *testing.T) {
 
 	unhalted := &common.Halter{}
 	halted := &common.Halter{}
-	halted.Halt(context.Background())
+	halted.Halt()
 
 	tests := []struct {
 		name                      string
@@ -269,7 +269,7 @@ func TestExecute(t *testing.T) {
 
 			require.NoError(execute(
 				context.Background(),
-				test.haltable,
+				test.haltable.Halted,
 				logging.NoLog{}.Info,
 				db,
 				parser,

--- a/snow/engine/snowman/engine.go
+++ b/snow/engine/snowman/engine.go
@@ -434,8 +434,6 @@ func (*Engine) Timeout(context.Context) error {
 	return nil
 }
 
-func (*Engine) Halt(context.Context) {}
-
 func (e *Engine) Shutdown(ctx context.Context) error {
 	e.Ctx.Log.Info("shutting down consensus engine")
 

--- a/snow/engine/snowman/syncer/state_syncer.go
+++ b/snow/engine/snowman/syncer/state_syncer.go
@@ -109,10 +109,6 @@ func New(
 	}
 }
 
-func (ss *stateSyncer) Context() *snow.ConsensusContext {
-	return ss.Ctx
-}
-
 func (ss *stateSyncer) Start(ctx context.Context, startReqID uint32) error {
 	ss.Ctx.Log.Info("starting state sync")
 
@@ -603,8 +599,6 @@ func (ss *stateSyncer) Shutdown(ctx context.Context) error {
 
 	return ss.VM.Shutdown(ctx)
 }
-
-func (*stateSyncer) Halt(context.Context) {}
 
 func (*stateSyncer) Timeout(context.Context) error {
 	return nil

--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -77,6 +77,8 @@ type Handler interface {
 // handler passes incoming messages from the network to the consensus engine.
 // (Actually, it receives the incoming messages from a ChainRouter, but same difference.)
 type handler struct {
+	haltBootstrapping func()
+
 	metrics *metrics
 
 	// Useful for faking time in tests
@@ -138,20 +140,22 @@ func New(
 	peerTracker commontracker.Peers,
 	p2pTracker *p2p.PeerTracker,
 	reg prometheus.Registerer,
+	haltBootstrapping func(),
 ) (Handler, error) {
 	h := &handler{
-		ctx:             ctx,
-		validators:      validators,
-		msgFromVMChan:   msgFromVMChan,
-		preemptTimeouts: subnet.OnBootstrapCompleted(),
-		gossipFrequency: gossipFrequency,
-		timeouts:        make(chan struct{}, 1),
-		closingChan:     make(chan struct{}),
-		closed:          make(chan struct{}),
-		resourceTracker: resourceTracker,
-		subnet:          subnet,
-		peerTracker:     peerTracker,
-		p2pTracker:      p2pTracker,
+		haltBootstrapping: haltBootstrapping,
+		ctx:               ctx,
+		validators:        validators,
+		msgFromVMChan:     msgFromVMChan,
+		preemptTimeouts:   subnet.OnBootstrapCompleted(),
+		gossipFrequency:   gossipFrequency,
+		timeouts:          make(chan struct{}, 1),
+		closingChan:       make(chan struct{}),
+		closed:            make(chan struct{}),
+		resourceTracker:   resourceTracker,
+		subnet:            subnet,
+		peerTracker:       peerTracker,
+		p2pTracker:        p2pTracker,
 	}
 	h.asyncMessagePool.SetLimit(threadPoolSize)
 
@@ -316,7 +320,7 @@ func (h *handler) RegisterTimeout(d time.Duration) {
 // Note: It is possible for Stop to be called before/concurrently with Start.
 //
 // Invariant: Stop must never block.
-func (h *handler) Stop(ctx context.Context) {
+func (h *handler) Stop(_ context.Context) {
 	h.closeOnce.Do(func() {
 		h.startClosingTime = h.clock.Time()
 
@@ -325,25 +329,7 @@ func (h *handler) Stop(ctx context.Context) {
 		h.syncMessageQueue.Shutdown()
 		h.asyncMessageQueue.Shutdown()
 		close(h.closingChan)
-
-		// TODO: switch this to use a [context.Context] with a cancel function.
-		//
-		// Don't process any more bootstrap messages. If a dispatcher is
-		// processing a bootstrap message, stop. We do this because if we
-		// didn't, and the engine was in the middle of executing state
-		// transitions during bootstrapping, we wouldn't be able to grab
-		// [h.ctx.Lock] until the engine finished executing state transitions,
-		// which may take a long time. As a result, the router would time out on
-		// shutting down this chain.
-		state := h.ctx.State.Get()
-		bootstrapper, ok := h.engineManager.Get(state.Type).Get(snow.Bootstrapping)
-		if !ok {
-			h.ctx.Log.Error("bootstrapping engine doesn't exist",
-				zap.Stringer("type", state.Type),
-			)
-			return
-		}
-		bootstrapper.Halt(ctx)
+		h.haltBootstrapping()
 	})
 }
 

--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -77,6 +77,7 @@ func TestHandlerDropsTimedOutMessages(t *testing.T) {
 		commontracker.NewPeers(),
 		peerTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 	handler := handlerIntf.(*handler)
@@ -183,6 +184,7 @@ func TestHandlerClosesOnError(t *testing.T) {
 		commontracker.NewPeers(),
 		peerTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 	handler := handlerIntf.(*handler)
@@ -285,6 +287,7 @@ func TestHandlerDropsGossipDuringBootstrapping(t *testing.T) {
 		commontracker.NewPeers(),
 		peerTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 	handler := handlerIntf.(*handler)
@@ -375,6 +378,7 @@ func TestHandlerDispatchInternal(t *testing.T) {
 		commontracker.NewPeers(),
 		peerTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -550,6 +554,7 @@ func TestDynamicEngineTypeDispatch(t *testing.T) {
 				commontracker.NewPeers(),
 				peerTracker,
 				prometheus.NewRegistry(),
+				func() {},
 			)
 			require.NoError(err)
 
@@ -632,6 +637,7 @@ func TestHandlerStartError(t *testing.T) {
 		commontracker.NewPeers(),
 		peerTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 

--- a/snow/networking/handler/health_test.go
+++ b/snow/networking/handler/health_test.go
@@ -93,6 +93,7 @@ func TestHealthCheckSubnet(t *testing.T) {
 				peerTracker,
 				p2pTracker,
 				prometheus.NewRegistry(),
+				func() {},
 			)
 			require.NoError(err)
 

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -114,6 +114,7 @@ func TestShutdown(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -239,6 +240,7 @@ func TestConnectedAfterShutdownErrorLogRegression(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -371,6 +373,7 @@ func TestShutdownTimesOut(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -539,6 +542,7 @@ func TestRouterTimeout(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -1070,6 +1074,7 @@ func TestValidatorOnlyMessageDrops(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -1235,6 +1240,7 @@ func TestValidatorOnlyAllowedNodeMessageDrops(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -1486,6 +1492,7 @@ func newChainRouterTest(t *testing.T) (*ChainRouter, *enginetest.Engine) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(t, err)
 

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -140,6 +140,7 @@ func TestTimeout(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -398,6 +399,7 @@ func TestReliableMessages(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 
@@ -554,6 +556,7 @@ func TestReliableMessagesToMyself(t *testing.T) {
 		commontracker.NewPeers(),
 		p2pTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1319,6 +1319,9 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 	require.NoError(err)
 
 	bootstrapConfig := bootstrap.Config{
+		ShouldHalt: func() bool {
+			return false
+		},
 		NonVerifyingParse:              vm.ParseBlock,
 		AllGetsServer:                  snowGetHandler,
 		Ctx:                            consensusCtx,
@@ -1353,6 +1356,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		tracker.NewPeers(),
 		peerTracker,
 		prometheus.NewRegistry(),
+		func() {},
 	)
 	require.NoError(err)
 


### PR DESCRIPTION
## Why this should be merged

Halt() is only used for the bootstrapper engine, and not invoked on other engine types.
    
Context() is only used in tests.
    
Therefore, this commit removes these methods from the common engine API to simplify it.


## How this works

Tidies up some code.

## How this was tested

Unit tests
