### PR TITLE
[tmpnet] s/Network.ChainConfigs/Network.PrimaryChainConfigs/

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -102,8 +102,7 @@ type Network struct {
 	Genesis *genesis.UnparsedConfig
 
 	// Configuration for primary network chains (P, X, C)
-	// TODO(marun) Rename to PrimaryChainConfigs
-	ChainConfigs map[string]FlagsMap
+	PrimaryChainConfigs map[string]FlagsMap
 
 	// Default configuration to use when creating new nodes
 	DefaultFlags         FlagsMap
@@ -236,15 +235,15 @@ func (n *Network) EnsureDefaultConfig(log logging.Logger, avalancheGoPath string
 	}
 
 	// Ensure primary chains are configured
-	if n.ChainConfigs == nil {
-		n.ChainConfigs = map[string]FlagsMap{}
+	if n.PrimaryChainConfigs == nil {
+		n.PrimaryChainConfigs = map[string]FlagsMap{}
 	}
 	defaultChainConfigs := DefaultChainConfigs()
 	for alias, chainConfig := range defaultChainConfigs {
-		if _, ok := n.ChainConfigs[alias]; !ok {
-			n.ChainConfigs[alias] = FlagsMap{}
+		if _, ok := n.PrimaryChainConfigs[alias]; !ok {
+			n.PrimaryChainConfigs[alias] = FlagsMap{}
 		}
-		n.ChainConfigs[alias].SetDefaults(chainConfig)
+		n.PrimaryChainConfigs[alias].SetDefaults(chainConfig)
 	}
 
 	// Ensure runtime is configured

--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -123,7 +123,7 @@ func (n *Network) readChainConfigs() error {
 
 	// Clear the map of data that may end up stale (e.g. if a given
 	// chain is in the map but no longer exists on disk)
-	n.ChainConfigs = map[string]FlagsMap{}
+	n.PrimaryChainConfigs = map[string]FlagsMap{}
 
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -141,7 +141,7 @@ func (n *Network) readChainConfigs() error {
 		if err != nil {
 			return err
 		}
-		n.ChainConfigs[chainAlias] = chainConfig
+		n.PrimaryChainConfigs[chainAlias] = chainConfig
 	}
 
 	return nil
@@ -150,7 +150,7 @@ func (n *Network) readChainConfigs() error {
 func (n *Network) writeChainConfigs() error {
 	baseChainConfigDir := n.GetChainConfigDir()
 
-	for chainAlias, chainConfig := range n.ChainConfigs {
+	for chainAlias, chainConfig := range n.PrimaryChainConfigs {
 		// Create the directory
 		chainConfigDir := filepath.Join(baseChainConfigDir, chainAlias)
 		if err := os.MkdirAll(chainConfigDir, perms.ReadWriteExecute); err != nil {


### PR DESCRIPTION
## PR Chain: tmpnet+kube

This PR chain enables tmpnet to deploy temporary networks to Kubernetes. Early PRs refactor tmpnet to support the addition in #3615 of a new tmpnet node runtime for kube.  

- **>>>>>>** #3854 **<<<<<<**
- #3857
- #3870
- #3877
- #3867
- #3871
- #3881
- #3890
- #3884
- #3893
- #3894
- #3896
- #3897
- #3898
- #3882 
- #3615
- #3794 
