### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -575,11 +575,8 @@ func (n *Network) TrackedSubnetsForNode(nodeID ids.NodeID) string {
 			continue
 		}
 		// Only track subnets that this node validates
-		for _, validatorID := range subnet.ValidatorIDs {
-			if validatorID == nodeID {
-				subnetIDs = append(subnetIDs, subnet.SubnetID.String())
-				break
-			}
+		if slices.Contains(subnet.ValidatorIDs, nodeID) {
+			subnetIDs = append(subnetIDs, subnet.SubnetID.String())
 		}
 	}
 	return strings.Join(subnetIDs, ",")

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"math"
 	"net/http"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -2071,13 +2072,7 @@ func getStakeHelper(tx *txs.Tx, addrs set.Set[ids.ShortID], totalAmountStaked ma
 		}
 
 		// Check whether this output is owned by one of the given addresses
-		contains := false
-		for _, addr := range secpOut.Addrs {
-			if addrs.Contains(addr) {
-				contains = true
-				break
-			}
-		}
+		contains := slices.ContainsFunc(secpOut.Addrs, addrs.Contains)
 		if !contains {
 			// This output isn't owned by one of the given addresses. Ignore.
 			continue


### PR DESCRIPTION
## Why this should be merged

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
