### PR TITLE
[ci] Fix metrics link annotation emitted for e2e and upgrade jobs

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/notify-metrics-availability.sh
+++ b/.github/actions/run-monitored-tmpnet-cmd/notify-metrics-availability.sh
@@ -16,4 +16,8 @@ if [[ -n "${FILTER_BY_OWNER:-}" ]]; then
   metrics_url="${metrics_url}&var-filter=network_owner%7C%3D%7C${FILTER_BY_OWNER}"
 fi
 
-echo "::notice links::metrics ${metrics_url}"
+# Github annotations don't support direct links, so unfortunately the
+# resulting URL will have to be copied and pasted into the browser.
+#
+# Reference: https://github.com/orgs/community/discussions/72821#discussioncomment-11919890
+echo "::notice links::grafana_dashboard ${metrics_url}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
           run: E2E_SERIAL=1 ./scripts/tests.e2e.sh --delay-network-shutdown
+          filter_by_owner: avalanchego-e2e
           prometheus_username: ${{ secrets.PROMETHEUS_ID || '' }}
           prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           loki_username: ${{ secrets.LOKI_ID || '' }}
@@ -100,7 +101,6 @@ jobs:
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
           run: ./scripts/tests.upgrade.sh
-          filter_by_owner: avalanchego-e2e
           prometheus_username: ${{ secrets.PROMETHEUS_ID || '' }}
           prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           loki_username: ${{ secrets.LOKI_ID || '' }}

--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -369,7 +369,19 @@ metrics and logs.
 
 Collection of logs and metrics is enabled for CI jobs that use
 tmpnet. Each job will execute a step titled `Notify of metrics
-availability` that emits a link to grafana parameterized to show results
-for the job. Additional links to grafana parameterized to show results
-for individual network will appear in the logs displaying the start of
+availability` that emits a link to grafana parameterized to show
+results for the job. This link is emitted as a github actions
+annotation that appears on the summary page for a test run to increase
+the visibility of collected metrics and logs.
+
+Additional links to grafana parameterized to show results for
+individual network will appear in the logs displaying the start of
 those networks.
+
+In cases where a given job uses private networks in addition to the
+usual shared network, it may be useful to parameterize the
+[run_monitored_tmpnet_action](../../../.github/actions/run-monitored-tmpnet-cmd/action.yml)
+github action with `filter_by_owner` set to the owner string for the
+shared network. This ensures that the link emitted by the annotation
+displays results for only the shared network of the job rather than
+mixing results from all the networks started for the job.


### PR DESCRIPTION
## Why this should be merged

Previously, the upgrade job was configured to filter the metrics link annotation with `network_owner=avalanchego-e2e`. Not sure how it ended up that way, because only the e2e job should be so filtered. This was preventing the metrics link for both jobs from displaying results properly. This didn't effect links emitted as part of network start, only the link emitted as an annotation.

## How this works

- Moved `filter_by_owner` arg from the upgrade to the e2e job
- Also updated tmpnet README to better document the dashboard link annotation

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A