### PR TITLE
docs: add French quickstart to run an AvalancheGo node

### DIFF
--- a/docs/fr/run-a-node.md
+++ b/docs/fr/run-a-node.md
@@ -1,0 +1,16 @@
+# Démarrer un nœud Avalanche (FR)
+
+Ce guide décrit un démarrage rapide d’un nœud **AvalancheGo** pour développeurs/tests.
+
+## 1) Prérequis
+- Système Linux/Windows/Mac
+- Git
+- (Optionnel) Docker
+- Ports ouverts si vous souhaitez des connexions publiques (par défaut 9651/9650)
+
+## 2) Installation via binaire (Linux/macOS)
+1. Téléchargez la dernière version dans les Releases.
+2. Extrayez l’archive et placez l’exécutable `avalanchego` dans votre `$PATH`.
+3. Lancez le nœud :
+   ```bash
+   ./avalanchego


### PR DESCRIPTION
### Summary
Adds a French quickstart guide to run an AvalancheGo node.

### Changes
- Created docs/fr/run-a-node.md with:
  - Binary and Docker run instructions
  - Fuji testnet example
  - Basic health check (info.getNodeVersion)

### Notes
- Documentation only, no code changes
- Aims to help French-speaking users run a node quickly
