### PR TITLE
Add back empty schedule entry for reexecute w/ container job

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.json
@@ -18,5 +18,8 @@
                 "current-state-dir-src": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**"
             }
         ]
+    },
+    "schedule": {
+        "include": []
     }
 }


### PR DESCRIPTION
This PR replaces a "null" entry in the JSON with an empty matrix to avoid this error: https://github.com/ava-labs/avalanchego/actions/runs/17319662751/job/49169903818#step:3:28