### PR TITLE
feat: add config to enable block database

### DIFF
--- a/graft/coreth/plugin/evm/config/config.go
+++ b/graft/coreth/plugin/evm/config/config.go
@@ -144,6 +144,8 @@ type Config struct {
 	// SkipBlockDatabaseAutoMigrate skips auto-migrating block data from key-value
 	// database to the block database. Only new blocks will be stored in the block database.
 	SkipBlockDatabaseAutoMigrate bool `json:"skip-block-database-auto-migrate"`
+	// BlockDatabaseSync determines if fsync is called after each write.
+	BlockDatabaseSync bool `json:"block-database-sync"`
 
 	// SkipUpgradeCheck disables checking that upgrades must take place before the last
 	// accepted block. Skipping this check is useful when a node operator does not update

--- a/graft/coreth/plugin/evm/config/config.go
+++ b/graft/coreth/plugin/evm/config/config.go
@@ -139,7 +139,11 @@ type Config struct {
 	StateSyncRequestSize     uint16 `json:"state-sync-request-size"`
 
 	// Database Settings
-	InspectDatabase bool `json:"inspect-database"` // Inspects the database on startup if enabled.
+	InspectDatabase      bool `json:"inspect-database"`       // Inspects the database on startup if enabled.
+	BlockDatabaseEnabled bool `json:"block-database-enabled"` // Use block database for storing block data
+	// SkipBlockDatabaseAutoMigrate skips auto-migrating block data from key-value
+	// database to the block database. Only new blocks will be stored in the block database.
+	SkipBlockDatabaseAutoMigrate bool `json:"skip-block-database-auto-migrate"`
 
 	// SkipUpgradeCheck disables checking that upgrades must take place before the last
 	// accepted block. Skipping this check is useful when a node operator does not update

--- a/graft/coreth/plugin/evm/vm.go
+++ b/graft/coreth/plugin/evm/vm.go
@@ -130,6 +130,7 @@ var (
 	metadataPrefix  = []byte("metadata")
 	warpPrefix      = []byte("warp")
 	ethDBPrefix     = []byte("ethdb")
+	blockDBPrefix   = []byte("blockdb")
 )
 
 var (
@@ -312,7 +313,9 @@ func (vm *VM) Initialize(
 	}
 
 	// Initialize the database
-	vm.initializeDBs(db)
+	if err := vm.initializeDBs(db); err != nil {
+		return err
+	}
 	if vm.config.InspectDatabase {
 		if err := vm.inspectDatabases(); err != nil {
 			return err

--- a/graft/coreth/plugin/evm/vm_database.go
+++ b/graft/coreth/plugin/evm/vm_database.go
@@ -117,7 +117,7 @@ func (vm *VM) initBlockDB(db avalanchedatabase.Database) error {
 		return err
 	}
 	ssEnabled := vm.stateSyncEnabled(height)
-	cfg := heightindexdb.DefaultConfig().WithSyncToDisk(false)
+	cfg := heightindexdb.DefaultConfig().WithSyncToDisk(vm.config.BlockDatabaseSync)
 	bdb, initialized, err := blockdb.New(
 		metaDB,
 		vm.chaindb,

--- a/graft/coreth/plugin/evm/vm_database.go
+++ b/graft/coreth/plugin/evm/vm_database.go
@@ -4,6 +4,10 @@
 package evm
 
 import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/ava-labs/libevm/common"
@@ -13,13 +17,15 @@ import (
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/vms/evm/database"
+	"github.com/ava-labs/avalanchego/vms/evm/database/blockdb"
 
 	avalanchedatabase "github.com/ava-labs/avalanchego/database"
+	heightindexdb "github.com/ava-labs/avalanchego/x/blockdb"
 )
 
 // initializeDBs initializes the databases used by the VM.
 // coreth always uses the avalanchego provided database.
-func (vm *VM) initializeDBs(db avalanchedatabase.Database) {
+func (vm *VM) initializeDBs(db avalanchedatabase.Database) error {
 	// Use NewNested rather than New so that the structure of the database
 	// remains the same regardless of the provided baseDB type.
 	vm.chaindb = rawdb.NewDatabase(database.New(prefixdb.NewNested(ethDBPrefix, db)))
@@ -30,6 +36,13 @@ func (vm *VM) initializeDBs(db avalanchedatabase.Database) {
 	// that warp signatures are committed to the database atomically with
 	// the last accepted block.
 	vm.warpDB = prefixdb.New(warpPrefix, db)
+
+	// initBlockDB must be called after acceptedBlockDB and chaindb are initialized
+	// because it uses them.
+	if err := vm.initBlockDB(db); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (vm *VM) inspectDatabases() error {
@@ -78,5 +91,50 @@ func inspectDB(db avalanchedatabase.Database, label string) error {
 	}
 	// Display the database statistic.
 	log.Info("Database statistics", "label", label, "total", total.String(), "count", count)
+	return nil
+}
+
+// initBlockDB wraps the chaindb with a blockdb.Database that
+// stores blocks data in separate databases when enabled.
+func (vm *VM) initBlockDB(db avalanchedatabase.Database) error {
+	// Error if block database has been enabled and then disabled
+	metaDB := prefixdb.New(blockDBPrefix, db)
+	enabled, err := blockdb.IsEnabled(metaDB)
+	if err != nil {
+		return err
+	}
+	if !vm.config.BlockDatabaseEnabled {
+		if enabled {
+			return errors.New("block database should not be disabled after it has been enabled")
+		}
+		return nil
+	}
+
+	version := strconv.FormatUint(heightindexdb.IndexFileVersion, 10)
+	path := filepath.Join(vm.ctx.ChainDataDir, "blockdb", version)
+	_, height, err := vm.ReadLastAccepted()
+	if err != nil {
+		return err
+	}
+	ssEnabled := vm.stateSyncEnabled(height)
+	cfg := heightindexdb.DefaultConfig().WithSyncToDisk(false)
+	bdb, initialized, err := blockdb.New(
+		metaDB,
+		vm.chaindb,
+		path,
+		ssEnabled,
+		cfg,
+		vm.ctx.Log,
+		vm.sdkMetrics,
+	)
+	if err != nil {
+		return err
+	}
+	if initialized && !vm.config.SkipBlockDatabaseAutoMigrate {
+		if err := bdb.StartMigration(context.Background()); err != nil {
+			return err
+		}
+	}
+	vm.chaindb = bdb
 	return nil
 }

--- a/graft/coreth/plugin/evm/vm_test.go
+++ b/graft/coreth/plugin/evm/vm_test.go
@@ -2206,6 +2206,6 @@ func TestInspectDatabases(t *testing.T) {
 		db = memdb.New()
 	)
 
-	vm.initializeDBs(db)
+	require.NoError(t, vm.initializeDBs(db))
 	require.NoError(t, vm.inspectDatabases())
 }


### PR DESCRIPTION
## Why this should be merged

Part of #4500, resolves #4629. Adds config options in coreth to persist blocks in separate height-indexed databases instead of the current key-value store. Disabled by default.

## How this works

New `coreth` config options:
- `block-database-enabled`: When true, stores block header/body/receipts in separate height-indexed databases.
- `skip-block-database-auto-migrate`: When true, skips migrating existing blocks from KV DB to the block databases. Only new blocks will be stored.
- `block-database-sync`: When true, fsync is called after each write

Other Changes:
- Added `newChainDB` that creates a `blockdb.Database` wrapper when enabled.
- On state sync with no existing block data, initialize the BlockDBs in `BlockSyncer.Sync` before fetching blocks. This sets the min-height to the smaller block height that will be stored.
- Returns error if block database is disabled after being previously enabled.

## How this was tested

Unit tests & running Mainnet nodes with Block Database enabled.

## Need to be documented in RELEASES.md?

Yes