### PR TITLE
refactor: use reflect.TypeFor

### DIFF
--- a/vms/rpcchainvm/vm_test.go
+++ b/vms/rpcchainvm/vm_test.go
@@ -112,7 +112,7 @@ func TestHelperProcess(t *testing.T) {
 // interface are implemented.
 func TestVMServerInterface(t *testing.T) {
 	var wantMethods, gotMethods []string
-	pb := reflect.TypeOf((*vmpb.VMServer)(nil)).Elem()
+	pb := reflect.TypeFor[vm.VMServer]()
 	for i := 0; i < pb.NumMethod()-1; i++ {
 		wantMethods = append(wantMethods, pb.Method(i).Name)
 	}


### PR DESCRIPTION
## Why this should be merged

Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.

More info https://github.com/golang/go/issues/60088

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
