### PR TITLE
Remove compare benchmark that uses gh action cache

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -38,10 +38,6 @@ inputs:
     description: 'The password for the Prometheus instance.'
     required: true
     default: ''
-  external-data-json-cache-key:
-    description: 'Cache key for the external data JSON file provided for comparison to GitHub Action Benchmark.'
-    required: true
-    default: 'c-chain-reexecution-benchmark-data.json'
   workspace:
     description: 'Working directory to use for the benchmark.'
     required: true


### PR DESCRIPTION
This PR removes the two separate steps to compare benchmark results against GitHub Actions cache and separately push to `gh-pages`. This was based on trying to follow the examples in the GitHub Action Benchmark docs.

This changes to only use a single step that ditches using the GitHub Action cache in favor of only comparing against the last result archived into the `gh-pages` branch. This avoids reasoning about GitHub Action caching behavior, which is a rabbit hole.

Instead, this job adds all of the desired flags to a single step, which includes:
- optionally pushing data to `gh-pages`
- generating a GitHub step summary
- generating a comment/alert if a threshold is crossed