### PR TITLE
Grant marun ownership of tooling configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,16 @@
 
 * @StephenButtolph
 *.md @meaghanfitzgerald @StephenButtolph
+/.dockerignore @maru-ava
+/.envrc @maru-ava
 /.github/ @maru-ava
 /.github/*.md @maru-ava @meaghanfitzgerald
+/.gitignore @maru-ava @Stephenbuttolph
+/.golangci.yml @maru-ava
+/Dockerfile @maru-ava
+/Taskfile.yml @maru-ava
+/flake.lock @maru-ava
+/flake.nix @maru-ava
 /network/p2p/ @joshua-kim
 /network/p2p/*.md @joshua-kim @meaghanfitzgerald
 /scripts/ @maru-ava

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 /.github/ @maru-ava
 /.github/*.md @maru-ava @meaghanfitzgerald
 /.gitignore @maru-ava @Stephenbuttolph
-/.golangci.yml @maru-ava
+/.golangci.yml @maru-ava @Stephenbuttolph
 /Dockerfile @maru-ava
 /Taskfile.yml @maru-ava
 /flake.lock @maru-ava


### PR DESCRIPTION
## Why this should be merged

@maru-ava created half of these files (.envrc, Taskfile, flake.*) and the other half are his responsibility (docker, golangci). Granting him ownership avoids having @StephenButtolph be responsible for merging changes to these files.
