### PR TITLE
refactor: use ProofCreator

### DIFF
--- a/x/sync/client_test.go
+++ b/x/sync/client_test.go
@@ -39,10 +39,10 @@ func newDefaultDBConfig() merkledb.Config {
 
 func newFlakyRangeProofHandler(
 	t *testing.T,
-	db merkledb.MerkleDB,
+	proofCreator ProofCreator,
 	modifyResponse func(response *merkledb.RangeProof),
 ) p2p.Handler {
-	handler := NewGetRangeProofHandler(db)
+	handler := NewGetRangeProofHandler(proofCreator)
 
 	c := counter{m: 2}
 	return &p2p.TestHandler{
@@ -75,10 +75,10 @@ func newFlakyRangeProofHandler(
 
 func newFlakyChangeProofHandler(
 	t *testing.T,
-	db merkledb.MerkleDB,
+	proofCreator ProofCreator,
 	modifyResponse func(response *merkledb.ChangeProof),
 ) p2p.Handler {
-	handler := NewGetChangeProofHandler(db)
+	handler := NewGetChangeProofHandler(proofCreator)
 
 	c := counter{m: 2}
 	return &p2p.TestHandler{

--- a/x/sync/db.go
+++ b/x/sync/db.go
@@ -36,3 +36,8 @@ type ProofParser interface {
 	ParseRangeProof(ctx context.Context, responseBytes, rootHash []byte, startKey, endKey maybe.Maybe[[]byte], keyLimit uint32) (Proof, error)
 	ParseChangeProof(ctx context.Context, responseBytes, rootHash []byte, startKey, endKey maybe.Maybe[[]byte], keyLimit uint32) (Proof, error)
 }
+
+type ProofCreator interface {
+	RangeProof(ctx context.Context, root []byte, start, end maybe.Maybe[[]byte], keyLimit, byteLimit int) ([]byte, error)
+	ChangeProof(ctx context.Context, startRoot, endRoot []byte, start, end maybe.Maybe[[]byte], keyLimit, byteLimit int) ([]byte, error)
+}

--- a/x/sync/network_server_test.go
+++ b/x/sync/network_server_test.go
@@ -115,7 +115,7 @@ func Test_Server_GetRangeProof(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
-			handler := NewGetRangeProofHandler(smallTrieDB)
+			handler := NewGetRangeProofHandler(newProofCreator(smallTrieDB))
 			requestBytes, err := proto.Marshal(test.request)
 			require.NoError(err)
 			responseBytes, err := handler.AppRequest(context.Background(), test.nodeID, time.Time{}, requestBytes)
@@ -325,7 +325,7 @@ func Test_Server_GetChangeProof(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
-			handler := NewGetChangeProofHandler(serverDB)
+			handler := NewGetChangeProofHandler(newProofCreator(serverDB))
 
 			requestBytes, err := proto.Marshal(test.request)
 			require.NoError(err)


### PR DESCRIPTION
## Why this should be merged

This follows the DB decoupling established in #4155, separating request validity from proof formation.

Next steps are similar to the other PR as well:
- Move creator to separate package and provide instead of `DB`
- Separate testing implementations

## How this works

Moves all proof creation and retries to a separate interface, wrapped in creation.

## How this was tested

Existing UT

## Need to be documented in RELEASES.md?

No
