### PR TITLE
[tooling] Add scripts that build+run tools and put them in the path

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,11 +3,8 @@ use flake
 # Repo-local commands like ginkgo and tmpnetctl
 PATH_add bin
 
-# Built binaries like avalanchego and xsvm
-PATH_add build
-
 # Configure the explicit built path of avalanchego for tmpnet usage
-export AVALANCHEGO_PATH=$PWD/build/avalanchego
+export AVALANCHEGO_PATH=$PWD/bin/avalanchego
 
 # Configure the local plugin directory for both avalanchego and tmpnet usage
 mkdir -p $PWD/build/plugins                                       # avalanchego will FATAL if the directory does not exist

--- a/bin/avalanchego
+++ b/bin/avalanchego
@@ -1,0 +1,1 @@
+../scripts/run_avalanchego.sh

--- a/bin/ginkgo
+++ b/bin/ginkgo
@@ -1,10 +1,1 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-# Ensure the go command is run from the root of the repository so that its go.mod file is used
-AVALANCHE_PATH=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
-cd "${AVALANCHE_PATH}"
-
-# If an explicit version is not specified, go run uses the ginkgo version from go.mod
-go run github.com/onsi/ginkgo/v2/ginkgo "${@}"
+../scripts/run_ginkgo.sh

--- a/bin/tmpnetctl
+++ b/bin/tmpnetctl
@@ -1,10 +1,1 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-# Ensure the go command is run from the root of the repository
-AVALANCHE_PATH=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
-cd "${AVALANCHE_PATH}"
-
-# Use go run to ensure the correct version is always used
-go run ./tests/fixture/tmpnet/tmpnetctl "${@}"
+../scripts/run_tmpnetctl.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,9 +31,6 @@ source "${REPO_ROOT}"/scripts/constants.sh
 # Determine the git commit hash to use for the build
 source "${REPO_ROOT}"/scripts/git_commit.sh
 
-echo "Downloading dependencies..."
-go mod download
-
 echo "Building AvalancheGo with [$(go version)]..."
 go build ${race} -o "${avalanchego_path}" \
    -ldflags "-X github.com/ava-labs/avalanchego/version.GitCommit=$git_commit $static_ld_flags" \

--- a/scripts/run_avalanchego.sh
+++ b/scripts/run_avalanchego.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+AVALANCHE_PATH=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+cd "${AVALANCHE_PATH}"
+
+# Build the binary before execution to ensure it is always up-to-date. Faster than `go run`.
+./scripts/build.sh
+./build/avalanchego "${@}"

--- a/scripts/run_ginkgo.sh
+++ b/scripts/run_ginkgo.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Ensure the go command is run from the root of the repository so that its go.mod file is used
+AVALANCHE_PATH=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+cd "${AVALANCHE_PATH}"
+
+# Installing and then running is faster than `go run`.
+GOBIN="${AVALANCHE_PATH}/build" go install github.com/onsi/ginkgo/v2/ginkgo
+./build/ginkgo "${@}"

--- a/scripts/run_tmpnetctl.sh
+++ b/scripts/run_tmpnetctl.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+AVALANCHE_PATH=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+cd "${AVALANCHE_PATH}"
+
+# Build the binary before execution to ensure it is always up-to-date. Faster than `go run`.
+./scripts/build_tmpnetctl.sh
+./build/tmpnetctl "${@}"


### PR DESCRIPTION
## Why this should be merged

`go run` turns out to be slower than installing and running tooling. This change adds such scripts for ginkgo, avalanchego and tmpnetctl and symlinks them to the bin path so that they are in the path with direnv. This ensures executed binaries are always up-to-date when developing locally.

## How this was tested

All local

## Need to be documented in RELEASES.md?

N/A