### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/utils/crypto/keychain/keychain.go
+++ b/utils/crypto/keychain/keychain.go
@@ -137,7 +137,7 @@ func (l *ledgerSigner) SignHash(b []byte) ([]byte, error) {
 		)
 	}
 
-	return sigs[0], err
+	return sigs[0], nil
 }
 
 // expects to receive the unsigned tx bytes
@@ -157,7 +157,7 @@ func (l *ledgerSigner) Sign(b []byte) ([]byte, error) {
 		)
 	}
 
-	return sigs[0], err
+	return sigs[0], nil
 }
 
 func (l *ledgerSigner) Address() ids.ShortID {


### PR DESCRIPTION
## Why this should be merged

use a more straightforward return value


## How this works

## How this was tested

## Need to be documented in RELEASES.md?
