### PR TITLE
[ci] Update MacOS jobs to macos-14

### DIFF
--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build-mac:
     # The type of runner that the job will run on
-    runs-on: macos-14-arm64
+    runs-on: macos-14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build-mac:
     # The type of runner that the job will run on
-    runs-on: macos-12
+    runs-on: macos-14-arm64
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-arm64, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, custom-arm64-jammy, custom-arm64-noble]
+        os: [macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, custom-arm64-jammy, custom-arm64-noble]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go-for-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, custom-arm64-jammy, custom-arm64-noble]
+        os: [macos-14-arm64, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, custom-arm64-jammy, custom-arm64-noble]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go-for-project


### PR DESCRIPTION
## Why this should be merged

This is the the current stable version ~and arm64 makes more sense given apple silicon being 4 years old~ edit: arm64 macos runners are apparently not available.

Also, macos-12 is being discontinued in November: https://github.com/actions/runner-images/issues/10721

## How this works

N/A

## How this was tested

CI