### PR TITLE
[testing] Always use the go.mod version of ginkgo

### DIFF
--- a/scripts/ginkgo.sh
+++ b/scripts/ginkgo.sh
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-# Run the ginkgo version from go.mod
+# If an explicit version is not specified, go run uses the ginkgo version from go.mod
 go run github.com/onsi/ginkgo/v2/ginkgo "${@}"

--- a/scripts/ginkgo.sh
+++ b/scripts/ginkgo.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Run the ginkgo version from go.mod
+go run github.com/onsi/ginkgo/v2/ginkgo "${@}"

--- a/scripts/tests.e2e.bootstrap_monitor.sh
+++ b/scripts/tests.e2e.bootstrap_monitor.sh
@@ -63,5 +63,4 @@ ensure_command "kind-with-registry.sh" "https://raw.githubusercontent.com/kubern
 # call them without a qualifying path.
 PATH="${PWD}/bin:$PATH" bash -x "${PWD}/bin/kind-with-registry.sh"
 
-KUBECONFIG="$HOME/.kube/config" PATH="${PWD}/bin:$PATH" \
-          ./scripts/ginkgo.sh -v ./tests/fixture/bootstrapmonitor/e2e
+KUBECONFIG="$HOME/.kube/config" PATH="${PWD}/bin:$PATH" ./scripts/ginkgo.sh -v ./tests/fixture/bootstrapmonitor/e2e

--- a/scripts/tests.e2e.bootstrap_monitor.sh
+++ b/scripts/tests.e2e.bootstrap_monitor.sh
@@ -63,7 +63,5 @@ ensure_command "kind-with-registry.sh" "https://raw.githubusercontent.com/kubern
 # call them without a qualifying path.
 PATH="${PWD}/bin:$PATH" bash -x "${PWD}/bin/kind-with-registry.sh"
 
-# TODO(marun) Factor out ginkgo installation to avoid duplicating it across test scripts
-go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
-
-KUBECONFIG="$HOME/.kube/config" PATH="${PWD}/bin:$PATH" ginkgo -v ./tests/fixture/bootstrapmonitor/e2e
+KUBECONFIG="$HOME/.kube/config" PATH="${PWD}/bin:$PATH" \
+          ./scripts/ginkgo.sh -v ./tests/fixture/bootstrapmonitor/e2e

--- a/scripts/tests.e2e.existing.sh
+++ b/scripts/tests.e2e.existing.sh
@@ -22,7 +22,7 @@ function print_separator {
 function cleanup {
   print_separator
   echo "cleaning up reusable network"
-  ginkgo -v ./tests/e2e/e2e.test -- --stop-network
+  ./scripts/ginkgo.sh -v ./tests/e2e -- --stop-network
 }
 trap cleanup EXIT
 

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -20,13 +20,6 @@ fi
 # the instructions to build non-portable BLST.
 source ./scripts/constants.sh
 
-#################################
-echo "building e2e.test"
-# to install the ginkgo binary (required for test build and run)
-go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
-ACK_GINKGO_RC=true ginkgo build ./tests/e2e
-./tests/e2e/e2e.test --help
-
 # Enable subnet testing by building xsvm
 ./scripts/build_xsvm.sh
 echo ""
@@ -66,4 +59,4 @@ fi
 
 #################################
 # shellcheck disable=SC2086
-ginkgo ${GINKGO_ARGS} -v ./tests/e2e/e2e.test -- "${E2E_ARGS[@]}" "${@}"
+./scripts/ginkgo.sh ${GINKGO_ARGS} -v ./tests/e2e -- "${E2E_ARGS[@]}" "${@}"

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -63,16 +63,8 @@ find "/tmp/avalanchego-v${VERSION}"
 source ./scripts/constants.sh
 
 #################################
-echo "building upgrade.test"
-# to install the ginkgo binary (required for test build and run)
-go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
-ACK_GINKGO_RC=true ginkgo build ./tests/upgrade
-./tests/upgrade/upgrade.test --help
-
-#################################
 # By default, it runs all upgrade test cases!
 echo "running upgrade tests against the local cluster with ${AVALANCHEGO_PATH}"
-./tests/upgrade/upgrade.test \
-  --ginkgo.v \
+./scripts/ginkgo.sh -v ./tests/upgrade -- \
   --avalanchego-path="/tmp/avalanchego-v${VERSION}/avalanchego" \
   --avalanchego-path-to-upgrade-to="${AVALANCHEGO_PATH}"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -6,12 +6,9 @@
 ## Running tests
 
 ```bash
-go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.0.0
-ACK_GINKGO_RC=true ginkgo build ./tests/e2e
-./tests/e2e/e2e.test --help
-
-./tests/e2e/e2e.test \
---avalanchego-path=./build/avalanchego
+./scripts/build.sh        # Builds avalanchego for use in deploying a test network
+./scripts/build_xsvm.sh   # Builds xsvm for use in deploying a test network with a subnet
+./scripts/ginkgo.sh -v ./tests/e2e -- --avalanchego-path=./build/avalanchego
 ```
 
 See [`tests.e2e.sh`](../../scripts/tests.e2e.sh) for an example.
@@ -27,9 +24,7 @@ primarily target the X-Chain:
 
 
 ```bash
-./tests/e2e/e2e.test \
-  --avalanchego-path=./build/avalanchego \
-  --ginkgo.label-filter=x
+./scripts/ginkgo.sh -v --label-filter=x ./tests/e2e -- --avalanchego-path=./build/avalanchego
 ```
 
 The ginkgo docs provide further detail on [how to compose label
@@ -45,17 +40,14 @@ Create a new package to implement feature-specific tests, or add tests to an exi
 tests
 └── e2e
     ├── README.md
-    ├── e2e.go
     ├── e2e_test.go
     └── x
         └── transfer.go
             └── virtuous.go
 ```
 
-`e2e.go` defines common configuration for other test
-packages. `x/transfer/virtuous.go` defines X-Chain transfer tests,
-labeled with `x`, which can be selected by `./tests/e2e/e2e.test
---ginkgo.label-filter "x"`.
+`x/transfer/virtuous.go` defines X-Chain transfer tests,
+labeled with `x`, which can be selected by `--label-filter=x`.
 
 ## Reusing temporary networks
 
@@ -70,7 +62,7 @@ To enable network reuse across test runs, pass `--reuse-network` as an
 argument to the test suite:
 
 ```bash
-ginkgo -v ./tests/e2e -- --avalanchego-path=/path/to/avalanchego --reuse-network
+./scripts/gingko.sh -v ./tests/e2e -- --avalanchego-path=/path/to/avalanchego --reuse-network
 ```
 
 If a network is not already running the first time the suite runs with
@@ -93,7 +85,7 @@ To stop a network configured for reuse, invoke the test suite with the
 immediately without executing any tests:
 
 ```bash
-ginkgo -v ./tests/e2e -- --stop-network
+./scripts/gingko.sh -v ./tests/e2e -- --stop-network
 ```
 
 ## Skipping bootstrap checks
@@ -105,5 +97,5 @@ these bootstrap checks during development, set the
 `E2E_SKIP_BOOTSTRAP_CHECKS` env var to a non-empty value:
 
 ```bash
-E2E_SKIP_BOOTSTRAP_CHECKS=1 ginkgo -v ./tests/e2e ...
+E2E_SKIP_BOOTSTRAP_CHECKS=1 ./scripts/ginkgo.sh -v ./tests/e2e ...
 ```


### PR DESCRIPTION
## Why this should be merged

Previously, ginkgo was installed with an explicit version which made it easy for the ginkgo command and the test code to be using different versions. 

## How this works

- add new script `scripts/ginkgo.sh` that wraps `go run` execution with the go.mod version of ginkgo
- simplify all test scripts to execute tests with new script
- also: simplify test execution by running tests directly rather than via a test binary that needs to be built
  - this provides a nicer example for development usage since on-disk changes are always included

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A