### PR TITLE
Remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,12 +55,9 @@ linters:
     - goconst
     - gocritic
     # - goerr113
-    - gofmt
-    - gofumpt
     # - gomnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -79,7 +76,6 @@ linters:
     - stylecheck
     - tagalign
     - testifylint
-    - typecheck
     - unconvert
     - unparam
     - unused


### PR DESCRIPTION
Remove the following tools from enable that are no longer supported or are formatters:

- `gofmt` (formatter)
- `gofumpt` (formatter)
- `gosimple` (deprecated)
- `typecheck` (missing)

Without these changes, golangci-lint fails with errors. Locally tested per the [official migration guide](https://golangci-lint.run/product/migration-guide/).
