### PR TITLE
Add BLS healthcheck to communicate incorrect BLS key configuration

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -61,6 +61,7 @@ import (
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/dynamicip"
 	"github.com/ava-labs/avalanchego/utils/filesystem"
 	"github.com/ava-labs/avalanchego/utils/hashing"
@@ -1493,6 +1494,32 @@ func (n *Node) initHealthAPI() error {
 	err = n.health.RegisterHealthCheck("diskspace", diskSpaceCheck, health.ApplicationTag)
 	if err != nil {
 		return fmt.Errorf("couldn't register resource health check: %w", err)
+	}
+
+	wrongBLSKeyCheck := health.CheckerFunc(func(context.Context) (interface{}, error) {
+		vdr, ok := n.vdrs.GetValidator(constants.PrimaryNetworkID, n.ID)
+		if !ok {
+			return "node is not a validator", nil
+		}
+
+		vdrPK := vdr.PublicKey
+		if vdrPK == nil {
+			return "validator doesn't have a BLS key", nil
+		}
+
+		nodePK := n.Config.StakingSigningKey.PublicKey()
+		if nodePK.Equals(vdrPK) {
+			return "node has the correct BLS key", nil
+		}
+		return nil, fmt.Errorf("node has BLS key 0x%x, but is registered to the validator set with 0x%x",
+			bls.PublicKeyToCompressedBytes(nodePK),
+			bls.PublicKeyToCompressedBytes(vdrPK),
+		)
+	})
+
+	err = n.health.RegisterHealthCheck("bls", wrongBLSKeyCheck, health.ApplicationTag)
+	if err != nil {
+		return fmt.Errorf("couldn't register bls health check: %w", err)
 	}
 
 	handler, err := health.NewGetAndPostHandler(n.Log, n.health)


### PR DESCRIPTION
## Why this should be merged

One of the more common misconfigurations for avalanchego is to have misconfigured the BLS signer. This adds a healthcheck that attempts to warn that this has happened.

It isn't guaranteed to work (as the node may not actually consider itself as part of the validator set even though the rest of the network does). However, this check should have no false positives after bootstrapping has finished.

## How this works

Adds another health check that verifies that the node's BLS key matches the key that was registered under the node's ID.

## How this was tested

Ran locally:
```
[01-04|17:33:57.810] WARN health/worker.go:252 check started failing {"name": "health", "name": "bls", "tags": ["application"], "error": "node has BLS key 0xb42bd7dc7d21372a7612f78d4279a44e64c0f75f10f73d84f1a88ffac2e646fa4b95d97ceac33a846fbb8cd2618e20d6, but is registered to the validator set with 0xa3783a891cb41cadbfcf456da149f30e7af972677a162b984bef0779f254baac51ec042df1781d1295df80fb41c80126"}
```

## Need to be documented in RELEASES.md?

N/A