### PR TITLE
Allow issuing transactions when using partial-sync

### DIFF
--- a/vms/platformvm/block/executor/manager.go
+++ b/vms/platformvm/block/executor/manager.go
@@ -23,7 +23,8 @@ import (
 var (
 	_ Manager = (*manager)(nil)
 
-	ErrChainNotSynced = errors.New("chain not synced")
+	ErrChainNotSynced              = errors.New("chain not synced")
+	ErrImportTxWhilePartialSyncing = errors.New("issuing an import tx is not allowed while partial syncing")
 )
 
 type Manager interface {
@@ -122,6 +123,15 @@ func (m *manager) Preferred() ids.ID {
 func (m *manager) VerifyTx(tx *txs.Tx) error {
 	if !m.txExecutorBackend.Bootstrapped.Get() {
 		return ErrChainNotSynced
+	}
+
+	// If partial sync is enabled, this node isn't guaranteed to have the full
+	// UTXO set from shared memory. To avoid issuing invalid transactions,
+	// issuance of an ImportTx during this state is completely disallowed.
+	if m.txExecutorBackend.Config.PartialSyncPrimaryNetwork {
+		if _, isImportTx := tx.Unsigned.(*txs.ImportTx); isImportTx {
+			return ErrImportTxWhilePartialSyncing
+		}
 	}
 
 	recommendedPChainHeight, err := m.ctx.ValidatorState.GetMinimumHeight(context.TODO())

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -25,8 +24,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 )
-
-var errMempoolDisabledWithPartialSync = errors.New("mempool is disabled partial syncing")
 
 type Network struct {
 	*p2p.Network
@@ -190,18 +187,12 @@ func New(
 }
 
 func (n *Network) PushGossip(ctx context.Context) {
-	// TODO: Even though the node is running partial sync, we should support
-	// issuing transactions from the RPC.
-	if n.partialSyncPrimaryNetwork {
-		return
-	}
-
 	gossip.Every(ctx, n.log, n.txPushGossiper, n.txPushGossipFrequency)
 }
 
 func (n *Network) PullGossip(ctx context.Context) {
-	// If the node is running partial sync, we should not perform any pull
-	// gossip.
+	// If the node is running partial sync, we do not perform any pull gossip
+	// because we should never be a validator.
 	if n.partialSyncPrimaryNetwork {
 		return
 	}
@@ -221,15 +212,6 @@ func (n *Network) AppGossip(ctx context.Context, nodeID ids.NodeID, msgBytes []b
 }
 
 func (n *Network) IssueTxFromRPC(tx *txs.Tx) error {
-	// If we are partially syncing the Primary Network, we should not be
-	// maintaining the transaction mempool locally.
-	//
-	// TODO: We should still push the transaction to some peers when partial
-	// syncing.
-	if n.partialSyncPrimaryNetwork {
-		return errMempoolDisabledWithPartialSync
-	}
-
 	if err := n.mempool.Add(tx); err != nil {
 		return err
 	}

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -62,12 +62,11 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 	tx := &txs.Tx{}
 
 	type test struct {
-		name                      string
-		mempoolFunc               func(*gomock.Controller) pmempool.Mempool
-		txVerifier                testTxVerifier
-		partialSyncPrimaryNetwork bool
-		appSenderFunc             func(*gomock.Controller) common.AppSender
-		expectedErr               error
+		name          string
+		mempoolFunc   func(*gomock.Controller) pmempool.Mempool
+		txVerifier    testTxVerifier
+		appSenderFunc func(*gomock.Controller) common.AppSender
+		expectedErr   error
 	}
 
 	tests := []test{
@@ -130,17 +129,6 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 			expectedErr: errTest,
 		},
 		{
-			name: "mempool is disabled if primary network is not being fully synced",
-			mempoolFunc: func(ctrl *gomock.Controller) pmempool.Mempool {
-				return mempoolmock.NewMempool(ctrl)
-			},
-			partialSyncPrimaryNetwork: true,
-			appSenderFunc: func(ctrl *gomock.Controller) common.AppSender {
-				return commonmock.NewSender(ctrl)
-			},
-			expectedErr: errMempoolDisabledWithPartialSync,
-		},
-		{
 			name: "happy path",
 			mempoolFunc: func(ctrl *gomock.Controller) pmempool.Mempool {
 				mempool := mempoolmock.NewMempool(ctrl)
@@ -174,7 +162,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 				snowCtx.ValidatorState,
 				tt.txVerifier,
 				tt.mempoolFunc(ctrl),
-				tt.partialSyncPrimaryNetwork,
+				false,
 				tt.appSenderFunc(ctrl),
 				nil,
 				nil,


### PR DESCRIPTION
## Why this should be merged

Currently if `--partial-sync-primary-network` is set, the `platform.issueTx` API is disabled. This PR allows issuing transactions that can be verified by the node. 

## How this works

When `--partial-sync-primary-network` is enabled, ban `ImportTx`s. Otherwise, allow transactions to be issued as normal.

## How this was tested

Locally issued P-chain transactions to Fuji through a partial synced node.

## Need to be documented in RELEASES.md?

There is currently no reference to `--partial-sync-primary-network` in the docs for `issueTx`.