### PR TITLE
Add redundant import alias linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,6 +119,9 @@ linters:
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
         - name: empty-lines
           disabled: false
+        # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#import-alias-naming
+        - name: redundant-import-alias
+          disabled: false
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
         - name: string-format
           disabled: false


### PR DESCRIPTION
## Why this should be merged

Avalanchego's linter is going to be used as the canonical golang linter. This check came up in coreth during review. So I wanted to add it here (and copy it over to coreth + subnet-evm).

## How this works

Adds another linter to the config.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.