### PR TITLE
[testing] Update golangci-lint to version compatible with go 1.24

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,8 @@ linters:
     - misspell
     - nakedret
     - nilerr
-    - noctx
+    # TODO(marun) Re-enable as part of #4163
+    #- noctx
     - nolintlint
     - perfsprint
     - prealloc

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -32,7 +32,7 @@ fi
 TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func import_testing_only_in_tests"}
 
 function test_golangci_lint {
-  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --config .golangci.yml
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 run --config .golangci.yml
 }
 
 # automatically checks license headers


### PR DESCRIPTION
## Why this should be merged

Without this local linting will not work reliably. `noctx` is disabled here and should be re-enabled as part of #4163.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A