### PR TITLE
fix: time remaining should use better estimates

### DIFF
--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -41,6 +41,9 @@ const (
 	// outstanding when broadcasting.
 	maxOutstandingBroadcastRequests = 50
 
+	// minimumLogInterval is the minimum time between log entries to avoid noise
+	minimumLogInterval = 5 * time.Second
+
 	epsilon = 1e-6 // small amount to add to time to avoid division by 0
 )
 
@@ -95,6 +98,11 @@ type Bootstrapper struct {
 	initiallyFetched uint64
 	// Time that startSyncing was last called
 	startTime time.Time
+	// Time of the last progress update for accurate ETA calculation
+	lastProgressUpdateTime time.Time
+
+	// ETA tracker for more accurate time estimates
+	etaTracker *timer.EtaTracker
 
 	// tracks which validators were asked for which containers in which requests
 	outstandingRequests     *bimap.BiMap[common.Request, ids.ID]
@@ -138,6 +146,8 @@ func New(config Config, onFinished func(ctx context.Context, lastReqID uint32) e
 
 		executedStateTransitions: math.MaxInt,
 		onFinished:               onFinished,
+		lastProgressUpdateTime:   time.Now(),
+		etaTracker:               timer.NewEtaTracker(10, 1.2),
 	}
 
 	timeout := func() {
@@ -407,6 +417,10 @@ func (b *Bootstrapper) startSyncing(ctx context.Context, acceptedBlockIDs []ids.
 	b.initiallyFetched = b.tree.Len()
 	b.startTime = time.Now()
 
+	// Add the first sample to the EtaTracker to establish an accurate baseline
+	// This ensures t.lowestSample is set correctly from the start
+	b.etaTracker.AddSample(b.initiallyFetched, b.tipHeight-b.startingHeight, b.startTime)
+
 	// Process received blocks
 	for _, blk := range toProcess {
 		if err := b.process(ctx, blk, nil); err != nil {
@@ -603,26 +617,37 @@ func (b *Bootstrapper) process(
 		height := blk.Height()
 		b.tipHeight = max(b.tipHeight, height)
 
-		if numPreviouslyFetched/statusUpdateFrequency != numFetched/statusUpdateFrequency {
+		// Check if it's time to log progress (both progress-based and time-based frequency)
+		now := time.Now()
+		shouldLog := numPreviouslyFetched/statusUpdateFrequency != numFetched/statusUpdateFrequency &&
+			now.Sub(b.lastProgressUpdateTime) >= minimumLogInterval
+
+		if shouldLog {
 			totalBlocksToFetch := b.tipHeight - b.startingHeight
-			eta := timer.EstimateETA(
-				b.startTime,
-				numFetched-b.initiallyFetched,         // Number of blocks we have fetched during this run
-				totalBlocksToFetch-b.initiallyFetched, // Number of blocks we expect to fetch during this run
+
+			eta, progressPercentage := b.etaTracker.AddSample(
+				numFetched,
+				totalBlocksToFetch,
+				now,
 			)
 
-			if !b.restarted {
-				b.Ctx.Log.Info("fetching blocks",
-					zap.Uint64("numFetchedBlocks", numFetched),
-					zap.Uint64("numTotalBlocks", totalBlocksToFetch),
-					zap.Duration("eta", eta),
-				)
-			} else {
-				b.Ctx.Log.Debug("fetching blocks",
-					zap.Uint64("numFetchedBlocks", numFetched),
-					zap.Uint64("numTotalBlocks", totalBlocksToFetch),
-					zap.Duration("eta", eta),
-				)
+			// Update the last progress update time and previous progress for next iteration
+			b.lastProgressUpdateTime = now
+
+			// Only log if we have a valid ETA estimate
+			if eta != nil {
+				logger := b.Ctx.Log.Info
+				if b.restarted {
+					// lower log level for restarted bootstrapping
+					// Kept for compatibility; is this desired?
+					logger = b.Ctx.Log.Debug
+				}
+				logger("fetching blocks",
+						zap.Uint64("numFetchedBlocks", numFetched),
+						zap.Uint64("numTotalBlocks", totalBlocksToFetch),
+						zap.Duration("eta", *eta),
+						zap.Float64("pctComplete", progressPercentage),
+					)
 			}
 		}
 	}

--- a/snow/engine/snowman/bootstrap/storage.go
+++ b/snow/engine/snowman/bootstrap/storage.go
@@ -165,6 +165,7 @@ func execute(
 
 		startTime     = time.Now()
 		timeOfNextLog = startTime.Add(logPeriod)
+		etaTracker    = timer.NewEtaTracker(10, 1.2)
 	)
 	defer func() {
 		iterator.Release()
@@ -194,6 +195,9 @@ func execute(
 	log("executing blocks",
 		zap.Uint64("numToExecute", totalNumberToProcess),
 	)
+
+	// Add the first sample to the EtaTracker to establish an accurate baseline
+	etaTracker.AddSample(0, totalNumberToProcess, startTime)
 
 	for !shouldHalt() && iterator.Next() {
 		blkBytes := iterator.Value()
@@ -239,13 +243,22 @@ func execute(
 		if now := time.Now(); now.After(timeOfNextLog) {
 			var (
 				numProcessed = totalNumberToProcess - tree.Len()
-				eta          = timer.EstimateETA(startTime, numProcessed, totalNumberToProcess)
 			)
-			log("executing blocks",
-				zap.Uint64("numExecuted", numProcessed),
-				zap.Uint64("numToExecute", totalNumberToProcess),
-				zap.Duration("eta", eta),
-			)
+
+			// Use the tracked previous progress for accurate ETA calculation
+			currentProgress := numProcessed
+
+			etaPtr, progressPercentage := etaTracker.AddSample(currentProgress, totalNumberToProcess, now)
+			// Only log if we have a valid ETA estimate
+			if etaPtr != nil {
+				log("executing blocks",
+					zap.Uint64("numExecuted", numProcessed),
+					zap.Uint64("numToExecute", totalNumberToProcess),
+					zap.Duration("eta", *etaPtr),
+					zap.Float64("pctComplete", progressPercentage),
+				)
+			}
+
 			timeOfNextLog = now.Add(logPeriod)
 		}
 

--- a/utils/timer/eta.go
+++ b/utils/timer/eta.go
@@ -5,6 +5,7 @@ package timer
 
 import (
 	"encoding/binary"
+	"math"
 	"time"
 )
 
@@ -18,8 +19,108 @@ func ProgressFromHash(b []byte) uint64 {
 	return binary.BigEndian.Uint64(progress[:])
 }
 
-// EstimateETA attempts to estimate the remaining time for a job to finish given
-// the [startTime] and it's current progress.
+// A sample represents a completed amount and the timestamp of the sample
+type sample struct {
+	completed uint64
+	timestamp time.Time
+}
+
+// A EtaTracker tracks the ETA of a job
+type EtaTracker struct {
+	samples        []sample
+	samplePosition uint8
+	maxSamples     uint8
+	lowestSample   uint64
+	totalSamples   uint64
+	slowdownFactor float64
+}
+
+// NewEtaTracker creates a new EtaTracker with the given maximum number of samples
+// and a slowdown factor. The slowdown factor is a multiplier that is added to the ETA
+// based on the percentage completed.
+//
+// The adjustment works as follows:
+//   - At 0% progress: ETA is multiplied by complexityFactor
+//   - At 100% progress: ETA is the raw estimate (no adjustment)
+//   - Between 0% and 100%: Adjustment decreases linearly with progress
+//
+// Example: With slowdownFactor = 2.0:
+//   - At 0% progress: ETA = raw_estimate * 2.0
+//   - At 50% progress: ETA = raw_estimate * 1.5
+//   - At 100% progress: ETA = raw_estimate * 1.0
+//
+// If maxSamples is less than 1, it will default to 5
+func NewEtaTracker(maxSamples uint8, slowdownFactor float64) *EtaTracker {
+	if maxSamples < 1 {
+		maxSamples = 5
+	}
+	return &EtaTracker{
+		samples:        make([]sample, maxSamples),
+		samplePosition: 0,
+		maxSamples:     maxSamples,
+		lowestSample:   math.MaxUint64, // Initialize to maximum value
+		totalSamples:   0,
+		slowdownFactor: slowdownFactor,
+	}
+}
+
+// AddSample adds a sample to the EtaTracker
+// It returns the remaining time to complete the target and the percent complete
+// The returned values are rounded to the nearest second and 2 decimal places respectively
+// This function can return a nil time.Duration indicating that there are not yet enough
+// samples to calculate an accurate ETA.
+//
+// The first sample should be at 0% progress to establish a baseline
+func (t *EtaTracker) AddSample(completed uint64, target uint64, timestamp time.Time) (remaining *time.Duration, percentComplete float64) {
+	if completed < t.lowestSample {
+		t.lowestSample = completed
+	}
+
+	sample := sample{
+		completed: completed,
+		timestamp: timestamp,
+	}
+	// save the oldest sample; this will not be used if we don't have enough samples
+	t.samples[t.samplePosition] = sample
+	t.samplePosition = (t.samplePosition + 1) % t.maxSamples
+	t.totalSamples++
+
+	// If we don't have enough samples, return nil
+	if t.totalSamples < uint64(t.maxSamples) {
+		return nil, 0.0
+	}
+
+	oldestSample := t.samples[t.samplePosition]
+
+	// Calculate the time and progress since the oldest sample
+	timeSinceOldest := sample.timestamp.Sub(oldestSample.timestamp)
+	progressSinceOldest := sample.completed - oldestSample.completed
+
+	// Check if target is already completed or exceeded
+	if sample.completed >= target {
+		zeroDuration := time.Duration(0)
+		percentComplete := float64(sample.completed) / float64(target)
+		roundedPercentComplete := math.Round(percentComplete*10000) / 100 // Return percentage (0.0 to 100.0)
+		return &zeroDuration, roundedPercentComplete
+	}
+
+	rate := float64(progressSinceOldest) / float64(timeSinceOldest)
+	remainingProgress := target - sample.completed
+
+	actualPercentComplete := float64(sample.completed) / float64(target)
+	roundedScaledPercentComplete := math.Round(actualPercentComplete*10000) / 100
+
+	duration := float64(remainingProgress) / rate
+	adjustment := t.slowdownFactor - (t.slowdownFactor-1.0)*actualPercentComplete
+
+	adjustedDuration := duration * adjustment
+	eta := time.Duration(adjustedDuration)
+	roundedEta := eta.Round(time.Second)
+	return &roundedEta, roundedScaledPercentComplete
+}
+
+// This function calculates ETA from start time
+// Deprecated: use EtaTracker instead
 func EstimateETA(startTime time.Time, progress, end uint64) time.Duration {
 	timeSpent := time.Since(startTime)
 

--- a/utils/timer/eta_test.go
+++ b/utils/timer/eta_test.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package timer
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEtaTracker(t *testing.T) {
+	tracker := NewEtaTracker(3, 1.0)
+	now := time.Now()
+	target := uint64(1000)
+
+	thirdSampleEta := time.Duration(80 * time.Second)
+	fourthSampleEta := time.Duration(24 * time.Second)
+
+	tests := []struct {
+		name            string
+		completed       uint64
+		timestamp       time.Time
+		expectedEta     *time.Duration
+		expectedPercent float64
+		description     string
+	}{
+		{
+			name:            "first sample - insufficient data",
+			completed:       0,
+			timestamp:       now,
+			expectedEta:     nil,
+			expectedPercent: 0.0,
+			description:     "should return nil ETA and 0% complete",
+		},
+		{
+			name:            "second sample - insufficient data",
+			completed:       100,
+			timestamp:       now.Add(10 * time.Second),
+			expectedEta:     nil,
+			expectedPercent: 0.0,
+			description:     "should return nil ETA and 0% complete (rate is 10 per second)",
+		},
+		{
+			name:            "third sample - sufficient data for ETA",
+			completed:       200,
+			timestamp:       now.Add(20 * time.Second),
+			expectedEta:     &thirdSampleEta,
+			expectedPercent: 20.0,
+			description:     "should return 80s ETA and 20% complete (rate still 10 per second)",
+		},
+		{
+			name:            "fourth sample - non linear since we sped up",
+			completed:       600,
+			timestamp:       now.Add(40 * time.Second),
+			expectedEta:     &fourthSampleEta,
+			expectedPercent: 60.0,
+			description:     "should return 24s ETA and 60% complete (rate is 15 per second)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eta, percentComplete := tracker.AddSample(tt.completed, target, tt.timestamp)
+			// overly complex, see https://github.com/stretchr/testify/issues/1118
+			assert.EqualValues(t, tt.expectedEta, eta,
+				"%s exp=%v, got=%v", tt.description,
+				reflect.Indirect(reflect.ValueOf(tt.expectedEta)),
+				reflect.Indirect(reflect.ValueOf(eta)))
+			assert.Equal(t, tt.expectedPercent, percentComplete, "%s exp=%v, got=%v", tt.description, tt.expectedPercent, percentComplete)
+		})
+	}
+}


### PR DESCRIPTION
## Why this should be merged

This code does a much better job of estimating completion time, which improves my experience using avalanchego for bootstrapping.

## How this works

Correctly computing an estimate involves:

 - Estimating high early on, but gradually removing the fuzz as the load progresses. This code uses a 20% margin for this.
 - Using a rolling window of samples to see what the rate is. This prevents a few large or slow blocks from making a big impact on the estimate right way. This code uses a window size of 10.
  - Don't report estimates until we have some reasonable number of samples. Estimates will not be reported for about a minute with this code (10 samples at a minimum of 5s apart)
 - Include a percentage complete. I found myself running this calculation all the time and it's nice to see how far along it is as a percentage.

## How this was tested

Too many bootstraps. The 20% margin is a wild guess, but I wrote some code to show how much fuzz makes sense, and settled on 10 samples. It was not tested on a very slow machine.

## Need to be documented in RELEASES.md?

Not a bad idea.