### PR TITLE
Update minimum golang version to v1.23.9

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 To start developing on AvalancheGo, you'll need a few things installed.
 
-- Golang version >= 1.23.6
+- Golang version >= 1.23.9
 - gcc
 - g++
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The minimum recommended hardware specification for nodes connected to Mainnet is
 
 If you plan to build AvalancheGo from source, you will also need the following software:
 
-- [Go](https://golang.org/doc/install) version >= 1.23.6
+- [Go](https://golang.org/doc/install) version >= 1.23.9
 - [gcc](https://gcc.gnu.org/)
 - g++
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ module github.com/ava-labs/avalanchego
 //
 // - If updating between minor versions (e.g. 1.23.x -> 1.24.x):
 //   - Consider updating the version of golangci-lint (in scripts/lint.sh).
-go 1.23.6
+go 1.23.9
 
 require (
 	github.com/DataDog/zstd v1.5.2


### PR DESCRIPTION
## Why this should be merged

Latest golang security release. This doesn't actually impact us (afaik) but we waited for it to come to push the next release, so might as well bump it.

## How this works

Follow the on-screen instructions in the go.mod.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.