### PR TITLE
Address final nits

### DIFF
--- a/vms/evm/metrics/metricstest/metrics.go
+++ b/vms/evm/metrics/metricstest/metrics.go
@@ -18,12 +18,10 @@ var metricsLock sync.Mutex
 // [metrics.Enabled] is restored to its original value during testing cleanup.
 func WithMetrics(t testing.TB) {
 	metricsLock.Lock()
-	t.Cleanup(metricsLock.Unlock)
 	initialValue := metrics.Enabled
 	metrics.Enabled = true
-
-	// Restore the original value
 	t.Cleanup(func() {
 		metrics.Enabled = initialValue
+		metricsLock.Unlock()
 	})
 }

--- a/vms/evm/metrics/prometheus/prometheus.go
+++ b/vms/evm/metrics/prometheus/prometheus.go
@@ -32,7 +32,7 @@ type Gatherer struct {
 
 // Gather gathers metrics from the registry and converts them to
 // a slice of metric families.
-func (g *Gatherer) Gather() (mfs []*dto.MetricFamily, err error) {
+func (g *Gatherer) Gather() ([]*dto.MetricFamily, error) {
 	// Gather and pre-sort the metrics to avoid random listings
 	var names []string
 	g.registry.Each(func(name string, _ any) {
@@ -40,7 +40,10 @@ func (g *Gatherer) Gather() (mfs []*dto.MetricFamily, err error) {
 	})
 	slices.Sort(names)
 
-	var errs []error
+	var (
+		mfs  = make([]*dto.MetricFamily, 0, len(names))
+		errs []error
+	)
 	for _, name := range names {
 		mf, err := metricFamily(g.registry, name)
 		switch {


### PR DESCRIPTION
## Why this should be merged

1. Realized we could avoid one of the calls to `t.Cleanup`
2. Pre-allocated the metrics + avoided using named return values
3. Simplified the unit test + added TODO

## How this works

^

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.