### PR TITLE
Remove comment/fail on benchmark perf alerts

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -104,9 +104,7 @@ runs:
       with:
         tool: 'go'
         output-file-path: ${{ env.BENCHMARK_OUTPUT_FILE }}
-        fail-on-alert: true
         summary-always: true
-        comment-on-alert: true
         github-token: ${{ inputs.github-token }}
         auto-push: ${{ inputs.push-github-action-benchmark }}
 


### PR DESCRIPTION
This PR removes the comment/failure on alerts for the re-execution benchmarks.

The golang tool defaults to treat smaller as better to match the `ns/op` default. The alternative is to use `customBiggerIsBetter` or `customSmallerIsBetter` options, which are minimally documented in GitHub Action Benchmark and require transforming the benchmark results into an undocumented JSON output.

For now, we simply remove the alerts, which were misconfigured to treat a performance improvement as degradation and triggered for the first time after an outlier showed ~50mgas/s whereas we normally see > 100mgas/s in these benchmarks. 