### PR TITLE
Optionally support ARC for C-Chain re-execution

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -43,12 +43,28 @@ jobs:
         - name: Set task env via GITHUB_ENV
           id: set-params
           run: |
-            {
-              echo "START_BLOCK=${{ github.event.inputs.start-block || 101 }}"
-              echo "END_BLOCK=${{ github.event.inputs.end-block || 250000 }}"
-              echo "SOURCE_BLOCK_DIR=${{ github.event.inputs.source-block-dir || 's3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip' }}"
-              echo "CURRENT_STATE_DIR=${{ github.event.inputs.current-state-dir || 's3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip' }}"
-            } >> "$GITHUB_ENV"
+            if [[ "${{ github.event_name }}" == "schedule" ]]; then
+              {
+                echo "START_BLOCK=101"
+                echo "END_BLOCK=250000"
+                echo "SOURCE_BLOCK_DIR=s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip"
+                echo "CURRENT_STATE_DIR=s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip"
+              } >> "$GITHUB_ENV"
+            elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              {
+                echo "START_BLOCK=101"
+                echo "END_BLOCK=100000"
+                echo "SOURCE_BLOCK_DIR=s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip"
+                echo "CURRENT_STATE_DIR=s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip"
+              } >> "$GITHUB_ENV"
+            else
+              {
+                echo "START_BLOCK=${{ github.event.inputs.start-block }}"
+                echo "END_BLOCK=${{ github.event.inputs.end-block }}"
+                echo "SOURCE_BLOCK_DIR=${{ github.event.inputs.source-block-dir }}"
+                echo "CURRENT_STATE_DIR=${{ github.event.inputs.current-state-dir }}"
+              } >> "$GITHUB_ENV"
+            fi
         - uses: actions/checkout@v4
         - uses: ./.github/actions/setup-go-for-project
         - name: Run C-Chain Re-Execution

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -34,7 +34,18 @@ jobs:
         id-token: write
         contents: write
       runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+      container:
+        image: ${{ github.event.inputs.runner == 'ubuntu-latest' && '' || 'ghcr.io/actions/actions-runner:2.325.0' }}
       steps:
+        - name: Install ARC dependencies if required
+          shell: bash
+          if: ${{ github.event.inputs.runner != 'ubuntu-latest' }}
+          run: |
+            # xz-utils might be present on some containers. Install if not present.
+            if ! command -v xz &> /dev/null; then
+              sudo apt-get update
+              sudo apt-get install -y xz-utils
+            fi
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v4
           with:

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -76,9 +76,20 @@ jobs:
                 echo "CURRENT_STATE_DIR=${{ github.event.inputs.current-state-dir }}"
               } >> "$GITHUB_ENV"
             fi
+
+            # Determine if this is an external fork and set SHOULD_RUN accordingly
+            if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+              echo "SHOULD_RUN=false" >> "$GITHUB_ENV"
+            else
+              echo "SHOULD_RUN=true" >> "$GITHUB_ENV"
+            fi
+
         - uses: actions/checkout@v4
+          if: ${{ env.SHOULD_RUN == 'true' }}
         - uses: ./.github/actions/setup-go-for-project
+          if: ${{ env.SHOULD_RUN == 'true' }}
         - name: Run C-Chain Re-Execution
+          if: ${{ env.SHOULD_RUN == 'true' }}
           uses: ./.github/actions/run-monitored-tmpnet-cmd
           with:
             run: ./scripts/run_task.sh reexecute-cchain-range-with-copied-data EXECUTION_DATA_DIR=${{ github.workspace }}/reexecution-data BENCHMARK_OUTPUT_FILE=${{ github.workspace }}/reexecute-cchain-range-benchmark-res.txt
@@ -89,11 +100,13 @@ jobs:
             loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
             runtime: "" # Set runtime input to empty string to disable log collection
         - name: Download Previous Benchmark Result
+          if: ${{ env.SHOULD_RUN == 'true' }}
           uses: actions/cache@v4
           with:
             path: ./cache
             key: ${{ runner.os }}-reexecute-cchain-range-benchmark.json
         - name: Compare Benchmark Result
+          if: ${{ env.SHOULD_RUN == 'true' }}
           uses: benchmark-action/github-action-benchmark@v1
           with:
             tool: 'go'
@@ -105,7 +118,7 @@ jobs:
             comment-on-alert: true
             auto-push: false
         - name: Push Benchmark Result
-          if: github.event_name == 'schedule'
+          if: ${{ env.SHOULD_RUN == 'true' && github.event_name == 'schedule' }}
           uses: benchmark-action/github-action-benchmark@v1
           with:
             tool: 'go'


### PR DESCRIPTION
Specify `job.container.image=ghcr.io/actions/actions-runner:2.325.0` if running on ARC where it's required. Do not specify if running on GitHub runner where it's not needed and adds an unnecessary level of containerization.

If specified, optionally install extra ARC dependencies `xz-utils`.