### PR TITLE
Skip prealloc linting in test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -222,7 +222,7 @@ linters:
       # 2. Exclude any file prefixed with test_ in any directory.
       # 3. Exclude any directory suffixed with test.
       # 4. Exclude any file suffixed with _test.go.
-      - path: "(^tests/)|(^(.*/)*test_[^/]*.go$)|(.*test/.*)|(.*_test\\.go$)"
+      - path: "(^tests/)|(^(.*/)*test_[^/]*\\.go$)|(.*test/.*)|(.*_test\\.go$)"
         linters:
           - prealloc
 formatters:


### PR DESCRIPTION
## Why this should be merged

[@maru-ava brought up](https://github.com/ava-labs/avalanchego/pull/4431#issuecomment-3443808823) that performance based linting shouldn't be enforced for testing.

This removes the `prealloc` linting rules for test files.

## How this works

Exclues all files that include "test" in their path.

## How this was tested

Tested the behavior of:
- [x] `database/dbtest/dbtest.go`
- [x] `snow/consensus/avalanche/test_vertex.go`
- [x] `tests/notify_context.go`
- [x] `vms/platformvm/txs/fee/complexity_test.go`
- [x] `latest_version.go`
- [x] `test_version.go`
- [x] `version/latest.go`
- [x] `version/latest_version.go`

## Need to be documented in RELEASES.md?

Nah