### PR TITLE
Add comment to SendConfig documenting how to broadcast

### DIFF
--- a/snow/engine/common/sender.go
+++ b/snow/engine/common/sender.go
@@ -13,13 +13,13 @@ import (
 // SendConfig is used to specify who to send messages to over the p2p network.
 type SendConfig struct {
 	NodeIDs set.Set[ids.NodeID]
-	// If [Validators] >= number of connected validators, the message will be sent to all
+	// If Validators >= number of connected validators, the message will be sent to all
 	// connected validators.
 	Validators int
-	// If [NonValidators] >= number of connected non-validators, the message will be sent to
+	// If NonValidators >= number of connected non-validators, the message will be sent to
 	// all connected non-validators.
 	NonValidators int
-	// If [Peers] >= number of connected peers, the message will be sent to all connected peers.
+	// If Peers >= number of connected peers, the message will be sent to all connected peers.
 	Peers int
 }
 

--- a/snow/engine/common/sender.go
+++ b/snow/engine/common/sender.go
@@ -12,10 +12,15 @@ import (
 
 // SendConfig is used to specify who to send messages to over the p2p network.
 type SendConfig struct {
-	NodeIDs       set.Set[ids.NodeID]
-	Validators    int
+	NodeIDs set.Set[ids.NodeID]
+	// If [Validators] >= number of connected validators, the message will be sent to all
+	// connected validators.
+	Validators int
+	// If [NonValidators] >= number of connected non-validators, the message will be sent to
+	// all connected non-validators.
 	NonValidators int
-	Peers         int
+	// If [Peers] >= number of connected peers, the message will be sent to all connected peers.
+	Peers int
 }
 
 // Sender defines how a consensus engine sends messages and requests to other


### PR DESCRIPTION
## Why this should be merged

This PR adds documentation to explain how to perform a broadcast using the existing sender and `SendConfig`.

## How this works

n/a

## How this was tested

n/a

## Need to be documented in RELEASES.md?

no