### PR TITLE
Remove firewood entry from PR triggers due to flakes

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
@@ -24,14 +24,6 @@
                 "end-block": 250000,
                 "source-block-dir": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**",
                 "current-state-dir": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-archive-100/**"
-            },
-            {
-                "runner": "blacksmith-4vcpu-ubuntu-2404",
-                "config": "firewood",
-                "start-block": 101,
-                "end-block": 250000,
-                "source-block-dir": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**",
-                "current-state-dir": "s3://avalanchego-bootstrap-testing/cchain-current-state-firewood-100/**"
             }
         ]
     },


### PR DESCRIPTION
This PR removes the firewood run from the set of PR triggers due to https://github.com/ava-labs/coreth/issues/1158.