### PR TITLE
[testing] Fix bootstrap monitor e2e image build error check

### DIFF
--- a/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
+++ b/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
@@ -251,9 +251,7 @@ func buildImage(tc tests.TestContext, imageName string, forceNewHash bool, scrip
 		"SKIP_BUILD_RACE=1",
 	)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		require.FailNow("Image build failed: %v\nWith output: %s", err, output)
-	}
+	require.NoError(err, "Image build failed: %s", output)
 }
 
 // newNodeStatefulSet returns a statefulset for an avalanchego node.


### PR DESCRIPTION
testify was panicking on the previous error check which was preventing diagnosis of the underlying cause of image build flakes.
