### PR TITLE
avoid tmpnet to create empty genesis on disk

### DIFF
--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -90,6 +90,7 @@ func (n *Network) readGenesis() error {
 	bytes, err := os.ReadFile(n.GetGenesisPath())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			n.Genesis = nil
 			return nil
 		}
 		return fmt.Errorf("failed to read genesis: %w", err)


### PR DESCRIPTION
## Why this should be merged
Certain tmpnet configurations have a nil genesis field, such as fuji/mainnet/local network.
On write, an empty genesis file is always created in such cases, and, when reading the network again,
this genesis field is not nil anymore.
As some parts of the network initialization code check for genesis field being or not nil, it is 
safer to just keep the disk storage aligned with the original conf.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
