### PR TITLE
Allow internal messages from disallowed nodeIDs

### DIFF
--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -198,12 +198,23 @@ func (cr *ChainRouter) RegisterRequest(
 		shouldMeasureLatency,
 		uniqueRequestID,
 		func() {
-			cr.HandleInbound(ctx, timeoutMsg)
+			cr.HandleInternal(ctx, timeoutMsg)
 		},
 	)
 }
 
 func (cr *ChainRouter) HandleInbound(ctx context.Context, msg message.InboundMessage) {
+	cr.handleMessage(ctx, msg, false)
+}
+
+func (cr *ChainRouter) HandleInternal(ctx context.Context, msg message.InboundMessage) {
+	cr.handleMessage(ctx, msg, true)
+}
+
+// HandleMessage handles a message from a peer. The internal flag indicates
+// whether the message is being sent from an internal component, such as due to
+// a timeout, or if the message originated from a remote peer.
+func (cr *ChainRouter) handleMessage(ctx context.Context, msg message.InboundMessage, internal bool) {
 	nodeID := msg.NodeID()
 	op := msg.Op()
 
@@ -248,7 +259,7 @@ func (cr *ChainRouter) HandleInbound(ctx context.Context, msg message.InboundMes
 		return
 	}
 
-	if !chain.ShouldHandle(nodeID) {
+	if !internal && !chain.ShouldHandle(nodeID) {
 		cr.log.Debug("dropping message",
 			zap.Stringer("messageOp", op),
 			zap.Stringer("nodeID", nodeID),

--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -208,6 +208,10 @@ func (cr *ChainRouter) HandleInbound(ctx context.Context, msg message.InboundMes
 }
 
 func (cr *ChainRouter) HandleInternal(ctx context.Context, msg message.InboundMessage) {
+	// handleMessage is called in a separate goroutine because internal messages
+	// may be sent while holding the chain's context lock. To enforce the
+	// expected lock ordering, we must not grab the chain router lock while
+	// holding the chain's context lock.
 	go cr.handleMessage(ctx, msg, true)
 }
 

--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -211,9 +211,10 @@ func (cr *ChainRouter) HandleInternal(ctx context.Context, msg message.InboundMe
 	cr.handleMessage(ctx, msg, true)
 }
 
-// HandleMessage handles a message from a peer. The internal flag indicates
-// whether the message is being sent from an internal component, such as due to
-// a timeout, or if the message originated from a remote peer.
+// handleMessage routes a message to the specified chain. Messages may be
+// unrequested, responses, or timeouts. The internal flag indicates whether the
+// message is being sent from an internal component, such as due to a timeout,
+// or if the message originated from a remote peer.
 func (cr *ChainRouter) handleMessage(ctx context.Context, msg message.InboundMessage, internal bool) {
 	nodeID := msg.NodeID()
 	op := msg.Op()

--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -198,7 +198,7 @@ func (cr *ChainRouter) RegisterRequest(
 		shouldMeasureLatency,
 		uniqueRequestID,
 		func() {
-			cr.HandleInternal(ctx, timeoutMsg)
+			cr.handleMessage(ctx, timeoutMsg, true)
 		},
 	)
 }
@@ -208,7 +208,7 @@ func (cr *ChainRouter) HandleInbound(ctx context.Context, msg message.InboundMes
 }
 
 func (cr *ChainRouter) HandleInternal(ctx context.Context, msg message.InboundMessage) {
-	cr.handleMessage(ctx, msg, true)
+	go cr.handleMessage(ctx, msg, true)
 }
 
 // handleMessage routes a message to the specified chain. Messages may be

--- a/snow/networking/router/router.go
+++ b/snow/networking/router/router.go
@@ -56,4 +56,5 @@ type InternalHandler interface {
 		failedMsg message.InboundMessage,
 		engineType p2p.EngineType,
 	)
+	HandleInternal(context.Context, message.InboundMessage)
 }

--- a/snow/networking/router/router.go
+++ b/snow/networking/router/router.go
@@ -56,5 +56,9 @@ type InternalHandler interface {
 		failedMsg message.InboundMessage,
 		engineType p2p.EngineType,
 	)
+
+	// HandleInternal enqueues a message to be handled by the consensus engine
+	// in the future. This function should only be called with messages
+	// generated internally, and not from messages received from a peer.
 	HandleInternal(context.Context, message.InboundMessage)
 }

--- a/snow/networking/router/routermock/router.go
+++ b/snow/networking/router/routermock/router.go
@@ -111,6 +111,18 @@ func (mr *RouterMockRecorder) HandleInbound(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*Router)(nil).HandleInbound), arg0, arg1)
 }
 
+// HandleInternal mocks base method.
+func (m *Router) HandleInternal(arg0 context.Context, arg1 message.InboundMessage) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HandleInternal", arg0, arg1)
+}
+
+// HandleInternal indicates an expected call of HandleInternal.
+func (mr *RouterMockRecorder) HandleInternal(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInternal", reflect.TypeOf((*Router)(nil).HandleInternal), arg0, arg1)
+}
+
 // HealthCheck mocks base method.
 func (m *Router) HealthCheck(arg0 context.Context) (any, error) {
 	m.ctrl.T.Helper()

--- a/snow/networking/sender/sender.go
+++ b/snow/networking/sender/sender.go
@@ -39,7 +39,7 @@ type sender struct {
 	msgCreator message.OutboundMsgBuilder
 
 	sender   ExternalSender // Actually does the sending over the network
-	router   router.Router
+	router   router.InternalHandler
 	timeouts timeout.Manager
 
 	// Counts how many request have failed because the node was benched
@@ -53,7 +53,7 @@ func New(
 	ctx *snow.ConsensusContext,
 	msgCreator message.OutboundMsgBuilder,
 	externalSender ExternalSender,
-	router router.Router,
+	router router.InternalHandler,
 	timeouts timeout.Manager,
 	engineType p2p.EngineType,
 	subnet subnets.Subnet,
@@ -117,7 +117,7 @@ func (s *sender) SendGetStateSummaryFrontier(ctx context.Context, nodeIDs set.Se
 			deadline,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Create the outbound message.
@@ -171,7 +171,7 @@ func (s *sender) SendStateSummaryFrontier(ctx context.Context, nodeID ids.NodeID
 			summary,
 			nodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -262,7 +262,7 @@ func (s *sender) SendGetAcceptedStateSummary(ctx context.Context, nodeIDs set.Se
 			deadline,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Create the outbound message.
@@ -317,7 +317,7 @@ func (s *sender) SendAcceptedStateSummary(ctx context.Context, nodeID ids.NodeID
 			summaryIDs,
 			nodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -398,7 +398,7 @@ func (s *sender) SendGetAcceptedFrontier(ctx context.Context, nodeIDs set.Set[id
 			deadline,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Create the outbound message.
@@ -452,7 +452,7 @@ func (s *sender) SendAcceptedFrontier(ctx context.Context, nodeID ids.NodeID, re
 			containerID,
 			nodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -534,7 +534,7 @@ func (s *sender) SendGetAccepted(ctx context.Context, nodeIDs set.Set[ids.NodeID
 			containerIDs,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Create the outbound message.
@@ -589,7 +589,7 @@ func (s *sender) SendAccepted(ctx context.Context, nodeID ids.NodeID, requestID 
 			containerIDs,
 			nodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -662,7 +662,7 @@ func (s *sender) SendGetAncestors(ctx context.Context, nodeID ids.NodeID, reques
 			opLabel: message.GetAncestorsOp.String(),
 		}).Inc()
 		s.timeouts.RegisterRequestToUnreachableValidator()
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -686,7 +686,7 @@ func (s *sender) SendGetAncestors(ctx context.Context, nodeID ids.NodeID, reques
 			zap.Error(err),
 		)
 
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -710,7 +710,7 @@ func (s *sender) SendGetAncestors(ctx context.Context, nodeID ids.NodeID, reques
 		)
 
 		s.timeouts.RegisterRequestToUnreachableValidator()
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 }
 
@@ -771,7 +771,7 @@ func (s *sender) SendGet(ctx context.Context, nodeID ids.NodeID, requestID uint3
 
 	// Sending a Get to myself always fails.
 	if nodeID == s.ctx.NodeID {
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -782,7 +782,7 @@ func (s *sender) SendGet(ctx context.Context, nodeID ids.NodeID, requestID uint3
 			opLabel: message.GetOp.String(),
 		}).Inc()
 		s.timeouts.RegisterRequestToUnreachableValidator()
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -830,7 +830,7 @@ func (s *sender) SendGet(ctx context.Context, nodeID ids.NodeID, requestID uint3
 		)
 
 		s.timeouts.RegisterRequestToUnreachableValidator()
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 }
 
@@ -925,7 +925,7 @@ func (s *sender) SendPushQuery(
 			requestedHeight,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Some of [nodeIDs] may be benched. That is, they've been unresponsive so
@@ -946,7 +946,7 @@ func (s *sender) SendPushQuery(
 				s.ctx.ChainID,
 				requestID,
 			)
-			go s.router.HandleInbound(ctx, inMsg)
+			go s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 
@@ -1010,7 +1010,7 @@ func (s *sender) SendPushQuery(
 				s.ctx.ChainID,
 				requestID,
 			)
-			go s.router.HandleInbound(ctx, inMsg)
+			go s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 }
@@ -1062,7 +1062,7 @@ func (s *sender) SendPullQuery(
 			requestedHeight,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Some of the nodes in [nodeIDs] may be benched. That is, they've been
@@ -1082,7 +1082,7 @@ func (s *sender) SendPullQuery(
 				s.ctx.ChainID,
 				requestID,
 			)
-			go s.router.HandleInbound(ctx, inMsg)
+			go s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 
@@ -1136,7 +1136,7 @@ func (s *sender) SendPullQuery(
 				s.ctx.ChainID,
 				requestID,
 			)
-			go s.router.HandleInbound(ctx, inMsg)
+			go s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 }
@@ -1163,7 +1163,7 @@ func (s *sender) SendChits(
 			acceptedID,
 			nodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -1247,7 +1247,7 @@ func (s *sender) SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID]
 			appRequestBytes,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Some of the nodes in [nodeIDs] may be benched. That is, they've been
@@ -1270,7 +1270,7 @@ func (s *sender) SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID]
 				common.ErrTimeout.Code,
 				common.ErrTimeout.Message,
 			)
-			go s.router.HandleInbound(ctx, inMsg)
+			go s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 
@@ -1332,7 +1332,7 @@ func (s *sender) SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID]
 				common.ErrTimeout.Code,
 				common.ErrTimeout.Message,
 			)
-			go s.router.HandleInbound(ctx, inMsg)
+			go s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 	return nil
@@ -1348,7 +1348,7 @@ func (s *sender) SendAppResponse(ctx context.Context, nodeID ids.NodeID, request
 			appResponseBytes,
 			nodeID,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return nil
 	}
 
@@ -1411,7 +1411,7 @@ func (s *sender) SendAppError(ctx context.Context, nodeID ids.NodeID, requestID 
 			errorCode,
 			errorMessage,
 		)
-		go s.router.HandleInbound(ctx, inMsg)
+		go s.router.HandleInternal(ctx, inMsg)
 		return nil
 	}
 

--- a/snow/networking/sender/sender.go
+++ b/snow/networking/sender/sender.go
@@ -117,7 +117,7 @@ func (s *sender) SendGetStateSummaryFrontier(ctx context.Context, nodeIDs set.Se
 			deadline,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Create the outbound message.
@@ -171,7 +171,7 @@ func (s *sender) SendStateSummaryFrontier(ctx context.Context, nodeID ids.NodeID
 			summary,
 			nodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -262,7 +262,7 @@ func (s *sender) SendGetAcceptedStateSummary(ctx context.Context, nodeIDs set.Se
 			deadline,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Create the outbound message.
@@ -317,7 +317,7 @@ func (s *sender) SendAcceptedStateSummary(ctx context.Context, nodeID ids.NodeID
 			summaryIDs,
 			nodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -398,7 +398,7 @@ func (s *sender) SendGetAcceptedFrontier(ctx context.Context, nodeIDs set.Set[id
 			deadline,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Create the outbound message.
@@ -452,7 +452,7 @@ func (s *sender) SendAcceptedFrontier(ctx context.Context, nodeID ids.NodeID, re
 			containerID,
 			nodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -534,7 +534,7 @@ func (s *sender) SendGetAccepted(ctx context.Context, nodeIDs set.Set[ids.NodeID
 			containerIDs,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Create the outbound message.
@@ -589,7 +589,7 @@ func (s *sender) SendAccepted(ctx context.Context, nodeID ids.NodeID, requestID 
 			containerIDs,
 			nodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -662,7 +662,7 @@ func (s *sender) SendGetAncestors(ctx context.Context, nodeID ids.NodeID, reques
 			opLabel: message.GetAncestorsOp.String(),
 		}).Inc()
 		s.timeouts.RegisterRequestToUnreachableValidator()
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -686,7 +686,7 @@ func (s *sender) SendGetAncestors(ctx context.Context, nodeID ids.NodeID, reques
 			zap.Error(err),
 		)
 
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -710,7 +710,7 @@ func (s *sender) SendGetAncestors(ctx context.Context, nodeID ids.NodeID, reques
 		)
 
 		s.timeouts.RegisterRequestToUnreachableValidator()
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 }
 
@@ -771,7 +771,7 @@ func (s *sender) SendGet(ctx context.Context, nodeID ids.NodeID, requestID uint3
 
 	// Sending a Get to myself always fails.
 	if nodeID == s.ctx.NodeID {
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -782,7 +782,7 @@ func (s *sender) SendGet(ctx context.Context, nodeID ids.NodeID, requestID uint3
 			opLabel: message.GetOp.String(),
 		}).Inc()
 		s.timeouts.RegisterRequestToUnreachableValidator()
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -830,7 +830,7 @@ func (s *sender) SendGet(ctx context.Context, nodeID ids.NodeID, requestID uint3
 		)
 
 		s.timeouts.RegisterRequestToUnreachableValidator()
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 }
 
@@ -925,7 +925,7 @@ func (s *sender) SendPushQuery(
 			requestedHeight,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Some of [nodeIDs] may be benched. That is, they've been unresponsive so
@@ -946,7 +946,7 @@ func (s *sender) SendPushQuery(
 				s.ctx.ChainID,
 				requestID,
 			)
-			go s.router.HandleInternal(ctx, inMsg)
+			s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 
@@ -1010,7 +1010,7 @@ func (s *sender) SendPushQuery(
 				s.ctx.ChainID,
 				requestID,
 			)
-			go s.router.HandleInternal(ctx, inMsg)
+			s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 }
@@ -1062,7 +1062,7 @@ func (s *sender) SendPullQuery(
 			requestedHeight,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Some of the nodes in [nodeIDs] may be benched. That is, they've been
@@ -1082,7 +1082,7 @@ func (s *sender) SendPullQuery(
 				s.ctx.ChainID,
 				requestID,
 			)
-			go s.router.HandleInternal(ctx, inMsg)
+			s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 
@@ -1136,7 +1136,7 @@ func (s *sender) SendPullQuery(
 				s.ctx.ChainID,
 				requestID,
 			)
-			go s.router.HandleInternal(ctx, inMsg)
+			s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 }
@@ -1163,7 +1163,7 @@ func (s *sender) SendChits(
 			acceptedID,
 			nodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return
 	}
 
@@ -1247,7 +1247,7 @@ func (s *sender) SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID]
 			appRequestBytes,
 			s.ctx.NodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 	}
 
 	// Some of the nodes in [nodeIDs] may be benched. That is, they've been
@@ -1270,7 +1270,7 @@ func (s *sender) SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID]
 				common.ErrTimeout.Code,
 				common.ErrTimeout.Message,
 			)
-			go s.router.HandleInternal(ctx, inMsg)
+			s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 
@@ -1332,7 +1332,7 @@ func (s *sender) SendAppRequest(ctx context.Context, nodeIDs set.Set[ids.NodeID]
 				common.ErrTimeout.Code,
 				common.ErrTimeout.Message,
 			)
-			go s.router.HandleInternal(ctx, inMsg)
+			s.router.HandleInternal(ctx, inMsg)
 		}
 	}
 	return nil
@@ -1348,7 +1348,7 @@ func (s *sender) SendAppResponse(ctx context.Context, nodeID ids.NodeID, request
 			appResponseBytes,
 			nodeID,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return nil
 	}
 
@@ -1411,7 +1411,7 @@ func (s *sender) SendAppError(ctx context.Context, nodeID ids.NodeID, requestID 
 			errorCode,
 			errorMessage,
 		)
-		go s.router.HandleInternal(ctx, inMsg)
+		s.router.HandleInternal(ctx, inMsg)
 		return nil
 	}
 

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -6,7 +6,7 @@ package sender_test
 import (
 	"context"
 	"fmt"
-	"math/rand/v2"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -864,15 +864,10 @@ func TestSender_Bootstrap_Requests(t *testing.T) {
 
 			// Make sure we send a message to ourselves since [myNodeID]
 			// is in [nodeIDs].
-			// Note that HandleInternal is called in a separate goroutine
-			// so we need to use a channel to synchronize the test.
-			calledHandleInternal := make(chan struct{})
 			router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 				func(_ context.Context, msg message.InboundMessage) {
-					// Make sure we're sending ourselves
-					// the expected message.
+					// Make sure we're sending ourselves the expected message.
 					tt.assertMsgToMyself(require, msg)
-					close(calledHandleInternal)
 				},
 			)
 
@@ -883,8 +878,6 @@ func TestSender_Bootstrap_Requests(t *testing.T) {
 			tt.setExternalSenderExpect(externalSender)
 
 			tt.sendF(require, sender, nodeIDsCopy)
-
-			<-calledHandleInternal
 		})
 	}
 }
@@ -1064,17 +1057,13 @@ func TestSender_Bootstrap_Responses(t *testing.T) {
 
 			// Case: sending to ourselves
 			{
-				calledHandleInternal := make(chan struct{})
 				router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 					func(_ context.Context, msg message.InboundMessage) {
-						// Make sure we're sending ourselves
-						// the expected message.
+						// Make sure we're sending ourselves the expected message.
 						tt.assertMsgToMyself(require, msg)
-						close(calledHandleInternal)
 					},
 				)
 				tt.sendF(require, sender, ctx.NodeID)
-				<-calledHandleInternal
 			}
 
 			// Case: not sending to ourselves
@@ -1243,25 +1232,16 @@ func TestSender_Single_Request(t *testing.T) {
 					tt.expectedEngineType, // Engine Type
 				)
 
-				// Note that HandleInternal is called in a separate goroutine
-				// so we need to use a channel to synchronize the test.
-				calledHandleInternal := make(chan struct{})
 				if tt.shouldFailMessageToSelf {
 					router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 						func(_ context.Context, msg message.InboundMessage) {
-							// Make sure we're sending ourselves
-							// the expected message.
+							// Make sure we're sending ourselves the expected message.
 							tt.assertMsg(require, msg)
-							close(calledHandleInternal)
 						},
 					)
-				} else {
-					close(calledHandleInternal)
 				}
 
 				tt.sendF(require, sender, ctx.NodeID)
-
-				<-calledHandleInternal
 			}
 
 			// Case: Node is benched
@@ -1282,21 +1262,14 @@ func TestSender_Single_Request(t *testing.T) {
 					tt.expectedEngineType, // Engine Type
 				)
 
-				// Note that HandleInternal is called in a separate goroutine
-				// so we need to use a channel to synchronize the test.
-				calledHandleInternal := make(chan struct{})
 				router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 					func(_ context.Context, msg message.InboundMessage) {
-						// Make sure we're sending ourselves
-						// the expected message.
+						// Make sure we're sending ourselves the expected message.
 						tt.assertMsg(require, msg)
-						close(calledHandleInternal)
 					},
 				)
 
 				tt.sendF(require, sender, destinationNodeID)
-
-				<-calledHandleInternal
 			}
 
 			// Case: Node is not myself, not benched and send fails
@@ -1317,15 +1290,10 @@ func TestSender_Single_Request(t *testing.T) {
 					tt.expectedEngineType, // Engine Type
 				)
 
-				// Note that HandleInternal is called in a separate goroutine
-				// so we need to use a channel to synchronize the test.
-				calledHandleInternal := make(chan struct{})
 				router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 					func(_ context.Context, msg message.InboundMessage) {
-						// Make sure we're sending ourselves
-						// the expected message.
+						// Make sure we're sending ourselves the expected message.
 						tt.assertMsg(require, msg)
-						close(calledHandleInternal)
 					},
 				)
 
@@ -1336,8 +1304,6 @@ func TestSender_Single_Request(t *testing.T) {
 				tt.setExternalSenderExpect(externalSender, set.Set[ids.NodeID]{})
 
 				tt.sendF(require, sender, destinationNodeID)
-
-				<-calledHandleInternal
 			}
 		})
 	}

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -5,7 +5,7 @@ package sender_test
 
 import (
 	"context"
-	"math/rand"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -307,314 +307,165 @@ func TestTimeout(t *testing.T) {
 }
 
 func TestReliableMessages(t *testing.T) {
-	require := require.New(t)
+	for _, validatorOnly := range []bool{false, true} {
+		t.Run(fmt.Sprintf("validatorOnly_%v", validatorOnly), func(t *testing.T) {
+			require := require.New(t)
 
-	snowCtx := snowtest.Context(t, snowtest.CChainID)
-	ctx := snowtest.ConsensusContext(snowCtx)
-	vdrs := validators.NewManager()
-	require.NoError(vdrs.AddStaker(ctx.SubnetID, ids.BuildTestNodeID([]byte{1}), nil, ids.Empty, 1))
-	benchlist := benchlist.NewNoBenchlist()
-	tm, err := timeout.NewManager(
-		&timer.AdaptiveTimeoutConfig{
-			InitialTimeout:     time.Millisecond,
-			MinimumTimeout:     time.Millisecond,
-			MaximumTimeout:     time.Millisecond,
-			TimeoutHalflife:    5 * time.Minute,
-			TimeoutCoefficient: 1.25,
-		},
-		benchlist,
-		prometheus.NewRegistry(),
-		prometheus.NewRegistry(),
-	)
-	require.NoError(err)
+			benchlist := benchlist.NewNoBenchlist()
+			snowCtx := snowtest.Context(t, snowtest.CChainID)
+			ctx := snowtest.ConsensusContext(snowCtx)
+			vdrs := validators.NewManager()
+			require.NoError(vdrs.AddStaker(ctx.SubnetID, ids.GenerateTestNodeID(), nil, ids.Empty, 1))
+			tm, err := timeout.NewManager(
+				&timer.AdaptiveTimeoutConfig{
+					InitialTimeout:     10 * time.Millisecond,
+					MinimumTimeout:     10 * time.Millisecond,
+					MaximumTimeout:     10 * time.Millisecond, // Timeout fires immediately
+					TimeoutHalflife:    5 * time.Minute,
+					TimeoutCoefficient: 1.25,
+				},
+				benchlist,
+				prometheus.NewRegistry(),
+				prometheus.NewRegistry(),
+			)
+			require.NoError(err)
 
-	go tm.Dispatch()
+			go tm.Dispatch()
 
-	chainRouter := router.ChainRouter{}
+			chainRouter := router.ChainRouter{}
 
-	metrics := prometheus.NewRegistry()
-	mc, err := message.NewCreator(
-		metrics,
-		constants.DefaultNetworkCompressionType,
-		10*time.Second,
-	)
-	require.NoError(err)
+			metrics := prometheus.NewRegistry()
+			mc, err := message.NewCreator(
+				metrics,
+				constants.DefaultNetworkCompressionType,
+				10*time.Second,
+			)
+			require.NoError(err)
 
-	require.NoError(chainRouter.Initialize(
-		ids.EmptyNodeID,
-		logging.NoLog{},
-		tm,
-		time.Second,
-		set.Set[ids.ID]{},
-		true,
-		set.Set[ids.ID]{},
-		nil,
-		router.HealthConfig{},
-		prometheus.NewRegistry(),
-	))
+			require.NoError(chainRouter.Initialize(
+				ids.EmptyNodeID,
+				logging.NoLog{},
+				tm,
+				time.Second,
+				set.Set[ids.ID]{},
+				true,
+				set.Set[ids.ID]{},
+				nil,
+				router.HealthConfig{},
+				prometheus.NewRegistry(),
+			))
 
-	externalSender := &sendertest.External{TB: t}
-	externalSender.Default(false)
+			externalSender := &sendertest.External{TB: t}
+			externalSender.Default(false)
 
-	sender, err := New(
-		ctx,
-		mc,
-		externalSender,
-		&chainRouter,
-		tm,
-		p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
-		subnets.New(ctx.NodeID, subnets.Config{}),
-		prometheus.NewRegistry(),
-	)
-	require.NoError(err)
+			subnet := subnets.New(ctx.NodeID, subnets.Config{
+				ValidatorOnly: validatorOnly,
+			})
+			sender, err := New(
+				ctx,
+				mc,
+				externalSender,
+				&chainRouter,
+				tm,
+				p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
+				subnet,
+				prometheus.NewRegistry(),
+			)
+			require.NoError(err)
 
-	ctx2 := snowtest.ConsensusContext(snowCtx)
-	resourceTracker, err := tracker.NewResourceTracker(
-		prometheus.NewRegistry(),
-		resource.NoUsage,
-		meter.ContinuousFactory{},
-		time.Second,
-	)
-	require.NoError(err)
+			ctx2 := snowtest.ConsensusContext(snowCtx)
+			resourceTracker, err := tracker.NewResourceTracker(
+				prometheus.NewRegistry(),
+				resource.NoUsage,
+				meter.ContinuousFactory{},
+				time.Second,
+			)
+			require.NoError(err)
 
-	p2pTracker, err := p2p.NewPeerTracker(
-		logging.NoLog{},
-		"",
-		prometheus.NewRegistry(),
-		nil,
-		version.CurrentApp,
-	)
-	require.NoError(err)
+			p2pTracker, err := p2p.NewPeerTracker(
+				logging.NoLog{},
+				"",
+				prometheus.NewRegistry(),
+				nil,
+				version.CurrentApp,
+			)
+			require.NoError(err)
 
-	h, err := handler.New(
-		ctx2,
-		vdrs,
-		nil,
-		1,
-		testThreadPoolSize,
-		resourceTracker,
-		subnets.New(ctx.NodeID, subnets.Config{}),
-		commontracker.NewPeers(),
-		p2pTracker,
-		prometheus.NewRegistry(),
-		func() {},
-	)
-	require.NoError(err)
+			h, err := handler.New(
+				ctx2,
+				vdrs,
+				nil,
+				time.Second,
+				testThreadPoolSize,
+				resourceTracker,
+				subnet,
+				commontracker.NewPeers(),
+				p2pTracker,
+				prometheus.NewRegistry(),
+				func() {},
+			)
+			require.NoError(err)
 
-	bootstrapper := &enginetest.Bootstrapper{
-		Engine: enginetest.Engine{
-			T: t,
-		},
-	}
-	bootstrapper.Default(true)
-	bootstrapper.CantGossip = false
-	bootstrapper.ContextF = func() *snow.ConsensusContext {
-		return ctx2
-	}
-	bootstrapper.ConnectedF = func(context.Context, ids.NodeID, *version.Application) error {
-		return nil
-	}
-	queriesToSend := 1000
-	awaiting := make([]chan struct{}, queriesToSend)
-	for i := 0; i < queriesToSend; i++ {
-		awaiting[i] = make(chan struct{}, 1)
-	}
-	bootstrapper.QueryFailedF = func(_ context.Context, _ ids.NodeID, reqID uint32) error {
-		close(awaiting[int(reqID)])
-		return nil
-	}
-	bootstrapper.CantGossip = false
-	h.SetEngineManager(&handler.EngineManager{
-		Avalanche: &handler.Engine{
-			StateSyncer:  nil,
-			Bootstrapper: bootstrapper,
-			Consensus:    nil,
-		},
-		Snowman: &handler.Engine{
-			StateSyncer:  nil,
-			Bootstrapper: bootstrapper,
-			Consensus:    nil,
-		},
-	})
-	ctx2.State.Set(snow.EngineState{
-		Type:  p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
-		State: snow.Bootstrapping, // assumed bootstrap is ongoing
-	})
+			bootstrapper := &enginetest.Bootstrapper{
+				Engine: enginetest.Engine{
+					T: t,
+				},
+			}
+			bootstrapper.Default(true)
+			bootstrapper.CantGossip = false
+			bootstrapper.ContextF = func() *snow.ConsensusContext {
+				return ctx2
+			}
+			bootstrapper.ConnectedF = func(context.Context, ids.NodeID, *version.Application) error {
+				return nil
+			}
+			queriesToSend := 2
+			awaiting := make([]chan struct{}, queriesToSend)
+			for i := 0; i < queriesToSend; i++ {
+				awaiting[i] = make(chan struct{}, 1)
+			}
+			bootstrapper.QueryFailedF = func(_ context.Context, _ ids.NodeID, reqID uint32) error {
+				close(awaiting[int(reqID)])
+				return nil
+			}
+			h.SetEngineManager(&handler.EngineManager{
+				Avalanche: &handler.Engine{
+					StateSyncer:  nil,
+					Bootstrapper: bootstrapper,
+					Consensus:    nil,
+				},
+				Snowman: &handler.Engine{
+					StateSyncer:  nil,
+					Bootstrapper: bootstrapper,
+					Consensus:    nil,
+				},
+			})
+			ctx2.State.Set(snow.EngineState{
+				Type:  p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
+				State: snow.Bootstrapping, // assumed bootstrap is ongoing
+			})
 
-	chainRouter.AddChain(context.Background(), h)
+			chainRouter.AddChain(context.Background(), h)
 
-	bootstrapper.StartF = func(context.Context, uint32) error {
-		return nil
-	}
-	h.Start(context.Background(), false)
+			bootstrapper.StartF = func(context.Context, uint32) error {
+				return nil
+			}
+			h.Start(context.Background(), false)
 
-	go func() {
-		for i := 0; i < queriesToSend; i++ {
-			vdrIDs := set.Of(ids.BuildTestNodeID([]byte{1}))
+			go func() {
+				for i := 0; i < queriesToSend; i++ {
+					// Send a pull query to some random peer that won't respond
+					// because they don't exist. This will almost immediately trigger
+					// a query failed message
+					vdrIDs := set.Of(ids.GenerateTestNodeID())
+					sender.SendPullQuery(context.Background(), vdrIDs, uint32(i), ids.Empty, 0)
+				}
+			}()
 
-			sender.SendPullQuery(context.Background(), vdrIDs, uint32(i), ids.Empty, 0)
-			time.Sleep(time.Duration(rand.Float64() * float64(time.Microsecond))) // #nosec G404
-		}
-	}()
-
-	for _, await := range awaiting {
-		<-await
-	}
-}
-
-func TestReliableMessagesToMyself(t *testing.T) {
-	require := require.New(t)
-
-	benchlist := benchlist.NewNoBenchlist()
-	snowCtx := snowtest.Context(t, snowtest.CChainID)
-	ctx := snowtest.ConsensusContext(snowCtx)
-	vdrs := validators.NewManager()
-	require.NoError(vdrs.AddStaker(ctx.SubnetID, ids.GenerateTestNodeID(), nil, ids.Empty, 1))
-	tm, err := timeout.NewManager(
-		&timer.AdaptiveTimeoutConfig{
-			InitialTimeout:     10 * time.Millisecond,
-			MinimumTimeout:     10 * time.Millisecond,
-			MaximumTimeout:     10 * time.Millisecond, // Timeout fires immediately
-			TimeoutHalflife:    5 * time.Minute,
-			TimeoutCoefficient: 1.25,
-		},
-		benchlist,
-		prometheus.NewRegistry(),
-		prometheus.NewRegistry(),
-	)
-	require.NoError(err)
-
-	go tm.Dispatch()
-
-	chainRouter := router.ChainRouter{}
-
-	metrics := prometheus.NewRegistry()
-	mc, err := message.NewCreator(
-		metrics,
-		constants.DefaultNetworkCompressionType,
-		10*time.Second,
-	)
-	require.NoError(err)
-
-	require.NoError(chainRouter.Initialize(
-		ids.EmptyNodeID,
-		logging.NoLog{},
-		tm,
-		time.Second,
-		set.Set[ids.ID]{},
-		true,
-		set.Set[ids.ID]{},
-		nil,
-		router.HealthConfig{},
-		prometheus.NewRegistry(),
-	))
-
-	externalSender := &sendertest.External{TB: t}
-	externalSender.Default(false)
-
-	sender, err := New(
-		ctx,
-		mc,
-		externalSender,
-		&chainRouter,
-		tm,
-		p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
-		subnets.New(ctx.NodeID, subnets.Config{}),
-		prometheus.NewRegistry(),
-	)
-	require.NoError(err)
-
-	ctx2 := snowtest.ConsensusContext(snowCtx)
-	resourceTracker, err := tracker.NewResourceTracker(
-		prometheus.NewRegistry(),
-		resource.NoUsage,
-		meter.ContinuousFactory{},
-		time.Second,
-	)
-	require.NoError(err)
-
-	p2pTracker, err := p2p.NewPeerTracker(
-		logging.NoLog{},
-		"",
-		prometheus.NewRegistry(),
-		nil,
-		version.CurrentApp,
-	)
-	require.NoError(err)
-
-	h, err := handler.New(
-		ctx2,
-		vdrs,
-		nil,
-		time.Second,
-		testThreadPoolSize,
-		resourceTracker,
-		subnets.New(ctx.NodeID, subnets.Config{}),
-		commontracker.NewPeers(),
-		p2pTracker,
-		prometheus.NewRegistry(),
-		func() {},
-	)
-	require.NoError(err)
-
-	bootstrapper := &enginetest.Bootstrapper{
-		Engine: enginetest.Engine{
-			T: t,
-		},
-	}
-	bootstrapper.Default(true)
-	bootstrapper.CantGossip = false
-	bootstrapper.ContextF = func() *snow.ConsensusContext {
-		return ctx2
-	}
-	bootstrapper.ConnectedF = func(context.Context, ids.NodeID, *version.Application) error {
-		return nil
-	}
-	queriesToSend := 2
-	awaiting := make([]chan struct{}, queriesToSend)
-	for i := 0; i < queriesToSend; i++ {
-		awaiting[i] = make(chan struct{}, 1)
-	}
-	bootstrapper.QueryFailedF = func(_ context.Context, _ ids.NodeID, reqID uint32) error {
-		close(awaiting[int(reqID)])
-		return nil
-	}
-	h.SetEngineManager(&handler.EngineManager{
-		Avalanche: &handler.Engine{
-			StateSyncer:  nil,
-			Bootstrapper: bootstrapper,
-			Consensus:    nil,
-		},
-		Snowman: &handler.Engine{
-			StateSyncer:  nil,
-			Bootstrapper: bootstrapper,
-			Consensus:    nil,
-		},
-	})
-	ctx2.State.Set(snow.EngineState{
-		Type:  p2ppb.EngineType_ENGINE_TYPE_SNOWMAN,
-		State: snow.Bootstrapping, // assumed bootstrap is ongoing
-	})
-
-	chainRouter.AddChain(context.Background(), h)
-
-	bootstrapper.StartF = func(context.Context, uint32) error {
-		return nil
-	}
-	h.Start(context.Background(), false)
-
-	go func() {
-		for i := 0; i < queriesToSend; i++ {
-			// Send a pull query to some random peer that won't respond
-			// because they don't exist. This will almost immediately trigger
-			// a query failed message
-			vdrIDs := set.Of(ids.GenerateTestNodeID())
-			sender.SendPullQuery(context.Background(), vdrIDs, uint32(i), ids.Empty, 0)
-		}
-	}()
-
-	for _, await := range awaiting {
-		<-await
+			for _, await := range awaiting {
+				<-await
+			}
+		})
 	}
 }
 
@@ -856,15 +707,15 @@ func TestSender_Bootstrap_Requests(t *testing.T) {
 
 			// Make sure we send a message to ourselves since [myNodeID]
 			// is in [nodeIDs].
-			// Note that HandleInbound is called in a separate goroutine
+			// Note that HandleInternal is called in a separate goroutine
 			// so we need to use a channel to synchronize the test.
-			calledHandleInbound := make(chan struct{})
-			router.EXPECT().HandleInbound(gomock.Any(), gomock.Any()).Do(
+			calledHandleInternal := make(chan struct{})
+			router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 				func(_ context.Context, msg message.InboundMessage) {
 					// Make sure we're sending ourselves
 					// the expected message.
 					tt.assertMsgToMyself(require, msg)
-					close(calledHandleInbound)
+					close(calledHandleInternal)
 				},
 			)
 
@@ -876,7 +727,7 @@ func TestSender_Bootstrap_Requests(t *testing.T) {
 
 			tt.sendF(require, sender, nodeIDsCopy)
 
-			<-calledHandleInbound
+			<-calledHandleInternal
 		})
 	}
 }
@@ -1056,17 +907,17 @@ func TestSender_Bootstrap_Responses(t *testing.T) {
 
 			// Case: sending to ourselves
 			{
-				calledHandleInbound := make(chan struct{})
-				router.EXPECT().HandleInbound(gomock.Any(), gomock.Any()).Do(
+				calledHandleInternal := make(chan struct{})
+				router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 					func(_ context.Context, msg message.InboundMessage) {
 						// Make sure we're sending ourselves
 						// the expected message.
 						tt.assertMsgToMyself(require, msg)
-						close(calledHandleInbound)
+						close(calledHandleInternal)
 					},
 				)
 				tt.sendF(require, sender, ctx.NodeID)
-				<-calledHandleInbound
+				<-calledHandleInternal
 			}
 
 			// Case: not sending to ourselves
@@ -1235,25 +1086,25 @@ func TestSender_Single_Request(t *testing.T) {
 					tt.expectedEngineType, // Engine Type
 				)
 
-				// Note that HandleInbound is called in a separate goroutine
+				// Note that HandleInternal is called in a separate goroutine
 				// so we need to use a channel to synchronize the test.
-				calledHandleInbound := make(chan struct{})
+				calledHandleInternal := make(chan struct{})
 				if tt.shouldFailMessageToSelf {
-					router.EXPECT().HandleInbound(gomock.Any(), gomock.Any()).Do(
+					router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 						func(_ context.Context, msg message.InboundMessage) {
 							// Make sure we're sending ourselves
 							// the expected message.
 							tt.assertMsg(require, msg)
-							close(calledHandleInbound)
+							close(calledHandleInternal)
 						},
 					)
 				} else {
-					close(calledHandleInbound)
+					close(calledHandleInternal)
 				}
 
 				tt.sendF(require, sender, ctx.NodeID)
 
-				<-calledHandleInbound
+				<-calledHandleInternal
 			}
 
 			// Case: Node is benched
@@ -1274,21 +1125,21 @@ func TestSender_Single_Request(t *testing.T) {
 					tt.expectedEngineType, // Engine Type
 				)
 
-				// Note that HandleInbound is called in a separate goroutine
+				// Note that HandleInternal is called in a separate goroutine
 				// so we need to use a channel to synchronize the test.
-				calledHandleInbound := make(chan struct{})
-				router.EXPECT().HandleInbound(gomock.Any(), gomock.Any()).Do(
+				calledHandleInternal := make(chan struct{})
+				router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 					func(_ context.Context, msg message.InboundMessage) {
 						// Make sure we're sending ourselves
 						// the expected message.
 						tt.assertMsg(require, msg)
-						close(calledHandleInbound)
+						close(calledHandleInternal)
 					},
 				)
 
 				tt.sendF(require, sender, destinationNodeID)
 
-				<-calledHandleInbound
+				<-calledHandleInternal
 			}
 
 			// Case: Node is not myself, not benched and send fails
@@ -1309,15 +1160,15 @@ func TestSender_Single_Request(t *testing.T) {
 					tt.expectedEngineType, // Engine Type
 				)
 
-				// Note that HandleInbound is called in a separate goroutine
+				// Note that HandleInternal is called in a separate goroutine
 				// so we need to use a channel to synchronize the test.
-				calledHandleInbound := make(chan struct{})
-				router.EXPECT().HandleInbound(gomock.Any(), gomock.Any()).Do(
+				calledHandleInternal := make(chan struct{})
+				router.EXPECT().HandleInternal(gomock.Any(), gomock.Any()).Do(
 					func(_ context.Context, msg message.InboundMessage) {
 						// Make sure we're sending ourselves
 						// the expected message.
 						tt.assertMsg(require, msg)
-						close(calledHandleInbound)
+						close(calledHandleInternal)
 					},
 				)
 
@@ -1329,7 +1180,7 @@ func TestSender_Single_Request(t *testing.T) {
 
 				tt.sendF(require, sender, destinationNodeID)
 
-				<-calledHandleInbound
+				<-calledHandleInternal
 			}
 		})
 	}


### PR DESCRIPTION
## Why this should be merged

Fixes handling of internal messages from disallowed nodeIDs.

## How this works

Skips allowlist check for internal messages.

## How this was tested

Added unit test.

## Need to be documented in RELEASES.md?
