### PR TITLE
[e2e] Add wallet balance logging to staking rewards test

### DIFF
--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/antithesis"
+	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
@@ -152,22 +153,7 @@ func (w *workload) run(ctx context.Context) {
 	defer tc.Cleanup()
 	require := require.New(tc)
 
-	var (
-		xWallet  = w.wallet.X()
-		xBuilder = xWallet.Builder()
-		pWallet  = w.wallet.P()
-		pBuilder = pWallet.Builder()
-	)
-	xBalances, err := xBuilder.GetFTBalance()
-	require.NoError(err, "failed to fetch X-chain balances")
-	pBalances, err := pBuilder.GetBalance()
-	require.NoError(err, "failed to fetch P-chain balances")
-	var (
-		xContext    = xBuilder.Context()
-		avaxAssetID = xContext.AVAXAssetID
-		xAVAX       = xBalances[avaxAssetID]
-		pAVAX       = pBalances[avaxAssetID]
-	)
+	xAVAX, pAVAX := e2e.GetWalletBalances(tc, w.wallet)
 	log.Printf("wallet starting with %d X-chain nAVAX and %d P-chain nAVAX", xAVAX, pAVAX)
 	assert.Reachable("wallet starting", map[string]any{
 		"worker":   w.id,

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -111,6 +111,8 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 		require.NoError(err)
 
 		tc.By("adding alpha node as a validator", func() {
+			e2e.OutputWalletBalances(tc, baseWallet)
+
 			endTime := time.Now().Add(targetValidationPeriod)
 			tc.Outf("validation period ending at: %v\n", endTime)
 
@@ -143,6 +145,8 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 		tc.Outf("beta node validation period ending at: %v\n", betaValidatorEndTime)
 
 		tc.By("adding beta node as a validator", func() {
+			e2e.OutputWalletBalances(tc, baseWallet)
+
 			_, err := pWallet.IssueAddPermissionlessValidatorTx(
 				&txs.SubnetValidator{
 					Validator: txs.Validator{
@@ -173,6 +177,8 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 		require.NoError(err)
 
 		tc.By("adding gamma as a delegator to the alpha node", func() {
+			e2e.OutputWalletBalances(tc, baseWallet)
+
 			endTime := time.Now().Add(targetDelegationPeriod)
 			tc.Outf("delegation period ending at: %v\n", endTime)
 
@@ -196,6 +202,8 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 		})
 
 		tc.By("adding delta as delegator to the beta node", func() {
+			e2e.OutputWalletBalances(tc, baseWallet)
+
 			endTime := time.Now().Add(targetDelegationPeriod)
 			tc.Outf("delegation period ending at: %v\n", endTime)
 


### PR DESCRIPTION
## Why this should be merged

[Recent flakes](https://github.com/ava-labs/avalanchego/issues/3424) suggest funds exhaustion but reproduction is difficult without knowing what the balances are.

## How this works

- Refactors balance retrieval from the antithesis test for reuse
- Updates staking rewards tests to output balances at each step 

## How this was tested

- CI against regression
- Locally verified expected output