### PR TITLE
Remove unexpected workarounds of the prealloc linter

### DIFF
--- a/cache/lru/cache_test.go
+++ b/cache/lru/cache_test.go
@@ -88,8 +88,10 @@ func TestCacheOnEvict(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			evictedKeys := make([]int, 0)
-			evictedValues := make([]int, 0)
+			var (
+				evictedKeys   []int
+				evictedValues []int
+			)
 			c := NewCacheWithOnEvict(tt.cacheSize, func(key, value int) {
 				evictedKeys = append(evictedKeys, key)
 				evictedValues = append(evictedValues, value)

--- a/codec/codectest/codectest.go
+++ b/codec/codectest/codectest.go
@@ -770,7 +770,7 @@ func TestSliceWithEmptySerialization(t testing.TB, codec codecpkg.GeneralCodec) 
 	require.NoError(manager.RegisterCodec(0, codec))
 
 	val := &nestedSliceStruct{
-		Arr: make([]emptyStruct, 0),
+		Arr: []emptyStruct{},
 	}
 	expected := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00} // codec version (0x00, 0x00) then (0x00, 0x00, 0x00, 0x00) for numElts
 	result, err := manager.Marshal(0, val)

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -330,8 +330,6 @@ func TestGenesisFromFlag(t *testing.T) {
 				case constants.LocalID:
 					genBytes, err = json.Marshal(&LocalConfig)
 					require.NoError(err)
-				default:
-					genBytes = make([]byte, 0)
 				}
 			} else {
 				genBytes = test.customConfig

--- a/network/p2p/acp118/aggregator_test.go
+++ b/network/p2p/acp118/aggregator_test.go
@@ -645,8 +645,10 @@ func TestSignatureAggregator_AggregateSignatures(t *testing.T) {
 			bitSet := set.BitsFromBytes(gotSignature.Signers)
 			require.Equal(tt.wantSigners, bitSet.Len())
 
-			pks := make([]*bls.PublicKey, 0)
-			wantAggregatedStake := uint64(0)
+			var (
+				pks                 []*bls.PublicKey
+				wantAggregatedStake uint64
+			)
 			for i := 0; i < bitSet.BitLen(); i++ {
 				if !bitSet.Contains(i) {
 					continue

--- a/network/p2p/validators_test.go
+++ b/network/p2p/validators_test.go
@@ -172,16 +172,18 @@ func TestValidatorsSample(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockValidators := validatorsmock.NewState(ctrl)
 
-			calls := make([]any, 0)
+			calls := make([]any, 0, 2*len(tt.calls))
 			for _, call := range tt.calls {
-				calls = append(calls, mockValidators.EXPECT().
-					GetCurrentHeight(gomock.Any()).Return(call.height, call.getCurrentHeightErr))
+				calls = append(
+					calls,
+					mockValidators.EXPECT().GetCurrentHeight(gomock.Any()).Return(call.height, call.getCurrentHeightErr),
+				)
 
 				if call.getCurrentHeightErr != nil {
 					continue
 				}
 
-				validatorSet := make(map[ids.NodeID]*validators.GetValidatorOutput, 0)
+				validatorSet := make(map[ids.NodeID]*validators.GetValidatorOutput, len(call.validators))
 				for _, validator := range call.validators {
 					validatorSet[validator] = &validators.GetValidatorOutput{
 						NodeID: validator,
@@ -189,10 +191,10 @@ func TestValidatorsSample(t *testing.T) {
 					}
 				}
 
-				calls = append(calls,
-					mockValidators.EXPECT().
-						GetValidatorSet(gomock.Any(), gomock.Any(), subnetID).
-						Return(validatorSet, call.getValidatorSetErr))
+				calls = append(
+					calls,
+					mockValidators.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), subnetID).Return(validatorSet, call.getValidatorSetErr),
+				)
 			}
 			gomock.InOrder(calls...)
 
@@ -337,7 +339,7 @@ func TestValidatorsTop(t *testing.T) {
 			require := require.New(t)
 			ctrl := gomock.NewController(t)
 
-			validatorSet := make(map[ids.NodeID]*validators.GetValidatorOutput, 0)
+			validatorSet := make(map[ids.NodeID]*validators.GetValidatorOutput, len(test.validators))
 			for _, validator := range test.validators {
 				validatorSet[validator.nodeID] = &validators.GetValidatorOutput{
 					NodeID: validator.nodeID,

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -166,13 +166,13 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 					}
 				}
 
-				testBalances := make([]uint64, 0)
+				testBalances := make([]uint64, len(wallets))
 				for i, w := range wallets {
 					balances, err := w.X().Builder().GetFTBalance()
 					require.NoError(err)
 
 					bal := balances[avaxAssetID]
-					testBalances = append(testBalances, bal)
+					testBalances[i] = bal
 
 					tc.Log().Info("balance in AVAX",
 						zap.Uint64("balance", bal),

--- a/vms/platformvm/txs/fee/complexity_test.go
+++ b/vms/platformvm/txs/fee/complexity_test.go
@@ -136,11 +136,7 @@ func TestOutputComplexity(t *testing.T) {
 		{
 			name: "any can spend",
 			out: &avax.TransferableOutput{
-				Out: &secp256k1fx.TransferOutput{
-					OutputOwners: secp256k1fx.OutputOwners{
-						Addrs: make([]ids.ShortID, 0),
-					},
-				},
+				Out: &secp256k1fx.TransferOutput{},
 			},
 			expected: gas.Dimensions{
 				gas.Bandwidth: 60,
@@ -236,15 +232,9 @@ func TestInputComplexity(t *testing.T) {
 		{
 			name: "any can spend",
 			in: &avax.TransferableInput{
-				In: &secp256k1fx.TransferInput{
-					Input: secp256k1fx.Input{
-						SigIndices: make([]uint32, 0),
-					},
-				},
+				In: &secp256k1fx.TransferInput{},
 			},
-			cred: &secp256k1fx.Credential{
-				Sigs: make([][secp256k1.SignatureLen]byte, 0),
-			},
+			cred: &secp256k1fx.Credential{},
 			expected: gas.Dimensions{
 				gas.Bandwidth: 92,
 				gas.DBRead:    1,
@@ -433,10 +423,8 @@ func TestOwnerComplexity(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "any can spend",
-			owner: &secp256k1fx.OutputOwners{
-				Addrs: make([]ids.ShortID, 0),
-			},
+			name:  "any can spend",
+			owner: &secp256k1fx.OutputOwners{},
 			expected: gas.Dimensions{
 				gas.Bandwidth: 16,
 			},
@@ -500,12 +488,8 @@ func TestAuthComplexity(t *testing.T) {
 	}{
 		{
 			name: "any can spend",
-			auth: &secp256k1fx.Input{
-				SigIndices: make([]uint32, 0),
-			},
-			cred: &secp256k1fx.Credential{
-				Sigs: make([][secp256k1.SignatureLen]byte, 0),
-			},
+			auth: &secp256k1fx.Input{},
+			cred: &secp256k1fx.Credential{},
 			expected: gas.Dimensions{
 				gas.Bandwidth: 8,
 			},

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -476,7 +476,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			}
 
 			// nil out non subnet validators
-			subnetIndexes := make([]int, 0)
+			subnetIndexes := make([]int, 0, len(validatorsTimes))
 			for idx, ev := range validatorsTimes {
 				if ev.eventType == startSubnetValidator {
 					subnetIndexes = append(subnetIndexes, idx)
@@ -527,7 +527,7 @@ func TestTimestampListGenerator(t *testing.T) {
 			}
 
 			// nil out non subnet validators
-			nonSubnetIndexes := make([]int, 0)
+			nonSubnetIndexes := make([]int, 0, len(validatorsTimes))
 			for idx, ev := range validatorsTimes {
 				if ev.eventType != startSubnetValidator {
 					nonSubnetIndexes = append(nonSubnetIndexes, idx)

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -1603,9 +1603,9 @@ func (b *builder) spend(
 		// Initialize the return values with empty slices to preserve backward
 		// compatibility of the json representation of transactions with no
 		// inputs or outputs.
-		inputs:        make([]*avax.TransferableInput, 0),
-		changeOutputs: make([]*avax.TransferableOutput, 0),
-		stakeOutputs:  make([]*avax.TransferableOutput, 0),
+		inputs:        []*avax.TransferableInput{},
+		changeOutputs: []*avax.TransferableOutput{},
+		stakeOutputs:  []*avax.TransferableOutput{},
 	}
 
 	utxosByLocktime := splitByLocktime(utxos, minIssuanceTime)

--- a/x/archivedb/key_test.go
+++ b/x/archivedb/key_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestNaturalDescSortingForSameKey(t *testing.T) {
-	key0, _ := newDBKeyFromUser(make([]byte, 0), 0)
-	key1, _ := newDBKeyFromUser(make([]byte, 0), 1)
-	key2, _ := newDBKeyFromUser(make([]byte, 0), 2)
-	key3, _ := newDBKeyFromUser(make([]byte, 0), 3)
+	key0, _ := newDBKeyFromUser(nil, 0)
+	key1, _ := newDBKeyFromUser(nil, 1)
+	key2, _ := newDBKeyFromUser(nil, 2)
+	key3, _ := newDBKeyFromUser(nil, 3)
 
 	entry := [][]byte{key0, key1, key2, key3}
 	expected := [][]byte{key3, key2, key1, key0}


### PR DESCRIPTION
## Why this should be merged

We enforce the `prealloc` linter, which will complain if we lazily populate a slice. However, it seems that there has been some code added that avoids the linter without actually achieving the linter's goal.

This PR removes such instances.

## How this works

Either leave slices as nil or pre-allocates the slices.

## How this was tested

I tried to find a linter / configuration that would catch this in CI... But I couldn't figure out how to do it.

I found all these instances by greping for instances that matched the `make\(.*, 0\)` regex.

## Need to be documented in RELEASES.md?

No