### PR TITLE
Rename `constantsAreUnmodified` to `immutableFieldsAreUnmodified`

### DIFF
--- a/vms/platformvm/state/subnet_only_validator.go
+++ b/vms/platformvm/state/subnet_only_validator.go
@@ -88,9 +88,10 @@ func (v SubnetOnlyValidator) Compare(o SubnetOnlyValidator) int {
 	}
 }
 
-// constantsAreUnmodified returns true if the constants of this validator have
-// not been modified compared to the other validator.
-func (v SubnetOnlyValidator) constantsAreUnmodified(o SubnetOnlyValidator) bool {
+// immutableFieldsAreUnmodified returns true if two versions of the same
+// validator are valid. Either because the validationID has changed or because
+// no unexpected fields have been modified.
+func (v SubnetOnlyValidator) immutableFieldsAreUnmodified(o SubnetOnlyValidator) bool {
 	if v.ValidationID != o.ValidationID {
 		return true
 	}

--- a/vms/platformvm/state/subnet_only_validator_test.go
+++ b/vms/platformvm/state/subnet_only_validator_test.go
@@ -75,7 +75,7 @@ func TestSubnetOnlyValidator_Compare(t *testing.T) {
 	}
 }
 
-func TestSubnetOnlyValidator_constantsAreUnmodified(t *testing.T) {
+func TestSubnetOnlyValidator_immutableFieldsAreUnmodified(t *testing.T) {
 	var (
 		randomSOV = func() SubnetOnlyValidator {
 			return SubnetOnlyValidator{
@@ -100,41 +100,41 @@ func TestSubnetOnlyValidator_constantsAreUnmodified(t *testing.T) {
 
 	t.Run("equal", func(t *testing.T) {
 		v := randomizeSOV(sov)
-		require.True(t, sov.constantsAreUnmodified(v))
+		require.True(t, sov.immutableFieldsAreUnmodified(v))
 	})
 	t.Run("everything is different", func(t *testing.T) {
 		v := randomizeSOV(randomSOV())
-		require.True(t, sov.constantsAreUnmodified(v))
+		require.True(t, sov.immutableFieldsAreUnmodified(v))
 	})
 	t.Run("different subnetID", func(t *testing.T) {
 		v := randomizeSOV(sov)
 		v.SubnetID = ids.GenerateTestID()
-		require.False(t, sov.constantsAreUnmodified(v))
+		require.False(t, sov.immutableFieldsAreUnmodified(v))
 	})
 	t.Run("different nodeID", func(t *testing.T) {
 		v := randomizeSOV(sov)
 		v.NodeID = ids.GenerateTestNodeID()
-		require.False(t, sov.constantsAreUnmodified(v))
+		require.False(t, sov.immutableFieldsAreUnmodified(v))
 	})
 	t.Run("different publicKey", func(t *testing.T) {
 		v := randomizeSOV(sov)
 		v.PublicKey = utils.RandomBytes(bls.PublicKeyLen)
-		require.False(t, sov.constantsAreUnmodified(v))
+		require.False(t, sov.immutableFieldsAreUnmodified(v))
 	})
 	t.Run("different remainingBalanceOwner", func(t *testing.T) {
 		v := randomizeSOV(sov)
 		v.RemainingBalanceOwner = utils.RandomBytes(32)
-		require.False(t, sov.constantsAreUnmodified(v))
+		require.False(t, sov.immutableFieldsAreUnmodified(v))
 	})
 	t.Run("different deactivationOwner", func(t *testing.T) {
 		v := randomizeSOV(sov)
 		v.DeactivationOwner = utils.RandomBytes(32)
-		require.False(t, sov.constantsAreUnmodified(v))
+		require.False(t, sov.immutableFieldsAreUnmodified(v))
 	})
 	t.Run("different startTime", func(t *testing.T) {
 		v := randomizeSOV(sov)
 		v.StartTime = rand.Uint64() // #nosec G404
-		require.False(t, sov.constantsAreUnmodified(v))
+		require.False(t, sov.immutableFieldsAreUnmodified(v))
 	})
 }
 


### PR DESCRIPTION
## Why this should be merged

Slightly improves readability.

## How this works

Just a name change.

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No.