### PR TITLE
Fix array type check in reflect codec

### DIFF
--- a/codec/reflectcodec/type_codec.go
+++ b/codec/reflectcodec/type_codec.go
@@ -398,9 +398,8 @@ func (c *genericCodec) marshal(
 		}
 		return nil
 	case reflect.Array:
-		if elemKind := value.Type().Kind(); elemKind == reflect.Uint8 {
-			sliceVal := value.Convert(reflect.TypeOf([]byte{}))
-			p.PackFixedBytes(sliceVal.Bytes())
+		if value.CanAddr() && value.Type().Elem().Kind() == reflect.Uint8 {
+			p.PackFixedBytes(value.Bytes())
 			return p.Err
 		}
 		numElts := value.Len()


### PR DESCRIPTION
## Why this should be merged

This optimization enables faster marshaling.

## How this works

Currently the optimization is never actually triggered. `value.Type().Kind()` always reports `Array`. We had intended to get the type of the element of the array (which we do when handling slices and other instances of arrays.

`value.CanAddr()` is required because calling `.Bytes()` on a non-addressable array panics.

## How this was tested

Existing unit tests (I also verified that the new code is hit by looking at coverage).

## Need to be documented in RELEASES.md?
