### PR TITLE
Accept info.Peers args

### DIFF
--- a/api/info/client.go
+++ b/api/info/client.go
@@ -25,7 +25,7 @@ type Client interface {
 	GetNetworkID(context.Context, ...rpc.Option) (uint32, error)
 	GetNetworkName(context.Context, ...rpc.Option) (string, error)
 	GetBlockchainID(context.Context, string, ...rpc.Option) (ids.ID, error)
-	Peers(context.Context, ...rpc.Option) ([]Peer, error)
+	Peers(context.Context, []ids.NodeID, ...rpc.Option) ([]Peer, error)
 	IsBootstrapped(context.Context, string, ...rpc.Option) (bool, error)
 	GetTxFee(context.Context, ...rpc.Option) (*GetTxFeeResponse, error)
 	Upgrades(context.Context, ...rpc.Option) (*upgrade.Config, error)
@@ -83,9 +83,11 @@ func (c *client) GetBlockchainID(ctx context.Context, alias string, options ...r
 	return res.BlockchainID, err
 }
 
-func (c *client) Peers(ctx context.Context, options ...rpc.Option) ([]Peer, error) {
+func (c *client) Peers(ctx context.Context, nodeIDs []ids.NodeID, options ...rpc.Option) ([]Peer, error) {
 	res := &PeersReply{}
-	err := c.requester.SendRequest(ctx, "info.peers", struct{}{}, res, options...)
+	err := c.requester.SendRequest(ctx, "info.peers", &PeersArgs{
+		NodeIDs: nodeIDs,
+	}, res, options...)
 	return res.Peers, err
 }
 

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -68,7 +68,7 @@ func checkConnectedPeers(tc tests.TestContext, existingNodes []*tmpnet.Node, new
 
 	// Collect the node ids of the new node's peers
 	infoClient := info.NewClient(newNode.URI)
-	peers, err := infoClient.Peers(tc.DefaultContext())
+	peers, err := infoClient.Peers(tc.DefaultContext(), nil)
 	require.NoError(err)
 	peerIDs := set.NewSet[ids.NodeID](len(existingNodes))
 	for _, peer := range peers {
@@ -81,7 +81,7 @@ func checkConnectedPeers(tc tests.TestContext, existingNodes []*tmpnet.Node, new
 
 		// Check that the new node is a peer
 		infoClient := info.NewClient(existingNode.URI)
-		peers, err := infoClient.Peers(tc.DefaultContext())
+		peers, err := infoClient.Peers(tc.DefaultContext(), nil)
 		require.NoError(err)
 		isPeer := false
 		for _, peer := range peers {


### PR DESCRIPTION
## Why this should be merged
Corrects an oversight in which the nodeIDs argument was omitted from the `info.Peers` client receiver. The server already handles this argument as expected.

## How this works

Adds an argument to `Client.Peers()` to accept the list of node IDs.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No