### PR TITLE
cleanup(tmpnet): resolve chainconfig post-etna TODO

### DIFF
--- a/tests/fixture/tmpnet/genesis.go
+++ b/tests/fixture/tmpnet/genesis.go
@@ -149,10 +149,9 @@ func NewTestGenesis(
 	chainID := big.NewInt(int64(networkID))
 	// Define C-Chain genesis
 	cChainGenesis := &core.Genesis{
-		// TODO: remove this after Etna and set only the chainID
-		Config:     params.GetChainConfig(upgrade.Default, chainID), // upgrade will be again set by VM according to the snow.Context
-		Difficulty: big.NewInt(0),                                   // Difficulty is a mandatory field
-		Timestamp:  uint64(upgrade.InitiallyActiveTime.Unix()),      // This time enables Avalanche upgrades by default
+		Config:     &params.ChainConfig{ChainID: chainID},      // The rest of the config is set in coreth on VM initialization
+		Difficulty: big.NewInt(0),                              // Difficulty is a mandatory field
+		Timestamp:  uint64(upgrade.InitiallyActiveTime.Unix()), // This time enables Avalanche upgrades by default
 		GasLimit:   defaultGasLimit,
 		Alloc:      cChainBalances,
 	}


### PR DESCRIPTION
## Why this should be merged
This is no longer needed post etna, and params.GetChainConfig can be removed after this change

## How this works
Simplifies the chain config specification to only the chain ID

## How this was tested
CI

## Need to be documented in RELEASES.md?
No