### PR TITLE
Migrate X-Chain from LevelDB to Firewood and PebbleDB

### DIFF
--- a/database/memdb/db.go
+++ b/database/memdb/db.go
@@ -5,6 +5,7 @@ package memdb
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -36,6 +37,21 @@ type Database struct {
 // New returns a map with the Database interface methods implemented.
 func New() *Database {
 	return NewWithSize(DefaultSize)
+}
+
+// Copy returns a Database with the same key-value pairs as db
+func Copy(db *Database) (*Database, error) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	result := New()
+	for k, v := range db.db {
+		if err := result.Put([]byte(k), v); err != nil {
+			return nil, fmt.Errorf("failed to insert key: %w", err)
+		}
+	}
+
+	return result, nil
 }
 
 // NewWithSize returns a map pre-allocated to the provided size with the

--- a/vms/avm/block/builder/builder.go
+++ b/vms/avm/block/builder/builder.go
@@ -174,5 +174,5 @@ func (b *builder) BuildBlock(context.Context) (snowman.Block, error) {
 		return nil, err
 	}
 
-	return b.manager.NewBlock(statelessBlk), nil
+	return b.manager.NewBlock(statelessBlk, b.backend.Ctx.SharedMemory), nil
 }

--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/codecmock"
 	"github.com/ava-labs/avalanchego/database/memdb"
@@ -291,8 +292,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				manager.EXPECT().VerifyUniqueInputs(preferredID, gomock.Any()).Return(nil)
 				// Assert created block has one tx, tx1,
 				// and other fields are set correctly.
-				manager.EXPECT().NewBlock(gomock.Any()).DoAndReturn(
-					func(block *block.StandardBlock) snowman.Block {
+				manager.EXPECT().NewBlock(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(
+						block *block.StandardBlock,
+						_ atomic.SharedMemory,
+					) snowman.Block {
 						require.Len(t, block.Transactions, 1)
 						require.Equal(t, tx1, block.Transactions[0])
 						require.Equal(t, preferredHeight+1, block.Height())
@@ -350,8 +354,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				manager.EXPECT().GetState(preferredID).Return(preferredState, true)
 				manager.EXPECT().VerifyUniqueInputs(preferredID, gomock.Any()).Return(nil)
 				// Assert that the created block has the right timestamp
-				manager.EXPECT().NewBlock(gomock.Any()).DoAndReturn(
-					func(block *block.StandardBlock) snowman.Block {
+				manager.EXPECT().NewBlock(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(
+						block *block.StandardBlock,
+						_ atomic.SharedMemory,
+					) snowman.Block {
 						require.Equal(t, preferredTimestamp.Unix(), block.Timestamp().Unix())
 						return nil
 					},
@@ -422,8 +429,11 @@ func TestBuilderBuildBlock(t *testing.T) {
 				manager.EXPECT().GetState(preferredID).Return(preferredState, true)
 				manager.EXPECT().VerifyUniqueInputs(preferredID, gomock.Any()).Return(nil)
 				// Assert that the created block has the right timestamp
-				manager.EXPECT().NewBlock(gomock.Any()).DoAndReturn(
-					func(block *block.StandardBlock) snowman.Block {
+				manager.EXPECT().NewBlock(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(
+						block *block.StandardBlock,
+						_ atomic.SharedMemory,
+					) snowman.Block {
 						require.Equal(t, now.Unix(), block.Timestamp().Unix())
 						return nil
 					},
@@ -526,7 +536,7 @@ func TestBlockBuilderAddLocalTx(t *testing.T) {
 	parentBlk, err := block.NewStandardBlock(parentID, 0, parentTimestamp, txs, cm)
 	require.NoError(err)
 	state.AddBlock(parentBlk)
-	state.SetLastAccepted(parentBlk.ID())
+	state.SetLastAccepted(parentBlk.ID(), parentBlk.Height())
 
 	metrics, err := metrics.New(registerer)
 	require.NoError(err)

--- a/vms/avm/block/executor/block_test.go
+++ b/vms/avm/block/executor/block_test.go
@@ -683,6 +683,7 @@ func TestBlockAccept(t *testing.T) {
 							},
 						},
 					},
+					sharedMemory: mockSharedMemory,
 				}
 			},
 			expectedErr: errTest,
@@ -726,6 +727,7 @@ func TestBlockAccept(t *testing.T) {
 							},
 						},
 					},
+					sharedMemory: mockSharedMemory,
 				}
 			},
 			expectedErr: errTest,
@@ -748,7 +750,7 @@ func TestBlockAccept(t *testing.T) {
 				// because we mock the call to shared memory
 				mockManagerState.EXPECT().CommitBatch().Return(nil, nil)
 				mockManagerState.EXPECT().Abort()
-				mockManagerState.EXPECT().Checksum().Return(ids.Empty)
+				mockManagerState.EXPECT().Checksum(gomock.Any()).Return(ids.Empty, nil)
 
 				mockSharedMemory := atomicmock.NewSharedMemory(ctrl)
 				mockSharedMemory.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil)
@@ -772,6 +774,7 @@ func TestBlockAccept(t *testing.T) {
 							},
 						},
 					},
+					sharedMemory: mockSharedMemory,
 				}
 			},
 			expectedErr: nil,

--- a/vms/avm/block/executor/executormock/manager.go
+++ b/vms/avm/block/executor/executormock/manager.go
@@ -12,6 +12,7 @@ package executormock
 import (
 	reflect "reflect"
 
+	atomic "github.com/ava-labs/avalanchego/chains/atomic"
 	ids "github.com/ava-labs/avalanchego/ids"
 	snowman "github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	set "github.com/ava-labs/avalanchego/utils/set"
@@ -105,17 +106,17 @@ func (mr *ManagerMockRecorder) LastAccepted() *gomock.Call {
 }
 
 // NewBlock mocks base method.
-func (m *Manager) NewBlock(arg0 block.Block) snowman.Block {
+func (m *Manager) NewBlock(blk block.Block, sm atomic.SharedMemory) snowman.Block {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewBlock", arg0)
+	ret := m.ctrl.Call(m, "NewBlock", blk, sm)
 	ret0, _ := ret[0].(snowman.Block)
 	return ret0
 }
 
 // NewBlock indicates an expected call of NewBlock.
-func (mr *ManagerMockRecorder) NewBlock(arg0 any) *gomock.Call {
+func (mr *ManagerMockRecorder) NewBlock(blk, sm any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewBlock", reflect.TypeOf((*Manager)(nil).NewBlock), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewBlock", reflect.TypeOf((*Manager)(nil).NewBlock), blk, sm)
 }
 
 // Preferred mocks base method.
@@ -130,6 +131,18 @@ func (m *Manager) Preferred() ids.ID {
 func (mr *ManagerMockRecorder) Preferred() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Preferred", reflect.TypeOf((*Manager)(nil).Preferred))
+}
+
+// SetLastAccepted mocks base method.
+func (m *Manager) SetLastAccepted(id ids.ID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLastAccepted", id)
+}
+
+// SetLastAccepted indicates an expected call of SetLastAccepted.
+func (mr *ManagerMockRecorder) SetLastAccepted(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*Manager)(nil).SetLastAccepted), id)
 }
 
 // SetPreference mocks base method.

--- a/vms/avm/factory.go
+++ b/vms/avm/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms"
 	"github.com/ava-labs/avalanchego/vms/avm/config"
+	"github.com/ava-labs/avalanchego/vms/avm/state"
 )
 
 var _ vms.Factory = (*Factory)(nil)
@@ -16,5 +17,9 @@ type Factory struct {
 }
 
 func (f *Factory) New(logging.Logger) (interface{}, error) {
-	return &VM{Config: f.Config}, nil
+	return &VM{
+			Config:         f.Config,
+			StateMigration: &state.FirewoodMigration{CommitFrequency: 1_000},
+		},
+		nil
 }

--- a/vms/avm/state/diff.go
+++ b/vms/avm/state/diff.go
@@ -38,8 +38,9 @@ type diff struct {
 	addedBlockIDs map[uint64]ids.ID      // map of height -> blockID
 	addedBlocks   map[ids.ID]block.Block // map of blockID -> block
 
-	lastAccepted ids.ID
-	timestamp    time.Time
+	lastAccepted       ids.ID
+	lastAcceptedHeight uint64
+	timestamp          time.Time
 }
 
 func NewDiff(
@@ -149,8 +150,9 @@ func (d *diff) GetLastAccepted() ids.ID {
 	return d.lastAccepted
 }
 
-func (d *diff) SetLastAccepted(lastAccepted ids.ID) {
+func (d *diff) SetLastAccepted(lastAccepted ids.ID, height uint64) {
 	d.lastAccepted = lastAccepted
+	d.lastAcceptedHeight = height
 }
 
 func (d *diff) GetTimestamp() time.Time {
@@ -178,6 +180,6 @@ func (d *diff) Apply(state Chain) {
 		state.AddBlock(blk)
 	}
 
-	state.SetLastAccepted(d.lastAccepted)
+	state.SetLastAccepted(d.lastAccepted, d.lastAcceptedHeight)
 	state.SetTimestamp(d.timestamp)
 }

--- a/vms/avm/state/firewood.go
+++ b/vms/avm/state/firewood.go
@@ -1,0 +1,131 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/firewood"
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+var atomicTxPrefix = []byte("atomic_tx")
+
+type firewoodDB struct {
+	db        *firewood.DB
+	versionDB *versiondb.Database
+}
+
+var _ ChainDB = (*firewoodDB)(nil)
+
+func (f *firewoodDB) AddAtomicTx(txID ids.ID) {
+	f.db.Put(firewood.Prefix(atomicTxPrefix, txID[:]), []byte{})
+}
+
+func (f *firewoodDB) Repair(ctx context.Context, vm VM, s State) error {
+	lastAcceptedBlk, err := s.GetBlock(s.GetLastAccepted())
+	if err != nil {
+		return fmt.Errorf("getting last accepted block: %w", err)
+	}
+
+	var replayStartHeight int
+	if firewoodHeight, ok := f.db.Height(); !ok {
+		// A height of zero means that we have not flushed any data to firewood yet,
+		// so we need to replay all blocks including genesis.
+		replayStartHeight = -1
+	} else {
+		replayStartHeight = int(firewoodHeight)
+	}
+
+	// Replay any blocks until the last accepted height to synchronize the chain
+	// and local dbs.
+	for i := replayStartHeight; i < int(lastAcceptedBlk.Height()); i++ {
+		blkID, err := s.GetBlockIDAtHeight(uint64(i + 1))
+		if err != nil {
+			return fmt.Errorf("getting block id: %w", err)
+		}
+
+		blk, err := s.GetBlock(blkID)
+		if err != nil {
+			return fmt.Errorf("getting block: %w", err)
+		}
+
+		if err := vm.Replay(ctx, blk); err != nil {
+			return fmt.Errorf("replaying block: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (f *firewoodDB) Abort() {
+	f.db.Abort()
+}
+
+func (f *firewoodDB) CommitBatch(height uint64) (
+	database.Batch,
+	error,
+) {
+	b, err := f.versionDB.CommitBatch()
+	if err != nil {
+		return nil, err
+	}
+
+	return &firewoodBatch{
+		Batch:           b,
+		nextStateHeight: height,
+		firewoodDB:      f.db,
+	}, nil
+}
+
+func (f *firewoodDB) Close(ctx context.Context) error {
+	return f.db.Close(ctx)
+}
+
+// firewoodBatch wraps the underlying batch to also write to firewood after
+// it is written to.
+type firewoodBatch struct {
+	database.Batch
+	nextStateHeight uint64
+	firewoodDB      *firewood.DB
+}
+
+func (f *firewoodBatch) Write() error {
+	chainDBHeight, ok := f.firewoodDB.Height()
+	if !ok && f.nextStateHeight > 1 {
+		// This should always be initialized after the first (non-genesis) block is
+		// accepted.
+		return errors.New("chain db was not initialized")
+	}
+
+	if nextFirewoodHeight := chainDBHeight + 1; ok && nextFirewoodHeight != f.nextStateHeight {
+		// Avoid writing state if the next revision height would be out-of-sync
+		// because firewood should never be out-of-sync with versiondb after we have
+		// finished repairing. We should only create one firewood revision per
+		// block height.
+		//
+		// We cannot perform this check if the height is not initialized because
+		// there is no height in firewood before the genesis block is written.
+		return fmt.Errorf(
+			"%w: next height is at %d but next revision would be %d",
+			errDBsOutOfSync,
+			f.nextStateHeight,
+			nextFirewoodHeight,
+		)
+	}
+
+	if err := f.Batch.Write(); err != nil {
+		return fmt.Errorf("writing versiondb batch: %w", err)
+	}
+
+	if err := f.firewoodDB.Flush(); err != nil {
+		return fmt.Errorf("flushing to firewood: %w", err)
+	}
+
+	return nil
+}

--- a/vms/avm/state/granite.go
+++ b/vms/avm/state/granite.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"context"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+// Deprecated: after the firewood db migration this type should no longer be
+// used.
+//
+// NoChainDB is used before the Firewood migration when chain state was kept in
+// the same database as the rest of the state.
+type NoChainDB struct {
+	VersionDB *versiondb.Database
+}
+
+var _ ChainDB = (*NoChainDB)(nil)
+
+// AddAtomicTx is a no-op because atomic txs are not a part of chain state
+func (*NoChainDB) AddAtomicTx(ids.ID) {}
+
+// Repair is a no-op because the db is always written atomically with the
+// rest of the State.
+func (*NoChainDB) Repair(context.Context, VM, State) error {
+	return nil
+}
+
+// Abort is a no-op because there is no chain-specific db.
+func (*NoChainDB) Abort() {}
+
+func (db *NoChainDB) CommitBatch(uint64) (database.Batch, error) {
+	return db.VersionDB.CommitBatch()
+}
+
+func (*NoChainDB) Close(context.Context) error {
+	return nil
+}

--- a/vms/avm/state/migration.go
+++ b/vms/avm/state/migration.go
@@ -1,0 +1,445 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/pebbledb"
+	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/firewood"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/avm/block"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+)
+
+var (
+	migrationStatusKey   = []byte("status")
+	lastMigratedUTXOKey  = []byte("utxo")
+	lastMigratedTxKey    = []byte("tx")
+	lastMigratedBlockKey = []byte("block")
+)
+
+type Migration interface {
+	Migrate(
+		log logging.Logger,
+		parser block.Parser,
+		metrics prometheus.Registerer,
+		prev State,
+		prevVersionDB *versiondb.Database,
+		prevUTXODB database.Database,
+		prevTXDB database.Database,
+		prevBlockIDDB database.Database,
+		prevBlockDB database.Database,
+		prevSingletonDB database.Database,
+		chainDataDir string,
+		stopVertexID ids.ID,
+		genesisTimestamp time.Time,
+	) (State, ChainDB, error)
+}
+
+type NoMigration struct{}
+
+var _ Migration = (*NoMigration)(nil)
+
+func (NoMigration) Migrate(
+	_ logging.Logger,
+	_ block.Parser,
+	_ prometheus.Registerer,
+	prev State,
+	vdb *versiondb.Database,
+	_ database.Database,
+	_ database.Database,
+	_ database.Database,
+	_ database.Database,
+	_ database.Database,
+	_ string,
+	_ ids.ID,
+	_ time.Time,
+) (State, ChainDB, error) {
+	return prev, &NoChainDB{VersionDB: vdb}, nil
+}
+
+type FirewoodMigration struct {
+	CommitFrequency int
+
+	updates int
+}
+
+var _ Migration = (*FirewoodMigration)(nil)
+
+func (f *FirewoodMigration) Migrate(
+	log logging.Logger,
+	parser block.Parser,
+	metrics prometheus.Registerer,
+	_ State,
+	prevVersionDB *versiondb.Database,
+	prevUTXODB database.Database,
+	prevTxDB database.Database,
+	prevBlockIDDB database.Database,
+	prevBlockDB database.Database,
+	prevSingletonDB database.Database,
+	chainDataDir string,
+	stopVertexID ids.ID,
+	genesisTimestamp time.Time,
+) (State, ChainDB, error) {
+	next, chainDB, err := newMigrationState(parser, metrics, chainDataDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("initializing state: %w", err)
+	}
+
+	done, err := next.GetMigrationStatus()
+	if errors.Is(err, database.ErrNotFound) {
+		if err := next.PutMigrationStatus(false); err != nil {
+			return nil, nil, fmt.Errorf("putting migration status: %w", err)
+		}
+	} else if err != nil {
+		return nil, nil, fmt.Errorf("getting state migration status: %w", err)
+	}
+
+	if done {
+		log.Debug("skipping state migration")
+		return next, chainDB, nil
+	}
+
+	log.Info("starting state migration")
+	lastMigratedUTXO, err := next.GetLastMigratedUTXO()
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting last migrated utxo: %w", err)
+	}
+
+	log.Debug("deleting utxos")
+	itr := prevUTXODB.NewIteratorWithStart(lastMigratedUTXO[:])
+	for itr.Next() {
+		utxoID, err := ids.ToID(itr.Key())
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing utxo id: %w", err)
+		}
+
+		if err := next.PutLastMigratedUTXO(utxoID); err != nil {
+			return nil, nil, fmt.Errorf("putting last migrated utxo: %w", err)
+		}
+
+		if err := prevUTXODB.Delete(itr.Key()); err != nil {
+			return nil, nil, fmt.Errorf("deleting utxo: %w", err)
+		}
+
+		ok, err := f.commit(prevVersionDB, next.versionDB)
+		if err != nil {
+			return nil, nil, fmt.Errorf("committing db: %w", err)
+		}
+		if !ok {
+			continue
+		}
+
+		log.Verbo("committed migration progress",
+			zap.Stringer("utxoID", utxoID),
+		)
+	}
+
+	if err := itr.Error(); err != nil {
+		return nil, nil, fmt.Errorf("iterating db: %w", err)
+	}
+
+	log.Debug("deleting txs")
+	lastMigratedTx, err := next.GetLastMigratedTx()
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting last migrated tx: %w", err)
+	}
+
+	itr = prevTxDB.NewIteratorWithStart(lastMigratedTx[:])
+	for itr.Next() {
+		txID, err := ids.ToID(itr.Key())
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing tx id: %w", err)
+		}
+
+		if err := next.PutLastMigratedTx(txID); err != nil {
+			return nil, nil, fmt.Errorf("putting last migrated tx: %w", err)
+		}
+
+		if err := prevTxDB.Delete(itr.Key()); err != nil {
+			return nil, nil, fmt.Errorf("deleting migrated tx: %w", err)
+		}
+
+		ok, err := f.commit(prevVersionDB, next.versionDB)
+		if err != nil {
+			return nil, nil, fmt.Errorf("committing db: %w", err)
+		}
+		if !ok {
+			continue
+		}
+
+		log.Verbo("committed migration progress", zap.Stringer("txID", txID))
+	}
+
+	if err := itr.Error(); err != nil {
+		return nil, nil, fmt.Errorf("iterating db: %w", err)
+	}
+
+	log.Debug("migrating blocks")
+	lastMigratedBlk, err := next.GetLastMigratedBlock()
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting last migrated block: %w", err)
+	}
+
+	itr = prevBlockDB.NewIteratorWithStart(lastMigratedBlk[:])
+	for itr.Next() {
+		blkID, err := ids.ToID(itr.Key())
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing block id: %w", err)
+		}
+
+		blk, err := parser.ParseBlock(itr.Value())
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing block: %w", err)
+		}
+
+		next.AddBlock(blk)
+
+		if err := next.PutLastMigratedBlock(blkID); err != nil {
+			return nil, nil, fmt.Errorf("putting last migrated block: %w", err)
+		}
+
+		if err := prevBlockDB.Delete(itr.Key()); err != nil {
+			return nil, nil, fmt.Errorf("deleting migrated block: %w", err)
+		}
+
+		if err := prevBlockIDDB.Delete(database.PackUInt64(blk.Height())); err != nil {
+			return nil, nil, fmt.Errorf("deleting migrated block: %w", err)
+		}
+
+		ok, err := f.commit(prevVersionDB, next.versionDB)
+		if err != nil {
+			return nil, nil, fmt.Errorf("committing db: %w", err)
+		}
+		if !ok {
+			continue
+		}
+
+		log.Verbo("committed migration progress", zap.Stringer("blkID", blkID))
+	}
+
+	if err := itr.Error(); err != nil {
+		return nil, nil, fmt.Errorf("iterating db: %w", err)
+	}
+
+	log.Debug("migrating singletons")
+	itr = prevSingletonDB.NewIterator()
+	for itr.Next() {
+		if err := next.singletonDB.Put(itr.Key(), itr.Value()); err != nil {
+			return nil, nil, fmt.Errorf("migrating singleton: %w", err)
+		}
+
+		if err := prevSingletonDB.Delete(itr.Key()); err != nil {
+			return nil, nil, fmt.Errorf("deleting singleton: %w", err)
+		}
+	}
+
+	if err := itr.Error(); err != nil {
+		return nil, nil, fmt.Errorf("iterating db: %w", err)
+	}
+
+	if err := next.PutMigrationStatus(true); err != nil {
+		return nil, nil, fmt.Errorf("putting migration status: %w", err)
+	}
+
+	if err := next.versionDB.Commit(); err != nil {
+		return nil, nil, fmt.Errorf("committing state: %w", err)
+	}
+
+	if err := prevVersionDB.Commit(); err != nil {
+		return nil, nil, fmt.Errorf("committing state: %w", err)
+	}
+
+	// It is safe to call InitializeChainState because it was called before the
+	// migration when creating the previous state - so it is not possible for us
+	// to create two revisions at genesis.
+	if err := next.InitializeChainState(stopVertexID, genesisTimestamp); err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize chain state: %w", err)
+	}
+
+	log.Info("migration complete")
+
+	return next, chainDB, nil
+}
+
+func (f *FirewoodMigration) commit(
+	prev *versiondb.Database,
+	next *versiondb.Database,
+) (
+	bool,
+	error,
+) {
+	f.updates++
+	if f.updates%f.CommitFrequency != 0 {
+		return false, nil
+	}
+
+	if err := next.Commit(); err != nil {
+		return false, err
+	}
+
+	if err := prev.Commit(); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+type migrationState struct {
+	State
+	versionDB   *versiondb.Database
+	singletonDB database.Database
+	migrationDB database.Database
+}
+
+func newMigrationState(
+	parser block.Parser,
+	metrics prometheus.Registerer,
+	chainDataDir string,
+) (*migrationState, ChainDB, error) {
+	// The state db is used for state agreed upon by consensus
+	stateDB, err := firewood.New(filepath.Join(chainDataDir, "state"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("initializing state db: %w", err)
+	}
+
+	// The local db is used for all other data not agreed upon by consensus
+	localDB, err := pebbledb.New(
+		filepath.Join(chainDataDir, "local"),
+		nil,
+		logging.NoLog{},
+		metrics,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("initializing local db: %w", err)
+	}
+
+	versionDB := versiondb.New(localDB)
+
+	// Reserve a prefix for future re-indexing
+	v1PrefixDB := prefixdb.New([]byte("v1"), versionDB)
+	utxoIndexDB := prefixdb.New([]byte("utxo_index"), v1PrefixDB)
+	txDB := prefixdb.New([]byte("tx"), v1PrefixDB)
+	blockIDDB := prefixdb.New([]byte("block_id"), v1PrefixDB)
+	blockDB := prefixdb.New([]byte("block"), v1PrefixDB)
+	singletonDB := prefixdb.New([]byte("singleton"), v1PrefixDB)
+	migrationDB := prefixdb.New([]byte("migration"), versionDB)
+	chainDB := &firewoodDB{
+		db:        stateDB,
+		versionDB: versionDB,
+	}
+
+	s, err := NewWithFormat(
+		"foo_state",
+		chainDB,
+		localDB,
+		versionDB,
+		utxoIndexDB,
+		txDB,
+		blockIDDB,
+		blockDB,
+		singletonDB,
+		avax.NewFirewoodUTXODB(stateDB, parser.Codec()),
+		parser,
+		metrics,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("initializing state: %w", err)
+	}
+
+	return &migrationState{
+			State:       s,
+			versionDB:   versionDB,
+			singletonDB: singletonDB,
+			migrationDB: migrationDB,
+		},
+		chainDB,
+		nil
+}
+
+func (m *migrationState) GetMigrationStatus() (bool, error) {
+	return database.GetBool(m.migrationDB, migrationStatusKey)
+}
+
+func (m *migrationState) PutMigrationStatus(done bool) error {
+	return database.PutBool(m.migrationDB, migrationStatusKey, done)
+}
+
+func (m *migrationState) GetLastMigratedUTXO() (ids.ID, error) {
+	utxoIDBytes, err := m.migrationDB.Get(lastMigratedUTXOKey)
+	if errors.Is(err, database.ErrNotFound) {
+		return ids.ID{}, nil
+	}
+	if err != nil {
+		return ids.ID{}, err
+	}
+
+	utxoID, err := ids.ToID(utxoIDBytes)
+	if err != nil {
+		return ids.ID{}, err
+	}
+
+	return utxoID, nil
+}
+
+func (m *migrationState) PutLastMigratedUTXO(utxoID ids.ID) error {
+	return m.migrationDB.Put(lastMigratedUTXOKey, utxoID[:])
+}
+
+func (m *migrationState) GetLastMigratedTx() (ids.ID, error) {
+	txIDBytes, err := m.migrationDB.Get(lastMigratedTxKey)
+	if errors.Is(err, database.ErrNotFound) {
+		return ids.ID{}, nil
+	}
+	if err != nil {
+		return ids.ID{}, err
+	}
+
+	txID, err := ids.ToID(txIDBytes)
+	if err != nil {
+		return ids.ID{}, err
+	}
+
+	return txID, nil
+}
+
+func (m *migrationState) PutLastMigratedTx(txID ids.ID) error {
+	if err := m.migrationDB.Put(lastMigratedTxKey, txID[:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *migrationState) GetLastMigratedBlock() (ids.ID, error) {
+	blkIDBytes, err := m.migrationDB.Get(lastMigratedBlockKey)
+	if errors.Is(err, database.ErrNotFound) {
+		return ids.ID{}, nil
+	}
+	if err != nil {
+		return ids.ID{}, err
+	}
+
+	blkID, err := ids.ToID(blkIDBytes)
+	if err != nil {
+		return ids.ID{}, err
+	}
+
+	return blkID, nil
+}
+
+func (m *migrationState) PutLastMigratedBlock(blkID ids.ID) error {
+	return m.migrationDB.Put(lastMigratedBlockKey, blkID[:])
+}

--- a/vms/avm/state/statemock/chain.go
+++ b/vms/avm/state/statemock/chain.go
@@ -181,15 +181,15 @@ func (mr *ChainMockRecorder) GetUTXO(utxoID any) *gomock.Call {
 }
 
 // SetLastAccepted mocks base method.
-func (m *Chain) SetLastAccepted(blkID ids.ID) {
+func (m *Chain) SetLastAccepted(blkID ids.ID, height uint64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetLastAccepted", blkID)
+	m.ctrl.Call(m, "SetLastAccepted", blkID, height)
 }
 
 // SetLastAccepted indicates an expected call of SetLastAccepted.
-func (mr *ChainMockRecorder) SetLastAccepted(blkID any) *gomock.Call {
+func (mr *ChainMockRecorder) SetLastAccepted(blkID, height any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*Chain)(nil).SetLastAccepted), blkID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*Chain)(nil).SetLastAccepted), blkID, height)
 }
 
 // SetTimestamp mocks base method.

--- a/vms/avm/state/statemock/diff.go
+++ b/vms/avm/state/statemock/diff.go
@@ -194,15 +194,15 @@ func (mr *DiffMockRecorder) GetUTXO(utxoID any) *gomock.Call {
 }
 
 // SetLastAccepted mocks base method.
-func (m *Diff) SetLastAccepted(blkID ids.ID) {
+func (m *Diff) SetLastAccepted(blkID ids.ID, height uint64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetLastAccepted", blkID)
+	m.ctrl.Call(m, "SetLastAccepted", blkID, height)
 }
 
 // SetLastAccepted indicates an expected call of SetLastAccepted.
-func (mr *DiffMockRecorder) SetLastAccepted(blkID any) *gomock.Call {
+func (mr *DiffMockRecorder) SetLastAccepted(blkID, height any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*Diff)(nil).SetLastAccepted), blkID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*Diff)(nil).SetLastAccepted), blkID, height)
 }
 
 // SetTimestamp mocks base method.

--- a/vms/avm/state/statemock/state.go
+++ b/vms/avm/state/statemock/state.go
@@ -10,6 +10,7 @@
 package statemock
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -94,31 +95,32 @@ func (mr *StateMockRecorder) AddUTXO(utxo any) *gomock.Call {
 }
 
 // Checksum mocks base method.
-func (m *State) Checksum() ids.ID {
+func (m *State) Checksum(ctx context.Context) (ids.ID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Checksum")
+	ret := m.ctrl.Call(m, "Checksum", ctx)
 	ret0, _ := ret[0].(ids.ID)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Checksum indicates an expected call of Checksum.
-func (mr *StateMockRecorder) Checksum() *gomock.Call {
+func (mr *StateMockRecorder) Checksum(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Checksum", reflect.TypeOf((*State)(nil).Checksum))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Checksum", reflect.TypeOf((*State)(nil).Checksum), ctx)
 }
 
 // Close mocks base method.
-func (m *State) Close() error {
+func (m *State) Close(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
+	ret := m.ctrl.Call(m, "Close", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Close indicates an expected call of Close.
-func (mr *StateMockRecorder) Close() *gomock.Call {
+func (mr *StateMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*State)(nil).Close))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*State)(nil).Close), ctx)
 }
 
 // Commit mocks base method.
@@ -294,15 +296,15 @@ func (mr *StateMockRecorder) SetInitialized() *gomock.Call {
 }
 
 // SetLastAccepted mocks base method.
-func (m *State) SetLastAccepted(blkID ids.ID) {
+func (m *State) SetLastAccepted(blkID ids.ID, height uint64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetLastAccepted", blkID)
+	m.ctrl.Call(m, "SetLastAccepted", blkID, height)
 }
 
 // SetLastAccepted indicates an expected call of SetLastAccepted.
-func (mr *StateMockRecorder) SetLastAccepted(blkID any) *gomock.Call {
+func (mr *StateMockRecorder) SetLastAccepted(blkID, height any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*State)(nil).SetLastAccepted), blkID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*State)(nil).SetLastAccepted), blkID, height)
 }
 
 // SetTimestamp mocks base method.

--- a/vms/components/avax/firewood.go
+++ b/vms/components/avax/firewood.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package avax
+
+import (
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/firewood"
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+var utxoPrefix = []byte("utxo")
+
+type FirewoodUTXODB struct {
+	db    *firewood.DB
+	codec codec.Manager
+}
+
+var _ UTXODB = (*FirewoodUTXODB)(nil)
+
+func NewFirewoodUTXODB(db *firewood.DB, codec codec.Manager) *FirewoodUTXODB {
+	return &FirewoodUTXODB{
+		db:    db,
+		codec: codec,
+	}
+}
+
+func (f *FirewoodUTXODB) Get(inputID ids.ID) (*UTXO, error) {
+	bytes, err := f.db.Get(firewood.Prefix(utxoPrefix, inputID[:]))
+	if err != nil {
+		return nil, err
+	}
+
+	u := &UTXO{}
+	if _, err := f.codec.Unmarshal(bytes, u); err != nil {
+		return nil, err
+	}
+
+	return u, nil
+}
+
+func (f *FirewoodUTXODB) Put(u *UTXO) error {
+	bytes, err := f.codec.Marshal(codecVersion, u)
+	if err != nil {
+		return err
+	}
+
+	inputID := u.InputID()
+	f.db.Put(firewood.Prefix(utxoPrefix, inputID[:]), bytes)
+	return nil
+}
+
+func (f *FirewoodUTXODB) Delete(key []byte) error {
+	f.db.Delete(firewood.Prefix(utxoPrefix, key))
+	return nil
+}
+
+// InitChecksum is a no-op because firewood already initializes the merkle root.
+func (*FirewoodUTXODB) InitChecksum() error {
+	return nil
+}
+
+// UpdateChecksum is a no-op because firewood already updates the merkle root.
+func (*FirewoodUTXODB) UpdateChecksum(ids.ID) {}
+
+func (f *FirewoodUTXODB) Checksum() (ids.ID, error) {
+	return f.db.Root()
+}
+
+// Close is a no-op because this is a subset of firewoodDB which performs
+// Close.
+func (*FirewoodUTXODB) Close() error {
+	return nil
+}

--- a/vms/components/avax/utxo_fetching_test.go
+++ b/vms/components/avax/utxo_fetching_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
@@ -45,8 +46,12 @@ func TestFetchUTXOs(t *testing.T) {
 	require.NoError(c.RegisterType(&secp256k1fx.TransferOutput{}))
 	require.NoError(manager.RegisterCodec(codecVersion, c))
 
-	db := memdb.New()
-	s, err := NewUTXOState(db, manager, trackChecksum)
+	s, err := NewUTXOState(
+		memdb.New(),
+		memdb.New(),
+		manager,
+		trackChecksum,
+	)
 	require.NoError(err)
 
 	require.NoError(s.PutUTXO(utxo))
@@ -79,7 +84,12 @@ func TestGetPaginatedUTXOs(t *testing.T) {
 	require.NoError(manager.RegisterCodec(codecVersion, c))
 
 	db := memdb.New()
-	s, err := NewUTXOState(db, manager, trackChecksum)
+	s, err := NewUTXOState(
+		prefixdb.New([]byte("foo"), db),
+		prefixdb.New([]byte("bar"), db),
+		manager,
+		trackChecksum,
+	)
 	require.NoError(err)
 
 	// Create 1000 UTXOs each on addr0, addr1, and addr2.

--- a/vms/components/avax/utxo_state_test.go
+++ b/vms/components/avax/utxo_state_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
@@ -52,7 +53,11 @@ func TestUTXOState(t *testing.T) {
 	require.NoError(manager.RegisterCodec(codecVersion, c))
 
 	db := memdb.New()
-	s, err := NewUTXOState(db, manager, trackChecksum)
+	s, err := NewUTXOState(
+		prefixdb.New([]byte("foo"), db),
+		prefixdb.New([]byte("bar"), db),
+		manager,
+		trackChecksum)
 	require.NoError(err)
 
 	_, err = s.GetUTXO(utxoID)
@@ -80,7 +85,12 @@ func TestUTXOState(t *testing.T) {
 
 	require.NoError(s.PutUTXO(utxo))
 
-	s, err = NewUTXOState(db, manager, trackChecksum)
+	s, err = NewUTXOState(
+		prefixdb.New([]byte("foo"), db),
+		prefixdb.New([]byte("bar"), db),
+		manager,
+		trackChecksum,
+	)
 	require.NoError(err)
 
 	readUTXO, err = s.GetUTXO(utxoID)

--- a/vms/platformvm/block/executor/acceptor.go
+++ b/vms/platformvm/block/executor/acceptor.go
@@ -39,8 +39,7 @@ func (a *acceptor) BanffCommitBlock(b *block.BanffCommitBlock) error {
 }
 
 func (a *acceptor) BanffProposalBlock(b *block.BanffProposalBlock) error {
-	a.proposalBlock(b, "banff proposal")
-	return nil
+	return a.proposalBlock(b, "banff proposal")
 }
 
 func (a *acceptor) BanffStandardBlock(b *block.BanffStandardBlock) error {
@@ -56,8 +55,7 @@ func (a *acceptor) ApricotCommitBlock(b *block.ApricotCommitBlock) error {
 }
 
 func (a *acceptor) ApricotProposalBlock(b *block.ApricotProposalBlock) error {
-	a.proposalBlock(b, "apricot proposal")
-	return nil
+	return a.proposalBlock(b, "apricot proposal")
 }
 
 func (a *acceptor) ApricotStandardBlock(b *block.ApricotStandardBlock) error {
@@ -102,13 +100,18 @@ func (a *acceptor) ApricotAtomicBlock(b *block.ApricotAtomicBlock) error {
 		)
 	}
 
+	checksum, err := a.state.Checksum()
+	if err != nil {
+		return fmt.Errorf("getting checksum: %w", err)
+	}
+
 	a.ctx.Log.Trace(
 		"accepted block",
 		zap.String("blockType", "apricot atomic"),
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", b.Parent()),
-		zap.Stringer("checksum", a.state.Checksum()),
+		zap.Stringer("checksum", checksum),
 	)
 
 	return nil
@@ -172,19 +175,24 @@ func (a *acceptor) optionBlock(b block.Block, blockType string) error {
 		onAcceptFunc()
 	}
 
+	checksum, err := a.state.Checksum()
+	if err != nil {
+		return fmt.Errorf("getting checksum: %w", err)
+	}
+
 	a.ctx.Log.Trace(
 		"accepted block",
 		zap.String("blockType", blockType),
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", parentID),
-		zap.Stringer("checksum", a.state.Checksum()),
+		zap.Stringer("checksum", checksum),
 	)
 
 	return nil
 }
 
-func (a *acceptor) proposalBlock(b block.Block, blockType string) {
+func (a *acceptor) proposalBlock(b block.Block, blockType string) error {
 	// Note that:
 	//
 	// * We don't free the proposal block in this method.
@@ -204,14 +212,21 @@ func (a *acceptor) proposalBlock(b block.Block, blockType string) {
 	blkID := b.ID()
 	a.backend.lastAccepted = blkID
 
+	checksum, err := a.state.Checksum()
+	if err != nil {
+		return fmt.Errorf("getting checksum: %w", err)
+	}
+
 	a.ctx.Log.Trace(
 		"accepted block",
 		zap.String("blockType", blockType),
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", b.Parent()),
-		zap.Stringer("checksum", a.state.Checksum()),
+		zap.Stringer("checksum", checksum),
 	)
+
+	return nil
 }
 
 func (a *acceptor) standardBlock(b block.Block, blockType string) error {
@@ -251,13 +266,18 @@ func (a *acceptor) standardBlock(b block.Block, blockType string) error {
 		onAcceptFunc()
 	}
 
+	checksum, err := a.state.Checksum()
+	if err != nil {
+		return fmt.Errorf("getting checksum: %w", err)
+	}
+
 	a.ctx.Log.Trace(
 		"accepted block",
 		zap.String("blockType", blockType),
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", b.Parent()),
-		zap.Stringer("checksum", a.state.Checksum()),
+		zap.Stringer("checksum", checksum),
 	)
 
 	return nil

--- a/vms/platformvm/block/executor/acceptor_test.go
+++ b/vms/platformvm/block/executor/acceptor_test.go
@@ -48,7 +48,7 @@ func TestAcceptorVisitProposalBlock(t *testing.T) {
 	blkID := blk.ID()
 
 	s := state.NewMockState(ctrl)
-	s.EXPECT().Checksum().Return(ids.Empty).Times(1)
+	s.EXPECT().Checksum().Return(ids.Empty, nil).Times(1)
 
 	acceptor := &acceptor{
 		backend: &backend{
@@ -149,7 +149,7 @@ func TestAcceptorVisitAtomicBlock(t *testing.T) {
 	s.EXPECT().Abort().Times(1)
 	onAcceptState.EXPECT().Apply(s).Times(1)
 	sharedMemory.EXPECT().Apply(atomicRequests, batch).Return(nil).Times(1)
-	s.EXPECT().Checksum().Return(ids.Empty).Times(1)
+	s.EXPECT().Checksum().Return(ids.Empty, nil).Times(1)
 
 	require.NoError(acceptor.ApricotAtomicBlock(blk))
 }
@@ -235,7 +235,7 @@ func TestAcceptorVisitStandardBlock(t *testing.T) {
 	s.EXPECT().Abort().Times(1)
 	onAcceptState.EXPECT().Apply(s).Times(1)
 	sharedMemory.EXPECT().Apply(atomicRequests, batch).Return(nil).Times(1)
-	s.EXPECT().Checksum().Return(ids.Empty).Times(1)
+	s.EXPECT().Checksum().Return(ids.Empty, nil).Times(1)
 
 	require.NoError(acceptor.BanffStandardBlock(blk))
 	require.True(calledOnAcceptFunc)
@@ -342,7 +342,7 @@ func TestAcceptorVisitCommitBlock(t *testing.T) {
 		parentOnCommitState.EXPECT().Apply(s).Times(1),
 		s.EXPECT().CommitBatch().Return(batch, nil).Times(1),
 		sharedMemory.EXPECT().Apply(atomicRequests, batch).Return(nil).Times(1),
-		s.EXPECT().Checksum().Return(ids.Empty).Times(1),
+		s.EXPECT().Checksum().Return(ids.Empty, nil).Times(1),
 		s.EXPECT().Abort().Times(1),
 	)
 
@@ -451,7 +451,7 @@ func TestAcceptorVisitAbortBlock(t *testing.T) {
 		parentOnAbortState.EXPECT().Apply(s).Times(1),
 		s.EXPECT().CommitBatch().Return(batch, nil).Times(1),
 		sharedMemory.EXPECT().Apply(atomicRequests, batch).Return(nil).Times(1),
-		s.EXPECT().Checksum().Return(ids.Empty).Times(1),
+		s.EXPECT().Checksum().Return(ids.Empty, nil).Times(1),
 		s.EXPECT().Abort().Times(1),
 	)
 

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -206,11 +206,12 @@ func (mr *MockStateMockRecorder) ApplyValidatorWeightDiffs(ctx, validators, star
 }
 
 // Checksum mocks base method.
-func (m *MockState) Checksum() ids.ID {
+func (m *MockState) Checksum() (ids.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Checksum")
 	ret0, _ := ret[0].(ids.ID)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Checksum indicates an expected call of Checksum.


### PR DESCRIPTION
## Why this should be merged

Implements a database migration from the legacy database format into a database format that supports a merkle-ized prefix of state

## How this works

Changes db schema

## How this was tested

Added a migration unit test + tested state migration on Fuji

```
[03-20|16:01:06.597] INFO <X Chain> avm/vm.go:173 VM config initialized {"config": {"network":{"max-validator-set-staleness":60000000000,"target-gossip-size":20480,"push-gossip-percent-stake":0.9,"push-gossip-num-validators":100,"push-gossip-num-peers":0,"push-regossip-num-validators":10,"push-regossip-num-peers":0,"push-gossip-discarded-cache-size":16384,"push-gossip-max-regossip-frequency":30000000000,"push-gossip-frequency":500000000,"pull-gossip-poll-size":1,"pull-gossip-frequency":1500000000,"pull-gossip-throttling-period":10000000000,"pull-gossip-throttling-limit":2,"expected-bloom-filter-elements":8192,"expected-bloom-filter-false-positive-probability":0.01,"max-bloom-filter-false-positive-probability":0.05},"index-transactions":false,"index-allow-incomplete":false,"checksums-enabled":false}}
[03-20|16:01:06.597] INFO <X Chain> avm/vm.go:598 fee asset is established {"alias": "AVAX", "assetID": "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK"}
[03-20|16:01:06.597] INFO <X Chain> avm/vm.go:257 address transaction indexing is disabled
[03-20|16:01:06.599] INFO <X Chain> snowman/engine.go:96 initializing consensus engine
[03-20|16:01:06.599] INFO <X Chain> bootstrap/bootstrapper.go:320 starting bootstrap
[03-20|16:01:06.601] INFO <X Chain> bootstrap/bootstrapper.go:600 executing transactions
[03-20|16:01:06.601] INFO <X Chain> queue/jobs.go:223 executed operations {"numExecuted": 0}
[03-20|16:01:06.601] INFO <X Chain> bootstrap/bootstrapper.go:612 executing vertices
[03-20|16:01:06.601] INFO <X Chain> queue/jobs.go:223 executed operations {"numExecuted": 0}
[03-20|16:01:06.603] INFO <X Chain> avm/state_migration.go:143 starting state migration
[03-20|16:04:53.784] INFO <X Chain> avm/state_migration.go:321 migration complete
[03-20|16:04:53.790] INFO <X Chain> proposervm/vm.go:209 initialized proposervm {"state": "after fork", "forkHeight": 1, "lastAcceptedHeight": 32356}
[03-20|16:04:53.790] INFO <X Chain> bootstrap/bootstrapper.go:182 starting bootstrapper {"lastAcceptedID": "8o6VfSzPHhjLXwr7FEZDxuVAwXYVCx6dP7vrwLoW9mwYRPZi4", "lastAcceptedHeight": 32356}
[03-20|16:05:42.318] INFO <X Chain> bootstrap/bootstrapper.go:387 starting to fetch blocks {"numKnownBlocks": 99, "numAcceptedBlocks": 1, "numMissingBlocks": 100}
[03-20|16:05:42.857] INFO <X Chain> bootstrap/storage.go:194 executing blocks {"numToExecute": 45}
[03-20|16:05:43.116] INFO <X Chain> bootstrap/storage.go:186 executed blocks {"numExecuted": 45, "numToExecute": 45, "halted": false, "duration": "258.784792ms"}
```

## Need to be documented in RELEASES.md?

Yes