### PR TITLE
Add newline to workflow dispatch

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -49,7 +49,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             {
               echo "matrix<<EOF"
-              printf '{ "include": [{ "start-block": "%s", "end-block": "%s", "source-block-dir": "%s", "current-state-dir": "%s", "config": "%s", "runner": "%s" }] }' \
+              printf '{ "include": [{ "start-block": "%s", "end-block": "%s", "source-block-dir": "%s", "current-state-dir": "%s", "config": "%s", "runner": "%s" }] }\n' \
                 "${{ github.event.inputs.start-block }}" \
                 "${{ github.event.inputs.end-block }}" \
                 "${{ github.event.inputs.source-block-dir }}" \


### PR DESCRIPTION
Add newline to fix manual workflow dispatch of w/ container job.

Fixes https://github.com/ava-labs/avalanchego/actions/runs/17302494155 and re-aligns the define matrix job with the GH Native version.