### PR TITLE
Add P-Chain state test

### DIFF
--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -1628,6 +1628,29 @@ func TestL1Validators(t *testing.T) {
 			},
 		},
 		{
+			name: "increase inactive weight",
+			initial: []L1Validator{
+				{
+					ValidationID:      l1Validator.ValidationID,
+					SubnetID:          l1Validator.SubnetID,
+					NodeID:            l1Validator.NodeID,
+					PublicKey:         pkBytes,
+					Weight:            1, // Not removed
+					EndAccumulatedFee: 0, // Inactive
+				},
+			},
+			l1Validators: []L1Validator{
+				{
+					ValidationID:      l1Validator.ValidationID,
+					SubnetID:          l1Validator.SubnetID,
+					NodeID:            l1Validator.NodeID,
+					PublicKey:         pkBytes,
+					Weight:            2, // Increased
+					EndAccumulatedFee: 0, // Inactive
+				},
+			},
+		},
+		{
 			name: "decrease active weight",
 			initial: []L1Validator{
 				{


### PR DESCRIPTION
## Why this should be merged

Adds a test case to ensure that inactive L1 validators can have their weights modified correctly.

## How this works

Adds another test vector.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.