### PR TITLE
Add support for XSVM grpc server reflection

### DIFF
--- a/vms/example/xsvm/vm.go
+++ b/vms/example/xsvm/vm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/versiondb"
@@ -157,6 +158,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 func (vm *VM) CreateHTTP2Handler(context.Context) (http.Handler, error) {
 	server := grpc.NewServer()
 	server.RegisterService(&xsvm.Ping_ServiceDesc, &api.PingService{Log: vm.chainContext.Log})
+	reflection.Register(server)
 	return server, nil
 }
 


### PR DESCRIPTION
## Why this should be merged

Allows clients to discover the service definition + request/response types without knowing the proto file

## How this works

Registers the xsvm grpc server into the grpc reflection api. Clients who don't know the proto file (postman, grpcurl) can query the reflection api to discover the available grpc services + its types to be able to communicate with the server without having the proto definition.

## How this was tested

Tested manually
```
➜  avalanchego git:(xsvm-server-reflection) ✗ grpcurl -H 'chain-id: Q3fReCSX3QSXxGXkcFC4wyU4ZmPsc22HAGjoge8oxWCzQ8bQD' -d '{"message": "foo"}' -plaintext 127.0.0.1:9650 xsvm.Ping/Ping

{
  "message": "foo"
}
```

## Need to be documented in RELEASES.md?

No