### PR TITLE
chore(customrawdb): unexport `customrawdb.NewSyncPerformedIterator`

### DIFF
--- a/vms/evm/sync/customrawdb/sync_progress.go
+++ b/vms/evm/sync/customrawdb/sync_progress.go
@@ -180,20 +180,14 @@ func WriteSyncPerformed(db ethdb.KeyValueWriter, blockNumber uint64) error {
 	return db.Put(bytes, nil)
 }
 
-// NewSyncPerformedIterator returns an iterator over all block numbers the VM
-// has state synced to.
-func NewSyncPerformedIterator(db ethdb.Iteratee) ethdb.Iterator {
-	return rawdb.NewKeyLengthIterator(db.NewIterator(syncPerformedPrefix, nil), syncPerformedKeyLength)
-}
-
 // GetLatestSyncPerformed returns the latest block number state synced performed to.
 func GetLatestSyncPerformed(db ethdb.Iteratee) (uint64, error) {
-	it := NewSyncPerformedIterator(db)
+	it := newSyncPerformedIterator(db)
 	defer it.Release()
 
 	var latestSyncPerformed uint64
 	for it.Next() {
-		syncPerformed := ParseSyncPerformedKey(it.Key())
+		syncPerformed := parseSyncPerformedKey(it.Key())
 		if syncPerformed > latestSyncPerformed {
 			latestSyncPerformed = syncPerformed
 		}
@@ -201,9 +195,15 @@ func GetLatestSyncPerformed(db ethdb.Iteratee) (uint64, error) {
 	return latestSyncPerformed, it.Error()
 }
 
-// ParseSyncPerformedKey returns the block number from keys returned by
+// newSyncPerformedIterator returns an iterator over all block numbers the VM
+// has state synced to.
+func newSyncPerformedIterator(db ethdb.Iteratee) ethdb.Iterator {
+	return rawdb.NewKeyLengthIterator(db.NewIterator(syncPerformedPrefix, nil), syncPerformedKeyLength)
+}
+
+// parseSyncPerformedKey returns the block number from keys returned by
 // NewSyncPerformedIterator. It panics if the key is shorter than `syncPerformedKeyLength`.
-func ParseSyncPerformedKey(key []byte) uint64 {
+func parseSyncPerformedKey(key []byte) uint64 {
 	return binary.BigEndian.Uint64(key[len(syncPerformedPrefix):])
 }
 

--- a/vms/evm/sync/customrawdb/sync_progress_test.go
+++ b/vms/evm/sync/customrawdb/sync_progress_test.go
@@ -185,7 +185,7 @@ func TestSyncPerformedAndLatest(t *testing.T) {
 	require.NoError(t, WriteSyncPerformed(db, 15))
 
 	// Iterator yields all
-	vals := mapIterator(t, NewSyncPerformedIterator(db), ParseSyncPerformedKey)
+	vals := mapIterator(t, newSyncPerformedIterator(db), parseSyncPerformedKey)
 
 	require.Equal(t, []uint64{10, 15, 20}, vals)
 


### PR DESCRIPTION
## Why this should be merged

- This function is no longer needed by `coreth` so it can be unexported.

## How this works

- Rename `NewSyncPerformedIterator ` to `newSyncPerformedIterator `

## How this was tested

existing UT

## Need to be documented in RELEASES.md?

no

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)
