### PR TITLE
fix: goroutine concurrency issue with nodeID in the loop

### DIFF
--- a/node/beacon_manager_test.go
+++ b/node/beacon_manager_test.go
@@ -55,6 +55,7 @@ func TestBeaconManager_DataRace(t *testing.T) {
 		})
 
 	for _, nodeID := range validatorIDs {
+		nodeID := nodeID
 		go func() {
 			b.Connected(nodeID, version.CurrentApp, constants.PrimaryNetworkID)
 			b.Connected(nodeID, version.CurrentApp, ids.GenerateTestID())


### PR DESCRIPTION
## Why this should be merged
This change resolves a concurrency issue where all goroutines could receive the same `nodeID` due to it being captured from the outer scope. By passing `nodeID` as an argument, each goroutine will now work with its own local copy, ensuring correct behavior.

## How this works
The `nodeID` is passed as an argument to each goroutine inside the loop, ensuring that each goroutine has its own distinct value. This avoids the issue of capturing the value from the outer scope, which could result in goroutines working with the same `nodeID`.

## How this was tested
Tested by running the code with multiple goroutines in a loop and verifying that each goroutine receives the correct `nodeID` corresponding to its iteration. Verified that no goroutines shared the same `nodeID`.

## Need to be documented in RELEASES.md?
No, this is a minor fix related to concurrency handling and doesn't require a change in the release notes.