### PR TITLE
ci(antithesis): pass commit_hash as ARG in Dockerfile

### DIFF
--- a/scripts/build_antithesis_images.sh
+++ b/scripts/build_antithesis_images.sh
@@ -41,7 +41,7 @@ GO_VERSION="$(go list -m -f '{{.GoVersion}}')"
 # Helper to simplify calling build_builder_image for test setups in this repo
 function build_builder_image_for_avalanchego {
   echo "Building builder image"
-  build_antithesis_builder_image "${GO_VERSION}" "antithesis-avalanchego-builder:${IMAGE_TAG}" "${AVALANCHE_PATH}" "${AVALANCHE_PATH}"
+  build_antithesis_builder_image "${GO_VERSION}" "${commit_hash}" "antithesis-avalanchego-builder:${IMAGE_TAG}" "${AVALANCHE_PATH}" "${AVALANCHE_PATH}"
 }
 
 # Helper to simplify calling build_antithesis_images for test setups in this repo

--- a/scripts/lib_build_antithesis_images.sh
+++ b/scripts/lib_build_antithesis_images.sh
@@ -13,9 +13,10 @@ set -euo pipefail
 # on amd64 and non-instrumented binaries if built on arm64.
 function build_antithesis_builder_image {
   local go_version=$1
-  local image_name=$2
-  local avalanchego_path=$3
-  local target_path=$4
+  local commit_hash=$2
+  local image_name=$3
+  local avalanchego_path=$4
+  local target_path=$5
 
   local base_dockerfile="${avalanchego_path}/tests/antithesis/Dockerfile"
   local builder_dockerfile="${base_dockerfile}.builder-instrumented"
@@ -25,7 +26,7 @@ function build_antithesis_builder_image {
     builder_dockerfile="${base_dockerfile}.builder-uninstrumented"
   fi
 
-  docker buildx build --build-arg GO_VERSION="${go_version}" -t "${image_name}" -f "${builder_dockerfile}" "${target_path}"
+  docker buildx build --build-arg GO_VERSION="${go_version}" --build-arg COMMIT_HASH="${commit_hash}" -t "${image_name}" -f "${builder_dockerfile}" "${target_path}"
 }
 
 # Build the antithesis node, workload, and config images.

--- a/tests/antithesis/Dockerfile.builder-instrumented
+++ b/tests/antithesis/Dockerfile.builder-instrumented
@@ -1,6 +1,7 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
 ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
+ARG COMMIT_HASH=""
 
 # Antithesis: Getting the Antithesis golang instrumentation library
 FROM docker.io/antithesishq/go-instrumentor AS instrumentor
@@ -21,7 +22,7 @@ COPY . .
 RUN [ -d ./build ] && rm -rf ./build/* || true
 
 # Keep the commit hash to easily verify the exact version that is running
-RUN git rev-parse HEAD > ./commit_hash.txt
+RUN echo "$COMMIT_HASH" > ./commit_hash.txt
 
 # Copy the instrumentor and supporting files to their correct locations
 COPY --from=instrumentor /opt/antithesis /opt/antithesis

--- a/tests/antithesis/Dockerfile.builder-instrumented
+++ b/tests/antithesis/Dockerfile.builder-instrumented
@@ -1,7 +1,6 @@
 # The version is supplied as a build argument rather than hard-coded
 # to minimize the cost of version changes.
 ARG GO_VERSION=INVALID # This value isn't intended to be used but silences a warning
-ARG COMMIT_HASH=""
 
 # Antithesis: Getting the Antithesis golang instrumentation library
 FROM docker.io/antithesishq/go-instrumentor AS instrumentor
@@ -21,6 +20,8 @@ COPY . .
 # Ensure pre-existing builds are not available for inclusion in the final image
 RUN [ -d ./build ] && rm -rf ./build/* || true
 
+# Commit hash should be passed as an arg, in case .git is not available
+ARG COMMIT_HASH=""
 # Keep the commit hash to easily verify the exact version that is running
 RUN echo "$COMMIT_HASH" > ./commit_hash.txt
 

--- a/tests/antithesis/Dockerfile.builder-instrumented
+++ b/tests/antithesis/Dockerfile.builder-instrumented
@@ -32,10 +32,6 @@ COPY --from=instrumentor /opt/antithesis/lib /lib
 # Create the destination output directory for the instrumented code
 RUN mkdir -p /instrumented
 
-# Park the .git file in a safe location
-RUN mkdir -p /opt/tmp/
-RUN cp -r .git /opt/tmp/
-
 # Instrument the code
 RUN /opt/antithesis/bin/goinstrumentor \
     -stderrthreshold=INFO \
@@ -45,4 +41,3 @@ RUN /opt/antithesis/bin/goinstrumentor \
 
 WORKDIR /instrumented/customer
 RUN go mod download
-RUN ln -s /opt/tmp/.git .git


### PR DESCRIPTION
it seems there is some problems copying the .git directory with some branches that contain `/` in them.
So this is a workaround, passing the commit hash as a docker argument.