### PR TITLE
Fix wrong pkg import for Primary Wallet

### DIFF
--- a/wallet/subnet/primary/api.go
+++ b/wallet/subnet/primary/api.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/coreth/ethclient"
+	"github.com/ava-labs/coreth/plugin/evm/atomic"
 	"github.com/ava-labs/coreth/plugin/evm/client"
 
 	"github.com/ava-labs/avalanchego/api/info"
-	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"


### PR DESCRIPTION
The wrong `atomic` package was being used.
