### PR TITLE
Update coreth to hash that exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/StephenButtolph/canoto v0.17.3
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/avalanchego/graft/coreth v0.16.0-rc.0
+	github.com/ava-labs/avalanchego/graft/coreth v0.0.0-20251201152440-a263a7cedcd0
 	github.com/ava-labs/libevm v1.13.15-0.20251016142715-1bccf4f2ddb2
 	github.com/ava-labs/subnet-evm v0.8.1-0.20251124174652-9114d48a927d
 	github.com/btcsuite/btcd/btcutil v1.1.3


### PR DESCRIPTION
## Why this should be merged

Currently, it is not possible to use avalanchego as a dependency, because the go.mod references a grafted coreth version that doesn't exist.

## How this works

The coreth version in the go.mod isn't actually used for local builds, because of the replace directive. However, when other libraries attempt to fetch avalanchego, they do not honor the replace directive. This means that they will attempt to fetch the version of coreth in our go.mod, which doesn't exist.

## How this was tested

I was able to update subnet-evm to this version of avalanchego after updating this reference.

## Need to be documented in RELEASES.md?

no