### PR TITLE
[ci] Enable run-monitored-tmpnet-cmd to use a remote flake file

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -48,7 +48,7 @@ runs:
     - uses: cachix/install-nix-action@v30
       with:
         github_access_token: ${{ inputs.github_token }}
-    - run: nix develop --command echo "dependencies installed"
+    - run: ${{ github.action_path }}/nix-develop.sh --command echo "dependencies installed"
       shell: bash
     - name: Notify of metrics availability
       if: (inputs.prometheus_username != '')
@@ -65,7 +65,7 @@ runs:
     - name: Run command
       shell: bash
       # --impure ensures the env vars are accessible to the command
-      run: ${{ inputs.run_env }} nix develop --impure --command bash -x ${{ inputs.run }}
+      run: ${{ inputs.run_env }} ${{ github.action_path }}/nix-develop.sh --impure --command bash -x ${{ inputs.run }}
       env:
         TMPNET_START_COLLECTORS: ${{ inputs.prometheus_username != '' }}
         TMPNET_CHECK_MONITORING: ${{ inputs.prometheus_username != '' }}
@@ -81,7 +81,7 @@ runs:
         GH_JOB_ID: ${{ inputs.job }}
     # This step is duplicated from upload-tmpnet-artifact for the same
     # reason as the nix installation. There doesn't appear to be an
-    # easy way to composee custom actions for use by other repos
+    # easy way to compose custom actions for use by other repos
     # without running into versioning issues.
     - name: Upload tmpnet data
       if: always()

--- a/.github/actions/run-monitored-tmpnet-cmd/nix-develop.sh
+++ b/.github/actions/run-monitored-tmpnet-cmd/nix-develop.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -f "flake.nix" ]]; then
+  echo "Starting nix shell for local flake"
+  FLAKE=
+else
+  echo "No local flake found, will attempt to use avalanchego flake"
+
+  # Get module details from go.mod
+  MODULE_DETAILS="$(go list -m "github.com/ava-labs/avalanchego" 2>/dev/null)"
+
+  # Extract the version part
+  AVALANCHE_VERSION="$(echo "${MODULE_DETAILS}" | awk '{print $2}')"
+
+  if [[ -z "${AVALANCHE_VERSION}" ]]; then
+    echo "Failed to get avalanchego version from go.mod"
+    exit 1
+  fi
+
+  # Check if the version matches the pattern where the last part is the module hash
+  # v*YYYYMMDDHHMMSS-abcdef123456
+  #
+  # If not, the value is assumed to represent a tag
+  if [[ "${AVALANCHE_VERSION}" =~ ^v.*[0-9]{14}-[0-9a-f]{12}$ ]]; then
+    # Use the module hash as the version
+    AVALANCHE_VERSION="$(echo "${AVALANCHE_VERSION}" | cut -d'-' -f3)"
+  fi
+
+  FLAKE="github:ava-labs/avalanchego?ref=${AVALANCHE_VERSION}"
+  echo "Starting nix shell for ${FLAKE}"
+fi
+
+nix develop "${FLAKE}" "${@}"


### PR DESCRIPTION
## Why this should be merged

Previously the run-monitored-tmpnet-cmd custom action assumed a local flake file. This required any user of the action to define a local flake file even if they had no local need for one. Now the command will attempt to use a local flake file but if one is not present, fall back to invoking the avalanchego flake file at the vendored version.

## How this works

- Adds a wrapper script to the action that checks for a local flake and if not found discovers the vendored version of avalanchego and targets that flake 

## How this was tested

- avalanchego CI
- [hypersdk CI validating the use of a remote flake](https://github.com/ava-labs/hypersdk/actions/runs/13975322901/job/39127551828?pr=1990)

## Need to be documented in RELEASES.md?

N/A