### PR TITLE
Add optional step to archive post-reexecution state to S3

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -43,6 +43,9 @@ inputs:
     description: 'Whether to push the benchmark result to GitHub.'
     required: true
     default: false
+  push-post-state:
+    description: 'S3 destination to copy the current-state directory after completing re-execution. If empty, this will be skipped.'
+    default: ''
 
 runs:
   using: composite
@@ -100,3 +103,10 @@ runs:
         output-file-path: ${{ env.BENCHMARK_OUTPUT_FILE }}
         github-token: ${{ inputs.github-token }}
         auto-push: ${{ inputs.push-github-action-benchmark }}
+
+    - uses: ./.github/actions/install-nix
+      if: ${{ inputs.push-post-state != '' }}
+    - name: Copy Post-State to S3
+      if: ${{ inputs.push-post-state != '' }}
+      shell: nix develop --command bash -x {0}
+      run: ./scripts/run_task.sh export-dir-to-s3 LOCAL_SRC=$CURRENT_STATE_DIR S3_DEST=${{ inputs.push-post-state }}

--- a/.github/workflows/c-chain-reexecution-benchmark-arc.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-arc.yml
@@ -24,6 +24,9 @@ on:
         description: 'Runner to execute the benchmark. Input to the runs-on field of the job.'
         required: false
         default: ubuntu-latest
+      push-post-state-dir:
+        description: 'S3 location to push post-execution state directory. Skips this step if left unpopulated.'
+        default: ''
 
   schedule:
     - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
@@ -85,3 +88,4 @@ jobs:
           aws-role: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-post-state-dir: ${{ github.event.inputs.push-post-state-dir }}


### PR DESCRIPTION
This PR adds an optional step to the re-execution custom action to archive the S3 post execution state.

This also updates the ARC action to provide an added optional input to the manual workflow trigger that will use it.

TODO: add a R/W IAM role to AWS and GitHub secrets to perform the archive step (only IAM role in secrets currently only has read access).