### PR TITLE
Simplify test block creation

### DIFF
--- a/simplex/block.go
+++ b/simplex/block.go
@@ -172,9 +172,7 @@ func (bt *blockTracker) verifyAndTrackBlock(ctx context.Context, block *Block) e
 		return nil
 	}
 
-	// verify the block
-	err := block.vmBlock.Verify(ctx)
-	if err != nil {
+	if err := block.vmBlock.Verify(ctx); err != nil {
 		return fmt.Errorf("failed to verify block: %w", err)
 	}
 

--- a/simplex/block_test.go
+++ b/simplex/block_test.go
@@ -229,6 +229,9 @@ func TestVerifyInnerBlockBreaksHashChain(t *testing.T) {
 	b := newBlock(t, newBlockConfig{
 		prev: genesis,
 	})
+
+	// This block does not extend the genesis, however it has a valid previous
+	// digest.
 	b.vmBlock.(*snowmantest.Block).ParentV[0]++
 
 	_, err := b.Verify(ctx)

--- a/simplex/util_test.go
+++ b/simplex/util_test.go
@@ -17,45 +17,52 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 )
 
-type testBlockConfig struct {
-	vmBlock      snowman.Block
-	blockTracker *blockTracker
-	round        uint64
-	seq          uint64
-	prev         simplex.Digest
+type newBlockConfig struct {
+	// If prev is nil, newBlock will create the genesis block
+	prev *Block
+	// If vmBlock is nil, a random child of prev will be created
+	vmBlock snowman.Block
+	// If round is 0, it will be set to one higher than the prev's round
+	round uint64
 }
 
-// newBlock constructs a random child block of the genesis. This is a helper function
-// used for testing. This is helpful since otherwise we would
-// need the blockDeserializer to create the block.
-func newBlock(t *testing.T, config *testBlockConfig) *Block {
-	genesisBlock := newGenesisBlock(t)
-
-	if config == nil {
-		config = &testBlockConfig{
-			vmBlock:      snowmantest.BuildChild(snowmantest.Genesis),
-			blockTracker: newBlockTracker(genesisBlock),
-			round:        1,
-			seq:          1,
-			prev:         genesisBlock.digest,
+func newBlock(t *testing.T, config newBlockConfig) *Block {
+	if config.prev == nil {
+		block := &Block{
+			vmBlock: snowmantest.Genesis,
+			metadata: simplex.ProtocolMetadata{
+				Version: 1,
+				Epoch:   1,
+				Round:   0,
+				Seq:     0,
+			},
 		}
+		bytes, err := block.Bytes()
+		require.NoError(t, err)
+
+		digest := computeDigest(bytes)
+		block.digest = digest
+
+		block.blockTracker = newBlockTracker(block)
+		return block
 	}
-	if config.blockTracker == nil {
-		config.blockTracker = newBlockTracker(genesisBlock)
-	}
+
 	if config.vmBlock == nil {
-		config.vmBlock = snowmantest.BuildChild(snowmantest.Genesis)
+		config.vmBlock = snowmantest.BuildChild(config.prev.vmBlock.(*snowmantest.Block))
+	}
+	if config.round == 0 {
+		config.round = config.prev.metadata.Round + 1
 	}
 
 	block := &Block{
 		vmBlock:      config.vmBlock,
-		blockTracker: config.blockTracker,
+		blockTracker: config.prev.blockTracker,
 		metadata: simplex.ProtocolMetadata{
 			Version: 1,
 			Epoch:   1,
 			Round:   config.round,
-			Seq:     config.seq,
-			Prev:    config.prev,
+			Seq:     config.vmBlock.Height(),
+			Prev:    config.prev.digest,
 		},
 	}
 
@@ -64,27 +71,6 @@ func newBlock(t *testing.T, config *testBlockConfig) *Block {
 
 	digest := computeDigest(bytes)
 	block.digest = digest
-
-	return block
-}
-
-func newGenesisBlock(t *testing.T) *Block {
-	block := &Block{
-		vmBlock: snowmantest.Genesis,
-		metadata: simplex.ProtocolMetadata{
-			Version: 1,
-			Epoch:   1,
-			Round:   0,
-			Seq:     0,
-		},
-	}
-
-	bytes, err := block.Bytes()
-	require.NoError(t, err)
-
-	digest := computeDigest(bytes)
-	block.digest = digest
-
 	return block
 }
 


### PR DESCRIPTION
## Why this should be merged

Reduces the number of options required to provide to the `newBlock` test helper.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
