### PR TITLE
Handle ACP176 excess overflow during scaling

### DIFF
--- a/vms/evm/acp176/acp176.go
+++ b/vms/evm/acp176/acp176.go
@@ -208,6 +208,9 @@ func scaleExcess(
 
 	bigTarget.SetUint64(uint64(previousTargetPerSecond))
 	bigExcess.Div(&bigExcess, &bigTarget)
+	if !bigExcess.IsUint64() {
+		return math.MaxUint64
+	}
 	return gas.Gas(bigExcess.Uint64())
 }
 

--- a/vms/evm/acp176/acp176_test.go
+++ b/vms/evm/acp176/acp176_test.go
@@ -595,6 +595,24 @@ var (
 				TargetExcess: maxTargetExcess - MaxTargetExcessDiff,
 			},
 		},
+		{
+			name: "overflow_excess",
+			initial: State{
+				Gas: gas.State{
+					Capacity: math.MaxUint64,
+					Excess:   math.MaxUint64,
+				},
+				TargetExcess: maxTargetExcess - MaxTargetExcessDiff,
+			},
+			desiredTargetExcess: maxTargetExcess,
+			expected: State{
+				Gas: gas.State{
+					Capacity: math.MaxUint64,
+					Excess:   math.MaxUint64,
+				},
+				TargetExcess: maxTargetExcess,
+			},
+		},
 	}
 	parseTests = []struct {
 		name        string


### PR DESCRIPTION
## Why this should be merged

While this can't happen on the C-chain (an excess can never get close to this value), it may be possible to happen in the future depending on the fee manager precompile in subnet-evm.

## How this works

Clamps excess to avoid overflow.

## How this was tested

Added a regression test

## Need to be documented in RELEASES.md?

no