### PR TITLE
Remove external-data-json-path from benchmark push step

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -78,6 +78,5 @@ jobs:
           with:
             tool: 'go'
             output-file-path: ${{ github.workspace }}/reexecute-cchain-range-benchmark-res.txt
-            external-data-json-path: ./cache/${{ runner.os }}-reexecute-cchain-range-benchmark.json
             github-token: ${{ secrets.GITHUB_TOKEN }}
             auto-push: true


### PR DESCRIPTION
This PR removes the `external-data-json-path` param from the push step of the C-Chain benchmark.

This causes the job to fail because it attempts to supply both the external data json path and the branch to pull data from, which conflict: https://github.com/ava-labs/avalanchego/actions/runs/16591734124/job/46928821681#step:9:30.