### PR TITLE
Simplify json-rpc client handling

### DIFF
--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -14,86 +14,65 @@ import (
 	"github.com/ava-labs/avalanchego/utils/rpc"
 )
 
-var _ Client = (*client)(nil)
-
-// Client interface for the Avalanche Platform Info API Endpoint
-type Client interface {
-	StartCPUProfiler(context.Context, ...rpc.Option) error
-	StopCPUProfiler(context.Context, ...rpc.Option) error
-	MemoryProfile(context.Context, ...rpc.Option) error
-	LockProfile(context.Context, ...rpc.Option) error
-	Alias(ctx context.Context, endpoint string, alias string, options ...rpc.Option) error
-	AliasChain(ctx context.Context, chainID string, alias string, options ...rpc.Option) error
-	GetChainAliases(ctx context.Context, chainID string, options ...rpc.Option) ([]string, error)
-	Stacktrace(context.Context, ...rpc.Option) error
-	LoadVMs(context.Context, ...rpc.Option) (map[ids.ID][]string, map[ids.ID]string, error)
-	SetLoggerLevel(ctx context.Context, loggerName, logLevel, displayLevel string, options ...rpc.Option) (map[string]LogAndDisplayLevels, error)
-	GetLoggerLevel(ctx context.Context, loggerName string, options ...rpc.Option) (map[string]LogAndDisplayLevels, error)
-	GetConfig(ctx context.Context, options ...rpc.Option) (interface{}, error)
-	DBGet(ctx context.Context, key []byte, options ...rpc.Option) ([]byte, error)
+type Client struct {
+	Requester rpc.EndpointRequester
 }
 
-// Client implementation for the Avalanche Platform Info API Endpoint
-type client struct {
-	requester rpc.EndpointRequester
-}
-
-// NewClient returns a new Info API Client
-func NewClient(uri string) Client {
-	return &client{requester: rpc.NewEndpointRequester(
+func NewClient(uri string) *Client {
+	return &Client{Requester: rpc.NewEndpointRequester(
 		uri + "/ext/admin",
 	)}
 }
 
-func (c *client) StartCPUProfiler(ctx context.Context, options ...rpc.Option) error {
-	return c.requester.SendRequest(ctx, "admin.startCPUProfiler", struct{}{}, &api.EmptyReply{}, options...)
+func (c *Client) StartCPUProfiler(ctx context.Context, options ...rpc.Option) error {
+	return c.Requester.SendRequest(ctx, "admin.startCPUProfiler", struct{}{}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) StopCPUProfiler(ctx context.Context, options ...rpc.Option) error {
-	return c.requester.SendRequest(ctx, "admin.stopCPUProfiler", struct{}{}, &api.EmptyReply{}, options...)
+func (c *Client) StopCPUProfiler(ctx context.Context, options ...rpc.Option) error {
+	return c.Requester.SendRequest(ctx, "admin.stopCPUProfiler", struct{}{}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) MemoryProfile(ctx context.Context, options ...rpc.Option) error {
-	return c.requester.SendRequest(ctx, "admin.memoryProfile", struct{}{}, &api.EmptyReply{}, options...)
+func (c *Client) MemoryProfile(ctx context.Context, options ...rpc.Option) error {
+	return c.Requester.SendRequest(ctx, "admin.memoryProfile", struct{}{}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) LockProfile(ctx context.Context, options ...rpc.Option) error {
-	return c.requester.SendRequest(ctx, "admin.lockProfile", struct{}{}, &api.EmptyReply{}, options...)
+func (c *Client) LockProfile(ctx context.Context, options ...rpc.Option) error {
+	return c.Requester.SendRequest(ctx, "admin.lockProfile", struct{}{}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) Alias(ctx context.Context, endpoint, alias string, options ...rpc.Option) error {
-	return c.requester.SendRequest(ctx, "admin.alias", &AliasArgs{
+func (c *Client) Alias(ctx context.Context, endpoint, alias string, options ...rpc.Option) error {
+	return c.Requester.SendRequest(ctx, "admin.alias", &AliasArgs{
 		Endpoint: endpoint,
 		Alias:    alias,
 	}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) AliasChain(ctx context.Context, chain, alias string, options ...rpc.Option) error {
-	return c.requester.SendRequest(ctx, "admin.aliasChain", &AliasChainArgs{
+func (c *Client) AliasChain(ctx context.Context, chain, alias string, options ...rpc.Option) error {
+	return c.Requester.SendRequest(ctx, "admin.aliasChain", &AliasChainArgs{
 		Chain: chain,
 		Alias: alias,
 	}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) GetChainAliases(ctx context.Context, chain string, options ...rpc.Option) ([]string, error) {
+func (c *Client) GetChainAliases(ctx context.Context, chain string, options ...rpc.Option) ([]string, error) {
 	res := &GetChainAliasesReply{}
-	err := c.requester.SendRequest(ctx, "admin.getChainAliases", &GetChainAliasesArgs{
+	err := c.Requester.SendRequest(ctx, "admin.getChainAliases", &GetChainAliasesArgs{
 		Chain: chain,
 	}, res, options...)
 	return res.Aliases, err
 }
 
-func (c *client) Stacktrace(ctx context.Context, options ...rpc.Option) error {
-	return c.requester.SendRequest(ctx, "admin.stacktrace", struct{}{}, &api.EmptyReply{}, options...)
+func (c *Client) Stacktrace(ctx context.Context, options ...rpc.Option) error {
+	return c.Requester.SendRequest(ctx, "admin.stacktrace", struct{}{}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) LoadVMs(ctx context.Context, options ...rpc.Option) (map[ids.ID][]string, map[ids.ID]string, error) {
+func (c *Client) LoadVMs(ctx context.Context, options ...rpc.Option) (map[ids.ID][]string, map[ids.ID]string, error) {
 	res := &LoadVMsReply{}
-	err := c.requester.SendRequest(ctx, "admin.loadVMs", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "admin.loadVMs", struct{}{}, res, options...)
 	return res.NewVMs, res.FailedVMs, err
 }
 
-func (c *client) SetLoggerLevel(
+func (c *Client) SetLoggerLevel(
 	ctx context.Context,
 	loggerName,
 	logLevel,
@@ -118,7 +97,7 @@ func (c *client) SetLoggerLevel(
 		}
 	}
 	res := &LoggerLevelReply{}
-	err = c.requester.SendRequest(ctx, "admin.setLoggerLevel", &SetLoggerLevelArgs{
+	err = c.Requester.SendRequest(ctx, "admin.setLoggerLevel", &SetLoggerLevelArgs{
 		LoggerName:   loggerName,
 		LogLevel:     &logLevelArg,
 		DisplayLevel: &displayLevelArg,
@@ -126,32 +105,32 @@ func (c *client) SetLoggerLevel(
 	return res.LoggerLevels, err
 }
 
-func (c *client) GetLoggerLevel(
+func (c *Client) GetLoggerLevel(
 	ctx context.Context,
 	loggerName string,
 	options ...rpc.Option,
 ) (map[string]LogAndDisplayLevels, error) {
 	res := &LoggerLevelReply{}
-	err := c.requester.SendRequest(ctx, "admin.getLoggerLevel", &GetLoggerLevelArgs{
+	err := c.Requester.SendRequest(ctx, "admin.getLoggerLevel", &GetLoggerLevelArgs{
 		LoggerName: loggerName,
 	}, res, options...)
 	return res.LoggerLevels, err
 }
 
-func (c *client) GetConfig(ctx context.Context, options ...rpc.Option) (interface{}, error) {
+func (c *Client) GetConfig(ctx context.Context, options ...rpc.Option) (interface{}, error) {
 	var res interface{}
-	err := c.requester.SendRequest(ctx, "admin.getConfig", struct{}{}, &res, options...)
+	err := c.Requester.SendRequest(ctx, "admin.getConfig", struct{}{}, &res, options...)
 	return res, err
 }
 
-func (c *client) DBGet(ctx context.Context, key []byte, options ...rpc.Option) ([]byte, error) {
+func (c *Client) DBGet(ctx context.Context, key []byte, options ...rpc.Option) ([]byte, error) {
 	keyStr, err := formatting.Encode(formatting.HexNC, key)
 	if err != nil {
 		return nil, err
 	}
 
 	res := &DBGetReply{}
-	err = c.requester.SendRequest(ctx, "admin.dbGet", &DBGetArgs{
+	err = c.Requester.SendRequest(ctx, "admin.dbGet", &DBGetArgs{
 		Key: keyStr,
 	}, res, options...)
 	if err != nil {

--- a/api/admin/client_test.go
+++ b/api/admin/client_test.go
@@ -77,7 +77,7 @@ func (mc *mockClient) SendRequest(_ context.Context, _ string, _ interface{}, re
 func TestStartCPUProfiler(t *testing.T) {
 	for _, test := range SuccessResponseTests {
 		t.Run(test.name, func(t *testing.T) {
-			mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
+			mockClient := Client{Requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
 			err := mockClient.StartCPUProfiler(context.Background())
 			require.ErrorIs(t, err, test.expectedErr)
 		})
@@ -87,7 +87,7 @@ func TestStartCPUProfiler(t *testing.T) {
 func TestStopCPUProfiler(t *testing.T) {
 	for _, test := range SuccessResponseTests {
 		t.Run(test.name, func(t *testing.T) {
-			mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
+			mockClient := Client{Requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
 			err := mockClient.StopCPUProfiler(context.Background())
 			require.ErrorIs(t, err, test.expectedErr)
 		})
@@ -97,7 +97,7 @@ func TestStopCPUProfiler(t *testing.T) {
 func TestMemoryProfile(t *testing.T) {
 	for _, test := range SuccessResponseTests {
 		t.Run(test.name, func(t *testing.T) {
-			mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
+			mockClient := Client{Requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
 			err := mockClient.MemoryProfile(context.Background())
 			require.ErrorIs(t, err, test.expectedErr)
 		})
@@ -107,7 +107,7 @@ func TestMemoryProfile(t *testing.T) {
 func TestLockProfile(t *testing.T) {
 	for _, test := range SuccessResponseTests {
 		t.Run(test.name, func(t *testing.T) {
-			mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
+			mockClient := Client{Requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
 			err := mockClient.LockProfile(context.Background())
 			require.ErrorIs(t, err, test.expectedErr)
 		})
@@ -117,7 +117,7 @@ func TestLockProfile(t *testing.T) {
 func TestAlias(t *testing.T) {
 	for _, test := range SuccessResponseTests {
 		t.Run(test.name, func(t *testing.T) {
-			mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
+			mockClient := Client{Requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
 			err := mockClient.Alias(context.Background(), "alias", "alias2")
 			require.ErrorIs(t, err, test.expectedErr)
 		})
@@ -127,7 +127,7 @@ func TestAlias(t *testing.T) {
 func TestAliasChain(t *testing.T) {
 	for _, test := range SuccessResponseTests {
 		t.Run(test.name, func(t *testing.T) {
-			mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
+			mockClient := Client{Requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
 			err := mockClient.AliasChain(context.Background(), "chain", "chain-alias")
 			require.ErrorIs(t, err, test.expectedErr)
 		})
@@ -139,7 +139,7 @@ func TestGetChainAliases(t *testing.T) {
 		require := require.New(t)
 
 		expectedReply := []string{"alias1", "alias2"}
-		mockClient := client{requester: NewMockClient(&GetChainAliasesReply{
+		mockClient := Client{Requester: NewMockClient(&GetChainAliasesReply{
 			Aliases: expectedReply,
 		}, nil)}
 
@@ -149,7 +149,7 @@ func TestGetChainAliases(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		mockClient := client{requester: NewMockClient(&GetChainAliasesReply{}, errTest)}
+		mockClient := Client{Requester: NewMockClient(&GetChainAliasesReply{}, errTest)}
 		_, err := mockClient.GetChainAliases(context.Background(), "chain")
 		require.ErrorIs(t, err, errTest)
 	})
@@ -158,7 +158,7 @@ func TestGetChainAliases(t *testing.T) {
 func TestStacktrace(t *testing.T) {
 	for _, test := range SuccessResponseTests {
 		t.Run(test.name, func(t *testing.T) {
-			mockClient := client{requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
+			mockClient := Client{Requester: NewMockClient(&api.EmptyReply{}, test.expectedErr)}
 			err := mockClient.Stacktrace(context.Background())
 			require.ErrorIs(t, err, test.expectedErr)
 		})
@@ -177,7 +177,7 @@ func TestReloadInstalledVMs(t *testing.T) {
 			ids.GenerateTestID(): "oops",
 			ids.GenerateTestID(): "uh-oh",
 		}
-		mockClient := client{requester: NewMockClient(&LoadVMsReply{
+		mockClient := Client{Requester: NewMockClient(&LoadVMsReply{
 			NewVMs:    expectedNewVMs,
 			FailedVMs: expectedFailedVMs,
 		}, nil)}
@@ -189,7 +189,7 @@ func TestReloadInstalledVMs(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		mockClient := client{requester: NewMockClient(&LoadVMsReply{}, errTest)}
+		mockClient := Client{Requester: NewMockClient(&LoadVMsReply{}, errTest)}
 		_, _, err := mockClient.LoadVMs(context.Background())
 		require.ErrorIs(t, err, errTest)
 	})
@@ -244,8 +244,8 @@ func TestSetLoggerLevel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			c := client{
-				requester: NewMockClient(
+			c := Client{
+				Requester: NewMockClient(
 					&LoggerLevelReply{
 						LoggerLevels: tt.serviceResponse,
 					},
@@ -297,8 +297,8 @@ func TestGetLoggerLevel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			c := client{
-				requester: NewMockClient(
+			c := Client{
+				Requester: NewMockClient(
 					&LoggerLevelReply{
 						LoggerLevels: tt.serviceResponse,
 					},
@@ -344,8 +344,8 @@ func TestGetConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			c := client{
-				requester: NewMockClient(tt.expectedResponse, tt.serviceErr),
+			c := Client{
+				Requester: NewMockClient(tt.expectedResponse, tt.serviceErr),
 			}
 			res, err := c.GetConfig(context.Background())
 			require.ErrorIs(err, tt.clientErr)

--- a/api/admin/key_value_reader.go
+++ b/api/admin/key_value_reader.go
@@ -12,10 +12,10 @@ import (
 var _ database.KeyValueReader = (*KeyValueReader)(nil)
 
 type KeyValueReader struct {
-	client Client
+	client *Client
 }
 
-func NewKeyValueReader(client Client) *KeyValueReader {
+func NewKeyValueReader(client *Client) *KeyValueReader {
 	return &KeyValueReader{
 		client: client,
 	}

--- a/api/health/client.go
+++ b/api/health/client.go
@@ -10,65 +10,52 @@ import (
 	"github.com/ava-labs/avalanchego/utils/rpc"
 )
 
-var _ Client = (*client)(nil)
-
-// Client interface for Avalanche Health API Endpoint
-// For helpers to wait for Readiness, Health, or Liveness, see AwaitReady,
-// AwaitHealthy, and AwaitAlive.
-type Client interface {
-	// Readiness returns if the node has finished initialization
-	Readiness(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error)
-	// Health returns a summation of the health of the node
-	Health(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error)
-	// Liveness returns if the node is in need of a restart
-	Liveness(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error)
+type Client struct {
+	Requester rpc.EndpointRequester
 }
 
-// Client implementation for Avalanche Health API Endpoint
-type client struct {
-	requester rpc.EndpointRequester
-}
-
-// NewClient returns a client to interact with Health API endpoint
-func NewClient(uri string) Client {
-	return &client{requester: rpc.NewEndpointRequester(
+func NewClient(uri string) *Client {
+	return &Client{Requester: rpc.NewEndpointRequester(
 		uri + "/ext/health",
 	)}
 }
 
-func (c *client) Readiness(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error) {
+// Readiness returns if the node has finished initialization
+func (c *Client) Readiness(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error) {
 	res := &APIReply{}
-	err := c.requester.SendRequest(ctx, "health.readiness", &APIArgs{Tags: tags}, res, options...)
+	err := c.Requester.SendRequest(ctx, "health.readiness", &APIArgs{Tags: tags}, res, options...)
 	return res, err
 }
 
-func (c *client) Health(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error) {
+// Health returns a summation of the health of the node
+func (c *Client) Health(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error) {
 	res := &APIReply{}
-	err := c.requester.SendRequest(ctx, "health.health", &APIArgs{Tags: tags}, res, options...)
+	err := c.Requester.SendRequest(ctx, "health.health", &APIArgs{Tags: tags}, res, options...)
 	return res, err
 }
 
-func (c *client) Liveness(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error) {
+// Liveness returns if the node is in need of a restart
+func (c *Client) Liveness(ctx context.Context, tags []string, options ...rpc.Option) (*APIReply, error) {
 	res := &APIReply{}
-	err := c.requester.SendRequest(ctx, "health.liveness", &APIArgs{Tags: tags}, res, options...)
+	err := c.Requester.SendRequest(ctx, "health.liveness", &APIArgs{Tags: tags}, res, options...)
 	return res, err
 }
 
 // AwaitReady polls the node every [freq] until the node reports ready.
 // Only returns an error if [ctx] returns an error.
-func AwaitReady(ctx context.Context, c Client, freq time.Duration, tags []string, options ...rpc.Option) (bool, error) {
+func AwaitReady(ctx context.Context, c *Client, freq time.Duration, tags []string, options ...rpc.Option) (bool, error) {
 	return await(ctx, freq, c.Readiness, tags, options...)
 }
 
 // AwaitHealthy polls the node every [freq] until the node reports healthy.
 // Only returns an error if [ctx] returns an error.
-func AwaitHealthy(ctx context.Context, c Client, freq time.Duration, tags []string, options ...rpc.Option) (bool, error) {
+func AwaitHealthy(ctx context.Context, c *Client, freq time.Duration, tags []string, options ...rpc.Option) (bool, error) {
 	return await(ctx, freq, c.Health, tags, options...)
 }
 
 // AwaitAlive polls the node every [freq] until the node reports liveness.
 // Only returns an error if [ctx] returns an error.
-func AwaitAlive(ctx context.Context, c Client, freq time.Duration, tags []string, options ...rpc.Option) (bool, error) {
+func AwaitAlive(ctx context.Context, c *Client, freq time.Duration, tags []string, options ...rpc.Option) (bool, error) {
 	return await(ctx, freq, c.Liveness, tags, options...)
 }
 

--- a/api/health/client_test.go
+++ b/api/health/client_test.go
@@ -43,8 +43,8 @@ func TestClient(t *testing.T) {
 		err:    nil,
 		onCall: func() {},
 	}
-	c := &client{
-		requester: mc,
+	c := &Client{
+		Requester: mc,
 	}
 
 	{

--- a/api/info/client.go
+++ b/api/info/client.go
@@ -14,105 +14,85 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 )
 
-var _ Client = (*client)(nil)
-
-// Client interface for an Info API Client.
-// See also AwaitBootstrapped.
-type Client interface {
-	GetNodeVersion(context.Context, ...rpc.Option) (*GetNodeVersionReply, error)
-	GetNodeID(context.Context, ...rpc.Option) (ids.NodeID, *signer.ProofOfPossession, error)
-	GetNodeIP(context.Context, ...rpc.Option) (netip.AddrPort, error)
-	GetNetworkID(context.Context, ...rpc.Option) (uint32, error)
-	GetNetworkName(context.Context, ...rpc.Option) (string, error)
-	GetBlockchainID(context.Context, string, ...rpc.Option) (ids.ID, error)
-	Peers(context.Context, []ids.NodeID, ...rpc.Option) ([]Peer, error)
-	IsBootstrapped(context.Context, string, ...rpc.Option) (bool, error)
-	Upgrades(context.Context, ...rpc.Option) (*upgrade.Config, error)
-	Uptime(context.Context, ...rpc.Option) (*UptimeResponse, error)
-	GetVMs(context.Context, ...rpc.Option) (map[ids.ID][]string, error)
+type Client struct {
+	Requester rpc.EndpointRequester
 }
 
-// Client implementation for an Info API Client
-type client struct {
-	requester rpc.EndpointRequester
-}
-
-// NewClient returns a new Info API Client
-func NewClient(uri string) Client {
-	return &client{requester: rpc.NewEndpointRequester(
+func NewClient(uri string) *Client {
+	return &Client{Requester: rpc.NewEndpointRequester(
 		uri + "/ext/info",
 	)}
 }
 
-func (c *client) GetNodeVersion(ctx context.Context, options ...rpc.Option) (*GetNodeVersionReply, error) {
+func (c *Client) GetNodeVersion(ctx context.Context, options ...rpc.Option) (*GetNodeVersionReply, error) {
 	res := &GetNodeVersionReply{}
-	err := c.requester.SendRequest(ctx, "info.getNodeVersion", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "info.getNodeVersion", struct{}{}, res, options...)
 	return res, err
 }
 
-func (c *client) GetNodeID(ctx context.Context, options ...rpc.Option) (ids.NodeID, *signer.ProofOfPossession, error) {
+func (c *Client) GetNodeID(ctx context.Context, options ...rpc.Option) (ids.NodeID, *signer.ProofOfPossession, error) {
 	res := &GetNodeIDReply{}
-	err := c.requester.SendRequest(ctx, "info.getNodeID", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "info.getNodeID", struct{}{}, res, options...)
 	return res.NodeID, res.NodePOP, err
 }
 
-func (c *client) GetNodeIP(ctx context.Context, options ...rpc.Option) (netip.AddrPort, error) {
+func (c *Client) GetNodeIP(ctx context.Context, options ...rpc.Option) (netip.AddrPort, error) {
 	res := &GetNodeIPReply{}
-	err := c.requester.SendRequest(ctx, "info.getNodeIP", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "info.getNodeIP", struct{}{}, res, options...)
 	return res.IP, err
 }
 
-func (c *client) GetNetworkID(ctx context.Context, options ...rpc.Option) (uint32, error) {
+func (c *Client) GetNetworkID(ctx context.Context, options ...rpc.Option) (uint32, error) {
 	res := &GetNetworkIDReply{}
-	err := c.requester.SendRequest(ctx, "info.getNetworkID", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "info.getNetworkID", struct{}{}, res, options...)
 	return uint32(res.NetworkID), err
 }
 
-func (c *client) GetNetworkName(ctx context.Context, options ...rpc.Option) (string, error) {
+func (c *Client) GetNetworkName(ctx context.Context, options ...rpc.Option) (string, error) {
 	res := &GetNetworkNameReply{}
-	err := c.requester.SendRequest(ctx, "info.getNetworkName", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "info.getNetworkName", struct{}{}, res, options...)
 	return res.NetworkName, err
 }
 
-func (c *client) GetBlockchainID(ctx context.Context, alias string, options ...rpc.Option) (ids.ID, error) {
+func (c *Client) GetBlockchainID(ctx context.Context, alias string, options ...rpc.Option) (ids.ID, error) {
 	res := &GetBlockchainIDReply{}
-	err := c.requester.SendRequest(ctx, "info.getBlockchainID", &GetBlockchainIDArgs{
+	err := c.Requester.SendRequest(ctx, "info.getBlockchainID", &GetBlockchainIDArgs{
 		Alias: alias,
 	}, res, options...)
 	return res.BlockchainID, err
 }
 
-func (c *client) Peers(ctx context.Context, nodeIDs []ids.NodeID, options ...rpc.Option) ([]Peer, error) {
+func (c *Client) Peers(ctx context.Context, nodeIDs []ids.NodeID, options ...rpc.Option) ([]Peer, error) {
 	res := &PeersReply{}
-	err := c.requester.SendRequest(ctx, "info.peers", &PeersArgs{
+	err := c.Requester.SendRequest(ctx, "info.peers", &PeersArgs{
 		NodeIDs: nodeIDs,
 	}, res, options...)
 	return res.Peers, err
 }
 
-func (c *client) IsBootstrapped(ctx context.Context, chainID string, options ...rpc.Option) (bool, error) {
+func (c *Client) IsBootstrapped(ctx context.Context, chainID string, options ...rpc.Option) (bool, error) {
 	res := &IsBootstrappedResponse{}
-	err := c.requester.SendRequest(ctx, "info.isBootstrapped", &IsBootstrappedArgs{
+	err := c.Requester.SendRequest(ctx, "info.isBootstrapped", &IsBootstrappedArgs{
 		Chain: chainID,
 	}, res, options...)
 	return res.IsBootstrapped, err
 }
 
-func (c *client) Upgrades(ctx context.Context, options ...rpc.Option) (*upgrade.Config, error) {
+func (c *Client) Upgrades(ctx context.Context, options ...rpc.Option) (*upgrade.Config, error) {
 	res := &upgrade.Config{}
-	err := c.requester.SendRequest(ctx, "info.upgrades", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "info.upgrades", struct{}{}, res, options...)
 	return res, err
 }
 
-func (c *client) Uptime(ctx context.Context, options ...rpc.Option) (*UptimeResponse, error) {
+func (c *Client) Uptime(ctx context.Context, options ...rpc.Option) (*UptimeResponse, error) {
 	res := &UptimeResponse{}
-	err := c.requester.SendRequest(ctx, "info.uptime", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "info.uptime", struct{}{}, res, options...)
 	return res, err
 }
 
-func (c *client) GetVMs(ctx context.Context, options ...rpc.Option) (map[ids.ID][]string, error) {
+func (c *Client) GetVMs(ctx context.Context, options ...rpc.Option) (map[ids.ID][]string, error) {
 	res := &GetVMsReply{}
-	err := c.requester.SendRequest(ctx, "info.getVMs", struct{}{}, res, options...)
+	err := c.Requester.SendRequest(ctx, "info.getVMs", struct{}{}, res, options...)
 	return res.VMs, err
 }
 
@@ -120,7 +100,7 @@ func (c *client) GetVMs(ctx context.Context, options ...rpc.Option) (map[ids.ID]
 // finished bootstrapping. Returns true once [chainID] reports that it has
 // finished bootstrapping.
 // Only returns an error if [ctx] returns an error.
-func AwaitBootstrapped(ctx context.Context, c Client, chainID string, freq time.Duration, options ...rpc.Option) (bool, error) {
+func AwaitBootstrapped(ctx context.Context, c *Client, chainID string, freq time.Duration, options ...rpc.Option) (bool, error) {
 	ticker := time.NewTicker(freq)
 	defer ticker.Stop()
 

--- a/api/info/client_test.go
+++ b/api/info/client_test.go
@@ -41,8 +41,8 @@ func TestClient(t *testing.T) {
 		err:    nil,
 		onCall: func() {},
 	}
-	c := &client{
-		requester: mc,
+	c := &Client{
+		Requester: mc,
 	}
 
 	{

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -29,10 +29,10 @@ func (mc *mockClient) SendRequest(_ context.Context, method string, _ interface{
 
 func TestIndexClient(t *testing.T) {
 	require := require.New(t)
-	client := client{}
+	client := Client{}
 	{
 		// Test GetIndex
-		client.requester = &mockClient{
+		client.Requester = &mockClient{
 			require:        require,
 			expectedMethod: "index.getIndex",
 			onSendRequestF: func(reply interface{}) error {
@@ -50,7 +50,7 @@ func TestIndexClient(t *testing.T) {
 		bytes := utils.RandomBytes(10)
 		bytesStr, err := formatting.Encode(formatting.Hex, bytes)
 		require.NoError(err)
-		client.requester = &mockClient{
+		client.Requester = &mockClient{
 			require:        require,
 			expectedMethod: "index.getLastAccepted",
 			onSendRequestF: func(reply interface{}) error {
@@ -74,7 +74,7 @@ func TestIndexClient(t *testing.T) {
 		bytes := utils.RandomBytes(10)
 		bytesStr, err := formatting.Encode(formatting.Hex, bytes)
 		require.NoError(err)
-		client.requester = &mockClient{
+		client.Requester = &mockClient{
 			require:        require,
 			expectedMethod: "index.getContainerRange",
 			onSendRequestF: func(reply interface{}) error {
@@ -93,7 +93,7 @@ func TestIndexClient(t *testing.T) {
 	}
 	{
 		// Test IsAccepted
-		client.requester = &mockClient{
+		client.Requester = &mockClient{
 			require:        require,
 			expectedMethod: "index.isAccepted",
 			onSendRequestF: func(reply interface{}) error {
@@ -111,7 +111,7 @@ func TestIndexClient(t *testing.T) {
 		bytes := utils.RandomBytes(10)
 		bytesStr, err := formatting.Encode(formatting.Hex, bytes)
 		require.NoError(err)
-		client.requester = &mockClient{
+		client.Requester = &mockClient{
 			require:        require,
 			expectedMethod: "index.getContainerByID",
 			onSendRequestF: func(reply interface{}) error {

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -319,7 +319,7 @@ var _ = ginkgo.Describe("[Staking Rewards]", func() {
 // TODO(marun) Enable GetConfig to return *node.Config directly. Currently, due
 // to a circular dependency issue, a map-based equivalent is used for which
 // manual unmarshaling is required.
-func getRewardConfig(tc tests.TestContext, client admin.Client) reward.Config {
+func getRewardConfig(tc tests.TestContext, client *admin.Client) reward.Config {
 	require := require.New(tc)
 
 	rawNodeConfigMap, err := client.GetConfig(tc.DefaultContext())

--- a/tests/e2e/p/validator_sets.go
+++ b/tests/e2e/p/validator_sets.go
@@ -82,7 +82,7 @@ var _ = e2e.DescribePChain("[Validator Sets]", func() {
 
 		tc.By("checking that validator sets are equal across all heights for all nodes", func() {
 			localURIs := env.GetNodeURIs()
-			pvmClients := make([]platformvm.Client, len(localURIs))
+			pvmClients := make([]*platformvm.Client, len(localURIs))
 			for i, nodeURI := range localURIs {
 				pvmClients[i] = platformvm.NewClient(nodeURI.URI)
 				// Ensure that the height of the target node is at least the expected height

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -252,7 +252,7 @@ func (s *Subnet) HasChainConfig() bool {
 func WaitForActiveValidators(
 	ctx context.Context,
 	log logging.Logger,
-	pChainClient platformvm.Client,
+	pChainClient *platformvm.Client,
 	subnet *Subnet,
 ) error {
 	ticker := time.NewTicker(DefaultPollingInterval)

--- a/vms/avm/client.go
+++ b/vms/avm/client.go
@@ -27,7 +27,9 @@ var (
 
 // Client for interacting with an AVM (X-Chain) instance
 type Client interface {
-	WalletClient
+	// IssueTx issues a transaction to a node and returns the TxID
+	IssueTx(ctx context.Context, tx []byte, options ...rpc.Option) (ids.ID, error)
+
 	// GetBlock returns the block with the given id.
 	GetBlock(ctx context.Context, blkID ids.ID, options ...rpc.Option) ([]byte, error)
 	// GetBlockByHeight returns the block at the given [height].
@@ -125,6 +127,7 @@ func (c *client) GetHeight(ctx context.Context, options ...rpc.Option) (uint64, 
 	return uint64(res.Height), err
 }
 
+// IssueTx issues a transaction to a node and returns the TxID
 func (c *client) IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error) {
 	txStr, err := formatting.Encode(formatting.Hex, txBytes)
 	if err != nil {

--- a/vms/avm/wallet_client.go
+++ b/vms/avm/wallet_client.go
@@ -14,42 +14,39 @@ import (
 	"github.com/ava-labs/avalanchego/utils/rpc"
 )
 
-var _ WalletClient = (*client)(nil)
-
-// interface of an AVM wallet client for interacting with avm managed wallet on [chain]
-type WalletClient interface {
-	// IssueTx issues a transaction to a node and returns the TxID
-	IssueTx(ctx context.Context, tx []byte, options ...rpc.Option) (ids.ID, error)
-}
-
-// implementation of an AVM wallet client for interacting with avm managed wallet on [chain]
-type walletClient struct {
-	requester rpc.EndpointRequester
-}
-
-// NewWalletClient returns an AVM wallet client for interacting with avm managed wallet on [chain]
+// WalletClient for interacting with avm managed wallet.
 //
 // Deprecated: Transactions should be issued using the
 // `avalanchego/wallet/chain/x.Wallet` utility.
-func NewWalletClient(uri, chain string) WalletClient {
+type WalletClient struct {
+	Requester rpc.EndpointRequester
+}
+
+// NewWalletClient returns an AVM wallet client for interacting with avm managed
+// wallet
+//
+// Deprecated: Transactions should be issued using the
+// `avalanchego/wallet/chain/x.Wallet` utility.
+func NewWalletClient(uri, chain string) *WalletClient {
 	path := fmt.Sprintf(
 		"%s/ext/%s/%s/wallet",
 		uri,
 		constants.ChainAliasPrefix,
 		chain,
 	)
-	return &walletClient{
-		requester: rpc.NewEndpointRequester(path),
+	return &WalletClient{
+		Requester: rpc.NewEndpointRequester(path),
 	}
 }
 
-func (c *walletClient) IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error) {
+// IssueTx issues a transaction to a node and returns the TxID
+func (c *WalletClient) IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error) {
 	txStr, err := formatting.Encode(formatting.Hex, txBytes)
 	if err != nil {
 		return ids.Empty, err
 	}
 	res := &api.JSONTxID{}
-	err = c.requester.SendRequest(ctx, "wallet.issueTx", &api.FormattedTx{
+	err = c.Requester.SendRequest(ctx, "wallet.issueTx", &api.FormattedTx{
 		Tx:       txStr,
 		Encoding: formatting.Hex,
 	}, res, options...)

--- a/vms/example/xsvm/api/client.go
+++ b/vms/example/xsvm/api/client.go
@@ -19,75 +19,28 @@ import (
 
 const DefaultPollingInterval = 50 * time.Millisecond
 
-// Client defines the xsvm API client.
-type Client interface {
-	Network(
-		ctx context.Context,
-		options ...rpc.Option,
-	) (uint32, ids.ID, ids.ID, error)
-	Genesis(
-		ctx context.Context,
-		options ...rpc.Option,
-	) (*genesis.Genesis, error)
-	Nonce(
-		ctx context.Context,
-		address ids.ShortID,
-		options ...rpc.Option,
-	) (uint64, error)
-	Balance(
-		ctx context.Context,
-		address ids.ShortID,
-		assetID ids.ID,
-		options ...rpc.Option,
-	) (uint64, error)
-	Loan(
-		ctx context.Context,
-		chainID ids.ID,
-		options ...rpc.Option,
-	) (uint64, error)
-	IssueTx(
-		ctx context.Context,
-		tx *tx.Tx,
-		options ...rpc.Option,
-	) (ids.ID, error)
-	LastAccepted(
-		ctx context.Context,
-		options ...rpc.Option,
-	) (ids.ID, *block.Stateless, error)
-	Block(
-		ctx context.Context,
-		blkID ids.ID,
-		options ...rpc.Option,
-	) (*block.Stateless, error)
-	Message(
-		ctx context.Context,
-		txID ids.ID,
-		options ...rpc.Option,
-	) (*warp.UnsignedMessage, []byte, error)
-}
-
-func NewClient(uri, chain string) Client {
+func NewClient(uri, chain string) *Client {
 	path := fmt.Sprintf(
 		"%s/ext/%s/%s",
 		uri,
 		constants.ChainAliasPrefix,
 		chain,
 	)
-	return &client{
-		req: rpc.NewEndpointRequester(path),
+	return &Client{
+		Req: rpc.NewEndpointRequester(path),
 	}
 }
 
-type client struct {
-	req rpc.EndpointRequester
+type Client struct {
+	Req rpc.EndpointRequester
 }
 
-func (c *client) Network(
+func (c *Client) Network(
 	ctx context.Context,
 	options ...rpc.Option,
 ) (uint32, ids.ID, ids.ID, error) {
 	resp := new(NetworkReply)
-	err := c.req.SendRequest(
+	err := c.Req.SendRequest(
 		ctx,
 		"xsvm.network",
 		nil,
@@ -97,12 +50,12 @@ func (c *client) Network(
 	return resp.NetworkID, resp.SubnetID, resp.ChainID, err
 }
 
-func (c *client) Genesis(
+func (c *Client) Genesis(
 	ctx context.Context,
 	options ...rpc.Option,
 ) (*genesis.Genesis, error) {
 	resp := new(GenesisReply)
-	err := c.req.SendRequest(
+	err := c.Req.SendRequest(
 		ctx,
 		"xsvm.genesis",
 		nil,
@@ -112,13 +65,13 @@ func (c *client) Genesis(
 	return resp.Genesis, err
 }
 
-func (c *client) Nonce(
+func (c *Client) Nonce(
 	ctx context.Context,
 	address ids.ShortID,
 	options ...rpc.Option,
 ) (uint64, error) {
 	resp := new(NonceReply)
-	err := c.req.SendRequest(
+	err := c.Req.SendRequest(
 		ctx,
 		"xsvm.nonce",
 		&NonceArgs{
@@ -130,14 +83,14 @@ func (c *client) Nonce(
 	return resp.Nonce, err
 }
 
-func (c *client) Balance(
+func (c *Client) Balance(
 	ctx context.Context,
 	address ids.ShortID,
 	assetID ids.ID,
 	options ...rpc.Option,
 ) (uint64, error) {
 	resp := new(BalanceReply)
-	err := c.req.SendRequest(
+	err := c.Req.SendRequest(
 		ctx,
 		"xsvm.balance",
 		&BalanceArgs{
@@ -150,13 +103,13 @@ func (c *client) Balance(
 	return resp.Balance, err
 }
 
-func (c *client) Loan(
+func (c *Client) Loan(
 	ctx context.Context,
 	chainID ids.ID,
 	options ...rpc.Option,
 ) (uint64, error) {
 	resp := new(LoanReply)
-	err := c.req.SendRequest(
+	err := c.Req.SendRequest(
 		ctx,
 		"xsvm.loan",
 		&LoanArgs{
@@ -168,7 +121,7 @@ func (c *client) Loan(
 	return resp.Amount, err
 }
 
-func (c *client) IssueTx(
+func (c *Client) IssueTx(
 	ctx context.Context,
 	newTx *tx.Tx,
 	options ...rpc.Option,
@@ -179,7 +132,7 @@ func (c *client) IssueTx(
 	}
 
 	resp := new(IssueTxReply)
-	err = c.req.SendRequest(
+	err = c.Req.SendRequest(
 		ctx,
 		"xsvm.issueTx",
 		&IssueTxArgs{
@@ -191,12 +144,12 @@ func (c *client) IssueTx(
 	return resp.TxID, err
 }
 
-func (c *client) LastAccepted(
+func (c *Client) LastAccepted(
 	ctx context.Context,
 	options ...rpc.Option,
 ) (ids.ID, *block.Stateless, error) {
 	resp := new(LastAcceptedReply)
-	err := c.req.SendRequest(
+	err := c.Req.SendRequest(
 		ctx,
 		"xsvm.lastAccepted",
 		nil,
@@ -206,13 +159,13 @@ func (c *client) LastAccepted(
 	return resp.BlockID, resp.Block, err
 }
 
-func (c *client) Block(
+func (c *Client) Block(
 	ctx context.Context,
 	blkID ids.ID,
 	options ...rpc.Option,
 ) (*block.Stateless, error) {
 	resp := new(BlockReply)
-	err := c.req.SendRequest(
+	err := c.Req.SendRequest(
 		ctx,
 		"xsvm.lastAccepted",
 		&BlockArgs{
@@ -224,13 +177,13 @@ func (c *client) Block(
 	return resp.Block, err
 }
 
-func (c *client) Message(
+func (c *Client) Message(
 	ctx context.Context,
 	txID ids.ID,
 	options ...rpc.Option,
 ) (*warp.UnsignedMessage, []byte, error) {
 	resp := new(MessageReply)
-	err := c.req.SendRequest(
+	err := c.Req.SendRequest(
 		ctx,
 		"xsvm.message",
 		&MessageArgs{
@@ -247,7 +200,7 @@ func (c *client) Message(
 
 func AwaitTxAccepted(
 	ctx context.Context,
-	c Client,
+	c *Client,
 	address ids.ShortID,
 	nonce uint64,
 	freq time.Duration,

--- a/wallet/chain/c/context.go
+++ b/wallet/chain/c/context.go
@@ -30,7 +30,7 @@ func NewContextFromURI(ctx context.Context, uri string) (*Context, error) {
 
 func NewContextFromClients(
 	ctx context.Context,
-	infoClient info.Client,
+	infoClient *info.Client,
 	xChainClient avm.Client,
 ) (*Context, error) {
 	networkID, err := infoClient.GetNetworkID(ctx)

--- a/wallet/chain/c/context.go
+++ b/wallet/chain/c/context.go
@@ -31,7 +31,7 @@ func NewContextFromURI(ctx context.Context, uri string) (*Context, error) {
 func NewContextFromClients(
 	ctx context.Context,
 	infoClient *info.Client,
-	xChainClient avm.Client,
+	xChainClient *avm.Client,
 ) (*Context, error) {
 	networkID, err := infoClient.GetNetworkID(ctx)
 	if err != nil {

--- a/wallet/chain/p/client.go
+++ b/wallet/chain/p/client.go
@@ -16,7 +16,7 @@ import (
 var _ wallet.Client = (*Client)(nil)
 
 func NewClient(
-	c platformvm.Client,
+	c *platformvm.Client,
 	b wallet.Backend,
 ) *Client {
 	return &Client{
@@ -26,7 +26,7 @@ func NewClient(
 }
 
 type Client struct {
-	client  platformvm.Client
+	client  *platformvm.Client
 	backend wallet.Backend
 }
 

--- a/wallet/chain/p/context.go
+++ b/wallet/chain/p/context.go
@@ -27,7 +27,7 @@ func NewContextFromURI(ctx context.Context, uri string) (*builder.Context, error
 func NewContextFromClients(
 	ctx context.Context,
 	infoClient *info.Client,
-	chainClient platformvm.Client,
+	chainClient *platformvm.Client,
 ) (*builder.Context, error) {
 	networkID, err := infoClient.GetNetworkID(ctx)
 	if err != nil {

--- a/wallet/chain/p/context.go
+++ b/wallet/chain/p/context.go
@@ -26,7 +26,7 @@ func NewContextFromURI(ctx context.Context, uri string) (*builder.Context, error
 
 func NewContextFromClients(
 	ctx context.Context,
-	infoClient info.Client,
+	infoClient *info.Client,
 	chainClient platformvm.Client,
 ) (*builder.Context, error) {
 	networkID, err := infoClient.GetNetworkID(ctx)

--- a/wallet/chain/x/context.go
+++ b/wallet/chain/x/context.go
@@ -20,7 +20,7 @@ func NewContextFromURI(ctx context.Context, uri string) (*builder.Context, error
 func NewContextFromClients(
 	ctx context.Context,
 	infoClient *info.Client,
-	xChainClient avm.Client,
+	xChainClient *avm.Client,
 ) (*builder.Context, error) {
 	networkID, err := infoClient.GetNetworkID(ctx)
 	if err != nil {

--- a/wallet/chain/x/context.go
+++ b/wallet/chain/x/context.go
@@ -19,7 +19,7 @@ func NewContextFromURI(ctx context.Context, uri string) (*builder.Context, error
 
 func NewContextFromClients(
 	ctx context.Context,
-	infoClient info.Client,
+	infoClient *info.Client,
 	xChainClient avm.Client,
 ) (*builder.Context, error) {
 	networkID, err := infoClient.GetNetworkID(ctx)

--- a/wallet/chain/x/wallet.go
+++ b/wallet/chain/x/wallet.go
@@ -142,7 +142,7 @@ type Wallet interface {
 func NewWallet(
 	builder builder.Builder,
 	signer signer.Signer,
-	client avm.Client,
+	client *avm.Client,
 	backend Backend,
 ) Wallet {
 	return &wallet{
@@ -157,7 +157,7 @@ type wallet struct {
 	backend Backend
 	builder builder.Builder
 	signer  signer.Signer
-	client  avm.Client
+	client  *avm.Client
 }
 
 func (w *wallet) Builder() builder.Builder {

--- a/wallet/subnet/primary/api.go
+++ b/wallet/subnet/primary/api.go
@@ -39,10 +39,8 @@ const (
 	fetchLimit = 1024
 )
 
-// TODO: Refactor UTXOClient definition to allow the client implementations to
-// perform their own assertions.
 var (
-	_ UTXOClient = platformvm.Client(nil)
+	_ UTXOClient = (*platformvm.Client)(nil)
 	_ UTXOClient = (*avm.Client)(nil)
 )
 
@@ -59,7 +57,7 @@ type UTXOClient interface {
 }
 
 type AVAXState struct {
-	PClient platformvm.Client
+	PClient *platformvm.Client
 	PCTX    *pbuilder.Context
 	XClient *avm.Client
 	XCTX    *xbuilder.Context
@@ -151,7 +149,7 @@ func FetchPState(
 	uri string,
 	addrs set.Set[ids.ShortID],
 ) (
-	platformvm.Client,
+	*platformvm.Client,
 	*pbuilder.Context,
 	walletcommon.UTXOs,
 	error,

--- a/wallet/subnet/primary/api.go
+++ b/wallet/subnet/primary/api.go
@@ -43,7 +43,7 @@ const (
 // perform their own assertions.
 var (
 	_ UTXOClient = platformvm.Client(nil)
-	_ UTXOClient = avm.Client(nil)
+	_ UTXOClient = (*avm.Client)(nil)
 )
 
 type UTXOClient interface {
@@ -61,7 +61,7 @@ type UTXOClient interface {
 type AVAXState struct {
 	PClient platformvm.Client
 	PCTX    *pbuilder.Context
-	XClient avm.Client
+	XClient *avm.Client
 	XCTX    *xbuilder.Context
 	CClient client.Client
 	CCTX    *c.Context


### PR DESCRIPTION
## Why this should be merged

Resolves #4056

## How this works

This PR:
1. Removes the various `Client` interfaces, instead exposing the structs directly.
2. Additionally, the `Requester` is exported, so `Client`s can be constructed with custom `Requester`s.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.