### PR TITLE
Comment out schedule trigger for re-execution on w/container

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -32,7 +32,7 @@ on:
         description: 'S3 location to push post-execution state directory. Skips this step if left unpopulated.'
         default: ''
 
-  # Disabled because scheduled trigger is empty. To enable, uncomment and add at least one vector to the shedule
+  # Disabled because scheduled trigger is empty. To enable, uncomment and add at least one vector to the schedule
   # entry in the corresponding JSON file.
   # schedule:
   #   - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)


### PR DESCRIPTION
This PR comments out the schedule trigger for the re-execution w/ container jobs.

Previous attempt to fix this is here :https://github.com/ava-labs/avalanchego/pull/4230. This assumed the only problem was creating an invalid JSON entry in the matrix and that generating an empty matrix would correctly execute as:

- define matrix with zero jobs
- pick up empty matrix and execute zero jobs

GitHub is a bit light on documentation for edge cases like this, but it turns out that creating an empty matrix results in marking the workflow as failed as it does here: https://github.com/ava-labs/avalanchego/actions/runs/17398784013/attempts/1.
