### PR TITLE
fix(ci): trigger labels workflow on push to master not main

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -2,7 +2,7 @@ name: labels
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - .github/labels.yml
       - .github/workflows/labels.yml


### PR DESCRIPTION
Tiny 1 line PR to fix the label workflow trigger to trigger on pushes to the master branch and not the main branch (worst change ever GITHUB!! Also sorry for missing this out)