### PR TITLE
Fix flaky bootstrapping test

### DIFF
--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/math/meter"
 	"github.com/ava-labs/avalanchego/utils/resource"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -1152,10 +1151,12 @@ func TestRestartFullyAccepted(t *testing.T) {
 	require.Equal(genesisID, lastAccepted)
 }
 
-// test bootstrapping the node
+// Test that after bootstrapping a node to an oracle block, the preference of
+// the child block is correctly initialized by the engine.
 func TestBootstrapPartiallyAccepted(t *testing.T) {
 	require := require.New(t)
 
+	// Initialize the VM so that we can pass it into the bootstrapping engine.
 	baseDB := memdb.New()
 	vmDB := prefixdb.New(chains.VMDBPrefix, baseDB)
 	bootstrappingDB := prefixdb.New(chains.ChainBootstrappingDBPrefix, baseDB)
@@ -1167,21 +1168,16 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		MinStakeDuration:       defaultMinStakingDuration,
 		MaxStakeDuration:       defaultMaxStakingDuration,
 		RewardConfig:           defaultRewardConfig,
-		UpgradeConfig:          upgradetest.GetConfigWithUpgradeTime(upgradetest.Durango, latestForkTime),
+		UpgradeConfig:          upgradetest.GetConfig(upgradetest.Latest),
 	}}
 
-	initialClkTime := latestForkTime.Add(time.Second)
-	vm.clock.Set(initialClkTime)
+	// Advance the time so that the VM will want to remove the first validator.
+	vm.clock.Set(genesistest.DefaultValidatorEndTime)
+
 	ctx := snowtest.Context(t, snowtest.PChainID)
-
-	atomicDB := prefixdb.New([]byte{1}, baseDB)
-	m := atomic.NewMemory(atomicDB)
-	ctx.SharedMemory = m.NewSharedMemory(ctx.ChainID)
-
-	consensusCtx := snowtest.ConsensusContext(ctx)
 	ctx.Lock.Lock()
 
-	msgChan := make(chan common.Message, 1)
+	toEngine := make(chan common.Message, 1)
 	require.NoError(vm.Initialize(
 		context.Background(),
 		ctx,
@@ -1189,57 +1185,11 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		genesistest.NewBytes(t, genesistest.Config{}),
 		nil,
 		nil,
-		msgChan,
+		toEngine,
 		nil,
 		nil,
 	))
 
-	// include a tx to make the block be accepted
-	tx := &txs.Tx{Unsigned: &txs.ImportTx{
-		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-			NetworkID:    vm.ctx.NetworkID,
-			BlockchainID: vm.ctx.ChainID,
-		}},
-		SourceChain: vm.ctx.XChainID,
-		ImportedInputs: []*avax.TransferableInput{{
-			UTXOID: avax.UTXOID{
-				TxID:        ids.Empty.Prefix(1),
-				OutputIndex: 1,
-			},
-			Asset: avax.Asset{ID: vm.ctx.AVAXAssetID},
-			In: &secp256k1fx.TransferInput{
-				Amt: 50000,
-			},
-		}},
-	}}
-	require.NoError(tx.Initialize(txs.Codec))
-
-	nextChainTime := initialClkTime.Add(time.Second)
-
-	preferredID := vm.manager.Preferred()
-	preferred, err := vm.manager.GetBlock(preferredID)
-	require.NoError(err)
-	preferredHeight := preferred.Height()
-
-	statelessBlk, err := block.NewBanffStandardBlock(
-		nextChainTime,
-		preferredID,
-		preferredHeight+1,
-		[]*txs.Tx{tx},
-	)
-	require.NoError(err)
-
-	advanceTimeBlk := vm.manager.NewBlock(statelessBlk)
-	require.NoError(err)
-
-	advanceTimeBlkID := advanceTimeBlk.ID()
-	advanceTimeBlkBytes := advanceTimeBlk.Bytes()
-
-	peerID := ids.BuildTestNodeID([]byte{1, 2, 3, 4, 5, 4, 3, 2, 1})
-	beacons := validators.NewManager()
-	require.NoError(beacons.AddStaker(ctx.SubnetID, peerID, nil, ids.Empty, 1))
-
-	benchlist := benchlist.NewNoBenchlist()
 	timeoutManager, err := timeout.NewManager(
 		&timer.AdaptiveTimeoutConfig{
 			InitialTimeout:     time.Millisecond,
@@ -1248,7 +1198,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 			TimeoutHalflife:    5 * time.Minute,
 			TimeoutCoefficient: 1.25,
 		},
-		benchlist,
+		benchlist.NewNoBenchlist(),
 		prometheus.NewRegistry(),
 		prometheus.NewRegistry(),
 	)
@@ -1258,27 +1208,31 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 	defer timeoutManager.Stop()
 
 	chainRouter := &router.ChainRouter{}
-
-	metrics := prometheus.NewRegistry()
-	mc, err := message.NewCreator(logging.NoLog{}, metrics, constants.DefaultNetworkCompressionType, 10*time.Second)
-	require.NoError(err)
-
 	require.NoError(chainRouter.Initialize(
-		ids.EmptyNodeID,
-		logging.NoLog{},
+		ctx.NodeID,
+		ctx.Log,
 		timeoutManager,
 		time.Second,
-		set.Set[ids.ID]{},
+		nil,
 		true,
-		set.Set[ids.ID]{},
+		nil,
 		nil,
 		router.HealthConfig{},
 		prometheus.NewRegistry(),
 	))
 
+	mc, err := message.NewCreator(
+		ctx.Log,
+		prometheus.NewRegistry(),
+		constants.DefaultNetworkCompressionType,
+		10*time.Second,
+	)
+	require.NoError(err)
+
+	consensusCtx := snowtest.ConsensusContext(ctx)
 	externalSender := &sendertest.External{TB: t}
 	externalSender.Default(true)
-
+	subnet := subnets.New(ctx.NodeID, subnets.Config{})
 	// Passes messages from the consensus engine to the network
 	sender, err := sender.New(
 		consensusCtx,
@@ -1287,7 +1241,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		chainRouter,
 		timeoutManager,
 		p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
-		subnets.New(consensusCtx.NodeID, subnets.Config{}),
+		subnet,
 		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
@@ -1303,27 +1257,30 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		},
 	}
 
+	// Create a validator manager for the bootstrapping engine.
+	vdrID := ids.GenerateTestNodeID()
+	beacons := validators.NewManager()
+	require.NoError(beacons.AddStaker(ctx.SubnetID, vdrID, nil, ids.Empty, 1))
+
 	peers := tracker.NewPeers()
-	totalWeight, err := beacons.TotalWeight(ctx.SubnetID)
-	require.NoError(err)
-	startup := tracker.NewStartup(peers, (totalWeight+1)/2)
+	startup := tracker.NewStartup(peers, 1)
 	beacons.RegisterSetCallbackListener(ctx.SubnetID, startup)
 
 	// The engine handles consensus
 	snowGetHandler, err := snowgetter.New(
 		vm,
 		sender,
-		consensusCtx.Log,
+		ctx.Log,
 		time.Second,
 		2000,
-		consensusCtx.Registerer,
+		prometheus.NewRegistry(),
 	)
 	require.NoError(err)
 
 	peerTracker, err := p2p.NewPeerTracker(
 		ctx.Log,
 		"peer_tracker",
-		consensusCtx.Registerer,
+		prometheus.NewRegistry(),
 		set.Of(ctx.NodeID),
 		nil,
 	)
@@ -1335,7 +1292,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		AllGetsServer:                  snowGetHandler,
 		Ctx:                            consensusCtx,
 		Beacons:                        beacons,
-		SampleK:                        beacons.NumValidators(ctx.SubnetID),
+		SampleK:                        1,
 		StartupTracker:                 startup,
 		PeerTracker:                    peerTracker,
 		Sender:                         sender,
@@ -1357,12 +1314,12 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 	h, err := handler.New(
 		bootstrapConfig.Ctx,
 		beacons,
-		msgChan,
+		toEngine,
 		time.Hour,
 		2,
 		cpuTracker,
-		subnets.New(ctx.NodeID, subnets.Config{}),
-		tracker.NewPeers(),
+		subnet,
+		peers,
 		peerTracker,
 		prometheus.NewRegistry(),
 		func() {},
@@ -1370,11 +1327,12 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 	require.NoError(err)
 
 	engineConfig := smeng.Config{
-		Ctx:           bootstrapConfig.Ctx,
-		AllGetsServer: snowGetHandler,
-		VM:            bootstrapConfig.VM,
-		Sender:        bootstrapConfig.Sender,
-		Validators:    beacons,
+		Ctx:                 bootstrapConfig.Ctx,
+		AllGetsServer:       snowGetHandler,
+		VM:                  bootstrapConfig.VM,
+		Sender:              bootstrapConfig.Sender,
+		Validators:          beacons,
+		ConnectedValidators: peers,
 		Params: snowball.Parameters{
 			K:                     1,
 			AlphaPreference:       1,
@@ -1398,11 +1356,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 	bootstrapper.TimeoutRegistrar = &enginetest.Timer{}
 
 	h.SetEngineManager(&handler.EngineManager{
-		Avalanche: &handler.Engine{
-			StateSyncer:  nil,
-			Bootstrapper: bootstrapper,
-			Consensus:    engine,
-		},
+		Avalanche: nil,
 		Snowman: &handler.Engine{
 			StateSyncer:  nil,
 			Bootstrapper: bootstrapper,
@@ -1412,7 +1366,7 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 
 	consensusCtx.State.Set(snow.EngineState{
 		Type:  p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
-		State: snow.NormalOp,
+		State: snow.Bootstrapping,
 	})
 
 	// Allow incoming messages to be routed to the new chain
@@ -1422,6 +1376,8 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 	h.Start(context.Background(), false)
 
 	ctx.Lock.Lock()
+
+	// Mark the validator as connected. We should request the accepted frontier.
 	var reqID uint32
 	externalSender.SendF = func(msg message.OutboundMessage, config common.SendConfig, _ ids.ID, _ subnets.Allower) set.Set[ids.NodeID] {
 		inMsg, err := mc.Parse(msg.Bytes(), ctx.NodeID, func() {})
@@ -1435,9 +1391,35 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		return config.NodeIDs
 	}
 
-	peerTracker.Connected(peerID, version.CurrentApp)
-	require.NoError(bootstrapper.Connected(context.Background(), peerID, version.CurrentApp))
+	peerTracker.Connected(vdrID, version.CurrentApp)
+	require.NoError(bootstrapper.Connected(context.Background(), vdrID, version.CurrentApp))
 
+	// Create a valid block to remove the first genesis validator that is not
+	// related to the VM.
+	lastAcceptedID := vm.state.GetLastAccepted()
+	lastAccepted, err := vm.state.GetStatelessBlock(lastAcceptedID)
+	require.NoError(err)
+
+	currentStakerIterator, err := vm.state.GetCurrentStakerIterator()
+	require.NoError(err)
+	require.True(currentStakerIterator.Next())
+
+	stakerToRemove := currentStakerIterator.Value()
+	rewardValidatorTx, err := blockbuilder.NewRewardValidatorTx(ctx, stakerToRemove.TxID)
+	require.NoError(err)
+	currentStakerIterator.Release()
+
+	rewardValidatorBlk, err := block.NewBanffProposalBlock(
+		stakerToRemove.EndTime,
+		lastAcceptedID,
+		lastAccepted.Height()+1,
+		rewardValidatorTx,
+		nil,
+	)
+	require.NoError(err)
+
+	// Report the validator removal as the last accepted block with the accepted
+	// frontier. We should request a confirmation that this block is accepted.
 	externalSender.SendF = func(msg message.OutboundMessage, config common.SendConfig, _ ids.ID, _ subnets.Allower) set.Set[ids.NodeID] {
 		inMsgIntf, err := mc.Parse(msg.Bytes(), ctx.NodeID, func() {})
 		require.NoError(err)
@@ -1448,8 +1430,10 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		return config.NodeIDs
 	}
 
-	require.NoError(bootstrapper.AcceptedFrontier(context.Background(), peerID, reqID, advanceTimeBlkID))
+	require.NoError(bootstrapper.AcceptedFrontier(context.Background(), vdrID, reqID, rewardValidatorBlk.ID()))
 
+	// Report the validator removal as accepted. We should request the validator
+	// removal block and any ancestors of it.
 	externalSender.SendF = func(msg message.OutboundMessage, config common.SendConfig, _ ids.ID, _ subnets.Allower) set.Set[ids.NodeID] {
 		inMsgIntf, err := mc.Parse(msg.Bytes(), ctx.NodeID, func() {})
 		require.NoError(err)
@@ -1460,13 +1444,15 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 
 		containerID, err := ids.ToID(inMsg.ContainerId)
 		require.NoError(err)
-		require.Equal(advanceTimeBlkID, containerID)
+		require.Equal(rewardValidatorBlk.ID(), containerID)
 		return config.NodeIDs
 	}
 
-	frontier := set.Of(advanceTimeBlkID)
-	require.NoError(bootstrapper.Accepted(context.Background(), peerID, reqID, frontier))
+	frontier := set.Of(rewardValidatorBlk.ID())
+	require.NoError(bootstrapper.Accepted(context.Background(), vdrID, reqID, frontier))
 
+	// Provide the validator removal block. We should process this block and
+	// then do another round of bootstrapping.
 	externalSender.SendF = func(msg message.OutboundMessage, config common.SendConfig, _ ids.ID, _ subnets.Allower) set.Set[ids.NodeID] {
 		inMsg, err := mc.Parse(msg.Bytes(), ctx.NodeID, func() {})
 		require.NoError(err)
@@ -1479,8 +1465,10 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		return config.NodeIDs
 	}
 
-	require.NoError(bootstrapper.Ancestors(context.Background(), peerID, reqID, [][]byte{advanceTimeBlkBytes}))
+	require.NoError(bootstrapper.Ancestors(context.Background(), vdrID, reqID, [][]byte{rewardValidatorBlk.Bytes()}))
 
+	// We should again report the validator removal block as the last accepted
+	// block.
 	externalSender.SendF = func(msg message.OutboundMessage, config common.SendConfig, _ ids.ID, _ subnets.Allower) set.Set[ids.NodeID] {
 		inMsgIntf, err := mc.Parse(msg.Bytes(), ctx.NodeID, func() {})
 		require.NoError(err)
@@ -1491,13 +1479,28 @@ func TestBootstrapPartiallyAccepted(t *testing.T) {
 		return config.NodeIDs
 	}
 
-	require.NoError(bootstrapper.AcceptedFrontier(context.Background(), peerID, reqID, advanceTimeBlkID))
+	require.NoError(bootstrapper.AcceptedFrontier(context.Background(), vdrID, reqID, rewardValidatorBlk.ID()))
 
+	// Again confirming the validator removal block as accepted should
+	// transition us out of bootstrapping. At this point we should check for
+	// option blocks and register them in the correct order.
 	externalSender.SendF = nil
 	externalSender.CantSend = false
 
-	require.NoError(bootstrapper.Accepted(context.Background(), peerID, reqID, frontier))
-	require.Equal(advanceTimeBlk.ID(), vm.manager.Preferred())
+	require.NoError(bootstrapper.Accepted(context.Background(), vdrID, reqID, frontier))
+
+	// Verify the locally preferred option on the validator removal aligns with
+	// our consensus preference.
+	//
+	// We should prefer commit because our VM thinks we have been offline for
+	// the staking duration.
+	commitBlock, err := block.NewBanffCommitBlock(
+		rewardValidatorBlk.Timestamp(),
+		rewardValidatorBlk.ID(),
+		rewardValidatorBlk.Height()+1,
+	)
+	require.NoError(err)
+	require.Equal(commitBlock.ID(), vm.manager.Preferred())
 
 	ctx.Lock.Unlock()
 	chainRouter.Shutdown(context.Background())


### PR DESCRIPTION
## Why this should be merged

This bootstrapping test has deviated pretty far from the original purpose of the test. This returns the test to verify the originally expected behavior, and resolves #3951.

Specifically, this test was originally added to verify that the correct preference is set if the oracle block was accepted during bootstrapping.

During the removal of the AdvanceTimestampTx, it seems that this test was modified and the oracle blocks were removed entirely (completely missing the whole point of the test).

In #3943 the test context was modified to generate the nodeID in the test context, which broke this test.

## How this works

Re-writes the flaky test.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No