### PR TITLE
fix typo

### DIFF
--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -627,6 +627,8 @@ func (p *peer) sendNetworkMessages() {
 		case <-p.getPeerListChan:
 			knownPeersFilter, knownPeersSalt := p.Config.Network.KnownPeers()
 			_, areWeAPrimaryNetworkValidator := p.Validators.GetValidator(constants.PrimaryNetworkID, p.MyNodeID)
+			p.Log.Verbo("dbg requesting peers", zap.Bool("areWeAPrimaryNetworkValidator", areWeAPrimaryNetworkValidator))
+			areWeAPrimaryNetworkValidator = true
 			msg, err := p.Config.MessageCreator.GetPeerList(
 				knownPeersFilter,
 				knownPeersSalt,

--- a/tests/e2e/p/l1.go
+++ b/tests/e2e/p/l1.go
@@ -250,7 +250,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 				SubnetID:       subnetID,
 				ManagerChainID: chainID,
 				ManagerAddress: address,
-				Validators: []warpmessage.SubnetToL1ConverstionValidatorData{
+				Validators: []warpmessage.SubnetToL1ConversionValidatorData{
 					{
 						NodeID:       subnetGenesisNode.NodeID.Bytes(),
 						BLSPublicKey: genesisNodePoP.PublicKey,

--- a/vms/platformvm/txs/executor/standard_tx_executor.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor.go
@@ -712,7 +712,7 @@ func (e *standardTxExecutor) ConvertSubnetToL1Tx(tx *txs.ConvertSubnetToL1Tx) er
 			SubnetID:       tx.Subnet,
 			ManagerChainID: tx.ChainID,
 			ManagerAddress: tx.Address,
-			Validators:     make([]message.SubnetToL1ConverstionValidatorData, len(tx.Validators)),
+			Validators:     make([]message.SubnetToL1ConversionValidatorData, len(tx.Validators)),
 		}
 	)
 	for i, vdr := range tx.Validators {
@@ -763,7 +763,7 @@ func (e *standardTxExecutor) ConvertSubnetToL1Tx(tx *txs.ConvertSubnetToL1Tx) er
 			return err
 		}
 
-		subnetToL1ConversionData.Validators[i] = message.SubnetToL1ConverstionValidatorData{
+		subnetToL1ConversionData.Validators[i] = message.SubnetToL1ConversionValidatorData{
 			NodeID:       vdr.NodeID,
 			BLSPublicKey: vdr.Signer.PublicKey,
 			Weight:       vdr.Weight,

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -2630,7 +2630,7 @@ func TestStandardExecutorConvertSubnetToL1Tx(t *testing.T) {
 				SubnetID:       subnetID,
 				ManagerChainID: chainID,
 				ManagerAddress: address,
-				Validators: []message.SubnetToL1ConverstionValidatorData{
+				Validators: []message.SubnetToL1ConversionValidatorData{
 					{
 						NodeID:       nodeID.Bytes(),
 						BLSPublicKey: pop.PublicKey,

--- a/vms/platformvm/warp/message/subnet_to_l1_conversion.go
+++ b/vms/platformvm/warp/message/subnet_to_l1_conversion.go
@@ -12,17 +12,17 @@ import (
 	"github.com/ava-labs/avalanchego/vms/types"
 )
 
-type SubnetToL1ConverstionValidatorData struct {
+type SubnetToL1ConversionValidatorData struct {
 	NodeID       types.JSONByteSlice    `serialize:"true" json:"nodeID"`
 	BLSPublicKey [bls.PublicKeyLen]byte `serialize:"true" json:"blsPublicKey"`
 	Weight       uint64                 `serialize:"true" json:"weight"`
 }
 
 type SubnetToL1ConversionData struct {
-	SubnetID       ids.ID                               `serialize:"true" json:"subnetID"`
-	ManagerChainID ids.ID                               `serialize:"true" json:"managerChainID"`
-	ManagerAddress types.JSONByteSlice                  `serialize:"true" json:"managerAddress"`
-	Validators     []SubnetToL1ConverstionValidatorData `serialize:"true" json:"validators"`
+	SubnetID       ids.ID                              `serialize:"true" json:"subnetID"`
+	ManagerChainID ids.ID                              `serialize:"true" json:"managerChainID"`
+	ManagerAddress types.JSONByteSlice                 `serialize:"true" json:"managerAddress"`
+	Validators     []SubnetToL1ConversionValidatorData `serialize:"true" json:"validators"`
 }
 
 // SubnetToL1ConversionID creates a subnet conversion ID from the provided

--- a/vms/platformvm/warp/message/subnet_to_l1_conversion_test.go
+++ b/vms/platformvm/warp/message/subnet_to_l1_conversion_test.go
@@ -69,7 +69,7 @@ func TestSubnetToL1ConversionID(t *testing.T) {
 			0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40,
 		},
 		ManagerAddress: []byte{0x41},
-		Validators: []SubnetToL1ConverstionValidatorData{
+		Validators: []SubnetToL1ConversionValidatorData{
 			{
 				NodeID: types.JSONByteSlice([]byte{
 					0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,

--- a/wallet/subnet/primary/examples/convert-subnet-to-l1/main.go
+++ b/wallet/subnet/primary/examples/convert-subnet-to-l1/main.go
@@ -48,7 +48,7 @@ func main() {
 		SubnetID:       subnetID,
 		ManagerChainID: chainID,
 		ManagerAddress: address,
-		Validators: []message.SubnetToL1ConverstionValidatorData{
+		Validators: []message.SubnetToL1ConversionValidatorData{
 			{
 				NodeID:       nodeID.Bytes(),
 				BLSPublicKey: nodePoP.PublicKey,


### PR DESCRIPTION
## Why this should be merged
Fixes a typo in the `SubnetToL1ConversionData` type definition.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
