### PR TITLE
ProposerVM Epochs POC

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -73,7 +73,8 @@ var (
 		CortinaXChainStopVertexID:    ids.Empty,
 		DurangoTime:                  InitiallyActiveTime,
 		EtnaTime:                     InitiallyActiveTime,
-		FUpgradeTime:                 UnscheduledActivationTime,
+		FUpgradeTime:                 InitiallyActiveTime,
+		FUpgradeEpochDuration:        30,
 	}
 
 	ErrInvalidUpgradeTimes = errors.New("invalid upgrade configuration")
@@ -95,6 +96,7 @@ type Config struct {
 	DurangoTime                  time.Time `json:"durangoTime"`
 	EtnaTime                     time.Time `json:"etnaTime"`
 	FUpgradeTime                 time.Time `json:"fUpgradeTime"`
+	FUpgradeEpochDuration        uint64    `json:"fUpgradeEpochDuration"`
 }
 
 func (c *Config) Validate() error {

--- a/vms/proposervm/block/block.go
+++ b/vms/proposervm/block/block.go
@@ -35,6 +35,7 @@ type SignedBlock interface {
 	Block
 
 	PChainHeight() uint64
+	PChainEpochHeight() uint64
 	Timestamp() time.Time
 
 	// Proposer returns the ID of the node that proposed this block. If no node
@@ -43,11 +44,12 @@ type SignedBlock interface {
 }
 
 type statelessUnsignedBlock struct {
-	ParentID     ids.ID `serialize:"true"`
-	Timestamp    int64  `serialize:"true"`
-	PChainHeight uint64 `serialize:"true"`
-	Certificate  []byte `serialize:"true"`
-	Block        []byte `serialize:"true"`
+	ParentID          ids.ID `serialize:"true"`
+	Timestamp         int64  `serialize:"true"`
+	PChainHeight      uint64 `serialize:"true"`
+	PChainEpochHeight uint64 `serialize:"true"`
+	Certificate       []byte `serialize:"true"`
+	Block             []byte `serialize:"true"`
 }
 
 type statelessBlock struct {
@@ -125,6 +127,10 @@ func (b *statelessBlock) verify(chainID ids.ID) error {
 
 func (b *statelessBlock) PChainHeight() uint64 {
 	return b.StatelessBlock.PChainHeight
+}
+
+func (b *statelessBlock) PChainEpochHeight() uint64 {
+	return b.StatelessBlock.PChainEpochHeight
 }
 
 func (b *statelessBlock) Timestamp() time.Time {

--- a/vms/proposervm/block/build.go
+++ b/vms/proposervm/block/build.go
@@ -18,15 +18,17 @@ func BuildUnsigned(
 	parentID ids.ID,
 	timestamp time.Time,
 	pChainHeight uint64,
+	pChainEpochHeight uint64,
 	blockBytes []byte,
 ) (SignedBlock, error) {
 	var block SignedBlock = &statelessBlock{
 		StatelessBlock: statelessUnsignedBlock{
-			ParentID:     parentID,
-			Timestamp:    timestamp.Unix(),
-			PChainHeight: pChainHeight,
-			Certificate:  nil,
-			Block:        blockBytes,
+			ParentID:          parentID,
+			Timestamp:         timestamp.Unix(),
+			PChainHeight:      pChainHeight,
+			PChainEpochHeight: pChainEpochHeight,
+			Certificate:       nil,
+			Block:             blockBytes,
 		},
 		timestamp: timestamp,
 	}
@@ -43,6 +45,7 @@ func Build(
 	parentID ids.ID,
 	timestamp time.Time,
 	pChainHeight uint64,
+	pChainEpochHeight uint64,
 	cert *staking.Certificate,
 	blockBytes []byte,
 	chainID ids.ID,
@@ -50,11 +53,12 @@ func Build(
 ) (SignedBlock, error) {
 	block := &statelessBlock{
 		StatelessBlock: statelessUnsignedBlock{
-			ParentID:     parentID,
-			Timestamp:    timestamp.Unix(),
-			PChainHeight: pChainHeight,
-			Certificate:  cert.Raw,
-			Block:        blockBytes,
+			ParentID:          parentID,
+			Timestamp:         timestamp.Unix(),
+			PChainHeight:      pChainHeight,
+			PChainEpochHeight: pChainEpochHeight,
+			Certificate:       cert.Raw,
+			Block:             blockBytes,
 		},
 		timestamp: timestamp,
 		cert:      cert,

--- a/vms/proposervm/mocks_test.go
+++ b/vms/proposervm/mocks_test.go
@@ -227,6 +227,21 @@ func (mr *MockPostForkBlockMockRecorder) getStatelessBlk() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getStatelessBlk", reflect.TypeOf((*MockPostForkBlock)(nil).getStatelessBlk))
 }
 
+// pChainEpochHeight mocks base method.
+func (m *MockPostForkBlock) pChainEpochHeight(arg0 context.Context) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "pChainEpochHeight", arg0)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// pChainEpochHeight indicates an expected call of pChainEpochHeight.
+func (mr *MockPostForkBlockMockRecorder) pChainEpochHeight(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "pChainEpochHeight", reflect.TypeOf((*MockPostForkBlock)(nil).pChainEpochHeight), arg0)
+}
+
 // pChainHeight mocks base method.
 func (m *MockPostForkBlock) pChainHeight(arg0 context.Context) (uint64, error) {
 	m.ctrl.T.Helper()

--- a/vms/proposervm/post_fork_block.go
+++ b/vms/proposervm/post_fork_block.go
@@ -157,6 +157,10 @@ func (b *postForkBlock) pChainHeight(context.Context) (uint64, error) {
 	return b.PChainHeight(), nil
 }
 
+func (b *postForkBlock) pChainEpochHeight(context.Context) (uint64, error) {
+	return b.PChainEpochHeight(), nil
+}
+
 func (b *postForkBlock) getStatelessBlk() block.Block {
 	return b.SignedBlock
 }

--- a/vms/proposervm/post_fork_option.go
+++ b/vms/proposervm/post_fork_option.go
@@ -122,6 +122,14 @@ func (b *postForkOption) pChainHeight(ctx context.Context) (uint64, error) {
 	return parent.pChainHeight(ctx)
 }
 
+func (b *postForkOption) pChainEpochHeight(ctx context.Context) (uint64, error) {
+	parent, err := b.vm.getBlock(ctx, b.ParentID())
+	if err != nil {
+		return 0, err
+	}
+	return parent.pChainEpochHeight(ctx)
+}
+
 func (b *postForkOption) getStatelessBlk() block.Block {
 	return b.Block
 }

--- a/vms/proposervm/pre_fork_block.go
+++ b/vms/proposervm/pre_fork_block.go
@@ -211,6 +211,7 @@ func (b *preForkBlock) buildChild(ctx context.Context) (Block, error) {
 		parentID,
 		newTimestamp,
 		pChainHeight,
+		pChainHeight,
 		innerBlock.Bytes(),
 	)
 	if err != nil {
@@ -236,5 +237,9 @@ func (b *preForkBlock) buildChild(ctx context.Context) (Block, error) {
 }
 
 func (*preForkBlock) pChainHeight(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (*preForkBlock) pChainEpochHeight(context.Context) (uint64, error) {
 	return 0, nil
 }

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -107,6 +107,15 @@ type VM struct {
 	acceptedBlocksSlotHistogram prometheus.Histogram
 }
 
+// Epochs are numbered starting from 0.
+// The 0th epoch is defined as ending at FUpgradeTime + FUpgradeEpochDuration
+func (vm *VM) GetEpoch(timestamp time.Time) uint64 {
+	if timestamp.Before(vm.Upgrades.FUpgradeTime) {
+		return 0
+	}
+	return uint64(timestamp.Sub(vm.Upgrades.FUpgradeTime).Seconds()) / vm.Upgrades.FUpgradeEpochDuration
+}
+
 // New performs best when [minBlkDelay] is whole seconds. This is because block
 // timestamps are only specific to the second.
 func New(

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -2530,3 +2530,57 @@ func TestLocalParse(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEpoch(t *testing.T) {
+	t0 := time.Now()
+	vm := New(
+		&fullVM{},
+		Config{
+			Upgrades: upgrade.Config{
+				FUpgradeTime:          t0,
+				FUpgradeEpochDuration: 10,
+			},
+		},
+	)
+
+	testCases := []struct {
+		timestamp time.Time
+		epoch     uint64
+	}{
+		{
+			timestamp: t0.Add(-10 * time.Second),
+			epoch:     0,
+		},
+		{
+			timestamp: t0.Add(-1 * time.Second),
+			epoch:     0,
+		},
+		{
+			timestamp: t0,
+			epoch:     0,
+		},
+		{
+			timestamp: t0.Add(1 * time.Second),
+			epoch:     0,
+		},
+		{
+			timestamp: t0.Add(9 * time.Second),
+			epoch:     0,
+		},
+		{
+			timestamp: t0.Add(10 * time.Second),
+			epoch:     1,
+		},
+		{
+			timestamp: t0.Add(11 * time.Second),
+			epoch:     1,
+		},
+		{
+			timestamp: t0.Add(20 * time.Second),
+			epoch:     2,
+		},
+	}
+	for i := range testCases {
+		require.Equal(t, vm.GetEpoch(testCases[i].timestamp), testCases[i].epoch)
+	}
+}


### PR DESCRIPTION
## Why this should be merged

Implements ProposerVM epochs as described in https://github.com/avalanche-foundation/ACPs/pull/181

## How this works
Adds a field `PChainEpochHeight` to proposervm blocks that remains fixed for the epoch's duration. This height is passed to the innerVM block, rather than the windowed P-Chain height.

## How this was tested

Added unit test for the epoch calculation, but unit/integration tests for the rest of the changed are still TODO

## Need to be documented in RELEASES.md?
Yes
