### PR TITLE
refactor(metervm): remove mockable clock

### DIFF
--- a/vms/metervm/batched_vm.go
+++ b/vms/metervm/batched_vm.go
@@ -31,8 +31,7 @@ func (vm *blockVM) GetAncestors(
 		maxBlocksSize,
 		maxBlocksRetrivalTime,
 	)
-	end := time.Now()
-	vm.blockMetrics.getAncestors.Observe(float64(end.Sub(start)))
+	vm.blockMetrics.getAncestors.Observe(float64(time.Since(start)))
 	return ancestors, err
 }
 
@@ -43,8 +42,7 @@ func (vm *blockVM) BatchedParseBlock(ctx context.Context, blks [][]byte) ([]snow
 
 	start := time.Now()
 	blocks, err := vm.batchedVM.BatchedParseBlock(ctx, blks)
-	end := time.Now()
-	vm.blockMetrics.batchedParseBlock.Observe(float64(end.Sub(start)))
+	vm.blockMetrics.batchedParseBlock.Observe(float64(time.Since(start)))
 
 	wrappedBlocks := make([]snowman.Block, len(blocks))
 	for i, block := range blocks {

--- a/vms/metervm/batched_vm.go
+++ b/vms/metervm/batched_vm.go
@@ -23,7 +23,7 @@ func (vm *blockVM) GetAncestors(
 		return nil, block.ErrRemoteVMNotImplemented
 	}
 
-	start := vm.clock.Time()
+	start := time.Now()
 	ancestors, err := vm.batchedVM.GetAncestors(
 		ctx,
 		blkID,
@@ -31,7 +31,7 @@ func (vm *blockVM) GetAncestors(
 		maxBlocksSize,
 		maxBlocksRetrivalTime,
 	)
-	end := vm.clock.Time()
+	end := time.Now()
 	vm.blockMetrics.getAncestors.Observe(float64(end.Sub(start)))
 	return ancestors, err
 }
@@ -41,9 +41,9 @@ func (vm *blockVM) BatchedParseBlock(ctx context.Context, blks [][]byte) ([]snow
 		return nil, block.ErrRemoteVMNotImplemented
 	}
 
-	start := vm.clock.Time()
+	start := time.Now()
 	blocks, err := vm.batchedVM.BatchedParseBlock(ctx, blks)
-	end := vm.clock.Time()
+	end := time.Now()
 	vm.blockMetrics.batchedParseBlock.Observe(float64(end.Sub(start)))
 
 	wrappedBlocks := make([]snowman.Block, len(blocks))

--- a/vms/metervm/block.go
+++ b/vms/metervm/block.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
@@ -27,9 +28,9 @@ type meterBlock struct {
 }
 
 func (mb *meterBlock) Verify(ctx context.Context) error {
-	start := mb.vm.clock.Time()
+	start := time.Now()
 	err := mb.Block.Verify(ctx)
-	end := mb.vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	if err != nil {
 		mb.vm.blockMetrics.verifyErr.Observe(duration)
@@ -40,18 +41,18 @@ func (mb *meterBlock) Verify(ctx context.Context) error {
 }
 
 func (mb *meterBlock) Accept(ctx context.Context) error {
-	start := mb.vm.clock.Time()
+	start := time.Now()
 	err := mb.Block.Accept(ctx)
-	end := mb.vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	mb.vm.blockMetrics.accept.Observe(duration)
 	return err
 }
 
 func (mb *meterBlock) Reject(ctx context.Context) error {
-	start := mb.vm.clock.Time()
+	start := time.Now()
 	err := mb.Block.Reject(ctx)
-	end := mb.vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	mb.vm.blockMetrics.reject.Observe(duration)
 	return err
@@ -85,9 +86,9 @@ func (mb *meterBlock) ShouldVerifyWithContext(ctx context.Context) (bool, error)
 		return false, nil
 	}
 
-	start := mb.vm.clock.Time()
+	start := time.Now()
 	shouldVerify, err := blkWithCtx.ShouldVerifyWithContext(ctx)
-	end := mb.vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	mb.vm.blockMetrics.shouldVerifyWithContext.Observe(duration)
 	return shouldVerify, err
@@ -99,9 +100,9 @@ func (mb *meterBlock) VerifyWithContext(ctx context.Context, blockCtx *block.Con
 		return fmt.Errorf("%w but got %T", errExpectedBlockWithVerifyContext, mb.Block)
 	}
 
-	start := mb.vm.clock.Time()
+	start := time.Now()
 	err := blkWithCtx.VerifyWithContext(ctx, blockCtx)
-	end := mb.vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	if err != nil {
 		mb.vm.blockMetrics.verifyWithContextErr.Observe(duration)

--- a/vms/metervm/block.go
+++ b/vms/metervm/block.go
@@ -30,8 +30,7 @@ type meterBlock struct {
 func (mb *meterBlock) Verify(ctx context.Context) error {
 	start := time.Now()
 	err := mb.Block.Verify(ctx)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	if err != nil {
 		mb.vm.blockMetrics.verifyErr.Observe(duration)
 	} else {
@@ -43,8 +42,7 @@ func (mb *meterBlock) Verify(ctx context.Context) error {
 func (mb *meterBlock) Accept(ctx context.Context) error {
 	start := time.Now()
 	err := mb.Block.Accept(ctx)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	mb.vm.blockMetrics.accept.Observe(duration)
 	return err
 }
@@ -52,8 +50,7 @@ func (mb *meterBlock) Accept(ctx context.Context) error {
 func (mb *meterBlock) Reject(ctx context.Context) error {
 	start := time.Now()
 	err := mb.Block.Reject(ctx)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	mb.vm.blockMetrics.reject.Observe(duration)
 	return err
 }
@@ -88,8 +85,7 @@ func (mb *meterBlock) ShouldVerifyWithContext(ctx context.Context) (bool, error)
 
 	start := time.Now()
 	shouldVerify, err := blkWithCtx.ShouldVerifyWithContext(ctx)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	mb.vm.blockMetrics.shouldVerifyWithContext.Observe(duration)
 	return shouldVerify, err
 }
@@ -102,8 +98,7 @@ func (mb *meterBlock) VerifyWithContext(ctx context.Context, blockCtx *block.Con
 
 	start := time.Now()
 	err := blkWithCtx.VerifyWithContext(ctx, blockCtx)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	if err != nil {
 		mb.vm.blockMetrics.verifyWithContextErr.Observe(duration)
 	} else {

--- a/vms/metervm/block_vm.go
+++ b/vms/metervm/block_vm.go
@@ -76,8 +76,7 @@ func (vm *blockVM) Initialize(
 func (vm *blockVM) BuildBlock(ctx context.Context) (snowman.Block, error) {
 	start := time.Now()
 	blk, err := vm.ChainVM.BuildBlock(ctx)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	if err != nil {
 		vm.blockMetrics.buildBlockErr.Observe(duration)
 		return nil, err
@@ -92,8 +91,7 @@ func (vm *blockVM) BuildBlock(ctx context.Context) (snowman.Block, error) {
 func (vm *blockVM) ParseBlock(ctx context.Context, b []byte) (snowman.Block, error) {
 	start := time.Now()
 	blk, err := vm.ChainVM.ParseBlock(ctx, b)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	if err != nil {
 		vm.blockMetrics.parseBlockErr.Observe(duration)
 		return nil, err
@@ -108,8 +106,7 @@ func (vm *blockVM) ParseBlock(ctx context.Context, b []byte) (snowman.Block, err
 func (vm *blockVM) GetBlock(ctx context.Context, id ids.ID) (snowman.Block, error) {
 	start := time.Now()
 	blk, err := vm.ChainVM.GetBlock(ctx, id)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	if err != nil {
 		vm.blockMetrics.getBlockErr.Observe(duration)
 		return nil, err
@@ -124,23 +121,20 @@ func (vm *blockVM) GetBlock(ctx context.Context, id ids.ID) (snowman.Block, erro
 func (vm *blockVM) SetPreference(ctx context.Context, id ids.ID) error {
 	start := time.Now()
 	err := vm.ChainVM.SetPreference(ctx, id)
-	end := time.Now()
-	vm.blockMetrics.setPreference.Observe(float64(end.Sub(start)))
+	vm.blockMetrics.setPreference.Observe(float64(time.Since(start)))
 	return err
 }
 
 func (vm *blockVM) LastAccepted(ctx context.Context) (ids.ID, error) {
 	start := time.Now()
 	lastAcceptedID, err := vm.ChainVM.LastAccepted(ctx)
-	end := time.Now()
-	vm.blockMetrics.lastAccepted.Observe(float64(end.Sub(start)))
+	vm.blockMetrics.lastAccepted.Observe(float64(time.Since(start)))
 	return lastAcceptedID, err
 }
 
 func (vm *blockVM) GetBlockIDAtHeight(ctx context.Context, height uint64) (ids.ID, error) {
 	start := time.Now()
 	blockID, err := vm.ChainVM.GetBlockIDAtHeight(ctx, height)
-	end := time.Now()
-	vm.blockMetrics.getBlockIDAtHeight.Observe(float64(end.Sub(start)))
+	vm.blockMetrics.getBlockIDAtHeight.Observe(float64(time.Since(start)))
 	return blockID, err
 }

--- a/vms/metervm/block_vm.go
+++ b/vms/metervm/block_vm.go
@@ -5,6 +5,7 @@ package metervm
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 )
 
 var (
@@ -32,7 +32,6 @@ type blockVM struct {
 
 	blockMetrics
 	registry prometheus.Registerer
-	clock    mockable.Clock
 }
 
 func NewBlockVM(
@@ -75,9 +74,9 @@ func (vm *blockVM) Initialize(
 }
 
 func (vm *blockVM) BuildBlock(ctx context.Context) (snowman.Block, error) {
-	start := vm.clock.Time()
+	start := time.Now()
 	blk, err := vm.ChainVM.BuildBlock(ctx)
-	end := vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	if err != nil {
 		vm.blockMetrics.buildBlockErr.Observe(duration)
@@ -91,9 +90,9 @@ func (vm *blockVM) BuildBlock(ctx context.Context) (snowman.Block, error) {
 }
 
 func (vm *blockVM) ParseBlock(ctx context.Context, b []byte) (snowman.Block, error) {
-	start := vm.clock.Time()
+	start := time.Now()
 	blk, err := vm.ChainVM.ParseBlock(ctx, b)
-	end := vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	if err != nil {
 		vm.blockMetrics.parseBlockErr.Observe(duration)
@@ -107,9 +106,9 @@ func (vm *blockVM) ParseBlock(ctx context.Context, b []byte) (snowman.Block, err
 }
 
 func (vm *blockVM) GetBlock(ctx context.Context, id ids.ID) (snowman.Block, error) {
-	start := vm.clock.Time()
+	start := time.Now()
 	blk, err := vm.ChainVM.GetBlock(ctx, id)
-	end := vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	if err != nil {
 		vm.blockMetrics.getBlockErr.Observe(duration)
@@ -123,25 +122,25 @@ func (vm *blockVM) GetBlock(ctx context.Context, id ids.ID) (snowman.Block, erro
 }
 
 func (vm *blockVM) SetPreference(ctx context.Context, id ids.ID) error {
-	start := vm.clock.Time()
+	start := time.Now()
 	err := vm.ChainVM.SetPreference(ctx, id)
-	end := vm.clock.Time()
+	end := time.Now()
 	vm.blockMetrics.setPreference.Observe(float64(end.Sub(start)))
 	return err
 }
 
 func (vm *blockVM) LastAccepted(ctx context.Context) (ids.ID, error) {
-	start := vm.clock.Time()
+	start := time.Now()
 	lastAcceptedID, err := vm.ChainVM.LastAccepted(ctx)
-	end := vm.clock.Time()
+	end := time.Now()
 	vm.blockMetrics.lastAccepted.Observe(float64(end.Sub(start)))
 	return lastAcceptedID, err
 }
 
 func (vm *blockVM) GetBlockIDAtHeight(ctx context.Context, height uint64) (ids.ID, error) {
-	start := vm.clock.Time()
+	start := time.Now()
 	blockID, err := vm.ChainVM.GetBlockIDAtHeight(ctx, height)
-	end := vm.clock.Time()
+	end := time.Now()
 	vm.blockMetrics.getBlockIDAtHeight.Observe(float64(end.Sub(start)))
 	return blockID, err
 }

--- a/vms/metervm/build_block_with_context_vm.go
+++ b/vms/metervm/build_block_with_context_vm.go
@@ -18,8 +18,7 @@ func (vm *blockVM) BuildBlockWithContext(ctx context.Context, blockCtx *block.Co
 
 	start := time.Now()
 	blk, err := vm.buildBlockVM.BuildBlockWithContext(ctx, blockCtx)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	if err != nil {
 		vm.blockMetrics.buildBlockWithContextErr.Observe(duration)
 		return nil, err

--- a/vms/metervm/build_block_with_context_vm.go
+++ b/vms/metervm/build_block_with_context_vm.go
@@ -5,6 +5,7 @@ package metervm
 
 import (
 	"context"
+	"time"
 
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
@@ -15,9 +16,9 @@ func (vm *blockVM) BuildBlockWithContext(ctx context.Context, blockCtx *block.Co
 		return vm.BuildBlock(ctx)
 	}
 
-	start := vm.clock.Time()
+	start := time.Now()
 	blk, err := vm.buildBlockVM.BuildBlockWithContext(ctx, blockCtx)
-	end := vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	if err != nil {
 		vm.blockMetrics.buildBlockWithContextErr.Observe(duration)

--- a/vms/metervm/state_syncable_vm.go
+++ b/vms/metervm/state_syncable_vm.go
@@ -5,6 +5,7 @@ package metervm
 
 import (
 	"context"
+	"time"
 
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 )
@@ -14,9 +15,9 @@ func (vm *blockVM) StateSyncEnabled(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	start := vm.clock.Time()
+	start := time.Now()
 	enabled, err := vm.ssVM.StateSyncEnabled(ctx)
-	end := vm.clock.Time()
+	end := time.Now()
 	vm.blockMetrics.stateSyncEnabled.Observe(float64(end.Sub(start)))
 	return enabled, err
 }
@@ -26,9 +27,9 @@ func (vm *blockVM) GetOngoingSyncStateSummary(ctx context.Context) (block.StateS
 		return nil, block.ErrStateSyncableVMNotImplemented
 	}
 
-	start := vm.clock.Time()
+	start := time.Now()
 	summary, err := vm.ssVM.GetOngoingSyncStateSummary(ctx)
-	end := vm.clock.Time()
+	end := time.Now()
 	vm.blockMetrics.getOngoingSyncStateSummary.Observe(float64(end.Sub(start)))
 	return summary, err
 }
@@ -38,9 +39,9 @@ func (vm *blockVM) GetLastStateSummary(ctx context.Context) (block.StateSummary,
 		return nil, block.ErrStateSyncableVMNotImplemented
 	}
 
-	start := vm.clock.Time()
+	start := time.Now()
 	summary, err := vm.ssVM.GetLastStateSummary(ctx)
-	end := vm.clock.Time()
+	end := time.Now()
 	vm.blockMetrics.getLastStateSummary.Observe(float64(end.Sub(start)))
 	return summary, err
 }
@@ -50,9 +51,9 @@ func (vm *blockVM) ParseStateSummary(ctx context.Context, summaryBytes []byte) (
 		return nil, block.ErrStateSyncableVMNotImplemented
 	}
 
-	start := vm.clock.Time()
+	start := time.Now()
 	summary, err := vm.ssVM.ParseStateSummary(ctx, summaryBytes)
-	end := vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	if err != nil {
 		vm.blockMetrics.parseStateSummaryErr.Observe(duration)
@@ -67,9 +68,9 @@ func (vm *blockVM) GetStateSummary(ctx context.Context, height uint64) (block.St
 		return nil, block.ErrStateSyncableVMNotImplemented
 	}
 
-	start := vm.clock.Time()
+	start := time.Now()
 	summary, err := vm.ssVM.GetStateSummary(ctx, height)
-	end := vm.clock.Time()
+	end := time.Now()
 	duration := float64(end.Sub(start))
 	if err != nil {
 		vm.blockMetrics.getStateSummaryErr.Observe(duration)

--- a/vms/metervm/state_syncable_vm.go
+++ b/vms/metervm/state_syncable_vm.go
@@ -17,8 +17,7 @@ func (vm *blockVM) StateSyncEnabled(ctx context.Context) (bool, error) {
 
 	start := time.Now()
 	enabled, err := vm.ssVM.StateSyncEnabled(ctx)
-	end := time.Now()
-	vm.blockMetrics.stateSyncEnabled.Observe(float64(end.Sub(start)))
+	vm.blockMetrics.stateSyncEnabled.Observe(float64(time.Since(start)))
 	return enabled, err
 }
 
@@ -29,8 +28,7 @@ func (vm *blockVM) GetOngoingSyncStateSummary(ctx context.Context) (block.StateS
 
 	start := time.Now()
 	summary, err := vm.ssVM.GetOngoingSyncStateSummary(ctx)
-	end := time.Now()
-	vm.blockMetrics.getOngoingSyncStateSummary.Observe(float64(end.Sub(start)))
+	vm.blockMetrics.getOngoingSyncStateSummary.Observe(float64(time.Since(start)))
 	return summary, err
 }
 
@@ -41,8 +39,7 @@ func (vm *blockVM) GetLastStateSummary(ctx context.Context) (block.StateSummary,
 
 	start := time.Now()
 	summary, err := vm.ssVM.GetLastStateSummary(ctx)
-	end := time.Now()
-	vm.blockMetrics.getLastStateSummary.Observe(float64(end.Sub(start)))
+	vm.blockMetrics.getLastStateSummary.Observe(float64(time.Since(start)))
 	return summary, err
 }
 
@@ -53,8 +50,7 @@ func (vm *blockVM) ParseStateSummary(ctx context.Context, summaryBytes []byte) (
 
 	start := time.Now()
 	summary, err := vm.ssVM.ParseStateSummary(ctx, summaryBytes)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	if err != nil {
 		vm.blockMetrics.parseStateSummaryErr.Observe(duration)
 		return nil, err
@@ -70,8 +66,7 @@ func (vm *blockVM) GetStateSummary(ctx context.Context, height uint64) (block.St
 
 	start := time.Now()
 	summary, err := vm.ssVM.GetStateSummary(ctx, height)
-	end := time.Now()
-	duration := float64(end.Sub(start))
+	duration := float64(time.Since(start))
 	if err != nil {
 		vm.blockMetrics.getStateSummaryErr.Observe(duration)
 		return nil, err


### PR DESCRIPTION
## Why this should be merged

In `metervm`, we have a mockable clock which we use to get the current time. We don't use any of the mock features of the clock and so making a call to `vm.clock.Time()` is equivalent to `time.Now()`, which is easier to understand and reduces code indirection.

## How this works

Replaces all calls to the mockable clock with `time.Now()`.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
