### PR TITLE
Move `validators.TestManager` to `validatorstest.Manager`

### DIFF
--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -46,12 +46,12 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/txstest"
 	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
+	"github.com/ava-labs/avalanchego/vms/platformvm/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/chain/p/wallet"
 
 	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/block/executor"
 	txexecutor "github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
-	pvalidators "github.com/ava-labs/avalanchego/vms/platformvm/validators"
 )
 
 const (
@@ -153,7 +153,7 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 		metrics,
 		res.state,
 		&res.backend,
-		pvalidators.TestManager,
+		validatorstest.Manager,
 	)
 
 	txVerifier := network.NewLockedTxVerifier(&res.ctx.Lock, res.blkManager)

--- a/vms/platformvm/block/executor/acceptor_test.go
+++ b/vms/platformvm/block/executor/acceptor_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/metrics"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	"github.com/ava-labs/avalanchego/vms/platformvm/validators"
+	"github.com/ava-labs/avalanchego/vms/platformvm/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
@@ -62,7 +62,7 @@ func TestAcceptorVisitProposalBlock(t *testing.T) {
 			state: s,
 		},
 		metrics:    metrics.Noop,
-		validators: validators.TestManager,
+		validators: validatorstest.Manager,
 	}
 
 	require.NoError(acceptor.ApricotProposalBlock(blk))
@@ -97,7 +97,7 @@ func TestAcceptorVisitAtomicBlock(t *testing.T) {
 			},
 		},
 		metrics:    metrics.Noop,
-		validators: validators.TestManager,
+		validators: validatorstest.Manager,
 	}
 
 	blk, err := block.NewApricotAtomicBlock(
@@ -177,7 +177,7 @@ func TestAcceptorVisitStandardBlock(t *testing.T) {
 			},
 		},
 		metrics:    metrics.Noop,
-		validators: validators.TestManager,
+		validators: validatorstest.Manager,
 	}
 
 	blk, err := block.NewBanffStandardBlock(
@@ -266,7 +266,7 @@ func TestAcceptorVisitCommitBlock(t *testing.T) {
 			},
 		},
 		metrics:      metrics.Noop,
-		validators:   validators.TestManager,
+		validators:   validatorstest.Manager,
 		bootstrapped: &utils.Atomic[bool]{},
 	}
 
@@ -376,7 +376,7 @@ func TestAcceptorVisitAbortBlock(t *testing.T) {
 			},
 		},
 		metrics:      metrics.Noop,
-		validators:   validators.TestManager,
+		validators:   validatorstest.Manager,
 		bootstrapped: &utils.Atomic[bool]{},
 	}
 

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -46,10 +46,9 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/txstest"
 	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
+	"github.com/ava-labs/avalanchego/vms/platformvm/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/chain/p/wallet"
-
-	pvalidators "github.com/ava-labs/avalanchego/vms/platformvm/validators"
 )
 
 const (
@@ -166,7 +165,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller, f upgradetest.Fork) *
 			metrics,
 			res.state,
 			res.backend,
-			pvalidators.TestManager,
+			validatorstest.Manager,
 		)
 		addSubnet(t, res)
 	} else {
@@ -175,7 +174,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller, f upgradetest.Fork) *
 			metrics,
 			res.mockedState,
 			res.backend,
-			pvalidators.TestManager,
+			validatorstest.Manager,
 		)
 		// we do not add any subnet to state, since we can mock
 		// whatever we need

--- a/vms/platformvm/validators/validatorstest/manager.go
+++ b/vms/platformvm/validators/validatorstest/manager.go
@@ -1,16 +1,18 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package validators
+package validatorstest
 
 import (
 	"context"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow/validators"
+
+	snowvalidators "github.com/ava-labs/avalanchego/snow/validators"
+	vmvalidators "github.com/ava-labs/avalanchego/vms/platformvm/validators"
 )
 
-var TestManager Manager = testManager{}
+var Manager vmvalidators.Manager = testManager{}
 
 type testManager struct{}
 
@@ -26,7 +28,7 @@ func (testManager) GetSubnetID(context.Context, ids.ID) (ids.ID, error) {
 	return ids.Empty, nil
 }
 
-func (testManager) GetValidatorSet(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+func (testManager) GetValidatorSet(context.Context, uint64, ids.ID) (map[ids.NodeID]*snowvalidators.GetValidatorOutput, error) {
 	return nil, nil
 }
 

--- a/vms/platformvm/validators/validatorstest/manager.go
+++ b/vms/platformvm/validators/validatorstest/manager.go
@@ -12,24 +12,24 @@ import (
 	vmvalidators "github.com/ava-labs/avalanchego/vms/platformvm/validators"
 )
 
-var Manager vmvalidators.Manager = testManager{}
+var Manager vmvalidators.Manager = manager{}
 
-type testManager struct{}
+type manager struct{}
 
-func (testManager) GetMinimumHeight(context.Context) (uint64, error) {
+func (manager) GetMinimumHeight(context.Context) (uint64, error) {
 	return 0, nil
 }
 
-func (testManager) GetCurrentHeight(context.Context) (uint64, error) {
+func (manager) GetCurrentHeight(context.Context) (uint64, error) {
 	return 0, nil
 }
 
-func (testManager) GetSubnetID(context.Context, ids.ID) (ids.ID, error) {
+func (manager) GetSubnetID(context.Context, ids.ID) (ids.ID, error) {
 	return ids.Empty, nil
 }
 
-func (testManager) GetValidatorSet(context.Context, uint64, ids.ID) (map[ids.NodeID]*snowvalidators.GetValidatorOutput, error) {
+func (manager) GetValidatorSet(context.Context, uint64, ids.ID) (map[ids.NodeID]*snowvalidators.GetValidatorOutput, error) {
 	return nil, nil
 }
 
-func (testManager) OnAcceptedBlockID(ids.ID) {}
+func (manager) OnAcceptedBlockID(ids.ID) {}


### PR DESCRIPTION
## Why this should be merged

Moves testing only code out of the production package.

## How this works

Moves code around.

## How this was tested

- [X] CI