### PR TITLE
Set `subnets.Config.ConsensusParameters` to serialize with omitempty

### DIFF
--- a/subnets/config.go
+++ b/subnets/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	// AllowedNodes is the set of node IDs that are explicitly allowed to connect to this Subnet when
 	// ValidatorOnly is enabled.
 	AllowedNodes        set.Set[ids.NodeID] `json:"allowedNodes"        yaml:"allowedNodes"`
-	ConsensusParameters snowball.Parameters `json:"consensusParameters" yaml:"consensusParameters",omitempty`
+	ConsensusParameters snowball.Parameters `json:"consensusParameters" yaml:"consensusParameters,omitempty"`
 
 	// ProposerMinBlockDelay is the minimum delay this node will enforce when
 	// building a snowman++ block.


### PR DESCRIPTION
## Why this should be merged

This results in serializing with a zero-value of nil (valid) rather than a zero value of `snowball.Parameters` with zero-value fields (invalid). This change allows tmpnet to use `subnet.Config` to define configuration intended to be serialized.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A