### PR TITLE
Fix broken Buf documentation link in proto README

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -16,7 +16,7 @@ Any changes made to proto definition can be updated by running
 `protobuf_codegen.sh` located in the `scripts/` directory of AvalancheGo.
 
 Introduction to `buf`
-[https://docs.buf.build/tour/introduction](https://docs.buf.build/tour/introduction)
+[https://buf.build/docs/get-started](https://buf.build/docs/cli/quickstart/)
 
 ## Protocol Version Compatibility
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -16,7 +16,7 @@ Any changes made to proto definition can be updated by running
 `protobuf_codegen.sh` located in the `scripts/` directory of AvalancheGo.
 
 `buf` Quickstart
-[https://buf.build/docs/get-started](https://buf.build/docs/cli/quickstart/)
+[https://buf.build/docs/cli/quickstart](https://buf.build/docs/cli/quickstart)
 
 ## Protocol Version Compatibility
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -15,7 +15,7 @@ Please find installation instructions on
 Any changes made to proto definition can be updated by running
 `protobuf_codegen.sh` located in the `scripts/` directory of AvalancheGo.
 
-Introduction to `buf`
+`buf` Quickstart
 [https://buf.build/docs/get-started](https://buf.build/docs/cli/quickstart/)
 
 ## Protocol Version Compatibility


### PR DESCRIPTION
Update outdated Buf documentation link that was returning 404 error.
Replace https://docs.buf.build/tour/introduction with https://buf.build/docs/cli/quickstart/
to point to the current Buf documentation.
This update ensures developers can access the correct resource when learning about the Buf tool used in the Avalanche gRPC implementation.
