### PR TITLE
docs: fix broken links and ignore private ones

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -5,4 +5,7 @@ excludedFiles:
 ignorePatterns:
   - pattern: '^http://localhost.*$'              # Localhost links are used during tutorials
   - pattern: "^https://.+\\.avax-dev\\.network$" # This check doesn't have the correct credentials
+  - pattern: "^https://github\\.com/ava-labs/devops-argocd/.*$" # Private repository requiring authentication
+  - pattern: "^https://github\\.com/ava-labs/eng-resources.*$" # Private repository requiring authentication
+  - pattern: "^https://github\\.com/ava-labs/external-plugins-builder.*$" # Private repository requiring authentication
 useGitIgnore: true

--- a/graft/subnet-evm/precompile/contracts/warp/README.md
+++ b/graft/subnet-evm/precompile/contracts/warp/README.md
@@ -25,7 +25,7 @@ The Avalanche Warp Precompile enables this flow to send a message from blockchai
 
 ### Warp Precompile
 
-The Warp Precompile is broken down into three functions defined in the Solidity interface file [IWarpMessenger.sol](../../../contracts/contracts/interfaces/IWarpMessenger.sol).
+The Warp Precompile is broken down into three functions defined in the Solidity interface file [IWarpMessenger.sol](../../../precompile/contracts/warp/warpbindings/IWarpMessenger.sol).
 
 #### sendWarpMessage
 


### PR DESCRIPTION
## Why this should be merged
There are a few private links in the readme of the graft repositories -- this PR fixes them. 

## How this was tested
CI