### PR TITLE
Fail fast in tests if avalancheGo executable isn't an absolute path

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -8,7 +8,7 @@
 ```bash
 ./scripts/build.sh        # Builds avalanchego for use in deploying a test network
 ./scripts/build_xsvm.sh   # Builds xsvm for use in deploying a test network with a subnet
-./bin/ginkgo -v ./tests/e2e -- --avalanchego-path=./build/avalanchego
+./bin/ginkgo -v ./tests/e2e -- --avalanchego-path=$PWD/build/avalanchego # Note that the path given for --avalanchego-path must be an absolute and not a relative path.
 ```
 
 See [`tests.e2e.sh`](../../scripts/tests.e2e.sh) for an example.
@@ -32,7 +32,7 @@ primarily target the X-Chain:
 
 
 ```bash
-./bin/ginkgo -v --label-filter=x ./tests/e2e -- --avalanchego-path=./build/avalanchego
+./bin/ginkgo -v --label-filter=x ./tests/e2e -- --avalanchego-path=$PWD/build/avalanchego
 ```
 
 The ginkgo docs provide further detail on [how to compose label

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -133,10 +133,13 @@ func NewTestEnvironment(tc tests.TestContext, flagVars *FlagVars, desiredNetwork
 	// Start a new network
 	if network == nil {
 		network = desiredNetwork
+		avalancheBinaryPath, err := flagVars.AvalancheGoExecPath()
+		require.NoError(err)
+
 		StartNetwork(
 			tc,
 			network,
-			flagVars.AvalancheGoExecPath(),
+			avalancheBinaryPath,
 			flagVars.PluginDir(),
 			flagVars.NetworkShutdownDelay(),
 			flagVars.StartNetwork(),


### PR DESCRIPTION
## How this works

Currently when running ginkgo tests with --avalanchego flag with a relative path, the tests fail when trying to ascertain the rpcvm plugin path, because they execute the binary without an absolute path, and the binary path is evaluated from a wrong location.

In order to make the underlying issue clear, I added a check that fails the test and warns that an absolute path must be used.

## Why this should be merged

Checks if the path is relative and if so, fails fast with an error.

## How this was tested

ran it locally:

```
➜  avalanchego git:(absolutePath) ginkgo -v --focus-file=faultinjection/duplicate_node_id.go  ./tests/e2e -- --avalanchego-path=./build/avalanchego        
Running Suite: e2e test suites - /Users/yacov.manevich/avalanchego/tests/e2e
============================================================================
Random Seed: 1738883202

Will run 1 of 13 specs
------------------------------
[SynchronizedBeforeSuite] 
/Users/yacov.manevich/avalanchego/tests/e2e/e2e_test.go:34
  [FAILED] in [SynchronizedBeforeSuite] - /Users/yacov.manevich/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1545 @ 02/07/25 00:06:52.681
[SynchronizedBeforeSuite] [FAILED] [0.023 seconds]
[SynchronizedBeforeSuite] 
/Users/yacov.manevich/avalanchego/tests/e2e/e2e_test.go:34

  [FAILED] 
        Error Trace:    /Users/yacov.manevich/avalanchego/tests/fixture/e2e/env.go:137
                                                /Users/yacov.manevich/avalanchego/tests/e2e/e2e_test.go:39
                                                /Users/yacov.manevich/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.darwin-amd64/src/reflect/value.go:596
                                                /Users/yacov.manevich/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.darwin-amd64/src/reflect/value.go:380
                                                /Users/yacov.manevich/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/node.go:486
                                                /Users/yacov.manevich/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/suite.go:642
                                                /Users/yacov.manevich/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.1/internal/suite.go:889
                                                /Users/yacov.manevich/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.darwin-amd64/src/runtime/asm_amd64.s:1695
        Error:          Received unexpected error:
                        avalanchego-path (./build/avalanchego) is a relative path but must be an absolute path
  
  In [SynchronizedBeforeSuite] at: /Users/yacov.manevich/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1545 @ 02/07/25 00:06:52.681
```

## Need to be documented in RELEASES.md?

No