### PR TITLE
[ci] Always use the specified go version

### DIFF
--- a/.github/actions/set-go-version-in-env/go_version_env.sh
+++ b/.github/actions/set-go-version-in-env/go_version_env.sh
@@ -11,4 +11,4 @@ set -euo pipefail
 # 3 directories above this script
 AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd ../../.. && pwd )
 
-echo GO_VERSION="~$(sed -n -e 's/^go //p' "${AVALANCHE_PATH}"/go.mod)"
+echo GO_VERSION="$(sed -n -e 's/^go //p' "${AVALANCHE_PATH}"/go.mod)"

--- a/.github/actions/setup-go-for-project/action.yml
+++ b/.github/actions/setup-go-for-project/action.yml
@@ -22,4 +22,3 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: '${{ env.GO_VERSION }}'
-        check-latest: true


### PR DESCRIPTION
By virtue of supplying `check-latest` to the setup-go action, CI jobs were using the latest release of the specified golang version rather than the exact version. Better to always use the exact version to ensure that the version used for testing matches that used for development.

As per [this CI log](https://github.com/ava-labs/avalanchego/actions/runs/12438735022/job/34731199899?pr=3614#step:3:22):
```
...
Setup go version spec ~1.22.8
Attempting to resolve the latest version from the manifest...
matching ~1.22.8...
Resolved as '1.22.10'
...
```
