### PR TITLE
fix function batch_test.go

### DIFF
--- a/database/pebbledb/batch_test.go
+++ b/database/pebbledb/batch_test.go
@@ -28,7 +28,7 @@ func TestBatch(t *testing.T) {
 
 	key1, value1 := []byte("key1"), []byte("value1")
 	require.NoError(batch.Put(key1, value1))
-	require.Equal(len(key1)+len(value1)+pebbleByteOverHead, batch.Size())
+	require.Equal(len(key1)+len(value1)+pebbleByteOverhead, batch.Size())
 
 	require.NoError(batch.Write())
 


### PR DESCRIPTION
## Why this should be merged
// The variable name 'pebbleByteOverHead' contains a typo:
// 'overhead' should be spelled as one word, e.g. 'pebbleByteOverhead'.
