### PR TITLE
Remove observedSubnetUptime from Info Docs

### DIFF
--- a/api/info/service.md
+++ b/api/info/service.md
@@ -512,7 +512,6 @@ info.peers({
     lastReceived: string,
     benched: string[],
     observedUptime: int,
-    observedSubnetUptime: map[string]int,
   }
 }
 ```
@@ -558,7 +557,6 @@ curl -X POST --data '{
         "lastReceived": "2020-06-01T15:22:57Z",
         "benched": [],
         "observedUptime": "99",
-        "observedSubnetUptimes": {},
         "trackedSubnets": [],
         "benched": []
       },


### PR DESCRIPTION
Noticed the info api was updated recently but the deprecated `observedSubnetUptime` field was not removed
