### PR TITLE
Remove dead “Turtle’s Way HTTP/gRPC” link

### DIFF
--- a/vms/rpcchainvm/ghttp/http_server.go
+++ b/vms/rpcchainvm/ghttp/http_server.go
@@ -151,7 +151,7 @@ func (s *Server) Handle(ctx context.Context, req *httppb.HTTPRequest) (*httppb.H
 }
 
 // HandleSimple handles http requests over http2 using a simple request response model.
-// Websockets are not supported. Based on https://www.weave.works/blog/turtles-way-http-grpc/
+// Websockets are not supported. Additional information: https://grpc.github.io/grpc/core/md_doc__p_r_o_t_o_c_o_l-_h_t_t_p2.html
 func (s *Server) HandleSimple(ctx context.Context, r *httppb.HandleSimpleHTTPRequest) (*httppb.HandleSimpleHTTPResponse, error) {
 	req, err := http.NewRequest(r.Method, r.Url, bytes.NewBuffer(r.Body))
 	if err != nil {

--- a/vms/rpcchainvm/ghttp/http_server.go
+++ b/vms/rpcchainvm/ghttp/http_server.go
@@ -151,7 +151,7 @@ func (s *Server) Handle(ctx context.Context, req *httppb.HTTPRequest) (*httppb.H
 }
 
 // HandleSimple handles http requests over http2 using a simple request response model.
-// Websockets are not supported. Additional information: https://grpc.github.io/grpc/core/md_doc__p_r_o_t_o_c_o_l-_h_t_t_p2.html
+// Websockets are not supported.
 func (s *Server) HandleSimple(ctx context.Context, r *httppb.HandleSimpleHTTPRequest) (*httppb.HandleSimpleHTTPResponse, error) {
 	req, err := http.NewRequest(r.Method, r.Url, bytes.NewBuffer(r.Body))
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged
because present link doesn't work anymore. 
## How this works

## How this was tested

## Need to be documented in RELEASES.md?
