### PR TITLE
replace acp176 package with the one in avalanchego

### DIFF
--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ava-labs/coreth/plugin/evm/upgrade/acp176"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/cortina"
 	"github.com/ava-labs/libevm/accounts/abi"
 	"github.com/ava-labs/libevm/common"
@@ -21,6 +20,7 @@ import (
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/vms/evm/acp176"
 )
 
 // This test uses the compiled bytecode for `consume_gas.sol` as well as its ABI


### PR DESCRIPTION
## Why this should be merged

We have moved acp176 to avalanchego previously but e2e still depends on coreth (which soon to be removed as well)

## How this works

uses avalanchego acp176 package

## How this was tested

e2e tests 

## Need to be documented in RELEASES.md?

no
