### PR TITLE
feat: randomize compactions

### DIFF
--- a/database/leveldb/db.go
+++ b/database/leveldb/db.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/libevm/log"
 )
 
 const (
@@ -275,7 +274,7 @@ func New(file string, configBytes []byte, log logging.Logger, reg prometheus.Reg
 	}
 
 	if parsedConfig.ManualCompationFrequency > 0 {
-		wrappedDB.startCompactions(parsedConfig.ManualCompationFrequency)
+		wrappedDB.startCompactions(log, parsedConfig.ManualCompationFrequency)
 	}
 
 	return wrappedDB, nil
@@ -364,7 +363,7 @@ func (db *Database) Compact(start []byte, limit []byte) error {
 	return updateError(db.DB.CompactRange(util.Range{Start: start, Limit: limit}))
 }
 
-func (db *Database) startCompactions(compactionInterval time.Duration) {
+func (db *Database) startCompactions(log logging.Logger, compactionInterval time.Duration) {
 	db.closeWg.Add(1)
 	go func() {
 		defer db.closeWg.Done()
@@ -385,7 +384,7 @@ func (db *Database) startCompactions(compactionInterval time.Duration) {
 
 		for {
 			if err := db.Compact(nil, nil); err != nil {
-				log.Error("failed to compact leveldb",
+				log.Warn("failed to compact leveldb",
 					zap.Error(err),
 				)
 			}


### PR DESCRIPTION
## Why this should be merged

To unsync compactions across nodes, we ensure that the regular compation interval is maintained, but the first compaction happens at some random point in time.

## How this works

Picks a random time to start compacting, and then compacts regularly at the interval provided in the config. This is hidden behind a config flag

## How this was tested

It hasn't been!

## Need to be documented in RELEASES.md?

No
