### PR TITLE
ACP-77: Allow legacy validator removal after conversion

### DIFF
--- a/vms/platformvm/txs/executor/staker_tx_verification.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification.go
@@ -41,7 +41,6 @@ var (
 	ErrDurangoUpgradeNotActive         = errors.New("attempting to use a Durango-upgrade feature prior to activation")
 	ErrAddValidatorTxPostDurango       = errors.New("AddValidatorTx is not permitted post-Durango")
 	ErrAddDelegatorTxPostDurango       = errors.New("AddDelegatorTx is not permitted post-Durango")
-	ErrRemoveValidatorManagedSubnet    = errors.New("RemoveSubnetValidatorTx cannot be used to remove a validator from a Subnet with a manager")
 )
 
 // verifySubnetValidatorPrimaryNetworkRequirements verifies the primary
@@ -305,16 +304,6 @@ func verifyRemoveSubnetValidatorTx(
 	)
 	if err := avax.VerifyMemoFieldLength(tx.Memo, isDurangoActive); err != nil {
 		return nil, false, err
-	}
-
-	if backend.Config.UpgradeConfig.IsEtnaActivated(currentTimestamp) {
-		_, err := chainState.GetSubnetConversion(tx.Subnet)
-		if err == nil {
-			return nil, false, fmt.Errorf("%w: %q", ErrRemoveValidatorManagedSubnet, tx.Subnet)
-		}
-		if err != database.ErrNotFound {
-			return nil, false, err
-		}
 	}
 
 	isCurrentValidator := true


### PR DESCRIPTION
## Why this should be merged

ACP-77 was updated to allow removal of legacy subnet validators after the conversion.

## How this works

Removes the checks.

## How this was tested

updates the test

## Need to be documented in RELEASES.md?

No.