### PR TITLE
Consolidate scheduled runs

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
@@ -35,29 +35,11 @@
             {
                 "runner": "blacksmith-4vcpu-ubuntu-2404",
                 "config": "default",
-                "start-block": 101,
-                "end-block": 250000,
-                "block-dir-src": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**",
-                "current-state-dir-src": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**",
-                "timeout-minutes": 30
-            },
-            {
-                "runner": "blacksmith-4vcpu-ubuntu-2404",
-                "config": "archive",
-                "start-block": 101,
-                "end-block": 250000,
-                "block-dir-src": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**",
-                "current-state-dir-src": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-archive-100/**",
-                "timeout-minutes": 30
-            },
-            {
-                "runner": "blacksmith-4vcpu-ubuntu-2404",
-                "config": "firewood",
-                "start-block": 101,
-                "end-block": 250000,
-                "block-dir-src": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**",
-                "current-state-dir-src": "s3://avalanchego-bootstrap-testing/cchain-current-state-firewood-100/**",
-                "timeout-minutes": 30
+                "start-block": 33000001,
+                "end-block": 33500000,
+                "block-dir-src": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-30m-40m-ldb/**",
+                "current-state-dir-src": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-33m/**",
+                "timeout-minutes": 1440
             }
         ]
     }


### PR DESCRIPTION
This PR consolidates the benchmark cronjobs to run a single job with the default config on Blacksmith using the range (33m, 33.5m].