### PR TITLE
chore(sync/types): add sync/types package that contains the main Syncer interface

### DIFF
--- a/vms/evm/sync/types/types.go
+++ b/vms/evm/sync/types/types.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package types
+
+import "context"
+
+// Syncer is the common interface for all sync operations.
+// This provides a unified interface for atomic state sync and state trie sync.
+type Syncer interface {
+	// Sync completes the full sync operation, returning any errors encountered.
+	// The sync will respect context cancellation.
+	Sync(ctx context.Context) error
+
+	// Name returns a human-readable name for this syncer implementation.
+	Name() string
+
+	// ID returns a stable, machine-oriented identifier (e.g., "state_block_sync", "state_code_sync",
+	// "state_evm_state_sync", "state_atomic_sync"). Implementations should ensure this is unique and
+	// stable across renames for logging/metrics/deduplication.
+	ID() string
+}


### PR DESCRIPTION
## Why this should be merged

Check #4404 

## How this works

- Migrate `Syncer` interface type that will be the main contract for all syncer implementations migrated in follow up PRs.

## How this was tested

existing UT

## Need to be documented in RELEASES.md?

no

resolves #4404

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)