### PR TITLE
[ci] Update to golangci-lint version compatible with go 1.23

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,12 +20,11 @@ run:
   build-tags:
     - test
 
-output:
+issues:
   # Make issues output unique by line.
   # Default: true
   uniq-by-line: false
 
-issues:
   # Maximum issues count per one linter.
   # Set to 0 to disable.
   # Default: 50

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -32,7 +32,7 @@ fi
 TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func import_testing_only_in_tests"}
 
 function test_golangci_lint {
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
   golangci-lint run --config .golangci.yml
 }
 


### PR DESCRIPTION
## Why this should be merged

Local execution of lint.sh results in the following error despite the installed version of golang being the official 1.23.6 binary for linux/arm64.

```
Error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.6)
Failed executing command with error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.6)
```

Updating to a newer version of golangci-lint removes this error.


