### PR TITLE
fix: validate allocations locked amount in genesis to prevent panic

### DIFF
--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -46,6 +46,7 @@ var (
 	errFutureStartTime                 = errors.New("startTime cannot be in the future")
 	errInitialStakeDurationTooLow      = errors.New("initial stake duration is too low")
 	errOverridesStandardNetworkConfig  = errors.New("overrides standard network genesis config")
+	errAllocationsLockedAmountTooLow   = errors.New("total allocations locked amount is too low")
 )
 
 // validateInitialStakedFunds ensures all staked
@@ -113,6 +114,27 @@ func validateInitialStakedFunds(config *Config) error {
 	return nil
 }
 
+// validateAllocationsLockedAmount ensures that the sum of all locked
+// allocation amounts is at least the number of initial stakers.
+func validateAllocationsLockedAmount(config *Config) error {
+	totalLocked := uint64(0)
+	for _, allocation := range config.Allocations {
+		for _, unlock := range allocation.UnlockSchedule {
+			totalLocked += unlock.Amount
+		}
+	}
+	stakersCount := len(config.InitialStakers)
+	if totalLocked < uint64(stakersCount) {
+		return fmt.Errorf(
+			"%w: %d locked < %d stakers",
+			errAllocationsLockedAmountTooLow,
+			totalLocked,
+			stakersCount,
+		)
+	}
+	return nil
+}
+
 // validateConfig returns an error if the provided
 // *Config is not considered valid.
 func validateConfig(networkID uint32, config *Config, stakingCfg *StakingConfig) error {
@@ -171,6 +193,10 @@ func validateConfig(networkID uint32, config *Config, stakingCfg *StakingConfig)
 
 	if err := validateInitialStakedFunds(config); err != nil {
 		return fmt.Errorf("initial staked funds validation failed: %w", err)
+	}
+
+	if err := validateAllocationsLockedAmount(config); err != nil {
+		return err
 	}
 
 	if len(config.CChainGenesis) == 0 {
@@ -533,7 +559,10 @@ func splitAllocations(allocations []Allocation, numSplits int) [][]Allocation {
 		}
 	}
 
-	return append(allNodeAllocations, currentNodeAllocation)
+	if len(currentNodeAllocation) > 0 {
+		allNodeAllocations = append(allNodeAllocations, currentNodeAllocation)
+	}
+	return allNodeAllocations
 }
 
 func VMGenesis(genesisBytes []byte, vmID ids.ID) (*pchaintxs.Tx, error) {

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -559,10 +559,7 @@ func splitAllocations(allocations []Allocation, numSplits int) [][]Allocation {
 		}
 	}
 
-	if len(currentNodeAllocation) > 0 {
-		allNodeAllocations = append(allNodeAllocations, currentNodeAllocation)
-	}
-	return allNodeAllocations
+	return append(allNodeAllocations, currentNodeAllocation)
 }
 
 func VMGenesis(genesisBytes []byte, vmID ids.ID) (*pchaintxs.Tx, error) {

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -121,6 +121,15 @@ func TestValidateConfig(t *testing.T) {
 			}(),
 			expectedErr: errInitialStakeDurationTooLow,
 		},
+		"empty initial staked funds": {
+			networkID: 12345,
+			config: func() *Config {
+				thisConfig := LocalConfig
+				thisConfig.InitialStakedFunds = []ids.ShortID(nil)
+				return &thisConfig
+			}(),
+			expectedErr: errNoInitiallyStakedFunds,
+		},
 		"duplicate initial staked funds": {
 			networkID: 12345,
 			config: func() *Config {

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -33,6 +33,9 @@ var (
 		"networkID": 9999}}}}
 	}`)
 
+	//go:embed genesis_test_invalid_allocations.json
+	customGenesisConfigInvalidAllocationsJSON []byte
+
 	genesisStakingCfg = &StakingConfig{
 		MaxStakeDuration: 365 * 24 * time.Hour,
 	}
@@ -117,29 +120,6 @@ func TestValidateConfig(t *testing.T) {
 				return &thisConfig
 			}(),
 			expectedErr: errInitialStakeDurationTooLow,
-		},
-		"locked allocations amount too low": {
-			networkID: 12345,
-			config: func() *Config {
-				thisConfig := LocalConfig
-				alloc := thisConfig.Allocations[0]
-				alloc.InitialAmount = 1000
-				alloc.UnlockSchedule = []LockedAmount{
-					{Amount: 3, Locktime: 0},
-				}
-				thisConfig.Allocations = []Allocation{alloc}
-				return &thisConfig
-			}(),
-			expectedErr: errAllocationsLockedAmountTooLow,
-		},
-		"empty initial staked funds": {
-			networkID: 12345,
-			config: func() *Config {
-				thisConfig := LocalConfig
-				thisConfig.InitialStakedFunds = []ids.ShortID(nil)
-				return &thisConfig
-			}(),
-			expectedErr: errNoInitiallyStakedFunds,
 		},
 		"duplicate initial staked funds": {
 			networkID: 12345,
@@ -240,6 +220,11 @@ func TestGenesisFromFile(t *testing.T) {
 			networkID:       9999,
 			missingFilepath: "missing.json",
 			expectedErr:     os.ErrNotExist,
+		},
+		"custom (locked allocations amount too low)": {
+			networkID:    9999,
+			customConfig: customGenesisConfigInvalidAllocationsJSON,
+			expectedErr:  errAllocationsLockedAmountTooLow,
 		},
 	}
 

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -118,6 +118,20 @@ func TestValidateConfig(t *testing.T) {
 			}(),
 			expectedErr: errInitialStakeDurationTooLow,
 		},
+		"locked allocations amount too low": {
+			networkID: 12345,
+			config: func() *Config {
+				thisConfig := LocalConfig
+				alloc := thisConfig.Allocations[0]
+				alloc.InitialAmount = 1000
+				alloc.UnlockSchedule = []LockedAmount{
+					{Amount: 3, Locktime: 0},
+				}
+				thisConfig.Allocations = []Allocation{alloc}
+				return &thisConfig
+			}(),
+			expectedErr: errAllocationsLockedAmountTooLow,
+		},
 		"empty initial staked funds": {
 			networkID: 12345,
 			config: func() *Config {

--- a/genesis/genesis_test_invalid_allocations.json
+++ b/genesis/genesis_test_invalid_allocations.json
@@ -1,0 +1,40 @@
+{
+  "networkID": 9999,
+  "allocations": [
+    {
+      "ethAddr": "0x46a9c04f4bf783aa69daabd519dcf36978168b66",
+      "avaxAddr": "X-custom1g65uqn6t77p656w64023nh8nd9updzmxwd59gh",
+      "initialAmount": 22,
+      "unlockSchedule": [
+        {
+          "amount": 2,
+          "unlockTime": 1660987200
+        }
+      ]
+    }
+  ],
+  "startTime": 1660987200,
+  "initialStakeDuration": 31536000,
+  "initialStakedFunds": [
+    "X-custom1g65uqn6t77p656w64023nh8nd9updzmxwd59gh"
+  ],
+  "initialStakers": [
+    {
+      "nodeID": "NodeID-7gX65ndj8b6UA7uMp4vjQq3FcaC6aqY3Z",
+      "rewardAddress": "X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p",
+      "delegationFee": 5000
+    },
+    {
+      "nodeID": "NodeID-BW6UnRcxVBvFB4LTfdt8BpBaaw4Vt7ZeR",
+      "rewardAddress": "X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p",
+      "delegationFee": 5001
+    },
+    {
+      "nodeID": "NodeID-NAyhSLKgrm4Bxd49e5dUwooDDdrStRaj5",
+      "rewardAddress": "X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p",
+      "delegationFee": 5002
+    }
+  ],
+  "cChainGenesis": "{\"config\":{\"chainId\":43112}}",
+  "message": ""
+}


### PR DESCRIPTION
## Why this should be merged

Prevents panics when the allocations locked amount in genesis cannot be split across the initial stakers.
Fixes #3901

## How this works

Add `validateLockedAllocationsAmount` to genesis `validateConfig`

## How this was tested

Manually tested via `avalanchego --genesis-file=` and new unit test.

## Need to be documented in RELEASES.md?

