### PR TITLE
[tmpnet] Re-enable reuse of dynamically allocated API ports

### DIFF
--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -89,10 +89,13 @@ A temporary network can be managed in code:
 
 ```golang
 network := &tmpnet.Network{                   // Configure non-default values for the new network
+    DefaultRuntimeConfig{
+        ReuseDynamicPorts: true,              // Configure process-based nodes to reuse a dynamically allocated API port when restarting
+    },
     DefaultFlags: tmpnet.FlagsMap{
         config.LogLevelKey: "INFO",           // Change one of the network's defaults
     },
-    Nodes: tmpnet.NewNodesOrPanic(5),           // Number of initial validating nodes
+    Nodes: tmpnet.NewNodesOrPanic(5),         // Number of initial validating nodes
     Subnets: []*tmpnet.Subnet{                // Subnets to create on the new network once it is running
         {
             Name: "xsvm-a",                   // User-defined name used to reference subnet in code and on disk

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -516,6 +516,16 @@ func (n *Network) StartNode(ctx context.Context, log logging.Logger, node *Node)
 
 // Restart a single node.
 func (n *Network) RestartNode(ctx context.Context, log logging.Logger, node *Node) error {
+	if node.RuntimeConfig.ReuseDynamicPorts {
+		// Attempt to save the API port currently being used so the
+		// restarted node can reuse it. This may result in the node
+		// failing to start if the operating system allocates the port
+		// to a different process between node stop and start.
+		if err := node.SaveAPIPort(); err != nil {
+			return err
+		}
+	}
+
 	if err := node.Stop(ctx); err != nil {
 		return fmt.Errorf("failed to stop node %s: %w", node.NodeID, err)
 	}


### PR DESCRIPTION
## Why this should be merged

By popular demand, tmpnet will once again attempt to reuse dynamically allocated API ports. The only difference is that this needs to be explicitly configured (via `Network.DefaultRuntimeConfig.ReuseDynamicPorts`) to allow for an error to be reported if a network so configured is started with a kube runtime.

## How this works

- Enables a dynamically-allocated API port to be saved in the node flags for use on a subsequent restart if `ReuseDynamicPorts` is set

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A