### PR TITLE
X-Chain API fix

### DIFF
--- a/vms/avm/service.md
+++ b/vms/avm/service.md
@@ -233,10 +233,6 @@ curl -X POST --data '{
 }
 ```
 
-<!--
-TODO: Add avm.createAsset
--->
-
 ### `avm.createFixedCapAsset`
 
 :::caution
@@ -596,10 +592,6 @@ curl -X POST --data '{
   "id": 1
 }
 ```
-
-<!--
-TODO: Add avm.exportAVAX
--->
 
 ### `avm.exportKey`
 
@@ -1490,10 +1482,6 @@ curl -X POST --data '{
   "id": 1
 }
 ```
-
-<!--
-TODO: Add avm.importAVAX
--->
 
 ### `avm.importKey`
 


### PR DESCRIPTION
## Why this should be merged

The docs site fails to build due to the following error:

```
api.mdx:237:2: Unexpected character `!` (U+0021) before name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a comment in MDX, use `{/* text */}`)
```

## How this works

Removes formatting that cause build to fail

## How this was tested

na

## Need to be documented in RELEASES.md?

no
