### PR TITLE
[tmpnet] Move monitoring label handling to node

### DIFF
--- a/tests/fixture/tmpnet/check_monitoring.go
+++ b/tests/fixture/tmpnet/check_monitoring.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -271,13 +272,11 @@ func getSelectors(networkUUID string) (string, error) {
 
 	// Fall back to using Github labels as selectors
 	selectors := []string{}
-	githubLabels := githubLabelsFromEnv()
-	for label := range githubLabels {
-		value := githubLabels[label]
-		if len(value) == 0 {
-			continue
+	for _, label := range githubLabels {
+		value := os.Getenv(strings.ToUpper(label))
+		if len(value) > 0 {
+			selectors = append(selectors, fmt.Sprintf(`%s="%s"`, label, value))
 		}
-		selectors = append(selectors, fmt.Sprintf(`%s="%s"`, label, value))
 	}
 	if len(selectors) == 0 {
 		return "", errors.New("no GH_* env vars set to use for selectors")

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,16 @@ var (
 	errMissingTLSKeyForNodeID = fmt.Errorf("failed to ensure node ID: missing value for %q", config.StakingTLSKeyContentKey)
 	errMissingCertForNodeID   = fmt.Errorf("failed to ensure node ID: missing value for %q", config.StakingCertContentKey)
 	errInvalidKeypair         = fmt.Errorf("%q and %q must be provided together or not at all", config.StakingTLSKeyContentKey, config.StakingCertContentKey)
+
+	// Labels expected to be available in the environment when running in GitHub Actions
+	githubLabels = []string{
+		"gh_repo",
+		"gh_workflow",
+		"gh_run_id",
+		"gh_run_number",
+		"gh_run_attempt",
+		"gh_job_id",
+	}
 )
 
 // NodeRuntime defines the methods required to support running a node.
@@ -417,4 +428,27 @@ func (n *Node) WaitForHealthy(ctx context.Context) error {
 		case <-ticker.C:
 		}
 	}
+}
+
+// getMonitoringLabels retrieves the map of labels and their values to be
+// applied to metrics and logs collected from the node.
+func (n *Node) getMonitoringLabels() map[string]string {
+	labels := map[string]string{
+		// Explicitly setting an instance label avoids the default
+		// behavior of using the node's URI since the URI isn't
+		// guaranteed stable (e.g. port may change after restart).
+		"instance":          n.GetUniqueID(),
+		"network_uuid":      n.network.UUID,
+		"node_id":           n.NodeID.String(),
+		"is_ephemeral_node": strconv.FormatBool(n.IsEphemeral),
+		"network_owner":     n.network.Owner,
+	}
+	// Include the values of github labels if available
+	for _, label := range githubLabels {
+		value := os.Getenv(strings.ToUpper(label))
+		if len(value) > 0 {
+			labels[label] = value
+		}
+	}
+	return labels
 }


### PR DESCRIPTION
## PR Chain: tmpnet+kube

This PR chain enables tmpnet to deploy temporary networks to Kubernetes. Early PRs refactor tmpnet to support the addition in #3615 of a new tmpnet node runtime for kube.  

- #3854
- #3857
- #3870
- #3877
- #3867
- #3871
- #3881
- #3890
- #3884
- #3893
- #3894
- #3896
- #3897
- **>>>>>>** #3898 **<<<<<<** 
- #3882 
- #3615
- #3794
 
## Why this should be merged

Previously, determination of labels to apply to collected logs and metrics was the responsibility of the process runtime. Since these labels are common to both runtimes, it makes sense for the node to own it. 

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A

## TODO

- [x] Merge parent #3897 