### PR TITLE
Add ACP-118 caching support

### DIFF
--- a/network/p2p/acp118/handler.go
+++ b/network/p2p/acp118/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/proto/pb/sdk"
@@ -30,7 +31,22 @@ type Verifier interface {
 
 // NewHandler returns an instance of Handler
 func NewHandler(verifier Verifier, signer warp.Signer) *Handler {
+	return NewCachedHandler(
+		&cache.Empty[ids.ID, []byte]{},
+		verifier,
+		signer,
+	)
+}
+
+// NewCachedHandler returns an instance of Handler that caches successful
+// requests.
+func NewCachedHandler(
+	cacher cache.Cacher[ids.ID, []byte],
+	verifier Verifier,
+	signer warp.Signer,
+) *Handler {
 	return &Handler{
+		cacher:   cacher,
 		verifier: verifier,
 		signer:   signer,
 	}
@@ -40,6 +56,7 @@ func NewHandler(verifier Verifier, signer warp.Signer) *Handler {
 type Handler struct {
 	p2p.NoOpHandler
 
+	cacher   cache.Cacher[ids.ID, []byte]
 	verifier Verifier
 	signer   warp.Signer
 }
@@ -66,6 +83,11 @@ func (h *Handler) AppRequest(
 		}
 	}
 
+	msgID := msg.ID()
+	if responseBytes, ok := h.cacher.Get(msgID); ok {
+		return responseBytes, nil
+	}
+
 	if err := h.verifier.Verify(ctx, msg, request.Justification); err != nil {
 		return nil, err
 	}
@@ -90,5 +112,6 @@ func (h *Handler) AppRequest(
 		}
 	}
 
+	h.cacher.Put(msgID, responseBytes)
 	return responseBytes, nil
 }


### PR DESCRIPTION
## Why this should be merged

If multiple nodes are attempting to relay a Warp message, caching the signature can be a noticeable performance improvement.

## How this works

Allows the ACP-118 handler to be configured with a cache.

## How this was tested

- [X] Updated unit test