### PR TITLE
Alert upon an unknown future upgrade

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1498,8 +1498,8 @@ func (n *Node) initHealthAPI() error {
 		Name: "time_until",
 		Help: "Time until an upcoming network upgrade (ns). +Inf means the upgrade is unscheduled.",
 	})
-	timeUntilUnscheduledUpgrade := math.Inf(1)
-	timeUntilUpgradeMetric.Set(timeUntilUnscheduledUpgrade)
+	infinity := math.Inf(1)
+	timeUntilUpgradeMetric.Set(infinity)
 	if err := upgradeReg.Register(timeUntilUpgradeMetric); err != nil {
 		return fmt.Errorf("couldn't register time until upgrade metric: %w", err)
 	}
@@ -1550,7 +1550,7 @@ func (n *Node) initHealthAPI() error {
 			"numUpgradeTimes":             len(upgradeTimes),
 		}
 		if localUpgradeTimeUnix >= modeUpgradeTimeUnix || modeUpgradeWeightPortion < .5 {
-			timeUntilUpgradeMetric.Set(timeUntilUnscheduledUpgrade)
+			timeUntilUpgradeMetric.Set(infinity)
 			return result, nil
 		}
 


### PR DESCRIPTION
## Why this should be merged

During the Fuji activation of Granite, multiple L1s missed the upgrade. This resulted in downtime and complex recovery procedures.

This PR aims to improve observability of an unknown scheduled upgrade by:

1. Initially logging info logs
2. Increasing alerts to warning logs
3. Marking the node as unhealthy
4. Increasing alerts to error logs

Increasing the frequency and severity of the alerts as the upgrade gets closer.

This PR does _not_ FATAL the node or preemptively halt any chains.

## How this works

Every 12 hours that a future upgrade is detected more than a week in the future:
```
[11-06|12:47:02.634] INFO node/node.go:1574 unknown upgrade detected - this node should be updated to a compatible version {"upgradeTime": "[11-14|12:46:33.000]", "timeUntilUpgrade": "191h59m30.365878s"}
```

Every 12 hours that a future upgrade is detected less than a week but more than 3 days in the future:
```
[11-06|12:48:41.108] WARN node/node.go:1574 unknown upgrade detected - this node should be updated to a compatible version {"upgradeTime": "[11-12|12:48:11.000]", "timeUntilUpgrade": "143h59m29.891544s"}
```

Every hour that a future upgrade is detected less than 3 days but more than a day in the future:
```
[11-06|12:49:53.170] WARN node/node.go:1574 unknown upgrade detected - this node should be updated to a compatible version {"upgradeTime": "[11-08|12:49:23.000]", "timeUntilUpgrade": "47h59m29.829943s", "error": "unknown network upgrade detected"}
```
Node is additionally marked as unhealthy.

Every hour that a future upgrade is detected less than a day but more than an hour in the future:
```
[11-06|12:51:55.820] ERROR node/node.go:1574 unknown upgrade detected - this node should be updated to a compatible version {"upgradeTime": "[11-07|08:51:26.000]", "timeUntilUpgrade": "19h59m30.179793s", "error": "unknown network upgrade detected - update as soon as possible"}
```
Node is additionally marked as unhealthy.

Every 30s that a future upgrade is detected less than an hour in the future:
```
[11-06|12:53:22.509] ERROR node/node.go:1574 unknown upgrade detected - this node should be updated to a compatible version {"upgradeTime": "[11-06|13:22:52.000]", "timeUntilUpgrade": "29m29.49049s", "error": "imminent network upgrade detected - update immediately"}
```
Node is additionally marked as unhealthy.

---

Additionally, a new metric is added:
```
# HELP avalanche_upgrade_time_until Time until an upcoming network upgrade (ns). +Inf means the upgrade is unscheduled.
# TYPE avalanche_upgrade_time_until gauge
avalanche_upgrade_time_until +Inf
```

## How this was tested

Locally by overwriting the network upgrade times and local upgrade times.

## Need to be documented in RELEASES.md?

Yes
