### PR TITLE
fix: nix build error on macos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,9 +71,6 @@
 
             # s5cmd for rapid s3 interactions
             s5cmd
-          ] ++ lib.optionals stdenv.isDarwin [
-            # macOS-specific frameworks
-            darwin.apple_sdk.frameworks.Security
           ];
 
           # Add scripts/ directory to PATH so kind-with-registry.sh is accessible


### PR DESCRIPTION
## Why this should be merged

Nix is failing on MacOS after the 25.11 change added in https://github.com/ava-labs/avalanchego/pull/4768.

```bash
direnv: using flake
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at «github:NixOS/nixpkgs/c6f52ebd45e5925c188d1a20119978aa4ffd5ef6?narHash=sha256-m5KWt1nOm76ILk/JSCxBM4MfK3rYY7Wq9/TZIIeGnT8%3D»/pkgs/stdenv/generic/make-derivation.nix:541:13

       … while evaluating attribute '__impureHostDeps' of derivation 'nix-shell'
         at «github:NixOS/nixpkgs/c6f52ebd45e5925c188d1a20119978aa4ffd5ef6?narHash=sha256-m5KWt1nOm76ILk/JSCxBM4MfK3rYY7Wq9/TZIIeGnT8%3D»/pkgs/stdenv/generic/make-derivation.nix:693:15:
          692|               );
          693|               __impureHostDeps =
             |               ^
          694|                 computedImpureHostDeps

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: darwin.apple_sdk_11_0 has been removed as it was a legacy compatibility stub; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks> for migration instructions
direnv: nix-direnv: Evaluating current devShell failed. Falling back to previous environment!
```

## How this works

Removing the apple security framework in flake.nix fixed it for me. This was added previously in https://github.com/ava-labs/avalanchego/pull/3769 to fix a build issue. but it seems to be no longer an issue as after this change I was able to run `task build-tmpnetctl` without issues.

## How this was tested

Running `nix develop` and `task build-tmpnetctl`

## Need to be documented in RELEASES.md?
