### PR TITLE
add L1 validators API nits

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -39,8 +39,10 @@ The plugin version is unchanged at `38` and is compatible with versions `v1.12.0
   - `avm.GetTxFee`
   - `platform.getValidatorFeeConfig`
   - `platform.getValidatorFeeState`
-  - `validationID` to `platform.getL1Validator` results
+  - `validationID` field to `platform.getL1Validator` results
   - L1 validators to `platform.getCurrentValidators`
+- Removed:
+  - `StakeAmount` field from `platform.getCurrentValidators` results
 
 ### Configs
 
@@ -53,7 +55,7 @@ The plugin version is unchanged at `38` and is compatible with versions `v1.12.0
   - `--add-subnet-validator-fee`
   - `--add-subnet-delegator-fee`
 - Removed `--api-keystore-enabled`
-  
+
 ### What's Changed
 
 **Full Changelog**: https://github.com/ava-labs/avalanchego/compare/v1.12.1...v1.12.2

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -750,8 +750,10 @@ func (s *Service) getL1Validators(
 		return nil, err
 	}
 
+	fetchAll := nodeIDs.Len() == 0
+
 	for _, staker := range baseStakers {
-		if nodeIDs.Len() != 0 && !nodeIDs.Contains(staker.NodeID) {
+		if !fetchAll && !nodeIDs.Contains(staker.NodeID) {
 			continue
 		}
 
@@ -760,7 +762,7 @@ func (s *Service) getL1Validators(
 	}
 
 	for _, l1Validator := range l1Validators {
-		if nodeIDs.Len() != 0 && !nodeIDs.Contains(l1Validator.NodeID) {
+		if !fetchAll && !nodeIDs.Contains(l1Validator.NodeID) {
 			continue
 		}
 

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -656,7 +656,7 @@ type GetCurrentValidatorsArgs struct {
 // GetCurrentValidatorsReply are the results from calling GetCurrentValidators.
 // Each validator contains a list of delegators to itself.
 type GetCurrentValidatorsReply struct {
-	Validators []interface{} `json:"validators"`
+	Validators []any `json:"validators"`
 }
 
 func (s *Service) loadStakerTxAttributes(txID ids.ID) (*stakerAttributes, error) {
@@ -704,7 +704,7 @@ func (s *Service) loadStakerTxAttributes(txID ids.ID) (*stakerAttributes, error)
 // GetCurrentValidators returns the current validators. If a single nodeID
 // is provided, full delegators information is also returned. Otherwise only
 // delegators' number and total weight is returned.
-func (s *Service) GetCurrentValidators(r *http.Request, args *GetCurrentValidatorsArgs, reply *GetCurrentValidatorsReply) error {
+func (s *Service) GetCurrentValidators(request *http.Request, args *GetCurrentValidatorsArgs, reply *GetCurrentValidatorsReply) error {
 	s.vm.ctx.Log.Debug("API called",
 		zap.String("service", "platform"),
 		zap.String("method", "getCurrentValidators"),
@@ -718,7 +718,7 @@ func (s *Service) GetCurrentValidators(r *http.Request, args *GetCurrentValidato
 
 	// Check if subnet is L1
 	_, err := s.vm.state.GetSubnetToL1Conversion(args.SubnetID)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		// Subnet is not L1, get validators for the subnet
 		reply.Validators, err = s.getPrimaryOrSubnetValidators(
 			args.SubnetID,
@@ -732,7 +732,7 @@ func (s *Service) GetCurrentValidators(r *http.Request, args *GetCurrentValidato
 
 	// Subnet is L1, get validators for L1
 	reply.Validators, err = s.getL1Validators(
-		r.Context(),
+		request.Context(),
 		args.SubnetID,
 		nodeIDs,
 	)
@@ -743,8 +743,8 @@ func (s *Service) getL1Validators(
 	ctx context.Context,
 	subnetID ids.ID,
 	nodeIDs set.Set[ids.NodeID],
-) ([]interface{}, error) {
-	validators := []interface{}{}
+) ([]any, error) {
+	validators := []any{}
 	baseStakers, l1Validators, _, err := s.vm.state.GetCurrentValidators(ctx, subnetID)
 	if err != nil {
 		return nil, err
@@ -777,7 +777,7 @@ func (s *Service) getL1Validators(
 	return validators, nil
 }
 
-func (s *Service) getPrimaryOrSubnetValidators(subnetID ids.ID, nodeIDs set.Set[ids.NodeID]) ([]interface{}, error) {
+func (s *Service) getPrimaryOrSubnetValidators(subnetID ids.ID, nodeIDs set.Set[ids.NodeID]) ([]any, error) {
 	numNodeIDs := nodeIDs.Len()
 
 	targetStakers := make([]*state.Staker, 0, numNodeIDs)
@@ -785,7 +785,7 @@ func (s *Service) getPrimaryOrSubnetValidators(subnetID ids.ID, nodeIDs set.Set[
 	// Validator's node ID as string --> Delegators to them
 	vdrToDelegators := map[ids.NodeID][]platformapi.PrimaryDelegator{}
 
-	validators := []interface{}{}
+	validators := []any{}
 
 	if numNodeIDs == 0 { // Include all nodes
 		currentStakerIterator, err := s.vm.state.GetCurrentStakerIterator()

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -215,7 +215,7 @@ type State interface {
 	SetHeight(height uint64)
 
 	// GetCurrentValidators returns subnet and L1 validators for the given
-	// subnetID along with current P-chain height.
+	// subnetID along with the current P-chain height.
 	// This method works for both subnets and L1s. Depending of the requested
 	// subnet/L1 validator schema, the return values can include only subnet
 	// validator, only L1 validators or both if there are initial stakers in the
@@ -845,10 +845,6 @@ func (s *state) GetCurrentValidators(ctx context.Context, subnetID ids.ID) ([]*S
 	legacyBaseStakers := s.currentStakers.validators[subnetID]
 	legacyStakers := make([]*Staker, 0, len(legacyBaseStakers))
 	for _, staker := range legacyBaseStakers {
-		if err := ctx.Err(); err != nil {
-			return nil, nil, 0, err
-		}
-
 		legacyStakers = append(legacyStakers, staker.validator)
 	}
 

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -422,9 +422,6 @@ func (m *manager) GetCurrentValidatorSet(ctx context.Context, subnetID ids.ID) (
 	}
 
 	for _, validator := range baseStakers {
-		if err := ctx.Err(); err != nil {
-			return nil, 0, err
-		}
 		result[validator.TxID] = &validators.GetCurrentValidatorOutput{
 			ValidationID:  validator.TxID,
 			NodeID:        validator.NodeID,
@@ -438,9 +435,6 @@ func (m *manager) GetCurrentValidatorSet(ctx context.Context, subnetID ids.ID) (
 	}
 
 	for _, validator := range l1Validators {
-		if err := ctx.Err(); err != nil {
-			return nil, 0, err
-		}
 		result[validator.ValidationID] = &validators.GetCurrentValidatorOutput{
 			ValidationID:  validator.ValidationID,
 			NodeID:        validator.NodeID,


### PR DESCRIPTION
## Why this should be merged

[3564](https://github.com/ava-labs/avalanchego/pull/3564) already got approved, this PR responses to few nits in that PR. 

## How this works
This pull request includes several changes to the `vms/platformvm` service, focusing on improving the readability and consistency of the codebase, as well as updating the `GetCurrentValidators` functionality.

### Codebase Improvements:

* [`vms/platformvm/service.go`](diffhunk://#diff-af8b9e474af3c655d336a7197787dd893faab39f52452c5dcfa6eedf50a2b5ebL659-R659): Replaced `interface{}` with `any` in multiple functions to improve readability and modernize the code. [[1]](diffhunk://#diff-af8b9e474af3c655d336a7197787dd893faab39f52452c5dcfa6eedf50a2b5ebL659-R659) [[2]](diffhunk://#diff-af8b9e474af3c655d336a7197787dd893faab39f52452c5dcfa6eedf50a2b5ebL746-R756) [[3]](diffhunk://#diff-af8b9e474af3c655d336a7197787dd893faab39f52452c5dcfa6eedf50a2b5ebL778-R788)
* [`vms/platformvm/service.go`](diffhunk://#diff-af8b9e474af3c655d336a7197787dd893faab39f52452c5dcfa6eedf50a2b5ebL707-R707): Renamed parameter `r` to `request` in the `GetCurrentValidators` function for better clarity.
* [`vms/platformvm/service.go`](diffhunk://#diff-af8b9e474af3c655d336a7197787dd893faab39f52452c5dcfa6eedf50a2b5ebL721-R721): Used `errors.Is` instead of direct comparison to check for `database.ErrNotFound` to follow best practices.
* [`vms/platformvm/state/state.go`](diffhunk://#diff-602ce6ed16158db7a4822a397925858d586f5f96cbe37af869676fb1b10161efL848-L851): Removed unnecessary ctx error checks within loops to simplify the code. [[1]](diffhunk://#diff-602ce6ed16158db7a4822a397925858d586f5f96cbe37af869676fb1b10161efL848-L851) [[2]](diffhunk://#diff-7f6a0292ff300ae14a37f4cde259fb8b0673871a2dbe96e081227cb4db9aa453L425-L427) [[3]](diffhunk://#diff-7f6a0292ff300ae14a37f4cde259fb8b0673871a2dbe96e081227cb4db9aa453L441-L443)

### Documentation Updates:

* [`RELEASES.md`](diffhunk://#diff-4a00447b47c36ebd3ded77321deff288e424f4605496ee1199fc9953a20f4473L42-R45): Corrected the description of the `validationID` field and removed the `StakeAmount` field from `platform.getCurrentValidators` results.

## How this was tested

Covered by existing tests

## Need to be documented in RELEASES.md?

Updated few stuff