### PR TITLE
test: add blockdb config to reexecution tests

### DIFF
--- a/tests/reexecute/c/vm_reexecute_test.go
+++ b/tests/reexecute/c/vm_reexecute_test.go
@@ -81,6 +81,9 @@ var (
 			"pruning-enabled": true,
 			"state-sync-enabled": false
 		}`,
+		"blockdb": `{
+			"block-database-enabled": true
+		}`,
 	}
 
 	configNameArg  string


### PR DESCRIPTION
## Why this should be merged

Enable running reexecution tests with blockdb enabled for workflow runs.

The config is added in https://github.com/ava-labs/coreth/pull/1189

## How this works

Enables block database for the c-chain. Block database is disabled by default.

## How this was tested

## Need to be documented in RELEASES.md?
