### PR TITLE
ACP-77: Filter the inactive validator from block proposals and tx gossip

### DIFF
--- a/network/p2p/validators.go
+++ b/network/p2p/validators.go
@@ -98,6 +98,8 @@ func (v *Validators) refresh(ctx context.Context) {
 		return
 	}
 
+	delete(validatorSet, ids.EmptyNodeID) // Ignore inactive ACP-77 validators.
+
 	for nodeID, vdr := range validatorSet {
 		v.validatorList = append(v.validatorList, validator{
 			nodeID: nodeID,

--- a/network/p2p/validators_test.go
+++ b/network/p2p/validators_test.go
@@ -296,6 +296,31 @@ func TestValidatorsTop(t *testing.T) {
 				nodeID1,
 			},
 		},
+		{
+			name: "top ignores inactive validators",
+			validators: []validator{
+				{
+					nodeID: ids.EmptyNodeID,
+					weight: 4,
+				},
+				{
+					nodeID: nodeID1,
+					weight: 2,
+				},
+				{
+					nodeID: nodeID2,
+					weight: 1,
+				},
+				{
+					nodeID: nodeID3,
+					weight: 1,
+				},
+			},
+			percentage: .5,
+			expected: []ids.NodeID{
+				nodeID1,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/vms/proposervm/proposer/windower.go
+++ b/vms/proposervm/proposer/windower.go
@@ -238,6 +238,8 @@ func (w *windower) makeSampler(
 		return nil, nil, err
 	}
 
+	delete(validatorsMap, ids.EmptyNodeID) // Ignore inactive ACP-77 validators.
+
 	validators := make([]validatorData, 0, len(validatorsMap))
 	for k, v := range validatorsMap {
 		validators = append(validators, validatorData{


### PR DESCRIPTION
## Why this should be merged

After ACP-77, inactive validators are grouped into a single `EmptyNodeID` entry. This `EmptyNodeID` should not be considered for block production or transaction gossip.

## How this works

Filters the `EmptyNodeID` from the validator set prior to the usage for tx gossip and generation of the proposal list.

## How this was tested

Added unit tests.

## Need to be documented in RELEASES.md?

This is not a user facing change.