### PR TITLE
Remove UptimeManager#IsConnected

### DIFF
--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -160,6 +160,13 @@ func (p *Peers) Disconnected(nodeID ids.NodeID) {
 	p.set.Remove(nodeID)
 }
 
+func (p *Peers) Has(nodeID ids.NodeID) bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.set.Contains(nodeID)
+}
+
 // Sample returns a pseudo-random sample of up to limit Peers
 func (p *Peers) Sample(limit int) []ids.NodeID {
 	p.lock.RLock()

--- a/network/p2p/network_test.go
+++ b/network/p2p/network_test.go
@@ -983,3 +983,20 @@ func TestNetworkValidators_ConnectAndDisconnect(t *testing.T) {
 		})
 	}
 }
+
+func TestPeers_Has(t *testing.T) {
+	require := require.New(t)
+
+	peers := &Peers{}
+	network, err := NewNetwork(
+		logging.NoLog{},
+		&enginetest.Sender{},
+		prometheus.NewRegistry(),
+		"",
+		peers,
+	)
+	require.NoError(err)
+	require.NoError(network.Connected(context.Background(), ids.EmptyNodeID, nil))
+
+	require.True(peers.Has(ids.EmptyNodeID))
+}

--- a/snow/uptime/manager.go
+++ b/snow/uptime/manager.go
@@ -30,7 +30,6 @@ type Tracker interface {
 	StartedTracking() bool
 
 	Connect(nodeID ids.NodeID) error
-	IsConnected(nodeID ids.NodeID) bool
 	Disconnect(nodeID ids.NodeID) error
 }
 

--- a/snow/uptime/manager_test.go
+++ b/snow/uptime/manager_test.go
@@ -230,13 +230,7 @@ func TestConnectAndDisconnect(t *testing.T) {
 
 	s.AddNode(nodeID0, startTime)
 
-	connected := up.IsConnected(nodeID0)
-	require.False(connected)
-
 	require.NoError(up.StartTracking([]ids.NodeID{nodeID0}))
-
-	connected = up.IsConnected(nodeID0)
-	require.False(connected)
 
 	duration, lastUpdated, err := up.CalculateUptime(nodeID0)
 	require.NoError(err)
@@ -244,9 +238,6 @@ func TestConnectAndDisconnect(t *testing.T) {
 	require.Equal(clk.UnixTime(), lastUpdated)
 
 	require.NoError(up.Connect(nodeID0))
-
-	connected = up.IsConnected(nodeID0)
-	require.True(connected)
 
 	currentTime = currentTime.Add(time.Second)
 	clk.Set(currentTime)
@@ -257,9 +248,6 @@ func TestConnectAndDisconnect(t *testing.T) {
 	require.Equal(clk.UnixTime(), lastUpdated)
 
 	require.NoError(up.Disconnect(nodeID0))
-
-	connected = up.IsConnected(nodeID0)
-	require.False(connected)
 
 	currentTime = currentTime.Add(time.Second)
 	clk.Set(currentTime)

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -37,6 +37,7 @@ type Network struct {
 	txPushGossipFrequency time.Duration
 	txPullGossiper        gossip.Gossiper
 	txPullGossipFrequency time.Duration
+	peers                 *p2p.Peers
 }
 
 func New(
@@ -60,13 +61,14 @@ func New(
 		vdrs,
 		config.MaxValidatorSetStaleness,
 	)
-
+	peers := &p2p.Peers{}
 	p2pNetwork, err := p2p.NewNetwork(
 		log,
 		appSender,
 		registerer,
 		"p2p",
 		validators,
+		peers,
 	)
 	if err != nil {
 		return nil, err
@@ -189,6 +191,7 @@ func New(
 		txPushGossipFrequency:     config.PushGossipFrequency,
 		txPullGossiper:            txPullGossiper,
 		txPullGossipFrequency:     config.PullGossipFrequency,
+		peers:                     peers,
 	}, nil
 }
 
@@ -223,4 +226,8 @@ func (n *Network) IssueTxFromRPC(tx *txs.Tx) error {
 	}
 	n.txPushGossiper.Add(tx)
 	return nil
+}
+
+func (n *Network) Peers() *p2p.Peers {
+	return n.peers
 }

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -868,7 +868,7 @@ func (s *Service) getPrimaryOrSubnetValidators(subnetID ids.ID, nodeIDs set.Set[
 				if err != nil {
 					return nil, err
 				}
-				isConnected := s.vm.uptimeManager.IsConnected(currentStaker.NodeID)
+				isConnected := s.vm.Network.Peers().Has(currentStaker.NodeID)
 				connected = &isConnected
 				uptime = &currentUptime
 			}


### PR DESCRIPTION
## Why this should be merged

Slim down interface. Having `IsConnected` on the interface makes some edge-cases look confusing where we check for if the inner uptime manager is in-sync with us, which I'm not sure is possible or not ([ref](https://github.com/ava-labs/subnet-evm/blob/53f53056e9d161ada1ea42506b9537755018715d/plugin/evm/validators/uptime/pausable_manager.go#L40))

## How this works

Removes `IsConnected` from `UptimeManager`

## How this was tested

UT added

## Need to be documented in RELEASES.md?

No