### PR TITLE
[ci] Update run-monitored-tmpnet-cmd to not require tools/go.modfile

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -83,7 +83,10 @@ runs:
     - run: $GITHUB_ACTION_PATH/nix-develop.sh --command go mod download
       if: steps.go-mod-cache.outputs.cache-hit != 'true'
       shell: bash
-    - run: $GITHUB_ACTION_PATH/nix-develop.sh --command go mod download -modfile=tools/go.mod
+    - run: |
+        if [[ -f tools/go.mod ]]; then
+          $GITHUB_ACTION_PATH/nix-develop.sh --command go mod download -modfile=tools/go.mod
+        fi
       if: steps.go-mod-cache.outputs.cache-hit != 'true'
       shell: bash
     - name: Notify of metrics availability


### PR DESCRIPTION
## Why this should be merged

The recent switch of CLI tooling to golang 1.24's `go tool` also updated the run-monitored-tmpnet-cmd to require that tools/go.mod exist to enable module caching for tooling. This change makes that behavior optional to avoid requiring (while still allowing) subnet-evm and coreth to follow the same example.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A