### PR TITLE
test(load): add firewood workflow

### DIFF
--- a/.github/workflows/firewood-load-test.yml
+++ b/.github/workflows/firewood-load-test.yml
@@ -1,7 +1,6 @@
 name: Load Test with Firewood for 30 minutes
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)


### PR DESCRIPTION
## Why this should be merged

As part of integrating the load framework with Firewood, we should be running the load test with Firewood enabled on a consistent basis. 

In the future, we would integrate @Elvis339's comparative analysis work as part of this workflow. For now though, results of the workflow (i.e. Grafana link) would be sent to the Firewood team who would then manually inspect the results.

## How this works

Adds a long-running load test workflow that tests C-Chain performance utilizing Firewood. This workflow runs daily and can also be triggered manually.

## How this was tested

Tested in CI (https://github.com/ava-labs/avalanchego/actions/runs/17681080345/job/50255209950?pr=4268)

## Need to be documented in RELEASES.md?

No
