### PR TITLE
[docker] Update all images to debian12/bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG GO_VERSION=INVALID # This value is not intended to be used but silences a wa
 
 # ============= Compilation Stage ================
 # Always use the native platform to ensure fast builds
-FROM --platform=$BUILDPLATFORM golang:$GO_VERSION-bullseye AS builder
+FROM --platform=$BUILDPLATFORM golang:$GO_VERSION-bookworm AS builder
 
 WORKDIR /build
 
@@ -54,7 +54,7 @@ RUN mkdir -p /avalanchego/build
 # ============= Cleanup Stage ================
 # Commands executed in this stage may be emulated (i.e. very slow) if TARGETPLATFORM and
 # BUILDPLATFORM have different arches.
-FROM debian:11-slim AS execution
+FROM debian:12-slim AS execution
 
 # Maintain compatibility with previous images
 COPY --from=builder /avalanchego/build /avalanchego/build

--- a/tests/antithesis/Dockerfile.builder-instrumented
+++ b/tests/antithesis/Dockerfile.builder-instrumented
@@ -6,7 +6,7 @@ ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a war
 FROM docker.io/antithesishq/go-instrumentor AS instrumentor
 
 # ============= Instrumentation Stage ================
-FROM golang:$GO_VERSION-bullseye
+FROM golang:$GO_VERSION-bookworm
 
 WORKDIR /build
 # Copy and download dependencies using go mod

--- a/tests/antithesis/Dockerfile.builder-uninstrumented
+++ b/tests/antithesis/Dockerfile.builder-uninstrumented
@@ -2,7 +2,7 @@
 # to minimize the cost of version changes.
 ARG GO_VERSION=INVALID # This value is not intended to be used but silences a warning
 
-FROM golang:$GO_VERSION-bullseye
+FROM golang:$GO_VERSION-bookworm
 
 WORKDIR /build
 # Copy and download dependencies using go mod

--- a/tests/antithesis/avalanchego/Dockerfile.node
+++ b/tests/antithesis/avalanchego/Dockerfile.node
@@ -11,7 +11,7 @@ WORKDIR /instrumented/customer
 RUN ./scripts/build.sh -r
 
 # ============= Cleanup Stage ================
-FROM debian:11-slim AS execution
+FROM debian:12-slim AS execution
 
 # Install curl to simplify debugging
 RUN apt update && apt install curl -y

--- a/vms/example/xsvm/Dockerfile
+++ b/vms/example/xsvm/Dockerfile
@@ -6,7 +6,7 @@ ARG GO_VERSION=INVALID # This value is not intended to be used but silences a wa
 ARG AVALANCHEGO_NODE_IMAGE=INVALID # This value is not intended to be used but silences a warning
 
 # ============= Compilation Stage ================
-FROM golang:$GO_VERSION-bullseye AS builder
+FROM golang:$GO_VERSION-bookworm AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Why this should be merged

With the EOL of debian11-based Ubuntu 20.04/focal and the deprecation and impending removal of 20.04 runners from github actions, an upgrade to our image userland to debian12/bookworm ensures our images use a userland that is being tested with the debian12-based 22.04.

This will also ensure compatibility of subnet-evm binaries built with goreleaser on 22.04 runners (and so requiring a debian12 userland) with avalanchego-based images that will now also have a debian12 userland.

## How this was tested

CI

## Need to be documented in RELEASES.md?

Maybe?

