### PR TITLE
uplift: add `customlogs` package from evm repositories

### DIFF
--- a/vms/evm/customlogs/log_ext.go
+++ b/vms/evm/customlogs/log_ext.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package customlogs
+
+import ethtypes "github.com/ava-labs/libevm/core/types"
+
+// FlattenLogs converts a nested array of logs to a single array of logs.
+func FlattenLogs(list [][]*ethtypes.Log) []*ethtypes.Log {
+	var flat []*ethtypes.Log
+	for _, logs := range list {
+		flat = append(flat, logs...)
+	}
+	return flat
+}


### PR DESCRIPTION
## Why this should be merged
There are packages in subnet-evm and coreth that share a lot of functionality / are mirrored. As has been discussed as an evm team wide effort, we are working to uplift these packages to AvalancheGo to prevent the duplicative maintenance of two sets of the same code. This particular package, `customlogs` is a relatively easy lift. 

## How this was tested
This is currently 'dead' code; after a new AvalancheGo release is dropped, we can use the code in the evm repositories. 

## Need to be documented in RELEASES.md?
No