### PR TITLE
Unsync LevelDB Compactions Across Nodes

### DIFF
--- a/database/leveldb/db_test.go
+++ b/database/leveldb/db_test.go
@@ -73,3 +73,14 @@ func BenchmarkInterface(b *testing.B) {
 		}
 	}
 }
+
+func TestRandomizeCompactionParams(t *testing.T) {
+	var cfg config
+	randomizeCompactionParams(&cfg)
+
+	require.GreaterOrEqual(t, cfg.CompactionL0Trigger, minCompactionL0Trigger)
+	require.LessOrEqual(t, cfg.CompactionL0Trigger, maxCompactionL0Trigger)
+
+	require.GreaterOrEqual(t, cfg.CompactionTableSize, minCompactionTableSize)
+	require.LessOrEqual(t, cfg.CompactionTableSize, maxCompactionTableSize)
+}


### PR DESCRIPTION
## Why this should be merged

We have noticed synchronous spikes in LevelDB compactions across our nodes. This potentially causes network blips if Disk IO or CPU resources get overconsumed by many nodes in the network at the same time.

<img width="3346" height="402" alt="Screenshot 2025-11-07 at 11 21 19 AM" src="https://github.com/user-attachments/assets/8ab73446-cf89-4e9d-a629-e9fc2b20e05b" />

## How this works

Our nodes are configured by using the default `levelDB` configuration. This may be the reason for why we are seeing synchrony in compactions. We update this by deterministically randomizing two levelDB config parameters when levelDB is set up. These parameters should provide enough variance to offset the compaction synchrony. 

`CompactionL0Trigger` ->  The default for this is 4. This means compaction for level-0 tables will start when 4 L0 files are created. We set this value to be a random value(seeded by nodeID) from 3-7. By changing this value we get variance in when L0 compactions are triggered.

`CompactionTableSize` -> The default value for this is 2MiB. It defines the target size for files produced by compaction. By increasing this, compaction runs less often but consumes more cpu & I/O. We now randomize this value from `2MiB - 4MiB`

## How this was tested

I spun up a mainnet node on an EC2 instance. Initially it was created with the default compaction config for levelDB, but then I restarted the node with two different sets of configs. One with `CompactionTrigger` to `3` and Size to `4MiB` and then another restart with a `CompationL0Trigger` of 7 and Size of `3MiB`. The node appeared healthy after the restart. 


## Need to be documented in RELEASES.md?
