### PR TITLE
Add SoV Excess to P-chain state

### DIFF
--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -91,6 +91,7 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 	// setup state to validate proposal block transaction
 	onParentAccept.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 	onParentAccept.EXPECT().GetFeeState().Return(gas.State{}).AnyTimes()
+	onParentAccept.EXPECT().GetSoVExcess().Return(gas.Gas(0)).AnyTimes()
 	onParentAccept.EXPECT().GetAccruedFees().Return(uint64(0)).AnyTimes()
 
 	onParentAccept.EXPECT().GetCurrentStakerIterator().Return(
@@ -162,6 +163,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	onParentAccept := state.NewMockDiff(ctrl)
 	onParentAccept.EXPECT().GetTimestamp().Return(parentTime).AnyTimes()
 	onParentAccept.EXPECT().GetFeeState().Return(gas.State{}).AnyTimes()
+	onParentAccept.EXPECT().GetSoVExcess().Return(gas.Gas(0)).AnyTimes()
 	onParentAccept.EXPECT().GetAccruedFees().Return(uint64(0)).AnyTimes()
 	onParentAccept.EXPECT().GetCurrentSupply(constants.PrimaryNetworkID).Return(uint64(1000), nil).AnyTimes()
 

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -59,6 +59,7 @@ func TestApricotStandardBlockTimeVerification(t *testing.T) {
 	chainTime := env.clk.Time().Truncate(time.Second)
 	onParentAccept.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 	onParentAccept.EXPECT().GetFeeState().Return(gas.State{}).AnyTimes()
+	onParentAccept.EXPECT().GetSoVExcess().Return(gas.Gas(0)).AnyTimes()
 	onParentAccept.EXPECT().GetAccruedFees().Return(uint64(0)).AnyTimes()
 
 	// wrong height
@@ -134,6 +135,7 @@ func TestBanffStandardBlockTimeVerification(t *testing.T) {
 
 	onParentAccept.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 	onParentAccept.EXPECT().GetFeeState().Return(gas.State{}).AnyTimes()
+	onParentAccept.EXPECT().GetSoVExcess().Return(gas.Gas(0)).AnyTimes()
 	onParentAccept.EXPECT().GetAccruedFees().Return(uint64(0)).AnyTimes()
 
 	txID := ids.GenerateTestID()

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -103,6 +103,7 @@ func TestVerifierVisitProposalBlock(t *testing.T) {
 	// One call for each of onCommitState and onAbortState.
 	parentOnAcceptState.EXPECT().GetTimestamp().Return(timestamp).Times(2)
 	parentOnAcceptState.EXPECT().GetFeeState().Return(gas.State{}).Times(2)
+	parentOnAcceptState.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(2)
 	parentOnAcceptState.EXPECT().GetAccruedFees().Return(uint64(0)).Times(2)
 
 	backend := &backend{
@@ -335,6 +336,7 @@ func TestVerifierVisitStandardBlock(t *testing.T) {
 	timestamp := time.Now()
 	parentState.EXPECT().GetTimestamp().Return(timestamp).Times(1)
 	parentState.EXPECT().GetFeeState().Return(gas.State{}).Times(1)
+	parentState.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(1)
 	parentState.EXPECT().GetAccruedFees().Return(uint64(0)).Times(1)
 	parentStatelessBlk.EXPECT().Height().Return(uint64(1)).Times(1)
 	mempool.EXPECT().Remove(apricotBlk.Txs()).Times(1)
@@ -597,6 +599,7 @@ func TestBanffAbortBlockTimestampChecks(t *testing.T) {
 			s.EXPECT().GetLastAccepted().Return(parentID).Times(3)
 			s.EXPECT().GetTimestamp().Return(parentTime).Times(3)
 			s.EXPECT().GetFeeState().Return(gas.State{}).Times(3)
+			s.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(3)
 			s.EXPECT().GetAccruedFees().Return(uint64(0)).Times(3)
 
 			onDecisionState, err := state.NewDiff(parentID, backend)
@@ -695,6 +698,7 @@ func TestBanffCommitBlockTimestampChecks(t *testing.T) {
 			s.EXPECT().GetLastAccepted().Return(parentID).Times(3)
 			s.EXPECT().GetTimestamp().Return(parentTime).Times(3)
 			s.EXPECT().GetFeeState().Return(gas.State{}).Times(3)
+			s.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(3)
 			s.EXPECT().GetAccruedFees().Return(uint64(0)).Times(3)
 
 			onDecisionState, err := state.NewDiff(parentID, backend)
@@ -811,6 +815,7 @@ func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 	parentStatelessBlk.EXPECT().Height().Return(uint64(1)).Times(1)
 	parentState.EXPECT().GetTimestamp().Return(timestamp).Times(1)
 	parentState.EXPECT().GetFeeState().Return(gas.State{}).Times(1)
+	parentState.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(1)
 	parentState.EXPECT().GetAccruedFees().Return(uint64(0)).Times(1)
 	parentStatelessBlk.EXPECT().Parent().Return(grandParentID).Times(1)
 

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -37,6 +37,7 @@ type diff struct {
 
 	timestamp   time.Time
 	feeState    gas.State
+	sovExcess   gas.Gas
 	accruedFees uint64
 
 	// Subnet ID --> supply of native asset of the subnet
@@ -80,6 +81,7 @@ func NewDiff(
 		stateVersions:     stateVersions,
 		timestamp:         parentState.GetTimestamp(),
 		feeState:          parentState.GetFeeState(),
+		sovExcess:         parentState.GetSoVExcess(),
 		accruedFees:       parentState.GetAccruedFees(),
 		expiryDiff:        newExpiryDiff(),
 		subnetOwners:      make(map[ids.ID]fx.Owner),
@@ -115,6 +117,14 @@ func (d *diff) GetFeeState() gas.State {
 
 func (d *diff) SetFeeState(feeState gas.State) {
 	d.feeState = feeState
+}
+
+func (d *diff) GetSoVExcess() gas.Gas {
+	return d.sovExcess
+}
+
+func (d *diff) SetSoVExcess(excess gas.Gas) {
+	d.sovExcess = excess
 }
 
 func (d *diff) GetAccruedFees() uint64 {
@@ -482,6 +492,7 @@ func (d *diff) DeleteUTXO(utxoID ids.ID) {
 func (d *diff) Apply(baseState Chain) error {
 	baseState.SetTimestamp(d.timestamp)
 	baseState.SetFeeState(d.feeState)
+	baseState.SetSoVExcess(d.sovExcess)
 	baseState.SetAccruedFees(d.accruedFees)
 	for subnetID, supply := range d.currentSupply {
 		baseState.SetCurrentSupply(subnetID, supply)

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -68,6 +68,24 @@ func TestDiffFeeState(t *testing.T) {
 	assertChainsEqual(t, state, d)
 }
 
+func TestDiffSoVExcess(t *testing.T) {
+	require := require.New(t)
+
+	state := newTestState(t, memdb.New())
+
+	d, err := NewDiffOn(state)
+	require.NoError(err)
+
+	initialExcess := state.GetSoVExcess()
+	newExcess := initialExcess + 1
+	d.SetSoVExcess(newExcess)
+	require.Equal(newExcess, d.GetSoVExcess())
+	require.Equal(initialExcess, state.GetSoVExcess())
+
+	require.NoError(d.Apply(state))
+	assertChainsEqual(t, state, d)
+}
+
 func TestDiffAccruedFees(t *testing.T) {
 	require := require.New(t)
 
@@ -270,6 +288,7 @@ func TestDiffCurrentValidator(t *testing.T) {
 	// Called in NewDiffOn
 	state.EXPECT().GetTimestamp().Return(time.Now()).Times(1)
 	state.EXPECT().GetFeeState().Return(gas.State{}).Times(1)
+	state.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(1)
 	state.EXPECT().GetAccruedFees().Return(uint64(0)).Times(1)
 
 	d, err := NewDiffOn(state)
@@ -305,6 +324,7 @@ func TestDiffPendingValidator(t *testing.T) {
 	// Called in NewDiffOn
 	state.EXPECT().GetTimestamp().Return(time.Now()).Times(1)
 	state.EXPECT().GetFeeState().Return(gas.State{}).Times(1)
+	state.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(1)
 	state.EXPECT().GetAccruedFees().Return(uint64(0)).Times(1)
 
 	d, err := NewDiffOn(state)
@@ -346,6 +366,7 @@ func TestDiffCurrentDelegator(t *testing.T) {
 	// Called in NewDiffOn
 	state.EXPECT().GetTimestamp().Return(time.Now()).Times(1)
 	state.EXPECT().GetFeeState().Return(gas.State{}).Times(1)
+	state.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(1)
 	state.EXPECT().GetAccruedFees().Return(uint64(0)).Times(1)
 
 	d, err := NewDiffOn(state)
@@ -390,6 +411,7 @@ func TestDiffPendingDelegator(t *testing.T) {
 	// Called in NewDiffOn
 	state.EXPECT().GetTimestamp().Return(time.Now()).Times(1)
 	state.EXPECT().GetFeeState().Return(gas.State{}).Times(1)
+	state.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(1)
 	state.EXPECT().GetAccruedFees().Return(uint64(0)).Times(1)
 
 	d, err := NewDiffOn(state)
@@ -528,6 +550,7 @@ func TestDiffTx(t *testing.T) {
 	// Called in NewDiffOn
 	state.EXPECT().GetTimestamp().Return(time.Now()).Times(1)
 	state.EXPECT().GetFeeState().Return(gas.State{}).Times(1)
+	state.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(1)
 	state.EXPECT().GetAccruedFees().Return(uint64(0)).Times(1)
 
 	d, err := NewDiffOn(state)
@@ -626,6 +649,7 @@ func TestDiffUTXO(t *testing.T) {
 	// Called in NewDiffOn
 	state.EXPECT().GetTimestamp().Return(time.Now()).Times(1)
 	state.EXPECT().GetFeeState().Return(gas.State{}).Times(1)
+	state.EXPECT().GetSoVExcess().Return(gas.Gas(0)).Times(1)
 	state.EXPECT().GetAccruedFees().Return(uint64(0)).Times(1)
 
 	d, err := NewDiffOn(state)
@@ -703,6 +727,7 @@ func assertChainsEqual(t *testing.T, expected, actual Chain) {
 
 	require.Equal(expected.GetTimestamp(), actual.GetTimestamp())
 	require.Equal(expected.GetFeeState(), actual.GetFeeState())
+	require.Equal(expected.GetSoVExcess(), actual.GetSoVExcess())
 	require.Equal(expected.GetAccruedFees(), actual.GetAccruedFees())
 
 	expectedCurrentSupply, err := expected.GetCurrentSupply(constants.PrimaryNetworkID)

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -353,6 +353,20 @@ func (mr *MockChainMockRecorder) GetPendingValidator(subnetID, nodeID any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockChain)(nil).GetPendingValidator), subnetID, nodeID)
 }
 
+// GetSoVExcess mocks base method.
+func (m *MockChain) GetSoVExcess() gas.Gas {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSoVExcess")
+	ret0, _ := ret[0].(gas.Gas)
+	return ret0
+}
+
+// GetSoVExcess indicates an expected call of GetSoVExcess.
+func (mr *MockChainMockRecorder) GetSoVExcess() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSoVExcess", reflect.TypeOf((*MockChain)(nil).GetSoVExcess))
+}
+
 // GetSubnetConversion mocks base method.
 func (m *MockChain) GetSubnetConversion(subnetID ids.ID) (SubnetConversion, error) {
 	m.ctrl.T.Helper()
@@ -570,6 +584,18 @@ func (m *MockChain) SetFeeState(f gas.State) {
 func (mr *MockChainMockRecorder) SetFeeState(f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFeeState", reflect.TypeOf((*MockChain)(nil).SetFeeState), f)
+}
+
+// SetSoVExcess mocks base method.
+func (m *MockChain) SetSoVExcess(e gas.Gas) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSoVExcess", e)
+}
+
+// SetSoVExcess indicates an expected call of SetSoVExcess.
+func (mr *MockChainMockRecorder) SetSoVExcess(e any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSoVExcess", reflect.TypeOf((*MockChain)(nil).SetSoVExcess), e)
 }
 
 // SetSubnetConversion mocks base method.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -367,6 +367,20 @@ func (mr *MockDiffMockRecorder) GetPendingValidator(subnetID, nodeID any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockDiff)(nil).GetPendingValidator), subnetID, nodeID)
 }
 
+// GetSoVExcess mocks base method.
+func (m *MockDiff) GetSoVExcess() gas.Gas {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSoVExcess")
+	ret0, _ := ret[0].(gas.Gas)
+	return ret0
+}
+
+// GetSoVExcess indicates an expected call of GetSoVExcess.
+func (mr *MockDiffMockRecorder) GetSoVExcess() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSoVExcess", reflect.TypeOf((*MockDiff)(nil).GetSoVExcess))
+}
+
 // GetSubnetConversion mocks base method.
 func (m *MockDiff) GetSubnetConversion(subnetID ids.ID) (SubnetConversion, error) {
 	m.ctrl.T.Helper()
@@ -584,6 +598,18 @@ func (m *MockDiff) SetFeeState(f gas.State) {
 func (mr *MockDiffMockRecorder) SetFeeState(f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFeeState", reflect.TypeOf((*MockDiff)(nil).SetFeeState), f)
+}
+
+// SetSoVExcess mocks base method.
+func (m *MockDiff) SetSoVExcess(e gas.Gas) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSoVExcess", e)
+}
+
+// SetSoVExcess indicates an expected call of SetSoVExcess.
+func (mr *MockDiffMockRecorder) SetSoVExcess(e any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSoVExcess", reflect.TypeOf((*MockDiff)(nil).SetSoVExcess), e)
 }
 
 // SetSubnetConversion mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -527,6 +527,20 @@ func (mr *MockStateMockRecorder) GetRewardUTXOs(txID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRewardUTXOs", reflect.TypeOf((*MockState)(nil).GetRewardUTXOs), txID)
 }
 
+// GetSoVExcess mocks base method.
+func (m *MockState) GetSoVExcess() gas.Gas {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSoVExcess")
+	ret0, _ := ret[0].(gas.Gas)
+	return ret0
+}
+
+// GetSoVExcess indicates an expected call of GetSoVExcess.
+func (mr *MockStateMockRecorder) GetSoVExcess() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSoVExcess", reflect.TypeOf((*MockState)(nil).GetSoVExcess))
+}
+
 // GetStartTime mocks base method.
 func (m *MockState) GetStartTime(nodeID ids.NodeID) (time.Time, error) {
 	m.ctrl.T.Helper()
@@ -843,6 +857,18 @@ func (m *MockState) SetLastAccepted(blkID ids.ID) {
 func (mr *MockStateMockRecorder) SetLastAccepted(blkID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*MockState)(nil).SetLastAccepted), blkID)
+}
+
+// SetSoVExcess mocks base method.
+func (m *MockState) SetSoVExcess(e gas.Gas) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSoVExcess", e)
+}
+
+// SetSoVExcess indicates an expected call of SetSoVExcess.
+func (mr *MockStateMockRecorder) SetSoVExcess(e any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSoVExcess", reflect.TypeOf((*MockState)(nil).SetSoVExcess), e)
 }
 
 // SetSubnetConversion mocks base method.

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -87,6 +87,7 @@ var (
 
 	TimestampKey       = []byte("timestamp")
 	FeeStateKey        = []byte("fee state")
+	SoVExcessKey       = []byte("sov excess")
 	AccruedFeesKey     = []byte("accrued fees")
 	CurrentSupplyKey   = []byte("current supply")
 	LastAcceptedKey    = []byte("last accepted")
@@ -109,6 +110,9 @@ type Chain interface {
 
 	GetFeeState() gas.State
 	SetFeeState(f gas.State)
+
+	GetSoVExcess() gas.Gas
+	SetSoVExcess(e gas.Gas)
 
 	GetAccruedFees() uint64
 	SetAccruedFees(f uint64)
@@ -289,6 +293,7 @@ type stateBlk struct {
  *   |-- blocksReindexedKey -> nil
  *   |-- timestampKey -> timestamp
  *   |-- feeStateKey -> feeState
+ *   |-- sovExcessKey -> sovExcess
  *   |-- accruedFeesKey -> accruedFees
  *   |-- currentSupplyKey -> currentSupply
  *   |-- lastAcceptedKey -> lastAccepted
@@ -386,6 +391,7 @@ type state struct {
 	// The persisted fields represent the current database value
 	timestamp, persistedTimestamp         time.Time
 	feeState, persistedFeeState           gas.State
+	sovExcess, persistedSOVExcess         gas.Gas
 	accruedFees, persistedAccruedFees     uint64
 	currentSupply, persistedCurrentSupply uint64
 	// [lastAccepted] is the most recently accepted block.
@@ -1091,6 +1097,14 @@ func (s *state) SetFeeState(feeState gas.State) {
 	s.feeState = feeState
 }
 
+func (s *state) GetSoVExcess() gas.Gas {
+	return s.sovExcess
+}
+
+func (s *state) SetSoVExcess(e gas.Gas) {
+	s.sovExcess = e
+}
+
 func (s *state) GetAccruedFees() uint64 {
 	return s.accruedFees
 }
@@ -1390,6 +1404,13 @@ func (s *state) loadMetadata() error {
 	}
 	s.persistedFeeState = feeState
 	s.SetFeeState(feeState)
+
+	sovExcess, err := database.WithDefault(database.GetUInt64, s.singletonDB, SoVExcessKey, 0)
+	if err != nil {
+		return err
+	}
+	s.persistedSOVExcess = gas.Gas(sovExcess)
+	s.SetSoVExcess(gas.Gas(sovExcess))
 
 	accruedFees, err := database.WithDefault(database.GetUInt64, s.singletonDB, AccruedFeesKey, 0)
 	if err != nil {
@@ -2438,6 +2459,12 @@ func (s *state) writeMetadata() error {
 			return fmt.Errorf("failed to write fee state: %w", err)
 		}
 		s.persistedFeeState = s.feeState
+	}
+	if s.sovExcess != s.persistedSOVExcess {
+		if err := database.PutUInt64(s.singletonDB, SoVExcessKey, uint64(s.sovExcess)); err != nil {
+			return fmt.Errorf("failed to write sov excess: %w", err)
+		}
+		s.persistedSOVExcess = s.sovExcess
 	}
 	if s.accruedFees != s.persistedAccruedFees {
 		if err := database.PutUInt64(s.singletonDB, AccruedFeesKey, s.accruedFees); err != nil {

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -1474,6 +1474,22 @@ func TestStateFeeStateCommitAndLoad(t *testing.T) {
 	require.Equal(expectedFeeState, s.GetFeeState())
 }
 
+// Verify that committing the state writes the sov excess to the database and
+// that loading the state fetches the sov excess from the database.
+func TestStateSoVExcessCommitAndLoad(t *testing.T) {
+	require := require.New(t)
+
+	db := memdb.New()
+	s := newTestState(t, db)
+
+	const expectedSoVExcess gas.Gas = 10
+	s.SetSoVExcess(expectedSoVExcess)
+	require.NoError(s.Commit())
+
+	s = newTestState(t, db)
+	require.Equal(expectedSoVExcess, s.GetSoVExcess())
+}
+
 // Verify that committing the state writes the accrued fees to the database and
 // that loading the state fetches the accrued fees from the database.
 func TestStateAccruedFeesCommitAndLoad(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

For ACP-77's usage of dynamic fees, we must track the excess.

This was factored out of: #3388

## How this works

Adds `SetSoVExcess` and `GetSovExcess` to the `state.Chain` interface.

## How this was tested

- [X] Added unit tests