### PR TITLE
Move C-Chain benchmark to custom action and add ARC + GH runner triggers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,8 @@
 /.github/ @joshua-kim @maru-ava
 /.github/*.md @joshua-kim @maru-ava @meaghanfitzgerald
 /.github/CODEOWNERS @StephenButtolph
-/.github/workflows/c-chain-reexecution-benchmark.yml @aaronbuchwald
+/.github/actions/c-chain-reexecution-benchmark/ @aaronbuchwald
+/.github/workflows/c-chain-reexecution-benchmark* @aaronbuchwald
 /.gitignore @joshua-kim @maru-ava @StephenButtolph
 /.golangci.yml @joshua-kim @maru-ava @StephenButtolph
 /Dockerfile @joshua-kim @maru-ava

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -43,7 +43,7 @@ inputs:
   github-token:
     description: 'GitHub token provided to GitHub Action Benchmark.'
     required: true
-  push:
+  push-github-action-benchmark:
     description: 'Whether to push the benchmark result to GitHub.'
     required: false
     default: false
@@ -95,10 +95,10 @@ runs:
         auto-push: false
 
     - name: Push Benchmark Result
-      if: ${{ inputs.push }}
+      if: ${{ inputs.push-github-action-benchmark }}
       uses: benchmark-action/github-action-benchmark@v1
       with:
         tool: 'go'
         output-file-path: ${{ env.BENCHMARK_OUTPUT_FILE }}
         github-token: ${{ inputs.github-token }}
-        auto-push: true
+        auto-push: ${{ inputs.push-github-action-benchmark }}

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -21,11 +21,9 @@ inputs:
   aws-role:
     description: 'AWS role to assume for S3 access.'
     required: true
-    default: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
   aws-region:
     description: 'AWS region to use for S3 access.'
     required: true
-    default: 'us-east-2'
   prometheus-username:
     description: 'The username for the Prometheus instance.'
     required: false
@@ -45,7 +43,6 @@ inputs:
   github-token:
     description: 'GitHub token provided to GitHub Action Benchmark.'
     required: true
-    default: ${{ secrets.GITHUB_TOKEN }}
   push:
     description: 'Whether to push the benchmark result to GitHub.'
     required: false

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -51,6 +51,7 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: ./.github/actions/setup-go-for-project
     - name: Set task env
       shell: bash
       run: |

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -52,6 +52,7 @@ runs:
   using: composite
   steps:
     - name: Set task env
+      shell: bash
       run: |
         {
           echo "EXECUTION_DATA_DIR=${{ inputs.workspace }}/reexecution-data"

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -69,8 +69,6 @@ runs:
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/setup-go-for-project
     - name: Run C-Chain Re-Execution
       uses: ./.github/actions/run-monitored-tmpnet-cmd
       with:

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -4,19 +4,15 @@ description: 'Run C-Chain re-execution benchmark'
 inputs:
   start-block:
     description: 'The start block for the benchmark.'
-    required: false
     default: '101'
   end-block:
     description: 'The end block for the benchmark.'
-    required: false
     default: '250000'
   source-block-dir:
     description: 'The source block directory. Supports S3 directory/zip and local directories.'
-    required: false
     default: 's3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip'
   current-state-dir:
     description: 'The current state directory. Supports S3 directory/zip and local directories.'
-    required: false
     default: 's3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip'
   aws-role:
     description: 'AWS role to assume for S3 access.'
@@ -26,26 +22,26 @@ inputs:
     required: true
   prometheus-username:
     description: 'The username for the Prometheus instance.'
-    required: false
+    required: true
     default: ''
   prometheus-password:
     description: 'The password for the Prometheus instance.'
-    required: false
+    required: true
     default: ''
   external-data-json-cache-key:
     description: 'Cache key for the external data JSON file provided for comparison to GitHub Action Benchmark.'
-    required: false
+    required: true
     default: 'c-chain-reexecution-benchmark-data.json'
   workspace:
     description: 'Working directory to use for the benchmark.'
-    required: false
+    required: true
     default: ${{ github.workspace }}
   github-token:
     description: 'GitHub token provided to GitHub Action Benchmark.'
     required: true
   push-github-action-benchmark:
     description: 'Whether to push the benchmark result to GitHub.'
-    required: false
+    required: true
     default: false
 
 runs:
@@ -72,6 +68,7 @@ runs:
       uses: ./.github/actions/run-monitored-tmpnet-cmd
       with:
         run: ./scripts/run_task.sh reexecute-cchain-range-with-copied-data
+        prometheus_push_url: ${{ inputs.prometheus-push-url }}
         prometheus_username: ${{ inputs.prometheus-username }}
         prometheus_password: ${{ inputs.prometheus-password }}
         grafana_dashboard_id: 'Gl1I20mnk/c-chain'

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -1,0 +1,108 @@
+name: 'C-Chain Re-Execution Benchmark'
+description: 'Run C-Chain re-execution benchmark'
+
+inputs:
+  start-block:
+    description: 'The start block for the benchmark.'
+    required: false
+    default: '101'
+  end-block:
+    description: 'The end block for the benchmark.'
+    required: false
+    default: '250000'
+  source-block-dir:
+    description: 'The source block directory. Supports S3 directory/zip and local directories.'
+    required: false
+    default: 's3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip'
+  current-state-dir:
+    description: 'The current state directory. Supports S3 directory/zip and local directories.'
+    required: false
+    default: 's3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip'
+  aws-role:
+    description: 'AWS role to assume for S3 access.'
+    required: true
+    default: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
+  aws-region:
+    description: 'AWS region to use for S3 access.'
+    required: true
+    default: 'us-east-2'
+  prometheus-username:
+    description: 'The username for the Prometheus instance.'
+    required: false
+    default: ''
+  prometheus-password:
+    description: 'The password for the Prometheus instance.'
+    required: false
+    default: ''
+  external-data-json-cache-key:
+    description: 'Cache key for the external data JSON file provided for comparison to GitHub Action Benchmark.'
+    required: false
+    default: 'c-chain-reexecution-benchmark-data.json'
+  workspace:
+    description: 'Working directory to use for the benchmark.'
+    required: false
+    default: ${{ github.workspace }}
+  github-token:
+    description: 'GitHub token provided to GitHub Action Benchmark.'
+    required: true
+    default: ${{ secrets.GITHUB_TOKEN }}
+  push:
+    description: 'Whether to push the benchmark result to GitHub.'
+    required: false
+    default: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set task env
+      run: |
+        {
+          echo "EXECUTION_DATA_DIR=${{ inputs.workspace }}/reexecution-data"
+          echo "BENCHMARK_OUTPUT_FILE=${{ inputs.workspace }}/reexecute-cchain-range-benchmark-res.txt"
+          echo "START_BLOCK=${{ inputs.start-block }}"
+          echo "END_BLOCK=${{ inputs.end-block }}"
+          echo "SOURCE_BLOCK_DIR=${{ inputs.source-block-dir }}"
+          echo "CURRENT_STATE_DIR=${{ inputs.current-state-dir }}"
+        } >> $GITHUB_ENV
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role }}
+        aws-region: ${{ inputs.aws-region }}
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/setup-go-for-project
+    - name: Run C-Chain Re-Execution
+      uses: ./.github/actions/run-monitored-tmpnet-cmd
+      with:
+        run: ./scripts/run_task.sh reexecute-cchain-range-with-copied-data
+        prometheus_username: ${{ inputs.prometheus-username }}
+        prometheus_password: ${{ inputs.prometheus-password }}
+        grafana_dashboard_id: 'Gl1I20mnk/c-chain'
+        runtime: "" # Set runtime input to empty string to disable log collection
+
+    - name: Download Previous Benchmark Result
+      uses: actions/cache@v4
+      with:
+        path: ./cache
+        key: ${{ inputs.external-data-json-cache-key }}
+
+    - name: Compare Benchmark Result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        tool: 'go'
+        output-file-path: ${{ env.BENCHMARK_OUTPUT_FILE }}
+        external-data-json-path: ./cache/${{ inputs.external-data-json-cache-key }}
+        fail-on-alert: true
+        github-token: ${{ inputs.github-token }}
+        summary-always: true
+        comment-on-alert: true
+        auto-push: false
+
+    - name: Push Benchmark Result
+      if: ${{ inputs.push }}
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        tool: 'go'
+        output-file-path: ${{ env.BENCHMARK_OUTPUT_FILE }}
+        github-token: ${{ inputs.github-token }}
+        auto-push: true

--- a/.github/workflows/c-chain-reexecution-benchmark-arc.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-arc.yml
@@ -1,4 +1,4 @@
-name: C-Chain Re-Execution Benchmark
+name: C-Chain Re-Execution Benchmark ARC
 
 on:
   pull_request:
@@ -82,27 +82,6 @@ jobs:
           prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
           prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           push-github-action-benchmark: ${{ github.event_name == 'schedule' }}
-          aws-role: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
-          aws-region: 'us-east-2'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  c-chain-reexecution-pr-gh-runner: # Smoke test on GitHub hosted runner
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego'}}
-    permissions:
-      id-token: write
-      contents: write
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run C-Chain Re-Execution Benchmark
-        uses: ./.github/actions/c-chain-reexecution-benchmark
-        with:
-          start-block: 101
-          end-block: 250000
-          source-block-dir: s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip
-          current-state-dir: s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip
-          prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
-          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           aws-role: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-runner.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-runner.yml
@@ -1,0 +1,26 @@
+name: C-Chain Re-Execution Benchmark GH Runner
+
+on:
+  pull_request:
+
+jobs:
+  c-chain-reexecution-pr-gh-runner: # Smoke test on GitHub hosted runner
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego'}}
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run C-Chain Re-Execution Benchmark
+        uses: ./.github/actions/c-chain-reexecution-benchmark
+        with:
+          start-block: 101
+          end-block: 250000
+          source-block-dir: s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip
+          current-state-dir: s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip
+          prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
+          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          aws-role: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
+          aws-region: 'us-east-2'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -36,10 +36,10 @@ jobs:
         contents: write
       runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
       container:
-        image: ${{ github.event.inputs.runner == 'ubuntu-latest' && '' || 'ghcr.io/actions/actions-runner:2.325.0' }}
+        image: ${{ runner.name != 'GitHub Actions' && 'ghcr.io/actions/actions-runner:2.325.0' || '' }}
       steps:
         - name: Install ARC Dependencies if Required
-          if: github.event.inputs.runner != 'ubuntu-latest'
+          if: ${{ runner.name != 'GitHub Actions' }}
           run: |
             # xz-utils might be present on some containers. Install if not present.
             if ! command -v xz &> /dev/null; then

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -38,6 +38,8 @@ jobs:
     container:
       image: ghcr.io/actions/actions-runner:2.325.0
     steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go-for-project
       - name: Set task parameters
         id: set-params
         run: |
@@ -89,6 +91,8 @@ jobs:
       contents: write
     runs-on: 'ubuntu-latest'
     steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go-for-project
       - name: Run C-Chain Re-Execution Benchmark
         uses: ./.github/actions/c-chain-reexecution-benchmark
         with:

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Run C-Chain Re-Execution Benchmark
         uses: ./.github/actions/c-chain-reexecution-benchmark
         with:
-          start-block: 100
+          start-block: 101
           end-block: 250000
           source-block-dir: s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip
           current-state-dir: s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -29,89 +29,72 @@ on:
     - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 
 jobs:
-    c-chain-reexecution:
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego'
-      permissions:
-        id-token: write
-        contents: write
-      runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
-      container:
-        image: |
-          ${{ (github.event.inputs.runner != '' && github.event.inputs.runner != 'ubuntu-latest')
-          && 'ghcr.io/actions/actions-runner:2.325.0'
-          || '' }}
-      steps:
-        - name: Install ARC Dependencies if Required
-          if: ${{ github.event.inputs.runner != '' && github.event.inputs.runner != 'ubuntu-latest' }}
-          run: |
-            # xz-utils might be present on some containers. Install if not present.
-            if ! command -v xz &> /dev/null; then
-              sudo apt-get update
-              sudo apt-get install -y xz-utils
-            fi
-        - name: Configure AWS Credentials
-          uses: aws-actions/configure-aws-credentials@v4
-          with:
-            role-to-assume: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
-            aws-region: us-east-2
-        - name: Set task env via GITHUB_ENV
-          id: set-params
-          run: |
-            if [[ "${{ github.event_name }}" == "schedule" ]]; then
-              {
-                echo "START_BLOCK=101"
-                echo "END_BLOCK=250000"
-                echo "SOURCE_BLOCK_DIR=s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip"
-                echo "CURRENT_STATE_DIR=s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip"
-              } >> "$GITHUB_ENV"
-            elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              {
-                echo "START_BLOCK=101"
-                echo "END_BLOCK=100000"
-                echo "SOURCE_BLOCK_DIR=s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip"
-                echo "CURRENT_STATE_DIR=s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip"
-              } >> "$GITHUB_ENV"
-            else
-              {
-                echo "START_BLOCK=${{ github.event.inputs.start-block }}"
-                echo "END_BLOCK=${{ github.event.inputs.end-block }}"
-                echo "SOURCE_BLOCK_DIR=${{ github.event.inputs.source-block-dir }}"
-                echo "CURRENT_STATE_DIR=${{ github.event.inputs.current-state-dir }}"
-              } >> "$GITHUB_ENV"
-            fi
-        - uses: actions/checkout@v4
-        - uses: ./.github/actions/setup-go-for-project
-        - name: Run C-Chain Re-Execution
-          uses: ./.github/actions/run-monitored-tmpnet-cmd
-          with:
-            run: ./scripts/run_task.sh reexecute-cchain-range-with-copied-data EXECUTION_DATA_DIR=${{ github.workspace }}/reexecution-data BENCHMARK_OUTPUT_FILE=${{ github.workspace }}/reexecute-cchain-range-benchmark-res.txt
-            prometheus_username: ${{ secrets.PROMETHEUS_ID || '' }}
-            prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
-            grafana_dashboard_id: 'Gl1I20mnk/c-chain'
-            loki_username: ${{ secrets.LOKI_ID || '' }}
-            loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
-            runtime: "" # Set runtime input to empty string to disable log collection
-        - name: Download Previous Benchmark Result
-          uses: actions/cache@v4
-          with:
-            path: ./cache
-            key: ${{ runner.os }}-reexecute-cchain-range-benchmark.json
-        - name: Compare Benchmark Result
-          uses: benchmark-action/github-action-benchmark@v1
-          with:
-            tool: 'go'
-            output-file-path: ${{ github.workspace }}/reexecute-cchain-range-benchmark-res.txt
-            external-data-json-path: ./cache/${{ runner.os }}-reexecute-cchain-range-benchmark.json
-            fail-on-alert: true
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            summary-always: true
-            comment-on-alert: true
-            auto-push: false
-        - name: Push Benchmark Result
-          if: github.event_name == 'schedule'
-          uses: benchmark-action/github-action-benchmark@v1
-          with:
-            tool: 'go'
-            output-file-path: ${{ github.workspace }}/reexecute-cchain-range-benchmark-res.txt
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            auto-push: true
+  c-chain-reexecution-arc: # PR smoke test + scheduled run + manual workflow
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego')
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ${{ github.event.inputs.runner || 'avalanche-avalanchego-runner-2ti' }}
+    container:
+      image: ghcr.io/actions/actions-runner:2.325.0
+    steps:
+      - name: Set task parameters
+        id: set-params
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            {
+              echo "start-block=33000001"
+              echo "end-block=34000000"
+              echo "source-block-dir=s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-50m-ldb.zip"
+              echo "current-state-dir=s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-33m/"
+            } >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            {
+              echo "start-block=101"
+              echo "end-block=250000"
+              echo "source-block-dir=s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip"
+              echo "current-state-dir=s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip"
+            } >> $GITHUB_OUTPUT
+          else
+            {
+              echo "start-block=${{ github.event.inputs.start-block }}"
+              echo "end-block=${{ github.event.inputs.end-block }}"
+              echo "source-block-dir=${{ github.event.inputs.source-block-dir }}"
+              echo "current-state-dir=${{ github.event.inputs.current-state-dir }}"
+            } >> $GITHUB_OUTPUT
+          fi
+      - name: Install ARC Dependencies
+        shell: bash
+        run: |
+          # xz-utils might be present on some containers. Install if not present.
+          if ! command -v xz &> /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          fi
+      - name: Run C-Chain Re-Execution Benchmark
+        uses: ./.github/actions/c-chain-reexecution-benchmark
+        with:
+          start-block: ${{ steps.set-params.outputs.start-block }}
+          end-block: ${{ steps.set-params.outputs.end-block }}
+          source-block-dir: ${{ steps.set-params.outputs.source-block-dir }}
+          current-state-dir: ${{ steps.set-params.outputs.current-state-dir }}
+          prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
+          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          push: ${{ github.event_name == 'schedule' }}
+
+  c-chain-reexecution-pr-gh-runner: # Smoke test on GitHub hosted runner
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego'}}
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Run C-Chain Re-Execution Benchmark
+        uses: ./.github/actions/c-chain-reexecution-benchmark
+        with:
+          start-block: 100
+          end-block: 250000
+          source-block-dir: s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip
+          current-state-dir: s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip
+          prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
+          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   c-chain-reexecution-arc: # PR smoke test + scheduled run + manual workflow
-    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego')
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego' }}
     permissions:
       id-token: write
       contents: write
@@ -39,7 +39,6 @@ jobs:
       image: ghcr.io/actions/actions-runner:2.325.0
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-go-for-project
       - name: Set task parameters
         id: set-params
         run: |
@@ -95,7 +94,6 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-go-for-project
       - name: Run C-Chain Re-Execution Benchmark
         uses: ./.github/actions/c-chain-reexecution-benchmark
         with:

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -82,7 +82,7 @@ jobs:
           current-state-dir: ${{ steps.set-params.outputs.current-state-dir }}
           prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
           prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
-          push: ${{ github.event_name == 'schedule' }}
+          push-github-action-benchmark: ${{ github.event_name == 'schedule' }}
           aws-role: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -36,10 +36,13 @@ jobs:
         contents: write
       runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
       container:
-        image: ${{ runner.name != 'GitHub Actions' && 'ghcr.io/actions/actions-runner:2.325.0' || '' }}
+        image: |
+          ${{ (github.event.inputs.runner != '' && github.event.inputs.runner != 'ubuntu-latest')
+          && 'ghcr.io/actions/actions-runner:2.325.0'
+          || '' }}
       steps:
         - name: Install ARC Dependencies if Required
-          if: ${{ runner.name != 'GitHub Actions' }}
+          if: ${{ github.event.inputs.runner != '' && github.event.inputs.runner != 'ubuntu-latest' }}
           run: |
             # xz-utils might be present on some containers. Install if not present.
             if ! command -v xz &> /dev/null; then

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -35,7 +35,17 @@ jobs:
         id-token: write
         contents: write
       runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+      container:
+        image: ${{ github.event.inputs.runner == 'ubuntu-latest' && '' || 'ghcr.io/actions/actions-runner:2.325.0' }}
       steps:
+        - name: Install ARC Dependencies if Required
+          if: github.event.inputs.runner != 'ubuntu-latest'
+          run: |
+            # xz-utils might be present on some containers. Install if not present.
+            if ! command -v xz &> /dev/null; then
+              sudo apt-get update
+              sudo apt-get install -y xz-utils
+            fi
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v4
           with:

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -49,21 +49,21 @@ jobs:
               echo "end-block=34000000"
               echo "source-block-dir=s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-50m-ldb.zip"
               echo "current-state-dir=s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-33m/"
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             {
               echo "start-block=101"
               echo "end-block=250000"
               echo "source-block-dir=s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb.zip"
               echo "current-state-dir=s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip"
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
           else
             {
               echo "start-block=${{ github.event.inputs.start-block }}"
               echo "end-block=${{ github.event.inputs.end-block }}"
               echo "source-block-dir=${{ github.event.inputs.source-block-dir }}"
               echo "current-state-dir=${{ github.event.inputs.current-state-dir }}"
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
           fi
       - name: Install ARC Dependencies
         shell: bash

--- a/.github/workflows/c-chain-reexecution-benchmark.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark.yml
@@ -83,6 +83,9 @@ jobs:
           prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
           prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           push: ${{ github.event_name == 'schedule' }}
+          aws-role: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
+          aws-region: 'us-east-2'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   c-chain-reexecution-pr-gh-runner: # Smoke test on GitHub hosted runner
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego'}}
@@ -102,3 +105,6 @@ jobs:
           current-state-dir: s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100.zip
           prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
           prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          aws-role: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
+          aws-region: 'us-east-2'
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Unfortunately, GitHub Actions can be restrictive in unexpected and tedious ways.

This PR updates the C-Chain execution benchmark workflow to run on both Actions Runner Controller and a GitHub hosted runner.

To run on ARC, we need to specify the image parameter in the runs-on section, but do not want to add this extra layer when running on a GitHub runner. Unfortunately, if you populate this parameter and even conditionally evaluate it to an empty string, it's still interpreted differently from not being there in the first place

ie.

```
    runs-on: ${{ github.event.inputs.runner || 'avalanche-avalanchego-runner-2ti' }}
    container:
      image: ''
```

is invalid as once `container.image` is specified, it must provide an image parameter.

As a result, this PR migrates the bulk of the logic for the benchmark to a custom action and sets up two separate jobs so that the `runs-on` and `container.image` params can be set separately for ARC vs. GitHub runner.

Now that ARC is supported and we have current state snapshots in the S3 bucket every 10m blocks and at height 33m, this changes the scheduled benchmark run to execute the range [33000001, 34000000].