### PR TITLE
Fix misleading comment on info.peers

### DIFF
--- a/api/info/service.go
+++ b/api/info/service.go
@@ -254,7 +254,9 @@ type PeersReply struct {
 	Peers []Peer `json:"peers"`
 }
 
-// Peers returns the list of current validators
+// Peers returns the current peers this node is connected to. If nodeIDs are
+// provided, the response is filtered to just include peers that match those
+// IDs.
 func (i *Info) Peers(_ *http.Request, args *PeersArgs, reply *PeersReply) error {
 	i.log.Debug("API called",
 		zap.String("service", "info"),


### PR DESCRIPTION
## Why this should be merged

This comment was probably an incorrect copy+paste issue. `Peers` returns more than just validators.

Resolves #4441.

## How this works

Updates a comment

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No