### PR TITLE
Add With and WithOptions receivers to the Logger interface

### DIFF
--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -114,6 +114,20 @@ func (l *log) Verbo(msg string, fields ...zap.Field) {
 	l.log(Verbo, msg, fields...)
 }
 
+func (l *log) With(fields ...zap.Field) Logger {
+	return &log{
+		internalLogger: l.internalLogger.With(fields...),
+		wrappedCores:   l.wrappedCores,
+	}
+}
+
+func (l *log) WithOptions(opts ...zap.Option) Logger {
+	return &log{
+		internalLogger: l.internalLogger.WithOptions(opts...),
+		wrappedCores:   l.wrappedCores,
+	}
+}
+
 func (l *log) SetLevel(level Level) {
 	for _, core := range l.wrappedCores {
 		core.AtomicLevel.SetLevel(zapcore.Level(level))

--- a/utils/logging/log_test.go
+++ b/utils/logging/log_test.go
@@ -20,7 +20,7 @@ func (w *testLogWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (w *testLogWriter) Close() error {
+func (*testLogWriter) Close() error {
 	return nil
 }
 
@@ -59,7 +59,7 @@ func TestWithOption(t *testing.T) {
 
 	hookTriggered := new(bool)
 
-	hook := func(entry zapcore.Entry) error {
+	hook := func(_ zapcore.Entry) error {
 		*hookTriggered = true
 		return nil
 	}

--- a/utils/logging/log_test.go
+++ b/utils/logging/log_test.go
@@ -57,10 +57,10 @@ func TestWithOption(t *testing.T) {
 	testWriter := &testLogWriter{}
 	parentLogger := NewLogger("", NewWrappedCore(Info, testWriter, Plain.ConsoleEncoder()))
 
-	hookTriggered := new(bool)
+	hookTriggered := false
 
 	hook := func(_ zapcore.Entry) error {
-		*hookTriggered = true
+		hookTriggered = true
 		return nil
 	}
 
@@ -68,9 +68,9 @@ func TestWithOption(t *testing.T) {
 
 	parentLogger.Info("parent message")
 	require.Len(t, testWriter.logs, 1)
-	require.False(t, *hookTriggered)
+	require.False(t, hookTriggered)
 
 	childLogger.Info("child message")
 	require.Len(t, testWriter.logs, 2)
-	require.True(t, *hookTriggered)
+	require.True(t, hookTriggered)
 }

--- a/utils/logging/log_test.go
+++ b/utils/logging/log_test.go
@@ -7,7 +7,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
+
+type testLogWriter struct {
+	logs [][]byte // Each element is a call to Write
+}
+
+func (w *testLogWriter) Write(p []byte) (int, error) {
+	w.logs = append(w.logs, p)
+	return len(p), nil
+}
+
+func (w *testLogWriter) Close() error {
+	return nil
+}
 
 func TestLog(t *testing.T) {
 	log := NewLogger("", NewWrappedCore(Info, Discard, Plain.ConsoleEncoder()))
@@ -22,4 +37,40 @@ func TestLog(t *testing.T) {
 	log.RecoverAndExit(panicFunc, exitFunc)
 
 	require.True(t, *recovered)
+}
+
+func TestWith(t *testing.T) {
+	testWriter := &testLogWriter{}
+	parentLogger := NewLogger("", NewWrappedCore(Info, testWriter, Plain.ConsoleEncoder()))
+
+	childLogger := parentLogger.With(zap.Bool("bool", true))
+	childLogger.Info("child message")
+	require.Len(t, testWriter.logs, 1)
+	require.Contains(t, string(testWriter.logs[0]), `"bool": true`)
+
+	parentLogger.Info("parent message")
+	require.Len(t, testWriter.logs, 2)
+	require.NotContains(t, string(testWriter.logs[1]), `"bool": true`)
+}
+
+func TestWithOption(t *testing.T) {
+	testWriter := &testLogWriter{}
+	parentLogger := NewLogger("", NewWrappedCore(Info, testWriter, Plain.ConsoleEncoder()))
+
+	hookTriggered := new(bool)
+
+	hook := func(entry zapcore.Entry) error {
+		*hookTriggered = true
+		return nil
+	}
+
+	childLogger := parentLogger.WithOptions(zap.Hooks(hook))
+
+	parentLogger.Info("parent message")
+	require.Len(t, testWriter.logs, 1)
+	require.False(t, *hookTriggered)
+
+	childLogger.Info("child message")
+	require.Len(t, testWriter.logs, 2)
+	require.True(t, *hookTriggered)
 }

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -40,6 +40,13 @@ type Logger interface {
 	// aspect of the program
 	Verbo(msg string, fields ...zap.Field)
 
+	// With creates a new child logger with provided structured fields added as context
+	// It doesn't modify the parent logger
+	With(fields ...zap.Field) Logger
+
+	// WithOptions clones the current Logger, applies the supplied Options, and returns the resulting Logger.
+	WithOptions(opts ...zap.Option) Logger
+
 	// SetLevel that this logger should log to
 	SetLevel(level Level)
 	// Enabled returns true if the given level is at or above this level.

--- a/utils/logging/test_log.go
+++ b/utils/logging/test_log.go
@@ -36,6 +36,14 @@ func (NoLog) Debug(string, ...zap.Field) {}
 
 func (NoLog) Verbo(string, ...zap.Field) {}
 
+func (n NoLog) With(...zap.Field) Logger {
+	return n
+}
+
+func (n NoLog) WithOptions(...zap.Option) Logger {
+	return n
+}
+
 func (NoLog) SetLevel(Level) {}
 
 func (NoLog) Enabled(Level) bool {


### PR DESCRIPTION
## Why this should be merged
Being able to use hooks in `WithOptions` to test logging, and `With` to create child loggers with particular contexts is useful. 
## How this works
Creates a clone of the log struct  with the internal loggers replaced with returns of zap methods but keeping the same wrapped cores to preserve existing functionality. 

Originally included `WithLazy` as well but removed it since I didn't see a good way of testing that it's actually doing lazy modification properly with our setup being behind the interface.

## How this was tested
Existing tests should pass and new unit tests added. They are not vectorized since they only have two cases but happy to change it if that's the preference. 

## Need to be documented in RELEASES.md?
No