### PR TITLE
Shrink proposerVM minRecentlyAcceptedWindowSize to 0

### DIFF
--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -26,8 +26,8 @@ import (
 const (
 	validatorSetsCacheSize        = 64
 	maxRecentlyAcceptedWindowSize = 64
-	minRecentlyAcceptedWindowSize = 16
-	recentlyAcceptedWindowTTL     = 2 * time.Minute
+	minRecentlyAcceptedWindowSize = 0
+	recentlyAcceptedWindowTTL     = 30 * time.Second
 )
 
 var (


### PR DESCRIPTION
## Why this should be merged
Currently there's a big wallclock delay between other chains proposer VM heights and P-chain tip. This is an issue for brand new L1s being deployed on Fuji since chain operator needs to wait 16 P-chain blocks before being able to do any interop or warp message signing from their L1. 

Additionally messages signed by c-chain  are also likely to be invalid for a while if there is any recent change in it's validator set which can happen often during bounty activity. 

The issue mostly exists on Fuji right now since there is more frequent block production on the mainnet but this should hopefully be a safe change. 

## How this works
Shrinks the `minRecentlyAcceptedWindowSize` to 0 and `recentlyAcceptedWindowTL` to 30 seconds. 

## How this was tested
CI