### PR TITLE
chore: replaced faulty link

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ avalanche network status
 
 A node needs to catch up to the latest network state before it can participate in consensus and serve API calls. This process (called bootstrapping) currently takes several days for a new node connected to Mainnet.
 
-A node will not [report healthy](https://docs.avax.network/build/avalanchego-apis/health) until it is done bootstrapping.
+A node will not [report healthy](https://docs.avax.network/api-reference/health-api) until it is done bootstrapping.
 
 Improvements that reduce the amount of time it takes to bootstrap are under development.
 


### PR DESCRIPTION

the previous link did not work, replaced it with a new one