### PR TITLE
[tmpnet] Document why disk space checks are disabled by default

### DIFF
--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -38,13 +38,15 @@ const (
 // Flags suggested for temporary networks. Applied by default.
 func DefaultTmpnetFlags() FlagsMap {
 	return FlagsMap{
+		config.NetworkPeerListPullGossipFreqKey: "250ms",
+		config.NetworkMaxReconnectDelayKey:      "1s",
+		config.HealthCheckFreqKey:               "2s",
+		config.AdminAPIEnabledKey:               "true",
+		config.IndexEnabledKey:                  "true",
+		// Disable disk checks by default since temporary networks often run in
+		// resource-constrained environments that commonly have low disk space.
 		config.SystemTrackerRequiredAvailableDiskSpacePercentageKey: "0",
 		config.SystemTrackerWarningAvailableDiskSpacePercentageKey:  "0",
-		config.NetworkPeerListPullGossipFreqKey:                     "250ms",
-		config.NetworkMaxReconnectDelayKey:                          "1s",
-		config.HealthCheckFreqKey:                                   "2s",
-		config.AdminAPIEnabledKey:                                   "true",
-		config.IndexEnabledKey:                                      "true",
 	}
 }
 


### PR DESCRIPTION
 #4770 disabled the disk check for tmpnet and I wanted to make it clear to future maintainers why that is the case. 