### PR TITLE
Clarify partial sync flag

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -176,7 +176,9 @@ must be the same with the number of given `--state-sync-ids`.
 
 #### `--partial-sync-primary-network` (string)
 
-Partial sync enables non-validators to optionally sync only the P-chain on the primary network.
+Partial sync enables nodes that are not primary validators to optionally sync only
+the P-chain on the primary network. Nodes that use this option can still track 
+Subnets. After the Etna upgrade, nodes that use this option can also validate L1s.
 
 ## Chain Configs
 


### PR DESCRIPTION
## Why this should be merged
Clarifies that nodes can using the `partial-sync-primary-network` flag can be L1 validators post-Etna activation.

## How this works
Updates documentation.

## How this was tested
N/A

## Need to be documented in RELEASES.md?
No