### PR TITLE
Move task args to cli instead of run_env

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -81,7 +81,8 @@ runs:
     - name: Run C-Chain Re-Execution
       uses: ./.github/actions/run-monitored-tmpnet-cmd
       with:
-        run_env: |
+        run: |
+          ./scripts/run_task.sh reexecute-cchain-range-with-copied-data
             CONFIG=${{ inputs.config }} \
             EXECUTION_DATA_DIR=${{ env.EXECUTION_DATA_DIR }} \
             BLOCK_DIR_SRC=${{ env.BLOCK_DIR_SRC }} \
@@ -92,7 +93,6 @@ runs:
             BENCHMARK_OUTPUT_FILE=${{ env.BENCHMARK_OUTPUT_FILE }} \
             RUNNER_NAME=${{ inputs.runner_name }} \
             METRICS_ENABLED=true
-        run: ./scripts/run_task.sh reexecute-cchain-range-with-copied-data
         prometheus_push_url: ${{ inputs.prometheus-push-url }}
         prometheus_username: ${{ inputs.prometheus-username }}
         prometheus_password: ${{ inputs.prometheus-password }}

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -82,7 +82,7 @@ runs:
       uses: ./.github/actions/run-monitored-tmpnet-cmd
       with:
         run: |
-          ./scripts/run_task.sh reexecute-cchain-range-with-copied-data
+          ./scripts/run_task.sh reexecute-cchain-range-with-copied-data \
             CONFIG=${{ inputs.config }} \
             EXECUTION_DATA_DIR=${{ env.EXECUTION_DATA_DIR }} \
             BLOCK_DIR_SRC=${{ env.BLOCK_DIR_SRC }} \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -220,7 +220,7 @@ tasks:
       BLOCK_DIR_SRC: '{{.BLOCK_DIR_SRC | default "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**"}}'
       CURRENT_STATE_DIR_SRC: '{{.CURRENT_STATE_DIR_SRC | default "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**"}}'
       RUNNER_NAME: '{{.RUNNER_NAME | default "dev"}}'
-      CONFIG: '{{.CONFIG }}'
+      CONFIG: '{{.CONFIG | default ""}}'
       START_BLOCK: '{{.START_BLOCK | default "101"}}'
       END_BLOCK: '{{.END_BLOCK | default "250000"}}'
       LABELS: '{{.LABELS | default ""}}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -220,7 +220,7 @@ tasks:
       BLOCK_DIR_SRC: '{{.BLOCK_DIR_SRC | default "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**"}}'
       CURRENT_STATE_DIR_SRC: '{{.CURRENT_STATE_DIR_SRC | default "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**"}}'
       RUNNER_NAME: '{{.RUNNER_NAME | default "dev"}}'
-      CONFIG: '{{.CONFIG | default ""}}'
+      CONFIG: '{{.CONFIG }}'
       START_BLOCK: '{{.START_BLOCK | default "101"}}'
       END_BLOCK: '{{.END_BLOCK | default "250000"}}'
       LABELS: '{{.LABELS | default ""}}'


### PR DESCRIPTION
This PR removes the usage of `run_env` from the re-execution benchmarks, which did not pass task arguments correctly with nix.