### PR TITLE
Add config option for AWS S3 read only credential duration

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -67,6 +67,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}
+        role-duration-seconds: 43200 # 12 hours
     - name: Run C-Chain Re-Execution
       uses: ./.github/actions/run-monitored-tmpnet-cmd
       with:

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -20,6 +20,10 @@ inputs:
   aws-region:
     description: 'AWS region to use for S3 access.'
     required: true
+  aws-role-duration-seconds:
+    description: 'The duration of the AWS role to assume for S3 access.'
+    required: true
+    default: '43200' # 12 hours
   prometheus-username:
     description: 'The username for the Prometheus instance.'
     required: true
@@ -67,7 +71,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}
-        role-duration-seconds: 43200 # 12 hours
+        role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
     - name: Run C-Chain Re-Execution
       uses: ./.github/actions/run-monitored-tmpnet-cmd
       with:


### PR DESCRIPTION
This PR adds a config option to make the OIDC credential duration configurable via the custom GitHub Action and updates the default to 12hrs given the expected long-running nature of these jobs.

This in conjunction with raising the limit on the AWS role itself should fix https://github.com/ava-labs/avalanchego/actions/runs/17106732594/job/48517513513.

These jobs need to handle two timeouts:
- AWS credential timeout
- GitHub Action default timeout