### PR TITLE
fix metrics tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
     - bodyclose
     - copyloopvar
     - depguard
-    - dupword
     - errcheck
     - errorlint
     - forbidigo

--- a/api/metrics/label_gatherer_test.go
+++ b/api/metrics/label_gatherer_test.go
@@ -30,8 +30,8 @@ func TestLabelGatherer_Gather(t *testing.T) {
 		expectErr   bool
 	}{
 		{
-			name:        "no overlap",
-			labelName:   customLabelName,
+			name:      "no overlap",
+			labelName: customLabelName,
 			wantMetrics: "" +
 				"# HELP counter help\n" +
 				"# TYPE counter counter\n" +

--- a/api/metrics/label_gatherer_test.go
+++ b/api/metrics/label_gatherer_test.go
@@ -32,12 +32,11 @@ func TestLabelGatherer_Gather(t *testing.T) {
 		{
 			name:        "no overlap",
 			labelName:   customLabelName,
-			wantMetrics: `
-# HELP counter help
-# TYPE counter counter
-counter{smith="morty",tag="b"} 1
-counter{smith="rick",tag="a"} 0
-`,
+			wantMetrics: "" +
+				"# HELP counter help\n" +
+				"# TYPE counter counter\n" +
+				"counter{smith=\"morty\",tag=\"b\"} 1\n" +
+				"counter{smith=\"rick\",tag=\"a\"} 0\n",
 		},
 		{
 			name:      "has overlap",

--- a/api/metrics/label_gatherer_test.go
+++ b/api/metrics/label_gatherer_test.go
@@ -32,7 +32,12 @@ func TestLabelGatherer_Gather(t *testing.T) {
 		{
 			name:        "no overlap",
 			labelName:   customLabelName,
-			wantMetrics: "\n# HELP counter help\n# TYPE counter counter{smith=\"morty\",tag=\"b\"} 1\ncounter{smith=\"rick\",tag=\"a\"}",
+			wantMetrics: `
+# HELP counter help
+# TYPE counter counter
+counter{smith="morty",tag="b"} 1
+counter{smith="rick",tag="a"} 0
+`,
 		},
 		{
 			name:      "has overlap",

--- a/api/metrics/label_gatherer_test.go
+++ b/api/metrics/label_gatherer_test.go
@@ -4,11 +4,12 @@
 package metrics
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -23,68 +24,19 @@ func TestLabelGatherer_Gather(t *testing.T) {
 		customLabelValueB = "b"
 	)
 	tests := []struct {
-		name            string
-		labelName       string
-		expectedMetrics []*dto.Metric
-		expectErr       bool
+		name        string
+		labelName   string
+		wantMetrics string
+		expectErr   bool
 	}{
 		{
-			name:      "no overlap",
-			labelName: customLabelName,
-			expectedMetrics: []*dto.Metric{
-				{
-					Label: []*dto.LabelPair{
-						{
-							Name:  proto.String(labelName),
-							Value: proto.String(labelValueB),
-						},
-						{
-							Name:  proto.String(customLabelName),
-							Value: proto.String(customLabelValueB),
-						},
-					},
-					Counter: &dto.Counter{
-						Value: proto.Float64(1),
-					},
-				},
-				{
-					Label: []*dto.LabelPair{
-						{
-							Name:  proto.String(labelName),
-							Value: proto.String(labelValueA),
-						},
-						{
-							Name:  proto.String(customLabelName),
-							Value: proto.String(customLabelValueA),
-						},
-					},
-					Counter: &dto.Counter{
-						Value: proto.Float64(0),
-					},
-				},
-			},
-			expectErr: false,
+			name:        "no overlap",
+			labelName:   customLabelName,
+			wantMetrics: "\n# HELP counter help\n# TYPE counter counter{smith=\"morty\",tag=\"b\"} 1\ncounter{smith=\"rick\",tag=\"a\"}",
 		},
 		{
 			name:      "has overlap",
 			labelName: labelName,
-			expectedMetrics: []*dto.Metric{
-				{
-					Label: []*dto.LabelPair{
-						{
-							Name:  proto.String(labelName),
-							Value: proto.String(labelValueB),
-						},
-						{
-							Name:  proto.String(customLabelName),
-							Value: proto.String(customLabelValueB),
-						},
-					},
-					Counter: &dto.Counter{
-						Value: proto.Float64(1),
-					},
-				},
-			},
 			expectErr: true,
 		},
 	}
@@ -117,23 +69,17 @@ func TestLabelGatherer_Gather(t *testing.T) {
 				require.NoError(registerB.Register(counterB))
 			}
 
-			metrics, err := gatherer.Gather()
 			if test.expectErr {
-				require.Error(err) //nolint:forbidigo // the error is not exported
+				require.Error(testutil.GatherAndCompare( //nolint:forbidigo // the error is not exported
+					gatherer,
+					strings.NewReader(test.wantMetrics),
+				))
 			} else {
-				require.NoError(err)
+				require.NoError(testutil.GatherAndCompare(
+					gatherer,
+					strings.NewReader(test.wantMetrics),
+				))
 			}
-			require.Equal(
-				[]*dto.MetricFamily{
-					{
-						Name:   proto.String(counterOpts.Name),
-						Help:   proto.String(counterOpts.Help),
-						Type:   dto.MetricType_COUNTER.Enum(),
-						Metric: test.expectedMetrics,
-					},
-				},
-				metrics,
-			)
 		})
 	}
 }

--- a/api/metrics/label_gatherer_test.go
+++ b/api/metrics/label_gatherer_test.go
@@ -32,11 +32,12 @@ func TestLabelGatherer_Gather(t *testing.T) {
 		{
 			name:      "no overlap",
 			labelName: customLabelName,
-			wantMetrics: "" +
-				"# HELP counter help\n" +
-				"# TYPE counter counter\n" +
-				"counter{smith=\"morty\",tag=\"b\"} 1\n" +
-				"counter{smith=\"rick\",tag=\"a\"} 0\n",
+			wantMetrics: `
+# HELP counter help
+# TYPE counter counter
+counter{smith="morty",tag="b"} 1
+counter{smith="rick",tag="a"} 0
+`,
 		},
 		{
 			name:      "has overlap",

--- a/api/metrics/prefix_gatherer_test.go
+++ b/api/metrics/prefix_gatherer_test.go
@@ -35,14 +35,15 @@ func TestPrefixGatherer_Gather(t *testing.T) {
 		require.NoError(registerB.Register(counterB))
 	}
 
-	wantMetrics := "" +
-		"# HELP a_counter help\n" +
-		"# TYPE a_counter counter\n" +
-		"a_counter 0\n" +
-		"\n" +
-		"# HELP b_counter help\n" +
-		"# TYPE b_counter counter\n" +
-		"b_counter 1\n"
+	wantMetrics := `
+# HELP a_counter help
+# TYPE a_counter counter
+a_counter 0
+
+# HELP b_counter help
+# TYPE b_counter counter
+b_counter 1
+`
 
 	require.NoError(testutil.GatherAndCompare(
 		gatherer,

--- a/api/metrics/prefix_gatherer_test.go
+++ b/api/metrics/prefix_gatherer_test.go
@@ -35,15 +35,14 @@ func TestPrefixGatherer_Gather(t *testing.T) {
 		require.NoError(registerB.Register(counterB))
 	}
 
-	wantMetrics := `
-# HELP a_counter help
-# TYPE a_counter counter
-a_counter 0
-
-# HELP b_counter help
-# TYPE b_counter counter
-b_counter 1
-`
+	wantMetrics := "" +
+		"# HELP a_counter help\n" +
+		"# TYPE a_counter counter\n" +
+		"a_counter 0\n" +
+		"\n" +
+		"# HELP b_counter help\n" +
+		"# TYPE b_counter counter\n" +
+		"b_counter 1\n"
 
 	require.NoError(testutil.GatherAndCompare(
 		gatherer,

--- a/api/metrics/prefix_gatherer_test.go
+++ b/api/metrics/prefix_gatherer_test.go
@@ -4,11 +4,12 @@
 package metrics
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -34,39 +35,20 @@ func TestPrefixGatherer_Gather(t *testing.T) {
 		require.NoError(registerB.Register(counterB))
 	}
 
-	metrics, err := gatherer.Gather()
-	require.NoError(err)
-	require.Equal(
-		[]*dto.MetricFamily{
-			{
-				Name: proto.String("a_counter"),
-				Help: proto.String(counterOpts.Help),
-				Type: dto.MetricType_COUNTER.Enum(),
-				Metric: []*dto.Metric{
-					{
-						Label: []*dto.LabelPair{},
-						Counter: &dto.Counter{
-							Value: proto.Float64(0),
-						},
-					},
-				},
-			},
-			{
-				Name: proto.String("b_counter"),
-				Help: proto.String(counterOpts.Help),
-				Type: dto.MetricType_COUNTER.Enum(),
-				Metric: []*dto.Metric{
-					{
-						Label: []*dto.LabelPair{},
-						Counter: &dto.Counter{
-							Value: proto.Float64(1),
-						},
-					},
-				},
-			},
-		},
-		metrics,
-	)
+	wantMetrics := `
+# HELP a_counter help
+# TYPE a_counter counter
+a_counter 0
+
+# HELP b_counter help
+# TYPE b_counter counter
+b_counter 1
+`
+
+	require.NoError(testutil.GatherAndCompare(
+		gatherer,
+		strings.NewReader(wantMetrics),
+	))
 }
 
 func TestPrefixGatherer_Register(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

Test is failing locally on master on my machine:

```
--- FAIL: TestLabelGatherer_Gather (0.00s)
    --- FAIL: TestLabelGatherer_Gather/no_overlap (0.00s)
        label_gatherer_test.go:126:
            	Error Trace:	/Users/joshua.kim/workspace/avalanchego/api/metrics/label_gatherer_test.go:126
            	Error:      	Not equal:
            	            	expected: []*io_prometheus_client.MetricFamily{(*io_prometheus_client.MetricFamily)(0x140000904e0)}
            	            	actual  : []*io_prometheus_client.MetricFamily{(*io_prometheus_client.MetricFamily)(0x14000090420)}

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -76,3 +76,17 @@
            	            	      Exemplar: (*io_prometheus_client.Exemplar)(<nil>),
            	            	-     CreatedTimestamp: (*timestamppb.Timestamp)(<nil>)
            	            	+     CreatedTimestamp: (*timestamppb.Timestamp)({
            	            	+      state: (impl.MessageState) {
            	            	+       NoUnkeyedLiterals: (pragma.NoUnkeyedLiterals) {
            	            	+       },
            	            	+       DoNotCompare: (pragma.DoNotCompare) {
            	            	+       },
            	            	+       DoNotCopy: (pragma.DoNotCopy) {
            	            	+       },
            	            	+       atomicMessageInfo: (*impl.MessageInfo)(<nil>)
            	            	+      },
            	            	+      Seconds: (int64) 1753913687,
            	            	+      Nanos: (int32) 173611000,
            	            	+      unknownFields: ([]uint8) <nil>,
            	            	+      sizeCache: (int32) 0
            	            	+     })
            	            	     }),
            	            	@@ -142,3 +156,17 @@
            	            	      Exemplar: (*io_prometheus_client.Exemplar)(<nil>),
            	            	-     CreatedTimestamp: (*timestamppb.Timestamp)(<nil>)
            	            	+     CreatedTimestamp: (*timestamppb.Timestamp)({
            	            	+      state: (impl.MessageState) {
            	            	+       NoUnkeyedLiterals: (pragma.NoUnkeyedLiterals) {
            	            	+       },
            	            	+       DoNotCompare: (pragma.DoNotCompare) {
            	            	+       },
            	            	+       DoNotCopy: (pragma.DoNotCopy) {
            	            	+       },
            	            	+       atomicMessageInfo: (*impl.MessageInfo)(<nil>)
            	            	+      },
            	            	+      Seconds: (int64) 1753913687,
            	            	+      Nanos: (int32) 173606000,
            	            	+      unknownFields: ([]uint8) <nil>,
            	            	+      sizeCache: (int32) 0
            	            	+     })
            	            	     }),
            	Test:       	TestLabelGatherer_Gather/no_overlap
```

## How this works

Just check for expected values using testutil instead

## How this was tested

Updated tests

## Need to be documented in RELEASES.md?

No