### PR TITLE
Move RPC metrics registration after its client's initialization

### DIFF
--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -156,10 +156,6 @@ func (vm *VMClient) Initialize(
 		return err
 	}
 
-	if err := chainCtx.Metrics.Register("", vm); err != nil {
-		return err
-	}
-
 	// Initialize the database
 	dbServerListener, err := grpcutils.NewListener()
 	if err != nil {
@@ -226,6 +222,10 @@ func (vm *VMClient) Initialize(
 		ServerAddr:      serverAddr,
 	})
 	if err != nil {
+		return err
+	}
+
+	if err := chainCtx.Metrics.Register("", vm); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Why this should be merged

It makes no sense to have a metrics collector that uses RPC invocations to be registered before its remote RPC service has been initialized.

Changed the order of initialization accordingly.


## How this works

Switched initialization order of gRPC Initialize invocation and the metrics registration.

## How this was tested

CI
