### PR TITLE
[ci] Move monitoring check from github action to code

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -68,6 +68,7 @@ runs:
       run: ${{ inputs.run_env }} nix develop --impure --command bash -x ${{ inputs.run }}
       env:
         TMPNET_START_COLLECTORS: ${{ inputs.prometheus_username != '' }}
+        TMPNET_CHECK_MONITORING: ${{ inputs.prometheus_username != '' }}
         LOKI_USERNAME: ${{ inputs.loki_username }}
         LOKI_PASSWORD: ${{ inputs.loki_password }}
         PROMETHEUS_USERNAME: ${{ inputs.prometheus_username }}
@@ -92,30 +93,3 @@ runs:
           ~/.tmpnet/prometheus/prometheus.log
           ~/.tmpnet/promtail/promtail.log
         if-no-files-found: error
-    # TODO(marun) Maybe optionally run these checks in an AfterSuite step?
-    - name: Check that logs were collected
-      if: (inputs.prometheus_username != '')
-      shell: bash
-      run: go run github.com/ava-labs/avalanchego/tests/fixture/tmpnet/cmd check-logs
-      env:
-        LOKI_USERNAME: ${{ inputs.loki_username }}
-        LOKI_PASSWORD: ${{ inputs.loki_password }}
-        GH_REPO: ${{ inputs.repository_owner }}/${{ inputs.repository_name }}
-        GH_WORKFLOW: ${{ inputs.workflow }}
-        GH_RUN_ID: ${{ inputs.run_id }}
-        GH_RUN_NUMBER: ${{ inputs.run_number }}
-        GH_RUN_ATTEMPT: ${{ inputs.run_attempt }}
-        GH_JOB_ID: ${{ inputs.job }}
-    - name: Check that metrics were collected
-      if: (inputs.prometheus_username != '')
-      shell: bash
-      run: go run github.com/ava-labs/avalanchego/tests/fixture/tmpnet/cmd check-metrics
-      env:
-        PROMETHEUS_USERNAME: ${{ inputs.prometheus_username }}
-        PROMETHEUS_PASSWORD: ${{ inputs.prometheus_password }}
-        GH_REPO: ${{ inputs.repository_owner }}/${{ inputs.repository_name }}
-        GH_WORKFLOW: ${{ inputs.workflow }}
-        GH_RUN_ID: ${{ inputs.run_id }}
-        GH_RUN_NUMBER: ${{ inputs.run_number }}
-        GH_RUN_ATTEMPT: ${{ inputs.run_attempt }}
-        GH_JOB_ID: ${{ inputs.job }}

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -21,6 +21,7 @@ type FlagVars struct {
 	networkDir          string
 	reuseNetwork        bool
 	startCollectors     bool
+	checkMonitoring     bool
 	startNetwork        bool
 	stopNetwork         bool
 	restartNetwork      bool
@@ -75,6 +76,10 @@ func (v *FlagVars) RestartNetwork() bool {
 
 func (v *FlagVars) StartCollectors() bool {
 	return v.startCollectors
+}
+
+func (v *FlagVars) CheckMonitoring() bool {
+	return v.checkMonitoring
 }
 
 func (v *FlagVars) NetworkShutdownDelay() time.Duration {
@@ -140,7 +145,10 @@ func RegisterFlags() *FlagVars {
 		false,
 		"[optional] restart an existing network previously started with --reuse-network. Useful for ensuring a network is running with the current state of binaries on disk. Ignored if a network is not already running or --stop-network is provided.",
 	)
-	SetStartCollectorsFlag(&vars.startCollectors)
+	SetMonitoringFlags(
+		&vars.startCollectors,
+		&vars.checkMonitoring,
+	)
 	flag.BoolVar(
 		&vars.startNetwork,
 		"start-network",
@@ -170,11 +178,17 @@ func RegisterFlags() *FlagVars {
 }
 
 // Enable reuse by the upgrade job
-func SetStartCollectorsFlag(p *bool) {
+func SetMonitoringFlags(startCollectors *bool, checkMonitoring *bool) {
 	flag.BoolVar(
-		p,
+		startCollectors,
 		"start-collectors",
 		cast.ToBool(tmpnet.GetEnvWithDefault("TMPNET_START_COLLECTORS", "false")),
 		"[optional] whether to start collectors of logs and metrics from nodes of the temporary network.",
+	)
+	flag.BoolVar(
+		checkMonitoring,
+		"check-monitoring",
+		cast.ToBool(tmpnet.GetEnvWithDefault("TMPNET_CHECK_MONITORING", "false")),
+		"[optional] whether to check that logs and metrics have been collected from nodes of the temporary network.",
 	)
 }

--- a/tests/fixture/tmpnet/check_monitoring.go
+++ b/tests/fixture/tmpnet/check_monitoring.go
@@ -27,6 +27,15 @@ import (
 
 type getCountFunc func() (int, error)
 
+// CheckMonitoring checks if logs and metrics exist for the given network. Github labels
+// are also used as filters if provided as env vars (GH_*).
+func CheckMonitoring(ctx context.Context, log logging.Logger, networkUUID string) error {
+	return errors.Join(
+		CheckLogsExist(ctx, log, networkUUID),
+		CheckMetricsExist(ctx, log, networkUUID),
+	)
+}
+
 // waitForCount waits until the provided function returns greater than zero.
 func waitForCount(ctx context.Context, log logging.Logger, name string, getCount getCountFunc) error {
 	err := pollUntilContextCancel(
@@ -56,7 +65,7 @@ func waitForCount(ctx context.Context, log logging.Logger, name string, getCount
 }
 
 // CheckLogsExist checks if logs exist for the given network. Github labels are also
-// included if provided as env vars (GH_*).
+// used as filters if provided as env vars (GH_*).
 func CheckLogsExist(ctx context.Context, log logging.Logger, networkUUID string) error {
 	username, password, err := getCollectorCredentials(promtailCmd)
 	if err != nil {
@@ -163,7 +172,7 @@ func queryLoki(
 }
 
 // CheckMetricsExist checks if metrics exist for the given network. Github labels are also
-// included if provided as env vars (GH_*).
+// used as filters if provided as env vars (GH_*).
 func CheckMetricsExist(ctx context.Context, log logging.Logger, networkUUID string) error {
 	username, password, err := getCollectorCredentials(prometheusCmd)
 	if err != nil {

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -121,6 +121,7 @@ type Network struct {
 
 func NewDefaultNetwork(owner string) *Network {
 	return &Network{
+		UUID:  uuid.NewString(),
 		Owner: owner,
 		Nodes: NewNodesOrPanic(DefaultNodeCount),
 	}


### PR DESCRIPTION
## Why this should be merged

This avoids requiring that downstream repos be able to produce a tmpnetctl binary.

## How this works

 - Enables the e2e and upgrade suites to optionally run the monitoring check after network shutdown
 - Since the check runs in its own DeferCleanup, it's failure won't prevent tests or other cleanup from running

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A
