### PR TITLE
removed duplicative title/subtitle from the file

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -6,11 +6,7 @@ pagination_label: AvalancheGo Configs and Flags
 sidebar_position: 0
 ---
 
-# AvalancheGo Configs and Flags
-
 <!-- markdownlint-disable MD001 -->
-
-You can specify the configuration of a node with the arguments below.
 
 ## APIs
 


### PR DESCRIPTION
## Why this should be merged
remove duplicative title and subtitle at the [page](https://build.avax.network/docs/nodes/configure/configs-flags) that is remote fetched automatically.

## How this works
duplicate text removal

## How this was tested
locally build remote to test the correct fetching file with the changes.

## Need to be documented in RELEASES.md?
no

https://github.com/ava-labs/builders-hub/pull/2119#issuecomment-2683216995