### PR TITLE
refactor(reexecute/c): export CreateBlockChanFromLevelDB

### DIFF
--- a/tests/reexecute/c/vm_reexecute_test.go
+++ b/tests/reexecute/c/vm_reexecute_test.go
@@ -5,7 +5,6 @@ package vm
 
 import (
 	"context"
-	"encoding/binary"
 	"flag"
 	"fmt"
 	"maps"
@@ -37,6 +36,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/tests/reexecute"
 	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
@@ -232,7 +232,7 @@ func benchmarkReexecuteRange(
 		zap.Int("chan-size", chanSize),
 	)
 
-	blockChan, err := createBlockChanFromLevelDB(b, blockDir, startBlock, endBlock, chanSize)
+	blockChan, err := reexecute.CreateBlockChanFromLevelDB(b, blockDir, startBlock, endBlock, chanSize)
 	r.NoError(err)
 
 	dbLogger := tests.NewDefaultLogger("db")
@@ -357,12 +357,6 @@ func newMainnetCChainVM(
 	return vm, nil
 }
 
-type blockResult struct {
-	BlockBytes []byte
-	Height     uint64
-	Err        error
-}
-
 type vmExecutorConfig struct {
 	Log logging.Logger
 	// Registry is the registry to register the metrics with.
@@ -418,7 +412,7 @@ func (e *vmExecutor) execute(ctx context.Context, blockBytes []byte) error {
 	return nil
 }
 
-func (e *vmExecutor) executeSequence(ctx context.Context, blkChan <-chan blockResult) error {
+func (e *vmExecutor) executeSequence(ctx context.Context, blkChan <-chan reexecute.BlockResult) error {
 	blkID, err := e.vm.LastAccepted(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get last accepted block: %w", err)
@@ -483,75 +477,13 @@ func (e *vmExecutor) executeSequence(ctx context.Context, blkChan <-chan blockRe
 	return nil
 }
 
-func createBlockChanFromLevelDB(tb testing.TB, sourceDir string, startBlock, endBlock uint64, chanSize int) (<-chan blockResult, error) {
-	r := require.New(tb)
-	ch := make(chan blockResult, chanSize)
-
-	db, err := leveldb.New(sourceDir, nil, logging.NoLog{}, prometheus.NewRegistry())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create leveldb database from %q: %w", sourceDir, err)
-	}
-	tb.Cleanup(func() {
-		r.NoError(db.Close())
-	})
-
-	go func() {
-		defer close(ch)
-
-		iter := db.NewIteratorWithStart(blockKey(startBlock))
-		defer iter.Release()
-
-		currentHeight := startBlock
-
-		for iter.Next() {
-			key := iter.Key()
-			if len(key) != database.Uint64Size {
-				ch <- blockResult{
-					BlockBytes: nil,
-					Err:        fmt.Errorf("expected key length %d while looking for block at height %d, got %d", database.Uint64Size, currentHeight, len(key)),
-				}
-				return
-			}
-			height := binary.BigEndian.Uint64(key)
-			if height != currentHeight {
-				ch <- blockResult{
-					BlockBytes: nil,
-					Err:        fmt.Errorf("expected next height %d, got %d", currentHeight, height),
-				}
-				return
-			}
-			ch <- blockResult{
-				BlockBytes: iter.Value(),
-				Height:     height,
-			}
-			currentHeight++
-			if currentHeight > endBlock {
-				break
-			}
-		}
-		if iter.Error() != nil {
-			ch <- blockResult{
-				BlockBytes: nil,
-				Err:        fmt.Errorf("failed to iterate over blocks at height %d: %w", currentHeight, iter.Error()),
-			}
-			return
-		}
-	}()
-
-	return ch, nil
-}
-
-func blockKey(height uint64) []byte {
-	return binary.BigEndian.AppendUint64(nil, height)
-}
-
 func TestExportBlockRange(t *testing.T) {
 	exportBlockRange(t, blockDirSrcArg, blockDirDstArg, startBlockArg, endBlockArg, chanSizeArg)
 }
 
 func exportBlockRange(tb testing.TB, blockDirSrc string, blockDirDst string, startBlock, endBlock uint64, chanSize int) {
 	r := require.New(tb)
-	blockChan, err := createBlockChanFromLevelDB(tb, blockDirSrc, startBlock, endBlock, chanSize)
+	blockChan, err := reexecute.CreateBlockChanFromLevelDB(tb, blockDirSrc, startBlock, endBlock, chanSize)
 	r.NoError(err)
 
 	db, err := leveldb.New(blockDirDst, nil, logging.NoLog{}, prometheus.NewRegistry())
@@ -562,7 +494,7 @@ func exportBlockRange(tb testing.TB, blockDirSrc string, blockDirDst string, sta
 
 	batch := db.NewBatch()
 	for blkResult := range blockChan {
-		r.NoError(batch.Put(blockKey(blkResult.Height), blkResult.BlockBytes))
+		r.NoError(batch.Put(reexecute.BlockKey(blkResult.Height), blkResult.BlockBytes))
 
 		if batch.Size() > 10*units.MiB {
 			r.NoError(batch.Write())

--- a/tests/reexecute/db.go
+++ b/tests/reexecute/db.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package reexecute
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/leveldb"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+// BlockResult represents the result of reading a block from the database.
+// It contains either the block data and height, or an error if the read failed.
+type BlockResult struct {
+	BlockBytes []byte
+	Height     uint64
+	Err        error
+}
+
+// CreateBlockChanFromLevelDB creates a channel that streams blocks from a LevelDB database.
+// It opens the database at sourceDir and iterates through blocks from startBlock to endBlock (inclusive).
+// Blocks are read sequentially and sent to the returned channel as BlockResult values.
+//
+// Any validation errors or iteration errors are sent as BlockResult with Err set, then the channel is closed.
+func CreateBlockChanFromLevelDB(tb testing.TB, sourceDir string, startBlock, endBlock uint64, chanSize int) (<-chan BlockResult, error) {
+	r := require.New(tb)
+	ch := make(chan BlockResult, chanSize)
+
+	db, err := leveldb.New(sourceDir, nil, logging.NoLog{}, prometheus.NewRegistry())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create leveldb database from %q: %w", sourceDir, err)
+	}
+	tb.Cleanup(func() {
+		r.NoError(db.Close())
+	})
+
+	go func() {
+		defer close(ch)
+
+		iter := db.NewIteratorWithStart(BlockKey(startBlock))
+		defer iter.Release()
+
+		currentHeight := startBlock
+
+		for iter.Next() {
+			key := iter.Key()
+			if len(key) != database.Uint64Size {
+				ch <- BlockResult{
+					BlockBytes: nil,
+					Err:        fmt.Errorf("expected key length %d while looking for block at height %d, got %d", database.Uint64Size, currentHeight, len(key)),
+				}
+				return
+			}
+			height := binary.BigEndian.Uint64(key)
+			if height != currentHeight {
+				ch <- BlockResult{
+					BlockBytes: nil,
+					Err:        fmt.Errorf("expected next height %d, got %d", currentHeight, height),
+				}
+				return
+			}
+			ch <- BlockResult{
+				BlockBytes: iter.Value(),
+				Height:     height,
+			}
+			currentHeight++
+			if currentHeight > endBlock {
+				break
+			}
+		}
+		if iter.Error() != nil {
+			ch <- BlockResult{
+				BlockBytes: nil,
+				Err:        fmt.Errorf("failed to iterate over blocks at height %d: %w", currentHeight, iter.Error()),
+			}
+			return
+		}
+	}()
+
+	return ch, nil
+}
+
+// BlockKey converts a block height to its corresponding database key.
+func BlockKey(height uint64) []byte {
+	return binary.BigEndian.AppendUint64(nil, height)
+}


### PR DESCRIPTION
## Why this should be merged

As part of switching from using `go bench` to custom benchmarks in the reexecution tests (#4508), we'll need to export `CreateBlockChanFromLevelDB()` so that the reexecution test and the export block range tool can use this (as they'll be living in separate packages as executables).

This PR is a precursor to #4639.

## How this works

Moves `CreateBlockChanFromLevelDB()` and `BlockKey()` to the `reexecute` package so that it's accessible to both the reexecution test and the export block range test.

## How this was tested

CI + ran `task export-cchain-block-range` locally

## Need to be documented in RELEASES.md?

No