### PR TITLE
fix: logging for Dispatch errors

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -168,10 +168,9 @@ func (a *app) Start() error {
 		}()
 
 		err := a.node.Dispatch()
-		a.log.Debug("dispatch returned",
-			zap.Error(err),
-		)
-	}()
+		if err != nil {
+		a.log.Debug("dispatch returned an error", zap.Error(err))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged
This change improves the clarity of the application logs, ensuring that errors are only logged when they occur, and preventing misleading log entries when `Dispatch()` returns `nil`.

## How this works
The check for `nil` errors was added to avoid logging unnecessary error messages when no error is actually returned from `Dispatch()`. The error is logged only if it is not `nil`.

## How this was tested
The change was tested by running the application and ensuring that only actual errors from `Dispatch()` are logged, and that no unnecessary log entries are made when there is no error.

## Need to be documented in RELEASES.md?
No, this is a small bug fix that doesn't require a mention in the release notes.