### PR TITLE
feat(reexecution): collect leveldb and meterdb metrics

### DIFF
--- a/tests/reexecute/c/vm_reexecute.go
+++ b/tests/reexecute/c/vm_reexecute.go
@@ -227,19 +227,19 @@ func benchmarkReexecuteRange(
 	r.NoError(err)
 
 	dbLogger := tests.NewDefaultLogger("db")
-	dbReg, err := metrics.MakeAndRegister(
+	dbRegistry, err := metrics.MakeAndRegister(
 		prefixGatherer,
 		metric.AppendNamespace(constants.PlatformName, "db"),
 	)
 	r.NoError(err)
-	db, err := leveldb.New(vmDBDir, nil, dbLogger, dbReg)
+	db, err := leveldb.New(vmDBDir, nil, dbLogger, dbRegistry)
 	r.NoError(err)
-	meterDBReg, err := metrics.MakeAndRegister(
+	meterDBRegistry, err := metrics.MakeAndRegister(
 		prefixGatherer,
 		metric.AppendNamespace(constants.PlatformName, "meterdb"),
 	)
 	r.NoError(err)
-	db, err = meterdb.New(meterDBReg, db)
+	db, err = meterdb.New(meterDBRegistry, db)
 	r.NoError(err)
 	defer func() {
 		log.Info("shutting down DB")


### PR DESCRIPTION
## Why this should be merged

Enables reexecution benchmarks to collect leveldb and meterdb metrics. This allows existing leveldb or meterdb related Grafana dashboards to work with metrics from benchmark runs.

With this change, metrics like `avalanche_db_non_level_0_comps` and `avalanche_meterdb_calls{method="get"}` are available during reexecution tests as well, allowing us to monitor db performance.

## How this works

- Registers leveldb metrics under `avalanche_db` namespace
- Wraps the database with meterdb and registers metrics under `avalanche_meterdb` namespace

## How this was tested

I ran a reexecution benchmark and confirmed that the leveldb and meterdb metrics are visible.

## Need to be documented in RELEASES.md?

No