### PR TITLE
Add default validator set functions to snowtest.context

### DIFF
--- a/snow/snowtest/context.go
+++ b/snow/snowtest/context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -81,6 +82,12 @@ func Context(tb testing.TB, chainID ids.ID) *snow.Context {
 			default:
 				return ids.Empty, errMissing
 			}
+		},
+		GetValidatorSetF: func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+			return map[ids.NodeID]*validators.GetValidatorOutput{}, nil
+		},
+		GetCurrentValidatorSetF: func(context.Context, ids.ID) (map[ids.ID]*validators.GetCurrentValidatorOutput, uint64, error) {
+			return map[ids.ID]*validators.GetCurrentValidatorOutput{}, 0, nil
 		},
 	}
 


### PR DESCRIPTION
## Why this should be merged
The old `ValidatorState` in `NewContext` was set by default to be `nil.` This behavior was not replicated in `snowtest.Context` and these empty default needs to be available to many tests in subnet-evm.  

## How this works
Returns `nil` for the two validator functions. 

## Need to be documented in RELEASES.md?
No 