### PR TITLE
Add warp accessors to `validators.State`

### DIFF
--- a/proto/pb/validatorstate/validator_state.pb.go
+++ b/proto/pb/validatorstate/validator_state.pb.go
@@ -198,6 +198,102 @@ func (x *GetSubnetIDResponse) GetSubnetId() []byte {
 	return nil
 }
 
+type GetWarpValidatorSetsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Height        uint64                 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWarpValidatorSetsRequest) Reset() {
+	*x = GetWarpValidatorSetsRequest{}
+	mi := &file_validatorstate_validator_state_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWarpValidatorSetsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWarpValidatorSetsRequest) ProtoMessage() {}
+
+func (x *GetWarpValidatorSetsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_validatorstate_validator_state_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWarpValidatorSetsRequest.ProtoReflect.Descriptor instead.
+func (*GetWarpValidatorSetsRequest) Descriptor() ([]byte, []int) {
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GetWarpValidatorSetsRequest) GetHeight() uint64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+type GetWarpValidatorSetRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Height        uint64                 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
+	SubnetId      []byte                 `protobuf:"bytes,2,opt,name=subnet_id,json=subnetId,proto3" json:"subnet_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWarpValidatorSetRequest) Reset() {
+	*x = GetWarpValidatorSetRequest{}
+	mi := &file_validatorstate_validator_state_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWarpValidatorSetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWarpValidatorSetRequest) ProtoMessage() {}
+
+func (x *GetWarpValidatorSetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_validatorstate_validator_state_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWarpValidatorSetRequest.ProtoReflect.Descriptor instead.
+func (*GetWarpValidatorSetRequest) Descriptor() ([]byte, []int) {
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GetWarpValidatorSetRequest) GetHeight() uint64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+func (x *GetWarpValidatorSetRequest) GetSubnetId() []byte {
+	if x != nil {
+		return x.SubnetId
+	}
+	return nil
+}
+
 type GetValidatorSetRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Height        uint64                 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
@@ -208,7 +304,7 @@ type GetValidatorSetRequest struct {
 
 func (x *GetValidatorSetRequest) Reset() {
 	*x = GetValidatorSetRequest{}
-	mi := &file_validatorstate_validator_state_proto_msgTypes[4]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -220,7 +316,7 @@ func (x *GetValidatorSetRequest) String() string {
 func (*GetValidatorSetRequest) ProtoMessage() {}
 
 func (x *GetValidatorSetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_validatorstate_validator_state_proto_msgTypes[4]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -233,7 +329,7 @@ func (x *GetValidatorSetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetValidatorSetRequest.ProtoReflect.Descriptor instead.
 func (*GetValidatorSetRequest) Descriptor() ([]byte, []int) {
-	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{4}
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *GetValidatorSetRequest) GetHeight() uint64 {
@@ -259,7 +355,7 @@ type GetCurrentValidatorSetRequest struct {
 
 func (x *GetCurrentValidatorSetRequest) Reset() {
 	*x = GetCurrentValidatorSetRequest{}
-	mi := &file_validatorstate_validator_state_proto_msgTypes[5]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -271,7 +367,7 @@ func (x *GetCurrentValidatorSetRequest) String() string {
 func (*GetCurrentValidatorSetRequest) ProtoMessage() {}
 
 func (x *GetCurrentValidatorSetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_validatorstate_validator_state_proto_msgTypes[5]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -284,7 +380,7 @@ func (x *GetCurrentValidatorSetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCurrentValidatorSetRequest.ProtoReflect.Descriptor instead.
 func (*GetCurrentValidatorSetRequest) Descriptor() ([]byte, []int) {
-	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{5}
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetCurrentValidatorSetRequest) GetSubnetId() []byte {
@@ -310,7 +406,7 @@ type Validator struct {
 
 func (x *Validator) Reset() {
 	*x = Validator{}
-	mi := &file_validatorstate_validator_state_proto_msgTypes[6]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -322,7 +418,7 @@ func (x *Validator) String() string {
 func (*Validator) ProtoMessage() {}
 
 func (x *Validator) ProtoReflect() protoreflect.Message {
-	mi := &file_validatorstate_validator_state_proto_msgTypes[6]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -335,7 +431,7 @@ func (x *Validator) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Validator.ProtoReflect.Descriptor instead.
 func (*Validator) Descriptor() ([]byte, []int) {
-	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{6}
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Validator) GetNodeId() []byte {
@@ -394,6 +490,222 @@ func (x *Validator) GetIsL1Validator() bool {
 	return false
 }
 
+type GetWarpValidatorSetsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ValidatorSets []*WarpValidatorSet    `protobuf:"bytes,1,rep,name=validator_sets,json=validatorSets,proto3" json:"validator_sets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWarpValidatorSetsResponse) Reset() {
+	*x = GetWarpValidatorSetsResponse{}
+	mi := &file_validatorstate_validator_state_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWarpValidatorSetsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWarpValidatorSetsResponse) ProtoMessage() {}
+
+func (x *GetWarpValidatorSetsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_validatorstate_validator_state_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWarpValidatorSetsResponse.ProtoReflect.Descriptor instead.
+func (*GetWarpValidatorSetsResponse) Descriptor() ([]byte, []int) {
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *GetWarpValidatorSetsResponse) GetValidatorSets() []*WarpValidatorSet {
+	if x != nil {
+		return x.ValidatorSets
+	}
+	return nil
+}
+
+type GetWarpValidatorSetResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TotalWeight   uint64                 `protobuf:"varint,1,opt,name=total_weight,json=totalWeight,proto3" json:"total_weight,omitempty"`
+	Validators    []*WarpValidator       `protobuf:"bytes,2,rep,name=validators,proto3" json:"validators,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWarpValidatorSetResponse) Reset() {
+	*x = GetWarpValidatorSetResponse{}
+	mi := &file_validatorstate_validator_state_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWarpValidatorSetResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWarpValidatorSetResponse) ProtoMessage() {}
+
+func (x *GetWarpValidatorSetResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_validatorstate_validator_state_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWarpValidatorSetResponse.ProtoReflect.Descriptor instead.
+func (*GetWarpValidatorSetResponse) Descriptor() ([]byte, []int) {
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GetWarpValidatorSetResponse) GetTotalWeight() uint64 {
+	if x != nil {
+		return x.TotalWeight
+	}
+	return 0
+}
+
+func (x *GetWarpValidatorSetResponse) GetValidators() []*WarpValidator {
+	if x != nil {
+		return x.Validators
+	}
+	return nil
+}
+
+type WarpValidatorSet struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SubnetId      []byte                 `protobuf:"bytes,1,opt,name=subnet_id,json=subnetId,proto3" json:"subnet_id,omitempty"`
+	TotalWeight   uint64                 `protobuf:"varint,2,opt,name=total_weight,json=totalWeight,proto3" json:"total_weight,omitempty"`
+	Validators    []*WarpValidator       `protobuf:"bytes,3,rep,name=validators,proto3" json:"validators,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WarpValidatorSet) Reset() {
+	*x = WarpValidatorSet{}
+	mi := &file_validatorstate_validator_state_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WarpValidatorSet) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WarpValidatorSet) ProtoMessage() {}
+
+func (x *WarpValidatorSet) ProtoReflect() protoreflect.Message {
+	mi := &file_validatorstate_validator_state_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WarpValidatorSet.ProtoReflect.Descriptor instead.
+func (*WarpValidatorSet) Descriptor() ([]byte, []int) {
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *WarpValidatorSet) GetSubnetId() []byte {
+	if x != nil {
+		return x.SubnetId
+	}
+	return nil
+}
+
+func (x *WarpValidatorSet) GetTotalWeight() uint64 {
+	if x != nil {
+		return x.TotalWeight
+	}
+	return 0
+}
+
+func (x *WarpValidatorSet) GetValidators() []*WarpValidator {
+	if x != nil {
+		return x.Validators
+	}
+	return nil
+}
+
+type WarpValidator struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PublicKey     []byte                 `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"` // Uncompressed public key, must not be empty
+	Weight        uint64                 `protobuf:"varint,2,opt,name=weight,proto3" json:"weight,omitempty"`
+	NodeIds       [][]byte               `protobuf:"bytes,3,rep,name=node_ids,json=nodeIds,proto3" json:"node_ids,omitempty"` // must not be empty
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WarpValidator) Reset() {
+	*x = WarpValidator{}
+	mi := &file_validatorstate_validator_state_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WarpValidator) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WarpValidator) ProtoMessage() {}
+
+func (x *WarpValidator) ProtoReflect() protoreflect.Message {
+	mi := &file_validatorstate_validator_state_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WarpValidator.ProtoReflect.Descriptor instead.
+func (*WarpValidator) Descriptor() ([]byte, []int) {
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *WarpValidator) GetPublicKey() []byte {
+	if x != nil {
+		return x.PublicKey
+	}
+	return nil
+}
+
+func (x *WarpValidator) GetWeight() uint64 {
+	if x != nil {
+		return x.Weight
+	}
+	return 0
+}
+
+func (x *WarpValidator) GetNodeIds() [][]byte {
+	if x != nil {
+		return x.NodeIds
+	}
+	return nil
+}
+
 type GetValidatorSetResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Validators    []*Validator           `protobuf:"bytes,1,rep,name=validators,proto3" json:"validators,omitempty"`
@@ -403,7 +715,7 @@ type GetValidatorSetResponse struct {
 
 func (x *GetValidatorSetResponse) Reset() {
 	*x = GetValidatorSetResponse{}
-	mi := &file_validatorstate_validator_state_proto_msgTypes[7]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -415,7 +727,7 @@ func (x *GetValidatorSetResponse) String() string {
 func (*GetValidatorSetResponse) ProtoMessage() {}
 
 func (x *GetValidatorSetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_validatorstate_validator_state_proto_msgTypes[7]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -428,7 +740,7 @@ func (x *GetValidatorSetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetValidatorSetResponse.ProtoReflect.Descriptor instead.
 func (*GetValidatorSetResponse) Descriptor() ([]byte, []int) {
-	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{7}
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetValidatorSetResponse) GetValidators() []*Validator {
@@ -448,7 +760,7 @@ type GetCurrentValidatorSetResponse struct {
 
 func (x *GetCurrentValidatorSetResponse) Reset() {
 	*x = GetCurrentValidatorSetResponse{}
-	mi := &file_validatorstate_validator_state_proto_msgTypes[8]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +772,7 @@ func (x *GetCurrentValidatorSetResponse) String() string {
 func (*GetCurrentValidatorSetResponse) ProtoMessage() {}
 
 func (x *GetCurrentValidatorSetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_validatorstate_validator_state_proto_msgTypes[8]
+	mi := &file_validatorstate_validator_state_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +785,7 @@ func (x *GetCurrentValidatorSetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCurrentValidatorSetResponse.ProtoReflect.Descriptor instead.
 func (*GetCurrentValidatorSetResponse) Descriptor() ([]byte, []int) {
-	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{8}
+	return file_validatorstate_validator_state_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetCurrentValidatorSetResponse) GetValidators() []*Validator {
@@ -502,7 +814,12 @@ const file_validatorstate_validator_state_proto_rawDesc = "" +
 	"\x12GetSubnetIDRequest\x12\x19\n" +
 	"\bchain_id\x18\x01 \x01(\fR\achainId\"2\n" +
 	"\x13GetSubnetIDResponse\x12\x1b\n" +
-	"\tsubnet_id\x18\x01 \x01(\fR\bsubnetId\"M\n" +
+	"\tsubnet_id\x18\x01 \x01(\fR\bsubnetId\"5\n" +
+	"\x1bGetWarpValidatorSetsRequest\x12\x16\n" +
+	"\x06height\x18\x01 \x01(\x04R\x06height\"Q\n" +
+	"\x1aGetWarpValidatorSetRequest\x12\x16\n" +
+	"\x06height\x18\x01 \x01(\x04R\x06height\x12\x1b\n" +
+	"\tsubnet_id\x18\x02 \x01(\fR\bsubnetId\"M\n" +
 	"\x16GetValidatorSetRequest\x12\x16\n" +
 	"\x06height\x18\x01 \x01(\x04R\x06height\x12\x1b\n" +
 	"\tsubnet_id\x18\x02 \x01(\fR\bsubnetId\"<\n" +
@@ -518,7 +835,25 @@ const file_validatorstate_validator_state_proto_rawDesc = "" +
 	"\tmin_nonce\x18\x05 \x01(\x04R\bminNonce\x12\x1b\n" +
 	"\tis_active\x18\x06 \x01(\bR\bisActive\x12#\n" +
 	"\rvalidation_id\x18\a \x01(\fR\fvalidationId\x12&\n" +
-	"\x0fis_l1_validator\x18\b \x01(\bR\risL1Validator\"T\n" +
+	"\x0fis_l1_validator\x18\b \x01(\bR\risL1Validator\"g\n" +
+	"\x1cGetWarpValidatorSetsResponse\x12G\n" +
+	"\x0evalidator_sets\x18\x01 \x03(\v2 .validatorstate.WarpValidatorSetR\rvalidatorSets\"\x7f\n" +
+	"\x1bGetWarpValidatorSetResponse\x12!\n" +
+	"\ftotal_weight\x18\x01 \x01(\x04R\vtotalWeight\x12=\n" +
+	"\n" +
+	"validators\x18\x02 \x03(\v2\x1d.validatorstate.WarpValidatorR\n" +
+	"validators\"\x91\x01\n" +
+	"\x10WarpValidatorSet\x12\x1b\n" +
+	"\tsubnet_id\x18\x01 \x01(\fR\bsubnetId\x12!\n" +
+	"\ftotal_weight\x18\x02 \x01(\x04R\vtotalWeight\x12=\n" +
+	"\n" +
+	"validators\x18\x03 \x03(\v2\x1d.validatorstate.WarpValidatorR\n" +
+	"validators\"a\n" +
+	"\rWarpValidator\x12\x1d\n" +
+	"\n" +
+	"public_key\x18\x01 \x01(\fR\tpublicKey\x12\x16\n" +
+	"\x06weight\x18\x02 \x01(\x04R\x06weight\x12\x19\n" +
+	"\bnode_ids\x18\x03 \x03(\fR\anodeIds\"T\n" +
 	"\x17GetValidatorSetResponse\x129\n" +
 	"\n" +
 	"validators\x18\x01 \x03(\v2\x19.validatorstate.ValidatorR\n" +
@@ -527,11 +862,13 @@ const file_validatorstate_validator_state_proto_rawDesc = "" +
 	"\n" +
 	"validators\x18\x01 \x03(\v2\x19.validatorstate.ValidatorR\n" +
 	"validators\x12%\n" +
-	"\x0ecurrent_height\x18\x02 \x01(\x04R\rcurrentHeight2\xf1\x03\n" +
+	"\x0ecurrent_height\x18\x02 \x01(\x04R\rcurrentHeight2\xd4\x05\n" +
 	"\x0eValidatorState\x12T\n" +
 	"\x10GetMinimumHeight\x12\x16.google.protobuf.Empty\x1a(.validatorstate.GetMinimumHeightResponse\x12T\n" +
 	"\x10GetCurrentHeight\x12\x16.google.protobuf.Empty\x1a(.validatorstate.GetCurrentHeightResponse\x12V\n" +
-	"\vGetSubnetID\x12\".validatorstate.GetSubnetIDRequest\x1a#.validatorstate.GetSubnetIDResponse\x12b\n" +
+	"\vGetSubnetID\x12\".validatorstate.GetSubnetIDRequest\x1a#.validatorstate.GetSubnetIDResponse\x12q\n" +
+	"\x14GetWarpValidatorSets\x12+.validatorstate.GetWarpValidatorSetsRequest\x1a,.validatorstate.GetWarpValidatorSetsResponse\x12n\n" +
+	"\x13GetWarpValidatorSet\x12*.validatorstate.GetWarpValidatorSetRequest\x1a+.validatorstate.GetWarpValidatorSetResponse\x12b\n" +
 	"\x0fGetValidatorSet\x12&.validatorstate.GetValidatorSetRequest\x1a'.validatorstate.GetValidatorSetResponse\x12w\n" +
 	"\x16GetCurrentValidatorSet\x12-.validatorstate.GetCurrentValidatorSetRequest\x1a..validatorstate.GetCurrentValidatorSetResponseB9Z7github.com/ava-labs/avalanchego/proto/pb/validatorstateb\x06proto3"
 
@@ -547,37 +884,50 @@ func file_validatorstate_validator_state_proto_rawDescGZIP() []byte {
 	return file_validatorstate_validator_state_proto_rawDescData
 }
 
-var file_validatorstate_validator_state_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_validatorstate_validator_state_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_validatorstate_validator_state_proto_goTypes = []any{
 	(*GetMinimumHeightResponse)(nil),       // 0: validatorstate.GetMinimumHeightResponse
 	(*GetCurrentHeightResponse)(nil),       // 1: validatorstate.GetCurrentHeightResponse
 	(*GetSubnetIDRequest)(nil),             // 2: validatorstate.GetSubnetIDRequest
 	(*GetSubnetIDResponse)(nil),            // 3: validatorstate.GetSubnetIDResponse
-	(*GetValidatorSetRequest)(nil),         // 4: validatorstate.GetValidatorSetRequest
-	(*GetCurrentValidatorSetRequest)(nil),  // 5: validatorstate.GetCurrentValidatorSetRequest
-	(*Validator)(nil),                      // 6: validatorstate.Validator
-	(*GetValidatorSetResponse)(nil),        // 7: validatorstate.GetValidatorSetResponse
-	(*GetCurrentValidatorSetResponse)(nil), // 8: validatorstate.GetCurrentValidatorSetResponse
-	(*emptypb.Empty)(nil),                  // 9: google.protobuf.Empty
+	(*GetWarpValidatorSetsRequest)(nil),    // 4: validatorstate.GetWarpValidatorSetsRequest
+	(*GetWarpValidatorSetRequest)(nil),     // 5: validatorstate.GetWarpValidatorSetRequest
+	(*GetValidatorSetRequest)(nil),         // 6: validatorstate.GetValidatorSetRequest
+	(*GetCurrentValidatorSetRequest)(nil),  // 7: validatorstate.GetCurrentValidatorSetRequest
+	(*Validator)(nil),                      // 8: validatorstate.Validator
+	(*GetWarpValidatorSetsResponse)(nil),   // 9: validatorstate.GetWarpValidatorSetsResponse
+	(*GetWarpValidatorSetResponse)(nil),    // 10: validatorstate.GetWarpValidatorSetResponse
+	(*WarpValidatorSet)(nil),               // 11: validatorstate.WarpValidatorSet
+	(*WarpValidator)(nil),                  // 12: validatorstate.WarpValidator
+	(*GetValidatorSetResponse)(nil),        // 13: validatorstate.GetValidatorSetResponse
+	(*GetCurrentValidatorSetResponse)(nil), // 14: validatorstate.GetCurrentValidatorSetResponse
+	(*emptypb.Empty)(nil),                  // 15: google.protobuf.Empty
 }
 var file_validatorstate_validator_state_proto_depIdxs = []int32{
-	6, // 0: validatorstate.GetValidatorSetResponse.validators:type_name -> validatorstate.Validator
-	6, // 1: validatorstate.GetCurrentValidatorSetResponse.validators:type_name -> validatorstate.Validator
-	9, // 2: validatorstate.ValidatorState.GetMinimumHeight:input_type -> google.protobuf.Empty
-	9, // 3: validatorstate.ValidatorState.GetCurrentHeight:input_type -> google.protobuf.Empty
-	2, // 4: validatorstate.ValidatorState.GetSubnetID:input_type -> validatorstate.GetSubnetIDRequest
-	4, // 5: validatorstate.ValidatorState.GetValidatorSet:input_type -> validatorstate.GetValidatorSetRequest
-	5, // 6: validatorstate.ValidatorState.GetCurrentValidatorSet:input_type -> validatorstate.GetCurrentValidatorSetRequest
-	0, // 7: validatorstate.ValidatorState.GetMinimumHeight:output_type -> validatorstate.GetMinimumHeightResponse
-	1, // 8: validatorstate.ValidatorState.GetCurrentHeight:output_type -> validatorstate.GetCurrentHeightResponse
-	3, // 9: validatorstate.ValidatorState.GetSubnetID:output_type -> validatorstate.GetSubnetIDResponse
-	7, // 10: validatorstate.ValidatorState.GetValidatorSet:output_type -> validatorstate.GetValidatorSetResponse
-	8, // 11: validatorstate.ValidatorState.GetCurrentValidatorSet:output_type -> validatorstate.GetCurrentValidatorSetResponse
-	7, // [7:12] is the sub-list for method output_type
-	2, // [2:7] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	11, // 0: validatorstate.GetWarpValidatorSetsResponse.validator_sets:type_name -> validatorstate.WarpValidatorSet
+	12, // 1: validatorstate.GetWarpValidatorSetResponse.validators:type_name -> validatorstate.WarpValidator
+	12, // 2: validatorstate.WarpValidatorSet.validators:type_name -> validatorstate.WarpValidator
+	8,  // 3: validatorstate.GetValidatorSetResponse.validators:type_name -> validatorstate.Validator
+	8,  // 4: validatorstate.GetCurrentValidatorSetResponse.validators:type_name -> validatorstate.Validator
+	15, // 5: validatorstate.ValidatorState.GetMinimumHeight:input_type -> google.protobuf.Empty
+	15, // 6: validatorstate.ValidatorState.GetCurrentHeight:input_type -> google.protobuf.Empty
+	2,  // 7: validatorstate.ValidatorState.GetSubnetID:input_type -> validatorstate.GetSubnetIDRequest
+	4,  // 8: validatorstate.ValidatorState.GetWarpValidatorSets:input_type -> validatorstate.GetWarpValidatorSetsRequest
+	5,  // 9: validatorstate.ValidatorState.GetWarpValidatorSet:input_type -> validatorstate.GetWarpValidatorSetRequest
+	6,  // 10: validatorstate.ValidatorState.GetValidatorSet:input_type -> validatorstate.GetValidatorSetRequest
+	7,  // 11: validatorstate.ValidatorState.GetCurrentValidatorSet:input_type -> validatorstate.GetCurrentValidatorSetRequest
+	0,  // 12: validatorstate.ValidatorState.GetMinimumHeight:output_type -> validatorstate.GetMinimumHeightResponse
+	1,  // 13: validatorstate.ValidatorState.GetCurrentHeight:output_type -> validatorstate.GetCurrentHeightResponse
+	3,  // 14: validatorstate.ValidatorState.GetSubnetID:output_type -> validatorstate.GetSubnetIDResponse
+	9,  // 15: validatorstate.ValidatorState.GetWarpValidatorSets:output_type -> validatorstate.GetWarpValidatorSetsResponse
+	10, // 16: validatorstate.ValidatorState.GetWarpValidatorSet:output_type -> validatorstate.GetWarpValidatorSetResponse
+	13, // 17: validatorstate.ValidatorState.GetValidatorSet:output_type -> validatorstate.GetValidatorSetResponse
+	14, // 18: validatorstate.ValidatorState.GetCurrentValidatorSet:output_type -> validatorstate.GetCurrentValidatorSetResponse
+	12, // [12:19] is the sub-list for method output_type
+	5,  // [5:12] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_validatorstate_validator_state_proto_init() }
@@ -591,7 +941,7 @@ func file_validatorstate_validator_state_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_validatorstate_validator_state_proto_rawDesc), len(file_validatorstate_validator_state_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/pb/validatorstate/validator_state_grpc.pb.go
+++ b/proto/pb/validatorstate/validator_state_grpc.pb.go
@@ -23,6 +23,8 @@ const (
 	ValidatorState_GetMinimumHeight_FullMethodName       = "/validatorstate.ValidatorState/GetMinimumHeight"
 	ValidatorState_GetCurrentHeight_FullMethodName       = "/validatorstate.ValidatorState/GetCurrentHeight"
 	ValidatorState_GetSubnetID_FullMethodName            = "/validatorstate.ValidatorState/GetSubnetID"
+	ValidatorState_GetWarpValidatorSets_FullMethodName   = "/validatorstate.ValidatorState/GetWarpValidatorSets"
+	ValidatorState_GetWarpValidatorSet_FullMethodName    = "/validatorstate.ValidatorState/GetWarpValidatorSet"
 	ValidatorState_GetValidatorSet_FullMethodName        = "/validatorstate.ValidatorState/GetValidatorSet"
 	ValidatorState_GetCurrentValidatorSet_FullMethodName = "/validatorstate.ValidatorState/GetCurrentValidatorSet"
 )
@@ -38,6 +40,13 @@ type ValidatorStateClient interface {
 	GetCurrentHeight(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*GetCurrentHeightResponse, error)
 	// GetSubnetID returns the subnetID of the provided chain.
 	GetSubnetID(ctx context.Context, in *GetSubnetIDRequest, opts ...grpc.CallOption) (*GetSubnetIDResponse, error)
+	// GetWarpValidatorSets returns the canonical warp validator set for all
+	// subnets at the requested P-chain height. If a subnet doesn't have a valid
+	// canonical warp validator set, it is omitted from the response.
+	GetWarpValidatorSets(ctx context.Context, in *GetWarpValidatorSetsRequest, opts ...grpc.CallOption) (*GetWarpValidatorSetsResponse, error)
+	// GetWarpValidatorSet returns the canonical warp validator set for the
+	// provided subnet at the requested P-chain height.
+	GetWarpValidatorSet(ctx context.Context, in *GetWarpValidatorSetRequest, opts ...grpc.CallOption) (*GetWarpValidatorSetResponse, error)
 	// GetValidatorSet returns the weights of the nodeIDs for the provided
 	// subnet at the requested P-chain height.
 	GetValidatorSet(ctx context.Context, in *GetValidatorSetRequest, opts ...grpc.CallOption) (*GetValidatorSetResponse, error)
@@ -84,6 +93,26 @@ func (c *validatorStateClient) GetSubnetID(ctx context.Context, in *GetSubnetIDR
 	return out, nil
 }
 
+func (c *validatorStateClient) GetWarpValidatorSets(ctx context.Context, in *GetWarpValidatorSetsRequest, opts ...grpc.CallOption) (*GetWarpValidatorSetsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetWarpValidatorSetsResponse)
+	err := c.cc.Invoke(ctx, ValidatorState_GetWarpValidatorSets_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *validatorStateClient) GetWarpValidatorSet(ctx context.Context, in *GetWarpValidatorSetRequest, opts ...grpc.CallOption) (*GetWarpValidatorSetResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetWarpValidatorSetResponse)
+	err := c.cc.Invoke(ctx, ValidatorState_GetWarpValidatorSet_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *validatorStateClient) GetValidatorSet(ctx context.Context, in *GetValidatorSetRequest, opts ...grpc.CallOption) (*GetValidatorSetResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetValidatorSetResponse)
@@ -115,6 +144,13 @@ type ValidatorStateServer interface {
 	GetCurrentHeight(context.Context, *emptypb.Empty) (*GetCurrentHeightResponse, error)
 	// GetSubnetID returns the subnetID of the provided chain.
 	GetSubnetID(context.Context, *GetSubnetIDRequest) (*GetSubnetIDResponse, error)
+	// GetWarpValidatorSets returns the canonical warp validator set for all
+	// subnets at the requested P-chain height. If a subnet doesn't have a valid
+	// canonical warp validator set, it is omitted from the response.
+	GetWarpValidatorSets(context.Context, *GetWarpValidatorSetsRequest) (*GetWarpValidatorSetsResponse, error)
+	// GetWarpValidatorSet returns the canonical warp validator set for the
+	// provided subnet at the requested P-chain height.
+	GetWarpValidatorSet(context.Context, *GetWarpValidatorSetRequest) (*GetWarpValidatorSetResponse, error)
 	// GetValidatorSet returns the weights of the nodeIDs for the provided
 	// subnet at the requested P-chain height.
 	GetValidatorSet(context.Context, *GetValidatorSetRequest) (*GetValidatorSetResponse, error)
@@ -139,6 +175,12 @@ func (UnimplementedValidatorStateServer) GetCurrentHeight(context.Context, *empt
 }
 func (UnimplementedValidatorStateServer) GetSubnetID(context.Context, *GetSubnetIDRequest) (*GetSubnetIDResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetSubnetID not implemented")
+}
+func (UnimplementedValidatorStateServer) GetWarpValidatorSets(context.Context, *GetWarpValidatorSetsRequest) (*GetWarpValidatorSetsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetWarpValidatorSets not implemented")
+}
+func (UnimplementedValidatorStateServer) GetWarpValidatorSet(context.Context, *GetWarpValidatorSetRequest) (*GetWarpValidatorSetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetWarpValidatorSet not implemented")
 }
 func (UnimplementedValidatorStateServer) GetValidatorSet(context.Context, *GetValidatorSetRequest) (*GetValidatorSetResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetValidatorSet not implemented")
@@ -221,6 +263,42 @@ func _ValidatorState_GetSubnetID_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ValidatorState_GetWarpValidatorSets_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetWarpValidatorSetsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ValidatorStateServer).GetWarpValidatorSets(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ValidatorState_GetWarpValidatorSets_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ValidatorStateServer).GetWarpValidatorSets(ctx, req.(*GetWarpValidatorSetsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ValidatorState_GetWarpValidatorSet_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetWarpValidatorSetRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ValidatorStateServer).GetWarpValidatorSet(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ValidatorState_GetWarpValidatorSet_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ValidatorStateServer).GetWarpValidatorSet(ctx, req.(*GetWarpValidatorSetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ValidatorState_GetValidatorSet_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetValidatorSetRequest)
 	if err := dec(in); err != nil {
@@ -275,6 +353,14 @@ var ValidatorState_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSubnetID",
 			Handler:    _ValidatorState_GetSubnetID_Handler,
+		},
+		{
+			MethodName: "GetWarpValidatorSets",
+			Handler:    _ValidatorState_GetWarpValidatorSets_Handler,
+		},
+		{
+			MethodName: "GetWarpValidatorSet",
+			Handler:    _ValidatorState_GetWarpValidatorSet_Handler,
 		},
 		{
 			MethodName: "GetValidatorSet",

--- a/proto/validatorstate/validator_state.proto
+++ b/proto/validatorstate/validator_state.proto
@@ -14,6 +14,13 @@ service ValidatorState {
   rpc GetCurrentHeight(google.protobuf.Empty) returns (GetCurrentHeightResponse);
   // GetSubnetID returns the subnetID of the provided chain.
   rpc GetSubnetID(GetSubnetIDRequest) returns (GetSubnetIDResponse);
+  // GetWarpValidatorSets returns the canonical warp validator set for all
+  // subnets at the requested P-chain height. If a subnet doesn't have a valid
+  // canonical warp validator set, it is omitted from the response.
+  rpc GetWarpValidatorSets(GetWarpValidatorSetsRequest) returns (GetWarpValidatorSetsResponse);
+  // GetWarpValidatorSet returns the canonical warp validator set for the
+  // provided subnet at the requested P-chain height.
+  rpc GetWarpValidatorSet(GetWarpValidatorSetRequest) returns (GetWarpValidatorSetResponse);
   // GetValidatorSet returns the weights of the nodeIDs for the provided
   // subnet at the requested P-chain height.
   rpc GetValidatorSet(GetValidatorSetRequest) returns (GetValidatorSetResponse);
@@ -38,6 +45,15 @@ message GetSubnetIDResponse {
   bytes subnet_id = 1;
 }
 
+message GetWarpValidatorSetsRequest {
+  uint64 height = 1;
+}
+
+message GetWarpValidatorSetRequest {
+  uint64 height = 1;
+  bytes subnet_id = 2;
+}
+
 message GetValidatorSetRequest {
   uint64 height = 1;
   bytes subnet_id = 2;
@@ -56,6 +72,27 @@ message Validator {
   bool is_active = 6; // can be empty
   bytes validation_id = 7; // can be empty
   bool is_l1_validator = 8; // can be empty
+}
+
+message GetWarpValidatorSetsResponse {
+  repeated WarpValidatorSet validator_sets = 1;
+}
+
+message GetWarpValidatorSetResponse {
+  uint64 total_weight = 1;
+  repeated WarpValidator validators = 2;
+}
+
+message WarpValidatorSet {
+  bytes subnet_id = 1;
+  uint64 total_weight = 2;
+  repeated WarpValidator validators = 3;
+}
+
+message WarpValidator {
+  bytes public_key = 1; // Uncompressed public key, must not be empty
+  uint64 weight = 2;
+  repeated bytes node_ids = 3; // must not be empty
 }
 
 message GetValidatorSetResponse {

--- a/snow/validators/gvalidators/validator_state_client.go
+++ b/snow/validators/gvalidators/validator_state_client.go
@@ -6,6 +6,7 @@ package gvalidators
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -53,6 +54,73 @@ func (c *Client) GetSubnetID(ctx context.Context, chainID ids.ID) (ids.ID, error
 		return ids.Empty, err
 	}
 	return ids.ToID(resp.SubnetId)
+}
+
+func (c *Client) GetWarpValidatorSets(
+	ctx context.Context,
+	height uint64,
+) (map[ids.ID]validators.WarpSet, error) {
+	resp, err := c.client.GetWarpValidatorSets(
+		ctx,
+		&pb.GetWarpValidatorSetsRequest{
+			Height: height,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get warp validator sets at %d: %w",
+			height,
+			err,
+		)
+	}
+
+	validatorSets := make(map[ids.ID]validators.WarpSet, len(resp.ValidatorSets))
+	for _, validatorSet := range resp.ValidatorSets {
+		subnetID, err := ids.ToID(validatorSet.GetSubnetId())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse subnet ID: %w", err)
+		}
+
+		vdrs, err := warpValidatorsFromProto(validatorSet.GetValidators())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse warp validators: %w", err)
+		}
+		validatorSets[subnetID] = validators.WarpSet{
+			Validators:  vdrs,
+			TotalWeight: validatorSet.GetTotalWeight(),
+		}
+	}
+
+	return validatorSets, nil
+}
+
+func (c *Client) GetWarpValidatorSet(
+	ctx context.Context,
+	height uint64,
+	subnetID ids.ID,
+) (validators.WarpSet, error) {
+	resp, err := c.client.GetWarpValidatorSet(
+		ctx,
+		&pb.GetWarpValidatorSetRequest{
+			Height:   height,
+			SubnetId: subnetID[:],
+		},
+	)
+	if err != nil {
+		return validators.WarpSet{}, fmt.Errorf("failed to get warp validator set at %d for %s: %w",
+			height,
+			subnetID,
+			err,
+		)
+	}
+
+	vdrs, err := warpValidatorsFromProto(resp.GetValidators())
+	if err != nil {
+		return validators.WarpSet{}, fmt.Errorf("failed to parse warp validators: %w", err)
+	}
+	return validators.WarpSet{
+		Validators:  vdrs,
+		TotalWeight: resp.GetTotalWeight(),
+	}, nil
 }
 
 func (c *Client) GetValidatorSet(
@@ -141,4 +209,31 @@ func (c *Client) GetCurrentValidatorSet(
 		}
 	}
 	return vdrs, resp.GetCurrentHeight(), nil
+}
+
+func warpValidatorsFromProto(proto []*pb.WarpValidator) ([]*validators.Warp, error) {
+	vdrs := make([]*validators.Warp, len(proto))
+	for i, vdr := range proto {
+		nodeIDsBytes := vdr.GetNodeIds()
+		nodeIDs := make([]ids.NodeID, len(nodeIDsBytes))
+		for j, nodeIDBytes := range nodeIDsBytes {
+			nodeID, err := ids.ToNodeID(nodeIDBytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse node ID: %w", err)
+			}
+			nodeIDs[j] = nodeID
+		}
+		pkBytes := vdr.GetPublicKey()
+		pk := bls.PublicKeyFromValidUncompressedBytes(pkBytes)
+		if pk == nil {
+			return nil, errFailedPublicKeyDeserialize
+		}
+		vdrs[i] = &validators.Warp{
+			PublicKey:      pk,
+			PublicKeyBytes: pkBytes,
+			Weight:         vdr.GetWeight(),
+			NodeIDs:        nodeIDs,
+		}
+	}
+	return vdrs, nil
 }

--- a/snow/validators/state.go
+++ b/snow/validators/state.go
@@ -24,6 +24,28 @@ type State interface {
 	// GetSubnetID returns the subnetID of the provided chain.
 	GetSubnetID(ctx context.Context, chainID ids.ID) (ids.ID, error)
 
+	// GetWarpValidatorSets returns the canonical warp validator set for all
+	// subnets at the requested P-chain height.
+	//
+	// If a subnet is not present in the returned map, that indicates that the
+	// subnet is not currently able to send warp messages.
+	//
+	// The returned map should not be modified.
+	GetWarpValidatorSets(ctx context.Context, height uint64) (map[ids.ID]WarpSet, error)
+
+	// GetWarpValidatorSet returns the canonical warp validator set for the
+	// requested subnet at the requested P-chain height.
+	//
+	// The returned set should not be modified.
+	//
+	// TODO: After Granite, this method should be removed and users should
+	// directly call GetWarpValidatorSets.
+	GetWarpValidatorSet(
+		ctx context.Context,
+		height uint64,
+		subnetID ids.ID,
+	) (WarpSet, error)
+
 	// GetValidatorSet returns the validators of the provided subnet at the
 	// requested P-chain height.
 	// The returned map should not be modified.
@@ -86,6 +108,27 @@ func (s *lockedState) GetValidatorSet(
 	return s.s.GetValidatorSet(ctx, height, subnetID)
 }
 
+func (s *lockedState) GetWarpValidatorSets(
+	ctx context.Context,
+	height uint64,
+) (map[ids.ID]WarpSet, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.s.GetWarpValidatorSets(ctx, height)
+}
+
+func (s *lockedState) GetWarpValidatorSet(
+	ctx context.Context,
+	height uint64,
+	subnetID ids.ID,
+) (WarpSet, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.s.GetWarpValidatorSet(ctx, height, subnetID)
+}
+
 func (s *lockedState) GetCurrentValidatorSet(
 	ctx context.Context,
 	subnetID ids.ID,
@@ -104,6 +147,14 @@ func NewNoValidatorsState(state State) State {
 	return &noValidators{
 		State: state,
 	}
+}
+
+func (*noValidators) GetWarpValidatorSets(context.Context, uint64) (map[ids.ID]WarpSet, error) {
+	return nil, nil
+}
+
+func (*noValidators) GetWarpValidatorSet(context.Context, uint64, ids.ID) (WarpSet, error) {
+	return WarpSet{}, nil
 }
 
 func (*noValidators) GetValidatorSet(context.Context, uint64, ids.ID) (map[ids.NodeID]*GetValidatorOutput, error) {

--- a/snow/validators/state.go
+++ b/snow/validators/state.go
@@ -28,7 +28,7 @@ type State interface {
 	// subnets at the requested P-chain height.
 	//
 	// If a subnet is not present in the returned map, that indicates that the
-	// subnet is not currently able to send warp messages.
+	// subnet is not currently able to produce valid warp message signatures.
 	//
 	// The returned map should not be modified.
 	GetWarpValidatorSets(ctx context.Context, height uint64) (map[ids.ID]WarpSet, error)

--- a/snow/validators/traced_state.go
+++ b/snow/validators/traced_state.go
@@ -21,6 +21,8 @@ type tracedState struct {
 	getMinimumHeightTag       string
 	getCurrentHeightTag       string
 	getSubnetIDTag            string
+	getWarpValidatorSetsTag   string
+	getWarpValidatorSetTag    string
 	getValidatorSetTag        string
 	getCurrentValidatorSetTag string
 	tracer                    trace.Tracer
@@ -32,6 +34,8 @@ func Trace(s State, name string, tracer trace.Tracer) State {
 		getMinimumHeightTag:       name + ".GetMinimumHeight",
 		getCurrentHeightTag:       name + ".GetCurrentHeight",
 		getSubnetIDTag:            name + ".GetSubnetID",
+		getWarpValidatorSetsTag:   name + ".GetWarpValidatorSets",
+		getWarpValidatorSetTag:    name + ".GetWarpValidatorSet",
 		getValidatorSetTag:        name + ".GetValidatorSet",
 		getCurrentValidatorSetTag: name + ".GetCurrentValidatorSet",
 		tracer:                    tracer,
@@ -59,6 +63,32 @@ func (s *tracedState) GetSubnetID(ctx context.Context, chainID ids.ID) (ids.ID, 
 	defer span.End()
 
 	return s.s.GetSubnetID(ctx, chainID)
+}
+
+func (s *tracedState) GetWarpValidatorSets(
+	ctx context.Context,
+	height uint64,
+) (map[ids.ID]WarpSet, error) {
+	ctx, span := s.tracer.Start(ctx, s.getWarpValidatorSetsTag, oteltrace.WithAttributes(
+		attribute.Int64("height", int64(height)),
+	))
+	defer span.End()
+
+	return s.s.GetWarpValidatorSets(ctx, height)
+}
+
+func (s *tracedState) GetWarpValidatorSet(
+	ctx context.Context,
+	height uint64,
+	subnetID ids.ID,
+) (WarpSet, error) {
+	ctx, span := s.tracer.Start(ctx, s.getWarpValidatorSetTag, oteltrace.WithAttributes(
+		attribute.Int64("height", int64(height)),
+		attribute.Stringer("subnetID", subnetID),
+	))
+	defer span.End()
+
+	return s.s.GetWarpValidatorSet(ctx, height, subnetID)
 }
 
 func (s *tracedState) GetValidatorSet(

--- a/snow/validators/validatorsmock/state.go
+++ b/snow/validators/validatorsmock/state.go
@@ -117,3 +117,33 @@ func (mr *StateMockRecorder) GetValidatorSet(ctx, height, subnetID any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorSet", reflect.TypeOf((*State)(nil).GetValidatorSet), ctx, height, subnetID)
 }
+
+// GetWarpValidatorSet mocks base method.
+func (m *State) GetWarpValidatorSet(ctx context.Context, height uint64, subnetID ids.ID) (validators.WarpSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWarpValidatorSet", ctx, height, subnetID)
+	ret0, _ := ret[0].(validators.WarpSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWarpValidatorSet indicates an expected call of GetWarpValidatorSet.
+func (mr *StateMockRecorder) GetWarpValidatorSet(ctx, height, subnetID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWarpValidatorSet", reflect.TypeOf((*State)(nil).GetWarpValidatorSet), ctx, height, subnetID)
+}
+
+// GetWarpValidatorSets mocks base method.
+func (m *State) GetWarpValidatorSets(ctx context.Context, height uint64) (map[ids.ID]validators.WarpSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWarpValidatorSets", ctx, height)
+	ret0, _ := ret[0].(map[ids.ID]validators.WarpSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWarpValidatorSets indicates an expected call of GetWarpValidatorSets.
+func (mr *StateMockRecorder) GetWarpValidatorSets(ctx, height any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWarpValidatorSets", reflect.TypeOf((*State)(nil).GetWarpValidatorSets), ctx, height)
+}

--- a/snow/validators/validatorstest/warp.go
+++ b/snow/validators/validatorstest/warp.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package validatorstest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
+)
+
+func NewWarp(t *testing.T, weight uint64) *validators.Warp {
+	t.Helper()
+
+	sk, err := localsigner.New()
+	require.NoError(t, err)
+
+	nodeID := ids.GenerateTestNodeID()
+	pk := sk.PublicKey()
+	return &validators.Warp{
+		PublicKey:      pk,
+		PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk),
+		Weight:         weight,
+		NodeIDs:        []ids.NodeID{nodeID},
+	}
+}
+
+func NewWarpSet(t *testing.T, n uint64) validators.WarpSet {
+	t.Helper()
+
+	vdrs := make([]*validators.Warp, n)
+	for i := range vdrs {
+		vdrs[i] = NewWarp(t, 1)
+	}
+	utils.Sort(vdrs)
+	return validators.WarpSet{
+		Validators:  vdrs,
+		TotalWeight: n,
+	}
+}

--- a/snow/validators/warp_test.go
+++ b/snow/validators/warp_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package validators
+package validators_test
 
 import (
 	"math"
@@ -11,42 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils"
-	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 
 	safemath "github.com/ava-labs/avalanchego/utils/math"
+
+	. "github.com/ava-labs/avalanchego/snow/validators"
 )
-
-func newWarp(t *testing.T) *Warp {
-	t.Helper()
-
-	sk, err := localsigner.New()
-	require.NoError(t, err)
-
-	nodeID := ids.GenerateTestNodeID()
-	pk := sk.PublicKey()
-	return &Warp{
-		PublicKey:      pk,
-		PublicKeyBytes: bls.PublicKeyToUncompressedBytes(pk),
-		Weight:         1,
-		NodeIDs:        []ids.NodeID{nodeID},
-	}
-}
-
-func newWarpSet(t *testing.T, n uint64) WarpSet {
-	t.Helper()
-
-	vdrs := make([]*Warp, n)
-	for i := range vdrs {
-		vdrs[i] = newWarp(t)
-	}
-	utils.Sort(vdrs)
-	return WarpSet{
-		Validators:  vdrs,
-		TotalWeight: n,
-	}
-}
 
 func warpToOutput(w *Warp) *GetValidatorOutput {
 	return &GetValidatorOutput{
@@ -58,7 +29,7 @@ func warpToOutput(w *Warp) *GetValidatorOutput {
 
 func TestFlattenValidatorSet(t *testing.T) {
 	var (
-		vdrs    = newWarpSet(t, 3)
+		vdrs    = validatorstest.NewWarpSet(t, 3)
 		nodeID0 = vdrs.Validators[0].NodeIDs[0]
 		nodeID1 = vdrs.Validators[1].NodeIDs[0]
 		nodeID2 = vdrs.Validators[2].NodeIDs[0]

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -230,12 +230,39 @@ func (m *manager) getCurrentHeight(context.Context) (uint64, error) {
 	return lastAccepted.Height(), nil
 }
 
-func (m *manager) GetAllValidatorSets(
+func (m *manager) GetWarpValidatorSets(
 	ctx context.Context,
 	targetHeight uint64,
-) (map[ids.ID]map[ids.NodeID]*validators.GetValidatorOutput, error) {
-	// TODO: cache all validator sets
-	return m.makeAllValidatorSets(ctx, targetHeight)
+) (map[ids.ID]validators.WarpSet, error) {
+	allValidators, err := m.makeAllValidatorSets(ctx, targetHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	validatorSets := make(map[ids.ID]validators.WarpSet, len(allValidators))
+	for subnetID, vdrSet := range allValidators {
+		ws, err := validators.FlattenValidatorSet(vdrSet)
+		if err != nil {
+			// If we can't flatten the validator set, skip it and disallow warp
+			// message verification from this subnet.
+			continue
+		}
+		validatorSets[subnetID] = ws
+	}
+	return validatorSets, nil
+}
+
+func (m *manager) GetWarpValidatorSet(
+	ctx context.Context,
+	targetHeight uint64,
+	subnetID ids.ID,
+) (validators.WarpSet, error) {
+	vdrSet, err := m.GetValidatorSet(ctx, targetHeight, subnetID)
+	if err != nil {
+		return validators.WarpSet{}, err
+	}
+
+	return validators.FlattenValidatorSet(vdrSet)
 }
 
 func (m *manager) GetValidatorSet(

--- a/vms/platformvm/validators/manager_test.go
+++ b/vms/platformvm/validators/manager_test.go
@@ -4,7 +4,9 @@
 package validators_test
 
 import (
+	"bytes"
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
@@ -25,6 +28,12 @@ import (
 
 	. "github.com/ava-labs/avalanchego/vms/platformvm/validators"
 )
+
+func newPublicKey(t *testing.T) *bls.PublicKey {
+	sk, err := localsigner.New()
+	require.NoError(t, err)
+	return sk.PublicKey()
+}
 
 func TestGetValidatorSet_AfterEtna(t *testing.T) {
 	require := require.New(t)
@@ -38,13 +47,11 @@ func TestGetValidatorSet_AfterEtna(t *testing.T) {
 		Upgrades:   upgrades,
 	})
 
-	sk, err := localsigner.New()
-	require.NoError(err)
 	var (
 		subnetID      = ids.GenerateTestID()
 		startTime     = genesistest.DefaultValidatorStartTime
 		endTime       = startTime.Add(24 * time.Hour)
-		pk            = sk.PublicKey()
+		pk            = newPublicKey(t)
 		primaryStaker = &state.Staker{
 			TxID:            ids.GenerateTestID(),
 			NodeID:          ids.GenerateTestNodeID(),
@@ -121,5 +128,213 @@ func TestGetValidatorSet_AfterEtna(t *testing.T) {
 		actual, err := m.GetValidatorSet(context.Background(), uint64(height), subnetID)
 		require.NoError(err)
 		require.Equal(expected, actual)
+	}
+}
+
+func TestGetWarpValidatorSets(t *testing.T) {
+	require := require.New(t)
+
+	vdrs := validators.NewManager()
+	s := statetest.New(t, statetest.Config{
+		Validators: vdrs,
+	})
+
+	// Warp validators are sorted by their public key bytes, so define the
+	// sorted order as 0 then 1.
+	var (
+		pk0      = newPublicKey(t)
+		pk0Bytes = bls.PublicKeyToUncompressedBytes(pk0)
+		pk1      = newPublicKey(t)
+		pk1Bytes = bls.PublicKeyToUncompressedBytes(pk1)
+	)
+	if bytes.Compare(pk0Bytes, pk1Bytes) > 0 {
+		pk0, pk1 = pk1, pk0
+		pk0Bytes, pk1Bytes = pk1Bytes, pk0Bytes
+	}
+
+	var (
+		subnetID       = ids.GenerateTestID()
+		startTime      = genesistest.DefaultValidatorStartTime
+		endTime        = startTime.Add(24 * time.Hour)
+		primaryStaker0 = &state.Staker{
+			TxID:            ids.GenerateTestID(),
+			NodeID:          ids.GenerateTestNodeID(),
+			PublicKey:       pk0,
+			SubnetID:        constants.PrimaryNetworkID,
+			Weight:          1,
+			StartTime:       startTime,
+			EndTime:         endTime,
+			PotentialReward: 1,
+		}
+		subnetStaker0 = &state.Staker{
+			TxID:      ids.GenerateTestID(),
+			NodeID:    primaryStaker0.NodeID,
+			PublicKey: nil, // inherited from primaryStaker
+			SubnetID:  subnetID,
+			Weight:    1,
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+		primaryStaker1 = &state.Staker{
+			TxID:            ids.GenerateTestID(),
+			NodeID:          ids.GenerateTestNodeID(),
+			PublicKey:       pk1,
+			SubnetID:        constants.PrimaryNetworkID,
+			Weight:          1,
+			StartTime:       startTime,
+			EndTime:         endTime,
+			PotentialReward: 1,
+		}
+		subnetStaker1 = &state.Staker{
+			TxID:      ids.GenerateTestID(),
+			NodeID:    primaryStaker1.NodeID,
+			PublicKey: nil, // inherited from primaryStaker1
+			SubnetID:  subnetID,
+			Weight:    math.MaxUint64,
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+	)
+
+	var lastHeight uint64
+	acceptBlock := func(
+		newStakers []*state.Staker,
+		removedStakers []*state.Staker,
+	) {
+		t.Helper()
+
+		lastHeight++
+		blk, err := block.NewBanffStandardBlock(s.GetTimestamp(), s.GetLastAccepted(), lastHeight, nil)
+		require.NoError(err)
+
+		s.SetHeight(blk.Height())
+		s.SetTimestamp(blk.Timestamp())
+		s.AddStatelessBlock(blk)
+		s.SetLastAccepted(blk.ID())
+
+		for _, v := range newStakers {
+			require.NoError(s.PutCurrentValidator(v))
+		}
+		for _, v := range removedStakers {
+			s.DeleteCurrentValidator(v)
+		}
+		require.NoError(s.Commit())
+	}
+
+	acceptBlock( // Add a subnet staker during the Etna upgrade
+		[]*state.Staker{primaryStaker0, subnetStaker0},
+		nil,
+	)
+	acceptBlock( // Overflow the subnet
+		[]*state.Staker{primaryStaker1, subnetStaker1},
+		nil,
+	)
+	acceptBlock( // Remove the subnet overflow
+		nil,
+		[]*state.Staker{subnetStaker1},
+	)
+	acceptBlock( // Remove the subnet entirely
+		nil,
+		[]*state.Staker{subnetStaker0},
+	)
+
+	m := NewManager(
+		config.Internal{
+			Validators: vdrs,
+		},
+		s,
+		metrics.Noop,
+		new(mockable.Clock),
+	)
+
+	expectedPrimaryNetworkWithAllValidators := validators.WarpSet{
+		Validators: []*validators.Warp{
+			{
+				PublicKey:      pk0,
+				PublicKeyBytes: pk0Bytes,
+				Weight:         1,
+				NodeIDs:        []ids.NodeID{primaryStaker0.NodeID},
+			},
+			{
+				PublicKey:      pk1,
+				PublicKeyBytes: pk1Bytes,
+				Weight:         1,
+				NodeIDs:        []ids.NodeID{primaryStaker1.NodeID},
+			},
+		},
+		TotalWeight: genesistest.DefaultValidatorWeight*uint64(len(genesistest.DefaultNodeIDs)) + 2,
+	}
+	expectedValidators := []map[ids.ID]validators.WarpSet{
+		{
+			constants.PrimaryNetworkID: {
+				Validators:  []*validators.Warp{},
+				TotalWeight: genesistest.DefaultValidatorWeight * uint64(len(genesistest.DefaultNodeIDs)),
+			},
+		}, // Subnet didn't exist at genesis
+		{
+			constants.PrimaryNetworkID: {
+				Validators: []*validators.Warp{
+					{
+						PublicKey:      pk0,
+						PublicKeyBytes: pk0Bytes,
+						Weight:         1,
+						NodeIDs:        []ids.NodeID{primaryStaker0.NodeID},
+					},
+				},
+				TotalWeight: genesistest.DefaultValidatorWeight*uint64(len(genesistest.DefaultNodeIDs)) + 1,
+			},
+			subnetID: {
+				Validators: []*validators.Warp{
+					{
+						PublicKey:      pk0,
+						PublicKeyBytes: pk0Bytes,
+						Weight:         1,
+						NodeIDs:        []ids.NodeID{subnetStaker0.NodeID},
+					},
+				},
+				TotalWeight: 1,
+			},
+		}, // Subnet was added at height 1
+		{
+			constants.PrimaryNetworkID: expectedPrimaryNetworkWithAllValidators,
+		}, // Subnet overflow occurred at height 1
+		{
+			constants.PrimaryNetworkID: expectedPrimaryNetworkWithAllValidators,
+			subnetID: {
+				Validators: []*validators.Warp{
+					{
+						PublicKey:      pk0,
+						PublicKeyBytes: pk0Bytes,
+						Weight:         1,
+						NodeIDs:        []ids.NodeID{subnetStaker0.NodeID},
+					},
+				},
+				TotalWeight: 1,
+			},
+		}, // Subnet overflow was removed at height 2
+		{
+			constants.PrimaryNetworkID: expectedPrimaryNetworkWithAllValidators,
+		}, // Subnet was removed at height 3
+	}
+	for height, expected := range expectedValidators {
+		actual, err := m.GetWarpValidatorSets(context.Background(), uint64(height))
+		require.NoError(err)
+		require.Equal(expected, actual)
+
+		actualPrimaryNetwork, err := m.GetWarpValidatorSet(context.Background(), uint64(height), constants.PrimaryNetworkID)
+		require.NoError(err)
+		require.Equal(expected[constants.PrimaryNetworkID], actualPrimaryNetwork)
+
+		actualSubnet, err := m.GetWarpValidatorSet(context.Background(), uint64(height), subnetID)
+		if err != nil {
+			require.NotContains(expected, subnetID)
+			continue
+		}
+
+		// Treat nil and empty slices as the same
+		if len(actualSubnet.Validators) == 0 {
+			actualSubnet.Validators = nil
+		}
+		require.Equal(expected[subnetID], actualSubnet)
 	}
 }

--- a/vms/platformvm/validators/manager_test.go
+++ b/vms/platformvm/validators/manager_test.go
@@ -154,45 +154,29 @@ func TestGetWarpValidatorSets(t *testing.T) {
 
 	var (
 		subnetID       = ids.GenerateTestID()
-		startTime      = genesistest.DefaultValidatorStartTime
-		endTime        = startTime.Add(24 * time.Hour)
 		primaryStaker0 = &state.Staker{
-			TxID:            ids.GenerateTestID(),
-			NodeID:          ids.GenerateTestNodeID(),
-			PublicKey:       pk0,
-			SubnetID:        constants.PrimaryNetworkID,
-			Weight:          1,
-			StartTime:       startTime,
-			EndTime:         endTime,
-			PotentialReward: 1,
+			NodeID:    ids.GenerateTestNodeID(),
+			PublicKey: pk0,
+			SubnetID:  constants.PrimaryNetworkID,
+			Weight:    1,
 		}
 		subnetStaker0 = &state.Staker{
-			TxID:      ids.GenerateTestID(),
 			NodeID:    primaryStaker0.NodeID,
 			PublicKey: nil, // inherited from primaryStaker
 			SubnetID:  subnetID,
 			Weight:    1,
-			StartTime: startTime,
-			EndTime:   endTime,
 		}
 		primaryStaker1 = &state.Staker{
-			TxID:            ids.GenerateTestID(),
-			NodeID:          ids.GenerateTestNodeID(),
-			PublicKey:       pk1,
-			SubnetID:        constants.PrimaryNetworkID,
-			Weight:          1,
-			StartTime:       startTime,
-			EndTime:         endTime,
-			PotentialReward: 1,
+			NodeID:    ids.GenerateTestNodeID(),
+			PublicKey: pk1,
+			SubnetID:  constants.PrimaryNetworkID,
+			Weight:    1,
 		}
 		subnetStaker1 = &state.Staker{
-			TxID:      ids.GenerateTestID(),
 			NodeID:    primaryStaker1.NodeID,
 			PublicKey: nil, // inherited from primaryStaker1
 			SubnetID:  subnetID,
 			Weight:    math.MaxUint64,
-			StartTime: startTime,
-			EndTime:   endTime,
 		}
 	)
 

--- a/vms/platformvm/validators/validatorstest/manager.go
+++ b/vms/platformvm/validators/validatorstest/manager.go
@@ -28,6 +28,14 @@ func (manager) GetSubnetID(context.Context, ids.ID) (ids.ID, error) {
 	return ids.Empty, nil
 }
 
+func (manager) GetWarpValidatorSets(context.Context, uint64) (map[ids.ID]snowvalidators.WarpSet, error) {
+	return nil, nil
+}
+
+func (manager) GetWarpValidatorSet(context.Context, uint64, ids.ID) (snowvalidators.WarpSet, error) {
+	return snowvalidators.WarpSet{}, nil
+}
+
 func (manager) GetValidatorSet(context.Context, uint64, ids.ID) (map[ids.NodeID]*snowvalidators.GetValidatorOutput, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Why this should be merged

[ACP-181](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/181-p-chain-epoched-views/README.md) adds epoched views of the P-chain for all warp verification.


For a given P-chain height and subnetID, warp message verification can be cached through the generation of the canonical validator set. After that, message-specific logic is performed. Such as aggregating a subset of public keys or verifying the aggregate signature.

The intent of change is to introduce caching inside the `validators.State` implementation to allow caching to be handled once by the P-chain.

## How this works

This PR adds two functions: `GetWarpValidatorSets(height)` and `GetWarpValidatorSet(height, subnetID)` to the `validators.State` interface and implements them on all of the `validators.State` implementations.

## How this was tested

Added tests for all new implementations:
- [x] `Client` @ `snow/validators/gvalidators/validator_state_client.go`
- [x] `manager` @ `vms/platformvm/validators/manager.go`

These implementations are "trivial" and therefore remain untested.
- `lockedState` @ `snow/validators/state.go`
- `noValidators` @ `snow/validators/state.go`
- `tracedState` @ `snow/validators/traced_state.go`

## Need to be documented in RELEASES.md?

no