### PR TITLE
unify re-execution benchmark github yaml w/ custom actions on snake case

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -8,41 +8,41 @@ inputs:
   config:
     description: 'The config to pass to the VM for the benchmark. See BenchmarkReexecuteRange for details.'
     default: ''
-  start-block:
+  start_block:
     description: 'The start block for the benchmark.'
     default: '101'
-  end-block:
+  end_block:
     description: 'The end block for the benchmark.'
     default: '250000'
-  block-dir-src:
+  block_dir_src:
     description: 'The source block directory. Supports S3 directory/zip and local directories.'
     default: 's3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**'
-  current-state-dir-src:
+  current_state_dir_src:
     description: 'The current state directory. Supports S3 directory/zip and local directories.'
     default: 's3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**'
-  aws-role:
+  aws_role:
     description: 'AWS role to assume for S3 access.'
     required: true
-  aws-region:
+  aws_region:
     description: 'AWS region to use for S3 access.'
     required: true
-  aws-role-duration-seconds:
+  aws_role_duration_seconds:
     description: 'The duration of the AWS role to assume for S3 access.'
     required: true
     default: '43200' # 12 hours
-  prometheus-url:
+  prometheus_url:
     description: 'The URL of the prometheus instance.'
     required: true
     default: ''
-  prometheus-push-url:
+  prometheus_push_url:
     description: 'The push URL of the prometheus instance.'
     required: true
     default: ''
-  prometheus-username:
+  prometheus_username:
     description: 'The username for the Prometheus instance.'
     required: true
     default: ''
-  prometheus-password:
+  prometheus_password:
     description: 'The password for the Prometheus instance.'
     required: true
     default: ''
@@ -50,14 +50,14 @@ inputs:
     description: 'Working directory to use for the benchmark.'
     required: true
     default: ${{ github.workspace }}
-  github-token:
+  github_token:
     description: 'GitHub token provided to GitHub Action Benchmark.'
     required: true
-  push-github-action-benchmark:
+  push_github_action_benchmark:
     description: 'Whether to push the benchmark result to GitHub.'
     required: true
     default: false
-  push-post-state:
+  push_post_state:
     description: 'S3 destination to copy the current-state directory after completing re-execution. If empty, this will be skipped.'
     default: ''
 
@@ -79,9 +79,9 @@ runs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ inputs.aws-role }}
-        aws-region: ${{ inputs.aws-region }}
-        role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
+        role-to-assume: ${{ inputs.aws_role }}
+        aws-region: ${{ inputs.aws_region }}
+        role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
     - name: Run C-Chain Re-Execution
       uses: ./.github/actions/run-monitored-tmpnet-cmd
       with:
@@ -97,10 +97,10 @@ runs:
             BENCHMARK_OUTPUT_FILE=${{ env.BENCHMARK_OUTPUT_FILE }} \
             RUNNER_NAME=${{ inputs.runner_name }} \
             METRICS_ENABLED=true
-        prometheus_url: ${{ inputs.prometheus-url }}
-        prometheus_push_url: ${{ inputs.prometheus-push-url }}
-        prometheus_username: ${{ inputs.prometheus-username }}
-        prometheus_password: ${{ inputs.prometheus-password }}
+        prometheus_url: ${{ inputs.prometheus_url }}
+        prometheus_push_url: ${{ inputs.prometheus_push_url }}
+        prometheus_username: ${{ inputs.prometheus_username }}
+        prometheus_password: ${{ inputs.prometheus_password }}
         grafana_dashboard_id: 'Gl1I20mnk/c-chain'
         runtime: "" # Set runtime input to empty string to disable log collection
 
@@ -110,12 +110,12 @@ runs:
         tool: 'go'
         output-file-path: ${{ env.BENCHMARK_OUTPUT_FILE }}
         summary-always: true
-        github-token: ${{ inputs.github-token }}
-        auto-push: ${{ inputs.push-github-action-benchmark }}
+        github-token: ${{ inputs.github_token }}
+        auto-push: ${{ inputs.push_github_action_benchmark }}
 
     - uses: ./.github/actions/install-nix
-      if: ${{ inputs.push-post-state != '' }}
+      if: ${{ inputs.push_post_state != '' }}
     - name: Push Post-State to S3 (if not exists)
-      if: ${{ inputs.push-post-state != '' }}
+      if: ${{ inputs.push_post_state != '' }}
       shell: nix develop --command bash -x {0}
-      run: ./scripts/run_task.sh export-dir-to-s3 LOCAL_SRC=${{ env.EXECUTION_DATA_DIR }}/current-state/ S3_DST=${{ inputs.push-post-state }}
+      run: ./scripts/run_task.sh export-dir-to-s3 LOCAL_SRC=${{ env.EXECUTION_DATA_DIR }}/current-state/ S3_DST=${{ inputs.push_post_state }}

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -97,6 +97,7 @@ runs:
             BENCHMARK_OUTPUT_FILE=${{ env.BENCHMARK_OUTPUT_FILE }} \
             RUNNER_NAME=${{ inputs.runner_name }} \
             METRICS_ENABLED=true
+        prometheus_url: ${{ inputs.prometheus-url }}
         prometheus_push_url: ${{ inputs.prometheus-push-url }}
         prometheus_username: ${{ inputs.prometheus-username }}
         prometheus_password: ${{ inputs.prometheus-password }}

--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: 'The duration of the AWS role to assume for S3 access.'
     required: true
     default: '43200' # 12 hours
+  prometheus-url:
+    description: 'The URL of the prometheus instance.'
+    required: true
+    default: ''
   prometheus-push-url:
     description: 'The push URL of the prometheus instance.'
     required: true

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -105,9 +105,10 @@ jobs:
           end-block: ${{ matrix.end-block }}
           block-dir-src: ${{ matrix.block-dir-src }}
           current-state-dir-src: ${{ matrix.current-state-dir-src }}
-          prometheus-push-url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
-          prometheus-username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
-          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           push-github-action-benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
           aws-role: ${{ github.event.inputs.push-post-state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -105,10 +105,10 @@ jobs:
           end-block: ${{ matrix.end-block }}
           block-dir-src: ${{ matrix.block-dir-src }}
           current-state-dir-src: ${{ matrix.current-state-dir-src }}
-          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
-          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
-          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
-          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          prometheus-url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus-push-url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus-username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           push-github-action-benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
           aws-role: ${{ github.event.inputs.push-post-state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -8,19 +8,19 @@ on:
         description: 'The config to pass to the VM for the benchmark. See BenchmarkReexecuteRange for details.'
         required: false
         default: ''
-      start-block:
+      start_block:
         description: 'The start block for the benchmark.'
         required: false
         default: 101
-      end-block:
+      end_block:
         description: 'The end block for the benchmark.'
         required: false
         default: 250000
-      block-dir-src:
+      block_dir_src:
         description: 'The source block directory. Supports S3 directory/zip and local directories.'
         required: false
         default: s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**
-      current-state-dir-src:
+      current_state_dir_src:
         description: 'The current state directory. Supports S3 directory/zip and local directories.'
         required: false
         default: s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**
@@ -28,10 +28,10 @@ on:
         description: 'Runner to execute the benchmark. Input to the runs-on field of the job.'
         required: false
         default: ubuntu-latest
-      push-post-state:
+      push_post_state:
         description: 'S3 location to push post-execution state directory. Skips this step if left unpopulated.'
         default: ''
-      timeout-minutes:
+      timeout_minutes:
         description: 'Timeout in minutes for the job.'
         required: false
         default: 30
@@ -55,14 +55,14 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             {
               echo "matrix<<EOF"
-              printf '{ "include": [{ "start-block": "%s", "end-block": "%s", "block-dir-src": "%s", "current-state-dir-src": "%s", "config": "%s", "runner": "%s", "timeout-minutes": %s }] }\n' \
-                "${{ github.event.inputs.start-block }}" \
-                "${{ github.event.inputs.end-block }}" \
-                "${{ github.event.inputs.block-dir-src }}" \
-                "${{ github.event.inputs.current-state-dir-src }}" \
+              printf '{ "include": [{ "start_block": "%s", "end_block": "%s", "block_dir_src": "%s", "current_state_dir_src": "%s", "config": "%s", "runner": "%s", "timeout_minutes": %s }] }\n' \
+                "${{ github.event.inputs.start_block }}" \
+                "${{ github.event.inputs.end_block }}" \
+                "${{ github.event.inputs.block_dir_src }}" \
+                "${{ github.event.inputs.current_state_dir_src }}" \
                 "${{ github.event.inputs.config }}" \
                 "${{ github.event.inputs.runner }}" \
-                "${{ github.event.inputs.timeout-minutes }}"
+                "${{ github.event.inputs.timeout_minutes }}"
               echo EOF
             } >> "$GITHUB_OUTPUT"
           else
@@ -101,17 +101,17 @@ jobs:
         uses: ./.github/actions/c-chain-reexecution-benchmark
         with:
           config: ${{ matrix.config }}
-          start-block: ${{ matrix.start-block }}
-          end-block: ${{ matrix.end-block }}
-          block-dir-src: ${{ matrix.block-dir-src }}
-          current-state-dir-src: ${{ matrix.current-state-dir-src }}
-          prometheus-url: ${{ secrets.PROMETHEUS_URL || '' }}
-          prometheus-push-url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
-          prometheus-username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
-          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
-          push-github-action-benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
-          aws-role: ${{ github.event.inputs.push-post-state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
-          aws-region: 'us-east-2'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          push-post-state: ${{ github.event.inputs.push-post-state }}
+          start_block: ${{ matrix.start_block }}
+          end_block: ${{ matrix.end_block }}
+          block_dir_src: ${{ matrix.block_dir_src }}
+          current_state_dir_src: ${{ matrix.current_state_dir_src }}
+          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          push_github_action_benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
+          aws_role: ${{ github.event.inputs.push_post_state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
+          aws_region: 'us-east-2'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          push_post_state: ${{ github.event.inputs.push_post_state }}
           runner_name: ${{ matrix.runner }}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -8,19 +8,19 @@ on:
         description: 'The config to pass to the VM for the benchmark. See BenchmarkReexecuteRange for details.'
         required: false
         default: ''
-      start-block:
+      start_block:
         description: 'The start block for the benchmark.'
         required: false
         default: 101
-      end-block:
+      end_block:
         description: 'The end block for the benchmark.'
         required: false
         default: 250000
-      block-dir-src:
+      block_dir_src:
         description: 'The source block directory. Supports S3 directory/zip and local directories.'
         required: false
         default: s3://avalanchego-bootstrap-testing/cchain-mainnet-blocks-1m-ldb/**
-      current-state-dir-src:
+      current_state_dir_src:
         description: 'The current state directory. Supports S3 directory/zip and local directories.'
         required: false
         default: s3://avalanchego-bootstrap-testing/cchain-current-state-hashdb-full-100/**
@@ -28,10 +28,10 @@ on:
         description: 'Runner to execute the benchmark. Input to the runs-on field of the job.'
         required: false
         default: ubuntu-latest
-      push-post-state:
+      push_post_state:
         description: 'S3 location to push post-execution state directory. Skips this step if left unpopulated.'
         default: ''
-      timeout-minutes:
+      timeout_minutes:
         description: 'Timeout in minutes for the job.'
         required: false
         default: 30
@@ -52,14 +52,14 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             {
               echo "matrix<<EOF"
-              printf '{ "include": [{ "start-block": "%s", "end-block": "%s", "block-dir-src": "%s", "current-state-dir-src": "%s", "config": "%s", "runner": "%s", "timeout-minutes": %s }] }\n' \
-                "${{ github.event.inputs.start-block }}" \
-                "${{ github.event.inputs.end-block }}" \
-                "${{ github.event.inputs.block-dir-src }}" \
-                "${{ github.event.inputs.current-state-dir-src }}" \
+              printf '{ "include": [{ "start_block": "%s", "end_block": "%s", "block_dir_src": "%s", "current_state_dir_src": "%s", "config": "%s", "runner": "%s", "timeout_minutes": %s }] }\n' \
+                "${{ github.event.inputs.start_block }}" \
+                "${{ github.event.inputs.end_block }}" \
+                "${{ github.event.inputs.block_dir_src }}" \
+                "${{ github.event.inputs.current_state_dir_src }}" \
                 "${{ github.event.inputs.config }}" \
                 "${{ github.event.inputs.runner }}" \
-                "${{ github.event.inputs.timeout-minutes }}"
+                "${{ github.event.inputs.timeout_minutes }}"
               echo EOF
             } >> "$GITHUB_OUTPUT"
           else
@@ -88,17 +88,17 @@ jobs:
         uses: ./.github/actions/c-chain-reexecution-benchmark
         with:
           config: ${{ matrix.config }}
-          start-block: ${{ matrix.start-block }}
-          end-block: ${{ matrix.end-block }}
-          block-dir-src: ${{ matrix.block-dir-src }}
-          current-state-dir-src: ${{ matrix.current-state-dir-src }}
-          prometheus-url: ${{ secrets.PROMETHEUS_URL || '' }}
-          prometheus-push-url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
-          prometheus-username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
-          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
-          push-github-action-benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
-          aws-role: ${{ github.event.inputs.push-post-state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
-          aws-region: 'us-east-2'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          push-post-state: ${{ github.event.inputs.push-post-state }}
+          start_block: ${{ matrix.start_block }}
+          end_block: ${{ matrix.end_block }}
+          block_dir_src: ${{ matrix.block_dir_src }}
+          current_state_dir_src: ${{ matrix.current_state_dir_src }}
+          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          push_github_action_benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
+          aws_role: ${{ github.event.inputs.push_post_state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
+          aws_region: 'us-east-2'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          push_post_state: ${{ github.event.inputs.push_post_state }}
           runner_name: ${{ matrix.runner }}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -92,10 +92,10 @@ jobs:
           end-block: ${{ matrix.end-block }}
           block-dir-src: ${{ matrix.block-dir-src }}
           current-state-dir-src: ${{ matrix.current-state-dir-src }}
-          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
-          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
-          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
-          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          prometheus-url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus-push-url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus-username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           push-github-action-benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
           aws-role: ${{ github.event.inputs.push-post-state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -92,9 +92,10 @@ jobs:
           end-block: ${{ matrix.end-block }}
           block-dir-src: ${{ matrix.block-dir-src }}
           current-state-dir-src: ${{ matrix.current-state-dir-src }}
-          prometheus-push-url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
-          prometheus-username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
-          prometheus-password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
           push-github-action-benchmark: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.repository == 'ava-labs/avalanchego' && github.ref_name == 'master') }}
           aws-role: ${{ github.event.inputs.push-post-state != '' && secrets.AWS_S3_RW_ROLE || secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'


### PR DESCRIPTION
This PR is a follow up to the TODO mentioned here: https://github.com/ava-labs/avalanchego/pull/4343#issuecomment-3335464788

After making the original comment, I realized that yaml syntax generally prefers kebab case over snake case, so opening this for discussion, but would prefer to close in favor of unifying GH Actions on kebab case as it seems to be more standard.

Given we often use third party actions that follow this convention, it should be preferred to follow that standard rather than deviating imho.