### PR TITLE
chore: fix minor typo in comment

### DIFF
--- a/vms/avm/network/config.go
+++ b/vms/avm/network/config.go
@@ -72,7 +72,7 @@ type Config struct {
 	// PullGossipThrottlingPeriod is how large of a window the throttler should
 	// use.
 	PullGossipThrottlingPeriod time.Duration `json:"pull-gossip-throttling-period"`
-	// PullGossipThrottlingLimit is the number of pull querys that are allowed
+	// PullGossipThrottlingLimit is the number of pull queries that are allowed
 	// by a validator in every throttling window.
 	PullGossipThrottlingLimit int `json:"pull-gossip-throttling-limit"`
 	// ExpectedBloomFilterElements is the number of elements to expect when

--- a/vms/platformvm/config/network.go
+++ b/vms/platformvm/config/network.go
@@ -72,7 +72,7 @@ type Network struct {
 	// PullGossipThrottlingPeriod is how large of a window the throttler should
 	// use.
 	PullGossipThrottlingPeriod time.Duration `json:"pull-gossip-throttling-period"`
-	// PullGossipThrottlingLimit is the number of pull querys that are allowed
+	// PullGossipThrottlingLimit is the number of pull queries that are allowed
 	// by a validator in every throttling window.
 	PullGossipThrottlingLimit int `json:"pull-gossip-throttling-limit"`
 	// ExpectedBloomFilterElements is the number of elements to expect when


### PR DESCRIPTION
## Description 

"querys"  must be "[queries](https://dictionary.cambridge.org/dictionary/english/query?q=queries)"

## Why this should be merged



## How this works

## How this was tested

## Need to be documented in RELEASES.md?
no