### PR TITLE
[testing] Enable verbose image build output for bootstrap-monitor e2e

### DIFF
--- a/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
+++ b/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
@@ -234,7 +234,10 @@ func buildImage(tc tests.TestContext, imageName string, forceNewHash bool, scrip
 	repoRoot, err := e2e.GetRepoRootPath(repoRelativePath)
 	require.NoError(err)
 
-	var args []string
+	args := []string{
+		"-x", // Ensure script output to aid in debugging
+		filepath.Join(repoRoot, "scripts", scriptName),
+	}
 	if forceNewHash {
 		// Ensure the build results in a new image hash by preventing use of a cached final stage
 		args = append(args, "--no-cache-filter", "execution")
@@ -242,7 +245,7 @@ func buildImage(tc tests.TestContext, imageName string, forceNewHash bool, scrip
 
 	cmd := exec.CommandContext(
 		tc.DefaultContext(),
-		filepath.Join(repoRoot, "scripts", scriptName),
+		"bash",
 		args...,
 	) // #nosec G204
 	cmd.Env = append(os.Environ(),


### PR DESCRIPTION
## Why this should be merged

Recent flakes of the bootstrap monitor e2e job are lacking sufficient detail to diagnose.

## How this works

Executes the image build script with `bash -x` to allow determining whether the flake is due the build script or docker.

## How this was tested

CI