### PR TITLE
Remove unused `ForceCreateChain` function from `testManager`

### DIFF
--- a/chains/test_manager.go
+++ b/chains/test_manager.go
@@ -13,8 +13,6 @@ type testManager struct{}
 
 func (testManager) QueueChainCreation(ChainParameters) {}
 
-func (testManager) ForceCreateChain(ChainParameters) {}
-
 func (testManager) AddRegistrant(Registrant) {}
 
 func (testManager) Aliases(ids.ID) ([]string, error) {

--- a/chains/test_manager.go
+++ b/chains/test_manager.go
@@ -39,10 +39,6 @@ func (testManager) StartChainCreator(ChainParameters) error {
 	return nil
 }
 
-func (testManager) SubnetID(ids.ID) (ids.ID, error) {
-	return ids.Empty, nil
-}
-
 func (testManager) IsBootstrapped(ids.ID) bool {
 	return false
 }


### PR DESCRIPTION
## Why this should be merged
The `ForceCreateChain` function in `testManager` was unused and did not conform to the `Manager` interface. Removing it removes "dead" code, does not affect test logic, and simplifies maintenance.
