### PR TITLE
ACP-226: add initial delay excess

### DIFF
--- a/vms/evm/acp226/acp226.go
+++ b/vms/evm/acp226/acp226.go
@@ -21,9 +21,9 @@ const (
 	// MaxDelayExcessDiff (Q) is the maximum change in excess per update
 	MaxDelayExcessDiff = 200
 
-	// DefaultDelayExcess represents the initial (≈2000ms) delay excess.
+	// InitialDelayExcess represents the initial (≈2000ms) delay excess.
 	// Formula: ConversionRate (2^20) * ln(2000) + 1
-	DefaultDelayExcess = 7_970_124
+	InitialDelayExcess = 7_970_124
 
 	maxDelayExcess = 46_516_320 // ConversionRate * ln(MaxUint64 / MinDelayMilliseconds) + 1
 )

--- a/vms/evm/acp226/acp226.go
+++ b/vms/evm/acp226/acp226.go
@@ -21,6 +21,8 @@ const (
 	// MaxDelayExcessDiff (Q) is the maximum change in excess per update
 	MaxDelayExcessDiff = 200
 
+	DefaultDelayExcess = 7_970_124
+
 	maxDelayExcess = 46_516_320 // ConversionRate * ln(MaxUint64 / MinDelayMilliseconds) + 1
 )
 

--- a/vms/evm/acp226/acp226.go
+++ b/vms/evm/acp226/acp226.go
@@ -21,6 +21,8 @@ const (
 	// MaxDelayExcessDiff (Q) is the maximum change in excess per update
 	MaxDelayExcessDiff = 200
 
+	// DefaultDelayExcess represents the initial (≈2000ms) delay excess.
+	// Formula: ConversionRate (2^20) * ln(2000) + 1
 	DefaultDelayExcess = 7_970_124
 
 	maxDelayExcess = 46_516_320 // ConversionRate * ln(MaxUint64 / MinDelayMilliseconds) + 1

--- a/vms/evm/acp226/acp226_test.go
+++ b/vms/evm/acp226/acp226_test.go
@@ -49,8 +49,8 @@ var (
 			delay:  1000,
 		},
 		{
-			name:   "2000ms_delay",
-			excess: 7_970_124, // ConversionRate (2^20) * ln(2000) + 1
+			name:   "2000ms_delay_default",
+			excess: DefaultDelayExcess, // ConversionRate (2^20) * ln(2000) + 1
 			delay:  2000,
 		},
 		{

--- a/vms/evm/acp226/acp226_test.go
+++ b/vms/evm/acp226/acp226_test.go
@@ -50,7 +50,7 @@ var (
 		},
 		{
 			name:   "2000ms_delay_default",
-			excess: DefaultDelayExcess, // ConversionRate (2^20) * ln(2000) + 1
+			excess: InitialDelayExcess, // ConversionRate (2^20) * ln(2000) + 1
 			delay:  2000,
 		},
 		{

--- a/vms/evm/acp226/acp226_test.go
+++ b/vms/evm/acp226/acp226_test.go
@@ -49,7 +49,7 @@ var (
 			delay:  1000,
 		},
 		{
-			name:   "2000ms_delay_default",
+			name:   "2000ms_delay_initial",
 			excess: InitialDelayExcess, // ConversionRate (2^20) * ln(2000) + 1
 			delay:  2000,
 		},


### PR DESCRIPTION
## Why this should be merged

Adds default delay excess as 7_970_124 (~2000ms delay)

## How this works

adds the default constant

## How this was tested

changed the test with constant

## Need to be documented in RELEASES.md?'


no
