### PR TITLE
[ci] Disable monitoring for jobs of PRs of fork branches

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -59,12 +59,16 @@ runs:
         GRAFANA_URL: https://grafana-poc.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-filter=is_ephemeral_node%7C%3D%7Cfalse&var-filter=gh_repo%7C%3D%7C${{ inputs.repository_owner }}%2F${{ inputs.repository_name }}&var-filter=gh_run_id%7C%3D%7C${{ inputs.run_id }}&var-filter=gh_run_attempt%7C%3D%7C${{ inputs.run_attempt }}
         GH_JOB_ID: ${{ inputs.job }}
         FILTER_BY_OWNER: ${{ inputs.filter_by_owner }}
+    - name: Warn that collection of metrics and logs will not be performed
+      if: (inputs.prometheus_username == '')
+      shell: bash
+      run: echo "::warning::Monitoring credentials not found. Skipping collector start. Is the PR from a fork branch?"
     - name: Run command
       shell: bash
       # --impure ensures the env vars are accessible to the command
       run: ${{ inputs.run_env }} nix develop --impure --command bash -x ${{ inputs.run }}
       env:
-        TMPNET_START_COLLECTORS: true
+        TMPNET_START_COLLECTORS: ${{ inputs.prometheus_username != '' }}
         LOKI_USERNAME: ${{ inputs.loki_username }}
         LOKI_PASSWORD: ${{ inputs.loki_password }}
         PROMETHEUS_USERNAME: ${{ inputs.prometheus_username }}
@@ -91,7 +95,7 @@ runs:
         if-no-files-found: error
     # TODO(marun) Maybe optionally run these checks in an AfterSuite step?
     - name: Check that logs were collected
-      if: always()
+      if: (inputs.prometheus_username != '')
       shell: bash
       run: go run github.com/ava-labs/avalanchego/tests/fixture/tmpnet/cmd check-logs
       env:
@@ -104,7 +108,7 @@ runs:
         GH_RUN_ATTEMPT: ${{ inputs.run_attempt }}
         GH_JOB_ID: ${{ inputs.job }}
     - name: Check that metrics were collected
-      if: always()
+      if: (inputs.prometheus_username != '')
       shell: bash
       run: go run github.com/ava-labs/avalanchego/tests/fixture/tmpnet/cmd check-metrics
       env:


### PR DESCRIPTION
## Why this should be merged

Jobs executing on PRs based on fork branches won't have access to the secrets required to configure collectors for logs and metrics. Disabling the collection in the custom action avoids failing such jobs. This was the behavior prior to the switch to starting collectors with golang.

## How this works

- makes collector start and collection checks in the run-monitored-tmpnet-cmd custom action conditional on credentials being non-empty
- emits an annotation if collector credentials are missing in the hopes of notifying interested parties of unintended misconfiguration 

## How this was tested

- [x] CI (should show no change)
- [ ] Passing run from a fork branch

## Need to be documented in RELEASES.md?

N/A