### PR TITLE
Disallow slow sorting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,6 +112,7 @@ linters-settings:
       - 'require\.EqualValues$(# Equal should be used instead)?'
       - 'require\.NotEqualValues$(# NotEqual should be used instead)?'
       - '^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the require library should be used instead)?'
+      - '^sort\.(Slice|Strings)$(# the slices package should be used instead)?'
     # Exclude godoc examples from forbidigo checks.
     exclude_godoc_examples: false
   gci:

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -153,7 +153,7 @@ func TestGetValidatorsSetProperty(t *testing.T) {
 			// Checks: let's look back at validator sets at previous heights and
 			// make sure they match the snapshots already taken
 			snapshotHeights := maps.Keys(validatorSetByHeightAndSubnet)
-			sort.Slice(snapshotHeights, func(i, j int) bool { return snapshotHeights[i] < snapshotHeights[j] })
+			slices.Sort(snapshotHeights)
 			for idx, snapShotHeight := range snapshotHeights {
 				lastAcceptedHeight, err := vm.GetCurrentHeight(context.Background())
 				if err != nil {

--- a/x/merkledb/view_iterator_test.go
+++ b/x/merkledb/view_iterator_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"math/rand"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -258,7 +258,7 @@ func Test_View_Iterator_Random(t *testing.T) {
 
 	iter := view3.NewIterator()
 	uniqueKeys := maps.Keys(uniqueKeyChanges)
-	sort.Strings(uniqueKeys)
+	slices.Sort(uniqueKeys)
 	i := 0
 	for iter.Next() {
 		expectedKey := uniqueKeys[i]


### PR DESCRIPTION
## Why this should be merged

`sort.Slice` is an old method of sorting that relies on reflection. The `slices.Sort` method is generic and runs faster.

## How this works

This doesn't disallow `sort` entirely, as there are still some usages of the `sort.Interface` which are a bit more complex to change... Although we should probably change those as well eventually.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.