### PR TITLE
fix(reexecute/c): execution data directory

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -203,6 +203,7 @@ tasks:
   reexecute-cchain-range:
     desc: Re-execute a range of C-Chain blocks.
     vars:
+      TASK_NAME: '{{.TASK_NAME | default .TASK}}'
       CURRENT_STATE_DIR: '{{.CURRENT_STATE_DIR}}'
       BLOCK_DIR: '{{.BLOCK_DIR}}'
       CONFIG: '{{.CONFIG | default ""}}'
@@ -211,7 +212,7 @@ tasks:
       LABELS: '{{.LABELS | default ""}}'
       BENCHMARK_OUTPUT_FILE: '{{.BENCHMARK_OUTPUT_FILE | default ""}}'
       TIMESTAMP: '{{.TIMESTAMP | default (now | date "20060102-150405")}}'
-      EXECUTION_DATA_DIR: '{{.EXECUTION_DATA_DIR | default (printf "/tmp/%s-%s" .TASK .TIMESTAMP)}}'
+      EXECUTION_DATA_DIR: '{{.EXECUTION_DATA_DIR | default (printf "/tmp/%s-%s" .TASK_NAME .TIMESTAMP)}}'
     cmd: |
       CURRENT_STATE_DIR={{.CURRENT_STATE_DIR}} \
       BLOCK_DIR={{.BLOCK_DIR}} \


### PR DESCRIPTION
## Why this should be merged

#4443 introduced a bug where running `task reexecute-cchain-range` would fail if `EXECUTION_DATA_DIR` was not set by the client. Clients would get the following error log:

```
task: [reexecute-cchain-range] CURRENT_STATE_DIR=/Users/rodrigo.villar/exec-data/current-state \
BLOCK_DIR=/Users/rodrigo.villar/exec-data/blocks \
CONFIG= \
START_BLOCK=1 \
END_BLOCK=10_000 \
LABELS= \
BENCHMARK_OUTPUT_FILE= \
EXECUTION_DATA_DIR=/tmp/%!s(<nil>)-20251202-090826 \
bash -x ./scripts/benchmark_cchain_range.sh

task: Failed to run task "reexecute-cchain-range": 8:28: a command can only contain words and redirects; encountered (
```

The source of this bug seems to be the usage of `.TASK_NAME`, which doesn't exist. Using `.TASK` however seems to work.

## How this works

Switches from using `.TASK_NAME` to `.TASK`

## How this was tested

Ran `task reexecute-cchain-range START_BLOCK=1 END_BLOCK=50_000` with `CURRENT_STATE_DIR` and `BLOCK_DIR` set as environment variables.

## Need to be documented in RELEASES.md?

No