### PR TITLE
Refactor `logging.Format` to expose constants

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/compression"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/dynamicip"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/ulimit"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
@@ -142,7 +143,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.String(LogsDirKey, defaultLogDir, "Logging directory for Avalanche")
 	fs.String(LogLevelKey, "info", "The log level. Should be one of {verbo, debug, trace, info, warn, error, fatal, off}")
 	fs.String(LogDisplayLevelKey, "", "The log display level. If left blank, will inherit the value of log-level. Otherwise, should be one of {verbo, debug, trace, info, warn, error, fatal, off}")
-	fs.String(LogFormatKey, "auto", "The structure of log format. Defaults to 'auto' which formats terminal-like logs, when the output is a terminal. Otherwise, should be one of {auto, plain, colors, json}")
+	fs.String(LogFormatKey, logging.AutoString, "The structure of log format. Defaults to 'auto' which formats terminal-like logs, when the output is a terminal. Otherwise, should be one of {auto, plain, colors, json}")
 	fs.Uint(LogRotaterMaxSizeKey, 8, "The maximum file size in megabytes of the log file before it gets rotated.")
 	fs.Uint(LogRotaterMaxFilesKey, 7, "The maximum number of old log files to retain. 0 means retain all old log files.")
 	fs.Uint(LogRotaterMaxAgeKey, 0, "The maximum number of days to retain old log files based on the timestamp encoded in their filename. 0 means retain all old log files.")

--- a/config/flags.go
+++ b/config/flags.go
@@ -143,7 +143,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.String(LogsDirKey, defaultLogDir, "Logging directory for Avalanche")
 	fs.String(LogLevelKey, "info", "The log level. Should be one of {verbo, debug, trace, info, warn, error, fatal, off}")
 	fs.String(LogDisplayLevelKey, "", "The log display level. If left blank, will inherit the value of log-level. Otherwise, should be one of {verbo, debug, trace, info, warn, error, fatal, off}")
-	fs.String(LogFormatKey, logging.AutoString, "The structure of log format. Defaults to 'auto' which formats terminal-like logs, when the output is a terminal. Otherwise, should be one of {auto, plain, colors, json}")
+	fs.String(LogFormatKey, logging.AutoString, logging.FormatDescription)
 	fs.Uint(LogRotaterMaxSizeKey, 8, "The maximum file size in megabytes of the log file before it gets rotated.")
 	fs.Uint(LogRotaterMaxFilesKey, 7, "The maximum number of old log files to retain. 0 means retain all old log files.")
 	fs.Uint(LogRotaterMaxAgeKey, 0, "The maximum number of days to retain old log files based on the timestamp encoded in their filename. 0 means retain all old log files.")

--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -155,6 +155,7 @@ func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadIm
 			config.NetworkNameKey:             constants.LocalName,
 			config.LogLevelKey:                logging.Debug.String(),
 			config.LogDisplayLevelKey:         logging.Trace.String(),
+			config.LogFormatKey:               logging.JSONString,
 			config.HTTPHostKey:                "0.0.0.0",
 			config.PublicIPKey:                address,
 			config.StakingTLSKeyContentKey:    tlsKey,

--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -155,7 +155,6 @@ func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadIm
 			config.NetworkNameKey:             constants.LocalName,
 			config.LogLevelKey:                logging.Debug.String(),
 			config.LogDisplayLevelKey:         logging.Trace.String(),
-			config.LogFormatKey:               logging.JSONString,
 			config.HTTPHostKey:                "0.0.0.0",
 			config.PublicIPKey:                address,
 			config.StakingTLSKeyContentKey:    tlsKey,

--- a/tests/fixture/bootstrapmonitor/cmd/main.go
+++ b/tests/fixture/bootstrapmonitor/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&podName, "pod-name", os.Getenv("POD_NAME"), "The name of the pod")
 	rootCmd.PersistentFlags().StringVar(&nodeContainerName, "node-container-name", "", "The name of the node container in the pod")
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", "", "The path of the data directory used for the bootstrap job")
-	rootCmd.PersistentFlags().StringVar(&rawLogFormat, "log-format", logging.AutoString, "The structure of log format. Defaults to 'auto' which formats terminal-like logs, when the output is a terminal. Otherwise, should be one of {auto, plain, colors, json}")
+	rootCmd.PersistentFlags().StringVar(&rawLogFormat, "log-format", logging.AutoString, logging.FormatDescription)
 
 	versionCmd := &cobra.Command{
 		Use:   "version",

--- a/tests/fixture/bootstrapmonitor/cmd/main.go
+++ b/tests/fixture/bootstrapmonitor/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&podName, "pod-name", os.Getenv("POD_NAME"), "The name of the pod")
 	rootCmd.PersistentFlags().StringVar(&nodeContainerName, "node-container-name", "", "The name of the node container in the pod")
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", "", "The path of the data directory used for the bootstrap job")
-	rootCmd.PersistentFlags().StringVar(&rawLogFormat, "log-format", "auto", "The structure of log format. Defaults to 'auto' which formats terminal-like logs, when the output is a terminal. Otherwise, should be one of {auto, plain, colors, json}")
+	rootCmd.PersistentFlags().StringVar(&rawLogFormat, "log-format", logging.AutoString, "The structure of log format. Defaults to 'auto' which formats terminal-like logs, when the output is a terminal. Otherwise, should be one of {auto, plain, colors, json}")
 
 	versionCmd := &cobra.Command{
 		Use:   "version",

--- a/utils/logging/format.go
+++ b/utils/logging/format.go
@@ -24,6 +24,8 @@ const (
 	ColorsString = "colors"
 	JSONString   = "json"
 
+	FormatDescription = "The structure of log format. Defaults to 'auto' which formats terminal-like logs, when the output is a terminal. Otherwise, should be one of {auto, plain, colors, json}"
+
 	termTimeFormat = "[01-02|15:04:05.000]"
 )
 

--- a/utils/logging/format.go
+++ b/utils/logging/format.go
@@ -14,14 +14,27 @@ import (
 
 // Format modes available
 const (
-	Plain Format = iota
+	Auto Format = iota
+	Plain
 	Colors
 	JSON
+
+	AutoString   = "auto"
+	PlainString  = "plain"
+	ColorsString = "colors"
+	JSONString   = "json"
 
 	termTimeFormat = "[01-02|15:04:05.000]"
 )
 
 var (
+	formatJSON = []string{
+		`"auto"`,
+		`"plain"`,
+		`"colors"`,
+		`"json"`,
+	}
+
 	errUnknownFormat = errors.New("unknown format")
 
 	defaultEncoderConfig = zapcore.EncoderConfig{
@@ -51,34 +64,28 @@ type Format int
 
 // ToFormat chooses a highlighting mode
 func ToFormat(h string, fd uintptr) (Format, error) {
-	switch strings.ToUpper(h) {
-	case "PLAIN":
-		return Plain, nil
-	case "COLORS":
-		return Colors, nil
-	case "JSON":
-		return JSON, nil
-	case "AUTO":
+	switch strings.ToLower(h) {
+	case AutoString:
 		if !term.IsTerminal(int(fd)) {
 			return Plain, nil
 		}
 		return Colors, nil
+	case PlainString:
+		return Plain, nil
+	case ColorsString:
+		return Colors, nil
+	case JSONString:
+		return JSON, nil
 	default:
 		return Plain, fmt.Errorf("unknown format mode: %s", h)
 	}
 }
 
 func (f Format) MarshalJSON() ([]byte, error) {
-	switch f {
-	case Plain:
-		return []byte(`"PLAIN"`), nil
-	case Colors:
-		return []byte(`"COLORS"`), nil
-	case JSON:
-		return []byte(`"JSON"`), nil
-	default:
+	if f < 0 || int(f) >= len(formatJSON) {
 		return nil, errUnknownFormat
 	}
+	return []byte(formatJSON[f]), nil
 }
 
 func (f Format) WrapPrefix(prefix string) string {


### PR DESCRIPTION
## Why this should be merged

Allows referencing constants rather than hard-coded values.

## How this works

Adds a few variables.

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No.