### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/utils/bloom/filter_test.go
+++ b/utils/bloom/filter_test.go
@@ -79,8 +79,7 @@ func BenchmarkAdd(b *testing.B) {
 	f, err := New(8, 16*units.KiB)
 	require.NoError(b, err)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		f.Add(1)
 	}
 }
@@ -89,8 +88,7 @@ func BenchmarkMarshal(b *testing.B) {
 	f, err := New(OptimalParameters(10_000, .01))
 	require.NoError(b, err)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		f.Marshal()
 	}
 }

--- a/utils/bloom/hasher_test.go
+++ b/utils/bloom/hasher_test.go
@@ -27,8 +27,7 @@ func BenchmarkHash(b *testing.B) {
 	key := ids.GenerateTestID()
 	salt := ids.GenerateTestID()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Hash(key[:], salt[:])
 	}
 }

--- a/utils/bloom/read_filter_test.go
+++ b/utils/bloom/read_filter_test.go
@@ -64,8 +64,7 @@ func BenchmarkParse(b *testing.B) {
 	require.NoError(b, err)
 	bytes := f.Marshal()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = Parse(bytes)
 	}
 }
@@ -73,8 +72,7 @@ func BenchmarkParse(b *testing.B) {
 func BenchmarkContains(b *testing.B) {
 	f := NewMaliciousFilter(maxHashes, 1)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		f.Contains(1)
 	}
 }


### PR DESCRIPTION
## Why this should be merged

These changes use b.Loop() to simplify the code and improve performance

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop

More info can see https://go.dev/issue/73137.

Before:

```shell
 go test -run=^$ -bench=. ./utils/bloom -timeout=1h       
goos: darwin
goarch: arm64
pkg: github.com/ava-labs/avalanchego/utils/bloom
cpu: Apple M4
BenchmarkAdd-10         	26548256	        64.03 ns/op
BenchmarkMarshal-10     	  664564	      2399 ns/op
BenchmarkHash-10        	25119997	        46.51 ns/op
BenchmarkParse-10       	34626578	        45.12 ns/op
BenchmarkContains-10    	51443085	        27.84 ns/op
PASS
ok  	github.com/ava-labs/avalanchego/utils/bloom	10.856s
```

After:

```shell
go test -run=^$ -bench=. ./utils/bloom -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/ava-labs/avalanchego/utils/bloom
cpu: Apple M4
BenchmarkAdd-10         	129046768	         9.401 ns/op
BenchmarkMarshal-10     	 1477620	       810.7 ns/op
BenchmarkHash-10        	26748348	        44.88 ns/op
BenchmarkParse-10       	41709570	        27.22 ns/op
BenchmarkContains-10    	90781576	        13.20 ns/op
PASS
ok  	github.com/ava-labs/avalanchego/utils/bloom	8.355s
```

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
