### PR TITLE
[WIP] Use libevm instead of go-ethereum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,13 +13,13 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/coreth v0.14.2-verify-interface4
+	github.com/ava-labs/coreth v0.14.1-rc.1.0.20250131190254-e03e01ffd4f8
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60
+	github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593
 	github.com/compose-spec/compose-go v1.20.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
-	github.com/ethereum/go-ethereum v1.13.14
 	github.com/google/btree v1.1.2
 	github.com/google/renameio/v2 v2.0.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -64,10 +64,12 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/coreth v0.14.2-verify-interface4 h1:AYeN8R6ZnNu/K8KwBQD4ELphvLpvNxAjkX3SBcJ+bps=
-github.com/ava-labs/coreth v0.14.2-verify-interface4/go.mod h1:wQaeiolUP0vCHS1mC0lIMXzHF05vbjugSLCBFDnO4Gs=
+github.com/ava-labs/coreth v0.14.1-rc.1.0.20250131190254-e03e01ffd4f8 h1:QBZP8WOpS890RBvd9g0Kr1Usd33vNfN0z4lT8GJiOG4=
+github.com/ava-labs/coreth v0.14.1-rc.1.0.20250131190254-e03e01ffd4f8/go.mod h1:PWwzUiW36xclxPKx3OV39tnKBb6S7nH1BECwQTTqJ10=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60 h1:EL66gtXOAwR/4KYBjOV03LTWgkEXvLePribLlJNu4g0=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60/go.mod h1:/7qKobTfbzBu7eSTVaXMTr56yTYk4j2Px6/8G+idxHo=
+github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2 h1:CVbn0hSsPCl6gCkTCnqwuN4vtJgdVbkCqLXzYAE7qF8=
+github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2/go.mod h1:yBctIV/wnxXTF38h95943jvpuk4aj07TrjbpoGor6LQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -192,8 +194,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
-github.com/ethereum/go-ethereum v1.13.14 h1:EwiY3FZP94derMCIam1iW4HFVrSgIcpsu0HwTQtm6CQ=
-github.com/ethereum/go-ethereum v1.13.14/go.mod h1:TN8ZiHrdJwSe8Cb6x+p0hs5CxhJZPbqB7hHkaUXcmIU=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=

--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ava-labs/libevm/accounts/abi"
+	"github.com/ava-labs/libevm/common"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/utils/crypto/secp256k1/secp256k1.go
+++ b/utils/crypto/secp256k1/secp256k1.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/crypto"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 
 	stdecdsa "crypto/ecdsa"
+
 	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 

--- a/utils/crypto/secp256k1/secp256k1.go
+++ b/utils/crypto/secp256k1/secp256k1.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 
 	stdecdsa "crypto/ecdsa"
-
 	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 

--- a/vms/secp256k1fx/keychain.go
+++ b/vms/secp256k1fx/keychain.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ava-labs/libevm/common"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/keychain"

--- a/wallet/chain/c/backend.go
+++ b/wallet/chain/c/backend.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 var (

--- a/wallet/chain/c/builder.go
+++ b/wallet/chain/c/builder.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 const avaxConversionRateInt = 1_000_000_000

--- a/wallet/chain/c/builder_with_options.go
+++ b/wallet/chain/c/builder_with_options.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 var _ Builder = (*builderWithOptions)(nil)

--- a/wallet/chain/c/signer.go
+++ b/wallet/chain/c/signer.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ava-labs/libevm/common"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 var _ Wallet = (*wallet)(nil)

--- a/wallet/chain/c/wallet_with_options.go
+++ b/wallet/chain/c/wallet_with_options.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 var _ Wallet = (*walletWithOptions)(nil)

--- a/wallet/subnet/primary/api.go
+++ b/wallet/subnet/primary/api.go
@@ -28,7 +28,7 @@ import (
 	pbuilder "github.com/ava-labs/avalanchego/wallet/chain/p/builder"
 	xbuilder "github.com/ava-labs/avalanchego/wallet/chain/x/builder"
 	walletcommon "github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 const (

--- a/wallet/subnet/primary/common/options.go
+++ b/wallet/subnet/primary/common/options.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 const defaultPollFrequency = 100 * time.Millisecond


### PR DESCRIPTION
## Why this should be merged
`libevm` is fork of `go-ethereum` that is currently at the same upstream version as we use here (`v1.13.14`). In case should want or need to back-port upstream changes from `go-ethereum` in the future without needing to fully update to a newer upstream version, we should import the `libevm` packages and remove the direct dependency on `go-ethereum` entirely.

## How this works
Self-explanatory

## How this was tested
CI

## Need to be documented in RELEASES.md?
No
