### PR TITLE
Add test-unit-fast task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -369,6 +369,13 @@ tasks:
     # Invoking with bash ensures compatibility with CI execution on Windows
     cmd: bash ./scripts/build_test.sh
 
+  test-unit-fast:
+    desc: Runs unit tests
+    env:
+      NO_SHUFFLE: TRUE # Allows caching
+      NO_RACE: TRUE    # Tests are much faster without race detection
+    cmd: bash ./scripts/build_test.sh
+
   test-upgrade:
     desc: Runs upgrade tests
     cmds:

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -7,6 +7,18 @@ AVALANCHE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Load the constants
 source "$AVALANCHE_PATH"/scripts/constants.sh
 
+# Run the tests with shuffling unless NO_SHUFFLE is set.
+shuffle="-shuffle=on"
+if [[ -n "${NO_SHUFFLE:-}" ]]; then
+    shuffle=""
+fi
+
+# Run the tests with race detection unless NO_RACE is set.
+race="-race"
+if [[ -n "${NO_RACE:-}" ]]; then
+    race=""
+fi
+
 EXCLUDED_TARGETS="| grep -v /mocks | grep -v proto | grep -v tests/e2e | grep -v tests/load/c | grep -v tests/upgrade | grep -v tests/fixture/bootstrapmonitor/e2e | grep -v tests/reexecute"
 
 if [[ "$(go env GOOS)" == "windows" ]]; then
@@ -18,4 +30,4 @@ fi
 TEST_TARGETS="$(eval "go list ./... ${EXCLUDED_TARGETS}")"
 
 # shellcheck disable=SC2086
-go test -tags test -shuffle=on -race -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}
+go test -tags test ${shuffle:-} ${race:-} -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}


### PR DESCRIPTION
## Why this should be merged

```sh
time task test-unit
```

reports:
```
task test-unit  322.95s user 113.78s system 401% cpu 1:48.80 total
```

```sh
time task test-unit-fast
```

reports:
```
task test-unit-fast  30.95s user 63.20s system 732% cpu 12.848 total
```

aka almost 2m to run the unit tests replaced with about 13s.

## How this works

Adds a task to run the unit tests with:
- Race detection disabled (much faster)
- Shuffling disabled (allows the test runs to be cached)

## How this was tested

Locally

## Need to be documented in RELEASES.md?

no