### PR TITLE
[docker] Silence remaining InvalidDefaultArgInFrom warnings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,5 @@
 LICENSE
 *.md
 
-Dockerfile
-
+# Ignore all dockerfiles not just the main one
+Dockerfile*

--- a/tests/antithesis/avalanchego/Dockerfile.workload
+++ b/tests/antithesis/avalanchego/Dockerfile.workload
@@ -2,7 +2,7 @@
 ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value isn't intended to be used but silences a warning
+ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/tests/antithesis/xsvm/Dockerfile.node
+++ b/tests/antithesis/xsvm/Dockerfile.node
@@ -2,7 +2,7 @@
 ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing avalanchego node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value isn't intended to be used but silences a warning
+ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/tests/antithesis/xsvm/Dockerfile.workload
+++ b/tests/antithesis/xsvm/Dockerfile.workload
@@ -2,7 +2,7 @@
 ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value isn't intended to be used but silences a warning
+ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value isn't intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder


### PR DESCRIPTION
## Why this should be merged

A previous PR added invalid default arguments to silence unwanted docker build warnings, but missed a few values that are used to populated image names. Such values need to be quoted to be effective in silencing the warnings.

## How this was tested

CI, manual inspection

## Need to be documented in RELEASES.md?

N/A