### PR TITLE
Use IPv4 addresses if possible

### DIFF
--- a/message/outbound_msg_builder.go
+++ b/message/outbound_msg_builder.go
@@ -246,15 +246,13 @@ func (b *outMsgBuilder) Handshake(
 ) (OutboundMessage, error) {
 	subnetIDBytes := make([][]byte, len(trackedSubnets))
 	encodeIDs(trackedSubnets, subnetIDBytes)
-	// TODO: Use .AsSlice() after v1.12.x activates.
-	addr := ip.Addr().As16()
 	return b.builder.createOutbound(
 		&p2p.Message{
 			Message: &p2p.Message_Handshake{
 				Handshake: &p2p.Handshake{
 					NetworkId:      networkID,
 					MyTime:         myTime,
-					IpAddr:         addr[:],
+					IpAddr:         ip.Addr().AsSlice(),
 					IpPort:         uint32(ip.Port()),
 					IpSigningTime:  ipSigningTime,
 					IpNodeIdSig:    ipNodeIDSig,
@@ -306,11 +304,9 @@ func (b *outMsgBuilder) GetPeerList(
 func (b *outMsgBuilder) PeerList(peers []*ips.ClaimedIPPort, bypassThrottling bool) (OutboundMessage, error) {
 	claimIPPorts := make([]*p2p.ClaimedIpPort, len(peers))
 	for i, p := range peers {
-		// TODO: Use .AsSlice() after v1.12.x activates.
-		ip := p.AddrPort.Addr().As16()
 		claimIPPorts[i] = &p2p.ClaimedIpPort{
 			X509Certificate: p.Cert.Raw,
-			IpAddr:          ip[:],
+			IpAddr:          p.AddrPort.Addr().AsSlice(),
 			IpPort:          uint32(p.AddrPort.Port()),
 			Timestamp:       p.Timestamp,
 			Signature:       p.Signature,


### PR DESCRIPTION
## Why this should be merged

Saves 12 bytes per IP!

## How this works

On the receiving side of these IPs, we already handle IPv4 addresses. However for compatibility reasons, we only send IPv6 addresses currently. This is no longer required (as of Etna activation). So we can save the 12 bytes.

## How this was tested

The e2e upgrade test verifies that this is backwards compatible.

## Need to be documented in RELEASES.md?
