### PR TITLE
Add Mempool to XSVM

### DIFF
--- a/vms/example/xsvm/execute/block.go
+++ b/vms/example/xsvm/execute/block.go
@@ -30,10 +30,7 @@ func Block(
 	}
 
 	for _, currentTx := range blk.Txs {
-		txID, err := currentTx.ID()
-		if err != nil {
-			return err
-		}
+		txID := currentTx.ID()
 		sender, err := currentTx.SenderID()
 		if err != nil {
 			return err

--- a/vms/example/xsvm/mempool/mempool.go
+++ b/vms/example/xsvm/mempool/mempool.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package mempool
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
+	"github.com/ava-labs/avalanchego/vms/example/xsvm/builder"
+	"github.com/ava-labs/avalanchego/vms/example/xsvm/tx"
+	"github.com/ava-labs/avalanchego/vms/txs/mempool"
+)
+
+const (
+	bloomChurnMultiplier           = 3
+	minTargetElements              = 1000
+	targetFalsePositiveProbability = 0.01
+	resetFalsePositiveProbability  = 0.1
+)
+
+func NewMempool(
+	namespace string,
+	registerer prometheus.Registerer,
+) (mempool.Mempool[*tx.Tx], error) {
+	metrics, err := mempool.NewMetrics(namespace, registerer)
+	if err != nil {
+		return nil, err
+	}
+	return mempool.New[*tx.Tx](metrics), nil
+}
+
+type GossipMempool struct {
+	builder.Builder
+	lock sync.RWMutex
+
+	mempool mempool.Mempool[*tx.Tx]
+	bloom   *gossip.BloomFilter
+}
+
+var _ gossip.Set[*tx.Tx] = (*GossipMempool)(nil)
+
+func NewGossipMempool(
+	mempool mempool.Mempool[*tx.Tx],
+	registerer prometheus.Registerer,
+	builder builder.Builder,
+) (*GossipMempool, error) {
+	bloom, err := gossip.NewBloomFilter(registerer, "mempool_bloom_filter", minTargetElements, targetFalsePositiveProbability, resetFalsePositiveProbability)
+
+	return &GossipMempool{
+		mempool: mempool,
+		bloom:   bloom,
+		Builder: builder,
+	}, err
+}
+
+func (g *GossipMempool) Has(id ids.ID) bool {
+	_, exists := g.mempool.Get(id)
+	return exists
+}
+
+func (g *GossipMempool) Add(t *tx.Tx) error {
+	return g.AddWithContext(context.Background(), t)
+}
+
+func (g *GossipMempool) AddWithContext(ctx context.Context, t *tx.Tx) error {
+	// no need to add to g.mempool, since the builder adds to g.mempool via its reference
+	err := g.Builder.AddTx(ctx, t)
+	if err != nil {
+		return fmt.Errorf("failed to add tx to builder: %w", err)
+	}
+
+	// note: we do not verify transactions that are gossiped to us.
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	g.bloom.Add(t)
+	reset, err := gossip.ResetBloomFilterIfNeeded(g.bloom, g.mempool.Len()*bloomChurnMultiplier)
+	if err != nil {
+		return err
+	}
+
+	if reset {
+		g.mempool.Iterate(func(tx *tx.Tx) bool {
+			g.bloom.Add(tx)
+			return true
+		})
+	}
+
+	return nil
+}
+
+func (g *GossipMempool) GetFilter() ([]byte, []byte) {
+	g.lock.RLock()
+	defer g.lock.RUnlock()
+
+	return g.bloom.Marshal()
+}
+
+func (g *GossipMempool) Iterate(f func(*tx.Tx) bool) {
+	g.mempool.Iterate(f)
+}

--- a/vms/example/xsvm/vm.go
+++ b/vms/example/xsvm/vm.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"connectrpc.com/grpcreflect"
 	"github.com/gorilla/rpc/v2"
@@ -19,17 +20,22 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/acp118"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/json"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/api"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/builder"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/chain"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/execute"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/example/xsvm/mempool"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/state"
+	"github.com/ava-labs/avalanchego/vms/example/xsvm/tx"
 
 	smblock "github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	xsblock "github.com/ava-labs/avalanchego/vms/example/xsvm/block"
@@ -38,6 +44,19 @@ import (
 var (
 	_ smblock.ChainVM                      = (*VM)(nil)
 	_ smblock.BuildBlockWithContextChainVM = (*VM)(nil)
+
+	// mempool gossip parameters
+	TargetGossipSize               = 20 * units.KiB
+	PushGossipPercentStake         = .9
+	PushGossipNumValidators        = 100
+	PushGossipNumPeers             = 0
+	PushRegossipNumValidators      = 10
+	PushRegossipNumPeers           = 0
+	PushGossipDiscardedCacheSize   = 16384
+	PushGossipMaxRegossipFrequency = 30 * time.Second
+	PushGossipFrequency            = 500 * time.Millisecond
+	PullGossipPollSize             = 1
+	PullGossipFrequency            = 1500 * time.Millisecond
 )
 
 type VM struct {
@@ -48,7 +67,13 @@ type VM struct {
 	genesis      *genesis.Genesis
 
 	chain   chain.Chain
-	builder builder.Builder
+	mempool *mempool.GossipMempool
+
+	// Cancelled on shutdown
+	onShutdownCtx       context.Context
+	onShutdownCtxCancel context.CancelFunc
+
+	validators *p2p.Validators
 }
 
 func (vm *VM) Initialize(
@@ -113,7 +138,17 @@ func (vm *VM) Initialize(
 		return fmt.Errorf("failed to initialize chain manager: %w", err)
 	}
 
-	vm.builder = builder.New(chainContext, vm.chain)
+	vm.validators = p2p.NewValidators(
+		vm.chainContext.Log,
+		vm.chainContext.SubnetID,
+		vm.chainContext.ValidatorState,
+		time.Minute,
+	)
+
+	err = vm.setAndInitializeMempool(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to initialize mempool: %w", err)
+	}
 
 	chainContext.Log.Info("initialized xsvm",
 		zap.Stringer("lastAcceptedID", vm.chain.LastAccepted()),
@@ -130,6 +165,8 @@ func (vm *VM) Shutdown(context.Context) error {
 	if vm.chainContext == nil {
 		return nil
 	}
+	vm.chainContext.Log.Info("shutting down xsvm")
+	vm.onShutdownCtxCancel()
 	return vm.db.Close()
 }
 
@@ -146,7 +183,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 		vm.genesis,
 		vm.db,
 		vm.chain,
-		vm.builder,
+		vm.mempool,
 	)
 	return map[string]http.Handler{
 		"": server,
@@ -185,15 +222,15 @@ func (vm *VM) ParseBlock(_ context.Context, blkBytes []byte) (snowman.Block, err
 }
 
 func (vm *VM) WaitForEvent(ctx context.Context) (common.Message, error) {
-	return vm.builder.WaitForEvent(ctx)
+	return vm.mempool.WaitForEvent(ctx)
 }
 
 func (vm *VM) BuildBlock(ctx context.Context) (snowman.Block, error) {
-	return vm.builder.BuildBlock(ctx, nil)
+	return vm.mempool.BuildBlock(ctx, nil)
 }
 
 func (vm *VM) SetPreference(_ context.Context, preferred ids.ID) error {
-	vm.builder.SetPreference(preferred)
+	vm.mempool.SetPreference(preferred)
 	return nil
 }
 
@@ -202,9 +239,117 @@ func (vm *VM) LastAccepted(context.Context) (ids.ID, error) {
 }
 
 func (vm *VM) BuildBlockWithContext(ctx context.Context, blockContext *smblock.Context) (snowman.Block, error) {
-	return vm.builder.BuildBlock(ctx, blockContext)
+	return vm.mempool.BuildBlock(ctx, blockContext)
 }
 
 func (vm *VM) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, error) {
 	return state.GetBlockIDByHeight(vm.db, height)
+}
+
+var _ gossip.Marshaller[*tx.Tx] = (*txMarshaller)(nil)
+
+type txMarshaller struct{}
+
+func (txMarshaller) MarshalGossip(marshalTx *tx.Tx) ([]byte, error) {
+	return tx.Codec.Marshal(tx.CodecVersion, marshalTx)
+}
+
+func (txMarshaller) UnmarshalGossip(bytes []byte) (*tx.Tx, error) {
+	return tx.Parse(bytes)
+}
+
+func (vm *VM) Connected(ctx context.Context, nodeID ids.NodeID, v *version.Application) error {
+	vm.validators.Connected(nodeID)
+	return vm.Network.Connected(ctx, nodeID, v)
+}
+
+// setAndInitializeMempool sets up the mempool along with its associated
+// push/pull gossipers. It expects the vm to be initialized with
+// chainContext, chain, Network, and validators.
+func (vm *VM) setAndInitializeMempool(
+	register prometheus.Registerer,
+) error {
+	mem, err := mempool.NewMempool(
+		constants.XSVMName,
+		register,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create mempool: %w", err)
+	}
+
+	builder := builder.New(vm.chainContext, vm.chain, mem)
+	txGossipClient := vm.Network.NewClient(p2p.TxGossipHandlerID, vm.validators)
+	marshaller := &txMarshaller{}
+
+	txGossipMetrics, err := gossip.NewMetrics(register, "tx")
+	if err != nil {
+		return err
+	}
+	gossipMempool, err := mempool.NewGossipMempool(
+		mem,
+		register,
+		builder,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create gossip mempool: %w", err)
+	}
+
+	txPushGossiper, err := gossip.NewPushGossiper(
+		marshaller,
+		gossipMempool,
+		vm.validators,
+		txGossipClient,
+		txGossipMetrics,
+		// config parameters from /avm/network/config.go
+		gossip.BranchingFactor{
+			StakePercentage: PushGossipPercentStake,
+			Validators:      PushGossipNumValidators,
+			Peers:           PushGossipNumPeers,
+		},
+		gossip.BranchingFactor{
+			Validators: PushRegossipNumValidators,
+			Peers:      PushRegossipNumPeers,
+		},
+		PushGossipDiscardedCacheSize,
+		TargetGossipSize,
+		PushGossipMaxRegossipFrequency,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create push gossiper: %w", err)
+	}
+
+	var txPullGossiper gossip.Gossiper = gossip.NewPullGossiper[*tx.Tx](
+		vm.chainContext.Log,
+		marshaller,
+		gossipMempool,
+		txGossipClient,
+		txGossipMetrics,
+		PullGossipPollSize,
+	)
+
+	handler := gossip.NewHandler[*tx.Tx](
+		vm.chainContext.Log,
+		marshaller,
+		gossipMempool,
+		txGossipMetrics,
+		TargetGossipSize,
+	)
+
+	err = vm.Network.AddHandler(p2p.TxGossipHandlerID, handler)
+	if err != nil {
+		return fmt.Errorf("failed to add tx gossip handler to network: %w", err)
+	}
+
+	// Context to shut down the gossipers
+	vm.onShutdownCtx, vm.onShutdownCtxCancel = context.WithCancel(context.Background())
+
+	// Start the push/pull gossipers
+	// TODO: when i passed in chainContext.Log I couldn't see the logs printed during gossiping
+	// is there another logger to use?
+	go gossip.Every(vm.onShutdownCtx, vm.chainContext.Log, txPushGossiper, PushGossipFrequency)
+
+	go gossip.Every(vm.onShutdownCtx, vm.chainContext.Log, txPullGossiper, PullGossipFrequency)
+
+	vm.mempool = gossipMempool
+	return nil
 }


### PR DESCRIPTION
## Why this should be merged

Adding a gossipable mempool to the XSVM whcih allows for mempool transactions to be gossiped to other nodes. This is useful for consensus protocols like simplex, where block proposers can only propose during their proposal window. Gossiping allows block proposers to listen and propose blocks with transactions that might not have been sent to them.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
