### PR TITLE
[testing] Update bootstrap-monitor to output default configuration

### DIFF
--- a/tests/fixture/bootstrapmonitor/README.md
+++ b/tests/fixture/bootstrapmonitor/README.md
@@ -15,7 +15,10 @@ regressions in compatibility.
 ### Types of bootstrap testing for C-Chain
 
 The X-Chain and P-Chain always synchronize all state, but the bulk of
-data for testnet and mainnet is on the C-Chain and there are 2 options:
+data for testnet and mainnet is on the C-Chain. There are 2 primary
+options ([as documented in the coreth
+repo](https://github.com/ava-labs/coreth/tree/master/sync)) for
+configuring synchronization of the C-Chain:
 
 #### State Sync
 
@@ -120,6 +123,33 @@ and initiates a new test when one is found.
    image is found, the managing `StatefulSet` is updated with the
    details of the image to trigger a new test. The process to detect a
    new image is the same as was described for the `init` command.
+
+### Configuration
+
+The simplest way to provide configuration to avalanchego running in a
+pod is via environment variables (env vars). Providing configuration
+via the filesystem to a pod (e.g. `--config-file-dir`) would require
+maintaining the configuration in a configmap - separate from the pod -
+and mapping the volume so the pod could read it. Simpler to define the
+configuration directly in the pod spec as an env var.
+
+In the interests of simplifying the maintenance of configuration
+intended to be supplied via env var, the `bootstrap-monitor` binary
+provides commands for outputting configuration in the marshaled and
+base64-encoded format expected by the following env vars:
+
+ - `AVAGO_CHAIN_CONFIG_CONTENT`
+   - `bootstrap-monitor chain-config --state-sync-enabled=true`
+     - Generates chain configuration for state sync bootstrap
+   - `bootstrap-monitor chain-config --state-sync-enabled=false`
+     - Generates chain configuration for full sync bootstrap
+ - `AVAGO_DB_CONFIG_FILE_CONTENT`
+   - `bootstrap-monitor db-config`
+     - Generates db configuration common to all bootstrap tests
+
+When the configuration for one of these vars needs to be changed, the
+relevant `bootstrap-monitor` command can be modified and its output
+applied to the appropriate env vars.
 
 ## Package details
 


### PR DESCRIPTION
## Why this should be merged

Maintaining chain and db config in the format required by bootstrap testing is complicated by the need to marshal and base64-encode it. Rather than require a manual process, this PR adds commands to the `bootstrap-monitor` binary.

The output of the new commands is used by https://github.com/ava-labs/devops-argocd/pull/8156

## How this works

Adds new commands to the `bootstrap-monitor` binary that output the marshaled and base64-encoded configuration for relevant avalanchego env vars.

## How this was tested

Output of the new commands manually verified by updating manually-deployed bootstrap tests. 