### PR TITLE
Fix codeowners to simplify PR review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,17 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
 # Code owners are the final gate for PR approval to their named section of code.
-# If a single PR involves multiple code owners, every code owner should approve
-# a PR prior to merging.
+# If a single PR modifies multiple files with different code owner groups, at
+# least one code owner of the touched file should approve the PR prior to
+# merging.
 
 * @StephenButtolph
+*.md @meaghanfitzgerald @StephenButtolph
 /.github/ @marun
+/.github/*.md @marun @meaghanfitzgerald
 /network/p2p/ @joshua-kim
+/network/p2p/*.md @joshua-kim @meaghanfitzgerald
 /scripts/ @marun
+/scripts/*.md @marun @meaghanfitzgerald
 /tests/ @marun
-*.md @meaghanfitzgerald
+/tests/*.md @marun @meaghanfitzgerald


### PR DESCRIPTION
## Why this should be merged

The current code owners file _requires_ meag to review all `.md` files. The intent was to allow her to provide the reviews for PRs that touch `README`s... Not to require it.

## How this works

Unfortunately, this isn't very easy to communicate in the CODEOWNERs file... It requires duplicating basically every line.

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No.