### PR TITLE
fix(load): totalSupply overflow

### DIFF
--- a/tests/load/main/main.go
+++ b/tests/load/main/main.go
@@ -168,10 +168,10 @@ func newTokenContract(
 	}
 
 	var (
-		totalRecipients = int64(len(recipients) + 1)
+		totalRecipients = big.NewInt(int64(len(recipients)) + 1)
 		// assumes that token has 18 decimals
 		recipientAmount = big.NewInt(1e18)
-		totalSupply     = big.NewInt(totalRecipients * 1e18)
+		totalSupply     = new(big.Int).Mul(totalRecipients, recipientAmount)
 	)
 
 	_, tx, contract, err := contracts.DeployERC20(txOpts, client, totalSupply)


### PR DESCRIPTION
## Why this should be merged

While working on making the number of workers in the load test parametrizable, I found that setting the number of workers to a high enough value (e.g. `20`) results in an integer overflow when computing `totalSupply`. 

## How this works

Prevents overflow by computing `totalSupply` entirely with `big.Int`.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
