### PR TITLE
docs: fix flag name to `--proposervm-min-block-delay`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -33,7 +33,7 @@ The plugin version is unchanged at `39` and is compatible with version `v1.12.2`
 ### Configs
 
 - Added:
-  - `--proposervm-min-block-duration`
+  - `--proposervm-min-block-delay`
   - `--network-no-ingress-connections-grace-period` to configure how long after startup it is expected for a Mainnet validator to have received an ingress connection.
 
 ### What's Changed

--- a/config/config.md
+++ b/config/config.md
@@ -945,7 +945,7 @@ The value must be greater than `0`. Defaults to `2m`.
 
 Have the ProposerVM always report the last accepted P-chain block height. Defaults to `false`.
 
-### `--proposervm-min-block-duration` (duration)
+### `--proposervm-min-block-delay` (duration)
 
 The minimum delay to enforce when building a snowman++ block for the primary network
 chains and the default minimum delay for subnets. Defaults to `1s`. A non-default


### PR DESCRIPTION

Fixes `--proposervm-min-block-delay` flag name in docs