### PR TITLE
ACP-77: Include validator capacity into the fee config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -793,8 +793,8 @@ func getTxFeeConfig(v *viper.Viper, networkID uint32) genesis.TxFeeConfig {
 				MinPrice:                 gas.Price(v.GetUint64(DynamicFeesMinGasPriceKey)),
 				ExcessConversionConstant: gas.Gas(v.GetUint64(DynamicFeesExcessConversionConstantKey)),
 			},
-			ValidatorFeeCapacity: gas.Gas(v.GetUint64(ValidatorFeesCapacityKey)),
 			ValidatorFeeConfig: validatorfee.Config{
+				Capacity:                 gas.Gas(v.GetUint64(ValidatorFeesCapacityKey)),
 				Target:                   gas.Gas(v.GetUint64(ValidatorFeesTargetKey)),
 				MinPrice:                 gas.Price(v.GetUint64(ValidatorFeesMinPriceKey)),
 				ExcessConversionConstant: gas.Gas(v.GetUint64(ValidatorFeesExcessConversionConstantKey)),

--- a/config/flags.go
+++ b/config/flags.go
@@ -106,7 +106,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 
 	// AVAX fees:
 	// Validator fees:
-	fs.Uint64(ValidatorFeesCapacityKey, uint64(genesis.LocalParams.ValidatorFeeCapacity), "Maximum number of validators")
+	fs.Uint64(ValidatorFeesCapacityKey, uint64(genesis.LocalParams.ValidatorFeeConfig.Capacity), "Maximum number of validators")
 	fs.Uint64(ValidatorFeesTargetKey, uint64(genesis.LocalParams.ValidatorFeeConfig.Target), "Target number of validators")
 	fs.Uint64(ValidatorFeesMinPriceKey, uint64(genesis.LocalParams.ValidatorFeeConfig.MinPrice), "Minimum validator price in nAVAX per second")
 	fs.Uint64(ValidatorFeesExcessConversionConstantKey, uint64(genesis.LocalParams.ValidatorFeeConfig.ExcessConversionConstant), "Constant to convert validator excess price")

--- a/genesis/genesis_fuji.go
+++ b/genesis/genesis_fuji.go
@@ -48,8 +48,8 @@ var (
 				MinPrice:                 1,
 				ExcessConversionConstant: 5_000,
 			},
-			ValidatorFeeCapacity: 20_000,
 			ValidatorFeeConfig: validatorfee.Config{
+				Capacity: 20_000,
 				Target:   10_000,
 				MinPrice: gas.Price(512 * units.NanoAvax),
 				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -66,8 +66,8 @@ var (
 				MinPrice:                 1,
 				ExcessConversionConstant: 5_000,
 			},
-			ValidatorFeeCapacity: 20_000,
 			ValidatorFeeConfig: validatorfee.Config{
+				Capacity: 20_000,
 				Target:   10_000,
 				MinPrice: gas.Price(1 * units.NanoAvax),
 				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)

--- a/genesis/genesis_mainnet.go
+++ b/genesis/genesis_mainnet.go
@@ -48,8 +48,8 @@ var (
 				MinPrice:                 1,
 				ExcessConversionConstant: 5_000,
 			},
-			ValidatorFeeCapacity: 20_000,
 			ValidatorFeeConfig: validatorfee.Config{
+				Capacity: 20_000,
 				Target:   10_000,
 				MinPrice: gas.Price(512 * units.NanoAvax),
 				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)

--- a/genesis/params.go
+++ b/genesis/params.go
@@ -38,11 +38,10 @@ type StakingConfig struct {
 }
 
 type TxFeeConfig struct {
-	CreateAssetTxFee     uint64              `json:"createAssetTxFee"`
-	StaticFeeConfig      txfee.StaticConfig  `json:"staticFeeConfig"`
-	DynamicFeeConfig     gas.Config          `json:"dynamicFeeConfig"`
-	ValidatorFeeCapacity gas.Gas             `json:"validatorFeeCapacity"`
-	ValidatorFeeConfig   validatorfee.Config `json:"validatorFeeConfig"`
+	CreateAssetTxFee   uint64              `json:"createAssetTxFee"`
+	StaticFeeConfig    txfee.StaticConfig  `json:"staticFeeConfig"`
+	DynamicFeeConfig   gas.Config          `json:"dynamicFeeConfig"`
+	ValidatorFeeConfig validatorfee.Config `json:"validatorFeeConfig"`
 }
 
 type Params struct {

--- a/node/node.go
+++ b/node/node.go
@@ -1217,7 +1217,6 @@ func (n *Node) initVMs() error {
 				CreateAssetTxFee:          n.Config.CreateAssetTxFee,
 				StaticFeeConfig:           n.Config.StaticFeeConfig,
 				DynamicFeeConfig:          n.Config.DynamicFeeConfig,
-				ValidatorFeeCapacity:      n.Config.ValidatorFeeCapacity,
 				ValidatorFeeConfig:        n.Config.ValidatorFeeConfig,
 				UptimePercentage:          n.Config.UptimeRequirement,
 				MinValidatorStake:         n.Config.MinValidatorStake,

--- a/vms/platformvm/config/config.go
+++ b/vms/platformvm/config/config.go
@@ -42,8 +42,7 @@ type Config struct {
 	DynamicFeeConfig gas.Config
 
 	// ACP-77 validator fees are active after Etna
-	ValidatorFeeCapacity gas.Gas
-	ValidatorFeeConfig   validatorfee.Config
+	ValidatorFeeConfig validatorfee.Config
 
 	// Provides access to the uptime manager as a thread safe data structure
 	UptimeLockedCalculator uptime.LockedCalculator

--- a/vms/platformvm/validators/fee/fee.go
+++ b/vms/platformvm/validators/fee/fee.go
@@ -13,6 +13,7 @@ import (
 
 // Config contains all the static parameters of the dynamic fee mechanism.
 type Config struct {
+	Capacity                 gas.Gas   `json:"capacity"`
 	Target                   gas.Gas   `json:"target"`
 	MinPrice                 gas.Price `json:"minPrice"`
 	ExcessConversionConstant gas.Gas   `json:"excessConversionConstant"`


### PR DESCRIPTION
## Why this should be merged

Initially, `Capacity` wasn't included in the fee config because the `Capacity` isn't used to calculate the fees... But as we use this config more, it is becoming increasingly annoying to need to pass around a struct and a value.. We could add a second wrapper struct... but I felt like this was the cleanest option right now.

## How this works

Moves the capacity var into the config.

## How this was tested

N/A