### PR TITLE
feat(reexecute/c): explicit metrics port

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -95,6 +95,7 @@ runs:
             LABELS=${{ env.LABELS }} \
             BENCHMARK_OUTPUT_FILE=${{ env.BENCHMARK_OUTPUT_FILE }} \
             RUNNER_NAME=${{ inputs.runner_name }} \
+            METRICS_SERVER_ENABLED=true \
             METRICS_COLLECTOR_ENABLED=true
         prometheus_url: ${{ inputs.prometheus-url }}
         prometheus_push_url: ${{ inputs.prometheus-push-url }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -207,6 +207,7 @@ tasks:
       END_BLOCK: '{{.END_BLOCK}}'
       LABELS: '{{.LABELS | default ""}}'
       BENCHMARK_OUTPUT_FILE: '{{.BENCHMARK_OUTPUT_FILE | default ""}}'
+      METRICS_SERVER_ENABLED: '{{.METRICS_SERVER_ENABLED | default "false"}}'
       METRICS_SERVER_PORT: '{{.METRICS_SERVER_PORT}}'
       METRICS_COLLECTOR_ENABLED: '{{.METRICS_COLLECTOR_ENABLED | default "false"}}'
     cmd: |
@@ -218,6 +219,7 @@ tasks:
       END_BLOCK={{.END_BLOCK}} \
       LABELS={{.LABELS}} \
       BENCHMARK_OUTPUT_FILE={{.BENCHMARK_OUTPUT_FILE}} \
+      METRICS_SERVER_ENABLED={{.METRICS_SERVER_ENABLED}} \
       METRICS_SERVER_PORT={{.METRICS_SERVER_PORT}} \
       METRICS_COLLECTOR_ENABLED={{.METRICS_COLLECTOR_ENABLED}} \
       bash -x ./scripts/benchmark_cchain_range.sh
@@ -234,6 +236,7 @@ tasks:
       END_BLOCK: '{{.END_BLOCK | default "250000"}}'
       LABELS: '{{.LABELS | default ""}}'
       BENCHMARK_OUTPUT_FILE: '{{.BENCHMARK_OUTPUT_FILE | default ""}}'
+      METRICS_SERVER_ENABLED: '{{.METRICS_SERVER_ENABLED | default "false"}}'
       METRICS_SERVER_PORT: '{{.METRICS_SERVER_PORT}}'
       METRICS_COLLECTOR_ENABLED: '{{.METRICS_COLLECTOR_ENABLED | default "false"}}'
     cmds:
@@ -252,6 +255,7 @@ tasks:
           END_BLOCK: '{{.END_BLOCK}}'
           LABELS: '{{.LABELS}}'
           BENCHMARK_OUTPUT_FILE: '{{.BENCHMARK_OUTPUT_FILE}}'
+          METRICS_SERVER_ENABLED: '{{.METRICS_SERVER_ENABLED}}'
           METRICS_SERVER_PORT: '{{.METRICS_SERVER_PORT}}'
           METRICS_COLLECTOR_ENABLED: '{{.METRICS_COLLECTOR_ENABLED}}'
 

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #   END_BLOCK: The ending block height (inclusive).
 #   LABELS (optional): Comma-separated key=value pairs for metric labels.
 #   BENCHMARK_OUTPUT_FILE (optional): If set, benchmark output is also written to this file.
+#   METRICS_SERVER_ENABLED (optional): If set, enables the metrics server.
 #   METRICS_SERVER_PORT (optional): If set, determines the port the metrics server will listen to.
 #   METRICS_COLLECTOR_ENABLED (optional): If set, enables the metrics collector.
 
@@ -27,6 +28,7 @@ cmd="go test -timeout=0 -v -benchtime=1x -bench=BenchmarkReexecuteRange -run=^$ 
   --start-block=\"${START_BLOCK}\" \
   --end-block=\"${END_BLOCK}\" \
   ${LABELS:+--labels=\"${LABELS}\"} \
+  ${METRICS_SERVER_ENABLED:+--metrics-server-enabled=\"${METRICS_SERVER_ENABLED}\"} \
   ${METRICS_SERVER_PORT:+--metrics-server-port=\"${METRICS_SERVER_PORT}\"} \
   ${METRICS_COLLECTOR_ENABLED:+--metrics-collector-enabled=\"${METRICS_COLLECTOR_ENABLED}\"}"
 

--- a/tests/reexecute/c/README.md
+++ b/tests/reexecute/c/README.md
@@ -44,12 +44,13 @@ export AWS_REGION=us-east-2
 
 If running locally, metrics collection can be customized via the following parameters:
 
-- `METRICS_SERVER_PORT`: if set, starts a Prometheus server exporting VM metrics and sets the port the server will listen to.
-- `METRICS_COLLECTOR_ENABLED`: starts a Prometheus collector. If `METRICS_SERVER_PORT` is not set, enabling the collector implicitly sets `METRICS_SERVER_PORT` to `0`.
+- `METRICS_SERVER_ENABLED`: starts a Prometheus server exporting VM metrics.
+- `METRICS_SERVER_PORT`: if set, determines the port the Prometheus server will listen to (set to `0` by default).
+- `METRICS_COLLECTOR_ENABLED`: starts a Prometheus collector. If `METRICS_SERVER_ENABLED` is not set, enabling the collector implicitly sets `METRICS_SERVER_ENABLED` to `true`.
 
 When utilizing the metrics collector feature, follow the instructions in the e2e [README](../../e2e/README.md#monitoring) to set the required Prometheus environment variables.
 
-Running the re-execution test in CI will always set `METRICS_COLLECTOR_ENABLED=true`.
+Running the re-execution test in CI will always set `METRICS_SERVER_ENABLED=true` and `METRICS_COLLECTOR_ENABLED=true`.
 
 ## Quick Start
 
@@ -237,7 +238,7 @@ The `CONFIG` parameter currently only supports pre-defined configs and not passi
 
 The C-Chain benchmarks export VM metrics to the same Grafana instance as AvalancheGo CI: https://grafana-poc.avax-dev.network/.
 
-To export metrics for a local run, simply set the Taskfile variable `METRICS_COLLECTOR_ENABLED=true` either via environment variable or passing it at the command line.
+To export metrics for a local run, simply set the Taskfile variables `METRICS_SERVER_ENABLED=true` and `METRICS_COLLECTOR_ENABLED=true` either via environment variable or passing it at the command line.
 
 You can view granular C-Chain processing metrics with the label attached to this job (job="c-chain-reexecution") [here](https://grafana-poc.avax-dev.network/d/Gl1I20mnk/c-chain?orgId=1&from=now-5m&to=now&timezone=browser&var-datasource=P1809F7CD0C75ACF3&var-filter=job%7C%3D%7Cc-chain-reexecution&var-chain=C&refresh=10s).
 


### PR DESCRIPTION
## Why this should be merged

As referenced in #4362, this PR allows clients of the reexecution test to specify the port which the metrics server will listen on.

## How this works

Adds a `metrics-server-port` flag to the reexecution test.

## How this was tested

CI + queried metrics server locally.

## Need to be documented in RELEASES.md?

No