### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/utils/timer/mockable/clock.go
+++ b/utils/timer/mockable/clock.go
@@ -36,9 +36,6 @@ func (c *Clock) UnixTime() time.Time {
 
 // Unix returns the unix timestamp on this clock.
 func (c *Clock) Unix() uint64 {
-	unix := c.Time().Unix()
-	if unix < 0 {
-		unix = 0
-	}
+	unix := max(c.Time().Unix(), 0)
 	return uint64(unix)
 }


### PR DESCRIPTION
## Why this should be merged

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
