### PR TITLE
[ci] Update the bootstrap monitor job to save kind logs as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,17 @@ jobs:
       - name: Run e2e tests
         shell: bash
         run: nix develop --command ./scripts/run_task.sh test-bootstrap-monitor-e2e
+      - name: Export kind logs
+        if: always()
+        shell: bash
+        run: kind export logs /tmp/kind-logs
+      - name: Upload kind logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bootstrap-monitor-kind-logs
+          path: /tmp/kind-logs
+          if-no-files-found: error
   load:
     name: Run process-based load test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why this should be merged

Noticed when helping to debug #4514, the bootstrap monitor e2e job isn't saving the kind logs required to diagnose failures. 

## How this was tested

- [x] CI
- [x] Checked that [the kind logs artifact was collected for the bootstrap job](https://github.com/ava-labs/avalanchego/actions/runs/19436108598/artifacts/4590798353)

## Need to be documented in RELEASES.md?

N/A
