### PR TITLE
Provide a useful default for `snowtest.Context`

### DIFF
--- a/snow/snowtest/context.go
+++ b/snow/snowtest/context.go
@@ -75,6 +75,9 @@ func Context(tb testing.TB, chainID ids.ID) *snow.Context {
 		GetMinimumHeightF: func(context.Context) (uint64, error) {
 			return 0, nil
 		},
+		GetCurrentHeightF: func(context.Context) (uint64, error) {
+			return 0, nil
+		},
 		GetSubnetIDF: func(_ context.Context, chainID ids.ID) (ids.ID, error) {
 			switch chainID {
 			case PChainID, XChainID, CChainID:


### PR DESCRIPTION
## Why this should be merged

This allows using the `snowtest.Context` directly with the `p2p.Validators` struct.

This came up in SAE testing.

## How this works

Implementation mirrors `GetMinimumHeightF`.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No