### PR TITLE
Update daily re-execution benchmark

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.json
@@ -22,6 +22,25 @@
         ]
     },
     "schedule": {
-        "include": []
+        "include": [
+            {
+                "runner": "avago-runner-m6i-4xlarge-ebs-fast",
+                "config": "default",
+                "start-block": 33000001,
+                "end-block": 33500000,
+                "block-dir-src": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-30m-40m-ldb/**",
+                "current-state-dir-src": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-33m/**",
+                "timeout-minutes": 1440
+            },
+            {
+                "runner": "avago-runner-i4i-4xlarge-local-ssd",
+                "config": "default",
+                "start-block": 33000001,
+                "end-block": 33500000,
+                "block-dir-src": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-30m-40m-ldb/**",
+                "current-state-dir-src": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-33m/**",
+                "timeout-minutes": 1440
+            }
+        ]
     }
 }

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -38,8 +38,8 @@ on:
 
   # Disabled because scheduled trigger is empty. To enable, uncomment and add at least one vector to the schedule
   # entry in the corresponding JSON file.
-  # schedule:
-  #   - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
+  schedule:
+    - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 
 jobs:
   define-matrix:

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
@@ -31,16 +31,6 @@
         ]
     },
     "schedule": {
-        "include": [
-            {
-                "runner": "blacksmith-4vcpu-ubuntu-2404",
-                "config": "default",
-                "start-block": 33000001,
-                "end-block": 33500000,
-                "block-dir-src": "s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-30m-40m-ldb/**",
-                "current-state-dir-src": "s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-33m/**",
-                "timeout-minutes": 1440
-            }
-        ]
+        "include": []
     }
 }

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -35,8 +35,11 @@ on:
         description: 'Timeout in minutes for the job.'
         required: false
         default: 30
-  schedule:
-    - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
+
+  # Disabled because scheduled trigger is empty. To enable, uncomment and add at least one vector to the schedule
+  # entry in the corresponding JSON file.
+  # schedule:
+  #   - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 
 jobs:
   define-matrix:


### PR DESCRIPTION
This PR updates the daily re-execution benchmark to use ARC instead of Blacksmith as recent Blacksmith runs have started to flake with no indication as to the error.

Triggered equivalents via manual workflow to confirm they are expected to pass before merge here:
- https://github.com/ava-labs/avalanchego/actions/runs/18015789101
- https://github.com/ava-labs/avalanchego/actions/runs/18015806720
