### PR TITLE
adds config.json for C-Chain during antithesis docker-compose - log-j…

### DIFF
--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -124,6 +124,15 @@ func initComposeConfig(
 			if err := os.MkdirAll(volumePath, perms.ReadWriteExecute); err != nil {
 				return fmt.Errorf("failed to create volume path %q: %w", volumePath, err)
 			}
+			if filepath.Base(volumePath) == "C" &&
+				filepath.Base(filepath.Dir(volumePath)) == "chains" &&
+				filepath.Base(filepath.Dir(filepath.Dir(volumePath))) == "configs" {
+				configFilePath := filepath.Join(volumePath, "config.json")
+				configContent := []byte("{\n  \"log-json-format\": true\n}\n")
+				if err := os.WriteFile(configFilePath, configContent, perms.ReadWrite); err != nil {
+					return fmt.Errorf("failed to write config.json to %q: %w", configFilePath, err)
+				}
+			}
 		}
 	}
 	return nil
@@ -172,6 +181,11 @@ func newComposeProject(network *tmpnet.Network, nodeImageName string, workloadIm
 				Type:   types.VolumeTypeBind,
 				Source: fmt.Sprintf("./volumes/%s/logs", serviceName),
 				Target: "/root/.avalanchego/logs",
+			},
+			{
+				Type:   types.VolumeTypeBind,
+				Source: fmt.Sprintf("./volumes/%s/configs/chains/C", serviceName),
+				Target: "/root/.avalanchego/configs/chains/C",
 			},
 		}
 


### PR DESCRIPTION
…son-format

## Why this should be merged

Stop mixing json and text log formats during antithesis test in docker-compose.
Closes #3933 

## How this works

Per [documentation](https://build.avax.network/docs/nodes/chain-configs/c-chain) adding `config.json` file in the `$HOME/.avalanchego/configs/chains/C` with content:

```
{
  "log-json-format": true
}
```

Converts C-Chain logs to json format during Antithesis tests.

## How this was tested

Commands:

* `task test-build-antithesis-images-avalanchego`
* `task test-build-antithesis-images-xsvm`

Before change logs were in json while C-Chain logs were in text:

```
{"level":"info","timestamp":"2025-05-16T22:16:14.816Z","caller":"chains/manager.go:1157","msg":"creating proposervm wrapper","activationTime":"2020-12-05T05:00:00.000Z","minPChainHeight":0,"minBlockDelay":1000000000,"numHistoricalBlocks":0}
[05-16|22:16:14.817] INFO <C Chain> plugin/evm/vm.go:380 Initializing Coreth VM                   Version=v0.15.1 "libevm version"=1.13.14-0.2.0.release Config="{GasTarget:<nil> SnowmanAPIEnabled:false AdminAPIEnabled:false AdminAPIDir: CorethAdminAPIEnabled:false CorethAdminAPIDir: WarpAPIEnabled:false EnabledEthAPIs:[eth eth-filter net web3 internal-eth internal-blockchain internal-transaction] ContinuousProfilerDir: ContinuousProfilerFrequency:15m0s ContinuousProfilerMaxFiles:5 RPCGasCap:50000000 RPCTxFeeCap:100 TrieCleanCache:512 TrieDirtyCache:512 TrieDirtyCommitTarget:20 TriePrefetcherParallelism:16 SnapshotCache:256 Preimages:false SnapshotWait:false SnapshotVerify:false Pruning:true AcceptorQueueLimit:64 CommitInterval:4096 AllowMissingTries:false PopulateMissingTries:<nil> PopulateMissingTriesParallelism:1024 PruneWarpDB:false HistoricalProofQueryWindow:43200 MetricsExpensiveEnabled:true LocalTxsEnabled:false PriceOptionSlowFeePercentage:95 PriceOptionFastFeePercentage:105 PriceOptionMaxTip:20000000000 TxPoolPriceLimit:1 TxPoolPriceBump:10 TxPoolAccountSlots:16 TxPoolGlobalSlots:5120 TxPoolAccountQueue:64 TxPoolGlobalQueue:1024 TxPoolLifetime:10m0s APIMaxDuration:0s WSCPURefillRate:0s WSCPUMaxStored:0s MaxBlocksPerRequest:0 AllowUnfinalizedQueries:false AllowUnprotectedTxs:false AllowUnprotectedTxHashes:[0xfefb2da535e927b85fe68eb81cb2e4a5827c905f78381a01ef2322aa9b0aee8e] KeystoreDirectory: KeystoreExternalSigner: KeystoreInsecureUnlockAllowed:false PushGossipPercentStake:0.9 PushGossipNumValidators:100 PushGossipNumPeers:0 PushRegossipNumValidators:10 PushRegossipNumPeers:0 PushGossipFrequency:100ms PullGossipFrequency:1s RegossipFrequency:30s TxRegossipFrequency:0s LogLevel:info LogJSONFormat:false OfflinePruning:false OfflinePruningBloomFilterSize:512 OfflinePruningDataDirectory: MaxOutboundActiveRequests:16 StateSyncEnabled:<nil> StateSyncSkipResume:false StateSyncServerTrieCache:64 StateSyncIDs: StateSyncCommitInterval:16384 StateSyncMinBlocks:300000 StateSyncRequestSize:1024 InspectDatabase:false SkipUpgradeCheck:false AcceptedCacheSize:32 TransactionHistory:0 TxLookupLimit:0 SkipTxIndexing:false WarpOffChainMessages:[] HttpBodyLimit:0}"
[05-16|22:16:14.818] INFO <C Chain> core/state_processor_ext.go:54 Activating new precompile                name=warpConfig config="{\"blockTimestamp\":1607144400,\"quorumNumerator\":0,\"requirePrimaryNetworkSigners\":false}"
[05-16|22:16:14.818] INFO <C Chain> /go/pkg/mod/github.com/ava-labs/libevm@v1.13.14-0.2.0.release/triedb/hashdb/database.go:447 Persisted trie from memory database      nodes=3 size=406.00B time="3.084µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
[05-16|22:16:14.819] INFO <C Chain> plugin/evm/vm.go:461 "lastAccepted = 0x17a7011ebbed7c97c7858cec856bd462a1fe9c216ef5f110b40c3b573dc84c6f"
[05-16|22:16:14.819] INFO <C Chain> eth/backend.go:146 Allocated memory caches                  "trie clean"=512.00MiB "trie dirty"=512.00MiB "snapshot clean"=256.00MiB
[05-16|22:16:14.820] INFO <C Chain> /go/pkg/mod/github.com/ava-labs/libevm@v1.13.14-0.2.0.release/core/rawdb/accessors_trie.go:334 State schema set to default              scheme=hash
[05-16|22:16:14.820] INFO <C Chain> eth/backend.go:194 Initialising Ethereum protocol           network=43112 dbversion=<nil>
[05-16|22:16:14.820] WARN <C Chain> eth/backend.go:200 Upgrade blockchain database version      from=<nil> to=8
[05-16|22:16:14.821] INFO <C Chain> core/genesis.go:138 Writing genesis to database
[05-16|22:16:14.821] INFO <C Chain> core/state_processor_ext.go:54 Activating new precompile                name=warpConfig config="{\"blockTimestamp\":1607144400,\"quorumNumerator\":0,\"requirePrimaryNetworkSigners\":false}"
[05-16|22:16:14.821] INFO <C Chain> triedb/hashdb/database.go:562 Persisted trie from memory database      nodes=3 size=406.00B time="42.708µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
[05-16|22:16:14.821] INFO <C Chain> core/blockchain.go:378
[05-16|22:16:14.821] INFO <C Chain> core/blockchain.go:379 ---------------------------------------------------------------------------------------------------------------------------------------------------------
[05-16|22:16:14.822] INFO <C Chain> core/blockchain.go:381 Chain ID:  43112 (unknown)
[05-16|22:16:14.822] INFO <C Chain> core/blockchain.go:381 Consensus: unknown
[05-16|22:16:14.822] INFO <C Chain> core/blockchain.go:381
[05-16|22:16:14.822] INFO <C Chain> core/blockchain.go:381 Pre-Merge hard forks (block based):
[05-16|22:16:14.823] INFO <C Chain> core/blockchain.go:381  - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)
[05-16|22:16:14.823] INFO <C Chain> core/blockchain.go:381  - DAO Fork:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/dao-fork.md)
[05-16|22:16:14.823] INFO <C Chain> core/blockchain.go:381  - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)
[05-16|22:16:14.823] INFO <C Chain> core/blockchain.go:381  - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)
[05-16|22:16:14.825] INFO <C Chain> core/blockchain.go:381  - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)
[05-16|22:16:14.825] INFO <C Chain> core/blockchain.go:381  - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)
[05-16|22:16:14.825] INFO <C Chain> core/blockchain.go:381  - {"level":"info","timestamp":"2025-05-16T22:16:14.816Z","caller":"chains/manager.go:1157","msg":"creating proposervm wrapper","activationTime":"2020-12-05T05:00:00.000Z","minPChainHeight":0,"minBlockDelay":1000000000,"numHistoricalBlocks":0}
[05-16|22:16:14.817] INFO <C Chain> plugin/evm/vm.go:380 Initializing Coreth VM                   Version=v0.15.1 "libevm version"=1.13.14-0.2.0.release Config="{GasTarget:<nil> SnowmanAPIEnabled:false AdminAPIEnabled:false AdminAPIDir: CorethAdminAPIEnabled:false CorethAdminAPIDir: WarpAPIEnabled:false EnabledEthAPIs:[eth eth-filter net web3 internal-eth internal-blockchain internal-transaction] ContinuousProfilerDir: ContinuousProfilerFrequency:15m0s ContinuousProfilerMaxFiles:5 RPCGasCap:50000000 RPCTxFeeCap:100 TrieCleanCache:512 TrieDirtyCache:512 TrieDirtyCommitTarget:20 TriePrefetcherParallelism:16 SnapshotCache:256 Preimages:false SnapshotWait:false SnapshotVerify:false Pruning:true AcceptorQueueLimit:64 CommitInterval:4096 AllowMissingTries:false PopulateMissingTries:<nil> PopulateMissingTriesParallelism:1024 PruneWarpDB:false HistoricalProofQueryWindow:43200 MetricsExpensiveEnabled:true LocalTxsEnabled:false PriceOptionSlowFeePercentage:95 PriceOptionFastFeePercentage:105 PriceOptionMaxTip:20000000000 TxPoolPriceLimit:1 TxPoolPriceBump:10 TxPoolAccountSlots:16 TxPoolGlobalSlots:5120 TxPoolAccountQueue:64 TxPoolGlobalQueue:1024 TxPoolLifetime:10m0s APIMaxDuration:0s WSCPURefillRate:0s WSCPUMaxStored:0s MaxBlocksPerRequest:0 AllowUnfinalizedQueries:false AllowUnprotectedTxs:false AllowUnprotectedTxHashes:[0xfefb2da535e927b85fe68eb81cb2e4a5827c905f78381a01ef2322aa9b0aee8e] KeystoreDirectory: KeystoreExternalSigner: KeystoreInsecureUnlockAllowed:false PushGossipPercentStake:0.9 PushGossipNumValidators:100 PushGossipNumPeers:0 PushRegossipNumValidators:10 PushRegossipNumPeers:0 PushGossipFrequency:100ms PullGossipFrequency:1s RegossipFrequency:30s TxRegossipFrequency:0s LogLevel:info LogJSONFormat:false OfflinePruning:false OfflinePruningBloomFilterSize:512 OfflinePruningDataDirectory: MaxOutboundActiveRequests:16 StateSyncEnabled:<nil> StateSyncSkipResume:false StateSyncServerTrieCache:64 StateSyncIDs: StateSyncCommitInterval:16384 StateSyncMinBlocks:300000 StateSyncRequestSize:1024 InspectDatabase:false SkipUpgradeCheck:false AcceptedCacheSize:32 TransactionHistory:0 TxLookupLimit:0 SkipTxIndexing:false WarpOffChainMessages:[] HttpBodyLimit:0}"
[05-16|22:16:14.818] INFO <C Chain> core/state_processor_ext.go:54 Activating new precompile                name=warpConfig config="{\"blockTimestamp\":1607144400,\"quorumNumerator\":0,\"requirePrimaryNetworkSigners\":false}"
[05-16|22:16:14.818] INFO <C Chain> /go/pkg/mod/github.com/ava-labs/libevm@v1.13.14-0.2.0.release/triedb/hashdb/database.go:447 Persisted trie from memory database      nodes=3 size=406.00B time="3.084µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
[05-16|22:16:14.819] INFO <C Chain> plugin/evm/vm.go:461 "lastAccepted = 0x17a7011ebbed7c97c7858cec856bd462a1fe9c216ef5f110b40c3b573dc84c6f"
[05-16|22:16:14.819] INFO <C Chain> eth/backend.go:146 Allocated memory caches                  "trie clean"=512.00MiB "trie dirty"=512.00MiB "snapshot clean"=256.00MiB
[05-16|22:16:14.820] INFO <C Chain> /go/pkg/mod/github.com/ava-labs/libevm@v1.13.14-0.2.0.release/core/rawdb/accessors_trie.go:334 State schema set to default              scheme=hash
[05-16|22:16:14.820] INFO <C Chain> eth/backend.go:194 Initialising Ethereum protocol           network=43112 dbversion=<nil>
[05-16|22:16:14.820] WARN <C Chain> eth/backend.go:200 Upgrade blockchain database version      from=<nil> to=8
[05-16|22:16:14.821] INFO <C Chain> core/genesis.go:138 Writing genesis to database
[05-16|22:16:14.821] INFO <C Chain> core/state_processor_ext.go:54 Activating new precompile                name=warpConfig config="{\"blockTimestamp\":1607144400,\"quorumNumerator\":0,\"requirePrimaryNetworkSigners\":false}"
[05-16|22:16:14.821] INFO <C Chain> triedb/hashdb/database.go:562 Persisted trie from memory database      nodes=3 size=406.00B time="42.708µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
[05-16|22:16:14.821] INFO <C Chain> core/blockchain.go:378
[05-16|22:16:14.821] INFO <C Chain> core/blockchain.go:379 ---------------------------------------------------------------------------------------------------------------------------------------------------------
[05-16|22:16:14.822] INFO <C Chain> core/blockchain.go:381 Chain ID:  43112 (unknown)
[05-16|22:16:14.822] INFO <C Chain> core/blockchain.go:381 Consensus: unknown
[05-16|22:16:14.822] INFO <C Chain> core/blockchain.go:381
[05-16|22:16:14.822] INFO <C Chain> core/blockchain.go:381 Pre-Merge hard forks (block based):
[05-16|22:16:14.823] INFO <C Chain> core/blockchain.go:381  - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)
[05-16|22:16:14.823] INFO <C Chain> core/blockchain.go:381  - DAO Fork:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/dao-fork.md)
[05-16|22:16:14.823] INFO <C Chain> core/blockchain.go:381  - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)
[05-16|22:16:14.823] INFO <C Chain> core/blockchain.go:381  - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)
[05-16|22:16:14.824] INFO <C Chain> core/blockchain.go:381  - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)
[05-16|22:16:14.825] INFO <C Chain> core/blockchain.go:381  - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)
[05-16|22:16:14.825] INFO <C Chain> core/blockchain.go:381  - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)
[05-16|22:16:14.825] INFO <C Chain> core/blockchain.go:381  - London:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)
[05-16|22:16:14.825] INFO <C Chain> core/blockchain.go:381
:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)
[05-16|22:16:14.825] INFO <C Chain> core/blockchain.go:381
```

After changes:

```
{"level":"info","timestamp":"2025-05-16T22:01:39.406Z","caller":"chains/manager.go:1157","msg":"creating proposervm wrapper","activationTime":"2020-12-05T05:00:00.000Z","minPChainHeight":0,"minBlockDelay":1000000000,"numHistoricalBlocks":0}
{"timestamp":"2025-05-16T22:01:39.406879426Z","level":"info","msg":"Initializing Coreth VM","Version":"v0.15.1","libevm version":"1.13.14-0.2.0.release","Config":{"snowman-api-enabled":false,"admin-api-enabled":false,"admin-api-dir":"","coreth-admin-api-enabled":false,"coreth-admin-api-dir":"","warp-api-enabled":false,"eth-apis":["eth","eth-filter","net","web3","internal-eth","internal-blockchain","internal-transaction"],"continuous-profiler-dir":"","continuous-profiler-frequency":"15m0s","continuous-profiler-max-files":5,"rpc-gas-cap":50000000,"rpc-tx-fee-cap":100,"trie-clean-cache":512,"trie-dirty-cache":512,"trie-dirty-commit-target":20,"trie-prefetcher-parallelism":16,"snapshot-cache":256,"preimages-enabled":false,"snapshot-wait":false,"snapshot-verification-enabled":false,"pruning-enabled":true,"accepted-queue-limit":64,"commit-interval":4096,"allow-missing-tries":false,"populate-missing-tries-parallelism":1024,"prune-warp-db-enabled":false,"historical-proof-query-window":43200,"metrics-expensive-enabled":true,"local-txs-enabled":false,"price-options-slow-fee-percentage":95,"price-options-fast-fee-percentage":105,"price-options-max-tip":20000000000,"tx-pool-price-limit":1,"tx-pool-price-bump":10,"tx-pool-account-slots":16,"tx-pool-global-slots":5120,"tx-pool-account-queue":64,"tx-pool-global-queue":1024,"tx-pool-lifetime":"10m0s","api-max-duration":"0s","ws-cpu-refill-rate":"0s","ws-cpu-max-stored":"0s","api-max-blocks-per-request":0,"allow-unfinalized-queries":false,"allow-unprotected-txs":false,"allow-unprotected-tx-hashes":["0xfefb2da535e927b85fe68eb81cb2e4a5827c905f78381a01ef2322aa9b0aee8e"],"keystore-directory":"","keystore-external-signer":"","keystore-insecure-unlock-allowed":false,"push-gossip-percent-stake":0.9,"push-gossip-num-validators":100,"push-gossip-num-peers":0,"push-regossip-num-validators":10,"push-regossip-num-peers":0,"push-gossip-frequency":"100ms","pull-gossip-frequency":"1s","regossip-frequency":"30s","tx-regossip-frequency":"0s","log-level":"info","log-json-format":true,"offline-pruning-enabled":false,"offline-pruning-bloom-filter-size":512,"offline-pruning-data-directory":"","max-outbound-active-requests":16,"state-sync-enabled":null,"state-sync-skip-resume":false,"state-sync-server-trie-cache":64,"state-sync-ids":"","state-sync-commit-interval":16384,"state-sync-min-blocks":300000,"state-sync-request-size":1024,"inspect-database":false,"skip-upgrade-check":false,"accepted-cache-size":32,"transaction-history":0,"tx-lookup-limit":0,"skip-tx-indexing":false,"warp-off-chain-messages":null,"http-body-limit":0},"logger":"C Chain","caller":"plugin/evm/vm.go:380"}
{"timestamp":"2025-05-16T22:01:39.407871843Z","level":"info","msg":"Activating new precompile","name":"warpConfig","config":"{\"blockTimestamp\":1607144400,\"quorumNumerator\":0,\"requirePrimaryNetworkSigners\":false}","logger":"C Chain","caller":"core/state_processor_ext.go:54"}
{"timestamp":"2025-05-16T22:01:39.408266676Z","level":"info","msg":"Persisted trie from memory database","nodes":3,"size":"406.00 B","time":"3.042µs","gcnodes":0,"gcsize":"0.00 B","gctime":"0s","livenodes":0,"livesize":"0.00 B","logger":"C Chain","caller":"/go/pkg/mod/github.com/ava-labs/libevm@v1.13.14-0.2.0.release/triedb/hashdb/database.go:447"}
{"timestamp":"2025-05-16T22:01:39.408621718Z","level":"info","msg":"lastAccepted = 0x17a7011ebbed7c97c7858cec856bd462a1fe9c216ef5f110b40c3b573dc84c6f","logger":"C Chain","caller":"plugin/evm/vm.go:461"}
{"timestamp":"2025-05-16T22:01:39.409713801Z","level":"info","msg":"Allocated memory caches","trie clean":"512.00 MiB","trie dirty":"512.00 MiB","snapshot clean":"256.00 MiB","logger":"C Chain","caller":"eth/backend.go:146"}
{"timestamp":"2025-05-16T22:01:39.40982901Z","level":"info","msg":"State schema set to default","scheme":"hash","logger":"C Chain","caller":"/go/pkg/mod/github.com/ava-labs/libevm@v1.13.14-0.2.0.release/core/rawdb/accessors_trie.go:334"}
{"timestamp":"2025-05-16T22:01:39.409928218Z","level":"info","msg":"Initialising Ethereum protocol","network":43112,"dbversion":"<nil>","logger":"C Chain","caller":"eth/backend.go:194"}
{"timestamp":"2025-05-16T22:01:39.410080426Z","level":"warn","msg":"Upgrade blockchain database version","from":"<nil>","to":8,"logger":"C Chain","caller":"eth/backend.go:200"}
{"timestamp":"2025-05-16T22:01:39.411635135Z","level":"info","msg":"Writing genesis to database","logger":"C Chain","caller":"core/genesis.go:138"}
{"timestamp":"2025-05-16T22:01:39.411916885Z","level":"info","msg":"Activating new precompile","name":"warpConfig","config":"{\"blockTimestamp\":1607144400,\"quorumNumerator\":0,\"requirePrimaryNetworkSigners\":false}","logger":"C Chain","caller":"core/state_processor_ext.go:54"}
{"timestamp":"2025-05-16T22:01:39.412292718Z","level":"info","msg":"Persisted trie from memory database","nodes":3,"size":"406.00 B","time":"64.083µs","gcnodes":0,"gcsize":"0.00 B","gctime":"0s","livenodes":0,"livesize":"0.00 B","logger":"C Chain","caller":"triedb/hashdb/database.go:562"}
{"timestamp":"2025-05-16T22:01:39.412709051Z","level":"info","msg":"","logger":"C Chain","caller":"core/blockchain.go:378"}
{"timestamp":"2025-05-16T22:01:39.413269051Z","level":"info","msg":"---------------------------------------------------------------------------------------------------------------------------------------------------------","logger":"C Chain","caller":"core/blockchain.go:379"}
{"timestamp":"2025-05-16T22:01:39.414877635Z","level":"info","msg":"Chain ID:  43112 (unknown)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.415059593Z","level":"info","msg":"Consensus: unknown","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.415283218Z","level":"info","msg":"","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.415394176Z","level":"info","msg":"Pre-Merge hard forks (block based):","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.415603093Z","level":"info","msg":" - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.415851635Z","level":"info","msg":" - DAO Fork:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/dao-fork.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.416068051Z","level":"info","msg":" - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.416561801Z","level":"info","msg":" - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.416706926Z","level":"info","msg":" - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.416911885Z","level":"info","msg":" - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.416989135Z","level":"info","msg":" - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.417211926Z","level":"info","msg":" - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.417325635Z","level":"info","msg":" - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.41765401Z","level":"info","msg":" - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.417772468Z","level":"info","msg":" - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
{"timestamp":"2025-05-16T22:01:39.417952468Z","level":"info","msg":" - London:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)","logger":"C Chain","caller":"core/blockchain.go:381"}
```

## Need to be documented in RELEASES.md?

N/A
