### PR TITLE
Set TestNetwork minCompatibleTime to Fortuna Activation

### DIFF
--- a/network/test_network.go
+++ b/network/test_network.go
@@ -11,7 +11,6 @@ import (
 	"net/netip"
 	"runtime"
 	"sync"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/subnets"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
@@ -210,7 +210,6 @@ func NewTestNetwork(
 	metrics prometheus.Registerer,
 	cfg *Config,
 	router router.ExternalHandler,
-	minCompatibleTime time.Time,
 ) (Network, error) {
 	msgCreator, err := message.NewCreator(
 		logging.NoLog{},
@@ -224,7 +223,7 @@ func NewTestNetwork(
 
 	return NewNetwork(
 		cfg,
-		minCompatibleTime,
+		upgrade.GetConfig(cfg.NetworkID).FortunaTime,
 		msgCreator,
 		metrics,
 		log,

--- a/network/test_network.go
+++ b/network/test_network.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/subnets"
-	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
@@ -210,6 +210,7 @@ func NewTestNetwork(
 	metrics prometheus.Registerer,
 	cfg *Config,
 	router router.ExternalHandler,
+	minCompatibleTime time.Time,
 ) (Network, error) {
 	msgCreator, err := message.NewCreator(
 		logging.NoLog{},
@@ -223,7 +224,7 @@ func NewTestNetwork(
 
 	return NewNetwork(
 		cfg,
-		upgrade.InitiallyActiveTime,
+		minCompatibleTime,
 		msgCreator,
 		metrics,
 		log,


### PR DESCRIPTION
## Why this should be merged
Aligns `TestNetwork` compatibility with the `Network` created for full AvalancheGo nodes [here](https://github.com/ava-labs/avalanchego/blob/master/node/node.go#L632). This should be updated in the future when required network upgrades are scheduled.

## How this works
Uses the Fortuna activation time instead of `InitiallyActiveTime` as the `minCompatibleTime` of `TestNetwork` instances. Setting the `minCompatibleTime` to `InitiallyActiveTime` resulted in applications using `TestNetwork` to be unable to connect with nodes running the previous minor AvalancheGo version prior the network upgrade activating.

## How this was tested
N/A

## Need to be documented in RELEASES.md?
No