### PR TITLE
Expose p2p.Peers.Len

### DIFF
--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -167,6 +167,13 @@ func (p *Peers) Has(nodeID ids.NodeID) bool {
 	return p.set.Contains(nodeID)
 }
 
+func (p *Peers) Len() int {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.set.Len()
+}
+
 // Sample returns a pseudo-random sample of up to limit Peers
 func (p *Peers) Sample(limit int) []ids.NodeID {
 	p.lock.RLock()

--- a/network/p2p/network_test.go
+++ b/network/p2p/network_test.go
@@ -574,6 +574,7 @@ func TestPeersSample(t *testing.T) {
 			sampleable := set.Set[ids.NodeID]{}
 			sampleable.Union(tt.connected)
 			sampleable.Difference(tt.disconnected)
+			require.Equal(sampleable.Len(), peers.Len())
 
 			sampled := peers.Sample(tt.limit)
 			require.Len(sampled, min(tt.limit, len(sampleable)))


### PR DESCRIPTION
## Why this should be merged

This allows proper implementation of the [`net_peerCount`](https://ethereum.org/developers/docs/apis/json-rpc/#net_peercount) API.

## How this works

Exposes `Len` on the peers struct.

## How this was tested

Extended unit test to include asserting the number of peers.

## Need to be documented in RELEASES.md?

No.