### PR TITLE
refactor(reexecute): export NewMainnetCChainVM() [1/2]

### DIFF
--- a/tests/reexecute/c/vm_reexecute.go
+++ b/tests/reexecute/c/vm_reexecute.go
@@ -22,35 +22,15 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api/metrics"
-	"github.com/ava-labs/avalanchego/chains/atomic"
-	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/leveldb"
-	"github.com/ava-labs/avalanchego/database/prefixdb"
-	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm"
-	"github.com/ava-labs/avalanchego/graft/coreth/plugin/factory"
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
 	"github.com/ava-labs/avalanchego/tests/reexecute"
-	"github.com/ava-labs/avalanchego/upgrade"
-	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/perms"
 	"github.com/ava-labs/avalanchego/utils/timer"
-	"github.com/ava-labs/avalanchego/vms/metervm"
-	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
-)
-
-var (
-	mainnetXChainID    = ids.FromStringOrPanic("2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM")
-	mainnetCChainID    = ids.FromStringOrPanic("2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5")
-	mainnetAvaxAssetID = ids.FromStringOrPanic("FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z")
 )
 
 var (
@@ -252,7 +232,7 @@ func benchmarkReexecuteRange(
 		r.NoError(db.Close())
 	}()
 
-	vm, err := newMainnetCChainVM(
+	vm, err := reexecute.NewMainnetCChainVM(
 		ctx,
 		db,
 		chainDataDir,
@@ -287,87 +267,6 @@ func benchmarkReexecuteRange(
 	if len(benchmarkOutputFile) != 0 {
 		r.NoError(benchmarkTool.saveToFile(benchmarkOutputFile))
 	}
-}
-
-func newMainnetCChainVM(
-	ctx context.Context,
-	vmAndSharedMemoryDB database.Database,
-	chainDataDir string,
-	configBytes []byte,
-	vmMultiGatherer metrics.MultiGatherer,
-	meterVMRegistry prometheus.Registerer,
-) (block.ChainVM, error) {
-	factory := factory.Factory{}
-	vmIntf, err := factory.New(logging.NoLog{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create VM from factory: %w", err)
-	}
-	vm := vmIntf.(block.ChainVM)
-
-	blsKey, err := localsigner.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create BLS key: %w", err)
-	}
-
-	blsPublicKey := blsKey.PublicKey()
-	warpSigner := warp.NewSigner(blsKey, constants.MainnetID, mainnetCChainID)
-
-	genesisConfig := genesis.GetConfig(constants.MainnetID)
-
-	sharedMemoryDB := prefixdb.New([]byte("sharedmemory"), vmAndSharedMemoryDB)
-	atomicMemory := atomic.NewMemory(sharedMemoryDB)
-
-	chainIDToSubnetID := map[ids.ID]ids.ID{
-		mainnetXChainID: constants.PrimaryNetworkID,
-		mainnetCChainID: constants.PrimaryNetworkID,
-		ids.Empty:       constants.PrimaryNetworkID,
-	}
-
-	vm = metervm.NewBlockVM(vm, meterVMRegistry)
-
-	if err := vm.Initialize(
-		ctx,
-		&snow.Context{
-			NetworkID:       constants.MainnetID,
-			SubnetID:        constants.PrimaryNetworkID,
-			ChainID:         mainnetCChainID,
-			NodeID:          ids.GenerateTestNodeID(),
-			PublicKey:       blsPublicKey,
-			NetworkUpgrades: upgrade.Mainnet,
-
-			XChainID:    mainnetXChainID,
-			CChainID:    mainnetCChainID,
-			AVAXAssetID: mainnetAvaxAssetID,
-
-			Log:          tests.NewDefaultLogger("mainnet-vm-reexecution"),
-			SharedMemory: atomicMemory.NewSharedMemory(mainnetCChainID),
-			BCLookup:     ids.NewAliaser(),
-			Metrics:      vmMultiGatherer,
-
-			WarpSigner: warpSigner,
-
-			ValidatorState: &validatorstest.State{
-				GetSubnetIDF: func(_ context.Context, chainID ids.ID) (ids.ID, error) {
-					subnetID, ok := chainIDToSubnetID[chainID]
-					if ok {
-						return subnetID, nil
-					}
-					return ids.Empty, fmt.Errorf("unknown chainID: %s", chainID)
-				},
-			},
-			ChainDataDir: chainDataDir,
-		},
-		prefixdb.New([]byte("vm"), vmAndSharedMemoryDB),
-		[]byte(genesisConfig.CChainGenesis),
-		nil,
-		configBytes,
-		nil,
-		&enginetest.Sender{},
-	); err != nil {
-		return nil, fmt.Errorf("failed to initialize VM: %w", err)
-	}
-
-	return vm, nil
 }
 
 type vmExecutorConfig struct {

--- a/tests/reexecute/vm.go
+++ b/tests/reexecute/vm.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package reexecute
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ava-labs/avalanchego/api/metrics"
+	"github.com/ava-labs/avalanchego/chains/atomic"
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/genesis"
+	"github.com/ava-labs/avalanchego/graft/coreth/plugin/factory"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
+	"github.com/ava-labs/avalanchego/tests"
+	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/metervm"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
+)
+
+var (
+	mainnetXChainID    = ids.FromStringOrPanic("2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM")
+	mainnetCChainID    = ids.FromStringOrPanic("2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5")
+	mainnetAvaxAssetID = ids.FromStringOrPanic("FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z")
+)
+
+func NewMainnetCChainVM(
+	ctx context.Context,
+	vmAndSharedMemoryDB database.Database,
+	chainDataDir string,
+	configBytes []byte,
+	vmMultiGatherer metrics.MultiGatherer,
+	meterVMRegistry prometheus.Registerer,
+) (block.ChainVM, error) {
+	factory := factory.Factory{}
+	vmIntf, err := factory.New(logging.NoLog{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VM from factory: %w", err)
+	}
+	vm := vmIntf.(block.ChainVM)
+
+	blsKey, err := localsigner.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create BLS key: %w", err)
+	}
+
+	blsPublicKey := blsKey.PublicKey()
+	warpSigner := warp.NewSigner(blsKey, constants.MainnetID, mainnetCChainID)
+
+	genesisConfig := genesis.GetConfig(constants.MainnetID)
+
+	sharedMemoryDB := prefixdb.New([]byte("sharedmemory"), vmAndSharedMemoryDB)
+	atomicMemory := atomic.NewMemory(sharedMemoryDB)
+
+	chainIDToSubnetID := map[ids.ID]ids.ID{
+		mainnetXChainID: constants.PrimaryNetworkID,
+		mainnetCChainID: constants.PrimaryNetworkID,
+		ids.Empty:       constants.PrimaryNetworkID,
+	}
+
+	vm = metervm.NewBlockVM(vm, meterVMRegistry)
+
+	if err := vm.Initialize(
+		ctx,
+		&snow.Context{
+			NetworkID:       constants.MainnetID,
+			SubnetID:        constants.PrimaryNetworkID,
+			ChainID:         mainnetCChainID,
+			NodeID:          ids.GenerateTestNodeID(),
+			PublicKey:       blsPublicKey,
+			NetworkUpgrades: upgrade.Mainnet,
+
+			XChainID:    mainnetXChainID,
+			CChainID:    mainnetCChainID,
+			AVAXAssetID: mainnetAvaxAssetID,
+
+			Log:          tests.NewDefaultLogger("mainnet-vm-reexecution"),
+			SharedMemory: atomicMemory.NewSharedMemory(mainnetCChainID),
+			BCLookup:     ids.NewAliaser(),
+			Metrics:      vmMultiGatherer,
+
+			WarpSigner: warpSigner,
+
+			ValidatorState: &validatorstest.State{
+				GetSubnetIDF: func(_ context.Context, chainID ids.ID) (ids.ID, error) {
+					subnetID, ok := chainIDToSubnetID[chainID]
+					if ok {
+						return subnetID, nil
+					}
+					return ids.Empty, fmt.Errorf("unknown chainID: %s", chainID)
+				},
+			},
+			ChainDataDir: chainDataDir,
+		},
+		prefixdb.New([]byte("vm"), vmAndSharedMemoryDB),
+		[]byte(genesisConfig.CChainGenesis),
+		nil,
+		configBytes,
+		nil,
+		&enginetest.Sender{},
+	); err != nil {
+		return nil, fmt.Errorf("failed to initialize VM: %w", err)
+	}
+
+	return vm, nil
+}


### PR DESCRIPTION
## Why this should be merged

A prerequiste of #4695 is that we need to create a Coreth instance to read the last accepted block. We can do this with `newCChainMainnetVM()`, but this is currently unexported and lives in the `reexecute/c` package.

## How this works

Exports `NewMainnetCChainVM()` and moves it to `reexecute` for usage by `reexecute/c` and the future `reexecute/chaos` packages.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
