### PR TITLE
Remove unused wallet interface

### DIFF
--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -153,7 +153,7 @@ func main() {
 type workload struct {
 	id     int
 	log    logging.Logger
-	wallet primary.Wallet
+	wallet *primary.Wallet
 	addrs  set.Set[ids.ShortID]
 	uris   []string
 }

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -135,7 +135,7 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 				xContext := xBuilder.Context()
 				avaxAssetID := xContext.AVAXAssetID
 
-				wallets := make([]primary.Wallet, len(testKeys))
+				wallets := make([]*primary.Wallet, len(testKeys))
 				shortAddrs := make([]ids.ShortID, len(testKeys))
 				for i := range wallets {
 					shortAddrs[i] = testKeys[i].PublicKey().Address()

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -61,7 +61,7 @@ func NewPrivateKey(tc tests.TestContext) *secp256k1.PrivateKey {
 }
 
 // Create a new wallet for the provided keychain against the specified node URI.
-func NewWallet(tc tests.TestContext, keychain *secp256k1fx.Keychain, nodeURI tmpnet.NodeURI) primary.Wallet {
+func NewWallet(tc tests.TestContext, keychain *secp256k1fx.Keychain, nodeURI tmpnet.NodeURI) *primary.Wallet {
 	tc.Log().Info("initializing a new wallet",
 		zap.Stringer("nodeID", nodeURI.NodeID),
 		zap.String("URI", nodeURI.URI),
@@ -87,12 +87,12 @@ func NewWallet(tc tests.TestContext, keychain *secp256k1fx.Keychain, nodeURI tmp
 }
 
 // OutputWalletBalances outputs the X-Chain and P-Chain balances of the provided wallet.
-func OutputWalletBalances(tc tests.TestContext, wallet primary.Wallet) {
+func OutputWalletBalances(tc tests.TestContext, wallet *primary.Wallet) {
 	_, _ = GetWalletBalances(tc, wallet)
 }
 
 // GetWalletBalances retrieves the X-Chain and P-Chain balances of the provided wallet.
-func GetWalletBalances(tc tests.TestContext, wallet primary.Wallet) (uint64, uint64) {
+func GetWalletBalances(tc tests.TestContext, wallet *primary.Wallet) (uint64, uint64) {
 	require := require.New(tc)
 	var (
 		xWallet  = wallet.X()

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -91,7 +91,7 @@ type Subnet struct {
 }
 
 // Retrieves a wallet configured for use with the subnet
-func (s *Subnet) GetWallet(ctx context.Context, uri string) (primary.Wallet, error) {
+func (s *Subnet) GetWallet(ctx context.Context, uri string) (*primary.Wallet, error) {
 	keychain := secp256k1fx.NewKeychain(s.OwningKey)
 
 	// Only fetch the subnet transaction if a subnet ID is present. This won't be true when

--- a/wallet/subnet/primary/wallet.go
+++ b/wallet/subnet/primary/wallet.go
@@ -23,36 +23,28 @@ import (
 	xsigner "github.com/ava-labs/avalanchego/wallet/chain/x/signer"
 )
 
-var _ Wallet = (*wallet)(nil)
-
 // Wallet provides chain wallets for the primary network.
-type Wallet interface {
-	P() pwallet.Wallet
-	X() x.Wallet
-	C() c.Wallet
-}
-
-type wallet struct {
+type Wallet struct {
 	p pwallet.Wallet
 	x x.Wallet
 	c c.Wallet
 }
 
-func (w *wallet) P() pwallet.Wallet {
+func (w *Wallet) P() pwallet.Wallet {
 	return w.p
 }
 
-func (w *wallet) X() x.Wallet {
+func (w *Wallet) X() x.Wallet {
 	return w.x
 }
 
-func (w *wallet) C() c.Wallet {
+func (w *Wallet) C() c.Wallet {
 	return w.c
 }
 
 // Creates a new default wallet
-func NewWallet(p pwallet.Wallet, x x.Wallet, c c.Wallet) Wallet {
-	return &wallet{
+func NewWallet(p pwallet.Wallet, x x.Wallet, c c.Wallet) *Wallet {
+	return &Wallet{
 		p: p,
 		x: x,
 		c: c,
@@ -60,11 +52,11 @@ func NewWallet(p pwallet.Wallet, x x.Wallet, c c.Wallet) Wallet {
 }
 
 // Creates a Wallet with the given set of options
-func NewWalletWithOptions(w Wallet, options ...common.Option) Wallet {
+func NewWalletWithOptions(w *Wallet, options ...common.Option) *Wallet {
 	return NewWallet(
-		pwallet.WithOptions(w.P(), options...),
-		x.NewWalletWithOptions(w.X(), options...),
-		c.NewWalletWithOptions(w.C(), options...),
+		pwallet.WithOptions(w.p, options...),
+		x.NewWalletWithOptions(w.x, options...),
+		c.NewWalletWithOptions(w.c, options...),
 	)
 }
 
@@ -92,7 +84,7 @@ type WalletConfig struct {
 // transactions.
 //
 // The wallet manages all state locally, and performs all tx signing locally.
-func MakeWallet(ctx context.Context, config *WalletConfig) (Wallet, error) {
+func MakeWallet(ctx context.Context, config *WalletConfig) (*Wallet, error) {
 	avaxAddrs := config.AVAXKeychain.Addresses()
 	avaxState, err := FetchState(ctx, config.URI, avaxAddrs)
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged

We only have one struct that implements the `Wallet` interface, we can just pass around a struct.

## How this works

Removes the interface and exports the struct.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.