### PR TITLE
Set `activationTime` equal to `upgrade.InitiallyActiveTime` for `propservm`

### DIFF
--- a/snow/consensus/snowman/snowmantest/block.go
+++ b/snow/consensus/snowman/snowmantest/block.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils"
 )
 
 const (
 	GenesisHeight        uint64 = 0
-	GenesisUnixTimestamp int64  = 1607144400
+	GenesisUnixTimestamp        = upgrade.InitiallyActiveTimeUnix
 )
 
 var (

--- a/snow/consensus/snowman/snowmantest/block.go
+++ b/snow/consensus/snowman/snowmantest/block.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	GenesisHeight        uint64 = 0
-	GenesisUnixTimestamp int64  = 1
+	GenesisUnixTimestamp int64  = 1607144400
 )
 
 var (

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -12,8 +12,10 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 )
 
+const InitiallyActiveTimeUnix = 1599696000
+
 var (
-	InitiallyActiveTime       = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
+	InitiallyActiveTime       = time.Date(2020, time.September, 10, 0, 0, 0, 0, time.UTC)
 	UnscheduledActivationTime = time.Date(9999, time.December, 1, 0, 0, 0, 0, time.UTC)
 
 	Mainnet = Config{

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -46,3 +46,7 @@ func TestInvalidUpgrade(t *testing.T) {
 	err := upgrade.Validate()
 	require.ErrorIs(err, ErrInvalidUpgradeTimes)
 }
+
+func TestInitiallyActiveTime(t *testing.T) {
+	require.Equal(t, int64(InitiallyActiveTimeUnix), InitiallyActiveTime.Unix())
+}

--- a/vms/proposervm/batched_vm_test.go
+++ b/vms/proposervm/batched_vm_test.go
@@ -37,8 +37,8 @@ func TestCoreVMNotRemote(t *testing.T) {
 	// if coreVM is not remote VM, a specific error is returned
 	require := require.New(t)
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	_, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -190,8 +190,8 @@ func TestGetAncestorsPreForkOnly(t *testing.T) {
 func TestGetAncestorsPostForkOnly(t *testing.T) {
 	require := require.New(t)
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, proRemoteVM := initTestRemoteProposerVM(t, activationTime, durangoTime)
 	defer func() {
@@ -690,8 +690,8 @@ func makeParseableBlocks(t *testing.T, parentID ids.ID, timestamp time.Time, pCh
 func TestBatchedParseBlockPostForkOnly(t *testing.T) {
 	require := require.New(t)
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, proRemoteVM := initTestRemoteProposerVM(t, activationTime, durangoTime)
 	defer func() {

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -111,7 +111,7 @@ func TestPreDurangoValidatorNodeBlockBuiltDelaysTests(t *testing.T) {
 	ctx := context.Background()
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -241,7 +241,7 @@ func TestPreDurangoNonValidatorNodeBlockBuiltDelaysTests(t *testing.T) {
 	ctx := context.Background()
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)

--- a/vms/proposervm/post_fork_block_test.go
+++ b/vms/proposervm/post_fork_block_test.go
@@ -45,8 +45,8 @@ func TestOracle_PostForkBlock_ImplementsInterface(t *testing.T) {
 
 	// setup
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	_, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -90,7 +90,7 @@ func TestBlockVerify_PostForkBlock_PreDurango_ParentChecks(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -181,8 +181,8 @@ func TestBlockVerify_PostForkBlock_PostDurango_ParentChecks(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime // post Durango
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime // post Durango
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -277,7 +277,7 @@ func TestBlockVerify_PostForkBlock_TimestampChecks(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -481,8 +481,8 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -635,7 +635,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -804,8 +804,8 @@ func TestBlockVerify_PostForkBlock_CoreBlockVerifyIsCalledOnce(t *testing.T) {
 	// Verify a block once (in this test by building it).
 	// Show that other verify call would not call coreBlk.Verify()
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -863,8 +863,8 @@ func TestBlockAccept_PostForkBlock_SetsLastAcceptedBlock(t *testing.T) {
 
 	// setup
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -922,8 +922,8 @@ func TestBlockAccept_PostForkBlock_TwoProBlocksWithSameCoreBlock_OneIsAccepted(t
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -965,8 +965,8 @@ func TestBlockReject_PostForkBlock_InnerBlockIsNotRejected(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -991,8 +991,8 @@ func TestBlockVerify_PostForkBlock_ShouldBePostForkOption(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -1084,8 +1084,8 @@ func TestBlockVerify_PostForkBlock_PChainTooLow(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 5)
 	defer func() {

--- a/vms/proposervm/post_fork_option_test.go
+++ b/vms/proposervm/post_fork_option_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman/snowmantest"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/vms/proposervm/block"
 )
@@ -40,8 +41,8 @@ func TestBlockVerify_PostForkOption_ParentChecks(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -129,8 +130,8 @@ func TestBlockVerify_PostForkOption_CoreBlockVerifyIsCalledOnce(t *testing.T) {
 
 	// Verify an option once; then show that another verify call would not call coreBlk.Verify()
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -211,8 +212,8 @@ func TestBlockAccept_PostForkOption_SetsLastAcceptedBlock(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -296,8 +297,8 @@ func TestBlockReject_InnerBlockIsNotRejected(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -368,8 +369,8 @@ func TestBlockVerify_PostForkOption_ParentIsNotOracleWithError(t *testing.T) {
 
 	// Verify an option once; then show that another verify call would not call coreBlk.Verify()
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -441,8 +442,8 @@ func TestOptionTimestampValidity(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, db := initTestProposerVM(t, activationTime, durangoTime, 0)
 

--- a/vms/proposervm/pre_fork_block_test.go
+++ b/vms/proposervm/pre_fork_block_test.go
@@ -120,7 +120,7 @@ func TestOracle_PostForkBlkCanBuiltOnPreForkOption(t *testing.T) {
 
 	var (
 		activationTime = snowmantest.GenesisTimestamp.Add(10 * time.Second)
-		durangoTime    = activationTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -129,14 +129,14 @@ func TestOracle_PostForkBlkCanBuiltOnPreForkOption(t *testing.T) {
 
 	// create pre fork oracle block pre activation time...
 	coreTestBlk := snowmantest.BuildChild(snowmantest.Genesis)
-	coreTestBlk.TimestampV = activationTime.Add(-1 * time.Second)
+	coreTestBlk.TimestampV = upgrade.InitiallyActiveTime.Add(-1 * time.Second)
 
 	// ... whose options are post activation time
 	preferredBlk := snowmantest.BuildChild(coreTestBlk)
-	preferredBlk.TimestampV = activationTime.Add(time.Second)
+	preferredBlk.TimestampV = upgrade.InitiallyActiveTime.Add(time.Second)
 
 	unpreferredBlk := snowmantest.BuildChild(coreTestBlk)
-	unpreferredBlk.TimestampV = activationTime.Add(time.Second)
+	unpreferredBlk.TimestampV = upgrade.InitiallyActiveTime.Add(time.Second)
 
 	oracleCoreBlk := &TestOptionsBlock{
 		Block: *coreTestBlk,
@@ -194,7 +194,7 @@ func TestBlockVerify_PreFork_ParentChecks(t *testing.T) {
 
 	var (
 		activationTime = snowmantest.GenesisTimestamp.Add(10 * time.Second)
-		durangoTime    = activationTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -256,14 +256,14 @@ func TestBlockVerify_BlocksBuiltOnPreForkGenesis(t *testing.T) {
 
 	var (
 		activationTime = snowmantest.GenesisTimestamp.Add(10 * time.Second)
-		durangoTime    = activationTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
 		require.NoError(proVM.Shutdown(context.Background()))
 	}()
 
-	preActivationTime := activationTime.Add(-1 * time.Second)
+	preActivationTime := upgrade.InitiallyActiveTime.Add(-1 * time.Second)
 	proVM.Set(preActivationTime)
 
 	coreBlk := snowmantest.BuildChild(snowmantest.Genesis)
@@ -303,7 +303,7 @@ func TestBlockVerify_BlocksBuiltOnPreForkGenesis(t *testing.T) {
 	require.ErrorIs(err, errProposersNotActivated)
 
 	// once activation time is crossed postForkBlock are produced
-	postActivationTime := activationTime.Add(time.Second)
+	postActivationTime := upgrade.InitiallyActiveTime.Add(time.Second)
 	proVM.Set(postActivationTime)
 
 	coreVM.SetPreferenceF = func(context.Context, ids.ID) error {
@@ -365,7 +365,7 @@ func TestBlockVerify_BlocksBuiltOnPostForkGenesis(t *testing.T) {
 
 	var (
 		activationTime = snowmantest.GenesisTimestamp.Add(-1 * time.Second)
-		durangoTime    = activationTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	proVM.Set(activationTime)
@@ -482,14 +482,14 @@ func TestBlockVerify_ForkBlockIsOracleBlock(t *testing.T) {
 
 	var (
 		activationTime = snowmantest.GenesisTimestamp.Add(10 * time.Second)
-		durangoTime    = activationTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
 		require.NoError(proVM.Shutdown(context.Background()))
 	}()
 
-	postActivationTime := activationTime.Add(time.Second)
+	postActivationTime := upgrade.InitiallyActiveTime.Add(time.Second)
 	proVM.Set(postActivationTime)
 
 	coreTestBlk := snowmantest.BuildChild(snowmantest.Genesis)
@@ -552,14 +552,14 @@ func TestBlockVerify_ForkBlockIsOracleBlockButChildrenAreSigned(t *testing.T) {
 
 	var (
 		activationTime = snowmantest.GenesisTimestamp.Add(10 * time.Second)
-		durangoTime    = activationTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
 		require.NoError(proVM.Shutdown(context.Background()))
 	}()
 
-	postActivationTime := activationTime.Add(time.Second)
+	postActivationTime := upgrade.InitiallyActiveTime.Add(time.Second)
 	proVM.Set(postActivationTime)
 
 	coreTestBlk := snowmantest.BuildChild(snowmantest.Genesis)

--- a/vms/proposervm/vm_byzantine_test.go
+++ b/vms/proposervm/vm_byzantine_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/hex"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman/snowmantest"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/vms/proposervm/block"
 )
 
@@ -33,8 +33,8 @@ func TestInvalidByzantineProposerParent(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -86,8 +86,8 @@ func TestInvalidByzantineProposerOracleParent(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	proVM.Set(snowmantest.GenesisTimestamp)
@@ -170,8 +170,8 @@ func TestInvalidByzantineProposerPreForkParent(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -237,8 +237,8 @@ func TestBlockVerify_PostForkOption_FaultyParent(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	proVM.Set(snowmantest.GenesisTimestamp)
@@ -316,8 +316,8 @@ func TestBlockVerify_InvalidPostForkOption(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	proVM.Set(snowmantest.GenesisTimestamp)
@@ -445,8 +445,8 @@ func TestGetBlock_MutatedSignature(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -2542,8 +2542,8 @@ func TestTimestampMetrics(t *testing.T) {
 
 	innerBlock := snowmantest.BuildChild(snowmantest.Genesis)
 
-	outerTime := time.Unix(1.6071444e+09, 0)
-	innerTime := time.Unix(142857, 0)
+	outerTime := time.Unix(upgrade.InitiallyActiveTimeUnix+1000, 0)
+	innerTime := time.Unix(49463, 0) // the actual numbers do not matter here, we just verify the metrics are populated correctly
 	proVM.Clock.Set(outerTime)
 	innerBlock.TimestampV = innerTime
 

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -247,8 +247,8 @@ func TestBuildBlockTimestampAreRoundedToSeconds(t *testing.T) {
 
 	// given the same core block, BuildBlock returns the same proposer block
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -275,8 +275,8 @@ func TestBuildBlockIsIdempotent(t *testing.T) {
 
 	// given the same core block, BuildBlock returns the same proposer block
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -305,8 +305,8 @@ func TestFirstProposerBlockIsBuiltOnTopOfGenesis(t *testing.T) {
 
 	// setup
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -334,8 +334,8 @@ func TestProposerBlocksAreBuiltOnPreferredProBlock(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -406,8 +406,8 @@ func TestCoreBlocksMustBeBuiltOnPreferredCoreBlock(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -479,8 +479,8 @@ func TestCoreBlockFailureCauseProposerBlockParseFailure(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -519,8 +519,8 @@ func TestTwoProBlocksWrappingSameCoreBlockCanBeParsed(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -589,8 +589,8 @@ func TestTwoProBlocksWithSameParentCanBothVerify(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -972,8 +972,8 @@ func TestInnerBlockDeduplication(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -1235,7 +1235,7 @@ func TestBuildBlockDuringWindow(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -1324,7 +1324,7 @@ func TestTwoForks_OneIsAccepted(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -1396,7 +1396,7 @@ func TestTooFarAdvanced(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -1469,7 +1469,7 @@ func TestTwoOptions_OneIsAccepted(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -1517,8 +1517,8 @@ func TestLaggedPChainHeight(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -2375,8 +2375,8 @@ func TestGetPostDurangoSlotTimeWithNoValidators(t *testing.T) {
 	require := require.New(t)
 
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 	)
 	coreVM, valState, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
 	defer func() {
@@ -2531,7 +2531,7 @@ func TestTimestampMetrics(t *testing.T) {
 	ctx := context.Background()
 
 	var (
-		activationTime = time.Unix(0, 0)
+		activationTime = upgrade.InitiallyActiveTime
 		durangoTime    = upgrade.UnscheduledActivationTime
 	)
 	coreVM, _, proVM, _ := initTestProposerVM(t, activationTime, durangoTime, 0)
@@ -2542,7 +2542,7 @@ func TestTimestampMetrics(t *testing.T) {
 
 	innerBlock := snowmantest.BuildChild(snowmantest.Genesis)
 
-	outerTime := time.Unix(314159, 0)
+	outerTime := time.Unix(1.6071444e+09, 0)
 	innerTime := time.Unix(142857, 0)
 	proVM.Clock.Set(outerTime)
 	innerBlock.TimestampV = innerTime
@@ -2574,8 +2574,8 @@ func TestTimestampMetrics(t *testing.T) {
 
 func TestSelectChildPChainHeight(t *testing.T) {
 	var (
-		activationTime = time.Unix(0, 0)
-		durangoTime    = activationTime
+		activationTime = upgrade.InitiallyActiveTime
+		durangoTime    = upgrade.InitiallyActiveTime
 
 		beforeOverrideEnds = fujiOverridePChainHeightUntilTimestamp.Add(-time.Minute)
 	)


### PR DESCRIPTION
## Why this should be merged
This PR builds towards using the upgradetest package for forks, and that package uses the upgrade.InitiallyActiveTime values. Next we can replace all the values with the fork. 

## How this was tested
Existing CI

## Need to be documented in RELEASES.md?
No
