### PR TITLE
[testing] Update bootstrap monitor to output disk usage in bytes

### DIFF
--- a/tests/fixture/bootstrapmonitor/wait.go
+++ b/tests/fixture/bootstrapmonitor/wait.go
@@ -197,7 +197,7 @@ func getDiskUsage(log logging.Logger, dir string) uint64 {
 	usage, err := strconv.ParseUint(rawUsage, 10, 64)
 	if err != nil {
 		log.Error("Failed to parse disk usage",
-			zap.String("rawUsage", string(rawUsage)),
+			zap.String("rawUsage", rawUsage),
 		)
 	}
 


### PR DESCRIPTION
Previously the output was in human-readable form which is fine for logs but not easily graphable.
