### PR TITLE
refactor(reexecution/c): rename  args

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -115,4 +115,4 @@ runs:
     - name: Push Post-State to S3 (if not exists)
       if: ${{ inputs.push-post-state != '' }}
       shell: nix develop --command bash -x {0}
-      run: ./scripts/run_task.sh export-dir-to-s3 LOCAL_SRC=${{ env.EXECUTION_DATA_DIR }}/current-state/ S3_DST=${{ inputs.push-post-state }}
+      run: ./scripts/run_task.sh export-dir-to-s3 SRC=${{ env.EXECUTION_DATA_DIR }}/current-state/ DST=${{ inputs.push-post-state }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -109,10 +109,10 @@ tasks:
   export-dir-to-s3:
     desc: Copies a directory to s3
     vars:
-      LOCAL_SRC: '{{.LOCAL_SRC}}'
-      S3_DST: '{{.S3_DST}}'
+      SRC: '{{.SRC}}'
+      DST: '{{.DST}}'
     cmds:
-      - cmd: bash -x ./scripts/copy_dir.sh {{.LOCAL_SRC}} {{.S3_DST}}
+      - cmd: bash -x ./scripts/copy_dir.sh {{.SRC}} {{.DST}}
 
   generate-mocks:
     desc: Generates testing mocks

--- a/tests/reexecute/c/README.md
+++ b/tests/reexecute/c/README.md
@@ -173,15 +173,15 @@ After generating the `$EXECUTION_DATA_DIR/current-state` directory from executin
 
 Since we are already using the S3 bucket `s3://avalanchego-bootstrap-testing`, we'll re-use it here. We'll use the `export-dir-to-s3` task, which takes in two parameters:
 
-- `LOCAL_SRC` - local path to recursive copy contents from
-- `S3_DST` - S3 bucket destination path
+- `SRC` - local path to recursive copy contents from
+- `DST` - S3 bucket destination path
 
 To avoid clobbering useful data, `export-dir-to-s3` will first attempt to check that the destination does not yet exist and that the path does not have any nesting. For example, `s3://avalanchego-bootstrap-testing/target-dir/` is valid, but `s3://avalanchego-bootstrap-testing/nested/target-dir/` is invalid because it contains two levels of nesting.
 
 As a result, if you run into a warning using this command, check the current contents using either the AWS Console or `s5cmd ls` and pick a valid, unused prefix.
 
 ```bash
-task export-dir-to-s3 LOCAL_SRC=$EXECUTION_DATA_DIR/current-state/ S3_DST=s3://avalanchego-bootstrap-testing/cchain-current-state-test/
+task export-dir-to-s3 SRC=$EXECUTION_DATA_DIR/current-state/ DST=s3://avalanchego-bootstrap-testing/cchain-current-state-test/
 ```
 
 ### Re-Execute C-Chain Range


### PR DESCRIPTION
## Why this should be merged

As mentioned in #4360, we can simply the args for `export-s3-to-dir`.

## How this works

Changes `LOCAL_SRC => SRC` and `S3_DST => DST`

## How this was tested

Ran workflow to verify that exporting to s3 works as expected: https://github.com/ava-labs/avalanchego/actions/runs/18196006625/job/51802293747

## Need to be documented in RELEASES.md?

No