### PR TITLE
Update coreth to v0.15.3-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/StephenButtolph/canoto v0.17.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/coreth v0.15.3-0.20250707191145-055af77d543b
+	github.com/ava-labs/coreth v0.15.3-rc.0
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60
 	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1
 	github.com/btcsuite/btcd/btcutil v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/coreth v0.15.3-0.20250707191145-055af77d543b h1:+Dmp2AiyY+A9eTyDFkElYtM3ZxJe8bSxAjTAePVoHB8=
-github.com/ava-labs/coreth v0.15.3-0.20250707191145-055af77d543b/go.mod h1:uRMiwnKMtGac3Oftq9/tULLjtgjChe5zoRjQhvhePaw=
+github.com/ava-labs/coreth v0.15.3-rc.0 h1:OD554F6lyPP0y8emTW3ffKoPx7Dnn8tuNP/tD3OQVnA=
+github.com/ava-labs/coreth v0.15.3-rc.0/go.mod h1:vDlKR8FRuAtecXepgrZ7NPo5ZNb2LPTh+fb8yfouofA=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60 h1:EL66gtXOAwR/4KYBjOV03LTWgkEXvLePribLlJNu4g0=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60/go.mod h1:/7qKobTfbzBu7eSTVaXMTr56yTYk4j2Px6/8G+idxHo=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1 h1:vBMYo+Iazw0rGTr+cwjkBdh5eadLPlv4ywI4lKye3CA=


### PR DESCRIPTION
## Why this should be merged

Currently we depend on a version of coreth that implemented `WaitForEvent` prior to the code reviews for the implementation. This version was reviewed and merged to coreth master.

## How this works

Updated dep.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.