### PR TITLE
use only relevant package to subnet-evm

### DIFF
--- a/tests/imports_test.go
+++ b/tests/imports_test.go
@@ -15,13 +15,16 @@ import (
 func TestMustNotImport(t *testing.T) {
 	require := require.New(t)
 
+	illegalPaths := []string{
+		"github.com/ava-labs/coreth/params",
+		"github.com/ava-labs/coreth/plugin/evm/customtypes",
+	}
 	mustNotImport := map[string][]string{
 		// Importing these packages configures libevm globally. This must not be
 		// done to support both coreth and subnet-evm.
-		"tests/...": {
-			"github.com/ava-labs/coreth/params",
-			"github.com/ava-labs/coreth/plugin/evm/customtypes",
-		},
+		"tests/":            illegalPaths,
+		"tests/antithesis/": illegalPaths,
+		"tests/fixture/...": illegalPaths,
 	}
 	for packageName, forbiddenImports := range mustNotImport {
 		packagePath := path.Join("github.com/ava-labs/avalanchego", packageName)


### PR DESCRIPTION
## Why this should be merged

The check was too strict, it should only cover those potentially can be imported from subnet-evm

## How this works

relaxes the test by only checking:

* direct `tests` package
* direct `tests/antithesis` package
* `tests/fixture` and subpackages

## How this was tested

UT

## Need to be documented in RELEASES.md?

no
