### PR TITLE
Add git to nix packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,9 @@
         default = pkgs.mkShell {
           # The Nix packages provided in the environment
           packages = with pkgs; [
+            # Build requirements
+            git
+
             # Task runner
             go-task
 


### PR DESCRIPTION
## Why this should be merged

After running `nix develop` and then `./scripts/run_task build` I ran into:
```
$ ./scripts/run_task.sh build
task: [build] ./scripts/build.sh
error: tool 'git' not found
task: Failed to run task "build": exit status 1
```

After adding `git` to the required packages and re-running `nix develop` and then `./scripts/run_task build`, the build succeeded without issue.

## How this works

Adds `git` as a dependent package in nix.

## How this was tested

Locally

## Need to be documented in RELEASES.md?

No