### PR TITLE
Simplify P-Chain block has changes check

### DIFF
--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -1365,7 +1365,6 @@ func TestDeactivateLowBalanceL1ValidatorBlockChanges(t *testing.T) {
 			currentFork:       upgradetest.Etna,
 			durationToAdvance: time.Second,
 			networkID:         constants.UnitTestID,
-			expectedErr:       ErrStandardBlockWithoutChanges,
 		},
 		{
 			name:              "After F Upgrade - L1 validators evicted",

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -2180,7 +2180,7 @@ func TestValidatorSetRaceCondition(t *testing.T) {
 	vm.ctx.Lock.Lock()
 }
 
-func TestL1ValidatorDeactivationCausesTrackingOfInvalidBlock(t *testing.T) {
+func TestBanffStandardBlockWithNoChangesRemainsInvalid(t *testing.T) {
 	require := require.New(t)
 	vm, _, _ := defaultVM(t, upgradetest.Etna)
 	vm.ctx.Lock.Lock()


### PR DESCRIPTION
## Why this should be merged

This removes some special case handling that was added for the Fortuna activation.

## How this works

Because all networks are post Fortuna activation now, there is no need to enforce additional pre-fortuna verification rules.

## How this was tested

Updated unit tests.

## Need to be documented in RELEASES.md?

No.