### PR TITLE
[tmpnet] Switch back to using maps for subnet config

### DIFF
--- a/subnets/config.go
+++ b/subnets/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	// AllowedNodes is the set of node IDs that are explicitly allowed to connect to this Subnet when
 	// ValidatorOnly is enabled.
 	AllowedNodes        set.Set[ids.NodeID] `json:"allowedNodes"        yaml:"allowedNodes"`
-	ConsensusParameters snowball.Parameters `json:"consensusParameters" yaml:"consensusParameters,omitempty"`
+	ConsensusParameters snowball.Parameters `json:"consensusParameters" yaml:"consensusParameters"`
 
 	// ProposerMinBlockDelay is the minimum delay this node will enforce when
 	// building a snowman++ block.

--- a/tests/fixture/subnet/xsvm.go
+++ b/tests/fixture/subnet/xsvm.go
@@ -33,6 +33,10 @@ func NewXSVMOrPanic(name string, key *secp256k1.PrivateKey, nodes ...*tmpnet.Nod
 
 	return &tmpnet.Subnet{
 		Name: name,
+		Config: tmpnet.FlagsMap{
+			// Reducing this from the 1s default speeds up tx acceptance
+			"proposerMinBlockDelay": 0,
+		},
 		Chains: []*tmpnet.Chain{
 			{
 				VMID:         constants.XSVMID,

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -108,7 +107,7 @@ type Network struct {
 	Genesis *genesis.UnparsedConfig
 
 	// Configuration for primary subnets
-	PrimarySubnetConfig *subnets.Config
+	PrimarySubnetConfig FlagsMap
 
 	// Configuration for primary network chains (P, X, C)
 	PrimaryChainConfigs map[string]FlagsMap
@@ -871,10 +870,10 @@ func (n *Network) GetGenesisFileContent() (string, error) {
 // GetSubnetConfigContent returns the base64-encoded and
 // JSON-marshaled map of subnetID to subnet configuration.
 func (n *Network) GetSubnetConfigContent() (string, error) {
-	subnetConfigs := map[ids.ID]subnets.Config{}
+	subnetConfigs := map[ids.ID]FlagsMap{}
 
-	if n.PrimarySubnetConfig != nil {
-		subnetConfigs[constants.PrimaryNetworkID] = *n.PrimarySubnetConfig
+	if len(n.PrimarySubnetConfig) > 0 {
+		subnetConfigs[constants.PrimaryNetworkID] = n.PrimarySubnetConfig
 	}
 
 	// Collect configuration for non-primary subnets
@@ -884,10 +883,10 @@ func (n *Network) GetSubnetConfigContent() (string, error) {
 			// possible to supply configuration without an ID.
 			continue
 		}
-		if subnet.Config == nil {
+		if len(subnet.Config) == 0 {
 			continue
 		}
-		subnetConfigs[subnet.SubnetID] = *subnet.Config
+		subnetConfigs[subnet.SubnetID] = subnet.Config
 	}
 
 	if len(subnetConfigs) == 0 {

--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 
 	"github.com/ava-labs/avalanchego/genesis"
-	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/perms"
 )
@@ -131,7 +130,7 @@ func (n *Network) readConfig() error {
 type serializedNetworkConfig struct {
 	UUID                 string                  `json:",omitempty"`
 	Owner                string                  `json:",omitempty"`
-	PrimarySubnetConfig  *subnets.Config         `json:",omitempty"`
+	PrimarySubnetConfig  FlagsMap                `json:",omitempty"`
 	PrimaryChainConfigs  map[string]FlagsMap     `json:",omitempty"`
 	DefaultFlags         FlagsMap                `json:",omitempty"`
 	DefaultRuntimeConfig NodeRuntimeConfig       `json:",omitempty"`

--- a/tests/fixture/tmpnet/network_test.go
+++ b/tests/fixture/tmpnet/network_test.go
@@ -8,10 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 func TestNetworkSerialization(t *testing.T) {
@@ -21,9 +18,8 @@ func TestNetworkSerialization(t *testing.T) {
 
 	network := NewDefaultNetwork("testnet")
 	// Validate round-tripping of primary subnet configuration
-	network.PrimarySubnetConfig = &subnets.Config{
-		ValidatorOnly: true,
-		AllowedNodes:  set.Set[ids.NodeID]{},
+	network.PrimarySubnetConfig = FlagsMap{
+		"validatorOnly": true,
 	}
 	require.NoError(network.EnsureDefaultConfig(logging.NoLog{}, "/path/to/avalanche/go", ""))
 	require.NoError(network.Create(tmpDir))

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -56,7 +55,7 @@ type Subnet struct {
 	// networks (since the SubnetID will be different every time the subnet is created)
 	Name string
 
-	Config *subnets.Config
+	Config FlagsMap
 
 	// The ID of the transaction that created the subnet
 	SubnetID ids.ID


### PR DESCRIPTION
## PR Chain: tmpnet+kube

This PR chain enables tmpnet to deploy temporary networks to Kubernetes. Early PRs refactor tmpnet to support the addition in #3615 of a new tmpnet node runtime for kube.  

- #3854
- #3857
- #3870
- **>>>>>>** #3877 **<<<<<<**
- #3867
- #3871
- #3881
- #3890
- #3884
- #3893
- #3894
- #3896
- #3897
- #3898
- #3882 
- #3615
- #3794 

## Why this should be merged

Using subnet.Config to define subnet configuration initially seemed like a good idea - typing for the win - but went down in flames due to a combination the semantics of JSON marshaling and how subnet config defaults are set by the node. So, back to maps we go.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A