### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/vms/platformvm/reward/calculator.go
+++ b/vms/platformvm/reward/calculator.go
@@ -63,11 +63,7 @@ func (c *calculator) Calculate(stakedDuration time.Duration, stakedAmount, curre
 	}
 
 	finalReward := reward.Uint64()
-	if finalReward > remainingSupply {
-		return remainingSupply
-	}
-
-	return finalReward
+	return min(remainingSupply, finalReward)
 }
 
 // Split [totalAmount] into [totalAmount * shares percentage] and the remainder.


### PR DESCRIPTION
## Why this should be merged

Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#min


## How this works

## How this was tested

## Need to be documented in RELEASES.md?
