### PR TITLE
feat(deps): pin coreth to c512d57d for firewood v0.0.10 compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/StephenButtolph/canoto v0.17.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/coreth v0.15.4-0.20250822180419-87fa386ffea9
+	github.com/ava-labs/coreth v0.15.4-rc.1.0.20250827164817-c512d57d5250
 	github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60
 	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6
 	github.com/btcsuite/btcd/btcutil v1.1.3
@@ -87,7 +87,7 @@ require (
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9 // indirect
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.10 // indirect
 	github.com/ava-labs/simplex v0.0.0-20250819180907-c9b5ae6aad19
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,10 +70,10 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/coreth v0.15.4-0.20250822180419-87fa386ffea9 h1:lg7DWh3WJIVmc8uGsDgsgiUkOWOz5/qRtPJLckhoHuY=
-github.com/ava-labs/coreth v0.15.4-0.20250822180419-87fa386ffea9/go.mod h1:ZMzhjHxfW1j0jAajxD7e/VdiTfFe2Ftnir0EOLalZfU=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9 h1:zw0g+cUbZDsGdWx1PKmBChkpy+ixL3QgiI86DUOuXvo=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
+github.com/ava-labs/coreth v0.15.4-rc.1.0.20250827164817-c512d57d5250 h1:6LZXaan+PNTZvzEvJT/obAdAc3Y/UTxH6frvLnFuS6Q=
+github.com/ava-labs/coreth v0.15.4-rc.1.0.20250827164817-c512d57d5250/go.mod h1:I7RwEZqSAe+8IN8Qe1u26rLzuJEaHodz7LXI9pDbz6c=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.0.10 h1:HixarMq0XEhAtXZlGNNzmuKCOYNCtCMSv3Q5IObYqBc=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.0.10/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60 h1:EL66gtXOAwR/4KYBjOV03LTWgkEXvLePribLlJNu4g0=
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20241009183145-e6f90a8a1a60/go.mod h1:/7qKobTfbzBu7eSTVaXMTr56yTYk4j2Px6/8G+idxHo=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6 h1:tyM659nDOknwTeU4A0fUVsGNIU7k0v738wYN92nqs/Y=


### PR DESCRIPTION
Pin coreth dependency to custom build using firewood v0.0.10 for release compatibility.

## Changes
- Updated coreth dependency to commit [c512d57d](https://github.com/ava-labs/coreth/tree/coreth-v15.4-rc.0-firewood-v0.0.10) (firewood v0.0.10 build)
- Downgraded from firewood v0.0.12 to v0.0.10 in coreth