### PR TITLE
Remove RequestBuildBlock on P-Chain Mempool

### DIFF
--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/fee"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
+	"github.com/ava-labs/avalanchego/vms/txs/mempool"
 
 	smblock "github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/block/executor"
@@ -54,7 +54,7 @@ var (
 
 type Builder interface {
 	smblock.BuildBlockWithContextChainVM
-	mempool.Mempool
+	mempool.Mempool[*txs.Tx]
 
 	// StartBlockTimer starts to issue block creation requests to advance the
 	// chain timestamp.
@@ -83,7 +83,7 @@ type Builder interface {
 
 // builder implements a simple builder to convert txs into valid blocks
 type builder struct {
-	mempool.Mempool
+	mempool.Mempool[*txs.Tx]
 
 	toEngine          chan<- common.Message
 	txExecutorBackend *txexecutor.Backend
@@ -97,7 +97,7 @@ type builder struct {
 }
 
 func New(
-	mempool mempool.Mempool,
+	mempool mempool.Mempool[*txs.Tx],
 	toEngine chan<- common.Message,
 	txExecutorBackend *txexecutor.Backend,
 	blkManager blockexecutor.Manager,
@@ -418,7 +418,7 @@ func packDurangoBlockTxs(
 	ctx context.Context,
 	parentID ids.ID,
 	parentState state.Chain,
-	mempool mempool.Mempool,
+	mempool mempool.Mempool[*txs.Tx],
 	backend *txexecutor.Backend,
 	manager blockexecutor.Manager,
 	timestamp time.Time,
@@ -479,7 +479,7 @@ func packEtnaBlockTxs(
 	ctx context.Context,
 	parentID ids.ID,
 	parentState state.Chain,
-	mempool mempool.Mempool,
+	mempool mempool.Mempool[*txs.Tx],
 	backend *txexecutor.Backend,
 	manager blockexecutor.Manager,
 	timestamp time.Time,
@@ -579,7 +579,7 @@ func executeTx(
 	ctx context.Context,
 	parentID ids.ID,
 	stateDiff state.Diff,
-	mempool mempool.Mempool,
+	mempool mempool.Mempool[*txs.Tx],
 	backend *txexecutor.Backend,
 	manager blockexecutor.Manager,
 	pChainHeight uint64,

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -142,11 +142,12 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 	metrics, err := metrics.New(registerer)
 	require.NoError(err)
 
-	res.mempool, err = mempool.New("mempool", registerer, nil)
+	res.mempool, err = mempool.New("mempool", registerer)
 	require.NoError(err)
 
 	res.blkManager = blockexecutor.NewManager(
 		res.mempool,
+		nil,
 		metrics,
 		res.state,
 		&res.backend,
@@ -161,6 +162,7 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 		res.backend.Ctx.ValidatorState,
 		txVerifier,
 		res.mempool,
+		nil,
 		res.backend.Config.PartialSyncPrimaryNetwork,
 		res.sender,
 		&res.ctx.Lock,
@@ -173,6 +175,7 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 
 	res.Builder = New(
 		res.mempool,
+		nil,
 		&res.backend,
 		res.blkManager,
 	)

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -51,6 +51,7 @@ import (
 
 	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/block/executor"
 	txexecutor "github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
+	txmempool "github.com/ava-labs/avalanchego/vms/txs/mempool"
 )
 
 const (
@@ -67,7 +68,7 @@ type mutableSharedMemory struct {
 type environment struct {
 	Builder
 	blkManager blockexecutor.Manager
-	mempool    mempool.Mempool
+	mempool    txmempool.Mempool[*txs.Tx]
 	network    *network.Network
 	sender     *enginetest.Sender
 

--- a/vms/platformvm/block/executor/backend.go
+++ b/vms/platformvm/block/executor/backend.go
@@ -12,14 +12,15 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/txs/mempool"
 )
 
 var errConflictingParentTxs = errors.New("block contains a transaction that conflicts with a transaction in a parent block")
 
 // Shared fields used by visitors.
 type backend struct {
-	mempool.Mempool
+	mempool.Mempool[*txs.Tx]
 	// lastAccepted is the ID of the last block that had Accept() called on it.
 	lastAccepted ids.ID
 

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -153,7 +153,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller, f upgradetest.Fork) *
 	metrics := metrics.Noop
 
 	var err error
-	res.mempool, err = mempool.New("mempool", registerer, nil)
+	res.mempool, err = mempool.New("mempool", registerer)
 	if err != nil {
 		panic(fmt.Errorf("failed to create mempool: %w", err))
 	}
@@ -161,6 +161,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller, f upgradetest.Fork) *
 	if ctrl == nil {
 		res.blkManager = NewManager(
 			res.mempool,
+			nil,
 			metrics,
 			res.state,
 			res.backend,
@@ -170,6 +171,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller, f upgradetest.Fork) *
 	} else {
 		res.blkManager = NewManager(
 			res.mempool,
+			nil,
 			metrics,
 			res.mockedState,
 			res.backend,

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -48,6 +48,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/chain/p/wallet"
+
+	txmempool "github.com/ava-labs/avalanchego/vms/txs/mempool"
 )
 
 const (
@@ -81,7 +83,7 @@ type test struct {
 
 type environment struct {
 	blkManager Manager
-	mempool    mempool.Mempool
+	mempool    txmempool.Mempool[*txs.Tx]
 	sender     *enginetest.Sender
 
 	isBootstrapped *utils.Atomic[bool]

--- a/vms/platformvm/block/executor/manager.go
+++ b/vms/platformvm/block/executor/manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/metrics"
@@ -52,6 +53,7 @@ type Manager interface {
 
 func NewManager(
 	mempool mempool.Mempool,
+	toEngine chan<- common.Message,
 	metrics metrics.Metrics,
 	s state.State,
 	txExecutorBackend *executor.Backend,
@@ -76,6 +78,7 @@ func NewManager(
 		},
 		rejector: &rejector{
 			backend:         backend,
+			toEngine:        toEngine,
 			addTxsToMempool: !txExecutorBackend.Config.PartialSyncPrimaryNetwork,
 		},
 		preferred:         lastAccepted,

--- a/vms/platformvm/block/executor/manager.go
+++ b/vms/platformvm/block/executor/manager.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/fee"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validators"
+	"github.com/ava-labs/avalanchego/vms/txs/mempool"
 )
 
 var (
@@ -52,7 +52,7 @@ type Manager interface {
 }
 
 func NewManager(
-	mempool mempool.Mempool,
+	mempool mempool.Mempool[*txs.Tx],
 	toEngine chan<- common.Message,
 	metrics metrics.Metrics,
 	s state.State,

--- a/vms/platformvm/block/executor/rejector_test.go
+++ b/vms/platformvm/block/executor/rejector_test.go
@@ -120,7 +120,7 @@ func TestRejectBlock(t *testing.T) {
 			blk, err := tt.newBlockFunc()
 			require.NoError(err)
 
-			mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+			mempool, err := mempool.New("", prometheus.NewRegistry())
 			require.NoError(err)
 			state := state.NewMockState(ctrl)
 			blkIDToState := map[ids.ID]*blockState{

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -454,7 +454,7 @@ func TestVerifierVisitCommitBlock(t *testing.T) {
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 	parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -528,7 +528,7 @@ func TestVerifierVisitAbortBlock(t *testing.T) {
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 	parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -603,7 +603,7 @@ func TestVerifyUnverifiedParent(t *testing.T) {
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 
@@ -674,7 +674,7 @@ func TestBanffAbortBlockTimestampChecks(t *testing.T) {
 
 			// Create mocked dependencies.
 			s := state.NewMockState(ctrl)
-			mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+			mempool, err := mempool.New("", prometheus.NewRegistry())
 			require.NoError(err)
 			parentID := ids.GenerateTestID()
 			parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -775,7 +775,7 @@ func TestBanffCommitBlockTimestampChecks(t *testing.T) {
 
 			// Create mocked dependencies.
 			s := state.NewMockState(ctrl)
-			mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+			mempool, err := mempool.New("", prometheus.NewRegistry())
 			require.NoError(err)
 			parentID := ids.GenerateTestID()
 			parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -844,7 +844,7 @@ func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) 
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 	parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -901,7 +901,7 @@ func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 	parentStatelessBlk := block.NewMockBlock(ctrl)

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -75,7 +75,7 @@ func newTestVerifier(t testing.TB, c testVerifierConfig) *verifier {
 		c.ValidatorFeeConfig = genesis.LocalParams.ValidatorFeeConfig
 	}
 
-	mempool, err := mempool.New("", prometheus.NewRegistry(), nil)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 
 	var (

--- a/vms/platformvm/network/gossip.go
+++ b/vms/platformvm/network/gossip.go
@@ -19,8 +19,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/txs/mempool"
-
-	pmempool "github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
 )
 
 var (
@@ -68,7 +66,7 @@ func (txMarshaller) UnmarshalGossip(bytes []byte) (*txs.Tx, error) {
 }
 
 func newGossipMempool(
-	mempool pmempool.Mempool,
+	mempool mempool.Mempool[*txs.Tx],
 	toEngine chan<- common.Message,
 	registerer prometheus.Registerer,
 	log logging.Logger,
@@ -88,7 +86,7 @@ func newGossipMempool(
 }
 
 type gossipMempool struct {
-	pmempool.Mempool
+	mempool.Mempool[*txs.Tx]
 	toEngine   chan<- common.Message
 	log        logging.Logger
 	txVerifier TxVerifier

--- a/vms/platformvm/network/gossip_test.go
+++ b/vms/platformvm/network/gossip_test.go
@@ -29,12 +29,13 @@ func TestGossipMempoolAddVerificationError(t *testing.T) {
 		TxID: txID,
 	}
 
-	mempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+	mempool, err := pmempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	txVerifier := testTxVerifier{err: errFoo}
 
 	gossipMempool, err := newGossipMempool(
 		mempool,
+		nil,
 		prometheus.NewRegistry(),
 		logging.NoLog{},
 		txVerifier,
@@ -66,6 +67,7 @@ func TestMempoolDuplicate(t *testing.T) {
 	require.NoError(testMempool.Add(tx))
 	gossipMempool, err := newGossipMempool(
 		testMempool,
+		nil,
 		prometheus.NewRegistry(),
 		logging.NoLog{},
 		txVerifier,
@@ -91,11 +93,12 @@ func TestGossipAddBloomFilter(t *testing.T) {
 	}
 
 	txVerifier := testTxVerifier{}
-	mempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+	mempool, err := pmempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 
 	gossipMempool, err := newGossipMempool(
 		mempool,
+		nil,
 		prometheus.NewRegistry(),
 		logging.NoLog{},
 		txVerifier,

--- a/vms/platformvm/network/gossip_test.go
+++ b/vms/platformvm/network/gossip_test.go
@@ -54,7 +54,7 @@ func TestGossipMempoolAddVerificationError(t *testing.T) {
 func TestMempoolDuplicate(t *testing.T) {
 	require := require.New(t)
 
-	testMempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+	testMempool, err := pmempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	txVerifier := testTxVerifier{}
 

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -46,6 +46,7 @@ func New(
 	vdrs validators.State,
 	txVerifier TxVerifier,
 	mempool mempool.Mempool,
+	toEngine chan<- common.Message,
 	partialSyncPrimaryNetwork bool,
 	appSender common.AppSender,
 	stateLock sync.Locker,
@@ -78,6 +79,7 @@ func New(
 
 	gossipMempool, err := newGossipMempool(
 		mempool,
+		toEngine,
 		registerer,
 		log,
 		txVerifier,

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -21,8 +21,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs/mempool"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/avalanchego/vms/txs/mempool"
 )
 
 type Network struct {
@@ -45,7 +45,7 @@ func New(
 	subnetID ids.ID,
 	vdrs validators.State,
 	txVerifier TxVerifier,
-	mempool mempool.Mempool,
+	mempool mempool.Mempool[*txs.Tx],
 	toEngine chan<- common.Message,
 	partialSyncPrimaryNetwork bool,
 	appSender common.AppSender,

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -72,7 +72,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "mempool has transaction",
 			mempool: func() pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				require.NoError(t, mempool.Add(&txs.Tx{Unsigned: &txs.BaseTx{}}))
 				return mempool
@@ -86,7 +86,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "transaction marked as dropped in mempool",
 			mempool: func() pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				mempool.MarkDropped(ids.Empty, errTest)
 				return mempool
@@ -101,7 +101,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "tx dropped",
 			mempool: func() pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool
 			}(),
@@ -116,7 +116,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "tx too big",
 			mempool: func() pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool
 			}(),
@@ -135,7 +135,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "tx conflicts",
 			mempool: func() pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 
 				tx := &txs.Tx{
@@ -177,7 +177,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "mempool full",
 			mempool: func() pmempool.Mempool {
-				m, err := pmempool.New("", prometheus.NewRegistry(), nil)
+				m, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 
 				for i := 0; i < 1024; i++ {
@@ -231,6 +231,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 				snowCtx.ValidatorState,
 				tt.txVerifier,
 				tt.mempool,
+				nil,
 				false,
 				tt.appSenderFunc(ctrl),
 				nil,

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -61,7 +61,7 @@ func (t testTxVerifier) VerifyTx(*txs.Tx) error {
 func TestNetworkIssueTxFromRPC(t *testing.T) {
 	type test struct {
 		name          string
-		mempool       pmempool.Mempool
+		mempool       *pmempool.Mempool
 		txVerifier    testTxVerifier
 		appSenderFunc func(*gomock.Controller) common.AppSender
 		tx            *txs.Tx
@@ -71,7 +71,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 	tests := []test{
 		{
 			name: "mempool has transaction",
-			mempool: func() pmempool.Mempool {
+			mempool: func() *pmempool.Mempool {
 				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				require.NoError(t, mempool.Add(&txs.Tx{Unsigned: &txs.BaseTx{}}))
@@ -85,7 +85,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		},
 		{
 			name: "transaction marked as dropped in mempool",
-			mempool: func() pmempool.Mempool {
+			mempool: func() *pmempool.Mempool {
 				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				mempool.MarkDropped(ids.Empty, errTest)
@@ -100,7 +100,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		},
 		{
 			name: "tx dropped",
-			mempool: func() pmempool.Mempool {
+			mempool: func() *pmempool.Mempool {
 				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool
@@ -115,7 +115,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		},
 		{
 			name: "tx too big",
-			mempool: func() pmempool.Mempool {
+			mempool: func() *pmempool.Mempool {
 				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool
@@ -134,7 +134,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		},
 		{
 			name: "tx conflicts",
-			mempool: func() pmempool.Mempool {
+			mempool: func() *pmempool.Mempool {
 				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 
@@ -176,7 +176,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		},
 		{
 			name: "mempool full",
-			mempool: func() pmempool.Mempool {
+			mempool: func() *pmempool.Mempool {
 				m, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 
@@ -203,7 +203,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		},
 		{
 			name: "happy path",
-			mempool: func() pmempool.Mempool {
+			mempool: func() *pmempool.Mempool {
 				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -204,7 +204,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "happy path",
 			mempool: func() pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), nil)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool
 			}(),

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 
 	txmempool "github.com/ava-labs/avalanchego/vms/txs/mempool"
@@ -23,26 +22,13 @@ var (
 
 type Mempool interface {
 	txmempool.Mempool[*txs.Tx]
-
-	// RequestBuildBlock notifies the consensus engine that a block should be
-	// built. If [emptyBlockPermitted] is true, the notification will be sent
-	// regardless of whether there are no transactions in the mempool. If not,
-	// a notification will only be sent if there is at least one transaction in
-	// the mempool.
-	RequestBuildBlock(emptyBlockPermitted bool)
 }
 
 type mempool struct {
 	txmempool.Mempool[*txs.Tx]
-
-	toEngine chan<- common.Message
 }
 
-func New(
-	namespace string,
-	registerer prometheus.Registerer,
-	toEngine chan<- common.Message,
-) (Mempool, error) {
+func New(namespace string, registerer prometheus.Registerer) (Mempool, error) {
 	metrics, err := txmempool.NewMetrics(namespace, registerer)
 	if err != nil {
 		return nil, err
@@ -50,10 +36,7 @@ func New(
 	pool := txmempool.New[*txs.Tx](
 		metrics,
 	)
-	return &mempool{
-		Mempool:  pool,
-		toEngine: toEngine,
-	}, nil
+	return &mempool{Mempool: pool}, nil
 }
 
 func (m *mempool) Add(tx *txs.Tx) error {
@@ -66,15 +49,4 @@ func (m *mempool) Add(tx *txs.Tx) error {
 	}
 
 	return m.Mempool.Add(tx)
-}
-
-func (m *mempool) RequestBuildBlock(emptyBlockPermitted bool) {
-	if !emptyBlockPermitted && m.Len() == 0 {
-		return
-	}
-
-	select {
-	case m.toEngine <- common.PendingTxs:
-	default:
-	}
 }

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -14,21 +14,15 @@ import (
 )
 
 var (
-	_ Mempool = (*mempool)(nil)
-
 	ErrCantIssueAdvanceTimeTx     = errors.New("can not issue an advance time tx")
 	ErrCantIssueRewardValidatorTx = errors.New("can not issue a reward validator tx")
 )
 
-type Mempool interface {
+type Mempool struct {
 	txmempool.Mempool[*txs.Tx]
 }
 
-type mempool struct {
-	txmempool.Mempool[*txs.Tx]
-}
-
-func New(namespace string, registerer prometheus.Registerer) (Mempool, error) {
+func New(namespace string, registerer prometheus.Registerer) (*Mempool, error) {
 	metrics, err := txmempool.NewMetrics(namespace, registerer)
 	if err != nil {
 		return nil, err
@@ -36,10 +30,10 @@ func New(namespace string, registerer prometheus.Registerer) (Mempool, error) {
 	pool := txmempool.New[*txs.Tx](
 		metrics,
 	)
-	return &mempool{Mempool: pool}, nil
+	return &Mempool{Mempool: pool}, nil
 }
 
-func (m *mempool) Add(tx *txs.Tx) error {
+func (m *Mempool) Add(tx *txs.Tx) error {
 	switch tx.Unsigned.(type) {
 	case *txs.AdvanceTimeTx:
 		return ErrCantIssueAdvanceTimeTx

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -167,13 +167,14 @@ func (vm *VM) Initialize(
 		Bootstrapped: &vm.bootstrapped,
 	}
 
-	mempool, err := pmempool.New("mempool", registerer, toEngine)
+	mempool, err := pmempool.New("mempool", registerer)
 	if err != nil {
 		return fmt.Errorf("failed to create mempool: %w", err)
 	}
 
 	vm.manager = blockexecutor.NewManager(
 		mempool,
+		toEngine,
 		vm.metrics,
 		vm.state,
 		txExecutorBackend,
@@ -191,6 +192,7 @@ func (vm *VM) Initialize(
 		),
 		txVerifier,
 		mempool,
+		toEngine,
 		txExecutorBackend.Config.PartialSyncPrimaryNetwork,
 		appSender,
 		chainCtx.Lock.RLocker(),
@@ -211,6 +213,7 @@ func (vm *VM) Initialize(
 
 	vm.Builder = blockbuilder.New(
 		mempool,
+		toEngine,
 		txExecutorBackend,
 		vm.manager,
 	)


### PR DESCRIPTION
## Why this should be merged

This function doesn't seem to belong on the mempool type because consensus is responsible for building the block. I think another alternative would be to put `RequestBuildBlock` onto a static function somewhere, but I'm not sure where it would live (probably not the mempool package) + I don't think the cost of duplicate code is bad here.

## How this works

Removes `RequestBuildBlock` and replaces the usage of it with usage of the `toEngine` channel

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
