### PR TITLE
Granite ACP-176

### DIFF
--- a/vms/evm/acp176/acp176.go
+++ b/vms/evm/acp176/acp176.go
@@ -117,7 +117,7 @@ func (s *State) AdvanceSeconds(seconds uint64) {
 func (s *State) AdvanceMilliseconds(milliseconds uint64) {
 	targetPerSecond := s.Target()
 	targetPerMS := targetPerSecond / 1000
-	maxPerMS := mulWithUpperBound(targetPerMS, TargetToMax)            // R - this can't overflow since 1000 > TargetToMax.
+	maxPerMS := targetPerMS * TargetToMax                              // R - this can't overflow since 1000 > TargetToMax.
 	maxPerSecond := mulWithUpperBound(targetPerSecond, TargetToMax)    // rate used for calculating maxCapacity
 	maxCapacity := mulWithUpperBound(maxPerSecond, TimeToFillCapacity) // C
 	s.Gas = s.Gas.AdvanceTime(

--- a/vms/evm/acp176/acp176.go
+++ b/vms/evm/acp176/acp176.go
@@ -96,9 +96,10 @@ func (s *State) GasPrice() gas.Price {
 	return gas.CalculatePrice(MinGasPrice, s.Gas.Excess, priceUpdateConversion)
 }
 
-// AdvanceTime increases the gas capacity and decreases the gas excess based on
+// AdvanceSeconds increases the gas capacity and decreases the gas excess based on
 // the elapsed seconds.
-func (s *State) AdvanceTime(seconds uint64) {
+// This is used in Fortuna.
+func (s *State) AdvanceSeconds(seconds uint64) {
 	targetPerSecond := s.Target()
 	maxPerSecond := mulWithUpperBound(targetPerSecond, TargetToMax)    // R
 	maxCapacity := mulWithUpperBound(maxPerSecond, TimeToFillCapacity) // C
@@ -107,6 +108,23 @@ func (s *State) AdvanceTime(seconds uint64) {
 		maxPerSecond,
 		targetPerSecond,
 		seconds,
+	)
+}
+
+// AdvanceMilliseconds increases the gas capacity and decreases the gas excess based on
+// the elapsed milliseconds.
+// This is used in Granite.
+func (s *State) AdvanceMilliseconds(milliseconds uint64) {
+	targetPerSecond := s.Target()
+	targetPerMS := targetPerSecond / 1000
+	maxPerMS := mulWithUpperBound(targetPerMS, TargetToMax)            // R - this can't overflow since 1000 > TargetToMax.
+	maxPerSecond := mulWithUpperBound(targetPerSecond, TargetToMax)    // rate used for calculating maxCapacity
+	maxCapacity := mulWithUpperBound(maxPerSecond, TimeToFillCapacity) // C
+	s.Gas = s.Gas.AdvanceTime(
+		maxCapacity,
+		maxPerMS,
+		targetPerMS,
+		milliseconds,
 	)
 }
 

--- a/vms/evm/acp176/acp176_test.go
+++ b/vms/evm/acp176/acp176_test.go
@@ -317,7 +317,7 @@ var (
 			seconds: 1,
 			expected: State{
 				Gas: gas.State{
-					Capacity: 3_689_348_878_490_565_692,                        // greater than MaxUint64/10
+					Capacity: 3_689_348_878_490_565_692,                        // greater than MaxUint / TargetToMaxCapacity
 					Excess:   math.MaxUint64 - (3_689_348_878_490_565_692 / 2), // MaxUint64 - capacity / TargetToMax
 				},
 				TargetExcess: 947_688_692, // unmodified
@@ -336,8 +336,8 @@ var (
 			seconds: 1,
 			expected: State{
 				Gas: gas.State{
-					Capacity: math.MaxUint64,            // greater than MaxUint64/10
-					Excess:   9_223_371_875_007_030_354, // less than MaxUint64/2
+					Capacity: math.MaxUint64,            // greater than MaxUint / TargetToMaxCapacity
+					Excess:   9_223_371_875_007_030_354, // less than MaxUint / TargetToMax
 				},
 				TargetExcess: 1_001_692_467, // unmodified
 			},
@@ -350,7 +350,7 @@ var (
 		expected     State
 	}{
 		{
-			name: "0_seconds",
+			name: "0_ms",
 			initial: State{
 				Gas: gas.State{
 					Capacity: 0,
@@ -369,7 +369,7 @@ var (
 			},
 		},
 		{
-			name: "1_seconds",
+			name: "1000_ms",
 			initial: State{
 				Gas: gas.State{
 					Capacity: 0,
@@ -388,7 +388,7 @@ var (
 			},
 		},
 		{
-			name: "5_seconds",
+			name: "5000_ms",
 			initial: State{
 				Gas: gas.State{
 					Capacity: 0,
@@ -407,7 +407,7 @@ var (
 			},
 		},
 		{
-			name: "0_seconds_over_capacity",
+			name: "0_ms_over_capacity",
 			initial: State{
 				Gas: gas.State{
 					Capacity: 16_000_000, // Could happen if the targetExcess was modified
@@ -440,7 +440,7 @@ var (
 			milliseconds: 1000,
 			expected: State{
 				Gas: gas.State{
-					Capacity: 3_689_348_878_490_564_000,                        // greater than MaxUint64/10
+					Capacity: 3_689_348_878_490_564_000,                        // greater than MaxUint64 / TargetToMaxCapacity
 					Excess:   math.MaxUint64 - (3_689_348_878_490_564_000 / 2), // MaxUint64 - capacity / TargetToMax
 				},
 				TargetExcess: 947_688_692, // unmodified
@@ -459,8 +459,8 @@ var (
 			milliseconds: 1000,
 			expected: State{
 				Gas: gas.State{
-					Capacity: math.MaxUint64,            // greater than MaxUint64/10
-					Excess:   9_223_371_875_007_030_615, // less than MaxUint64/2
+					Capacity: math.MaxUint64,            // greater than MaxUint64 / TargetToMaxCapacity
+					Excess:   9_223_371_875_007_030_615, // less than MaxUint / TargetToMax
 				},
 				TargetExcess: 1_001_692_467, // unmodified
 			},


### PR DESCRIPTION
## Why this should be merged

Enables ava-labs/coreth#1169 - Capacity refill and gas calculations need to be adjusted to be millisecond based in granite, but keeping the same method of calculation.

Additionally, one of the old ACP-176 tests wasn't testing what it intended to after a parameter change, so the test adds additional comments to ease recalculation in the future if necessary.

## How this works

Converts TargetPerSecond to TargetPerMS (rounding down when necessary) for rate calculations based on the millisecond

## How this was tested

New UT

## Need to be documented in RELEASES.md?

No.
