### PR TITLE
Push benchmark re-execute results on master workflow dispatch

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -100,7 +100,7 @@ jobs:
           current-state-dir: ${{ matrix.current-state-dir }}
           prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
           prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
-          push-github-action-benchmark: ${{ github.event_name == 'schedule' }}
+          push-github-action-benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
           aws-role: ${{ github.event.inputs.push-post-state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -89,7 +89,7 @@ jobs:
           current-state-dir: ${{ matrix.current-state-dir }}
           prometheus-username: ${{ secrets.PROMETHEUS_ID || '' }}
           prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
-          push-github-action-benchmark: ${{ github.event_name == 'schedule' }}
+          push-github-action-benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
           aws-role: ${{ github.event.inputs.push-post-state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the params passed in to C-Chain re-execution benchmarks to push benchmark results to `gh-pages` via GitHub Action Benchmark when triggered by both scheduled jobs on the master branch and workflow dispatch events on the master branch.

Note: this does give developers the ability to trigger arbitrary runs on the master branch that we will store the results of. This is alright because they will be properly named and separated based on the parameters ie. config and execution range.

What a developer could do is push benchmark results from an arbitrary range that we may not want to persist like [37, 63].

Adding the workflow dispatch has the following benefits that justify this increased chance of pushing un-interesting results:
- easier to debug archiving benchmark resutls
- enables triggering archived test runs before deciding what triggers to add on a persistent basis