### PR TITLE
Fix json parsing of GetValidatorsAtArgs

### DIFF
--- a/vms/platformvm/api/height.go
+++ b/vms/platformvm/api/height.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
 	"math"
 
@@ -27,11 +28,15 @@ func (h Height) MarshalJSON() ([]byte, error) {
 }
 
 func (h *Height) UnmarshalJSON(b []byte) error {
-	if string(b) == ProposedHeightFlag {
+	// First try to unmarshal as a string
+	// and check if it is the proposed height flag
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err == nil && s == ProposedHeightFlag {
 		*h = ProposedHeight
 		return nil
 	}
-	err := (*avajson.Uint64)(h).UnmarshalJSON(b)
+	err = (*avajson.Uint64)(h).UnmarshalJSON(b)
 	if err != nil {
 		return errInvalidHeight
 	}

--- a/vms/platformvm/api/height_test.go
+++ b/vms/platformvm/api/height_test.go
@@ -4,46 +4,102 @@
 package api
 
 import (
-	"encoding/json"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestMarshallHeight(t *testing.T) {
-	require := require.New(t)
-	h := Height(56)
-	bytes, err := h.MarshalJSON()
-	require.NoError(err)
-	require.Equal(`"56"`, string(bytes))
+func TestHeightMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		height   Height
+		expected string
+	}{
+		{
+			name:     "0",
+			height:   0,
+			expected: `"0"`,
+		},
+		{
+			name:     "56",
+			height:   56,
+			expected: `"56"`,
+		},
+		{
+			name:     "proposed",
+			height:   ProposedHeight,
+			expected: `"proposed"`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
 
-	h = Height(ProposedHeight)
-	bytes, err = h.MarshalJSON()
-	require.NoError(err)
-	require.Equal(`"proposed"`, string(bytes))
+			bytes, err := test.height.MarshalJSON()
+			require.NoError(err)
+			require.Equal(test.expected, string(bytes))
+		})
+	}
 }
 
-func TestUnmarshallHeight(t *testing.T) {
-	require := require.New(t)
+func TestHeightUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		initial     Height
+		json        string
+		expected    Height
+		expectedErr error
+	}{
+		{
+			name:     "null 56",
+			initial:  56,
+			json:     "null",
+			expected: 56,
+		},
+		{
+			name:     "null proposed",
+			initial:  ProposedHeight,
+			json:     "null",
+			expected: ProposedHeight,
+		},
+		{
+			name:     "proposed",
+			json:     `"proposed"`,
+			expected: ProposedHeight,
+		},
+		{
+			name:        "not a number",
+			json:        `"not a number"`,
+			expectedErr: errInvalidHeight,
+		},
+		{
+			name:     "56",
+			json:     `56`,
+			expected: 56,
+		},
+		{
+			name:     `"56"`,
+			json:     `"56"`,
+			expected: 56,
+		},
+		{
+			name:        "max uint64",
+			json:        "18446744073709551615",
+			expectedErr: errInvalidHeight,
+		},
+		{
+			name:        `"max uint64"`,
+			json:        `"18446744073709551615"`,
+			expectedErr: errInvalidHeight,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
 
-	var h Height
-
-	require.NoError(h.UnmarshalJSON([]byte("56")))
-	require.Equal(Height(56), h)
-
-	marshalledFlagBytes, err := json.Marshal(ProposedHeightFlag)
-	require.NoError(err)
-
-	require.NoError(h.UnmarshalJSON(marshalledFlagBytes))
-	require.Equal(Height(ProposedHeight), h)
-	require.True(h.IsProposed())
-
-	err = h.UnmarshalJSON([]byte("invalid"))
-	require.ErrorIs(err, errInvalidHeight)
-	require.Equal(Height(0), h)
-
-	err = h.UnmarshalJSON([]byte(`"` + strconv.FormatUint(uint64(ProposedHeight), 10) + `"`))
-	require.ErrorIs(err, errInvalidHeight)
-	require.Equal(Height(0), h)
+			err := test.initial.UnmarshalJSON([]byte(test.json))
+			require.ErrorIs(err, test.expectedErr)
+			require.Equal(test.expected, test.initial)
+		})
+	}
 }

--- a/vms/platformvm/api/height_test.go
+++ b/vms/platformvm/api/height_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -31,11 +32,14 @@ func TestUnmarshallHeight(t *testing.T) {
 	require.NoError(h.UnmarshalJSON([]byte("56")))
 	require.Equal(Height(56), h)
 
-	require.NoError(h.UnmarshalJSON([]byte(ProposedHeightFlag)))
+	marshalledFlagBytes, err := json.Marshal(ProposedHeightFlag)
+	require.NoError(err)
+
+	require.NoError(h.UnmarshalJSON(marshalledFlagBytes))
 	require.Equal(Height(ProposedHeight), h)
 	require.True(h.IsProposed())
 
-	err := h.UnmarshalJSON([]byte("invalid"))
+	err = h.UnmarshalJSON([]byte("invalid"))
 	require.ErrorIs(err, errInvalidHeight)
 	require.Equal(Height(0), h)
 


### PR DESCRIPTION
## Why this should be merged
Bugfix for a bug introduced in #3531  for the new `"proposed"` flag to `platform.getValidatorsAt`
## How this works

Encoded bytes when passed in to the `UnmarshalJSON` contain extra quotes and escape characters. We need to unmarshal the string before comparison instead of doing it directly. 

## How this was tested

Adds new test `TestGetValidatorsAtArgsMarshalling` that fails before this fix and succeeds now 

## Need to be documented in RELEASES.md?
no (bugfix for already documented feature)
