### PR TITLE
[ci] Fix post-merge protobuf lint job breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,10 @@ jobs:
         with:
           input: "proto"
           pr_comment: false
+          # buf-action defaults to pushing on non-fork branch pushes
+          # which is never desirable for this job. The buf-push job is
+          # responsible for pushes.
+          push: false
           version: 1.35.0
   check_generated_protobuf:
     name: Up-to-date protobuf


### PR DESCRIPTION
## Why this should be merged

Without push being explicitly disabled on the lint job, it will attempt to push when run post-merge. Without a buf token, that push will fail. The `buf-push` is responsible for pushing so there's no reason for the lint job to attempt it.

## How this works

Disables push for the protobuf lint job

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A