### PR TITLE
[tmpnet] Ensure Node has a reference to Network

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -542,7 +542,7 @@ func (n *Network) RestartNode(ctx context.Context, log logging.Logger, node *Nod
 // Stops all nodes in the network.
 func (n *Network) Stop(ctx context.Context) error {
 	// Target all nodes, including the ephemeral ones
-	nodes, err := ReadNodes(n.Dir, true /* includeEphemeral */)
+	nodes, err := ReadNodes(n, true /* includeEphemeral */)
 	if err != nil {
 		return err
 	}
@@ -585,11 +585,8 @@ func (n *Network) Restart(ctx context.Context, log logging.Logger) error {
 // no action will be taken.
 // TODO(marun) Reword or refactor to account for the differing behavior pre- vs post-start
 func (n *Network) EnsureNodeConfig(node *Node) error {
-	// Ensure nodes can label their metrics with the network uuid
-	node.NetworkUUID = n.UUID
-
-	// Ensure nodes can label metrics with an indication of the shared/private nature of the network
-	node.NetworkOwner = n.Owner
+	// Ensure the node has access to network configuration
+	node.network = n
 
 	if err := node.EnsureKeys(); err != nil {
 		return err
@@ -818,7 +815,7 @@ func (n *Network) GetNodeURIs() []NodeURI {
 // For consumption outside of avalanchego. Needs to be kept exported.
 func (n *Network) GetBootstrapIPsAndIDs(skippedNode *Node) ([]string, []string, error) {
 	// Collect staking addresses of non-ephemeral nodes for use in bootstrapping a node
-	nodes, err := ReadNodes(n.Dir, false /* includeEphemeral */)
+	nodes, err := ReadNodes(n, false /* includeEphemeral */)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read network's nodes: %w", err)
 	}

--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -59,7 +59,7 @@ func (n *Network) readNetwork() error {
 
 // Read the non-ephemeral nodes associated with the network from disk.
 func (n *Network) readNodes() error {
-	nodes, err := ReadNodes(n.Dir, false /* includeEphemeral */)
+	nodes, err := ReadNodes(n, false /* includeEphemeral */)
 	if err != nil {
 		return err
 	}

--- a/tests/fixture/tmpnet/node_config.go
+++ b/tests/fixture/tmpnet/node_config.go
@@ -49,8 +49,6 @@ func (n *Node) readConfig() error {
 }
 
 type serializedNodeConfig struct {
-	NetworkUUID   string
-	NetworkOwner  string
 	IsEphemeral   bool
 	Flags         FlagsMap
 	RuntimeConfig *NodeRuntimeConfig
@@ -58,8 +56,6 @@ type serializedNodeConfig struct {
 
 func (n *Node) writeConfig() error {
 	config := serializedNodeConfig{
-		NetworkUUID:   n.NetworkUUID,
-		NetworkOwner:  n.NetworkOwner,
 		IsEphemeral:   n.IsEphemeral,
 		Flags:         n.Flags,
 		RuntimeConfig: n.RuntimeConfig,

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -258,10 +258,10 @@ func (p *NodeProcess) writeMonitoringConfig() error {
 		// behavior of using the node's URI since the URI isn't
 		// guaranteed stable (e.g. port may change after restart).
 		"instance":          p.node.GetUniqueID(),
-		"network_uuid":      p.node.NetworkUUID,
+		"network_uuid":      p.node.network.UUID,
 		"node_id":           p.node.NodeID,
 		"is_ephemeral_node": strconv.FormatBool(p.node.IsEphemeral),
-		"network_owner":     p.node.NetworkOwner,
+		"network_owner":     p.node.network.Owner,
 	}
 	commonLabels.SetDefaults(githubLabelsFromEnv())
 
@@ -296,7 +296,7 @@ func (p *NodeProcess) getMonitoringConfigPath(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(serviceDiscoveryDir, fmt.Sprintf("%s_%s.json", p.node.NetworkUUID, p.node.NodeID)), nil
+	return filepath.Join(serviceDiscoveryDir, fmt.Sprintf("%s_%s.json", p.node.network.UUID, p.node.NodeID)), nil
 }
 
 // Ensure the removal of the monitoring configuration files for this node.


### PR DESCRIPTION
## PR Chain: tmpnet+kube

This PR chain enables tmpnet to deploy temporary networks to Kubernetes. Early PRs refactor tmpnet to support the addition in #3615 of a new tmpnet node runtime for kube.  

- #3854
- #3857
- **>>>>>>** #3870 **<<<<<<**
- #3877
- #3867
- #3871
- #3881
- #3890
- #3884
- #3893
- #3894
- #3896
- #3897
- #3898
- #3882 
- #3615
- #3794 

# Why this should be merged

Previously tmpnet.Node was serialized with a subset of tmpnet.Network fields like UUID and Owner. Intead, tmpnet.Node gets a reference to its owning tmpnet.Network on read or start to ensure it has full access to all network details.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A