### PR TITLE
Update config.md

### DIFF
--- a/vms/avm/config.md
+++ b/vms/avm/config.md
@@ -1,12 +1,3 @@
----
-tags: [Nodes, AvalancheGo]
-description: Reference for all available X-chain config options and flags.
-pagination_label: X-Chain Configs
-sidebar_position: 2
----
-
-# X-Chain
-
 In order to specify a config for the X-Chain, a JSON config file should be
 placed at `{chain-config-dir}/X/config.json`.
 


### PR DESCRIPTION
## Why this should be merged

removes duplicate title in docs 

## How this works

Will remove bolded "**X-Chain**" from page view
<img width="658" height="273" alt="image" src="https://github.com/user-attachments/assets/2f77658b-87a5-4027-babe-d0f3c6459999" />

link to view: https://build.avax.network/docs/nodes/configure/chain-configs/x-chain

