### PR TITLE
Add back schedule trigger to gh native

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -35,6 +35,8 @@ on:
         description: 'Timeout in minutes for the job.'
         required: false
         default: 30
+  schedule:
+    - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 
 jobs:
   define-matrix:


### PR DESCRIPTION
This PR adds back the schedule trigger for the GH Native C-Chain re-execution benchmark jobs (removed accidentally when removing the trigger for the w/ container jobs).