### PR TITLE
Remove schedule trigger for w/ container job that evaluates to empty matrix

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.json
@@ -18,8 +18,5 @@
                 "current-state-dir": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**"
             }
         ]
-    },
-    "schedule": {
-        "include": []
     }
 }

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -32,9 +32,6 @@ on:
         description: 'S3 location to push post-execution state directory. Skips this step if left unpopulated.'
         default: ''
 
-  schedule:
-    - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
-
 jobs:
   define-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR removes the `schedule` trigger from the re-execute cronjob w/ container since it currently results in an empty matrix and causes this error https://github.com/ava-labs/avalanchego/actions/runs/17262397635.