### PR TITLE
Remove support for AVM tx checksums

### DIFF
--- a/vms/avm/block/executor/block.go
+++ b/vms/avm/block/executor/block.go
@@ -252,7 +252,7 @@ func (b *Block) Accept(context.Context) error {
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", b.Parent()),
-		zap.Stringer("checksum", checksum),
+		zap.Stringer("checksum", b.manager.state.Checksum()),
 	)
 	return nil
 }

--- a/vms/avm/block/executor/block.go
+++ b/vms/avm/block/executor/block.go
@@ -246,14 +246,13 @@ func (b *Block) Accept(context.Context) error {
 		return err
 	}
 
-	txChecksum, utxoChecksum := b.manager.state.Checksums()
+	checksum := b.manager.state.Checksum()
 	b.manager.backend.Ctx.Log.Trace(
 		"accepted block",
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", b.Parent()),
-		zap.Stringer("txChecksum", txChecksum),
-		zap.Stringer("utxoChecksum", utxoChecksum),
+		zap.Stringer("checksum", checksum),
 	)
 	return nil
 }

--- a/vms/avm/block/executor/block.go
+++ b/vms/avm/block/executor/block.go
@@ -246,7 +246,6 @@ func (b *Block) Accept(context.Context) error {
 		return err
 	}
 
-	checksum := b.manager.state.Checksum()
 	b.manager.backend.Ctx.Log.Trace(
 		"accepted block",
 		zap.Stringer("blkID", blkID),

--- a/vms/avm/block/executor/block_test.go
+++ b/vms/avm/block/executor/block_test.go
@@ -749,7 +749,7 @@ func TestBlockAccept(t *testing.T) {
 				// because we mock the call to shared memory
 				mockManagerState.EXPECT().CommitBatch().Return(nil, nil)
 				mockManagerState.EXPECT().Abort()
-				mockManagerState.EXPECT().Checksums().Return(ids.Empty, ids.Empty)
+				mockManagerState.EXPECT().Checksum().Return(ids.Empty)
 
 				mockSharedMemory := atomicmock.NewSharedMemory(ctrl)
 				mockSharedMemory.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil)

--- a/vms/avm/state/statemock/state.go
+++ b/vms/avm/state/statemock/state.go
@@ -93,19 +93,18 @@ func (mr *StateMockRecorder) AddUTXO(utxo any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUTXO", reflect.TypeOf((*State)(nil).AddUTXO), utxo)
 }
 
-// Checksums mocks base method.
-func (m *State) Checksums() (ids.ID, ids.ID) {
+// Checksum mocks base method.
+func (m *State) Checksum() ids.ID {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Checksums")
+	ret := m.ctrl.Call(m, "Checksum")
 	ret0, _ := ret[0].(ids.ID)
-	ret1, _ := ret[1].(ids.ID)
-	return ret0, ret1
+	return ret0
 }
 
-// Checksums indicates an expected call of Checksums.
-func (mr *StateMockRecorder) Checksums() *gomock.Call {
+// Checksum indicates an expected call of Checksum.
+func (mr *StateMockRecorder) Checksum() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Checksums", reflect.TypeOf((*State)(nil).Checksums))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Checksum", reflect.TypeOf((*State)(nil).Checksum))
 }
 
 // Close mocks base method.

--- a/vms/platformvm/block/executor/acceptor.go
+++ b/vms/platformvm/block/executor/acceptor.go
@@ -110,7 +110,7 @@ func (a *acceptor) ApricotAtomicBlock(b *block.ApricotAtomicBlock) error {
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", b.Parent()),
-		zap.Stringer("utxoChecksum", a.state.Checksum()),
+		zap.Stringer("checksum", a.state.Checksum()),
 	)
 
 	return nil
@@ -180,7 +180,7 @@ func (a *acceptor) optionBlock(b block.Block, blockType string) error {
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", parentID),
-		zap.Stringer("utxoChecksum", a.state.Checksum()),
+		zap.Stringer("checksum", a.state.Checksum()),
 	)
 
 	return nil
@@ -212,7 +212,7 @@ func (a *acceptor) proposalBlock(b block.Block, blockType string) {
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", b.Parent()),
-		zap.Stringer("utxoChecksum", a.state.Checksum()),
+		zap.Stringer("checksum", a.state.Checksum()),
 	)
 }
 
@@ -259,7 +259,7 @@ func (a *acceptor) standardBlock(b block.Block, blockType string) error {
 		zap.Stringer("blkID", blkID),
 		zap.Uint64("height", b.Height()),
 		zap.Stringer("parentID", b.Parent()),
-		zap.Stringer("utxoChecksum", a.state.Checksum()),
+		zap.Stringer("checksum", a.state.Checksum()),
 	)
 
 	return nil


### PR DESCRIPTION
## Why this should be merged

Once we merge https://github.com/ava-labs/avalanchego/pull/3732, checksums will be updated to be return the merkle root instead. We have to make a decision to either continue to maintain the current tx checksumming, or store our txs in a merkle trie. The only current use-case of the tx checksum is for debugging/logging purposes, so this PR removes support for it entirely.

## How this works

Removes support for tx checksumming

## How this was tested

CI

## Need to be documented in RELEASES.md?

Yes