### PR TITLE
fix: update log commands for stopping collectors

### DIFF
--- a/tests/fixture/tmpnet/monitor_processes.go
+++ b/tests/fixture/tmpnet/monitor_processes.go
@@ -57,7 +57,7 @@ func StartPrometheus(ctx context.Context, log logging.Logger) error {
 	if err := waitForReadiness(ctx, log, prometheusCmd, prometheusReadinessURL); err != nil {
 		return err
 	}
-	log.Info("To stop: tmpnetctl stop-collectors")
+	log.Info("To stop: tmpnetctl stop-metrics-collectors")
 	return nil
 }
 
@@ -70,7 +70,7 @@ func StartPromtail(ctx context.Context, log logging.Logger) error {
 		return err
 	}
 	log.Info("skipping promtail readiness check until one or more nodes have written their service discovery configuration")
-	log.Info("To stop: tmpnetctl stop-collectors")
+	log.Info("To stop: tmpnetctl stop-logs-collectors")
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged

From `tmpnet help`:

```
tmpnetctl commands

Usage:
  tmpnetctl [command]

Available Commands:
  stop-logs-collector     Stop logs collector for local process-based nodes
  stop-metrics-collector  Stop metrics collector for local process-based nodes
```

However, when using `tmpnet` with the metrics and logs collectors enabled, we get the following logs:

```
[06-12|09:04:58.594] INFO avalanchego-load-test tmpnet/monitor_processes.go:547 collector ready {"cmd": "prometheus"}
[06-12|09:04:58.594] INFO avalanchego-load-test tmpnet/monitor_processes.go:60 To stop: tmpnetctl stop-collectors
[06-12|09:04:58.697] INFO avalanchego-load-test tmpnet/monitor_processes.go:471 started collector {"cmd": "promtail", "pid": 75082}
[06-12|09:04:59.699] INFO avalanchego-load-test tmpnet/monitor_processes.go:73 To stop: tmpnetctl stop-collectors
```

Running `./build/tmpctl stop-collectors` fails because it's an invalid command.

## How this works

Updates the log outputs to use `stop-logs-collector` and `stop-metrics-collector`.

## How this was tested

Ran `tmpnet` locally and observed the correct commands being logged.

## Need to be documented in RELEASES.md?

N/A