### PR TITLE
Remove redundant field in platformVM/network's Network

### DIFF
--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -32,7 +32,6 @@ type Network struct {
 	*p2p.Network
 
 	log                       logging.Logger
-	txVerifier                TxVerifier
 	mempool                   *gossipMempool
 	partialSyncPrimaryNetwork bool
 	appSender                 common.AppSender
@@ -178,7 +177,6 @@ func New(
 	return &Network{
 		Network:                   p2pNetwork,
 		log:                       log,
-		txVerifier:                txVerifier,
 		mempool:                   gossipMempool,
 		partialSyncPrimaryNetwork: partialSyncPrimaryNetwork,
 		appSender:                 appSender,


### PR DESCRIPTION
## Why this should be merged

The field `txVerifier` is unused 

## How this works

Removed the field

## How this was tested

Compile time check

## Need to be documented in RELEASES.md?

No
