### PR TITLE
[testing] Double image build timeout for bootstrap monitor e2e

### DIFF
--- a/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
+++ b/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
@@ -244,7 +244,7 @@ func buildImage(tc tests.TestContext, imageName string, forceNewHash bool, scrip
 	}
 
 	cmd := exec.CommandContext(
-		tc.DefaultContext(),
+		tc.ContextWithTimeout(e2e.DefaultTimeout*2), // Double the timeout to account for CI being really slow
 		"bash",
 		args...,
 	) // #nosec G204


### PR DESCRIPTION
## Why this should be merged

~Performing the image builds as part of the test suite seemed to provoke OOMkills in CI.~ 

Edit: Realized that image builds are actually being killed due to a context with too short a timeout. 

## How this works

~Performs image builds before running suite. The image build to update the hash is still performed by the suite though.~

Edit: Doubled the timeout

## How this was tested

CI