### PR TITLE
Fix empty standard block check

### DIFF
--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -260,7 +260,7 @@ func TestBanffStandardBlockTimeVerification(t *testing.T) {
 		require.NoError(err)
 		block := env.blkManager.NewBlock(banffChildBlk)
 		err = block.Verify(context.Background())
-		require.ErrorIs(err, errBanffStandardBlockWithoutChanges)
+		require.ErrorIs(err, ErrStandardBlockWithoutChanges)
 	}
 
 	{

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -478,7 +478,7 @@ func (v *verifier) standardBlock(
 	// Fortuna, it is.
 	timestamp := onAcceptState.GetTimestamp()
 	isFortuna := v.txExecutorBackend.Config.UpgradeConfig.IsFortunaActivated(timestamp)
-	if hasChanges := changed || len(txs) > 0 || (isFortuna && lowBalanceL1ValidatorsEvicted); !hasChanges { {
+	if hasChanges := changed || len(txs) > 0 || (isFortuna && lowBalanceL1ValidatorsEvicted); !hasChanges {
 		return ErrStandardBlockWithoutChanges
 	}
 

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -477,9 +477,8 @@ func (v *verifier) standardBlock(
 	// have enough balance for the next second is not considered a change. After
 	// Fortuna, it is.
 	timestamp := onAcceptState.GetTimestamp()
-	if !changed &&
-		len(txs) == 0 &&
-		(!v.txExecutorBackend.Config.UpgradeConfig.IsFortunaActivated(timestamp) || !lowBalanceL1ValidatorsEvicted) {
+	isFortuna := v.txExecutorBackend.Config.UpgradeConfig.IsFortunaActivated(timestamp)
+	if hasChanges := changed || len(txs) > 0 || (isFortuna && lowBalanceL1ValidatorsEvicted); !hasChanges { {
 		return ErrStandardBlockWithoutChanges
 	}
 

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -1349,19 +1349,19 @@ func TestDeactivateLowBalanceL1ValidatorBlockChanges(t *testing.T) {
 			name:              "Before F Upgrade - no L1 validators evicted",
 			currentFork:       upgradetest.Etna,
 			durationToAdvance: 0,
-			expectedErr:       errBanffStandardBlockWithoutChanges,
+			expectedErr:       ErrStandardBlockWithoutChanges,
 		},
 		{
 			name:              "After F Upgrade - no L1 validators evicted",
 			currentFork:       upgradetest.Fortuna,
 			durationToAdvance: 0,
-			expectedErr:       errBanffStandardBlockWithoutChanges,
+			expectedErr:       ErrStandardBlockWithoutChanges,
 		},
 		{
 			name:              "Before F Upgrade - L1 validators evicted",
 			currentFork:       upgradetest.Etna,
 			durationToAdvance: time.Second,
-			expectedErr:       errBanffStandardBlockWithoutChanges,
+			expectedErr:       ErrStandardBlockWithoutChanges,
 		},
 		{
 			name:              "After F Upgrade - L1 validators evicted",

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -2180,6 +2180,54 @@ func TestValidatorSetRaceCondition(t *testing.T) {
 	vm.ctx.Lock.Lock()
 }
 
+func TestL1ValidatorDeactivationCausesTrackingOfInvalidBlock(t *testing.T) {
+	require := require.New(t)
+	vm, _, _ := defaultVM(t, upgradetest.Etna)
+	vm.ctx.Lock.Lock()
+	defer vm.ctx.Lock.Unlock()
+
+	subnetID := testSubnet1.TxID
+	wallet := newWallet(t, vm, walletConfig{
+		subnetIDs: []ids.ID{subnetID},
+	})
+
+	nodeID := ids.GenerateTestNodeID()
+	sk, err := localsigner.New()
+	require.NoError(err)
+	pop, err := signer.NewProofOfPossession(sk)
+	require.NoError(err)
+
+	tx, err := wallet.IssueConvertSubnetToL1Tx(
+		subnetID,
+		ids.Empty,
+		nil,
+		[]*txs.ConvertSubnetToL1Validator{
+			{
+				NodeID:  nodeID[:],
+				Weight:  1,
+				Balance: uint64(vm.ValidatorFeeConfig.MinPrice) + 1,
+				Signer:  *pop,
+			},
+		},
+	)
+	require.NoError(err)
+
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTxFromRPC(tx))
+	vm.ctx.Lock.Lock()
+	require.NoError(buildAndAcceptStandardBlock(vm))
+
+	vm.clock.Set(time.Now().Add(1 * time.Minute))
+	blk, err := vm.BuildBlock(context.Background())
+	require.NoError(err)
+
+	err = blk.Verify(context.Background())
+	require.ErrorIs(err, blockexecutor.ErrStandardBlockWithoutChanges)
+
+	err = blk.Verify(context.Background())
+	require.ErrorIs(err, blockexecutor.ErrStandardBlockWithoutChanges)
+}
+
 func buildAndAcceptStandardBlock(vm *VM) error {
 	blk, err := vm.Builder.BuildBlock(context.Background())
 	if err != nil {

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -2203,8 +2203,11 @@ func TestL1ValidatorDeactivationCausesTrackingOfInvalidBlock(t *testing.T) {
 		nil,
 		[]*txs.ConvertSubnetToL1Validator{
 			{
-				NodeID:  nodeID[:],
-				Weight:  1,
+				NodeID: nodeID[:],
+				Weight: 1,
+				// Ensure that the validator is active for a 1 second and that
+				// it does not have sufficient balance to be active for 2
+				// seconds.
 				Balance: uint64(vm.ValidatorFeeConfig.MinPrice) + 1,
 				Signer:  *pop,
 			},

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -2217,15 +2217,14 @@ func TestL1ValidatorDeactivationCausesTrackingOfInvalidBlock(t *testing.T) {
 	vm.ctx.Lock.Lock()
 	require.NoError(buildAndAcceptStandardBlock(vm))
 
-	vm.clock.Set(time.Now().Add(1 * time.Minute))
+	vm.clock.Set(vm.clock.Time().Add(1 * time.Minute))
 	blk, err := vm.BuildBlock(context.Background())
 	require.NoError(err)
 
-	err = blk.Verify(context.Background())
-	require.ErrorIs(err, blockexecutor.ErrStandardBlockWithoutChanges)
-
-	err = blk.Verify(context.Background())
-	require.ErrorIs(err, blockexecutor.ErrStandardBlockWithoutChanges)
+	for range 2 {
+		err = blk.Verify(context.Background())
+		require.ErrorIs(err, blockexecutor.ErrStandardBlockWithoutChanges)
+	}
 }
 
 func buildAndAcceptStandardBlock(vm *VM) error {

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -109,7 +109,7 @@ var (
 	defaultValidatorFeeConfig = fee.Config{
 		Capacity:                 100,
 		Target:                   50,
-		MinPrice:                 1,
+		MinPrice:                 2,
 		ExcessConversionConstant: 100,
 	}
 

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -107,8 +107,11 @@ var (
 		ExcessConversionConstant: 5_000,
 	}
 	defaultValidatorFeeConfig = fee.Config{
-		Capacity:                 100,
-		Target:                   50,
+		Capacity: 100,
+		Target:   50,
+		// The minimum price is set to 2 so that tests can include cases where
+		// L1 validator balances do not evenly divide into a timestamp granular
+		// to a second.
 		MinPrice:                 2,
 		ExcessConversionConstant: 100,
 	}


### PR DESCRIPTION
## Why this should be merged

This code has not yet been included in an official release, but is the root cause for [Fuji instability](https://status.avax.network/incidents/n4dnd7sb1n6h).

If `(*verifier).standardBlock` returns nil, it marks the block as valid by storing the `blockState` into the `blkIDToState` map. If we later mark the block as invalid by returning an error, the block is temporarily dropped by the consensus engine. However, the P-chain still has the `blockState` stored as a valid state.

Because of the introduction of Warp messaging on the P-chain in Etna, it is expected for the same block to potentially be verified multiple times. When this is the case, full block verification is skipped if it is detected that the block previous passed verification (based on the `blockState` in the `blkIDToState` map).

Because of this, a block which at first was marked as invalid, if verified again, may signal that it is valid.

## How this works

Moved the `is useful` check to before storing the `blockState` into the `blkIDToState` map (but still after the post-block execution for L1 validator eviction).

## How this was tested

Added a regression test.