### PR TITLE
[tmpnet] Separate start of prometheus and promtail collectors

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -67,9 +67,10 @@ runs:
       # --impure ensures the env vars are accessible to the command
       run: ${{ inputs.run_env }} ${{ github.action_path }}/nix-develop.sh --impure --command bash -x ${{ inputs.run }}
       env:
-        TMPNET_START_METRIC_COLLECTOR: ${{ inputs.prometheus_username != '' }}
-        TMPNET_START_LOG_COLLECTOR: ${{ inputs.loki_username != '' }}
-        TMPNET_CHECK_MONITORING: ${{ inputs.prometheus_username != '' }}
+        TMPNET_START_METRICS_COLLECTOR: ${{ inputs.prometheus_username != '' }}
+        TMPNET_START_LOGS_COLLECTOR: ${{ inputs.loki_username != '' }}
+        TMPNET_CHECK_METRICS_COLLECTED: ${{ inputs.prometheus_username != '' }}
+        TMPNET_CHECK_LOGS_COLLECTED: ${{ inputs.loki_username != '' }}
         LOKI_USERNAME: ${{ inputs.loki_username }}
         LOKI_PASSWORD: ${{ inputs.loki_password }}
         PROMETHEUS_USERNAME: ${{ inputs.prometheus_username }}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -113,9 +113,10 @@ E2E_SKIP_BOOTSTRAP_CHECKS=1 ./bin/ginkgo -v ./tests/e2e ...
 It is possible to enable collection of logs and metrics from the
 temporary networks used for e2e testing by:
 
- - Supplying `--start-collectors` as an argument to the test suite
+ - Supplying `--start-metrics-collector` and `--start-logs-collector`
+   as arguments to the test suite
  - Starting collectors in advance of a test run with `tmpnetctl
-   start-collectors`
+   start-metrics-collector` and ` tmpnetctl start-logs-collector`
 
 Both methods require:
 
@@ -126,11 +127,11 @@ Both methods require:
    - `LOKI_PASSWORD`
  - The availability in the path of binaries for promtail and prometheus
    - Starting a development shell with `nix develop` is one way to
-     ensure this and requires the [installation of
-     nix](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#install-nix).
+     ensure this and requires the installation of nix
+     (e.g. `./scripts/run_task.sh install-nix`).
 
 Once started, the collectors will continue to run in the background
-until stopped by `tmpnetctl stop-collectors`.
+until stopped by `tmpnetctl stop-metrics-collector` and `tmpnetctl stop-logs-collector`.
 
 The results of collection will be viewable at
 https://grafana-poc.avax-dev.network.

--- a/tests/fixture/tmpnet/README.md
+++ b/tests/fixture/tmpnet/README.md
@@ -28,10 +28,9 @@ orchestrate the same temporary networks without the use of an rpc daemon.
     - [Process details](#process-details)
 - [Monitoring](#monitoring)
   - [Example usage](#example-usage)
-  - [Starting collectors](#starting-collectors)
-  - [Stopping collectors](#stopping-collectors)
-  - [Metrics collection](#metrics-collection)
-  - [Log collection](#log-collection)
+  - [Running collectors](#running-collectors)
+  - [Metric collection configuration](#metric-collection-configuration)
+  - [Log collection configuration](#log-collection-configuration)
   - [Labels](#labels)
   - [CI Collection](#ci-collection)
   - [Viewing](#viewing)
@@ -332,49 +331,50 @@ PROMETHEUS_USERNAME=<username> \
 PROMETHEUS_PASSWORD=<password> \
 LOKI_USERNAME=<username> \
 LOKI_PASSWORD=<password> \
-./bin/tmpnetctl start-collectors
+./bin/tmpnetctl start-metrics-collector
+./bin/tmpnetctl start-logs-collector
 
 # Network start emits link to grafana displaying collected logs and metrics
 ./bin/tmpnetctl start-network
 
 # When done with the network, stop the collectors
-./bin/tmpnetctl stop-collectors
+./bin/tmpnetctl stop-metrics-collector
+./bin/tmpnetctl stop-logs-collector
 ```
 
-### Starting collectors
+### Running collectors
 [Top](#table-of-contents)
 
-Collectors for logs and metrics can be started by `tmpnetctl
-start-collectors`:
+ - `tmpnetctl start-metrics-collector` starts `prometheus` in agent mode
+   configured to scrape metrics from configured nodes and forward
+   them to https://prometheus-poc.avax-dev.network.
+   - Requires:
+     - Credentials supplied as env vars:
+       - `PROMETHEUS_USERNAME`
+       - `PROMETHEUS_PASSWORD`
+     - A `prometheus` binary available in the path
+   - Once started, `prometheus` can be stopped by `tmpnetctl stop-metrics-collector`
+ - `tmpnetctl start-logs-collector` starts `promtail` configured to collect logs
+   from configured nodes and forward them to
+   https://loki-poc.avax-dev.network.
+   - Requires:
+     - Credentials supplied as env vars:
+       - `LOKI_USERNAME`
+       - `LOKI_PASSWORD`
+     - A `promtail` binary available in the path
+   - Once started, `promtail` can be stopped by `tmpnetctl stop-logs-collector`
+ - Starting a development shell with `nix develop` is one way to
+   ensure availability of the necessary binaries and requires the
+   installation of nix (e.g. `./scripts/run_task.sh install-nix`).
 
- - Requires that the following env vars be set
-   - `PROMETHEUS_USERNAME`
-   - `PROMETHEUS_PASSWORD`
-   - `LOKI_USERNAME`
-   - `LOKI_PASSWORD`
- - Requires that binaries for promtail and prometheus be available in the path
-   - Starting a development shell with `nix develop` is one way to
-     ensure this and requires the [installation of
-     nix](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#install-nix).
- - Starts prometheus in agent mode configured to scrape metrics from
-   configured nodes and forward them to
-   https://prometheus-poc.avax-dev.network.
- - Starts promtail configured to collect logs from configured nodes
-   and forward them to https://loki-poc.avax-dev.network.
-
-### Stopping collectors
-
-Collectors for logs and metrics can be stopped by `tmpnetctl
-stop-collectors`:
-
-### Metrics collection
+### Metric collection configuration
 [Top](#table-of-contents)
 
 When a node is started, configuration enabling collection of metrics
 from the node is written to
 `~/.tmpnet/prometheus/file_sd_configs/[network uuid]-[node id].json`.
 
-### Log collection
+### Log collection configuration
 [Top](#table-of-contents)
 
 Nodes log are stored at `~/.tmpnet/networks/[network id]/[node

--- a/tests/fixture/tmpnet/check_monitoring.go
+++ b/tests/fixture/tmpnet/check_monitoring.go
@@ -28,16 +28,6 @@ import (
 
 type getCountFunc func() (int, error)
 
-// CheckMonitoring checks if logs and metrics exist for the given network. If no network
-// UUID is provided, an attempt will be made to derive selectors from env vars (GH_*)
-// identifying a github actions run.
-func CheckMonitoring(ctx context.Context, log logging.Logger, networkUUID string) error {
-	return errors.Join(
-		CheckLogsExist(ctx, log, networkUUID),
-		CheckMetricsExist(ctx, log, networkUUID),
-	)
-}
-
 // waitForCount waits until the provided function returns greater than zero.
 func waitForCount(ctx context.Context, log logging.Logger, name string, getCount getCountFunc) error {
 	err := pollUntilContextCancel(

--- a/tests/fixture/tmpnet/monitor_processes.go
+++ b/tests/fixture/tmpnet/monitor_processes.go
@@ -46,15 +46,7 @@ const (
 	NetworkShutdownDelay = prometheusScrapeInterval + 2*time.Second
 )
 
-// StartCollectors ensures collectors are running to collect logs and metrics from local nodes.
-func StartCollectors(ctx context.Context, log logging.Logger) error {
-	if err := StartPrometheus(ctx, log); err != nil {
-		return err
-	}
-	return StartPromtail(ctx, log)
-}
-
-// StartPrometheus ensures a collector is running to collect metrics from local nodes.
+// StartPrometheus ensures prometheus is running to collect metrics from local nodes.
 func StartPrometheus(ctx context.Context, log logging.Logger) error {
 	if _, ok := ctx.Deadline(); !ok {
 		return errors.New("unable to start prometheus with a context without a deadline")
@@ -69,10 +61,10 @@ func StartPrometheus(ctx context.Context, log logging.Logger) error {
 	return nil
 }
 
-// StartPromtail ensures a collector is running to collect logs from local nodes.
+// StartPromtail ensures promtail is running to collect logs from local nodes.
 func StartPromtail(ctx context.Context, log logging.Logger) error {
 	if _, ok := ctx.Deadline(); !ok {
-		return errors.New("unable to start collectors with a context without a deadline")
+		return errors.New("unable to start promtail with a context without a deadline")
 	}
 	if err := startPromtail(ctx, log); err != nil {
 		return err
@@ -88,70 +80,79 @@ func WaitForPromtailReadiness(ctx context.Context, log logging.Logger) error {
 	return waitForReadiness(ctx, log, promtailCmd, promtailReadinessURL)
 }
 
-// EnsureCollectorsStopped ensures collectors are not running.
-func StopCollectors(ctx context.Context, log logging.Logger) error {
+// StopMetricsCollector ensures prometheus is not running.
+func StopMetricsCollector(ctx context.Context, log logging.Logger) error {
+	return stopCollector(ctx, log, prometheusCmd)
+}
+
+// StopLogsCollector ensures promtail is not running.
+func StopLogsCollector(ctx context.Context, log logging.Logger) error {
+	return stopCollector(ctx, log, promtailCmd)
+}
+
+// stopCollector stops the collector process if it is running.
+func stopCollector(ctx context.Context, log logging.Logger, cmdName string) error {
 	if _, ok := ctx.Deadline(); !ok {
 		return errors.New("unable to start collectors with a context without a deadline")
 	}
-	for _, cmdName := range []string{promtailCmd, prometheusCmd} {
-		// Determine if the process is running
-		workingDir, err := getWorkingDir(cmdName)
-		if err != nil {
-			return err
-		}
-		pidPath := getPIDPath(workingDir)
-		proc, err := processFromPIDFile(workingDir, pidPath)
-		if err != nil {
-			return err
-		}
-		if proc == nil {
-			log.Info("collector not running",
-				zap.String("cmd", cmdName),
-			)
-			continue
-		}
 
-		log.Info("sending SIGTERM to collector process",
-			zap.String("cmd", cmdName),
-			zap.Int("pid", proc.Pid),
-		)
-		if err := proc.Signal(syscall.SIGTERM); err != nil {
-			return fmt.Errorf("failed to send SIGTERM to pid %d: %w", proc.Pid, err)
-		}
-
-		log.Info("waiting for collector process to stop",
-			zap.String("cmd", cmdName),
-			zap.Int("pid", proc.Pid),
-		)
-		err = pollUntilContextCancel(
-			ctx,
-			func(_ context.Context) (bool, error) {
-				p, err := getProcess(proc.Pid)
-				if err != nil {
-					return false, fmt.Errorf("failed to retrieve process: %w", err)
-				}
-				if p == nil {
-					// Process is no longer running
-
-					// Attempt to clear the PID file. Not critical that it is removed, just good housekeeping.
-					if err := clearStalePIDFile(log, cmdName, pidPath); err != nil {
-						log.Warn("failed to remove stale PID file",
-							zap.String("cmd", cmdName),
-							zap.String("pidFile", pidPath),
-							zap.Error(err),
-						)
-					}
-				}
-				return p == nil, nil
-			},
-		)
-		if err != nil {
-			return err
-		}
-		log.Info("collector stopped",
-			zap.String("cmdName", cmdName),
-		)
+	// Determine if the process is running
+	workingDir, err := getWorkingDir(cmdName)
+	if err != nil {
+		return err
 	}
+	pidPath := getPIDPath(workingDir)
+	proc, err := processFromPIDFile(workingDir, pidPath)
+	if err != nil {
+		return err
+	}
+	if proc == nil {
+		log.Info("collector not running",
+			zap.String("cmd", cmdName),
+		)
+		return nil
+	}
+
+	log.Info("sending SIGTERM to collector process",
+		zap.String("cmd", cmdName),
+		zap.Int("pid", proc.Pid),
+	)
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("failed to send SIGTERM to pid %d: %w", proc.Pid, err)
+	}
+
+	log.Info("waiting for collector process to stop",
+		zap.String("cmd", cmdName),
+		zap.Int("pid", proc.Pid),
+	)
+	err = pollUntilContextCancel(
+		ctx,
+		func(_ context.Context) (bool, error) {
+			p, err := getProcess(proc.Pid)
+			if err != nil {
+				return false, fmt.Errorf("failed to retrieve process: %w", err)
+			}
+			if p == nil {
+				// Process is no longer running
+
+				// Attempt to clear the PID file. Not critical that it is removed, just good housekeeping.
+				if err := clearStalePIDFile(log, cmdName, pidPath); err != nil {
+					log.Warn("failed to remove stale PID file",
+						zap.String("cmd", cmdName),
+						zap.String("pidFile", pidPath),
+						zap.Error(err),
+					)
+				}
+			}
+			return p == nil, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+	log.Info("collector stopped",
+		zap.String("cmdName", cmdName),
+	)
 
 	return nil
 }

--- a/tests/fixture/tmpnet/tmpnetctl/main.go
+++ b/tests/fixture/tmpnet/tmpnetctl/main.go
@@ -154,9 +154,9 @@ func main() {
 	}
 	rootCmd.AddCommand(restartNetworkCmd)
 
-	startCollectorsCmd := &cobra.Command{
-		Use:   "start-collectors",
-		Short: "Start log and metric collectors for local process-based nodes",
+	startMetricsCollectorCmd := &cobra.Command{
+		Use:   "start-metrics-collector",
+		Short: "Start metrics collector for local process-based nodes",
 		RunE: func(*cobra.Command, []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), tmpnet.DefaultNetworkTimeout)
 			defer cancel()
@@ -164,14 +164,14 @@ func main() {
 			if err != nil {
 				return err
 			}
-			return tmpnet.StartCollectors(ctx, log)
+			return tmpnet.StartPrometheus(ctx, log)
 		},
 	}
-	rootCmd.AddCommand(startCollectorsCmd)
+	rootCmd.AddCommand(startMetricsCollectorCmd)
 
-	stopCollectorsCmd := &cobra.Command{
-		Use:   "stop-collectors",
-		Short: "Stop log and metric collectors for local process-based nodes",
+	startLogsCollectorCmd := &cobra.Command{
+		Use:   "start-logs-collector",
+		Short: "Start logs collector for local process-based nodes",
 		RunE: func(*cobra.Command, []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), tmpnet.DefaultNetworkTimeout)
 			defer cancel()
@@ -179,10 +179,40 @@ func main() {
 			if err != nil {
 				return err
 			}
-			return tmpnet.StopCollectors(ctx, log)
+			return tmpnet.StartPromtail(ctx, log)
 		},
 	}
-	rootCmd.AddCommand(stopCollectorsCmd)
+	rootCmd.AddCommand(startLogsCollectorCmd)
+
+	stopMetricsCollectorCmd := &cobra.Command{
+		Use:   "stop-metrics-collector",
+		Short: "Stop metrics collector for local process-based nodes",
+		RunE: func(*cobra.Command, []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), tmpnet.DefaultNetworkTimeout)
+			defer cancel()
+			log, err := tests.LoggerForFormat("", rawLogFormat)
+			if err != nil {
+				return err
+			}
+			return tmpnet.StopMetricsCollector(ctx, log)
+		},
+	}
+	rootCmd.AddCommand(stopMetricsCollectorCmd)
+
+	stopLogsCollectorCmd := &cobra.Command{
+		Use:   "stop-logs-collector",
+		Short: "Stop logs collector for local process-based nodes",
+		RunE: func(*cobra.Command, []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), tmpnet.DefaultNetworkTimeout)
+			defer cancel()
+			log, err := tests.LoggerForFormat("", rawLogFormat)
+			if err != nil {
+				return err
+			}
+			return tmpnet.StopLogsCollector(ctx, log)
+		},
+	}
+	rootCmd.AddCommand(stopLogsCollectorCmd)
 
 	var networkUUID string
 

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -24,8 +24,10 @@ func TestUpgrade(t *testing.T) {
 var (
 	avalancheGoExecPath            string
 	avalancheGoExecPathToUpgradeTo string
-	startCollectors                bool
-	checkMonitoring                bool
+	startMetricsCollector          bool
+	startLogsCollector             bool
+	checkMetricsCollected          bool
+	checkLogsCollected             bool
 )
 
 func init() {
@@ -41,9 +43,11 @@ func init() {
 		"",
 		"avalanchego executable path to upgrade to",
 	)
-	e2e.SetSimpleMonitoringFlags(
-		&startCollectors,
-		&checkMonitoring,
+	e2e.SetMonitoringFlags(
+		&startMetricsCollector,
+		&startLogsCollector,
+		&checkMetricsCollected,
+		&checkLogsCollected,
 	)
 }
 
@@ -66,17 +70,28 @@ var _ = ginkgo.Describe("[Upgrade]", func() {
 		network.Genesis = genesis
 
 		shutdownDelay := 0 * time.Second
-		if startCollectors {
-			require.NoError(tmpnet.StartCollectors(tc.DefaultContext(), tc.Log()))
+		if startMetricsCollector {
+			require.NoError(tmpnet.StartPrometheus(tc.DefaultContext(), tc.Log()))
 			shutdownDelay = tmpnet.NetworkShutdownDelay // Ensure a final metrics scrape
 		}
-		if checkMonitoring {
-			// Since cleanups are run in LIFO order, adding this cleanup before
-			// StartNetwork is called ensures network shutdown will be called first.
+		if startLogsCollector {
+			require.NoError(tmpnet.StartPromtail(tc.DefaultContext(), tc.Log()))
+		}
+
+		// Since cleanups are run in LIFO order, adding these cleanups before StartNetwork
+		// is called ensures network shutdown will be called first.
+		if checkMetricsCollected {
 			tc.DeferCleanup(func() {
 				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
 				defer cancel()
-				require.NoError(tmpnet.CheckMonitoring(ctx, tc.Log(), network.UUID))
+				require.NoError(tmpnet.CheckMetricsExist(ctx, tc.Log(), network.UUID))
+			})
+		}
+		if checkLogsCollected {
+			tc.DeferCleanup(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
+				defer cancel()
+				require.NoError(tmpnet.CheckLogsExist(ctx, tc.Log(), network.UUID))
 			})
 		}
 


### PR DESCRIPTION
- #3854
- #3857
- #3870
- #3877
- #3867
- #3871
- #3881
- #3890
- #3884
- #3893
- #3894
- #3896
- #3897
- #3898
- #3882 
- #3945
- **>>>>>>** #3947 **<<<<<<** 
- #3615
- #3794

## Why this should be merged

Previously local collectors were always started together. For kube, though, it makes sense to support only starting prometheus (e.g. to collect metrics from the load generation framework) since logs and metrics for nodes will be collected by agents within the kube cluster.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A