### PR TITLE
feat(reexecution/c): print grafana link during local run

### DIFF
--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -1120,7 +1120,7 @@ func getRPCVersion(log logging.Logger, command string, versionArgs ...string) (u
 // with the given UUID. The start and end times are accepted as strings to support the
 // use of Grafana's time range syntax (e.g. `now`, `now-1h`).
 func MetricsLinkForNetwork(networkUUID string, startTime string, endTime string) string {
-	return NewGrafanaLink(
+	return NewGrafanaURI(
 		networkUUID,
 		startTime,
 		endTime,
@@ -1128,8 +1128,8 @@ func MetricsLinkForNetwork(networkUUID string, startTime string, endTime string)
 	)
 }
 
-// NewGrafanaLink returns a Grafana dashboard link.
-func NewGrafanaLink(
+// NewGrafanaURI returns a Grafana dashboard URI.
+func NewGrafanaURI(
 	networkUUID string,
 	startTime string,
 	endTime string,

--- a/tests/reexecute/c/vm_reexecute_test.go
+++ b/tests/reexecute/c/vm_reexecute_test.go
@@ -601,7 +601,7 @@ func collectRegistry(tb testing.TB, log logging.Logger, name string, gatherer pr
 	log.Info("metrics available via grafana",
 		zap.String(
 			"url",
-			tmpnet.NewGrafanaLink(networkUUID, startTime, "", grafanaURI),
+			tmpnet.NewGrafanaURI(networkUUID, startTime, "", grafanaURI),
 		),
 	)
 }


### PR DESCRIPTION
## Why this should be merged

As mentioned in #4290, the Grafana dashboard link is not printed out when running the re-execution tests locally. This PR fixes this by printing the link even when running locally.

The changes in the `tmpnet` package are relevant in #4372, as we'll call `NewGrafanaLink()` to generate the dashboard link when running against an external network.

## How this works

Prints the Grafana dashboard link of a re-execution test when running locally.

## How this was tested

CI + ran re-execution test to verify that the dashboard link is printed and is as expected.

## Need to be documented in RELEASES.md?

No