### PR TITLE
Add already implemented merkledb.View to MerkleDB interface

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -151,7 +151,7 @@ type Prefetcher interface {
 type MerkleDB interface {
 	database.Database
 	Clearer
-	Trie
+	View
 	MerkleRootGetter
 	ProofGetter
 	ChangeProofer


### PR DESCRIPTION
This PR adds `merkledb.View` to the `merkledb.MerkleDB` interface. This adds the already implemented `CommitToDB` function to the exported interface.

Downstream code (HyperSDK) uses `merkledb.View` type to represent the view calculated for an individual block. After committing a view, that view is no longer safe to use and the last committed state is represented directly by the `MerkleDB` instance. However, this complicates using the existing interface for the "view" of the last accepted block since `CommitToDB` is not implemented.