### PR TITLE
Capitalize secrets references

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -23,15 +23,15 @@ jobs:
         run: docker buildx create --use
       - name: Build and publish images to DockerHub
         env:
-          DOCKER_USERNAME: ${{ secrets.docker_username }}
-          DOCKER_PASS: ${{ secrets.docker_pass }}
-          DOCKER_IMAGE: ${{ secrets.docker_repo }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+          DOCKER_IMAGE: ${{ secrets.DOCKER_REPO }}
           BUILD_MULTI_ARCH: 1
         run: scripts/run_task.sh build-image
       - name: Build and publish bootstrap-monitor image to DockerHub
         env:
-          DOCKER_USERNAME: ${{ secrets.docker_username }}
-          DOCKER_PASS: ${{ secrets.docker_pass }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
           DOCKER_IMAGE: avaplatform/bootstrap-monitor
           BUILD_MULTI_ARCH: 1
         run: scripts/run_task.sh build-bootstrap-monitor-image


### PR DESCRIPTION
## Why this should be merged

During a secrets cleanup, I incorrectly removed the docker secrets because they were reported as not being used. It turns out that the secrets lookup is _not_ case sensitive but my scan _was_ case sensitive... Whoops.

This aligns the docker secrets with the rest of the repo as being uppercase.

## How this works

capitalizes secret envs.

## How this was tested

Wasn't.

## Need to be documented in RELEASES.md?

No.