### PR TITLE
[ci] Source shellcheck from nix instead of installing via script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,12 +127,13 @@ jobs:
       - name: Run static analysis tests
         shell: bash
         run: scripts/lint.sh
-      - name: Run shellcheck
-        shell: bash
-        run: scripts/shellcheck.sh
       - name: Run actionlint
         shell: bash
         run: scripts/actionlint.sh
+      - uses: ./.github/actions/install-nix
+      - name: Run shellcheck
+        shell: bash
+        run: nix develop --command bash -x scripts/shellcheck.sh
   buf-lint:
     name: Protobuf Lint
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,9 @@
             kind                                       # Kubernetes-in-Docker
             kubernetes-helm                            # Helm CLI (Kubernetes package manager)
             self.packages.${system}.kind-with-registry # Script installing kind configured with a local registry
+
+            # Linters
+            shellcheck
           ] ++ lib.optionals stdenv.isDarwin [
             # macOS-specific frameworks
             darwin.apple_sdk.frameworks.Security

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -12,42 +12,10 @@ if ! [[ "$0" =~ scripts/shellcheck.sh ]]; then
   exit 255
 fi
 
-VERSION="v0.9.0"
-
-function get_version {
-  local target_path=$1
-  if command -v "${target_path}" > /dev/null; then
-    echo "v$("${target_path}" --version | grep version: | awk '{print $2}')"
-  fi
-}
-
-SYSTEM_VERSION="$(get_version shellcheck)"
-if [[ "${SYSTEM_VERSION}" == "${VERSION}" ]]; then
-  SHELLCHECK=shellcheck
-else
-  # Try to install a local version
-  SHELLCHECK=./bin/shellcheck
-  LOCAL_VERSION="$(get_version "${SHELLCHECK}")"
-  if [[ -z "${LOCAL_VERSION}" || "${LOCAL_VERSION}" != "${VERSION}" ]]; then
-    if which sw_vers &> /dev/null; then
-      echo "on macos, only x86_64 binaries are available so rosetta is required"
-      echo "to avoid using rosetta, install via homebrew: brew install shellcheck"
-      DIST=darwin.x86_64
-    else
-      # Linux - binaries for common arches *should* be available
-      arch="$(uname -i)"
-      DIST="linux.${arch}"
-    fi
-    curl -s -L "https://github.com/koalaman/shellcheck/releases/download/${VERSION}/shellcheck-${VERSION}.${DIST}.tar.xz" | tar Jxv -C /tmp > /dev/null
-    mkdir -p "$(dirname "${SHELLCHECK}")"
-    cp /tmp/shellcheck-"${VERSION}"/shellcheck "${SHELLCHECK}"
-  fi
-fi
-
 # `find *` is the simplest way to ensure find does not include a
 # leading `.` in filenames it emits. A leading `.` will prevent the
 # use of `git apply` to fix reported shellcheck issues. This is
 # compatible with both macos and linux (unlike the use of -printf).
 #
 # shellcheck disable=SC2035
-find * -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}" "${@}"
+find * -name "*.sh" -type f -print0 | xargs -0 shellcheck "${@}"


### PR DESCRIPTION
## Why this should be merged

We're already using nix and it's simpler not to have to maintain a multi-platform installer.

## How this works

- Adds shellcheck to the flake devshell
- Removes installation from the shellcheck script
- Updates the CI job to use nix 

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A