### PR TITLE
Fix testifylint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -189,16 +189,16 @@ linters:
         - serialize
       strict: true
     testifylint:
-    # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
-    # Default: false
-    enable-all: true
-    # Disable checkers by name
-    # (in addition to default
-    #   suite-thelper
-    # ).
-    disable:
-      - go-require
-      - float-compare
+      # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
+      # Default: false
+      enable-all: true
+      # Disable checkers by name
+      # (in addition to default
+      #   suite-thelper
+      # ).
+      disable:
+        - go-require
+        - float-compare
     unused:
       # Mark all struct fields that have been written to as used.
       # Default: true

--- a/cache/lru/sized_cache_test.go
+++ b/cache/lru/sized_cache_test.go
@@ -69,18 +69,18 @@ func TestSizedLRUSizeAlteringRegression(t *testing.T) {
 	valueA := "ab"
 	cache.Put("a", &valueA)
 
-	require.InDelta(expectedPortionFilled, cache.PortionFilled(), 0)
+	require.Equal(expectedPortionFilled, cache.PortionFilled())
 
 	// mutate first value
 	valueA = "abcd"
-	require.InDelta(expectedPortionFilled, cache.PortionFilled(), 0, "after value A mutation, portion filled should be the same")
+	require.Equal(expectedPortionFilled, cache.PortionFilled(), "after value A mutation, portion filled should be the same")
 
 	// put second value
 	expectedPortionFilled = 0.8
 	valueB := "bcd"
 	cache.Put("b", &valueB)
 
-	require.InDelta(expectedPortionFilled, cache.PortionFilled(), 0)
+	require.Equal(expectedPortionFilled, cache.PortionFilled())
 
 	_, ok := cache.Get("a")
 	require.False(ok, "key a shouldn't exist after b is put")

--- a/network/ip_tracker_test.go
+++ b/network/ip_tracker_test.go
@@ -48,15 +48,15 @@ func requireEqual(t *testing.T, expected, actual *ipTracker) {
 
 func requireMetricsConsistent(t *testing.T, tracker *ipTracker) {
 	require := require.New(t)
-	require.InDelta(float64(len(tracker.tracked)), testutil.ToFloat64(tracker.numTrackedPeers), 0)
+	require.Equal(float64(len(tracker.tracked)), testutil.ToFloat64(tracker.numTrackedPeers))
 	var numGossipableIPs int
 	for _, subnet := range tracker.subnet {
 		numGossipableIPs += len(subnet.gossipableIndices)
 	}
-	require.InDelta(float64(numGossipableIPs), testutil.ToFloat64(tracker.numGossipableIPs), 0)
-	require.InDelta(float64(len(tracker.subnet)), testutil.ToFloat64(tracker.numTrackedSubnets), 0)
-	require.InDelta(float64(tracker.bloom.Count()), testutil.ToFloat64(tracker.bloomMetrics.Count), 0)
-	require.InDelta(float64(tracker.maxBloomCount), testutil.ToFloat64(tracker.bloomMetrics.MaxCount), 0)
+	require.Equal(float64(numGossipableIPs), testutil.ToFloat64(tracker.numGossipableIPs))
+	require.Equal(float64(len(tracker.subnet)), testutil.ToFloat64(tracker.numTrackedSubnets))
+	require.Equal(float64(tracker.bloom.Count()), testutil.ToFloat64(tracker.bloomMetrics.Count))
+	require.Equal(float64(tracker.maxBloomCount), testutil.ToFloat64(tracker.bloomMetrics.MaxCount))
 }
 
 func TestIPTracker_ManuallyTrack(t *testing.T) {

--- a/network/p2p/gossip/bloom_test.go
+++ b/network/p2p/gossip/bloom_test.go
@@ -99,7 +99,7 @@ func TestBloomFilterRefresh(t *testing.T) {
 			}
 
 			require.Equal(tt.resetCount, resetCount)
-			require.InDelta(float64(tt.resetCount+1), testutil.ToFloat64(bloom.metrics.ResetCount), 0)
+			require.Equal(float64(tt.resetCount+1), testutil.ToFloat64(bloom.metrics.ResetCount))
 			for _, expected := range tt.expected {
 				require.True(bloom.Has(expected))
 			}

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -202,7 +202,7 @@ func TestGossiperGossip(t *testing.T) {
 			require.Len(requestSet.txs, tt.expectedLen)
 			require.Subset(tt.expectedPossibleValues, maps.Values(requestSet.txs))
 			require.Equal(len(tt.responder) > 0, testHistogram.observed)
-			require.InDelta(tt.expectedHitRate, testHistogram.observedVal, 0)
+			require.Equal(tt.expectedHitRate, testHistogram.observedVal)
 
 			// we should not receive anything that we already had before we
 			// requested the gossip

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -538,7 +538,7 @@ func RecordPollSplitVoteNoChangeTest(t *testing.T, factory Factory) {
 
 	metrics := gatherCounterGauge(t, registerer)
 	require.Zero(metrics["polls_failed"])
-	require.InDelta(float64(1), metrics["polls_successful"], 0)
+	require.Equal(float64(1), metrics["polls_successful"])
 
 	// The second poll will do nothing
 	require.NoError(sm.RecordPoll(context.Background(), votes))
@@ -546,8 +546,8 @@ func RecordPollSplitVoteNoChangeTest(t *testing.T, factory Factory) {
 	require.Equal(2, sm.NumProcessing())
 
 	metrics = gatherCounterGauge(t, registerer)
-	require.InDelta(float64(1), metrics["polls_failed"], 0)
-	require.InDelta(float64(1), metrics["polls_successful"], 0)
+	require.Equal(float64(1), metrics["polls_failed"])
+	require.Equal(float64(1), metrics["polls_successful"])
 }
 
 func RecordPollWhenFinalizedTest(t *testing.T, factory Factory) {

--- a/snow/networking/tracker/resource_tracker_test.go
+++ b/snow/networking/tracker/resource_tracker_test.go
@@ -71,7 +71,7 @@ func TestCPUTracker(t *testing.T) {
 
 	cumulative := cpuTracker.TotalUsage()
 	sum := node1Utilization + node2Utilization
-	require.InDelta(sum, cumulative, 0)
+	require.Equal(sum, cumulative)
 
 	mockUser.EXPECT().CPUUsage().Return(.5).Times(3)
 

--- a/snow/networking/tracker/targeter_test.go
+++ b/snow/networking/tracker/targeter_test.go
@@ -39,8 +39,8 @@ func TestNewTargeter(t *testing.T) {
 	targeter := targeterIntf.(*targeter)
 	require.Equal(vdrs, targeter.vdrs)
 	require.Equal(tracker, targeter.tracker)
-	require.InDelta(config.MaxNonVdrUsage, targeter.maxNonVdrUsage, 0)
-	require.InDelta(config.MaxNonVdrNodeUsage, targeter.maxNonVdrNodeUsage, 0)
+	require.Equal(config.MaxNonVdrUsage, targeter.maxNonVdrUsage)
+	require.Equal(config.MaxNonVdrNodeUsage, targeter.maxNonVdrNodeUsage)
 }
 
 func TestTarget(t *testing.T) {
@@ -123,7 +123,7 @@ func TestTarget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setup()
 			target := targeter.TargetUsage(tt.nodeID)
-			require.InDelta(t, tt.expectedTarget, target, 0)
+			require.Equal(t, tt.expectedTarget, target)
 		})
 	}
 }

--- a/snow/uptime/manager_test.go
+++ b/snow/uptime/manager_test.go
@@ -367,7 +367,7 @@ func TestCalculateUptimeWhenNeverTracked(t *testing.T) {
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, startTime.Truncate(time.Second))
 	require.NoError(err)
-	require.InDelta(float64(1), uptime, 0)
+	require.Equal(float64(1), uptime)
 }
 
 func TestCalculateUptimeWhenNeverConnected(t *testing.T) {
@@ -390,12 +390,12 @@ func TestCalculateUptimeWhenNeverConnected(t *testing.T) {
 
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0)
 	require.NoError(err)
-	require.Equal(time.Duration(0), duration)
+	require.Zero(duration)
 	require.Equal(clk.UnixTime(), lastUpdated)
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, startTime)
 	require.NoError(err)
-	require.InDelta(float64(0), uptime, 0)
+	require.Zero(uptime)
 }
 
 func TestCalculateUptimeWhenConnectedBeforeTracking(t *testing.T) {
@@ -489,7 +489,7 @@ func TestCalculateUptimePercentageDivBy0(t *testing.T) {
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, startTime.Truncate(time.Second))
 	require.NoError(err)
-	require.InDelta(float64(1), uptime, 0)
+	require.Equal(float64(1), uptime)
 }
 
 func TestCalculateUptimePercentage(t *testing.T) {
@@ -512,7 +512,7 @@ func TestCalculateUptimePercentage(t *testing.T) {
 
 	uptime, err := up.CalculateUptimePercentFrom(nodeID0, startTime.Truncate(time.Second))
 	require.NoError(err)
-	require.InDelta(float64(0), uptime, 0)
+	require.Zero(uptime)
 }
 
 func TestStopTrackingUnixTimeRegression(t *testing.T) {

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -290,12 +290,12 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 					// by now
 					currentXBlksProcessing, _ := tests.GetMetricValue(mm, blksProcessingMetric, xChainMetricLabels)
 					previousXBlksProcessing, _ := tests.GetMetricValue(prev, blksProcessingMetric, xChainMetricLabels)
-					require.InDelta(currentXBlksProcessing, previousXBlksProcessing, 0)
+					require.Equal(currentXBlksProcessing, previousXBlksProcessing)
 
 					// +1 since X-chain tx must have been accepted by now
 					currentXBlksAccepted, _ := tests.GetMetricValue(mm, blksAcceptedMetric, xChainMetricLabels)
 					previousXBlksAccepted, _ := tests.GetMetricValue(prev, blksAcceptedMetric, xChainMetricLabels)
-					require.InDelta(currentXBlksAccepted, previousXBlksAccepted+1, 0)
+					require.Equal(currentXBlksAccepted, previousXBlksAccepted+1)
 
 					metricsBeforeTx[u] = mm
 				}

--- a/utils/json/float32_test.go
+++ b/utils/json/float32_test.go
@@ -54,6 +54,6 @@ func TestFloat32(t *testing.T) {
 
 		var f Float32
 		require.NoError(f.UnmarshalJSON(jsonBytes))
-		require.InDelta(tt.expectedUnmarshalled, float32(f), 0)
+		require.Equal(tt.expectedUnmarshalled, float32(f))
 	}
 }

--- a/utils/math/continuous_averager_test.go
+++ b/utils/math/continuous_averager_test.go
@@ -21,7 +21,7 @@ func TestAverager(t *testing.T) {
 
 	currentTime = currentTime.Add(halflife)
 	a.Observe(1, currentTime)
-	require.InDelta(1.0/1.5, a.Read(), 0)
+	require.Equal(1.0/1.5, a.Read())
 }
 
 func TestAveragerTimeTravel(t *testing.T) {
@@ -31,11 +31,11 @@ func TestAveragerTimeTravel(t *testing.T) {
 	currentTime := time.Now()
 
 	a := NewSyncAverager(NewAverager(1, halflife, currentTime))
-	require.InDelta(float64(1), a.Read(), 0)
+	require.Equal(float64(1), a.Read())
 
 	currentTime = currentTime.Add(-halflife)
 	a.Observe(0, currentTime)
-	require.InDelta(1.0/1.5, a.Read(), 0)
+	require.Equal(1.0/1.5, a.Read())
 }
 
 func TestUninitializedAverager(t *testing.T) {
@@ -50,5 +50,5 @@ func TestUninitializedAverager(t *testing.T) {
 	require.Zero(a.Read())
 
 	a.Observe(firstObservation, currentTime)
-	require.InDelta(firstObservation, a.Read(), 0)
+	require.Equal(firstObservation, a.Read())
 }

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -660,7 +660,7 @@ func TestGetCurrentValidators(t *testing.T) {
 			require.Equal(validator.EndTime().Unix(), int64(gotVdr.EndTime))
 			require.Equal(validator.StartTime().Unix(), int64(gotVdr.StartTime))
 			require.Equal(connectedIDs.Contains(validator.NodeID()), *gotVdr.Connected)
-			require.InDelta(float32(avajson.Float32(100)), float32(*gotVdr.Uptime), 0)
+			require.Equal(float32(avajson.Float32(100)), float32(*gotVdr.Uptime))
 			found = true
 			break
 		}

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -2561,7 +2561,7 @@ func TestTimestampMetrics(t *testing.T) {
 		t.Run(tt.blockType, func(t *testing.T) {
 			gauge, err := gaugeVec.GetMetricWithLabelValues(tt.blockType)
 			require.NoError(t, err)
-			require.InDelta(t, float64(tt.want.Unix()), testutil.ToFloat64(gauge), 0)
+			require.Equal(t, float64(tt.want.Unix()), testutil.ToFloat64(gauge))
 		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged

The golangci.yml file has some incorrect indentation which came up with the coreth linting effort.

## How this works

Fixes the indentation and cleans up the backflips we needed to do to work around that misconfiguration.

## How this was tested

CI

## Need to be documented in RELEASES.md?
