### PR TITLE
[tmpnet] Add --start-network to support hypersdk MODE=run

### DIFF
--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -135,6 +135,7 @@ func NewTestEnvironment(tc tests.TestContext, flagVars *FlagVars, desiredNetwork
 			flagVars.AvalancheGoExecPath(),
 			flagVars.PluginDir(),
 			flagVars.NetworkShutdownDelay(),
+			flagVars.StartNetwork(),
 			flagVars.ReuseNetwork(),
 		)
 
@@ -156,6 +157,10 @@ func NewTestEnvironment(tc tests.TestContext, flagVars *FlagVars, desiredNetwork
 			}
 			return true
 		}, DefaultTimeout, DefaultPollingInterval, "failed to see all chains bootstrap before timeout")
+	}
+
+	if flagVars.StartNetwork() {
+		os.Exit(0)
 	}
 
 	suiteConfig, _ := ginkgo.GinkgoConfiguration()
@@ -214,6 +219,7 @@ func (te *TestEnvironment) StartPrivateNetwork(network *tmpnet.Network) {
 		sharedNetwork.DefaultRuntimeConfig.AvalancheGoPath,
 		pluginDir,
 		te.PrivateNetworkShutdownDelay,
+		false, /* skipShutdown */
 		false, /* reuseNetwork */
 	)
 }

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -22,6 +22,7 @@ type FlagVars struct {
 	networkDir           string
 	reuseNetwork         bool
 	delayNetworkShutdown bool
+	startNetwork         bool
 	stopNetwork          bool
 	restartNetwork       bool
 	nodeCount            int
@@ -60,6 +61,10 @@ func (v *FlagVars) NetworkShutdownDelay() time.Duration {
 		return networkShutdownDelay
 	}
 	return 0
+}
+
+func (v *FlagVars) StartNetwork() bool {
+	return v.startNetwork
 }
 
 func (v *FlagVars) StopNetwork() bool {
@@ -112,13 +117,13 @@ func RegisterFlags() *FlagVars {
 		&vars.reuseNetwork,
 		"reuse-network",
 		false,
-		"[optional] reuse an existing network. If an existing network is not already running, create a new one and leave it running for subsequent usage.",
+		"[optional] reuse an existing network previously started with --reuse-network. If a network is not already running, create a new one and leave it running for subsequent usage. Ignored if --stop-network is provided.",
 	)
 	flag.BoolVar(
 		&vars.restartNetwork,
 		"restart-network",
 		false,
-		"[optional] restarts an existing network. Useful for ensuring a network is running with the current state of binaries on disk. Ignored if a network is not already running or --stop-network is provided.",
+		"[optional] restart an existing network previously started with --reuse-network. Useful for ensuring a network is running with the current state of binaries on disk. Ignored if a network is not already running or --stop-network is provided.",
 	)
 	flag.BoolVar(
 		&vars.delayNetworkShutdown,
@@ -127,10 +132,16 @@ func RegisterFlags() *FlagVars {
 		"[optional] whether to delay network shutdown to allow a final metrics scrape.",
 	)
 	flag.BoolVar(
+		&vars.startNetwork,
+		"start-network",
+		false,
+		"[optional] start a new network and exit without executing any tests. The new network cannot be reused with --reuse-network. Ignored if either --reuse-network or --stop-network is provided.",
+	)
+	flag.BoolVar(
 		&vars.stopNetwork,
 		"stop-network",
 		false,
-		"[optional] stop an existing network and exit without executing any tests.",
+		"[optional] stop an existing network started with --reuse-network and exit without executing any tests.",
 	)
 	flag.IntVar(
 		&vars.nodeCount,

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -231,6 +231,7 @@ func StartNetwork(
 	avalancheGoExecPath string,
 	pluginDir string,
 	shutdownDelay time.Duration,
+	skipShutdown bool,
 	reuseNetwork bool,
 ) {
 	require := require.New(tc)
@@ -267,6 +268,11 @@ func StartNetwork(
 	tc.DeferCleanup(func() {
 		if reuseNetwork {
 			tc.Outf("{{yellow}}Skipping shutdown for network %s (symlinked to %s) to enable reuse{{/}}\n", network.Dir, symlinkPath)
+			return
+		}
+
+		if skipShutdown {
+			tc.Outf("{{yellow}}Skipping shutdown for network %s{{/}}\n", network.Dir)
 			return
 		}
 

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -51,7 +51,15 @@ var _ = ginkgo.Describe("[Upgrade]", func() {
 		require.NoError(err)
 		network.Genesis = genesis
 
-		e2e.StartNetwork(tc, network, avalancheGoExecPath, "" /* pluginDir */, 0 /* shutdownDelay */, false /* reuseNetwork */)
+		e2e.StartNetwork(
+			tc,
+			network,
+			avalancheGoExecPath,
+			"",    /* pluginDir */
+			0,     /* shutdownDelay */
+			false, /* skipShutdown */
+			false, /* reuseNetwork */
+		)
 
 		tc.By(fmt.Sprintf("restarting all nodes with %q binary", avalancheGoExecPathToUpgradeTo))
 		for _, node := range network.Nodes {


### PR DESCRIPTION
## Why this should be merged

Hypersdk tooling has long supported supplying `MODE=run` to its `run.sh` script to start a network and leave it running without executing any tests. When hypersdk switched to tmpnet, the run script was updated to specify `--reuse-network` and run a trivial test, but the use of `--reuse-network` risks confusion if a user expects the resulting network to reflect the latest binary state. Adding explicit support for always starting a new network avoids this risk. 

## How this works

- Add new flag `--start-network` to the tmpnet env flags
- If the flag is provided, start a new network, avoid stopping it on cleanup, and exit before running any tests

## How this was tested

CI for regression, locally to check that a new network was started and stayed running