### PR TITLE
[tmpnet] Watch for and report FATAL log entries on node startup

### DIFF
--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -346,6 +346,10 @@ func (p *NodeProcess) writeMonitoringConfigFile(tmpnetDir string, name string, c
 // its lines for the string 'FATAL' until such a line is observed or the provided context
 // is canceled. If line containing 'FATAL' is encountered, it will be provided as an error
 // to the provided cancelWithCause function.
+//
+// Errors encountered while looking for FATAL log entries are considered potential rather
+// than positive indications of failure and are printed to the provided writer instead of
+// being provided to the cancelWithCause function.
 func watchLogFileForFatal(ctx context.Context, cancelWithCause context.CancelCauseFunc, w io.Writer, path string) {
 	waitInterval := 100 * time.Millisecond
 	// Wait for the file to exist


### PR DESCRIPTION
## Why this should be merged

Previously, tmpnet would not report FATAL errors that prevented node startup - the only indication of failure was a context timeout. This change ensures that such errors are reported.

## How this works

- adds a goroutine to watch for FATAL in a node's main.log until the node reports healthy (or times out waiting for health)
- adds a shared context that the goroutine can use to signal the loop waiting for the process context file so that the error can be propogated

This solution is a bit of a compromise, as there are some errors - e.g. a config file containing invalid json - that preclude the node from writing to main.log. Reading stdout and stderr directly from the child process in golang seems to prevent the child process from outliving the parent (which is required to start a network that will be reused). A future improvement could include redirecting stderr and stdout to a file (i.e. by running the avalanchego binary with `bash -c "avalanchego --config-file=..." &> out.txt &`) and similarly watching for text indicating node startup failure so that it could be reported to the user.

## How this was tested

Manually. Failure output: 

```
Error: failed to start local node: failed to load process context for node "NodeID-3wZBgT2xsNjA3A4eJt5ahA578y9oGiFhy": [11-11|18:51:19.477] FATAL app/app.go:75 failed to initialize node {"error": "couldn't initialize API server: listen tcp 127.0.0.1:9650: bind: address already in use"}
```
## Need to be documented in RELEASES.md?

N/A