### PR TITLE
Reintroduce the deprecated `info.getTxFee` API

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,7 +8,7 @@ The plugin version is unchanged at `38` and is compatible with versions `v1.12.0
 
 ### APIs
 
-- Removed:
+- Deprecated:
   - `info.GetTxFee`
 - Added:
   - `avm.GetTxFee`

--- a/api/info/service.md
+++ b/api/info/service.md
@@ -382,6 +382,73 @@ curl -X POST --data '{
 }
 ```
 
+### `info.getTxFee`
+
+<Callout type="warn">
+Deprecated as of [v1.12.2](https://github.com/ava-labs/avalanchego/releases/tag/v1.12.2).
+</Callout>
+
+Get the fees of the network.
+
+**Signature**:
+
+```
+info.getTxFee() ->
+{
+  txFee: uint64,
+  createAssetTxFee: uint64,
+  createSubnetTxFee: uint64,
+  transformSubnetTxFee: uint64,
+  createBlockchainTxFee: uint64,
+  addPrimaryNetworkValidatorFee: uint64,
+  addPrimaryNetworkDelegatorFee: uint64,
+  addSubnetValidatorFee: uint64,
+  addSubnetDelegatorFee: uint64
+}
+```
+
+- `txFee` is the default fee for issuing X-Chain transactions.
+- `createAssetTxFee` is the fee for issuing a `CreateAssetTx` on the X-Chain.
+- `createSubnetTxFee` is no longer used.
+- `transformSubnetTxFee` is no longer used.
+- `createBlockchainTxFee` is no longer used.
+- `addPrimaryNetworkValidatorFee` is no longer used.
+- `addPrimaryNetworkDelegatorFee` is no longer used.
+- `addSubnetValidatorFee` is no longer used.
+- `addSubnetDelegatorFee` is no longer used.
+
+All fees are denominated in nAVAX.
+
+**Example Call**:
+
+```sh
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"info.getTxFee"
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/info
+```
+
+**Example Response**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "txFee": "1000000",
+    "createAssetTxFee": "10000000",
+    "createSubnetTxFee": "1000000000",
+    "transformSubnetTxFee": "10000000000",
+    "createBlockchainTxFee": "1000000000",
+    "addPrimaryNetworkValidatorFee": "0",
+    "addPrimaryNetworkDelegatorFee": "0",
+    "addSubnetValidatorFee": "1000000",
+    "addSubnetDelegatorFee": "1000000"
+  }
+}
+```
+
 ### `info.getVMs`
 
 Get the virtual machines installed on this node.

--- a/node/node.go
+++ b/node/node.go
@@ -1409,6 +1409,9 @@ func (n *Node) initInfoAPI() error {
 			NetworkID: n.Config.NetworkID,
 			VMManager: n.VMManager,
 			Upgrades:  n.Config.UpgradeConfig,
+
+			TxFee:            n.Config.TxFee,
+			CreateAssetTxFee: n.Config.CreateAssetTxFee,
 		},
 		n.Log,
 		n.vdrs,


### PR DESCRIPTION
## Why this should be merged

This API can't be removed without a deprecation window. It'll likely be removed in a few releases.

## How this works

Reintroduces `info.getTxFee` in a minimally invasive way and marks it as deprecated.

## How this was tested

Manually.

## Need to be documented in RELEASES.md?

Done.