### PR TITLE
Improve results handling

### DIFF
--- a/vms/evm/predicate/predicate_test.go
+++ b/vms/evm/predicate/predicate_test.go
@@ -227,31 +227,31 @@ func TestFromAccessList(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		rules allowSet
+		rules set.Set[common.Address]
 		list  types.AccessList
 		want  map[common.Address][]Predicate
 	}{
 		{
 			name:  "empty_list",
-			rules: allowSet{addrA: struct{}{}},
+			rules: set.Of(addrA),
 			list:  types.AccessList{},
 			want:  map[common.Address][]Predicate{},
 		},
 		{
 			name:  "no_allowed_addresses",
-			rules: allowSet{addrB: struct{}{}},
+			rules: set.Of(addrB),
 			list:  types.AccessList{{Address: addrA, StorageKeys: []common.Hash{h1}}},
 			want:  map[common.Address][]Predicate{},
 		},
 		{
 			name:  "single_tuple_allowed",
-			rules: allowSet{addrA: struct{}{}},
+			rules: set.Of(addrA),
 			list:  types.AccessList{{Address: addrA, StorageKeys: []common.Hash{h1, h2}}},
 			want:  map[common.Address][]Predicate{addrA: {{h1, h2}}},
 		},
 		{
 			name:  "repeated_address_accumulates",
-			rules: allowSet{addrA: struct{}{}},
+			rules: set.Of(addrA),
 			list: types.AccessList{
 				{Address: addrA, StorageKeys: []common.Hash{h1, h2}},
 				{Address: addrA, StorageKeys: []common.Hash{h3}},
@@ -260,7 +260,7 @@ func TestFromAccessList(t *testing.T) {
 		},
 		{
 			name:  "mixed_addresses_filtered",
-			rules: allowSet{addrA: struct{}{}, addrC: struct{}{}},
+			rules: set.Of(addrA, addrC),
 			list: types.AccessList{
 				{Address: addrA, StorageKeys: []common.Hash{h1}},
 				{Address: addrB, StorageKeys: []common.Hash{h2}},
@@ -276,7 +276,7 @@ func TestFromAccessList(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := require.New(t)
-			got := FromAccessList(tc.rules, tc.list)
+			got := FromAccessList(allowSet(tc.rules), tc.list)
 			req.Equal(tc.want, got)
 		})
 	}

--- a/vms/evm/predicate/results.go
+++ b/vms/evm/predicate/results.go
@@ -52,16 +52,16 @@ func ParseBlockResults(b []byte) (BlockResults, error) {
 	}
 
 	// Convert encoded representation into in-memory representation
-	blockResults := make(BlockResults, len(encodedResults))
+	results := make(BlockResults, len(encodedResults))
 	for txHash, addrToBytes := range encodedResults {
 		decoded := make(PrecompileResults, len(addrToBytes))
 		for addr, bs := range addrToBytes {
 			decoded[addr] = set.BitsFromBytes(bs)
 		}
-		blockResults[txHash] = decoded
+		results[txHash] = decoded
 	}
 
-	return blockResults, nil
+	return results, nil
 }
 
 // Get returns the predicate results for txHash from precompile address.
@@ -88,16 +88,16 @@ func (b *BlockResults) Set(txHash common.Hash, txResults PrecompileResults) {
 
 // Bytes marshals the predicate results.
 func (b *BlockResults) Bytes() ([]byte, error) {
-	// Convert to encoded representation before marshaling to avoid serializing
+	// Convert to results representation before marshaling to avoid serializing
 	// set.Bits directly, which is not supported by the codec.
-	encoded := make(encodedBlockResults, len(*b))
+	results := make(encodedBlockResults, len(*b))
 	for txHash, addrToBits := range *b {
-		enc := make(map[common.Address][]byte, len(addrToBits))
+		encoded := make(map[common.Address][]byte, len(addrToBits))
 		for addr, bits := range addrToBits {
-			enc[addr] = bits.Bytes()
+			encoded[addr] = bits.Bytes()
 		}
-		encoded[txHash] = enc
+		results[txHash] = encoded
 	}
 
-	return resultsCodec.Marshal(version, encoded)
+	return resultsCodec.Marshal(version, results)
 }

--- a/vms/evm/predicate/results_test.go
+++ b/vms/evm/predicate/results_test.go
@@ -282,7 +282,7 @@ func TestBlockResultsBytes(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple txs single result",
+			name: "multiple_txs_single_result",
 			input: BlockResults{
 				{1}: {
 					{2}: set.NewBits(1, 2, 3),
@@ -329,7 +329,7 @@ func TestBlockResultsBytes(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple txs multiple results",
+			name: "multiple_txs_multiple_results",
 			input: BlockResults{
 				{1}: {
 					{2}: set.NewBits(1, 2, 3),

--- a/vms/evm/predicate/results_test.go
+++ b/vms/evm/predicate/results_test.go
@@ -50,7 +50,7 @@ func TestParseBlockResultsInvalid(t *testing.T) {
 				},
 				make([]byte, 1<<24), // Append the bitset
 			),
-			wantErr: codec.ErrCantUnpackVersion,
+			wantErr: codec.ErrUnmarshalTooBig,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Why this should be merged

1. This adds explicit tests of the serialization format. This is important because any changes to the serialization format (even if they are symmetric between `Parse` and `Bytes`) could break existing logic.
2. This removes the usage of structs to instead prefer using the maps directly (which the reflect codec fully supports).
3. This aligns the behavior of `Set` and `Get` where after `Set`ing a zero value, `Get` behaves the same as if the value was never set.
4. This aligns the behavior that `Set` had previously (which is required to remain compatible with the C-chain's block building logic)

## How this works

Updated logic to better align with coreth and improved the tests to fully verify the behaviors we expect.

## How this was tested

Unit tests

## Need to be documented in RELEASES.md?

No.