### PR TITLE
fix(ids): `%x` formatting of `ID` and `ShortID`

### DIFF
--- a/ids/format.go
+++ b/ids/format.go
@@ -17,10 +17,15 @@ func (id ShortID) Format(s fmt.State, verb rune) {
 	format(s, verb, id)
 }
 
-// format implements the [fmt.Formatter] interface for [ID] and [ShortID].
-func format[T interface {
+type idForFormatting interface {
 	String() string
 	Hex() string
+}
+
+// format implements the [fmt.Formatter] interface for [ID] and [ShortID].
+func format[T interface {
+	idForFormatting
+	ID | ShortID
 }](s fmt.State, verb rune, id T) {
 	switch verb {
 	case 'x':

--- a/ids/format.go
+++ b/ids/format.go
@@ -22,9 +22,9 @@ func format[T interface {
 	switch verb {
 	case 'x':
 		if s.Flag('#') {
-			s.Write([]byte("0x"))
+			s.Write([]byte("0x")) //nolint:errcheck // [fmt.Formatter] doesn't allow for returning errors, and the implementation of [fmt.State] always returns nil on Write()
 		}
-		s.Write([]byte(id.Hex()))
+		s.Write([]byte(id.Hex())) //nolint:errcheck // See above
 
 	case 'q':
 		str := id.String()
@@ -32,9 +32,9 @@ func format[T interface {
 		buf[0] = '"'
 		buf[len(buf)-1] = '"'
 		copy(buf[1:], str)
-		s.Write(buf)
+		s.Write(buf) //nolint:errcheck // See above
 
 	default:
-		s.Write([]byte(id.String()))
+		s.Write([]byte(id.String())) //nolint:errcheck // See above
 	}
 }

--- a/ids/format.go
+++ b/ids/format.go
@@ -1,0 +1,40 @@
+package ids
+
+import "fmt"
+
+var _ = []fmt.Formatter{ID{}, ShortID{}}
+
+// Format implements the [fmt.Formatter] interface.
+func (id ID) Format(s fmt.State, verb rune) {
+	format(s, verb, id)
+}
+
+// Format implements the [fmt.Formatter] interface.
+func (id ShortID) Format(s fmt.State, verb rune) {
+	format(s, verb, id)
+}
+
+// format implements the [fmt.Formatter] interface for [ID] and [ShortID].
+func format[T interface {
+	String() string
+	Hex() string
+}](s fmt.State, verb rune, id T) {
+	switch verb {
+	case 'x':
+		if s.Flag('#') {
+			s.Write([]byte("0x"))
+		}
+		s.Write([]byte(id.Hex()))
+
+	case 'q':
+		str := id.String()
+		buf := make([]byte, len(str)+2)
+		buf[0] = '"'
+		buf[len(buf)-1] = '"'
+		copy(buf[1:], str)
+		s.Write(buf)
+
+	default:
+		s.Write([]byte(id.String()))
+	}
+}

--- a/ids/format.go
+++ b/ids/format.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package ids
 
 import "fmt"

--- a/ids/format.go
+++ b/ids/format.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/format_test.go
+++ b/ids/format_test.go
@@ -42,6 +42,7 @@ func TestFormat(t *testing.T) {
 		t.Run(tt.id.String(), func(t *testing.T) {
 			for format, want := range tt.want {
 				if got := fmt.Sprintf(format, tt.id); got != want {
+					//nolint:forbidigo // require.Equal() is inappropriate as it unnecessarily stops future tests and `assert.Equal()` isn't allowed
 					t.Errorf("fmt.Sprintf(%q, %T) got %q; want %q", format, tt.id, got, want)
 				}
 			}
@@ -49,7 +50,7 @@ func TestFormat(t *testing.T) {
 	}
 }
 
-func BenchmarkFormat(b *testing.B) {
+func BenchmarkFormat(*testing.B) {
 	// %q uses a []byte so this is just to demonstrate that it's on the stack
 	// otherwise someone, not naming any names, might want to "fix" it.
 	_ = fmt.Sprintf("%q", ID{})

--- a/ids/format_test.go
+++ b/ids/format_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package ids
 
 import (

--- a/ids/format_test.go
+++ b/ids/format_test.go
@@ -45,10 +45,3 @@ func TestFormat(t *testing.T) {
 		})
 	}
 }
-
-func BenchmarkFormat(*testing.B) {
-	// %q uses a []byte so this is just to demonstrate that it's on the stack
-	// otherwise someone, not naming any names, might want to "fix" it.
-	_ = fmt.Sprintf("%q", ID{})
-	_ = fmt.Sprintf("%q", ShortID{})
-}

--- a/ids/format_test.go
+++ b/ids/format_test.go
@@ -6,6 +6,8 @@ package ids
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormat(t *testing.T) {
@@ -38,10 +40,7 @@ func TestFormat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {
 			for format, want := range tt.want {
-				if got := fmt.Sprintf(format, tt.id); got != want {
-					//nolint:forbidigo // require.Equal() is inappropriate as it unnecessarily stops future tests and `assert.Equal()` isn't allowed
-					t.Errorf("fmt.Sprintf(%q, %T) got %q; want %q", format, tt.id, got, want)
-				}
+				require.Equalf(t, want, fmt.Sprintf(format, tt.id), "fmt.Sprintf(%q, %T)", format, tt.id)
 			}
 		})
 	}

--- a/ids/format_test.go
+++ b/ids/format_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/format_test.go
+++ b/ids/format_test.go
@@ -9,17 +9,11 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	type (
-		idInterface interface {
-			String() string
-			Hex() string
-		}
-		test struct {
-			id   idInterface
-			want map[string]string // format -> output
-		}
-	)
-	makeTestCase := func(id idInterface) test {
+	type test struct {
+		id   idForFormatting
+		want map[string]string // format -> output
+	}
+	makeTestCase := func(id idForFormatting) test {
 		return test{
 			id: id,
 			want: map[string]string{


### PR DESCRIPTION
## Why this should be merged

`fmt.Sprintf("%x", ids.ID{})` returns the hex encoding of the `cb58` encoding, not of the raw bytes.

## How this works

Implement the `fmt.Formatter` interface for both `ids.ID` and `ids.ShortID`.

## How this was tested

Unit test of formatting with `%v`, `%s` and `%q` (equivalent to `String()`), plus `%x` and `%#x` (equivalent to `Hex()`).

## Need to be documented in RELEASES.md?

Not sure. Maybe. I dunno `¯\_(ツ)_/¯`