### PR TITLE
[testing] Enable bootstrap testing of partial sync

### DIFF
--- a/tests/fixture/bootstrapmonitor/README.md
+++ b/tests/fixture/bootstrapmonitor/README.md
@@ -34,8 +34,8 @@ flag.
 #### Full Sync
 
 In this mode, the full history of the X-, P- and C-Chains will be
-processed. This is configured by including `state-sync-enabled:
-false` in the C-Chain configuration.
+processed. This is configured by including
+`state-sync-enabled:false` in the C-Chain configuration.
 
 ## Overview
 

--- a/tests/fixture/bootstrapmonitor/README.md
+++ b/tests/fixture/bootstrapmonitor/README.md
@@ -65,7 +65,9 @@ and initiates a new test when one is found.
      - The `full-sync` mode is enabled by including
        `state-sync-enabled:false` in the
        `AVAGO_CHAIN_CONFIG_CONTENT` env var set for the avalanchego
-       container.
+       container and either not including a value for
+       `AVAGO_PARTIAL_SYNC_PRIMARY_NETWORK` or setting it to
+       `"false"`.
    - The image used by the test is determined by the image configured
      for the avalanchego container.
    - The versions of the avalanchego image used by the test is

--- a/tests/fixture/bootstrapmonitor/README.md
+++ b/tests/fixture/bootstrapmonitor/README.md
@@ -12,22 +12,30 @@ node is running be compatible with the historical data of that
 network. Bootstrapping regularly is a good way of insuring against
 regressions in compatibility.
 
-### Types of bootstrap testing for C-Chain
+### Sync modes for bootstrap testing
 
-The X-Chain and P-Chain always synchronize all state, but the bulk of
-data for testnet and mainnet is on the C-Chain and there are 2 options:
+The 'sync mode' for a bootstrap test determines what history will be
+processed (fetched and executed) during the bootstrap process of a
+non-validating node. There are 3 such modes:
 
-#### State Sync
+#### C-Chain State Sync
 
-A bootstrap with state sync enabled (the default) ensures that only
-recent blocks will be processed.
+In this mode, the full history of the X- and P-Chains will
+processed. Only recent blocks of the C-Chain will be processed. This
+is the default mode.
+
+#### Only P-Chain Full Sync
+
+In this mode, only the full history of the P-Chain will be
+processed. This is the expected mode for L1 validators. This mode is
+configured by the supplying the `--partial-sync-primary-network`
+flag.
 
 #### Full Sync
 
-All history will be processed, though with pruning (enabled by
-default) not all history will be stored.
-
-To enable, supply `state-sync-enabled: false` as C-Chain configuration.
+In this mode, the full history of the X-, P- and C-Chains will be
+processed. This is configured by including `state-sync-enabled:
+false` in the C-Chain configuration.
 
 ## Overview
 
@@ -48,9 +56,16 @@ and initiates a new test when one is found.
    - The network targeted by the test is determined by the value of
      the `AVAGO_NETWORK_NAME` env var set for the avalanchego
      container.
-   - Whether state sync is enabled is determined by the value of the
-     `AVAGO_CHAIN_CONFIG_CONTENT` env var set for the avalanchego
-     container.
+   - By default, the sync mode will be `full-sync`. The other sync
+     modes require providing additional configuration:
+     - The `only-p-chain-full-sync` mode is enabled by setting the
+       `AVAGO_PARTIAL_SYNC_PRIMARY_NETWORK` env var to `"true"` for
+       the avalanchego container. If this mode is enabled, the state
+       sync configuration for the C-Chain will be ignored.
+     - The `c-chain-state-sync` mode is enabled by including
+       `state-sync-enabled:false` in the
+       `AVAGO_CHAIN_CONFIG_CONTENT` env var set for the avalanchego
+       container.
    - The image used by the test is determined by the image configured
      for the avalanchego container.
    - The versions of the avalanchego image used by the test is

--- a/tests/fixture/bootstrapmonitor/README.md
+++ b/tests/fixture/bootstrapmonitor/README.md
@@ -56,13 +56,13 @@ and initiates a new test when one is found.
    - The network targeted by the test is determined by the value of
      the `AVAGO_NETWORK_NAME` env var set for the avalanchego
      container.
-   - By default, the sync mode will be `full-sync`. The other sync
+   - By default, the sync mode will be `c-chain-state-sync`. The other sync
      modes require providing additional configuration:
      - The `only-p-chain-full-sync` mode is enabled by setting the
        `AVAGO_PARTIAL_SYNC_PRIMARY_NETWORK` env var to `"true"` for
        the avalanchego container. If this mode is enabled, the state
        sync configuration for the C-Chain will be ignored.
-     - The `c-chain-state-sync` mode is enabled by including
+     - The `full-sync` mode is enabled by including
        `state-sync-enabled:false` in the
        `AVAGO_CHAIN_CONFIG_CONTENT` env var set for the avalanchego
        container.

--- a/tests/fixture/bootstrapmonitor/bootstrap_test_config.go
+++ b/tests/fixture/bootstrapmonitor/bootstrap_test_config.go
@@ -21,6 +21,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// The sync mode of a bootstrap configuration should be as explicit as possible to ensure
+// unambiguous names if/when new sync modes become supported.
+//
+// For example, at time of writing only the C-Chain supports state sync. The temptation
+// might be to call this mode that tests C-Chain state sync `state-sync`. But if the P-
+// or X-Chains start supporting state sync in the future, a name like
+// `c-chain-state-sync` ensures that logs and metrics for historical results can be
+// differentiated from new results that involve state sync of the other chains.
 type SyncMode string
 
 const (

--- a/tests/fixture/bootstrapmonitor/bootstrap_test_config.go
+++ b/tests/fixture/bootstrapmonitor/bootstrap_test_config.go
@@ -21,11 +21,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const VersionsAnnotationKey = "avalanche.avax.network/avalanchego-versions"
+type SyncMode string
+
+const (
+	FullSync           SyncMode = "full-sync"
+	CChainStateSync    SyncMode = "c-chain-state-sync"     // aka state sync
+	OnlyPChainFullSync SyncMode = "p-chain-full-sync-only" // aka partial sync
+
+	VersionsAnnotationKey = "avalanche.avax.network/avalanchego-versions"
+)
 
 var (
-	chainConfigContentEnvName = config.EnvVarName(config.EnvPrefix, config.ChainConfigContentKey)
-	networkEnvName            = config.EnvVarName(config.EnvPrefix, config.NetworkNameKey)
+	chainConfigContentEnvName        = config.EnvVarName(config.EnvPrefix, config.ChainConfigContentKey)
+	networkEnvName                   = config.EnvVarName(config.EnvPrefix, config.NetworkNameKey)
+	partialSyncPrimaryNetworkEnvName = config.EnvVarName(config.EnvPrefix, config.PartialSyncPrimaryNetworkKey)
 
 	// Errors for bootstrapTestConfigForPod
 	errContainerNotFound          = errors.New("container not found")
@@ -40,10 +49,10 @@ var (
 )
 
 type BootstrapTestConfig struct {
-	Network          string            `json:"network"`
-	StateSyncEnabled bool              `json:"stateSyncEnabled"`
-	Image            string            `json:"image"`
-	Versions         *version.Versions `json:"versions,omitempty"`
+	Network  string            `json:"network"`
+	SyncMode SyncMode          `json:"syncMode"`
+	Image    string            `json:"image"`
+	Versions *version.Versions `json:"versions,omitempty"`
 }
 
 // GetBootstrapTestConfigFromPod extracts the bootstrap test configuration from the specified pod.
@@ -81,16 +90,16 @@ func bootstrapTestConfigForPod(pod *corev1.Pod, nodeContainerName string) (*Boot
 		return nil, fmt.Errorf("%w in container %q", errInvalidNetworkEnvVar, nodeContainerName)
 	}
 
-	// Determine whether state sync is enabled in the env vars
-	stateSyncEnabled, err := stateSyncEnabledFromEnvVars(nodeContainer.Env)
+	// Determine the sync mode from the env vars
+	syncMode, err := syncModeFromEnvVars(nodeContainer.Env)
 	if err != nil {
 		return nil, err
 	}
 
 	testConfig := &BootstrapTestConfig{
-		Network:          network,
-		StateSyncEnabled: stateSyncEnabled,
-		Image:            nodeContainer.Image,
+		Network:  network,
+		SyncMode: syncMode,
+		Image:    nodeContainer.Image,
 	}
 
 	// Attempt to retrieve the image versions from a pod annotation. The annotation may not be populated in
@@ -103,6 +112,52 @@ func bootstrapTestConfigForPod(pod *corev1.Pod, nodeContainerName string) (*Boot
 	}
 
 	return testConfig, nil
+}
+
+// syncModeFromEnvVars derives the bootstrap sync mode from the provided environment variables.
+func syncModeFromEnvVars(env []corev1.EnvVar) (SyncMode, error) {
+	partialSyncPrimaryNetwork, err := partialSyncEnabledFromEnvVars(env)
+	if err != nil {
+		return "", err
+	}
+	if partialSyncPrimaryNetwork {
+		// If partial sync is enabled, only the P-Chain will be synced so the state sync
+		// configuration of the C-Chain is irrelevant.
+		return OnlyPChainFullSync, nil
+	}
+	stateSyncEnabled, err := stateSyncEnabledFromEnvVars(env)
+	if err != nil {
+		return "", err
+	}
+	if !stateSyncEnabled {
+		// Full sync is enabled
+		return FullSync, nil
+	}
+
+	// C-Chain state sync is assumed if the other modes are not explicitly enabled
+	return CChainStateSync, nil
+}
+
+// partialSyncEnabledFromEnvVars determines whether the env vars configure partial sync
+// for a node container. Partial sync is assumed to be enabled if the
+// AVAGO_PARTIAL_SYNC_PRIMARY_NETWORK env var is set and evaluates to true.
+func partialSyncEnabledFromEnvVars(env []corev1.EnvVar) (bool, error) {
+	var rawPartialSyncPrimaryNetwork string
+	for _, envVar := range env {
+		if envVar.Name == partialSyncPrimaryNetworkEnvName {
+			rawPartialSyncPrimaryNetwork = envVar.Value
+			break
+		}
+	}
+	if len(rawPartialSyncPrimaryNetwork) == 0 {
+		return false, nil
+	}
+
+	partialSyncPrimaryNetwork, err := cast.ToBoolE(rawPartialSyncPrimaryNetwork)
+	if err != nil {
+		return false, fmt.Errorf("%w (%v): %w", errFailedToCastToBool, rawPartialSyncPrimaryNetwork, err)
+	}
+	return partialSyncPrimaryNetwork, nil
 }
 
 // stateSyncEnabledFromEnvVars determines whether the env vars configure state sync for a


### PR DESCRIPTION
## Why this should be merged

Previously there were only 2 modes for bootstrap testing - state sync and full sync. This change enables support for partial sync which only processes the history of the P-Chain and is expected to be used by L1 validators.

## How this works

Replaced the `StateSyncEnabled` field in the bootstrap test config with `SyncMode` and 3 initial values: `full-sync`, `c-chain-state-sync` and `p-chain-full-sync-only`. The value of `SyncMode` is determined from the set of env vars defined for an avalanchego container.

## How this was tested

Add unit tests to validate determination of sync mode.

## Need to be documented in RELEASES.md?

This is not a user facing change.