### PR TITLE
[ci] Use go env {GOOS,GOARCH} for os and arch detection

### DIFF
--- a/scripts/run_prometheus.sh
+++ b/scripts/run_prometheus.sh
@@ -61,23 +61,19 @@ if ! command -v "${CMD}" &> /dev/null; then
   if ! command -v "${CMD}" &> /dev/null; then
     echo "prometheus not found, attempting to install..."
 
-    # Determine the arch
-    if which sw_vers &> /dev/null; then
+    GOOS="$(go env GOOS)"
+    GOARCH="$(go env GOARCH)"
+    if [[ "${GOOS}" == "darwin" && "${GOARCH}" == "arm64" ]]; then
       echo "On macos, only amd64 binaries are available so rosetta is required on apple silicon machines."
       echo "To avoid using rosetta, install via homebrew: brew install prometheus"
-      DIST=darwin
-    else
-      ARCH="$(uname -i)"
-      if [[ "${ARCH}" != "x86_64" ]]; then
-        echo "On linux, only amd64 binaries are available. manual installation of prometheus is required."
+    fi
+    if [[ "${GOOS}" == "linux" && "${GOARCH}" != "amd64" ]]; then
+        echo "On linux, only amd64 binaries are available. Manual installation of prometheus is required."
         exit 1
-      else
-        DIST="linux"
-      fi
     fi
 
     # Install the specified release
-    PROMETHEUS_FILE="prometheus-${VERSION}.${DIST}-amd64"
+    PROMETHEUS_FILE="prometheus-${VERSION}.${GOOS}-amd64"
     URL="https://github.com/prometheus/prometheus/releases/download/v${VERSION}/${PROMETHEUS_FILE}.tar.gz"
     curl -s -L "${URL}" | tar zxv -C /tmp > /dev/null
     mkdir -p "$(dirname "${CMD}")"

--- a/scripts/run_promtail.sh
+++ b/scripts/run_promtail.sh
@@ -57,18 +57,11 @@ if ! command -v "${CMD}" &> /dev/null; then
   CMD="${PWD}/bin/promtail"
   if ! command -v "${CMD}" &> /dev/null; then
     echo "promtail not found, attempting to install..."
-    # Determine the arch
-    if which sw_vers &> /dev/null; then
-      DIST="darwin-$(uname -m)"
-    else
-      ARCH="$(uname -i)"
-      if [[ "${ARCH}" == "aarch64" ]]; then
-        ARCH="arm64"
-      elif [[ "${ARCH}" == "x86_64" ]]; then
-        ARCH="amd64"
-      fi
-      DIST="linux-${ARCH}"
-    fi
+
+    # Determine the platform
+    GOOS="$(go env GOOS)"
+    GOARCH="$(go env GOARCH)"
+    DIST="${GOOS}-${GOARCH}"
 
     # Install the specified release
     PROMTAIL_FILE="promtail-${DIST}"

--- a/scripts/tests.e2e.bootstrap_monitor.sh
+++ b/scripts/tests.e2e.bootstrap_monitor.sh
@@ -9,26 +9,8 @@ if ! [[ "$0" =~ scripts/tests.e2e.bootstrap_monitor.sh ]]; then
   exit 255
 fi
 
-# Determine DIST and ARCH in case installation is required for kubectl and kind
-#
-# TODO(marun) Factor this out for reuse
-if which sw_vers &> /dev/null; then
-  OS="darwin"
-  ARCH="$(uname -m)"
-else
-  # Assume linux (windows is not supported)
-  OS="linux"
-  RAW_ARCH="$(uname -i)"
-  # Convert the linux arch string to the string used for k8s releases
-  if [[ "${RAW_ARCH}" == "aarch64" ]]; then
-    ARCH="arm64"
-  elif [[ "${RAW_ARCH}" == "x86_64" ]]; then
-    ARCH="amd64"
-  else
-    echo "Unsupported architecture: ${RAW_ARCH}"
-    exit 1
-  fi
-fi
+GOOS="$(go env GOOS)"
+GOARCH="$(go env GOARCH)"
 
 function ensure_command {
   local cmd=$1
@@ -49,11 +31,11 @@ function ensure_command {
 
 # Ensure the kubectl command is available
 KUBECTL_VERSION=v1.30.2
-ensure_command kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${OS}/${ARCH}/kubectl"
+ensure_command kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${GOOS}/${GOARCH}/kubectl"
 
 # Ensure the kind command is available
 KIND_VERSION=v0.23.0
-ensure_command kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${OS}-${ARCH}"
+ensure_command kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${GOOS}-${GOARCH}"
 
 # Ensure the kind-with-registry command is available
 ensure_command "kind-with-registry.sh" "https://raw.githubusercontent.com/kubernetes-sigs/kind/7cb9e6be25b48a0e248097eef29d496ab1a044d0/site/static/examples/kind-with-registry.sh"


### PR DESCRIPTION
## Why this should be merged

Some scripts were discovering the os and arch of tools to install in unnecessarily complicated ways. Switching them to use the simpler `go env GOOS` and `go env GOOARCH` methods.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A