### PR TITLE
Add `ValidatorWeightDiff` `Add` and `Sub` helpers

### DIFF
--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -283,7 +283,7 @@ func (d *diffValidator) WeightDiff() (ValidatorWeightDiff, error) {
 	}
 
 	for _, staker := range d.deletedDelegators {
-		if err := weightDiff.Add(true, staker.Weight); err != nil {
+		if err := weightDiff.Sub(staker.Weight); err != nil {
 			return ValidatorWeightDiff{}, fmt.Errorf("failed to decrease node weight diff: %w", err)
 		}
 	}
@@ -294,7 +294,7 @@ func (d *diffValidator) WeightDiff() (ValidatorWeightDiff, error) {
 	for addedDelegatorIterator.Next() {
 		staker := addedDelegatorIterator.Value()
 
-		if err := weightDiff.Add(false, staker.Weight); err != nil {
+		if err := weightDiff.Add(staker.Weight); err != nil {
 			return ValidatorWeightDiff{}, fmt.Errorf("failed to increase node weight diff: %w", err)
 		}
 	}

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -425,7 +425,15 @@ type ValidatorWeightDiff struct {
 	Amount   uint64 `serialize:"true"`
 }
 
-func (v *ValidatorWeightDiff) Add(negative bool, amount uint64) error {
+func (v *ValidatorWeightDiff) Add(amount uint64) error {
+	return v.add(false, amount)
+}
+
+func (v *ValidatorWeightDiff) Sub(amount uint64) error {
+	return v.add(true, amount)
+}
+
+func (v *ValidatorWeightDiff) add(negative bool, amount uint64) error {
 	if v.Decrease == negative {
 		var err error
 		v.Amount, err = safemath.Add(v.Amount, amount)

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -671,29 +671,32 @@ func createPermissionlessDelegatorTx(subnetID ids.ID, delegatorData txs.Validato
 }
 
 func TestValidatorWeightDiff(t *testing.T) {
+	type op struct {
+		op     func(*ValidatorWeightDiff, uint64) error
+		amount uint64
+	}
 	type test struct {
 		name        string
-		ops         []func(*ValidatorWeightDiff) error
+		ops         []op
 		expected    *ValidatorWeightDiff
 		expectedErr error
 	}
 
+	var (
+		add = (*ValidatorWeightDiff).Add
+		sub = (*ValidatorWeightDiff).Sub
+	)
 	tests := []test{
 		{
 			name:        "no ops",
-			ops:         []func(*ValidatorWeightDiff) error{},
 			expected:    &ValidatorWeightDiff{},
 			expectedErr: nil,
 		},
 		{
 			name: "simple decrease",
-			ops: []func(*ValidatorWeightDiff) error{
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, 1)
-				},
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, 1)
-				},
+			ops: []op{
+				{sub, 1},
+				{sub, 1},
 			},
 			expected: &ValidatorWeightDiff{
 				Decrease: true,
@@ -703,26 +706,17 @@ func TestValidatorWeightDiff(t *testing.T) {
 		},
 		{
 			name: "decrease overflow",
-			ops: []func(*ValidatorWeightDiff) error{
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, math.MaxUint64)
-				},
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, 1)
-				},
+			ops: []op{
+				{sub, math.MaxUint64},
+				{sub, 1},
 			},
-			expected:    &ValidatorWeightDiff{},
 			expectedErr: safemath.ErrOverflow,
 		},
 		{
 			name: "simple increase",
-			ops: []func(*ValidatorWeightDiff) error{
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(false, 1)
-				},
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(false, 1)
-				},
+			ops: []op{
+				{add, 1},
+				{add, 1},
 			},
 			expected: &ValidatorWeightDiff{
 				Decrease: false,
@@ -732,58 +726,24 @@ func TestValidatorWeightDiff(t *testing.T) {
 		},
 		{
 			name: "increase overflow",
-			ops: []func(*ValidatorWeightDiff) error{
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(false, math.MaxUint64)
-				},
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(false, 1)
-				},
+			ops: []op{
+				{add, math.MaxUint64},
+				{add, 1},
 			},
-			expected:    &ValidatorWeightDiff{},
 			expectedErr: safemath.ErrOverflow,
 		},
 		{
 			name: "varied use",
-			ops: []func(*ValidatorWeightDiff) error{
-				// Add to 0
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(false, 2) // Value 2
-				},
-				// Subtract from positive number
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, 1) // Value 1
-				},
-				// Subtract from positive number
-				// to make it negative
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, 3) // Value -2
-				},
-				// Subtract from a negative number
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, 3) // Value -5
-				},
-				// Add to a negative number
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(false, 1) // Value -4
-				},
-				// Add to a negative number
-				// to make it positive
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(false, 5) // Value 1
-				},
-				// Add to a positive number
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(false, 1) // Value 2
-				},
-				// Get to zero
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, 2) // Value 0
-				},
-				// Subtract from zero
-				func(d *ValidatorWeightDiff) error {
-					return d.Add(true, 2) // Value -2
-				},
+			ops: []op{
+				{add, 2}, // = 2
+				{sub, 1}, // = 1
+				{sub, 3}, // = -2
+				{sub, 3}, // = -5
+				{add, 1}, // = -4
+				{add, 5}, // = 1
+				{add, 1}, // = 2
+				{sub, 2}, // = 0
+				{sub, 2}, // = -2
 			},
 			expected: &ValidatorWeightDiff{
 				Decrease: true,
@@ -796,10 +756,13 @@ func TestValidatorWeightDiff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			diff := &ValidatorWeightDiff{}
-			errs := wrappers.Errs{}
+
+			var (
+				diff = &ValidatorWeightDiff{}
+				errs = wrappers.Errs{}
+			)
 			for _, op := range tt.ops {
-				errs.Add(op(diff))
+				errs.Add(op.op(diff, op.amount))
 			}
 			require.ErrorIs(errs.Err, tt.expectedErr)
 			if tt.expectedErr != nil {


### PR DESCRIPTION
## Why this should be merged

Currently `Add(true/false, amount)` is pretty clunky to use. It was implemented this way to avoid duplicate code in the implementation, but adds needless complexity during the usage.

## How this works

This PR un-exports the current `Add(bool, uint64)` function and replaces it with `Add(uint64)` and `Sub(uint64)`.

## How this was tested

Updated existing tests.

## Need to be documented in RELEASES.md?

No user facing changes.