### PR TITLE
Add logging to corruptabledb closure

### DIFF
--- a/database/corruptabledb/db_test.go
+++ b/database/corruptabledb/db_test.go
@@ -15,13 +15,14 @@ import (
 	"github.com/ava-labs/avalanchego/database/databasemock"
 	"github.com/ava-labs/avalanchego/database/dbtest"
 	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
 var errTest = errors.New("non-nil error")
 
 func newDB() *Database {
 	baseDB := memdb.New()
-	return New(baseDB)
+	return New(baseDB, logging.NoLog{})
 }
 
 func TestInterface(t *testing.T) {

--- a/database/factory/factory.go
+++ b/database/factory/factory.go
@@ -28,6 +28,7 @@ import (
 // dbMetricsPrefix is used to create a new metrics registerer for the database.
 // meterDBRegName is used to create a new metrics registerer for the meter DB.
 func New(
+	log logging.Logger,
 	name string,
 	path string,
 	readOnly bool,
@@ -70,7 +71,7 @@ func New(
 	}
 
 	// Wrap with corruptable DB
-	db = corruptabledb.New(db)
+	db = corruptabledb.New(db, log)
 
 	if readOnly && name != memdb.Name {
 		db = versiondb.New(db)

--- a/database/rpcdb/db_test.go
+++ b/database/rpcdb/db_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/database/corruptabledb"
 	"github.com/ava-labs/avalanchego/database/dbtest"
 	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/grpcutils"
 
 	rpcdbpb "github.com/ava-labs/avalanchego/proto/pb/rpcdb"
@@ -120,7 +121,7 @@ func TestHealthCheck(t *testing.T) {
 			require := require.New(t)
 
 			baseDB := setupDB(t)
-			db := corruptabledb.New(baseDB.server)
+			db := corruptabledb.New(baseDB.server, logging.NoLog{})
 			defer db.Close()
 			require.NoError(scenario.testFn(db))
 

--- a/node/node.go
+++ b/node/node.go
@@ -770,6 +770,7 @@ func (n *Node) initDatabase() error {
 
 	var err error
 	n.DB, err = databasefactory.New(
+		n.Log,
 		n.Config.DatabaseConfig.Name,
 		dbFullPath,
 		n.Config.DatabaseConfig.ReadOnly,

--- a/vms/rpcchainvm/vm_server.go
+++ b/vms/rpcchainvm/vm_server.go
@@ -183,6 +183,7 @@ func (vm *VMServer) Initialize(ctx context.Context, req *vmpb.InitializeRequest)
 	vm.connCloser.Add(dbClientConn)
 	vm.db = corruptabledb.New(
 		rpcdb.NewClient(rpcdbpb.NewDatabaseClient(dbClientConn)),
+		logging.NoLog{},
 	)
 
 	// TODO: Allow the logger to be configured by the client


### PR DESCRIPTION
## Why this should be merged

Adds visibility to the closure reason in avalanchego's db

## How this works

Adds a log upon hitting an error

## How this was tested

Did not

## Need to be documented in RELEASES.md?

No
