### PR TITLE
Add public network support to tmpnet

### DIFF
--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -154,6 +154,7 @@ func (n *Network) readConfig() error {
 type serializedNetworkConfig struct {
 	UUID                 string                  `json:"uuid,omitempty"`
 	Owner                string                  `json:"owner,omitempty"`
+	NetworkID            uint32                  `json:"networkID,omitempty"`
 	PrimarySubnetConfig  ConfigMap               `json:"primarySubnetConfig,omitempty"`
 	PrimaryChainConfigs  map[string]ConfigMap    `json:"primaryChainConfigs,omitempty"`
 	DefaultFlags         FlagsMap                `json:"defaultFlags,omitempty"`
@@ -165,6 +166,7 @@ func (n *Network) writeNetworkConfig() error {
 	config := &serializedNetworkConfig{
 		UUID:                 n.UUID,
 		Owner:                n.Owner,
+		NetworkID:            n.NetworkID,
 		PrimarySubnetConfig:  n.PrimarySubnetConfig,
 		PrimaryChainConfigs:  n.PrimaryChainConfigs,
 		DefaultFlags:         n.DefaultFlags,

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/tests/fixture/stacktrace"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 )
@@ -369,10 +370,14 @@ func (n *Node) composeFlags() (FlagsMap, error) {
 	// Convert the network id to a string to ensure consistency in JSON round-tripping.
 	flags.SetDefault(config.NetworkNameKey, strconv.FormatUint(uint64(n.network.GetNetworkID()), 10))
 
-	// Set the bootstrap configuration
-	bootstrapIPs, bootstrapIDs := n.network.GetBootstrapIPsAndIDs(n)
-	flags.SetDefault(config.BootstrapIDsKey, strings.Join(bootstrapIDs, ","))
-	flags.SetDefault(config.BootstrapIPsKey, strings.Join(bootstrapIPs, ","))
+	// Set the bootstrap configuration only for non-public networks
+	// Public networks should use avalanchego's built-in bootstrappers
+	networkID := n.network.GetNetworkID()
+	if networkID != constants.FujiID && networkID != constants.MainnetID {
+		bootstrapIPs, bootstrapIDs := n.network.GetBootstrapIPsAndIDs(n)
+		flags.SetDefault(config.BootstrapIDsKey, strings.Join(bootstrapIDs, ","))
+		flags.SetDefault(config.BootstrapIPsKey, strings.Join(bootstrapIPs, ","))
+	}
 
 	// TODO(marun) Maybe avoid computing content flags for each node start?
 


### PR DESCRIPTION
## Why this should be merged
Supersedes https://github.com/ava-labs/avalanchego/pull/4267

This change enables tmpnet to work with public networks (Fuji and Mainnet) by properly handling their configuration differences. Previously, tmpnet would attempt to configure bootstrap nodes for all networks, but public networks should use avalanchego's built-in bootstrappers instead of custom ones. Additionally, the NetworkID field was missing from persistence, causing configuration loss across sessions.
  
## How this works
- Adds NetworkID field to the serialized network configuration  for proper persistence across tmpnet sessions
- Modifies bootstrap configuration logic to skip custom bootstrap setup for public networks, allowing them to use avalanchego's built-in bootstrappers
  
## How this was tested
CLI L1 fuji validators on local machine

## Need to be documented in RELEASES.md?