### PR TITLE
Added Juan wherever Maru - expect discussion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,21 +8,21 @@
 * @StephenButtolph
 *.md @meaghanfitzgerald @StephenButtolph
 /.dockerignore @maru-ava
-/.envrc @maru-ava
-/.github/ @maru-ava
-/.github/*.md @maru-ava @meaghanfitzgerald
+/.envrc @maru-ava @JuanLeon2
+/.github/ @maru-ava @JuanLeon2
+/.github/*.md @maru-ava @JuanLeon2 @meaghanfitzgerald
 /.github/CODEOWNERS @StephenButtolph
-/.gitignore @maru-ava @StephenButtolph
-/.golangci.yml @maru-ava @StephenButtolph
-/Dockerfile @maru-ava
-/Taskfile.yml @maru-ava
-/flake.lock @maru-ava
-/flake.nix @maru-ava
+/.gitignore @maru-ava @JuanLeon2 @StephenButtolph
+/.golangci.yml @maru-ava @JuanLeon2 @StephenButtolph
+/Dockerfile @maru-ava @JuanLeon2
+/Taskfile.yml @maru-ava @JuanLeon2
+/flake.lock @maru-ava @JuanLeon2
+/flake.nix @maru-ava @JuanLeon2
 /network/p2p/ @joshua-kim
 /network/p2p/*.md @joshua-kim @meaghanfitzgerald
-/scripts/ @maru-ava
-/scripts/*.md @maru-ava @meaghanfitzgerald
-/tests/ @maru-ava
-/tests/*.md @maru-ava @meaghanfitzgerald
+/scripts/ @maru-ava @JuanLeon2
+/scripts/*.md @maru-ava @JuanLeon2 @meaghanfitzgerald
+/tests/ @maru-ava @JuanLeon2
+/tests/*.md @maru-ava @JuanLeon2 @meaghanfitzgerald
 /x/merkledb @joshua-kim @rrazvan1
 /x/sync @joshua-kim @rrazvan1


### PR DESCRIPTION
## Why this should be merged

Maru wants to take a step back from responsibility.  Juan would *very carefully* look at PRs for which currently Maru is a required reviewer (other then Stephen).    Half of the argument is that we need someone to look at those PRs.  The other half is that other than action workflows, and those are debatable, there is little damage these subtrees can do directly to AvalancheGo. 

This is temporary, until someone steps up, or is hired, and comes to be trusted (this does not imply Juan is trusted)

