### PR TITLE
Expose merkledb defaults

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -159,6 +159,21 @@ type MerkleDB interface {
 	Prefetcher
 }
 
+func NewConfig() Config {
+	return Config{
+		BranchFactor:                BranchFactor16,
+		Hasher:                      DefaultHasher,
+		RootGenConcurrency:          0,
+		HistoryLength:               300,
+		ValueNodeCacheSize:          units.MiB,
+		IntermediateNodeCacheSize:   units.MiB,
+		IntermediateWriteBufferSize: units.KiB,
+		IntermediateWriteBatchSize:  256 * units.KiB,
+		TraceLevel:                  InfoTrace,
+		Tracer:                      trace.Noop,
+	}
+}
+
 type Config struct {
 	// BranchFactor determines the number of children each node can have.
 	BranchFactor BranchFactor

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -14,21 +14,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/dbtest"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/maybe"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
 )
-
-const defaultHistoryLength = 300
 
 // newDB returns a new merkle database with the underlying type so that tests can access unexported fields
 func newDB(ctx context.Context, db database.Database, config Config) (*merkleDB, error) {
@@ -37,22 +33,6 @@ func newDB(ctx context.Context, db database.Database, config Config) (*merkleDB,
 		return nil, err
 	}
 	return db.(*merkleDB), nil
-}
-
-func newDefaultConfig() Config {
-	return Config{
-		BranchFactor:                BranchFactor16,
-		Hasher:                      DefaultHasher,
-		RootGenConcurrency:          0,
-		HistoryLength:               defaultHistoryLength,
-		ValueNodeCacheSize:          units.MiB,
-		IntermediateNodeCacheSize:   units.MiB,
-		IntermediateWriteBufferSize: units.KiB,
-		IntermediateWriteBatchSize:  256 * units.KiB,
-		Reg:                         prometheus.NewRegistry(),
-		TraceLevel:                  InfoTrace,
-		Tracer:                      trace.Noop,
-	}
 }
 
 func Test_MerkleDB_Get_Safety(t *testing.T) {
@@ -134,7 +114,7 @@ func Test_MerkleDB_DB_Load_Root_From_DB(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		baseDB,
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 
@@ -162,7 +142,7 @@ func Test_MerkleDB_DB_Load_Root_From_DB(t *testing.T) {
 	db, err = New(
 		context.Background(),
 		baseDB,
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 
@@ -176,7 +156,7 @@ func Test_MerkleDB_DB_Rebuild(t *testing.T) {
 
 	initialSize := 5_000
 
-	config := newDefaultConfig()
+	config := NewConfig()
 	config.ValueNodeCacheSize = uint(initialSize)
 	config.IntermediateNodeCacheSize = uint(initialSize)
 
@@ -233,7 +213,7 @@ func Test_MerkleDB_Failed_Batch_Commit(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		memDB,
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 
@@ -254,7 +234,7 @@ func Test_MerkleDB_Value_Cache(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		memDB,
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 
@@ -903,13 +883,13 @@ const (
 )
 
 func runRandDBTest(require *require.Assertions, r *rand.Rand, rt randTest, tokenSize int) {
-	db, err := getBasicDBWithBranchFactor(tokenSizeToBranchFactor[tokenSize])
+	config := NewConfig()
+	config.BranchFactor = tokenSizeToBranchFactor[tokenSize]
+	db, err := New(context.Background(), memdb.New(), config)
 	require.NoError(err)
 
-	const (
-		maxProofLen  = 100
-		maxPastRoots = defaultHistoryLength
-	)
+	maxProofLen := 100
+	maxPastRoots := int(config.HistoryLength)
 
 	var (
 		values               = make(map[Key][]byte) // tracks content of the trie
@@ -966,7 +946,7 @@ func runRandDBTest(require *require.Assertions, r *rand.Rand, rt randTest, token
 				end,
 				root,
 				tokenSize,
-				db.hasher,
+				config.Hasher,
 			))
 		case opGenerateChangeProof:
 			root, err := db.GetMerkleRoot(context.Background())
@@ -1301,7 +1281,7 @@ func TestCrashRecovery(t *testing.T) {
 	merkleDB, err := newDatabase(
 		context.Background(),
 		baseDB,
-		newDefaultConfig(),
+		NewConfig(),
 		&mockMetrics{},
 	)
 	require.NoError(err)
@@ -1319,7 +1299,7 @@ func TestCrashRecovery(t *testing.T) {
 	newMerkleDB, err := newDatabase(
 		context.Background(),
 		baseDB,
-		newDefaultConfig(),
+		NewConfig(),
 		&mockMetrics{},
 	)
 	require.NoError(err)

--- a/x/merkledb/helpers_test.go
+++ b/x/merkledb/helpers_test.go
@@ -20,19 +20,18 @@ func getBasicDB() (*merkleDB, error) {
 	return newDatabase(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 		&mockMetrics{},
 	)
 }
 
-func getBasicDBWithBranchFactor(bf BranchFactor) (*merkleDB, error) {
-	config := newDefaultConfig()
+func getBasicDBWithBranchFactor(bf BranchFactor) (MerkleDB, error) {
+	config := NewConfig()
 	config.BranchFactor = bf
-	return newDatabase(
+	return New(
 		context.Background(),
 		memdb.New(),
 		config,
-		&mockMetrics{},
 	)
 }
 

--- a/x/merkledb/history_test.go
+++ b/x/merkledb/history_test.go
@@ -22,7 +22,7 @@ func Test_History_Simple(t *testing.T) {
 	db, err := newDB(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 	batch := db.NewBatch()
@@ -87,7 +87,7 @@ func Test_History_Large(t *testing.T) {
 	numIters := 250
 
 	for i := 1; i < 5; i++ {
-		config := newDefaultConfig()
+		config := NewConfig()
 		// History must be large enough to get the change proof
 		// after this loop.
 		config.HistoryLength = uint(numIters)
@@ -149,7 +149,7 @@ func Test_History_Large(t *testing.T) {
 func Test_History_Bad_GetValueChanges_Input(t *testing.T) {
 	require := require.New(t)
 
-	config := newDefaultConfig()
+	config := NewConfig()
 	config.HistoryLength = 5
 
 	db, err := newDB(
@@ -215,7 +215,7 @@ func Test_History_Bad_GetValueChanges_Input(t *testing.T) {
 func Test_History_Trigger_History_Queue_Looping(t *testing.T) {
 	require := require.New(t)
 
-	config := newDefaultConfig()
+	config := NewConfig()
 	config.HistoryLength = 2
 
 	db, err := newDB(
@@ -274,7 +274,7 @@ func Test_History_Trigger_History_Queue_Looping(t *testing.T) {
 func Test_History_Values_Lookup_Over_Queue_Break(t *testing.T) {
 	require := require.New(t)
 
-	config := newDefaultConfig()
+	config := NewConfig()
 	config.HistoryLength = 4
 	db, err := newDB(
 		context.Background(),
@@ -327,7 +327,7 @@ func Test_History_RepeatedRoot(t *testing.T) {
 	db, err := newDB(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 	batch := db.NewBatch()
@@ -371,7 +371,7 @@ func Test_History_ExcessDeletes(t *testing.T) {
 	db, err := newDB(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 	batch := db.NewBatch()
@@ -403,7 +403,7 @@ func Test_History_DontIncludeAllNodes(t *testing.T) {
 	db, err := newDB(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 	batch := db.NewBatch()
@@ -431,7 +431,7 @@ func Test_History_Branching2Nodes(t *testing.T) {
 	db, err := newDB(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 	batch := db.NewBatch()
@@ -459,7 +459,7 @@ func Test_History_Branching3Nodes(t *testing.T) {
 	db, err := newDB(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 	batch := db.NewBatch()
@@ -484,7 +484,7 @@ func Test_History_Branching3Nodes(t *testing.T) {
 func Test_History_MaxLength(t *testing.T) {
 	require := require.New(t)
 
-	config := newDefaultConfig()
+	config := NewConfig()
 	config.HistoryLength = 2
 	db, err := newDB(
 		context.Background(),
@@ -519,7 +519,7 @@ func Test_Change_List(t *testing.T) {
 	db, err := newDB(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(err)
 

--- a/x/merkledb/metrics_test.go
+++ b/x/merkledb/metrics_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Test_Metrics_Basic_Usage(t *testing.T) {
-	config := newDefaultConfig()
+	config := NewConfig()
 	// Set to nil so that we use a mockMetrics instead of the real one inside
 	// merkledb.
 	config.Reg = nil
@@ -54,7 +54,7 @@ func Test_Metrics_Initialize(t *testing.T) {
 	db, err := New(
 		context.Background(),
 		memdb.New(),
-		newDefaultConfig(),
+		NewConfig(),
 	)
 	require.NoError(t, err)
 

--- a/x/merkledb/trie_test.go
+++ b/x/merkledb/trie_test.go
@@ -917,7 +917,7 @@ func Test_Trie_MultipleStates(t *testing.T) {
 			db, err := New(
 				context.Background(),
 				rdb,
-				newDefaultConfig(),
+				NewConfig(),
 			)
 			require.NoError(err)
 			defer db.Close()

--- a/x/merkledb/view_test.go
+++ b/x/merkledb/view_test.go
@@ -53,7 +53,7 @@ var hashChangedNodesTests = []struct {
 }
 
 func makeViewForHashChangedNodes(t require.TestingT, numKeys uint64, parallelism uint) *view {
-	config := newDefaultConfig()
+	config := NewConfig()
 	config.RootGenConcurrency = parallelism
 	db, err := newDatabase(
 		context.Background(),


### PR DESCRIPTION
## Why this should be merged

When we merkle-ize the P and X Chains, it's likely that we're going to use similar merkledb configurations so this PR exposes defaults to avoid some boilerplate setup code.

## How this works

Exposes `NewConfig` that contains a `Config` with default values

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
