### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"math/rand"
 	"slices"
 	"strconv"
@@ -999,9 +1000,7 @@ func runRandDBTest(require *require.Assertions, r *rand.Rand, rt randTest, token
 				continue
 			}
 
-			for key, value := range uncommittedKeyValues {
-				values[key] = value
-			}
+			maps.Copy(values, uncommittedKeyValues)
 			clear(uncommittedKeyValues)
 
 			for key := range uncommittedDeletes {


### PR DESCRIPTION
## Why this should be merged

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
