### PR TITLE
Print git commit version upon startup

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -59,12 +59,16 @@ runs:
         GRAFANA_URL: https://grafana-poc.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-filter=is_ephemeral_node%7C%3D%7Cfalse&var-filter=gh_repo%7C%3D%7C${{ inputs.repository_owner }}%2F${{ inputs.repository_name }}&var-filter=gh_run_id%7C%3D%7C${{ inputs.run_id }}&var-filter=gh_run_attempt%7C%3D%7C${{ inputs.run_attempt }}
         GH_JOB_ID: ${{ inputs.job }}
         FILTER_BY_OWNER: ${{ inputs.filter_by_owner }}
+    - name: Warn that collection of metrics and logs will not be performed
+      if: (inputs.prometheus_username == '')
+      shell: bash
+      run: echo "::warning::Monitoring credentials not found. Skipping collector start. Is the PR from a fork branch?"
     - name: Run command
       shell: bash
       # --impure ensures the env vars are accessible to the command
       run: ${{ inputs.run_env }} nix develop --impure --command bash -x ${{ inputs.run }}
       env:
-        TMPNET_START_COLLECTORS: true
+        TMPNET_START_COLLECTORS: ${{ inputs.prometheus_username != '' }}
         LOKI_USERNAME: ${{ inputs.loki_username }}
         LOKI_PASSWORD: ${{ inputs.loki_password }}
         PROMETHEUS_USERNAME: ${{ inputs.prometheus_username }}
@@ -91,7 +95,7 @@ runs:
         if-no-files-found: error
     # TODO(marun) Maybe optionally run these checks in an AfterSuite step?
     - name: Check that logs were collected
-      if: always()
+      if: (inputs.prometheus_username != '')
       shell: bash
       run: go run github.com/ava-labs/avalanchego/tests/fixture/tmpnet/cmd check-logs
       env:
@@ -104,7 +108,7 @@ runs:
         GH_RUN_ATTEMPT: ${{ inputs.run_attempt }}
         GH_JOB_ID: ${{ inputs.job }}
     - name: Check that metrics were collected
-      if: always()
+      if: (inputs.prometheus_username != '')
       shell: bash
       run: go run github.com/ava-labs/avalanchego/tests/fixture/tmpnet/cmd check-metrics
       env:

--- a/node/node.go
+++ b/node/node.go
@@ -145,6 +145,7 @@ func New(
 
 	logger.Info("initializing node",
 		zap.Stringer("version", version.CurrentApp),
+		zap.String("commit", version.GitCommit),
 		zap.Stringer("nodeID", n.ID),
 		zap.Stringer("stakingKeyType", tlsCert.PublicKeyAlgorithm),
 		zap.Reflect("nodePOP", pop),


### PR DESCRIPTION
## Why this should be merged

In order to better know the exact code version that is run, it's useful if the node would print it upon startup.

## How this works

Just prints the commit which is set at compile time.

## How this was tested

built the binary and ran it.

## Need to be documented in RELEASES.md?

no
