### PR TITLE
Improve `p2ptest.Client`

### DIFF
--- a/network/p2p/acp118/handler_test.go
+++ b/network/p2p/acp118/handler_test.go
@@ -52,15 +52,7 @@ func TestHandler(t *testing.T) {
 			chainID := ids.GenerateTestID()
 			signer := warp.NewSigner(sk, networkID, chainID)
 			h := NewHandler(tt.verifier, signer)
-			clientNodeID := ids.GenerateTestNodeID()
-			serverNodeID := ids.GenerateTestNodeID()
-			c := p2ptest.NewClient(
-				t,
-				ctx,
-				h,
-				clientNodeID,
-				serverNodeID,
-			)
+			c := p2ptest.Client{Handler: h}
 
 			unsignedMessage, err := warp.NewUnsignedMessage(
 				networkID,
@@ -95,7 +87,7 @@ func TestHandler(t *testing.T) {
 				require.Equal(tt.expectedVerify, bls.Verify(pk, signature, request.Message))
 			}
 
-			require.NoError(c.AppRequest(ctx, set.Of(clientNodeID), requestBytes, onResponse))
+			require.NoError(c.AppRequest(ctx, set.Of(ids.EmptyNodeID), requestBytes, onResponse))
 			<-done
 		})
 	}

--- a/network/p2p/acp118/handler_test.go
+++ b/network/p2p/acp118/handler_test.go
@@ -52,7 +52,7 @@ func TestHandler(t *testing.T) {
 			chainID := ids.GenerateTestID()
 			signer := warp.NewSigner(sk, networkID, chainID)
 			h := NewHandler(tt.verifier, signer)
-			c := p2ptest.Client{Handler: h}
+			c := p2ptest.Client{ServerHandler: h}
 
 			unsignedMessage, err := warp.NewUnsignedMessage(
 				networkID,

--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -24,17 +24,23 @@ var (
 )
 
 type ClientInterface interface {
+	// AppRequestAny issues an AppRequest to an arbitrary node decided by Client.
+	// If a specific node needs to be requested, use AppRequest instead.
+	// See AppRequest for more docs.
 	AppRequestAny(
 		ctx context.Context,
 		appRequestBytes []byte,
 		onResponse AppResponseCallback,
 	) error
+	// AppRequest issues an arbitrary request to a node.
+	// [onResponse] is invoked upon an error or a response.
 	AppRequest(
 		ctx context.Context,
 		nodeIDs set.Set[ids.NodeID],
 		appRequestBytes []byte,
 		onResponse AppResponseCallback,
 	) error
+	// AppGossip sends a gossip message to a random set of peers.
 	AppGossip(
 		ctx context.Context,
 		config common.SendConfig,
@@ -61,9 +67,6 @@ type Client struct {
 	options       *clientOptions
 }
 
-// AppRequestAny issues an AppRequest to an arbitrary node decided by Client.
-// If a specific node needs to be requested, use AppRequest instead.
-// See AppRequest for more docs.
 func (c *Client) AppRequestAny(
 	ctx context.Context,
 	appRequestBytes []byte,
@@ -78,8 +81,6 @@ func (c *Client) AppRequestAny(
 	return c.AppRequest(ctx, nodeIDs, appRequestBytes, onResponse)
 }
 
-// AppRequest issues an arbitrary request to a node.
-// [onResponse] is invoked upon an error or a response.
 func (c *Client) AppRequest(
 	ctx context.Context,
 	nodeIDs set.Set[ids.NodeID],
@@ -133,7 +134,6 @@ func (c *Client) AppRequest(
 	return nil
 }
 
-// AppGossip sends a gossip message to a random set of peers.
 func (c *Client) AppGossip(
 	ctx context.Context,
 	config common.SendConfig,

--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -19,7 +19,28 @@ import (
 var (
 	ErrRequestPending = errors.New("request pending")
 	ErrNoPeers        = errors.New("no peers")
+
+	_ ClientInterface = (*Client)(nil)
 )
+
+type ClientInterface interface {
+	AppRequestAny(
+		ctx context.Context,
+		appRequestBytes []byte,
+		onResponse AppResponseCallback,
+	) error
+	AppRequest(
+		ctx context.Context,
+		nodeIDs set.Set[ids.NodeID],
+		appRequestBytes []byte,
+		onResponse AppResponseCallback,
+	) error
+	AppGossip(
+		ctx context.Context,
+		config common.SendConfig,
+		appGossipBytes []byte,
+	) error
+}
 
 // AppResponseCallback is called upon receiving an AppResponse for an AppRequest
 // issued by Client.

--- a/network/p2p/p2ptest/client.go
+++ b/network/p2p/p2ptest/client.go
@@ -19,9 +19,9 @@ var _ p2p.ClientInterface = (*Client)(nil)
 // server handler. The zero value of Client times out AppRequest and drops
 // outbound AppGossip messages.
 type Client struct {
-	NodeID       ids.NodeID
-	ServerNodeID ids.NodeID
-	Handler      p2p.Handler
+	NodeID        ids.NodeID
+	ServerNodeID  ids.NodeID
+	ServerHandler p2p.Handler
 }
 
 func (c Client) AppRequestAny(ctx context.Context, appRequestBytes []byte, onResponse p2p.AppResponseCallback) error {
@@ -29,12 +29,12 @@ func (c Client) AppRequestAny(ctx context.Context, appRequestBytes []byte, onRes
 }
 
 func (c Client) AppRequest(ctx context.Context, _ set.Set[ids.NodeID], appRequestBytes []byte, onResponse p2p.AppResponseCallback) error {
-	if c.Handler == nil {
+	if c.ServerHandler == nil {
 		onResponse(ctx, c.ServerNodeID, nil, common.ErrTimeout)
 		return nil
 	}
 
-	responseBytes, err := c.Handler.AppRequest(ctx, c.NodeID, time.Time{}, appRequestBytes)
+	responseBytes, err := c.ServerHandler.AppRequest(ctx, c.NodeID, time.Time{}, appRequestBytes)
 	if err != nil {
 		onResponse(ctx, c.ServerNodeID, nil, err)
 		return nil
@@ -45,10 +45,10 @@ func (c Client) AppRequest(ctx context.Context, _ set.Set[ids.NodeID], appReques
 }
 
 func (c Client) AppGossip(ctx context.Context, _ common.SendConfig, appGossipBytes []byte) error {
-	if c.Handler == nil {
+	if c.ServerHandler == nil {
 		return nil
 	}
 
-	c.Handler.AppGossip(ctx, c.NodeID, appGossipBytes)
+	c.ServerHandler.AppGossip(ctx, c.NodeID, appGossipBytes)
 	return nil
 }

--- a/network/p2p/p2ptest/client_test.go
+++ b/network/p2p/p2ptest/client_test.go
@@ -27,7 +27,7 @@ func TestNewClient_AppGossip(t *testing.T) {
 		},
 	}
 
-	client := NewClient(t, ctx, testHandler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+	client := Client{Handler: testHandler}
 	require.NoError(client.AppGossip(ctx, common.SendConfig{}, []byte("foobar")))
 	<-appGossipChan
 }
@@ -37,12 +37,12 @@ func TestNewClient_AppRequest(t *testing.T) {
 		name        string
 		appResponse []byte
 		appErr      error
-		appRequestF func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error
+		appRequestF func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error
 	}{
 		{
 			name:        "AppRequest - response",
 			appResponse: []byte("foobar"),
-			appRequestF: func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error {
+			appRequestF: func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error {
 				return client.AppRequest(ctx, set.Of(ids.GenerateTestNodeID()), []byte("foo"), onResponse)
 			},
 		},
@@ -52,14 +52,14 @@ func TestNewClient_AppRequest(t *testing.T) {
 				Code:    123,
 				Message: "foobar",
 			},
-			appRequestF: func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error {
+			appRequestF: func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error {
 				return client.AppRequest(ctx, set.Of(ids.GenerateTestNodeID()), []byte("foo"), onResponse)
 			},
 		},
 		{
 			name:        "AppRequestAny - response",
 			appResponse: []byte("foobar"),
-			appRequestF: func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error {
+			appRequestF: func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error {
 				return client.AppRequestAny(ctx, []byte("foo"), onResponse)
 			},
 		},
@@ -69,7 +69,7 @@ func TestNewClient_AppRequest(t *testing.T) {
 				Code:    123,
 				Message: "foobar",
 			},
-			appRequestF: func(ctx context.Context, client *p2p.Client, onResponse p2p.AppResponseCallback) error {
+			appRequestF: func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error {
 				return client.AppRequestAny(ctx, []byte("foo"), onResponse)
 			},
 		},
@@ -94,7 +94,7 @@ func TestNewClient_AppRequest(t *testing.T) {
 				},
 			}
 
-			client := NewClient(t, ctx, testHandler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+			client := &Client{Handler: testHandler}
 			require.NoError(tt.appRequestF(
 				ctx,
 				client,

--- a/network/p2p/p2ptest/client_test.go
+++ b/network/p2p/p2ptest/client_test.go
@@ -37,12 +37,12 @@ func TestNewClient_AppRequest(t *testing.T) {
 		name        string
 		appResponse []byte
 		appErr      error
-		appRequestF func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error
+		appRequestF func(ctx context.Context, client Client, onResponse p2p.AppResponseCallback) error
 	}{
 		{
 			name:        "AppRequest - response",
 			appResponse: []byte("foobar"),
-			appRequestF: func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error {
+			appRequestF: func(ctx context.Context, client Client, onResponse p2p.AppResponseCallback) error {
 				return client.AppRequest(ctx, set.Of(ids.GenerateTestNodeID()), []byte("foo"), onResponse)
 			},
 		},
@@ -52,14 +52,14 @@ func TestNewClient_AppRequest(t *testing.T) {
 				Code:    123,
 				Message: "foobar",
 			},
-			appRequestF: func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error {
+			appRequestF: func(ctx context.Context, client Client, onResponse p2p.AppResponseCallback) error {
 				return client.AppRequest(ctx, set.Of(ids.GenerateTestNodeID()), []byte("foo"), onResponse)
 			},
 		},
 		{
 			name:        "AppRequestAny - response",
 			appResponse: []byte("foobar"),
-			appRequestF: func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error {
+			appRequestF: func(ctx context.Context, client Client, onResponse p2p.AppResponseCallback) error {
 				return client.AppRequestAny(ctx, []byte("foo"), onResponse)
 			},
 		},
@@ -69,7 +69,7 @@ func TestNewClient_AppRequest(t *testing.T) {
 				Code:    123,
 				Message: "foobar",
 			},
-			appRequestF: func(ctx context.Context, client *Client, onResponse p2p.AppResponseCallback) error {
+			appRequestF: func(ctx context.Context, client Client, onResponse p2p.AppResponseCallback) error {
 				return client.AppRequestAny(ctx, []byte("foo"), onResponse)
 			},
 		},
@@ -94,7 +94,7 @@ func TestNewClient_AppRequest(t *testing.T) {
 				},
 			}
 
-			client := &Client{Handler: testHandler}
+			client := Client{Handler: testHandler}
 			require.NoError(tt.appRequestF(
 				ctx,
 				client,

--- a/network/p2p/p2ptest/client_test.go
+++ b/network/p2p/p2ptest/client_test.go
@@ -27,7 +27,7 @@ func TestNewClient_AppGossip(t *testing.T) {
 		},
 	}
 
-	client := Client{Handler: testHandler}
+	client := Client{ServerHandler: testHandler}
 	require.NoError(client.AppGossip(ctx, common.SendConfig{}, []byte("foobar")))
 	<-appGossipChan
 }
@@ -94,7 +94,7 @@ func TestNewClient_AppRequest(t *testing.T) {
 				},
 			}
 
-			client := Client{Handler: testHandler}
+			client := Client{ServerHandler: testHandler}
 			require.NoError(tt.appRequestF(
 				ctx,
 				client,

--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -143,8 +143,8 @@ type Manager struct {
 // TODO remove non-config values out of this struct
 type ManagerConfig struct {
 	DB                    DB
-	RangeProofClient      *p2p.Client
-	ChangeProofClient     *p2p.Client
+	RangeProofClient      p2p.ClientInterface
+	ChangeProofClient     p2p.ClientInterface
 	SimultaneousWorkLimit int
 	Log                   logging.Logger
 	TargetRoot            ids.ID
@@ -447,7 +447,7 @@ func (m *Manager) requestRangeProof(ctx context.Context, work *workItem) {
 	m.metrics.RequestMade()
 }
 
-func (m *Manager) sendRequest(ctx context.Context, client *p2p.Client, requestBytes []byte, onResponse p2p.AppResponseCallback) error {
+func (m *Manager) sendRequest(ctx context.Context, client p2p.ClientInterface, requestBytes []byte, onResponse p2p.AppResponseCallback) error {
 	if len(m.config.StateSyncNodes) == 0 {
 		return client.AppRequestAny(ctx, requestBytes, onResponse)
 	}

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -36,11 +36,10 @@ func Test_Creation(t *testing.T) {
 	)
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
 		BranchFactor:          merkledb.BranchFactor16,
@@ -69,11 +68,10 @@ func Test_Completion(t *testing.T) {
 	)
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, emptyDB), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, emptyDB), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, emptyDB)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, emptyDB)},
 		TargetRoot:            emptyRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -174,11 +172,10 @@ func Test_Sync_FindNextKey_InSync(t *testing.T) {
 	)
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -250,11 +247,10 @@ func Test_Sync_FindNextKey_Deleted(t *testing.T) {
 	syncRoot, err := db.GetMerkleRoot(context.Background())
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -300,11 +296,10 @@ func Test_Sync_FindNextKey_BranchInLocal(t *testing.T) {
 	proof, err := db.GetProof(context.Background(), []byte{0x11, 0x11})
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            targetRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -337,11 +332,10 @@ func Test_Sync_FindNextKey_BranchInReceived(t *testing.T) {
 	proof, err := db.GetProof(context.Background(), []byte{0x12})
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            targetRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -373,11 +367,10 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 	)
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -435,11 +428,10 @@ func TestFindNextKeyEmptyEndProof(t *testing.T) {
 	)
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            ids.Empty,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -504,11 +496,10 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 	)
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -727,11 +718,10 @@ func TestFindNextKeyRandom(t *testing.T) {
 		}
 
 		// Get the actual value from the syncer
-		ctx := context.Background()
 		syncer, err := NewManager(ManagerConfig{
 			DB:                    localDB,
-			RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, remoteDB), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-			ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, remoteDB), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+			RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, remoteDB)},
+			ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, remoteDB)},
 			TargetRoot:            ids.GenerateTestID(),
 			SimultaneousWorkLimit: 5,
 			Log:                   logging.NoLog{},
@@ -767,32 +757,32 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 	tests := []struct {
 		name              string
 		db                merkledb.MerkleDB
-		rangeProofClient  func(db merkledb.MerkleDB) *p2p.Client
-		changeProofClient func(db merkledb.MerkleDB) *p2p.Client
+		rangeProofClient  func(db merkledb.MerkleDB) p2p.ClientInterface
+		changeProofClient func(db merkledb.MerkleDB) p2p.ClientInterface
 	}{
 		{
 			name: "range proof bad response - too many leaves in response",
-			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
 					response.KeyValues = append(response.KeyValues, merkledb.KeyValue{})
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "range proof bad response - removed first key in response",
-			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
 					response.KeyValues = response.KeyValues[min(1, len(response.KeyValues)):]
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "range proof bad response - removed first key in response and replaced proof",
-			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
 					response.KeyValues = response.KeyValues[min(1, len(response.KeyValues)):]
 					response.KeyValues = []merkledb.KeyValue{
@@ -813,111 +803,111 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					}
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "range proof bad response - removed key from middle of response",
-			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
 					i := rand.Intn(max(1, len(response.KeyValues)-1)) // #nosec G404
 					_ = slices.Delete(response.KeyValues, i, min(len(response.KeyValues), i+1))
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "range proof bad response - start and end proof nodes removed",
-			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
 					response.StartProof = nil
 					response.EndProof = nil
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "range proof bad response - end proof removed",
-			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
 					response.EndProof = nil
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "range proof bad response - empty proof",
-			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
 					response.StartProof = nil
 					response.EndProof = nil
 					response.KeyValues = nil
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "range proof server flake",
-			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
-				return p2ptest.NewClient(t, context.Background(), &flakyHandler{
+			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
+				return p2ptest.Client{Handler: &flakyHandler{
 					Handler: NewGetRangeProofHandler(logging.NoLog{}, db),
 					c:       &counter{m: 2},
-				}, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				}}
 			},
 		},
 		{
 			name: "change proof bad response - too many keys in response",
-			changeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			changeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyChangeProofHandler(t, db, func(response *merkledb.ChangeProof) {
 					response.KeyChanges = append(response.KeyChanges, make([]merkledb.KeyChange, defaultRequestKeyLimit)...)
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "change proof bad response - removed first key in response",
-			changeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			changeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyChangeProofHandler(t, db, func(response *merkledb.ChangeProof) {
 					response.KeyChanges = response.KeyChanges[min(1, len(response.KeyChanges)):]
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "change proof bad response - removed key from middle of response",
-			changeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			changeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyChangeProofHandler(t, db, func(response *merkledb.ChangeProof) {
 					i := rand.Intn(max(1, len(response.KeyChanges)-1)) // #nosec G404
 					_ = slices.Delete(response.KeyChanges, i, min(len(response.KeyChanges), i+1))
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "change proof bad response - all proof keys removed from response",
-			changeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
+			changeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
 				handler := newFlakyChangeProofHandler(t, db, func(response *merkledb.ChangeProof) {
 					response.StartProof = nil
 					response.EndProof = nil
 				})
 
-				return p2ptest.NewClient(t, context.Background(), handler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				return p2ptest.Client{Handler: handler}
 			},
 		},
 		{
 			name: "change proof flaky server",
-			changeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
-				return p2ptest.NewClient(t, context.Background(), &flakyHandler{
+			changeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
+				return p2ptest.Client{Handler: &flakyHandler{
 					Handler: NewGetChangeProofHandler(logging.NoLog{}, db),
 					c:       &counter{m: 2},
-				}, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+				}}
 			},
 		},
 	}
@@ -941,18 +931,18 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 			require.NoError(err)
 
 			var (
-				rangeProofClient  *p2p.Client
-				changeProofClient *p2p.Client
+				rangeProofClient  p2p.ClientInterface
+				changeProofClient p2p.ClientInterface
 			)
 
 			rangeProofHandler := NewGetRangeProofHandler(logging.NoLog{}, dbToSync)
-			rangeProofClient = p2ptest.NewClient(t, ctx, rangeProofHandler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+			rangeProofClient = p2ptest.Client{Handler: rangeProofHandler}
 			if tt.rangeProofClient != nil {
 				rangeProofClient = tt.rangeProofClient(dbToSync)
 			}
 
 			changeProofHandler := NewGetChangeProofHandler(logging.NoLog{}, dbToSync)
-			changeProofClient = p2ptest.NewClient(t, ctx, changeProofHandler, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+			changeProofClient = p2ptest.Client{Handler: changeProofHandler}
 			if tt.changeProofClient != nil {
 				changeProofClient = tt.changeProofClient(dbToSync)
 			}
@@ -1028,11 +1018,10 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 	)
 	require.NoError(err)
 
-	ctx := context.Background()
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -1058,8 +1047,8 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 
 	newSyncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, dbToSync), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -1127,16 +1116,15 @@ func Test_Sync_Result_Correct_Root_Update_Root_During(t *testing.T) {
 	updatedRootChan := make(chan struct{}, 1)
 	updatedRootChan <- struct{}{}
 
-	ctx := context.Background()
-	rangeProofClient := p2ptest.NewClient(t, ctx, &waitingHandler{
+	rangeProofClient := p2ptest.Client{Handler: &waitingHandler{
 		handler:         NewGetRangeProofHandler(logging.NoLog{}, dbToSync),
 		updatedRootChan: updatedRootChan,
-	}, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+	}}
 
-	changeProofClient := p2ptest.NewClient(t, ctx, &waitingHandler{
+	changeProofClient := p2ptest.Client{Handler: &waitingHandler{
 		handler:         NewGetChangeProofHandler(logging.NoLog{}, dbToSync),
 		updatedRootChan: updatedRootChan,
-	}, ids.GenerateTestNodeID(), ids.GenerateTestNodeID())
+	}}
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
@@ -1184,11 +1172,10 @@ func Test_Sync_UpdateSyncTarget(t *testing.T) {
 		newDefaultDBConfig(),
 	)
 	require.NoError(err)
-	ctx := context.Background()
 	m, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.NewClient(t, ctx, NewGetRangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
-		ChangeProofClient:     p2ptest.NewClient(t, ctx, NewGetChangeProofHandler(logging.NoLog{}, db), ids.GenerateTestNodeID(), ids.GenerateTestNodeID()),
+		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            ids.Empty,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -38,8 +38,8 @@ func Test_Creation(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
 		BranchFactor:          merkledb.BranchFactor16,
@@ -70,8 +70,8 @@ func Test_Completion(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, emptyDB)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, emptyDB)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, emptyDB)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, emptyDB)},
 		TargetRoot:            emptyRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -174,8 +174,8 @@ func Test_Sync_FindNextKey_InSync(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -249,8 +249,8 @@ func Test_Sync_FindNextKey_Deleted(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -298,8 +298,8 @@ func Test_Sync_FindNextKey_BranchInLocal(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            targetRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -334,8 +334,8 @@ func Test_Sync_FindNextKey_BranchInReceived(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            targetRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -369,8 +369,8 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -430,8 +430,8 @@ func TestFindNextKeyEmptyEndProof(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            ids.Empty,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -498,8 +498,8 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -720,8 +720,8 @@ func TestFindNextKeyRandom(t *testing.T) {
 		// Get the actual value from the syncer
 		syncer, err := NewManager(ManagerConfig{
 			DB:                    localDB,
-			RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, remoteDB)},
-			ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, remoteDB)},
+			RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, remoteDB)},
+			ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, remoteDB)},
 			TargetRoot:            ids.GenerateTestID(),
 			SimultaneousWorkLimit: 5,
 			Log:                   logging.NoLog{},
@@ -767,7 +767,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					response.KeyValues = append(response.KeyValues, merkledb.KeyValue{})
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -777,7 +777,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					response.KeyValues = response.KeyValues[min(1, len(response.KeyValues)):]
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -803,7 +803,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					}
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -814,7 +814,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					_ = slices.Delete(response.KeyValues, i, min(len(response.KeyValues), i+1))
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -825,7 +825,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					response.EndProof = nil
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -835,7 +835,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					response.EndProof = nil
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -847,13 +847,13 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					response.KeyValues = nil
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
 			name: "range proof server flake",
 			rangeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
-				return p2ptest.Client{Handler: &flakyHandler{
+				return p2ptest.Client{ServerHandler: &flakyHandler{
 					Handler: NewGetRangeProofHandler(logging.NoLog{}, db),
 					c:       &counter{m: 2},
 				}}
@@ -866,7 +866,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					response.KeyChanges = append(response.KeyChanges, make([]merkledb.KeyChange, defaultRequestKeyLimit)...)
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -876,7 +876,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					response.KeyChanges = response.KeyChanges[min(1, len(response.KeyChanges)):]
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -887,7 +887,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					_ = slices.Delete(response.KeyChanges, i, min(len(response.KeyChanges), i+1))
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
@@ -898,13 +898,13 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					response.EndProof = nil
 				})
 
-				return p2ptest.Client{Handler: handler}
+				return p2ptest.Client{ServerHandler: handler}
 			},
 		},
 		{
 			name: "change proof flaky server",
 			changeProofClient: func(db merkledb.MerkleDB) p2p.ClientInterface {
-				return p2ptest.Client{Handler: &flakyHandler{
+				return p2ptest.Client{ServerHandler: &flakyHandler{
 					Handler: NewGetChangeProofHandler(logging.NoLog{}, db),
 					c:       &counter{m: 2},
 				}}
@@ -936,13 +936,13 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 			)
 
 			rangeProofHandler := NewGetRangeProofHandler(logging.NoLog{}, dbToSync)
-			rangeProofClient = p2ptest.Client{Handler: rangeProofHandler}
+			rangeProofClient = p2ptest.Client{ServerHandler: rangeProofHandler}
 			if tt.rangeProofClient != nil {
 				rangeProofClient = tt.rangeProofClient(dbToSync)
 			}
 
 			changeProofHandler := NewGetChangeProofHandler(logging.NoLog{}, dbToSync)
-			changeProofClient = p2ptest.Client{Handler: changeProofHandler}
+			changeProofClient = p2ptest.Client{ServerHandler: changeProofHandler}
 			if tt.changeProofClient != nil {
 				changeProofClient = tt.changeProofClient(dbToSync)
 			}
@@ -1020,8 +1020,8 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 
 	syncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -1047,8 +1047,8 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 
 	newSyncer, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, dbToSync)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, dbToSync)},
 		TargetRoot:            syncRoot,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},
@@ -1116,12 +1116,12 @@ func Test_Sync_Result_Correct_Root_Update_Root_During(t *testing.T) {
 	updatedRootChan := make(chan struct{}, 1)
 	updatedRootChan <- struct{}{}
 
-	rangeProofClient := p2ptest.Client{Handler: &waitingHandler{
+	rangeProofClient := p2ptest.Client{ServerHandler: &waitingHandler{
 		handler:         NewGetRangeProofHandler(logging.NoLog{}, dbToSync),
 		updatedRootChan: updatedRootChan,
 	}}
 
-	changeProofClient := p2ptest.Client{Handler: &waitingHandler{
+	changeProofClient := p2ptest.Client{ServerHandler: &waitingHandler{
 		handler:         NewGetChangeProofHandler(logging.NoLog{}, dbToSync),
 		updatedRootChan: updatedRootChan,
 	}}
@@ -1174,8 +1174,8 @@ func Test_Sync_UpdateSyncTarget(t *testing.T) {
 	require.NoError(err)
 	m, err := NewManager(ManagerConfig{
 		DB:                    db,
-		RangeProofClient:      p2ptest.Client{Handler: NewGetRangeProofHandler(logging.NoLog{}, db)},
-		ChangeProofClient:     p2ptest.Client{Handler: NewGetChangeProofHandler(logging.NoLog{}, db)},
+		RangeProofClient:      p2ptest.Client{ServerHandler: NewGetRangeProofHandler(logging.NoLog{}, db)},
+		ChangeProofClient:     p2ptest.Client{ServerHandler: NewGetChangeProofHandler(logging.NoLog{}, db)},
 		TargetRoot:            ids.Empty,
 		SimultaneousWorkLimit: 5,
 		Log:                   logging.NoLog{},


### PR DESCRIPTION
## Why this should be merged

* Simplifies code for `p2ptest`
* Zero-value of `Client` is now useful

## How this works

* Adds an interface and a testing implementation of `p2p.ClientInterface`

## How this was tested

* UTs
