### PR TITLE
wrap db in initDatabase with corruptable db

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/config/node"
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/corruptabledb"
 	"github.com/ava-labs/avalanchego/database/leveldb"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/meterdb"
@@ -786,6 +787,9 @@ func (n *Node) initDatabase() error {
 			pebbledb.Name,
 		)
 	}
+
+	// Wrap with corruptable DB
+	n.DB = corruptabledb.New(n.DB)
 
 	if n.Config.ReadOnly && n.Config.DatabaseConfig.Name != memdb.Name {
 		n.DB = versiondb.New(n.DB)


### PR DESCRIPTION
## Why this should be merged

Current DBs are not wrapped with Corruptable DB wrapper after removal of db manager [here](https://github.com/ava-labs/avalanchego/pull/2239).

## How this works

Wraps DB with corruptable DB in node `initDatabase` 

## How this was tested

Not sure how to test this

## Need to be documented in RELEASES.md?

No
