### PR TITLE
Add context to errors in `avm`

### DIFF
--- a/vms/avm/block/executor/block.go
+++ b/vms/avm/block/executor/block.go
@@ -80,7 +80,7 @@ func (b *Block) Verify(context.Context) error {
 		if err != nil {
 			txID := tx.ID()
 			b.manager.mempool.MarkDropped(txID, err)
-			return err
+			return fmt.Errorf("failed to syntactically verify tx %s: %w", txID, err)
 		}
 	}
 
@@ -88,7 +88,7 @@ func (b *Block) Verify(context.Context) error {
 	parentID := b.Parent()
 	parent, err := b.manager.GetStatelessBlock(parentID)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get parent %s: %w", parentID, err)
 	}
 
 	// Verify that currentBlkHeight = parentBlkHeight + 1.
@@ -105,7 +105,11 @@ func (b *Block) Verify(context.Context) error {
 
 	stateDiff, err := state.NewDiff(parentID, b.manager)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"failed to initialize state diff on state at %s: %w",
+			parentID,
+			err,
+		)
 	}
 
 	parentChainTime := stateDiff.GetTimestamp()
@@ -138,7 +142,7 @@ func (b *Block) Verify(context.Context) error {
 		if err != nil {
 			txID := tx.ID()
 			b.manager.mempool.MarkDropped(txID, err)
-			return err
+			return fmt.Errorf("failed to semantically verify tx %s: %w", txID, err)
 		}
 
 		// Apply the txs state changes to the state.
@@ -155,7 +159,7 @@ func (b *Block) Verify(context.Context) error {
 		if err != nil {
 			txID := tx.ID()
 			b.manager.mempool.MarkDropped(txID, err)
-			return err
+			return fmt.Errorf("failed to execute tx %s: %w", txID, err)
 		}
 
 		// Verify that the transaction we just executed didn't consume inputs
@@ -188,7 +192,11 @@ func (b *Block) Verify(context.Context) error {
 	// already imported in a currently processing block.
 	err = b.manager.VerifyUniqueInputs(parentID, blockState.importedInputs)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"failed to verify unique inputs on state at %s: %w",
+			parent,
+			err,
+		)
 	}
 
 	// Now that the block has been executed, we can add the block data to the

--- a/vms/avm/state/state.go
+++ b/vms/avm/state/state.go
@@ -341,6 +341,7 @@ func (s *state) InitializeChainState(stopVertexID ids.ID, genesisTimestamp time.
 
 	s.timestamp = timestamp
 	s.persistedTimestamp = timestamp
+
 	return nil
 }
 

--- a/vms/avm/state/state.go
+++ b/vms/avm/state/state.go
@@ -333,14 +333,17 @@ func (s *state) InitializeChainState(stopVertexID ids.ID, genesisTimestamp time.
 	}
 	s.lastAccepted = lastAccepted
 	s.persistedLastAccepted = lastAccepted
-	if s.timestamp, err = database.GetTimestamp(
+
+	timestamp, err := database.GetTimestamp(
 		s.singletonDB,
 		timestampKey,
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("failed to get last accepted timestamp: %w", err)
 	}
 
-	s.persistedTimestamp = s.timestamp
+	s.timestamp = timestamp
+	s.persistedTimestamp = timestamp
 	return nil
 }
 

--- a/vms/avm/state/state.go
+++ b/vms/avm/state/state.go
@@ -334,10 +334,7 @@ func (s *state) InitializeChainState(stopVertexID ids.ID, genesisTimestamp time.
 	s.lastAccepted = lastAccepted
 	s.persistedLastAccepted = lastAccepted
 
-	timestamp, err := database.GetTimestamp(
-		s.singletonDB,
-		timestampKey,
-	)
+	timestamp, err := database.GetTimestamp(s.singletonDB, timestampKey)
 	if err != nil {
 		return fmt.Errorf("failed to get last accepted timestamp: %w", err)
 	}

--- a/vms/avm/state/state.go
+++ b/vms/avm/state/state.go
@@ -329,13 +329,19 @@ func (s *state) InitializeChainState(stopVertexID ids.ID, genesisTimestamp time.
 	if err == database.ErrNotFound {
 		return s.initializeChainState(stopVertexID, genesisTimestamp)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to get last accepted block: %w", err)
 	}
 	s.lastAccepted = lastAccepted
 	s.persistedLastAccepted = lastAccepted
-	s.timestamp, err = database.GetTimestamp(s.singletonDB, timestampKey)
+	if s.timestamp, err = database.GetTimestamp(
+		s.singletonDB,
+		timestampKey,
+	); err != nil {
+		return fmt.Errorf("failed to get last accepted timestamp: %w", err)
+	}
+
 	s.persistedTimestamp = s.timestamp
-	return err
+	return nil
 }
 
 func (s *state) initializeChainState(stopVertexID ids.ID, genesisTimestamp time.Time) error {
@@ -347,13 +353,18 @@ func (s *state) initializeChainState(stopVertexID ids.ID, genesisTimestamp time.
 		s.parser.Codec(),
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to initialize genesis block: %w", err)
 	}
 
 	s.SetLastAccepted(genesis.ID())
 	s.SetTimestamp(genesis.Timestamp())
 	s.AddBlock(genesis)
-	return s.Commit()
+
+	if err := s.Commit(); err != nil {
+		return fmt.Errorf("failed to commit genesis block: %w", err)
+	}
+
+	return nil
 }
 
 func (s *state) IsInitialized() (bool, error) {

--- a/vms/avm/txs/executor/semantic_verifier.go
+++ b/vms/avm/txs/executor/semantic_verifier.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -36,19 +37,19 @@ func (v *SemanticVerifier) BaseTx(tx *txs.BaseTx) error {
 		// syntactic verification, which happens before semantic verification.
 		cred := v.Tx.Creds[i].Credential
 		if err := v.verifyTransfer(tx, in, cred); err != nil {
-			return err
+			return fmt.Errorf("failed to verify transfer: %w", err)
 		}
 	}
 
 	for _, out := range tx.Outs {
 		fxIndex, err := v.getFx(out.Out)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get fx: %w", err)
 		}
 
 		assetID := out.AssetID()
 		if err := v.verifyFxUsage(fxIndex, assetID); err != nil {
-			return err
+			return fmt.Errorf("failed to verify fx usage: %w", err)
 		}
 	}
 
@@ -153,7 +154,7 @@ func (v *SemanticVerifier) verifyTransfer(
 ) error {
 	utxo, err := v.State.GetUTXO(in.UTXOID.InputID())
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get utxo %s: %w", in.UTXOID.InputID(), err)
 	}
 	return v.verifyTransferOfUTXO(tx, in, cred, utxo)
 }

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -388,9 +388,8 @@ func (vm *VM) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, erro
 
 func (vm *VM) Linearize(ctx context.Context, stopVertexID ids.ID, toEngine chan<- common.Message) error {
 	time := vm.Config.Upgrades.CortinaTime
-	err := vm.state.InitializeChainState(stopVertexID, time)
-	if err != nil {
-		return err
+	if err := vm.state.InitializeChainState(stopVertexID, time); err != nil {
+		return fmt.Errorf("failed to initialize chain state: %w", err)
 	}
 
 	mempool, err := xmempool.New("mempool", vm.registerer, toEngine)


### PR DESCRIPTION
## Why this should be merged

Helps debug errors, since we currently bubble them up without contexts so it's impossible to find where the error came from.

## How this works

Adds contexts around the errors

## How this was tested

CI

## Need to be documented in RELEASES.md?

No