### PR TITLE
feat(github): add "needs Go upgrade" label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -52,6 +52,9 @@
 - name: "go"
   color: "16e2e2"
   description: "Pull requests that update Go code"
+- name: "needs Go upgrade"
+  color: "16e2e2"
+  description: "This requires a minor upgrade of Go to be supported"
 
 # Avalanchego specific labels
 - name: "antithesis"


### PR DESCRIPTION
## Why this should be merged

There is one issue that should benefit from this label, so we can through these kind of issues when bumping Go minor version.

## How this works

Add a "needs Go Upgrade" label

## How this was tested

CI dry run of labels workflow

## Need to be documented in RELEASES.md?

No
