### PR TITLE
Add s5cmd progress bar

### DIFF
--- a/scripts/copy_dir.sh
+++ b/scripts/copy_dir.sh
@@ -27,7 +27,7 @@ function copy_source() {
     if [[ "$source" == s3://* || "$dest" == s3://* ]]; then
         # Use s5cmd to copy from S3
         echo "Copying from S3: $source to $dest"
-        time s5cmd cp "$source" "$dest"
+        time s5cmd cp --show-progress "$source" "$dest"
     else
         # Use cp for local filesystem with recursive support
         


### PR DESCRIPTION
## Why this should be merged

When downloading large objects from `s3`, the following is often shown:

<img width="1269" height="521" alt="Screenshot 2025-08-22 at 15 15 34" src="https://github.com/user-attachments/assets/f41530bf-e8d1-45b5-ac3e-5c6fcec77ab4" />

The repeating text at the bottom isn't useful, however, as it doesn't show the current progress towards downloading the `s3` object. Using the `--show-progress` flag, however, reveals the current download progress, which I find extremely useful for large object downloads:

<img width="1265" height="294" alt="Screenshot 2025-08-22 at 15 16 38" src="https://github.com/user-attachments/assets/7c19dd13-30b6-497b-87b0-564401cff46f" />


## How this works

Adds the `--show-progress` flag to the `s5cmd cp` command.

## How this was tested

CI + ran `import-s3-to-dir` task locally.

## Need to be documented in RELEASES.md?

No
