### PR TITLE
Cancel parent context when aborting bootstrapping

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -262,6 +262,8 @@ type manager struct {
 	// processed.
 	chainCreatorShutdownCh chan struct{}
 	chainCreatorExited     sync.WaitGroup
+	context                context.Context
+	cancelContext          context.CancelFunc
 
 	chainsLock sync.Mutex
 	// Key: Chain's ID
@@ -324,7 +326,11 @@ func New(config *ManagerConfig) (Manager, error) {
 		return nil, err
 	}
 
+	ctx, cancelContext := context.WithCancel(context.Background())
+
 	return &manager{
+		context:                ctx,
+		cancelContext:          cancelContext,
 		Aliaser:                ids.NewAliaser(),
 		ManagerConfig:          *config,
 		chains:                 make(map[ids.ID]handler.Handler),
@@ -468,7 +474,7 @@ func (m *manager) createChain(chainParams ChainParameters) {
 
 	// Tell the chain to start processing messages.
 	// If the X, P, or C Chain panics, do not attempt to recover
-	chain.Handler.Start(context.TODO(), !m.CriticalChains.Contains(chainParams.ID))
+	chain.Handler.Start(m.context, !m.CriticalChains.Contains(chainParams.ID))
 }
 
 // Create a chain
@@ -1523,6 +1529,7 @@ func (m *manager) Shutdown() {
 	m.Log.Info("shutting down chain manager")
 	m.chainsQueue.Close()
 	close(m.chainCreatorShutdownCh)
+	m.cancelContext()
 	m.chainCreatorExited.Wait()
 	m.ManagerConfig.Router.Shutdown(context.TODO())
 }


### PR DESCRIPTION
## Why this should be merged

Currently, when the X-chain executes transactions while bootstrapping, it cannot halt until it finishes executing the current batch of transactions, because the context is never cancelled and the code never checks for the bootstrapper being halted until it finishes handling the batch.

## How this works

I just added a context and a corresponding cancellation in the chain manager, and now when the chain manager is stopped, the context is cancelled and it ripples throughout the bootstrapping procedure across the various engines.

## How this was tested

First, I picked up a [similar bug fix](https://github.com/ava-labs/coreth/commit/84766a8c65ada62fa8e55874fb8652e49db7be05) for the C-chain.

I ran locally a Fuji node and waited until it synced the P-chain.
When it started syncing the X and C chains I did `ctrl+C` and observed that it shuts down immediately: 

 
```
[11-25|18:38:53.982] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 385000}
[11-25|18:39:00.024] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 390000}
[11-25|18:39:05.916] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 395000}
[11-25|18:39:11.944] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 400000}
[11-25|18:39:18.310] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 405000}
[11-25|18:39:24.409] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 410000}
[11-25|18:39:30.871] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 415000}
[11-25|18:39:36.725] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 420000}
[11-25|18:39:42.140] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 425000}
[11-25|18:39:47.919] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 430000}
[11-25|18:39:53.340] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 435000}
[11-25|18:39:53.564] INFO <C Chain> sync/statesync/trie_sync_stats.go:132 state sync: syncing account trie         ETA=12m
[11-25|18:39:58.896] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 440000}
[11-25|18:40:04.206] INFO <X Chain> bootstrap/bootstrapper.go:521 fetched vertices {"numVerticesFetched": 445000}
[11-25|18:40:11.465] INFO <X Chain> bootstrap/bootstrapper.go:600 executing transactions
[11-25|18:40:41.466] INFO <X Chain> queue/jobs.go:202 executing operations {"numExecuted": 20380, "numToExecute": 508608, "eta": "11m59s"}
[11-25|18:40:53.588] INFO <C Chain> sync/statesync/trie_sync_stats.go:132 state sync: syncing account trie         ETA=11m
[11-25|18:41:11.467] INFO <X Chain> queue/jobs.go:202 executing operations {"numExecuted": 37198, "numToExecute": 508608, "eta": "12m40s"}
[11-25|18:41:41.468] INFO <X Chain> queue/jobs.go:202 executing operations {"numExecuted": 57645, "numToExecute": 508608, "eta": "11m44s"}
[11-25|18:41:53.627] INFO <C Chain> sync/statesync/trie_sync_stats.go:132 state sync: syncing account trie         ETA=10m
[11-25|18:42:11.469] INFO <X Chain> queue/jobs.go:202 executing operations {"numExecuted": 75604, "numToExecute": 508608, "eta": "11m27s"}
^C[11-25|18:42:31.277] INFO node/node.go:1841 shutting down node {"exitCode": 0}
[11-25|18:42:31.277] INFO health/worker.go:115 registered new check and initialized its state to failing {"name": "health", "name": "shuttingDown", "tags": ["application"]}
[11-25|18:42:31.277] INFO chains/manager.go:1529 shutting down chain manager
[11-25|18:42:31.277] INFO router/chain_router.go:374 shutting down chain router
[11-25|18:42:31.278] INFO <C Chain> syncer/state_syncer.go:595 shutting down state syncer
[11-25|18:42:31.278] INFO <P Chain> bootstrap/bootstrapper.go:805 shutting down bootstrapper
[11-25|18:42:31.278] INFO <X Chain> queue/jobs.go:137 interrupted execution {"numExecuted": 88585}
[11-25|18:42:31.279] INFO <P Chain> router/chain_router.go:398 chain shutdown {"shutdownDuration": "1.464541ms"}
[11-25|18:42:31.279] INFO <X Chain> bootstrap/bootstrapper.go:307 shutting down Bootstrapper
[11-25|18:42:31.290] INFO <C Chain> plugin/evm/vmsync/registry.go:91 syncer cancelled                         name="Code Syncer"         summary=0xdecc5921651f0a79af74d30a7c0632bc696865c1ec63f30ca2ea54d5fc0e3baa height=48,054,272
[11-25|18:42:31.293] INFO <C Chain> plugin/evm/vmsync/registry.go:91 syncer cancelled                         name="EVM State Syncer"    summary=0xdecc5921651f0a79af74d30a7c0632bc696865c1ec63f30ca2ea54d5fc0e3baa height=48,054,272
[11-25|18:42:31.293] INFO <C Chain> plugin/evm/vmsync/client.go:307 stateSync completed, notifying engine    err="could not get code (CodeRequest(Hashes=0x8007d645eaf0838a448831e461b232fa9f0f454afe0eb0ec2997a40565c11c45, 0x98004ada9444f7aa3cd3ddbf9152f2fdd9633b7b7ed5f4952e2d74de00905f9e, 0xe0c452796f56826c32afa8d01011e67525a719c2da7f85734dc1b371ac764cea, 0x962bb638f336c321e2ed14d9a899bc47671ee2797ba8c82311920c7fa5f8a2a8, 0x0b9c7b6e00ff5a296cbd5d9b89148cbb9104b2266ba24c62f46bc469ff49b044)): context canceled"
[11-25|18:42:31.293] INFO <C Chain> core/txpool/legacypool/legacypool.go:449 Transaction pool stopped
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:972 Closing quit channel
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:975 Stopping Acceptor
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:978 Acceptor queue drained                   t="55.208µs"
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:981 Shutting down sender cacher
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:985 Closing scope
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:989 Waiting for background processes to complete
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:1008 Shutting down state manager
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:1013 State manager shut down                  t="20.458µs"
[11-25|18:42:31.294] INFO <C Chain> core/blockchain.go:1018 Blockchain stopped
[11-25|18:42:31.294] INFO <C Chain> eth/backend.go:404 Stopped shutdownTracker
[11-25|18:42:31.294] INFO <C Chain> eth/backend.go:407 Closed chaindb
[11-25|18:42:31.294] INFO <C Chain> eth/backend.go:409 Stopped EventMux
[11-25|18:42:31.294] INFO <C Chain> router/chain_router.go:398 chain shutdown {"shutdownDuration": "16.89475ms"}
[11-25|18:42:31.295] INFO <X Chain> router/chain_router.go:398 chain shutdown {"shutdownDuration": "1.655792ms"}
[11-25|18:42:31.295] INFO network/network.go:1142 shutting down the p2p networking
[11-25|18:42:31.299] INFO nat/nat.go:193 Unmapped all ports
[11-25|18:42:31.302] INFO node/node.go:1895 cleaning up plugin runtimes
[11-25|18:42:31.325] INFO node/node.go:1923 finished node shutdown
```

## Need to be documented in RELEASES.md?
