### PR TITLE
refactor(sync): simplify generics, add optional proof factories, dedupe proof handling

### DIFF
--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
 
+	xsync "github.com/ava-labs/avalanchego/x/sync"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -37,7 +38,8 @@ const (
 )
 
 var (
-	_ MerkleDB = (*merkleDB)(nil)
+	_ MerkleDB                            = (*merkleDB)(nil)
+	_ xsync.DB[*RangeProof, *ChangeProof] = (MerkleDB)(nil)
 
 	metadataPrefix         = []byte{0}
 	valueNodePrefix        = []byte{1}

--- a/x/merkledb/history.go
+++ b/x/merkledb/history.go
@@ -5,7 +5,6 @@ package merkledb
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"slices"
 
@@ -15,11 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/buffer"
 	"github.com/ava-labs/avalanchego/utils/heap"
 	"github.com/ava-labs/avalanchego/utils/maybe"
-)
-
-var (
-	ErrInsufficientHistory = errors.New("insufficient history to generate proof")
-	ErrNoEndRoot           = fmt.Errorf("%w: end root not found", ErrInsufficientHistory)
+	"github.com/ava-labs/avalanchego/x/sync"
 )
 
 // stores previous trie states
@@ -144,7 +139,7 @@ func (th *trieHistory) getValueChanges(
 	// [endRootChanges] is the last change in the history resulting in [endRoot].
 	endRootChanges, ok := th.getRootChanges(endRoot)
 	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrNoEndRoot, endRoot)
+		return nil, fmt.Errorf("%w: %s", sync.ErrEndRootNotFound, endRoot)
 	}
 
 	// Confirm there's a change resulting in [startRoot] before
@@ -152,7 +147,7 @@ func (th *trieHistory) getValueChanges(
 	// [startRootChanges] is the last appearance of [startRoot].
 	startRootChanges, ok := th.getRootChanges(startRoot)
 	if !ok {
-		return nil, fmt.Errorf("%w: start root %s not found", ErrInsufficientHistory, startRoot)
+		return nil, fmt.Errorf("%w: start root %s not found", sync.ErrStartRootNotFound, startRoot)
 	}
 
 	var (
@@ -189,7 +184,7 @@ func (th *trieHistory) getValueChanges(
 			if i == 0 {
 				return nil, fmt.Errorf(
 					"%w: start root %s not found before end root %s",
-					ErrInsufficientHistory, startRoot, endRoot,
+					sync.ErrStartRootNotFound, startRoot, endRoot,
 				)
 			}
 		}
@@ -331,7 +326,7 @@ func (th *trieHistory) getChangesToGetToRoot(rootID ids.ID, start maybe.Maybe[[]
 	// [lastRootChange] is the last change in the history resulting in [rootID].
 	lastRootChange, ok := th.getRootChanges(rootID)
 	if !ok {
-		return nil, ErrInsufficientHistory
+		return nil, sync.ErrStartRootNotFound
 	}
 
 	var (

--- a/x/merkledb/history_test.go
+++ b/x/merkledb/history_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/maybe"
+	"github.com/ava-labs/avalanchego/x/sync"
 )
 
 func Test_History_Simple(t *testing.T) {
@@ -197,7 +198,7 @@ func Test_History_Bad_GetValueChanges_Input(t *testing.T) {
 	require.ErrorIs(err, ErrInvalidMaxLength)
 
 	_, err = db.history.getValueChanges(root3, root2, maybe.Nothing[[]byte](), maybe.Nothing[[]byte](), 1)
-	require.ErrorIs(err, ErrInsufficientHistory)
+	require.ErrorIs(err, sync.ErrStartRootNotFound)
 
 	// Cause root1 to be removed from the history
 	batch = db.NewBatch()
@@ -205,7 +206,7 @@ func Test_History_Bad_GetValueChanges_Input(t *testing.T) {
 	require.NoError(batch.Write())
 
 	_, err = db.history.getValueChanges(root1, root3, maybe.Nothing[[]byte](), maybe.Nothing[[]byte](), 1)
-	require.ErrorIs(err, ErrInsufficientHistory)
+	require.ErrorIs(err, sync.ErrStartRootNotFound)
 
 	// same start/end roots should yield an empty changelist
 	changes, err := db.history.getValueChanges(root3, root3, maybe.Nothing[[]byte](), maybe.Nothing[[]byte](), 10)
@@ -271,7 +272,7 @@ func Test_History_Trigger_History_Queue_Looping(t *testing.T) {
 
 	// proof from first root shouldn't be generatable since it should have been removed from the history
 	_, err = db.GetRangeProofAtRoot(context.Background(), origRootID, maybe.Some([]byte("k")), maybe.Some([]byte("key3")), 10)
-	require.ErrorIs(err, ErrInsufficientHistory)
+	require.ErrorIs(err, sync.ErrStartRootNotFound)
 }
 
 func Test_History_Values_Lookup_Over_Queue_Break(t *testing.T) {

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/maybe"
+	"github.com/ava-labs/avalanchego/x/sync"
 	"github.com/ava-labs/avalanchego/x/sync/protoutils"
 
 	pb "github.com/ava-labs/avalanchego/proto/pb/sync"
@@ -30,6 +31,8 @@ var (
 	_ encoding.BinaryUnmarshaler = (*ChangeProof)(nil)
 	_ encoding.BinaryMarshaler   = (*RangeProof)(nil)
 	_ encoding.BinaryUnmarshaler = (*RangeProof)(nil)
+	_ sync.Proof                 = (*ChangeProof)(nil)
+	_ sync.Proof                 = (*RangeProof)(nil)
 
 	ErrInvalidProof                  = errors.New("proof obtained an invalid root ID")
 	ErrInvalidMaxLength              = errors.New("expected max length to be > 0")

--- a/x/merkledb/proof_test.go
+++ b/x/merkledb/proof_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/maybe"
 	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/x/sync"
 
 	pb "github.com/ava-labs/avalanchego/proto/pb/sync"
 )
@@ -820,8 +821,7 @@ func Test_ChangeProof_Missing_History_For_EndRoot(t *testing.T) {
 		maybe.Nothing[[]byte](),
 		50,
 	)
-	require.ErrorIs(err, ErrNoEndRoot)
-	require.ErrorIs(err, ErrInsufficientHistory)
+	require.ErrorIs(err, sync.ErrEndRootNotFound)
 
 	_, err = db.GetChangeProof(
 		context.Background(),
@@ -831,8 +831,7 @@ func Test_ChangeProof_Missing_History_For_EndRoot(t *testing.T) {
 		maybe.Nothing[[]byte](),
 		50,
 	)
-	require.NotErrorIs(err, ErrNoEndRoot)
-	require.ErrorIs(err, ErrInsufficientHistory)
+	require.ErrorIs(err, sync.ErrStartRootNotFound)
 
 	_, err = db.GetChangeProof(
 		context.Background(),

--- a/x/sync/db.go
+++ b/x/sync/db.go
@@ -17,17 +17,13 @@ var (
 	ErrEndRootNotFound   = errors.New("end root not found")
 )
 
-type DB[TRange, TChange Proof] interface {
+type DB[PRange Proof, PChange Proof] interface {
 	GetMerkleRoot(ctx context.Context) (ids.ID, error)
 	Clear() error
-	ChangeProofer[TChange]
-	RangeProofer[TRange]
+	ChangeProofer[PChange]
+	RangeProofer[PRange]
 }
 
-type PProof[T any] interface {
-	*T
-	Proof
-}
 type Proof interface {
 	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
@@ -57,8 +53,8 @@ type ChangeProofer[T Proof] interface {
 	//   - [start] <= [end].
 	//   - [proof] is non-empty.
 	//   - [proof] is well-formed.
-	//   - The keys in [proof] is not longer than [maxLength].
-	//   - All keys in [proof] and [proof] are in [start, end].
+	//   - The number of keys referenced by [proof] does not exceed [maxLength].
+	//   - All keys referenced by [proof] are within [start, end].
 	//     If [start] is nothing, all keys are considered > [start].
 	//     If [end] is nothing, all keys are considered < [end].
 	//   - When the changes in [proof] are applied,
@@ -96,8 +92,8 @@ type RangeProofer[T Proof] interface {
 	//   - [start] <= [end].
 	//   - [proof] is non-empty.
 	//   - [proof] is well-formed.
-	//   - The keys in [proof] is not longer than [maxLength].
-	//   - All keys in [proof] and [proof] are in [start, end].
+	//   - The number of keys referenced by [proof] does not exceed [maxLength].
+	//   - All keys referenced by [proof] are within [start, end].
 	//     If [start] is nothing, all keys are considered > [start].
 	//     If [end] is nothing, all keys are considered < [end].
 	//   - When the changes in [proof] are applied,

--- a/x/sync/db.go
+++ b/x/sync/db.go
@@ -6,17 +6,15 @@ package sync
 import (
 	"context"
 	"encoding"
+	"errors"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/maybe"
-	"github.com/ava-labs/avalanchego/x/merkledb"
 )
 
 var (
-	_ DB[*merkledb.RangeProof, *merkledb.ChangeProof] = (merkledb.MerkleDB)(nil)
-
-	_ Proof = (*merkledb.RangeProof)(nil)
-	_ Proof = (*merkledb.ChangeProof)(nil)
+	ErrStartRootNotFound = errors.New("start root not found")
+	ErrEndRootNotFound   = errors.New("end root not found")
 )
 
 type DB[TRange, TChange Proof] interface {

--- a/x/sync/db.go
+++ b/x/sync/db.go
@@ -3,12 +3,118 @@
 
 package sync
 
-import "github.com/ava-labs/avalanchego/x/merkledb"
+import (
+	"context"
+	"encoding"
 
-type DB interface {
-	merkledb.Clearer
-	merkledb.MerkleRootGetter
-	merkledb.ProofGetter
-	merkledb.ChangeProofer
-	merkledb.RangeProofer
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/maybe"
+	"github.com/ava-labs/avalanchego/x/merkledb"
+)
+
+var (
+	_ DB[*merkledb.RangeProof, *merkledb.ChangeProof] = (merkledb.MerkleDB)(nil)
+
+	_ Proof = (*merkledb.RangeProof)(nil)
+	_ Proof = (*merkledb.ChangeProof)(nil)
+)
+
+type DB[TRange, TChange Proof] interface {
+	GetMerkleRoot(ctx context.Context) (ids.ID, error)
+	Clear() error
+	ChangeProofer[TChange]
+	RangeProofer[TRange]
+}
+
+type PProof[T any] interface {
+	*T
+	Proof
+}
+type Proof interface {
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+}
+
+type ChangeProofer[T Proof] interface {
+	// GetChangeProof returns a proof for a subset of the key/value changes in key range
+	// [start, end] that occurred between [startRootID] and [endRootID].
+	// Returns at most [maxLength] key/value pairs.
+	// Returns [ErrInsufficientHistory] if this node has insufficient history
+	// to generate the proof.
+	// Returns ErrEmptyProof if [endRootID] is ids.Empty.
+	// Note that [endRootID] == ids.Empty means the trie is empty
+	// (i.e. we don't need a change proof.)
+	// Returns [ErrNoEndRoot], which wraps [ErrInsufficientHistory], if the
+	// history doesn't contain the [endRootID].
+	GetChangeProof(
+		ctx context.Context,
+		startRootID ids.ID,
+		endRootID ids.ID,
+		start maybe.Maybe[[]byte],
+		end maybe.Maybe[[]byte],
+		maxLength int,
+	) (T, error)
+
+	// Returns nil iff all the following hold:
+	//   - [start] <= [end].
+	//   - [proof] is non-empty.
+	//   - [proof] is well-formed.
+	//   - The keys in [proof] is not longer than [maxLength].
+	//   - All keys in [proof] and [proof] are in [start, end].
+	//     If [start] is nothing, all keys are considered > [start].
+	//     If [end] is nothing, all keys are considered < [end].
+	//   - When the changes in [proof] are applied,
+	//     the root ID of the database is [expectedEndRootID].
+	VerifyChangeProof(
+		ctx context.Context,
+		proof T,
+		start maybe.Maybe[[]byte],
+		end maybe.Maybe[[]byte],
+		expectedEndRootID ids.ID,
+		maxLength int,
+	) error
+
+	// CommitChangeProof commits the key/value pairs within the [proof] to the db.
+	CommitChangeProof(ctx context.Context, end maybe.Maybe[[]byte], proof T) (maybe.Maybe[[]byte], error)
+}
+
+type RangeProofer[T Proof] interface {
+	// GetRangeProofAtRoot returns a proof for the key/value pairs in this trie within the range
+	// [start, end] when the root of the trie was [rootID].
+	// If [start] is Nothing, there's no lower bound on the range.
+	// If [end] is Nothing, there's no upper bound on the range.
+	// Returns an error if [rootID] is ids.Empty.
+	// Note that [rootID] == ids.Empty means the trie is empty
+	// (i.e. we don't need a range proof.)
+	GetRangeProofAtRoot(
+		ctx context.Context,
+		rootID ids.ID,
+		start maybe.Maybe[[]byte],
+		end maybe.Maybe[[]byte],
+		maxLength int,
+	) (T, error)
+
+	// Returns nil iff all the following hold:
+	//   - [start] <= [end].
+	//   - [proof] is non-empty.
+	//   - [proof] is well-formed.
+	//   - The keys in [proof] is not longer than [maxLength].
+	//   - All keys in [proof] and [proof] are in [start, end].
+	//     If [start] is nothing, all keys are considered > [start].
+	//     If [end] is nothing, all keys are considered < [end].
+	//   - When the changes in [proof] are applied,
+	//     the root ID of the database is [expectedEndRootID].
+	VerifyRangeProof(
+		ctx context.Context,
+		proof T,
+		start maybe.Maybe[[]byte],
+		end maybe.Maybe[[]byte],
+		expectedEndRootID ids.ID,
+		maxLength int,
+	) error
+
+	// CommitRangeProof commits the key/value pairs within the [proof] to the db.
+	// [start] is the smallest possible key in the range this [proof] covers.
+	// [end] is the largest possible key in the range this [proof] covers.
+	CommitRangeProof(ctx context.Context, start, end maybe.Maybe[[]byte], proof T) (maybe.Maybe[[]byte], error)
 }

--- a/x/sync/merkledb_test/client_test.go
+++ b/x/sync/merkledb_test/client_test.go
@@ -23,7 +23,11 @@ import (
 	xsync "github.com/ava-labs/avalanchego/x/sync"
 )
 
-var _ p2p.Handler = (*flakyHandler)(nil)
+var (
+	_ p2p.Handler = (*xsync.GetChangeProofHandler[*merkledb.RangeProof, *merkledb.ChangeProof])(nil)
+	_ p2p.Handler = (*xsync.GetRangeProofHandler[*merkledb.RangeProof, *merkledb.ChangeProof])(nil)
+	_ p2p.Handler = (*flakyHandler)(nil)
+)
 
 func newDefaultDBConfig() merkledb.Config {
 	return merkledb.Config{

--- a/x/sync/merkledb_test/sync_test.go
+++ b/x/sync/merkledb_test/sync_test.go
@@ -40,13 +40,16 @@ func Test_Creation(t *testing.T) {
 	require.NoError(err)
 
 	ctx := context.Background()
-	syncer, err := xsync.NewManager(xsync.ManagerConfig{
-		DB:                    db,
-		RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetRangeProofHandler(db)),
-		ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(db)),
-		SimultaneousWorkLimit: 5,
-		Log:                   logging.NoLog{},
-	}, prometheus.NewRegistry())
+	syncer, err := xsync.NewManager(
+		db,
+		xsync.ManagerConfig{
+			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetRangeProofHandler(db)),
+			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(db)),
+			SimultaneousWorkLimit: 5,
+			Log:                   logging.NoLog{},
+		},
+		prometheus.NewRegistry(),
+	)
 	require.NoError(err)
 	require.NotNil(syncer)
 	require.NoError(syncer.Start(context.Background()))
@@ -718,14 +721,17 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 				changeProofClient = tt.changeProofClient(dbToSync)
 			}
 
-			syncer, err := xsync.NewManager(xsync.ManagerConfig{
-				DB:                    db,
-				RangeProofClient:      rangeProofClient,
-				ChangeProofClient:     changeProofClient,
-				TargetRoot:            syncRoot,
-				SimultaneousWorkLimit: 5,
-				Log:                   logging.NoLog{},
-			}, prometheus.NewRegistry())
+			syncer, err := xsync.NewManager(
+				db,
+				xsync.ManagerConfig{
+					RangeProofClient:      rangeProofClient,
+					ChangeProofClient:     changeProofClient,
+					TargetRoot:            syncRoot,
+					SimultaneousWorkLimit: 5,
+					Log:                   logging.NoLog{},
+				},
+				prometheus.NewRegistry(),
+			)
 
 			require.NoError(err)
 			require.NotNil(syncer)
@@ -790,14 +796,17 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 
 	ctx := context.Background()
 	cancelCtx, cancel := context.WithCancel(ctx)
-	syncer, err := xsync.NewManager(xsync.ManagerConfig{
-		DB:                    db,
-		RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, newRangeProofHandlerCancel(dbToSync, cancel)),
-		ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
-		TargetRoot:            syncRoot,
-		SimultaneousWorkLimit: 5,
-		Log:                   logging.NoLog{},
-	}, prometheus.NewRegistry())
+	syncer, err := xsync.NewManager(
+		db,
+		xsync.ManagerConfig{
+			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, newRangeProofHandlerCancel(dbToSync, cancel)),
+			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
+			TargetRoot:            syncRoot,
+			SimultaneousWorkLimit: 5,
+			Log:                   logging.NoLog{},
+		},
+		prometheus.NewRegistry(),
+	)
 	require.NoError(err)
 	require.NotNil(syncer)
 
@@ -807,14 +816,17 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 	require.ErrorIs(err, context.Canceled)
 	syncer.Close()
 
-	newSyncer, err := xsync.NewManager(xsync.ManagerConfig{
-		DB:                    db,
-		RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetRangeProofHandler(dbToSync)),
-		ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
-		TargetRoot:            syncRoot,
-		SimultaneousWorkLimit: 5,
-		Log:                   logging.NoLog{},
-	}, prometheus.NewRegistry())
+	newSyncer, err := xsync.NewManager(
+		db,
+		xsync.ManagerConfig{
+			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetRangeProofHandler(dbToSync)),
+			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
+			TargetRoot:            syncRoot,
+			SimultaneousWorkLimit: 5,
+			Log:                   logging.NoLog{},
+		},
+		prometheus.NewRegistry(),
+	)
 	require.NoError(err)
 	require.NotNil(newSyncer)
 
@@ -854,14 +866,17 @@ func Test_Sync_UpdateSyncTarget(t *testing.T) {
 	require.NoError(err)
 
 	rangeProofHandler := newRangeProofHandlerCancel(dbToSync, func() {})
-	m, err := xsync.NewManager(xsync.ManagerConfig{
-		DB:                    db,
-		RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, rangeProofHandler),
-		ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
-		TargetRoot:            root1,
-		SimultaneousWorkLimit: 5,
-		Log:                   logging.NoLog{},
-	}, prometheus.NewRegistry())
+	m, err := xsync.NewManager(
+		db,
+		xsync.ManagerConfig{
+			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, rangeProofHandler),
+			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
+			TargetRoot:            root1,
+			SimultaneousWorkLimit: 5,
+			Log:                   logging.NoLog{},
+		},
+		prometheus.NewRegistry(),
+	)
 	require.NoError(err)
 
 	// Update sync target on first request

--- a/x/sync/merkledb_test/sync_test.go
+++ b/x/sync/merkledb_test/sync_test.go
@@ -42,7 +42,7 @@ func Test_Creation(t *testing.T) {
 	ctx := context.Background()
 	syncer, err := xsync.NewManager(
 		db,
-		xsync.ManagerConfig{
+		xsync.ManagerConfig[*merkledb.RangeProof, *merkledb.ChangeProof]{
 			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetRangeProofHandler(db)),
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(db)),
 			SimultaneousWorkLimit: 5,
@@ -723,7 +723,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 
 			syncer, err := xsync.NewManager(
 				db,
-				xsync.ManagerConfig{
+				xsync.ManagerConfig[*merkledb.RangeProof, *merkledb.ChangeProof]{
 					RangeProofClient:      rangeProofClient,
 					ChangeProofClient:     changeProofClient,
 					TargetRoot:            syncRoot,
@@ -798,7 +798,7 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	syncer, err := xsync.NewManager(
 		db,
-		xsync.ManagerConfig{
+		xsync.ManagerConfig[*merkledb.RangeProof, *merkledb.ChangeProof]{
 			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, newRangeProofHandlerCancel(dbToSync, cancel)),
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
 			TargetRoot:            syncRoot,
@@ -818,7 +818,7 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 
 	newSyncer, err := xsync.NewManager(
 		db,
-		xsync.ManagerConfig{
+		xsync.ManagerConfig[*merkledb.RangeProof, *merkledb.ChangeProof]{
 			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetRangeProofHandler(dbToSync)),
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
 			TargetRoot:            syncRoot,
@@ -868,7 +868,7 @@ func Test_Sync_UpdateSyncTarget(t *testing.T) {
 	rangeProofHandler := newRangeProofHandlerCancel(dbToSync, func() {})
 	m, err := xsync.NewManager(
 		db,
-		xsync.ManagerConfig{
+		xsync.ManagerConfig[*merkledb.RangeProof, *merkledb.ChangeProof]{
 			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, rangeProofHandler),
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, xsync.NewGetChangeProofHandler(dbToSync)),
 			TargetRoot:            root1,

--- a/x/sync/network_server.go
+++ b/x/sync/network_server.go
@@ -102,10 +102,6 @@ func (g *GetChangeProofHandler[TRange, TChange]) AppRequest(ctx context.Context,
 	for keyLimit > 0 {
 		changeProof, err := g.db.GetChangeProof(ctx, startRoot, endRoot, start, end, int(keyLimit))
 		if err != nil {
-			if errors.Is(err, ErrEndRootNotFound) {
-				// We don't have the end root. Drop the request.
-				return nil, nil
-			}
 			if !errors.Is(err, ErrStartRootNotFound) {
 				// We should only fail to get a change proof if we have insufficient history.
 				// Other errors are unexpected.

--- a/x/sync/network_server.go
+++ b/x/sync/network_server.go
@@ -46,23 +46,23 @@ var (
 	errInvalidBounds        = errors.New("start key is greater than end key")
 	errInvalidRootHash      = fmt.Errorf("root hash must have length %d", hashing.HashLen)
 
-	_ p2p.Handler = (*GetChangeProofHandler)(nil)
-	_ p2p.Handler = (*GetRangeProofHandler)(nil)
+	_ p2p.Handler = (*GetChangeProofHandler[*merkledb.RangeProof, *merkledb.ChangeProof])(nil)
+	_ p2p.Handler = (*GetRangeProofHandler[*merkledb.RangeProof, *merkledb.ChangeProof])(nil)
 )
 
-func NewGetChangeProofHandler(db DB) *GetChangeProofHandler {
-	return &GetChangeProofHandler{
+func NewGetChangeProofHandler[TRange, TChange Proof](db DB[TRange, TChange]) *GetChangeProofHandler[TRange, TChange] {
+	return &GetChangeProofHandler[TRange, TChange]{
 		db: db,
 	}
 }
 
-type GetChangeProofHandler struct {
-	db DB
+type GetChangeProofHandler[TRange, TChange Proof] struct {
+	db DB[TRange, TChange]
 }
 
-func (*GetChangeProofHandler) AppGossip(context.Context, ids.NodeID, []byte) {}
+func (*GetChangeProofHandler[TRange, TChange]) AppGossip(context.Context, ids.NodeID, []byte) {}
 
-func (g *GetChangeProofHandler) AppRequest(ctx context.Context, _ ids.NodeID, _ time.Time, requestBytes []byte) ([]byte, *common.AppError) {
+func (g *GetChangeProofHandler[TRange, TChange]) AppRequest(ctx context.Context, _ ids.NodeID, _ time.Time, requestBytes []byte) ([]byte, *common.AppError) {
 	req := &pb.GetChangeProofRequest{}
 	if err := proto.Unmarshal(requestBytes, req); err != nil {
 		return nil, &common.AppError{
@@ -135,7 +135,7 @@ func (g *GetChangeProofHandler) AppRequest(ctx context.Context, _ ids.NodeID, _ 
 					KeyLimit:   req.KeyLimit,
 					BytesLimit: req.BytesLimit,
 				},
-				func(rangeProof *merkledb.RangeProof) ([]byte, error) {
+				func(rangeProof TRange) ([]byte, error) {
 					proofBytes, err := rangeProof.MarshalBinary()
 					if err != nil {
 						return nil, err
@@ -183,7 +183,7 @@ func (g *GetChangeProofHandler) AppRequest(ctx context.Context, _ ids.NodeID, _ 
 		}
 
 		// The proof was too large. Try to shrink it.
-		keyLimit = uint32(len(changeProof.KeyChanges)) / 2
+		keyLimit /= 2
 	}
 
 	return nil, &common.AppError{
@@ -192,19 +192,19 @@ func (g *GetChangeProofHandler) AppRequest(ctx context.Context, _ ids.NodeID, _ 
 	}
 }
 
-func NewGetRangeProofHandler(db DB) *GetRangeProofHandler {
-	return &GetRangeProofHandler{
+func NewGetRangeProofHandler[TRange, TChange Proof](db DB[TRange, TChange]) *GetRangeProofHandler[TRange, TChange] {
+	return &GetRangeProofHandler[TRange, TChange]{
 		db: db,
 	}
 }
 
-type GetRangeProofHandler struct {
-	db DB
+type GetRangeProofHandler[TRange, TChange Proof] struct {
+	db DB[TRange, TChange]
 }
 
-func (*GetRangeProofHandler) AppGossip(context.Context, ids.NodeID, []byte) {}
+func (*GetRangeProofHandler[_, _]) AppGossip(context.Context, ids.NodeID, []byte) {}
 
-func (g *GetRangeProofHandler) AppRequest(ctx context.Context, _ ids.NodeID, _ time.Time, requestBytes []byte) ([]byte, *common.AppError) {
+func (g *GetRangeProofHandler[TRange, TChange]) AppRequest(ctx context.Context, _ ids.NodeID, _ time.Time, requestBytes []byte) ([]byte, *common.AppError) {
 	req := &pb.GetRangeProofRequest{}
 	if err := proto.Unmarshal(requestBytes, req); err != nil {
 		return nil, &common.AppError{
@@ -228,7 +228,7 @@ func (g *GetRangeProofHandler) AppRequest(ctx context.Context, _ ids.NodeID, _ t
 		ctx,
 		g.db,
 		req,
-		func(rangeProof *merkledb.RangeProof) ([]byte, error) {
+		func(rangeProof TRange) ([]byte, error) {
 			return rangeProof.MarshalBinary()
 		},
 	)
@@ -250,11 +250,11 @@ func (g *GetRangeProofHandler) AppRequest(ctx context.Context, _ ids.NodeID, _ t
 // If no sufficiently small proof can be generated, returns [ErrMinProofSizeIsTooLarge].
 // TODO improve range proof generation so we don't need to iteratively
 // reduce the key limit.
-func getRangeProof(
+func getRangeProof[TRange, TChange Proof](
 	ctx context.Context,
-	db DB,
+	db DB[TRange, TChange],
 	req *pb.GetRangeProofRequest,
-	marshalFunc func(*merkledb.RangeProof) ([]byte, error),
+	marshalFunc func(TRange) ([]byte, error),
 ) ([]byte, error) {
 	root, err := ids.ToID(req.RootHash)
 	if err != nil {
@@ -288,7 +288,7 @@ func getRangeProof(
 		}
 
 		// The proof was too large. Try to shrink it.
-		keyLimit = len(rangeProof.KeyChanges) / 2
+		keyLimit /= 2
 	}
 	return nil, ErrMinProofSizeIsTooLarge
 }


### PR DESCRIPTION
## Why this should be merged
Simplifies integration of generics in x/sync.

## How this works

- Reduce from 4 type params to 2: `Manager[PRange Proof, PChange Proof]`.
- ManagerConfig is now generic: `ManagerConfig[PRange, PChange]`.
- If `NewRangeProof/NewChangeProof` are nil, default to zero-value constructors.
- Callers can still inject factories for pooling/preallocation support.
- Extract helpers: unmarshalVerifyCommitRangeWithBounds`, `unmarshalVerifyCommitChange`.
- Handlers call helpers, reducing duplication and clarifying flow.
- Tighten DB interface generics: `DB[PRange Proof, PChange Proof]`.

## How this was tested
existing UT

## Need to be documented in RELEASES.md?
no

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)