### PR TITLE
Bound GetNextStakerChangeTime for ACP-77

### DIFF
--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/iterator/iteratormock"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
@@ -279,7 +280,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 
 		block := env.blkManager.NewBlock(statelessProposalBlock)
 		err = block.Verify(context.Background())
-		require.ErrorIs(err, errChildBlockEarlierThanParent)
+		require.ErrorIs(err, executor.ErrChildBlockEarlierThanParent)
 	}
 
 	{
@@ -1377,7 +1378,7 @@ func TestAddValidatorProposalBlock(t *testing.T) {
 
 	// Advance time until next staker change time is [validatorEndTime]
 	for {
-		nextStakerChangeTime, err := state.GetNextStakerChangeTime(env.state)
+		nextStakerChangeTime, err := state.GetNextStakerChangeTime(env.state, mockable.MaxTime)
 		require.NoError(err)
 		if nextStakerChangeTime.Equal(validatorEndTime) {
 			break

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -212,7 +212,7 @@ func TestBanffStandardBlockTimeVerification(t *testing.T) {
 		require.NoError(err)
 		block := env.blkManager.NewBlock(banffChildBlk)
 		err = block.Verify(context.Background())
-		require.ErrorIs(err, errChildBlockEarlierThanParent)
+		require.ErrorIs(err, executor.ErrChildBlockEarlierThanParent)
 	}
 
 	{

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -27,7 +27,6 @@ var (
 	errApricotBlockIssuedAfterFork           = errors.New("apricot block issued after fork")
 	errBanffStandardBlockWithoutChanges      = errors.New("BanffStandardBlock performs no state changes")
 	errIncorrectBlockHeight                  = errors.New("incorrect block height")
-	errChildBlockEarlierThanParent           = errors.New("proposed timestamp before current chain time")
 	errOptionBlockTimestampNotMatchingParent = errors.New("option block proposed timestamp not matching parent block one")
 )
 
@@ -278,26 +277,11 @@ func (v *verifier) banffNonOptionBlock(b block.BanffBlock) error {
 	}
 
 	newChainTime := b.Timestamp()
-	parentChainTime := parentState.GetTimestamp()
-	if newChainTime.Before(parentChainTime) {
-		return fmt.Errorf(
-			"%w: proposed timestamp (%s), chain time (%s)",
-			errChildBlockEarlierThanParent,
-			newChainTime,
-			parentChainTime,
-		)
-	}
-
-	nextStakerChangeTime, err := state.GetNextStakerChangeTime(parentState)
-	if err != nil {
-		return fmt.Errorf("could not verify block timestamp: %w", err)
-	}
-
 	now := v.txExecutorBackend.Clk.Time()
 	return executor.VerifyNewChainTime(
 		newChainTime,
-		nextStakerChangeTime,
 		now,
+		parentState,
 	)
 }
 

--- a/vms/platformvm/state/chain_time_helpers_test.go
+++ b/vms/platformvm/state/chain_time_helpers_test.go
@@ -5,15 +5,130 @@ package state
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/genesis"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis/genesistest"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/fee"
 )
+
+func TestNextBlockTime(t *testing.T) {
+	tests := []struct {
+		name           string
+		chainTime      time.Time
+		now            time.Time
+		expectedTime   time.Time
+		expectedCapped bool
+	}{
+		{
+			name:           "parent time is after now",
+			chainTime:      genesistest.DefaultValidatorStartTime,
+			now:            genesistest.DefaultValidatorStartTime.Add(-time.Second),
+			expectedTime:   genesistest.DefaultValidatorStartTime,
+			expectedCapped: false,
+		},
+		{
+			name:           "parent time is before now",
+			chainTime:      genesistest.DefaultValidatorStartTime,
+			now:            genesistest.DefaultValidatorStartTime.Add(time.Second),
+			expectedTime:   genesistest.DefaultValidatorStartTime.Add(time.Second),
+			expectedCapped: false,
+		},
+		{
+			name:           "now is at next staker change time",
+			chainTime:      genesistest.DefaultValidatorStartTime,
+			now:            genesistest.DefaultValidatorEndTime,
+			expectedTime:   genesistest.DefaultValidatorEndTime,
+			expectedCapped: true,
+		},
+		{
+			name:           "now is after next staker change time",
+			chainTime:      genesistest.DefaultValidatorStartTime,
+			now:            genesistest.DefaultValidatorEndTime.Add(time.Second),
+			expectedTime:   genesistest.DefaultValidatorEndTime,
+			expectedCapped: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				require = require.New(t)
+				s       = newTestState(t, memdb.New())
+				clk     mockable.Clock
+			)
+
+			s.SetTimestamp(test.chainTime)
+			clk.Set(test.now)
+
+			actualTime, actualCapped, err := NextBlockTime(s, &clk)
+			require.NoError(err)
+			require.Equal(test.expectedTime.Local(), actualTime.Local())
+			require.Equal(test.expectedCapped, actualCapped)
+		})
+	}
+}
+
+func TestGetNextStakerChangeTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		pending  []*Staker
+		maxTime  time.Time
+		expected time.Time
+	}{
+		{
+			name:     "only current validators",
+			maxTime:  mockable.MaxTime,
+			expected: genesistest.DefaultValidatorEndTime,
+		},
+		{
+			name: "current and pending validators",
+			pending: []*Staker{
+				{
+					TxID:      ids.GenerateTestID(),
+					NodeID:    ids.GenerateTestNodeID(),
+					PublicKey: nil,
+					SubnetID:  constants.PrimaryNetworkID,
+					Weight:    1,
+					StartTime: genesistest.DefaultValidatorStartTime.Add(time.Second),
+					EndTime:   genesistest.DefaultValidatorEndTime,
+					NextTime:  genesistest.DefaultValidatorStartTime.Add(time.Second),
+					Priority:  txs.PrimaryNetworkValidatorPendingPriority,
+				},
+			},
+			maxTime:  mockable.MaxTime,
+			expected: genesistest.DefaultValidatorStartTime.Add(time.Second),
+		},
+		{
+			name:     "restricted timestamp",
+			maxTime:  genesistest.DefaultValidatorStartTime,
+			expected: genesistest.DefaultValidatorStartTime,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				require = require.New(t)
+				s       = newTestState(t, memdb.New())
+			)
+			for _, staker := range test.pending {
+				require.NoError(s.PutPendingValidator(staker))
+			}
+
+			actual, err := GetNextStakerChangeTime(s, test.maxTime)
+			require.NoError(err)
+			require.Equal(test.expected.Local(), actual.Local())
+		})
+	}
+}
 
 func TestPickFeeCalculator(t *testing.T) {
 	var (

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -126,7 +126,8 @@ func TestAdvanceTimeTxTimestampTooEarly(t *testing.T) {
 	require.ErrorIs(err, ErrChildBlockEarlierThanParent)
 }
 
-// Ensure semantic verification fails when proposed timestamp is after next validator set change time
+// Ensure semantic verification fails when proposed timestamp is after next
+// validator set change time
 func TestAdvanceTimeTxTimestampTooLate(t *testing.T) {
 	require := require.New(t)
 	env := newEnvironment(t, upgradetest.ApricotPhase5)
@@ -167,8 +168,8 @@ func TestAdvanceTimeTxTimestampTooLate(t *testing.T) {
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
-	// fast forward clock to 10 seconds before genesis validators stop validating
-	env.clk.Set(genesistest.DefaultValidatorEndTime.Add(-10 * time.Second))
+	// fast forward clock to when genesis validators stop validating
+	env.clk.Set(genesistest.DefaultValidatorEndTime)
 
 	{
 		// Proposes advancing timestamp to 1 second after genesis validators stop validating

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -99,12 +99,13 @@ func TestAdvanceTimeTxUpdatePrimaryNetworkStakers(t *testing.T) {
 	require.True(ok)
 }
 
-// Ensure semantic verification fails when proposed timestamp is at or before current timestamp
+// Ensure semantic verification fails when proposed timestamp is before the
+// current timestamp
 func TestAdvanceTimeTxTimestampTooEarly(t *testing.T) {
 	require := require.New(t)
 	env := newEnvironment(t, upgradetest.ApricotPhase5)
 
-	tx, err := newAdvanceTimeTx(t, env.state.GetTimestamp())
+	tx, err := newAdvanceTimeTx(t, env.state.GetTimestamp().Add(-time.Second))
 	require.NoError(err)
 
 	onCommitState, err := state.NewDiff(lastAcceptedID, env)
@@ -122,7 +123,7 @@ func TestAdvanceTimeTxTimestampTooEarly(t *testing.T) {
 		Tx:            tx,
 	}
 	err = tx.Unsigned.Visit(&executor)
-	require.ErrorIs(err, ErrChildBlockNotAfterParent)
+	require.ErrorIs(err, ErrChildBlockEarlierThanParent)
 }
 
 // Ensure semantic verification fails when proposed timestamp is after next validator set change time

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -16,23 +16,50 @@ import (
 )
 
 var (
+	ErrChildBlockEarlierThanParent     = errors.New("proposed timestamp before current chain time")
 	ErrChildBlockAfterStakerChangeTime = errors.New("proposed timestamp later than next staker change time")
 	ErrChildBlockBeyondSyncBound       = errors.New("proposed timestamp is too far in the future relative to local time")
 )
 
-// VerifyNewChainTime returns nil if the [newChainTime] is a valid chain time
-// given the wall clock time ([now]) and when the next staking set change occurs
-// ([nextStakerChangeTime]).
+// VerifyNewChainTime returns nil if the [newChainTime] is a valid chain time.
 // Requires:
-//   - [newChainTime] <= [nextStakerChangeTime]: so that no staking set changes
-//     are skipped.
+//   - [newChainTime] >= [currentChainTime]: to ensure chain time advances
+//     monotonically.
 //   - [newChainTime] <= [now] + [SyncBound]: to ensure chain time approximates
 //     "real" time.
+//   - [newChainTime] <= [nextStakerChangeTime]: so that no staking set changes
+//     are skipped.
 func VerifyNewChainTime(
-	newChainTime,
-	nextStakerChangeTime,
+	newChainTime time.Time,
 	now time.Time,
+	currentState state.Chain,
 ) error {
+	currentChainTime := currentState.GetTimestamp()
+	if newChainTime.Before(currentChainTime) {
+		return fmt.Errorf(
+			"%w: proposed timestamp (%s), chain time (%s)",
+			ErrChildBlockEarlierThanParent,
+			newChainTime,
+			currentChainTime,
+		)
+	}
+
+	// Only allow timestamp to be reasonably far forward
+	maxNewChainTime := now.Add(SyncBound)
+	if newChainTime.After(maxNewChainTime) {
+		return fmt.Errorf(
+			"%w, proposed time (%s), local time (%s)",
+			ErrChildBlockBeyondSyncBound,
+			newChainTime,
+			now,
+		)
+	}
+
+	nextStakerChangeTime, err := state.GetNextStakerChangeTime(currentState, newChainTime)
+	if err != nil {
+		return fmt.Errorf("could not verify block timestamp: %w", err)
+	}
+
 	// Only allow timestamp to move as far forward as the time of the next
 	// staker set change
 	if newChainTime.After(nextStakerChangeTime) {
@@ -41,17 +68,6 @@ func VerifyNewChainTime(
 			ErrChildBlockAfterStakerChangeTime,
 			newChainTime,
 			nextStakerChangeTime,
-		)
-	}
-
-	// Only allow timestamp to reasonably far forward
-	maxNewChainTime := now.Add(SyncBound)
-	if newChainTime.After(maxNewChainTime) {
-		return fmt.Errorf(
-			"%w, proposed time (%s), local time (%s)",
-			ErrChildBlockBeyondSyncBound,
-			newChainTime,
-			now,
 		)
 	}
 	return nil

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -55,6 +55,8 @@ func VerifyNewChainTime(
 		)
 	}
 
+	// nextStakerChangeTime is calculated last to ensure that the function is
+	// able to be calculated efficiently.
 	nextStakerChangeTime, err := state.GetNextStakerChangeTime(currentState, newChainTime)
 	if err != nil {
 		return fmt.Errorf("could not verify block timestamp: %w", err)

--- a/vms/platformvm/txs/executor/state_changes_test.go
+++ b/vms/platformvm/txs/executor/state_changes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -75,7 +76,7 @@ func TestAdvanceTimeTo_UpdatesFeeState(t *testing.T) {
 
 			// Ensure the invariant that [nextTime <= nextStakerChangeTime] on
 			// AdvanceTimeTo is maintained.
-			nextStakerChangeTime, err := state.GetNextStakerChangeTime(s)
+			nextStakerChangeTime, err := state.GetNextStakerChangeTime(s, mockable.MaxTime)
 			require.NoError(err)
 			require.False(nextTime.After(nextStakerChangeTime))
 


### PR DESCRIPTION
## Why this should be merged

For ACP-77, when checking for the maximum allowed block time, we need to search for the first time that a SoV will need to be deactivated. To perform this search efficiently, we should bound that search as much as possible. This PR introduces a maximum time to `GetNextStakerChangeTime` which will be used to implement this efficient search.

## How this works

- Moves the `GetNextStakerChangeTime` verification last in the timestamp checks.
- Unifies the `Banff` block timestamp verification and the `AdvanceTimeTx` verification
  - This does change the verification rule for `AdvanceTimeTx`. However, it makes it less strict, and this transaction is no longer allowed to be issued. So this is a backwards compatible change.
- Introduces hourly polling to the P-chain block building logic.

## How this was tested

 - [x] Added unit tests for `GetNextStakerChangeTime` and `NextBlockTime`