### PR TITLE
Remove max contiguous height

### DIFF
--- a/x/blockdb/README.md
+++ b/x/blockdb/README.md
@@ -55,10 +55,9 @@ Index File Header (64 bytes):
 │ Version                        │ 8 bytes │
 │ Max Data File Size             │ 8 bytes │
 │ Min Block Height               │ 8 bytes │
-│ Max Contiguous Height          │ 8 bytes │
 │ Max Block Height               │ 8 bytes │
 │ Next Write Offset              │ 8 bytes │
-│ Reserved                       │ 16 bytes│
+│ Reserved                       │ 24 bytes│
 └────────────────────────────────┴─────────┘
 
 Index Entry (16 bytes):
@@ -119,8 +118,8 @@ On startup, BlockDB checks for signs of an unclean shutdown by comparing the dat
 2. For each unindexed block found:
    - Validates the block entry header and checksum
    - Writes the corresponding index entry
-3. Calculates the max contiguous height and max block height
-4. Updates the index header with the updated max contiguous height, max block height, and next write offset
+3. Calculates the max block height
+4. Updates the index header with the updated max block height and next write offset
 
 ## Usage
 

--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -131,15 +131,14 @@ func (e *indexEntry) UnmarshalBinary(data []byte) error {
 
 // indexFileHeader is the header of the index file.
 type indexFileHeader struct {
-	Version             uint64
-	MaxDataFileSize     uint64
-	MinHeight           BlockHeight
-	MaxContiguousHeight BlockHeight
-	MaxHeight           BlockHeight
-	NextWriteOffset     uint64
-	// reserve remaining 16 bytes for future use while keeping the
+	Version         uint64
+	MaxDataFileSize uint64
+	MinHeight       BlockHeight
+	MaxHeight       BlockHeight
+	NextWriteOffset uint64
+	// reserve remaining 24 bytes for future use while keeping the
 	// size of the index file header multiple of sizeOfIndexEntry.
-	Reserved [16]byte
+	Reserved [24]byte
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler for indexFileHeader.
@@ -148,9 +147,8 @@ func (h indexFileHeader) MarshalBinary() ([]byte, error) {
 	binary.LittleEndian.PutUint64(buf[0:], h.Version)
 	binary.LittleEndian.PutUint64(buf[8:], h.MaxDataFileSize)
 	binary.LittleEndian.PutUint64(buf[16:], h.MinHeight)
-	binary.LittleEndian.PutUint64(buf[24:], h.MaxContiguousHeight)
-	binary.LittleEndian.PutUint64(buf[32:], h.MaxHeight)
-	binary.LittleEndian.PutUint64(buf[40:], h.NextWriteOffset)
+	binary.LittleEndian.PutUint64(buf[24:], h.MaxHeight)
+	binary.LittleEndian.PutUint64(buf[32:], h.NextWriteOffset)
 	return buf, nil
 }
 
@@ -165,17 +163,9 @@ func (h *indexFileHeader) UnmarshalBinary(data []byte) error {
 	h.Version = binary.LittleEndian.Uint64(data[0:])
 	h.MaxDataFileSize = binary.LittleEndian.Uint64(data[8:])
 	h.MinHeight = binary.LittleEndian.Uint64(data[16:])
-	h.MaxContiguousHeight = binary.LittleEndian.Uint64(data[24:])
-	h.MaxHeight = binary.LittleEndian.Uint64(data[32:])
-	h.NextWriteOffset = binary.LittleEndian.Uint64(data[40:])
+	h.MaxHeight = binary.LittleEndian.Uint64(data[24:])
+	h.NextWriteOffset = binary.LittleEndian.Uint64(data[32:])
 	return nil
-}
-
-type blockHeights struct {
-	// maxBlockHeight tracks the highest block height that has been written to the db, even if there are gaps in the sequence.
-	maxBlockHeight BlockHeight
-	// maxContiguousHeight tracks the highest block height known to be contiguously stored.
-	maxContiguousHeight BlockHeight
 }
 
 // Database stores blockchain blocks on disk and provides methods to read and write blocks.
@@ -195,8 +185,8 @@ type Database struct {
 	// fileOpenMu prevents race conditions when multiple threads try to open the same data file
 	fileOpenMu sync.Mutex
 
-	// blockHeights holds the max block height and max contiguous height
-	blockHeights atomic.Pointer[blockHeights]
+	// maxBlockHeight tracks the highest block height written
+	maxBlockHeight atomic.Uint64
 	// nextDataWriteOffset tracks the next position to write new data in the data file.
 	nextDataWriteOffset atomic.Uint64
 	// headerWriteOccupied prevents concurrent writes to the index header
@@ -260,41 +250,13 @@ func New(config DatabaseConfig, log logging.Logger) (*Database, error) {
 		return nil, fmt.Errorf("recovery failed: %w", err)
 	}
 
-	heights := s.getBlockHeights()
+	maxHeight := s.maxBlockHeight.Load()
 	s.log.Info("BlockDB initialized successfully",
 		zap.Uint64("nextWriteOffset", s.nextDataWriteOffset.Load()),
-		zap.Uint64("maxContiguousHeight", heights.maxContiguousHeight),
-		zap.Uint64("maxBlockHeight", heights.maxBlockHeight),
+		zap.Uint64("maxBlockHeight", maxHeight),
 	)
 
 	return s, nil
-}
-
-// MaxContiguousHeight returns the highest block height known to be contiguously stored.
-func (s *Database) MaxContiguousHeight() (height BlockHeight, found bool) {
-	heights := s.getBlockHeights()
-	if heights.maxContiguousHeight == unsetHeight {
-		return 0, false
-	}
-	return heights.maxContiguousHeight, true
-}
-
-func (s *Database) setBlockHeights(maxBlock, maxContiguous BlockHeight) {
-	heights := &blockHeights{
-		maxBlockHeight:      maxBlock,
-		maxContiguousHeight: maxContiguous,
-	}
-	s.blockHeights.Store(heights)
-}
-
-func (s *Database) updateBlockHeightsAtomically(updateFn func(*blockHeights) *blockHeights) {
-	for {
-		current := s.getBlockHeights()
-		updated := updateFn(current)
-		if s.blockHeights.CompareAndSwap(current, updated) {
-			break
-		}
-	}
 }
 
 // Close flushes pending writes and closes the store files.
@@ -402,8 +364,8 @@ func (s *Database) Put(height BlockHeight, block BlockData) error {
 		return err
 	}
 
-	if err := s.updateBlockHeights(height); err != nil {
-		s.log.Error("Failed to write block: error updating block heights",
+	if err := s.updateBlockMaxHeight(height); err != nil {
+		s.log.Error("Failed to write block: error updating max block height",
 			zap.Uint64("height", height),
 			zap.Error(err),
 		)
@@ -431,21 +393,21 @@ func (s *Database) readBlockIndex(height BlockHeight) (indexEntry, error) {
 	}
 
 	// Skip the index entry read if we know the block is past the max height.
-	heights := s.getBlockHeights()
-	if heights.maxBlockHeight == unsetHeight {
+	maxHeight := s.maxBlockHeight.Load()
+	if maxHeight == unsetHeight {
 		s.log.Debug("Block not found",
 			zap.Uint64("height", height),
 			zap.String("reason", "no blocks written yet"),
 		)
 		return entry, fmt.Errorf("%w: no blocks written yet", database.ErrNotFound)
 	}
-	if height > heights.maxBlockHeight {
+	if height > maxHeight {
 		s.log.Debug("Block not found",
 			zap.Uint64("height", height),
-			zap.Uint64("maxHeight", heights.maxBlockHeight),
+			zap.Uint64("maxHeight", maxHeight),
 			zap.String("reason", "height beyond max"),
 		)
-		return entry, fmt.Errorf("%w: height %d is beyond max height %d", database.ErrNotFound, height, heights.maxBlockHeight)
+		return entry, fmt.Errorf("%w: height %d is beyond max height %d", database.ErrNotFound, height, maxHeight)
 	}
 
 	entry, err := s.readIndexEntry(height)
@@ -635,9 +597,7 @@ func (s *Database) persistIndexHeaderInternal() error {
 
 	// Update the header with the current state of the database.
 	header.NextWriteOffset = s.nextDataWriteOffset.Load()
-	heights := s.getBlockHeights()
-	header.MaxContiguousHeight = heights.maxContiguousHeight
-	header.MaxHeight = heights.maxBlockHeight
+	header.MaxHeight = s.maxBlockHeight.Load()
 	headerBytes, err := header.MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("failed to serialize header for writing state: %w", err)
@@ -646,17 +606,6 @@ func (s *Database) persistIndexHeaderInternal() error {
 		return fmt.Errorf("failed to write header state to index file: %w", err)
 	}
 	return nil
-}
-
-func (s *Database) getBlockHeights() *blockHeights {
-	heights := s.blockHeights.Load()
-	if heights == nil {
-		return &blockHeights{
-			maxBlockHeight:      unsetHeight,
-			maxContiguousHeight: unsetHeight,
-		}
-	}
-	return heights
 }
 
 // recover detects and recovers unindexed blocks by scanning data files and updating the index.
@@ -679,9 +628,9 @@ func (s *Database) recover() error {
 	}
 
 	// ensure no data files are missing
-	// If any data files are missing, we would need to recalculate the max height
-	// and max contiguous height. This can be supported in the future but for now
-	// to keep things simple, we will just error if the data files are not as expected.
+	// If any data files are missing, we would need to recalculate the max height.
+	// This can be supported in the future but for now to keep things simple,
+	// we will just error if the data files are not as expected.
 	for i := 0; i <= maxIndex; i++ {
 		if _, exists := dataFiles[i]; !exists {
 			return fmt.Errorf("%w: data file at index %d is missing", ErrCorrupted, i)
@@ -769,10 +718,19 @@ func (s *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error {
 	}
 	s.nextDataWriteOffset.Store(currentScanOffset)
 
-	// Update block heights based on recovered blocks
+	// Update the max block height if max recovered height is greater than
+	// the current max height.
 	if len(recoveredHeights) > 0 {
-		if err := s.updateRecoveredBlockHeights(recoveredHeights); err != nil {
-			return fmt.Errorf("recovery: failed to update block heights: %w", err)
+		maxRecoveredHeight := recoveredHeights[0]
+		for _, height := range recoveredHeights[1:] {
+			if height > maxRecoveredHeight {
+				maxRecoveredHeight = height
+			}
+		}
+
+		currentMaxHeight := s.maxBlockHeight.Load()
+		if maxRecoveredHeight > currentMaxHeight || currentMaxHeight == unsetHeight {
+			s.maxBlockHeight.Store(maxRecoveredHeight)
 		}
 	}
 
@@ -780,12 +738,11 @@ func (s *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error {
 		return fmt.Errorf("recovery: failed to save index header after recovery scan: %w", err)
 	}
 
-	heights := s.getBlockHeights()
+	maxHeight := s.maxBlockHeight.Load()
 	s.log.Info("Recovery: Scan finished",
 		zap.Int("recoveredBlocks", len(recoveredHeights)),
 		zap.Uint64("finalNextWriteOffset", s.nextDataWriteOffset.Load()),
-		zap.Uint64("maxContiguousBlockHeight", heights.maxContiguousHeight),
-		zap.Uint64("maxBlockHeight", heights.maxBlockHeight),
+		zap.Uint64("maxBlockHeight", maxHeight),
 	)
 	return nil
 }
@@ -926,14 +883,13 @@ func (s *Database) loadOrInitializeHeader() error {
 	if fileInfo.Size() == 0 {
 		s.log.Info("Index file is empty, writing initial index file header")
 		s.header = indexFileHeader{
-			Version:             IndexFileVersion,
-			MinHeight:           s.config.MinimumHeight,
-			MaxDataFileSize:     s.config.MaxDataFileSize,
-			MaxHeight:           unsetHeight,
-			MaxContiguousHeight: unsetHeight,
-			NextWriteOffset:     0,
+			Version:         IndexFileVersion,
+			MinHeight:       s.config.MinimumHeight,
+			MaxDataFileSize: s.config.MaxDataFileSize,
+			MaxHeight:       unsetHeight,
+			NextWriteOffset: 0,
 		}
-		s.setBlockHeights(unsetHeight, unsetHeight)
+		s.maxBlockHeight.Store(unsetHeight)
 
 		headerBytes, err := s.header.MarshalBinary()
 		if err != nil {
@@ -961,7 +917,7 @@ func (s *Database) loadOrInitializeHeader() error {
 		return fmt.Errorf("mismatched index file version: found %d, expected %d", s.header.Version, IndexFileVersion)
 	}
 	s.nextDataWriteOffset.Store(s.header.NextWriteOffset)
-	s.setBlockHeights(s.header.MaxHeight, s.header.MaxContiguousHeight)
+	s.maxBlockHeight.Store(s.header.MaxHeight)
 	s.logConfigAndHeaderMismatches()
 
 	return nil
@@ -1084,59 +1040,17 @@ func (s *Database) writeBlockAt(offset uint64, bh blockEntryHeader, block BlockD
 	}
 }
 
-func (s *Database) updateBlockHeights(writtenBlockHeight BlockHeight) error {
-	s.updateBlockHeightsAtomically(func(current *blockHeights) *blockHeights {
-		updated := &blockHeights{
-			maxBlockHeight:      current.maxBlockHeight,
-			maxContiguousHeight: current.maxContiguousHeight,
+func (s *Database) updateBlockMaxHeight(writtenBlockHeight BlockHeight) error {
+	for {
+		maxHeight := s.maxBlockHeight.Load()
+		if writtenBlockHeight <= maxHeight && maxHeight != unsetHeight {
+			break
 		}
-
-		// Update max block height if needed
-		if writtenBlockHeight > current.maxBlockHeight || current.maxBlockHeight == unsetHeight {
-			updated.maxBlockHeight = writtenBlockHeight
+		if s.maxBlockHeight.CompareAndSwap(maxHeight, writtenBlockHeight) {
+			break
 		}
-
-		// Update max contiguous height logic
-		prevContiguousCandidate := uint64(unsetHeight)
-		if writtenBlockHeight > s.header.MinHeight {
-			prevContiguousCandidate = writtenBlockHeight - 1
-		}
-
-		if current.maxContiguousHeight == prevContiguousCandidate {
-			// We can extend the contiguous sequence. Try to extend it further
-			// by checking if the next height is also available, which would repair gaps in the sequence.
-			currentMax := writtenBlockHeight
-			for {
-				nextHeightToVerify, err := safemath.Add(currentMax, 1)
-				if err != nil {
-					s.log.Error("Failed to update block heights: overflow in height calculation",
-						zap.Uint64("currentMax", currentMax),
-						zap.Error(err),
-					)
-					break
-				}
-				// Check if we have indexed a block at the next height, which would extend our contiguous sequence
-				_, err = s.readIndexEntry(nextHeightToVerify)
-				if err != nil {
-					// If no block exists at this height, we've reached the end of our contiguous sequence
-					if errors.Is(err, database.ErrNotFound) {
-						break
-					}
-
-					// log unexpected error
-					s.log.Error("Failed to update block heights: error reading index entry",
-						zap.Uint64("height", nextHeightToVerify),
-						zap.Error(err),
-					)
-					break
-				}
-				currentMax = nextHeightToVerify
-			}
-			updated.maxContiguousHeight = currentMax
-		}
-
-		return updated
-	})
+		// If CAS failed, retry with the new max height
+	}
 
 	// Check if we need to persist header on checkpoint interval
 	if writtenBlockHeight%s.config.CheckpointInterval == 0 {
@@ -1144,54 +1058,6 @@ func (s *Database) updateBlockHeights(writtenBlockHeight BlockHeight) error {
 			return fmt.Errorf("block %d written, but checkpoint failed: %w", writtenBlockHeight, err)
 		}
 	}
-
-	return nil
-}
-
-func (s *Database) updateRecoveredBlockHeights(recoveredHeights []BlockHeight) error {
-	if len(recoveredHeights) == 0 {
-		return nil
-	}
-
-	// Find the maximum block height among recovered blocks
-	maxRecoveredHeight := recoveredHeights[0]
-	for _, height := range recoveredHeights[1:] {
-		if height > maxRecoveredHeight {
-			maxRecoveredHeight = height
-		}
-	}
-
-	// Update max block height (no CAS needed since we're single-threaded during recovery)
-	currentHeights := s.getBlockHeights()
-	currentMaxHeight := currentHeights.maxBlockHeight
-	if maxRecoveredHeight > currentMaxHeight || currentMaxHeight == unsetHeight {
-		currentMaxHeight = maxRecoveredHeight
-	}
-
-	// Update max contiguous height by extending from current max contiguous height
-	currentMaxContiguous := currentHeights.maxContiguousHeight
-	nextHeightToVerify := s.header.MinHeight
-	if currentMaxContiguous != unsetHeight {
-		nextHeightToVerify = currentMaxContiguous + 1
-	}
-	for {
-		_, err := s.readIndexEntry(nextHeightToVerify)
-		if err != nil {
-			// If no block exists at this height, we've reached the end of our contiguous sequence
-			if errors.Is(err, database.ErrNotFound) {
-				break
-			}
-
-			// Log unexpected error but continue
-			s.log.Error("Failed to update recovered block heights: error reading index entry",
-				zap.Uint64("height", nextHeightToVerify),
-				zap.Error(err),
-			)
-			return err
-		}
-		nextHeightToVerify++
-	}
-	s.setBlockHeights(currentMaxHeight, nextHeightToVerify-1)
 
 	return nil
 }

--- a/x/blockdb/database_test.go
+++ b/x/blockdb/database_test.go
@@ -153,12 +153,11 @@ func TestNew_IndexFileErrors(t *testing.T) {
 				// Create a valid index file with wrong version
 				indexPath := filepath.Join(indexDir, indexFileName)
 				header := indexFileHeader{
-					Version:             999, // Wrong version
-					MinHeight:           0,
-					MaxDataFileSize:     DefaultMaxDataFileSize,
-					MaxHeight:           unsetHeight,
-					MaxContiguousHeight: unsetHeight,
-					NextWriteOffset:     0,
+					Version:         999, // Wrong version
+					MinHeight:       0,
+					MaxDataFileSize: DefaultMaxDataFileSize,
+					MaxHeight:       unsetHeight,
+					NextWriteOffset: 0,
 				}
 
 				headerBytes, err := header.MarshalBinary()

--- a/x/blockdb/helpers_test.go
+++ b/x/blockdb/helpers_test.go
@@ -57,20 +57,11 @@ func fixedSizeBlock(t *testing.T, size int, height uint64) []byte {
 	return b
 }
 
-func checkDatabaseState(t *testing.T, db *Database, maxHeight uint64, maxContiguousHeight uint64) {
-	heights := db.blockHeights.Load()
-	if heights != nil {
-		require.Equal(t, maxHeight, heights.maxBlockHeight, "maxBlockHeight mismatch")
-	} else {
-		require.Equal(t, uint64(unsetHeight), maxHeight, "maxBlockHeight mismatch")
-	}
-	gotMCH, ok := db.MaxContiguousHeight()
-	if maxContiguousHeight != unsetHeight {
-		require.True(t, ok, "MaxContiguousHeight is not set, want %d", maxContiguousHeight)
-		require.Equal(t, maxContiguousHeight, gotMCH, "maxContiguousHeight mismatch")
-	} else {
-		require.False(t, ok)
-	}
+func checkDatabaseState(t *testing.T, db *Database, maxHeight uint64) {
+	t.Helper()
+
+	actualMaxHeight := db.maxBlockHeight.Load()
+	require.Equal(t, maxHeight, actualMaxHeight, "maxBlockHeight mismatch")
 }
 
 // Helper function to create a pointer to uint64

--- a/x/blockdb/recovery_test.go
+++ b/x/blockdb/recovery_test.go
@@ -70,12 +70,11 @@ func TestRecovery_Success(t *testing.T) {
 				firstBlockOffset := uint64(sizeOfBlockEntryHeader) + uint64(firstBlockCompressedSize)
 
 				header := indexFileHeader{
-					Version:             IndexFileVersion,
-					MaxDataFileSize:     4 * 10 * 1024, // 10KB per file
-					MinHeight:           0,
-					MaxContiguousHeight: 0,
-					MaxHeight:           0,
-					NextWriteOffset:     firstBlockOffset,
+					Version:         IndexFileVersion,
+					MaxDataFileSize: 4 * 10 * 1024, // 10KB per file
+					MinHeight:       0,
+					MaxHeight:       0,
+					NextWriteOffset: firstBlockOffset,
 				}
 
 				// Write the header
@@ -135,7 +134,6 @@ func TestRecovery_Success(t *testing.T) {
 				}
 				blockSize := uint64(sizeOfBlockEntryHeader) + uint64(lastBlockCompressedSize)
 				header.NextWriteOffset -= blockSize
-				header.MaxContiguousHeight = 3
 				header.MaxHeight = 8
 
 				// Write the corrupted header back
@@ -211,7 +209,7 @@ func TestRecovery_Success(t *testing.T) {
 				require.NoError(t, store.Put(height, block))
 				blocks[height] = block
 			}
-			checkDatabaseState(t, store, 8, 4)
+			checkDatabaseState(t, store, 8)
 			require.NoError(t, store.Close())
 
 			// Corrupt the index file according to the test case
@@ -229,7 +227,7 @@ func TestRecovery_Success(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, blocks[height], readBlock, "block %d should be the same", height)
 			}
-			checkDatabaseState(t, recoveredStore, 8, 4)
+			checkDatabaseState(t, recoveredStore, 8)
 		})
 	}
 }
@@ -559,12 +557,11 @@ func resetIndexToBlock(store *Database, blockSize uint64, minHeight uint64) erro
 	defer indexFile.Close()
 
 	header := indexFileHeader{
-		Version:             IndexFileVersion,
-		MaxDataFileSize:     DefaultMaxDataFileSize,
-		MinHeight:           minHeight,
-		MaxContiguousHeight: minHeight,
-		MaxHeight:           minHeight,
-		NextWriteOffset:     uint64(sizeOfBlockEntryHeader) + blockSize,
+		Version:         IndexFileVersion,
+		MaxDataFileSize: DefaultMaxDataFileSize,
+		MinHeight:       minHeight,
+		MaxHeight:       minHeight,
+		NextWriteOffset: uint64(sizeOfBlockEntryHeader) + blockSize,
 	}
 
 	headerBytes, err := header.MarshalBinary()

--- a/x/blockdb/writeblock_test.go
+++ b/x/blockdb/writeblock_test.go
@@ -61,92 +61,78 @@ func TestPut_MaxHeight(t *testing.T) {
 		name               string
 		blockHeights       []uint64 // block heights to write, in order
 		config             DatabaseConfig
-		expectedMCH        uint64 // expected max contiguous height
 		expectedMaxHeight  uint64
 		syncToDisk         bool
 		checkpointInterval uint64
 	}{
 		{
 			name:              "no blocks to write",
-			expectedMCH:       unsetHeight,
 			expectedMaxHeight: unsetHeight,
 		},
 		{
 			name:              "single block at min height",
 			blockHeights:      []uint64{0},
-			expectedMCH:       0,
 			expectedMaxHeight: 0,
 		},
 		{
 			name:              "sequential blocks from min",
 			blockHeights:      []uint64{0, 1, 2, 3},
-			expectedMCH:       3,
 			expectedMaxHeight: 3,
 		},
 		{
 			name:              "out of order with no gaps",
 			blockHeights:      []uint64{3, 1, 2, 0, 4},
-			expectedMCH:       4,
 			expectedMaxHeight: 4,
 		},
 		{
 			name:              "blocks with gaps",
 			blockHeights:      []uint64{0, 1, 3, 5, 6},
-			expectedMCH:       1,
 			expectedMaxHeight: 6,
 		},
 		{
 			name:              "start with gap",
 			blockHeights:      []uint64{5, 6},
-			expectedMCH:       unsetHeight,
 			expectedMaxHeight: 6,
 		},
 		{
 			name:              "overwrite same height",
 			blockHeights:      []uint64{0, 1, 0}, // Write to height 0 twice
-			expectedMCH:       1,
 			expectedMaxHeight: 1,
 		},
 		{
 			name:              "custom min height single block",
 			blockHeights:      []uint64{10},
 			config:            customConfig,
-			expectedMCH:       10,
 			expectedMaxHeight: 10,
 		},
 		{
 			name:              "custom min height out of order",
 			blockHeights:      []uint64{13, 11, 10, 12},
 			config:            customConfig,
-			expectedMCH:       13,
 			expectedMaxHeight: 13,
 		},
 		{
 			name:              "custom min height with gaps",
 			blockHeights:      []uint64{10, 11, 13, 15},
 			config:            customConfig,
-			expectedMCH:       11,
 			expectedMaxHeight: 15,
 		},
 		{
 			name:              "custom min height start with gap",
 			blockHeights:      []uint64{11, 12},
 			config:            customConfig,
-			expectedMCH:       unsetHeight,
 			expectedMaxHeight: 12,
 		},
 		{
 			name:              "with sync to disk",
 			blockHeights:      []uint64{0, 1, 2, 5},
 			syncToDisk:        true,
-			expectedMCH:       2,
 			expectedMaxHeight: 5,
 		},
 		{
 			name:               "custom checkpoint interval",
 			blockHeights:       []uint64{0, 1, 2, 3, 4},
 			checkpointInterval: 2,
-			expectedMCH:        4,
 			expectedMaxHeight:  4,
 		},
 		{
@@ -154,7 +140,6 @@ func TestPut_MaxHeight(t *testing.T) {
 			blockHeights: []uint64{
 				10, 3, 2, 9, 35, 34, 30, 1, 9, 88, 83, 4, 43, 5, 0,
 			},
-			expectedMCH:       5,
 			expectedMaxHeight: 88,
 		},
 	}
@@ -178,7 +163,7 @@ func TestPut_MaxHeight(t *testing.T) {
 				blocksWritten[h] = block
 			}
 
-			checkDatabaseState(t, store, tt.expectedMaxHeight, tt.expectedMCH)
+			checkDatabaseState(t, store, tt.expectedMaxHeight)
 		})
 	}
 }
@@ -229,7 +214,7 @@ func TestWriteBlock_Concurrency(t *testing.T) {
 			require.Equal(t, blocks[i], block, "block mismatch at height %d", height)
 		}
 	}
-	checkDatabaseState(t, store, 19, 4)
+	checkDatabaseState(t, store, 19)
 }
 
 func TestWriteBlock_Errors(t *testing.T) {
@@ -333,7 +318,7 @@ func TestWriteBlock_Errors(t *testing.T) {
 			} else {
 				require.ErrorIs(t, err, tt.wantErr)
 			}
-			checkDatabaseState(t, store, unsetHeight, unsetHeight)
+			checkDatabaseState(t, store, unsetHeight)
 		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Removing this because max contiguous height is not needed currently and maintaining it creates extra complexity.

Resolves [#4075](https://github.com/ava-labs/avalanchego/issues/4075), see https://github.com/ava-labs/avalanchego/issues/4075#issuecomment-3377042201 for details on an issue the max contiguous height can cause.

## How this works

Removes `MaxContiguousHeight` from the index file header and logic related to updating the max contiguous height.
Size of `indexFileHeader` remains unchanged. The extra 8 bytes is added to the reserve.

## How this was tested

Unit tests

## Need to be documented in RELEASES.md?
