### PR TITLE
Simplex QuorumCertificate and BLS aggregator

### DIFF
--- a/simplex/comm_test.go
+++ b/simplex/comm_test.go
@@ -90,7 +90,7 @@ func TestCommFailsWithoutCurrentNode(t *testing.T) {
 	config.Sender = sender
 
 	// set the curNode to a different nodeID than the one in the config
-	vdrs := generateTestValidators(t, 3)
+	vdrs := generateTestNodes(t, 3)
 	config.Validators = newTestValidatorInfo(vdrs)
 
 	_, err := NewComm(config)

--- a/simplex/quorum.go
+++ b/simplex/quorum.go
@@ -1,0 +1,183 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package simplex
+
+import (
+	"encoding/asn1"
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/simplex"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+)
+
+var (
+	_ simplex.QuorumCertificate   = (*QC)(nil)
+	_ simplex.QCDeserializer      = QCDeserializer{}
+	_ simplex.SignatureAggregator = (*SignatureAggregator)(nil)
+
+	// QC errors
+	errFailedToParseQC       = errors.New("failed to parse quorum certificate")
+	errUnexpectedSigners     = errors.New("unexpected number of signers in quorum certificate")
+	errSignatureAggregation  = errors.New("signature aggregation failed")
+	errEncodingMessageToSign = errors.New("failed to encode message to sign")
+)
+
+// QC represents a quorum certificate in the Simplex consensus protocol.
+type QC struct {
+	verifier BLSVerifier
+	sig      bls.Signature
+	signers  []simplex.NodeID
+}
+
+// Signers returns the list of signers for the quorum certificate.
+func (qc *QC) Signers() []simplex.NodeID {
+	return qc.signers
+}
+
+// Verify checks if the quorum certificate is valid by verifying the aggregated signature against the signers' public keys.
+func (qc *QC) Verify(msg []byte) error {
+	pks := make([]*bls.PublicKey, 0, len(qc.signers))
+	if len(qc.signers) != simplex.Quorum(len(qc.verifier.nodeID2PK)) {
+		return fmt.Errorf("%w: expected %d signers but got %d", errUnexpectedSigners, simplex.Quorum(len(qc.verifier.nodeID2PK)), len(qc.signers))
+	}
+
+	// ensure all signers are in the membership set
+	for _, signer := range qc.signers {
+		pk, exists := qc.verifier.nodeID2PK[ids.NodeID(signer)]
+		if !exists {
+			return fmt.Errorf("%w: %x", errSignerNotFound, signer)
+		}
+
+		pks = append(pks, pk)
+	}
+
+	// aggregate the public keys
+	aggPK, err := bls.AggregatePublicKeys(pks)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errSignatureAggregation, err)
+	}
+
+	message2Verify, err := encodeMessageToSign(msg, qc.verifier.chainID, qc.verifier.networkID)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errEncodingMessageToSign, err)
+	}
+
+	if !bls.Verify(aggPK, &qc.sig, message2Verify) {
+		return errSignatureVerificationFailed
+	}
+
+	return nil
+}
+
+// asn1QC is the ASN.1 structure for the quorum certificate.
+// It contains the signers' public keys and the aggregated signature.
+// The signers are represented as byte slices of their IDs.
+type asn1QC struct {
+	Signers   [][]byte
+	Signature []byte
+}
+
+func (qc *QC) MarshalASN1() ([]byte, error) {
+	sigBytes := bls.SignatureToBytes(&qc.sig)
+
+	signersBytes := make([][]byte, len(qc.signers))
+	for i, signer := range qc.signers {
+		s := signer // avoid aliasing
+		signersBytes[i] = s[:]
+	}
+	asn1Data := asn1QC{
+		Signers:   signersBytes,
+		Signature: sigBytes,
+	}
+	return asn1.Marshal(asn1Data)
+}
+
+func (qc *QC) UnmarshalASN1(data []byte) error {
+	var decoded asn1QC
+	_, err := asn1.Unmarshal(data, &decoded)
+	if err != nil {
+		return err
+	}
+	qc.signers = make([]simplex.NodeID, len(decoded.Signers))
+	for i, signerBytes := range decoded.Signers {
+		if len(signerBytes) != ids.ShortIDLen { // TODO: so long as simplex is in a separate repo, we should decouple these ids as much as possible
+			return errors.New("invalid signer length")
+		}
+		qc.signers[i] = simplex.NodeID(signerBytes)
+	}
+	sig, err := bls.SignatureFromBytes(decoded.Signature)
+	if err != nil {
+		return err
+	}
+	qc.sig = *sig
+
+	return nil
+}
+
+// Bytes serializes the quorum certificate into bytes.
+func (qc *QC) Bytes() []byte {
+	bytes, err := qc.MarshalASN1()
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal QC: %w", err))
+	}
+	return bytes
+}
+
+type QCDeserializer BLSVerifier
+
+// DeserializeQuorumCertificate deserializes a quorum certificate from bytes.
+func (d QCDeserializer) DeserializeQuorumCertificate(bytes []byte) (simplex.QuorumCertificate, error) {
+	var qc QC
+	if err := qc.UnmarshalASN1(bytes); err != nil {
+		return nil, fmt.Errorf("%w: %w", errFailedToParseQC, err)
+	}
+	qc.verifier = BLSVerifier(d)
+
+	return &qc, nil
+}
+
+// SignatureAggregator aggregates signatures into a quorum certificate.
+type SignatureAggregator BLSVerifier
+
+// Aggregate aggregates the provided signatures into a quorum certificate.
+// It requires at least a quorum of signatures to succeed.
+// If any signature is from a signer not in the membership set, it returns an error.
+func (a SignatureAggregator) Aggregate(signatures []simplex.Signature) (simplex.QuorumCertificate, error) {
+	quorumSize := simplex.Quorum(len(a.nodeID2PK))
+	if len(signatures) < quorumSize {
+		return nil, fmt.Errorf("%w: wanted %d signatures but got %d", errUnexpectedSigners, quorumSize, len(signatures))
+	}
+
+	signatures = signatures[:quorumSize]
+
+	signers := make([]simplex.NodeID, 0, quorumSize)
+	sigs := make([]*bls.Signature, 0, quorumSize)
+	for _, signature := range signatures {
+		signer := signature.Signer
+		_, exists := a.nodeID2PK[ids.NodeID(signer)]
+		if !exists {
+			return nil, fmt.Errorf("%w: %x", errSignerNotFound, signer)
+		}
+		signers = append(signers, signer)
+		sig, err := bls.SignatureFromBytes(signature.Value)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errFailedToParseSignature, err)
+		}
+		sigs = append(sigs, sig)
+	}
+
+	aggregatedSig, err := bls.AggregateSignatures(sigs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errSignatureAggregation, err)
+	}
+
+	return &QC{
+		verifier: BLSVerifier(a),
+		signers:  signers,
+		sig:      *aggregatedSig,
+	}, nil
+}

--- a/simplex/quorum_test.go
+++ b/simplex/quorum_test.go
@@ -1,0 +1,219 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package simplex
+
+import (
+	"testing"
+
+	"github.com/ava-labs/simplex"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+)
+
+// TestQCAggregateAndSign tests the aggregation of multiple signatures
+// and then verifies the generated quorum certificate on that message.
+func TestQCAggregateAndSign(t *testing.T) {
+	configs := newNetworkConfigs(t, 2)
+	quorum := simplex.Quorum(len(configs))
+
+	msg := []byte("Begin at the beginning, and go on till you come to the end: then stop")
+
+	signatures := make([]simplex.Signature, 0, quorum)
+	nodes := make([]simplex.NodeID, 0, quorum)
+	var signer BLSSigner
+	var verifier BLSVerifier
+
+	for _, config := range configs {
+		signer, verifier = NewBLSAuth(config)
+
+		sig, err := signer.Sign(msg)
+		require.NoError(t, err)
+		require.NoError(t, verifier.Verify(msg, sig, config.Ctx.NodeID[:]))
+
+		signatures = append(signatures, simplex.Signature{
+			Signer: config.Ctx.NodeID[:],
+			Value:  sig,
+		})
+		nodes = append(nodes, config.Ctx.NodeID[:])
+	}
+
+	// aggregate the signatures into a quorum certificate
+	signatureAggregator := SignatureAggregator(verifier)
+	qc, err := signatureAggregator.Aggregate(signatures)
+
+	require.NoError(t, err)
+	require.Equal(t, nodes, qc.Signers())
+	// verify the quorum certificate
+	require.NoError(t, qc.Verify(msg))
+
+	d := QCDeserializer(verifier)
+	// try to deserialize the quorum certificate
+	deserializedQC, err := d.DeserializeQuorumCertificate(qc.Bytes())
+	require.NoError(t, err)
+
+	require.Equal(t, qc.Signers(), deserializedQC.Signers())
+	require.NoError(t, deserializedQC.Verify(msg))
+	require.Equal(t, qc.Bytes(), deserializedQC.Bytes())
+}
+
+func TestQCSignerNotInMembershipSet(t *testing.T) {
+	node1 := newEngineConfig(t, 2)
+	signer, verifier := NewBLSAuth(node1)
+
+	// nodes 1 and 2 will sign the same message
+	msg := []byte("Begin at the beginning, and go on till you come to the end: then stop")
+	sig, err := signer.Sign(msg)
+	require.NoError(t, err)
+	require.NoError(t, verifier.Verify(msg, sig, node1.Ctx.NodeID[:]))
+
+	// add a new validator, but it won't be in the membership set of the first node signer/verifier
+	node2 := newEngineConfig(t, 2)
+	node2.Ctx.ChainID = node1.Ctx.ChainID
+
+	// sign the same message with the new node
+	signer2, verifier2 := NewBLSAuth(node2)
+	sig2, err := signer2.Sign(msg)
+	require.NoError(t, err)
+	require.NoError(t, verifier2.Verify(msg, sig2, node2.Ctx.NodeID[:]))
+
+	// aggregate the signatures into a quorum certificate
+	signatureAggregator := SignatureAggregator(verifier)
+	_, err = signatureAggregator.Aggregate(
+		[]simplex.Signature{
+			{Signer: node1.Ctx.NodeID[:], Value: sig},
+			{Signer: node2.Ctx.NodeID[:], Value: sig2},
+		},
+	)
+	require.ErrorIs(t, err, errSignerNotFound)
+}
+
+func TestQCDeserializerInvalidInput(t *testing.T) {
+	config := newEngineConfig(t, 2)
+
+	_, verifier := NewBLSAuth(config)
+	deserializer := QCDeserializer(verifier)
+
+	tests := []struct {
+		name  string
+		input []byte
+		err   error
+	}{
+		{
+			name:  "too short input",
+			input: make([]byte, 10),
+			err:   errFailedToParseQC,
+		},
+		{
+			name:  "invalid signature bytes",
+			input: make([]byte, simplex.Quorum(len(verifier.nodeID2PK))*ids.NodeIDLen+bls.SignatureLen),
+			err:   errFailedToParseQC,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := deserializer.DeserializeQuorumCertificate(tt.input)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestSignatureAggregatorInsufficientSignatures(t *testing.T) {
+	config := newEngineConfig(t, 3)
+
+	signer, verifier := NewBLSAuth(config)
+	msg := []byte("test message")
+	sig, err := signer.Sign(msg)
+	require.NoError(t, err)
+
+	// try to aggregate with only 1 signature when quorum is 2
+	signatureAggregator := SignatureAggregator(verifier)
+	_, err = signatureAggregator.Aggregate(
+		[]simplex.Signature{
+			{Signer: config.Ctx.NodeID[:], Value: sig},
+		},
+	)
+	require.ErrorIs(t, err, errUnexpectedSigners)
+}
+
+func TestSignatureAggregatorInvalidSignatureBytes(t *testing.T) {
+	config := newEngineConfig(t, 2)
+
+	signer, verifier := NewBLSAuth(config)
+	msg := []byte("test message")
+	sig, err := signer.Sign(msg)
+	require.NoError(t, err)
+
+	signatureAggregator := SignatureAggregator(verifier)
+	_, err = signatureAggregator.Aggregate(
+		[]simplex.Signature{
+			{Signer: config.Ctx.NodeID[:], Value: sig},
+			{Signer: config.Ctx.NodeID[:], Value: []byte("invalid signature")},
+		},
+	)
+	require.ErrorIs(t, err, errFailedToParseSignature)
+}
+
+func TestSignatureAggregatorExcessSignatures(t *testing.T) {
+	configs := newNetworkConfigs(t, 4)
+
+	msg := []byte("test message")
+
+	var nodeSigner BLSSigner
+	var verifier BLSVerifier
+	// Create signatures from all 4 nodes
+	signatures := make([]simplex.Signature, 4)
+	for i, config := range configs {
+		nodeSigner, verifier = NewBLSAuth(config)
+		sig, err := nodeSigner.Sign(msg)
+		require.NoError(t, err)
+
+		signatures[i] = simplex.Signature{Signer: config.Ctx.NodeID[:], Value: sig}
+	}
+
+	// Aggregate should only use the first 3 signatures
+	signatureAggregator := SignatureAggregator(verifier)
+	qc, err := signatureAggregator.Aggregate(signatures)
+	require.NoError(t, err)
+
+	// Should only have 3 signers, not 4
+	require.Len(t, qc.Signers(), simplex.Quorum(len(configs)))
+	require.NoError(t, qc.Verify(msg))
+}
+
+func TestQCVerifyWithWrongMessage(t *testing.T) {
+	configs := newNetworkConfigs(t, 2)
+
+	node1 := configs[0]
+	node2 := configs[1]
+	signer, verifier := NewBLSAuth(node1)
+	originalMsg := []byte("original message")
+	wrongMsg := []byte("wrong message")
+
+	// Create signatures for original message
+	sig1, err := signer.Sign(originalMsg)
+	require.NoError(t, err)
+
+	signer2, _ := NewBLSAuth(node2)
+	sig2, err := signer2.Sign(originalMsg)
+	require.NoError(t, err)
+
+	signatureAggregator := SignatureAggregator(verifier)
+	qc, err := signatureAggregator.Aggregate(
+		[]simplex.Signature{
+			{Signer: node1.Ctx.NodeID[:], Value: sig1},
+			{Signer: node2.Ctx.NodeID[:], Value: sig2},
+		},
+	)
+	require.NoError(t, err)
+
+	// Verify with original message should succeed
+	require.NoError(t, qc.Verify(originalMsg))
+
+	// Verify with wrong message should fail
+	err = qc.Verify(wrongMsg)
+	require.ErrorIs(t, err, errSignatureVerificationFailed)
+}


### PR DESCRIPTION
## Why this should be merged

Implements the simplex `QuorumCertificate`, `QCDeserializer` and `SignatureAggregator` interfaces. This allows simplex to parse, aggregate and verify quorum certificates(ex. finalizations and notarizations) during execution. 

## How this works

- Builds on top of the BLSVerifier to handle BLS signatures and public keys. 
- The bytes of a QC are serialized with `asn1`

## How this was tested

Added unit tests to `bls_test.go`.

## Need to be documented in RELEASES.md?

no