### PR TITLE
refactor: use `libevm/core/types` directly

### DIFF
--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/acp176"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/cortina"
 	"github.com/ava-labs/libevm/accounts/abi"
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -6,7 +6,7 @@ package c
 import (
 	"math/big"
 
-	"github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/libevm/core/types"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
 

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/ethclient"
 	"github.com/ava-labs/coreth/interfaces"
+	"github.com/ava-labs/libevm/core/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 


### PR DESCRIPTION
## Why this should be merged

All of the `coreth/core/types.*` identifiers used in AvalancheGo are just aliases of the `libevm` ones anyway. Removing them here allows for the aliases to be deleted in `coreth`.

## How this works

Find and replace.

## How this was tested

Existing tests.

## Need to be documented in RELEASES.md?

No