### PR TITLE
Fix: quotation mark

### DIFF
--- a/vms/avm/service.md
+++ b/vms/avm/service.md
@@ -989,10 +989,10 @@ avm.getBlockByHeight({
 ```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
-    "method": "avm.getBlockByHeight”,
+    "method": "avm.getBlockByHeight",
     "params": {
-        “height”: “275686313486”,
-        "encoding": “hex”
+        "height": "275686313486",
+        "encoding": "hex"
     },
     "id": 1
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X

--- a/vms/platformvm/docs/chain_time_update.md
+++ b/vms/platformvm/docs/chain_time_update.md
@@ -20,7 +20,7 @@ Before the Banff fork activation, `ChainTime` was incremented by an `AdvanceTime
 2. *Synchronicity*: proposed time must not be greater than node’s current time plus a synchronicity bound (currently set to 10 seconds).
 3. *No Skipping*: proposed time must be less than or equal to the next staking event, that is start/end of any staker.
 
-Note that *Synchronicity* makes sure that `ChainTime` approximates “real” time flow. If we dropped synchronicity requirement, a staker could declare any staking time and immediately push `ChainTime` to the end, so as to pocket a reward without having actually carried out any activity in the “real” time.
+Note that *Synchronicity* makes sure that `ChainTime` approximates "real" time flow. If we dropped synchronicity requirement, a staker could declare any staking time and immediately push `ChainTime` to the end, so as to pocket a reward without having actually carried out any activity in the "real" time.
 
 ## Post Banff fork context
 


### PR DESCRIPTION
Fix quotation marks in .md files. Some editors may not accurately render unexpected characters, appearing as gibberish or causing formatting problems.
