### PR TITLE
Deprecate the `snow.Context.Lock`

### DIFF
--- a/snow/context.go
+++ b/snow/context.go
@@ -42,7 +42,12 @@ type Context struct {
 	CChainID    ids.ID
 	AVAXAssetID ids.ID
 
-	Log          logging.Logger
+	Log logging.Logger
+	// Deprecated: This lock should not be used unless absolutely necessary.
+	// This lock will be removed in a future release once it is replaced with
+	// more granular locks.
+	//
+	// Warning: This lock is not correctly implemented over the rpcchainvm.
 	Lock         sync.RWMutex
 	SharedMemory atomic.SharedMemory
 	BCLookup     ids.AliaserReader


### PR DESCRIPTION
## Why this should be merged

The `snow.Context.Lock` is a terrible lock which reduces the performance of the node and introduces bugs. This documents that the lock is intended to be removed and that it shouldn't be relied upon when being used with the rpcchainvm.

## How this works

Adds a comment

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No.