### PR TITLE
[ci] Add working_directory input to run-monitored-tmpnet-cmd

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -8,6 +8,8 @@ inputs:
   run_env:
     description: 'a string containing env vars for the command e.g. "MY_VAR1=foo MY_VAR2=bar"'
     default: ''
+  working_directory:
+    default: ''
   filter_by_owner:
     default: ''
   artifact_prefix:
@@ -66,6 +68,7 @@ runs:
       shell: bash
       # --impure ensures the env vars are accessible to the command
       run: ${{ inputs.run_env }} nix develop --impure --command bash -x ${{ inputs.run }}
+      working-directory: ${{ inputs.working_directory }}
       env:
         TMPNET_START_COLLECTORS: ${{ inputs.prometheus_username != '' }}
         TMPNET_CHECK_MONITORING: ${{ inputs.prometheus_username != '' }}


### PR DESCRIPTION
## Why this should be merged

This supports use of the custom action for hypersdk VM testing.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A