### PR TITLE
Fix ACP-118 Aggregator Test Flake

### DIFF
--- a/network/p2p/acp118/aggregator_test.go
+++ b/network/p2p/acp118/aggregator_test.go
@@ -480,7 +480,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 		{
 			name: "single validator - context canceled",
 			peers: map[ids.NodeID]p2p.Handler{
-				nodeID0: NewHandler(&testVerifier{}, signer0),
+				nodeID0: p2p.NoOpHandler{},
 			},
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
@@ -515,9 +515,9 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 		{
 			name: "multiple validators - context canceled",
 			peers: map[ids.NodeID]p2p.Handler{
-				nodeID0: NewHandler(&testVerifier{}, signer0),
-				nodeID1: NewHandler(&testVerifier{}, signer1),
-				nodeID2: NewHandler(&testVerifier{}, signer2),
+				nodeID0: p2p.NoOpHandler{},
+				nodeID1: p2p.NoOpHandler{},
+				nodeID2: p2p.NoOpHandler{},
 			},
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Why this should be merged

Test flake introduced in https://github.com/ava-labs/avalanchego/pull/3394
```
-test.shuffle 1741887583746241191
--- FAIL: TestSignatureAggregator_AggregateSignatures (0.06s)
    --- FAIL: TestSignatureAggregator_AggregateSignatures/multiple_validators_-_context_canceled (0.00s)
        aggregator_test.go:645: 
            	Error Trace:	/home/runner/work/avalanchego/avalanchego/network/p2p/acp118/aggregator_test.go:645
            	Error:      	Not equal: 
            	            	expected: 0
            	            	actual  : 1
            	Test:       	TestSignatureAggregator_AggregateSignatures/multiple_validators_-_context_canceled
FAIL
coverage: 81.0% of statements
```

## How this works

`select` chooses randomly if multiple cases are executable. The test flakes because peers are also responding with signatures when the context is cancelled, so both cases are able to be executed.

This PR update tests to not respond w/ signatures so that the assertion will always result in no signatures

## How this was tested

CI

## Need to be documented in RELEASES.md?

No