### PR TITLE
Don't unmarshal Stateless Block in XSVM

### DIFF
--- a/vms/example/xsvm/api/client.go
+++ b/vms/example/xsvm/api/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/rpc"
-	"github.com/ava-labs/avalanchego/vms/example/xsvm/block"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/tx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
@@ -147,7 +146,7 @@ func (c *Client) IssueTx(
 func (c *Client) LastAccepted(
 	ctx context.Context,
 	options ...rpc.Option,
-) (ids.ID, *block.Stateless, error) {
+) (ids.ID, []byte, error) {
 	resp := new(LastAcceptedReply)
 	err := c.Req.SendRequest(
 		ctx,
@@ -156,14 +155,14 @@ func (c *Client) LastAccepted(
 		resp,
 		options...,
 	)
-	return resp.BlockID, resp.Block, err
+	return resp.BlockID, resp.BlockBytes, err
 }
 
 func (c *Client) Block(
 	ctx context.Context,
 	blkID ids.ID,
 	options ...rpc.Option,
-) (*block.Stateless, error) {
+) ([]byte, error) {
 	resp := new(BlockReply)
 	err := c.Req.SendRequest(
 		ctx,
@@ -174,7 +173,7 @@ func (c *Client) Block(
 		resp,
 		options...,
 	)
-	return resp.Block, err
+	return resp.BlockBytes, err
 }
 
 func (c *Client) Message(

--- a/vms/example/xsvm/api/server.go
+++ b/vms/example/xsvm/api/server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/vms/example/xsvm/block"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/builder"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/chain"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/genesis"
@@ -148,8 +147,8 @@ func (s *server) IssueTx(r *http.Request, args *IssueTxArgs, reply *IssueTxReply
 }
 
 type LastAcceptedReply struct {
-	BlockID ids.ID           `json:"blockID"`
-	Block   *block.Stateless `json:"block"`
+	BlockID    ids.ID `json:"blockID"`
+	BlockBytes []byte `json:"blockBytes"`
 }
 
 func (s *server) LastAccepted(_ *http.Request, _ *struct{}, reply *LastAcceptedReply) error {
@@ -157,11 +156,7 @@ func (s *server) LastAccepted(_ *http.Request, _ *struct{}, reply *LastAcceptedR
 	reply.BlockID = s.chain.LastAccepted()
 	s.ctx.Lock.RUnlock()
 	blkBytes, err := state.GetBlock(s.state, reply.BlockID)
-	if err != nil {
-		return err
-	}
-
-	reply.Block, err = block.Parse(blkBytes)
+	reply.BlockBytes = blkBytes
 	return err
 }
 
@@ -170,16 +165,12 @@ type BlockArgs struct {
 }
 
 type BlockReply struct {
-	Block *block.Stateless `json:"block"`
+	BlockBytes []byte `json:"blockBytes"`
 }
 
 func (s *server) Block(_ *http.Request, args *BlockArgs, reply *BlockReply) error {
 	blkBytes, err := state.GetBlock(s.state, args.BlockID)
-	if err != nil {
-		return err
-	}
-
-	reply.Block, err = block.Parse(blkBytes)
+	reply.BlockBytes = blkBytes
 	return err
 }
 


### PR DESCRIPTION
## Why this should be merged

Previously calling `xsvmclient.Block` and `LastAccepted` would error since [there is an interface](https://github.com/ava-labs/avalanchego/blob/7320593e3d105b07c60913b428e09c04774e7cd1/vms/example/xsvm/tx/tx.go#L15) in `block.Stateless`. JSON will error when unmarshalling an interface.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
