### PR TITLE
[tmpnet] Update script to run instead of install

### DIFF
--- a/bin/tmpnetctl
+++ b/bin/tmpnetctl
@@ -6,8 +6,5 @@ set -euo pipefail
 AVALANCHE_PATH=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 cd "${AVALANCHE_PATH}"
 
-# Build if needed
-if [[ ! -f ./build/tmpnetctl ]]; then
-   ./scripts/build_tmpnetctl.sh
-fi
-./build/tmpnetctl "${@}"
+# Use go run to ensure the correct version is always used
+go run ./tests/fixture/tmpnet/tmpnetctl "${@}"


### PR DESCRIPTION
## Why this should be merged

This ensures the correct version at the cost of startup latency. The latency could be addressed in the future with either go 1.24's go tool support or provision via a nix package.

## How this was tested

Locally

## Need to be documented in RELEASES.md?

N/A