### PR TITLE
Update proposervm summary to roll forward only

### DIFF
--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -649,7 +649,7 @@ func TestStateSummaryAcceptSkipOlderBlockInnerVM(t *testing.T) {
 			return nil, database.ErrNotFound
 		}
 	}
-	innerVM.GetStateSummaryF = func(_ context.Context, h uint64) (block.StateSummary, error) {
+	innerVM.GetStateSummaryF = func(context.Context, uint64) (block.StateSummary, error) {
 		return innerSummary1, nil
 	}
 	innerVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
@@ -716,8 +716,8 @@ func TestStateSummaryAcceptSkipOlderBlockInnerVM(t *testing.T) {
 	require.NoError(err)
 	require.Equal(block.StateSyncSkipped, status)
 	require.True(calledInnerAccept)
-
 	require.NoError(vm.SetState(context.Background(), snow.Bootstrapping))
+
 	require.Equal(innerBlk2.Height(), vm.lastAcceptedHeight)
 	lastAcceptedID, err := vm.LastAccepted(context.Background())
 	require.NoError(err)

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -529,7 +529,7 @@ func TestStateSummaryAcceptOlderBlock(t *testing.T) {
 
 	require.NoError(vm.SetForkHeight(innerSummary.Height() - 1))
 
-	// Set the last accepted block height to be higher that the state summary
+	// Set the last accepted block height to be higher than the state summary
 	// we are going to attempt to accept
 	vm.lastAcceptedHeight = innerSummary.Height() + 1
 
@@ -627,7 +627,7 @@ func TestStateSummaryAcceptOlderBlockSkipStateSync(t *testing.T) {
 
 	require.NoError(vm.SetForkHeight(innerSummary1.Height() - 1))
 
-	// Set the last accepted block height to be higher that the state summary
+	// Set the last accepted block height to be higher than the state summary
 	// we are going to attempt to accept
 	vm.lastAcceptedHeight = innerBlk2.Height()
 
@@ -657,10 +657,12 @@ func TestStateSummaryAcceptOlderBlockSkipStateSync(t *testing.T) {
 		case bytes.Equal(b, innerBlk2.BytesV):
 			return innerBlk2, nil
 		default:
-			panic("unexpected parse block")
+			require.FailNow("unexpected parse block")
+			// Unreachable, but required to satisfy the compiler
+			// since we use FailNow instead of panic
+			return nil, nil
 		}
 	}
-	// Setup innerSummary.AcceptF to return StateSyncSkipped and check it was called
 	calledInnerAccept := false
 	innerSummary1.AcceptF = func(context.Context) (block.StateSyncMode, error) {
 		calledInnerAccept = true
@@ -707,7 +709,7 @@ func TestStateSummaryAcceptOlderBlockSkipStateSync(t *testing.T) {
 
 	summary, err := vm.GetStateSummary(context.Background(), innerBlk1.Height())
 	require.NoError(err)
-	require.Equal(summary.Height(), innerBlk1.Height())
+	require.Equal(innerBlk1.Height(), summary.Height())
 
 	// Process a state summary that would rewind the chain
 	// ProposerVM should ignore the rollback and accept the inner state summary to

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -712,8 +712,8 @@ func TestStateSummaryAcceptOlderBlockSkipStateSync(t *testing.T) {
 	// Process a state summary that would rewind the chain
 	// ProposerVM should ignore the rollback and accept the inner state summary to
 	// notify the innerVM.
-	// This can result in the ProposerVM and innerVM diverging their last accepted block,
-	// which should be rolled forward and re-aligned in SetState.
+	// This can result in the ProposerVM and innerVM diverging their last accepted block.
+	// These are re-aligned in SetState before transitioning to consensus.
 	status, err := summary.Accept(context.Background())
 	require.NoError(err)
 	require.Equal(block.StateSyncSkipped, status)


### PR DESCRIPTION
## Why this should be merged

This PR fixes https://github.com/ava-labs/avalanchego/issues/3948 caused by https://github.com/ava-labs/avalanchego/pull/3831 violating an invariant that the ProposerVM index must always be >= the innerVM index.

## How this works

Rather than the proposerVM always accepting the state sync summary, this PR ensures the ProposerVM index only moves forward. This means that if the accepted state sync summary is below the proposerVM's last accepted height, it allows the ProposerVM and InnerVM to diverge.

This will be corrected when state sync finishes and `SetState` is called and the ProposerVM re-aligns the two. Since we keep the ProposerVM roll forward only, we are still able to roll it back and guarantee that they are re-aligned before we entre consensus.

## How this was tested

Existing unit tests

## Need to be documented in RELEASES.md?

No
