### PR TITLE
[tmpnet] Minimize duration of tx acceptance for e2e testing

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -752,13 +752,11 @@ func (m *manager) createAvalancheChain(
 
 	// Initialize the ProposerVM and the vm wrapped inside it
 	var (
-		minBlockDelay       = proposervm.DefaultMinBlockDelay
-		numHistoricalBlocks = proposervm.DefaultNumHistoricalBlocks
-	)
-	if subnetCfg, ok := m.SubnetConfigs[ctx.SubnetID]; ok {
-		minBlockDelay = subnetCfg.ProposerMinBlockDelay
+		// A default subnet configuration will be present if explicit configuration is not provided
+		subnetCfg           = m.SubnetConfigs[ctx.SubnetID]
+		minBlockDelay       = subnetCfg.ProposerMinBlockDelay
 		numHistoricalBlocks = subnetCfg.ProposerNumHistoricalBlocks
-	}
+	)
 	m.Log.Info("creating proposervm wrapper",
 		zap.Time("activationTime", m.Upgrades.ApricotPhase4Time),
 		zap.Uint64("minPChainHeight", m.Upgrades.ApricotPhase4MinPChainHeight),
@@ -1150,13 +1148,11 @@ func (m *manager) createSnowmanChain(
 	}
 
 	var (
-		minBlockDelay       = proposervm.DefaultMinBlockDelay
-		numHistoricalBlocks = proposervm.DefaultNumHistoricalBlocks
-	)
-	if subnetCfg, ok := m.SubnetConfigs[ctx.SubnetID]; ok {
-		minBlockDelay = subnetCfg.ProposerMinBlockDelay
+		// A default subnet configuration will be present if explicit configuration is not provided
+		subnetCfg           = m.SubnetConfigs[ctx.SubnetID]
+		minBlockDelay       = subnetCfg.ProposerMinBlockDelay
 		numHistoricalBlocks = subnetCfg.ProposerNumHistoricalBlocks
-	}
+	)
 	m.Log.Info("creating proposervm wrapper",
 		zap.Time("activationTime", m.Upgrades.ApricotPhase4Time),
 		zap.Uint64("minPChainHeight", m.Upgrades.ApricotPhase4MinPChainHeight),

--- a/config/config.go
+++ b/config/config.go
@@ -1132,7 +1132,7 @@ func getDefaultSubnetConfig(v *viper.Viper) subnets.Config {
 	return subnets.Config{
 		ConsensusParameters:         getConsensusConfig(v),
 		ValidatorOnly:               false,
-		ProposerMinBlockDelay:       proposervm.DefaultMinBlockDelay,
+		ProposerMinBlockDelay:       v.GetDuration(ProposerMinBlockDelayKey),
 		ProposerNumHistoricalBlocks: proposervm.DefaultNumHistoricalBlocks,
 	}
 }

--- a/config/config.md
+++ b/config/config.md
@@ -953,6 +953,12 @@ The value must be greater than `0`. Defaults to `2m`.
 
 Have the ProposerVM always report the last accepted P-chain block height. Defaults to `false`.
 
+### `--proposervm-min-block-duration` (duration)
+
+The minimum delay to enforce when building a snowman++ block for the primary network
+chains and the default minimum delay for subnets. Defaults to `1s`. A non-default
+value is only suggested for non-production nodes.
+
 ### Continuous Profiling
 
 You can configure your node to continuously run memory/CPU profiles and save the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -382,19 +382,16 @@ func TestGetSubnetConfigsFromFile(t *testing.T) {
 			},
 			expectedErr: errUnmarshalling,
 		},
-		"subnet is not tracked": {
-			fileName:  "Gmt4fuNsGJAd2PX86LBvycGaBpgCYKbuULdCLZs3SEs1Jx1LU.json",
-			givenJSON: `{"validatorOnly": true}`,
-			testF: func(require *require.Assertions, given map[ids.ID]subnets.Config) {
-				require.Empty(given)
-			},
-			expectedErr: nil,
-		},
-		"wrong extension": {
+		"default config when incorrect extension used": {
 			fileName:  "2Ctt6eGAeo4MLqTmGa7AdRecuVMPGWEX9wSsCLBYrLhX4a394i.yaml",
 			givenJSON: `{"validatorOnly": true}`,
 			testF: func(require *require.Assertions, given map[ids.ID]subnets.Config) {
-				require.Empty(given)
+				v := setupViperFlags()
+				defaultConfig := getDefaultSubnetConfig(v)
+				expected := map[ids.ID]subnets.Config{
+					subnetID: defaultConfig,
+				}
+				require.Equal(expected, given)
 			},
 			expectedErr: nil,
 		},
@@ -455,10 +452,15 @@ func TestGetSubnetConfigsFromFlags(t *testing.T) {
 		testF       func(*require.Assertions, map[ids.ID]subnets.Config)
 		expectedErr error
 	}{
-		"no configs": {
+		"default config used when no config provided": {
 			givenJSON: `{}`,
 			testF: func(require *require.Assertions, given map[ids.ID]subnets.Config) {
-				require.Empty(given)
+				v := setupViperFlags()
+				defaultConfig := getDefaultSubnetConfig(v)
+				expected := map[ids.ID]subnets.Config{
+					subnetID: defaultConfig,
+				}
+				require.Equal(expected, given)
 			},
 			expectedErr: nil,
 		},
@@ -471,13 +473,6 @@ func TestGetSubnetConfigsFromFlags(t *testing.T) {
 				require.True(ok)
 				// should respect defaults
 				require.Equal(20, config.ConsensusParameters.K)
-			},
-			expectedErr: nil,
-		},
-		"subnet is not tracked": {
-			givenJSON: `{"Gmt4fuNsGJAd2PX86LBvycGaBpgCYKbuULdCLZs3SEs1Jx1LU":{"validatorOnly":true}}`,
-			testF: func(require *require.Assertions, given map[ids.ID]subnets.Config) {
-				require.Empty(given)
 			},
 			expectedErr: nil,
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -368,6 +368,10 @@ func TestGetSubnetConfigsFromFile(t *testing.T) {
 	subnetID, err := ids.FromString("2Ctt6eGAeo4MLqTmGa7AdRecuVMPGWEX9wSsCLBYrLhX4a394i")
 	require.NoError(t, err)
 
+	defaultConfigs := map[ids.ID]subnets.Config{
+		subnetID: getDefaultSubnetConfig(setupViperFlags()),
+	}
+
 	tests := map[string]struct {
 		fileName    string
 		givenJSON   string
@@ -382,16 +386,19 @@ func TestGetSubnetConfigsFromFile(t *testing.T) {
 			},
 			expectedErr: errUnmarshalling,
 		},
+		"subnet is not tracked": {
+			fileName:  "Gmt4fuNsGJAd2PX86LBvycGaBpgCYKbuULdCLZs3SEs1Jx1LU.json",
+			givenJSON: `{"validatorOnly": true}`,
+			testF: func(require *require.Assertions, given map[ids.ID]subnets.Config) {
+				require.Equal(defaultConfigs, given)
+			},
+			expectedErr: nil,
+		},
 		"default config when incorrect extension used": {
 			fileName:  "2Ctt6eGAeo4MLqTmGa7AdRecuVMPGWEX9wSsCLBYrLhX4a394i.yaml",
 			givenJSON: `{"validatorOnly": true}`,
 			testF: func(require *require.Assertions, given map[ids.ID]subnets.Config) {
-				v := setupViperFlags()
-				defaultConfig := getDefaultSubnetConfig(v)
-				expected := map[ids.ID]subnets.Config{
-					subnetID: defaultConfig,
-				}
-				require.Equal(expected, given)
+				require.Equal(defaultConfigs, given)
 			},
 			expectedErr: nil,
 		},
@@ -447,6 +454,10 @@ func TestGetSubnetConfigsFromFlags(t *testing.T) {
 	subnetID, err := ids.FromString("2Ctt6eGAeo4MLqTmGa7AdRecuVMPGWEX9wSsCLBYrLhX4a394i")
 	require.NoError(t, err)
 
+	defaultConfigs := map[ids.ID]subnets.Config{
+		subnetID: getDefaultSubnetConfig(setupViperFlags()),
+	}
+
 	tests := map[string]struct {
 		givenJSON   string
 		testF       func(*require.Assertions, map[ids.ID]subnets.Config)
@@ -455,12 +466,7 @@ func TestGetSubnetConfigsFromFlags(t *testing.T) {
 		"default config used when no config provided": {
 			givenJSON: `{}`,
 			testF: func(require *require.Assertions, given map[ids.ID]subnets.Config) {
-				v := setupViperFlags()
-				defaultConfig := getDefaultSubnetConfig(v)
-				expected := map[ids.ID]subnets.Config{
-					subnetID: defaultConfig,
-				}
-				require.Equal(expected, given)
+				require.Equal(defaultConfigs, given)
 			},
 			expectedErr: nil,
 		},
@@ -473,6 +479,13 @@ func TestGetSubnetConfigsFromFlags(t *testing.T) {
 				require.True(ok)
 				// should respect defaults
 				require.Equal(20, config.ConsensusParameters.K)
+			},
+			expectedErr: nil,
+		},
+		"default config used when subnet is not tracked": {
+			givenJSON: `{"Gmt4fuNsGJAd2PX86LBvycGaBpgCYKbuULdCLZs3SEs1Jx1LU":{"validatorOnly":true}}`,
+			testF: func(require *require.Assertions, given map[ids.ID]subnets.Config) {
+				require.Equal(defaultConfigs, given)
 			},
 			expectedErr: nil,
 		},

--- a/config/flags.go
+++ b/config/flags.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/ulimit"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
+	"github.com/ava-labs/avalanchego/vms/proposervm"
 )
 
 const (
@@ -384,6 +385,9 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
 
 	fs.String(ProcessContextFileKey, defaultProcessContextPath, "The path to write process context to (including PID, API URI, and staking address).")
+
+	// Primary Subnet Config
+	fs.Duration(ProposerMinBlockDelayKey, proposervm.DefaultMinBlockDelay, "Minimum delay to enforce when building a snowman++ block for the primary subnet")
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego

--- a/config/flags.go
+++ b/config/flags.go
@@ -322,6 +322,9 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Int(SnowMaxProcessingKey, snowball.DefaultParameters.MaxOutstandingItems, "Maximum number of processing items to be considered healthy")
 	fs.Duration(SnowMaxTimeProcessingKey, snowball.DefaultParameters.MaxItemProcessingTime, "Maximum amount of time an item should be processing and still be healthy")
 
+	// Primary Network Config
+	fs.Duration(ProposerMinBlockDelayKey, proposervm.DefaultMinBlockDelay, "Minimum delay to enforce when building a snowman++ block for the primary network chains")
+
 	// ProposerVM
 	fs.Bool(ProposerVMUseCurrentHeightKey, false, "Have the ProposerVM always report the last accepted P-chain block height")
 
@@ -386,8 +389,6 @@ func addNodeFlags(fs *pflag.FlagSet) {
 
 	fs.String(ProcessContextFileKey, defaultProcessContextPath, "The path to write process context to (including PID, API URI, and staking address).")
 
-	// Primary Subnet Config
-	fs.Duration(ProposerMinBlockDelayKey, proposervm.DefaultMinBlockDelay, "Minimum delay to enforce when building a snowman++ block for the primary subnet")
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego

--- a/config/flags.go
+++ b/config/flags.go
@@ -388,7 +388,6 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
 
 	fs.String(ProcessContextFileKey, defaultProcessContextPath, "The path to write process context to (including PID, API URI, and staking address).")
-
 }
 
 // BuildFlagSet returns a complete set of flags for avalanchego

--- a/config/flags.go
+++ b/config/flags.go
@@ -322,11 +322,9 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Int(SnowMaxProcessingKey, snowball.DefaultParameters.MaxOutstandingItems, "Maximum number of processing items to be considered healthy")
 	fs.Duration(SnowMaxTimeProcessingKey, snowball.DefaultParameters.MaxItemProcessingTime, "Maximum amount of time an item should be processing and still be healthy")
 
-	// Primary Network Config
-	fs.Duration(ProposerMinBlockDelayKey, proposervm.DefaultMinBlockDelay, "Minimum delay to enforce when building a snowman++ block for the primary network chains")
-
 	// ProposerVM
 	fs.Bool(ProposerVMUseCurrentHeightKey, false, "Have the ProposerVM always report the last accepted P-chain block height")
+	fs.Duration(ProposerVMMinBlockDelayKey, proposervm.DefaultMinBlockDelay, "Minimum delay to enforce when building a snowman++ block for the primary network chains and the default minimum delay for subnets")
 
 	// Metrics
 	fs.Bool(MeterVMsEnabledKey, true, "Enable Meter VMs to track VM performance with more granularity")

--- a/config/keys.go
+++ b/config/keys.go
@@ -208,4 +208,5 @@ const (
 	TracingExporterTypeKey                             = "tracing-exporter-type"
 	TracingHeadersKey                                  = "tracing-headers"
 	ProcessContextFileKey                              = "process-context-file"
+	ProposerMinBlockDelayKey                           = "proposer-min-block-delay"
 )

--- a/config/keys.go
+++ b/config/keys.go
@@ -152,6 +152,7 @@ const (
 	ConsensusShutdownTimeoutKey                        = "consensus-shutdown-timeout"
 	ConsensusFrontierPollFrequencyKey                  = "consensus-frontier-poll-frequency"
 	ProposerVMUseCurrentHeightKey                      = "proposervm-use-current-height"
+	ProposerVMMinBlockDelayKey                         = "proposervm-min-block-delay"
 	FdLimitKey                                         = "fd-limit"
 	IndexEnabledKey                                    = "index-enabled"
 	IndexAllowIncompleteKey                            = "index-allow-incomplete"
@@ -208,5 +209,4 @@ const (
 	TracingExporterTypeKey                             = "tracing-exporter-type"
 	TracingHeadersKey                                  = "tracing-headers"
 	ProcessContextFileKey                              = "process-context-file"
-	ProposerMinBlockDelayKey                           = "proposer-min-block-delay"
 )

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -299,7 +299,6 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 
 			for i := 0; i < totalRounds; i++ {
 				runFunc(i)
-				time.Sleep(time.Second)
 			}
 
 			_ = e2e.CheckBootstrapIsPossible(tc, env.GetNetwork())

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -84,6 +84,8 @@ func NewWallet(tc tests.TestContext, keychain *secp256k1fx.Keychain, nodeURI tmp
 				)
 			},
 		),
+		// Reducing the default from 100ms speeds up detection of tx acceptance
+		common.WithPollFrequency(10*time.Millisecond),
 	)
 	OutputWalletBalances(tc, wallet)
 	return wallet

--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -60,7 +60,7 @@ func DefaultTmpnetFlags() FlagsMap {
 		config.MinStakeDurationKey:           DefaultMinStakeDuration.String(),
 		config.ProposerVMUseCurrentHeightKey: true,
 		// Reducing this from the 1s default speeds up tx acceptance
-		config.ProposerMinBlockDelayKey: "0s",
+		config.ProposerVMMinBlockDelayKey: "0s",
 	}
 	flags.SetDefaults(DefaultTestFlags())
 	return flags
@@ -76,13 +76,5 @@ func DefaultChainConfigs() map[string]FlagsMap {
 			"warp-api-enabled": true,
 			"log-level":        "trace",
 		},
-	}
-}
-
-// A set of subnet configuration appropriate for testing.
-func DefaultSubnetConfig() FlagsMap {
-	return FlagsMap{
-		// Reducing this from the 1s default speeds up tx acceptance
-		"proposerMinBlockDelay": 0, // Needs to be a number to be valid in subnet configuration
 	}
 }

--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -59,6 +59,8 @@ func DefaultTmpnetFlags() FlagsMap {
 		// Specific to e2e testing
 		config.MinStakeDurationKey:           DefaultMinStakeDuration.String(),
 		config.ProposerVMUseCurrentHeightKey: true,
+		// Reducing this from the 1s default speeds up tx acceptance
+		config.ProposerMinBlockDelayKey: "0s",
 	}
 	flags.SetDefaults(DefaultTestFlags())
 	return flags
@@ -74,5 +76,13 @@ func DefaultChainConfigs() map[string]FlagsMap {
 			"warp-api-enabled": true,
 			"log-level":        "trace",
 		},
+	}
+}
+
+// A set of subnet configuration appropriate for testing.
+func DefaultSubnetConfig() FlagsMap {
+	return FlagsMap{
+		// Reducing this from the 1s default speeds up tx acceptance
+		"proposerMinBlockDelay": 0, // Needs to be a number to be valid in subnet configuration
 	}
 }

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -689,12 +689,6 @@ func (n *Network) CreateSubnets(ctx context.Context, log logging.Logger, apiURI 
 			zap.String("name", subnet.Name),
 		)
 
-		// Apply tmpnet defaults
-		if subnet.Config == nil {
-			subnet.Config = FlagsMap{}
-		}
-		subnet.Config.SetDefaults(DefaultSubnetConfig())
-
 		if subnet.OwningKey == nil {
 			// Allocate a pre-funded key and remove it from the network so it won't be used for
 			// other purposes

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -689,6 +689,12 @@ func (n *Network) CreateSubnets(ctx context.Context, log logging.Logger, apiURI 
 			zap.String("name", subnet.Name),
 		)
 
+		// Apply tmpnet defaults
+		if subnet.Config == nil {
+			subnet.Config = FlagsMap{}
+		}
+		subnet.Config.SetDefaults(DefaultSubnetConfig())
+
 		if subnet.OwningKey == nil {
 			// Allocate a pre-funded key and remove it from the network so it won't be used for
 			// other purposes


### PR DESCRIPTION
## Why this should be merged

Faster tests mean faster iteration

## How this works

- Enable configuration of min block delay for primary subnet with the addition of node flag `--proposer-min-block-delay`
- Configure tmpnet to default the block delay to zero for all subnets
- Reduce the wallet poll interval from 100ms to 10ms
- Remove unnecessary sleep in virtuous test

## How this was tested

CI against regression, manually verified decreased runtime

## Need to be documented in RELEASES.md?

New node flag should be documented.