### PR TITLE
[tmpnet] Avoid serializing the node data directory

### DIFF
--- a/tests/antithesis/init_db.go
+++ b/tests/antithesis/init_db.go
@@ -45,7 +45,7 @@ func initBootstrapDB(network *tmpnet.Network, destPath string) error {
 	}
 
 	// Copy the db state from the bootstrap node to the compose volume path.
-	sourcePath := filepath.Join(network.Nodes[0].GetDataDir(), "db")
+	sourcePath := filepath.Join(network.Nodes[0].DataDir, "db")
 	if err := os.MkdirAll(destPath, perms.ReadWriteExecute); err != nil {
 		return fmt.Errorf("failed to create db path %q: %w", destPath, err)
 	}

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -5,7 +5,6 @@ package faultinjection
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
@@ -27,23 +26,22 @@ var _ = ginkgo.Describe("Duplicate node handling", func() {
 		network := e2e.GetEnv(tc).GetNetwork()
 
 		tc.By("creating new node")
-		node1 := e2e.AddEphemeralNode(tc, network, tmpnet.FlagsMap{})
+		node1 := e2e.AddEphemeralNode(tc, network, tmpnet.NewEphemeralNode(tmpnet.FlagsMap{}))
 		e2e.WaitForHealthy(tc, node1)
 
 		tc.By("checking that the new node is connected to its peers")
 		checkConnectedPeers(tc, network.Nodes, node1)
 
 		tc.By("creating a second new node with the same staking keypair as the first new node")
-		node1Flags := node1.Flags
-		node2Flags := tmpnet.FlagsMap{
-			config.StakingTLSKeyContentKey: node1Flags[config.StakingTLSKeyContentKey],
-			config.StakingCertContentKey:   node1Flags[config.StakingCertContentKey],
-			// Construct a unique data dir to ensure the two nodes' data will be stored
-			// separately. Usually the dir name is the node ID but in this one case the nodes have
-			// the same node ID.
-			config.DataDirKey: fmt.Sprintf("%s-second", node1Flags[config.DataDirKey]),
-		}
-		node2 := e2e.AddEphemeralNode(tc, network, node2Flags)
+		node2 := tmpnet.NewEphemeralNode(tmpnet.FlagsMap{
+			config.StakingTLSKeyContentKey: node1.Flags[config.StakingTLSKeyContentKey],
+			config.StakingCertContentKey:   node1.Flags[config.StakingCertContentKey],
+		})
+		// Construct a unique data dir to ensure the two nodes' data will be stored
+		// separately. Usually the dir name is the node ID but in this one case the nodes have
+		// the same node ID.
+		node2.DataDir = node1.DataDir + "-second"
+		_ = e2e.AddEphemeralNode(tc, network, node2)
 
 		tc.By("checking that the second new node fails to become healthy before timeout")
 		err := tmpnet.WaitForHealthy(tc.DefaultContext(), node2)
@@ -77,6 +75,11 @@ func checkConnectedPeers(tc tests.TestContext, existingNodes []*tmpnet.Node, new
 	}
 
 	for _, existingNode := range existingNodes {
+		if existingNode.IsEphemeral {
+			// Ephemeral nodes may not be running
+			continue
+		}
+
 		// Check that the existing node is a peer of the new node
 		require.True(peerIDs.Contains(existingNode.NodeID))
 

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -108,7 +108,7 @@ var _ = e2e.DescribePChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainL
 		})
 
 		tc.By("adding new node and waiting for it to report healthy")
-		node := e2e.AddEphemeralNode(tc, network, tmpnet.FlagsMap{})
+		node := e2e.AddEphemeralNode(tc, network, tmpnet.NewEphemeralNode(tmpnet.FlagsMap{}))
 		e2e.WaitForHealthy(tc, node)
 
 		tc.By("retrieving new node's id and pop")

--- a/tests/e2e/p/l1.go
+++ b/tests/e2e/p/l1.go
@@ -172,9 +172,9 @@ var _ = e2e.DescribePChain("[L1]", func() {
 		})
 
 		tc.By("creating the genesis validator")
-		subnetGenesisNode := e2e.AddEphemeralNode(tc, env.GetNetwork(), tmpnet.FlagsMap{
+		subnetGenesisNode := e2e.AddEphemeralNode(tc, env.GetNetwork(), tmpnet.NewEphemeralNode(tmpnet.FlagsMap{
 			config.TrackSubnetsKey: subnetID.String(),
-		})
+		}))
 
 		genesisNodePoP, err := subnetGenesisNode.GetProofOfPossession()
 		require.NoError(err)
@@ -348,9 +348,9 @@ var _ = e2e.DescribePChain("[L1]", func() {
 		tc.By("advancing the proposervm P-chain height", advanceProposerVMPChainHeight)
 
 		tc.By("creating the validator to register")
-		subnetRegisterNode := e2e.AddEphemeralNode(tc, env.GetNetwork(), tmpnet.FlagsMap{
+		subnetRegisterNode := e2e.AddEphemeralNode(tc, env.GetNetwork(), tmpnet.NewEphemeralNode(tmpnet.FlagsMap{
 			config.TrackSubnetsKey: subnetID.String(),
-		})
+		}))
 
 		registerNodePoP, err := subnetRegisterNode.GetProofOfPossession()
 		require.NoError(err)

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -55,9 +55,9 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 		})
 
 		tc.By("adding alpha node, whose uptime should result in a staking reward")
-		alphaNode := e2e.AddEphemeralNode(tc, network, tmpnet.FlagsMap{})
+		alphaNode := e2e.AddEphemeralNode(tc, network, tmpnet.NewEphemeralNode(tmpnet.FlagsMap{}))
 		tc.By("adding beta node, whose uptime should not result in a staking reward")
-		betaNode := e2e.AddEphemeralNode(tc, network, tmpnet.FlagsMap{})
+		betaNode := e2e.AddEphemeralNode(tc, network, tmpnet.NewEphemeralNode(tmpnet.FlagsMap{}))
 
 		// Wait to check health until both nodes have started to minimize the duration
 		// required for both nodes to report healthy.

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -133,10 +133,9 @@ func NewEthClient(tc tests.TestContext, nodeURI tmpnet.NodeURI) ethclient.Client
 }
 
 // Adds an ephemeral node intended to be used by a single test.
-func AddEphemeralNode(tc tests.TestContext, network *tmpnet.Network, flags tmpnet.FlagsMap) *tmpnet.Node {
+func AddEphemeralNode(tc tests.TestContext, network *tmpnet.Network, node *tmpnet.Node) *tmpnet.Node {
 	require := require.New(tc)
 
-	node := tmpnet.NewEphemeralNode(flags)
 	require.NoError(network.StartNode(tc.DefaultContext(), tc.Log(), node))
 
 	tc.DeferCleanup(func() {

--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -56,13 +56,35 @@ func (n *Network) readNetwork() error {
 	return n.readConfig()
 }
 
-// Read the non-ephemeral nodes associated with the network from disk.
+// Read the nodes associated with the network from disk.
 func (n *Network) readNodes() error {
-	nodes, err := ReadNodes(n, false /* includeEphemeral */)
+	nodes := []*Node{}
+
+	// Node configuration is stored in child directories
+	entries, err := os.ReadDir(n.Dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read dir: %w", err)
 	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		node := NewNode()
+		dataDir := filepath.Join(n.Dir, entry.Name())
+		err := node.Read(n, dataDir)
+		if errors.Is(err, os.ErrNotExist) {
+			// If no config file exists, assume this is not the path of a node
+			continue
+		} else if err != nil {
+			return err
+		}
+
+		nodes = append(nodes, node)
+	}
+
 	n.Nodes = nodes
+
 	return nil
 }
 
@@ -128,13 +150,13 @@ func (n *Network) readConfig() error {
 
 // The subset of network fields to store in the network config file.
 type serializedNetworkConfig struct {
-	UUID                 string                  `json:",omitempty"`
-	Owner                string                  `json:",omitempty"`
-	PrimarySubnetConfig  FlagsMap                `json:",omitempty"`
-	PrimaryChainConfigs  map[string]FlagsMap     `json:",omitempty"`
-	DefaultFlags         FlagsMap                `json:",omitempty"`
-	DefaultRuntimeConfig NodeRuntimeConfig       `json:",omitempty"`
-	PreFundedKeys        []*secp256k1.PrivateKey `json:",omitempty"`
+	UUID                 string                  `json:"uuid,omitempty"`
+	Owner                string                  `json:"owner,omitempty"`
+	PrimarySubnetConfig  FlagsMap                `json:"primarySubnetConfig,omitempty"`
+	PrimaryChainConfigs  map[string]FlagsMap     `json:"primaryChainConfigs,omitempty"`
+	DefaultFlags         FlagsMap                `json:"defaultFlags,omitempty"`
+	DefaultRuntimeConfig NodeRuntimeConfig       `json:"defaultRuntimeConfig,omitempty"`
+	PreFundedKeys        []*secp256k1.PrivateKey `json:"preFundedKeys,omitempty"`
 }
 
 func (n *Network) writeNetworkConfig() error {

--- a/tests/fixture/tmpnet/node_process.go
+++ b/tests/fixture/tmpnet/node_process.go
@@ -121,7 +121,7 @@ func (p *NodeProcess) Start(log logging.Logger) error {
 	// that includes the log entry.
 	ctx, cancelWithCause := context.WithCancelCause(context.Background())
 	defer cancelWithCause(nil)
-	logPath := p.node.GetDataDir() + "/logs/main.log"
+	logPath := p.node.DataDir + "/logs/main.log"
 	go watchLogFileForFatal(ctx, cancelWithCause, log, logPath)
 
 	// A node writes a process context file on start. If the file is not
@@ -133,7 +133,7 @@ func (p *NodeProcess) Start(log logging.Logger) error {
 
 	log.Info("started local node",
 		zap.Stringer("nodeID", p.node.NodeID),
-		zap.String("dataDir", p.node.GetDataDir()),
+		zap.String("dataDir", p.node.DataDir),
 		zap.Bool("isEphemeral", p.node.IsEphemeral),
 	)
 
@@ -198,7 +198,7 @@ func (p *NodeProcess) IsHealthy(ctx context.Context) (bool, error) {
 }
 
 func (p *NodeProcess) getProcessContextPath() string {
-	return filepath.Join(p.node.GetDataDir(), config.DefaultProcessContextFilename)
+	return filepath.Join(p.node.DataDir, config.DefaultProcessContextFilename)
 }
 
 func (p *NodeProcess) waitForProcessContext(ctx context.Context) error {
@@ -287,7 +287,7 @@ func (p *NodeProcess) writeMonitoringConfig() error {
 	}
 
 	promtailLabels := FlagsMap{
-		"__path__": filepath.Join(p.node.GetDataDir(), "logs", "*.log"),
+		"__path__": filepath.Join(p.node.DataDir, "logs", "*.log"),
 	}
 	promtailLabels.SetDefaults(commonLabels)
 	promtailConfig := []FlagsMap{


### PR DESCRIPTION
## PR Chain: tmpnet+kube

This PR chain enables tmpnet to deploy temporary networks to Kubernetes. Early PRs refactor tmpnet to support the addition in #3615 of a new tmpnet node runtime for kube.  

- #3854
- #3857
- #3870
- #3877
- #3867
- #3871
- **>>>>>>** #3881 **<<<<<<**
- #3890
- #3884
- #3893
- #3894
- #3896
- #3897
- #3898
- #3882 
- #3615
- #3794 

## Why this should be merged

This is intended to simplify usage by CLI. It also moves responsibility for setting the data dir to the runtime since the dir will differ between the node (local fs) and kube runtimes (pvc).

## How this was tested

CI, local testing of tmpnetctl

## Need to be documented in RELEASES.md?

N/A

## TODO

- [x] Merge https://github.com/ava-labs/avalanchego/pull/3871