### PR TITLE
[testing] Add local kube support for load tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -232,6 +232,12 @@ tasks:
       - task: generate-load-contract-bindings
       - task: build
       - cmd: go run ./tests/load/c/main --avalanchego-path=./build/avalanchego {{.CLI_ARGS}}
+    
+  test-load-kube:
+    desc: Runs load tests against a network deployed to kube
+    cmds: 
+      - task: generate-load-contract-bindings
+      - cmd: bash -x ./scripts/tests.load.kube.sh {{.CLI_ARGS}}
 
   test-unit:
     desc: Runs unit tests

--- a/scripts/tests.load.kube.sh
+++ b/scripts/tests.load.kube.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Run load test against nodes deployed to a kind cluster
+
+if ! [[ "$0" =~ scripts/tests.load.kube.sh ]]; then
+    echo "must be run from repository root"
+    exit 255
+fi
+
+# This script will use kubeconfig arguments if supplied
+./scripts/start_kind_cluster.sh "$@"
+
+# Build AvalancheGo image
+DOCKER_IMAGE=localhost:5001/avalanchego FORCE_TAG_LATEST=1 ./scripts/build_image.sh 
+
+go run ./tests/load/c/main --runtime=kube "$@"


### PR DESCRIPTION
## Why this should be merged

This PR extends the functionality of the load tests by allowing it to run against a deployed Kube network.

## How this works

```bash
./scripts/run_task.sh test-load-kube
```

## How this was tested

## Need to be documented in RELEASES.md?

N/A