### PR TITLE
ACP-77: Allow xsvm to sign arbitrary warp messages

### DIFF
--- a/vms/example/xsvm/warp.go
+++ b/vms/example/xsvm/warp.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package xsvm
+
+import (
+	"context"
+
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
+)
+
+// acp118Verifier allows signing all warp messages
+type acp118Verifier struct{}
+
+func (acp118Verifier) Verify(context.Context, *warp.UnsignedMessage, []byte) *common.AppError {
+	return nil
+}

--- a/vms/example/xsvm/warp.go
+++ b/vms/example/xsvm/warp.go
@@ -6,9 +6,12 @@ package xsvm
 import (
 	"context"
 
+	"github.com/ava-labs/avalanchego/network/p2p/acp118"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 )
+
+var _ acp118.Verifier = (*acp118Verifier)(nil)
 
 // acp118Verifier allows signing all warp messages
 type acp118Verifier struct{}


### PR DESCRIPTION
## Why this should be merged

This PR will allow creation of E2E tests for ACP-77.

## How this works

Adds ACP-118 support to the XSVM without performing any message verification.

## How this was tested

N/A