### PR TITLE
Update owner of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,9 @@
 /.envrc @maru-ava
 /.github/ @maru-ava
 /.github/*.md @maru-ava @meaghanfitzgerald
-/.gitignore @maru-ava @Stephenbuttolph
-/.golangci.yml @maru-ava @Stephenbuttolph
+/.github/CODEOWNERS @StephenButtolph
+/.gitignore @maru-ava @StephenButtolph
+/.golangci.yml @maru-ava @StephenButtolph
 /Dockerfile @maru-ava
 /Taskfile.yml @maru-ava
 /flake.lock @maru-ava


### PR DESCRIPTION
## Why this should be merged

When @maru-ava took ownership of the `.github` folder, that included the CODEOWNERS file. This reverts that ownership change.

This also fixes some capitalizations of my username in the file.

## How this works

Updates owners.

## How this was tested

> This CODEOWNERS file is valid.

## Need to be documented in RELEASES.md?

No.