### PR TITLE
Simplex QuorumCertificate and BLS aggregator

### DIFF
--- a/simplex/bls.go
+++ b/simplex/bls.go
@@ -1,17 +1,3 @@
-
-
-var (
-	errSignatureVerificationFailed = errors.New("signature verification failed")
-	errSignerNotFound              = errors.New("signer not found in the membership set")
-	errFailedToParseSignature      = errors.New("failed to parse signature")
-	errFailedToParseQC             = errors.New("failed to parse quorum certificate")
-	errNotEnoughSigners            = errors.New("not enough signers")
-	errSignatureAggregation        = errors.New("signature aggregation failed")
-	errEncodingMessageToSign       = errors.New("failed to encode message to sign")
-	simplexLabel                   = []byte("simplex")
-// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
-// See the file LICENSE for licensing terms.
-
 package simplex
 
 import (
@@ -29,6 +15,13 @@ var (
 	errSignerNotFound              = errors.New("signer not found in the membership set")
 	errInvalidNodeID               = errors.New("unable to parse node ID")
 	errFailedToParseSignature      = errors.New("failed to parse signature")
+
+	// QC errors
+	errFailedToParseQC             = errors.New("failed to parse quorum certificate")
+	errNotEnoughSigners            = errors.New("not enough signers")
+	errSignatureAggregation        = errors.New("signature aggregation failed")
+	errEncodingMessageToSign       = errors.New("failed to encode message to sign")
+	simplexLabel                   = []byte("simplex")
 )
 
 var _ simplex.Signer = (*BLSSigner)(nil)

--- a/simplex/bls_test.go
+++ b/simplex/bls_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/simplex"
 )
 
 func TestBLSVerifier(t *testing.T) {

--- a/simplex/quorum.go
+++ b/simplex/quorum.go
@@ -46,7 +46,7 @@ func (qc *QC) Verify(msg []byte) error {
 			return fmt.Errorf("%w: %x", errSignerNotFound, signer)
 		}
 
-		pks = append(pks, &pk)
+		pks = append(pks, pk)
 	}
 
 	// aggregate the public keys
@@ -55,7 +55,7 @@ func (qc *QC) Verify(msg []byte) error {
 		return fmt.Errorf("%w: %w", errSignatureAggregation, err)
 	}
 
-	message2Verify, err := encodeMessageToSign(msg, qc.verifier.chainID, qc.verifier.subnetID)
+	message2Verify, err := encodeMessageToSign(msg, qc.verifier.chainID, qc.verifier.networkID)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errEncodingMessageToSign, err)
 	}

--- a/simplex/util_test.go
+++ b/simplex/util_test.go
@@ -36,42 +36,42 @@ func newTestValidators(allVds []*testSigner) map[ids.NodeID]*validators.GetValid
 	return vds
 }
 
-func newEngineConfig(t *testing.T, numNodes uint64) *testConfig {
-	if numNodes == 0 {
-		panic("numNodes must be greater than 0")
-	}
+// func newEngineConfig(t *testing.T, numNodes uint64) *testConfig {
+// 	if numNodes == 0 {
+// 		panic("numNodes must be greater than 0")
+// 	}
 
-	ls, err := localsigner.New()
-	require.NoError(t, err)
+// 	ls, err := localsigner.New()
+// 	require.NoError(t, err)
 
-	nodeID := ids.GenerateTestNodeID()
+// 	nodeID := ids.GenerateTestNodeID()
 
-	simplexChainContext := SimplexChainContext{
-		NodeID:   nodeID,
-		ChainID:  ids.GenerateTestID(),
-		SubnetID: ids.GenerateTestID(),
-	}
+// 	simplexChainContext := SimplexChainContext{
+// 		NodeID:   nodeID,
+// 		ChainID:  ids.GenerateTestID(),
+// 		SubnetID: ids.GenerateTestID(),
+// 	}
 
-	nodeInfo := &testSigner{
-		GetValidatorOutput: validators.GetValidatorOutput{
-			NodeID:    nodeID,
-			PublicKey: ls.PublicKey(),
-		},
-		sign: ls.Sign,
-	}
+// 	nodeInfo := &testSigner{
+// 		GetValidatorOutput: validators.GetValidatorOutput{
+// 			NodeID:    nodeID,
+// 			PublicKey: ls.PublicKey(),
+// 		},
+// 		sign: ls.Sign,
+// 	}
 
-	nodes := generateTestValidators(t, numNodes-1)
-	nodes = append([]*testSigner{nodeInfo}, nodes...)
+// 	nodes := generateTestValidators(t, numNodes-1)
+// 	nodes = append([]*testSigner{nodeInfo}, nodes...)
 
-	return &testConfig{
-		Config: Config{
-			Ctx:        simplexChainContext,
-			Validators: newTestValidators(nodes),
-			SignBLS:    ls.Sign,
-		},
-		Nodes: nodes,
-	}
-}
+// 	return &testConfig{
+// 		Config: Config{
+// 			Ctx:        simplexChainContext,
+// 			Validators: newTestValidators(nodes),
+// 			SignBLS:    ls.Sign,
+// 		},
+// 		Nodes: nodes,
+// 	}
+// }
 
 func generateTestValidators(t *testing.T, num uint64) []*testSigner {
 	vds := make([]*testSigner, num)


### PR DESCRIPTION
## Why this should be merged

Implements the simplex `QuorumCertificate`, `QCDeserializer` and `SignatureAggregator` interfaces. This allows simplex to parse, aggregate and verify quorum certificates(ex. finalizations and notarizations) during execution. 

## How this works

- Builds on top of the BLSVerifier to handle BLS signatures and public keys. 
- The bytes of a QC are serialized with `asn1`

## How this was tested

Added unit tests to `bls_test.go`.

## Need to be documented in RELEASES.md?

no