### PR TITLE
remove x-chain api obsolete metadata 

### DIFF
--- a/vms/avm/service.md
+++ b/vms/avm/service.md
@@ -1,14 +1,10 @@
 ---
-tags: [X-Chain, AvalancheGo APIs]
+title: X-Chain API
 description: This page is an overview of the Exchange Chain (X-Chain) API associated with AvalancheGo.
-sidebar_label: API
-pagination_label: X-Chain API
 ---
 
-# X-Chain API
-
 The [X-Chain](/learn/avalanche/avalanche-platform.md#x-chain),
-Avalanche’s native platform for creating and trading assets, is an instance of the Avalanche Virtual
+Avalanche's native platform for creating and trading assets, is an instance of the Avalanche Virtual
 Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances
 of the AVM.
 

--- a/vms/avm/service.md
+++ b/vms/avm/service.md
@@ -1,8 +1,3 @@
----
-title: X-Chain API
-description: This page is an overview of the Exchange Chain (X-Chain) API associated with AvalancheGo.
----
-
 The [X-Chain](/learn/avalanche/avalanche-platform.md#x-chain),
 Avalanche's native platform for creating and trading assets, is an instance of the Avalanche Virtual
 Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances


### PR DESCRIPTION
## Why this should be merged

Removes metadata that is no longer processed by the docs' new framework.

## How this works

removes metadata from top of doc

## How this was tested

local build of docs

## Need to be documented in RELEASES.md?

no
