### PR TITLE
Use `acp226.DelayExcess` rather than `uint64`

### DIFF
--- a/vms/evm/acp226/acp226_test.go
+++ b/vms/evm/acp226/acp226_test.go
@@ -98,7 +98,7 @@ var (
 	updateExcessTests = []struct {
 		name          string
 		initial       DelayExcess
-		desiredExcess uint64
+		desiredExcess DelayExcess
 		expected      DelayExcess
 	}{
 		{
@@ -203,7 +203,7 @@ func TestDesiredDelayExcess(t *testing.T) {
 			continue
 		}
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.excess, DelayExcess(DesiredDelayExcess(test.delay)))
+			require.Equal(t, test.excess, DesiredDelayExcess(test.delay))
 		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Using the defined type reduces the number of casts required by the user and makes the code more readable.

## How this works

- `UpdateDelayExcess` takes in a `DelayExcess` (not a time)
- `DesiredDelayExcess` returns a `DelayExcess` (not a time)

## How this was tested

N/A

## Need to be documented in RELEASES.md?

no