### PR TITLE
Fix change/range proofs + simplify the code

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1111,19 +1111,16 @@ func (db *merkleDB) VerifyChangeProof(
 	}
 
 	// Validate proof.
-	err := validateRangeChangeProof(start, end, proof.StartProof, proof.EndProof, keys, db.tokenSize)
-	if err != nil {
+	if err := validateChangeProof(start, end, proof.StartProof, proof.EndProof, keys, db.tokenSize); err != nil {
 		return err
 	}
 
-	var (
-		// [startProof] is an inclusion/exclusion proof of [startKey]
-		startProofKey = maybe.Bind(start, ToKey)
+	// [startProof] is an inclusion/exclusion proof of [startKey]
+	startProofKey := maybe.Bind(start, ToKey)
 
-		// [endProof] is an inclusion of the largest key in [keyValues],
-		// or an exclusion proof of [end] if [keyValues] is empty.
-		endProofKey = maybe.Bind(end, ToKey)
-	)
+	// [endProof] is an inclusion of the largest key in [keyValues],
+	// or an exclusion proof of [end] if [keyValues] is empty.
+	endProofKey := maybe.Bind(end, ToKey)
 
 	// Update [endProofKey] with the largest key in [keyValues].
 	if len(proof.KeyChanges) > 0 {

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1188,7 +1188,7 @@ func (db *merkleDB) VerifyChangeProof(
 		startProofKey,
 		endProofKey,
 	); err != nil {
-		return fmt.Errorf("failed to end end proof path info: %w", err)
+		return fmt.Errorf("failed to add end proof path info: %w", err)
 	}
 
 	// Make sure we get the expected root.

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1102,6 +1102,9 @@ func (db *merkleDB) VerifyChangeProof(
 	keys := make([]Key, len(proof.KeyChanges))
 	for i, keyValue := range proof.KeyChanges {
 		k := ToKey(keyValue.Key)
+		if k.hasPartialByte() {
+			return ErrProofKeyPartialByte
+		}
 
 		keyChanges[k] = keyValue.Value
 		keys[i] = k

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -317,7 +317,7 @@ func Test_MerkleDB_CommitRangeProof_DeletesValuesInRange(t *testing.T) {
 	require.NoError(err)
 
 	// confirm there are no key.values in the proof
-	require.Empty(proof.KeyValues)
+	require.Empty(proof.KeyChanges)
 
 	// add values to be deleted by proof commit
 	batch := db.NewBatch()
@@ -938,7 +938,7 @@ func runRandDBTest(require *require.Assertions, r *rand.Rand, rt randTest, token
 				continue
 			}
 			require.NoError(err)
-			require.LessOrEqual(len(rangeProof.KeyValues), maxProofLen)
+			require.LessOrEqual(len(rangeProof.KeyChanges), maxProofLen)
 
 			require.NoError(rangeProof.Verify(
 				context.Background(),

--- a/x/merkledb/helpers_test.go
+++ b/x/merkledb/helpers_test.go
@@ -25,13 +25,15 @@ func getBasicDB() (*merkleDB, error) {
 	)
 }
 
-func getBasicDBWithBranchFactor(bf BranchFactor) (MerkleDB, error) {
+func getBasicDBWithBranchFactor(bf BranchFactor) (*merkleDB, error) {
 	config := NewConfig()
 	config.BranchFactor = bf
-	return New(
+
+	return newDatabase(
 		context.Background(),
 		memdb.New(),
 		config,
+		&mockMetrics{},
 	)
 }
 

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -733,33 +733,6 @@ type ChangeOrRangeProof struct {
 // Returns nil iff both hold:
 // 1. [kvs] is sorted by key in increasing order.
 // 2. All keys in [kvs] are in the range [start, end].
-// If [start] is Nothing, there is no lower bound on acceptable keys.
-// If [end] is Nothing, there is no upper bound on acceptable keys.
-// If [kvs] is empty, returns nil.
-func verifyKeyChanges(kvs []KeyChange, start maybe.Maybe[[]byte], end maybe.Maybe[[]byte]) error {
-	if len(kvs) == 0 {
-		return nil
-	}
-
-	// ensure that the keys are in increasing order
-	for i := 0; i < len(kvs)-1; i++ {
-		if bytes.Compare(kvs[i].Key, kvs[i+1].Key) >= 0 {
-			return ErrNonIncreasingValues
-		}
-	}
-
-	// ensure that the keys are within the range [start, end]
-	if (start.HasValue() && bytes.Compare(kvs[0].Key, start.Value()) < 0) ||
-		(end.HasValue() && bytes.Compare(kvs[len(kvs)-1].Key, end.Value()) > 0) {
-		return ErrStateFromOutsideOfRange
-	}
-
-	return nil
-}
-
-// Returns nil iff both hold:
-// 1. [kvs] is sorted by key in increasing order.
-// 2. All keys in [kvs] are in the range [start, end].
 // If [start] is nil, there is no lower bound on acceptable keys.
 // If [end] is nothing, there is no upper bound on acceptable keys.
 // If [kvs] is empty, returns nil.

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -289,8 +289,11 @@ func validateRangeChangeProof(
 		// [startProof] is an inclusion/exclusion proof of [start]
 		startProofKey = maybe.Bind(start, ToKey)
 
-		// [endProof] is an inclusion of the largest key in [keyValues],
-		// or an exclusion proof of [end] if [keyValues] is empty.
+		// [endProof] is an inclusion of the largest key in [keyValues].
+		//
+		// If [keyValues] is empty:
+		// - range proof: an exclusion proof of [end]
+		// - change proof: an inclusion/exclusion proof of [end].
 		endProofKey = maybe.Bind(end, ToKey)
 	)
 
@@ -902,6 +905,7 @@ func addPathInfo(
 
 		// Add [proofNode]'s children which are outside the range
 		// [insertChildrenLessThan, insertChildrenGreaterThan].
+		// What is inside the range, should be included in provided key-values.
 		for index, childID := range proofNode.Children {
 			var compressedKey Key
 			if existingChild, ok := n.children[index]; ok {

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -646,7 +646,7 @@ func verifyProofPath(proof []ProofNode, key Key, tokenSize int) error {
 		// exclusionProof
 
 		if key.HasPrefix(lastNode.Key) {
-			// [lastNode] is the parent of the node
+			// [lastNode] is an ancestor of the node
 			nextIndex := key.Token(lastNode.Key.length, tokenSize)
 
 			if _, ok := lastNode.Children[nextIndex]; ok {

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -294,10 +294,6 @@ func (proof *RangeProof) UnmarshalProto(pbProof *pb.RangeProof) error {
 	return nil
 }
 
-func (proof *RangeProof) AsChangeProof() *ChangeProof {
-	return (*ChangeProof)(proof)
-}
-
 // Validate received data from change/range proof requests
 // using the requested range.
 func validateChangeProof(
@@ -378,7 +374,7 @@ func (proof *RangeProof) Verify(
 		return err
 	}
 
-	return db.VerifyChangeProof(ctx, proof.AsChangeProof(), start, end, expectedRootID)
+	return db.VerifyChangeProof(ctx, (*ChangeProof)(proof), start, end, expectedRootID)
 }
 
 type KeyChange struct {

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -22,32 +22,35 @@ import (
 const verificationCacheSize = math.MaxUint16
 
 var (
-	ErrInvalidProof                = errors.New("proof obtained an invalid root ID")
-	ErrInvalidMaxLength            = errors.New("expected max length to be > 0")
-	ErrNonIncreasingValues         = errors.New("keys sent are not in increasing order")
-	ErrStateFromOutsideOfRange     = errors.New("state key falls outside of the start->end range")
-	ErrNonIncreasingProofNodes     = errors.New("each proof node key must be a strict prefix of the next")
-	ErrExtraProofNodes             = errors.New("extra proof nodes in path")
-	ErrDataInMissingRootProof      = errors.New("there should be no state or deleted keys in a change proof that had a missing root")
-	ErrEmptyProof                  = errors.New("proof is empty")
-	ErrNoMerkleProof               = errors.New("empty key response must include merkle proof")
-	ErrShouldJustBeRoot            = errors.New("end proof should only contain root")
-	ErrNoStartProof                = errors.New("no start proof")
-	ErrNoEndProof                  = errors.New("no end proof")
-	ErrProofNodeNotForKey          = errors.New("the provided node has a key that is not a prefix of the specified key")
-	ErrProofValueDoesntMatch       = errors.New("the provided value does not match the proof node for the provided key's value")
-	ErrProofNodeHasUnincludedValue = errors.New("the provided proof has a value for a key within the range that is not present in the provided key/values")
-	ErrInvalidMaybe                = errors.New("maybe is nothing but has value")
-	ErrNilProofNode                = errors.New("proof node is nil")
-	ErrNilValueOrHash              = errors.New("proof node's valueOrHash field is nil")
-	ErrNilKey                      = errors.New("key is nil")
-	ErrInvalidKeyLength            = errors.New("key length doesn't match bytes length, check specified branchFactor")
-	ErrNilRangeProof               = errors.New("range proof is nil")
-	ErrNilChangeProof              = errors.New("change proof is nil")
-	ErrNilMaybeBytes               = errors.New("maybe bytes is nil")
-	ErrNilProof                    = errors.New("proof is nil")
-	ErrNilValue                    = errors.New("value is nil")
-	ErrUnexpectedEndProof          = errors.New("end proof should be empty")
+	ErrInvalidProof                  = errors.New("proof obtained an invalid root ID")
+	ErrInvalidMaxLength              = errors.New("expected max length to be > 0")
+	ErrNonIncreasingValues           = errors.New("keys sent are not in increasing order")
+	ErrStateFromOutsideOfRange       = errors.New("state key falls outside of the start->end range")
+	ErrNonIncreasingProofNodes       = errors.New("each proof node key must be a strict prefix of the next")
+	ErrExtraProofNodes               = errors.New("extra proof nodes in path")
+	ErrDataInMissingRootProof        = errors.New("there should be no state or deleted keys in a change proof that had a missing root")
+	ErrEmptyProof                    = errors.New("proof is empty")
+	ErrNoMerkleProof                 = errors.New("empty key response must include merkle proof")
+	ErrShouldJustBeRoot              = errors.New("end proof should only contain root")
+	ErrNoEndProof                    = errors.New("no end proof")
+	ErrProofNodeNotForKey            = errors.New("the provided path has a key that is not a prefix of the specified key")
+	ErrExclusionProofMissingEndNodes = errors.New("missing end nodes from path")
+	ErrExclusionProofUnexpectedValue = errors.New("exclusion proof's value should be empty")
+	ErrExclusionProofInvalidNode     = errors.New("invalid node for exclusion proof")
+	ErrProofValueDoesntMatch         = errors.New("the provided value does not match the proof node for the provided key's value")
+	ErrProofNodeHasUnincludedValue   = errors.New("the provided proof has a value for a key within the range that is not present in the provided key/values")
+	ErrInvalidMaybe                  = errors.New("maybe is nothing but has value")
+	ErrNilProofNode                  = errors.New("proof node is nil")
+	ErrNilValueOrHash                = errors.New("proof node's valueOrHash field is nil")
+	ErrNilKey                        = errors.New("key is nil")
+	ErrInvalidKeyLength              = errors.New("key length doesn't match bytes length, check specified branchFactor")
+	ErrNilRangeProof                 = errors.New("range proof is nil")
+	ErrNilChangeProof                = errors.New("change proof is nil")
+	ErrNilMaybeBytes                 = errors.New("maybe bytes is nil")
+	ErrNilProof                      = errors.New("proof is nil")
+	ErrNilValue                      = errors.New("value is nil")
+	ErrUnexpectedEndProof            = errors.New("end proof should be empty")
+	ErrUnexpectedStartProof          = errors.New("start proof should be empty")
 )
 
 type ProofNode struct {
@@ -142,30 +145,19 @@ func (proof *Proof) Verify(
 		return ErrEmptyProof
 	}
 
-	if err := verifyProofPath(proof.Path, maybe.Some(proof.Key)); err != nil {
-		return err
-	}
-
-	// Confirm that the last proof node's value matches the claimed proof value
 	lastNode := proof.Path[len(proof.Path)-1]
+	inclusionProof := lastNode.Key.Compare(proof.Key) == 0
 
-	// If the last proof node's key is [proof.Key] (i.e. this is an inclusion proof)
-	// then the value of the last proof node must match [proof.Value].
-	// Note partial byte length keys can never match the [proof.Key] since it's bytes,
-	// and thus has a whole number of bytes
-	if !lastNode.Key.hasPartialByte() &&
-		proof.Key == lastNode.Key &&
-		!valueOrHashMatches(hasher, proof.Value, lastNode.ValueOrHash) {
+	if inclusionProof && !valueOrHashMatches(hasher, proof.Value, lastNode.ValueOrHash) {
 		return ErrProofValueDoesntMatch
 	}
 
-	// If the last proof node has a length not evenly divisible into bytes or a different key than [proof.Key]
-	// then this is an exclusion proof and should prove that [proof.Key] isn't in the trie.
-	// Note length not evenly divisible into bytes can never match the [proof.Key] since it's bytes,
-	// and thus an exact number of bytes.
-	if (lastNode.Key.hasPartialByte() || proof.Key != lastNode.Key) &&
-		proof.Value.HasValue() {
-		return ErrProofValueDoesntMatch
+	if !inclusionProof && proof.Value.HasValue() {
+		return ErrExclusionProofUnexpectedValue
+	}
+
+	if err := verifyProofPath(proof.Path, proof.Key, tokenSize); err != nil {
+		return err
 	}
 
 	// Don't bother locking [view] -- nobody else has a reference to it.
@@ -247,22 +239,83 @@ type KeyValue struct {
 type RangeProof struct {
 	// Invariant: At least one of [StartProof], [EndProof], [KeyValues] is non-empty.
 
-	// A proof that the smallest key in the requested range does/doesn't exist.
+	// An inclusion/exclusion proof for the lower range bound.
+	//
+	// If no lower range bound was given, this is empty.
+	//
 	// Note that this may not be an entire proof -- nodes are omitted if
 	// they are also in [EndProof].
 	StartProof []ProofNode
 
-	// If no upper range bound was given and [KeyValues] is empty, this is empty.
+	// An inclusion proof for the largest key in [KeyValues].
 	//
-	// If no upper range bound was given and [KeyValues] is non-empty, this is
-	// a proof for the largest key in [KeyValues].
+	// If [KeyValues] is empty, this is an exclusion proof for the upper range bound.
 	//
-	// Otherwise this is a proof for the upper range bound.
+	// If [KeyValues] is empty, and no upper range bound was given, this is empty.
 	EndProof []ProofNode
 
-	// This proof proves that the key-value pairs in [KeyValues] are in the trie.
-	// Sorted by increasing key.
+	// A subset of the requested key-value range, (because otherwise the proof may be too large)).
+	// Each key is in the requested range (inclusive).
+	// The first key-value is the first key-value at/after the range start.
+	// The key-value pairs are consecutive.
+	// Sorted by increasing key and with no duplicate keys.
 	KeyValues []KeyValue
+}
+
+// Validate received data from change/range proof requests
+// using the requested range.
+func validateRangeChangeProof(
+	start maybe.Maybe[[]byte],
+	end maybe.Maybe[[]byte],
+	startProof []ProofNode,
+	endProof []ProofNode,
+	keys []Key,
+	tokenSize int,
+) error {
+	switch {
+	case start.HasValue() && end.HasValue() && bytes.Compare(start.Value(), end.Value()) > 0:
+		return ErrStartAfterEnd
+	case len(keys) == 0 && len(startProof) == 0 && len(endProof) == 0:
+		return ErrEmptyProof
+	case end.IsNothing() && len(keys) == 0 && len(endProof) != 0:
+		return ErrUnexpectedEndProof
+	case start.IsNothing() && len(startProof) > 0:
+		return ErrUnexpectedStartProof
+	case len(endProof) == 0 && (end.HasValue() || len(keys) > 0):
+		return ErrNoEndProof
+	}
+
+	var (
+		// [startProof] is an inclusion/exclusion proof of [start]
+		startProofKey = maybe.Bind(start, ToKey)
+
+		// [endProof] is an inclusion of the largest key in [keyValues],
+		// or an exclusion proof of [end] if [keyValues] is empty.
+		endProofKey = maybe.Bind(end, ToKey)
+	)
+
+	// Make sure the key-value pairs are sorted and in [start, end].
+	if err := verifyKeyValues(keys, startProofKey, endProofKey); err != nil {
+		return err
+	}
+
+	if len(keys) > 0 {
+		endProofKey = maybe.Some(keys[len(keys)-1])
+	}
+
+	// Ensure that the start proof is valid.
+	// If [startProof] is non-empty, [end] is non-empty (length is checked inside verifyProofPath).
+	if err := verifyProofPath(startProof, startProofKey.Value(), tokenSize); err != nil {
+		return err
+	}
+
+	// Ensure that the end proof is valid.
+	// If [endProof] is non-empty, [end] is non-empty (length is checked inside verifyProofPath).
+	if err := verifyProofPath(endProof, endProofKey.Value(), tokenSize); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Verify returns nil iff all the following hold:
@@ -283,22 +336,6 @@ func (proof *RangeProof) Verify(
 	tokenSize int,
 	hasher Hasher,
 ) error {
-	switch {
-	case start.HasValue() && end.HasValue() && bytes.Compare(start.Value(), end.Value()) > 0:
-		return ErrStartAfterEnd
-	case len(proof.KeyValues) == 0 && len(proof.StartProof) == 0 && len(proof.EndProof) == 0:
-		return ErrEmptyProof
-	case end.IsNothing() && len(proof.KeyValues) == 0 && len(proof.EndProof) != 0:
-		return ErrUnexpectedEndProof
-	case len(proof.EndProof) == 0 && (end.HasValue() || len(proof.KeyValues) > 0):
-		return ErrNoEndProof
-	}
-
-	// Make sure the key-value pairs are sorted and in [start, end].
-	if err := verifyKeyValues(proof.KeyValues, start, end); err != nil {
-		return err
-	}
-
 	// [proof] allegedly provides and proves all key-value
 	// pairs in [smallestProvenKey, largestProvenKey].
 	// If [smallestProvenKey] is Nothing, [proof] should
@@ -306,48 +343,57 @@ func (proof *RangeProof) Verify(
 	// If [largestProvenKey] is Nothing, [proof] should
 	// provide and prove all keys > [smallestProvenKey].
 	// If both are Nothing, [proof] should prove the entire trie.
-	smallestProvenKey := maybe.Bind(start, ToKey)
 
-	largestProvenKey := maybe.Bind(end, ToKey)
+	// The key-value pairs (allegedly) are proven by [proof].
+	keyValues := make(map[Key][]byte, len(proof.KeyValues))
+	keys := make([]Key, len(proof.KeyValues))
+	for i, keyValue := range proof.KeyValues {
+		k := ToKey(keyValue.Key)
 
+		keyValues[k] = keyValue.Value
+		keys[i] = k
+	}
+
+	// Validate proof.
+	err := validateRangeChangeProof(start, end, proof.StartProof, proof.EndProof, keys, tokenSize)
+	if err != nil {
+		return err
+	}
+
+	var (
+		// [startProof] is an inclusion/exclusion proof of [startKey]
+		startProofKey = maybe.Bind(start, ToKey)
+
+		// [endProof] is an inclusion of the largest key in [keyValues],
+		// or an exclusion proof of [end] if [keyValues] is empty.
+		endProofKey = maybe.Bind(end, ToKey)
+	)
+
+	// Update [endProofKey] with the largest key in [keyValues].
 	if len(proof.KeyValues) > 0 {
 		// If [proof] has key-value pairs, we should insert children
 		// greater than [largestProvenKey] to ancestors of the node containing
 		// [largestProvenKey] so that we get the expected root ID.
-		largestProvenKey = maybe.Some(ToKey(proof.KeyValues[len(proof.KeyValues)-1].Key))
+		endProofKey = maybe.Some(ToKey(proof.KeyValues[len(proof.KeyValues)-1].Key))
 	}
 
-	// The key-value pairs (allegedly) are proven by [proof].
-	keyValues := make(map[Key][]byte, len(proof.KeyValues))
-	for _, keyValue := range proof.KeyValues {
-		keyValues[ToKey(keyValue.Key)] = keyValue.Value
-	}
-
-	// Ensure that the start proof is valid and contains values that
-	// match the key/values that were sent.
-	if err := verifyProofPath(proof.StartProof, smallestProvenKey); err != nil {
-		return err
-	}
+	// Ensure that the [startProof] contains values that match the key/values that were sent.
 	if err := verifyAllRangeProofKeyValuesPresent(
 		hasher,
 		proof.StartProof,
-		smallestProvenKey,
-		largestProvenKey,
+		startProofKey,
+		endProofKey,
 		keyValues,
 	); err != nil {
 		return err
 	}
 
-	// Ensure that the end proof is valid and contains values that
-	// match the key/values that were sent.
-	if err := verifyProofPath(proof.EndProof, largestProvenKey); err != nil {
-		return err
-	}
+	// Ensure that the [endProof] contains values that match the key/values that were sent.
 	if err := verifyAllRangeProofKeyValuesPresent(
 		hasher,
 		proof.EndProof,
-		smallestProvenKey,
-		largestProvenKey,
+		startProofKey,
+		endProofKey,
 		keyValues,
 	); err != nil {
 		return err
@@ -377,16 +423,17 @@ func (proof *RangeProof) Verify(
 	if err := addPathInfo(
 		view,
 		proof.StartProof,
-		smallestProvenKey,
-		largestProvenKey,
+		startProofKey,
+		endProofKey,
 	); err != nil {
 		return err
 	}
+
 	if err := addPathInfo(
 		view,
 		proof.EndProof,
-		smallestProvenKey,
-		largestProvenKey,
+		startProofKey,
+		endProofKey,
 	); err != nil {
 		return err
 	}
@@ -395,9 +442,11 @@ func (proof *RangeProof) Verify(
 	if err != nil {
 		return err
 	}
+
 	if expectedRootID != calculatedRoot {
 		return fmt.Errorf("%w:[%s], expected:[%s]", ErrInvalidProof, calculatedRoot, expectedRootID)
 	}
+
 	return nil
 }
 
@@ -498,12 +547,12 @@ type KeyChange struct {
 // between two trie roots, where each key-value pair's key is
 // between some lower and upper bound (inclusive).
 type ChangeProof struct {
-	// Invariant: At least one of [StartProof], [EndProof], or
-	// [KeyChanges] is non-empty.
+	// Invariant: At least one of [StartProof], [EndProof], [KeyChanges] is non-empty.
 
-	// A proof that the smallest key in the requested range does/doesn't
-	// exist in the trie with the requested start root.
-	// Empty if no lower bound on the requested range was given.
+	// An inclusion/exclusion proof for the lower range bound.
+	//
+	// If no lower range bound was given, this is empty.
+	//
 	// Note that this may not be an entire proof -- nodes are omitted if
 	// they are also in [EndProof].
 	StartProof []ProofNode
@@ -714,61 +763,96 @@ func verifyKeyChanges(kvs []KeyChange, start maybe.Maybe[[]byte], end maybe.Mayb
 // If [start] is nil, there is no lower bound on acceptable keys.
 // If [end] is nothing, there is no upper bound on acceptable keys.
 // If [kvs] is empty, returns nil.
-func verifyKeyValues(kvs []KeyValue, start maybe.Maybe[[]byte], end maybe.Maybe[[]byte]) error {
+func verifyKeyValues(kvs []Key, start maybe.Maybe[Key], end maybe.Maybe[Key]) error {
 	hasLowerBound := start.HasValue()
 	hasUpperBound := end.HasValue()
 	for i := 0; i < len(kvs); i++ {
-		if i < len(kvs)-1 && bytes.Compare(kvs[i].Key, kvs[i+1].Key) >= 0 {
+		if i < len(kvs)-1 && kvs[i].Compare(kvs[i+1]) >= 0 {
 			return ErrNonIncreasingValues
 		}
-		if (hasLowerBound && bytes.Compare(kvs[i].Key, start.Value()) < 0) ||
-			(hasUpperBound && bytes.Compare(kvs[i].Key, end.Value()) > 0) {
+
+		if (hasLowerBound && kvs[i].Compare(start.Value()) < 0) ||
+			(hasUpperBound && kvs[i].Compare(end.Value()) > 0) {
 			return ErrStateFromOutsideOfRange
 		}
 	}
 	return nil
 }
 
+// If the last element in [proof] is [key], this is an inclusion proof.
+// Otherwise, this is an exclusion proof and [key] must not be in [proof].
+
 // Returns nil iff all the following hold:
+//
 //   - Any node with a partial byte length, should not have a value associated with it
 //     since all keys with values are written in complete bytes([]byte).
+//
 //   - Each key in [proof] is a strict prefix of the following key.
-//   - Each key in [proof] is a strict prefix of [keyBytes], except possibly the last.
-//   - If the last element in [proof] is [Key], this is an inclusion proof.
-//     Otherwise, this is an exclusion proof and [keyBytes] must not be in [proof].
-func verifyProofPath(proof []ProofNode, key maybe.Maybe[Key]) error {
+//
+//   - Each key in [proof] is a strict prefix of [key], except possibly the last.
+//
+//   - If this is an inclusionProof, the last key in [proof] is the [key].
+//
+//   - If this is an exclusionProof:
+//     -> the last key in [proof] is the replacement child and is at the corresponding index of the parent's children.
+//     -> the last key in [proof] is the possible parent and it doesn't have a child at the corresponding index.
+func verifyProofPath(proof []ProofNode, key Key, tokenSize int) error {
 	if len(proof) == 0 {
 		return nil
 	}
 
 	// loop over all but the last node since it will not have the prefix in exclusion proofs
-	for i := 0; i < len(proof)-1; i++ {
-		currentProofNode := proof[i]
-		nodeKey := currentProofNode.Key
+	for i, proofNode := range proof[:len(proof)-1] {
+		nodeKey := proofNode.Key
 
 		// Because the interface only supports []byte keys,
 		// a key with a partial byte may not store a value
-		if nodeKey.hasPartialByte() && proof[i].ValueOrHash.HasValue() {
+		if nodeKey.hasPartialByte() && proofNode.ValueOrHash.HasValue() {
 			return ErrPartialByteLengthWithValue
 		}
 
-		// each node should have a key that has the proven key as a prefix
-		if key.HasValue() && !key.Value().HasStrictPrefix(nodeKey) {
+		// each node's key should be a prefix of [key]
+		if !key.HasStrictPrefix(nodeKey) {
 			return ErrProofNodeNotForKey
 		}
 
-		// each node should have a key that has a matching TokenConfig and is a prefix of the next node's key
+		// each node's key must be a prefix of the next node's key
 		nextKey := proof[i+1].Key
 		if !nextKey.HasStrictPrefix(nodeKey) {
 			return ErrNonIncreasingProofNodes
 		}
 	}
 
-	// check the last node for a value since the above loop doesn't check the last node
-	if len(proof) > 0 {
-		lastNode := proof[len(proof)-1]
-		if lastNode.Key.hasPartialByte() && !lastNode.ValueOrHash.IsNothing() {
-			return ErrPartialByteLengthWithValue
+	lastNode := proof[len(proof)-1]
+	if lastNode.Key.hasPartialByte() && !lastNode.ValueOrHash.IsNothing() {
+		return ErrPartialByteLengthWithValue
+	}
+
+	if lastNode.Key.Compare(key) != 0 {
+		// exclusionProof
+
+		if key.HasPrefix(lastNode.Key) {
+			// [lastNode] is the parent of the node
+			nextIndex := key.Token(lastNode.Key.length, tokenSize)
+
+			if _, ok := lastNode.Children[nextIndex]; ok {
+				// [lastNode] shouldn't contain any other child at the specific index
+				return ErrExclusionProofMissingEndNodes
+			}
+		} else if len(proof) > 1 {
+			// For [lastNode] to be the replacement child, it should be at the same index as [key] would be
+			// inside the parent.
+			// So, we need to check that the first [number of bits of the parent] + [tokenSize] bits of both,
+			// [lastNode] and [key] are the same. Otherwise, it means the replacement child is at the wrong index.
+
+			lastNodeParent := proof[len(proof)-2]
+			parentKeyLen := lastNodeParent.Key.Length()
+			bitsToCheck := parentKeyLen + tokenSize
+
+			if !key.HasPrefix(lastNode.Key.Take(bitsToCheck)) {
+				// [lastNode] at wrong index inside parent
+				return ErrExclusionProofInvalidNode
+			}
 		}
 	}
 

--- a/x/merkledb/proof_test.go
+++ b/x/merkledb/proof_test.go
@@ -96,7 +96,7 @@ func Test_Proof_Inclusion(t *testing.T) {
 	}{
 		{
 			name:   "happy path",
-			modify: func(p *Proof) {},
+			modify: func(_ *Proof) {},
 		},
 		{
 			name: "last proof node with missing value",

--- a/x/merkledb/proof_test.go
+++ b/x/merkledb/proof_test.go
@@ -360,14 +360,12 @@ func Test_Proof_Path(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(dbTrie)
 
-	var (
-		key  = []byte{0x6B, 0x65, 0x79}
-		key0 = []byte{0x6B, 0x65, 0x79, 0x30}
-		key1 = []byte{0x6B, 0x65, 0x79, 0x31}
-		key2 = []byte{0x6B, 0x65, 0x79, 0x32}
-		key3 = []byte{0x6B, 0x65, 0x79, 0x33}
-		key4 = []byte{0x6B, 0x65, 0x79, 0x34}
-	)
+	key := []byte("key")
+	key0 := []byte("key0")
+	key1 := []byte("key1")
+	key2 := []byte("key2")
+	key3 := []byte("key3")
+	key4 := []byte("key4")
 
 	trie, err := dbTrie.NewView(
 		context.Background(),
@@ -1282,8 +1280,6 @@ func TestVerifyKeyValues(t *testing.T) {
 }
 
 func TestVerifyProofPath(t *testing.T) {
-	tokenSize := 8
-
 	type test struct {
 		name        string
 		path        []ProofNode
@@ -1488,7 +1484,7 @@ func TestVerifyProofPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			err := verifyProofPath(tt.path, tt.proofKey, tokenSize)
+			err := verifyProofPath(tt.path, tt.proofKey, 8)
 			require.ErrorIs(err, tt.expectedErr)
 		})
 	}

--- a/x/merkledb/trie.go
+++ b/x/merkledb/trie.go
@@ -234,12 +234,14 @@ func getRangeProof(
 		err      error
 	)
 	if len(result.KeyValues) > 0 {
+		// [endProof] => inclusion proof for the largest key
 		greatestKey := result.KeyValues[len(result.KeyValues)-1].Key
 		endProof, err = getProof(t, greatestKey)
 		if err != nil {
 			return nil, err
 		}
 	} else if end.HasValue() {
+		// [endProof] => exclusion proof for the [end] key
 		endProof, err = getProof(t, end.Value())
 		if err != nil {
 			return nil, err
@@ -250,6 +252,7 @@ func getRangeProof(
 	}
 
 	if start.HasValue() {
+		// [startProof] => inclusion/exclusion proof for [start] key
 		startProof, err := getProof(t, start.Value())
 		if err != nil {
 			return nil, err

--- a/x/merkledb/trie.go
+++ b/x/merkledb/trie.go
@@ -211,14 +211,14 @@ func getRangeProof(
 	}
 
 	result := RangeProof{
-		KeyValues: make([]KeyValue, 0, initKeyValuesSize),
+		KeyChanges: make([]KeyChange, 0, initKeyValuesSize),
 	}
 	it := t.NewIteratorWithStart(start.Value())
-	for it.Next() && len(result.KeyValues) < maxLength && (end.IsNothing() || bytes.Compare(it.Key(), end.Value()) <= 0) {
+	for it.Next() && len(result.KeyChanges) < maxLength && (end.IsNothing() || bytes.Compare(it.Key(), end.Value()) <= 0) {
 		// clone the value to prevent editing of the values stored within the trie
-		result.KeyValues = append(result.KeyValues, KeyValue{
+		result.KeyChanges = append(result.KeyChanges, KeyChange{
 			Key:   it.Key(),
-			Value: slices.Clone(it.Value()),
+			Value: maybe.Some(slices.Clone(it.Value())),
 		})
 	}
 	it.Release()
@@ -233,9 +233,9 @@ func getRangeProof(
 		endProof *Proof
 		err      error
 	)
-	if len(result.KeyValues) > 0 {
+	if len(result.KeyChanges) > 0 {
 		// [endProof] => inclusion proof for the largest key
-		greatestKey := result.KeyValues[len(result.KeyValues)-1].Key
+		greatestKey := result.KeyChanges[len(result.KeyChanges)-1].Key
 		endProof, err = getProof(t, greatestKey)
 		if err != nil {
 			return nil, err

--- a/x/sync/g_db/db_server.go
+++ b/x/sync/g_db/db_server.go
@@ -175,7 +175,7 @@ func (s *DBServer) GetRangeProof(
 		Proof: &pb.RangeProof{
 			StartProof: make([]*pb.ProofNode, len(proof.StartProof)),
 			EndProof:   make([]*pb.ProofNode, len(proof.EndProof)),
-			KeyValues:  make([]*pb.KeyValue, len(proof.KeyValues)),
+			KeyValues:  make([]*pb.KeyValue, len(proof.KeyChanges)),
 		},
 	}
 	for i, node := range proof.StartProof {
@@ -184,10 +184,10 @@ func (s *DBServer) GetRangeProof(
 	for i, node := range proof.EndProof {
 		protoProof.Proof.EndProof[i] = node.ToProto()
 	}
-	for i, kv := range proof.KeyValues {
+	for i, kv := range proof.KeyChanges {
 		protoProof.Proof.KeyValues[i] = &pb.KeyValue{
 			Key:   kv.Key,
-			Value: kv.Value,
+			Value: kv.Value.Value(),
 		}
 	}
 

--- a/x/sync/manager.go
+++ b/x/sync/manager.go
@@ -541,8 +541,8 @@ func (m *Manager) handleRangeProofResponse(
 		return nil
 	}
 
-	if len(rangeProof.KeyValues) > 0 {
-		largestHandledKey = maybe.Some(rangeProof.KeyValues[len(rangeProof.KeyValues)-1].Key)
+	if len(rangeProof.KeyChanges) > 0 {
+		largestHandledKey = maybe.Some(rangeProof.KeyChanges[len(rangeProof.KeyChanges)-1].Key)
 	}
 
 	m.completeWorkItem(ctx, work, largestHandledKey, targetRootID, rangeProof.EndProof)
@@ -634,13 +634,13 @@ func (m *Manager) handleChangeProofResponse(
 		}
 
 		largestHandledKey := work.end
-		if len(rangeProof.KeyValues) > 0 {
+		if len(rangeProof.KeyChanges) > 0 {
 			// Add all the key-value pairs we got to the database.
 			if err := m.config.DB.CommitRangeProof(ctx, work.start, work.end, &rangeProof); err != nil {
 				m.setError(err)
 				return nil
 			}
-			largestHandledKey = maybe.Some(rangeProof.KeyValues[len(rangeProof.KeyValues)-1].Key)
+			largestHandledKey = maybe.Some(rangeProof.KeyChanges[len(rangeProof.KeyChanges)-1].Key)
 		}
 
 		m.completeWorkItem(ctx, work, largestHandledKey, targetRootID, rangeProof.EndProof)
@@ -1155,10 +1155,10 @@ func verifyRangeProof(
 	}
 
 	// Ensure the response does not contain more than the maximum requested number of leaves.
-	if len(rangeProof.KeyValues) > keyLimit {
+	if len(rangeProof.KeyChanges) > keyLimit {
 		return fmt.Errorf(
 			"%w: (%d) > %d)",
-			errTooManyKeys, len(rangeProof.KeyValues), keyLimit,
+			errTooManyKeys, len(rangeProof.KeyChanges), keyLimit,
 		)
 	}
 

--- a/x/sync/network_server.go
+++ b/x/sync/network_server.go
@@ -290,7 +290,7 @@ func getRangeProof(
 		}
 
 		// The proof was too large. Try to shrink it.
-		keyLimit = len(rangeProof.KeyValues) / 2
+		keyLimit = len(rangeProof.KeyChanges) / 2
 	}
 	return nil, ErrMinProofSizeIsTooLarge
 }

--- a/x/sync/network_server_test.go
+++ b/x/sync/network_server_test.go
@@ -138,7 +138,7 @@ func Test_Server_GetRangeProof(t *testing.T) {
 			require.NoError(proof.UnmarshalProto(&proofProto))
 
 			if test.expectedResponseLen > 0 {
-				require.LessOrEqual(len(proof.KeyValues), test.expectedResponseLen)
+				require.LessOrEqual(len(proof.KeyChanges), test.expectedResponseLen)
 			}
 
 			bytes, err := proto.Marshal(proof.ToProto())

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -194,7 +194,7 @@ func Test_Sync_FindNextKey_InSync(t *testing.T) {
 	require.NoError(err)
 
 	// the two dbs should be in sync, so next key should be nil
-	lastKey := proof.KeyValues[len(proof.KeyValues)-1].Key
+	lastKey := proof.KeyChanges[len(proof.KeyChanges)-1].Key
 	nextKey, err := syncer.findNextKey(context.Background(), lastKey, maybe.Nothing[[]byte](), proof.EndProof)
 	require.NoError(err)
 	require.True(nextKey.IsNothing())
@@ -393,7 +393,7 @@ func Test_Sync_FindNextKey_ExtraValues(t *testing.T) {
 	require.NoError(err)
 
 	// add an extra value to local db
-	lastKey := proof.KeyValues[len(proof.KeyValues)-1].Key
+	lastKey := proof.KeyChanges[len(proof.KeyChanges)-1].Key
 	midpoint := midPoint(maybe.Some(lastKey), maybe.Nothing[[]byte]())
 	midPointVal := midpoint.Value()
 
@@ -521,7 +521,7 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 
 	proof, err := dbToSync.GetRangeProof(context.Background(), maybe.Nothing[[]byte](), maybe.Nothing[[]byte](), 100)
 	require.NoError(err)
-	lastKey := proof.KeyValues[len(proof.KeyValues)-1].Key
+	lastKey := proof.KeyChanges[len(proof.KeyChanges)-1].Key
 
 	// local db has a different child than remote db
 	lastKey = append(lastKey, 16)
@@ -529,10 +529,10 @@ func Test_Sync_FindNextKey_DifferentChild(t *testing.T) {
 
 	require.NoError(dbToSync.Put(lastKey, []byte{2}))
 
-	proof, err = dbToSync.GetRangeProof(context.Background(), maybe.Nothing[[]byte](), maybe.Some(proof.KeyValues[len(proof.KeyValues)-1].Key), 100)
+	proof, err = dbToSync.GetRangeProof(context.Background(), maybe.Nothing[[]byte](), maybe.Some(proof.KeyChanges[len(proof.KeyChanges)-1].Key), 100)
 	require.NoError(err)
 
-	nextKey, err := syncer.findNextKey(context.Background(), proof.KeyValues[len(proof.KeyValues)-1].Key, maybe.Nothing[[]byte](), proof.EndProof)
+	nextKey, err := syncer.findNextKey(context.Background(), proof.KeyChanges[len(proof.KeyChanges)-1].Key, maybe.Nothing[[]byte](), proof.EndProof)
 	require.NoError(err)
 	require.True(nextKey.HasValue())
 	require.Equal(lastKey, nextKey.Value())
@@ -616,10 +616,10 @@ func TestFindNextKeyRandom(t *testing.T) {
 		)
 		require.NoError(err)
 
-		if len(remoteProof.KeyValues) == 0 {
+		if len(remoteProof.KeyChanges) == 0 {
 			continue
 		}
-		lastReceivedKey := remoteProof.KeyValues[len(remoteProof.KeyValues)-1].Key
+		lastReceivedKey := remoteProof.KeyChanges[len(remoteProof.KeyChanges)-1].Key
 
 		// Commit the proof to the local database as we do
 		// in the actual syncer.
@@ -774,7 +774,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 			name: "range proof bad response - too many leaves in response",
 			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
-					response.KeyValues = append(response.KeyValues, merkledb.KeyValue{})
+					response.KeyChanges = append(response.KeyChanges, merkledb.KeyChange{})
 				})
 
 				return p2ptest.NewSelfClient(t, context.Background(), ids.EmptyNodeID, handler)
@@ -784,7 +784,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 			name: "range proof bad response - removed first key in response",
 			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
-					response.KeyValues = response.KeyValues[min(1, len(response.KeyValues)):]
+					response.KeyChanges = response.KeyChanges[min(1, len(response.KeyChanges)):]
 				})
 
 				return p2ptest.NewSelfClient(t, context.Background(), ids.EmptyNodeID, handler)
@@ -794,11 +794,11 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 			name: "range proof bad response - removed first key in response and replaced proof",
 			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
-					response.KeyValues = response.KeyValues[min(1, len(response.KeyValues)):]
-					response.KeyValues = []merkledb.KeyValue{
+					response.KeyChanges = response.KeyChanges[min(1, len(response.KeyChanges)):]
+					response.KeyChanges = []merkledb.KeyChange{
 						{
 							Key:   []byte("foo"),
-							Value: []byte("bar"),
+							Value: maybe.Some([]byte("bar")),
 						},
 					}
 					response.StartProof = []merkledb.ProofNode{
@@ -820,8 +820,8 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 			name: "range proof bad response - removed key from middle of response",
 			rangeProofClient: func(db merkledb.MerkleDB) *p2p.Client {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
-					i := rand.Intn(max(1, len(response.KeyValues)-1)) // #nosec G404
-					_ = slices.Delete(response.KeyValues, i, min(len(response.KeyValues), i+1))
+					i := rand.Intn(max(1, len(response.KeyChanges)-1)) // #nosec G404
+					_ = slices.Delete(response.KeyChanges, i, min(len(response.KeyChanges), i+1))
 				})
 
 				return p2ptest.NewSelfClient(t, context.Background(), ids.EmptyNodeID, handler)
@@ -854,7 +854,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 				handler := newFlakyRangeProofHandler(t, db, func(response *merkledb.RangeProof) {
 					response.StartProof = nil
 					response.EndProof = nil
-					response.KeyValues = nil
+					response.KeyChanges = nil
 				})
 
 				return p2ptest.NewSelfClient(t, context.Background(), ids.EmptyNodeID, handler)


### PR DESCRIPTION
## Why this should be merged

Fixing proof verification bugs:
1. exclusion proofs -> passing when providing a proof path which has the last node: a sibling of an ancestor of the existing node
2. exclusion proofs -> passing when providing not fully extended proof
This issues were mainly affecting the simple proofs verification, but also change/range proofs.

And also, simplifying the code for better readability and maintainability.

## How this works
- moving the main logic of proofs validation inside **verifyProofPath(proofPath []ProofNode, key Key)** and simplifying the specific proof verifications.
- added new specific errors
- more details within comments
- unifying change/range proof flows

## How this was tested
UTs

## Need to be documented in RELEASES.md?
