### PR TITLE
Add Load Framework

### DIFF
--- a/tests/load/agent.go
+++ b/tests/load/agent.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package load
+
+type Agent[T, U comparable] struct {
+	Issuer   Issuer[T]
+	Listener Listener[T]
+	Tracker  Tracker[U]
+}
+
+func NewAgent[T, U comparable](
+	issuer Issuer[T],
+	listener Listener[T],
+	tracker Tracker[U],
+) Agent[T, U] {
+	return Agent[T, U]{
+		Issuer:   issuer,
+		Listener: listener,
+		Tracker:  tracker,
+	}
+}
+
+func GetTotalObservedConfirmed[T, U comparable](agents []Agent[T, U]) uint64 {
+	total := uint64(0)
+	for _, agent := range agents {
+		total += agent.Tracker.GetObservedConfirmed()
+	}
+	return total
+}

--- a/tests/load/dependencies.go
+++ b/tests/load/dependencies.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package load
+
+import (
+	"context"
+)
+
+type Issuer[T comparable] interface {
+	// GenerateAndIssueTx generates and sends a tx to the network, and informs the
+	// tracker that it sent said transaction. It returns the sent transaction.
+	GenerateAndIssueTx(ctx context.Context) (tx T, err error)
+}
+
+type Listener[T comparable] interface {
+	// Listen for the final status of transactions and notify the tracker
+	// Listen stops if the context is done, an error occurs, or if it received
+	// all the transactions issued and the issuer no longer issues any.
+	// Listen MUST return a nil error if the context is canceled.
+	Listen(ctx context.Context) error
+
+	// RegisterIssued informs the listener that a transaction was issued.
+	RegisterIssued(tx T)
+
+	// IssuingDone informs the listener that no more transactions will be issued.
+	IssuingDone()
+}
+
+// Tracker keeps track of the status of transactions.
+// This must be thread-safe, so it can be called in parallel by the issuer(s) or orchestrator.
+type Tracker[T comparable] interface {
+	// Issue records a transaction that was submitted, but whose final status is
+	// not yet known.
+	Issue(T)
+	// ObserveConfirmed records a transaction that was confirmed.
+	ObserveConfirmed(T)
+	// ObserveFailed records a transaction that failed (e.g. expired)
+	ObserveFailed(T)
+
+	// GetObservedIssued returns the number of transactions that the tracker has
+	// confirmed were issued.
+	GetObservedIssued() uint64
+	// GetObservedConfirmed returns the number of transactions that the tracker has
+	// confirmed were accepted.
+	GetObservedConfirmed() uint64
+	// GetObservedFailed returns the number of transactions that the tracker has
+	// confirmed failed.
+	GetObservedFailed() uint64
+}
+
+// orchestrator executes the load test by coordinating the issuers to send
+// transactions, in a manner depending on the implementation.
+type orchestrator interface {
+	// Execute the load test
+	Execute(ctx context.Context) error
+}

--- a/tests/load/gradual_orchestrator.go
+++ b/tests/load/gradual_orchestrator.go
@@ -1,0 +1,268 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package load
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	_ orchestrator = (*GradualOrchestrator[any, any])(nil)
+
+	ErrFailedToReachTargetTPS = errors.New("failed to reach target TPS")
+)
+
+type GradualOrchestratorConfig struct {
+	// The maximum TPS the orchestrator should aim for.
+	MaxTPS uint64
+	// The minimum TPS the orchestrator should start with.
+	MinTPS uint64
+	// The step size to increase the TPS by.
+	Step uint64
+
+	// The factor by which to pad the number of txs an issuer sends per second
+	// for example, if targetTPS = 1000 and numIssuers = 10, then each issuer
+	// will send (1000/10)*TxRateMultiplier transactions per second.
+	//
+	// Maintaining a multiplier above target provides a toggle to keep load
+	// persistently above instead of below target. This ensures load generation
+	// does not pause issuance at the target and persistently under-issue and
+	// fail to account for the time it takes to add more load.
+	TxRateMultiplier float64
+
+	// The time period which TPS is averaged over
+	// Similarly, the time period which the orchestrator will wait before
+	// computing the average TPS.
+	SustainedTime time.Duration
+	// The number of attempts to try achieving a given target TPS before giving up.
+	MaxAttempts uint64
+
+	// Whether the orchestrator should return if the maxTPS has been reached
+	Terminate bool
+}
+
+func DefaultGradualOrchestratorConfig() GradualOrchestratorConfig {
+	return GradualOrchestratorConfig{
+		MaxTPS:           5_000,
+		MinTPS:           1_000,
+		Step:             1_000,
+		TxRateMultiplier: 1.3,
+		SustainedTime:    20 * time.Second,
+		MaxAttempts:      3,
+		Terminate:        true,
+	}
+}
+
+// GradualOrchestrator tests the network by continuously sending
+// transactions at a given rate (currTargetTPS) and increasing that rate until it detects that
+// the network can no longer make progress (i.e. the rate at the network accepts
+// transactions is less than currTargetTPS).
+type GradualOrchestrator[T, U comparable] struct {
+	agents []Agent[T, U]
+
+	log logging.Logger
+
+	maxObservedTPS atomic.Uint64
+
+	observerGroup errgroup.Group
+	issuerGroup   *errgroup.Group
+
+	config GradualOrchestratorConfig
+}
+
+func NewGradualOrchestrator[T, U comparable](
+	agents []Agent[T, U],
+	log logging.Logger,
+	config GradualOrchestratorConfig,
+) (*GradualOrchestrator[T, U], error) {
+	return &GradualOrchestrator[T, U]{
+		agents: agents,
+		log:    log,
+		config: config,
+	}, nil
+}
+
+func (o *GradualOrchestrator[T, U]) Execute(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+
+	// start a goroutine to confirm each issuer's transactions
+	for _, agent := range o.agents {
+		o.observerGroup.Go(func() error { return agent.Listener.Listen(ctx) })
+	}
+
+	// start the test and block until it's done
+	success := o.run(ctx)
+
+	var err error
+	if !success {
+		err = ErrFailedToReachTargetTPS
+	}
+
+	// stop the observers and issuers
+	cancel()
+
+	// block until both the observers and issuers have stopped
+	return errors.Join(o.issuerGroup.Wait(), o.observerGroup.Wait(), err)
+}
+
+// run the gradual load test by continuously increasing the rate at which
+// transactions are sent
+//
+// run blocks until one of the following conditions is met:
+//
+// 1. an issuer has errored
+// 2. the max TPS target has been reached and we can terminate
+// 3. the maximum number of attempts to reach a target TPS has been reached
+func (o *GradualOrchestrator[T, U]) run(ctx context.Context) bool {
+	var (
+		prevConfirmed        = GetTotalObservedConfirmed(o.agents)
+		prevTime             = time.Now()
+		currTargetTPS        = new(atomic.Uint64)
+		attempts      uint64 = 1
+		// true if the orchestrator has reached the max TPS target
+		achievedTargetTPS bool
+	)
+
+	currTargetTPS.Store(o.config.MinTPS)
+
+	issuerGroup, issuerCtx := errgroup.WithContext(ctx)
+	o.issuerGroup = issuerGroup
+
+	o.issueTxs(issuerCtx, currTargetTPS)
+
+	for {
+		// wait for the sustained time to pass or for the context to be cancelled
+		select {
+		case <-time.After(o.config.SustainedTime):
+		case <-issuerCtx.Done(): // the parent context was cancelled or an issuer errored
+		}
+
+		if issuerCtx.Err() != nil {
+			break // Case 1
+		}
+
+		currConfirmed := GetTotalObservedConfirmed(o.agents)
+		currTime := time.Now()
+
+		tps := computeTPS(prevConfirmed, currConfirmed, currTime.Sub(prevTime))
+		o.setMaxObservedTPS(tps)
+
+		// if max TPS target has been reached and we don't terminate, then continue here
+		// so we do not keep increasing the target TPS
+		if achievedTargetTPS && !o.config.Terminate {
+			o.log.Info(
+				"current network state",
+				zap.Uint64("current TPS", tps),
+				zap.Uint64("max observed TPS", o.maxObservedTPS.Load()),
+			)
+			continue
+		}
+
+		if tps >= currTargetTPS.Load() {
+			if currTargetTPS.Load() >= o.config.MaxTPS {
+				achievedTargetTPS = true
+				o.log.Info(
+					"max TPS target reached",
+					zap.Uint64("max TPS target", currTargetTPS.Load()),
+					zap.Uint64("average TPS", tps),
+				)
+				if o.config.Terminate {
+					o.log.Info("terminating orchestrator")
+					break // Case 2
+				} else {
+					o.log.Info("orchestrator will now continue running at max TPS")
+					continue
+				}
+			}
+			o.log.Info(
+				"increasing TPS",
+				zap.Uint64("previous target TPS", currTargetTPS.Load()),
+				zap.Uint64("average TPS", tps),
+				zap.Uint64("new target TPS", currTargetTPS.Load()+o.config.Step),
+			)
+			currTargetTPS.Add(o.config.Step)
+			attempts = 1
+		} else {
+			if attempts >= o.config.MaxAttempts {
+				o.log.Info(
+					"max attempts reached",
+					zap.Uint64("attempted target TPS", currTargetTPS.Load()),
+					zap.Uint64("number of attempts", attempts),
+				)
+				break // Case 3
+			}
+			o.log.Info(
+				"failed to reach target TPS, retrying",
+				zap.Uint64("current target TPS", currTargetTPS.Load()),
+				zap.Uint64("average TPS", tps),
+				zap.Uint64("attempt number", attempts),
+			)
+			attempts++
+		}
+
+		prevConfirmed = currConfirmed
+		prevTime = currTime
+	}
+
+	return achievedTargetTPS
+}
+
+// GetObservedIssued returns the max TPS the orchestrator observed
+func (o *GradualOrchestrator[T, U]) GetMaxObservedTPS() uint64 {
+	return o.maxObservedTPS.Load()
+}
+
+// start a goroutine to each issuer to continuously send transactions
+// if an issuer errors, all other issuers will stop as well.
+func (o *GradualOrchestrator[T, U]) issueTxs(ctx context.Context, currTargetTPS *atomic.Uint64) {
+	for _, agent := range o.agents {
+		o.issuerGroup.Go(func() error {
+			for {
+				if ctx.Err() != nil {
+					return nil //nolint:nilerr
+				}
+				currTime := time.Now()
+				txsPerIssuer := uint64(math.Ceil(float64(currTargetTPS.Load())/float64(len(o.agents))) * o.config.TxRateMultiplier)
+				// always listen until listener context is cancelled, do not call agent.Listener.IssuingDone().
+				for range txsPerIssuer {
+					tx, err := agent.Issuer.GenerateAndIssueTx(ctx)
+					if err != nil {
+						return err
+					}
+					agent.Listener.RegisterIssued(tx)
+				}
+				diff := time.Second - time.Since(currTime)
+				if diff > 0 {
+					time.Sleep(diff)
+				}
+			}
+		})
+	}
+}
+
+// setMaxObservedTPS only if tps > the current max observed TPS.
+func (o *GradualOrchestrator[T, U]) setMaxObservedTPS(tps uint64) {
+	if tps > o.maxObservedTPS.Load() {
+		o.maxObservedTPS.Store(tps)
+	}
+}
+
+func computeTPS(initial uint64, final uint64, duration time.Duration) uint64 {
+	if duration <= 0 {
+		return 0
+	}
+
+	numTxs := final - initial
+	tps := float64(numTxs) / duration.Seconds()
+
+	return uint64(tps)
+}

--- a/tests/load/gradual_orchestrator_test.go
+++ b/tests/load/gradual_orchestrator_test.go
@@ -1,0 +1,202 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package load
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+var _ Issuer[ids.ID] = (*mockIssuer)(nil)
+
+func TestGradualOrchestratorTPS(t *testing.T) {
+	tests := []struct {
+		name        string
+		serverTPS   uint64
+		config      GradualOrchestratorConfig
+		expectedErr error
+	}{
+		{
+			name:      "orchestrator achieves max TPS",
+			serverTPS: math.MaxUint64,
+			config: GradualOrchestratorConfig{
+				MaxTPS:           2_000,
+				MinTPS:           1_000,
+				Step:             1_000,
+				TxRateMultiplier: 1.5,
+				SustainedTime:    time.Second,
+				MaxAttempts:      2,
+				Terminate:        true,
+			},
+		},
+		{
+			name:      "orchestrator TPS limited by network",
+			serverTPS: 1_000,
+			config: GradualOrchestratorConfig{
+				MaxTPS:           2_000,
+				MinTPS:           1_000,
+				Step:             1_000,
+				TxRateMultiplier: 1.3,
+				SustainedTime:    time.Second,
+				MaxAttempts:      2,
+				Terminate:        true,
+			},
+			expectedErr: ErrFailedToReachTargetTPS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tracker, err := NewPrometheusTracker[ids.ID](prometheus.NewRegistry())
+			r.NoError(err)
+
+			agents := []Agent[ids.ID, ids.ID]{
+				NewAgent(
+					&mockIssuer{
+						generateTxF: func() (ids.ID, error) {
+							return ids.GenerateTestID(), nil
+						},
+						tracker: tracker,
+						maxTxs:  tt.serverTPS,
+					},
+					&mockListener{},
+					tracker,
+				),
+			}
+
+			orchestrator, err := NewGradualOrchestrator(
+				agents,
+				logging.NoLog{},
+				tt.config,
+			)
+			r.NoError(err)
+
+			r.ErrorIs(orchestrator.Execute(ctx), tt.expectedErr)
+
+			if tt.expectedErr == nil {
+				r.GreaterOrEqual(orchestrator.GetMaxObservedTPS(), tt.config.MaxTPS)
+			} else {
+				r.Less(orchestrator.GetMaxObservedTPS(), tt.config.MaxTPS)
+			}
+		})
+	}
+}
+
+// test that the orchestrator returns early if the txGenerators or the issuers error
+func TestGradualOrchestratorExecution(t *testing.T) {
+	var (
+		errMockTxGenerator = errors.New("mock tx generator error")
+		errMockIssuer      = errors.New("mock issuer error")
+	)
+
+	tracker, err := NewPrometheusTracker[ids.ID](prometheus.NewRegistry())
+	require.NoError(t, err, "creating tracker")
+
+	tests := []struct {
+		name        string
+		agents      []Agent[ids.ID, ids.ID]
+		expectedErr error
+	}{
+		{
+			name: "generator error",
+			agents: []Agent[ids.ID, ids.ID]{
+				NewAgent[ids.ID, ids.ID](
+					&mockIssuer{
+						generateTxF: func() (ids.ID, error) {
+							return ids.Empty, errMockTxGenerator
+						},
+					},
+					&mockListener{},
+					tracker,
+				),
+			},
+			expectedErr: errMockTxGenerator,
+		},
+		{
+			name: "issuer error",
+			agents: []Agent[ids.ID, ids.ID]{
+				NewAgent[ids.ID, ids.ID](
+					&mockIssuer{
+						generateTxF: func() (ids.ID, error) {
+							return ids.GenerateTestID(), nil
+						},
+						issueTxErr: errMockIssuer,
+					},
+					&mockListener{},
+					tracker,
+				),
+			},
+			expectedErr: errMockIssuer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			orchestrator, err := NewGradualOrchestrator(
+				tt.agents,
+				logging.NoLog{},
+				DefaultGradualOrchestratorConfig(),
+			)
+			r.NoError(err)
+
+			r.ErrorIs(orchestrator.Execute(ctx), tt.expectedErr)
+		})
+	}
+}
+
+type mockIssuer struct {
+	generateTxF   func() (ids.ID, error)
+	currTxsIssued uint64
+	maxTxs        uint64
+	tracker       Tracker[ids.ID]
+	issueTxErr    error
+}
+
+// GenerateAndIssueTx immediately generates, issues and confirms a tx.
+// To simulate TPS, the number of txs IssueTx can issue/confirm is capped by maxTxs
+func (m *mockIssuer) GenerateAndIssueTx(_ context.Context) (ids.ID, error) {
+	id, err := m.generateTxF()
+	if err != nil {
+		return id, err
+	}
+
+	if m.issueTxErr != nil {
+		return ids.ID{}, m.issueTxErr
+	}
+
+	if m.currTxsIssued >= m.maxTxs {
+		return ids.ID{}, nil
+	}
+
+	m.tracker.Issue(id)
+	m.tracker.ObserveConfirmed(id)
+	m.currTxsIssued++
+	return id, nil
+}
+
+type mockListener struct{}
+
+func (*mockListener) Listen(context.Context) error {
+	return nil
+}
+
+func (*mockListener) RegisterIssued(ids.ID) {}
+
+func (*mockListener) IssuingDone() {}

--- a/tests/load/prometheus_tracker.go
+++ b/tests/load/prometheus_tracker.go
@@ -1,0 +1,121 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package load
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const namespace = "load"
+
+var _ Tracker[any] = (*PrometheusTracker[any])(nil)
+
+type PrometheusTracker[T comparable] struct {
+	lock sync.RWMutex
+
+	outstandingTxs map[T]time.Time
+
+	txsIssued    uint64
+	txsConfirmed uint64
+	txsFailed    uint64
+
+	// metrics
+	txsIssuedCounter    prometheus.Counter
+	txsConfirmedCounter prometheus.Counter
+	txsFailedCounter    prometheus.Counter
+	txLatency           prometheus.Histogram
+}
+
+func NewPrometheusTracker[T comparable](reg *prometheus.Registry) (*PrometheusTracker[T], error) {
+	prometheusTracker := &PrometheusTracker[T]{
+		outstandingTxs: make(map[T]time.Time),
+		txsIssuedCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "txs_issued",
+			Help:      "Number of transactions issued",
+		}),
+		txsConfirmedCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "txs_confirmed",
+			Help:      "Number of transactions confirmed",
+		}),
+		txsFailedCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "txs_failed",
+			Help:      "Number of transactions failed",
+		}),
+		txLatency: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "tx_latency",
+			Help:      "Latency of transactions",
+		}),
+	}
+
+	errs := wrappers.Errs{}
+	errs.Add(
+		reg.Register(prometheusTracker.txsIssuedCounter),
+		reg.Register(prometheusTracker.txsConfirmedCounter),
+		reg.Register(prometheusTracker.txsFailedCounter),
+		reg.Register(prometheusTracker.txLatency),
+	)
+	return prometheusTracker, errs.Err
+}
+
+func (p *PrometheusTracker[T]) GetObservedConfirmed() uint64 {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.txsConfirmed
+}
+
+func (p *PrometheusTracker[T]) GetObservedFailed() uint64 {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.txsFailed
+}
+
+func (p *PrometheusTracker[T]) GetObservedIssued() uint64 {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.txsIssued
+}
+
+func (p *PrometheusTracker[T]) Issue(tx T) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.outstandingTxs[tx] = time.Now()
+	p.txsIssued++
+	p.txsIssuedCounter.Inc()
+}
+
+func (p *PrometheusTracker[T]) ObserveConfirmed(tx T) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	startTime := p.outstandingTxs[tx]
+	delete(p.outstandingTxs, tx)
+
+	p.txsConfirmed++
+	p.txsConfirmedCounter.Inc()
+	p.txLatency.Observe(float64(time.Since(startTime).Milliseconds()))
+}
+
+func (p *PrometheusTracker[T]) ObserveFailed(tx T) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	startTime := p.outstandingTxs[tx]
+	delete(p.outstandingTxs, tx)
+
+	p.txsFailed++
+	p.txsFailedCounter.Inc()
+	p.txLatency.Observe(float64(time.Since(startTime).Milliseconds()))
+}


### PR DESCRIPTION
## Why this should be merged

This PR migrates the load framework from the HyperSDK to AvalancheGo, enabling its usage in both the HyperSDK and any other project (e.g. Coreth, Subnet-EVM, etc.) which wishes to benchmark its TPS numbers.

## How this works

Migration of code from HyperSDK to AvalancheGo.

## How this was tested

Both the gradual and burst orchestrators were tested against HyperVMs in the HyperSDK. Furthermore, we have UTs for the gradual orchestrator.

## Need to be documented in RELEASES.md?

No
