### PR TITLE
[antithesis] Set AVAGO_PLUGIN_DIR for VM images

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -36,14 +36,6 @@ const (
 	defaultUnexpandedDataDir = "$" + AvalancheGoDataDirVar
 
 	DefaultProcessContextFilename = "process.json"
-
-	// The default plugin path of $HOME/.avalanchego/plugins is not
-	// suitable for docker images since $HOME might be writable but
-	// the plugin directory should not be. The value below is in the
-	// same hierarchy as avalanchego on the docker image
-	// (/avalanchego/build/avalanchego) and consistent with the
-	// location already used by subnet-evm.
-	DefaultImagePluginDir = "/avalanchego/build/plugins"
 )
 
 var (

--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -193,11 +193,6 @@ func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadIm
 			return nil, err
 		}
 		if len(trackSubnets) > 0 {
-			// The plugin dir is only required when subnets will be
-			// tracked. VM images are expected to put their plugins in
-			// the default dir.
-			env[config.PluginDirKey] = config.DefaultImagePluginDir
-
 			env[config.TrackSubnetsKey] = trackSubnets
 			if i == bootstrapIndex {
 				// DB volume for bootstrap node will need to initialized with the subnet

--- a/tests/antithesis/xsvm/Dockerfile.node
+++ b/tests/antithesis/xsvm/Dockerfile.node
@@ -23,8 +23,11 @@ FROM $AVALANCHEGO_NODE_IMAGE AS execution
 # The builder workdir will vary between instrumented and non-instrumented builders
 ARG BUILDER_WORKDIR
 
+# Configure the node with the location of the xsvm plugin
+ENV AVAGO_PLUGIN_DIR=/avalanchego/build/plugins
+
 # Copy the executable into the container
 COPY --from=builder $BUILDER_WORKDIR/build/xsvm \
-    /avalanchego/build/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH
+    $AVAGO_PLUGIN_DIR/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH
 
 # The node image's entrypoint will be reused.

--- a/vms/example/xsvm/Dockerfile
+++ b/vms/example/xsvm/Dockerfile
@@ -24,7 +24,10 @@ RUN ./scripts/build_xsvm.sh
 # ============= Cleanup Stage ================
 FROM $AVALANCHEGO_NODE_IMAGE AS execution
 
+# Configure the node with the location of the xsvm plugin
+ENV AVAGO_PLUGIN_DIR=/avalanchego/build/plugins
+
 # Copy the xsvm binary to the default plugin dir for images
-COPY --from=builder /build/build/xsvm /avalanchego/build/plugins/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH
+COPY --from=builder /build/build/xsvm $AVAGO_PLUGIN_DIR/v3m4wPxaHpvGr8qfMeyK6PRW3idZrPHmYcMTt7oXdK47yurVH
 
 # The node image's entrypoint will be reused.


### PR DESCRIPTION
## Why this should be merged

This makes the plugin dir configuration entirely the responsibility of the image and avoids having to conditionally set a plugin dir only if VM use is indicated by the configuration of subnets.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A