### PR TITLE
Remove requestID expectation for UnrequestedOps

### DIFF
--- a/message/fields.go
+++ b/message/fields.go
@@ -83,14 +83,9 @@ type requestIDGetter interface {
 
 func GetRequestID(m any) (uint32, bool) {
 	if msg, ok := m.(requestIDGetter); ok {
-		requestID := msg.GetRequestId()
-		return requestID, true
+		return msg.GetRequestId(), true
 	}
-
-	// AppGossip is the only inbound message not containing a requestID. For
-	// ease of handling, imagine that it does have a requestID.
-	_, ok := m.(*p2p.AppGossip)
-	return 0, ok
+	return 0, false
 }
 
 type engineTypeGetter interface {

--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -221,18 +221,6 @@ func (cr *ChainRouter) HandleInbound(ctx context.Context, msg message.InboundMes
 		return
 	}
 
-	requestID, ok := message.GetRequestID(m)
-	if !ok {
-		cr.log.Debug("dropping message with invalid field",
-			zap.Stringer("nodeID", nodeID),
-			zap.Stringer("messageOp", op),
-			zap.String("field", "RequestID"),
-		)
-
-		msg.OnFinishedHandling()
-		return
-	}
-
 	cr.lock.Lock()
 	defer cr.lock.Unlock()
 
@@ -293,6 +281,18 @@ func (cr *ChainRouter) HandleInbound(ctx context.Context, msg message.InboundMes
 				EngineType:     engineType,
 			},
 		)
+		return
+	}
+
+	requestID, ok := message.GetRequestID(m)
+	if !ok {
+		cr.log.Debug("dropping message with invalid field",
+			zap.Stringer("nodeID", nodeID),
+			zap.Stringer("messageOp", op),
+			zap.String("field", "RequestID"),
+		)
+
+		msg.OnFinishedHandling()
 		return
 	}
 


### PR DESCRIPTION
## Why this should be merged

Currently there is a hack to ensure that we can fetch `RequestID`s from all p2p messages handled by the chain router. We now only expect to be able to get a `RequestID` from responses (or timeouts). Inbound requests do not require a `RequestID`.

## How this works

Moves checks around.

## How this was tested

CI

## Need to be documented in RELEASES.md?
