### PR TITLE
fix: blockdb has block don't error if invalid block height

### DIFF
--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -537,7 +537,7 @@ func (s *Database) HasBlock(height BlockHeight) (bool, error) {
 
 	_, err := s.readBlockIndex(height)
 	if err != nil {
-		if errors.Is(err, ErrBlockNotFound) {
+		if errors.Is(err, ErrBlockNotFound) || errors.Is(err, ErrInvalidBlockHeight) {
 			return false, nil
 		}
 		s.log.Error("Failed to check if block exists: failed to read index entry",


### PR DESCRIPTION
## Why this should be merged

Fix the behaviour of `HasBlock` in `x/blockdb`. Currently if request a block below the min height of the database or a large block height that is not supported by the index file, then it returns an `ErrInvalidBlockHeight` error. Instead, we should just return `false` with no error as that makes more sense.

## How this works

Treat both `ErrInvalidBlockHeight` and `ErrBlockNotFound` as expected errors for `HasBlock`

## How this was tested

Add unit tests for HasBlock behaviour

## Need to be documented in RELEASES.md?
