### PR TITLE
Move HTTP2 routing information into headers

### DIFF
--- a/api/grpcclient/client.go
+++ b/api/grpcclient/client.go
@@ -8,16 +8,17 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/ava-labs/avalanchego/ids"
 )
 
-// NewChainClient returns grpc.ClientConn that prefixes method calls with the
-// provided chainID prefix
+// NewChainClient returns grpc.ClientConn that sets the chain-id header for
+// all requests
 func NewChainClient(uri string, chainID ids.ID, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	dialOpts := []grpc.DialOption{
-		grpc.WithUnaryInterceptor(PrefixChainIDUnaryClientInterceptor(chainID)),
-		grpc.WithStreamInterceptor(PrefixChainIDStreamClientInterceptor(chainID)),
+		grpc.WithUnaryInterceptor(SetChainIDHeaderUnaryClientInterceptor(chainID)),
+		grpc.WithStreamInterceptor(SetChainIDHeaderStreamClientInterceptor(chainID)),
 	}
 
 	dialOpts = append(dialOpts, opts...)
@@ -30,9 +31,9 @@ func NewChainClient(uri string, chainID ids.ID, opts ...grpc.DialOption) (*grpc.
 	return conn, nil
 }
 
-// PrefixChainIDUnaryClientInterceptor prefixes unary grpc calls with the
+// SetChainIDHeaderUnaryClientInterceptor prefixes unary grpc calls with the
 // provided chainID prefix
-func PrefixChainIDUnaryClientInterceptor(chainID ids.ID) grpc.UnaryClientInterceptor {
+func SetChainIDHeaderUnaryClientInterceptor(chainID ids.ID) grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
 		method string,
@@ -42,13 +43,14 @@ func PrefixChainIDUnaryClientInterceptor(chainID ids.ID) grpc.UnaryClientInterce
 		invoker grpc.UnaryInvoker,
 		opts ...grpc.CallOption,
 	) error {
-		return invoker(ctx, prefix(chainID, method), req, reply, cc, opts...)
+		ctx = newContextWithChainIDHeader(ctx, chainID)
+		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }
 
-// PrefixChainIDStreamClientInterceptor prefixes streaming grpc calls with the
+// SetChainIDHeaderStreamClientInterceptor prefixes streaming grpc calls with the
 // provided chainID prefix
-func PrefixChainIDStreamClientInterceptor(chainID ids.ID) grpc.StreamClientInterceptor {
+func SetChainIDHeaderStreamClientInterceptor(chainID ids.ID) grpc.StreamClientInterceptor {
 	return func(
 		ctx context.Context,
 		desc *grpc.StreamDesc,
@@ -57,11 +59,13 @@ func PrefixChainIDStreamClientInterceptor(chainID ids.ID) grpc.StreamClientInter
 		streamer grpc.Streamer,
 		opts ...grpc.CallOption,
 	) (grpc.ClientStream, error) {
-		return streamer(ctx, desc, cc, prefix(chainID, method), opts...)
+		ctx = newContextWithChainIDHeader(ctx, chainID)
+		return streamer(ctx, desc, cc, method, opts...)
 	}
 }
 
-// http/2 :path takes the form of /ChainID/Service/Method
-func prefix(chainID ids.ID, method string) string {
-	return "/" + chainID.String() + method
+// newContextWithChainHeader sets the chain-id header which is the server uses
+// to route the client grpc request
+func newContextWithChainIDHeader(ctx context.Context, chainID ids.ID) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, "chain-id", chainID.String())
 }

--- a/api/server/http2_router.go
+++ b/api/server/http2_router.go
@@ -25,15 +25,9 @@ func newHTTP2Router() *http2Router {
 }
 
 func (h *http2Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// The :path pseudo-header takes the form of /Prefix/Path
-	parsed := strings.Split(r.URL.Path, "/")
-	if len(parsed) < 2 {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	chainID := parsed[1]
-
+	// the chain-id header must be set to route the request to the correct chain
+	// http2 handler
+	chainID := r.Header.Get("chain-id")
 	h.lock.RLock()
 	handler, ok := h.handlers[chainID]
 	h.lock.RUnlock()


### PR DESCRIPTION
## Why this should be merged

Modifying the http2 `:path` is hacky because it's typically a read-only value, and supporting other tools like postman/grpcurl require more hacks where we have to keep injecting this value

## How this works

Moves the chain id information into an http header, which tooling generally has access to read/write to

## How this was tested

xsvm e2e test

## Need to be documented in RELEASES.md?

No (this feature wasn't released yet)
