### PR TITLE
[tmpnet] Upgrade prometheus agent version to avoid use of bitnami images

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -85,6 +85,14 @@ tasks:
       - cmd: go mod tidy
       - task: check-clean-branch
 
+  create-kind-cluster:
+    desc: Creates the default kind cluster
+    cmd: bash -x ./scripts/start_kind_cluster.sh {{.CLI_ARGS}}
+
+  delete-kind-cluster:
+    desc: Deletes the default kind cluster
+    cmd: kind delete cluster
+
   export-cchain-block-range:
     desc: Export range of C-Chain blocks from source to target directory.
     vars:

--- a/scripts/start_kind_cluster.sh
+++ b/scripts/start_kind_cluster.sh
@@ -12,4 +12,6 @@ for arg in "$@"; do
     START_CLUSTER_ARGS+=("${arg}")
   fi
 done
+echo "Starting kind cluster with args: ${START_CLUSTER_ARGS[*]}"
+echo "To cleanup the cluster, run ./scripts/run_task.sh delete-kind-cluster"
 ./bin/tmpnetctl start-kind-cluster "${START_CLUSTER_ARGS[@]}"

--- a/tests/fixture/tmpnet/yaml/prometheus-agent.yaml
+++ b/tests/fixture/tmpnet/yaml/prometheus-agent.yaml
@@ -44,8 +44,7 @@ metadata:
   name: prometheus-config
   namespace: ci-monitoring
 data:
-  # This template needs to have PROMETHEUS_USERNAME and PROMETHEUS_PASSWORD substituted before use
-  prometheus.yaml.template: |
+  prometheus.yaml: |
     global:
       # Make sure this value takes into account the network-shutdown-delay in tests/fixture/e2e/env.go
       scrape_interval: 10s     # Default is every 1 minute.
@@ -109,8 +108,8 @@ data:
     remote_write:
     - url: "https://prometheus-poc.avax-dev.network/api/v1/write"
       basic_auth:
-        username: "${PROMETHEUS_USERNAME}"
-        password: "${PROMETHEUS_PASSWORD}"
+        username_file: /run/secrets/username
+        password_file: /run/secrets/password
 
 ---
 apiVersion: apps/v1
@@ -132,42 +131,14 @@ spec:
         app: prometheus-agent
     spec:
       serviceAccountName: prometheus-agent
-      # Since prometheus doesn't support env substitution, an init
-      # container is required to parameterize the config file with
-      # auth credentials.
-      initContainers:
-      - name: init-prometheus-config
-        # This is one of the few published images that includes
-        # envsubst. Simpler than having to maintain our own image.
-        image: bitnami/nginx:1.27.3
-        command: ["/bin/sh", "-c"]
-        args:
-        - |
-          envsubst < /tmp/config-template/prometheus.yaml.template > /tmp/config/prometheus.yaml
-        env:
-        - name: PROMETHEUS_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-credentials
-              key: username
-        - name: PROMETHEUS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-credentials
-              key: password
-        volumeMounts:
-        - name: config-template
-          mountPath: /tmp/config-template
-        - name: config
-          mountPath: /tmp/config
       containers:
       - name: prometheus
-        # For consistency use the same minor version as the scripts/run_prometheus.sh
-        image: prom/prometheus:v2.45.6
+        # Latest stable LTS, released 2025-07-14, end of support 2026-07-31
+        image: prom/prometheus:v3.5.0
         args:
         - --config.file=/etc/prometheus/config/prometheus.yaml
         - --storage.agent.path=/prometheus
-        - --enable-feature=agent
+        - --agent
         volumeMounts:
         - name: config
           mountPath: /etc/prometheus/config/prometheus.yaml
@@ -175,15 +146,16 @@ spec:
           readOnly: true
         - name: prometheus-data
           mountPath: /prometheus
+        - name: prometheus-credentials
+          mountPath: /run/secrets
+          readOnly: true
       volumes:
-      - name: config-template
+      - name: config
         configMap:
           name: prometheus-config
-      - name: config
-        # The config path doesn't need to be persistent since the config
-        # file will be written to the volume by the init container every
-        # time the pod starts.
-        emptyDir: {}
+      - name: prometheus-credentials
+        secret:
+          secretName: prometheus-credentials
   volumeClaimTemplates:
   - metadata:
       name: prometheus-data


### PR DESCRIPTION
## Why this should be merged

Fixes #4237 

## How this works

Upgrades to version of prometheus that supports reading files for username and password which removes the need for the bitnami image.

## How this was tested

CI (`e2e_kube` specifically, the rest against regression)

## Need to be documented in RELEASES.md?

N/A