### PR TITLE
[antithesis] Enable reuse of banff e2e test for antithesis testing

### DIFF
--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -218,7 +218,11 @@ func (w *workload) executeTest(ctx context.Context) {
 	defer tc.Recover()
 	require := require.New(tc)
 
-	val, err := rand.Int(rand.Reader, big.NewInt(5))
+	// Ensure this value matches the number of tests + 1 to offset
+	// 0-based + 1 for sleep case in the switch statement for flowID
+	testCount := int64(6)
+
+	val, err := rand.Int(rand.Reader, big.NewInt(testCount))
 	require.NoError(err, "failed to read randomness")
 
 	flowID := val.Int64()

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -170,7 +170,7 @@ func (w *workload) run(ctx context.Context) {
 	tc := w.newTestContext(ctx)
 	// Any assertion failure from this test context will result in process exit due to the
 	// panic being rethrown. This ensures that failures in test setup are fatal.
-	defer tc.Recover(true /* rethrow */)
+	defer tc.RecoverAndRethrow()
 
 	xAVAX, pAVAX := e2e.GetWalletBalances(tc, w.wallet)
 	assert.Reachable("wallet starting", map[string]any{
@@ -215,7 +215,7 @@ func (w *workload) run(ctx context.Context) {
 func (w *workload) executeTest(ctx context.Context) {
 	tc := w.newTestContext(ctx)
 	// Panics will be recovered without being rethrown, ensuring that test failures are not fatal.
-	defer tc.Recover(false /* rethrow */)
+	defer tc.Recover()
 	require := require.New(tc)
 
 	val, err := rand.Int(rand.Reader, big.NewInt(5))

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -45,7 +45,6 @@ import (
 
 const NumKeys = 5
 
-// TODO(marun) Switch to using zap for logging
 // TODO(marun) Extract the common elements of test execution for reuse across test setups
 
 func main() {
@@ -223,7 +222,6 @@ func (w *workload) executeTest(ctx context.Context) {
 	val, err := rand.Int(rand.Reader, big.NewInt(6))
 	require.NoError(err, "failed to read randomness")
 
-	// TODO(marun)
 	flowID := val.Int64()
 	switch flowID {
 	case 0:

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -245,7 +245,7 @@ func (w *workload) executeTest(ctx context.Context) {
 	case 5:
 		w.log.Info("executing banff.TestCustomAssetTransfer")
 		addr, _ := w.addrs.Peek()
-		banff.TestCustomAssetTransfer(tc, w.wallet, addr)
+		banff.TestCustomAssetTransfer(tc, *w.wallet, addr)
 	case 6:
 		w.log.Info("sleeping")
 	}

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/antithesis"
-	"github.com/ava-labs/avalanchego/tests/e2e/banff"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -219,7 +218,7 @@ func (w *workload) executeTest(ctx context.Context) {
 	defer tc.Recover(false /* rethrow */)
 	require := require.New(tc)
 
-	val, err := rand.Int(rand.Reader, big.NewInt(6))
+	val, err := rand.Int(rand.Reader, big.NewInt(5))
 	require.NoError(err, "failed to read randomness")
 
 	flowID := val.Int64()
@@ -241,12 +240,13 @@ func (w *workload) executeTest(ctx context.Context) {
 		w.log.Info("executing issuePToXTransfer")
 		w.issuePToXTransfer(ctx)
 	case 5:
-		w.log.Info("executing banff.TestCustomAssetTransfer")
-		addr, _ := w.addrs.Peek()
-		banff.TestCustomAssetTransfer(tc, *w.wallet, addr)
-	case 6:
 		w.log.Info("sleeping")
 	}
+
+	// TODO(marun) Enable execution of the banff e2e test as part of https://github.com/ava-labs/avalanchego/issues/4049
+	// w.log.Info("executing banff.TestCustomAssetTransfer")
+	// addr, _ := w.addrs.Peek()
+	// banff.TestCustomAssetTransfer(tc, *w.wallet, addr)
 }
 
 func (w *workload) issueXChainBaseTx(ctx context.Context) {

--- a/tests/antithesis/context.go
+++ b/tests/antithesis/context.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package antithesis
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
+	"github.com/ava-labs/avalanchego/tests"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+// NewInstrumentedTestContext returns a test context that makes antithesis SDK assertions.
+func NewInstrumentedTestContext(log logging.Logger) *tests.SimpleTestContext {
+	return NewInstrumentedTestContextWithArgs(context.Background(), log, nil)
+}
+
+// NewInstrumentedTestContextWithArgs returns a test context that makes antithesis SDK assertions.
+func NewInstrumentedTestContextWithArgs(
+	ctx context.Context,
+	log logging.Logger,
+	details map[string]any,
+) *tests.SimpleTestContext {
+	return tests.NewTestContextWithArgs(
+		ctx,
+		log,
+		func(format string, args ...any) {
+			assert.Unreachable(fmt.Sprintf("Assertion failure: "+format, args...), details)
+		},
+		func(r any) {
+			detailsClone := maps.Clone(details)
+			details["panic"] = r
+			assert.Unreachable("unexpected panic", detailsClone)
+		},
+	)
+}

--- a/tests/antithesis/context.go
+++ b/tests/antithesis/context.go
@@ -33,7 +33,7 @@ func NewInstrumentedTestContextWithArgs(
 		},
 		func(r any) {
 			detailsClone := maps.Clone(details)
-			details["panic"] = r
+			detailsClone["panic"] = r
 			assert.Unreachable("unexpected panic", detailsClone)
 		},
 	)

--- a/tests/antithesis/xsvm/main.go
+++ b/tests/antithesis/xsvm/main.go
@@ -39,8 +39,8 @@ const (
 
 func main() {
 	// TODO(marun) Support choosing the log format
-	tc := tests.NewTestContext(tests.NewDefaultLogger(""))
-	defer tc.Cleanup()
+	tc := antithesis.NewInstrumentedTestContext(tests.NewDefaultLogger(""))
+	defer tc.RecoverAndExit()
 	require := require.New(tc)
 
 	c := antithesis.NewConfigWithSubnets(
@@ -55,6 +55,8 @@ func main() {
 		},
 	)
 	ctx := tests.DefaultNotifyContext(c.Duration, tc.DeferCleanup)
+	// Ensure contexts sourced from the test context use the notify context as their parent
+	tc.SetDefaultContextParent(ctx)
 
 	require.Len(c.ChainIDs, 1)
 	tc.Log().Debug("raw chain ID",
@@ -140,8 +142,16 @@ type workload struct {
 func (w *workload) run(ctx context.Context) {
 	timer := timerpkg.StoppedTimer()
 
-	tc := tests.NewTestContext(w.log)
-	defer tc.Cleanup()
+	tc := antithesis.NewInstrumentedTestContextWithArgs(
+		ctx,
+		w.log,
+		map[string]any{
+			"worker": w.id,
+		},
+	)
+	// Any assertion failure from this test context will result in process exit due to the
+	// panic being rethrown. This ensures that failures in test setup are fatal.
+	defer tc.Recover(true /* rethrow */)
 	require := require.New(tc)
 
 	uri := w.uris[w.id%len(w.uris)]

--- a/tests/antithesis/xsvm/main.go
+++ b/tests/antithesis/xsvm/main.go
@@ -151,7 +151,7 @@ func (w *workload) run(ctx context.Context) {
 	)
 	// Any assertion failure from this test context will result in process exit due to the
 	// panic being rethrown. This ensures that failures in test setup are fatal.
-	defer tc.Recover(true /* rethrow */)
+	defer tc.RecoverAndRethrow()
 	require := require.New(tc)
 
 	uri := w.uris[w.id%len(w.uris)]

--- a/tests/context_helpers.go
+++ b/tests/context_helpers.go
@@ -17,9 +17,6 @@ const DefaultTimeout = 2 * time.Minute
 // Helper simplifying use of a timed context by canceling the context with the test context.
 func ContextWithTimeout(tc TestContext, duration time.Duration) context.Context {
 	parent := tc.GetDefaultContextParent()
-	if parent == nil {
-		parent = context.Background()
-	}
 	ctx, cancel := context.WithTimeout(parent, duration)
 	tc.DeferCleanup(cancel)
 	return ctx

--- a/tests/context_helpers.go
+++ b/tests/context_helpers.go
@@ -16,7 +16,11 @@ const DefaultTimeout = 2 * time.Minute
 
 // Helper simplifying use of a timed context by canceling the context with the test context.
 func ContextWithTimeout(tc TestContext, duration time.Duration) context.Context {
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	parent := tc.GetDefaultContextParent()
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, duration)
 	tc.DeferCleanup(cancel)
 	return ctx
 }

--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -9,115 +9,117 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
 )
 
 var _ = ginkgo.Describe("[Banff]", func() {
-	tc := e2e.NewTestContext()
+	ginkgo.It("can send custom assets X->P and P->X", func() {
+		e2e.ExecuteAPITest(TestCustomAssetTransfer)
+	})
+})
+
+func TestCustomAssetTransfer(
+	tc tests.TestContext,
+	wallet primary.Wallet,
+	ownerAddress ids.ShortID,
+) {
 	require := require.New(tc)
 
-	ginkgo.It("can send custom assets X->P and P->X",
-		func() {
-			env := e2e.GetEnv(tc)
-			keychain := env.NewKeychain()
-			wallet := e2e.NewWallet(tc, keychain, env.GetRandomNodeURI())
+	// Get the P-chain and the X-chain wallets
+	pWallet := wallet.P()
+	xWallet := wallet.X()
+	xBuilder := xWallet.Builder()
+	xContext := xBuilder.Context()
 
-			// Get the P-chain and the X-chain wallets
-			pWallet := wallet.P()
-			xWallet := wallet.X()
-			xBuilder := xWallet.Builder()
-			xContext := xBuilder.Context()
+	// Pull out useful constants to use when issuing transactions.
+	xChainID := xContext.BlockchainID
+	owner := &secp256k1fx.OutputOwners{
+		Threshold: 1,
+		Addrs: []ids.ShortID{
+			ownerAddress,
+		},
+	}
 
-			// Pull out useful constants to use when issuing transactions.
-			xChainID := xContext.BlockchainID
-			owner := &secp256k1fx.OutputOwners{
-				Threshold: 1,
-				Addrs: []ids.ShortID{
-					keychain.Keys[0].Address(),
+	var assetID ids.ID
+	tc.By("creating new X-chain asset", func() {
+		tx, err := xWallet.IssueCreateAssetTx(
+			"RnM",
+			"RNM",
+			9,
+			map[uint32][]verify.State{
+				0: {
+					&secp256k1fx.TransferOutput{
+						Amt:          100 * units.Schmeckle,
+						OutputOwners: *owner,
+					},
 				},
-			}
+			},
+			tc.WithDefaultContext(),
+		)
+		require.NoError(err)
+		assetID = tx.ID()
+	})
 
-			var assetID ids.ID
-			tc.By("create new X-chain asset", func() {
-				tx, err := xWallet.IssueCreateAssetTx(
-					"RnM",
-					"RNM",
-					9,
-					map[uint32][]verify.State{
-						0: {
-							&secp256k1fx.TransferOutput{
-								Amt:          100 * units.Schmeckle,
-								OutputOwners: *owner,
-							},
-						},
+	tc.By("exporting new X-chain asset to P-chain", func() {
+		_, err := xWallet.IssueExportTx(
+			constants.PlatformChainID,
+			[]*avax.TransferableOutput{
+				{
+					Asset: avax.Asset{
+						ID: assetID,
 					},
-					tc.WithDefaultContext(),
-				)
-				require.NoError(err)
-				assetID = tx.ID()
-			})
-
-			tc.By("export new X-chain asset to P-chain", func() {
-				_, err := xWallet.IssueExportTx(
-					constants.PlatformChainID,
-					[]*avax.TransferableOutput{
-						{
-							Asset: avax.Asset{
-								ID: assetID,
-							},
-							Out: &secp256k1fx.TransferOutput{
-								Amt:          100 * units.Schmeckle,
-								OutputOwners: *owner,
-							},
-						},
+					Out: &secp256k1fx.TransferOutput{
+						Amt:          100 * units.Schmeckle,
+						OutputOwners: *owner,
 					},
-					tc.WithDefaultContext(),
-				)
-				require.NoError(err)
-			})
+				},
+			},
+			tc.WithDefaultContext(),
+		)
+		require.NoError(err)
+	})
 
-			tc.By("import new asset from X-chain on the P-chain", func() {
-				_, err := pWallet.IssueImportTx(
-					xChainID,
-					owner,
-					tc.WithDefaultContext(),
-				)
-				require.NoError(err)
-			})
+	tc.By("importing new asset from X-chain on the P-chain", func() {
+		_, err := pWallet.IssueImportTx(
+			xChainID,
+			owner,
+			tc.WithDefaultContext(),
+		)
+		require.NoError(err)
+	})
 
-			tc.By("export asset from P-chain to the X-chain", func() {
-				_, err := pWallet.IssueExportTx(
-					xChainID,
-					[]*avax.TransferableOutput{
-						{
-							Asset: avax.Asset{
-								ID: assetID,
-							},
-							Out: &secp256k1fx.TransferOutput{
-								Amt:          100 * units.Schmeckle,
-								OutputOwners: *owner,
-							},
-						},
+	tc.By("exporting asset from P-chain to the X-chain", func() {
+		_, err := pWallet.IssueExportTx(
+			xChainID,
+			[]*avax.TransferableOutput{
+				{
+					Asset: avax.Asset{
+						ID: assetID,
 					},
-					tc.WithDefaultContext(),
-				)
-				require.NoError(err)
-			})
+					Out: &secp256k1fx.TransferOutput{
+						Amt:          100 * units.Schmeckle,
+						OutputOwners: *owner,
+					},
+				},
+			},
+			tc.WithDefaultContext(),
+		)
+		require.NoError(err)
+	})
 
-			tc.By("import asset from P-chain on the X-chain", func() {
-				_, err := xWallet.IssueImportTx(
-					constants.PlatformChainID,
-					owner,
-					tc.WithDefaultContext(),
-				)
-				require.NoError(err)
-			})
-
-			_ = e2e.CheckBootstrapIsPossible(tc, env.GetNetwork())
-		})
-})
+	tc.By("importing asset from P-chain on the X-chain", func() {
+		_, err := xWallet.IssueImportTx(
+			constants.PlatformChainID,
+			owner,
+			tc.WithDefaultContext(),
+		)
+		require.NoError(err)
+	})
+}

--- a/tests/fixture/e2e/apitest.go
+++ b/tests/fixture/e2e/apitest.go
@@ -12,8 +12,8 @@ import (
 // TODO(marun) What else does a test need? e.g. node URIs?
 type APITestFunction func(tc tests.TestContext, wallet primary.Wallet, ownerAddress ids.ShortID)
 
-// ExecuteAPITest executes a test primary dependency is being able to access the API of one or
-// more avalanchego nodes.
+// ExecuteAPITest executes a test whose primary dependency is being
+// able to access the API of one or more avalanchego nodes.
 func ExecuteAPITest(apiTest APITestFunction) {
 	tc := NewTestContext()
 	env := GetEnv(tc)

--- a/tests/fixture/e2e/apitest.go
+++ b/tests/fixture/e2e/apitest.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package e2e
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
+)
+
+// TODO(marun) What else does a test need? e.g. node URIs?
+type APITestFunction func(tc tests.TestContext, wallet primary.Wallet, ownerAddress ids.ShortID)
+
+// ExecuteAPITest executes a test primary dependency is being able to access the API of one or
+// more avalanchego nodes.
+func ExecuteAPITest(apiTest APITestFunction) {
+	tc := NewTestContext()
+	env := GetEnv(tc)
+	keychain := env.NewKeychain()
+	wallet := NewWallet(tc, keychain, env.GetRandomNodeURI())
+	apiTest(tc, *wallet, keychain.Keys[0].Address())
+	_ = CheckBootstrapIsPossible(tc, env.GetNetwork())
+}

--- a/tests/fixture/e2e/ginkgo_test_context.go
+++ b/tests/fixture/e2e/ginkgo_test_context.go
@@ -118,7 +118,7 @@ func (tc *GinkgoTestContext) WithDefaultContext() common.Option {
 }
 
 func (*GinkgoTestContext) GetDefaultContextParent() context.Context {
-	return nil
+	return context.Background()
 }
 
 // Re-implementation of testify/require.Eventually that is compatible with ginkgo. testify's

--- a/tests/fixture/e2e/ginkgo_test_context.go
+++ b/tests/fixture/e2e/ginkgo_test_context.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
 
+var _ tests.TestContext = (*GinkgoTestContext)(nil)
+
 type ginkgoWriteCloser struct{}
 
 func (*ginkgoWriteCloser) Write(p []byte) (n int, err error) {
@@ -113,6 +115,10 @@ func (tc *GinkgoTestContext) DefaultContext() context.Context {
 // Helper simplifying use via an option of a timed context configured with the default timeout.
 func (tc *GinkgoTestContext) WithDefaultContext() common.Option {
 	return tests.WithDefaultContext(tc)
+}
+
+func (*GinkgoTestContext) GetDefaultContextParent() context.Context {
+	return nil
 }
 
 // Re-implementation of testify/require.Eventually that is compatible with ginkgo. testify's

--- a/tests/load/c/main/main.go
+++ b/tests/load/c/main/main.go
@@ -45,7 +45,7 @@ func init() {
 func main() {
 	log := tests.NewDefaultLogger(logPrefix)
 	tc := tests.NewTestContext(log)
-	defer tc.Cleanup()
+	defer tc.RecoverAndExit()
 
 	require := require.New(tc)
 	ctx := context.Background()

--- a/tests/load2/generator.go
+++ b/tests/load2/generator.go
@@ -85,10 +85,7 @@ func (l LoadGenerator) Run(
 				default:
 				}
 
-				ctx, cancel := context.WithTimeout(ctx, testTimeout)
-				defer cancel()
-
-				execTestWithRecovery(ctx, log, l.test, l.wallets[i])
+				execTestWithRecovery(ctx, log, l.test, l.wallets[i], testTimeout)
 			}
 		})
 	}
@@ -98,8 +95,10 @@ func (l LoadGenerator) Run(
 
 // execTestWithRecovery ensures assertion-related panics encountered during test execution are recovered
 // and that deferred cleanups are always executed before returning.
-func execTestWithRecovery(ctx context.Context, log logging.Logger, test Test, wallet *Wallet) {
+func execTestWithRecovery(ctx context.Context, log logging.Logger, test Test, wallet *Wallet, testTimeout time.Duration) {
 	tc := tests.NewTestContext(log)
 	defer tc.Recover()
-	test.Run(tc, ctx, wallet)
+	contextWithTimeout, cancel := context.WithTimeout(ctx, testTimeout)
+	defer cancel()
+	test.Run(tc, contextWithTimeout, wallet)
 }

--- a/tests/load2/generator.go
+++ b/tests/load2/generator.go
@@ -69,10 +69,9 @@ func (l LoadGenerator) Run(
 ) {
 	eg := &errgroup.Group{}
 
-	childCtx := ctx
 	if loadTimeout != 0 {
-		ctx, cancel := context.WithTimeout(ctx, loadTimeout)
-		childCtx = ctx
+		childCtx, cancel := context.WithTimeout(ctx, loadTimeout)
+		ctx = childCtx
 		defer cancel()
 	}
 
@@ -80,7 +79,7 @@ func (l LoadGenerator) Run(
 		eg.Go(func() error {
 			for {
 				select {
-				case <-childCtx.Done():
+				case <-ctx.Done():
 					return nil
 				default:
 				}

--- a/tests/load2/main/main.go
+++ b/tests/load2/main/main.go
@@ -50,7 +50,7 @@ func init() {
 func main() {
 	log := tests.NewDefaultLogger("")
 	tc := tests.NewTestContext(log)
-	defer tc.Cleanup()
+	defer tc.RecoverAndExit()
 
 	require := require.New(tc)
 
@@ -116,5 +116,5 @@ func main() {
 	)
 	require.NoError(err)
 
-	generator.Run(tc, ctx, loadTimeout, testTimeout)
+	generator.Run(ctx, log, loadTimeout, testTimeout)
 }

--- a/tests/simple_test_context.go
+++ b/tests/simple_test_context.go
@@ -102,11 +102,25 @@ func (tc *SimpleTestContext) RecoverAndExit() {
 	}
 }
 
+// Recover is intended to be deferred in a function executing a test whose
+// assertions may result in panics. Such a panic is intended to be recovered to
+// allow cleanup functions to be called before execution continues.
+func (tc *SimpleTestContext) Recover() {
+	tc.recover(false /* rethrow */)
+}
+
+// RecoverAndRethrow is intended to be deferred in a function executing a test
+// whose assertions may result in panics.  Such a panic is intended to be recovered
+// to allow cleanup functions to be called before the panic is rethrown.
+func (tc *SimpleTestContext) RecoverAndRethrow() {
+	tc.recover(true /* rethrow */)
+}
+
 // Recover is intended to be deferred in a function executing a test
 // whose assertions may result in panics. Such a panic is intended to
 // be recovered to allow cleanup functions to be called. A panic can
 // be optionally rethrown by setting `rethrow` to true.
-func (tc *SimpleTestContext) Recover(rethrow bool) {
+func (tc *SimpleTestContext) recover(rethrow bool) {
 	// Recover from test failure
 	var panicData any
 	if panicData = recover(); panicData != nil {

--- a/tests/simple_test_context.go
+++ b/tests/simple_test_context.go
@@ -10,41 +10,64 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
 
+var _ TestContext = (*SimpleTestContext)(nil)
+
 const failNowMessage = "SimpleTestContext.FailNow called"
 
+type ErrorfHandler func(format string, args ...any)
+
+type PanicHandler func(any)
+
 type SimpleTestContext struct {
-	log           logging.Logger
+	defaultContextParent context.Context
+	log                  logging.Logger
+
 	cleanupFuncs  []func()
 	cleanupCalled bool
+
+	errorfHandler ErrorfHandler
+	panicHandler  PanicHandler
 }
 
 func NewTestContext(log logging.Logger) *SimpleTestContext {
+	return NewTestContextWithArgs(context.Background(), log, nil, nil)
+}
+
+func NewTestContextWithArgs(
+	ctx context.Context,
+	log logging.Logger,
+	errorfHandler ErrorfHandler,
+	panicHandler PanicHandler,
+) *SimpleTestContext {
 	return &SimpleTestContext{
-		log: log,
+		defaultContextParent: ctx,
+		log:                  log,
+		errorfHandler:        errorfHandler,
+		panicHandler:         panicHandler,
 	}
 }
 
-func (tc *SimpleTestContext) Errorf(format string, args ...interface{}) {
+func (tc *SimpleTestContext) Errorf(format string, args ...any) {
 	tc.log.Error(fmt.Sprintf(format, args...))
+	if tc.errorfHandler != nil {
+		tc.errorfHandler(format, args...)
+	}
 }
 
 func (*SimpleTestContext) FailNow() {
 	panic(failNowMessage)
 }
 
-// Cleanup is intended to be deferred by the caller to ensure cleanup is performed even
-// in the event that a panic occurs.
-func (tc *SimpleTestContext) Cleanup() {
-	if tc.cleanupCalled {
-		return
-	}
-	tc.cleanupCalled = true
-
+// RecoverAndExit is intended to be deferred by the caller to ensure
+// cleanup functions are called before exit or re-panic (in the event
+// of an unexpected panic or a panic during cleanup).
+func (tc *SimpleTestContext) RecoverAndExit() {
 	// Only exit non-zero if a cleanup caused a panic
 	exitNonZero := false
 
@@ -52,27 +75,26 @@ func (tc *SimpleTestContext) Cleanup() {
 	if r := recover(); r != nil {
 		errorString, ok := r.(string)
 		if !ok || errorString != failNowMessage {
+			tc.log.Error("unexpected panic",
+				zap.Any("panic", r),
+			)
+			if tc.panicHandler != nil {
+				tc.panicHandler(r)
+			}
 			// Retain the panic data to raise after cleanup
 			panicData = r
 		} else {
+			// Ensure a non-zero exit due to an assertion failure
 			exitNonZero = true
 		}
 	}
 
-	for _, cleanupFunc := range tc.cleanupFuncs {
-		func() {
-			// Ensure a failed cleanup doesn't prevent subsequent cleanup functions from running
-			defer func() {
-				if r := recover(); r != nil {
-					exitNonZero = true
-					fmt.Println("Recovered from panic during cleanup:", r)
-				}
-			}()
-			cleanupFunc()
-		}()
+	if panicDuringCleanup := tc.cleanup(); panicDuringCleanup {
+		exitNonZero = true
 	}
 
 	if panicData != nil {
+		// Re-throw an unexpected (non-assertion) panic
 		panic(panicData)
 	}
 	if exitNonZero {
@@ -80,13 +102,73 @@ func (tc *SimpleTestContext) Cleanup() {
 	}
 }
 
+// Recover is intended to be deferred in a function executing a test
+// whose assertions may result in panics. Such a panic is intended to
+// be recovered to allow cleanup functions to be called. A panic can
+// be optionally rethrown by setting `rethrow` to true.
+func (tc *SimpleTestContext) Recover(rethrow bool) {
+	// Recover from test failure
+	var panicData any
+	if panicData := recover(); panicData != nil {
+		errorString, ok := panicData.(string)
+		if !ok || errorString != failNowMessage {
+			tc.log.Error("unexpected panic",
+				zap.Any("panic", panicData),
+			)
+			if tc.panicHandler != nil {
+				tc.panicHandler(panicData)
+			}
+		}
+	}
+	// Ensure cleanup functions are called
+	_ = tc.cleanup()
+
+	if rethrow && panicData != nil {
+		panic(panicData)
+	}
+}
+
+// cleanup ensures that the registered cleanup functions have been
+// called. Cleanup functions will be called at most once. Returns a
+// boolean indication of whether a panic results from executing one or
+// more cleanup functions e.g. allow a non-zero exit.
+func (tc *SimpleTestContext) cleanup() bool {
+	if tc.cleanupCalled {
+		return false
+	}
+	tc.cleanupCalled = true
+
+	panicDuringCleanup := false
+	for _, cleanupFunc := range tc.cleanupFuncs {
+		func() {
+			// Ensure a failed cleanup doesn't prevent subsequent cleanup functions from running
+			defer func() {
+				if r := recover(); r != nil {
+					panicDuringCleanup = true
+					tc.log.Error("recovered from panic during cleanup",
+						zap.Any("panic", r),
+					)
+				}
+			}()
+			cleanupFunc()
+		}()
+	}
+	return panicDuringCleanup
+}
+
 func (tc *SimpleTestContext) DeferCleanup(cleanup func()) {
 	tc.cleanupFuncs = append(tc.cleanupFuncs, cleanup)
 }
 
-func (tc *SimpleTestContext) By(_ string, _ ...func()) {
-	tc.Errorf("By not yet implemented")
-	tc.FailNow()
+func (tc *SimpleTestContext) By(msg string, callback ...func()) {
+	tc.log.Info("Step: " + msg)
+
+	if len(callback) == 1 {
+		callback[0]()
+	} else if len(callback) > 1 {
+		tc.Errorf("just one callback per By, please")
+		tc.FailNow()
+	}
 }
 
 func (tc *SimpleTestContext) Log() logging.Logger {
@@ -106,6 +188,14 @@ func (tc *SimpleTestContext) DefaultContext() context.Context {
 // Helper simplifying use via an option of a timed context configured with the default timeout.
 func (tc *SimpleTestContext) WithDefaultContext() common.Option {
 	return WithDefaultContext(tc)
+}
+
+func (tc *SimpleTestContext) GetDefaultContextParent() context.Context {
+	return tc.defaultContextParent
+}
+
+func (tc *SimpleTestContext) SetDefaultContextParent(parent context.Context) {
+	tc.defaultContextParent = parent
 }
 
 func (tc *SimpleTestContext) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msg string) {

--- a/tests/simple_test_context.go
+++ b/tests/simple_test_context.go
@@ -109,7 +109,7 @@ func (tc *SimpleTestContext) RecoverAndExit() {
 func (tc *SimpleTestContext) Recover(rethrow bool) {
 	// Recover from test failure
 	var panicData any
-	if panicData := recover(); panicData != nil {
+	if panicData = recover(); panicData != nil {
 		errorString, ok := panicData.(string)
 		if !ok || errorString != failNowMessage {
 			tc.log.Error("unexpected panic",

--- a/tests/simple_test_context.go
+++ b/tests/simple_test_context.go
@@ -131,7 +131,7 @@ func (tc *SimpleTestContext) Recover(rethrow bool) {
 // cleanup ensures that the registered cleanup functions have been
 // called. Cleanup functions will be called at most once. Returns a
 // boolean indication of whether a panic results from executing one or
-// more cleanup functions e.g. allow a non-zero exit.
+// more cleanup functions i.e. to trigger a non-zero exit.
 func (tc *SimpleTestContext) cleanup() bool {
 	if tc.cleanupCalled {
 		return false

--- a/tests/test_context.go
+++ b/tests/test_context.go
@@ -31,6 +31,9 @@ type TestContext interface {
 	DefaultContext() context.Context
 	WithDefaultContext() common.Option
 
+	// The parent context (if non-nil) to use as the parent of default contexts
+	GetDefaultContextParent() context.Context
+
 	// Ensures compatibility with require.Eventually
 	Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msg string)
 }

--- a/tests/test_context.go
+++ b/tests/test_context.go
@@ -31,7 +31,7 @@ type TestContext interface {
 	DefaultContext() context.Context
 	WithDefaultContext() common.Option
 
-	// The parent context (if non-nil) to use as the parent of default contexts
+	// The parent context to use as the parent of default contexts
 	GetDefaultContextParent() context.Context
 
 	// Ensures compatibility with require.Eventually


### PR DESCRIPTION
## Why this should be merged

Having to duplicate existing test coverage to benefit from execution with antithesis is not ideal. Better to be able to trivially refactor compatible e2e coverage for reuse. This PR refactors the banff e2e test for reuse with antithesis to demonstrate that this is possible. 

## How this works

 - adds new `APITestFunction` type that a compatible e2e test can implement to allow for execution with both ginkgo and antithesis
 - adds `ExecuteAPITest` helper to simplify execution of an `APITestFunction` with ginkgo
 - Refactors the banff e2e test into an `APITestFunction` executed by `ExecuteAPITest`
 - Refactors the avalanchego antithesis test setup to support execution of the banff test
   - Moves test dispatch into a new function so that panics can be recovered via a deferred function
      - This supports use of require by e2e tests without risking an unhandled panic exiting the test process

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A
