### PR TITLE
Update SoV struct to align with latest ACP-77 spec

### DIFF
--- a/vms/platformvm/state/subnet_only_validator.go
+++ b/vms/platformvm/state/subnet_only_validator.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 )
 
 var (
 	_ btree.LessFunc[SubnetOnlyValidator] = SubnetOnlyValidator.Less
+	_ utils.Sortable[SubnetOnlyValidator] = (*SubnetOnlyValidator)(nil)
 
 	ErrMutatedSubnetOnlyValidator = errors.New("subnet only validator contains mutated constant fields")
 )

--- a/vms/platformvm/state/subnet_only_validator.go
+++ b/vms/platformvm/state/subnet_only_validator.go
@@ -88,9 +88,9 @@ func (v SubnetOnlyValidator) Compare(o SubnetOnlyValidator) int {
 	}
 }
 
-// validateConstants returns true if the constants of this validator have not
-// been modified.
-func (v SubnetOnlyValidator) validateConstants(o SubnetOnlyValidator) bool {
+// constantsAreUnmodified returns true if the constants of this validator have
+// not been modified compared to the other validator.
+func (v SubnetOnlyValidator) constantsAreUnmodified(o SubnetOnlyValidator) bool {
 	if v.ValidationID != o.ValidationID {
 		return true
 	}

--- a/vms/platformvm/state/subnet_only_validator.go
+++ b/vms/platformvm/state/subnet_only_validator.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/google/btree"
@@ -13,8 +15,15 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 )
 
-var _ btree.LessFunc[*SubnetOnlyValidator] = (*SubnetOnlyValidator).Less
+var (
+	_ btree.LessFunc[SubnetOnlyValidator] = SubnetOnlyValidator.Less
 
+	ErrMutatedSubnetOnlyValidator = errors.New("subnet only validator contains mutated constant fields")
+)
+
+// SubnetOnlyValidator defines an ACP-77 validator. For a given ValidationID, it
+// is expected for SubnetID, NodeID, PublicKey, RemainingBalanceOwner, and
+// StartTime to be constant.
 type SubnetOnlyValidator struct {
 	// ValidationID is not serialized because it is used as the key in the
 	// database, so it doesn't need to be stored in the value.
@@ -26,6 +35,14 @@ type SubnetOnlyValidator struct {
 	// PublicKey is the uncompressed BLS public key of the validator. It is
 	// guaranteed to be populated.
 	PublicKey []byte `serialize:"true"`
+
+	// RemainingBalanceOwner is the owner that will be used when returning the
+	// balance of the validator after removing accrued fees.
+	RemainingBalanceOwner []byte `serialize:"true"`
+
+	// DeactivationOwner is the owner that can manually deactivate the
+	// validator.
+	DeactivationOwner []byte `serialize:"true"`
 
 	// StartTime is the unix timestamp, in seconds, when this validator was
 	// added to the set.
@@ -46,44 +63,59 @@ type SubnetOnlyValidator struct {
 	// accrue before this validator must be deactivated. It is equal to the
 	// amount of fees this validator is willing to pay plus the amount of
 	// globally accumulated fees when this validator started validating.
+	//
+	// If this value is 0, the validator is inactive.
 	EndAccumulatedFee uint64 `serialize:"true"`
 }
 
-// Less determines a canonical ordering of *SubnetOnlyValidators based on their
-// EndAccumulatedFees and ValidationIDs.
-//
-// Returns true if:
-//
-//  1. This validator has a lower EndAccumulatedFee than the other.
-//  2. This validator has an equal EndAccumulatedFee to the other and has a
-//     lexicographically lower ValidationID.
-func (v *SubnetOnlyValidator) Less(o *SubnetOnlyValidator) bool {
+func (v SubnetOnlyValidator) Less(o SubnetOnlyValidator) bool {
+	return v.Compare(o) == -1
+}
+
+// Compare determines a canonical ordering of SubnetOnlyValidators based on
+// their EndAccumulatedFees and ValidationIDs. Lower EndAccumulatedFees result
+// in an earlier ordering.
+func (v SubnetOnlyValidator) Compare(o SubnetOnlyValidator) int {
 	switch {
 	case v.EndAccumulatedFee < o.EndAccumulatedFee:
-		return true
+		return -1
 	case o.EndAccumulatedFee < v.EndAccumulatedFee:
-		return false
+		return 1
 	default:
-		return v.ValidationID.Compare(o.ValidationID) == -1
+		return v.ValidationID.Compare(o.ValidationID)
 	}
 }
 
-func getSubnetOnlyValidator(db database.KeyValueReader, validationID ids.ID) (*SubnetOnlyValidator, error) {
+// validateConstants returns true if the constants of this validator have not
+// been modified.
+func (v SubnetOnlyValidator) validateConstants(o SubnetOnlyValidator) bool {
+	if v.ValidationID != o.ValidationID {
+		return true
+	}
+	return v.SubnetID == o.SubnetID &&
+		v.NodeID == o.NodeID &&
+		bytes.Equal(v.PublicKey, o.PublicKey) &&
+		bytes.Equal(v.RemainingBalanceOwner, o.RemainingBalanceOwner) &&
+		bytes.Equal(v.DeactivationOwner, o.DeactivationOwner) &&
+		v.StartTime == o.StartTime
+}
+
+func getSubnetOnlyValidator(db database.KeyValueReader, validationID ids.ID) (SubnetOnlyValidator, error) {
 	bytes, err := db.Get(validationID[:])
 	if err != nil {
-		return nil, err
+		return SubnetOnlyValidator{}, err
 	}
 
-	vdr := &SubnetOnlyValidator{
+	vdr := SubnetOnlyValidator{
 		ValidationID: validationID,
 	}
-	if _, err = block.GenesisCodec.Unmarshal(bytes, vdr); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal SubnetOnlyValidator: %w", err)
+	if _, err := block.GenesisCodec.Unmarshal(bytes, &vdr); err != nil {
+		return SubnetOnlyValidator{}, fmt.Errorf("failed to unmarshal SubnetOnlyValidator: %w", err)
 	}
-	return vdr, err
+	return vdr, nil
 }
 
-func putSubnetOnlyValidator(db database.KeyValueWriter, vdr *SubnetOnlyValidator) error {
+func putSubnetOnlyValidator(db database.KeyValueWriter, vdr SubnetOnlyValidator) error {
 	bytes, err := block.GenesisCodec.Marshal(block.CodecVersion, vdr)
 	if err != nil {
 		return fmt.Errorf("failed to marshal SubnetOnlyValidator: %w", err)

--- a/vms/platformvm/state/subnet_only_validator.go
+++ b/vms/platformvm/state/subnet_only_validator.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	_ btree.LessFunc[SubnetOnlyValidator] = SubnetOnlyValidator.Less
-	_ utils.Sortable[SubnetOnlyValidator] = (*SubnetOnlyValidator)(nil)
+	_ utils.Sortable[SubnetOnlyValidator] = SubnetOnlyValidator{}
 
 	ErrMutatedSubnetOnlyValidator = errors.New("subnet only validator contains mutated constant fields")
 )

--- a/vms/platformvm/state/subnet_only_validator_test.go
+++ b/vms/platformvm/state/subnet_only_validator_test.go
@@ -12,62 +12,184 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/vms/platformvm/block"
+	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
-func TestSubnetOnlyValidator_Less(t *testing.T) {
+func TestSubnetOnlyValidator_Compare(t *testing.T) {
 	tests := []struct {
-		name  string
-		v     *SubnetOnlyValidator
-		o     *SubnetOnlyValidator
-		equal bool
+		name     string
+		v        SubnetOnlyValidator
+		o        SubnetOnlyValidator
+		expected int
 	}{
 		{
 			name: "v.EndAccumulatedFee < o.EndAccumulatedFee",
-			v: &SubnetOnlyValidator{
+			v: SubnetOnlyValidator{
 				ValidationID:      ids.GenerateTestID(),
 				EndAccumulatedFee: 1,
 			},
-			o: &SubnetOnlyValidator{
+			o: SubnetOnlyValidator{
 				ValidationID:      ids.GenerateTestID(),
 				EndAccumulatedFee: 2,
 			},
-			equal: false,
+			expected: -1,
 		},
 		{
 			name: "v.EndAccumulatedFee = o.EndAccumulatedFee, v.ValidationID < o.ValidationID",
-			v: &SubnetOnlyValidator{
+			v: SubnetOnlyValidator{
 				ValidationID:      ids.ID{0},
 				EndAccumulatedFee: 1,
 			},
-			o: &SubnetOnlyValidator{
+			o: SubnetOnlyValidator{
 				ValidationID:      ids.ID{1},
 				EndAccumulatedFee: 1,
 			},
-			equal: false,
+			expected: -1,
 		},
 		{
 			name: "v.EndAccumulatedFee = o.EndAccumulatedFee, v.ValidationID = o.ValidationID",
-			v: &SubnetOnlyValidator{
+			v: SubnetOnlyValidator{
 				ValidationID:      ids.ID{0},
 				EndAccumulatedFee: 1,
 			},
-			o: &SubnetOnlyValidator{
+			o: SubnetOnlyValidator{
 				ValidationID:      ids.ID{0},
 				EndAccumulatedFee: 1,
 			},
-			equal: true,
+			expected: 0,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
-			less := test.v.Less(test.o)
-			require.Equal(!test.equal, less)
+			require.Equal(test.expected, test.v.Compare(test.o))
+			require.Equal(-test.expected, test.o.Compare(test.v))
+			require.Equal(test.expected == -1, test.v.Less(test.o))
+			require.False(test.o.Less(test.v))
+		})
+	}
+}
 
-			greater := test.o.Less(test.v)
-			require.False(greater)
+func TestSubnetOnlyValidator_validateConstants(t *testing.T) {
+	sov := SubnetOnlyValidator{
+		ValidationID:          ids.GenerateTestID(),
+		SubnetID:              ids.GenerateTestID(),
+		NodeID:                ids.GenerateTestNodeID(),
+		PublicKey:             utils.RandomBytes(bls.PublicKeyLen),
+		RemainingBalanceOwner: utils.RandomBytes(32),
+		DeactivationOwner:     utils.RandomBytes(32),
+		StartTime:             rand.Uint64(), // #nosec G404
+	}
+
+	tests := []struct {
+		name     string
+		v        SubnetOnlyValidator
+		expected bool
+	}{
+		{
+			name:     "equal",
+			v:        sov,
+			expected: true,
+		},
+		{
+			name: "everything is different",
+			v: SubnetOnlyValidator{
+				ValidationID:          ids.GenerateTestID(),
+				SubnetID:              ids.GenerateTestID(),
+				NodeID:                ids.GenerateTestNodeID(),
+				PublicKey:             utils.RandomBytes(bls.PublicKeyLen),
+				RemainingBalanceOwner: utils.RandomBytes(32),
+				DeactivationOwner:     utils.RandomBytes(32),
+				StartTime:             rand.Uint64(), // #nosec G404
+			},
+			expected: true,
+		},
+		{
+			name: "different subnetID",
+			v: SubnetOnlyValidator{
+				ValidationID:          sov.ValidationID,
+				SubnetID:              ids.GenerateTestID(),
+				NodeID:                sov.NodeID,
+				PublicKey:             sov.PublicKey,
+				RemainingBalanceOwner: sov.RemainingBalanceOwner,
+				DeactivationOwner:     sov.DeactivationOwner,
+				StartTime:             sov.StartTime,
+			},
+		},
+		{
+			name: "different nodeID",
+			v: SubnetOnlyValidator{
+				ValidationID:          sov.ValidationID,
+				SubnetID:              sov.SubnetID,
+				NodeID:                ids.GenerateTestNodeID(),
+				PublicKey:             sov.PublicKey,
+				RemainingBalanceOwner: sov.RemainingBalanceOwner,
+				DeactivationOwner:     sov.DeactivationOwner,
+				StartTime:             sov.StartTime,
+			},
+		},
+		{
+			name: "different publicKey",
+			v: SubnetOnlyValidator{
+				ValidationID:          sov.ValidationID,
+				SubnetID:              sov.SubnetID,
+				NodeID:                sov.NodeID,
+				PublicKey:             utils.RandomBytes(bls.PublicKeyLen),
+				RemainingBalanceOwner: sov.RemainingBalanceOwner,
+				DeactivationOwner:     sov.DeactivationOwner,
+				StartTime:             sov.StartTime,
+			},
+		},
+		{
+			name: "different remainingBalanceOwner",
+			v: SubnetOnlyValidator{
+				ValidationID:          sov.ValidationID,
+				SubnetID:              sov.SubnetID,
+				NodeID:                sov.NodeID,
+				PublicKey:             sov.PublicKey,
+				RemainingBalanceOwner: utils.RandomBytes(32),
+				DeactivationOwner:     sov.DeactivationOwner,
+				StartTime:             sov.StartTime,
+			},
+		},
+		{
+			name: "different deactivationOwner",
+			v: SubnetOnlyValidator{
+				ValidationID:          sov.ValidationID,
+				SubnetID:              sov.SubnetID,
+				NodeID:                sov.NodeID,
+				PublicKey:             sov.PublicKey,
+				RemainingBalanceOwner: sov.RemainingBalanceOwner,
+				DeactivationOwner:     utils.RandomBytes(32),
+				StartTime:             sov.StartTime,
+			},
+		},
+		{
+			name: "different startTime",
+			v: SubnetOnlyValidator{
+				ValidationID:          sov.ValidationID,
+				SubnetID:              sov.SubnetID,
+				NodeID:                sov.NodeID,
+				PublicKey:             sov.PublicKey,
+				RemainingBalanceOwner: sov.RemainingBalanceOwner,
+				DeactivationOwner:     sov.DeactivationOwner,
+				StartTime:             rand.Uint64(), // #nosec G404
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Randomize the unrelated fields
+			test.v.Weight = rand.Uint64()            // #nosec G404
+			test.v.MinNonce = rand.Uint64()          // #nosec G404
+			test.v.EndAccumulatedFee = rand.Uint64() // #nosec G404
+
+			require.Equal(t, test.expected, sov.validateConstants(test.v))
 		})
 	}
 }
@@ -78,22 +200,44 @@ func TestSubnetOnlyValidator_DatabaseHelpers(t *testing.T) {
 
 	sk, err := bls.NewSecretKey()
 	require.NoError(err)
+	pk := bls.PublicFromSecretKey(sk)
+	pkBytes := bls.PublicKeyToUncompressedBytes(pk)
 
-	vdr := &SubnetOnlyValidator{
-		ValidationID:      ids.GenerateTestID(),
-		SubnetID:          ids.GenerateTestID(),
-		NodeID:            ids.GenerateTestNodeID(),
-		PublicKey:         bls.PublicKeyToUncompressedBytes(bls.PublicFromSecretKey(sk)),
-		StartTime:         rand.Uint64(), // #nosec G404
-		Weight:            rand.Uint64(), // #nosec G404
-		MinNonce:          rand.Uint64(), // #nosec G404
-		EndAccumulatedFee: rand.Uint64(), // #nosec G404
+	var remainingBalanceOwner fx.Owner = &secp256k1fx.OutputOwners{
+		Threshold: 1,
+		Addrs: []ids.ShortID{
+			ids.GenerateTestShortID(),
+		},
+	}
+	remainingBalanceOwnerBytes, err := block.GenesisCodec.Marshal(block.CodecVersion, &remainingBalanceOwner)
+	require.NoError(err)
+
+	var deactivationOwner fx.Owner = &secp256k1fx.OutputOwners{
+		Threshold: 1,
+		Addrs: []ids.ShortID{
+			ids.GenerateTestShortID(),
+		},
+	}
+	deactivationOwnerBytes, err := block.GenesisCodec.Marshal(block.CodecVersion, &deactivationOwner)
+	require.NoError(err)
+
+	vdr := SubnetOnlyValidator{
+		ValidationID:          ids.GenerateTestID(),
+		SubnetID:              ids.GenerateTestID(),
+		NodeID:                ids.GenerateTestNodeID(),
+		PublicKey:             pkBytes,
+		RemainingBalanceOwner: remainingBalanceOwnerBytes,
+		DeactivationOwner:     deactivationOwnerBytes,
+		StartTime:             rand.Uint64(), // #nosec G404
+		Weight:                rand.Uint64(), // #nosec G404
+		MinNonce:              rand.Uint64(), // #nosec G404
+		EndAccumulatedFee:     rand.Uint64(), // #nosec G404
 	}
 
 	// Validator hasn't been put on disk yet
 	gotVdr, err := getSubnetOnlyValidator(db, vdr.ValidationID)
 	require.ErrorIs(err, database.ErrNotFound)
-	require.Nil(gotVdr)
+	require.Zero(gotVdr)
 
 	// Place the validator on disk
 	require.NoError(putSubnetOnlyValidator(db, vdr))
@@ -109,5 +253,5 @@ func TestSubnetOnlyValidator_DatabaseHelpers(t *testing.T) {
 	// Verify that the validator has been removed from disk
 	gotVdr, err = getSubnetOnlyValidator(db, vdr.ValidationID)
 	require.ErrorIs(err, database.ErrNotFound)
-	require.Nil(gotVdr)
+	require.Zero(gotVdr)
 }

--- a/vms/platformvm/state/subnet_only_validator_test.go
+++ b/vms/platformvm/state/subnet_only_validator_test.go
@@ -76,29 +76,9 @@ func TestSubnetOnlyValidator_Compare(t *testing.T) {
 }
 
 func TestSubnetOnlyValidator_constantsAreUnmodified(t *testing.T) {
-	sov := SubnetOnlyValidator{
-		ValidationID:          ids.GenerateTestID(),
-		SubnetID:              ids.GenerateTestID(),
-		NodeID:                ids.GenerateTestNodeID(),
-		PublicKey:             utils.RandomBytes(bls.PublicKeyLen),
-		RemainingBalanceOwner: utils.RandomBytes(32),
-		DeactivationOwner:     utils.RandomBytes(32),
-		StartTime:             rand.Uint64(), // #nosec G404
-	}
-
-	tests := []struct {
-		name     string
-		v        SubnetOnlyValidator
-		expected bool
-	}{
-		{
-			name:     "equal",
-			v:        sov,
-			expected: true,
-		},
-		{
-			name: "everything is different",
-			v: SubnetOnlyValidator{
+	var (
+		randomSOV = func() SubnetOnlyValidator {
+			return SubnetOnlyValidator{
 				ValidationID:          ids.GenerateTestID(),
 				SubnetID:              ids.GenerateTestID(),
 				NodeID:                ids.GenerateTestNodeID(),
@@ -106,92 +86,56 @@ func TestSubnetOnlyValidator_constantsAreUnmodified(t *testing.T) {
 				RemainingBalanceOwner: utils.RandomBytes(32),
 				DeactivationOwner:     utils.RandomBytes(32),
 				StartTime:             rand.Uint64(), // #nosec G404
-			},
-			expected: true,
-		},
-		{
-			name: "different subnetID",
-			v: SubnetOnlyValidator{
-				ValidationID:          sov.ValidationID,
-				SubnetID:              ids.GenerateTestID(),
-				NodeID:                sov.NodeID,
-				PublicKey:             sov.PublicKey,
-				RemainingBalanceOwner: sov.RemainingBalanceOwner,
-				DeactivationOwner:     sov.DeactivationOwner,
-				StartTime:             sov.StartTime,
-			},
-		},
-		{
-			name: "different nodeID",
-			v: SubnetOnlyValidator{
-				ValidationID:          sov.ValidationID,
-				SubnetID:              sov.SubnetID,
-				NodeID:                ids.GenerateTestNodeID(),
-				PublicKey:             sov.PublicKey,
-				RemainingBalanceOwner: sov.RemainingBalanceOwner,
-				DeactivationOwner:     sov.DeactivationOwner,
-				StartTime:             sov.StartTime,
-			},
-		},
-		{
-			name: "different publicKey",
-			v: SubnetOnlyValidator{
-				ValidationID:          sov.ValidationID,
-				SubnetID:              sov.SubnetID,
-				NodeID:                sov.NodeID,
-				PublicKey:             utils.RandomBytes(bls.PublicKeyLen),
-				RemainingBalanceOwner: sov.RemainingBalanceOwner,
-				DeactivationOwner:     sov.DeactivationOwner,
-				StartTime:             sov.StartTime,
-			},
-		},
-		{
-			name: "different remainingBalanceOwner",
-			v: SubnetOnlyValidator{
-				ValidationID:          sov.ValidationID,
-				SubnetID:              sov.SubnetID,
-				NodeID:                sov.NodeID,
-				PublicKey:             sov.PublicKey,
-				RemainingBalanceOwner: utils.RandomBytes(32),
-				DeactivationOwner:     sov.DeactivationOwner,
-				StartTime:             sov.StartTime,
-			},
-		},
-		{
-			name: "different deactivationOwner",
-			v: SubnetOnlyValidator{
-				ValidationID:          sov.ValidationID,
-				SubnetID:              sov.SubnetID,
-				NodeID:                sov.NodeID,
-				PublicKey:             sov.PublicKey,
-				RemainingBalanceOwner: sov.RemainingBalanceOwner,
-				DeactivationOwner:     utils.RandomBytes(32),
-				StartTime:             sov.StartTime,
-			},
-		},
-		{
-			name: "different startTime",
-			v: SubnetOnlyValidator{
-				ValidationID:          sov.ValidationID,
-				SubnetID:              sov.SubnetID,
-				NodeID:                sov.NodeID,
-				PublicKey:             sov.PublicKey,
-				RemainingBalanceOwner: sov.RemainingBalanceOwner,
-				DeactivationOwner:     sov.DeactivationOwner,
-				StartTime:             rand.Uint64(), // #nosec G404
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// Randomize the unrelated fields
-			test.v.Weight = rand.Uint64()            // #nosec G404
-			test.v.MinNonce = rand.Uint64()          // #nosec G404
-			test.v.EndAccumulatedFee = rand.Uint64() // #nosec G404
+			}
+		}
+		randomizeSOV = func(sov SubnetOnlyValidator) SubnetOnlyValidator {
+			// Randomize unrelated fields
+			sov.Weight = rand.Uint64()            // #nosec G404
+			sov.MinNonce = rand.Uint64()          // #nosec G404
+			sov.EndAccumulatedFee = rand.Uint64() // #nosec G404
+			return sov
+		}
+		sov = randomSOV()
+	)
 
-			require.Equal(t, test.expected, sov.constantsAreUnmodified(test.v))
-		})
-	}
+	t.Run("equal", func(t *testing.T) {
+		v := randomizeSOV(sov)
+		require.True(t, sov.constantsAreUnmodified(v))
+	})
+	t.Run("everything is different", func(t *testing.T) {
+		v := randomizeSOV(randomSOV())
+		require.True(t, sov.constantsAreUnmodified(v))
+	})
+	t.Run("different subnetID", func(t *testing.T) {
+		v := randomizeSOV(sov)
+		v.SubnetID = ids.GenerateTestID()
+		require.False(t, sov.constantsAreUnmodified(v))
+	})
+	t.Run("different nodeID", func(t *testing.T) {
+		v := randomizeSOV(sov)
+		v.NodeID = ids.GenerateTestNodeID()
+		require.False(t, sov.constantsAreUnmodified(v))
+	})
+	t.Run("different publicKey", func(t *testing.T) {
+		v := randomizeSOV(sov)
+		v.PublicKey = utils.RandomBytes(bls.PublicKeyLen)
+		require.False(t, sov.constantsAreUnmodified(v))
+	})
+	t.Run("different remainingBalanceOwner", func(t *testing.T) {
+		v := randomizeSOV(sov)
+		v.RemainingBalanceOwner = utils.RandomBytes(32)
+		require.False(t, sov.constantsAreUnmodified(v))
+	})
+	t.Run("different deactivationOwner", func(t *testing.T) {
+		v := randomizeSOV(sov)
+		v.DeactivationOwner = utils.RandomBytes(32)
+		require.False(t, sov.constantsAreUnmodified(v))
+	})
+	t.Run("different startTime", func(t *testing.T) {
+		v := randomizeSOV(sov)
+		v.StartTime = rand.Uint64() // #nosec G404
+		require.False(t, sov.constantsAreUnmodified(v))
+	})
 }
 
 func TestSubnetOnlyValidator_DatabaseHelpers(t *testing.T) {

--- a/vms/platformvm/state/subnet_only_validator_test.go
+++ b/vms/platformvm/state/subnet_only_validator_test.go
@@ -75,7 +75,7 @@ func TestSubnetOnlyValidator_Compare(t *testing.T) {
 	}
 }
 
-func TestSubnetOnlyValidator_validateConstants(t *testing.T) {
+func TestSubnetOnlyValidator_constantsAreUnmodified(t *testing.T) {
 	sov := SubnetOnlyValidator{
 		ValidationID:          ids.GenerateTestID(),
 		SubnetID:              ids.GenerateTestID(),
@@ -189,7 +189,7 @@ func TestSubnetOnlyValidator_validateConstants(t *testing.T) {
 			test.v.MinNonce = rand.Uint64()          // #nosec G404
 			test.v.EndAccumulatedFee = rand.Uint64() // #nosec G404
 
-			require.Equal(t, test.expected, sov.validateConstants(test.v))
+			require.Equal(t, test.expected, sov.constantsAreUnmodified(test.v))
 		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Factored out of #3388.

## How this works

1. Adds `RemainingBalanceOwner`
2. Adds `DeactivationOwner`
3. Clarifies that `EndAccumulatedFee == 0` implies inactive
4. Adds `Compare` onto `SubnetOnlyValidator`
5. Passes `SubnetOnlyValidator`s by value rather than reference so that modifying them can be done without changing the original value

## How this was tested

- [X] Added / modified unit tests