### PR TITLE
Comment on the need for `CGO_ENABLED=1` to support cross-compilation

### DIFF
--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -27,9 +27,7 @@ fi
 # We use "export" here instead of just setting a bash variable because we need
 # to pass this flag to all child processes spawned by the shell.
 export CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"
-# While CGO_ENABLED doesn't need to be explicitly set, it produces a much more
-# clear error due to the default value change in go1.20.
-export CGO_ENABLED=1
+export CGO_ENABLED=1 # Required for cross-compilation
 
 # Disable version control fallbacks
 export GOPROXY="https://proxy.golang.org"


### PR DESCRIPTION
While [ensuring testing](https://github.com/ava-labs/hypersdk/pull/1929) of multi-arch image build for hypersdk, time was spent trying to figure out a cross-compilation error that turned out to be due to `CGO_ENABLED=1` not being set. A literal reading of the comment removed in this PR did not suggest the importance of `CGO_ENABLED=1` to cross-compilation. Accordingly, this PR adds a new comment indicating that `CGO_ENABLED=1` is required when cross-compiling.