### PR TITLE
Ensure slices are zeroed

### DIFF
--- a/database/batch.go
+++ b/database/batch.go
@@ -7,7 +7,11 @@
 
 package database
 
-import "slices"
+import (
+	"slices"
+
+	"github.com/ava-labs/avalanchego/utils"
+)
 
 // Batch is a write-only database that commits changes to its host database
 // when Write is called. A batch cannot be used concurrently.
@@ -75,6 +79,7 @@ func (b *BatchOps) Size() int {
 }
 
 func (b *BatchOps) Reset() {
+	utils.ZeroSlice(b.Ops)
 	b.Ops = b.Ops[:0]
 	b.size = 0
 }

--- a/database/batch.go
+++ b/database/batch.go
@@ -7,11 +7,7 @@
 
 package database
 
-import (
-	"slices"
-
-	"github.com/ava-labs/avalanchego/utils"
-)
+import "slices"
 
 // Batch is a write-only database that commits changes to its host database
 // when Write is called. A batch cannot be used concurrently.
@@ -79,7 +75,7 @@ func (b *BatchOps) Size() int {
 }
 
 func (b *BatchOps) Reset() {
-	utils.ZeroSlice(b.Ops)
+	clear(b.Ops)
 	b.Ops = b.Ops[:0]
 	b.size = 0
 }

--- a/database/encdb/db.go
+++ b/database/encdb/db.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 )
 
@@ -205,7 +204,7 @@ func (b *batch) Reset() {
 	if cap(b.ops) > len(b.ops)*database.MaxExcessCapacityFactor {
 		b.ops = make([]database.BatchOp, 0, cap(b.ops)/database.CapacityReductionFactor)
 	} else {
-		utils.ZeroSlice(b.ops)
+		clear(b.ops)
 		b.ops = b.ops[:0]
 	}
 	b.Batch.Reset()

--- a/database/encdb/db.go
+++ b/database/encdb/db.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 )
 
@@ -204,6 +205,7 @@ func (b *batch) Reset() {
 	if cap(b.ops) > len(b.ops)*database.MaxExcessCapacityFactor {
 		b.ops = make([]database.BatchOp, 0, cap(b.ops)/database.CapacityReductionFactor)
 	} else {
+		utils.ZeroSlice(b.ops)
 		b.ops = b.ops[:0]
 	}
 	b.Batch.Reset()

--- a/database/prefixdb/db.go
+++ b/database/prefixdb/db.go
@@ -313,6 +313,7 @@ func (b *batch) Reset() {
 	if cap(b.ops) > len(b.ops)*database.MaxExcessCapacityFactor {
 		b.ops = make([]batchOp, 0, cap(b.ops)/database.CapacityReductionFactor)
 	} else {
+		utils.ZeroSlice(b.ops)
 		b.ops = b.ops[:0]
 	}
 	b.Batch.Reset()

--- a/database/prefixdb/db.go
+++ b/database/prefixdb/db.go
@@ -313,7 +313,7 @@ func (b *batch) Reset() {
 	if cap(b.ops) > len(b.ops)*database.MaxExcessCapacityFactor {
 		b.ops = make([]batchOp, 0, cap(b.ops)/database.CapacityReductionFactor)
 	} else {
-		utils.ZeroSlice(b.ops)
+		clear(b.ops)
 		b.ops = b.ops[:0]
 	}
 	b.Batch.Reset()

--- a/utils/set/sampleable_set.go
+++ b/utils/set/sampleable_set.go
@@ -108,9 +108,7 @@ func (s *SampleableSet[T]) Remove(elements ...T) {
 // Clear empties this set
 func (s *SampleableSet[T]) Clear() {
 	clear(s.indices)
-	for i := range s.elements {
-		s.elements[i] = utils.Zero[T]()
-	}
+	utils.ZeroSlice(s.elements)
 	s.elements = s.elements[:0]
 }
 

--- a/utils/set/sampleable_set.go
+++ b/utils/set/sampleable_set.go
@@ -108,7 +108,7 @@ func (s *SampleableSet[T]) Remove(elements ...T) {
 // Clear empties this set
 func (s *SampleableSet[T]) Clear() {
 	clear(s.indices)
-	utils.ZeroSlice(s.elements)
+	clear(s.elements)
 	s.elements = s.elements[:0]
 }
 

--- a/utils/zero.go
+++ b/utils/zero.go
@@ -4,16 +4,6 @@
 package utils
 
 // Returns a new instance of a T.
-func Zero[T any]() T {
-	return *new(T)
-}
-
-// ZeroSlice sets all values of the provided slice to the type's zero value.
-//
-// This can be useful to ensure that the garbage collector doesn't hold
-// references to values that are no longer desired.
-func ZeroSlice[T any](s []T) {
-	for i := range s {
-		s[i] = *new(T)
-	}
+func Zero[T any]() (_ T) {
+	return
 }


### PR DESCRIPTION
## Why this should be merged

Golang can only GC the memory if there are no remaining references to it. Because it's possible to re-extend slices, the memory doesn't get GCed.

## How this works

Uses `clear` (and deletes the `ZeroSlice` helper).

## How this was tested

N/A