### PR TITLE
Pretty print logged durations in E2E

### DIFF
--- a/tests/fixture/e2e/ginkgo_test_context.go
+++ b/tests/fixture/e2e/ginkgo_test_context.go
@@ -31,13 +31,14 @@ func (*ginkgoWriteCloser) Close() error {
 // Define a simple encoder config appropriate for logging with ginkgo
 var ginkgoEncoderConfig = zapcore.EncoderConfig{
 	// Time, name and caller are omitted for consistency with previous output.
-	TimeKey:       "",
-	LevelKey:      "level",
-	NameKey:       "",
-	CallerKey:     "",
-	MessageKey:    "msg",
-	StacktraceKey: "stacktrace",
-	EncodeLevel:   logging.ConsoleColorLevelEncoder,
+	TimeKey:        "",
+	LevelKey:       "level",
+	NameKey:        "",
+	CallerKey:      "",
+	MessageKey:     "msg",
+	StacktraceKey:  "stacktrace",
+	EncodeLevel:    logging.ConsoleColorLevelEncoder,
+	EncodeDuration: zapcore.StringDurationEncoder,
 }
 
 // NewGinkgoLogger returns a logger with limited output


### PR DESCRIPTION
## Why this should be merged

It seems that by default, durations are encoded with their unixnano time. ref: https://github.com/ava-labs/avalanchego/actions/runs/14783344371/job/41506889431?pr=3560#step:4:882

## How this works

Explicitly specifies human readable times.

## How this was tested

- [ ] Inspect CI logs

## Need to be documented in RELEASES.md?

No