### PR TITLE
[antithesis] Conditionally copy ./graft in builder dockerfiles

### DIFF
--- a/tests/antithesis/Dockerfile.builder-instrumented
+++ b/tests/antithesis/Dockerfile.builder-instrumented
@@ -12,7 +12,7 @@ WORKDIR /build
 # Copy and download dependencies using go mod
 COPY go.mod .
 COPY go.sum .
-# Copy graft if it exists to support the local replace directive
+# Copy graft if it exists to support local replace directives
 RUN --mount=type=bind,source=.,target=/context \
     if [ -d /context/graft ]; then cp -r /context/graft ./graft; fi
 RUN go mod download

--- a/tests/antithesis/Dockerfile.builder-uninstrumented
+++ b/tests/antithesis/Dockerfile.builder-uninstrumented
@@ -8,7 +8,7 @@ WORKDIR /build
 # Copy and download dependencies using go mod
 COPY go.mod .
 COPY go.sum .
-# Copy graft if it exists to support the local replace directive
+# Copy graft if it exists to support local replace directives
 RUN --mount=type=bind,source=.,target=/context \
     if [ -d /context/graft ]; then cp -r /context/graft ./graft; fi
 RUN go mod download


### PR DESCRIPTION
## Why this should be merged

The images are consumed by subnet-evm which doesn't have a ./graft path and that was causing subnet-evm's anithesis image build to fail.

## How this was tested

- CI for avalanchego
- Manually verified subnet-evm antithesis image build against this commit(6546ac1): 

```
 + docker buildx build --build-arg GO_VERSION=1.24.9 -t antithesis-subnet-evm-builder:cb454071 -f /home/user/src/subnet-evm/se_master/avalanchego/tests/antithesis/Dockerfile.builder-uninstrumented /home/user/src/subnet-evm/se_master
 [+] Building 34.3s (13/13) FINISHED                                                                                docker:default
  => [internal] load build definition from Dockerfile.builder-uninstrumented                                                  0.0s
  => => transferring dockerfile: 759B                                                                                         0.0s
  => [internal] load metadata for docker.io/library/golang:1.24.9-bookworm                                                    0.4s
  => [internal] load .dockerignore                                                                                            0.0s
  => => transferring context: 105B                                                                                            0.0s
  => [stage-0 1/8] FROM docker.io/library/golang:1.24.9-bookworm@sha256:737b40b61ce956d738bed59f18ba854d8d67e7a4c4fa63f64437  0.0s
  => [internal] load build context                                                                                            0.2s
  => => transferring context: 90.69MB                                                                                         0.2s
  => CACHED [stage-0 2/8] WORKDIR /build                                                                                      0.0s
  => CACHED [stage-0 3/8] COPY go.mod .                                                                                       0.0s
  => CACHED [stage-0 4/8] COPY go.sum .                                                                                       0.0s
  => [stage-0 5/8] RUN --mount=type=bind,source=.,target=/context     if [ -d /context/graft ]; then cp -r /context/graft ./  0.2s
  => [stage-0 6/8] RUN go mod download                                                                                       27.0s
  => [stage-0 7/8] COPY . .                                                                                                   1.5s
  => [stage-0 8/8] RUN [ -d ./build ] && rm -rf ./build/* || true                                                             0.3s
  => exporting to image                                                                                                       4.6s
  => => exporting layers                                                                                                      4.6s
  => => writing image sha256:3690f1a1a6dd4162fe6c4fda192c064137334d80bc1ddbef97f508825033261f                                 0.0s
  => => naming to docker.io/library/antithesis-subnet-evm-builder:cb454071                                                    0.0s
```

## Need to be documented in RELEASES.md?

N/A