### PR TITLE
ACP-77: Add subnetIDNodeID struct

### DIFF
--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -944,10 +944,6 @@ func TestState_ApplyValidatorDiffs(t *testing.T) {
 		d, err := NewDiffOn(state)
 		require.NoError(err)
 
-		type subnetIDNodeID struct {
-			subnetID ids.ID
-			nodeID   ids.NodeID
-		}
 		var expectedValidators set.Set[subnetIDNodeID]
 		for _, added := range diff.addedValidators {
 			require.NoError(d.PutCurrentValidator(&added))

--- a/vms/platformvm/state/subnet_id_node_id.go
+++ b/vms/platformvm/state/subnet_id_node_id.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+// subnetIDNodeID = [subnetID] + [nodeID]
+const subnetIDNodeIDEntryLength = ids.IDLen + ids.NodeIDLen
+
+var errUnexpectedSubnetIDNodeIDLength = fmt.Errorf("expected subnetID+nodeID entry length %d", subnetIDNodeIDEntryLength)
+
+type subnetIDNodeID struct {
+	subnetID ids.ID
+	nodeID   ids.NodeID
+}
+
+func (s *subnetIDNodeID) Marshal() []byte {
+	data := make([]byte, subnetIDNodeIDEntryLength)
+	copy(data, s.subnetID[:])
+	copy(data[ids.IDLen:], s.nodeID[:])
+	return data
+}
+
+func (s *subnetIDNodeID) Unmarshal(data []byte) error {
+	if len(data) != subnetIDNodeIDEntryLength {
+		return errUnexpectedSubnetIDNodeIDLength
+	}
+
+	copy(s.subnetID[:], data)
+	copy(s.nodeID[:], data[ids.IDLen:])
+	return nil
+}

--- a/vms/platformvm/state/subnet_id_node_id_test.go
+++ b/vms/platformvm/state/subnet_id_node_id_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thepudds/fzgen/fuzzer"
+)
+
+func FuzzSubnetIDNodeIDMarshal(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		require := require.New(t)
+
+		var v subnetIDNodeID
+		fz := fuzzer.NewFuzzer(data)
+		fz.Fill(&v)
+
+		marshalledData := v.Marshal()
+
+		var parsed subnetIDNodeID
+		require.NoError(parsed.Unmarshal(marshalledData))
+		require.Equal(v, parsed)
+	})
+}
+
+func FuzzSubnetIDNodeIDUnmarshal(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		require := require.New(t)
+
+		var v subnetIDNodeID
+		if err := v.Unmarshal(data); err != nil {
+			require.ErrorIs(err, errUnexpectedSubnetIDNodeIDLength)
+			return
+		}
+
+		marshalledData := v.Marshal()
+		require.Equal(data, marshalledData)
+	})
+}
+
+func FuzzSubnetIDNodeIDMarshalOrdering(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var (
+			v0 subnetIDNodeID
+			v1 subnetIDNodeID
+		)
+		fz := fuzzer.NewFuzzer(data)
+		fz.Fill(&v0, &v1)
+
+		if v0.subnetID == v1.subnetID {
+			return
+		}
+
+		key0 := v0.Marshal()
+		key1 := v1.Marshal()
+		require.Equal(
+			t,
+			v0.subnetID.Compare(v1.subnetID),
+			bytes.Compare(key0, key1),
+		)
+	})
+}


### PR DESCRIPTION
## Why this should be merged

Factored out of #3388.

## How this works

Adds a struct to merge `subnetID`s and `nodeID`s together. This struct supports directly marshaling into bytes because it will be used as a key into the database.

## How this was tested

- [X] Added fuzz tests.

## Need to be documented in RELEASES.md?

No.