### PR TITLE
Remove gzip middleware from API server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ go 1.23.9
 
 require (
 	github.com/DataDog/zstd v1.5.2
-	github.com/NYTimes/gziphandler v1.1.1
 	github.com/StephenButtolph/canoto v0.15.0
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
 	github.com/ava-labs/coreth v0.15.2-rc.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec/go.mod h1
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
-github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
-github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/StephenButtolph/canoto v0.15.0 h1:3iGdyTSQZ7/y09WaJCe0O/HIi53ZyTrnmVzfCqt64mM=
 github.com/StephenButtolph/canoto v0.15.0/go.mod h1:IcnAHC6nJUfQFVR9y60ko2ecUqqHHSB6UwI9NnBFZnE=


### PR DESCRIPTION
## Why this should be merged
Previously the gzip middleware added gzip header to all responses, which breaks gRPC support. Compression can be handled more cleanly somewhere upstream if needed, meaning this middleware is not necessary and should be removed.

## How this works
The `gziphandler.GzipHandler` wrapper is removed from the API server setup. The import was removed and `go.mod` and `go.sum` were cleaned up, removing the dependency.

## How this was tested
CI

## Need to be documented in RELEASES.md?
Yes