### PR TITLE
[tmpnet] Define reusable flags for configuring kubernetes client access

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,6 +89,10 @@ tasks:
     desc: Generates protobuf
     cmd: ./scripts/protobuf_codegen.sh
 
+  ginkgo-build:
+    desc: Runs ginkgo against the current working directory
+    cmd: ./bin/ginkgo build {{.USER_WORKING_DIR}}
+
   install-nix:
     desc: Installs nix with the determinate systems installer
     cmd: curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install

--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742512142,
-        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
-        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
-        "revCount": 715908,
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "revCount": 716288,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.715908%2Brev-7105ae3957700a9646cc4b766f5815b23ed0c682/0195b8ff-82a6-7d19-b362-1f70dcb1c7f7/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716288%2Brev-d02d88f8de5b882ccdde0465d8fa2db3aa1169f7/0195d574-d7fe-7866-9aa3-2e5ea0618cf6/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
 
             # Kube tools
             kubectl                                    # Kubernetes CLI
+            k9s                                        # Kubernetes TUI
             kind                                       # Kubernetes-in-Docker
             kubernetes-helm                            # Helm CLI (Kubernetes package manager)
             self.packages.${system}.kind-with-registry # Script installing kind configured with a local registry

--- a/scripts/start_kind_cluster.sh
+++ b/scripts/start_kind_cluster.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# --kubeconfig and --kubeconfig-context should be provided in the form --arg=value
+# to work with the simplistic mechanism enabling flag reuse.
+
 # Enable reuse of the arguments to ginkgo relevant to starting a cluster
 START_CLUSTER_ARGS=()
 for arg in "$@"; do

--- a/scripts/start_kind_cluster.sh
+++ b/scripts/start_kind_cluster.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Enable reuse of the arguments to ginkgo relevant to starting a cluster
+START_CLUSTER_ARGS=()
+for arg in "$@"; do
+  if [[ "${arg}" =~ "--kubeconfig" || "${arg}" =~ "--kubeconfig-context" ]]; then
+    START_CLUSTER_ARGS+=("${arg}")
+  fi
+done
+./bin/tmpnetctl start-kind-cluster "${START_CLUSTER_ARGS[@]}"

--- a/scripts/start_kind_cluster.sh
+++ b/scripts/start_kind_cluster.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Enable reuse of the arguments to ginkgo relevant to starting a cluster
 START_CLUSTER_ARGS=()
 for arg in "$@"; do
-  if [[ "${arg}" =~ "--kubeconfig" || "${arg}" =~ "--kubeconfig-context" ]]; then
+  if [[ "${arg}" =~ "--kubeconfig=" || "${arg}" =~ "--kubeconfig-context=" ]]; then
     START_CLUSTER_ARGS+=("${arg}")
   fi
 done

--- a/scripts/tests.e2e.bootstrap_monitor.sh
+++ b/scripts/tests.e2e.bootstrap_monitor.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 # Run e2e tests for bootstrap monitor.
+#
+# --kubeconfig and --kubeconfig-context should be provided in the form --arg=value
+# to work with the simplistic mechanism enabling flag reuse.
 
 if ! [[ "$0" =~ scripts/tests.e2e.bootstrap_monitor.sh ]]; then
   echo "must be run from repository root"

--- a/scripts/tests.e2e.bootstrap_monitor.sh
+++ b/scripts/tests.e2e.bootstrap_monitor.sh
@@ -9,6 +9,5 @@ if ! [[ "$0" =~ scripts/tests.e2e.bootstrap_monitor.sh ]]; then
   exit 255
 fi
 
-./bin/tmpnetctl start-kind-cluster
-
-KUBECONFIG="$HOME/.kube/config" ./bin/ginkgo -v ./tests/fixture/bootstrapmonitor/e2e
+./scripts/start_kind_cluster.sh "$@"
+./bin/ginkgo -v ./tests/fixture/bootstrapmonitor/e2e "$@"

--- a/tests/fixture/bootstrapmonitor/common.go
+++ b/tests/fixture/bootstrapmonitor/common.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet/flags"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/version"
 
@@ -221,6 +222,6 @@ func getLatestImageDetails(
 
 func getClientset(log logging.Logger) (*kubernetes.Clientset, error) {
 	log.Info("Initializing clientset")
-	kubeConfigPath := os.Getenv("KUBECONFIG")
+	kubeConfigPath := os.Getenv(flags.KubeConfigPathEnvVar)
 	return tmpnet.GetClientset(log, kubeConfigPath, "")
 }

--- a/tests/fixture/bootstrapmonitor/common.go
+++ b/tests/fixture/bootstrapmonitor/common.go
@@ -222,6 +222,6 @@ func getLatestImageDetails(
 
 func getClientset(log logging.Logger) (*kubernetes.Clientset, error) {
 	log.Info("Initializing clientset")
-	kubeConfigPath := os.Getenv(flags.KubeConfigPathEnvVar)
-	return tmpnet.GetClientset(log, kubeConfigPath, "")
+	kubeconfigPath := os.Getenv(flags.KubeconfigPathEnvVar)
+	return tmpnet.GetClientset(log, kubeconfigPath, "")
 }

--- a/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
+++ b/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ava-labs/avalanchego/tests/fixture/bootstrapmonitor"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet/flags"
 	"github.com/ava-labs/avalanchego/utils/constants"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -60,6 +61,7 @@ const (
 )
 
 var (
+	kubeconfigVars            *flags.KubeconfigVars
 	skipAvalanchegoImageBuild bool
 	skipMonitorImageBuild     bool
 
@@ -67,6 +69,7 @@ var (
 )
 
 func init() {
+	kubeconfigVars = flags.NewKubeconfigFlagVars()
 	flag.BoolVar(
 		&skipAvalanchegoImageBuild,
 		"skip-avalanchego-image-build",
@@ -103,8 +106,7 @@ var _ = ginkgo.Describe("[Bootstrap Tester]", func() {
 		}
 
 		ginkgo.By("Configuring a kubernetes client")
-		kubeconfigPath := os.Getenv("KUBECONFIG")
-		kubeconfig, err := tmpnet.GetClientConfig(tc.Log(), kubeconfigPath, "")
+		kubeconfig, err := tmpnet.GetClientConfig(tc.Log(), kubeconfigVars.Path, kubeconfigVars.Context)
 		require.NoError(err)
 		clientset, err := kubernetes.NewForConfig(kubeconfig)
 		require.NoError(err)

--- a/tests/fixture/tmpnet/flags/kube_config.go
+++ b/tests/fixture/tmpnet/flags/kube_config.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package flags
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+)
+
+const KubeConfigPathEnvVar = "KUBECONFIG"
+
+type KubeconfigVars struct {
+	Path    string
+	Context string
+}
+
+// NewKubeconfigFlagVars registers kubeconfig flag variables for stdlib flag
+func NewKubeconfigFlagVars() *KubeconfigVars {
+	return newKubeconfigFlagVars("")
+}
+
+// internal method enabling configuration of the doc prefix
+func newKubeconfigFlagVars(docPrefix string) *KubeconfigVars {
+	v := &KubeconfigVars{}
+	v.register(flag.StringVar, docPrefix)
+	return v
+}
+
+// NewKubeconfigFlagSetVars registers kubeconfig flag variables for pflag
+func NewKubeconfigFlagSetVars(flagSet *pflag.FlagSet) *KubeconfigVars {
+	return newKubeconfigFlagSetVars(flagSet, "")
+}
+
+// internal method enabling configuration of the doc prefix
+func newKubeconfigFlagSetVars(flagSet *pflag.FlagSet, docPrefix string) *KubeconfigVars {
+	v := &KubeconfigVars{}
+	v.register(flagSet.StringVar, docPrefix)
+	return v
+}
+
+func (v *KubeconfigVars) register(stringVar varFunc[string], docPrefix string) {
+	stringVar(
+		&v.Path,
+		"kubeconfig",
+		tmpnet.GetEnvWithDefault(KubeConfigPathEnvVar, os.ExpandEnv("$HOME/.kube/config")),
+		docPrefix+fmt.Sprintf(
+			"The path to a kubernetes configuration file for the target cluster. Also possible to configure via the %s env variable.",
+			KubeConfigPathEnvVar,
+		),
+	)
+	stringVar(
+		&v.Context,
+		"kubeconfig-context",
+		"",
+		docPrefix+"The optional kubeconfig context to use",
+	)
+}

--- a/tests/fixture/tmpnet/flags/kubeconfig.go
+++ b/tests/fixture/tmpnet/flags/kubeconfig.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 )
 
-const KubeConfigPathEnvVar = "KUBECONFIG"
+const KubeconfigPathEnvVar = "KUBECONFIG"
 
 type KubeconfigVars struct {
 	Path    string
@@ -48,10 +48,10 @@ func (v *KubeconfigVars) register(stringVar varFunc[string], docPrefix string) {
 	stringVar(
 		&v.Path,
 		"kubeconfig",
-		tmpnet.GetEnvWithDefault(KubeConfigPathEnvVar, os.ExpandEnv("$HOME/.kube/config")),
+		tmpnet.GetEnvWithDefault(KubeconfigPathEnvVar, os.ExpandEnv("$HOME/.kube/config")),
 		docPrefix+fmt.Sprintf(
 			"The path to a kubernetes configuration file for the target cluster. Also possible to configure via the %s env variable.",
-			KubeConfigPathEnvVar,
+			KubeconfigPathEnvVar,
 		),
 	)
 	stringVar(


### PR DESCRIPTION
## PR Chain: tmpnet+kube

This PR chain enables tmpnet to deploy temporary networks to Kubernetes. Early PRs refactor tmpnet to support the addition in #3615 of a new tmpnet node runtime for kube.  

- #3854
- #3857
- #3870
- #3877
- #3867
- #3871
- #3881
- #3890
- #3884
- #3893
- #3894
- #3896
- #3897
- #3898
- #3882
- - **>>>>>>** #3945 **<<<<<<**  
- #3947
- #3615
- #3794 

## Why this should be merged

Previously `tmpnetctl start-kind-cluster` and the bootstrap-monitor determined their kubeconfig and context separately. Simpler to do it one way and this will be reusable by the kube node runtime.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A