### PR TITLE
chore(deps): use coreth with geth-aligned ethclient package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/StephenButtolph/canoto v0.15.0
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523100307-aa2d3705c439
+	github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523163800-aac22d91be3f
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60
 	github.com/ava-labs/libevm v1.13.14-0.2.0.release
 	github.com/btcsuite/btcd/btcutil v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/StephenButtolph/canoto v0.15.0
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/coreth v0.15.1-rc.0.0.20250509150914-391115af7620
+	github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523100307-aa2d3705c439
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60
 	github.com/ava-labs/libevm v1.13.14-0.2.0.release
 	github.com/btcsuite/btcd/btcutil v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/coreth v0.15.1-rc.0.0.20250509150914-391115af7620 h1:Vm790Gn1PqUcUnOXSIbZw7BSnQCpsPAN7/IBgbqujNo=
-github.com/ava-labs/coreth v0.15.1-rc.0.0.20250509150914-391115af7620/go.mod h1:mfvr1iQAADUfqkKkmQXJPwm3q9LSpcWF+fzIGk4HHuw=
+github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523100307-aa2d3705c439 h1:LCuWz5xOGmN6P2DFcjRO4WfOz5WTZQSGMz5rIP3BCyI=
+github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523100307-aa2d3705c439/go.mod h1:6HipGuNCN6IIe30AXwvG11Ja0AudQMtrMdTypjsju5U=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60 h1:EL66gtXOAwR/4KYBjOV03LTWgkEXvLePribLlJNu4g0=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60/go.mod h1:/7qKobTfbzBu7eSTVaXMTr56yTYk4j2Px6/8G+idxHo=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release h1:uKGCc5/ceeBbfAPRVtBUxbQt50WzB2pEDb8Uy93ePgQ=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523100307-aa2d3705c439 h1:LCuWz5xOGmN6P2DFcjRO4WfOz5WTZQSGMz5rIP3BCyI=
-github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523100307-aa2d3705c439/go.mod h1:6HipGuNCN6IIe30AXwvG11Ja0AudQMtrMdTypjsju5U=
+github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523163800-aac22d91be3f h1:3hffiIkjWYrbdufcZEFeT0MWYPQOpFlgcgoSEPMbRw4=
+github.com/ava-labs/coreth v0.15.1-rc.0.0.20250523163800-aac22d91be3f/go.mod h1:b7qPAGDlViompJ0+aVkKs/0sHbcIJchhi7kg403jZRA=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60 h1:EL66gtXOAwR/4KYBjOV03LTWgkEXvLePribLlJNu4g0=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60/go.mod h1:/7qKobTfbzBu7eSTVaXMTr56yTYk4j2Px6/8G+idxHo=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release h1:uKGCc5/ceeBbfAPRVtBUxbQt50WzB2pEDb8Uy93ePgQ=

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -128,7 +128,7 @@ func GetWalletBalances(tc tests.TestContext, wallet *primary.Wallet) (uint64, ui
 }
 
 // Create a new eth client targeting the specified node URI.
-func NewEthClient(tc tests.TestContext, nodeURI tmpnet.NodeURI) ethclient.Client {
+func NewEthClient(tc tests.TestContext, nodeURI tmpnet.NodeURI) *ethclient.Client {
 	tc.Log().Info("initializing a new eth client",
 		zap.Stringer("nodeID", nodeURI.NodeID),
 		zap.String("URI", nodeURI.URI),
@@ -167,7 +167,7 @@ func WaitForHealthy(t require.TestingT, node *tmpnet.Node) {
 
 // Sends an eth transaction and waits for the transaction receipt from the
 // execution of the transaction.
-func SendEthTransaction(tc tests.TestContext, ethClient ethclient.Client, signedTx *types.Transaction) *types.Receipt {
+func SendEthTransaction(tc tests.TestContext, ethClient *ethclient.Client, signedTx *types.Transaction) *types.Receipt {
 	require := require.New(tc)
 
 	txID := signedTx.Hash()
@@ -200,7 +200,7 @@ func SendEthTransaction(tc tests.TestContext, ethClient ethclient.Client, signed
 
 // Determines the suggested gas price for the configured client that will
 // maximize the chances of transaction acceptance.
-func SuggestGasPrice(tc tests.TestContext, ethClient ethclient.Client) *big.Int {
+func SuggestGasPrice(tc tests.TestContext, ethClient *ethclient.Client) *big.Int {
 	gasPrice, err := ethClient.SuggestGasPrice(tc.DefaultContext())
 	require.NoError(tc, err)
 
@@ -216,7 +216,7 @@ func SuggestGasPrice(tc tests.TestContext, ethClient ethclient.Client) *big.Int 
 }
 
 // Helper simplifying use via an option of a gas price appropriate for testing.
-func WithSuggestedGasPrice(tc tests.TestContext, ethClient ethclient.Client) common.Option {
+func WithSuggestedGasPrice(tc tests.TestContext, ethClient *ethclient.Client) common.Option {
 	baseFee := SuggestGasPrice(tc, ethClient)
 	return common.WithBaseFee(baseFee)
 }

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -68,7 +68,7 @@ func NewWallet(
 	builder Builder,
 	signer Signer,
 	avaxClient client.Client,
-	ethClient ethclient.Client,
+	ethClient *ethclient.Client,
 	backend Backend,
 ) Wallet {
 	return &wallet{
@@ -85,7 +85,7 @@ type wallet struct {
 	builder    Builder
 	signer     Signer
 	avaxClient client.Client
-	ethClient  ethclient.Client
+	ethClient  *ethclient.Client
 }
 
 func (w *wallet) Builder() Builder {

--- a/wallet/subnet/primary/api.go
+++ b/wallet/subnet/primary/api.go
@@ -179,7 +179,7 @@ func FetchPState(
 }
 
 type EthState struct {
-	Client   ethclient.Client
+	Client   *ethclient.Client
 	Accounts map[ethcommon.Address]*c.Account
 }
 


### PR DESCRIPTION
## Why this should be merged

So we can have a textually aligned ethclient package with geth in coreth. This uses coreth from this master branch commit: https://github.com/ava-labs/coreth/commit/aac22d91be3fceeca235ce3e4f49415fd47887ff

~ℹ️  this is based on top of v1.13.1-rc.2 because that's what coreth is currently using (2025-05-23). I did try to base it on avalanchego master branch but that caused some tests to fail for unrelated reasons, and didn't have time to debug all this today.~

## How this works

Change using the `ethclient.Client` interface to the pointer `*ethclient.Client`. There was no point using an interface anyway.

## How this was tested

CI passing on both the coreth PR and this PR

## Need to be documented in RELEASES.md?

No