### PR TITLE
Add getProposedValidators RPC method

### DIFF
--- a/tests/e2e/p/proposed_validators.go
+++ b/tests/e2e/p/proposed_validators.go
@@ -4,12 +4,15 @@
 package p
 
 import (
+	"github.com/ava-labs/avalanchego/config"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
-	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/vms/platformvm"
 )
 
 var _ = e2e.DescribePChain("[Proposed Validators]", func() {
@@ -19,18 +22,43 @@ var _ = e2e.DescribePChain("[Proposed Validators]", func() {
 	)
 
 	ginkgo.It("should be able to fetch proposed validators", func() {
-		var (
-			env     = e2e.GetEnv(tc)
-			network = env.GetNetwork()
-		)
+		tc.By("creating a new private network to ensure isolation from other tests")
+		privateNetwork := tmpnet.NewDefaultNetwork("avalanchego-e2e-proposed-validators")
+		// Initialize config flags
+		privateNetwork.DefaultFlags = tmpnet.FlagsMap{}
+		// Ensure that the proposer uses the current height
+		privateNetwork.DefaultFlags.SetDefaults(tmpnet.FlagsMap{
+			config.ProposerVMUseCurrentHeightKey: true,
+		})
+
+		e2e.GetEnv(tc).StartPrivateNetwork(privateNetwork)
+
 		tc.By("fetching proposed validators", func() {
-			pvmClient := platformvm.NewClient(env.URIs[0].URI)
-			_, err := pvmClient.GetProposedValidators(
+			pvmClient := platformvm.NewClient(privateNetwork.GetNodeURIs()[0].URI)
+			proposedVdrs, err := pvmClient.GetProposedValidators(
 				tc.DefaultContext(),
 				constants.PrimaryNetworkID,
 			)
 			require.NoError(err)
+
+			tc.By("confirming proposed validators are the same as current validators", func() {
+				proposedVdrNodes := set.NewSet[ids.NodeID](len(proposedVdrs))
+				for _, vdr := range proposedVdrs {
+					proposedVdrNodes.Add(vdr.NodeID)
+				}
+				currentVdrs, err := pvmClient.GetCurrentValidators(
+					tc.DefaultContext(),
+					constants.PrimaryNetworkID,
+					nil,
+				)
+				require.NoError(err)
+				currentVdrNodes := set.NewSet[ids.NodeID](len(currentVdrs))
+				for _, vdr := range currentVdrs {
+					currentVdrNodes.Add(vdr.NodeID)
+				}
+				require.Equal(proposedVdrNodes, currentVdrNodes)
+			})
 		})
-		_ = e2e.CheckBootstrapIsPossible(tc, network)
+		_ = e2e.CheckBootstrapIsPossible(tc, privateNetwork)
 	})
 })

--- a/tests/e2e/p/proposed_validators.go
+++ b/tests/e2e/p/proposed_validators.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package p
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
+)
+
+var _ = e2e.DescribePChain("[Proposed Validators]", func() {
+	var (
+		tc      = e2e.NewTestContext()
+		require = require.New(tc)
+	)
+
+	ginkgo.It("should be able to fetch proposed validators", func() {
+		var (
+			env     = e2e.GetEnv(tc)
+			network = env.GetNetwork()
+		)
+		tc.By("fetching proposed validators", func() {
+			pvmClient := platformvm.NewClient(env.URIs[0].URI)
+			_, err := pvmClient.GetProposedValidators(
+				tc.DefaultContext(),
+				constants.PrimaryNetworkID,
+			)
+			require.NoError(err)
+		})
+		_ = e2e.CheckBootstrapIsPossible(tc, network)
+	})
+})

--- a/tests/e2e/p/proposed_validators.go
+++ b/tests/e2e/p/proposed_validators.go
@@ -4,6 +4,9 @@
 package p
 
 import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
@@ -11,8 +14,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
-	"github.com/onsi/ginkgo/v2"
-	"github.com/stretchr/testify/require"
 )
 
 var _ = e2e.DescribePChain("[Proposed Validators]", func() {

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -506,6 +506,18 @@ func (c *client) GetValidatorsAt(
 	return res.Validators, err
 }
 
+func (c *client) GetProposedValidators(
+	ctx context.Context,
+	subnetID ids.ID,
+	options ...rpc.Option,
+) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+	res := &GetProposedValidatorsReply{}
+	err := c.requester.SendRequest(ctx, "platform.getProposedValidators", &GetProposedValidatorsArgs{
+		SubnetID: subnetID,
+	}, res, options...)
+	return res.Validators, err
+}
+
 func (c *client) GetBlock(ctx context.Context, blockID ids.ID, options ...rpc.Option) ([]byte, error) {
 	res := &api.FormattedBlock{}
 	if err := c.requester.SendRequest(ctx, "platform.getBlock", &api.GetBlockArgs{

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -120,6 +120,13 @@ type Client interface {
 		height uint64,
 		options ...rpc.Option,
 	) (map[ids.NodeID]*validators.GetValidatorOutput, error)
+	// GetProposedValidators returns the weights of the validator set of a provided
+	// subnet at the proposer's height.
+	GetProposedValidators(
+		ctx context.Context,
+		subnetID ids.ID,
+		options ...rpc.Option,
+	) (map[ids.NodeID]*validators.GetValidatorOutput, error)
 	// GetBlock returns the block with the given id.
 	GetBlock(ctx context.Context, blockID ids.ID, options ...rpc.Option) ([]byte, error)
 	// GetBlockByHeight returns the block at the given [height].

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1780,6 +1780,33 @@ func (s *Service) GetValidatorsAt(r *http.Request, args *GetValidatorsAtArgs, re
 	return nil
 }
 
+type GetProposedValidatorsArgs struct {
+	SubnetID ids.ID `json:"subnetID"`
+}
+type GetProposedValidatorsReply struct {
+	GetValidatorsAtReply
+}
+
+func (s *Service) GetProposedValidators(r *http.Request, args *GetProposedValidatorsArgs, reply *GetProposedValidatorsReply) error {
+	s.vm.ctx.Log.Debug("API called",
+		zap.String("service", "platform"),
+		zap.String("method", "getProposedValidators"),
+		zap.Stringer("subnetID", args.SubnetID),
+	)
+	s.vm.ctx.Lock.Lock()
+	defer s.vm.ctx.Lock.Unlock()
+
+	ctx := r.Context()
+	proposerHeight, err := s.vm.GetMinimumHeight(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get proposer height: %w", err)
+	}
+	if reply.Validators, err = s.vm.GetValidatorSet(ctx, proposerHeight, args.SubnetID); err != nil {
+		return fmt.Errorf("failed to get validator set: %w", err)
+	}
+	return nil
+}
+
 func (s *Service) GetBlock(_ *http.Request, args *api.GetBlockArgs, response *api.GetBlockResponse) error {
 	s.vm.ctx.Log.Debug("API called",
 		zap.String("service", "platform"),

--- a/vms/platformvm/service.md
+++ b/vms/platformvm/service.md
@@ -1834,7 +1834,7 @@ platform.getProposedValidators(
 ```bash
 curl -X POST --data '{
     "jsonrpc": "2.0",
-    "method": "platform.getValidatorsAt",
+    "method": "platform.getProposedValidators",
     "params": {},
     "id": 1
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P

--- a/vms/platformvm/service.md
+++ b/vms/platformvm/service.md
@@ -1778,7 +1778,7 @@ platform.getValidatorsAt(
 ```
 
 - `height` is the P-Chain height to get the validator set at.
-- `subnetID` is the Subnet ID to get the validator set of. If not given, gets validator set of the
+- `subnetID` is the Subnet ID to get the validator set of. If not given, gets the validator set of the
   Primary Network.
 
 **Example Call:**
@@ -1790,6 +1790,52 @@ curl -X POST --data '{
     "params": {
         "height":1
     },
+    "id": 1
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "validators": {
+      "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg": 2000000000000000,
+      "NodeID-GWPcbFJZFfZreETSoWjPimr846mXEKCtu": 2000000000000000,
+      "NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ": 2000000000000000,
+      "NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN": 2000000000000000,
+      "NodeID-P7oB2McjBGgW2NXXWVYjV8JEDFoW9xDE5": 2000000000000000
+    }
+  },
+  "id": 1
+}
+```
+
+### `platform.getProposedValidators`
+
+Get the validators and their weights of a Subnet or the Primary Network at the current proposer VM height.
+
+**Signature:**
+
+```sh
+platform.getProposedValidators(
+    {
+        subnetID: string, // optional
+    }
+)
+```
+
+- `subnetID` is the Subnet ID to get the validator set of. If not given, gets the validator set of the
+  Primary Network.
+
+**Example Call:**
+
+```bash
+curl -X POST --data '{
+    "jsonrpc": "2.0",
+    "method": "platform.getValidatorsAt",
+    "params": {},
     "id": 1
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
 ```

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"math/rand"
 	"sync"
@@ -28,6 +27,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/iterator"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/maybe"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -109,620 +110,384 @@ func TestStateSyncGenesis(t *testing.T) {
 	)
 }
 
-// Whenever we store a staker, a whole bunch a data structures are updated
-// This test is meant to capture which updates are carried out
-func TestPersistStakers(t *testing.T) {
+// Whenever we add or remove a staker, a number of on-disk data structures
+// should be updated.
+//
+// This test verifies that the on-disk data structures are updated as expected.
+func TestState_writeStakers(t *testing.T) {
+	const (
+		primaryValidatorDuration = 28 * 24 * time.Hour
+		primaryDelegatorDuration = 14 * 24 * time.Hour
+		subnetValidatorDuration  = 21 * 24 * time.Hour
+
+		primaryValidatorReward = iota
+		primaryDelegatorReward
+		subnetValidatorReward
+	)
+	var (
+		primaryValidatorStartTime   = time.Now().Truncate(time.Second)
+		primaryValidatorEndTime     = primaryValidatorStartTime.Add(primaryValidatorDuration)
+		primaryValidatorEndTimeUnix = uint64(primaryValidatorEndTime.Unix())
+
+		primaryDelegatorStartTime   = primaryValidatorStartTime
+		primaryDelegatorEndTime     = primaryDelegatorStartTime.Add(primaryDelegatorDuration)
+		primaryDelegatorEndTimeUnix = uint64(primaryDelegatorEndTime.Unix())
+
+		subnetValidatorStartTime   = primaryValidatorStartTime
+		subnetValidatorEndTime     = subnetValidatorStartTime.Add(subnetValidatorDuration)
+		subnetValidatorEndTimeUnix = uint64(subnetValidatorEndTime.Unix())
+
+		primaryValidatorData = txs.Validator{
+			NodeID: ids.GenerateTestNodeID(),
+			End:    primaryValidatorEndTimeUnix,
+			Wght:   1234,
+		}
+		primaryDelegatorData = txs.Validator{
+			NodeID: primaryValidatorData.NodeID,
+			End:    primaryDelegatorEndTimeUnix,
+			Wght:   6789,
+		}
+		subnetValidatorData = txs.Validator{
+			NodeID: primaryValidatorData.NodeID,
+			End:    subnetValidatorEndTimeUnix,
+			Wght:   9876,
+		}
+
+		subnetID = ids.GenerateTestID()
+	)
+
+	unsignedAddPrimaryNetworkValidator := createPermissionlessValidatorTx(t, constants.PrimaryNetworkID, primaryValidatorData)
+	addPrimaryNetworkValidator := &txs.Tx{Unsigned: unsignedAddPrimaryNetworkValidator}
+	require.NoError(t, addPrimaryNetworkValidator.Initialize(txs.Codec))
+
+	primaryNetworkPendingValidatorStaker, err := NewPendingStaker(
+		addPrimaryNetworkValidator.ID(),
+		unsignedAddPrimaryNetworkValidator,
+	)
+	require.NoError(t, err)
+
+	primaryNetworkCurrentValidatorStaker, err := NewCurrentStaker(
+		addPrimaryNetworkValidator.ID(),
+		unsignedAddPrimaryNetworkValidator,
+		primaryValidatorStartTime,
+		primaryValidatorReward,
+	)
+	require.NoError(t, err)
+
+	unsignedAddPrimaryNetworkDelegator := createPermissionlessDelegatorTx(constants.PrimaryNetworkID, primaryDelegatorData)
+	addPrimaryNetworkDelegator := &txs.Tx{Unsigned: unsignedAddPrimaryNetworkDelegator}
+	require.NoError(t, addPrimaryNetworkDelegator.Initialize(txs.Codec))
+
+	primaryNetworkPendingDelegatorStaker, err := NewPendingStaker(
+		addPrimaryNetworkDelegator.ID(),
+		unsignedAddPrimaryNetworkDelegator,
+	)
+	require.NoError(t, err)
+
+	primaryNetworkCurrentDelegatorStaker, err := NewCurrentStaker(
+		addPrimaryNetworkDelegator.ID(),
+		unsignedAddPrimaryNetworkDelegator,
+		primaryDelegatorStartTime,
+		primaryDelegatorReward,
+	)
+	require.NoError(t, err)
+
+	unsignedAddSubnetValidator := createPermissionlessValidatorTx(t, subnetID, subnetValidatorData)
+	addSubnetValidator := &txs.Tx{Unsigned: unsignedAddSubnetValidator}
+	require.NoError(t, addSubnetValidator.Initialize(txs.Codec))
+
+	subnetCurrentValidatorStaker, err := NewCurrentStaker(
+		addSubnetValidator.ID(),
+		unsignedAddSubnetValidator,
+		subnetValidatorStartTime,
+		subnetValidatorReward,
+	)
+	require.NoError(t, err)
+
 	tests := map[string]struct {
-		// Insert or delete a staker to state and store it
-		storeStaker func(*require.Assertions, ids.ID /*=subnetID*/, *state) *Staker
+		initialStakers []*Staker
+		initialTxs     []*txs.Tx
+
+		// Staker to insert or remove
+		staker      *Staker
+		addStakerTx *txs.Tx // If tx is nil, the staker is being removed
 
 		// Check that the staker is duly stored/removed in P-chain state
-		checkStakerInState func(*require.Assertions, *state, *Staker)
+		expectedCurrentValidator  *Staker
+		expectedPendingValidator  *Staker
+		expectedCurrentDelegators []*Staker
+		expectedPendingDelegators []*Staker
 
-		// Check whether validators are duly reported in the validator set,
-		// with the right weight and showing the BLS key
-		checkValidatorsSet func(*require.Assertions, *state, *Staker)
-
-		// Check that node duly track stakers uptimes
-		checkValidatorUptimes func(*require.Assertions, *state, *Staker)
+		// Check that the validator entry has been set correctly in the
+		// in-memory validator set.
+		expectedValidatorSetOutput *validators.GetValidatorOutput
 
 		// Check whether weight/bls keys diffs are duly stored
-		checkDiffs func(*require.Assertions, *state, *Staker, uint64)
+		expectedWeightDiff    *ValidatorWeightDiff
+		expectedPublicKeyDiff maybe.Maybe[*bls.PublicKey]
 	}{
-		"add current validator": {
-			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
-				var (
-					startTime = time.Now().Unix()
-					endTime   = time.Now().Add(14 * 24 * time.Hour).Unix()
-
-					validatorsData = txs.Validator{
-						NodeID: ids.GenerateTestNodeID(),
-						End:    uint64(endTime),
-						Wght:   1234,
-					}
-					validatorReward uint64 = 5678
-				)
-
-				utx := createPermissionlessValidatorTx(r, subnetID, validatorsData)
-				addPermValTx := &txs.Tx{Unsigned: utx}
-				r.NoError(addPermValTx.Initialize(txs.Codec))
-
-				staker, err := NewCurrentStaker(
-					addPermValTx.ID(),
-					utx,
-					time.Unix(startTime, 0),
-					validatorReward,
-				)
-				r.NoError(err)
-
-				r.NoError(s.PutCurrentValidator(staker))
-				s.AddTx(addPermValTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-				return staker
+		"add current primary network validator": {
+			staker:                   primaryNetworkCurrentValidatorStaker,
+			addStakerTx:              addPrimaryNetworkValidator,
+			expectedCurrentValidator: primaryNetworkCurrentValidatorStaker,
+			expectedValidatorSetOutput: &validators.GetValidatorOutput{
+				NodeID:    primaryNetworkCurrentValidatorStaker.NodeID,
+				PublicKey: primaryNetworkCurrentValidatorStaker.PublicKey,
+				Weight:    primaryNetworkCurrentValidatorStaker.Weight,
 			},
-			checkStakerInState: func(r *require.Assertions, s *state, staker *Staker) {
-				retrievedStaker, err := s.GetCurrentValidator(staker.SubnetID, staker.NodeID)
-				r.NoError(err)
-				r.Equal(staker, retrievedStaker)
+			expectedWeightDiff: &ValidatorWeightDiff{
+				Decrease: false,
+				Amount:   primaryNetworkCurrentValidatorStaker.Weight,
 			},
-			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
-				valsMap := s.validators.GetMap(staker.SubnetID)
-				r.Contains(valsMap, staker.NodeID)
-				r.Equal(
-					&validators.GetValidatorOutput{
-						NodeID:    staker.NodeID,
-						PublicKey: staker.PublicKey,
-						Weight:    staker.Weight,
-					},
-					valsMap[staker.NodeID],
-				)
+			expectedPublicKeyDiff: maybe.Some[*bls.PublicKey](nil),
+		},
+		"add current primary network delegator": {
+			initialStakers:            []*Staker{primaryNetworkCurrentValidatorStaker},
+			initialTxs:                []*txs.Tx{addPrimaryNetworkValidator},
+			staker:                    primaryNetworkCurrentDelegatorStaker,
+			addStakerTx:               addPrimaryNetworkDelegator,
+			expectedCurrentValidator:  primaryNetworkCurrentValidatorStaker,
+			expectedCurrentDelegators: []*Staker{primaryNetworkCurrentDelegatorStaker},
+			expectedValidatorSetOutput: &validators.GetValidatorOutput{
+				NodeID:    primaryNetworkCurrentValidatorStaker.NodeID,
+				PublicKey: primaryNetworkCurrentValidatorStaker.PublicKey,
+				Weight:    primaryNetworkCurrentValidatorStaker.Weight + primaryNetworkCurrentDelegatorStaker.Weight,
 			},
-			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
-				upDuration, lastUpdated, err := s.GetUptime(staker.NodeID)
-				if staker.SubnetID != constants.PrimaryNetworkID {
-					// only primary network validators have uptimes
-					r.ErrorIs(err, database.ErrNotFound)
-				} else {
-					r.NoError(err)
-					r.Equal(upDuration, time.Duration(0))
-					r.Equal(lastUpdated, staker.StartTime)
-				}
-			},
-			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
-				weightDiffBytes, err := s.validatorWeightDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				r.NoError(err)
-				weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
-				r.NoError(err)
-				r.Equal(&ValidatorWeightDiff{
-					Decrease: false,
-					Amount:   staker.Weight,
-				}, weightDiff)
-
-				blsDiffBytes, err := s.validatorPublicKeyDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				if staker.SubnetID == constants.PrimaryNetworkID {
-					r.NoError(err)
-					r.Nil(blsDiffBytes)
-				} else {
-					r.ErrorIs(err, database.ErrNotFound)
-				}
+			expectedWeightDiff: &ValidatorWeightDiff{
+				Decrease: false,
+				Amount:   primaryNetworkCurrentDelegatorStaker.Weight,
 			},
 		},
-		"add current delegator": {
-			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
-				// insert the delegator and its validator
-				var (
-					valStartTime = time.Now().Truncate(time.Second).Unix()
-					delStartTime = time.Unix(valStartTime, 0).Add(time.Hour).Unix()
-					delEndTime   = time.Unix(delStartTime, 0).Add(30 * 24 * time.Hour).Unix()
-					valEndTime   = time.Unix(valStartTime, 0).Add(365 * 24 * time.Hour).Unix()
-
-					validatorsData = txs.Validator{
-						NodeID: ids.GenerateTestNodeID(),
-						End:    uint64(valEndTime),
-						Wght:   1234,
-					}
-					validatorReward uint64 = 5678
-
-					delegatorData = txs.Validator{
-						NodeID: validatorsData.NodeID,
-						End:    uint64(delEndTime),
-						Wght:   validatorsData.Wght / 2,
-					}
-					delegatorReward uint64 = 5432
-				)
-
-				utxVal := createPermissionlessValidatorTx(r, subnetID, validatorsData)
-				addPermValTx := &txs.Tx{Unsigned: utxVal}
-				r.NoError(addPermValTx.Initialize(txs.Codec))
-
-				val, err := NewCurrentStaker(
-					addPermValTx.ID(),
-					utxVal,
-					time.Unix(valStartTime, 0),
-					validatorReward,
-				)
-				r.NoError(err)
-
-				utxDel := createPermissionlessDelegatorTx(subnetID, delegatorData)
-				addPermDelTx := &txs.Tx{Unsigned: utxDel}
-				r.NoError(addPermDelTx.Initialize(txs.Codec))
-
-				del, err := NewCurrentStaker(
-					addPermDelTx.ID(),
-					utxDel,
-					time.Unix(delStartTime, 0),
-					delegatorReward,
-				)
-				r.NoError(err)
-
-				r.NoError(s.PutCurrentValidator(val))
-				s.AddTx(addPermValTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-
-				s.PutCurrentDelegator(del)
-				s.AddTx(addPermDelTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-				return del
+		"add pending primary network validator": {
+			staker:                   primaryNetworkPendingValidatorStaker,
+			addStakerTx:              addPrimaryNetworkValidator,
+			expectedPendingValidator: primaryNetworkPendingValidatorStaker,
+		},
+		"add pending primary network delegator": {
+			initialStakers:            []*Staker{primaryNetworkPendingValidatorStaker},
+			initialTxs:                []*txs.Tx{addPrimaryNetworkValidator},
+			staker:                    primaryNetworkPendingDelegatorStaker,
+			addStakerTx:               addPrimaryNetworkDelegator,
+			expectedPendingValidator:  primaryNetworkPendingValidatorStaker,
+			expectedPendingDelegators: []*Staker{primaryNetworkPendingDelegatorStaker},
+		},
+		"add current subnet validator": {
+			initialStakers:           []*Staker{primaryNetworkCurrentValidatorStaker},
+			initialTxs:               []*txs.Tx{addPrimaryNetworkValidator},
+			staker:                   subnetCurrentValidatorStaker,
+			addStakerTx:              addSubnetValidator,
+			expectedCurrentValidator: subnetCurrentValidatorStaker,
+			expectedValidatorSetOutput: &validators.GetValidatorOutput{
+				NodeID: subnetCurrentValidatorStaker.NodeID,
+				Weight: subnetCurrentValidatorStaker.Weight,
 			},
-			checkStakerInState: func(r *require.Assertions, s *state, staker *Staker) {
-				delIt, err := s.GetCurrentDelegatorIterator(staker.SubnetID, staker.NodeID)
-				r.NoError(err)
-				r.True(delIt.Next())
-				retrievedDelegator := delIt.Value()
-				r.False(delIt.Next())
-				delIt.Release()
-				r.Equal(staker, retrievedDelegator)
-			},
-			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
-				val, err := s.GetCurrentValidator(staker.SubnetID, staker.NodeID)
-				r.NoError(err)
-
-				valsMap := s.validators.GetMap(staker.SubnetID)
-				r.Contains(valsMap, staker.NodeID)
-				valOut := valsMap[staker.NodeID]
-				r.Equal(valOut.NodeID, staker.NodeID)
-				r.Equal(valOut.Weight, val.Weight+staker.Weight)
-			},
-			checkValidatorUptimes: func(*require.Assertions, *state, *Staker) {},
-			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
-				// validator's weight must increase of delegator's weight amount
-				weightDiffBytes, err := s.validatorWeightDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				r.NoError(err)
-				weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
-				r.NoError(err)
-				r.Equal(&ValidatorWeightDiff{
-					Decrease: false,
-					Amount:   staker.Weight,
-				}, weightDiff)
+			expectedWeightDiff: &ValidatorWeightDiff{
+				Decrease: false,
+				Amount:   subnetCurrentValidatorStaker.Weight,
 			},
 		},
-		"add pending validator": {
-			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
-				var (
-					startTime = time.Now().Unix()
-					endTime   = time.Now().Add(14 * 24 * time.Hour).Unix()
-
-					validatorsData = txs.Validator{
-						NodeID: ids.GenerateTestNodeID(),
-						Start:  uint64(startTime),
-						End:    uint64(endTime),
-						Wght:   1234,
-					}
-				)
-
-				utx := createPermissionlessValidatorTx(r, subnetID, validatorsData)
-				addPermValTx := &txs.Tx{Unsigned: utx}
-				r.NoError(addPermValTx.Initialize(txs.Codec))
-
-				staker, err := NewPendingStaker(
-					addPermValTx.ID(),
-					utx,
-				)
-				r.NoError(err)
-
-				r.NoError(s.PutPendingValidator(staker))
-				s.AddTx(addPermValTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-				return staker
+		"delete current primary network validator": {
+			initialStakers: []*Staker{primaryNetworkCurrentValidatorStaker},
+			initialTxs:     []*txs.Tx{addPrimaryNetworkValidator},
+			staker:         primaryNetworkCurrentValidatorStaker,
+			expectedWeightDiff: &ValidatorWeightDiff{
+				Decrease: true,
+				Amount:   primaryNetworkCurrentValidatorStaker.Weight,
 			},
-			checkStakerInState: func(r *require.Assertions, s *state, staker *Staker) {
-				retrievedStaker, err := s.GetPendingValidator(staker.SubnetID, staker.NodeID)
-				r.NoError(err)
-				r.Equal(staker, retrievedStaker)
+			expectedPublicKeyDiff: maybe.Some(primaryNetworkCurrentValidatorStaker.PublicKey),
+		},
+		"delete current primary network delegator": {
+			initialStakers: []*Staker{
+				primaryNetworkCurrentValidatorStaker,
+				primaryNetworkCurrentDelegatorStaker,
 			},
-			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
-				// pending validators are not showed in validators set
-				valsMap := s.validators.GetMap(staker.SubnetID)
-				r.NotContains(valsMap, staker.NodeID)
+			initialTxs: []*txs.Tx{
+				addPrimaryNetworkValidator,
+				addPrimaryNetworkDelegator,
 			},
-			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
-				// pending validators uptime is not tracked
-				_, _, err := s.GetUptime(staker.NodeID)
-				r.ErrorIs(err, database.ErrNotFound)
+			staker:                   primaryNetworkCurrentDelegatorStaker,
+			expectedCurrentValidator: primaryNetworkCurrentValidatorStaker,
+			expectedValidatorSetOutput: &validators.GetValidatorOutput{
+				NodeID:    primaryNetworkCurrentValidatorStaker.NodeID,
+				PublicKey: primaryNetworkCurrentValidatorStaker.PublicKey,
+				Weight:    primaryNetworkCurrentValidatorStaker.Weight,
 			},
-			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
-				// pending validators weight diff and bls diffs are not stored
-				_, err := s.validatorWeightDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				r.ErrorIs(err, database.ErrNotFound)
-
-				_, err = s.validatorPublicKeyDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				r.ErrorIs(err, database.ErrNotFound)
+			expectedWeightDiff: &ValidatorWeightDiff{
+				Decrease: true,
+				Amount:   primaryNetworkCurrentDelegatorStaker.Weight,
 			},
 		},
-		"add pending delegator": {
-			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
-				// insert the delegator and its validator
-				var (
-					valStartTime = time.Now().Truncate(time.Second).Unix()
-					delStartTime = time.Unix(valStartTime, 0).Add(time.Hour).Unix()
-					delEndTime   = time.Unix(delStartTime, 0).Add(30 * 24 * time.Hour).Unix()
-					valEndTime   = time.Unix(valStartTime, 0).Add(365 * 24 * time.Hour).Unix()
-
-					validatorsData = txs.Validator{
-						NodeID: ids.GenerateTestNodeID(),
-						Start:  uint64(valStartTime),
-						End:    uint64(valEndTime),
-						Wght:   1234,
-					}
-
-					delegatorData = txs.Validator{
-						NodeID: validatorsData.NodeID,
-						Start:  uint64(delStartTime),
-						End:    uint64(delEndTime),
-						Wght:   validatorsData.Wght / 2,
-					}
-				)
-
-				utxVal := createPermissionlessValidatorTx(r, subnetID, validatorsData)
-				addPermValTx := &txs.Tx{Unsigned: utxVal}
-				r.NoError(addPermValTx.Initialize(txs.Codec))
-
-				val, err := NewPendingStaker(addPermValTx.ID(), utxVal)
-				r.NoError(err)
-
-				utxDel := createPermissionlessDelegatorTx(subnetID, delegatorData)
-				addPermDelTx := &txs.Tx{Unsigned: utxDel}
-				r.NoError(addPermDelTx.Initialize(txs.Codec))
-
-				del, err := NewPendingStaker(addPermDelTx.ID(), utxDel)
-				r.NoError(err)
-
-				r.NoError(s.PutPendingValidator(val))
-				s.AddTx(addPermValTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-
-				s.PutPendingDelegator(del)
-				s.AddTx(addPermDelTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-
-				return del
-			},
-			checkStakerInState: func(r *require.Assertions, s *state, staker *Staker) {
-				delIt, err := s.GetPendingDelegatorIterator(staker.SubnetID, staker.NodeID)
-				r.NoError(err)
-				r.True(delIt.Next())
-				retrievedDelegator := delIt.Value()
-				r.False(delIt.Next())
-				delIt.Release()
-				r.Equal(staker, retrievedDelegator)
-			},
-			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
-				valsMap := s.validators.GetMap(staker.SubnetID)
-				r.NotContains(valsMap, staker.NodeID)
-			},
-			checkValidatorUptimes: func(*require.Assertions, *state, *Staker) {},
-			checkDiffs:            func(*require.Assertions, *state, *Staker, uint64) {},
+		"delete pending primary network validator": {
+			initialStakers: []*Staker{primaryNetworkPendingValidatorStaker},
+			initialTxs:     []*txs.Tx{addPrimaryNetworkValidator},
+			staker:         primaryNetworkPendingValidatorStaker,
 		},
-		"delete current validator": {
-			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
-				// add them remove the validator
-				var (
-					startTime = time.Now().Unix()
-					endTime   = time.Now().Add(14 * 24 * time.Hour).Unix()
-
-					validatorsData = txs.Validator{
-						NodeID: ids.GenerateTestNodeID(),
-						End:    uint64(endTime),
-						Wght:   1234,
-					}
-					validatorReward uint64 = 5678
-				)
-
-				utx := createPermissionlessValidatorTx(r, subnetID, validatorsData)
-				addPermValTx := &txs.Tx{Unsigned: utx}
-				r.NoError(addPermValTx.Initialize(txs.Codec))
-
-				staker, err := NewCurrentStaker(
-					addPermValTx.ID(),
-					utx,
-					time.Unix(startTime, 0),
-					validatorReward,
-				)
-				r.NoError(err)
-
-				r.NoError(s.PutCurrentValidator(staker))
-				s.AddTx(addPermValTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-
-				s.DeleteCurrentValidator(staker)
-				r.NoError(s.Commit())
-				return staker
+		"delete pending primary network delegator": {
+			initialStakers: []*Staker{
+				primaryNetworkPendingValidatorStaker,
+				primaryNetworkPendingDelegatorStaker,
 			},
-			checkStakerInState: func(r *require.Assertions, s *state, staker *Staker) {
-				_, err := s.GetCurrentValidator(staker.SubnetID, staker.NodeID)
-				r.ErrorIs(err, database.ErrNotFound)
+			initialTxs: []*txs.Tx{
+				addPrimaryNetworkValidator,
+				addPrimaryNetworkDelegator,
 			},
-			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
-				// deleted validators are not showed in the validators set anymore
-				valsMap := s.validators.GetMap(staker.SubnetID)
-				r.NotContains(valsMap, staker.NodeID)
-			},
-			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
-				// uptimes of delete validators are dropped
-				_, _, err := s.GetUptime(staker.NodeID)
-				r.ErrorIs(err, database.ErrNotFound)
-			},
-			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
-				weightDiffBytes, err := s.validatorWeightDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				r.NoError(err)
-				weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
-				r.NoError(err)
-				r.Equal(&ValidatorWeightDiff{
-					Decrease: true,
-					Amount:   staker.Weight,
-				}, weightDiff)
-
-				blsDiffBytes, err := s.validatorPublicKeyDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				if staker.SubnetID == constants.PrimaryNetworkID {
-					r.NoError(err)
-					r.Equal(bls.PublicKeyFromValidUncompressedBytes(blsDiffBytes), staker.PublicKey)
-				} else {
-					r.ErrorIs(err, database.ErrNotFound)
-				}
-			},
+			staker:                   primaryNetworkPendingDelegatorStaker,
+			expectedPendingValidator: primaryNetworkPendingValidatorStaker,
 		},
-		"delete current delegator": {
-			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
-				// insert validator and delegator, then remove the delegator
-				var (
-					valStartTime = time.Now().Truncate(time.Second).Unix()
-					delStartTime = time.Unix(valStartTime, 0).Add(time.Hour).Unix()
-					delEndTime   = time.Unix(delStartTime, 0).Add(30 * 24 * time.Hour).Unix()
-					valEndTime   = time.Unix(valStartTime, 0).Add(365 * 24 * time.Hour).Unix()
-
-					validatorsData = txs.Validator{
-						NodeID: ids.GenerateTestNodeID(),
-						End:    uint64(valEndTime),
-						Wght:   1234,
-					}
-					validatorReward uint64 = 5678
-
-					delegatorData = txs.Validator{
-						NodeID: validatorsData.NodeID,
-						End:    uint64(delEndTime),
-						Wght:   validatorsData.Wght / 2,
-					}
-					delegatorReward uint64 = 5432
-				)
-
-				utxVal := createPermissionlessValidatorTx(r, subnetID, validatorsData)
-				addPermValTx := &txs.Tx{Unsigned: utxVal}
-				r.NoError(addPermValTx.Initialize(txs.Codec))
-
-				val, err := NewCurrentStaker(
-					addPermValTx.ID(),
-					utxVal,
-					time.Unix(valStartTime, 0),
-					validatorReward,
-				)
-				r.NoError(err)
-
-				utxDel := createPermissionlessDelegatorTx(subnetID, delegatorData)
-				addPermDelTx := &txs.Tx{Unsigned: utxDel}
-				r.NoError(addPermDelTx.Initialize(txs.Codec))
-
-				del, err := NewCurrentStaker(
-					addPermDelTx.ID(),
-					utxDel,
-					time.Unix(delStartTime, 0),
-					delegatorReward,
-				)
-				r.NoError(err)
-
-				r.NoError(s.PutCurrentValidator(val))
-				s.AddTx(addPermValTx, status.Committed) // this is currently needed to reload the staker
-
-				s.PutCurrentDelegator(del)
-				s.AddTx(addPermDelTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-
-				s.DeleteCurrentDelegator(del)
-				r.NoError(s.Commit())
-
-				return del
+		"delete current subnet validator": {
+			initialStakers: []*Staker{primaryNetworkCurrentValidatorStaker, subnetCurrentValidatorStaker},
+			initialTxs:     []*txs.Tx{addPrimaryNetworkValidator, addSubnetValidator},
+			staker:         subnetCurrentValidatorStaker,
+			expectedWeightDiff: &ValidatorWeightDiff{
+				Decrease: true,
+				Amount:   subnetCurrentValidatorStaker.Weight,
 			},
-			checkStakerInState: func(r *require.Assertions, s *state, staker *Staker) {
-				delIt, err := s.GetCurrentDelegatorIterator(staker.SubnetID, staker.NodeID)
-				r.NoError(err)
-				r.False(delIt.Next())
-				delIt.Release()
-			},
-			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
-				val, err := s.GetCurrentValidator(staker.SubnetID, staker.NodeID)
-				r.NoError(err)
-
-				valsMap := s.validators.GetMap(staker.SubnetID)
-				r.Contains(valsMap, staker.NodeID)
-				valOut := valsMap[staker.NodeID]
-				r.Equal(valOut.NodeID, staker.NodeID)
-				r.Equal(valOut.Weight, val.Weight)
-			},
-			checkValidatorUptimes: func(*require.Assertions, *state, *Staker) {},
-			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
-				// validator's weight must decrease of delegator's weight amount
-				weightDiffBytes, err := s.validatorWeightDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				r.NoError(err)
-				weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
-				r.NoError(err)
-				r.Equal(&ValidatorWeightDiff{
-					Decrease: true,
-					Amount:   staker.Weight,
-				}, weightDiff)
-			},
-		},
-		"delete pending validator": {
-			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
-				var (
-					startTime = time.Now().Unix()
-					endTime   = time.Now().Add(14 * 24 * time.Hour).Unix()
-
-					validatorsData = txs.Validator{
-						NodeID: ids.GenerateTestNodeID(),
-						Start:  uint64(startTime),
-						End:    uint64(endTime),
-						Wght:   1234,
-					}
-				)
-
-				utx := createPermissionlessValidatorTx(r, subnetID, validatorsData)
-				addPermValTx := &txs.Tx{Unsigned: utx}
-				r.NoError(addPermValTx.Initialize(txs.Codec))
-
-				staker, err := NewPendingStaker(
-					addPermValTx.ID(),
-					utx,
-				)
-				r.NoError(err)
-
-				r.NoError(s.PutPendingValidator(staker))
-				s.AddTx(addPermValTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-
-				s.DeletePendingValidator(staker)
-				r.NoError(s.Commit())
-
-				return staker
-			},
-			checkStakerInState: func(r *require.Assertions, s *state, staker *Staker) {
-				_, err := s.GetPendingValidator(staker.SubnetID, staker.NodeID)
-				r.ErrorIs(err, database.ErrNotFound)
-			},
-			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
-				valsMap := s.validators.GetMap(staker.SubnetID)
-				r.NotContains(valsMap, staker.NodeID)
-			},
-			checkValidatorUptimes: func(r *require.Assertions, s *state, staker *Staker) {
-				_, _, err := s.GetUptime(staker.NodeID)
-				r.ErrorIs(err, database.ErrNotFound)
-			},
-			checkDiffs: func(r *require.Assertions, s *state, staker *Staker, height uint64) {
-				_, err := s.validatorWeightDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				r.ErrorIs(err, database.ErrNotFound)
-
-				_, err = s.validatorPublicKeyDiffsDB.Get(marshalDiffKey(staker.SubnetID, height, staker.NodeID))
-				r.ErrorIs(err, database.ErrNotFound)
-			},
-		},
-		"delete pending delegator": {
-			storeStaker: func(r *require.Assertions, subnetID ids.ID, s *state) *Staker {
-				// insert validator and delegator the remove the validator
-				var (
-					valStartTime = time.Now().Truncate(time.Second).Unix()
-					delStartTime = time.Unix(valStartTime, 0).Add(time.Hour).Unix()
-					delEndTime   = time.Unix(delStartTime, 0).Add(30 * 24 * time.Hour).Unix()
-					valEndTime   = time.Unix(valStartTime, 0).Add(365 * 24 * time.Hour).Unix()
-
-					validatorsData = txs.Validator{
-						NodeID: ids.GenerateTestNodeID(),
-						Start:  uint64(valStartTime),
-						End:    uint64(valEndTime),
-						Wght:   1234,
-					}
-
-					delegatorData = txs.Validator{
-						NodeID: validatorsData.NodeID,
-						Start:  uint64(delStartTime),
-						End:    uint64(delEndTime),
-						Wght:   validatorsData.Wght / 2,
-					}
-				)
-
-				utxVal := createPermissionlessValidatorTx(r, subnetID, validatorsData)
-				addPermValTx := &txs.Tx{Unsigned: utxVal}
-				r.NoError(addPermValTx.Initialize(txs.Codec))
-
-				val, err := NewPendingStaker(addPermValTx.ID(), utxVal)
-				r.NoError(err)
-
-				utxDel := createPermissionlessDelegatorTx(subnetID, delegatorData)
-				addPermDelTx := &txs.Tx{Unsigned: utxDel}
-				r.NoError(addPermDelTx.Initialize(txs.Codec))
-
-				del, err := NewPendingStaker(addPermDelTx.ID(), utxDel)
-				r.NoError(err)
-
-				r.NoError(s.PutPendingValidator(val))
-				s.AddTx(addPermValTx, status.Committed) // this is currently needed to reload the staker
-
-				s.PutPendingDelegator(del)
-				s.AddTx(addPermDelTx, status.Committed) // this is currently needed to reload the staker
-				r.NoError(s.Commit())
-
-				s.DeletePendingDelegator(del)
-				r.NoError(s.Commit())
-				return del
-			},
-			checkStakerInState: func(r *require.Assertions, s *state, staker *Staker) {
-				delIt, err := s.GetPendingDelegatorIterator(staker.SubnetID, staker.NodeID)
-				r.NoError(err)
-				r.False(delIt.Next())
-				delIt.Release()
-			},
-			checkValidatorsSet: func(r *require.Assertions, s *state, staker *Staker) {
-				valsMap := s.validators.GetMap(staker.SubnetID)
-				r.NotContains(valsMap, staker.NodeID)
-			},
-			checkValidatorUptimes: func(*require.Assertions, *state, *Staker) {},
-			checkDiffs:            func(*require.Assertions, *state, *Staker, uint64) {},
 		},
 	}
 
-	subnetIDs := []ids.ID{constants.PrimaryNetworkID, ids.GenerateTestID()}
-	for _, subnetID := range subnetIDs {
-		for name, test := range tests {
-			t.Run(fmt.Sprintf("%s - subnetID %s", name, subnetID), func(t *testing.T) {
-				require := require.New(t)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
 
-				db := memdb.New()
-				state := newTestState(t, db)
+			db := memdb.New()
+			state := newTestState(t, db)
 
-				// create and store the staker
-				staker := test.storeStaker(require, subnetID, state)
+			addOrDeleteStaker := func(staker *Staker, add bool) {
+				if add {
+					switch {
+					case staker.Priority.IsCurrentValidator():
+						require.NoError(state.PutCurrentValidator(staker))
+					case staker.Priority.IsPendingValidator():
+						require.NoError(state.PutPendingValidator(staker))
+					case staker.Priority.IsCurrentDelegator():
+						state.PutCurrentDelegator(staker)
+					case staker.Priority.IsPendingDelegator():
+						state.PutPendingDelegator(staker)
+					}
+				} else {
+					switch {
+					case staker.Priority.IsCurrentValidator():
+						state.DeleteCurrentValidator(staker)
+					case staker.Priority.IsPendingValidator():
+						state.DeletePendingValidator(staker)
+					case staker.Priority.IsCurrentDelegator():
+						state.DeleteCurrentDelegator(staker)
+					case staker.Priority.IsPendingDelegator():
+						state.DeletePendingDelegator(staker)
+					}
+				}
+			}
 
-				// check all relevant data are stored
-				test.checkStakerInState(require, state, staker)
-				test.checkValidatorsSet(require, state, staker)
-				test.checkValidatorUptimes(require, state, staker)
-				test.checkDiffs(require, state, staker, 0 /*height*/)
+			// create and store the initial stakers
+			for _, staker := range test.initialStakers {
+				addOrDeleteStaker(staker, true)
+			}
+			for _, tx := range test.initialTxs {
+				state.AddTx(tx, status.Committed)
+			}
 
-				// rebuild the state
-				rebuiltState := newTestState(t, db)
+			state.SetHeight(0)
+			require.NoError(state.Commit())
 
-				// check again that all relevant data are still available in rebuilt state
-				test.checkStakerInState(require, rebuiltState, staker)
-				test.checkValidatorsSet(require, rebuiltState, staker)
-				test.checkValidatorUptimes(require, rebuiltState, staker)
-				test.checkDiffs(require, rebuiltState, staker, 0 /*height*/)
-			})
-		}
+			// create and store the staker under test
+			addOrDeleteStaker(test.staker, test.addStakerTx != nil)
+			if test.addStakerTx != nil {
+				state.AddTx(test.addStakerTx, status.Committed)
+			}
+
+			state.SetHeight(1)
+			require.NoError(state.Commit())
+
+			// Perform the checks once immediately after committing to the
+			// state, and once after re-loading the state from disk.
+			for i := 0; i < 2; i++ {
+				currentValidator, err := state.GetCurrentValidator(test.staker.SubnetID, test.staker.NodeID)
+				if test.expectedCurrentValidator == nil {
+					require.ErrorIs(err, database.ErrNotFound)
+
+					if test.staker.SubnetID == constants.PrimaryNetworkID {
+						// Uptimes are only considered for primary network validators
+						_, _, err := state.GetUptime(test.staker.NodeID)
+						require.ErrorIs(err, database.ErrNotFound)
+					}
+				} else {
+					require.NoError(err)
+					require.Equal(test.expectedCurrentValidator, currentValidator)
+
+					if test.staker.SubnetID == constants.PrimaryNetworkID {
+						// Uptimes are only considered for primary network validators
+						upDuration, lastUpdated, err := state.GetUptime(currentValidator.NodeID)
+						require.NoError(err)
+						require.Zero(upDuration)
+						require.Equal(currentValidator.StartTime, lastUpdated)
+					}
+				}
+
+				pendingValidator, err := state.GetPendingValidator(test.staker.SubnetID, test.staker.NodeID)
+				if test.expectedPendingValidator == nil {
+					require.ErrorIs(err, database.ErrNotFound)
+				} else {
+					require.NoError(err)
+					require.Equal(test.expectedPendingValidator, pendingValidator)
+				}
+
+				it, err := state.GetCurrentDelegatorIterator(test.staker.SubnetID, test.staker.NodeID)
+				require.NoError(err)
+				require.Equal(
+					test.expectedCurrentDelegators,
+					iterator.ToSlice(it),
+				)
+
+				it, err = state.GetPendingDelegatorIterator(test.staker.SubnetID, test.staker.NodeID)
+				require.NoError(err)
+				require.Equal(
+					test.expectedPendingDelegators,
+					iterator.ToSlice(it),
+				)
+
+				require.Equal(
+					test.expectedValidatorSetOutput,
+					state.validators.GetMap(test.staker.SubnetID)[test.staker.NodeID],
+				)
+
+				diffKey := marshalDiffKey(test.staker.SubnetID, 1, test.staker.NodeID)
+				weightDiffBytes, err := state.validatorWeightDiffsDB.Get(diffKey)
+				if test.expectedWeightDiff == nil {
+					require.ErrorIs(err, database.ErrNotFound)
+				} else {
+					require.NoError(err)
+
+					weightDiff, err := unmarshalWeightDiff(weightDiffBytes)
+					require.NoError(err)
+					require.Equal(test.expectedWeightDiff, weightDiff)
+				}
+
+				publicKeyDiffBytes, err := state.validatorPublicKeyDiffsDB.Get(diffKey)
+				if test.expectedPublicKeyDiff.IsNothing() {
+					require.ErrorIs(err, database.ErrNotFound)
+				} else {
+					require.NoError(err)
+
+					expectedPublicKeyDiff := test.expectedPublicKeyDiff.Value()
+					if expectedPublicKeyDiff != nil {
+						require.Equal(expectedPublicKeyDiff, bls.PublicKeyFromValidUncompressedBytes(publicKeyDiffBytes))
+					} else {
+						require.Empty(publicKeyDiffBytes)
+					}
+				}
+
+				// re-load the state from disk for the second iteration
+				state = newTestState(t, db)
+			}
+		})
 	}
 }
 
-func createPermissionlessValidatorTx(r *require.Assertions, subnetID ids.ID, validatorsData txs.Validator) *txs.AddPermissionlessValidatorTx {
+func createPermissionlessValidatorTx(t testing.TB, subnetID ids.ID, validatorsData txs.Validator) *txs.AddPermissionlessValidatorTx {
 	var sig signer.Signer = &signer.Empty{}
 	if subnetID == constants.PrimaryNetworkID {
 		sk, err := bls.NewSecretKey()
-		r.NoError(err)
+		require.NoError(t, err)
 		sig = signer.NewProofOfPossession(sk)
 	}
 
@@ -988,43 +753,50 @@ func TestValidatorWeightDiff(t *testing.T) {
 	}
 }
 
-// Tests PutCurrentValidator, DeleteCurrentValidator, GetCurrentValidator,
-// ApplyValidatorWeightDiffs, ApplyValidatorPublicKeyDiffs
-func TestStateAddRemoveValidator(t *testing.T) {
+func TestState_ApplyValidatorDiffs(t *testing.T) {
 	require := require.New(t)
 
 	state := newTestState(t, memdb.New())
 
 	var (
-		numNodes  = 3
-		subnetID  = ids.GenerateTestID()
-		startTime = time.Now()
-		endTime   = startTime.Add(24 * time.Hour)
-		stakers   = make([]Staker, numNodes)
+		numNodes       = 5
+		subnetID       = ids.GenerateTestID()
+		startTime      = time.Now()
+		endTime        = startTime.Add(24 * time.Hour)
+		primaryStakers = make([]Staker, numNodes)
+		subnetStakers  = make([]Staker, numNodes)
 	)
-	for i := 0; i < numNodes; i++ {
-		stakers[i] = Staker{
+	for i := range primaryStakers {
+		sk, err := bls.NewSecretKey()
+		require.NoError(err)
+
+		timeOffset := time.Duration(i) * time.Second
+		primaryStakers[i] = Staker{
 			TxID:            ids.GenerateTestID(),
 			NodeID:          ids.GenerateTestNodeID(),
+			PublicKey:       bls.PublicFromSecretKey(sk),
+			SubnetID:        constants.PrimaryNetworkID,
 			Weight:          uint64(i + 1),
-			StartTime:       startTime.Add(time.Duration(i) * time.Second),
-			EndTime:         endTime.Add(time.Duration(i) * time.Second),
+			StartTime:       startTime.Add(timeOffset),
+			EndTime:         endTime.Add(timeOffset),
 			PotentialReward: uint64(i + 1),
 		}
-		if i%2 == 0 {
-			stakers[i].SubnetID = subnetID
-		} else {
-			sk, err := bls.NewSecretKey()
-			require.NoError(err)
-			stakers[i].PublicKey = bls.PublicFromSecretKey(sk)
-			stakers[i].SubnetID = constants.PrimaryNetworkID
+	}
+	for i, primaryStaker := range primaryStakers {
+		subnetStakers[i] = Staker{
+			TxID:            ids.GenerateTestID(),
+			NodeID:          primaryStaker.NodeID,
+			PublicKey:       nil, // Key is inherited from the primary network
+			SubnetID:        subnetID,
+			Weight:          uint64(i + 1),
+			StartTime:       primaryStaker.StartTime,
+			EndTime:         primaryStaker.EndTime,
+			PotentialReward: uint64(i + 1),
 		}
 	}
 
 	type diff struct {
 		addedValidators   []Staker
-		addedDelegators   []Staker
-		removedDelegators []Staker
 		removedValidators []Staker
 
 		expectedPrimaryValidatorSet map[ids.NodeID]*validators.GetValidatorOutput
@@ -1037,101 +809,172 @@ func TestStateAddRemoveValidator(t *testing.T) {
 			expectedSubnetValidatorSet:  map[ids.NodeID]*validators.GetValidatorOutput{},
 		},
 		{
-			// Add a subnet validator
-			addedValidators:             []Staker{stakers[0]},
-			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
+			// Add primary validator 0
+			addedValidators: []Staker{primaryStakers[0]},
+			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
+				primaryStakers[0].NodeID: {
+					NodeID:    primaryStakers[0].NodeID,
+					PublicKey: primaryStakers[0].PublicKey,
+					Weight:    primaryStakers[0].Weight,
+				},
+			},
+			expectedSubnetValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
+		},
+		{
+			// Add subnet validator 0
+			addedValidators: []Staker{subnetStakers[0]},
+			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
+				primaryStakers[0].NodeID: {
+					NodeID:    primaryStakers[0].NodeID,
+					PublicKey: primaryStakers[0].PublicKey,
+					Weight:    primaryStakers[0].Weight,
+				},
+			},
 			expectedSubnetValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
-				stakers[0].NodeID: {
-					NodeID: stakers[0].NodeID,
-					Weight: stakers[0].Weight,
+				subnetStakers[0].NodeID: {
+					NodeID: subnetStakers[0].NodeID,
+					Weight: subnetStakers[0].Weight,
 				},
 			},
 		},
 		{
-			// Remove a subnet validator
-			removedValidators:           []Staker{stakers[0]},
-			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
-			expectedSubnetValidatorSet:  map[ids.NodeID]*validators.GetValidatorOutput{},
-		},
-		{ // Add a primary network validator
-			addedValidators: []Staker{stakers[1]},
+			// Remove subnet validator 0
+			removedValidators: []Staker{subnetStakers[0]},
 			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
-				stakers[1].NodeID: {
-					NodeID:    stakers[1].NodeID,
-					PublicKey: stakers[1].PublicKey,
-					Weight:    stakers[1].Weight,
+				primaryStakers[0].NodeID: {
+					NodeID:    primaryStakers[0].NodeID,
+					PublicKey: primaryStakers[0].PublicKey,
+					Weight:    primaryStakers[0].Weight,
 				},
 			},
 			expectedSubnetValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
+		},
+		{
+			// Add primary network validator 1, and subnet validator 1
+			addedValidators: []Staker{primaryStakers[1], subnetStakers[1]},
+			// Remove primary network validator 0, and subnet validator 1
+			removedValidators: []Staker{primaryStakers[0], subnetStakers[1]},
+			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
+				primaryStakers[1].NodeID: {
+					NodeID:    primaryStakers[1].NodeID,
+					PublicKey: primaryStakers[1].PublicKey,
+					Weight:    primaryStakers[1].Weight,
+				},
+			},
+			expectedSubnetValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
+		},
+		{
+			// Add primary network validator 2, and subnet validator 2
+			addedValidators: []Staker{primaryStakers[2], subnetStakers[2]},
+			// Remove primary network validator 1
+			removedValidators: []Staker{primaryStakers[1]},
+			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
+				primaryStakers[2].NodeID: {
+					NodeID:    primaryStakers[2].NodeID,
+					PublicKey: primaryStakers[2].PublicKey,
+					Weight:    primaryStakers[2].Weight,
+				},
+			},
+			expectedSubnetValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
+				subnetStakers[2].NodeID: {
+					NodeID: subnetStakers[2].NodeID,
+					Weight: subnetStakers[2].Weight,
+				},
+			},
+		},
+		{
+			// Add primary network and subnet validators 3 & 4
+			addedValidators: []Staker{primaryStakers[3], primaryStakers[4], subnetStakers[3], subnetStakers[4]},
+			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
+				primaryStakers[2].NodeID: {
+					NodeID:    primaryStakers[2].NodeID,
+					PublicKey: primaryStakers[2].PublicKey,
+					Weight:    primaryStakers[2].Weight,
+				},
+				primaryStakers[3].NodeID: {
+					NodeID:    primaryStakers[3].NodeID,
+					PublicKey: primaryStakers[3].PublicKey,
+					Weight:    primaryStakers[3].Weight,
+				},
+				primaryStakers[4].NodeID: {
+					NodeID:    primaryStakers[4].NodeID,
+					PublicKey: primaryStakers[4].PublicKey,
+					Weight:    primaryStakers[4].Weight,
+				},
+			},
+			expectedSubnetValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
+				subnetStakers[2].NodeID: {
+					NodeID: subnetStakers[2].NodeID,
+					Weight: subnetStakers[2].Weight,
+				},
+				subnetStakers[3].NodeID: {
+					NodeID: subnetStakers[3].NodeID,
+					Weight: subnetStakers[3].Weight,
+				},
+				subnetStakers[4].NodeID: {
+					NodeID: subnetStakers[4].NodeID,
+					Weight: subnetStakers[4].Weight,
+				},
+			},
+		},
+		{
+			// Remove primary network and subnet validators 2 & 3 & 4
+			removedValidators: []Staker{
+				primaryStakers[2], primaryStakers[3], primaryStakers[4],
+				subnetStakers[2], subnetStakers[3], subnetStakers[4],
+			},
+			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
+			expectedSubnetValidatorSet:  map[ids.NodeID]*validators.GetValidatorOutput{},
 		},
 		{
 			// Do nothing
-			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
-				stakers[1].NodeID: {
-					NodeID:    stakers[1].NodeID,
-					PublicKey: stakers[1].PublicKey,
-					Weight:    stakers[1].Weight,
-				},
-			},
-			expectedSubnetValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
-		},
-		{ // Remove a primary network validator
-			removedValidators:           []Staker{stakers[1]},
-			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
-			expectedSubnetValidatorSet:  map[ids.NodeID]*validators.GetValidatorOutput{},
-		},
-		{
-			// Add 2 subnet validators and a primary network validator
-			addedValidators: []Staker{stakers[0], stakers[1], stakers[2]},
-			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
-				stakers[1].NodeID: {
-					NodeID:    stakers[1].NodeID,
-					PublicKey: stakers[1].PublicKey,
-					Weight:    stakers[1].Weight,
-				},
-			},
-			expectedSubnetValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{
-				stakers[0].NodeID: {
-					NodeID: stakers[0].NodeID,
-					Weight: stakers[0].Weight,
-				},
-				stakers[2].NodeID: {
-					NodeID: stakers[2].NodeID,
-					Weight: stakers[2].Weight,
-				},
-			},
-		},
-		{
-			// Remove 2 subnet validators and a primary network validator.
-			removedValidators:           []Staker{stakers[0], stakers[1], stakers[2]},
 			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
 			expectedSubnetValidatorSet:  map[ids.NodeID]*validators.GetValidatorOutput{},
 		},
 	}
 	for currentIndex, diff := range diffs {
+		d, err := NewDiffOn(state)
+		require.NoError(err)
+
+		type subnetIDNodeID struct {
+			subnetID ids.ID
+			nodeID   ids.NodeID
+		}
+		var expectedValidators set.Set[subnetIDNodeID]
 		for _, added := range diff.addedValidators {
-			added := added
-			require.NoError(state.PutCurrentValidator(&added))
-		}
-		for _, added := range diff.addedDelegators {
-			added := added
-			state.PutCurrentDelegator(&added)
-		}
-		for _, removed := range diff.removedDelegators {
-			removed := removed
-			state.DeleteCurrentDelegator(&removed)
+			require.NoError(d.PutCurrentValidator(&added))
+
+			expectedValidators.Add(subnetIDNodeID{
+				subnetID: added.SubnetID,
+				nodeID:   added.NodeID,
+			})
 		}
 		for _, removed := range diff.removedValidators {
-			removed := removed
-			state.DeleteCurrentValidator(&removed)
+			d.DeleteCurrentValidator(&removed)
+
+			expectedValidators.Remove(subnetIDNodeID{
+				subnetID: removed.SubnetID,
+				nodeID:   removed.NodeID,
+			})
 		}
+
+		require.NoError(d.Apply(state))
 
 		currentHeight := uint64(currentIndex + 1)
 		state.SetHeight(currentHeight)
 
 		require.NoError(state.Commit())
 
+		// Verify that the current state is as expected.
 		for _, added := range diff.addedValidators {
+			subnetNodeID := subnetIDNodeID{
+				subnetID: added.SubnetID,
+				nodeID:   added.NodeID,
+			}
+			if !expectedValidators.Contains(subnetNodeID) {
+				continue
+			}
+
 			gotValidator, err := state.GetCurrentValidator(added.SubnetID, added.NodeID)
 			require.NoError(err)
 			require.Equal(added, *gotValidator)
@@ -1142,37 +985,47 @@ func TestStateAddRemoveValidator(t *testing.T) {
 			require.ErrorIs(err, database.ErrNotFound)
 		}
 
+		primaryValidatorSet := state.validators.GetMap(constants.PrimaryNetworkID)
+		delete(primaryValidatorSet, defaultValidatorNodeID) // Ignore the genesis validator
+		require.Equal(diff.expectedPrimaryValidatorSet, primaryValidatorSet)
+
+		require.Equal(diff.expectedSubnetValidatorSet, state.validators.GetMap(subnetID))
+
+		// Verify that applying diffs against the current state results in the
+		// expected state.
 		for i := 0; i < currentIndex; i++ {
 			prevDiff := diffs[i]
 			prevHeight := uint64(i + 1)
 
-			primaryValidatorSet := copyValidatorSet(diff.expectedPrimaryValidatorSet)
-			require.NoError(state.ApplyValidatorWeightDiffs(
-				context.Background(),
-				primaryValidatorSet,
-				currentHeight,
-				prevHeight+1,
-				constants.PrimaryNetworkID,
-			))
-			requireEqualWeightsValidatorSet(require, prevDiff.expectedPrimaryValidatorSet, primaryValidatorSet)
+			{
+				primaryValidatorSet := copyValidatorSet(diff.expectedPrimaryValidatorSet)
+				require.NoError(state.ApplyValidatorWeightDiffs(
+					context.Background(),
+					primaryValidatorSet,
+					currentHeight,
+					prevHeight+1,
+					constants.PrimaryNetworkID,
+				))
+				require.NoError(state.ApplyValidatorPublicKeyDiffs(
+					context.Background(),
+					primaryValidatorSet,
+					currentHeight,
+					prevHeight+1,
+				))
+				require.Equal(prevDiff.expectedPrimaryValidatorSet, primaryValidatorSet)
+			}
 
-			require.NoError(state.ApplyValidatorPublicKeyDiffs(
-				context.Background(),
-				primaryValidatorSet,
-				currentHeight,
-				prevHeight+1,
-			))
-			requireEqualPublicKeysValidatorSet(require, prevDiff.expectedPrimaryValidatorSet, primaryValidatorSet)
-
-			subnetValidatorSet := copyValidatorSet(diff.expectedSubnetValidatorSet)
-			require.NoError(state.ApplyValidatorWeightDiffs(
-				context.Background(),
-				subnetValidatorSet,
-				currentHeight,
-				prevHeight+1,
-				subnetID,
-			))
-			requireEqualWeightsValidatorSet(require, prevDiff.expectedSubnetValidatorSet, subnetValidatorSet)
+			{
+				subnetValidatorSet := copyValidatorSet(diff.expectedSubnetValidatorSet)
+				require.NoError(state.ApplyValidatorWeightDiffs(
+					context.Background(),
+					subnetValidatorSet,
+					currentHeight,
+					prevHeight+1,
+					subnetID,
+				))
+				require.Equal(prevDiff.expectedSubnetValidatorSet, subnetValidatorSet)
+			}
 		}
 	}
 }
@@ -1186,36 +1039,6 @@ func copyValidatorSet(
 		result[nodeID] = &vdrCopy
 	}
 	return result
-}
-
-func requireEqualWeightsValidatorSet(
-	require *require.Assertions,
-	expected map[ids.NodeID]*validators.GetValidatorOutput,
-	actual map[ids.NodeID]*validators.GetValidatorOutput,
-) {
-	require.Len(actual, len(expected))
-	for nodeID, expectedVdr := range expected {
-		require.Contains(actual, nodeID)
-
-		actualVdr := actual[nodeID]
-		require.Equal(expectedVdr.NodeID, actualVdr.NodeID)
-		require.Equal(expectedVdr.Weight, actualVdr.Weight)
-	}
-}
-
-func requireEqualPublicKeysValidatorSet(
-	require *require.Assertions,
-	expected map[ids.NodeID]*validators.GetValidatorOutput,
-	actual map[ids.NodeID]*validators.GetValidatorOutput,
-) {
-	require.Len(actual, len(expected))
-	for nodeID, expectedVdr := range expected {
-		require.Contains(actual, nodeID)
-
-		actualVdr := actual[nodeID]
-		require.Equal(expectedVdr.NodeID, actualVdr.NodeID)
-		require.Equal(expectedVdr.PublicKey, actualVdr.PublicKey)
-	}
 }
 
 func TestParsedStateBlock(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged
Exposes via RPC the validators at the proposer VM height used by the inner VM to verify blocks. Useful for gathering ICM signatures from the validators at the height used to verify the block, as specified in [ACP-151](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/151-use-current-block-pchain-height-as-context) 

## How this works
Adds `GetProposedValidators` which fetches the validators at `State.GetMinimumHeight`. Other than that, the implementation is identical to `GetValidatorsAt`

## How this was tested
CI

## Need to be documented in RELEASES.md?
Yes
