### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/tests/fixture/tmpnet/kube.go
+++ b/tests/fixture/tmpnet/kube.go
@@ -407,9 +407,9 @@ func applyManifest(
 ) error {
 	// Split the manifest into individual resources
 	decoder := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	documents := strings.Split(string(manifest), "\n---\n")
+	documents := strings.SplitSeq(string(manifest), "\n---\n")
 
-	for _, doc := range documents {
+	for doc := range documents {
 		doc := strings.TrimSpace(doc)
 		if strings.TrimSpace(doc) == "" || strings.HasPrefix(doc, "#") {
 			continue


### PR DESCRIPTION
## Why this should be merged

Optimize code using a more modern writing style which can make the code more efficient and cleaner.
More info: https://github.com/golang/go/issues/61901


strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.



## How this works

## How this was tested

## Need to be documented in RELEASES.md?
