### PR TITLE
[docker] Switch to kube-compatible plugin path for images

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -36,6 +36,14 @@ const (
 	defaultUnexpandedDataDir = "$" + AvalancheGoDataDirVar
 
 	DefaultProcessContextFilename = "process.json"
+
+	// The default plugin path of $HOME/.avalanchego/plugins is not
+	// suitable for docker images since $HOME might be writable but
+	// the plugin directory should not be. The value below is in the
+	// same hierarchy as avalanchego on the docker image
+	// (/avalanchego/build/avalanchego) and consistent with the
+	// location already used by subnet-evm.
+	DefaultImagePluginDir = "/avalanchego/build/plugins"
 )
 
 var (

--- a/tests/antithesis/avalanchego/gencomposeconfig/main.go
+++ b/tests/antithesis/avalanchego/gencomposeconfig/main.go
@@ -18,7 +18,7 @@ const baseImageName = "antithesis-avalanchego"
 // Creates docker-compose.yml and its associated volumes in the target path.
 func main() {
 	network := tmpnet.LocalNetworkOrPanic()
-	if err := antithesis.GenerateComposeConfig(network, baseImageName, "" /* runtimePluginDir */); err != nil {
+	if err := antithesis.GenerateComposeConfig(network, baseImageName); err != nil {
 		tests.NewDefaultLogger("").Fatal("failed to generate compose config",
 			zap.Error(err),
 		)

--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -31,9 +31,8 @@ var (
 
 // Creates docker compose configuration for an antithesis test setup. Configuration is via env vars to
 // simplify usage by main entrypoints. If the provided network includes a subnet, the initial DB state for
-// the subnet will be created and written to the target path. The runtimePluginDir should be set if the node
-// image used for the test setup uses a path other than the default (~/.avalanchego/plugins).
-func GenerateComposeConfig(network *tmpnet.Network, baseImageName string, runtimePluginDir string) error {
+// the subnet will be created and written to the target path.
+func GenerateComposeConfig(network *tmpnet.Network, baseImageName string) error {
 	targetPath := os.Getenv("TARGET_PATH")
 	if len(targetPath) == 0 {
 		return errTargetPathEnvVarNotSet
@@ -70,7 +69,7 @@ func GenerateComposeConfig(network *tmpnet.Network, baseImageName string, runtim
 	nodeImageName := fmt.Sprintf("%s-node:%s", baseImageName, imageTag)
 	workloadImageName := fmt.Sprintf("%s-workload:%s", baseImageName, imageTag)
 
-	if err := initComposeConfig(network, nodeImageName, workloadImageName, targetPath, runtimePluginDir); err != nil {
+	if err := initComposeConfig(network, nodeImageName, workloadImageName, targetPath); err != nil {
 		return fmt.Errorf("failed to generate compose config: %w", err)
 	}
 
@@ -84,10 +83,9 @@ func initComposeConfig(
 	nodeImageName string,
 	workloadImageName string,
 	targetPath string,
-	pluginDir string,
 ) error {
 	// Generate a compose project for the specified network
-	project, err := newComposeProject(network, nodeImageName, workloadImageName, pluginDir)
+	project, err := newComposeProject(network, nodeImageName, workloadImageName)
 	if err != nil {
 		return fmt.Errorf("failed to create compose project: %w", err)
 	}
@@ -125,7 +123,7 @@ func initComposeConfig(
 
 // Create a new docker compose project for an antithesis test setup
 // for the provided network configuration.
-func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadImageName string, pluginDir string) (*types.Project, error) {
+func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadImageName string) (*types.Project, error) {
 	networkName := "avalanche-testnet"
 	baseNetworkAddress := "10.0.20"
 
@@ -163,11 +161,6 @@ func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadIm
 			config.StakingSignerKeyContentKey: signerKey,
 		}
 
-		// Set a non-default plugin dir if provided
-		if len(pluginDir) > 0 {
-			env[config.PluginDirKey] = pluginDir
-		}
-
 		// Apply configuration appropriate to a test network
 		for k, v := range tmpnet.DefaultTestFlags() {
 			switch value := v.(type) {
@@ -195,6 +188,11 @@ func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadIm
 			return nil, err
 		}
 		if len(trackSubnets) > 0 {
+			// The plugin dir is only required when subnets will be
+			// tracked. VM images are expected to put their plugins in
+			// the default dir.
+			env[config.PluginDirKey] = config.DefaultImagePluginDir
+
 			env[config.TrackSubnetsKey] = trackSubnets
 			if i == bootstrapIndex {
 				// DB volume for bootstrap node will need to initialized with the subnet

--- a/tests/antithesis/xsvm/Dockerfile.node
+++ b/tests/antithesis/xsvm/Dockerfile.node
@@ -24,8 +24,7 @@ FROM $AVALANCHEGO_NODE_IMAGE AS execution
 ARG BUILDER_WORKDIR
 
 # Copy the executable into the container
-RUN mkdir -p /root/.avalanchego/plugins
 COPY --from=builder $BUILDER_WORKDIR/build/xsvm \
-    /root/.avalanchego/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH
+    /avalanchego/build/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH
 
 # The node image's entrypoint will be reused.

--- a/tests/antithesis/xsvm/gencomposeconfig/main.go
+++ b/tests/antithesis/xsvm/gencomposeconfig/main.go
@@ -23,7 +23,7 @@ func main() {
 	network.Subnets = []*tmpnet.Subnet{
 		subnet.NewXSVMOrPanic("xsvm", genesis.VMRQKey, network.Nodes...),
 	}
-	if err := antithesis.GenerateComposeConfig(network, baseImageName, "" /* runtimePluginDir */); err != nil {
+	if err := antithesis.GenerateComposeConfig(network, baseImageName); err != nil {
 		tests.NewDefaultLogger("").Fatal("failed to generate compose config",
 			zap.Error(err),
 		)

--- a/vms/example/xsvm/Dockerfile
+++ b/vms/example/xsvm/Dockerfile
@@ -24,8 +24,7 @@ RUN ./scripts/build_xsvm.sh
 # ============= Cleanup Stage ================
 FROM $AVALANCHEGO_NODE_IMAGE AS execution
 
-# Copy the xsvm binary to the default plugin path
-RUN mkdir -p /root/.avalanchego/plugins
-COPY --from=builder /build/build/xsvm /root/.avalanchego/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH
+# Copy the xsvm binary to the default plugin dir for images
+COPY --from=builder /build/build/xsvm /avalanchego/build/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH
 
 # The node image's entrypoint will be reused.


### PR DESCRIPTION
## Why this should be merged

In attempting to deploy the xsvm docker image to kube, it became apparent that an image using the default plugin dir (`~/.avalanchego/plugins`) wasn't compatible with execution in kube due to permission issues. 

## How this works

- Uses `/avalanchego/build/plugins` as the plugin dir for images
- Updates xsvm image and antithesis configuration to use the new plugin dir

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A