### PR TITLE
Rebase validator diffs by height

### DIFF
--- a/node/overridden_manager.go
+++ b/node/overridden_manager.go
@@ -75,6 +75,10 @@ func (o *overriddenManager) Sample(_ ids.ID, size int) ([]ids.NodeID, error) {
 	return o.manager.Sample(o.subnetID, size)
 }
 
+func (o *overriddenManager) GetAllMaps() map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput {
+	return o.manager.GetAllMaps()
+}
+
 func (o *overriddenManager) GetMap(ids.ID) map[ids.NodeID]*validators.GetValidatorOutput {
 	return o.manager.GetMap(o.subnetID)
 }

--- a/snow/validators/manager.go
+++ b/snow/validators/manager.go
@@ -95,6 +95,9 @@ type Manager interface {
 	Sample(subnetID ids.ID, size int) ([]ids.NodeID, error)
 
 	// Map of the validators in this subnet
+	GetAllMaps() map[ids.ID]map[ids.NodeID]*GetValidatorOutput
+
+	// Map of the validators in this subnet
 	GetMap(subnetID ids.ID) map[ids.NodeID]*GetValidatorOutput
 
 	// When a validator is added, removed, or its weight changes, the listener
@@ -272,6 +275,17 @@ func (m *manager) Sample(subnetID ids.ID, size int) ([]ids.NodeID, error) {
 	}
 
 	return set.Sample(size)
+}
+
+func (m *manager) GetAllMaps() map[ids.ID]map[ids.NodeID]*GetValidatorOutput {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	set := make(map[ids.ID]map[ids.NodeID]*GetValidatorOutput, len(m.subnetToVdrs))
+	for subnetID, vdrs := range m.subnetToVdrs {
+		set[subnetID] = vdrs.Map()
+	}
+	return set
 }
 
 func (m *manager) GetMap(subnetID ids.ID) map[ids.NodeID]*GetValidatorOutput {

--- a/vms/platformvm/state/disk_staker_diff_iterator.go
+++ b/vms/platformvm/state/disk_staker_diff_iterator.go
@@ -39,17 +39,17 @@ func marshalStartDiffKey(subnetID ids.ID, height uint64) []byte {
 	return key
 }
 
-// marshalStartDiffKey2 is used to determine the starting key when iterating.
+// marshalStartDiffKeyByHeight is used to determine the starting key when iterating.
 //
 // Invariant: the result is a prefix of [marshalDiffKey] when called with the
 // same arguments.
-func marshalStartDiffKey2(height uint64) []byte {
+func marshalStartDiffKeyByHeight(height uint64) []byte {
 	key := make([]byte, database.Uint64Size)
 	packIterableHeight(key, height)
 	return key
 }
 
-func marshalDiffKey(subnetID ids.ID, height uint64, nodeID ids.NodeID) []byte {
+func marshalDiffKeyBySubnet(subnetID ids.ID, height uint64, nodeID ids.NodeID) []byte {
 	key := make([]byte, diffKeyLength)
 	copy(key, subnetID[:])
 	packIterableHeight(key[ids.IDLen:], height)
@@ -57,7 +57,7 @@ func marshalDiffKey(subnetID ids.ID, height uint64, nodeID ids.NodeID) []byte {
 	return key
 }
 
-func marshalDiffKey2(height uint64, subnetID ids.ID, nodeID ids.NodeID) []byte {
+func marshalDiffKeyByHeight(height uint64, subnetID ids.ID, nodeID ids.NodeID) []byte {
 	key := make([]byte, diffKeyLength)
 	packIterableHeight(key, height)
 	copy(key[database.Uint64Size:], subnetID[:])
@@ -65,7 +65,7 @@ func marshalDiffKey2(height uint64, subnetID ids.ID, nodeID ids.NodeID) []byte {
 	return key
 }
 
-func unmarshalDiffKey(key []byte) (ids.ID, uint64, ids.NodeID, error) {
+func unmarshalDiffKeyBySubnet(key []byte) (ids.ID, uint64, ids.NodeID, error) {
 	if len(key) != diffKeyLength {
 		return ids.Empty, 0, ids.EmptyNodeID, errUnexpectedDiffKeyLength
 	}
@@ -79,7 +79,7 @@ func unmarshalDiffKey(key []byte) (ids.ID, uint64, ids.NodeID, error) {
 	return subnetID, height, nodeID, nil
 }
 
-func unmarshalDiffKey2(key []byte) (uint64, ids.ID, ids.NodeID, error) {
+func unmarshalDiffKeyByHeight(key []byte) (uint64, ids.ID, ids.NodeID, error) {
 	if len(key) != diffKeyLength {
 		return 0, ids.Empty, ids.EmptyNodeID, errUnexpectedDiffKeyLength
 	}

--- a/vms/platformvm/state/disk_staker_diff_iterator.go
+++ b/vms/platformvm/state/disk_staker_diff_iterator.go
@@ -41,7 +41,7 @@ func marshalStartDiffKey(subnetID ids.ID, height uint64) []byte {
 
 // marshalStartDiffKeyByHeight is used to determine the starting key when iterating.
 //
-// Invariant: the result is a prefix of [marshalDiffKey] when called with the
+// Invariant: the result is a prefix of [marshalDiffKeyByHeight] when called with the
 // same arguments.
 func marshalStartDiffKeyByHeight(height uint64) []byte {
 	key := make([]byte, database.Uint64Size)

--- a/vms/platformvm/state/disk_staker_diff_iterator.go
+++ b/vms/platformvm/state/disk_staker_diff_iterator.go
@@ -45,7 +45,7 @@ func marshalStartDiffKey(subnetID ids.ID, height uint64) []byte {
 // same arguments.
 func marshalStartDiffKey2(height uint64) []byte {
 	key := make([]byte, database.Uint64Size)
-	packIterableHeight(key[:], height)
+	packIterableHeight(key, height)
 	return key
 }
 

--- a/vms/platformvm/state/disk_staker_diff_iterator_test.go
+++ b/vms/platformvm/state/disk_staker_diff_iterator_test.go
@@ -25,8 +25,8 @@ func FuzzMarshalDiffKey(f *testing.F) {
 		fz := fuzzer.NewFuzzer(data)
 		fz.Fill(&subnetID, &height, &nodeID)
 
-		key := marshalDiffKey(subnetID, height, nodeID)
-		parsedSubnetID, parsedHeight, parsedNodeID, err := unmarshalDiffKey(key)
+		key := marshalDiffKeyBySubnet(subnetID, height, nodeID)
+		parsedSubnetID, parsedHeight, parsedNodeID, err := unmarshalDiffKeyBySubnet(key)
 		require.NoError(err)
 		require.Equal(subnetID, parsedSubnetID)
 		require.Equal(height, parsedHeight)
@@ -38,13 +38,13 @@ func FuzzUnmarshalDiffKey(f *testing.F) {
 	f.Fuzz(func(t *testing.T, key []byte) {
 		require := require.New(t)
 
-		subnetID, height, nodeID, err := unmarshalDiffKey(key)
+		subnetID, height, nodeID, err := unmarshalDiffKeyBySubnet(key)
 		if err != nil {
 			require.ErrorIs(err, errUnexpectedDiffKeyLength)
 			return
 		}
 
-		formattedKey := marshalDiffKey(subnetID, height, nodeID)
+		formattedKey := marshalDiffKeyBySubnet(subnetID, height, nodeID)
 		require.Equal(key, formattedKey)
 	})
 }
@@ -60,13 +60,13 @@ func TestDiffIteration(t *testing.T) {
 	nodeID0 := ids.BuildTestNodeID([]byte{0x00})
 	nodeID1 := ids.BuildTestNodeID([]byte{0x01})
 
-	subnetID0Height0NodeID0 := marshalDiffKey(subnetID0, 0, nodeID0)
-	subnetID0Height1NodeID0 := marshalDiffKey(subnetID0, 1, nodeID0)
-	subnetID0Height1NodeID1 := marshalDiffKey(subnetID0, 1, nodeID1)
+	subnetID0Height0NodeID0 := marshalDiffKeyBySubnet(subnetID0, 0, nodeID0)
+	subnetID0Height1NodeID0 := marshalDiffKeyBySubnet(subnetID0, 1, nodeID0)
+	subnetID0Height1NodeID1 := marshalDiffKeyBySubnet(subnetID0, 1, nodeID1)
 
-	subnetID1Height0NodeID0 := marshalDiffKey(subnetID1, 0, nodeID0)
-	subnetID1Height1NodeID0 := marshalDiffKey(subnetID1, 1, nodeID0)
-	subnetID1Height1NodeID1 := marshalDiffKey(subnetID1, 1, nodeID1)
+	subnetID1Height0NodeID0 := marshalDiffKeyBySubnet(subnetID1, 0, nodeID0)
+	subnetID1Height1NodeID0 := marshalDiffKeyBySubnet(subnetID1, 1, nodeID0)
+	subnetID1Height1NodeID1 := marshalDiffKeyBySubnet(subnetID1, 1, nodeID1)
 
 	require.NoError(db.Put(subnetID0Height0NodeID0, nil))
 	require.NoError(db.Put(subnetID0Height1NodeID0, nil))

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -163,6 +163,20 @@ func (mr *MockStateMockRecorder) ApplyValidatorPublicKeyDiffs(ctx, validators, s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyValidatorPublicKeyDiffs", reflect.TypeOf((*MockState)(nil).ApplyValidatorPublicKeyDiffs), ctx, validators, startHeight, endHeight, subnetID)
 }
 
+// ApplyValidatorPublicKeyDiffsByHeight mocks base method.
+func (m *MockState) ApplyValidatorPublicKeyDiffsByHeight(ctx context.Context, validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyValidatorPublicKeyDiffsByHeight", ctx, validators, startHeight, endHeight)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyValidatorPublicKeyDiffsByHeight indicates an expected call of ApplyValidatorPublicKeyDiffsByHeight.
+func (mr *MockStateMockRecorder) ApplyValidatorPublicKeyDiffsByHeight(ctx, validators, startHeight, endHeight any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyValidatorPublicKeyDiffsByHeight", reflect.TypeOf((*MockState)(nil).ApplyValidatorPublicKeyDiffsByHeight), ctx, validators, startHeight, endHeight)
+}
+
 // ApplyValidatorWeightDiffs mocks base method.
 func (m *MockState) ApplyValidatorWeightDiffs(ctx context.Context, validators map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64, subnetID ids.ID) error {
 	m.ctrl.T.Helper()
@@ -175,6 +189,20 @@ func (m *MockState) ApplyValidatorWeightDiffs(ctx context.Context, validators ma
 func (mr *MockStateMockRecorder) ApplyValidatorWeightDiffs(ctx, validators, startHeight, endHeight, subnetID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyValidatorWeightDiffs", reflect.TypeOf((*MockState)(nil).ApplyValidatorWeightDiffs), ctx, validators, startHeight, endHeight, subnetID)
+}
+
+// ApplyValidatorWeightDiffsByHeight mocks base method.
+func (m *MockState) ApplyValidatorWeightDiffsByHeight(ctx context.Context, validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyValidatorWeightDiffsByHeight", ctx, validators, startHeight, endHeight)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyValidatorWeightDiffsByHeight indicates an expected call of ApplyValidatorWeightDiffsByHeight.
+func (mr *MockStateMockRecorder) ApplyValidatorWeightDiffsByHeight(ctx, validators, startHeight, endHeight any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyValidatorWeightDiffsByHeight", reflect.TypeOf((*MockState)(nil).ApplyValidatorWeightDiffsByHeight), ctx, validators, startHeight, endHeight)
 }
 
 // Checksum mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -149,6 +149,34 @@ func (mr *MockStateMockRecorder) AddUTXO(utxo any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUTXO", reflect.TypeOf((*MockState)(nil).AddUTXO), utxo)
 }
 
+// ApplyAllValidatorPublicKeyDiffs mocks base method.
+func (m *MockState) ApplyAllValidatorPublicKeyDiffs(ctx context.Context, validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyAllValidatorPublicKeyDiffs", ctx, validators, startHeight, endHeight)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyAllValidatorPublicKeyDiffs indicates an expected call of ApplyAllValidatorPublicKeyDiffs.
+func (mr *MockStateMockRecorder) ApplyAllValidatorPublicKeyDiffs(ctx, validators, startHeight, endHeight any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyAllValidatorPublicKeyDiffs", reflect.TypeOf((*MockState)(nil).ApplyAllValidatorPublicKeyDiffs), ctx, validators, startHeight, endHeight)
+}
+
+// ApplyAllValidatorWeightDiffs mocks base method.
+func (m *MockState) ApplyAllValidatorWeightDiffs(ctx context.Context, validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyAllValidatorWeightDiffs", ctx, validators, startHeight, endHeight)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyAllValidatorWeightDiffs indicates an expected call of ApplyAllValidatorWeightDiffs.
+func (mr *MockStateMockRecorder) ApplyAllValidatorWeightDiffs(ctx, validators, startHeight, endHeight any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyAllValidatorWeightDiffs", reflect.TypeOf((*MockState)(nil).ApplyAllValidatorWeightDiffs), ctx, validators, startHeight, endHeight)
+}
+
 // ApplyValidatorPublicKeyDiffs mocks base method.
 func (m *MockState) ApplyValidatorPublicKeyDiffs(ctx context.Context, validators map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64, subnetID ids.ID) error {
 	m.ctrl.T.Helper()
@@ -163,20 +191,6 @@ func (mr *MockStateMockRecorder) ApplyValidatorPublicKeyDiffs(ctx, validators, s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyValidatorPublicKeyDiffs", reflect.TypeOf((*MockState)(nil).ApplyValidatorPublicKeyDiffs), ctx, validators, startHeight, endHeight, subnetID)
 }
 
-// ApplyValidatorPublicKeyDiffsByHeight mocks base method.
-func (m *MockState) ApplyValidatorPublicKeyDiffsByHeight(ctx context.Context, validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyValidatorPublicKeyDiffsByHeight", ctx, validators, startHeight, endHeight)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ApplyValidatorPublicKeyDiffsByHeight indicates an expected call of ApplyValidatorPublicKeyDiffsByHeight.
-func (mr *MockStateMockRecorder) ApplyValidatorPublicKeyDiffsByHeight(ctx, validators, startHeight, endHeight any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyValidatorPublicKeyDiffsByHeight", reflect.TypeOf((*MockState)(nil).ApplyValidatorPublicKeyDiffsByHeight), ctx, validators, startHeight, endHeight)
-}
-
 // ApplyValidatorWeightDiffs mocks base method.
 func (m *MockState) ApplyValidatorWeightDiffs(ctx context.Context, validators map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64, subnetID ids.ID) error {
 	m.ctrl.T.Helper()
@@ -189,20 +203,6 @@ func (m *MockState) ApplyValidatorWeightDiffs(ctx context.Context, validators ma
 func (mr *MockStateMockRecorder) ApplyValidatorWeightDiffs(ctx, validators, startHeight, endHeight, subnetID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyValidatorWeightDiffs", reflect.TypeOf((*MockState)(nil).ApplyValidatorWeightDiffs), ctx, validators, startHeight, endHeight, subnetID)
-}
-
-// ApplyValidatorWeightDiffsByHeight mocks base method.
-func (m *MockState) ApplyValidatorWeightDiffsByHeight(ctx context.Context, validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, startHeight, endHeight uint64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyValidatorWeightDiffsByHeight", ctx, validators, startHeight, endHeight)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ApplyValidatorWeightDiffsByHeight indicates an expected call of ApplyValidatorWeightDiffsByHeight.
-func (mr *MockStateMockRecorder) ApplyValidatorWeightDiffsByHeight(ctx, validators, startHeight, endHeight any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyValidatorWeightDiffsByHeight", reflect.TypeOf((*MockState)(nil).ApplyValidatorWeightDiffsByHeight), ctx, validators, startHeight, endHeight)
 }
 
 // Checksum mocks base method.

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1458,7 +1458,7 @@ func (s *state) ApplyValidatorWeightDiffsByHeight(
 		vdrs, ok := allValidators[subnetID]
 		if !ok {
 			// If this subnet previously had no validators, add the map back
-			vdrs = make(map[ids.NodeID]*validators.GetValidatorOutput, 1)
+			vdrs = make(map[ids.NodeID]*validators.GetValidatorOutput)
 			allValidators[subnetID] = vdrs
 		}
 

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -212,7 +212,7 @@ type State interface {
 	) error
 
 	// TODO
-	ApplyValidatorWeightDiffsByHeight(
+	ApplyAllValidatorWeightDiffs(
 		ctx context.Context,
 		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 		startHeight uint64,
@@ -220,7 +220,7 @@ type State interface {
 	) error
 
 	// TODO
-	ApplyValidatorPublicKeyDiffsByHeight(
+	ApplyAllValidatorPublicKeyDiffs(
 		ctx context.Context,
 		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 		startHeight uint64,
@@ -1409,7 +1409,7 @@ func (s *state) SetCurrentSupply(subnetID ids.ID, cs uint64) {
 	}
 }
 
-func (s *state) ApplyValidatorWeightDiffsByHeight(
+func (s *state) ApplyAllValidatorWeightDiffs(
 	ctx context.Context,
 	allValidators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 	startHeight uint64,
@@ -1566,7 +1566,7 @@ func applyWeightDiff(
 	return nil
 }
 
-func (s *state) ApplyValidatorPublicKeyDiffsByHeight(
+func (s *state) ApplyAllValidatorPublicKeyDiffs(
 	ctx context.Context,
 	allValidators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 	startHeight uint64,

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1592,13 +1592,7 @@ func (s *state) ApplyValidatorPublicKeyDiffsByHeight(
 			break
 		}
 
-		vdrs, ok := allValidators[subnetID]
-		if !ok {
-			// A subnet that is eventually removed from the map for having no validators may have a key diff before it was removed
-			continue
-		}
-
-		vdr, ok := vdrs[nodeID]
+		vdr, ok := allValidators[subnetID][nodeID]
 		if !ok {
 			// A validator that is eventually removed may have a key diff before it was removed
 			continue

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -211,6 +211,22 @@ type State interface {
 		subnetID ids.ID,
 	) error
 
+	// TODO
+	ApplyValidatorWeightDiffsByHeight(
+		ctx context.Context,
+		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
+		startHeight uint64,
+		endHeight uint64,
+	) error
+
+	// TODO
+	ApplyValidatorPublicKeyDiffsByHeight(
+		ctx context.Context,
+		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
+		startHeight uint64,
+		endHeight uint64,
+	) error
+
 	SetHeight(height uint64)
 
 	// GetCurrentValidators returns subnet and L1 validators for the given
@@ -1410,7 +1426,7 @@ func (s *state) ApplyValidatorWeightDiffsByHeight(
 			return err
 		}
 
-		subnetID, parsedHeight, nodeID, err := unmarshalDiffKey(diffIter.Key())
+		parsedHeight, subnetID, nodeID, err := unmarshalDiffKey2(diffIter.Key())
 		if err != nil {
 			return err
 		}
@@ -1550,7 +1566,7 @@ func applyWeightDiff(
 	return nil
 }
 
-func (s *state) ApplyValidatorPublicKeyDiffsAllValidators(
+func (s *state) ApplyValidatorPublicKeyDiffsByHeight(
 	ctx context.Context,
 	allValidators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 	startHeight uint64,
@@ -1566,7 +1582,7 @@ func (s *state) ApplyValidatorPublicKeyDiffsAllValidators(
 			return err
 		}
 
-		subnetID, parsedHeight, nodeID, err := unmarshalDiffKey(diffIter.Key())
+		parsedHeight, subnetID, nodeID, err := unmarshalDiffKey2(diffIter.Key())
 		if err != nil {
 			return err
 		}

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -515,7 +515,7 @@ func TestState_writeStakers(t *testing.T) {
 
 				for subnetIDNodeID, expectedDiff := range test.expectedValidatorDiffs {
 					diffKey := marshalDiffKeyBySubnet(subnetIDNodeID.subnetID, 1, subnetIDNodeID.nodeID)
-					weightDiffBytes, err := state.validatorWeightDiffsDB.Get(diffKey)
+					weightDiffBytes, err := state.validatorWeightDiffsBySubnetIDDB.Get(diffKey)
 					if expectedDiff.weightDiff.Amount == 0 {
 						require.ErrorIs(err, database.ErrNotFound)
 					} else {
@@ -526,7 +526,7 @@ func TestState_writeStakers(t *testing.T) {
 						require.Equal(&expectedDiff.weightDiff, weightDiff)
 					}
 
-					publicKeyDiffBytes, err := state.validatorPublicKeyDiffsDB.Get(diffKey)
+					publicKeyDiffBytes, err := state.validatorPublicKeyDiffsBySubnetIDDB.Get(diffKey)
 					if bytes.Equal(expectedDiff.prevPublicKey, expectedDiff.newPublicKey) {
 						require.ErrorIs(err, database.ErrNotFound)
 					} else {

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -514,7 +514,7 @@ func TestState_writeStakers(t *testing.T) {
 				)
 
 				for subnetIDNodeID, expectedDiff := range test.expectedValidatorDiffs {
-					diffKey := marshalDiffKey(subnetIDNodeID.subnetID, 1, subnetIDNodeID.nodeID)
+					diffKey := marshalDiffKeyBySubnet(subnetIDNodeID.subnetID, 1, subnetIDNodeID.nodeID)
 					weightDiffBytes, err := state.validatorWeightDiffsDB.Get(diffKey)
 					if expectedDiff.weightDiff.Amount == 0 {
 						require.ErrorIs(err, database.ErrNotFound)

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -81,7 +81,7 @@ type State interface {
 		subnetID ids.ID,
 	) error
 
-	ApplyValidatorWeightDiffsAllValidators(
+	ApplyValidatorWeightDiffsByHeight(
 		ctx context.Context,
 		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 		startHeight uint64,
@@ -106,7 +106,7 @@ type State interface {
 		subnetID ids.ID,
 	) error
 
-	ApplyValidatorPublicKeyDiffsAllValidators(
+	ApplyValidatorPublicKeyDiffsByHeight(
 		ctx context.Context,
 		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 		startHeight uint64,
@@ -270,7 +270,7 @@ func (m *manager) makeAllValidatorSets(
 		return nil, 0, err
 	}
 	if currentHeight < targetHeight {
-		return nil, 0, fmt.Errorf("%w with SubnetID = %s: current P-chain height (%d) < requested P-Chain height (%d)",
+		return nil, 0, fmt.Errorf("%w: current P-chain height (%d) < requested P-Chain height (%d)",
 			errUnfinalizedHeight,
 			currentHeight,
 			targetHeight,
@@ -284,7 +284,7 @@ func (m *manager) makeAllValidatorSets(
 	// (targetHeight, currentHeight]. Because the state interface is implemented
 	// to be inclusive, we apply diffs in [targetHeight + 1, currentHeight].
 	lastDiffHeight := targetHeight + 1
-	err = m.state.ApplyValidatorWeightDiffsAllValidators(
+	err = m.state.ApplyValidatorWeightDiffsByHeight(
 		ctx,
 		allValidators,
 		currentHeight,
@@ -294,7 +294,7 @@ func (m *manager) makeAllValidatorSets(
 		return nil, 0, err
 	}
 
-	err = m.state.ApplyValidatorPublicKeyDiffsAllValidators(
+	err = m.state.ApplyValidatorPublicKeyDiffsByHeight(
 		ctx,
 		allValidators,
 		currentHeight,

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -81,6 +81,13 @@ type State interface {
 		subnetID ids.ID,
 	) error
 
+	ApplyValidatorWeightDiffsAllValidators(
+		ctx context.Context,
+		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
+		startHeight uint64,
+		endHeight uint64,
+	) error
+
 	// ApplyValidatorPublicKeyDiffs iterates from [startHeight] towards the
 	// genesis block until it has applied all of the diffs up to and including
 	// [endHeight]. Applying the diffs modifies [validators].
@@ -99,6 +106,13 @@ type State interface {
 		subnetID ids.ID,
 	) error
 
+	ApplyValidatorPublicKeyDiffsAllValidators(
+		ctx context.Context,
+		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
+		startHeight uint64,
+		endHeight uint64,
+	) error
+
 	GetCurrentValidators(ctx context.Context, subnetID ids.ID) ([]*state.Staker, []state.L1Validator, uint64, error)
 }
 
@@ -113,6 +127,7 @@ func NewManager(
 		state:   state,
 		metrics: metrics,
 		clk:     clk,
+		cache:   lru.NewCache[uint64, map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput](validatorSetsCacheSize),
 		caches:  make(map[ids.ID]cache.Cacher[uint64, map[ids.NodeID]*validators.GetValidatorOutput]),
 		recentlyAccepted: window.New[ids.ID](
 			window.Config{
@@ -132,6 +147,9 @@ type manager struct {
 	state   State
 	metrics metrics.Metrics
 	clk     *mockable.Clock
+
+	// Caches all validator sets at a given height.
+	cache cache.Cacher[uint64, map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput]
 
 	// Maps caches for each subnet that is currently tracked.
 	// Key: Subnet ID
@@ -242,6 +260,49 @@ func (m *manager) getValidatorSetCache(subnetID ids.ID) cache.Cacher[uint64, map
 	return validatorSetsCache
 }
 
+// TODO this can fail if we query a targetHeight before the new indexes existed
+func (m *manager) makeAllValidatorSets(
+	ctx context.Context,
+	targetHeight uint64,
+) (map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, uint64, error) {
+	allValidators, currentHeight, err := m.getAllCurrentValidatorSets(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	if currentHeight < targetHeight {
+		return nil, 0, fmt.Errorf("%w with SubnetID = %s: current P-chain height (%d) < requested P-Chain height (%d)",
+			errUnfinalizedHeight,
+			currentHeight,
+			targetHeight,
+		)
+	}
+
+	// Rebuild subnet validators at [targetHeight]
+	//
+	// Note: Since we are attempting to generate the validator set at
+	// [targetHeight], we want to apply the diffs from
+	// (targetHeight, currentHeight]. Because the state interface is implemented
+	// to be inclusive, we apply diffs in [targetHeight + 1, currentHeight].
+	lastDiffHeight := targetHeight + 1
+	err = m.state.ApplyValidatorWeightDiffsAllValidators(
+		ctx,
+		allValidators,
+		currentHeight,
+		lastDiffHeight,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	err = m.state.ApplyValidatorPublicKeyDiffsAllValidators(
+		ctx,
+		allValidators,
+		currentHeight,
+		lastDiffHeight,
+	)
+	return allValidators, currentHeight, err
+}
+
 func (m *manager) makeValidatorSet(
 	ctx context.Context,
 	targetHeight uint64,
@@ -286,6 +347,15 @@ func (m *manager) makeValidatorSet(
 		subnetID,
 	)
 	return validatorSet, currentHeight, err
+}
+
+func (m *manager) getAllCurrentValidatorSets(
+	ctx context.Context,
+) (map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, uint64, error) {
+	subnetsMap := m.cfg.Validators.GetAllMaps()
+	// TODO is there a race-condition here?
+	currentHeight, err := m.getCurrentHeight(ctx)
+	return subnetsMap, currentHeight, err
 }
 
 func (m *manager) getCurrentValidatorSet(

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -353,7 +353,6 @@ func (m *manager) getAllCurrentValidatorSets(
 	ctx context.Context,
 ) (map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, uint64, error) {
 	subnetsMap := m.cfg.Validators.GetAllMaps()
-	// TODO is there a race-condition here?
 	currentHeight, err := m.getCurrentHeight(ctx)
 	return subnetsMap, currentHeight, err
 }

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -81,7 +81,7 @@ type State interface {
 		subnetID ids.ID,
 	) error
 
-	ApplyValidatorWeightDiffsByHeight(
+	ApplyAllValidatorWeightDiffs(
 		ctx context.Context,
 		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 		startHeight uint64,
@@ -106,7 +106,7 @@ type State interface {
 		subnetID ids.ID,
 	) error
 
-	ApplyValidatorPublicKeyDiffsByHeight(
+	ApplyAllValidatorPublicKeyDiffs(
 		ctx context.Context,
 		validators map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput,
 		startHeight uint64,
@@ -284,7 +284,7 @@ func (m *manager) makeAllValidatorSets(
 	// (targetHeight, currentHeight]. Because the state interface is implemented
 	// to be inclusive, we apply diffs in [targetHeight + 1, currentHeight].
 	lastDiffHeight := targetHeight + 1
-	err = m.state.ApplyValidatorWeightDiffsByHeight(
+	err = m.state.ApplyAllValidatorWeightDiffs(
 		ctx,
 		allValidators,
 		currentHeight,
@@ -294,7 +294,7 @@ func (m *manager) makeAllValidatorSets(
 		return nil, 0, err
 	}
 
-	err = m.state.ApplyValidatorPublicKeyDiffsByHeight(
+	err = m.state.ApplyAllValidatorPublicKeyDiffs(
 		ctx,
 		allValidators,
 		currentHeight,


### PR DESCRIPTION
## Why this should be merged
Creates a new index for the validator diffs DB. We now key diffs by `height, subnetID, nodeID` in addition to the previous index of `subnetID, height, nodeID`. This will allow us to apply diffs for all validators of all subnets at a given height.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
N/A