### PR TITLE
[tmpnet] Enure node config is saved on restart for both runtimes

### DIFF
--- a/scripts/tests.e2e.existing.sh
+++ b/scripts/tests.e2e.existing.sh
@@ -26,6 +26,9 @@ function cleanup {
 }
 trap cleanup EXIT
 
+# TMPNET_NETWORK_DIR needs to be unset to ensure --reuse-network won't target an existing network
+unset TMPNET_NETWORK_DIR
+
 print_separator
 echo "starting initial test run that should create the reusable network"
 ./scripts/tests.e2e.sh --reuse-network --ginkgo.focus-file=xsvm.go "${@}"
@@ -37,7 +40,8 @@ INITIAL_NETWORK_DIR="$(realpath "${SYMLINK_PATH}")"
 
 print_separator
 echo "starting second test run that should reuse the network created by the first run"
-./scripts/tests.e2e.sh --reuse-network --ginkgo.focus-file=xsvm.go "${@}"
+echo "the network is first restarted to verify that the network state was correctly serialized"
+./scripts/tests.e2e.sh --restart-network --ginkgo.focus-file=xsvm.go "${@}"
 
 SUBSEQUENT_NETWORK_DIR="$(realpath "${SYMLINK_PATH}")"
 echo "checking that the symlink path remains the same, indicating that the network was reused"

--- a/tests/fixture/tmpnet/kube_runtime.go
+++ b/tests/fixture/tmpnet/kube_runtime.go
@@ -462,11 +462,6 @@ func (p *KubeRuntime) Restart(ctx context.Context) error {
 		return err
 	}
 
-	// Save node to disk to ensure the same state can be used to restart
-	if err := p.node.Write(); err != nil {
-		return err
-	}
-
 	statefulset, err := clientset.AppsV1().StatefulSets(namespace).Get(ctx, statefulSetName, metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -545,7 +545,7 @@ func (n *Network) Restart(ctx context.Context) error {
 	if err := restartNodes(ctx, nodes); err != nil {
 		return err
 	}
-	return WaitForHealthyNodes(ctx, n.log, n.Nodes)
+	return WaitForHealthyNodes(ctx, n.log, nodes)
 }
 
 // Waits for the provided nodes to become healthy.

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -188,6 +188,10 @@ func (n *Node) WaitForStopped(ctx context.Context) error {
 }
 
 func (n *Node) Restart(ctx context.Context) error {
+	// Ensure the config used to restart the node is persisted for future use
+	if err := n.Write(); err != nil {
+		return err
+	}
 	return n.getRuntime().Restart(ctx)
 }
 


### PR DESCRIPTION
## Why this should be merged

The addition of the kube node runtime added a `Restart` method to the `NodeRuntime` interface to support runtime-specific restart behavior. This introduced a disparity in restart behavior between the process and kube runtimes. The kube runtime was saving the node configuration before restarting, but the process runtime was not.

When starting a network configured with one or more subnets using the process runtime, this resulted in `track-subnets` for the bootstrap node not being serialized to disk. Only the bootstrap node was affected because only it was being restarted after having `track-subnets` set. The remaining nodes were started with `Network.StartNode` - which ensures serialization - after `track-subnets` was set.

This broke the xsvm and subnet-evm antithesis testing because both depend on the serialized state resulting from the process runtime initializing a target network, and the serialized bootstrap node config would end up without a `track-subnets` value. This resulted in 404 responses when trying to query a subnet's rest endpoint. 

e2e subnet tests for xsvm were unaffected because those tests only target running nodes for which `track-subnets` is set correctly without regard to whether node configuration is serialized. The issue would only have surfaced in the e2e suite if someone had tried to use the `--restart-network` flag (e.g. to restart the nodes to use an updated avalanchego and/or xsvm plugin binary).

## The fix

- Ensure that `Node.Restart` serializes node configuration regardless of runtime.
- Update the e2e-existing CI job to test against a restarted network

Replaces https://github.com/ava-labs/avalanchego/pull/4013

## How this was tested

- [x] Manual inspection of network configuration
- [x] CI (with updated e2e-existing job)
  - Also verified that adding restart to e2e-existing failed against master due to the bootstrap node misconfiguration 
- [x] Manual trigger of xsvm test setup

## Need to be documented in RELEASES.md?

N/A