### PR TITLE
fix: record wrong nil `err`

### DIFF
--- a/network/p2p/acp118/aggregator.go
+++ b/network/p2p/acp118/aggregator.go
@@ -154,7 +154,7 @@ func (s *SignatureAggregator) AggregateSignatures(
 				s.log.Debug(
 					"dropping response",
 					zap.Stringer("nodeID", result.NodeID),
-					zap.Error(err),
+					zap.Error(result.Err),
 				)
 				continue
 			}


### PR DESCRIPTION
## Why this should be merged

Since `err` has been checked before, `err` will be always nil here. So I think we should record `result.Err` instead of `err`

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
