### PR TITLE
refactor: warp e2e tests no longer in single function

### DIFF
--- a/graft/coreth/tests/warp/warp_test.go
+++ b/graft/coreth/tests/warp/warp_test.go
@@ -145,15 +145,25 @@ var _ = ginkgo.Describe("[Warp]", func() {
 				w = newWarpTest(combination.sendingSubnet(), combination.receivingSubnet())
 			})
 
-			ginkgo.It("should send warp message from sending subnet", w.sendMessageFromSendingSubnet)
+			ginkgo.It("should send warp message from sending subnet", func() {
+				w.sendMessageFromSendingSubnet()
+			})
 
-			ginkgo.It("should aggregate signatures via API", w.aggregateSignaturesViaAPI)
+			ginkgo.It("should aggregate signatures via API", func() {
+				w.aggregateSignaturesViaAPI()
+			})
 
-			ginkgo.It("should deliver addressed call payload to receiving subnet", w.deliverAddressedCallToReceivingSubnet)
+			ginkgo.It("should deliver addressed call payload to receiving subnet", func() {
+				w.deliverAddressedCallToReceivingSubnet()
+			})
 
-			ginkgo.It("should deliver block hash payload", w.deliverBlockHashPayload)
+			ginkgo.It("should deliver block hash payload", func() {
+				w.deliverBlockHashPayload()
+			})
 
-			ginkgo.It("should handle warp load testing", w.warpLoad)
+			ginkgo.It("should handle warp load testing", func() {
+				w.warpLoad()
+			})
 		})
 	}
 })

--- a/graft/subnet-evm/tests/warp/warp_test.go
+++ b/graft/subnet-evm/tests/warp/warp_test.go
@@ -177,17 +177,29 @@ var _ = ginkgo.Describe("[Warp]", func() {
 				w = newWarpTest(combination.sendingSubnet(), combination.receivingSubnet())
 			})
 
-			ginkgo.It("should send warp message from sending subnet", w.sendMessageFromSendingSubnet)
+			ginkgo.It("should send warp message from sending subnet", func() {
+				w.sendMessageFromSendingSubnet()
+			})
 
-			ginkgo.It("should aggregate signatures via API", w.aggregateSignaturesViaAPI)
+			ginkgo.It("should aggregate signatures via API", func() {
+				w.aggregateSignaturesViaAPI()
+			})
 
-			ginkgo.It("should deliver addressed call payload to receiving subnet", w.deliverAddressedCallToReceivingSubnet)
+			ginkgo.It("should deliver addressed call payload to receiving subnet", func() {
+				w.deliverAddressedCallToReceivingSubnet()
+			})
 
-			ginkgo.It("should deliver block hash payload", w.deliverBlockHashPayload)
+			ginkgo.It("should deliver block hash payload", func() {
+				w.deliverBlockHashPayload()
+			})
 
-			ginkgo.It("should verify warp bindings", w.warpBindingsTest)
+			ginkgo.It("should verify warp bindings", func() {
+				w.warpBindingsTest()
+			})
 
-			ginkgo.It("should handle warp load testing", w.warpLoad)
+			ginkgo.It("should handle warp load testing", func() {
+				w.warpLoad()
+			})
 		})
 	}
 })


### PR DESCRIPTION
## Why this should be merged

This  refactors the warp e2e tests in both subnet-evm and coreth to use a more standard ginkgo test structure (close to the one suggested by @michaelkaplan13 ). This provides better failure isolation by breaking each test functionality into its own `It` block within ordered `Describe` blocks for each test combination.

Closes https://github.com/ava-labs/avalanchego/issues/4699

## How this works

Explicitly defined test combinations. 

## How this was tested
CI 

## Need to be documented in RELEASES.md?
No 