### PR TITLE
Add tempdir in for chain ctx data dir

### DIFF
--- a/snow/snowtest/context.go
+++ b/snow/snowtest/context.go
@@ -98,6 +98,6 @@ func Context(tb testing.TB, chainID ids.ID) *snow.Context {
 		Metrics:  metrics.NewPrefixGatherer(),
 
 		ValidatorState: validatorState,
-		ChainDataDir:   "",
+		ChainDataDir:   tb.TempDir(),
 	}
 }


### PR DESCRIPTION
This PR adds sets `ChainDataDir` to a temporary directory for `snowtest.Context(...)`. The current behavior of leaving it as an empty string can lead to unexpected results for tests that attempt to use the provided directory.