### PR TITLE
bump coreth to master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/coreth v0.14.2-verify-interface4
+	github.com/ava-labs/coreth v0.14.1-rc.1.0.20250217192834-6060a4a6a6d3
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/coreth v0.14.2-verify-interface4 h1:AYeN8R6ZnNu/K8KwBQD4ELphvLpvNxAjkX3SBcJ+bps=
-github.com/ava-labs/coreth v0.14.2-verify-interface4/go.mod h1:wQaeiolUP0vCHS1mC0lIMXzHF05vbjugSLCBFDnO4Gs=
+github.com/ava-labs/coreth v0.14.1-rc.1.0.20250217192834-6060a4a6a6d3 h1:0OrQidq+b3kb7KlnDqc5mkB/73i1zxYEMiXioWSU4+w=
+github.com/ava-labs/coreth v0.14.1-rc.1.0.20250217192834-6060a4a6a6d3/go.mod h1:/XrU+CAm/0wiY5Ui05TLj2/n+czbCV6/Qrw/UMWp5aI=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60 h1:EL66gtXOAwR/4KYBjOV03LTWgkEXvLePribLlJNu4g0=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60/go.mod h1:/7qKobTfbzBu7eSTVaXMTr56yTYk4j2Px6/8G+idxHo=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=


### PR DESCRIPTION
## Why this should be merged
Semver issues, since coreth was tagged with v0.14.2-verify-interface4 but master is still v0.14.1, now we cannot update avalanchego to master in subnet-evm

## How this works
go get github.com/ava-labs/coreth@master
can make a tag if that's preferred?

## How this was tested
CI

## Need to be documented in RELEASES.md?
N/A