### PR TITLE
feat(vm_reexecute): add pprof profiling support

### DIFF
--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -11,9 +11,9 @@ set -euo pipefail
 #   RUNNER_TYPE (optional): Runner type/label to include in benchmark naming.
 #   LABELS (optional): Comma-separated key=value pairs for metric labels.
 #   BENCHMARK_OUTPUT_FILE (optional): If set, benchmark output is also written to this file.
-#   METRICS_SERVER_ENABLED (optional, bool): If set, starts HTTP server exposing /metrics endpoint
+#   METRICS_SERVER_ENABLED (optional): If set, enables the metrics server.
 #   METRICS_SERVER_PORT (optional): If set, determines the port the metrics server will listen to.
-#   METRICS_COLLECTOR_ENABLED (optional, bool): If set, starts Prometheus agent to collect and forward metrics to remote instance
+#   METRICS_COLLECTOR_ENABLED (optional): If set, enables the metrics collector.
 
 : "${BLOCK_DIR:?BLOCK_DIR must be set}"
 : "${CURRENT_STATE_DIR:?CURRENT_STATE_DIR must be set}"


### PR DESCRIPTION
## Why this should be merged

Adds `--pprof-dir <path>` flag to C-chain re-execution benchmark for CPU and memory profiling.

Part of cross-stack profiling effort: https://github.com/ava-labs/firewood/issues/1582

pprof shows time spent in CGO calls as black boxes we see that `ffi.(*Revision).Get` takes X% of CPU but not what happens inside Firewood it's still valuable because:
- Shows Go-side hotspots (GC, allocations, serialization, AvalancheGo)
- Identifies which Go code paths trigger FFI calls
- Measures total time per FFI function

Combined with Rust-side profiling, we get full visibility across the boundary.

## How this works

When `--pprof-dir <path>` is passed:
1. Creates directory at `<path>` directory
2. Starts CPU profiling
3. Writes `cpu.profile`, `mem.profile` and `lock.profile` on exit

## How this was tested

1. `nix develop` (make sure you have AWS credentials set, c-chain-reexecute requires S3 access)
2. Edit line 97 of `vm_reexecution` and set output dir then run `./scripts/run_task.sh c-chain-reexecution-firewood-101-250k`
3. `go tool pprof /tmp/pprof/cpu.profile`
    - `top 20`
    - `list Revision.*Get`

NOTE: `--pprof-dir` is intentionally not exposed in `benchmark_cchain_range.sh` yet the profiling API may evolve as other profiling needs arise https://github.com/ava-labs/firewood/issues/1582. The flag is still available when running the test directly via go run.

```
ROUTINE ======================== github.com/ava-labs/firewood-go-ethhash/ffi.(*Revision).Get in /Users/elvis.sabanovic/go/pkg/mod/github.com/ava-labs/firewood-go-ethhash/ffi@v0.0.18/revision.go
      20ms      6.27s (flat, cum)  1.06% of Total
         .          .     61:func (r *Revision) Get(key []byte) ([]byte, error) {
         .          .     62:   if r.handle == nil {
         .          .     63:           return nil, ErrDroppedRevision
         .          .     64:   }
         .          .     65:
         .       10ms     66:   var pinner runtime.Pinner
      10ms       10ms     67:   defer pinner.Unpin()
         .          .     68:
      10ms      110ms     69:   return getValueFromValueResult(C.fwd_get_from_revision(
         .          .     70:           r.handle,
         .          .     71:           newBorrowedBytes(key, &pinner),
         .      6.14s     72:   ))
         .          .     73:}
         .          .     74:
         .          .     75:// Iter creates an iterator starting from the provided key on revision.
         .          .     76:// pass empty slice to start from beginning
         .          .     77:// It returns ErrDroppedRevision if Drop has already been called.
ROUTINE ======================== github.com/ava-labs/firewood-go-ethhash/ffi.(*Revision).Get.func1 in /Users/elvis.sabanovic/go/pkg/mod/github.com/ava-labs/firewood-go-ethhash/ffi@v0.0.18/revision.go
         0      6.14s (flat, cum)  1.03% of Total
         .          .     69:   return getValueFromValueResult(C.fwd_get_from_revision(
         .          .     70:           r.handle,
         .       30ms     71:           newBorrowedBytes(key, &pinner),
         .      6.11s     72:   ))
         .          .     73:}
         .          .     74:
         .          .     75:// Iter creates an iterator starting from the provided key on revision.
         .          .     76:// pass empty slice to start from beginning
         .          .     77:// It returns ErrDroppedRevision if Drop has already been called.
```

## Need to be documented in RELEASES.md?

No