### PR TITLE
Add L1 validator fees API

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,15 @@ This version is backwards compatible to [v1.12.0](https://github.com/ava-labs/av
 
 The plugin version is unchanged at `38` and is compatible with versions `v1.12.0-v1.12.1`.
 
+### APIs
+
+- Removed:
+  - `info.GetTxFee`
+- Added:
+  - `avm.GetTxFee`
+  - `platform.getValidatorFeeConfig`
+  - `platform.getValidatorFeeState`
+
 ### Configs
 
 - Removed static fee config flags
@@ -16,11 +25,6 @@ The plugin version is unchanged at `38` and is compatible with versions `v1.12.0
   - `--add-primary-network-delegator-fee`
   - `--add-subnet-validator-fee`
   - `--add-subnet-delegator-fee`
-
-### APIs
-
-- Removed `info.GetTxFee`
-- Added `avm.GetTxFee`
   
 ### What's Changed
 

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
+	"github.com/ava-labs/avalanchego/vms/platformvm/validators/fee"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
 	platformapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
@@ -136,7 +137,22 @@ type Client interface {
 	// GetFeeConfig returns the dynamic fee config of the chain.
 	GetFeeConfig(ctx context.Context, options ...rpc.Option) (*gas.Config, error)
 	// GetFeeState returns the current fee state of the chain.
-	GetFeeState(ctx context.Context, options ...rpc.Option) (gas.State, gas.Price, time.Time, error)
+	GetFeeState(ctx context.Context, options ...rpc.Option) (
+		gas.State,
+		gas.Price,
+		time.Time,
+		error,
+	)
+	// GetValidatorFeeConfig returns the validator fee config of the chain.
+	GetValidatorFeeConfig(ctx context.Context, options ...rpc.Option) (*fee.Config, error)
+	// GetValidatorFeeState returns the current validator fee state of the
+	// chain.
+	GetValidatorFeeState(ctx context.Context, options ...rpc.Option) (
+		gas.Gas,
+		gas.Price,
+		time.Time,
+		error,
+	)
 }
 
 // Client implementation for interacting with the P Chain endpoint
@@ -615,10 +631,32 @@ func (c *client) GetFeeConfig(ctx context.Context, options ...rpc.Option) (*gas.
 	return res, err
 }
 
-func (c *client) GetFeeState(ctx context.Context, options ...rpc.Option) (gas.State, gas.Price, time.Time, error) {
+func (c *client) GetFeeState(ctx context.Context, options ...rpc.Option) (
+	gas.State,
+	gas.Price,
+	time.Time,
+	error,
+) {
 	res := &GetFeeStateReply{}
 	err := c.requester.SendRequest(ctx, "platform.getFeeState", struct{}{}, res, options...)
 	return res.State, res.Price, res.Time, err
+}
+
+func (c *client) GetValidatorFeeConfig(ctx context.Context, options ...rpc.Option) (*fee.Config, error) {
+	res := &fee.Config{}
+	err := c.requester.SendRequest(ctx, "platform.getValidatorFeeConfig", struct{}{}, res, options...)
+	return res, err
+}
+
+func (c *client) GetValidatorFeeState(ctx context.Context, options ...rpc.Option) (
+	gas.Gas,
+	gas.Price,
+	time.Time,
+	error,
+) {
+	res := &GetValidatorFeeStateReply{}
+	err := c.requester.SendRequest(ctx, "platform.getValidatorFeeState", struct{}{}, res, options...)
+	return res.Excess, res.Price, res.Time, err
 }
 
 func AwaitTxAccepted(

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -2003,7 +2003,7 @@ func (s *Service) GetFeeState(_ *http.Request, _ *struct{}, reply *GetFeeStateRe
 	return nil
 }
 
-// GetValidatorFeeConfig returns the dynamic fee config of the chain.
+// GetValidatorFeeConfig returns the validator fee config of the chain.
 func (s *Service) GetValidatorFeeConfig(_ *http.Request, _ *struct{}, reply *fee.Config) error {
 	s.vm.ctx.Log.Debug("API called",
 		zap.String("service", "platform"),

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/validators/fee"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/vms/types"
@@ -1972,12 +1973,6 @@ func (s *Service) GetFeeConfig(_ *http.Request, _ *struct{}, reply *gas.Config) 
 		zap.String("method", "getFeeConfig"),
 	)
 
-	// TODO: Remove after Etna is activated.
-	now := time.Now()
-	if !s.vm.Internal.UpgradeConfig.IsEtnaActivated(now) {
-		return nil
-	}
-
 	*reply = s.vm.DynamicFeeConfig
 	return nil
 }
@@ -2003,6 +1998,43 @@ func (s *Service) GetFeeState(_ *http.Request, _ *struct{}, reply *GetFeeStateRe
 		s.vm.DynamicFeeConfig.MinPrice,
 		reply.State.Excess,
 		s.vm.DynamicFeeConfig.ExcessConversionConstant,
+	)
+	reply.Time = s.vm.state.GetTimestamp()
+	return nil
+}
+
+// GetValidatorFeeConfig returns the dynamic fee config of the chain.
+func (s *Service) GetValidatorFeeConfig(_ *http.Request, _ *struct{}, reply *fee.Config) error {
+	s.vm.ctx.Log.Debug("API called",
+		zap.String("service", "platform"),
+		zap.String("method", "getValidatorFeeConfig"),
+	)
+
+	*reply = s.vm.ValidatorFeeConfig
+	return nil
+}
+
+type GetValidatorFeeStateReply struct {
+	Excess gas.Gas   `json:"excess"`
+	Price  gas.Price `json:"price"`
+	Time   time.Time `json:"timestamp"`
+}
+
+// GetValidatorFeeState returns the current validator fee state of the chain.
+func (s *Service) GetValidatorFeeState(_ *http.Request, _ *struct{}, reply *GetValidatorFeeStateReply) error {
+	s.vm.ctx.Log.Debug("API called",
+		zap.String("service", "platform"),
+		zap.String("method", "getValidatorFeeState"),
+	)
+
+	s.vm.ctx.Lock.Lock()
+	defer s.vm.ctx.Lock.Unlock()
+
+	reply.Excess = s.vm.state.GetL1ValidatorExcess()
+	reply.Price = gas.CalculatePrice(
+		s.vm.ValidatorFeeConfig.MinPrice,
+		reply.Excess,
+		s.vm.ValidatorFeeConfig.ExcessConversionConstant,
 	)
 	reply.Time = s.vm.state.GetTimestamp()
 	return nil

--- a/vms/platformvm/service.md
+++ b/vms/platformvm/service.md
@@ -2015,7 +2015,7 @@ curl -X POST --data '{
 
 ### `platform.getValidatorFeeConfig`
 
-Returns the validator fee configuration of the P-chain.
+Returns the validator fee configuration of the P-Chain.
 
 **Signature:**
 

--- a/vms/platformvm/service.md
+++ b/vms/platformvm/service.md
@@ -807,16 +807,16 @@ curl -X POST --data '{
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "result": {
-        "weights": [1,1000,1000,4],
-        "maxCapacity": 1000000,
-        "maxPerSecond": 100000,
-        "targetPerSecond": 50000,
-        "minPrice": 1,
-        "excessConversionConstant": 2164043
-    },
-    "id": 1
+  "jsonrpc": "2.0",
+  "result": {
+    "weights": [1, 1000, 1000, 4],
+    "maxCapacity": 1000000,
+    "maxPerSecond": 100000,
+    "targetPerSecond": 50000,
+    "minPrice": 1,
+    "excessConversionConstant": 2164043
+  },
+  "id": 1
 }
 ```
 
@@ -850,43 +850,36 @@ curl -X POST --data '{
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "result": {
-		    "capacity":973044,
-		    "excess":26956,
-		    "price":1,
-		    "timestamp":"2024-12-16T17:19:07Z"
-    },
-    "id": 1
+  "jsonrpc": "2.0",
+  "result": {
+    "capacity": 973044,
+    "excess": 26956,
+    "price": 1,
+    "timestamp": "2024-12-16T17:19:07Z"
+  },
+  "id": 1
 }
 ```
 
-### `platform.getValidatorFeeConfig`
+### `platform.getHeight`
 
-Returns the validator fee configuration of the P-chain.
+Returns the height of the last accepted block.
 
 **Signature:**
 
 ```
-platform.getValidatorFeeConfig() -> {
-  capacity: uint64,
-  target: uint64,
-  minPrice: uint64,
-  excessConversionConstant: uint64
+platform.getHeight() ->
+{
+  height: int,
 }
 ```
-
-- `capacity` is the maximum number of L1 validators the chain is allowed to have at any given time
-- `target` is the target number of L1 validators the chain should have to keep fees stable
-- `minPrice` is the minimum price per L1 validator
-- `excessConversionConstant` is used to convert excess L1 validators to a gas price
 
 **Example Call:**
 
 ```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
-    "method": "platform.getValidatorFeeConfig",
+    "method": "platform.getHeight",
     "params": {},
     "id": 1
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
@@ -896,53 +889,11 @@ curl -X POST --data '{
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "result": {
-        "capacity": 20000,
-        "target": 10000,
-        "minPrice": 512,
-        "excessConversionConstant": 1246488515
-    },
-    "id": 1
-}
-```
-
-### `platform.getValidatorFeeState`
-
-Returns the current validator fee state of the P-chain.
-
-**Signature:**
-
-```
-platform.getValidatorFeeState() -> {
-  excess: uint64,
-  price: uint64,
-  timestamp: string
-}
-```
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc": "2.0",
-    "method": "platform.getValidatorFeeState",
-    "params": {},
-    "id": 1
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
-```
-
-**Example Response:**
-
-```json
-{
-    "jsonrpc": "2.0",
-    "result": {
-		    "excess":26956,
-		    "price":512,
-		    "timestamp":"2024-12-16T17:19:07Z"
-    },
-    "id": 1
+  "jsonrpc": "2.0",
+  "result": {
+    "height": "56"
+  },
+  "id": 1
 }
 ```
 
@@ -1005,62 +956,26 @@ curl -X POST --data '{
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "result": {
-        "subnetID": "2DeHa7Qb6sufPkmQcFWG2uCd4pBPv9WB6dkzroiMQhd1NSRtof",
-        "nodeID": "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
-        "publicKey": "0x900c9b119b5c82d781d4b49be78c3fc7ae65f2b435b7ed9e3a8b9a03e475edff86d8a64827fec8db23a6f236afbf127d",
-        "remainingBalanceOwner": {
-            "locktime": "0",
-            "threshold": "0",
-            "addresses": []
-        },
-        "deactivationOwner": {
-            "locktime": "0",
-            "threshold": "0",
-            "addresses": []
-        },
-        "startTime": "1731445206",
-        "weight": "49463",
-        "minNonce": "0",
-        "balance": "1000000000",
-        "height": "3"
-    },
-    "id": 1
-}
-```
-
-### `platform.getHeight`
-
-Returns the height of the last accepted block.
-
-**Signature:**
-
-```
-platform.getHeight() ->
-{
-  height: int,
-}
-```
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc": "2.0",
-    "method": "platform.getHeight",
-    "params": {},
-    "id": 1
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
-```
-
-**Example Response:**
-
-```json
-{
   "jsonrpc": "2.0",
   "result": {
-    "height": "56"
+    "subnetID": "2DeHa7Qb6sufPkmQcFWG2uCd4pBPv9WB6dkzroiMQhd1NSRtof",
+    "nodeID": "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
+    "publicKey": "0x900c9b119b5c82d781d4b49be78c3fc7ae65f2b435b7ed9e3a8b9a03e475edff86d8a64827fec8db23a6f236afbf127d",
+    "remainingBalanceOwner": {
+      "locktime": "0",
+      "threshold": "0",
+      "addresses": []
+    },
+    "deactivationOwner": {
+      "locktime": "0",
+      "threshold": "0",
+      "addresses": []
+    },
+    "startTime": "1731445206",
+    "weight": "49463",
+    "minNonce": "0",
+    "balance": "1000000000",
+    "height": "3"
   },
   "id": 1
 }
@@ -1534,7 +1449,10 @@ curl -X POST --data '{
   "jsonrpc": "2.0",
   "result": {
     "isPermissioned": true,
-    "controlKeys": ["P-fuji1ztvstx6naeg6aarfd047fzppdt8v4gsah88e0c","P-fuji193kvt4grqewv6ce2x59wnhydr88xwdgfcedyr3"],
+    "controlKeys": [
+      "P-fuji1ztvstx6naeg6aarfd047fzppdt8v4gsah88e0c",
+      "P-fuji193kvt4grqewv6ce2x59wnhydr88xwdgfcedyr3"
+    ],
     "threshold": "1",
     "locktime": "0",
     "subnetTransformationTxID": "11111111111111111111111111111111LpoYY",
@@ -2060,7 +1978,7 @@ platform.getValidatorsAt(
 ```
 
 - `height` is the P-Chain height to get the validator set at, or the string literal "proposed"
-  to return the validator set at this node's ProposerVM height. 
+  to return the validator set at this node's ProposerVM height.
 - `subnetID` is the Subnet ID to get the validator set of. If not given, gets validator set of the
   Primary Network.
 
@@ -2090,6 +2008,92 @@ curl -X POST --data '{
       "NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN": 2000000000000000,
       "NodeID-P7oB2McjBGgW2NXXWVYjV8JEDFoW9xDE5": 2000000000000000
     }
+  },
+  "id": 1
+}
+```
+
+### `platform.getValidatorFeeConfig`
+
+Returns the validator fee configuration of the P-chain.
+
+**Signature:**
+
+```
+platform.getValidatorFeeConfig() -> {
+  capacity: uint64,
+  target: uint64,
+  minPrice: uint64,
+  excessConversionConstant: uint64
+}
+```
+
+- `capacity` is the maximum number of L1 validators the chain is allowed to have at any given time
+- `target` is the target number of L1 validators the chain should have to keep fees stable
+- `minPrice` is the minimum price per L1 validator
+- `excessConversionConstant` is used to convert excess L1 validators to a gas price
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc": "2.0",
+    "method": "platform.getValidatorFeeConfig",
+    "params": {},
+    "id": 1
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "capacity": 20000,
+    "target": 10000,
+    "targetPerSecond": 50000,
+    "minPrice": 512,
+    "excessConversionConstant": 1246488515
+  },
+  "id": 1
+}
+```
+
+### `platform.getValidatorFeeState`
+
+Returns the current validator fee state of the P-chain.
+
+**Signature:**
+
+```
+platform.getValidatorFeeState() -> {
+  excess: uint64,
+  price: uint64,
+  timestamp: string
+}
+```
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc": "2.0",
+    "method": "platform.getValidatorFeeState",
+    "params": {},
+    "id": 1
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "excess": 26956,
+    "price": 512,
+    "timestamp": "2024-12-16T17:19:07Z"
   },
   "id": 1
 }

--- a/vms/platformvm/service.md
+++ b/vms/platformvm/service.md
@@ -770,7 +770,7 @@ curl -X POST --data '{
 
 ### `platform.getFeeConfig`
 
-Returns the dynamic fees configuration of the P-chain.
+Returns the dynamic fee configuration of the P-chain.
 
 **Signature:**
 
@@ -855,6 +855,92 @@ curl -X POST --data '{
 		    "capacity":973044,
 		    "excess":26956,
 		    "price":1,
+		    "timestamp":"2024-12-16T17:19:07Z"
+    },
+    "id": 1
+}
+```
+
+### `platform.getValidatorFeeConfig`
+
+Returns the validator fee configuration of the P-chain.
+
+**Signature:**
+
+```
+platform.getValidatorFeeConfig() -> {
+  capacity: uint64,
+  target: uint64,
+  minPrice: uint64,
+  excessConversionConstant: uint64
+}
+```
+
+- `capacity` is the maximum number of L1 validators the chain is allowed to have at any given time
+- `target` is the target number of L1 validators the chain should have to keep fees stable
+- `minPrice` is the minimum price per L1 validator
+- `excessConversionConstant` is used to convert excess L1 validators to a gas price
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc": "2.0",
+    "method": "platform.getValidatorFeeConfig",
+    "params": {},
+    "id": 1
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
+```
+
+**Example Response:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "capacity": 20000,
+        "target": 10000,
+        "targetPerSecond": 50000,
+        "minPrice": 512,
+        "excessConversionConstant": 1246488515
+    },
+    "id": 1
+}
+```
+
+### `platform.getValidatorFeeState`
+
+Returns the current validator fee state of the P-chain.
+
+**Signature:**
+
+```
+platform.getValidatorFeeState() -> {
+  excess: uint64,
+  price: uint64,
+  timestamp: string
+}
+```
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc": "2.0",
+    "method": "platform.getValidatorFeeState",
+    "params": {},
+    "id": 1
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
+```
+
+**Example Response:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+		    "excess":26956,
+		    "price":512,
 		    "timestamp":"2024-12-16T17:19:07Z"
     },
     "id": 1

--- a/vms/platformvm/service.md
+++ b/vms/platformvm/service.md
@@ -2062,7 +2062,7 @@ curl -X POST --data '{
 
 ### `platform.getValidatorFeeState`
 
-Returns the current validator fee state of the P-chain.
+Returns the current validator fee state of the P-Chain.
 
 **Signature:**
 

--- a/vms/platformvm/service.md
+++ b/vms/platformvm/service.md
@@ -900,7 +900,6 @@ curl -X POST --data '{
     "result": {
         "capacity": 20000,
         "target": 10000,
-        "targetPerSecond": 50000,
         "minPrice": 512,
         "excessConversionConstant": 1246488515
     },

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -1344,7 +1344,7 @@ func TestGetFeeConfig(t *testing.T) {
 }
 
 func FuzzGetFeeState(f *testing.F) {
-	f.Fuzz(func(t *testing.T, capacity, excess, l1ValidatorExcess uint64) {
+	f.Fuzz(func(t *testing.T, capacity, excess uint64) {
 		require := require.New(t)
 
 		service, _ := defaultService(t)

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/validators/fee"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 
@@ -1333,38 +1334,17 @@ func TestServiceGetSubnets(t *testing.T) {
 }
 
 func TestGetFeeConfig(t *testing.T) {
-	tests := []struct {
-		name     string
-		etnaTime time.Time
-		expected gas.Config
-	}{
-		{
-			name:     "pre-etna",
-			etnaTime: time.Now().Add(time.Hour),
-			expected: gas.Config{},
-		},
-		{
-			name:     "post-etna",
-			etnaTime: time.Now().Add(-time.Hour),
-			expected: defaultDynamicFeeConfig,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			require := require.New(t)
+	require := require.New(t)
 
-			service, _ := defaultService(t)
-			service.vm.Internal.UpgradeConfig.EtnaTime = test.etnaTime
+	service, _ := defaultService(t)
 
-			var reply gas.Config
-			require.NoError(service.GetFeeConfig(nil, nil, &reply))
-			require.Equal(test.expected, reply)
-		})
-	}
+	var reply gas.Config
+	require.NoError(service.GetFeeConfig(nil, nil, &reply))
+	require.Equal(defaultDynamicFeeConfig, reply)
 }
 
 func FuzzGetFeeState(f *testing.F) {
-	f.Fuzz(func(t *testing.T, capacity, excess uint64) {
+	f.Fuzz(func(t *testing.T, capacity, excess, l1ValidatorExcess uint64) {
 		require := require.New(t)
 
 		service, _ := defaultService(t)
@@ -1388,6 +1368,47 @@ func FuzzGetFeeState(f *testing.F) {
 
 		service.vm.ctx.Lock.Lock()
 		service.vm.state.SetFeeState(expectedState)
+		service.vm.state.SetTimestamp(expectedTime)
+		service.vm.ctx.Lock.Unlock()
+
+		var reply GetFeeStateReply
+		require.NoError(service.GetFeeState(nil, nil, &reply))
+		require.Equal(expectedReply, reply)
+	})
+}
+
+func TestGetValidatorFeeConfig(t *testing.T) {
+	require := require.New(t)
+
+	service, _ := defaultService(t)
+
+	var reply fee.Config
+	require.NoError(service.GetValidatorFeeConfig(nil, nil, &reply))
+	require.Equal(defaultValidatorFeeConfig, reply)
+}
+
+func FuzzGetValidatorFeeState(f *testing.F) {
+	f.Fuzz(func(t *testing.T, l1ValidatorExcess uint64) {
+		require := require.New(t)
+
+		service, _ := defaultService(t)
+
+		var (
+			expectedL1ValidatorExcess = gas.Gas(l1ValidatorExcess)
+			expectedTime              = time.Now()
+			expectedReply             = GetValidatorFeeStateReply{
+				Excess: expectedL1ValidatorExcess,
+				Price: gas.CalculatePrice(
+					defaultValidatorFeeConfig.MinPrice,
+					expectedL1ValidatorExcess,
+					defaultValidatorFeeConfig.ExcessConversionConstant,
+				),
+				Time: expectedTime,
+			}
+		)
+
+		service.vm.ctx.Lock.Lock()
+		service.vm.state.SetL1ValidatorExcess(expectedL1ValidatorExcess)
 		service.vm.state.SetTimestamp(expectedTime)
 		service.vm.ctx.Lock.Unlock()
 

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -1412,8 +1412,8 @@ func FuzzGetValidatorFeeState(f *testing.F) {
 		service.vm.state.SetTimestamp(expectedTime)
 		service.vm.ctx.Lock.Unlock()
 
-		var reply GetFeeStateReply
-		require.NoError(service.GetFeeState(nil, nil, &reply))
+		var reply GetValidatorFeeStateReply
+		require.NoError(service.GetValidatorFeeState(nil, nil, &reply))
 		require.Equal(expectedReply, reply)
 	})
 }

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/txstest"
+	"github.com/ava-labs/avalanchego/vms/platformvm/validators/fee"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/chain/p/wallet"
 
@@ -105,6 +106,12 @@ var (
 		MinPrice:                 1,
 		ExcessConversionConstant: 5_000,
 	}
+	defaultValidatorFeeConfig = fee.Config{
+		Capacity:                 100,
+		Target:                   50,
+		MinPrice:                 1,
+		ExcessConversionConstant: 100,
+	}
 
 	// subnet that exists at genesis in defaultVM
 	testSubnet1 *txs.Tx
@@ -126,6 +133,7 @@ func defaultVM(t *testing.T, f upgradetest.Fork) (*VM, database.Database, *mutab
 		SybilProtectionEnabled: true,
 		Validators:             validators.NewManager(),
 		DynamicFeeConfig:       defaultDynamicFeeConfig,
+		ValidatorFeeConfig:     defaultValidatorFeeConfig,
 		MinValidatorStake:      defaultMinValidatorStake,
 		MaxValidatorStake:      defaultMaxValidatorStake,
 		MinDelegatorStake:      defaultMinDelegatorStake,


### PR DESCRIPTION
## Why this should be merged

Currently it is difficult to learn what the current fee is for L1 validators.

## How this works

Adds APIs:
  - `platform.getValidatorFeeConfig`
  - `platform.getValidatorFeeState`

It was decided against modifying the existing APIs `platform.getFeeConfig` and `platform.getFeeState` because that would have made the types more complex.

## How this was tested

Added unit tests similar to `platform.getFeeConfig` and `platform.getFeeState`.

## Need to be documented in RELEASES.md?

Documented the new APIs in both `service.md` and `RELEASES.md`.
