### PR TITLE
Remove unexpected block unwrapping

### DIFF
--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -1184,8 +1184,9 @@ func TestBlockExecutionWithComplexity(t *testing.T) {
 			}
 
 			require.Contains(verifier.blkIDToState, blkID)
-			onAcceptState := verifier.blkIDToState[blkID].onAcceptState
-			require.Equal(test.expectedFeeState, onAcceptState.GetFeeState())
+			blockState := verifier.blkIDToState[blkID]
+			require.Equal(blk, blockState.statelessBlock)
+			require.Equal(test.expectedFeeState, blockState.onAcceptState.GetFeeState())
 		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Currently we actually pass `ApricotProposalBlock` and `ApricotStandardBlock`s into `state.AddStatelessBlock` upon accept. This ends up not being a bug because the `Banff.*Block`s serialized format is still returned from `.Bytes()` and the parsed version of the block is not cached.

However, this is a very weird flow that seems very close to causing a bug.

## How this works

Passes the wrapped block types into the helper functions.

## How this was tested

- [X] Added additional test coverage that fails against master.