### PR TITLE
Update to go 1.23.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 To start developing on AvalancheGo, you'll need a few things installed.
 
-- Golang version >= 1.22.8
+- Golang version >= 1.23.6
 - gcc
 - g++
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The minimum recommended hardware specification for nodes connected to Mainnet is
 
 If you plan to build AvalancheGo from source, you will also need the following software:
 
-- [Go](https://golang.org/doc/install) version >= 1.22.8
+- [Go](https://golang.org/doc/install) version >= 1.23.6
 - [gcc](https://gcc.gnu.org/)
 - g++
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ module github.com/ava-labs/avalanchego
 //   - README.md
 //   - go.mod (here)
 //
-// - If updating between minor versions (e.g. 1.22.x -> 1.23.x):
+// - If updating between minor versions (e.g. 1.23.x -> 1.24.x):
 //   - Consider updating the version of golangci-lint (in scripts/lint.sh).
-go 1.22.8
+go 1.23.6
 
 require (
 	github.com/DataDog/zstd v1.5.2

--- a/utils/hashing/consistent/ring.go
+++ b/utils/hashing/consistent/ring.go
@@ -213,8 +213,8 @@ func (h *hashRing) get(key Hashable) (Hashable, error) {
 	// If found nothing ascending the tree, we need to wrap around the ring to
 	// the left-most (min) node.
 	if result == nil {
-		min, _ := h.ring.Min()
-		result = min.value
+		minNode, _ := h.ring.Min()
+		result = minNode.value
 	}
 	return result, nil
 }

--- a/utils/sampler/rand.go
+++ b/utils/sampler/rand.go
@@ -61,9 +61,9 @@ func (r *rng) Uint64Inclusive(n uint64) uint64 {
 	//
 	// ref: https://github.com/golang/go/blob/ce10e9d84574112b224eae88dc4e0f43710808de/src/math/rand/rand.go#L127-L132
 	default:
-		max := (1 << 63) - 1 - (1<<63)%(n+1)
+		maxUint := (1 << 63) - 1 - (1<<63)%(n+1)
 		v := r.uint63()
-		for v > max {
+		for v > maxUint {
 			v = r.uint63()
 		}
 		return v % (n + 1)

--- a/utils/sampler/rand.go
+++ b/utils/sampler/rand.go
@@ -61,9 +61,9 @@ func (r *rng) Uint64Inclusive(n uint64) uint64 {
 	//
 	// ref: https://github.com/golang/go/blob/ce10e9d84574112b224eae88dc4e0f43710808de/src/math/rand/rand.go#L127-L132
 	default:
-		maxUint := (1 << 63) - 1 - (1<<63)%(n+1)
+		maximum := (1 << 63) - 1 - (1<<63)%(n+1)
 		v := r.uint63()
-		for v > maxUint {
+		for v > maximum {
 			v = r.uint63()
 		}
 		return v % (n + 1)

--- a/utils/sampler/rand_test.go
+++ b/utils/sampler/rand_test.go
@@ -182,12 +182,12 @@ func FuzzRNG(f *testing.F) {
 		require := require.New(t)
 
 		var (
-			max        uint64
+			maximum    uint64
 			sourceNums []uint64
 		)
 		fz := fuzzer.NewFuzzer(data)
-		fz.Fill(&max, &sourceNums)
-		if max >= math.MaxInt64 {
+		fz.Fill(&maximum, &sourceNums)
+		if maximum >= math.MaxInt64 {
 			t.SkipNow()
 		}
 
@@ -196,14 +196,14 @@ func FuzzRNG(f *testing.F) {
 			nums:      sourceNums,
 		}
 		r := &rng{rng: source}
-		val := r.Uint64Inclusive(max)
+		val := r.Uint64Inclusive(maximum)
 
 		stdSource := &testSTDSource{
 			onInvalid: t.SkipNow,
 			nums:      sourceNums,
 		}
 		mathRNG := rand.New(stdSource) //#nosec G404
-		stdVal := mathRNG.Int63n(int64(max + 1))
+		stdVal := mathRNG.Int63n(int64(maximum + 1))
 		require.Equal(val, uint64(stdVal))
 		require.Len(stdSource.nums, len(source.nums))
 	})

--- a/utils/sampler/rand_test.go
+++ b/utils/sampler/rand_test.go
@@ -56,68 +56,68 @@ func (s *testSTDSource) Uint64() uint64 {
 
 func TestRNG(t *testing.T) {
 	tests := []struct {
-		max      uint64
+		maximum  uint64
 		nums     []uint64
 		expected uint64
 	}{
 		{
-			max: math.MaxUint64,
+			maximum: math.MaxUint64,
 			nums: []uint64{
 				0x01,
 			},
 			expected: 0x01,
 		},
 		{
-			max: math.MaxUint64,
+			maximum: math.MaxUint64,
 			nums: []uint64{
 				0x0102030405060708,
 			},
 			expected: 0x0102030405060708,
 		},
 		{
-			max: math.MaxUint64,
+			maximum: math.MaxUint64,
 			nums: []uint64{
 				0xF102030405060708,
 			},
 			expected: 0xF102030405060708,
 		},
 		{
-			max: math.MaxInt64,
+			maximum: math.MaxInt64,
 			nums: []uint64{
 				0x01,
 			},
 			expected: 0x01,
 		},
 		{
-			max: math.MaxInt64,
+			maximum: math.MaxInt64,
 			nums: []uint64{
 				0x0102030405060708,
 			},
 			expected: 0x0102030405060708,
 		},
 		{
-			max: math.MaxInt64,
+			maximum: math.MaxInt64,
 			nums: []uint64{
 				0x8102030405060708,
 			},
 			expected: 0x0102030405060708,
 		},
 		{
-			max: 15,
+			maximum: 15,
 			nums: []uint64{
 				0x810203040506071a,
 			},
 			expected: 0x0a,
 		},
 		{
-			max: math.MaxInt64 + 1,
+			maximum: math.MaxInt64 + 1,
 			nums: []uint64{
 				math.MaxInt64 + 1,
 			},
 			expected: math.MaxInt64 + 1,
 		},
 		{
-			max: math.MaxInt64 + 1,
+			maximum: math.MaxInt64 + 1,
 			nums: []uint64{
 				math.MaxInt64 + 2,
 				0,
@@ -125,7 +125,7 @@ func TestRNG(t *testing.T) {
 			expected: 0,
 		},
 		{
-			max: math.MaxInt64 + 1,
+			maximum: math.MaxInt64 + 1,
 			nums: []uint64{
 				math.MaxInt64 + 2,
 				0x0102030405060708,
@@ -133,14 +133,14 @@ func TestRNG(t *testing.T) {
 			expected: 0x0102030405060708,
 		},
 		{
-			max: 2,
+			maximum: 2,
 			nums: []uint64{
 				math.MaxInt64 - 2,
 			},
 			expected: 0x02,
 		},
 		{
-			max: 2,
+			maximum: 2,
 			nums: []uint64{
 				math.MaxInt64 - 1,
 				0x01,
@@ -157,11 +157,11 @@ func TestRNG(t *testing.T) {
 				nums:      test.nums,
 			}
 			r := &rng{rng: source}
-			val := r.Uint64Inclusive(test.max)
+			val := r.Uint64Inclusive(test.maximum)
 			require.Equal(test.expected, val)
 			require.Empty(source.nums)
 
-			if test.max >= math.MaxInt64 {
+			if test.maximum >= math.MaxInt64 {
 				return
 			}
 
@@ -170,7 +170,7 @@ func TestRNG(t *testing.T) {
 				nums:      test.nums,
 			}
 			mathRNG := rand.New(stdSource) //#nosec G404
-			stdVal := mathRNG.Int63n(int64(test.max + 1))
+			stdVal := mathRNG.Int63n(int64(test.maximum + 1))
 			require.Equal(test.expected, uint64(stdVal))
 			require.Empty(source.nums)
 		})

--- a/utils/ulimit/ulimit_bsd.go
+++ b/utils/ulimit/ulimit_bsd.go
@@ -23,10 +23,10 @@ const DefaultFDLimit = 32 * 1024
 // privileges. Bumping the Max limit further would require superuser privileges.
 // If the value is below the recommendation warn on start.
 // see: http://0pointer.net/blog/file-descriptor-limits.html
-func Set(max uint64, log logging.Logger) error {
+func Set(limit uint64, log logging.Logger) error {
 	// Note: BSD Rlimit is type int64
 	// ref: https://cs.opensource.google/go/x/sys/+/b874c991:unix/ztypes_freebsd_amd64.go
-	bsdMax := int64(max)
+	bsdMax := int64(limit)
 	var rLimit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {

--- a/utils/ulimit/ulimit_darwin.go
+++ b/utils/ulimit/ulimit_darwin.go
@@ -23,7 +23,7 @@ const DefaultFDLimit = 10 * 1024
 // privileges. Bumping the Max limit further would require superuser privileges.
 // If the value is below the recommendation warn on start.
 // see: http://0pointer.net/blog/file-descriptor-limits.html
-func Set(max uint64, log logging.Logger) error {
+func Set(limit uint64, log logging.Logger) error {
 	var rLimit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
@@ -34,11 +34,11 @@ func Set(max uint64, log logging.Logger) error {
 	// The max file limit is 10240, even though the max returned by
 	// Getrlimit is 1<<63-1. This is OPEN_MAX in sys/syslimits.h.
 	// See https://github.com/golang/go/issues/30401
-	if max > DefaultFDLimit {
-		return fmt.Errorf("error fd-limit: (%d) greater than max: (%d)", max, DefaultFDLimit)
+	if limit > DefaultFDLimit {
+		return fmt.Errorf("error fd-limit: (%d) greater than max: (%d)", limit, DefaultFDLimit)
 	}
 
-	rLimit.Cur = max
+	rLimit.Cur = limit
 
 	// set new limit
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {

--- a/utils/ulimit/ulimit_unix.go
+++ b/utils/ulimit/ulimit_unix.go
@@ -23,18 +23,18 @@ const DefaultFDLimit = 32 * 1024
 // privileges. Bumping the Max limit further would require superuser privileges.
 // If the current Max is below our recommendation we will warn on start.
 // see: http://0pointer.net/blog/file-descriptor-limits.html
-func Set(max uint64, log logging.Logger) error {
+func Set(limit uint64, log logging.Logger) error {
 	var rLimit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		return fmt.Errorf("error getting rlimit: %w", err)
 	}
 
-	if max > rLimit.Max {
-		return fmt.Errorf("error fd-limit: (%d) greater than max: (%d)", max, rLimit.Max)
+	if limit > rLimit.Max {
+		return fmt.Errorf("error fd-limit: (%d) greater than max: (%d)", limit, rLimit.Max)
 	}
 
-	rLimit.Cur = max
+	rLimit.Cur = limit
 
 	// set new limit
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {

--- a/utils/ulimit/ulimit_windows.go
+++ b/utils/ulimit/ulimit_windows.go
@@ -11,8 +11,8 @@ import "github.com/ava-labs/avalanchego/utils/logging"
 const DefaultFDLimit = 16384
 
 // Set is a no-op for windows and will warn if the default is not used.
-func Set(max uint64, log logging.Logger) error {
-	if max != DefaultFDLimit {
+func Set(limit uint64, log logging.Logger) error {
+	if limit != DefaultFDLimit {
 		log.Warn("fd-limit is not supported for windows")
 	}
 	return nil

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -68,22 +68,31 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 		Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 	}
 
+	sk, err := localsigner.New()
+	require.NoError(err)
+
 	// create valid tx
-	addValidatorTx, err := wallet.IssueAddValidatorTx(
-		&txs.Validator{
-			NodeID: nodeID,
-			Start:  uint64(validatorStartTime.Unix()),
-			End:    uint64(validatorEndTime.Unix()),
-			Wght:   vm.MinValidatorStake,
+	addPermissionlessValidatorTx, err := wallet.IssueAddPermissionlessValidatorTx(
+		&txs.SubnetValidator{
+			Validator: txs.Validator{
+				NodeID: nodeID,
+				Start:  uint64(validatorStartTime.Unix()),
+				End:    uint64(validatorEndTime.Unix()),
+				Wght:   vm.MinValidatorStake,
+			},
+			Subnet: constants.PrimaryNetworkID,
 		},
+		signer.NewProofOfPossession(sk),
+		vm.ctx.AVAXAssetID,
 		rewardsOwner,
-		reward.PercentDenominator,
+		rewardsOwner,
+		0,
 	)
 	require.NoError(err)
 
 	// trigger block creation
 	vm.ctx.Lock.Unlock()
-	require.NoError(vm.issueTxFromRPC(addValidatorTx))
+	require.NoError(vm.issueTxFromRPC(addPermissionlessValidatorTx))
 	vm.ctx.Lock.Lock()
 
 	// Accept addValidatorTx

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -68,31 +68,22 @@ func TestAddDelegatorTxOverDelegatedRegression(t *testing.T) {
 		Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 	}
 
-	sk, err := localsigner.New()
-	require.NoError(err)
-
 	// create valid tx
-	addPermissionlessValidatorTx, err := wallet.IssueAddPermissionlessValidatorTx(
-		&txs.SubnetValidator{
-			Validator: txs.Validator{
-				NodeID: nodeID,
-				Start:  uint64(validatorStartTime.Unix()),
-				End:    uint64(validatorEndTime.Unix()),
-				Wght:   vm.MinValidatorStake,
-			},
-			Subnet: constants.PrimaryNetworkID,
+	addValidatorTx, err := wallet.IssueAddValidatorTx(
+		&txs.Validator{
+			NodeID: nodeID,
+			Start:  uint64(validatorStartTime.Unix()),
+			End:    uint64(validatorEndTime.Unix()),
+			Wght:   vm.MinValidatorStake,
 		},
-		signer.NewProofOfPossession(sk),
-		vm.ctx.AVAXAssetID,
 		rewardsOwner,
-		rewardsOwner,
-		0,
+		reward.PercentDenominator,
 	)
 	require.NoError(err)
 
 	// trigger block creation
 	vm.ctx.Lock.Unlock()
-	require.NoError(vm.issueTxFromRPC(addPermissionlessValidatorTx))
+	require.NoError(vm.issueTxFromRPC(addValidatorTx))
 	vm.ctx.Lock.Lock()
 
 	// Accept addValidatorTx


### PR DESCRIPTION
## Why this should be merged

Go 1.24 was released earlier this week ([ref](https://tip.golang.org/doc/go1.24)), which means we're able to bump our go dependency to 1.23 (the previous minor version).

Some changes include changes to iterators, but I believe these will be non-trivial to review so I would prefer to implement this in a follow-up PR.

## How this works
 
Updates go dependency

## How this was tested

CI

## Need to be documented in RELEASES.md?

Yes
