### PR TITLE
[tmpnet] Avoid port forwarding when running in a kube cluster

### DIFF
--- a/tests/fixture/tmpnet/kube_runtime.go
+++ b/tests/fixture/tmpnet/kube_runtime.go
@@ -145,7 +145,7 @@ func (p *KubeRuntime) GetLocalURI(ctx context.Context) (string, func(), error) {
 	}
 
 	// Use direct pod URI if running inside the cluster
-	if p.isRunningInCluster() {
+	if isRunningInCluster() {
 		return p.node.URI, func() {}, nil
 	}
 
@@ -167,7 +167,7 @@ func (p *KubeRuntime) GetLocalStakingAddress(ctx context.Context) (netip.AddrPor
 	}
 
 	// Use direct pod staking address if running inside the cluster
-	if p.isRunningInCluster() {
+	if isRunningInCluster() {
 		return p.node.StakingAddress, func() {}, nil
 	}
 
@@ -845,7 +845,7 @@ func configureExclusiveScheduling(template *corev1.PodTemplateSpec, labelKey str
 // isRunningInCluster detects if this code is running inside a Kubernetes cluster
 // by checking for the presence of the service account token that's automatically
 // mounted in every pod.
-func (p *KubeRuntime) isRunningInCluster() bool {
+func isRunningInCluster() bool {
 	_, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	return err == nil
 }

--- a/tests/fixture/tmpnet/kube_runtime.go
+++ b/tests/fixture/tmpnet/kube_runtime.go
@@ -144,8 +144,10 @@ func (p *KubeRuntime) GetLocalURI(ctx context.Context) (string, func(), error) {
 		}
 	}
 
-	// TODO(marun) Detect whether this test code is running inside the cluster
-	//             and use the URI directly
+	// Use direct pod URI if running inside the cluster
+	if p.isRunningInCluster() {
+		return p.node.URI, func() {}, nil
+	}
 
 	port, stopChan, err := p.forwardPort(ctx, config.DefaultHTTPPort)
 	if err != nil {
@@ -164,8 +166,10 @@ func (p *KubeRuntime) GetLocalStakingAddress(ctx context.Context) (netip.AddrPor
 		}
 	}
 
-	// TODO(marun) Detect whether this test code is running inside the cluster
-	//             and use the URI directly
+	// Use direct pod staking address if running inside the cluster
+	if p.isRunningInCluster() {
+		return p.node.StakingAddress, func() {}, nil
+	}
 
 	port, stopChan, err := p.forwardPort(ctx, config.DefaultStakingPort)
 	if err != nil {
@@ -836,4 +840,12 @@ func configureExclusiveScheduling(template *corev1.PodTemplateSpec, labelKey str
 			},
 		},
 	}
+}
+
+// isRunningInCluster detects if this code is running inside a Kubernetes cluster
+// by checking for the presence of the service account token that's automatically
+// mounted in every pod.
+func (p *KubeRuntime) isRunningInCluster() bool {
+	_, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	return err == nil
 }


### PR DESCRIPTION
## Why this should be merged

Previously port forwarding was always used to communicate with a node even when a test workload was running inside a kube cluster (assumed to be the same cluster hosting the avalanchego nodes). Now the pod IP will be used if running in a kube cluster (as indicated by a service account token is observed on the local filesystem). This avoids the overhead of tunneling through the kube API when not needed.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A