### PR TITLE
fix spelling issues 

### DIFF
--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -296,7 +296,7 @@ type GetLoggerLevelArgs struct {
 func (a *Admin) GetLoggerLevel(_ *http.Request, args *GetLoggerLevelArgs, reply *LoggerLevelReply) error {
 	a.Log.Debug("API called",
 		zap.String("service", "admin"),
-		zap.String("method", "getLoggerLevels"),
+		zap.String("method", "getLoggerLevel"),
 		logging.UserString("loggerName", args.LoggerName),
 	)
 

--- a/api/health/health_test.go
+++ b/api/health/health_test.go
@@ -47,7 +47,7 @@ func awaitLiveness(t *testing.T, r Reporter, liveness bool) {
 	}, awaitTimeout, awaitFreq)
 }
 
-func TestDuplicatedRegistations(t *testing.T) {
+func TestDuplicatedRegistrations(t *testing.T) {
 	require := require.New(t)
 
 	check := CheckerFunc(func(context.Context) (interface{}, error) {

--- a/api/health/worker.go
+++ b/api/health/worker.go
@@ -24,7 +24,7 @@ var (
 	allTags = []string{AllTag}
 
 	errRestrictedTag  = errors.New("restricted tag")
-	errDuplicateCheck = errors.New("duplicated check")
+	errDuplicateCheck = errors.New("duplicate check")
 )
 
 type worker struct {


### PR DESCRIPTION
## Why this should be merged


api/admin/service.go
getLoggerLevels - getLoggerLevel

api/health/health_test.go
TestDuplicatedRegistations - TestDuplicatedRegistrations

api/health/worker.go
duplicated - duplicate