### PR TITLE
Remove unused metrics registry from sync ManagerConfig

### DIFF
--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -151,8 +151,7 @@ type ManagerConfig struct {
 	BranchFactor          merkledb.BranchFactor
 	StateSyncNodes        []ids.NodeID
 	// If not specified, [merkledb.DefaultHasher] will be used.
-	Hasher  merkledb.Hasher
-	Metrics prometheus.Registerer
+	Hasher merkledb.Hasher
 }
 
 func NewManager(config ManagerConfig, registerer prometheus.Registerer) (*Manager, error) {


### PR DESCRIPTION
This PR removes an unused field from the sync ManagerConfig found while reviewing https://github.com/ava-labs/hypersdk/pull/1613