### PR TITLE
refactor: Firewood Revisions

### DIFF
--- a/graft/coreth/core/txpool/legacypool/legacypool.go
+++ b/graft/coreth/core/txpool/legacypool/legacypool.go
@@ -446,6 +446,11 @@ func (pool *LegacyPool) Close() error {
 	if pool.journal != nil {
 		pool.journal.close()
 	}
+
+	// remove all references to state to allow GC to reclaim memory
+	pool.pendingNonces = nil
+	pool.currentState = nil
+
 	log.Info("Transaction pool stopped")
 	return nil
 }

--- a/graft/subnet-evm/core/txpool/legacypool/legacypool.go
+++ b/graft/subnet-evm/core/txpool/legacypool/legacypool.go
@@ -449,6 +449,11 @@ func (pool *LegacyPool) Close() error {
 	if pool.journal != nil {
 		pool.journal.close()
 	}
+
+	// remove all references to state to allow GC to reclaim memory
+	pool.pendingNonces = nil
+	pool.currentState = nil
+
 	log.Info("Transaction pool stopped")
 	return nil
 }


### PR DESCRIPTION
## Why this should be merged

Now that using `Revision` is concurrent safe and guaranteed to not cause undefined behavior, it should be used a more canonical way of accessing state. 

## How this works

Uses Firewood's `Revision` instead of relying on a one-Revision cache internal to Rust. The Revision has a finalizer attached to release all related memory when there are no more references.

## How this was tested

CI and re-execution tests

## Need to be documented in RELEASES.md?

No
