### PR TITLE
Reenable the upgrade tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,20 +117,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      #  TODO: Reactivate test once v1.14.0 is published
-      # - name: Run e2e tests
-      #   uses: ./.github/actions/run-monitored-tmpnet-cmd
-      #   with:
-      #     run: ./scripts/run_task.sh test-upgrade
-      #     artifact_prefix: upgrade
-      #     prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
-      #     prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
-      #     prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
-      #     prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
-      #     loki_url: ${{ secrets.LOKI_URL || '' }}
-      #     loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
-      #     loki_username: ${{ secrets.LOKI_USERNAME || '' }}
-      #     loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
+      - name: Run e2e tests
+        uses: ./.github/actions/run-monitored-tmpnet-cmd
+        with:
+          run: ./scripts/run_task.sh test-upgrade
+          artifact_prefix: upgrade
+          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          loki_url: ${{ secrets.LOKI_URL || '' }}
+          loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
+          loki_username: ${{ secrets.LOKI_USERNAME || '' }}
+          loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   Lint:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -16,8 +16,8 @@ fi
 # local network, this flag must be updated to the last compatible
 # version with the latest code.
 #
-# v1.13.0 is the earliest version that supports Fortuna.
-DEFAULT_VERSION="1.13.0"
+# v1.14.0 is the earliest version that supports Granite.
+DEFAULT_VERSION="1.14.0"
 
 VERSION="${1:-${DEFAULT_VERSION}}"
 if [[ -z "${VERSION}" ]]; then


### PR DESCRIPTION
## Why this should be merged

`v1.14.0` is out.

## How this works

Tests against `v1.14.0`.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No