### PR TITLE
chore: remove unzip mention

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,7 +144,7 @@ tasks:
           DST: '{{.EXECUTION_DATA_DIR}}/current-state'
 
   import-s3-to-dir:
-    desc: Imports an S3 path to a local directory. Unzipping if needed.
+    desc: Imports an S3 path to a local directory.
     vars:
       SRC: '{{.SRC}}'
       DST: '{{.DST}}'


### PR DESCRIPTION
## Why this should be merged

Currently, `import-s3-to-dir` doesn't actually unzip S3 objects. However, we don't plan on supporting unzipping since this is slower than just downloading the raw folder altogether.

## How this works

Remove unzipping reference.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No