### PR TITLE
Remove apostrophe from Dockerfile comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
-ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
+ARG GO_VERSION=INVALID # This value is not intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 # Always use the native platform to ensure fast builds

--- a/tests/antithesis/Dockerfile.builder-uninstrumented
+++ b/tests/antithesis/Dockerfile.builder-uninstrumented
@@ -1,6 +1,6 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
-ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
+ARG GO_VERSION=INVALID # This value is not intended to be used but silences a warning
 
 FROM golang:$GO_VERSION-bullseye
 

--- a/tests/antithesis/avalanchego/Dockerfile.node
+++ b/tests/antithesis/avalanchego/Dockerfile.node
@@ -1,5 +1,5 @@
 # BUILDER_IMAGE_TAG should identify the builder image
-ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
+ARG BUILDER_IMAGE_TAG=INVALID # This value is not intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/tests/antithesis/avalanchego/Dockerfile.workload
+++ b/tests/antithesis/avalanchego/Dockerfile.workload
@@ -1,8 +1,8 @@
 # BUILDER_IMAGE_TAG should identify the builder image
-ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
+ARG BUILDER_IMAGE_TAG=INVALID # This value is not intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value isn't intended to be used but silences a warning
+ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value is not intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/tests/antithesis/xsvm/Dockerfile.node
+++ b/tests/antithesis/xsvm/Dockerfile.node
@@ -1,8 +1,8 @@
 # BUILDER_IMAGE_TAG should identify the builder image
-ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
+ARG BUILDER_IMAGE_TAG=INVALID # This value is not intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing avalanchego node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value isn't intended to be used but silences a warning
+ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value is not intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/tests/antithesis/xsvm/Dockerfile.workload
+++ b/tests/antithesis/xsvm/Dockerfile.workload
@@ -1,8 +1,8 @@
 # BUILDER_IMAGE_TAG should identify the builder image
-ARG BUILDER_IMAGE_TAG=INVALID # This value isn't intended to be used but silences a warning
+ARG BUILDER_IMAGE_TAG=INVALID # This value is not intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value isn't intended to be used but silences a warning
+ARG AVALANCHEGO_NODE_IMAGE="invalid-image" # This value is not intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM antithesis-avalanchego-builder:$BUILDER_IMAGE_TAG AS builder

--- a/vms/example/xsvm/Dockerfile
+++ b/vms/example/xsvm/Dockerfile
@@ -1,9 +1,9 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
-ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
+ARG GO_VERSION=INVALID # This value is not intended to be used but silences a warning
 
 # AVALANCHEGO_NODE_IMAGE needs to identify an existing node image and should include the tag
-ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value isn't intended to be used but silences a warning
+ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value is not intended to be used but silences a warning
 
 # ============= Compilation Stage ================
 FROM golang:$GO_VERSION-bullseye AS builder


### PR DESCRIPTION
Remove apostrophe from inline comment within Dockerfile.

Prior to this change, Dockerfile does not display correctly within Visual Studio. Seems to be an odd edge case. Removing the apostrophe to improve locally. Feel free to ignore and close if preferred to leave as is.