### PR TITLE
Separate re-execution job params for PR from schedule

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
     c-chain-reexecution:
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego'
       permissions:
         id-token: write
         contents: write


### PR DESCRIPTION
This PR updates the params used on `pull_request` events to only execute the range [101, 100k], so that it runs in ~4mins. This is small enough to make sure it's not slowing down CI while also making sure that it runs, so we catch any potential break.