### PR TITLE
[ci]  Disable monitoring checks for grafana cloud migration

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -82,8 +82,9 @@ runs:
         TMPNET_START_METRICS_COLLECTOR: ${{ inputs.prometheus_username != '' }}
         # Skip local log collection when nodes are running in kube since collection will occur in-cluster.
         TMPNET_START_LOGS_COLLECTOR: ${{ inputs.loki_username != '' && inputs.runtime == 'process' }}
-        TMPNET_CHECK_METRICS_COLLECTED: ${{ inputs.prometheus_username != '' }}
-        TMPNET_CHECK_LOGS_COLLECTED: ${{ inputs.loki_username != '' }}
+        # TODO(marun) Re-enable these checks as part of a PR updating the metrics links
+        # TMPNET_CHECK_METRICS_COLLECTED: ${{ inputs.prometheus_username != '' }}
+        # TMPNET_CHECK_LOGS_COLLECTED: ${{ inputs.loki_username != '' }}
         LOKI_URL: ${{ inputs.loki_url }}
         LOKI_PUSH_URL: ${{ inputs.loki_push_url }}
         LOKI_USERNAME: ${{ inputs.loki_username }}

--- a/tests/reexecute/c/vm_reexecute.go
+++ b/tests/reexecute/c/vm_reexecute.go
@@ -490,7 +490,8 @@ func startCollector(tc tests.TestContext, name string, labels map[string]string,
 		}(),
 		)
 
-		r.NoError(tmpnet.CheckMetricsExist(tc.DefaultContext(), logger, networkUUID))
+		// TODO(marun) Re-enable this check as part of a PR updating the metrics links
+		// r.NoError(tmpnet.CheckMetricsExist(tc.DefaultContext(), logger, networkUUID))
 	})
 
 	sdConfigFilePath, err := tmpnet.WritePrometheusSDConfig(name, tmpnet.SDConfig{


### PR DESCRIPTION
## Why this should be merged

Disabling checks for metric and log collection avoids breaking CI during the migration to grafana cloud. These checks will be reenabled by #4299.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A