### PR TITLE
[tmpnet] Update URI and StakingAddress usage in support of kube

### DIFF
--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -53,7 +53,7 @@ var _ = e2e.DescribeCChain("[Dynamic Fees]", func() {
 		node := privateNetwork.Nodes[0]
 		nodeURI := tmpnet.NodeURI{
 			NodeID: node.NodeID,
-			URI:    node.URI,
+			URI:    e2e.GetLocalURI(tc, node),
 		}
 		ethClient := e2e.NewEthClient(tc, nodeURI)
 

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -62,7 +62,8 @@ var _ = ginkgo.Describe("Duplicate node handling", func() {
 	})
 })
 
-// Check that a new node is connected to existing nodes and vice versa
+// Check that a new node is connected to existing nodes and vice versa.
+// Safe to use Node.URI directly as long as this test isn't running against kube-hosted nodes.
 func checkConnectedPeers(tc tests.TestContext, existingNodes []*tmpnet.Node, newNode *tmpnet.Node) {
 	require := require.New(tc)
 

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -112,7 +112,8 @@ var _ = e2e.DescribePChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainL
 		e2e.WaitForHealthy(tc, node)
 
 		tc.By("retrieving new node's id and pop")
-		infoClient := info.NewClient(node.URI)
+		uri := e2e.GetLocalURI(tc, node)
+		infoClient := info.NewClient(uri)
 		nodeID, nodePOP, err := infoClient.GetNodeID(tc.DefaultContext())
 		require.NoError(err)
 

--- a/tests/e2e/p/l1.go
+++ b/tests/e2e/p/l1.go
@@ -186,10 +186,11 @@ var _ = e2e.DescribePChain("[L1]", func() {
 		var (
 			networkID           = env.GetNetwork().GetNetworkID()
 			genesisPeerMessages = buffer.NewUnboundedBlockingDeque[p2pmessage.InboundMessage](1)
+			stakingAddress      = e2e.GetLocalStakingAddress(tc, subnetGenesisNode)
 		)
 		genesisPeer, err := peer.StartTestPeer(
 			tc.DefaultContext(),
-			subnetGenesisNode.StakingAddress,
+			stakingAddress,
 			networkID,
 			router.InboundHandlerFunc(func(_ context.Context, m p2pmessage.InboundMessage) {
 				tc.Log().Info("received a message",
@@ -201,6 +202,8 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			}),
 		)
 		require.NoError(err)
+
+		subnetGenesisNodeURI := e2e.GetLocalURI(tc, subnetGenesisNode)
 
 		address := []byte{}
 		tc.By("issuing a ConvertSubnetToL1Tx", func() {
@@ -220,9 +223,9 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			)
 			require.NoError(err)
 
-			tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNode.URI, func() {
+			tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNodeURI, func() {
 				var (
-					client = platformvm.NewClient(subnetGenesisNode.URI)
+					client = platformvm.NewClient(subnetGenesisNodeURI)
 					txID   = tx.ID()
 				)
 				tc.Eventually(
@@ -420,9 +423,9 @@ var _ = e2e.DescribePChain("[L1]", func() {
 				)
 				require.NoError(err)
 
-				tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNode.URI, func() {
+				tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNodeURI, func() {
 					var (
-						client = platformvm.NewClient(subnetGenesisNode.URI)
+						client = platformvm.NewClient(subnetGenesisNodeURI)
 						txID   = tx.ID()
 					)
 					tc.Eventually(
@@ -558,9 +561,9 @@ var _ = e2e.DescribePChain("[L1]", func() {
 				)
 				require.NoError(err)
 
-				tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNode.URI, func() {
+				tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNodeURI, func() {
 					var (
-						client = platformvm.NewClient(subnetGenesisNode.URI)
+						client = platformvm.NewClient(subnetGenesisNodeURI)
 						txID   = tx.ID()
 					)
 					tc.Eventually(

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -67,12 +67,14 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 		e2e.WaitForHealthy(tc, betaNode)
 
 		tc.By("retrieving alpha node id and pop")
-		alphaInfoClient := info.NewClient(alphaNode.URI)
+		alphaNodeURI := e2e.GetLocalURI(tc, alphaNode)
+		alphaInfoClient := info.NewClient(alphaNodeURI)
 		alphaNodeID, alphaPOP, err := alphaInfoClient.GetNodeID(tc.DefaultContext())
 		require.NoError(err)
 
 		tc.By("retrieving beta node id and pop")
-		betaInfoClient := info.NewClient(betaNode.URI)
+		betaNodeURI := e2e.GetLocalURI(tc, betaNode)
+		betaInfoClient := info.NewClient(betaNodeURI)
 		betaNodeID, betaPOP, err := betaInfoClient.GetNodeID(tc.DefaultContext())
 		require.NoError(err)
 
@@ -97,14 +99,14 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 			keychain = env.NewKeychain()
 			nodeURI  = tmpnet.NodeURI{
 				NodeID: alphaNodeID,
-				URI:    alphaNode.URI,
+				URI:    alphaNodeURI,
 			}
 			baseWallet = e2e.NewWallet(tc, keychain, nodeURI)
 			pWallet    = baseWallet.P()
 			pBuilder   = pWallet.Builder()
 			pContext   = pBuilder.Context()
 
-			pvmClient = platformvm.NewClient(alphaNode.URI)
+			pvmClient = platformvm.NewClient(alphaNodeURI)
 		)
 
 		tc.By("retrieving supply before adding alpha node as a validator")

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net/netip"
 	"os"
 	"strings"
 	"time"
@@ -352,4 +353,27 @@ func GetRepoRootPath(suffix string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSuffix(cwd, suffix), nil
+}
+
+// GetLocalURI retrieves the locally-accessible URI of the provided node. When a node
+// is running as a local process, this will be the URI exposed by the node. For a
+// node running remotely in kube, the URI will be a local address whose port is
+// forwarded to the node's URI through the kube API server.
+func GetLocalURI(tc tests.TestContext, node *tmpnet.Node) string {
+	uri, cancel, err := node.GetLocalURI(tc.DefaultContext())
+	require.NoError(tc, err)
+	tc.DeferCleanup(cancel)
+	return uri
+}
+
+// GetLocalStakingAddress retrieves the locally-accessible staking address of the
+// provided node. When a node is a local process, this will be the staking address
+// exposed by the node. For a node running remotely in kube, the staking address will
+// be a local address whose port will be forwarded to the node's staking address
+// through the kube API server.
+func GetLocalStakingAddress(tc tests.TestContext, node *tmpnet.Node) netip.AddrPort {
+	stakingAddress, cancel, err := node.GetLocalStakingAddress(tc.DefaultContext())
+	require.NoError(tc, err)
+	tc.DeferCleanup(cancel)
+	return stakingAddress
 }

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -338,6 +339,14 @@ func (p *NodeProcess) writeMonitoringConfigFile(tmpnetDir string, name string, c
 	}
 
 	return nil
+}
+
+func (p *NodeProcess) GetLocalURI(_ context.Context) (string, func(), error) {
+	return p.node.URI, func() {}, nil
+}
+
+func (p *NodeProcess) GetLocalStakingAddress(_ context.Context) (netip.AddrPort, func(), error) {
+	return p.node.StakingAddress, func() {}, nil
 }
 
 // watchLogFileForFatal waits for the specified file path to exist and then checks each of


### PR DESCRIPTION
## Why this should be merged

Previously, `Node.URI` and `Node.StakingAddress` fields contained values for a local process and were always locally accessible. Nodes running in kubernetes may be running remotely, though, and only be accessible if e.g. a local port is forwarded to the port of a node's pod. To ensure compatibility with forwarded URIs and StakingAddresses, callers that aren't guaranteed to be running locally to a node are updated to access these values via functions that can ensure a remote endpoint is forwarded if the target node isn't running locally.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A

## TODO

- [x] Merge https://github.com/ava-labs/avalanchego/pull/3650