### PR TITLE
Apply latest tag only when the image tag matches a semantic version

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -116,8 +116,8 @@ if [[ -z "${SKIP_BUILD_RACE}" ]]; then
                  "$AVALANCHE_PATH" -f "$AVALANCHE_PATH/Dockerfile"
 fi
 
-# Only tag the latest image for the master branch when images are pushed to a registry
-if [[ "${DOCKER_IMAGE}" == *"/"* && $image_tag == "master" ]]; then
+# Tag latest when pushing to a registry and the tag is a release (vMAJOR.MINOR.PATCH)
+if [[ "${DOCKER_IMAGE}" == *"/"* && $image_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Tagging current avalanchego images as $DOCKER_IMAGE:latest"
   docker buildx imagetools create -t "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$commit_hash"
 fi


### PR DESCRIPTION
Changes scripts/build_image.sh so :latest is only applied when the image tag matches a semantic version (e.g., v1.3.0). Master builds continue to be tagged as :master (and by commit hash), not :latest, unless FORCE_TAG_LATEST is set.