### PR TITLE
Include untracked files for clean branch

### DIFF
--- a/.github/workflows/check-clean-branch.sh
+++ b/.github/workflows/check-clean-branch.sh
@@ -5,5 +5,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+git add .
 git update-index --really-refresh >> /dev/null
 git diff-index --quiet HEAD

--- a/.github/workflows/check-clean-branch.sh
+++ b/.github/workflows/check-clean-branch.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # Exits if any uncommitted changes are found.
 
-set -o errexit
-set -o nounset
-set -o pipefail
+set -euo pipefail
 
 git add --all
 git update-index --really-refresh >> /dev/null

--- a/.github/workflows/check-clean-branch.sh
+++ b/.github/workflows/check-clean-branch.sh
@@ -5,6 +5,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-git add .
+git add --all
 git update-index --really-refresh >> /dev/null
 git diff-index --quiet HEAD

--- a/.github/workflows/check-clean-branch.sh
+++ b/.github/workflows/check-clean-branch.sh
@@ -1,8 +1,9 @@
-#!/bin/bash
-# Exits if any uncommitted changes are found.
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 git add --all
 git update-index --really-refresh >> /dev/null
+
+# Exits if any uncommitted changes are found.
 git diff-index --quiet HEAD

--- a/scripts/mocks.mockgen.source.txt
+++ b/scripts/mocks.mockgen.source.txt
@@ -12,4 +12,3 @@ vms/platformvm/state/state.go=Chain=MockState=vms/platformvm/state/mock_state.go
 vms/platformvm/state/state.go=State=MockChain=vms/platformvm/state/mock_chain.go
 vms/platformvm/txs/unsigned_tx.go==UnsignedTx=vms/platformvm/txs/txsmock/unsigned_tx.go
 vms/proposervm/block.go=Block=MockPostForkBlock=vms/proposervm/mock_post_fork_block.go
-x/merkledb/db.go=ChangeProofer,RangeProofer,Clearer,Prefetcher=MockMerkleDB=x/merkledb/mock_db.go


### PR DESCRIPTION
## Why this should be merged

Currently the `check-clean-branch.sh` script does not catch untracked files.

## How this works

Adds all files so that they are tracked.

## How this was tested

- [X] CI is failing on the [first commit](https://github.com/ava-labs/avalanchego/actions/runs/11168607914/job/31047393099)
- [X] CI is passing on the [last commit](https://github.com/ava-labs/avalanchego/actions/runs/11168704750/job/31047900227?pr=3442)