### PR TITLE
[ci] Update to use commit SHAs for non-floating tags

### DIFF
--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 #v30
+    - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f #v31
       with:
         github_access_token: ${{ inputs.github_token }}
     - run: nix develop --command echo "dependencies installed"

--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -45,7 +45,7 @@ runs:
     # - Avoid using the install-nix custom action since a relative
     #   path wouldn't be resolveable from other repos and an absolute
     #   path would require setting a version.
-    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 #v30
+    - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f #v31
       with:
         github_access_token: ${{ inputs.github_token }}
     - run: ${{ github.action_path }}/nix-develop.sh --command echo "dependencies installed"

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@2232f407651f19e7e011fe9fe1dad409ae3c2e9b #v1
+      - uses: bufbuild/buf-action@1b8e0a0e793562b7850d7e6ff0228b5c0b16111c #v1.1.0
         with:
           input: "proto"
           # Breaking changes are managed by the rpcchainvm protocol version.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@2232f407651f19e7e011fe9fe1dad409ae3c2e9b #v1
+      - uses: bufbuild/buf-action@1b8e0a0e793562b7850d7e6ff0228b5c0b16111c #v1.1.0
         with:
           input: "proto"
           pr_comment: false
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go-for-project
-      - uses: bufbuild/buf-action@2232f407651f19e7e011fe9fe1dad409ae3c2e9b #v1
+      - uses: bufbuild/buf-action@1b8e0a0e793562b7850d7e6ff0228b5c0b16111c #v1.1.0
         with:
           setup_only: true
           version: 1.47.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@d7eaefbfa6606a4adc96bdf7b9ba23d7fa931e69 #v3
+        uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 #v3.28.13
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,4 +56,4 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@d7eaefbfa6606a4adc96bdf7b9ba23d7fa931e69 #v3
+        uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 #v3.28.13

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crazy-max/ghaction-github-labeler@31674a3852a9074f2086abcf1c53839d466a47e7 #v5
+      - uses: crazy-max/ghaction-github-labeler@31674a3852a9074f2086abcf1c53839d466a47e7 #v5.2.0
         with:
           dry-run: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/publish_antithesis_images.yml
+++ b/.github/workflows/publish_antithesis_images.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Login to GAR
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
       with:
         registry: ${{ env.REGISTRY }}
         username: _json_key

--- a/.github/workflows/trigger-antithesis-avalanchego.yml
+++ b/.github/workflows/trigger-antithesis-avalanchego.yml
@@ -25,7 +25,7 @@ jobs:
     name: Run Antithesis Avalanchego Test Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: antithesishq/antithesis-trigger-action@0843ed4168a88c305114511cd8bed2fe5ba352cb #v0.7
+      - uses: antithesishq/antithesis-trigger-action@b7d0c9d1d9316bd4de73a44144c56636ea3a64ba #v0.8
         with:
           notebook_name: avalanche
           tenant: avalanche

--- a/.github/workflows/trigger-antithesis-xsvm.yml
+++ b/.github/workflows/trigger-antithesis-xsvm.yml
@@ -25,7 +25,7 @@ jobs:
     name: Run Antithesis XSVM Test Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: antithesishq/antithesis-trigger-action@0843ed4168a88c305114511cd8bed2fe5ba352cb #v0.7
+      - uses: antithesishq/antithesis-trigger-action@b7d0c9d1d9316bd4de73a44144c56636ea3a64ba #v0.8
         with:
           notebook_name: avalanche
           tenant: avalanche


### PR DESCRIPTION
## Why this should be merged

The previous update used tag hashes instead of commit hashes, and some of the tag comments were for floating tags rather than regular tags. This PR consistently uses commit hashes and non-floating tags for all 3rd-party actions.

## How this was tested

- CI
- All commit SHAs were verified to exist in their respective repos

## Need to be documented in RELEASES.md?

N/A