### PR TITLE
Fix spelling errors in `majority.go`, `minority.go`, `compressor.go`, and `logger.go`

### DIFF
--- a/snow/consensus/snowman/bootstrapper/majority.go
+++ b/snow/consensus/snowman/bootstrapper/majority.go
@@ -18,7 +18,7 @@ import (
 var _ Poll = (*Majority)(nil)
 
 // Majority implements the bootstrapping poll to filter the initial set of
-// potentially accaptable blocks into a set of accepted blocks to sync to.
+// potentially acceptable blocks into a set of accepted blocks to sync to.
 //
 // Once the last accepted blocks have been fetched from the initial set of
 // peers, the set of blocks are sent to all peers. Each peer is expected to

--- a/snow/consensus/snowman/bootstrapper/minority.go
+++ b/snow/consensus/snowman/bootstrapper/minority.go
@@ -16,7 +16,7 @@ import (
 var _ Poll = (*Minority)(nil)
 
 // Minority implements the bootstrapping poll to determine the initial set of
-// potentially accaptable blocks.
+// potentially acceptable blocks.
 //
 // This poll fetches the last accepted block from an initial set of peers. In
 // order for the protocol to find a recently accepted block, there must be at

--- a/utils/compression/compressor.go
+++ b/utils/compression/compressor.go
@@ -3,7 +3,7 @@
 
 package compression
 
-// Compressor compresss and decompresses messages.
+// Compressor compress and decompresses messages.
 // Decompress is the inverse of Compress.
 // Decompress(Compress(msg)) == msg.
 type Compressor interface {

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -33,7 +33,7 @@ type Logger interface {
 	// Log an event that may be useful for understanding the order of the
 	// execution of the protocol
 	Trace(msg string, fields ...zap.Field)
-	// Log an event that may be useful for a programmer to see when debuging the
+	// Log an event that may be useful for a programmer to see when debugging the
 	// execution of the protocol
 	Debug(msg string, fields ...zap.Field)
 	// Log extremely detailed events that can be useful for inspecting every


### PR DESCRIPTION
  - `majority.go`: Fixed "accaptable" → "acceptable"
  - `minority.go`: Fixed "accaptable" → "acceptable"
  - `compressor.go`: Fixed "compresss" → "compress"
  - `logger.go`: Fixed "debuging" → "debugging"
