### PR TITLE
Run C-Chain Benchmark on Blacksmith

### DIFF
--- a/.github/workflows/c-chain-benchmark.yml
+++ b/.github/workflows/c-chain-benchmark.yml
@@ -26,7 +26,7 @@ jobs:
       permissions:
         id-token: write
         contents: write
-      runs-on: ubuntu-latest
+      runs-on: blacksmith-4vcpu-ubuntu-2404
       steps:
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
ref https://www.blacksmith.sh/

Trying out Blacksmith POC for the following benefits:
- 1.5 TB of storage
- Potentially higher performance IO
- Cheaper than GitHub Actions