### PR TITLE
make GOPROXY overridable in constants.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,20 +9,17 @@ print_usage() {
 
   Options:
 
-    -r           Build with race detector
-    -p <value>   use custom GOPROXY
+    -r  Build with race detector
 "
 }
 
 race=''
-proxy=''
-while getopts 'rp:' flag; do
+while getopts 'r' flag; do
   case "${flag}" in
     r)
       echo "Building with race detection enabled"
-      race='-race' ;;
-    p)
-      proxy="${OPTARG}" ;;
+      race='-race'
+      ;;
     *) print_usage
       exit 1 ;;
   esac
@@ -30,7 +27,7 @@ done
 
 REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Configure the build environment
-source "${REPO_ROOT}"/scripts/constants.sh $proxy
+source "${REPO_ROOT}"/scripts/constants.sh
 # Determine the git commit hash to use for the build
 source "${REPO_ROOT}"/scripts/git_commit.sh
 

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -30,8 +30,4 @@ export CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"
 export CGO_ENABLED=1 # Required for cross-compilation
 
 # Disable version control fallbacks
-if [ "$#" -gt 0 ]; then
-    export GOPROXY=$1
-else
-    export GOPROXY="https://proxxy.golang.org"
-fi
+export GOPROXY="${GOPROXY:-https://proxy.golang.org}"


### PR DESCRIPTION
## Why this should be merged
The default GOPROXY https://proxy.golang.org is not usable in China since the site has been blocked by GW firewall. It's a well-known issue in Chain and we use other mirrors to download go packages. So I add an extra parameter to build.sh to set an overriding GOPROXY for that.

## How this works
An extra parameter can be passed into build.sh, like:
```
scripts/build.sh -p https://goproxy.cn
```
This proxy (https://goproxy.cn) will override default GOPROXY in constants.sh, and the following "go build..." can download dependencies successfully.

## How this was tested
1. if no this extra parameter passed in, running scripts/build.sh would hang and end with I/O timeout downloading dependency packages like this:
```
golang.org/x/crypto@v0.36.0: Get "https://proxxy.golang.org/golang.org/x/crypto/@v/v0.36.0.zip": dial tcp [2404:6800:4012:8::2011]:443: i/o timeout
```
2. With this extra parameter passed in, running scripts/build.sh would download dependency packages and build the avalanchego binary successfully.

## Need to be documented in RELEASES.md?
Yes.