### PR TITLE
Fix ConvertSubnetToL1Tx flake

### DIFF
--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -2621,6 +2621,10 @@ func TestStandardExecutorConvertSubnetToL1Tx(t *testing.T) {
 					},
 				}
 
+				// Guarantee the validators are sorted by node id so that this tx is
+				// valid.
+				utils.Sort(convertSubnetToL1Tx.Validators)
+
 				tx, err := txs.NewSigned(
 					convertSubnetToL1Tx,
 					txs.Codec,


### PR DESCRIPTION
## Why this should be merged

This fixes a flake in TestStandardExecutorConvertSubnetToL1Tx

## How this works

The test uses a randomly generated node id which is not guaranteed to pass verification

## How this was tested

Sorts the validators in the tx to guarantee ordering

## Need to be documented in RELEASES.md?

No
