### PR TITLE
(coreth) Write block header/body/receipts on Accept

### DIFF
--- a/graft/coreth/core/blockchain_ext_test.go
+++ b/graft/coreth/core/blockchain_ext_test.go
@@ -1701,6 +1701,10 @@ func ReexecCorruptedStateTest(t *testing.T, create ReexecTestFunc) {
 	require.NoError(t, blockchain.writeBlockAcceptedIndices(chain[1]))
 	blockchain.Stop()
 
+	// Write accepted block to disk as we are no longer writing it on verify
+	rawdb.WriteBlock(blockchain.db, chain[1])
+	blockchain.Stop()
+
 	// Restart blockchain with existing state
 	newDir := copyDir(t, tempDir) // avoid file lock
 	restartedBlockchain, err := create(chainDB, gspec, chain[1].Hash(), newDir, 4096)

--- a/graft/coreth/core/blockchain_reader.go
+++ b/graft/coreth/core/blockchain_reader.go
@@ -61,18 +61,28 @@ func (bc *BlockChain) HasHeader(hash common.Hash, number uint64) bool {
 // GetHeader retrieves a block header from the database by hash and number,
 // caching it if found.
 func (bc *BlockChain) GetHeader(hash common.Hash, number uint64) *types.Header {
+	if block, ok := bc.verifiedBlockCache.Get(hash); ok {
+		return block.Header()
+	}
 	return bc.hc.GetHeader(hash, number)
 }
 
 // GetHeaderByHash retrieves a block header from the database by hash, caching it if
 // found.
 func (bc *BlockChain) GetHeaderByHash(hash common.Hash) *types.Header {
+	if block, ok := bc.verifiedBlockCache.Get(hash); ok {
+		return block.Header()
+	}
 	return bc.hc.GetHeaderByHash(hash)
 }
 
 // GetHeaderByNumber retrieves a block header from the database by number,
 // caching it (associated with its hash) if found.
 func (bc *BlockChain) GetHeaderByNumber(number uint64) *types.Header {
+	hash := rawdb.ReadCanonicalHash(bc.db, number)
+	if block, ok := bc.verifiedBlockCache.Get(hash); ok {
+		return block.Header()
+	}
 	return bc.hc.GetHeaderByNumber(number)
 }
 
@@ -82,6 +92,9 @@ func (bc *BlockChain) GetBody(hash common.Hash) *types.Body {
 	// Short circuit if the body's already in the cache, retrieve otherwise
 	if cached, ok := bc.bodyCache.Get(hash); ok {
 		return cached
+	}
+	if block, ok := bc.verifiedBlockCache.Get(hash); ok {
+		return block.Body()
 	}
 	number := bc.hc.GetBlockNumber(hash)
 	if number == nil {
@@ -99,6 +112,9 @@ func (bc *BlockChain) GetBody(hash common.Hash) *types.Body {
 // HasBlock checks if a block is fully present in the database or not.
 func (bc *BlockChain) HasBlock(hash common.Hash, number uint64) bool {
 	if bc.blockCache.Contains(hash) {
+		return true
+	}
+	if bc.verifiedBlockCache.Contains(hash) {
 		return true
 	}
 	if !bc.HasHeader(hash, number) {
@@ -123,6 +139,9 @@ func (bc *BlockChain) HasFastBlock(hash common.Hash, number uint64) bool {
 func (bc *BlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	// Short circuit if the block's already in the cache, retrieve otherwise
 	if block, ok := bc.blockCache.Get(hash); ok {
+		return block
+	}
+	if block, ok := bc.verifiedBlockCache.Get(hash); ok {
 		return block
 	}
 	block := rawdb.ReadBlock(bc.db, hash, number)
@@ -175,6 +194,9 @@ func (bc *BlockChain) GetBlocksFromHash(hash common.Hash, n int) (blocks []*type
 // GetReceiptsByHash retrieves the receipts for all transactions in a given block.
 func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	if receipts, ok := bc.receiptsCache.Get(hash); ok {
+		return receipts
+	}
+	if receipts, ok := bc.verifiedReceiptsCache.Get(hash); ok {
 		return receipts
 	}
 	number := rawdb.ReadHeaderNumber(bc.db, hash)

--- a/graft/coreth/core/blockchain_repair_test.go
+++ b/graft/coreth/core/blockchain_repair_test.go
@@ -638,8 +638,11 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 	// Iterate over all the remaining blocks and ensure there are no gaps
 	verifyNoGaps(t, newChain, true, canonblocks)
 	verifyNoGaps(t, newChain, false, sideblocks)
-	verifyCutoff(t, newChain, true, canonblocks, tt.expCanonicalBlocks)
-	verifyCutoff(t, newChain, false, sideblocks, tt.expSidechainBlocks)
+	// Only accepted blocks are persisted after restart.
+	cutoffHead := int(newChain.LastAcceptedBlock().NumberU64())
+	verifyCutoff(t, newChain, true, canonblocks, cutoffHead)
+	// Sidechain blocks are not persisted after restart; expect absence.
+	verifyCutoff(t, newChain, false, sideblocks, 0)
 
 	if head := newChain.CurrentHeader(); head.Number.Uint64() != tt.expHeadBlock {
 		t.Errorf("Head header mismatch: have %d, want %d", head.Number, tt.expHeadBlock)

--- a/graft/coreth/core/blockchain_snapshot_test.go
+++ b/graft/coreth/core/blockchain_snapshot_test.go
@@ -143,7 +143,9 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 func (basic *snapshotTestBasic) verify(t *testing.T, chain *BlockChain, blocks []*types.Block) {
 	// Iterate over all the remaining blocks and ensure there are no gaps
 	verifyNoGaps(t, chain, true, blocks)
-	verifyCutoff(t, chain, true, blocks, basic.expCanonicalBlocks)
+	// Only accepted blocks are persisted after restart.
+	acceptedHead := int(chain.LastAcceptedBlock().NumberU64())
+	verifyCutoff(t, chain, true, blocks, acceptedHead)
 
 	if head := chain.CurrentHeader(); head.Number.Uint64() != basic.expHeadBlock {
 		t.Errorf("Head header mismatch: have %d, want %d", head.Number, basic.expHeadBlock)

--- a/graft/coreth/core/headerchain_test.go
+++ b/graft/coreth/core/headerchain_test.go
@@ -54,7 +54,7 @@ func verifyUnbrokenCanonchain(bc *BlockChain) error {
 		if h.Number.Uint64() == 0 {
 			break
 		}
-		h = bc.hc.GetHeader(h.ParentHash, h.Number.Uint64()-1)
+		h = bc.GetHeader(h.ParentHash, h.Number.Uint64()-1)
 	}
 	return nil
 }

--- a/graft/coreth/eth/filters/filter_test.go
+++ b/graft/coreth/eth/filters/filter_test.go
@@ -273,6 +273,16 @@ func TestFilters(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Persist headers/bodies/receipts for testBackend lookups.
+	// The filter testBackend resolves headers directly from the database via
+	// hash->number and header reads, and our insert path does not write headers
+	// for unaccepted blocks.
+	for _, block := range chain {
+		rawdb.WriteBlock(db, block)
+		receipts := bc.GetReceiptsByHash(block.Hash())
+		rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), receipts)
+	}
+
 	// Set block 998 as Finalized (-3)
 	// bc.SetFinalized(chain[998].Header())
 	err = customrawdb.WriteAcceptorTip(db, chain[998].Hash())

--- a/graft/coreth/plugin/evm/vm_warp_test.go
+++ b/graft/coreth/plugin/evm/vm_warp_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/stretchr/testify/require"
@@ -125,7 +124,7 @@ func testSendWarpMessage(t *testing.T, scheme string) {
 	// Verify that the constructed block contains the expected log with an unsigned warp message in the log data
 	ethBlock1 := blk.(*chain.BlockWrapper).Block.(*wrappedBlock).ethBlock
 	require.Len(ethBlock1.Transactions(), 1)
-	receipts := rawdb.ReadReceipts(vm.chaindb, ethBlock1.Hash(), ethBlock1.NumberU64(), ethBlock1.Time(), vm.chainConfig)
+	receipts := vm.blockChain.GetReceiptsByHash(ethBlock1.Hash())
 	require.Len(receipts, 1)
 
 	require.Len(receipts[0].Logs, 1)

--- a/graft/coreth/plugin/evm/wrapped_block.go
+++ b/graft/coreth/plugin/evm/wrapped_block.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/rlp"
@@ -146,11 +145,11 @@ func (b *wrappedBlock) handlePrecompileAccept(rules extras.Rules) error {
 	}
 
 	// Read receipts from disk
-	receipts := rawdb.ReadReceipts(b.vm.chaindb, b.ethBlock.Hash(), b.ethBlock.NumberU64(), b.ethBlock.Time(), b.vm.chainConfig)
+	receipts := b.vm.blockChain.GetReceiptsByHash(b.ethBlock.Hash())
 	// If there are no receipts, ReadReceipts may be nil, so we check the length and confirm the ReceiptHash
 	// is empty to ensure that missing receipts results in an error on accept.
 	if len(receipts) == 0 && b.ethBlock.ReceiptHash() != types.EmptyRootHash {
-		return fmt.Errorf("failed to fetch receipts for accepted block with non-empty root hash (%s) (Block: %s, Height: %d)", b.ethBlock.ReceiptHash(), b.ethBlock.Hash(), b.ethBlock.NumberU64())
+		return fmt.Errorf("failed to fetch receipts for verified block with non-empty root hash (%s) (Block: %s, Height: %d)", b.ethBlock.ReceiptHash(), b.ethBlock.Hash(), b.ethBlock.NumberU64())
 	}
 	acceptCtx := &precompileconfig.AcceptContext{
 		SnowCtx: b.vm.ctx,


### PR DESCRIPTION
## Why this should be merged

Resolves #4628.

This PR defers writing block header/body/receipts from verify/insert to Accept. Instead of persisting blocks immediately upon verification, verified blocks are cached in memory and only written to disk when accepted.

This is needed for coreth to use `blockdb` before SAE. We should merge this if we want to enable blockdb before SAE is released.

## How this works

- **On verify/insert**: Instead of writing blocks and receipts to the database, they are stored in in-memory caches. The header number mapping, pre-images, and state trie changes are still written to disk immediately.
- **On Accept**: The block header/body and receipts are written to the database before adding the block to the acceptor queue. After writing, block data is removed from the verified caches to free memory.
- **On Reject**: Blocks are removed from both verified caches to free memory.
- **Block getters**: Updated to check the verified block cache, then fall back to the database. This preserves the ability to query both verified and accepted block headers/bodies/receipts.
- If the head block is missing on restart (e.g., due to a crash before the head block is accepted), the blockchain falls back to the last accepted block and updates the head accordingly.

This change means verified but not accepted blocks are no longer persisted to disk. If a blockchain crashes before a verified block is accepted, the block will be lost from memory but can be bootstrapped from the network.

## How this was tested

- I have Mainnet nodes running these changes (with and without block database enabled) running for +4 weeks.
- This is also used to test the blockdb changes in https://github.com/ava-labs/avalanchego/pull/4485