### PR TITLE
ACP-103: Document and update genesis test fee configs

### DIFF
--- a/genesis/genesis_fuji.go
+++ b/genesis/genesis_fuji.go
@@ -46,7 +46,7 @@ var (
 				MaxPerSecond:    250_000,
 				TargetPerSecond: 125_000, // Target block size ~125KB
 				MinPrice:        1,
-				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)
+				// ExcessConversionConstant = (MaxPerSecond - TargetPerSecond) * NumberOfSecondsPerDoubling / ln(2)
 				//
 				// ln(2) is a float and the result is consensus critical, so we
 				// hardcode the result.

--- a/genesis/genesis_fuji.go
+++ b/genesis/genesis_fuji.go
@@ -42,11 +42,15 @@ var (
 					gas.DBWrite:   1,
 					gas.Compute:   1,
 				},
-				MaxCapacity:              1_000_000,
-				MaxPerSecond:             1_000,
-				TargetPerSecond:          500,
-				MinPrice:                 1,
-				ExcessConversionConstant: 5_000,
+				MaxCapacity:     1_000_000, // Max block size ~1MB
+				MaxPerSecond:    250_000,
+				TargetPerSecond: 125_000, // Target block size ~125KB
+				MinPrice:        1,
+				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)
+				//
+				// ln(2) is a float and the result is consensus critical, so we
+				// hardcode the result.
+				ExcessConversionConstant: 5_410_106, // Double every 30s
 			},
 			ValidatorFeeConfig: validatorfee.Config{
 				Capacity: 20_000,

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -64,7 +64,7 @@ var (
 				MaxPerSecond:    250_000,
 				TargetPerSecond: 125_000, // Target block size ~125KB
 				MinPrice:        1,
-				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)
+				// ExcessConversionConstant = (MaxPerSecond - TargetPerSecond) * NumberOfSecondsPerDoubling / ln(2)
 				//
 				// ln(2) is a float and the result is consensus critical, so we
 				// hardcode the result.

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -60,11 +60,15 @@ var (
 					gas.DBWrite:   1,
 					gas.Compute:   1,
 				},
-				MaxCapacity:              1_000_000,
-				MaxPerSecond:             1_000,
-				TargetPerSecond:          500,
-				MinPrice:                 1,
-				ExcessConversionConstant: 5_000,
+				MaxCapacity:     1_000_000, // Max block size ~1MB
+				MaxPerSecond:    250_000,
+				TargetPerSecond: 125_000, // Target block size ~125KB
+				MinPrice:        1,
+				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)
+				//
+				// ln(2) is a float and the result is consensus critical, so we
+				// hardcode the result.
+				ExcessConversionConstant: 5_410_106, // Double every 30s
 			},
 			ValidatorFeeConfig: validatorfee.Config{
 				Capacity: 20_000,

--- a/genesis/genesis_mainnet.go
+++ b/genesis/genesis_mainnet.go
@@ -46,7 +46,7 @@ var (
 				MaxPerSecond:    250_000,
 				TargetPerSecond: 125_000, // Target block size ~125KB
 				MinPrice:        1,
-				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)
+				// ExcessConversionConstant = (MaxPerSecond - TargetPerSecond) * NumberOfSecondsPerDoubling / ln(2)
 				//
 				// ln(2) is a float and the result is consensus critical, so we
 				// hardcode the result.

--- a/genesis/genesis_mainnet.go
+++ b/genesis/genesis_mainnet.go
@@ -42,11 +42,15 @@ var (
 					gas.DBWrite:   1,
 					gas.Compute:   1,
 				},
-				MaxCapacity:              1_000_000,
-				MaxPerSecond:             1_000,
-				TargetPerSecond:          500,
-				MinPrice:                 1,
-				ExcessConversionConstant: 5_000,
+				MaxCapacity:     1_000_000, // Max block size ~1MB
+				MaxPerSecond:    250_000,
+				TargetPerSecond: 125_000, // Target block size ~125KB
+				MinPrice:        1,
+				// ExcessConversionConstant = (Capacity - Target) * NumberOfSecondsPerDoubling / ln(2)
+				//
+				// ln(2) is a float and the result is consensus critical, so we
+				// hardcode the result.
+				ExcessConversionConstant: 5_410_106, // Double every 30s
 			},
 			ValidatorFeeConfig: validatorfee.Config{
 				Capacity: 20_000,


### PR DESCRIPTION
## Why this should be merged

While these are not the final values, this change documents the meanings of each parameter and makes the default values (used in our tests) more useful.

Currently, It is possible for the tx fee to increase instantaneously by a factor of `e^200`. Which is just not suitable for testing.

## How this works

Significantly increases the `MaxPerSecond`, `TargetPerSecond`, and `ExcessConversionConstant` to produce more stable fees (using the same `MaxCapacity`).

One unit test needed to be modified because it didn't properly account for `MaxCapacity`.

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No.