### PR TITLE
[nix] Install protobuf codegen binaries in the dev shell

### DIFF
--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -21,4 +21,5 @@ jobs:
           # Breaking changes are managed by the rpcchainvm protocol version.
           breaking: false
           token: ${{ secrets.BUF_TOKEN }}
+          # This version should match the version installed in the nix dev shell
           version: 1.47.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
           # which is never desirable for this job. The buf-push job is
           # responsible for pushes.
           push: false
+          # This version should match the version installed in the nix dev shell
           version: 1.47.2
   check_generated_protobuf:
     name: Up-to-date protobuf
@@ -157,11 +158,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go-for-project
-      - uses: bufbuild/buf-action@1b8e0a0e793562b7850d7e6ff0228b5c0b16111c #v1.1.0
-        with:
-          setup_only: true
-          version: 1.47.2
-      - shell: bash
+      # Use the dev shell instead of bufbuild/buf-action to ensure the dev shell provides the expected versions
+      - uses: ./.github/actions/install-nix
+      - shell: nix develop --command bash -x {0}
         run: scripts/protobuf_codegen.sh
       - shell: bash
         run: .github/workflows/check-clean-branch.sh

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721949857,
-        "narHash": "sha256-DID446r8KsmJhbCzx4el8d9SnPiE8qa6+eEQOJ40vR0=",
-        "rev": "a1cc729dcbc31d9b0d11d86dc7436163548a9665",
-        "revCount": 633481,
+        "lastModified": 1742512142,
+        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
+        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
+        "revCount": 715908,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.633481%2Brev-a1cc729dcbc31d9b0d11d86dc7436163548a9665/0190ef32-8438-79be-9d83-2e97dc792840/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.715908%2Brev-7105ae3957700a9646cc4b766f5815b23ed0c682/0195b8ff-82a6-7d19-b362-1f70dcb1c7f7/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2405.%2A.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2411.%2A.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
   # Flake inputs
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2405.*.tar.gz";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2411.*.tar.gz";
   };
 
   # Flake outputs
@@ -45,6 +45,11 @@
 
             # Linters
             shellcheck
+
+            # Protobuf
+            buf
+            protoc-gen-go
+            protoc-gen-go-grpc
           ] ++ lib.optionals stdenv.isDarwin [
             # macOS-specific frameworks
             darwin.apple_sdk.frameworks.Security

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -9,10 +9,10 @@ breaking:
   use:
     - FILE
 deps:
-  - buf.build/prometheus/client-model 
+  - buf.build/prometheus/client-model
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - SERVICE_SUFFIX # service requirement of <name>+Service
     - RPC_REQUEST_STANDARD_NAME # explicit <rpc>+Request naming
@@ -24,7 +24,7 @@ lint:
     - aliasreader/aliasreader.proto
     - net/conn/conn.proto
   # allows RPC requests or responses to be google.protobuf.Empty messages. This can be set if you
-  # want to allow messages to be void forever, that is they will never take any parameters. 
+  # want to allow messages to be void forever, that is they will never take any parameters.
   rpc_allow_google_protobuf_empty_requests: true
   rpc_allow_google_protobuf_empty_responses: true
   # allows the same message type to be used for a single RPC's request and response type.

--- a/scripts/protobuf_codegen.sh
+++ b/scripts/protobuf_codegen.sh
@@ -7,6 +7,8 @@ if ! [[ "$0" =~ scripts/protobuf_codegen.sh ]]; then
   exit 255
 fi
 
+# the versions here should match those of the binaries installed in the nix dev shell
+
 ## ensure the correct version of "buf" is installed
 BUF_VERSION='1.47.2'
 if [[ $(buf --version | cut -f2 -d' ') != "${BUF_VERSION}" ]]; then
@@ -14,20 +16,16 @@ if [[ $(buf --version | cut -f2 -d' ') != "${BUF_VERSION}" ]]; then
   exit 255
 fi
 
-## install "protoc-gen-go"
+## ensure the correct version of "protoc-gen-go" is installed
 PROTOC_GEN_GO_VERSION='v1.35.1'
-go install -v google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
 if [[ $(protoc-gen-go --version | cut -f2 -d' ') != "${PROTOC_GEN_GO_VERSION}" ]]; then
-  # e.g., protoc-gen-go v1.28.1
   echo "could not find protoc-gen-go ${PROTOC_GEN_GO_VERSION}, is it installed + in PATH?"
   exit 255
 fi
 
-### install "protoc-gen-go-grpc"
+## ensure the correct version of "protoc-gen-go-grpc" is installed
 PROTOC_GEN_GO_GRPC_VERSION='1.3.0'
-go install -v google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${PROTOC_GEN_GO_GRPC_VERSION}
 if [[ $(protoc-gen-go-grpc --version | cut -f2 -d' ') != "${PROTOC_GEN_GO_GRPC_VERSION}" ]]; then
-  # e.g., protoc-gen-go-grpc 1.3.0
   echo "could not find protoc-gen-go-grpc ${PROTOC_GEN_GO_GRPC_VERSION}, is it installed + in PATH?"
   exit 255
 fi


### PR DESCRIPTION
## Why this should be merged

Moves installation of protobuf codegen binaries to the nix shell to ensure consistency across environments.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A