### PR TITLE
chore: Fix TestGetStakingSigner for pre-release builds

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -624,7 +624,7 @@ func TestGetStakingSigner(t *testing.T) {
 
 			// Avoid using the mainnet network name by default because not all
 			// builds support mainnet configurations.
-			v.Set(NetworkNameKey, constants.LocalName)
+			v.Set(NetworkNameKey, constants.UnitTestName)
 			for key, value := range tt.config {
 				v.Set(key, value)
 			}


### PR DESCRIPTION
## Why this should be merged
Makes the TestGetStakingSigner unit test cleaner and more robust for pre-releases.

See failure on pre-release branch here: https://github.com/ava-labs/avalanchego/actions/runs/18601415517/job/53040501469

## How this works
Sets the UT network name to local.

## How this was tested
UT

See success on pre-release branch here: https://github.com/ava-labs/avalanchego/actions/runs/18604733876/job/53051490526?pr=4423

## Need to be documented in RELEASES.md?
No.