### PR TITLE
[testing] Refactor kube cluster deployment for reuse

### DIFF
--- a/scripts/ensure_kube_cluster.sh
+++ b/scripts/ensure_kube_cluster.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script ensures that a kubernetes cluster is available with the
+# default kubeconfig. If a cluster is not already running, kind will
+# be used to start one.
+
+if ! [[ "$0" =~ scripts/ensure_kube_cluster.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+function ensure_command {
+  local cmd=$1
+  local install_uri=$2
+
+  echo "Ensuring ${cmd} is available"
+  if ! command -v "${cmd}" &> /dev/null; then
+    local local_cmd="${PWD}/bin/${cmd}"
+    mkdir -p "${PWD}/bin"
+    echo "${cmd} not found, attempting to install..."
+    curl -L -o "${local_cmd}" "${install_uri}"
+    # TODO(marun) Optionally validate the binary against published checksum
+    chmod +x "${local_cmd}"
+  fi
+}
+
+# Enables using a context other than the current default
+KUBE_CONTEXT="${KUBE_CONTEXT:-}"
+
+# Ensure locally-installed binaries are in the path
+PATH="${PWD}/bin:$PATH"
+
+# Determine the platform to download binaries for
+GOOS="$(go env GOOS)"
+GOARCH="$(go env GOARCH)"
+
+KUBECTL_VERSION=v1.30.2
+ensure_command kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${GOOS}/${GOARCH}/kubectl"
+
+# Compose the kubectl command
+KUBECTL_CMD="kubectl"
+if [[ -n "${KUBE_CONTEXT}" ]]; then
+  KUBECTL_CMD="${KUBECTL_CMD} --context=${KUBE_CONTEXT}"
+fi
+
+# Check if a cluster is already running
+if ${KUBECTL_CMD} cluster-info &> /dev/null; then
+  echo "A kube cluster is already accessible"
+  exit 0
+fi
+
+KIND_VERSION=v0.23.0
+ensure_command kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${GOOS}-${GOARCH}"
+
+SCRIPT_SHA=7cb9e6be25b48a0e248097eef29d496ab1a044d0
+ensure_command "kind-with-registry.sh" \
+  "https://raw.githubusercontent.com/kubernetes-sigs/kind/${SCRIPT_SHA}/site/static/examples/kind-with-registry.sh"
+
+echo "Deploying a new kind cluster with a local registry"
+bash -x "${PWD}/bin/kind-with-registry.sh"

--- a/scripts/tests.e2e.bootstrap_monitor.sh
+++ b/scripts/tests.e2e.bootstrap_monitor.sh
@@ -9,40 +9,6 @@ if ! [[ "$0" =~ scripts/tests.e2e.bootstrap_monitor.sh ]]; then
   exit 255
 fi
 
-GOOS="$(go env GOOS)"
-GOARCH="$(go env GOARCH)"
-
-function ensure_command {
-  local cmd=$1
-  local install_uri=$2
-
-  if ! command -v "${cmd}" &> /dev/null; then
-    # Try to use a local version
-    local local_cmd="${PWD}/bin/${cmd}"
-    mkdir -p "${PWD}/bin"
-    if ! command -v "${local_cmd}" &> /dev/null; then
-      echo "${cmd} not found, attempting to install..."
-      curl -L -o "${local_cmd}" "${install_uri}"
-      # TODO(marun) Optionally validate the binary against published checksum
-      chmod +x "${local_cmd}"
-    fi
-  fi
-}
-
-# Ensure the kubectl command is available
-KUBECTL_VERSION=v1.30.2
-ensure_command kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${GOOS}/${GOARCH}/kubectl"
-
-# Ensure the kind command is available
-KIND_VERSION=v0.23.0
-ensure_command kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${GOOS}-${GOARCH}"
-
-# Ensure the kind-with-registry command is available
-ensure_command "kind-with-registry.sh" "https://raw.githubusercontent.com/kubernetes-sigs/kind/7cb9e6be25b48a0e248097eef29d496ab1a044d0/site/static/examples/kind-with-registry.sh"
-
-# Deploy a kind cluster with a local registry. Include the local bin in the path to
-# ensure locally installed kind and kubectl are available since the script expects to
-# call them without a qualifying path.
-PATH="${PWD}/bin:$PATH" bash -x "${PWD}/bin/kind-with-registry.sh"
+./scripts/ensure_kube_cluster.sh
 
 KUBECONFIG="$HOME/.kube/config" PATH="${PWD}/bin:$PATH" ./scripts/ginkgo.sh -v ./tests/fixture/bootstrapmonitor/e2e


### PR DESCRIPTION
## Why this should be merged

In anticipation of using kube for more than bootstrap monitor testing, the functionality to deploy a kind cluster is factored out of the bootstrap monitor test script for reuse. The new script has also been updated to only deploy a cluster if one is not already running.

## How this was tested

CI, locally

## Need to be documented in RELEASES.md?

N/A

## TODO

 - [x] Merge https://github.com/ava-labs/avalanchego/pull/3661