### PR TITLE
Add runner name as metric label and benchmark name param

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -78,8 +78,7 @@ runs:
     - name: Run C-Chain Re-Execution
       uses: ./.github/actions/run-monitored-tmpnet-cmd
       with:
-        run: |
-          ./scripts/run_task.sh reexecute-cchain-range-with-copied-data \
+        run_env: |
             CONFIG=${{ inputs.config }} \
             EXECUTION_DATA_DIR=${{ env.EXECUTION_DATA_DIR }} \
             BLOCK_DIR_SRC=${{ env.BLOCK_DIR_SRC }} \
@@ -88,6 +87,8 @@ runs:
             END_BLOCK=${{ env.END_BLOCK }} \
             LABELS=${{ env.LABELS }} \
             BENCHMARK_OUTPUT_FILE=${{ env.BENCHMARK_OUTPUT_FILE }}
+        run: ./scripts/run_task.sh reexecute-cchain-range-with-copied-data
+
         prometheus_push_url: ${{ inputs.prometheus-push-url }}
         prometheus_username: ${{ inputs.prometheus-username }}
         prometheus_password: ${{ inputs.prometheus-password }}

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -2,6 +2,9 @@ name: 'C-Chain Re-Execution Benchmark'
 description: 'Run C-Chain re-execution benchmark'
 
 inputs:
+  runner_name:
+    description: 'The name of the runner to use and include in the Golang Benchmark name.'
+    required: true
   config:
     description: 'The config to pass to the VM for the benchmark. See BenchmarkReexecuteRange for details.'
     default: ''
@@ -86,7 +89,8 @@ runs:
             START_BLOCK=${{ env.START_BLOCK }} \
             END_BLOCK=${{ env.END_BLOCK }} \
             LABELS=${{ env.LABELS }} \
-            BENCHMARK_OUTPUT_FILE=${{ env.BENCHMARK_OUTPUT_FILE }}
+            BENCHMARK_OUTPUT_FILE=${{ env.BENCHMARK_OUTPUT_FILE }} \
+            RUNNER_NAME=${{ inputs.runner_name }}
         run: ./scripts/run_task.sh reexecute-cchain-range-with-copied-data
 
         prometheus_push_url: ${{ inputs.prometheus-push-url }}

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -112,3 +112,4 @@ jobs:
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-post-state: ${{ github.event.inputs.push-post-state }}
+          runner_name: ${{ matrix.runner }}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -97,3 +97,4 @@ jobs:
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-post-state: ${{ github.event.inputs.push-post-state }}
+          runner_name: ${{ matrix.runner }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -196,7 +196,7 @@ tasks:
     cmd: |
       CURRENT_STATE_DIR={{.CURRENT_STATE_DIR}} \
       BLOCK_DIR={{.BLOCK_DIR}} \
-      RUNNER_NAME: '{{.RUNNER_NAME | default "dev"}}'
+      RUNNER_NAME='{{.RUNNER_NAME | default "dev"}}' \
       CONFIG={{.CONFIG}} \
       START_BLOCK={{.START_BLOCK}} \
       END_BLOCK={{.END_BLOCK}} \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -186,6 +186,7 @@ tasks:
     vars:
       CURRENT_STATE_DIR: '{{.CURRENT_STATE_DIR}}'
       BLOCK_DIR: '{{.BLOCK_DIR}}'
+      RUNNER_NAME: '{{.RUNNER_NAME | default "dev"}}'
       CONFIG: '{{.CONFIG | default ""}}'
       START_BLOCK: '{{.START_BLOCK}}'
       END_BLOCK: '{{.END_BLOCK}}'
@@ -195,6 +196,7 @@ tasks:
     cmd: |
       CURRENT_STATE_DIR={{.CURRENT_STATE_DIR}} \
       BLOCK_DIR={{.BLOCK_DIR}} \
+      RUNNER_NAME: '{{.RUNNER_NAME | default "dev"}}'
       CONFIG={{.CONFIG}} \
       START_BLOCK={{.START_BLOCK}} \
       END_BLOCK={{.END_BLOCK}} \
@@ -209,6 +211,8 @@ tasks:
       EXECUTION_DATA_DIR: '{{.EXECUTION_DATA_DIR}}'
       BLOCK_DIR_SRC: '{{.BLOCK_DIR_SRC | default "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**"}}'
       CURRENT_STATE_DIR_SRC: '{{.CURRENT_STATE_DIR_SRC | default "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**"}}'
+      RUNNER_NAME: '{{.RUNNER_NAME | default "dev"}}'
+      CONFIG: '{{.CONFIG | default ""}}'
       START_BLOCK: '{{.START_BLOCK | default "101"}}'
       END_BLOCK: '{{.END_BLOCK | default "250000"}}'
       LABELS: '{{.LABELS | default ""}}'
@@ -224,12 +228,14 @@ tasks:
         vars:
           BLOCK_DIR: '{{.EXECUTION_DATA_DIR}}/blocks'
           CURRENT_STATE_DIR: '{{.EXECUTION_DATA_DIR}}/current-state'
+          RUNNER_NAME: '{{.RUNNER_NAME}}'
           CONFIG: '{{.CONFIG}}'
           START_BLOCK: '{{.START_BLOCK}}'
           END_BLOCK: '{{.END_BLOCK}}'
           LABELS: '{{.LABELS}}'
           BENCHMARK_OUTPUT_FILE: '{{.BENCHMARK_OUTPUT_FILE}}'
           METRICS_ENABLED: '{{.METRICS_ENABLED}}'
+          
 
   test-bootstrap-monitor-e2e:
     desc: Runs bootstrap monitor e2e tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -235,7 +235,6 @@ tasks:
           LABELS: '{{.LABELS}}'
           BENCHMARK_OUTPUT_FILE: '{{.BENCHMARK_OUTPUT_FILE}}'
           METRICS_ENABLED: '{{.METRICS_ENABLED}}'
-          
 
   test-bootstrap-monitor-e2e:
     desc: Runs bootstrap monitor e2e tests

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 cmd="go test -timeout=0 -v -benchtime=1x -bench=BenchmarkReexecuteRange -run=^$ github.com/ava-labs/avalanchego/tests/reexecute/c \
   --block-dir=\"${BLOCK_DIR}\" \
   --current-state-dir=\"${CURRENT_STATE_DIR}\" \
-  --runner-name=\"${RUNNER_NAME}\" \
+  --runner=\"${RUNNER_NAME}\" \
   ${CONFIG:+--config=\"${CONFIG}\"} \
   --start-block=\"${START_BLOCK}\" \
   --end-block=\"${END_BLOCK}\" \

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 cmd="go test -timeout=0 -v -benchtime=1x -bench=BenchmarkReexecuteRange -run=^$ github.com/ava-labs/avalanchego/tests/reexecute/c \
   --block-dir=\"${BLOCK_DIR}\" \
   --current-state-dir=\"${CURRENT_STATE_DIR}\" \
+  --runner-name=\"${RUNNER_NAME}\" \
   ${CONFIG:+--config=\"${CONFIG}\"} \
   --start-block=\"${START_BLOCK}\" \
   --end-block=\"${END_BLOCK}\" \

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 : "${BLOCK_DIR:?BLOCK_DIR must be set}"
 : "${CURRENT_STATE_DIR:?CURRENT_STATE_DIR must be set}"
+: "${RUNNER_NAME:?RUNNER_NAME must be set}"
 : "${START_BLOCK:?START_BLOCK must be set}"
 : "${END_BLOCK:?END_BLOCK must be set}"
 

--- a/tests/reexecute/c/vm_reexecute_test.go
+++ b/tests/reexecute/c/vm_reexecute_test.go
@@ -144,7 +144,6 @@ func BenchmarkReexecuteRange(b *testing.B) {
 			endBlockArg,
 			chanSizeArg,
 			metricsEnabledArg,
-			runnerNameArg,
 		)
 	})
 }
@@ -158,7 +157,6 @@ func benchmarkReexecuteRange(
 	endBlock uint64,
 	chanSize int,
 	metricsEnabled bool,
-	runnerName string,
 ) {
 	r := require.New(b)
 	ctx := context.Background()

--- a/tests/reexecute/c/vm_reexecute_test.go
+++ b/tests/reexecute/c/vm_reexecute_test.go
@@ -84,6 +84,7 @@ var (
 	}
 
 	configNameArg  string
+	runnerNameArg  string
 	configBytesArg []byte
 )
 
@@ -101,6 +102,7 @@ func TestMain(m *testing.M) {
 	predefinedConfigKeys := slices.Collect(maps.Keys(predefinedConfigs))
 	predefinedConfigOptionsStr := fmt.Sprintf("[%s]", strings.Join(predefinedConfigKeys, ", "))
 	flag.StringVar(&configNameArg, configKey, defaultConfigKey, fmt.Sprintf("Specifies the predefined config to use for the VM. Options include %s.", predefinedConfigOptionsStr))
+	flag.StringVar(&runnerNameArg, "runner", "dev", "Name of the runner executing this test. Added as a metric label and to the sub-benchmark's name to differentiate results on the runner key.")
 
 	// Flags specific to TestExportBlockRange.
 	flag.StringVar(&blockDirSrcArg, "block-dir-src", blockDirSrcArg, "Source block directory to copy from when running TestExportBlockRange.")
@@ -108,7 +110,7 @@ func TestMain(m *testing.M) {
 
 	flag.Parse()
 
-	customLabels, err := parseLabels(labelsArg)
+	customLabels, err := parseCustomLabels(labelsArg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to parse labels: %v\n", err)
 		os.Exit(1)
@@ -124,17 +126,40 @@ func TestMain(m *testing.M) {
 	labels[configKey] = configNameArg
 	configBytesArg = []byte(predefinedConfigStr)
 
+	// Set the runner name label on the metrics.
+	labels["runner"] = runnerNameArg
+
 	m.Run()
 }
 
 func BenchmarkReexecuteRange(b *testing.B) {
 	require.Equalf(b, 1, b.N, "BenchmarkReexecuteRange expects to run a single iteration because it overwrites the input current-state, but found (b.N=%d)", b.N)
-	b.Run(fmt.Sprintf("[%d,%d]-Config-%s", startBlockArg, endBlockArg, configNameArg), func(b *testing.B) {
-		benchmarkReexecuteRange(b, blockDirArg, currentStateDirArg, configBytesArg, startBlockArg, endBlockArg, chanSizeArg, metricsEnabledArg)
+	b.Run(fmt.Sprintf("[%d,%d]-Config-%s-Runner-%s", startBlockArg, endBlockArg, configNameArg, runnerNameArg), func(b *testing.B) {
+		benchmarkReexecuteRange(
+			b,
+			blockDirArg,
+			currentStateDirArg,
+			configBytesArg,
+			startBlockArg,
+			endBlockArg,
+			chanSizeArg,
+			metricsEnabledArg,
+			runnerNameArg,
+		)
 	})
 }
 
-func benchmarkReexecuteRange(b *testing.B, blockDir string, currentStateDir string, configBytes []byte, startBlock uint64, endBlock uint64, chanSize int, metricsEnabled bool) {
+func benchmarkReexecuteRange(
+	b *testing.B,
+	blockDir string,
+	currentStateDir string,
+	configBytes []byte,
+	startBlock uint64,
+	endBlock uint64,
+	chanSize int,
+	metricsEnabled bool,
+	runnerName string,
+) {
 	r := require.New(b)
 	ctx := context.Background()
 
@@ -553,7 +578,9 @@ func collectRegistry(tb testing.TB, name string, timeout time.Duration, gatherer
 	r.NoError(err)
 }
 
-func parseLabels(labelsStr string) (map[string]string, error) {
+// parseCustomLabels parses a comma-separated list of key-value pairs into a map
+// of custom labels.
+func parseCustomLabels(labelsStr string) (map[string]string, error) {
 	labels := make(map[string]string)
 	if labelsStr == "" {
 		return labels, nil


### PR DESCRIPTION
## Why this should be merged

This PR adds a runnerName argument to the benchmark tests, which is attached as both a metric label and incorporated into the benchmark name. This ensures that runs from two different machine types will not be treated the same and we know to differentiate runs on ARC from runs on GitHub runners, blacksmith, local runs, etc.

## How this works

Adds a runnerName flag to the benchmark, passes it through Taskfile and the benchmark script, and adds it into the custom action and workflow triggers.

## How this was tested

Testing locally shows that the default value of runner is correctly attached to the metrics and shows up in the benchmark name:

Metrics from local run here: https://grafana-poc.avax-dev.network/d/Gl1I20mnk/c-chain?orgId=1&from=now-15m&to=now&timezone=America%2FNew_York&var-datasource=P1809F7CD0C75ACF3&var-filter=runner%7C%3D%7Cdev&var-chain=C&refresh=10s


Output:

```
[09-04|11:55:21.810] INFO c-chain-reexecution c/vm_reexecute_test.go:206 shutting down DB
BenchmarkReexecuteRange/[101,5000]-Config-default-Runner-dev-12                        1               258.2 mgas/s
PASS
ok      github.com/ava-labs/avalanchego/tests/reexecute/c       16.453s
```

From CI:

Metrics correctly attach the new label: https://grafana-poc.avax-dev.network/d/Gl1I20mnk/c-chain?orgId=1&refresh=10s&var-filter=runner%7C%3D%7Cblacksmith-4vcpu-ubuntu-2404&from=2025-09-04T16:14:31.000Z&to=2025-09-04T16:29:31.000Z&timezone=America%2FNew_York&var-datasource=P1809F7CD0C75ACF3&var-chain=C

Output:

```
[09-04|16:18:52.233] INFO <2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5 Chain> eth/backend.go:409 Stopped EventMux
[09-04|16:18:52.233] INFO c-chain-reexecution c/vm_reexecute_test.go:206 shutting down DB
BenchmarkReexecuteRange/[101,250000]-Config-default-Runner-blacksmith-4vcpu-ubuntu-2404-6         	       1	       103.0 mgas/s
PASS
ok  	github.com/ava-labs/avalanchego/tests/reexecute/c	261.726s
```

## Need to be documented in RELEASES.md?

No
