### PR TITLE
[testing] Ensure run_prometheus.sh uses a writeable storage path

### DIFF
--- a/scripts/run_prometheus.sh
+++ b/scripts/run_prometheus.sh
@@ -115,7 +115,7 @@ echo "Wrote configuration to ${CONFIG_PATH}"
 
 echo "Starting prometheus..."
 cd "${PROMETHEUS_WORKING_DIR}"
-nohup "${CMD}" --config.file=prometheus.yaml --web.listen-address=localhost:0 --enable-feature=agent > prometheus.log 2>&1 &
+nohup "${CMD}" --config.file=prometheus.yaml --storage.agent.path=./data --web.listen-address=localhost:0 --enable-feature=agent > prometheus.log 2>&1 &
 echo $! > "${PIDFILE}"
 echo "prometheus started with pid $(cat "${PIDFILE}")"
 # shellcheck disable=SC2016


### PR DESCRIPTION
## Why this should be merged

If prometheus was installed by apt it will default to a /var storage path that isn't writeable by a non-root user. Explicitly specifying a writeable storage path ensures compatibility no matter how prometheus was installed.

## How this was tested

CI, locally

## Need to be documented in RELEASES.md?

N/A