### PR TITLE
Document ACP-77 handling of 0 weight requests

### DIFF
--- a/vms/platformvm/network/warp.go
+++ b/vms/platformvm/network/warp.go
@@ -331,6 +331,9 @@ func (s signatureRequestVerifier) verifyL1ValidatorWeight(
 	l1Validator, err := s.state.GetL1Validator(msg.ValidationID)
 	switch {
 	case err == database.ErrNotFound:
+		// If the peer is attempting to verify that the weight of the validator
+		// is 0, they should be requesting a [message.L1ValidatorRegistration]
+		// with Registered set to false.
 		return &common.AppError{
 			Code:    ErrValidationDoesNotExist,
 			Message: fmt.Sprintf("validation %q does not exist", msg.ValidationID),


### PR DESCRIPTION
## Why this should be merged

There was some confusion of how `message.L1ValidatorWeight` messages with `Weight=0` were supposed to be handled. 

Because the P-chain prunes all information about validators that have been removed (by setting `Weight=0`), there is nothing on disk to use to verify these messages.

To handle this, the caller is expected to provide a proof that the validator was removed in the justification of signing a `message.L1ValidatorRegistration` with `Registered=false`.

## How this works

Adds a comment.

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No.