### PR TITLE
Silence docker InvalidDefaultArgInFrom warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
-ARG GO_VERSION
+ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 # Always use the native platform to ensure fast builds

--- a/tests/antithesis/Dockerfile.builder-instrumented
+++ b/tests/antithesis/Dockerfile.builder-instrumented
@@ -1,6 +1,6 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
-ARG GO_VERSION
+ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
 
 # Antithesis: Getting the Antithesis golang instrumentation library
 FROM docker.io/antithesishq/go-instrumentor AS instrumentor

--- a/tests/antithesis/Dockerfile.builder-uninstrumented
+++ b/tests/antithesis/Dockerfile.builder-uninstrumented
@@ -1,6 +1,6 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
-ARG GO_VERSION
+ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
 
 FROM golang:$GO_VERSION-bullseye
 

--- a/tests/antithesis/avalanchego/Dockerfile.node
+++ b/tests/antithesis/avalanchego/Dockerfile.node
@@ -1,5 +1,5 @@
 # BUILDER_IMAGE_TAG should identify the builder image
-ARG BUILDER_IMAGE_TAG
+ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/tests/antithesis/avalanchego/Dockerfile.workload
+++ b/tests/antithesis/avalanchego/Dockerfile.workload
@@ -1,8 +1,8 @@
 # BUILDER_IMAGE_TAG should identify the builder image
-ARG BUILDER_IMAGE_TAG
+ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE
+ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/tests/antithesis/xsvm/Dockerfile.node
+++ b/tests/antithesis/xsvm/Dockerfile.node
@@ -1,8 +1,8 @@
 # BUILDER_IMAGE_TAG should identify the builder image
-ARG BUILDER_IMAGE_TAG
+ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing avalanchego node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE
+ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/tests/antithesis/xsvm/Dockerfile.workload
+++ b/tests/antithesis/xsvm/Dockerfile.workload
@@ -1,8 +1,8 @@
 # BUILDER_IMAGE_TAG should identify the builder image
-ARG BUILDER_IMAGE_TAG
+ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE
+ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/vms/example/xsvm/Dockerfile
+++ b/vms/example/xsvm/Dockerfile
@@ -1,9 +1,9 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
-ARG GO_VERSION
+ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE
+ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM golang:$GO_VERSION-bullseye AS builder


### PR DESCRIPTION
# Why this should be merged

All docker images in this repo depend on argument input for which defaults are not possible, but docker emits warnings for args without defaults. So, dummy defaults to work around docker's DX.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A