### PR TITLE
Cleanup GossipEthTxPool

### DIFF
--- a/graft/coreth/plugin/evm/eth_gossiper.go
+++ b/graft/coreth/plugin/evm/eth_gossiper.go
@@ -60,7 +60,7 @@ func NewGossipEthTxPool(mempool *txpool.TxPool, registerer prometheus.Registerer
 
 	return &GossipEthTxPool{
 		mempool:    mempool,
-		pendingTxs: make(chan core.NewTxsEvent, pendingTxsBuffer),
+		pendingTxs: pendingTxs,
 		sub:        sub,
 		bloom:      bloom,
 	}, nil

--- a/graft/coreth/plugin/evm/eth_gossiper.go
+++ b/graft/coreth/plugin/evm/eth_gossiper.go
@@ -7,6 +7,7 @@ package evm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -34,7 +35,7 @@ var (
 
 	_ eth.PushGossiper = (*EthPushGossiper)(nil)
 
-	errSubscribing = fmt.Errorf("subscribing to the mempool failed")
+	errSubscribing = errors.New("subscribing to the mempool failed")
 )
 
 // NewGossipEthTxPool creates a new GossipEthTxPool.

--- a/graft/coreth/plugin/evm/gossip_test.go
+++ b/graft/coreth/plugin/evm/gossip_test.go
@@ -63,11 +63,7 @@ func TestGossipSubscribe(t *testing.T) {
 	require.NoError(err)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	go gossipTxPool.Subscribe(ctx)
-
-	require.Eventually(func() bool {
-		return gossipTxPool.IsSubscribed()
-	}, 10*time.Second, 500*time.Millisecond, "expected gossipTxPool to be subscribed")
+	go gossipTxPool.UpdateBloomFilter(ctx)
 
 	// create eth txs
 	ethTxs := getValidEthTxs(key, 10, big.NewInt(226*utils.GWei))

--- a/graft/coreth/plugin/evm/vm.go
+++ b/graft/coreth/plugin/evm/vm.go
@@ -775,7 +775,7 @@ func (vm *VM) initBlockBuilding() error {
 	}
 	vm.shutdownWg.Add(1)
 	go func() {
-		ethTxPool.Subscribe(ctx)
+		ethTxPool.UpdateBloomFilter(ctx)
 		vm.shutdownWg.Done()
 	}()
 	pushGossipParams := avalanchegossip.BranchingFactor{


### PR DESCRIPTION
## Why this should be merged

1. `IsSubscribed` is a testing only function that really indicates that the implementation is inherently racy. The subscription should be synchronous while the handling of the subscription should be async.
2. `SubscribeTransactions` currently takes in `false`. This isn't a bug, because the bool is ignored for the legacy pool... But if it weren't ignored, then this would violate the invariant that the bloom filter is a superset of the inner set. So now it is set to `true`.

## How this works

imo, the code would be cleaner if there was a `Close` or `Shutdown` function on the mempool with the goroutine started in `NewGossipEthTxPool`... But that seemed to be a bigger refactor involving node shutdown.

## How this was tested

existing CI

## Need to be documented in RELEASES.md?

no