### PR TITLE
Code cleanups

### DIFF
--- a/x/merkledb/benchmarks/benchmark_test.go
+++ b/x/merkledb/benchmarks/benchmark_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/database/leveldb"
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/x/merkledb"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +28,7 @@ func testGoldenDatabaseCreation(t *testing.T, size uint64) {
 		require.NoError(t, os.RemoveAll(path))
 	}
 	require.NoError(t, createGoldenDatabase(size))
-	resetRunningDatabaseDirectory(size)
+	require.NoError(t, resetRunningDatabaseDirectory(size))
 	testGoldenDatabaseContent(t, size)
 	require.NoError(t, os.RemoveAll(path))
 	require.NoError(t, os.RemoveAll(getRunningDatabaseDirectory(size)))
@@ -58,7 +59,7 @@ func testGoldenDatabaseContent(t *testing.T, size uint64) {
 	// try an entry beyond.
 	entryHash := calculateIndexEncoding(size + 1)
 	_, err = mdb.Get(entryHash)
-	require.Error(t, err)
+	require.ErrorIs(t, err, database.ErrNotFound)
 
-	mdb.Clear()
+	require.NoError(t, mdb.Clear())
 }

--- a/x/merkledb/benchmarks_eth/benchmark.go
+++ b/x/merkledb/benchmarks_eth/benchmark.go
@@ -323,10 +323,6 @@ func runBenchmark(databaseEntries uint64) error {
 		if err != nil {
 			return fmt.Errorf("unable to update trie : %v", err)
 		}
-		err = trieDb.Commit(root, false)
-		if err != nil {
-			return fmt.Errorf("unable to commit trie : %v", err)
-		}
 		tdb, err = trie.New(trie.TrieID(root), trieDb)
 		if err != nil {
 			return fmt.Errorf("unable to create new trie : %v", err)

--- a/x/merkledb/benchmarks_eth/benchmark.go
+++ b/x/merkledb/benchmarks_eth/benchmark.go
@@ -231,6 +231,8 @@ func createGoldenDatabase(databaseEntries uint64) error {
 			return fmt.Errorf("unable to write value in database : %v", err)
 		}
 	}
+	// Note that without this commit, the final hash is not available
+	// TODO: figure out why this is necessary
 	err = trieDb.Commit(root, false)
 	if err != nil {
 		return fmt.Errorf("unable to commit trie : %v", err)

--- a/x/merkledb/benchmarks_eth/benchmark.go
+++ b/x/merkledb/benchmarks_eth/benchmark.go
@@ -26,76 +26,94 @@ import (
 )
 
 const (
-	defaultDatabaseEntries    = 1000000000 // 1B
-	databaseCreationBatchSize = 10000      // 10k
-	databaseRunningBatchSize  = 2500       // 2.5k
-	databaseRunningUpdateSize = 5000       // 5k
-	defaultMetricsPort        = 3000
+	defaultDatabaseEntries    = 1_000_000_000
+	databaseCreationBatchSize = 10_000
+	databaseRunningBatchSize  = databaseCreationBatchSize / 4
+	databaseRunningUpdateSize = databaseCreationBatchSize / 2
+	defaultMetricsPort        = 3_000
 	levelDBCacheSize          = 6_000
 	firewoodNumberOfRevisions = 120
 )
 
+var stats = struct {
+	inserts        prometheus.Counter
+	deletes        prometheus.Counter
+	updates        prometheus.Counter
+	batches        prometheus.Counter
+	deleteRate     prometheus.Gauge
+	updateRate     prometheus.Gauge
+	insertRate     prometheus.Gauge
+	batchWriteRate prometheus.Gauge
+	registry       *prometheus.Registry
+}{
+	inserts: prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "merkledb_bench",
+		Name:      "insert_counter",
+		Help:      "Total number of inserts",
+	}),
+	deletes: prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "merkledb_bench",
+		Name:      "deletes_counter",
+		Help:      "Total number of deletes",
+	}),
+	updates: prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "merkledb_bench",
+		Name:      "updates_counter",
+		Help:      "Total number of updates",
+	}),
+	batches: prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "merkledb_bench",
+		Name:      "batch",
+		Help:      "Total number of batches written",
+	}),
+	deleteRate: prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "merkledb_bench",
+		Name:      "entry_delete_rate",
+		Help:      "The rate at which elements are deleted",
+	}),
+	updateRate: prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "merkledb_bench",
+		Name:      "entry_update_rate",
+		Help:      "The rate at which elements are updated",
+	}),
+	insertRate: prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "merkledb_bench",
+		Name:      "entry_insert_rate",
+		Help:      "The rate at which elements are inserted",
+	}),
+	batchWriteRate: prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "merkledb_bench",
+		Name:      "batch_write_rate",
+		Help:      "The rate at which the batch was written",
+	}),
+
+	registry: prometheus.NewRegistry(),
+}
+
+// command line arguments
 var (
 	databaseEntries = pflag.Uint64("n", defaultDatabaseEntries, "number of database entries")
 	httpMetricPort  = pflag.Uint64("p", defaultMetricsPort, "default metrics port")
 	verbose         = pflag.Bool("v", false, "verbose")
-
-	insertsCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "merkledb_bench",
-		Name:      "insert_counter",
-		Help:      "Total number of inserts",
-	})
-	deletesCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "merkledb_bench",
-		Name:      "deletes_counter",
-		Help:      "Total number of deletes",
-	})
-	updatesCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "merkledb_bench",
-		Name:      "updates_counter",
-		Help:      "Total number of updates",
-	})
-	batchCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "merkledb_bench",
-		Name:      "batch",
-		Help:      "Total number of batches written",
-	})
-	deleteRate = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "merkledb_bench",
-		Name:      "entry_delete_rate",
-		Help:      "The rate at which elements are deleted",
-	})
-	updateRate = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "merkledb_bench",
-		Name:      "entry_update_rate",
-		Help:      "The rate at which elements are updated",
-	})
-	insertRate = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "merkledb_bench",
-		Name:      "entry_insert_rate",
-		Help:      "The rate at which elements are inserted",
-	})
-	batchWriteRate = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "merkledb_bench",
-		Name:      "batch_write_rate",
-		Help:      "The rate at which the batch was written",
-	})
-	promRegistry = prometheus.NewRegistry()
 )
 
+func Must[T any](obj T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
 func getGoldenStagingDatabaseDirectory(databaseEntries uint64) string {
-	wd, _ := os.Getwd()
-	return path.Join(wd, fmt.Sprintf("db-bench-test-golden-staging-%d", databaseEntries))
+	return path.Join(Must(os.Getwd()), fmt.Sprintf("db-bench-test-golden-staging-%d", databaseEntries))
 }
 
 func getGoldenDatabaseDirectory(databaseEntries uint64) string {
-	wd, _ := os.Getwd()
-	return path.Join(wd, fmt.Sprintf("db-bench-test-golden-%d", databaseEntries))
+	return path.Join(Must(os.Getwd()), fmt.Sprintf("db-bench-test-golden-%d", databaseEntries))
 }
 
 func getRunningDatabaseDirectory(databaseEntries uint64) string {
-	wd, _ := os.Getwd()
-	return path.Join(wd, fmt.Sprintf("db-bench-test-running-%d", databaseEntries))
+	return path.Join(Must(os.Getwd()), fmt.Sprintf("db-bench-test-running-%d", databaseEntries))
 }
 
 func calculateIndexEncoding(idx uint64) []byte {
@@ -117,19 +135,16 @@ func createGoldenDatabase(databaseEntries uint64) error {
 	stagingDirectory := getGoldenStagingDatabaseDirectory(databaseEntries)
 	err := os.RemoveAll(stagingDirectory)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to remove running directory : %v\n", err)
-		return err
+		return fmt.Errorf("unable to remove running directory : %v", err)
 	}
 	err = os.Mkdir(stagingDirectory, 0o777)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to create golden staging directory : %v\n", err)
-		return err
+		return fmt.Errorf("unable to create golden staging directory : %v", err)
 	}
 
 	ldb, err := rawdb.NewLevelDBDatabase(stagingDirectory, levelDBCacheSize, 200, "metrics_prefix", false)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to create level db database : %v\n", err)
-		return err
+		return fmt.Errorf("unable to create level db database : %v", err)
 	}
 
 	trieDb := triedb.NewDatabase(ldb, &triedb.Config{
@@ -163,18 +178,15 @@ func createGoldenDatabase(databaseEntries uint64) error {
 		root, nodes = tdb.Commit(false)
 		err = trieDb.Update(root, parentHash, blockHeight, trienode.NewWithNodeSet(nodes), nil /*states*/)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to update trie : %v\n", err)
-			return err
+			return fmt.Errorf("unable to update trie : %v", err)
 		}
 		err = trieDb.Commit(root, false)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to commit trie : %v\n", err)
-			return err
+			return fmt.Errorf("unable to commit trie : %v", err)
 		}
 		tdb, err = trie.New(trie.TrieID(root), trieDb)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to create new trie : %v\n", err)
-			return err
+			return fmt.Errorf("unable to create new trie : %v", err)
 		}
 		parentHash = root
 		blockHeight++
@@ -183,64 +195,57 @@ func createGoldenDatabase(databaseEntries uint64) error {
 
 	startInsertTime := time.Now()
 	startInsertBatchTime := startInsertTime
-	for entryIdx := uint64(0); entryIdx < databaseEntries; entryIdx++ {
+	for entryIdx := range databaseEntries {
 		entryHash := calculateIndexEncoding(entryIdx)
 		tdb.Update(entryHash, entryHash)
 
 		if entryIdx%databaseCreationBatchSize == (databaseCreationBatchSize - 1) {
 			addDuration := time.Since(startInsertBatchTime)
-			insertRate.Set(float64(databaseCreationBatchSize) * float64(time.Second) / float64(addDuration))
-			insertsCounter.Add(databaseCreationBatchSize)
+			stats.insertRate.Set(float64(databaseCreationBatchSize) * float64(time.Second) / float64(addDuration))
+			stats.inserts.Add(databaseCreationBatchSize)
 
 			batchWriteStartTime := time.Now()
 
 			err = writeBatch()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "unable to write value in database : %v\n", err)
-				return err
+				return fmt.Errorf("unable to write value in database : %v", err)
 			}
 
 			batchWriteDuration := time.Since(batchWriteStartTime)
-			batchWriteRate.Set(float64(time.Second) / float64(batchWriteDuration))
-			batchCounter.Inc()
+			stats.batchWriteRate.Set(float64(time.Second) / float64(batchWriteDuration))
+			stats.batches.Inc()
 
 			startInsertBatchTime = time.Now()
 		}
 	}
+	// write the last batch. In our default case, there won't be a last batch
 	if databaseEntries%databaseCreationBatchSize != 0 {
 		err = writeBatch()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to write value in database : %v\n", err)
-			return err
+			return fmt.Errorf("unable to write value in database : %v", err)
 		}
 	}
 	close(ticksCh)
 	fmt.Print(" done!\n")
 
-	err = trieDb.Close()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to close trie database : %v\n", err)
-		return err
+	if err = trieDb.Close(); err != nil {
+		return fmt.Errorf("unable to close trie database : %v", err)
 	}
-	err = ldb.Close()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to close levelDB database : %v\n", err)
-		return err
+
+	if err = ldb.Close(); err != nil {
+		return fmt.Errorf("unable to close levelDB database : %v", err)
 	}
 
 	fmt.Printf("Generated and inserted %d batches of size %d in %v\n",
 		databaseEntries/databaseCreationBatchSize, databaseCreationBatchSize, time.Since(startInsertTime))
 
-	err = os.WriteFile(path.Join(stagingDirectory, "root.txt"), root.Bytes(), 0o644)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to save root : %v\n", err)
-		return err
+	if err = os.WriteFile(path.Join(stagingDirectory, "root.txt"), root.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("unable to save root : %v", err)
 	}
 
 	err = os.Rename(getGoldenStagingDatabaseDirectory(databaseEntries), getGoldenDatabaseDirectory(databaseEntries))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to rename golden staging directory : %v\n", err)
-		return err
+		return fmt.Errorf("unable to rename golden staging directory : %v", err)
 	}
 	fmt.Printf("Completed initialization with hash of %v\n", root.Hex())
 	return nil
@@ -251,19 +256,16 @@ func resetRunningDatabaseDirectory(databaseEntries uint64) error {
 	if _, err := os.Stat(runningDir); err == nil {
 		err := os.RemoveAll(runningDir)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to remove running directory : %v\n", err)
-			return err
+			return fmt.Errorf("unable to remove running directory : %v", err)
 		}
 	}
 	err := os.Mkdir(runningDir, 0o777)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to create running directory : %v\n", err)
-		return err
+		return fmt.Errorf("unable to create running directory : %v", err)
 	}
 	err = CopyDirectory(getGoldenDatabaseDirectory(databaseEntries), runningDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to duplicate golden directory : %v\n", err)
-		return err
+		return fmt.Errorf("unable to duplicate golden directory : %v", err)
 	}
 	return nil
 }
@@ -271,8 +273,7 @@ func resetRunningDatabaseDirectory(databaseEntries uint64) error {
 func runBenchmark(databaseEntries uint64) error {
 	rootBytes, err := os.ReadFile(path.Join(getRunningDatabaseDirectory(databaseEntries), "root.txt"))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to read root : %v\n", err)
-		return err
+		return fmt.Errorf("unable to read root : %v", err)
 	}
 
 	ldb, err := rawdb.Open(rawdb.OpenOptions{
@@ -286,8 +287,7 @@ func runBenchmark(databaseEntries uint64) error {
 		Ephemeral:         false,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to create level db database : %v\n", err)
-		return err
+		return fmt.Errorf("unable to create level db database : %v", err)
 	}
 
 	trieDb := triedb.NewDatabase(ldb, &triedb.Config{
@@ -300,8 +300,7 @@ func runBenchmark(databaseEntries uint64) error {
 	parentHash := common.BytesToHash(rootBytes)
 	tdb, err := trie.New(trie.TrieID(parentHash), trieDb)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to create trie database : %v\n", err)
-		return err
+		return fmt.Errorf("unable to create trie database : %v", err)
 	}
 	var root common.Hash
 	blockHeight := (databaseEntries + databaseCreationBatchSize - 1) / databaseCreationBatchSize
@@ -310,18 +309,15 @@ func runBenchmark(databaseEntries uint64) error {
 		root, nodes = tdb.Commit(false)
 		err = trieDb.Update(root, parentHash, blockHeight, trienode.NewWithNodeSet(nodes), nil /*states*/)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to update trie : %v\n", err)
-			return err
+			return fmt.Errorf("unable to update trie : %v", err)
 		}
 		err = trieDb.Commit(root, false)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to commit trie : %v\n", err)
-			return err
+			return fmt.Errorf("unable to commit trie : %v", err)
 		}
 		tdb, err = trie.New(trie.TrieID(root), trieDb)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to create new trie : %v\n", err)
-			return err
+			return fmt.Errorf("unable to create new trie : %v", err)
 		}
 		parentHash = root
 		blockHeight++
@@ -339,13 +335,12 @@ func runBenchmark(databaseEntries uint64) error {
 			entryHash := calculateIndexEncoding(keyToDeleteIdx)
 			err = tdb.Delete(entryHash)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "unable to delete trie entry : %v\n", err)
-				return err
+				return fmt.Errorf("unable to delete trie entry : %v", err)
 			}
 		}
 		deleteDuration = time.Since(startDeleteTime)
-		deleteRate.Set(float64(databaseRunningBatchSize) * float64(time.Second) / float64(deleteDuration))
-		deletesCounter.Add(databaseRunningBatchSize)
+		stats.deleteRate.Set(float64(databaseRunningBatchSize) * float64(time.Second) / float64(deleteDuration))
+		stats.deletes.Add(databaseRunningBatchSize)
 
 		// add 2.5k past end.
 		startInsertTime := time.Now()
@@ -353,13 +348,12 @@ func runBenchmark(databaseEntries uint64) error {
 			entryHash := calculateIndexEncoding(keyToAddIdx)
 			err = tdb.Update(entryHash, entryHash)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "unable to insert trie entry : %v\n", err)
-				return err
+				return fmt.Errorf("unable to insert trie entry : %v", err)
 			}
 		}
 		addDuration = time.Since(startInsertTime)
-		insertRate.Set(float64(databaseRunningBatchSize) * float64(time.Second) / float64(addDuration))
-		insertsCounter.Add(databaseRunningBatchSize)
+		stats.insertRate.Set(float64(databaseRunningBatchSize) * float64(time.Second) / float64(addDuration))
+		stats.inserts.Add(databaseRunningBatchSize)
 
 		// update middle 5k entries
 		startUpdateTime := time.Now()
@@ -368,23 +362,21 @@ func runBenchmark(databaseEntries uint64) error {
 			updateEntryKey := calculateIndexEncoding(keyToUpdateIdx)
 			err = tdb.Update(updateEntryKey, updateEntryValue)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "unable to update trie entry : %v\n", err)
-				return err
+				return fmt.Errorf("unable to update trie entry : %v", err)
 			}
 		}
 		updateDuration = time.Since(startUpdateTime)
-		updateRate.Set(float64(databaseRunningUpdateSize) * float64(time.Second) / float64(updateDuration))
-		updatesCounter.Add(databaseRunningUpdateSize)
+		stats.updateRate.Set(float64(databaseRunningUpdateSize) * float64(time.Second) / float64(updateDuration))
+		stats.updates.Add(databaseRunningUpdateSize)
 
 		batchWriteStartTime := time.Now()
 		err = writeBatch()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to write batch : %v\n", err)
-			return err
+			return fmt.Errorf("unable to write batch : %v", err)
 		}
 		batchDuration = time.Since(startBatchTime)
 		batchWriteDuration := time.Since(batchWriteStartTime)
-		batchWriteRate.Set(float64(time.Second) / float64(batchWriteDuration))
+		stats.batchWriteRate.Set(float64(time.Second) / float64(batchWriteDuration))
 
 		if *verbose {
 			fmt.Printf("delete rate [%d]	update rate [%d]	insert rate [%d]	batch rate [%d]\n",
@@ -394,36 +386,34 @@ func runBenchmark(databaseEntries uint64) error {
 				time.Second/batchDuration)
 		}
 
-		batchCounter.Inc()
+		stats.batches.Inc()
 		low += databaseRunningBatchSize
 	}
-
-	// return nil
 }
 
 func setupMetrics() error {
-	if err := prometheus.Register(promRegistry); err != nil {
+	if err := prometheus.Register(stats.registry); err != nil {
 		return err
 	}
-	promRegistry.MustRegister(insertsCounter)
-	promRegistry.MustRegister(deletesCounter)
-	promRegistry.MustRegister(updatesCounter)
-	promRegistry.MustRegister(batchCounter)
-	promRegistry.MustRegister(deleteRate)
-	promRegistry.MustRegister(updateRate)
-	promRegistry.MustRegister(insertRate)
-	promRegistry.MustRegister(batchWriteRate)
+	stats.registry.MustRegister(stats.inserts)
+	stats.registry.MustRegister(stats.deletes)
+	stats.registry.MustRegister(stats.updates)
+	stats.registry.MustRegister(stats.batches)
+	stats.registry.MustRegister(stats.deleteRate)
+	stats.registry.MustRegister(stats.updateRate)
+	stats.registry.MustRegister(stats.insertRate)
+	stats.registry.MustRegister(stats.batchWriteRate)
 
 	http.Handle("/metrics", promhttp.Handler())
 
-	server := &http.Server{
+	prometheusServer := &http.Server{
 		Addr:              fmt.Sprintf(":%d", *httpMetricPort),
 		ReadHeaderTimeout: 3 * time.Second,
 	}
 	go func() {
-		err := server.ListenAndServe()
+		err := prometheusServer.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
-			fmt.Fprintf(os.Stderr, "unable to listen and serve : %v\n", err)
+			panic(fmt.Sprintf("unable to listen and serve : %v\n", err))
 		}
 	}()
 	return nil
@@ -432,25 +422,25 @@ func setupMetrics() error {
 func main() {
 	pflag.Parse()
 
-	if setupMetrics() != nil {
+	if err := setupMetrics(); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to setup metrics : %v\n", err)
 		os.Exit(1)
-		return
 	}
 
 	goldenDir := getGoldenDatabaseDirectory(*databaseEntries)
 	if _, err := os.Stat(goldenDir); os.IsNotExist(err) {
 		// create golden image.
-		if createGoldenDatabase(*databaseEntries) != nil {
+		if err := createGoldenDatabase(*databaseEntries); err != nil {
+			fmt.Fprintf(os.Stderr, "unable to create golden database : %v\n", err)
 			os.Exit(1)
-			return
 		}
 	}
-	if resetRunningDatabaseDirectory(*databaseEntries) != nil {
+	if err := resetRunningDatabaseDirectory(*databaseEntries); err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to reset running database directory: %v\n", err)
 		os.Exit(1)
-		return
 	}
-	if runBenchmark(*databaseEntries) != nil {
+	if err := runBenchmark(*databaseEntries); err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to run benchmark: %v\n", err)
 		os.Exit(1)
-		return
 	}
 }

--- a/x/merkledb/benchmarks_eth/go.mod
+++ b/x/merkledb/benchmarks_eth/go.mod
@@ -53,6 +53,7 @@ require (
 )
 
 require (
+	github.com/ava-labs/avalanchego v1.11.11
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/ethereum/go-ethereum v1.14.8

--- a/x/merkledb/benchmarks_eth/go.sum
+++ b/x/merkledb/benchmarks_eth/go.sum
@@ -4,6 +4,8 @@ github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjC
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
+github.com/ava-labs/avalanchego v1.11.11 h1:MIQq8xRavRj4ZXHA4G+aMiymig7SOScGOG1SApmMvBc=
+github.com/ava-labs/avalanchego v1.11.11/go.mod h1:yFx3V31Jy9NFa8GZlgGnwiVf8KGjeF2+Uc99l9Scd/8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=


### PR DESCRIPTION
 - Added _ for large numbers for readability
 - Added some comments, removed obvious ones
 - Move prometheus stats (into stats struct)
 - Added error handling for os.Getwd() et al
 - Switch to fmt.Errorf and printf at caller
 - use 'range INT` instead of usual for loop

## Why this should be merged

Cleaner code for blog post

## How this works

- Large numbers support _ as placeholders to improve readability [link](https://github.com/golang/go/issues/28493)
- Having variables grouped in a struct idenfies them as soley metrics for readability (`metrics.batches` vs `batchCounter`)
- Although `os.Getwd` is unlikely to fail, it isn't impossible, and it's best practice to at least panic if it fails
- fmt.Errorf returns an error, which can then be returned to the caller [link](https://pkg.go.dev/fmt#Errorf)
- range over integer is easier to read and functionally equivalent [link](https://github.com/golang/go/issues/61405)

## How this was tested

Ran bench locally, still seems to work:
```
➜  benchmarks_eth git:(rkuris/bench_merkledb) go run . --n 1000 --v
Initializing database. done!
Generated and inserted 0 batches of size 10000 in 4.153792ms
Completed initialization with hash of 0x788272ac157b96c5af259c14657cfa0f5b261c4d07fac7cbdfba53148ad0960e
delete rate [167]       update rate [289]       insert rate [585]       batch rate [47]
delete rate [117]       update rate [259]       insert rate [417]       batch rate [36]
```