### PR TITLE
Add script to configure metrics and log collection from a local node

### DIFF
--- a/scripts/configure-local-metrics-collection.sh
+++ b/scripts/configure-local-metrics-collection.sh
@@ -7,12 +7,12 @@ set -euo pipefail
 
 API_PORT="${API_PORT:-9650}"
 
-LOG_PATH="${LOG_PATH:-${HOME}/.avalanchego/logs}"
+LOGS_PATH="${LOGS_PATH:-${HOME}/.avalanchego/logs}"
 
 # Generate a uuid to uniquely identify the collected metrics
 METRICS_UUID="$(uuidgen)"
 
-echo "Configuring metrics and log collection for a local node"
+echo "Configuring metrics and log collection for a local node with API port ${API_PORT} and logs path ${LOGS_PATH}"
 
 PROMETHEUS_CONFIG_PATH="${HOME}/.tmpnet/prometheus/file_sd_configs"
 PROMETHEUS_CONFIG_FILE="${PROMETHEUS_CONFIG_PATH}/local.json"
@@ -38,7 +38,7 @@ cat > "${PROMTAIL_CONFIG_FILE}" <<EOL
 [
   {
     "labels": {
-      "__path__": "${LOG_PATH}/*.log",
+      "__path__": "${LOGS_PATH}/*.log",
       "network_uuid": "${METRICS_UUID}"
     },
     "targets": [


### PR DESCRIPTION
## Why this should be merged

Collecting logs and metrics shouldn't always require running on monitored infrastructure when collection to the CI monitoring stack from a local node is possible.

## How this works

Adds promtail and prometheus configuration for a local node to the path expected by the instances started by the `scripts/run_prometheus.sh` and `scripts/run_promtail.sh` scripts.

## How this was tested

Manually

## Need to be documented in RELEASES.md?

N/A