### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (C) 2019-2025, Ava Labs, Inc.
+Copyright (C) 2019-2026, Ava Labs, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Annual copyright year update.

- Updated year: 2025 -> 2026
- Files affected: LICENSE