### PR TITLE
[tmpnet] Update rpc version check to tolerate usage of `go run`

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -1027,7 +1027,7 @@ func getRPCVersion(log logging.Logger, command string, versionArgs ...string) (u
 
 	// Ignore output before the opening brace to tolerate the case of a command being invoked
 	// with `go run` and the go toolchain emitting diagnostic logging before the version output.
-	if idx := bytes.IndexByte(output, '{'); idx != -1 {
+	if idx := bytes.IndexByte(output, '{'); idx > 0 {
 		log.Info("ignoring leading bytes of JSON version output in advance of opening `{`",
 			zap.String("command", command),
 			zap.String("ignoredLeadingBytes", string(output[:idx])),


### PR DESCRIPTION
## Why this should be merged

When avalanchego is invoked with `go run`, the go toolchain may emit informational messages that corrupt the `--version-json` output. Being tolerant of such output enables downstream repos to use tmpnet with avalanchego invoked with `go run`.

## How this was tested

Manually tested with https://github.com/ava-labs/hypersdk/pull/2015

## Need to be documented in RELEASES.md?

N/A