### PR TITLE
Move canonical warp ordering to validators package

### DIFF
--- a/network/p2p/acp118/aggregator.go
+++ b/network/p2p/acp118/aggregator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/proto/pb/sdk"
+	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -24,7 +25,7 @@ import (
 var errFailedVerification = errors.New("failed verification")
 
 type indexedValidator struct {
-	*warp.Validator
+	*validators.Warp
 	Index int
 }
 
@@ -58,7 +59,7 @@ func (s *SignatureAggregator) AggregateSignatures(
 	ctx context.Context,
 	message *warp.Message,
 	justification []byte,
-	validators []*warp.Validator,
+	validators []*validators.Warp,
 	quorumNum uint64,
 	quorumDen uint64,
 ) (
@@ -100,8 +101,8 @@ func (s *SignatureAggregator) AggregateSignatures(
 		}
 
 		v := indexedValidator{
-			Index:     i,
-			Validator: validator,
+			Index: i,
+			Warp:  validator,
 		}
 
 		for _, nodeID := range v.NodeIDs {

--- a/network/p2p/acp118/aggregator_test.go
+++ b/network/p2p/acp118/aggregator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/p2ptest"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -49,7 +50,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 		ctx            context.Context
 		msg            *warp.Message
 		signature      warp.BitSetSignature
-		validators     []*warp.Validator
+		validators     []*validators.Warp
 		quorumNum      uint64
 		quorumDen      uint64
 		wantTotalStake int
@@ -75,7 +76,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -105,7 +106,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -136,7 +137,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -169,7 +170,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -212,7 +213,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -255,7 +256,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -298,7 +299,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -341,7 +342,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -384,7 +385,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -427,7 +428,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk1,
 					Weight:    1,
@@ -460,7 +461,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -501,7 +502,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -538,7 +539,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       &warp.BitSetSignature{},
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,
@@ -589,7 +590,7 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 					Signature:       sig,
 				}
 			}(),
-			validators: []*warp.Validator{
+			validators: []*validators.Warp{
 				{
 					PublicKey: pk0,
 					Weight:    1,

--- a/snow/validators/warp.go
+++ b/snow/validators/warp.go
@@ -25,7 +25,8 @@ type WarpSet struct {
 }
 
 type Warp struct {
-	PublicKey      *bls.PublicKey
+	PublicKey *bls.PublicKey
+	// PublicKeyBytes is expected to be in the uncompressed form.
 	PublicKeyBytes []byte
 	Weight         uint64
 	NodeIDs        []ids.NodeID

--- a/snow/validators/warp.go
+++ b/snow/validators/warp.go
@@ -17,9 +17,10 @@ import (
 var _ utils.Sortable[*Warp] = (*Warp)(nil)
 
 type WarpSet struct {
-	// Validators slice in canonical ordering of the validators that has public key
+	// Slice, in canonical ordering, of the validators that have a public key.
 	Validators []*Warp
-	// The total weight of all the validators, including the ones that doesn't have a public key
+	// The total weight of all the validators, including the ones that don't
+	// have a public key.
 	TotalWeight uint64
 }
 

--- a/snow/validators/warp.go
+++ b/snow/validators/warp.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package validators
+
+import (
+	"bytes"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/utils/math"
+)
+
+var _ utils.Sortable[*Warp] = (*Warp)(nil)
+
+type WarpSet struct {
+	// Validators slice in canonical ordering of the validators that has public key
+	Validators []*Warp
+	// The total weight of all the validators, including the ones that doesn't have a public key
+	TotalWeight uint64
+}
+
+type Warp struct {
+	PublicKey      *bls.PublicKey
+	PublicKeyBytes []byte
+	Weight         uint64
+	NodeIDs        []ids.NodeID
+}
+
+func (w *Warp) Compare(o *Warp) int {
+	return bytes.Compare(w.PublicKeyBytes, o.PublicKeyBytes)
+}
+
+// FlattenValidatorSet converts the provided vdrSet into a canonical ordering.
+func FlattenValidatorSet(vdrSet map[ids.NodeID]*GetValidatorOutput) (WarpSet, error) {
+	var (
+		vdrs        = make(map[string]*Warp, len(vdrSet))
+		totalWeight uint64
+		err         error
+	)
+	for _, vdr := range vdrSet {
+		totalWeight, err = math.Add(totalWeight, vdr.Weight)
+		if err != nil {
+			return WarpSet{}, err
+		}
+
+		if vdr.PublicKey == nil {
+			continue
+		}
+
+		pkBytes := bls.PublicKeyToUncompressedBytes(vdr.PublicKey)
+		uniqueVdr, ok := vdrs[string(pkBytes)]
+		if !ok {
+			uniqueVdr = &Warp{
+				PublicKey:      vdr.PublicKey,
+				PublicKeyBytes: pkBytes,
+			}
+			vdrs[string(pkBytes)] = uniqueVdr
+		}
+
+		uniqueVdr.Weight += vdr.Weight // Impossible to overflow here
+		uniqueVdr.NodeIDs = append(uniqueVdr.NodeIDs, vdr.NodeID)
+	}
+
+	// Sort validators by public key
+	vdrList := maps.Values(vdrs)
+	utils.Sort(vdrList)
+	return WarpSet{Validators: vdrList, TotalWeight: totalWeight}, nil
+}

--- a/snow/validators/warp_test.go
+++ b/snow/validators/warp_test.go
@@ -1,0 +1,168 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package validators
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
+
+	safemath "github.com/ava-labs/avalanchego/utils/math"
+)
+
+var (
+	_ utils.Sortable[*testWarp] = (*testWarp)(nil)
+
+	testVdrs []*testWarp
+)
+
+type testWarp struct {
+	nodeID ids.NodeID
+	sk     bls.Signer
+	vdr    *Warp
+}
+
+func (v *testWarp) Compare(o *testWarp) int {
+	return v.vdr.Compare(o.vdr)
+}
+
+func newTestValidator() *testWarp {
+	sk, err := localsigner.New()
+	if err != nil {
+		panic(err)
+	}
+
+	nodeID := ids.GenerateTestNodeID()
+	pk := sk.PublicKey()
+	return &testWarp{
+		nodeID: nodeID,
+		sk:     sk,
+		vdr: &Warp{
+			PublicKey:      pk,
+			PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk),
+			Weight:         3,
+			NodeIDs:        []ids.NodeID{nodeID},
+		},
+	}
+}
+
+func init() {
+	testVdrs = []*testWarp{
+		newTestValidator(),
+		newTestValidator(),
+		newTestValidator(),
+	}
+	utils.Sort(testVdrs)
+}
+
+func TestFlattenValidatorSet(t *testing.T) {
+	tests := []struct {
+		name       string
+		validators map[ids.NodeID]*GetValidatorOutput
+		want       WarpSet
+		wantErr    error
+	}{
+		{
+			name: "overflow",
+			validators: map[ids.NodeID]*GetValidatorOutput{
+				testVdrs[0].nodeID: {
+					NodeID:    testVdrs[0].nodeID,
+					PublicKey: testVdrs[0].vdr.PublicKey,
+					Weight:    math.MaxUint64,
+				},
+				testVdrs[1].nodeID: {
+					NodeID:    testVdrs[1].nodeID,
+					PublicKey: testVdrs[1].vdr.PublicKey,
+					Weight:    1,
+				},
+			},
+			wantErr: safemath.ErrOverflow,
+		},
+		{
+			name: "nil_public_key_skipped",
+			validators: map[ids.NodeID]*GetValidatorOutput{
+				testVdrs[0].nodeID: {
+					NodeID:    testVdrs[0].nodeID,
+					PublicKey: testVdrs[0].vdr.PublicKey,
+					Weight:    testVdrs[0].vdr.Weight,
+				},
+				testVdrs[1].nodeID: {
+					NodeID:    testVdrs[1].nodeID,
+					PublicKey: nil,
+					Weight:    1,
+				},
+			},
+			want: WarpSet{
+				Validators:  []*Warp{testVdrs[0].vdr},
+				TotalWeight: testVdrs[0].vdr.Weight + 1,
+			},
+		},
+		{
+			name: "sorted", // Would non-deterministically fail without sorting
+			validators: map[ids.NodeID]*GetValidatorOutput{
+				testVdrs[0].nodeID: {
+					NodeID:    testVdrs[0].nodeID,
+					PublicKey: testVdrs[0].vdr.PublicKey,
+					Weight:    testVdrs[0].vdr.Weight,
+				},
+				testVdrs[1].nodeID: {
+					NodeID:    testVdrs[1].nodeID,
+					PublicKey: testVdrs[1].vdr.PublicKey,
+					Weight:    testVdrs[1].vdr.Weight,
+				},
+				testVdrs[2].nodeID: {
+					NodeID:    testVdrs[2].nodeID,
+					PublicKey: testVdrs[2].vdr.PublicKey,
+					Weight:    testVdrs[2].vdr.Weight,
+				},
+			},
+			want: WarpSet{
+				Validators:  []*Warp{testVdrs[0].vdr, testVdrs[1].vdr, testVdrs[2].vdr},
+				TotalWeight: testVdrs[0].vdr.Weight + testVdrs[1].vdr.Weight + testVdrs[2].vdr.Weight,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			got, err := FlattenValidatorSet(test.validators)
+			require.ErrorIs(err, test.wantErr)
+			require.Equal(test.want, got)
+		})
+	}
+}
+
+func BenchmarkFlattenValidatorSet(b *testing.B) {
+	for size := 1; size <= 1<<10; size *= 2 {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			vdrs := make(
+				map[ids.NodeID]*GetValidatorOutput,
+				size,
+			)
+			for range size {
+				nodeID := ids.GenerateTestNodeID()
+				secretKey, err := localsigner.New()
+				require.NoError(b, err)
+				publicKey := secretKey.PublicKey()
+				vdrs[nodeID] = &GetValidatorOutput{
+					NodeID:    nodeID,
+					PublicKey: publicKey,
+					Weight:    1,
+				}
+			}
+			for b.Loop() {
+				_, err := FlattenValidatorSet(vdrs)
+				require.NoError(b, err)
+			}
+		})
+	}
+}

--- a/snow/validators/warp_test.go
+++ b/snow/validators/warp_test.go
@@ -29,7 +29,7 @@ func newWarp(t *testing.T) *Warp {
 	return &Warp{
 		PublicKey:      pk,
 		PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk),
-		Weight:         3,
+		Weight:         1,
 		NodeIDs:        []ids.NodeID{nodeID},
 	}
 }
@@ -44,7 +44,7 @@ func newWarpSet(t *testing.T, n uint64) WarpSet {
 	utils.Sort(vdrs)
 	return WarpSet{
 		Validators:  vdrs,
-		TotalWeight: 3 * n,
+		TotalWeight: n,
 	}
 }
 
@@ -88,12 +88,12 @@ func TestFlattenValidatorSet(t *testing.T) {
 				nodeID1: {
 					NodeID:    nodeID1,
 					PublicKey: nil,
-					Weight:    1,
+					Weight:    5, // don't use 1 to distinguish from default
 				},
 			},
 			want: WarpSet{
 				Validators:  []*Warp{vdrs.Validators[0]},
-				TotalWeight: vdrs.Validators[0].Weight + 1,
+				TotalWeight: vdrs.Validators[0].Weight + 5,
 			},
 		},
 		{

--- a/snow/validators/warp_test.go
+++ b/snow/validators/warp_test.go
@@ -72,15 +72,11 @@ func TestFlattenValidatorSet(t *testing.T) {
 		{
 			name: "overflow",
 			validators: map[ids.NodeID]*GetValidatorOutput{
-				nodeID0: {
-					NodeID:    nodeID0,
-					PublicKey: vdrs.Validators[0].PublicKey,
-					Weight:    math.MaxUint64,
-				},
+				nodeID0: warpToOutput(vdrs.Validators[0]),
 				nodeID1: {
 					NodeID:    nodeID1,
 					PublicKey: vdrs.Validators[1].PublicKey,
-					Weight:    1,
+					Weight:    math.MaxUint64,
 				},
 			},
 			wantErr: safemath.ErrOverflow,
@@ -88,11 +84,7 @@ func TestFlattenValidatorSet(t *testing.T) {
 		{
 			name: "nil_public_key_skipped",
 			validators: map[ids.NodeID]*GetValidatorOutput{
-				nodeID0: {
-					NodeID:    nodeID0,
-					PublicKey: vdrs.Validators[0].PublicKey,
-					Weight:    vdrs.Validators[0].Weight,
-				},
+				nodeID0: warpToOutput(vdrs.Validators[0]),
 				nodeID1: {
 					NodeID:    nodeID1,
 					PublicKey: nil,

--- a/vms/platformvm/warp/signature.go
+++ b/vms/platformvm/warp/signature.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
@@ -37,7 +38,7 @@ type Signature interface {
 	Verify(
 		msg *UnsignedMessage,
 		networkID uint32,
-		validators CanonicalValidatorSet,
+		validators validators.WarpSet,
 		quorumNum uint64,
 		quorumDen uint64,
 	) error
@@ -66,7 +67,7 @@ func (s *BitSetSignature) NumSigners() (int, error) {
 func (s *BitSetSignature) Verify(
 	msg *UnsignedMessage,
 	networkID uint32,
-	validators CanonicalValidatorSet,
+	validators validators.WarpSet,
 	quorumNum uint64,
 	quorumDen uint64,
 ) error {

--- a/vms/platformvm/warp/signature_test.go
+++ b/vms/platformvm/warp/signature_test.go
@@ -34,7 +34,7 @@ var (
 type testValidator struct {
 	nodeID ids.NodeID
 	sk     bls.Signer
-	vdr    *Validator
+	vdr    *validators.Warp
 }
 
 func (v *testValidator) Compare(o *testValidator) int {
@@ -52,7 +52,7 @@ func newTestValidator() *testValidator {
 	return &testValidator{
 		nodeID: nodeID,
 		sk:     sk,
-		vdr: &Validator{
+		vdr: &validators.Warp{
 			PublicKey:      pk,
 			PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk),
 			Weight:         3,
@@ -160,7 +160,7 @@ func TestSignatureVerification(t *testing.T) {
 	tests := []struct {
 		name       string
 		networkID  uint32
-		validators CanonicalValidatorSet
+		validators validators.WarpSet
 		quorumDen  uint64
 		signature  *BitSetSignature
 		wantErr    error
@@ -168,8 +168,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "wrong_networkID",
 			networkID: constants.UnitTestID + 1,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 					testVdrs[2].vdr,
 				},
@@ -187,8 +187,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "inefficient_bitset",
 			networkID: constants.UnitTestID,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 				},
 				TotalWeight: testVdrs[0].vdr.Weight +
@@ -205,8 +205,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "unknown_index",
 			networkID: constants.UnitTestID,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 				},
 				TotalWeight: testVdrs[0].vdr.Weight +
@@ -223,8 +223,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "insufficient_weight",
 			networkID: constants.UnitTestID,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 					testVdrs[1].vdr,
 					testVdrs[2].vdr,
@@ -243,8 +243,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "impossible_to_have_sufficient_weight",
 			networkID: constants.UnitTestID,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 				},
 				TotalWeight: testVdrs[0].vdr.Weight +
@@ -261,8 +261,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "malformed_signature",
 			networkID: constants.UnitTestID,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 				},
 				TotalWeight: testVdrs[0].vdr.Weight +
@@ -279,8 +279,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "invalid_signature",
 			networkID: constants.UnitTestID,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 				},
 				TotalWeight: testVdrs[0].vdr.Weight +
@@ -297,8 +297,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "valid",
 			networkID: constants.UnitTestID,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 					testVdrs[2].vdr,
 				},
@@ -315,8 +315,8 @@ func TestSignatureVerification(t *testing.T) {
 		{
 			name:      "valid_partial_signers",
 			networkID: constants.UnitTestID,
-			validators: CanonicalValidatorSet{
-				Validators: []*Validator{
+			validators: validators.WarpSet{
+				Validators: []*validators.Warp{
 					testVdrs[0].vdr,
 					testVdrs[1].vdr,
 					testVdrs[2].vdr,
@@ -386,7 +386,7 @@ func BenchmarkSignatureVerification(b *testing.B) {
 			aggSigBytes := [bls.SignatureLen]byte{}
 			copy(aggSigBytes[:], bls.SignatureToBytes(aggSig))
 
-			canonicalValidators, err := FlattenValidatorSet(vdrs)
+			canonicalValidators, err := validators.FlattenValidatorSet(vdrs)
 			require.NoError(b, err)
 
 			sig := &BitSetSignature{

--- a/vms/platformvm/warp/validator.go
+++ b/vms/platformvm/warp/validator.go
@@ -4,24 +4,18 @@
 package warp
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 
-	"golang.org/x/exp/maps"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"
-	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 var (
-	_ utils.Sortable[*Validator] = (*Validator)(nil)
-
 	ErrUnknownValidator = errors.New("unknown validator")
 	ErrWeightOverflow   = errors.New("weight overflowed")
 )
@@ -32,79 +26,33 @@ type ValidatorState interface {
 	GetValidatorSet(ctx context.Context, height uint64, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error)
 }
 
-type CanonicalValidatorSet struct {
-	// Validators slice in canonical ordering of the validators that has public key
-	Validators []*Validator
-	// The total weight of all the validators, including the ones that doesn't have a public key
-	TotalWeight uint64
-}
+type (
+	// Deprecated: use [validators.WarpSet] instead.
+	CanonicalValidatorSet = validators.WarpSet
+	// Deprecated: use [validators.Warp] instead.
+	Validator = validators.Warp
+)
 
-type Validator struct {
-	PublicKey      *bls.PublicKey
-	PublicKeyBytes []byte
-	Weight         uint64
-	NodeIDs        []ids.NodeID
-}
-
-func (v *Validator) Compare(o *Validator) int {
-	return bytes.Compare(v.PublicKeyBytes, o.PublicKeyBytes)
-}
+// Deprecated: use [validators.FlattenValidatorSet] instead.
+var FlattenValidatorSet = validators.FlattenValidatorSet
 
 // GetCanonicalValidatorSetFromSubnetID returns the CanonicalValidatorSet of [subnetID] at
-// [pChcainHeight]. The returned CanonicalValidatorSet includes the validator set in a canonical ordering
+// [pChainHeight]. The returned CanonicalValidatorSet includes the validator set in a canonical ordering
 // and the total weight.
 func GetCanonicalValidatorSetFromSubnetID(
 	ctx context.Context,
 	pChainState ValidatorState,
 	pChainHeight uint64,
 	subnetID ids.ID,
-) (CanonicalValidatorSet, error) {
+) (validators.WarpSet, error) {
 	// Get the validator set at the given height.
 	vdrSet, err := pChainState.GetValidatorSet(ctx, pChainHeight, subnetID)
 	if err != nil {
-		return CanonicalValidatorSet{}, err
+		return validators.WarpSet{}, err
 	}
 
 	// Convert the validator set into the canonical ordering.
-	return FlattenValidatorSet(vdrSet)
-}
-
-// FlattenValidatorSet converts the provided [vdrSet] into a canonical ordering.
-// Also returns the total weight of the validator set.
-func FlattenValidatorSet(vdrSet map[ids.NodeID]*validators.GetValidatorOutput) (CanonicalValidatorSet, error) {
-	var (
-		vdrs        = make(map[string]*Validator, len(vdrSet))
-		totalWeight uint64
-		err         error
-	)
-	for _, vdr := range vdrSet {
-		totalWeight, err = math.Add(totalWeight, vdr.Weight)
-		if err != nil {
-			return CanonicalValidatorSet{}, fmt.Errorf("%w: %w", ErrWeightOverflow, err)
-		}
-
-		if vdr.PublicKey == nil {
-			continue
-		}
-
-		pkBytes := bls.PublicKeyToUncompressedBytes(vdr.PublicKey)
-		uniqueVdr, ok := vdrs[string(pkBytes)]
-		if !ok {
-			uniqueVdr = &Validator{
-				PublicKey:      vdr.PublicKey,
-				PublicKeyBytes: pkBytes,
-			}
-			vdrs[string(pkBytes)] = uniqueVdr
-		}
-
-		uniqueVdr.Weight += vdr.Weight // Impossible to overflow here
-		uniqueVdr.NodeIDs = append(uniqueVdr.NodeIDs, vdr.NodeID)
-	}
-
-	// Sort validators by public key
-	vdrList := maps.Values(vdrs)
-	utils.Sort(vdrList)
-	return CanonicalValidatorSet{Validators: vdrList, TotalWeight: totalWeight}, nil
+	return validators.FlattenValidatorSet(vdrSet)
 }
 
 // FilterValidators returns the validators in [vdrs] whose bit is set to 1 in
@@ -113,8 +61,8 @@ func FlattenValidatorSet(vdrSet map[ids.NodeID]*validators.GetValidatorOutput) (
 // Returns an error if [indices] references an unknown validator.
 func FilterValidators(
 	indices set.Bits,
-	vdrs []*Validator,
-) ([]*Validator, error) {
+	vdrs []*validators.Warp,
+) ([]*validators.Warp, error) {
 	// Verify that all alleged signers exist
 	if indices.BitLen() > len(vdrs) {
 		return nil, fmt.Errorf(
@@ -125,7 +73,7 @@ func FilterValidators(
 		)
 	}
 
-	filteredVdrs := make([]*Validator, 0, len(vdrs))
+	filteredVdrs := make([]*validators.Warp, 0, len(vdrs))
 	for i, vdr := range vdrs {
 		if !indices.Contains(i) {
 			continue
@@ -137,7 +85,7 @@ func FilterValidators(
 }
 
 // SumWeight returns the total weight of the provided validators.
-func SumWeight(vdrs []*Validator) (uint64, error) {
+func SumWeight(vdrs []*validators.Warp) (uint64, error) {
 	var (
 		weight uint64
 		err    error
@@ -154,7 +102,7 @@ func SumWeight(vdrs []*Validator) (uint64, error) {
 // AggregatePublicKeys returns the public key of the provided validators.
 //
 // Invariant: All of the public keys in [vdrs] are valid.
-func AggregatePublicKeys(vdrs []*Validator) (*bls.PublicKey, error) {
+func AggregatePublicKeys(vdrs []*validators.Warp) (*bls.PublicKey, error) {
 	pks := make([]*bls.PublicKey, len(vdrs))
 	for i, vdr := range vdrs {
 		pks[i] = vdr.PublicKey
@@ -167,10 +115,10 @@ func GetCanonicalValidatorSetFromChainID(ctx context.Context,
 	pChainState validators.State,
 	pChainHeight uint64,
 	sourceChainID ids.ID,
-) (CanonicalValidatorSet, error) {
+) (validators.WarpSet, error) {
 	subnetID, err := pChainState.GetSubnetID(ctx, sourceChainID)
 	if err != nil {
-		return CanonicalValidatorSet{}, err
+		return validators.WarpSet{}, err
 	}
 
 	return GetCanonicalValidatorSetFromSubnetID(ctx, pChainState, pChainHeight, subnetID)

--- a/vms/platformvm/warp/validator_test.go
+++ b/vms/platformvm/warp/validator_test.go
@@ -19,15 +19,13 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/utils/set"
-
-	safemath "github.com/ava-labs/avalanchego/utils/math"
 )
 
 func TestGetCanonicalValidatorSet(t *testing.T) {
 	type test struct {
 		name           string
 		stateF         func(*gomock.Controller) validators.State
-		expectedVdrs   []*Validator
+		expectedVdrs   []*validators.Warp
 		expectedWeight uint64
 		expectedErr    error
 	}
@@ -63,7 +61,7 @@ func TestGetCanonicalValidatorSet(t *testing.T) {
 				)
 				return state
 			},
-			expectedVdrs:   []*Validator{testVdrs[0].vdr, testVdrs[1].vdr},
+			expectedVdrs:   []*validators.Warp{testVdrs[0].vdr, testVdrs[1].vdr},
 			expectedWeight: 6,
 			expectedErr:    nil,
 		},
@@ -93,7 +91,7 @@ func TestGetCanonicalValidatorSet(t *testing.T) {
 				)
 				return state
 			},
-			expectedVdrs: []*Validator{
+			expectedVdrs: []*validators.Warp{
 				{
 					PublicKey:      testVdrs[0].vdr.PublicKey,
 					PublicKeyBytes: testVdrs[0].vdr.PublicKeyBytes,
@@ -129,7 +127,7 @@ func TestGetCanonicalValidatorSet(t *testing.T) {
 				)
 				return state
 			},
-			expectedVdrs:   []*Validator{testVdrs[1].vdr},
+			expectedVdrs:   []*validators.Warp{testVdrs[1].vdr},
 			expectedWeight: 6,
 			expectedErr:    nil,
 		},
@@ -168,7 +166,7 @@ func TestFilterValidators(t *testing.T) {
 	sk0, err := localsigner.New()
 	require.NoError(t, err)
 	pk0 := sk0.PublicKey()
-	vdr0 := &Validator{
+	vdr0 := &validators.Warp{
 		PublicKey:      pk0,
 		PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk0),
 		Weight:         1,
@@ -177,7 +175,7 @@ func TestFilterValidators(t *testing.T) {
 	sk1, err := localsigner.New()
 	require.NoError(t, err)
 	pk1 := sk1.PublicKey()
-	vdr1 := &Validator{
+	vdr1 := &validators.Warp{
 		PublicKey:      pk1,
 		PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk1),
 		Weight:         2,
@@ -186,8 +184,8 @@ func TestFilterValidators(t *testing.T) {
 	type test struct {
 		name         string
 		indices      set.Bits
-		vdrs         []*Validator
-		expectedVdrs []*Validator
+		vdrs         []*validators.Warp
+		expectedVdrs []*validators.Warp
 		expectedErr  error
 	}
 
@@ -195,34 +193,34 @@ func TestFilterValidators(t *testing.T) {
 		{
 			name:         "empty",
 			indices:      set.NewBits(),
-			vdrs:         []*Validator{},
-			expectedVdrs: []*Validator{},
+			vdrs:         []*validators.Warp{},
+			expectedVdrs: []*validators.Warp{},
 			expectedErr:  nil,
 		},
 		{
 			name:        "unknown validator",
 			indices:     set.NewBits(2),
-			vdrs:        []*Validator{vdr0, vdr1},
+			vdrs:        []*validators.Warp{vdr0, vdr1},
 			expectedErr: ErrUnknownValidator,
 		},
 		{
 			name:    "two filtered out",
 			indices: set.NewBits(),
-			vdrs: []*Validator{
+			vdrs: []*validators.Warp{
 				vdr0,
 				vdr1,
 			},
-			expectedVdrs: []*Validator{},
+			expectedVdrs: []*validators.Warp{},
 			expectedErr:  nil,
 		},
 		{
 			name:    "one filtered out",
 			indices: set.NewBits(1),
-			vdrs: []*Validator{
+			vdrs: []*validators.Warp{
 				vdr0,
 				vdr1,
 			},
-			expectedVdrs: []*Validator{
+			expectedVdrs: []*validators.Warp{
 				vdr1,
 			},
 			expectedErr: nil,
@@ -230,11 +228,11 @@ func TestFilterValidators(t *testing.T) {
 		{
 			name:    "none filtered out",
 			indices: set.NewBits(0, 1),
-			vdrs: []*Validator{
+			vdrs: []*validators.Warp{
 				vdr0,
 				vdr1,
 			},
-			expectedVdrs: []*Validator{
+			expectedVdrs: []*validators.Warp{
 				vdr0,
 				vdr1,
 			},
@@ -257,19 +255,19 @@ func TestFilterValidators(t *testing.T) {
 }
 
 func TestSumWeight(t *testing.T) {
-	vdr0 := &Validator{
+	vdr0 := &validators.Warp{
 		Weight: 1,
 	}
-	vdr1 := &Validator{
+	vdr1 := &validators.Warp{
 		Weight: 2,
 	}
-	vdr2 := &Validator{
+	vdr2 := &validators.Warp{
 		Weight: math.MaxUint64,
 	}
 
 	type test struct {
 		name        string
-		vdrs        []*Validator
+		vdrs        []*validators.Warp
 		expectedSum uint64
 		expectedErr error
 	}
@@ -277,22 +275,22 @@ func TestSumWeight(t *testing.T) {
 	tests := []test{
 		{
 			name:        "empty",
-			vdrs:        []*Validator{},
+			vdrs:        []*validators.Warp{},
 			expectedSum: 0,
 		},
 		{
 			name:        "one",
-			vdrs:        []*Validator{vdr0},
+			vdrs:        []*validators.Warp{vdr0},
 			expectedSum: 1,
 		},
 		{
 			name:        "two",
-			vdrs:        []*Validator{vdr0, vdr1},
+			vdrs:        []*validators.Warp{vdr0, vdr1},
 			expectedSum: 3,
 		},
 		{
 			name:        "overflow",
-			vdrs:        []*Validator{vdr0, vdr2},
+			vdrs:        []*validators.Warp{vdr0, vdr2},
 			expectedErr: ErrWeightOverflow,
 		},
 	}
@@ -343,110 +341,6 @@ func BenchmarkGetCanonicalValidatorSet(b *testing.B) {
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := GetCanonicalValidatorSetFromSubnetID(context.Background(), validatorState, pChainHeight, subnetID)
-				require.NoError(b, err)
-			}
-		})
-	}
-}
-
-func TestFlattenValidatorSet(t *testing.T) {
-	tests := []struct {
-		name       string
-		validators map[ids.NodeID]*validators.GetValidatorOutput
-		want       CanonicalValidatorSet
-		wantErr    error
-	}{
-		{
-			name: "overflow",
-			validators: map[ids.NodeID]*validators.GetValidatorOutput{
-				testVdrs[0].nodeID: {
-					NodeID:    testVdrs[0].nodeID,
-					PublicKey: testVdrs[0].vdr.PublicKey,
-					Weight:    math.MaxUint64,
-				},
-				testVdrs[1].nodeID: {
-					NodeID:    testVdrs[1].nodeID,
-					PublicKey: testVdrs[1].vdr.PublicKey,
-					Weight:    1,
-				},
-			},
-			wantErr: safemath.ErrOverflow,
-		},
-		{
-			name: "nil_public_key_skipped",
-			validators: map[ids.NodeID]*validators.GetValidatorOutput{
-				testVdrs[0].nodeID: {
-					NodeID:    testVdrs[0].nodeID,
-					PublicKey: testVdrs[0].vdr.PublicKey,
-					Weight:    testVdrs[0].vdr.Weight,
-				},
-				testVdrs[1].nodeID: {
-					NodeID:    testVdrs[1].nodeID,
-					PublicKey: nil,
-					Weight:    1,
-				},
-			},
-			want: CanonicalValidatorSet{
-				Validators:  []*Validator{testVdrs[0].vdr},
-				TotalWeight: testVdrs[0].vdr.Weight + 1,
-			},
-		},
-		{
-			name: "sorted", // Would non-deterministically fail without sorting
-			validators: map[ids.NodeID]*validators.GetValidatorOutput{
-				testVdrs[0].nodeID: {
-					NodeID:    testVdrs[0].nodeID,
-					PublicKey: testVdrs[0].vdr.PublicKey,
-					Weight:    testVdrs[0].vdr.Weight,
-				},
-				testVdrs[1].nodeID: {
-					NodeID:    testVdrs[1].nodeID,
-					PublicKey: testVdrs[1].vdr.PublicKey,
-					Weight:    testVdrs[1].vdr.Weight,
-				},
-				testVdrs[2].nodeID: {
-					NodeID:    testVdrs[2].nodeID,
-					PublicKey: testVdrs[2].vdr.PublicKey,
-					Weight:    testVdrs[2].vdr.Weight,
-				},
-			},
-			want: CanonicalValidatorSet{
-				Validators:  []*Validator{testVdrs[0].vdr, testVdrs[1].vdr, testVdrs[2].vdr},
-				TotalWeight: testVdrs[0].vdr.Weight + testVdrs[1].vdr.Weight + testVdrs[2].vdr.Weight,
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			require := require.New(t)
-
-			got, err := FlattenValidatorSet(test.validators)
-			require.ErrorIs(err, test.wantErr)
-			require.Equal(test.want, got)
-		})
-	}
-}
-
-func BenchmarkFlattenValidatorSet(b *testing.B) {
-	for size := 1; size <= 1<<10; size *= 2 {
-		b.Run(strconv.Itoa(size), func(b *testing.B) {
-			vdrs := make(
-				map[ids.NodeID]*validators.GetValidatorOutput,
-				size,
-			)
-			for range size {
-				nodeID := ids.GenerateTestNodeID()
-				secretKey, err := localsigner.New()
-				require.NoError(b, err)
-				publicKey := secretKey.PublicKey()
-				vdrs[nodeID] = &validators.GetValidatorOutput{
-					NodeID:    nodeID,
-					PublicKey: publicKey,
-					Weight:    1,
-				}
-			}
-			for b.Loop() {
-				_, err := FlattenValidatorSet(vdrs)
 				require.NoError(b, err)
 			}
 		})


### PR DESCRIPTION
## Why this should be merged

We are working to add another method to the `validators.State` interface. The method will return all warp-canonical validator sets that exist on the network.

Therefore, we need to move the warp-canonical validator set definitions from the `warp` package into the `validators` package.

## How this works

Renames + moves:
- `warp.Validator` -> `validators.Warp`
- `warp.CanonicalValidatorSet` -> `validators.WarpSet`
- `warp.FlattenValidatorSet` -> `validators.FlattenValidatorSet`

This PR does not remove the previous types/function, but it does deprecate them and alias them to the new versions.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No.