### PR TITLE
fix: fix missing argument in `build_antithesis_images_for_avalanchego`

### DIFF
--- a/scripts/build_antithesis_images.sh
+++ b/scripts/build_antithesis_images.sh
@@ -87,5 +87,5 @@ else
                                 "${AVALANCHE_PATH}/build/antithesis/xsvm" \
                                 "AVALANCHEGO_PATH=${AVALANCHE_PATH}/build/avalanchego AVAGO_PLUGIN_DIR=${AVALANCHE_PATH}/build/plugins"
 
-  build_antithesis_images_for_avalanchego "${TEST_SETUP}" "${IMAGE_PREFIX}" "${AVALANCHE_PATH}/vms/example/xsvm/Dockerfile"
+  build_antithesis_images_for_avalanchego "${TEST_SETUP}" "${IMAGE_PREFIX}" "${AVALANCHE_PATH}/vms/example/xsvm/Dockerfile" "${NODE_ONLY:-}"
 fi


### PR DESCRIPTION
## Why this should be merged  
This update ensures that the `build_antithesis_images_for_avalanchego` function is called with the correct number of arguments, preventing potential runtime errors.

## How this works  
The missing fourth argument, `${NODE_ONLY:-}`, has been added to the function call, ensuring compatibility with its definition.

## How this was tested  
Tested the script by running it with the updated call, and confirmed that it executes without errors.

## Need to be documented in RELEASES.md?  
No, this is a minor fix with no significant impact on the overall functionality.
