### PR TITLE
[tmpnet] Move WaitForHealthy from a function to a tmpnet.Node method

### DIFF
--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -44,7 +44,7 @@ var _ = ginkgo.Describe("Duplicate node handling", func() {
 		_ = e2e.AddEphemeralNode(tc, network, node2)
 
 		tc.By("checking that the second new node fails to become healthy before timeout")
-		err := tmpnet.WaitForHealthy(tc.DefaultContext(), node2)
+		err := node2.WaitForHealthy(tc.DefaultContext())
 		require.ErrorIs(err, context.DeadlineExceeded)
 
 		tc.By("stopping the first new node")

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -154,7 +154,7 @@ func WaitForHealthy(t require.TestingT, node *tmpnet.Node) {
 	// Need to use explicit context (vs DefaultContext()) to support use with DeferCleanup
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()
-	require.NoError(t, tmpnet.WaitForHealthy(ctx, node))
+	require.NoError(t, node.WaitForHealthy(ctx))
 }
 
 // Sends an eth transaction and waits for the transaction receipt from the
@@ -248,7 +248,7 @@ func CheckBootstrapIsPossible(tc tests.TestContext, network *tmpnet.Network) *tm
 	})
 
 	// Check that the node becomes healthy within timeout
-	require.NoError(tmpnet.WaitForHealthy(tc.DefaultContext(), node))
+	require.NoError(node.WaitForHealthy(tc.DefaultContext()))
 
 	// Ensure that the primary validators are still healthy
 	for _, node := range network.Nodes {

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -507,7 +507,7 @@ func (n *Network) RestartNode(ctx context.Context, node *Node) error {
 	n.log.Info("waiting for node to report healthy",
 		zap.Stringer("nodeID", node.NodeID),
 	)
-	return WaitForHealthy(ctx, node)
+	return node.WaitForHealthy(ctx)
 }
 
 // Stops all nodes in the network.


### PR DESCRIPTION
## PR Chain: tmpnet+kube

This PR chain enables tmpnet to deploy temporary networks to Kubernetes. Early PRs refactor tmpnet to support the addition in #3615 of a new tmpnet node runtime for kube.  

- #3854
- #3857
- #3870
- #3877
- #3867
- #3871
- #3881
- #3890
- #3884
- #3893
- #3894
- **>>>>>>** #3896 **<<<<<<**
- #3897
- #3898
- #3882 
- #3615
- #3794 

## Why this should be merged

Nicer to be able to call `node.WaitForHealthy(ctx)` instead of `tmpnet.WaitForHealthy(ctx, node)`.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A

## TODO 

 - [x] Merge parent #3894 