### PR TITLE
[tmpnet] Rename NodeProcess to ProcessRuntime

### DIFF
--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -57,32 +57,32 @@ repositories.
 The functionality in this package is grouped by logical purpose into
 the following non-test files:
 
-| Filename                    | Types       | Purpose                                                                |
-|:----------------------------|:------------|:-----------------------------------------------------------------------|
-| flags/                      |             | Directory defining flags usable with both stdlib flags and spf13/pflag |
-| flags/common.go             |             | Defines type definitions common across other files                     |
-| flags/process_runtime.go    |             | Defines flags configuring the process node runtime                     |
-| flags/runtime.go            |             | Defines flags configuring node runtime                                 |
-| flags/start_network.go      |             | Defines flags configuring network start                                |
-| tmpnetctl/                  |             | Directory containing main entrypoint for tmpnetctl command             |
-| check_monitoring.go         |             | Enables checking if logs and metrics were collected                    |
-| defaults.go                 |             | Defines common default configuration                                   |
-| detached_process_default.go |             | Configures detached processes for darwin and linux                     |
-| detached_process_windows.go |             | No-op detached process configuration for windows                       |
-| flags.go                    | FlagsMap    | Simplifies configuration of avalanchego flags                          |
-| genesis.go                  |             | Creates test genesis                                                   |
-| kube.go                     |             | Library for Kubernetes interaction                                     |
-| local_network.go            |             | Defines configuration for the default local network                    |
-| monitor_processes.go        |             | Enables collection of logs and metrics from local processes            |
-| network.go                  | Network     | Orchestrates and configures temporary networks                         |
-| network_config.go           | Network     | Reads and writes network configuration                                 |
-| network_test.go             |             | Simple test round-tripping Network serialization                       |
-| node.go                     | Node        | Orchestrates and configures nodes                                      |
-| node_config.go              | Node        | Reads and writes node configuration                                    |
-| node_process.go             | NodeProcess | Orchestrates node processes                                            |
-| start_kind_cluster.go       |             | Starts a local kind cluster                                            |
-| subnet.go                   | Subnet      | Orchestrates subnets                                                   |
-| utils.go                    |             | Defines shared utility functions                                       |
+| Filename                    | Types          | Purpose                                                                |
+|:----------------------------|:---------------|:-----------------------------------------------------------------------|
+| flags/                      |                | Directory defining flags usable with both stdlib flags and spf13/pflag |
+| flags/common.go             |                | Defines type definitions common across other files                     |
+| flags/process_runtime.go    |                | Defines flags configuring the process node runtime                     |
+| flags/runtime.go            |                | Defines flags configuring node runtime                                 |
+| flags/start_network.go      |                | Defines flags configuring network start                                |
+| tmpnetctl/                  |                | Directory containing main entrypoint for tmpnetctl command             |
+| check_monitoring.go         |                | Enables checking if logs and metrics were collected                    |
+| defaults.go                 |                | Defines common default configuration                                   |
+| detached_process_default.go |                | Configures detached processes for darwin and linux                     |
+| detached_process_windows.go |                | No-op detached process configuration for windows                       |
+| flags.go                    | FlagsMap       | Simplifies configuration of avalanchego flags                          |
+| genesis.go                  |                | Creates test genesis                                                   |
+| kube.go                     |                | Library for Kubernetes interaction                                     |
+| local_network.go            |                | Defines configuration for the default local network                    |
+| monitor_processes.go        |                | Enables collection of logs and metrics from local processes            |
+| network.go                  | Network        | Orchestrates and configures temporary networks                         |
+| network_config.go           | Network        | Reads and writes network configuration                                 |
+| network_test.go             |                | Simple test round-tripping Network serialization                       |
+| node.go                     | Node           | Orchestrates and configures nodes                                      |
+| node_config.go              | Node           | Reads and writes node configuration                                    |
+| process_runtime.go          | ProcessRuntime | Orchestrates node processes                                            |
+| start_kind_cluster.go       |                | Starts a local kind cluster                                            |
+| subnet.go                   | Subnet         | Orchestrates subnets                                                   |
+| utils.go                    |                | Defines shared utility functions                                       |
 
 ## Usage
 

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -119,7 +119,7 @@ func NewNodesOrPanic(count int) []*Node {
 // Retrieves the runtime for the node.
 func (n *Node) getRuntime() NodeRuntime {
 	if n.runtime == nil {
-		n.runtime = &NodeProcess{
+		n.runtime = &ProcessRuntime{
 			node: n,
 		}
 	}


### PR DESCRIPTION
## PR Chain: tmpnet+kube

This PR chain enables tmpnet to deploy temporary networks to Kubernetes. Early PRs refactor tmpnet to support the addition in #3615 of a new tmpnet node runtime for kube.  

- #3854
- #3857
- #3870
- #3877
- #3867
- #3871
- #3881
- **>>>>>>** #3890 **<<<<<<**
- #3884
- #3893
- #3894
- #3896
- #3897
- #3898
- #3882 
- #3615
- #3794 

## Why this should be merged

This is intended to be consistent with the addition of KubeRuntime and the name of the runtime configuration (ProcessRuntimeConfig).

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A

## TODO

- [x] Merge #3881 