### PR TITLE
fix: correct typos in parser.go and tmpnet documentation

### DIFF
--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -369,7 +369,7 @@ metrics and logs.
 
 Collection of logs and metrics is enabled for CI jobs that use
 tmpnet. Each job will execute a step titled `Notify of metrics
-availability` that emits a link to grafana parametized to show results
-for the job. Additional links to grafana parametized to show results
+availability` that emits a link to grafana parameterized to show results
+for the job. Additional links to grafana parameterized to show results
 for individual network will appear in the logs displaying the start of
 those networks.

--- a/version/parser.go
+++ b/version/parser.go
@@ -35,8 +35,8 @@ func Parse(s string) (*Semantic, error) {
 
 func parseVersions(s string) (int, int, int, error) {
 	splitVersion := strings.SplitN(s, ".", 3)
-	if numSeperators := len(splitVersion); numSeperators != 3 {
-		return 0, 0, 0, fmt.Errorf("%w: expected 3 only got %d", errMissingVersions, numSeperators)
+	if numSeparators := len(splitVersion); numSeparators != 3 {
+		return 0, 0, 0, fmt.Errorf("%w: expected 3 only got %d", errMissingVersions, numSeparators)
 	}
 
 	major, err := strconv.Atoi(splitVersion[0])


### PR DESCRIPTION
Fix spelling errors in two files:

1. version/parser.go:
   - "Seperators" -> "Separators" in version parsing logic

2. tests/fixture/tmpnet/README.md:
   - "parametized" -> "parameterized" in CI monitoring section

These changes improve code and documentation readability while maintaining consistent spelling throughout the codebase.