### PR TITLE
Cleanup editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,13 @@
 # https://editorconfig.org/
+root = true
 
 [*]
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_newspace = true
+trim_trailing_whitespace = true
+
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab


### PR DESCRIPTION
## Why this should be merged

* `trim_trailing_newspace` should be `trim_trailing_whitespace`
* Only uses tab indents for golang files and two space indents for all other files

## How this works

pretty straightforward

## How this was tested

Manually