### PR TITLE
[ci] Update dependabot to only propose security updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,4 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0 # Disable non-security version updates


### PR DESCRIPTION
## Why this should be merged

We don't have the review bandwidth/expertise to review all potential updates to the github actions we use.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A