### PR TITLE
feat: Add meterdb for heightindex database

### DIFF
--- a/database/heightindexdb/meterdb/db_test.go
+++ b/database/heightindexdb/meterdb/db_test.go
@@ -136,7 +136,7 @@ func extractMetricValues(metrics []*dto.MetricFamily, metricName string) map[str
 				case "calls":
 					result[method] = *m.Counter.Value
 				case "duration":
-					result[method] = *m.Histogram.SampleSum
+					result[method] = *m.Gauge.Value
 				case "size":
 					result[method] = *m.Counter.Value
 				}


### PR DESCRIPTION
## Why this should be merged

Similar to `meterdb` for `database.Database`, this `meterdb` is for collecting basic metrics (size, duration, calls) for `database.HeightIndex`

## How this works

Wrapper around a `database.HeightIndex` and collects metrics on size, duration, and calls for Put, Get, Has, and Close.

## How this was tested

Unit tests

## Need to be documented in RELEASES.md?
