### PR TITLE
ci: lint all links

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,8 +1,6 @@
 dirs:
   - .
-excludedFiles:
-  - RELEASES.md # This file has too many links to efficiently check
 ignorePatterns:
-  - pattern: '^http://localhost.*$'              # Localhost links are used during tutorials
   - pattern: "^https://.+\\.avax-dev\\.network$" # This check doesn't have the correct credentials
 useGitIgnore: true
+modifiedFilesOnly: false


### PR DESCRIPTION
## Why this should be merged
Two reasons: 

- only linting links when we touch the files leads to a LOT of broken links. Very rarely do developers add broken links -- links break over time, and they have to be fixed. Without these proactive checks, we miss a lot of broken links which is a negative UX for users (they don't care we haven't updated a README in a minute)
- Not linting the README because it has too many links seems backwards. (This is not the slowest component of all CI, so assuming the checks are run concurrently, this does not extend CI time). 

## How this was tested
CI 

## Need to be documented in RELEASES.md?
No 
