### PR TITLE
Fix subnet antithesis tests

### DIFF
--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -6,6 +6,7 @@ package antithesis
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -116,6 +117,9 @@ func initComposeConfig(
 		return fmt.Errorf("failed to marshal compose project: %w", err)
 	}
 	composePath := filepath.Join(targetPath, "docker-compose.yml")
+
+	log.Printf("writing docker compose to: %q\n\n%s", composePath, string(bytes))
+
 	if err := os.WriteFile(composePath, bytes, perms.ReadWrite); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -469,19 +469,15 @@ func (n *Network) Bootstrap(ctx context.Context, log logging.Logger) error {
 	// TODO(marun) This restart might be unnecessary if:
 	// - sybil protection didn't change
 	// - the node is not a subnet validator
-	log.Info("restarting bootstrap node",
+	log.Info("stopping bootstrap node",
 		zap.Stringer("nodeID", bootstrapNode.NodeID),
 	)
-	if err := bootstrapNode.Restart(ctx); err != nil {
+	if err := bootstrapNode.Stop(ctx); err != nil {
 		return err
 	}
 
-	if len(n.Nodes) == 1 {
-		return nil
-	}
-
-	log.Info("starting remaining nodes")
-	return n.StartNodes(ctx, log, n.Nodes[1:]...)
+	log.Info("starting nodes")
+	return n.StartNodes(ctx, log, n.Nodes...)
 }
 
 // Starts the provided node after configuring it for the network.


### PR DESCRIPTION
## Why this should be merged

Currently, the bootstrap node is not correctly having `trackSubnets` set in the docker compose for the antithesis tests. This results in the antithesis tests failing on startup with a 404 of the initial funding logic. This PR fixes the generated docker compose files.

This PR also introduces logging of the docker compose so that we can see the published docker compose from the CI job.

## How this works

#3882 refactored some of the `*Network.Bootstrap` function to use `*Node.Restart` rather than `*Network.StartNode`. This seems to have introduced a regression causing the `track-subnets` flag to be cleared when reloading the flags for the bootstrap node.

## How this was tested

Locally running `./scripts/build_antithesis_images.sh` now produces a docker compose with the bootstrap node correctly configured with the `trackSubnets` flag.

## Need to be documented in RELEASES.md?
