### PR TITLE
chore: allow individuals to extend `direnv` config

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -12,3 +12,6 @@ export AVALANCHEGO_PATH=$PWD/build/avalanchego
 # Configure the local plugin directory for both avalanchego and tmpnet usage
 mkdir -p $PWD/build/plugins                                       # avalanchego will FATAL if the directory does not exist
 export AVAGO_PLUGIN_DIR="${AVAGO_PLUGIN_DIR:-$PWD/build/plugins}" # Use an existing value if set
+
+# Allow individuals to add their own customisation
+source_env_if_exists 

--- a/.envrc
+++ b/.envrc
@@ -14,4 +14,4 @@ mkdir -p $PWD/build/plugins                                       # avalanchego 
 export AVAGO_PLUGIN_DIR="${AVAGO_PLUGIN_DIR:-$PWD/build/plugins}" # Use an existing value if set
 
 # Allow individuals to add their own customisation
-source_env_if_exists 
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ vendor
 **/testdata
 
 .direnv
+# Personal extension to .envrc
+.envrc.local


### PR DESCRIPTION
## Why this should be merged

We use a project-wide `.envrc` to configure reproducible builds but each developer may wish to further customise their development environment.

## How this works

If a `.envrc.local` file is present, it is loaded at the end of the common `.envrc`. This file is in `.gitignore`.

## How this was tested

## Need to be documented in RELEASES.md?

No