### PR TITLE
fix improper use of FailNow in testing

### DIFF
--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -249,7 +249,7 @@ func StartNetwork(
 		if stopErr := network.Stop(tc.DefaultContext()); stopErr != nil {
 			tc.Outf("failed to stop network after bootstrap failure: %v", stopErr)
 		}
-		require.FailNow("failed to bootstrap network: %s", err)
+		require.FailNowf("network bootstrapping failed", "network bootstrapping error: %s", err)
 	}
 
 	tc.Outf("{{green}}Successfully started network{{/}}\n")


### PR DESCRIPTION
## Why this should be merged

This PR addresses a minor issue in testing, which causes the error to be printed as
```
  	Error:      	failed to bootstrap network: %s
  	Messages:   	failed to start local node: failed to load process context for node "NodeID-7JJiSVewCGTryysCg1kNNzaH3jKjC8FvY" before timeout: context deadline exceeded
```
instead of
```
  	Error:      network bootstrapping failed
  	Messages:   	network bootstrapping error: failed to load process context for node "NodeID-7JJiSVewCGTryysCg1kNNzaH3jKjC8FvY" before timeout: context deadline exceeded
```

## How this works

The source for the issue was the passing of `%s` as the first argument to the `FailNow` method.
Since the method doesn't format the first argument, the output would include the `%s`.

## How this was tested

Tested manually.