### PR TITLE
Add initial EVM codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@
 /tests/ @joshua-kim @maru-ava
 /tests/*.md @joshua-kim @maru-ava @meaghanfitzgerald
 /tests/reexecute/ @aaronbuchwald
+/vms/evm/ @ARR4N @joshua-kim @StephenButtolph
 /x/blockdb @DracoLi
 /x/merkledb @joshua-kim @rrazvan1
 /x/sync @joshua-kim @rrazvan1


### PR DESCRIPTION
## Why this should be merged

Reduces review burden on me.

## How this works

Adds josh (as he has already been acting as a codeowner of this folder) and arran as owners.

## How this was tested

ci

## Need to be documented in RELEASES.md?

no