### PR TITLE
add L1 support to getCurrentValidators API

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Pending Release
+
+### APIs
+
+- Added `validationID` to `platform.getL1Validator`
+- Added L1 support to `platform.getCurrentValidators`
+
 ## [v1.11.13](https://github.com/ava-labs/avalanchego/releases/tag/v1.11.13)
 
 This version is backwards compatible to [v1.11.0](https://github.com/ava-labs/avalanchego/releases/tag/v1.11.0). It is optional, but encouraged.

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -141,14 +141,6 @@ type GenesisPermissionlessValidator struct {
 	Signer             *signer.ProofOfPossession `json:"signer,omitempty"`
 }
 
-// PermissionedValidator is the repr. of a permissioned validator sent over APIs.
-type PermissionedValidator struct {
-	Staker
-	// The owner the staking reward, if applicable, will go to
-	Connected *bool         `json:"connected,omitempty"`
-	Uptime    *json.Float32 `json:"uptime,omitempty"`
-}
-
 // PrimaryDelegator is the repr. of a primary network delegator sent over APIs.
 type PrimaryDelegator struct {
 	Staker

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -528,6 +528,22 @@ func (mr *MockStateMockRecorder) GetL1ValidatorExcess() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetL1ValidatorExcess", reflect.TypeOf((*MockState)(nil).GetL1ValidatorExcess))
 }
 
+// GetL1Validators mocks base method.
+func (m *MockState) GetL1Validators(ctx context.Context, l1ID ids.ID) ([]*Staker, []L1Validator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetL1Validators", ctx, l1ID)
+	ret0, _ := ret[0].([]*Staker)
+	ret1, _ := ret[1].([]L1Validator)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetL1Validators indicates an expected call of GetL1Validators.
+func (mr *MockStateMockRecorder) GetL1Validators(ctx, l1ID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetL1Validators", reflect.TypeOf((*MockState)(nil).GetL1Validators), ctx, l1ID)
+}
+
 // GetLastAccepted mocks base method.
 func (m *MockState) GetLastAccepted() ids.ID {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why this should be merged

It adds L1 support and shows L1 validators in `platform.getCurrentValidators` API. 

## How this works

* Added `validationID` to the `platform.getL1Validator` API.
* Added L1 support to the `platform.getCurrentValidators` API. 
* Removed the `PermissionedValidator` struct as it is no longer used.
* Introduced `getL1Validators` and `getPrimaryOrSubnetValidators` methods to handle fetching validators based on subnet ID.
* Added `convertL1ValidatorToAPI` method to convert L1 validator data to API format. 
* Added `GetL1Validators` method to the `State` interface to return both base stakers and L1 validators in a converted L1.

## How this was tested

Locally

## Need to be documented in RELEASES.md?

Yes, updated.
