### PR TITLE
fix(ci): rename RUNNER_NAME to avoid GitHub env var conflict

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -21,8 +21,8 @@ inputs:
   current-state-dir-src:
     description: 'The current state directory. Supports S3 directory/zip and local directories.'
     default: ''
-  runner_name:
-    description: 'The name of the runner to use and include in the Golang Benchmark name.'
+  runner_type:
+    description: 'The type/label of the runner to include in the benchmark name for grouping results.'
     required: true
   aws-role:
     description: 'AWS role to assume for S3 access.'
@@ -168,7 +168,7 @@ runs:
             BENCHMARK_OUTPUT_FILE="${{ env.BENCHMARK_OUTPUT_FILE }}"
         fi
       env:
-        BENCHMARK_RUNNER_NAME: ${{ inputs.runner_name }}
+        RUNNER_TYPE: ${{ inputs.runner_type }}
         METRICS_COLLECTOR_ENABLED: ${{ inputs.prometheus-username != '' }}
         PROMETHEUS_URL: ${{ inputs.prometheus-url }}
         PROMETHEUS_PUSH_URL: ${{ inputs.prometheus-push-url }}

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -112,4 +112,4 @@ jobs:
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-post-state: ${{ github.event.inputs.push-post-state }}
-          runner_name: ${{ matrix.runner }}
+          runner_type: ${{ matrix.runner }}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -102,4 +102,4 @@ jobs:
           aws-region: 'us-east-2'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-post-state: ${{ github.event.inputs.push-post-state }}
-          runner_name: ${{ matrix.runner }}
+          runner_type: ${{ matrix.runner }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,7 +224,7 @@ tasks:
       EXECUTION_DATA_DIR={{.EXECUTION_DATA_DIR}} \
       bash -x ./scripts/benchmark_cchain_range.sh
     # Runtime context variables are read from environment by the script:
-    # - BENCHMARK_RUNNER_NAME (execution environment)
+    # - RUNNER_TYPE (execution environment)
     # - METRICS_SERVER_PORT (monitoring config)
     # - METRICS_SERVER_ENABLED (runtime monitoring decision)
     # - METRICS_COLLECTOR_ENABLED (runtime monitoring decision)

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   CURRENT_STATE_DIR: Path or S3 URL to the current state directory or zip.
 #   START_BLOCK: The starting block height (exclusive).
 #   END_BLOCK: The ending block height (inclusive).
-#   BENCHMARK_RUNNER_NAME (optional): Name of the runner to include in benchmark naming.
+#   RUNNER_TYPE (optional): Runner type/label to include in benchmark naming.
 #   LABELS (optional): Comma-separated key=value pairs for metric labels.
 #   BENCHMARK_OUTPUT_FILE (optional): If set, benchmark output is also written to this file.
 #   METRICS_SERVER_ENABLED (optional): If set, enables the metrics server.
@@ -23,7 +23,7 @@ set -euo pipefail
 go run github.com/ava-labs/avalanchego/tests/reexecute/c \
   --block-dir="${BLOCK_DIR}" \
   --current-state-dir="${CURRENT_STATE_DIR}" \
-  ${BENCHMARK_RUNNER_NAME:+--runner="${BENCHMARK_RUNNER_NAME}"} \
+  ${RUNNER_TYPE:+--runner="${RUNNER_TYPE}"} \
   ${CONFIG:+--config="${CONFIG}"} \
   --start-block="${START_BLOCK}" \
   --end-block="${END_BLOCK}" \

--- a/tests/reexecute/c/vm_reexecute.go
+++ b/tests/reexecute/c/vm_reexecute.go
@@ -76,7 +76,7 @@ var (
 	}
 
 	configNameArg  string
-	runnerNameArg  string
+	runnerTypeArg  string
 	configBytesArg []byte
 
 	benchmarkOutputFileArg string
@@ -100,7 +100,7 @@ func init() {
 	predefinedConfigKeys := slices.Collect(maps.Keys(predefinedConfigs))
 	predefinedConfigOptionsStr := fmt.Sprintf("[%s]", strings.Join(predefinedConfigKeys, ", "))
 	flag.StringVar(&configNameArg, configKey, defaultConfigKey, fmt.Sprintf("Specifies the predefined config to use for the VM. Options include %s.", predefinedConfigOptionsStr))
-	flag.StringVar(&runnerNameArg, "runner", "dev", "Name of the runner executing this test. Added as a metric label and to the sub-benchmark's name to differentiate results on the runner key.")
+	flag.StringVar(&runnerTypeArg, "runner", "dev", "Type/label of the runner executing this test. Added as a metric label and to the benchmark name for grouping results.")
 
 	flag.StringVar(&benchmarkOutputFileArg, "benchmark-output-file", benchmarkOutputFileArg, "Filepath where benchmark results will be written to.")
 
@@ -126,8 +126,8 @@ func init() {
 	labels[configKey] = configNameArg
 	configBytesArg = []byte(predefinedConfigStr)
 
-	// Set the runner name label on the metrics.
-	labels["runner"] = runnerNameArg
+	// Set the runner label on the metrics.
+	labels["runner"] = runnerTypeArg
 }
 
 func main() {
@@ -140,7 +140,7 @@ func main() {
 		startBlockArg,
 		endBlockArg,
 		configNameArg,
-		runnerNameArg,
+		runnerTypeArg,
 	)
 
 	benchmarkReexecuteRange(
@@ -206,7 +206,7 @@ func benchmarkReexecuteRange(
 
 	log := tc.Log()
 	log.Info("re-executing block range with params",
-		zap.String("runner", runnerNameArg),
+		zap.String("runner", runnerTypeArg),
 		zap.String("config", configNameArg),
 		zap.String("labels", labelsArg),
 		zap.String("metrics-server-enabled", strconv.FormatBool(metricsServerEnabled)),


### PR DESCRIPTION
## Why this should be merged

Every benchmark test run creates a new sub-dashboard instead of adding to the existing dashboard (ref: https://ava-labs.github.io/avalanchego/dev/bench/).

The runner name is changing for every test run because GitHub's built-in RUNNER_NAME env var (which contains the ephemeral ARC runner name like avalanche-avalanchego-runner-2ti-z284t-runner-88vxw) is overwriting the static runner name we pass.

This was introduced in #4443 when the approach changed from passing RUNNER_NAME as a task argument (highest precedence) to setting it as an environment variable (lower precedence than GitHub's built-in).

## How this works

Renames the custom environment variable from `RUNNER_NAME` to `BENCHMARK_RUNNER_NAME` to avoid conflicting with GitHub's built-in `RUNNER_NAME` variable.

## How this was tested

- CI: Compared against the working behavior before [#4443](https://github.com/ava-labs/avalanchego/actions/runs/19718501681/job/56496196216#step:5:599) and now https://github.com/ava-labs/avalanchego/actions/runs/20373088623/job/58544395265?pr=4775#step:5:599

## Need to be documented in RELEASES.md?

No