### PR TITLE
refactor: ledger interface to use public keys instead of addresses

### DIFF
--- a/utils/crypto/keychain/keychainmock/ledger.go
+++ b/utils/crypto/keychain/keychainmock/ledger.go
@@ -12,7 +12,7 @@ package keychainmock
 import (
 	reflect "reflect"
 
-	ids "github.com/ava-labs/avalanchego/ids"
+	secp256k1 "github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	version "github.com/ava-labs/avalanchego/version"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -41,36 +41,6 @@ func (m *Ledger) EXPECT() *LedgerMockRecorder {
 	return m.recorder
 }
 
-// Address mocks base method.
-func (m *Ledger) Address(displayHRP string, addressIndex uint32) (ids.ShortID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Address", displayHRP, addressIndex)
-	ret0, _ := ret[0].(ids.ShortID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Address indicates an expected call of Address.
-func (mr *LedgerMockRecorder) Address(displayHRP, addressIndex any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*Ledger)(nil).Address), displayHRP, addressIndex)
-}
-
-// Addresses mocks base method.
-func (m *Ledger) Addresses(addressIndices []uint32) ([]ids.ShortID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Addresses", addressIndices)
-	ret0, _ := ret[0].([]ids.ShortID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Addresses indicates an expected call of Addresses.
-func (mr *LedgerMockRecorder) Addresses(addressIndices any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addresses", reflect.TypeOf((*Ledger)(nil).Addresses), addressIndices)
-}
-
 // Disconnect mocks base method.
 func (m *Ledger) Disconnect() error {
 	m.ctrl.T.Helper()
@@ -83,6 +53,36 @@ func (m *Ledger) Disconnect() error {
 func (mr *LedgerMockRecorder) Disconnect() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*Ledger)(nil).Disconnect))
+}
+
+// PubKey mocks base method.
+func (m *Ledger) PubKey(addressIndex uint32) (*secp256k1.PublicKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PubKey", addressIndex)
+	ret0, _ := ret[0].(*secp256k1.PublicKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PubKey indicates an expected call of PubKey.
+func (mr *LedgerMockRecorder) PubKey(addressIndex any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PubKey", reflect.TypeOf((*Ledger)(nil).PubKey), addressIndex)
+}
+
+// PubKeys mocks base method.
+func (m *Ledger) PubKeys(addressIndices []uint32) ([]*secp256k1.PublicKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PubKeys", addressIndices)
+	ret0, _ := ret[0].([]*secp256k1.PublicKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PubKeys indicates an expected call of PubKeys.
+func (mr *LedgerMockRecorder) PubKeys(addressIndices any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PubKeys", reflect.TypeOf((*Ledger)(nil).PubKeys), addressIndices)
 }
 
 // Sign mocks base method.

--- a/utils/crypto/keychain/ledger.go
+++ b/utils/crypto/keychain/ledger.go
@@ -4,15 +4,15 @@
 package keychain
 
 import (
-	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/version"
 )
 
 // Ledger interface for the ledger wrapper
 type Ledger interface {
 	Version() (v *version.Semantic, err error)
-	Address(displayHRP string, addressIndex uint32) (ids.ShortID, error)
-	Addresses(addressIndices []uint32) ([]ids.ShortID, error)
+	PubKey(addressIndex uint32) (*secp256k1.PublicKey, error)
+	PubKeys(addressIndices []uint32) ([]*secp256k1.PublicKey, error)
 	SignHash(hash []byte, addressIndices []uint32) ([][]byte, error)
 	Sign(unsignedTxBytes []byte, addressIndices []uint32) ([][]byte, error)
 	Disconnect() error

--- a/utils/crypto/ledger/ledger_test.go
+++ b/utils/crypto/ledger/ledger_test.go
@@ -34,16 +34,18 @@ func TestLedger(t *testing.T) {
 	t.Logf("version: %s\n", version)
 
 	// Get Fuji Address
-	addr, err := device.Address(hrp, 0)
+	pubKey, err := device.PubKey(0)
 	require.NoError(err)
+	addr := pubKey.Address()
 	paddr, err := address.Format(chainAlias, hrp, addr[:])
 	require.NoError(err)
 	t.Logf("address: %s shortID: %s\n", paddr, addr)
 
-	// Get Extended Addresses
-	addresses, err := device.Addresses([]uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	// Get Extended Public Keys
+	pubKeys, err := device.PubKeys([]uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 	require.NoError(err)
-	for i, taddr := range addresses {
+	for i, pk := range pubKeys {
+		taddr := pk.Address()
 		paddr, err := address.Format(chainAlias, hrp, taddr[:])
 		require.NoError(err)
 		t.Logf("address(%d): %s shortID: %s\n", i, paddr, taddr)
@@ -66,7 +68,7 @@ func TestLedger(t *testing.T) {
 
 		pk, err := secp256k1.RecoverPublicKeyFromHash(rawHash, sig)
 		require.NoError(err)
-		require.Equal(addresses[addrIndex], pk.Address())
+		require.Equal(pubKeys[addrIndex].Address(), pk.Address())
 	}
 
 	// Disconnect


### PR DESCRIPTION
## Why this should be merged
The current ledger interface returns addresses (`ids.ShortID`) directly, which couples the ledger abstraction to a specific address format. This refactor changes the interface to return public keys instead, enabling:

- Support for multiple address formats (Avalanche and Ethereum) from the same ledger key
- **Satisfies `EthKeychain` interface, enabling ledger to be used to fully sign C-chain transactions on wallet**
  
## How this works
**Ledger Interface Changes:**
- `Ledger.Address()` → `Ledger.PubKey()` - returns `*secp256k1.PublicKey`
- `Ledger.Addresses()` → `Ledger.PubKeys()` - returns `[]*secp256k1.PublicKey`

**Ledger Keychain Changes:**
- Stores public keys internally instead of addresses
- Derives both Avalanche and Ethereum addresses from public keys
- Added `EthAddresses()` and `GetEth()` methods for EthKeychain implementation

**Implementation:**
- The ledger now queries the hardware device for public keys without requiring to provide HRP or display
- Public keys are cached with their ledger indices
- Addresses are derived on-demand using `pubKey.Address()` and `pubKey.EthAddress()`
- Both address types share the same derivation path from the ledger

## How this was tested
- unit tests
- ledger operations on CLI to deploy a L1 locally 

## Need to be documented in RELEASES.md?
