### PR TITLE
Split action benchmark comparison and push to gh-pages

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -61,7 +61,7 @@ jobs:
           with:
             path: ./cache
             key: ${{ runner.os }}-reexecute-cchain-range-benchmark.json
-        - name: Compare Benchmark Results
+        - name: Compare Benchmark Result
           uses: benchmark-action/github-action-benchmark@v1
           with:
             tool: 'go'
@@ -72,10 +72,12 @@ jobs:
             summary-always: true
             comment-on-alert: true
             auto-push: false
-        - name: Check git status
-          run: |
-            git status
-            git log
         - name: Push Benchmark Result
           if: github.event_name == 'schedule'
-          run: git push origin gh-pages
+          uses: benchmark-action/github-action-benchmark@v1
+          with:
+            tool: 'go'
+            output-file-path: ${{ github.workspace }}/reexecute-cchain-range-benchmark-res.txt
+            external-data-json-path: ./cache/${{ runner.os }}-reexecute-cchain-range-benchmark.json
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            auto-push: true

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -1,6 +1,7 @@
 name: C-Chain Re-Execution Benchmark
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       start-block:
@@ -71,6 +72,10 @@ jobs:
             summary-always: true
             comment-on-alert: true
             auto-push: false
+        - name: Check git status
+          run: |
+            git status
+            git log
         - name: Push Benchmark Result
           if: github.event_name == 'schedule'
           run: git push origin gh-pages


### PR DESCRIPTION
This PR fixes the scheduled runs of pushing the C-Chain benchmark to `gh-pages` branch by splitting comparison against the baseline and pushing to the branch into two separate steps.

https://github.com/benchmark-action/github-action-benchmark/ suggests to only push results from the master branch to ensure data from stray feature branches doesn't get mistakenly added to tracking.

Previously, this attempted to follow the vague documentation of using `git push ...` after running the action, which failed.

This instead uses the action for both comparison and archiving to the branch by splitting it into two steps with a different set of options passed to each.
