### PR TITLE
Add `Deregister` to `metrics.MultiGatherer` interface

### DIFF
--- a/api/metrics/label_gatherer.go
+++ b/api/metrics/label_gatherer.go
@@ -45,12 +45,14 @@ func (g *labelGatherer) Register(labelValue string, gatherer prometheus.Gatherer
 		)
 	}
 
-	g.names = append(g.names, labelValue)
-	g.gatherers = append(g.gatherers, &labeledGatherer{
-		labelName:  g.labelName,
-		labelValue: labelValue,
-		gatherer:   gatherer,
-	})
+	g.register(
+		labelValue,
+		&labeledGatherer{
+			labelName:  g.labelName,
+			labelValue: labelValue,
+			gatherer:   gatherer,
+		},
+	)
 	return nil
 }
 

--- a/api/metrics/multi_gatherer.go
+++ b/api/metrics/multi_gatherer.go
@@ -5,9 +5,12 @@ package metrics
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ava-labs/avalanchego/utils"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -20,13 +23,11 @@ type MultiGatherer interface {
 	// Register adds the outputs of [gatherer] to the results of future calls to
 	// Gather with the provided [name] added to the metrics.
 	Register(name string, gatherer prometheus.Gatherer) error
-}
 
-// Deprecated: Use NewPrefixGatherer instead.
-//
-// TODO: Remove once coreth is updated.
-func NewMultiGatherer() MultiGatherer {
-	return NewPrefixGatherer()
+	// Deregister removes the outputs of a gatherer with [name] from the results
+	// of future calls to Gather. Returns true if a gatherer with [name] was
+	// found.
+	Deregister(name string) bool
 }
 
 type multiGatherer struct {
@@ -40,6 +41,25 @@ func (g *multiGatherer) Gather() ([]*dto.MetricFamily, error) {
 	defer g.lock.RUnlock()
 
 	return g.gatherers.Gather()
+}
+
+func (g *multiGatherer) register(name string, gatherer prometheus.Gatherer) {
+	g.names = append(g.names, name)
+	g.gatherers = append(g.gatherers, gatherer)
+}
+
+func (g *multiGatherer) Deregister(name string) bool {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	index := slices.Index(g.names, name)
+	if index == -1 {
+		return false
+	}
+
+	g.names = utils.DeleteIndex(g.names, index)
+	g.gatherers = utils.DeleteIndex(g.gatherers, index)
+	return true
 }
 
 func MakeAndRegister(gatherer MultiGatherer, name string) (*prometheus.Registry, error) {

--- a/api/metrics/prefix_gatherer.go
+++ b/api/metrics/prefix_gatherer.go
@@ -45,11 +45,13 @@ func (g *prefixGatherer) Register(prefix string, gatherer prometheus.Gatherer) e
 		}
 	}
 
-	g.names = append(g.names, prefix)
-	g.gatherers = append(g.gatherers, &prefixedGatherer{
-		prefix:   prefix,
-		gatherer: gatherer,
-	})
+	g.register(
+		prefix,
+		&prefixedGatherer{
+			prefix:   prefix,
+			gatherer: gatherer,
+		},
+	)
 	return nil
 }
 

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utils
+
+// DeleteIndex moves the last element in the slice to index [i] and shrinks the
+// size of the slice by 1.
+//
+// This is an O(1) operation that allows the removal of an element from a slice
+// when the order of the slice is not important.
+//
+// If [i] is out of bounds, this function will panic.
+func DeleteIndex[S ~[]E, E any](s S, i int) S {
+	newSize := len(s) - 1
+	s[i] = s[newSize]
+	s[newSize] = Zero[E]()
+	s = s[:newSize]
+	return s
+}

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -14,6 +14,5 @@ func DeleteIndex[S ~[]E, E any](s S, i int) S {
 	newSize := len(s) - 1
 	s[i] = s[newSize]
 	s[newSize] = Zero[E]()
-	s = s[:newSize]
-	return s
+	return s[:newSize]
 }

--- a/utils/slice_test.go
+++ b/utils/slice_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        []int
+		i        int
+		expected []int
+	}{
+		{
+			name:     "delete only element",
+			s:        []int{0},
+			i:        0,
+			expected: []int{},
+		},
+		{
+			name:     "delete first element",
+			s:        []int{0, 1},
+			i:        0,
+			expected: []int{1},
+		},
+		{
+			name:     "delete middle element",
+			s:        []int{0, 1, 2, 3},
+			i:        1,
+			expected: []int{0, 3, 2},
+		},
+		{
+			name:     "delete last element",
+			s:        []int{0, 1, 2, 3},
+			i:        3,
+			expected: []int{0, 1, 2},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := DeleteIndex(test.s, test.i)
+			require.Equal(t, test.expected, s)
+		})
+	}
+}


### PR DESCRIPTION
## Why this should be merged

Metrics are registered throughout avalanchego, deregistering all of them individually would require extensive additional code flows during the shutdown process. However, there are only a handful of metrics namespaces. This PR allows easily deregistering an entire namespace of metrics.

## How this works

Adds `Deregister` to the `metrics.MultiGatherer` interface.

## How this was tested

- [X] Added unit tests.

## Need to be documented in RELEASES.md?

No.