### PR TITLE
chore: remove end year from license headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Mocks are auto-generated using [mockgen](https://pkg.go.dev/go.uber.org/mock/moc
   - if the file `mocks_generate_test.go` does not exist in the package where the interface is located, create it with content (adapt as needed):
 
     ```go
-    // Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+    // Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
     // See the file LICENSE for licensing terms.
 
     package mypackage

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (C) 2019-2026, Ava Labs, Inc.
+Copyright (C) 2019, Ava Labs, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package admin

--- a/api/admin/client_test.go
+++ b/api/admin/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package admin

--- a/api/admin/key_value_reader.go
+++ b/api/admin/key_value_reader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package admin

--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package admin

--- a/api/admin/service_test.go
+++ b/api/admin/service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package admin

--- a/api/common_args_responses.go
+++ b/api/common_args_responses.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/api/connectclient/client.go
+++ b/api/connectclient/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package connectclient

--- a/api/health/checker.go
+++ b/api/health/checker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/client.go
+++ b/api/health/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/client_test.go
+++ b/api/health/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/handler.go
+++ b/api/health/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/health.go
+++ b/api/health/health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/health_test.go
+++ b/api/health/health_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/result.go
+++ b/api/health/result.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/service.go
+++ b/api/health/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/service_test.go
+++ b/api/health/service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/health/worker.go
+++ b/api/health/worker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package health

--- a/api/info/client.go
+++ b/api/info/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package info

--- a/api/info/client_test.go
+++ b/api/info/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package info

--- a/api/info/service.go
+++ b/api/info/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package info

--- a/api/info/service_test.go
+++ b/api/info/service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package info

--- a/api/metrics/client.go
+++ b/api/metrics/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/api/metrics/gatherer_test.go
+++ b/api/metrics/gatherer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/api/metrics/label_gatherer.go
+++ b/api/metrics/label_gatherer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/api/metrics/label_gatherer_test.go
+++ b/api/metrics/label_gatherer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/api/metrics/multi_gatherer.go
+++ b/api/metrics/multi_gatherer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/api/metrics/prefix_gatherer.go
+++ b/api/metrics/prefix_gatherer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/api/metrics/prefix_gatherer_test.go
+++ b/api/metrics/prefix_gatherer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/api/server/allowed_hosts.go
+++ b/api/server/allowed_hosts.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package server

--- a/api/server/allowed_hosts_test.go
+++ b/api/server/allowed_hosts_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package server

--- a/api/server/metrics.go
+++ b/api/server/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package server

--- a/api/server/router.go
+++ b/api/server/router.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package server

--- a/api/server/router_test.go
+++ b/api/server/router_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package server

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package server

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package server

--- a/api/traced_handler.go
+++ b/api/traced_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/app/app.go
+++ b/app/app.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package app

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cache

--- a/cache/cachetest/cacher.go
+++ b/cache/cachetest/cacher.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cachetest

--- a/cache/empty.go
+++ b/cache/empty.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cache

--- a/cache/lru/cache.go
+++ b/cache/lru/cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package lru

--- a/cache/lru/cache_test.go
+++ b/cache/lru/cache_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package lru

--- a/cache/lru/deduplicator.go
+++ b/cache/lru/deduplicator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package lru

--- a/cache/lru/deduplicator_test.go
+++ b/cache/lru/deduplicator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package lru

--- a/cache/lru/sized_cache.go
+++ b/cache/lru/sized_cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package lru

--- a/cache/lru/sized_cache_test.go
+++ b/cache/lru/sized_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package lru

--- a/cache/metercacher/cache.go
+++ b/cache/metercacher/cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metercacher

--- a/cache/metercacher/cache_test.go
+++ b/cache/metercacher/cache_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metercacher

--- a/cache/metercacher/metrics.go
+++ b/cache/metercacher/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metercacher

--- a/chains/atomic/atomictest/shared_memory.go
+++ b/chains/atomic/atomictest/shared_memory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomictest

--- a/chains/atomic/codec.go
+++ b/chains/atomic/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/chains/atomic/gsharedmemory/filtered_batch.go
+++ b/chains/atomic/gsharedmemory/filtered_batch.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gsharedmemory

--- a/chains/atomic/gsharedmemory/shared_memory_client.go
+++ b/chains/atomic/gsharedmemory/shared_memory_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gsharedmemory

--- a/chains/atomic/gsharedmemory/shared_memory_server.go
+++ b/chains/atomic/gsharedmemory/shared_memory_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gsharedmemory

--- a/chains/atomic/gsharedmemory/shared_memory_test.go
+++ b/chains/atomic/gsharedmemory/shared_memory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gsharedmemory

--- a/chains/atomic/memory.go
+++ b/chains/atomic/memory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/chains/atomic/memory_test.go
+++ b/chains/atomic/memory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/chains/atomic/mocks_generate_test.go
+++ b/chains/atomic/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/chains/atomic/prefixes.go
+++ b/chains/atomic/prefixes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/chains/atomic/shared_memory.go
+++ b/chains/atomic/shared_memory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/chains/atomic/shared_memory_test.go
+++ b/chains/atomic/shared_memory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic_test

--- a/chains/atomic/state.go
+++ b/chains/atomic/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/chains/atomic/writer.go
+++ b/chains/atomic/writer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/chains/linearizable_vm.go
+++ b/chains/linearizable_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chains

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chains

--- a/chains/registrant.go
+++ b/chains/registrant.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chains

--- a/chains/subnets.go
+++ b/chains/subnets.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chains

--- a/chains/subnets_test.go
+++ b/chains/subnets_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chains

--- a/chains/test_manager.go
+++ b/chains/test_manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chains

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package codec

--- a/codec/codectest/codectest.go
+++ b/codec/codectest/codectest.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package codectest provides a test suite for testing codec implementations.

--- a/codec/general_codec.go
+++ b/codec/general_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package codec

--- a/codec/hierarchycodec/codec.go
+++ b/codec/hierarchycodec/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package hierarchycodec

--- a/codec/hierarchycodec/codec_test.go
+++ b/codec/hierarchycodec/codec_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package hierarchycodec

--- a/codec/linearcodec/codec.go
+++ b/codec/linearcodec/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linearcodec

--- a/codec/linearcodec/codec_test.go
+++ b/codec/linearcodec/codec_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linearcodec

--- a/codec/manager.go
+++ b/codec/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package codec

--- a/codec/mocks_generate_test.go
+++ b/codec/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package codec

--- a/codec/reflectcodec/struct_fielder.go
+++ b/codec/reflectcodec/struct_fielder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package reflectcodec

--- a/codec/reflectcodec/type_codec.go
+++ b/codec/reflectcodec/type_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package reflectcodec

--- a/codec/registry.go
+++ b/codec/registry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package codec

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/config/flags.go
+++ b/config/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/config/keys.go
+++ b/config/keys.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/config/node/config.go
+++ b/config/node/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/config/node/process_context.go
+++ b/config/node/process_context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/config/node/process_context_test.go
+++ b/config/node/process_context_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/config/viper.go
+++ b/config/viper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/database/batch.go
+++ b/database/batch.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // For ease of implementation, our database's interface matches Ethereum's

--- a/database/common.go
+++ b/database/common.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package database

--- a/database/corruptabledb/db.go
+++ b/database/corruptabledb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package corruptabledb

--- a/database/corruptabledb/db_test.go
+++ b/database/corruptabledb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package corruptabledb

--- a/database/database.go
+++ b/database/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // For ease of implementation, our database's interface matches Ethereum's

--- a/database/dbtest/benchmark.go
+++ b/database/dbtest/benchmark.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dbtest

--- a/database/dbtest/dbtest.go
+++ b/database/dbtest/dbtest.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dbtest

--- a/database/errors.go
+++ b/database/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package database

--- a/database/factory/factory.go
+++ b/database/factory/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package factory

--- a/database/heightindexdb/dbtest/dbtest.go
+++ b/database/heightindexdb/dbtest/dbtest.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dbtest

--- a/database/heightindexdb/memdb/database.go
+++ b/database/heightindexdb/memdb/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package memdb

--- a/database/heightindexdb/memdb/database_test.go
+++ b/database/heightindexdb/memdb/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package memdb

--- a/database/heightindexdb/meterdb/db.go
+++ b/database/heightindexdb/meterdb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meterdb

--- a/database/heightindexdb/meterdb/db_test.go
+++ b/database/heightindexdb/meterdb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meterdb

--- a/database/helpers.go
+++ b/database/helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package database

--- a/database/helpers_test.go
+++ b/database/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package database_test

--- a/database/iterator.go
+++ b/database/iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // For ease of implementation, our database's interface matches Ethereum's

--- a/database/leveldb/db.go
+++ b/database/leveldb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package leveldb

--- a/database/leveldb/db_test.go
+++ b/database/leveldb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package leveldb

--- a/database/leveldb/metrics.go
+++ b/database/leveldb/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package leveldb

--- a/database/linkeddb/codec.go
+++ b/database/linkeddb/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linkeddb

--- a/database/linkeddb/db_test.go
+++ b/database/linkeddb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linkeddb

--- a/database/linkeddb/linkeddb.go
+++ b/database/linkeddb/linkeddb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linkeddb

--- a/database/linkeddb/linkeddb_test.go
+++ b/database/linkeddb/linkeddb_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linkeddb

--- a/database/memdb/db.go
+++ b/database/memdb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package memdb

--- a/database/memdb/db_test.go
+++ b/database/memdb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package memdb

--- a/database/meterdb/db.go
+++ b/database/meterdb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meterdb

--- a/database/meterdb/db_test.go
+++ b/database/meterdb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meterdb

--- a/database/mocks_generate_test.go
+++ b/database/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package database

--- a/database/pebbledb/batch.go
+++ b/database/pebbledb/batch.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package pebbledb

--- a/database/pebbledb/batch_test.go
+++ b/database/pebbledb/batch_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package pebbledb

--- a/database/pebbledb/db.go
+++ b/database/pebbledb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package pebbledb

--- a/database/pebbledb/db_test.go
+++ b/database/pebbledb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package pebbledb

--- a/database/pebbledb/iterator.go
+++ b/database/pebbledb/iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package pebbledb

--- a/database/prefixdb/db.go
+++ b/database/prefixdb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package prefixdb

--- a/database/prefixdb/db_test.go
+++ b/database/prefixdb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package prefixdb

--- a/database/rpcdb/db_client.go
+++ b/database/rpcdb/db_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcdb

--- a/database/rpcdb/db_server.go
+++ b/database/rpcdb/db_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcdb

--- a/database/rpcdb/db_test.go
+++ b/database/rpcdb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcdb

--- a/database/rpcdb/errors.go
+++ b/database/rpcdb/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcdb

--- a/database/versiondb/db.go
+++ b/database/versiondb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package versiondb

--- a/database/versiondb/db_test.go
+++ b/database/versiondb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package versiondb

--- a/firewood/syncer/handler.go
+++ b/firewood/syncer/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncer

--- a/firewood/syncer/proof.go
+++ b/firewood/syncer/proof.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncer

--- a/firewood/syncer/syncer.go
+++ b/firewood/syncer/syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncer

--- a/firewood/syncer/syncer_test.go
+++ b/firewood/syncer/syncer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncer

--- a/genesis/aliases.go
+++ b/genesis/aliases.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/bootstrappers.go
+++ b/genesis/bootstrappers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/bootstrappers_test.go
+++ b/genesis/bootstrappers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/checkpoints.go
+++ b/genesis/checkpoints.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/config_test.go
+++ b/genesis/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/generate/checkpoints/main.go
+++ b/genesis/generate/checkpoints/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/genesis/generate/validators/main.go
+++ b/genesis/generate/validators/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/genesis_fuji.go
+++ b/genesis/genesis_fuji.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/genesis_mainnet.go
+++ b/genesis/genesis_mainnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/params.go
+++ b/genesis/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/unparsed_config.go
+++ b/genesis/unparsed_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/validators.go
+++ b/genesis/validators.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/graft/coreth/accounts/abi/abi.go
+++ b/graft/coreth/accounts/abi/abi.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/abi_extra_test.go
+++ b/graft/coreth/accounts/abi/abi_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package abi

--- a/graft/coreth/accounts/abi/abi_test.go
+++ b/graft/coreth/accounts/abi/abi_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/argument.go
+++ b/graft/coreth/accounts/abi/argument.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/auth.go
+++ b/graft/coreth/accounts/abi/bind/auth.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/backend.go
+++ b/graft/coreth/accounts/abi/bind/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/backends/simulated.go
+++ b/graft/coreth/accounts/abi/bind/backends/simulated.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/base.go
+++ b/graft/coreth/accounts/abi/bind/base.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/base_test.go
+++ b/graft/coreth/accounts/abi/bind/base_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/bind.go
+++ b/graft/coreth/accounts/abi/bind/bind.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/bind_extra_test.go
+++ b/graft/coreth/accounts/abi/bind/bind_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bind_test

--- a/graft/coreth/accounts/abi/bind/bind_test.go
+++ b/graft/coreth/accounts/abi/bind/bind_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/template.go
+++ b/graft/coreth/accounts/abi/bind/template.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/util.go
+++ b/graft/coreth/accounts/abi/bind/util.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/bind/util_test.go
+++ b/graft/coreth/accounts/abi/bind/util_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/doc.go
+++ b/graft/coreth/accounts/abi/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/error.go
+++ b/graft/coreth/accounts/abi/error.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/error_handling.go
+++ b/graft/coreth/accounts/abi/error_handling.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/event.go
+++ b/graft/coreth/accounts/abi/event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/event_test.go
+++ b/graft/coreth/accounts/abi/event_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/method.go
+++ b/graft/coreth/accounts/abi/method.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/method_test.go
+++ b/graft/coreth/accounts/abi/method_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/pack.go
+++ b/graft/coreth/accounts/abi/pack.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/pack_test.go
+++ b/graft/coreth/accounts/abi/pack_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/packing_test.go
+++ b/graft/coreth/accounts/abi/packing_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/reflect.go
+++ b/graft/coreth/accounts/abi/reflect.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/reflect_test.go
+++ b/graft/coreth/accounts/abi/reflect_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/topics.go
+++ b/graft/coreth/accounts/abi/topics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/topics_test.go
+++ b/graft/coreth/accounts/abi/topics_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/type.go
+++ b/graft/coreth/accounts/abi/type.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/type_test.go
+++ b/graft/coreth/accounts/abi/type_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/unpack.go
+++ b/graft/coreth/accounts/abi/unpack.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/unpack_test.go
+++ b/graft/coreth/accounts/abi/unpack_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/accounts/abi/utils.go
+++ b/graft/coreth/accounts/abi/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/cmd/simulator/config/flags.go
+++ b/graft/coreth/cmd/simulator/config/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/coreth/cmd/simulator/key/key.go
+++ b/graft/coreth/cmd/simulator/key/key.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package key

--- a/graft/coreth/cmd/simulator/load/funder.go
+++ b/graft/coreth/cmd/simulator/load/funder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/graft/coreth/cmd/simulator/load/loader.go
+++ b/graft/coreth/cmd/simulator/load/loader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/graft/coreth/cmd/simulator/load/worker.go
+++ b/graft/coreth/cmd/simulator/load/worker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/graft/coreth/cmd/simulator/main/main.go
+++ b/graft/coreth/cmd/simulator/main/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/coreth/cmd/simulator/metrics/metrics.go
+++ b/graft/coreth/cmd/simulator/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/graft/coreth/cmd/simulator/txs/agent.go
+++ b/graft/coreth/cmd/simulator/txs/agent.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/graft/coreth/cmd/simulator/txs/tx_generator.go
+++ b/graft/coreth/cmd/simulator/txs/tx_generator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/graft/coreth/consensus/consensus.go
+++ b/graft/coreth/consensus/consensus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/consensus/dummy/consensus.go
+++ b/graft/coreth/consensus/dummy/consensus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dummy

--- a/graft/coreth/consensus/errors.go
+++ b/graft/coreth/consensus/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/contracts/contracts/interfaces/IWarpMessenger.sol
+++ b/graft/coreth/contracts/contracts/interfaces/IWarpMessenger.sol
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // SPDX-License-Identifier: MIT

--- a/graft/coreth/core/bench_test.go
+++ b/graft/coreth/core/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/block_validator.go
+++ b/graft/coreth/core/block_validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/block_validator_test.go
+++ b/graft/coreth/core/block_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/blockchain_ext.go
+++ b/graft/coreth/core/blockchain_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/blockchain_ext_test.go
+++ b/graft/coreth/core/blockchain_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/blockchain_iterator.go
+++ b/graft/coreth/core/blockchain_iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/blockchain_log_test.go
+++ b/graft/coreth/core/blockchain_log_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/blockchain_reader.go
+++ b/graft/coreth/core/blockchain_reader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/blockchain_repair_test.go
+++ b/graft/coreth/core/blockchain_repair_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/blockchain_sethead_test.go
+++ b/graft/coreth/core/blockchain_sethead_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/blockchain_snapshot_test.go
+++ b/graft/coreth/core/blockchain_snapshot_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/blockchain_test.go
+++ b/graft/coreth/core/blockchain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/bloom_indexer.go
+++ b/graft/coreth/core/bloom_indexer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/bounded_buffer.go
+++ b/graft/coreth/core/bounded_buffer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/chain_indexer.go
+++ b/graft/coreth/core/chain_indexer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/chain_indexer_test.go
+++ b/graft/coreth/core/chain_indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/chain_makers.go
+++ b/graft/coreth/core/chain_makers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/chain_makers_test.go
+++ b/graft/coreth/core/chain_makers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/coretest/test_indices.go
+++ b/graft/coreth/core/coretest/test_indices.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package coretest

--- a/graft/coreth/core/error.go
+++ b/graft/coreth/core/error.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/events.go
+++ b/graft/coreth/core/events.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/evm.go
+++ b/graft/coreth/core/evm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/extstate/database.go
+++ b/graft/coreth/core/extstate/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extstate

--- a/graft/coreth/core/extstate/options.go
+++ b/graft/coreth/core/extstate/options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extstate

--- a/graft/coreth/core/extstate/state_object_test.go
+++ b/graft/coreth/core/extstate/state_object_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extstate

--- a/graft/coreth/core/extstate/statedb.go
+++ b/graft/coreth/core/extstate/statedb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extstate

--- a/graft/coreth/core/extstate/statedb_multicoin_test.go
+++ b/graft/coreth/core/extstate/statedb_multicoin_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extstate

--- a/graft/coreth/core/fifo_cache.go
+++ b/graft/coreth/core/fifo_cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/gaspool.go
+++ b/graft/coreth/core/gaspool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/genesis.go
+++ b/graft/coreth/core/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/genesis_extra_test.go
+++ b/graft/coreth/core/genesis_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/genesis_test.go
+++ b/graft/coreth/core/genesis_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/headerchain.go
+++ b/graft/coreth/core/headerchain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/headerchain_test.go
+++ b/graft/coreth/core/headerchain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/main_test.go
+++ b/graft/coreth/core/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/mkalloc.go
+++ b/graft/coreth/core/mkalloc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/predicate_check.go
+++ b/graft/coreth/core/predicate_check.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/predicate_check_test.go
+++ b/graft/coreth/core/predicate_check_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/rlp_test.go
+++ b/graft/coreth/core/rlp_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/sender_cacher.go
+++ b/graft/coreth/core/sender_cacher.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/pruner/bloom.go
+++ b/graft/coreth/core/state/pruner/bloom.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/pruner/pruner.go
+++ b/graft/coreth/core/state/pruner/pruner.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/context.go
+++ b/graft/coreth/core/state/snapshot/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/conversion.go
+++ b/graft/coreth/core/state/snapshot/conversion.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/difflayer.go
+++ b/graft/coreth/core/state/snapshot/difflayer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/difflayer_test.go
+++ b/graft/coreth/core/state/snapshot/difflayer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/disklayer.go
+++ b/graft/coreth/core/state/snapshot/disklayer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/disklayer_test.go
+++ b/graft/coreth/core/state/snapshot/disklayer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/generate.go
+++ b/graft/coreth/core/state/snapshot/generate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/generate_test.go
+++ b/graft/coreth/core/state/snapshot/generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/iterator.go
+++ b/graft/coreth/core/state/snapshot/iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/iterator_binary.go
+++ b/graft/coreth/core/state/snapshot/iterator_binary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/iterator_fast.go
+++ b/graft/coreth/core/state/snapshot/iterator_fast.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/iterator_test.go
+++ b/graft/coreth/core/state/snapshot/iterator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/journal.go
+++ b/graft/coreth/core/state/snapshot/journal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/snapshot.go
+++ b/graft/coreth/core/state/snapshot/snapshot.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/snapshot_ext.go
+++ b/graft/coreth/core/state/snapshot/snapshot_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snapshot

--- a/graft/coreth/core/state/snapshot/snapshot_test.go
+++ b/graft/coreth/core/state/snapshot/snapshot_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/utils.go
+++ b/graft/coreth/core/state/snapshot/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/wipe.go
+++ b/graft/coreth/core/state/snapshot/wipe.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state/snapshot/wipe_test.go
+++ b/graft/coreth/core/state/snapshot/wipe_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state_manager.go
+++ b/graft/coreth/core/state_manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state_manager_test.go
+++ b/graft/coreth/core/state_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/state_processor.go
+++ b/graft/coreth/core/state_processor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state_processor_ext.go
+++ b/graft/coreth/core/state_processor_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/coreth/core/state_processor_test.go
+++ b/graft/coreth/core/state_processor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state_transition.go
+++ b/graft/coreth/core/state_transition.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/state_transition_test.go
+++ b/graft/coreth/core/state_transition_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txindexer.go
+++ b/graft/coreth/core/txindexer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txindexer_test.go
+++ b/graft/coreth/core/txindexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/blobpool.go
+++ b/graft/coreth/core/txpool/blobpool/blobpool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/blobpool_test.go
+++ b/graft/coreth/core/txpool/blobpool/blobpool_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/config.go
+++ b/graft/coreth/core/txpool/blobpool/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/evictheap.go
+++ b/graft/coreth/core/txpool/blobpool/evictheap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/evictheap_test.go
+++ b/graft/coreth/core/txpool/blobpool/evictheap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/interface.go
+++ b/graft/coreth/core/txpool/blobpool/interface.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/limbo.go
+++ b/graft/coreth/core/txpool/blobpool/limbo.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/metrics.go
+++ b/graft/coreth/core/txpool/blobpool/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/priority.go
+++ b/graft/coreth/core/txpool/blobpool/priority.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/priority_test.go
+++ b/graft/coreth/core/txpool/blobpool/priority_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/slotter.go
+++ b/graft/coreth/core/txpool/blobpool/slotter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/blobpool/slotter_test.go
+++ b/graft/coreth/core/txpool/blobpool/slotter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/errors.go
+++ b/graft/coreth/core/txpool/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/legacypool/journal.go
+++ b/graft/coreth/core/txpool/legacypool/journal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/legacypool/legacypool.go
+++ b/graft/coreth/core/txpool/legacypool/legacypool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/legacypool/legacypool2_test.go
+++ b/graft/coreth/core/txpool/legacypool/legacypool2_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/legacypool/legacypool_test.go
+++ b/graft/coreth/core/txpool/legacypool/legacypool_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/legacypool/list.go
+++ b/graft/coreth/core/txpool/legacypool/list.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/legacypool/list_test.go
+++ b/graft/coreth/core/txpool/legacypool/list_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/legacypool/noncer.go
+++ b/graft/coreth/core/txpool/legacypool/noncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/subpool.go
+++ b/graft/coreth/core/txpool/subpool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/txpool.go
+++ b/graft/coreth/core/txpool/txpool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/txpool/validation.go
+++ b/graft/coreth/core/txpool/validation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/types.go
+++ b/graft/coreth/core/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/vm/runtime/doc.go
+++ b/graft/coreth/core/vm/runtime/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/vm/runtime/env.go
+++ b/graft/coreth/core/vm/runtime/env.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/vm/runtime/runtime.go
+++ b/graft/coreth/core/vm/runtime/runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/vm/runtime/runtime_example_test.go
+++ b/graft/coreth/core/vm/runtime/runtime_example_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/core/vm/runtime/runtime_test.go
+++ b/graft/coreth/core/vm/runtime/runtime_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/api.go
+++ b/graft/coreth/eth/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/api_admin.go
+++ b/graft/coreth/eth/api_admin.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/api_backend.go
+++ b/graft/coreth/eth/api_backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/api_backend_test.go
+++ b/graft/coreth/eth/api_backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/api_debug.go
+++ b/graft/coreth/eth/api_debug.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/api_debug_test.go
+++ b/graft/coreth/eth/api_debug_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/backend.go
+++ b/graft/coreth/eth/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/bloombits.go
+++ b/graft/coreth/eth/bloombits.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/chain_with_final_block.go
+++ b/graft/coreth/eth/chain_with_final_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //nolint:unused

--- a/graft/coreth/eth/ethconfig/config.go
+++ b/graft/coreth/eth/ethconfig/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/filters/api.go
+++ b/graft/coreth/eth/filters/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/filters/api_test.go
+++ b/graft/coreth/eth/filters/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/filters/bench_test.go
+++ b/graft/coreth/eth/filters/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/filters/filter.go
+++ b/graft/coreth/eth/filters/filter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/filters/filter_system.go
+++ b/graft/coreth/eth/filters/filter_system.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/filters/filter_system_test.go
+++ b/graft/coreth/eth/filters/filter_system_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/filters/filter_test.go
+++ b/graft/coreth/eth/filters/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/gasestimator/gasestimator.go
+++ b/graft/coreth/eth/gasestimator/gasestimator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/gasprice/fee_info_provider.go
+++ b/graft/coreth/eth/gasprice/fee_info_provider.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/gasprice/fee_info_provider_test.go
+++ b/graft/coreth/eth/gasprice/fee_info_provider_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gasprice

--- a/graft/coreth/eth/gasprice/feehistory.go
+++ b/graft/coreth/eth/gasprice/feehistory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/gasprice/feehistory_test.go
+++ b/graft/coreth/eth/gasprice/feehistory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/gasprice/gasprice.go
+++ b/graft/coreth/eth/gasprice/gasprice.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/gasprice/gasprice_test.go
+++ b/graft/coreth/eth/gasprice/gasprice_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/state_accessor.go
+++ b/graft/coreth/eth/state_accessor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/tracers/api.go
+++ b/graft/coreth/eth/tracers/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/tracers/api_test.go
+++ b/graft/coreth/eth/tracers/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/tracers/tracers.go
+++ b/graft/coreth/eth/tracers/tracers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/tracers/tracers_test.go
+++ b/graft/coreth/eth/tracers/tracers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/tracers/tracker.go
+++ b/graft/coreth/eth/tracers/tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/eth/tracers/tracker_test.go
+++ b/graft/coreth/eth/tracers/tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/ethclient/corethclient/corethclient.go
+++ b/graft/coreth/ethclient/corethclient/corethclient.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/ethclient/ethclient.go
+++ b/graft/coreth/ethclient/ethclient.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/ethclient/ethclient_ext.go
+++ b/graft/coreth/ethclient/ethclient_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ethclient

--- a/graft/coreth/ethclient/signer.go
+++ b/graft/coreth/ethclient/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/ethclient/simulated/backend.go
+++ b/graft/coreth/ethclient/simulated/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/ethclient/simulated/backend_test.go
+++ b/graft/coreth/ethclient/simulated/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/ethclient/simulated/options.go
+++ b/graft/coreth/ethclient/simulated/options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/ethclient/simulated/options_test.go
+++ b/graft/coreth/ethclient/simulated/options_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/interfaces/interfaces.go
+++ b/graft/coreth/interfaces/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interfaces

--- a/graft/coreth/internal/blocktest/test_hash.go
+++ b/graft/coreth/internal/blocktest/test_hash.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/debug/api.go
+++ b/graft/coreth/internal/debug/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/debug/flags.go
+++ b/graft/coreth/internal/debug/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/debug/loudpanic.go
+++ b/graft/coreth/internal/debug/loudpanic.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/debug/trace.go
+++ b/graft/coreth/internal/debug/trace.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/ethapi/addrlock.go
+++ b/graft/coreth/internal/ethapi/addrlock.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/ethapi/api.coreth.go
+++ b/graft/coreth/internal/ethapi/api.coreth.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ethapi

--- a/graft/coreth/internal/ethapi/api.coreth_test.go
+++ b/graft/coreth/internal/ethapi/api.coreth_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ethapi

--- a/graft/coreth/internal/ethapi/api.go
+++ b/graft/coreth/internal/ethapi/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/ethapi/api_extra.go
+++ b/graft/coreth/internal/ethapi/api_extra.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ethapi

--- a/graft/coreth/internal/ethapi/api_extra_test.go
+++ b/graft/coreth/internal/ethapi/api_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ethapi

--- a/graft/coreth/internal/ethapi/api_test.go
+++ b/graft/coreth/internal/ethapi/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/ethapi/backend.go
+++ b/graft/coreth/internal/ethapi/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/ethapi/errors.go
+++ b/graft/coreth/internal/ethapi/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/ethapi/transaction_args.go
+++ b/graft/coreth/internal/ethapi/transaction_args.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/ethapi/transaction_args_test.go
+++ b/graft/coreth/internal/ethapi/transaction_args_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/flags/categories.go
+++ b/graft/coreth/internal/flags/categories.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/flags/helpers.go
+++ b/graft/coreth/internal/flags/helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/shutdowncheck/shutdown_tracker.go
+++ b/graft/coreth/internal/shutdowncheck/shutdown_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/version/vcs.go
+++ b/graft/coreth/internal/version/vcs.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/internal/version/version.go
+++ b/graft/coreth/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/log/format.go
+++ b/graft/coreth/log/format.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/log/handler.go
+++ b/graft/coreth/log/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/log/logger.go
+++ b/graft/coreth/log/logger.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/miner/miner.go
+++ b/graft/coreth/miner/miner.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/miner/ordering.go
+++ b/graft/coreth/miner/ordering.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/miner/ordering_test.go
+++ b/graft/coreth/miner/ordering_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/miner/worker.go
+++ b/graft/coreth/miner/worker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/nativeasset/contract.go
+++ b/graft/coreth/nativeasset/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeasset

--- a/graft/coreth/nativeasset/contract_test.go
+++ b/graft/coreth/nativeasset/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeasset_test

--- a/graft/coreth/network/network.go
+++ b/graft/coreth/network/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/coreth/network/network_test.go
+++ b/graft/coreth/network/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/coreth/network/peer_tracker.go
+++ b/graft/coreth/network/peer_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/coreth/network/peer_tracker_test.go
+++ b/graft/coreth/network/peer_tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/coreth/network/stats/stats.go
+++ b/graft/coreth/network/stats/stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stats

--- a/graft/coreth/network/waiting_handler.go
+++ b/graft/coreth/network/waiting_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/coreth/node/api.go
+++ b/graft/coreth/node/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/node/config.go
+++ b/graft/coreth/node/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/node/defaults.go
+++ b/graft/coreth/node/defaults.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/node/errors.go
+++ b/graft/coreth/node/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/node/node.go
+++ b/graft/coreth/node/node.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/params/config.go
+++ b/graft/coreth/params/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/params/config_extra.go
+++ b/graft/coreth/params/config_extra.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/coreth/params/config_extra_test.go
+++ b/graft/coreth/params/config_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/coreth/params/config_libevm.go
+++ b/graft/coreth/params/config_libevm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/coreth/params/config_test.go
+++ b/graft/coreth/params/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/params/denomination.go
+++ b/graft/coreth/params/denomination.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/params/extras/config.go
+++ b/graft/coreth/params/extras/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/coreth/params/extras/config_extra_test.go
+++ b/graft/coreth/params/extras/config_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/coreth/params/extras/extrastest/test_rules.go
+++ b/graft/coreth/params/extras/extrastest/test_rules.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extrastest

--- a/graft/coreth/params/extras/network_upgrades.go
+++ b/graft/coreth/params/extras/network_upgrades.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/coreth/params/extras/precompile_upgrade.go
+++ b/graft/coreth/params/extras/precompile_upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/coreth/params/extras/precompiles.go
+++ b/graft/coreth/params/extras/precompiles.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/coreth/params/extras/rules.go
+++ b/graft/coreth/params/extras/rules.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/coreth/params/hooks_libevm.go
+++ b/graft/coreth/params/hooks_libevm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/coreth/params/network_params.go
+++ b/graft/coreth/params/network_params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/params/paramstest/forks.go
+++ b/graft/coreth/params/paramstest/forks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package paramstest

--- a/graft/coreth/params/protocol_params_ext.go
+++ b/graft/coreth/params/protocol_params_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/coreth/params/protocol_params_test.go
+++ b/graft/coreth/params/protocol_params_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/coreth/params/version.go
+++ b/graft/coreth/params/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/plugin/evm/admin.go
+++ b/graft/coreth/plugin/evm/admin.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/atomic/atomictest/ops.go
+++ b/graft/coreth/plugin/evm/atomic/atomictest/ops.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomictest

--- a/graft/coreth/plugin/evm/atomic/atomictest/shared_memories.go
+++ b/graft/coreth/plugin/evm/atomic/atomictest/shared_memories.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomictest

--- a/graft/coreth/plugin/evm/atomic/atomictest/tx.go
+++ b/graft/coreth/plugin/evm/atomic/atomictest/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomictest

--- a/graft/coreth/plugin/evm/atomic/codec.go
+++ b/graft/coreth/plugin/evm/atomic/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/export_tx.go
+++ b/graft/coreth/plugin/evm/atomic/export_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/gossip.go
+++ b/graft/coreth/plugin/evm/atomic/gossip.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/gossip_test.go
+++ b/graft/coreth/plugin/evm/atomic/gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/import_tx.go
+++ b/graft/coreth/plugin/evm/atomic/import_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/metadata.go
+++ b/graft/coreth/plugin/evm/atomic/metadata.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/params.go
+++ b/graft/coreth/plugin/evm/atomic/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/state/atomic_backend.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/coreth/plugin/evm/atomic/state/atomic_repository.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_repository.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/coreth/plugin/evm/atomic/state/atomic_repository_test.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_repository_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/coreth/plugin/evm/atomic/state/atomic_state.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/coreth/plugin/evm/atomic/state/atomic_trie.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_trie.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/coreth/plugin/evm/atomic/state/atomic_trie_iterator.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_trie_iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/coreth/plugin/evm/atomic/state/atomic_trie_iterator_test.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_trie_iterator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/coreth/plugin/evm/atomic/state/atomic_trie_test.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_trie_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/coreth/plugin/evm/atomic/status.go
+++ b/graft/coreth/plugin/evm/atomic/status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/sync/extender.go
+++ b/graft/coreth/plugin/evm/atomic/sync/extender.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/plugin/evm/atomic/sync/leaf_handler.go
+++ b/graft/coreth/plugin/evm/atomic/sync/leaf_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/plugin/evm/atomic/sync/summary.go
+++ b/graft/coreth/plugin/evm/atomic/sync/summary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/plugin/evm/atomic/sync/summary_parser.go
+++ b/graft/coreth/plugin/evm/atomic/sync/summary_parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/plugin/evm/atomic/sync/summary_provider.go
+++ b/graft/coreth/plugin/evm/atomic/sync/summary_provider.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/plugin/evm/atomic/sync/summary_test.go
+++ b/graft/coreth/plugin/evm/atomic/sync/summary_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/plugin/evm/atomic/sync/syncer.go
+++ b/graft/coreth/plugin/evm/atomic/sync/syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/plugin/evm/atomic/sync/syncer_test.go
+++ b/graft/coreth/plugin/evm/atomic/sync/syncer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/plugin/evm/atomic/tx.go
+++ b/graft/coreth/plugin/evm/atomic/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/tx_test.go
+++ b/graft/coreth/plugin/evm/atomic/tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/graft/coreth/plugin/evm/atomic/txpool/mempool.go
+++ b/graft/coreth/plugin/evm/atomic/txpool/mempool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txpool

--- a/graft/coreth/plugin/evm/atomic/txpool/mempool_test.go
+++ b/graft/coreth/plugin/evm/atomic/txpool/mempool_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txpool

--- a/graft/coreth/plugin/evm/atomic/txpool/metrics.go
+++ b/graft/coreth/plugin/evm/atomic/txpool/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txpool

--- a/graft/coreth/plugin/evm/atomic/txpool/tx_heap.go
+++ b/graft/coreth/plugin/evm/atomic/txpool/tx_heap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txpool

--- a/graft/coreth/plugin/evm/atomic/txpool/tx_heap_test.go
+++ b/graft/coreth/plugin/evm/atomic/txpool/tx_heap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txpool

--- a/graft/coreth/plugin/evm/atomic/txpool/txs.go
+++ b/graft/coreth/plugin/evm/atomic/txpool/txs.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txpool

--- a/graft/coreth/plugin/evm/atomic/vm/api.go
+++ b/graft/coreth/plugin/evm/atomic/vm/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/block_extension.go
+++ b/graft/coreth/plugin/evm/atomic/vm/block_extension.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/bonus_blocks.go
+++ b/graft/coreth/plugin/evm/atomic/vm/bonus_blocks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/export_tx_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/export_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/ext_data_hashes.go
+++ b/graft/coreth/plugin/evm/atomic/vm/ext_data_hashes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/formatting.go
+++ b/graft/coreth/plugin/evm/atomic/vm/formatting.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/import_tx_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/import_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/syncervm_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/syncervm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/tx_gossip_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/tx_gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/tx_semantic_verifier.go
+++ b/graft/coreth/plugin/evm/atomic/vm/tx_semantic_verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/tx_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/vm.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/atomic/vm/vm_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vm

--- a/graft/coreth/plugin/evm/block_builder.go
+++ b/graft/coreth/plugin/evm/block_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/block_builder_test.go
+++ b/graft/coreth/plugin/evm/block_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/client/client.go
+++ b/graft/coreth/plugin/evm/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package client

--- a/graft/coreth/plugin/evm/client/utils.go
+++ b/graft/coreth/plugin/evm/client/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package client

--- a/graft/coreth/plugin/evm/config/config.go
+++ b/graft/coreth/plugin/evm/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/coreth/plugin/evm/config/config_test.go
+++ b/graft/coreth/plugin/evm/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/coreth/plugin/evm/config/constants.go
+++ b/graft/coreth/plugin/evm/config/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/coreth/plugin/evm/config/default_config.go
+++ b/graft/coreth/plugin/evm/config/default_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/coreth/plugin/evm/customheader/base_fee.go
+++ b/graft/coreth/plugin/evm/customheader/base_fee.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/base_fee_test.go
+++ b/graft/coreth/plugin/evm/customheader/base_fee_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/block_gas_cost.go
+++ b/graft/coreth/plugin/evm/customheader/block_gas_cost.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/block_gas_cost_test.go
+++ b/graft/coreth/plugin/evm/customheader/block_gas_cost_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/dynamic_fee_state.go
+++ b/graft/coreth/plugin/evm/customheader/dynamic_fee_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/dynamic_fee_windower.go
+++ b/graft/coreth/plugin/evm/customheader/dynamic_fee_windower.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/dynamic_fee_windower_test.go
+++ b/graft/coreth/plugin/evm/customheader/dynamic_fee_windower_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/extra.go
+++ b/graft/coreth/plugin/evm/customheader/extra.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/extra_test.go
+++ b/graft/coreth/plugin/evm/customheader/extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/gas_limit.go
+++ b/graft/coreth/plugin/evm/customheader/gas_limit.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/gas_limit_test.go
+++ b/graft/coreth/plugin/evm/customheader/gas_limit_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/min_delay_excess.go
+++ b/graft/coreth/plugin/evm/customheader/min_delay_excess.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/min_delay_excess_test.go
+++ b/graft/coreth/plugin/evm/customheader/min_delay_excess_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/time.go
+++ b/graft/coreth/plugin/evm/customheader/time.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customheader/time_test.go
+++ b/graft/coreth/plugin/evm/customheader/time_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/coreth/plugin/evm/customtypes/aliases_test.go
+++ b/graft/coreth/plugin/evm/customtypes/aliases_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/coreth/plugin/evm/customtypes/block_ext.go
+++ b/graft/coreth/plugin/evm/customtypes/block_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/coreth/plugin/evm/customtypes/block_ext_test.go
+++ b/graft/coreth/plugin/evm/customtypes/block_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/coreth/plugin/evm/customtypes/block_test.go
+++ b/graft/coreth/plugin/evm/customtypes/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/plugin/evm/customtypes/hashes_ext.go
+++ b/graft/coreth/plugin/evm/customtypes/hashes_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/coreth/plugin/evm/customtypes/hashing_test.go
+++ b/graft/coreth/plugin/evm/customtypes/hashing_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/plugin/evm/customtypes/header_ext.go
+++ b/graft/coreth/plugin/evm/customtypes/header_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/coreth/plugin/evm/customtypes/header_ext_test.go
+++ b/graft/coreth/plugin/evm/customtypes/header_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/coreth/plugin/evm/customtypes/libevm.go
+++ b/graft/coreth/plugin/evm/customtypes/libevm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/coreth/plugin/evm/customtypes/rlp_fuzzer_test.go
+++ b/graft/coreth/plugin/evm/customtypes/rlp_fuzzer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/plugin/evm/customtypes/state_account_ext.go
+++ b/graft/coreth/plugin/evm/customtypes/state_account_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/coreth/plugin/evm/customtypes/types_test.go
+++ b/graft/coreth/plugin/evm/customtypes/types_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/plugin/evm/eth_gossiper.go
+++ b/graft/coreth/plugin/evm/eth_gossiper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // TODO: move to network

--- a/graft/coreth/plugin/evm/extension/config.go
+++ b/graft/coreth/plugin/evm/extension/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extension

--- a/graft/coreth/plugin/evm/gossip/handler.go
+++ b/graft/coreth/plugin/evm/gossip/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/graft/coreth/plugin/evm/gossip_test.go
+++ b/graft/coreth/plugin/evm/gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/health.go
+++ b/graft/coreth/plugin/evm/health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/libevm.go
+++ b/graft/coreth/plugin/evm/libevm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/log/log.go
+++ b/graft/coreth/plugin/evm/log/log.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package log

--- a/graft/coreth/plugin/evm/log/log_test.go
+++ b/graft/coreth/plugin/evm/log/log_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package log

--- a/graft/coreth/plugin/evm/message/block_request.go
+++ b/graft/coreth/plugin/evm/message/block_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/block_request_test.go
+++ b/graft/coreth/plugin/evm/message/block_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/block_sync_summary.go
+++ b/graft/coreth/plugin/evm/message/block_sync_summary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/block_sync_summary_parser.go
+++ b/graft/coreth/plugin/evm/message/block_sync_summary_parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/block_sync_summary_provider.go
+++ b/graft/coreth/plugin/evm/message/block_sync_summary_provider.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/block_sync_summary_test.go
+++ b/graft/coreth/plugin/evm/message/block_sync_summary_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/code_request.go
+++ b/graft/coreth/plugin/evm/message/code_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/code_request_test.go
+++ b/graft/coreth/plugin/evm/message/code_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/codec.go
+++ b/graft/coreth/plugin/evm/message/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/handler.go
+++ b/graft/coreth/plugin/evm/message/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/leafs_request.go
+++ b/graft/coreth/plugin/evm/message/leafs_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/leafs_request_test.go
+++ b/graft/coreth/plugin/evm/message/leafs_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/request.go
+++ b/graft/coreth/plugin/evm/message/request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/message/syncable.go
+++ b/graft/coreth/plugin/evm/message/syncable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/coreth/plugin/evm/network_handler.go
+++ b/graft/coreth/plugin/evm/network_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/prestate_tracer_test.go
+++ b/graft/coreth/plugin/evm/prestate_tracer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/syncervm_test.go
+++ b/graft/coreth/plugin/evm/syncervm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/tempextrastest/tempextras_test.go
+++ b/graft/coreth/plugin/evm/tempextrastest/tempextras_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package tempextrastest exists solely to test [evm.WithTempRegisteredLibEVMExtras]

--- a/graft/coreth/plugin/evm/tx_gossip_test.go
+++ b/graft/coreth/plugin/evm/tx_gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/upgrade/ap0/params.go
+++ b/graft/coreth/plugin/evm/upgrade/ap0/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // AP0 defines constants used during the initial network launch.

--- a/graft/coreth/plugin/evm/upgrade/ap1/params.go
+++ b/graft/coreth/plugin/evm/upgrade/ap1/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // AP1 defines constants used after the Apricot Phase 1 upgrade.

--- a/graft/coreth/plugin/evm/upgrade/ap3/window.go
+++ b/graft/coreth/plugin/evm/upgrade/ap3/window.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // AP3 defines the dynamic fee window used after the Apricot Phase 3 upgrade.

--- a/graft/coreth/plugin/evm/upgrade/ap3/window_test.go
+++ b/graft/coreth/plugin/evm/upgrade/ap3/window_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ap3

--- a/graft/coreth/plugin/evm/upgrade/ap4/cost.go
+++ b/graft/coreth/plugin/evm/upgrade/ap4/cost.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // AP4 implements the block gas cost logic activated by the Apricot Phase 4

--- a/graft/coreth/plugin/evm/upgrade/ap4/cost_test.go
+++ b/graft/coreth/plugin/evm/upgrade/ap4/cost_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ap4

--- a/graft/coreth/plugin/evm/upgrade/ap5/params.go
+++ b/graft/coreth/plugin/evm/upgrade/ap5/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // AP5 defines constants used after the Apricot Phase 5 upgrade.

--- a/graft/coreth/plugin/evm/upgrade/cortina/params.go
+++ b/graft/coreth/plugin/evm/upgrade/cortina/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Cortina defines constants used after the Cortina upgrade.

--- a/graft/coreth/plugin/evm/upgrade/etna/params.go
+++ b/graft/coreth/plugin/evm/upgrade/etna/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Etna defines constants used after the Etna upgrade.

--- a/graft/coreth/plugin/evm/version.go
+++ b/graft/coreth/plugin/evm/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/vm.go
+++ b/graft/coreth/plugin/evm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/vm_database.go
+++ b/graft/coreth/plugin/evm/vm_database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/vm_extensible.go
+++ b/graft/coreth/plugin/evm/vm_extensible.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/vm_test.go
+++ b/graft/coreth/plugin/evm/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/vm_warp_test.go
+++ b/graft/coreth/plugin/evm/vm_warp_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/evm/vmerrors/errors.go
+++ b/graft/coreth/plugin/evm/vmerrors/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmerrors

--- a/graft/coreth/plugin/evm/vmsync/client.go
+++ b/graft/coreth/plugin/evm/vmsync/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmsync

--- a/graft/coreth/plugin/evm/vmsync/doubles_test.go
+++ b/graft/coreth/plugin/evm/vmsync/doubles_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmsync

--- a/graft/coreth/plugin/evm/vmsync/executor_static.go
+++ b/graft/coreth/plugin/evm/vmsync/executor_static.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmsync

--- a/graft/coreth/plugin/evm/vmsync/registry.go
+++ b/graft/coreth/plugin/evm/vmsync/registry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmsync

--- a/graft/coreth/plugin/evm/vmsync/registry_test.go
+++ b/graft/coreth/plugin/evm/vmsync/registry_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmsync

--- a/graft/coreth/plugin/evm/vmsync/server.go
+++ b/graft/coreth/plugin/evm/vmsync/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmsync

--- a/graft/coreth/plugin/evm/vmtest/genesis.go
+++ b/graft/coreth/plugin/evm/vmtest/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmtest

--- a/graft/coreth/plugin/evm/vmtest/test_syncervm.go
+++ b/graft/coreth/plugin/evm/vmtest/test_syncervm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmtest

--- a/graft/coreth/plugin/evm/vmtest/test_vm.go
+++ b/graft/coreth/plugin/evm/vmtest/test_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmtest

--- a/graft/coreth/plugin/evm/wrapped_block.go
+++ b/graft/coreth/plugin/evm/wrapped_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/coreth/plugin/factory/factory.go
+++ b/graft/coreth/plugin/factory/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package factory

--- a/graft/coreth/plugin/keys.go
+++ b/graft/coreth/plugin/keys.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/coreth/plugin/main.go
+++ b/graft/coreth/plugin/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/coreth/plugin/params.go
+++ b/graft/coreth/plugin/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/coreth/precompile/contract/contract.go
+++ b/graft/coreth/precompile/contract/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contract

--- a/graft/coreth/precompile/contract/interfaces.go
+++ b/graft/coreth/precompile/contract/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Defines the interface for the configuration and execution of a precompile contract

--- a/graft/coreth/precompile/contract/utils.go
+++ b/graft/coreth/precompile/contract/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contract

--- a/graft/coreth/precompile/contract/utils_test.go
+++ b/graft/coreth/precompile/contract/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contract

--- a/graft/coreth/precompile/contracts/warp/config.go
+++ b/graft/coreth/precompile/contracts/warp/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/precompile/contracts/warp/config_test.go
+++ b/graft/coreth/precompile/contracts/warp/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/precompile/contracts/warp/contract.go
+++ b/graft/coreth/precompile/contracts/warp/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/precompile/contracts/warp/contract_test.go
+++ b/graft/coreth/precompile/contracts/warp/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/precompile/contracts/warp/contract_warp_handler.go
+++ b/graft/coreth/precompile/contracts/warp/contract_warp_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/precompile/contracts/warp/module.go
+++ b/graft/coreth/precompile/contracts/warp/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/precompile/contracts/warp/predicate_test.go
+++ b/graft/coreth/precompile/contracts/warp/predicate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/precompile/modules/module.go
+++ b/graft/coreth/precompile/modules/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package modules

--- a/graft/coreth/precompile/modules/registerer.go
+++ b/graft/coreth/precompile/modules/registerer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package modules

--- a/graft/coreth/precompile/modules/registerer_test.go
+++ b/graft/coreth/precompile/modules/registerer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package modules

--- a/graft/coreth/precompile/precompileconfig/config.go
+++ b/graft/coreth/precompile/precompileconfig/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Defines the stateless interface for unmarshalling an arbitrary config of a precompile

--- a/graft/coreth/precompile/precompileconfig/upgradeable.go
+++ b/graft/coreth/precompile/precompileconfig/upgradeable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompileconfig

--- a/graft/coreth/precompile/precompiletest/test_config.go
+++ b/graft/coreth/precompile/precompiletest/test_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompiletest

--- a/graft/coreth/precompile/precompiletest/test_precompile.go
+++ b/graft/coreth/precompile/precompiletest/test_precompile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompiletest

--- a/graft/coreth/precompile/precompiletest/test_predicate.go
+++ b/graft/coreth/precompile/precompiletest/test_predicate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompiletest

--- a/graft/coreth/precompile/registry/registry.go
+++ b/graft/coreth/precompile/registry/registry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Module to facilitate the registration of precompiles and their configuration.

--- a/graft/coreth/rpc/client.go
+++ b/graft/coreth/rpc/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/client_opt.go
+++ b/graft/coreth/rpc/client_opt.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/client_opt_test.go
+++ b/graft/coreth/rpc/client_opt_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/client_test.go
+++ b/graft/coreth/rpc/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/context_headers.go
+++ b/graft/coreth/rpc/context_headers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/doc.go
+++ b/graft/coreth/rpc/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/errors.go
+++ b/graft/coreth/rpc/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/handler.go
+++ b/graft/coreth/rpc/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/http.go
+++ b/graft/coreth/rpc/http.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/http_test.go
+++ b/graft/coreth/rpc/http_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/inproc.go
+++ b/graft/coreth/rpc/inproc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/json.go
+++ b/graft/coreth/rpc/json.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/main_test.go
+++ b/graft/coreth/rpc/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/metrics.go
+++ b/graft/coreth/rpc/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/server.go
+++ b/graft/coreth/rpc/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/server_test.go
+++ b/graft/coreth/rpc/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/service.go
+++ b/graft/coreth/rpc/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/subscription.go
+++ b/graft/coreth/rpc/subscription.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/subscription_test.go
+++ b/graft/coreth/rpc/subscription_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/testservice_test.go
+++ b/graft/coreth/rpc/testservice_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/types.go
+++ b/graft/coreth/rpc/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/types_test.go
+++ b/graft/coreth/rpc/types_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/websocket.go
+++ b/graft/coreth/rpc/websocket.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/rpc/websocket_test.go
+++ b/graft/coreth/rpc/websocket_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/sync/blocksync/syncer.go
+++ b/graft/coreth/sync/blocksync/syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocksync

--- a/graft/coreth/sync/blocksync/syncer_test.go
+++ b/graft/coreth/sync/blocksync/syncer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocksync

--- a/graft/coreth/sync/client/client.go
+++ b/graft/coreth/sync/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/coreth/sync/client/client_test.go
+++ b/graft/coreth/sync/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/coreth/sync/client/leaf_syncer.go
+++ b/graft/coreth/sync/client/leaf_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/coreth/sync/client/stats/stats.go
+++ b/graft/coreth/sync/client/stats/stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stats

--- a/graft/coreth/sync/client/test_client.go
+++ b/graft/coreth/sync/client/test_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/coreth/sync/client/test_network.go
+++ b/graft/coreth/sync/client/test_network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/coreth/sync/handlers/block_request.go
+++ b/graft/coreth/sync/handlers/block_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/coreth/sync/handlers/block_request_test.go
+++ b/graft/coreth/sync/handlers/block_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/coreth/sync/handlers/code_request.go
+++ b/graft/coreth/sync/handlers/code_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/coreth/sync/handlers/code_request_test.go
+++ b/graft/coreth/sync/handlers/code_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/coreth/sync/handlers/handler.go
+++ b/graft/coreth/sync/handlers/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/coreth/sync/handlers/leafs_request.go
+++ b/graft/coreth/sync/handlers/leafs_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/coreth/sync/handlers/leafs_request_test.go
+++ b/graft/coreth/sync/handlers/leafs_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/coreth/sync/handlers/stats/stats.go
+++ b/graft/coreth/sync/handlers/stats/stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stats

--- a/graft/coreth/sync/handlers/stats/statstest/test_stats.go
+++ b/graft/coreth/sync/handlers/stats/statstest/test_stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statstest

--- a/graft/coreth/sync/handlers/test_providers.go
+++ b/graft/coreth/sync/handlers/test_providers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/coreth/sync/statesync/code_queue.go
+++ b/graft/coreth/sync/statesync/code_queue.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/code_queue_test.go
+++ b/graft/coreth/sync/statesync/code_queue_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/code_syncer.go
+++ b/graft/coreth/sync/statesync/code_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/code_syncer_test.go
+++ b/graft/coreth/sync/statesync/code_syncer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/state_syncer.go
+++ b/graft/coreth/sync/statesync/state_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/statesynctest/test_sync.go
+++ b/graft/coreth/sync/statesync/statesynctest/test_sync.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesynctest

--- a/graft/coreth/sync/statesync/statesynctest/test_trie.go
+++ b/graft/coreth/sync/statesync/statesynctest/test_trie.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesynctest

--- a/graft/coreth/sync/statesync/sync_helpers.go
+++ b/graft/coreth/sync/statesync/sync_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/sync_test.go
+++ b/graft/coreth/sync/statesync/sync_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/trie_queue.go
+++ b/graft/coreth/sync/statesync/trie_queue.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/trie_segments.go
+++ b/graft/coreth/sync/statesync/trie_segments.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/trie_sync_stats.go
+++ b/graft/coreth/sync/statesync/trie_sync_stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/trie_sync_stats_test.go
+++ b/graft/coreth/sync/statesync/trie_sync_stats_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/statesync/trie_sync_tasks.go
+++ b/graft/coreth/sync/statesync/trie_sync_tasks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/coreth/sync/syncutils/iterators.go
+++ b/graft/coreth/sync/syncutils/iterators.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncutils

--- a/graft/coreth/sync/types.go
+++ b/graft/coreth/sync/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/coreth/tests/state_test_util.go
+++ b/graft/coreth/tests/state_test_util.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/tests/utils/command.go
+++ b/graft/coreth/tests/utils/command.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/tests/utils/constants.go
+++ b/graft/coreth/tests/utils/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/tests/utils/proposervm.go
+++ b/graft/coreth/tests/utils/proposervm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/tests/utils/subnet.go
+++ b/graft/coreth/tests/utils/subnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/tests/utils/tmpnet.go
+++ b/graft/coreth/tests/utils/tmpnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/tests/warp/warp_test.go
+++ b/graft/coreth/tests/warp/warp_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Implements solidity tests.

--- a/graft/coreth/triedb/hashdb/database.go
+++ b/graft/coreth/triedb/hashdb/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/database.go
+++ b/graft/coreth/triedb/pathdb/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/database_test.go
+++ b/graft/coreth/triedb/pathdb/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/difflayer.go
+++ b/graft/coreth/triedb/pathdb/difflayer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/difflayer_test.go
+++ b/graft/coreth/triedb/pathdb/difflayer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/disklayer.go
+++ b/graft/coreth/triedb/pathdb/disklayer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/errors.go
+++ b/graft/coreth/triedb/pathdb/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/history.go
+++ b/graft/coreth/triedb/pathdb/history.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/history_test.go
+++ b/graft/coreth/triedb/pathdb/history_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/journal.go
+++ b/graft/coreth/triedb/pathdb/journal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/layertree.go
+++ b/graft/coreth/triedb/pathdb/layertree.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/metrics.go
+++ b/graft/coreth/triedb/pathdb/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/nodebuffer.go
+++ b/graft/coreth/triedb/pathdb/nodebuffer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/triedb/pathdb/testutils.go
+++ b/graft/coreth/triedb/pathdb/testutils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/coreth/utils/address_range.go
+++ b/graft/coreth/utils/address_range.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/utils/bounded_workers.go
+++ b/graft/coreth/utils/bounded_workers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/utils/bytes.go
+++ b/graft/coreth/utils/bytes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/utils/bytes_test.go
+++ b/graft/coreth/utils/bytes_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/utils/denomination.go
+++ b/graft/coreth/utils/denomination.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/utils/metered_cache.go
+++ b/graft/coreth/utils/metered_cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/utils/numbers.go
+++ b/graft/coreth/utils/numbers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/utils/numbers_test.go
+++ b/graft/coreth/utils/numbers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/coreth/utils/rand/rand.go
+++ b/graft/coreth/utils/rand/rand.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rand

--- a/graft/coreth/utils/rpc/handler.go
+++ b/graft/coreth/utils/rpc/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/graft/coreth/utils/utilstest/context.go
+++ b/graft/coreth/utils/utilstest/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/coreth/utils/utilstest/key.go
+++ b/graft/coreth/utils/utilstest/key.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/coreth/utils/utilstest/pointer.go
+++ b/graft/coreth/utils/utilstest/pointer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/coreth/utils/utilstest/snow.go
+++ b/graft/coreth/utils/utilstest/snow.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/coreth/utils/utilstest/timeout.go
+++ b/graft/coreth/utils/utilstest/timeout.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/coreth/warp/backend.go
+++ b/graft/coreth/warp/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/warp/backend_test.go
+++ b/graft/coreth/warp/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/warp/client.go
+++ b/graft/coreth/warp/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/warp/service.go
+++ b/graft/coreth/warp/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/warp/verifier_backend.go
+++ b/graft/coreth/warp/verifier_backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/warp/verifier_backend_test.go
+++ b/graft/coreth/warp/verifier_backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/warp/verifier_stats.go
+++ b/graft/coreth/warp/verifier_stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/coreth/warp/warptest/block_client.go
+++ b/graft/coreth/warp/warptest/block_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // warptest exposes common functionality for testing the warp package.

--- a/graft/evm/constants/constants.go
+++ b/graft/evm/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/graft/evm/firewood/account_trie.go
+++ b/graft/evm/firewood/account_trie.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package firewood

--- a/graft/evm/firewood/hash_test.go
+++ b/graft/evm/firewood/hash_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package firewood

--- a/graft/evm/firewood/state.go
+++ b/graft/evm/firewood/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package firewood

--- a/graft/evm/firewood/storage_trie.go
+++ b/graft/evm/firewood/storage_trie.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package firewood

--- a/graft/evm/firewood/triedb.go
+++ b/graft/evm/firewood/triedb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package firewood

--- a/graft/subnet-evm/.github/CONTRIBUTING.md
+++ b/graft/subnet-evm/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Mocks are auto-generated using [mockgen](https://pkg.go.dev/go.uber.org/mock/moc
   - if the file `mocks_generate_test.go` does not exist in the package where the interface is located, create it with content (adapt as needed):
 
     ```go
-    // Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+    // Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
     // See the file LICENSE for licensing terms.
 
     package mypackage

--- a/graft/subnet-evm/accounts/abi/abi.go
+++ b/graft/subnet-evm/accounts/abi/abi.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/abi_extra_test.go
+++ b/graft/subnet-evm/accounts/abi/abi_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package abi

--- a/graft/subnet-evm/accounts/abi/abi_test.go
+++ b/graft/subnet-evm/accounts/abi/abi_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/argument.go
+++ b/graft/subnet-evm/accounts/abi/argument.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/auth.go
+++ b/graft/subnet-evm/accounts/abi/bind/auth.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/backend.go
+++ b/graft/subnet-evm/accounts/abi/bind/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/backends/simulated.go
+++ b/graft/subnet-evm/accounts/abi/bind/backends/simulated.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/base.go
+++ b/graft/subnet-evm/accounts/abi/bind/base.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/base_test.go
+++ b/graft/subnet-evm/accounts/abi/bind/base_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/bind.go
+++ b/graft/subnet-evm/accounts/abi/bind/bind.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/bind_extra.go
+++ b/graft/subnet-evm/accounts/abi/bind/bind_extra.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bind

--- a/graft/subnet-evm/accounts/abi/bind/bind_test.go
+++ b/graft/subnet-evm/accounts/abi/bind/bind_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_bind.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_bind.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_bind_test.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_bind_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_config_template.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_config_template.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompilebind

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_contract_template.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_contract_template.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompilebind

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_event_template.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_event_template.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompilebind

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_module_template.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_module_template.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompilebind

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest/precompile_config_test_template.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest/precompile_config_test_template.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package templatetest

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest/precompile_contract_test_template.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest/precompile_contract_test_template.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package templatetest

--- a/graft/subnet-evm/accounts/abi/bind/template.go
+++ b/graft/subnet-evm/accounts/abi/bind/template.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/util.go
+++ b/graft/subnet-evm/accounts/abi/bind/util.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/bind/util_test.go
+++ b/graft/subnet-evm/accounts/abi/bind/util_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/doc.go
+++ b/graft/subnet-evm/accounts/abi/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/error.go
+++ b/graft/subnet-evm/accounts/abi/error.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/error_handling.go
+++ b/graft/subnet-evm/accounts/abi/error_handling.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/event.go
+++ b/graft/subnet-evm/accounts/abi/event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/event_test.go
+++ b/graft/subnet-evm/accounts/abi/event_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/method.go
+++ b/graft/subnet-evm/accounts/abi/method.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/method_test.go
+++ b/graft/subnet-evm/accounts/abi/method_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/pack.go
+++ b/graft/subnet-evm/accounts/abi/pack.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/pack_test.go
+++ b/graft/subnet-evm/accounts/abi/pack_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/packing_test.go
+++ b/graft/subnet-evm/accounts/abi/packing_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/reflect.go
+++ b/graft/subnet-evm/accounts/abi/reflect.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/reflect_test.go
+++ b/graft/subnet-evm/accounts/abi/reflect_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/topics.go
+++ b/graft/subnet-evm/accounts/abi/topics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/topics_test.go
+++ b/graft/subnet-evm/accounts/abi/topics_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/type.go
+++ b/graft/subnet-evm/accounts/abi/type.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/type_test.go
+++ b/graft/subnet-evm/accounts/abi/type_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/unpack.go
+++ b/graft/subnet-evm/accounts/abi/unpack.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/unpack_test.go
+++ b/graft/subnet-evm/accounts/abi/unpack_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/accounts/abi/utils.go
+++ b/graft/subnet-evm/accounts/abi/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/cmd/precompilegen/main.go
+++ b/graft/subnet-evm/cmd/precompilegen/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/cmd/simulator/config/flags.go
+++ b/graft/subnet-evm/cmd/simulator/config/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/subnet-evm/cmd/simulator/key/key.go
+++ b/graft/subnet-evm/cmd/simulator/key/key.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package key

--- a/graft/subnet-evm/cmd/simulator/load/funder.go
+++ b/graft/subnet-evm/cmd/simulator/load/funder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/graft/subnet-evm/cmd/simulator/load/loader.go
+++ b/graft/subnet-evm/cmd/simulator/load/loader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/graft/subnet-evm/cmd/simulator/load/worker.go
+++ b/graft/subnet-evm/cmd/simulator/load/worker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/graft/subnet-evm/cmd/simulator/main/main.go
+++ b/graft/subnet-evm/cmd/simulator/main/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/subnet-evm/cmd/simulator/metrics/metrics.go
+++ b/graft/subnet-evm/cmd/simulator/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/graft/subnet-evm/cmd/simulator/txs/agent.go
+++ b/graft/subnet-evm/cmd/simulator/txs/agent.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/graft/subnet-evm/cmd/simulator/txs/tx_generator.go
+++ b/graft/subnet-evm/cmd/simulator/txs/tx_generator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/graft/subnet-evm/commontype/fee_config.go
+++ b/graft/subnet-evm/commontype/fee_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package commontype

--- a/graft/subnet-evm/commontype/fee_config_test.go
+++ b/graft/subnet-evm/commontype/fee_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package commontype

--- a/graft/subnet-evm/commontype/test_fee_config.go
+++ b/graft/subnet-evm/commontype/test_fee_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package commontype

--- a/graft/subnet-evm/consensus/consensus.go
+++ b/graft/subnet-evm/consensus/consensus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/consensus/dummy/consensus.go
+++ b/graft/subnet-evm/consensus/dummy/consensus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dummy

--- a/graft/subnet-evm/consensus/errors.go
+++ b/graft/subnet-evm/consensus/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/bench_test.go
+++ b/graft/subnet-evm/core/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/block_validator.go
+++ b/graft/subnet-evm/core/block_validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/block_validator_test.go
+++ b/graft/subnet-evm/core/block_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/blockchain_ext.go
+++ b/graft/subnet-evm/core/blockchain_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/blockchain_ext_test.go
+++ b/graft/subnet-evm/core/blockchain_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/blockchain_iterator.go
+++ b/graft/subnet-evm/core/blockchain_iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/blockchain_log_test.go
+++ b/graft/subnet-evm/core/blockchain_log_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/blockchain_reader.go
+++ b/graft/subnet-evm/core/blockchain_reader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/blockchain_repair_test.go
+++ b/graft/subnet-evm/core/blockchain_repair_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/blockchain_sethead_test.go
+++ b/graft/subnet-evm/core/blockchain_sethead_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/blockchain_snapshot_test.go
+++ b/graft/subnet-evm/core/blockchain_snapshot_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/blockchain_test.go
+++ b/graft/subnet-evm/core/blockchain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/bloom_indexer.go
+++ b/graft/subnet-evm/core/bloom_indexer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/bounded_buffer.go
+++ b/graft/subnet-evm/core/bounded_buffer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/chain_indexer.go
+++ b/graft/subnet-evm/core/chain_indexer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/chain_indexer_test.go
+++ b/graft/subnet-evm/core/chain_indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/chain_makers.go
+++ b/graft/subnet-evm/core/chain_makers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/chain_makers_test.go
+++ b/graft/subnet-evm/core/chain_makers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/coretest/test_indices.go
+++ b/graft/subnet-evm/core/coretest/test_indices.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package coretest

--- a/graft/subnet-evm/core/error.go
+++ b/graft/subnet-evm/core/error.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/events.go
+++ b/graft/subnet-evm/core/events.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/evm.go
+++ b/graft/subnet-evm/core/evm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/extstate/database.go
+++ b/graft/subnet-evm/core/extstate/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extstate

--- a/graft/subnet-evm/core/extstate/options.go
+++ b/graft/subnet-evm/core/extstate/options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extstate

--- a/graft/subnet-evm/core/extstate/statedb.go
+++ b/graft/subnet-evm/core/extstate/statedb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extstate

--- a/graft/subnet-evm/core/fifo_cache.go
+++ b/graft/subnet-evm/core/fifo_cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/gaspool.go
+++ b/graft/subnet-evm/core/gaspool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/genesis.go
+++ b/graft/subnet-evm/core/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/genesis_extra_test.go
+++ b/graft/subnet-evm/core/genesis_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/genesis_test.go
+++ b/graft/subnet-evm/core/genesis_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/headerchain.go
+++ b/graft/subnet-evm/core/headerchain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/headerchain_test.go
+++ b/graft/subnet-evm/core/headerchain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/main_test.go
+++ b/graft/subnet-evm/core/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/mkalloc.go
+++ b/graft/subnet-evm/core/mkalloc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/predicate_check.go
+++ b/graft/subnet-evm/core/predicate_check.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/predicate_check_test.go
+++ b/graft/subnet-evm/core/predicate_check_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/rlp_test.go
+++ b/graft/subnet-evm/core/rlp_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/sender_cacher.go
+++ b/graft/subnet-evm/core/sender_cacher.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/pruner/bloom.go
+++ b/graft/subnet-evm/core/state/pruner/bloom.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/pruner/pruner.go
+++ b/graft/subnet-evm/core/state/pruner/pruner.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/context.go
+++ b/graft/subnet-evm/core/state/snapshot/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/conversion.go
+++ b/graft/subnet-evm/core/state/snapshot/conversion.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/difflayer.go
+++ b/graft/subnet-evm/core/state/snapshot/difflayer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/difflayer_test.go
+++ b/graft/subnet-evm/core/state/snapshot/difflayer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/disklayer.go
+++ b/graft/subnet-evm/core/state/snapshot/disklayer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/disklayer_test.go
+++ b/graft/subnet-evm/core/state/snapshot/disklayer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/generate.go
+++ b/graft/subnet-evm/core/state/snapshot/generate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/generate_test.go
+++ b/graft/subnet-evm/core/state/snapshot/generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/iterator.go
+++ b/graft/subnet-evm/core/state/snapshot/iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/iterator_binary.go
+++ b/graft/subnet-evm/core/state/snapshot/iterator_binary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/iterator_fast.go
+++ b/graft/subnet-evm/core/state/snapshot/iterator_fast.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/iterator_test.go
+++ b/graft/subnet-evm/core/state/snapshot/iterator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/journal.go
+++ b/graft/subnet-evm/core/state/snapshot/journal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/snapshot.go
+++ b/graft/subnet-evm/core/state/snapshot/snapshot.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/snapshot_ext.go
+++ b/graft/subnet-evm/core/state/snapshot/snapshot_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snapshot

--- a/graft/subnet-evm/core/state/snapshot/snapshot_test.go
+++ b/graft/subnet-evm/core/state/snapshot/snapshot_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/utils.go
+++ b/graft/subnet-evm/core/state/snapshot/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/wipe.go
+++ b/graft/subnet-evm/core/state/snapshot/wipe.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/snapshot/wipe_test.go
+++ b/graft/subnet-evm/core/state/snapshot/wipe_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state/trie_prefetcher_extra_test.go
+++ b/graft/subnet-evm/core/state/trie_prefetcher_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/graft/subnet-evm/core/state_manager.go
+++ b/graft/subnet-evm/core/state_manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state_manager_test.go
+++ b/graft/subnet-evm/core/state_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/state_processor.go
+++ b/graft/subnet-evm/core/state_processor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state_processor_ext.go
+++ b/graft/subnet-evm/core/state_processor_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/state_processor_ext_test.go
+++ b/graft/subnet-evm/core/state_processor_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package core

--- a/graft/subnet-evm/core/state_processor_test.go
+++ b/graft/subnet-evm/core/state_processor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/state_transition.go
+++ b/graft/subnet-evm/core/state_transition.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/trie_stress_bench_test.go
+++ b/graft/subnet-evm/core/trie_stress_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txindexer.go
+++ b/graft/subnet-evm/core/txindexer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txindexer_test.go
+++ b/graft/subnet-evm/core/txindexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/blobpool.go
+++ b/graft/subnet-evm/core/txpool/blobpool/blobpool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/blobpool_test.go
+++ b/graft/subnet-evm/core/txpool/blobpool/blobpool_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/config.go
+++ b/graft/subnet-evm/core/txpool/blobpool/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/evictheap.go
+++ b/graft/subnet-evm/core/txpool/blobpool/evictheap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/evictheap_test.go
+++ b/graft/subnet-evm/core/txpool/blobpool/evictheap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/interface.go
+++ b/graft/subnet-evm/core/txpool/blobpool/interface.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/limbo.go
+++ b/graft/subnet-evm/core/txpool/blobpool/limbo.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/metrics.go
+++ b/graft/subnet-evm/core/txpool/blobpool/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/priority.go
+++ b/graft/subnet-evm/core/txpool/blobpool/priority.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/priority_test.go
+++ b/graft/subnet-evm/core/txpool/blobpool/priority_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/slotter.go
+++ b/graft/subnet-evm/core/txpool/blobpool/slotter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/blobpool/slotter_test.go
+++ b/graft/subnet-evm/core/txpool/blobpool/slotter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/errors.go
+++ b/graft/subnet-evm/core/txpool/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/legacypool/journal.go
+++ b/graft/subnet-evm/core/txpool/legacypool/journal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/legacypool/legacypool.go
+++ b/graft/subnet-evm/core/txpool/legacypool/legacypool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/legacypool/legacypool2_test.go
+++ b/graft/subnet-evm/core/txpool/legacypool/legacypool2_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/legacypool/legacypool_test.go
+++ b/graft/subnet-evm/core/txpool/legacypool/legacypool_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/legacypool/list.go
+++ b/graft/subnet-evm/core/txpool/legacypool/list.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/legacypool/list_test.go
+++ b/graft/subnet-evm/core/txpool/legacypool/list_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/legacypool/noncer.go
+++ b/graft/subnet-evm/core/txpool/legacypool/noncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/subpool.go
+++ b/graft/subnet-evm/core/txpool/subpool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/txpool.go
+++ b/graft/subnet-evm/core/txpool/txpool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/txpool/validation.go
+++ b/graft/subnet-evm/core/txpool/validation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/types.go
+++ b/graft/subnet-evm/core/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/vm/runtime/doc.go
+++ b/graft/subnet-evm/core/vm/runtime/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/vm/runtime/env.go
+++ b/graft/subnet-evm/core/vm/runtime/env.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/vm/runtime/runtime.go
+++ b/graft/subnet-evm/core/vm/runtime/runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/vm/runtime/runtime_example_test.go
+++ b/graft/subnet-evm/core/vm/runtime/runtime_example_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/core/vm/runtime/runtime_test.go
+++ b/graft/subnet-evm/core/vm/runtime/runtime_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/api.go
+++ b/graft/subnet-evm/eth/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/api_admin.go
+++ b/graft/subnet-evm/eth/api_admin.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/api_backend.go
+++ b/graft/subnet-evm/eth/api_backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/api_backend_test.go
+++ b/graft/subnet-evm/eth/api_backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/api_debug.go
+++ b/graft/subnet-evm/eth/api_debug.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/api_debug_test.go
+++ b/graft/subnet-evm/eth/api_debug_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/backend.go
+++ b/graft/subnet-evm/eth/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/bloombits.go
+++ b/graft/subnet-evm/eth/bloombits.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/chain_with_final_block.go
+++ b/graft/subnet-evm/eth/chain_with_final_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //nolint:unused

--- a/graft/subnet-evm/eth/ethconfig/config.go
+++ b/graft/subnet-evm/eth/ethconfig/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/filters/api.go
+++ b/graft/subnet-evm/eth/filters/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/filters/api_test.go
+++ b/graft/subnet-evm/eth/filters/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/filters/bench_test.go
+++ b/graft/subnet-evm/eth/filters/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/filters/filter.go
+++ b/graft/subnet-evm/eth/filters/filter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/filters/filter_system.go
+++ b/graft/subnet-evm/eth/filters/filter_system.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/filters/filter_system_test.go
+++ b/graft/subnet-evm/eth/filters/filter_system_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/filters/filter_test.go
+++ b/graft/subnet-evm/eth/filters/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/gasestimator/gasestimator.go
+++ b/graft/subnet-evm/eth/gasestimator/gasestimator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/gasprice/fee_info_provider.go
+++ b/graft/subnet-evm/eth/gasprice/fee_info_provider.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/gasprice/fee_info_provider_test.go
+++ b/graft/subnet-evm/eth/gasprice/fee_info_provider_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gasprice

--- a/graft/subnet-evm/eth/gasprice/feehistory.go
+++ b/graft/subnet-evm/eth/gasprice/feehistory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/gasprice/feehistory_test.go
+++ b/graft/subnet-evm/eth/gasprice/feehistory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/gasprice/gasprice.go
+++ b/graft/subnet-evm/eth/gasprice/gasprice.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/gasprice/gasprice_test.go
+++ b/graft/subnet-evm/eth/gasprice/gasprice_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/state_accessor.go
+++ b/graft/subnet-evm/eth/state_accessor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/tracers/api.go
+++ b/graft/subnet-evm/eth/tracers/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/tracers/api_extra_test.go
+++ b/graft/subnet-evm/eth/tracers/api_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracers

--- a/graft/subnet-evm/eth/tracers/api_test.go
+++ b/graft/subnet-evm/eth/tracers/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/tracers/tracers.go
+++ b/graft/subnet-evm/eth/tracers/tracers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/tracers/tracers_test.go
+++ b/graft/subnet-evm/eth/tracers/tracers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/tracers/tracker.go
+++ b/graft/subnet-evm/eth/tracers/tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/eth/tracers/tracker_test.go
+++ b/graft/subnet-evm/eth/tracers/tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/ethclient/ethclient.go
+++ b/graft/subnet-evm/ethclient/ethclient.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/ethclient/signer.go
+++ b/graft/subnet-evm/ethclient/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/ethclient/simulated/backend.go
+++ b/graft/subnet-evm/ethclient/simulated/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/ethclient/simulated/backend_test.go
+++ b/graft/subnet-evm/ethclient/simulated/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/ethclient/simulated/options.go
+++ b/graft/subnet-evm/ethclient/simulated/options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/ethclient/simulated/options_test.go
+++ b/graft/subnet-evm/ethclient/simulated/options_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/ethclient/subnetevmclient/subnet_evm_client.go
+++ b/graft/subnet-evm/ethclient/subnetevmclient/subnet_evm_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/examples/sign-uptime-message/main.go
+++ b/graft/subnet-evm/examples/sign-uptime-message/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/subnet-evm/interfaces/interfaces.go
+++ b/graft/subnet-evm/interfaces/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interfaces

--- a/graft/subnet-evm/internal/blocktest/test_hash.go
+++ b/graft/subnet-evm/internal/blocktest/test_hash.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/debug/api.go
+++ b/graft/subnet-evm/internal/debug/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/debug/flags.go
+++ b/graft/subnet-evm/internal/debug/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/debug/loudpanic.go
+++ b/graft/subnet-evm/internal/debug/loudpanic.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/debug/trace.go
+++ b/graft/subnet-evm/internal/debug/trace.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/ethapi/addrlock.go
+++ b/graft/subnet-evm/internal/ethapi/addrlock.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/ethapi/api.go
+++ b/graft/subnet-evm/internal/ethapi/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/ethapi/api_extra.go
+++ b/graft/subnet-evm/internal/ethapi/api_extra.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ethapi

--- a/graft/subnet-evm/internal/ethapi/api_extra_test.go
+++ b/graft/subnet-evm/internal/ethapi/api_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ethapi

--- a/graft/subnet-evm/internal/ethapi/api_test.go
+++ b/graft/subnet-evm/internal/ethapi/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/ethapi/backend.go
+++ b/graft/subnet-evm/internal/ethapi/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/ethapi/errors.go
+++ b/graft/subnet-evm/internal/ethapi/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/ethapi/transaction_args.go
+++ b/graft/subnet-evm/internal/ethapi/transaction_args.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/ethapi/transaction_args_test.go
+++ b/graft/subnet-evm/internal/ethapi/transaction_args_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/flags/categories.go
+++ b/graft/subnet-evm/internal/flags/categories.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/flags/flags.go
+++ b/graft/subnet-evm/internal/flags/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/flags/flags_test.go
+++ b/graft/subnet-evm/internal/flags/flags_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/flags/helpers.go
+++ b/graft/subnet-evm/internal/flags/helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/shutdowncheck/shutdown_tracker.go
+++ b/graft/subnet-evm/internal/shutdowncheck/shutdown_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/version/vcs.go
+++ b/graft/subnet-evm/internal/version/vcs.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/internal/version/version.go
+++ b/graft/subnet-evm/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/log/format.go
+++ b/graft/subnet-evm/log/format.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/log/handler.go
+++ b/graft/subnet-evm/log/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/log/logger.go
+++ b/graft/subnet-evm/log/logger.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/miner/miner.go
+++ b/graft/subnet-evm/miner/miner.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/miner/ordering.go
+++ b/graft/subnet-evm/miner/ordering.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/miner/ordering_test.go
+++ b/graft/subnet-evm/miner/ordering_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/miner/worker.go
+++ b/graft/subnet-evm/miner/worker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/network/network.go
+++ b/graft/subnet-evm/network/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/subnet-evm/network/network_test.go
+++ b/graft/subnet-evm/network/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/subnet-evm/network/peer_tracker.go
+++ b/graft/subnet-evm/network/peer_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/subnet-evm/network/peer_tracker_test.go
+++ b/graft/subnet-evm/network/peer_tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/subnet-evm/network/peertest/request_id.go
+++ b/graft/subnet-evm/network/peertest/request_id.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peertest

--- a/graft/subnet-evm/network/stats/stats.go
+++ b/graft/subnet-evm/network/stats/stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stats

--- a/graft/subnet-evm/network/waiting_handler.go
+++ b/graft/subnet-evm/network/waiting_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/graft/subnet-evm/node/api.go
+++ b/graft/subnet-evm/node/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/node/config.go
+++ b/graft/subnet-evm/node/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/node/defaults.go
+++ b/graft/subnet-evm/node/defaults.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/node/errors.go
+++ b/graft/subnet-evm/node/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/node/node.go
+++ b/graft/subnet-evm/node/node.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/params/config.go
+++ b/graft/subnet-evm/params/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/params/config_extra.go
+++ b/graft/subnet-evm/params/config_extra.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/subnet-evm/params/config_extra_test.go
+++ b/graft/subnet-evm/params/config_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/subnet-evm/params/config_libevm.go
+++ b/graft/subnet-evm/params/config_libevm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/subnet-evm/params/config_test.go
+++ b/graft/subnet-evm/params/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/params/denomination.go
+++ b/graft/subnet-evm/params/denomination.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/params/extras/config.go
+++ b/graft/subnet-evm/params/extras/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/config_extra_test.go
+++ b/graft/subnet-evm/params/extras/config_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/config_test.go
+++ b/graft/subnet-evm/params/extras/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/extrastest/rules.go
+++ b/graft/subnet-evm/params/extras/extrastest/rules.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extrastest

--- a/graft/subnet-evm/params/extras/network_upgrades.go
+++ b/graft/subnet-evm/params/extras/network_upgrades.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/network_upgrades_test.go
+++ b/graft/subnet-evm/params/extras/network_upgrades_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/precompile_config_test.go
+++ b/graft/subnet-evm/params/extras/precompile_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/precompile_upgrade.go
+++ b/graft/subnet-evm/params/extras/precompile_upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/precompile_upgrade_test.go
+++ b/graft/subnet-evm/params/extras/precompile_upgrade_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/precompiles.go
+++ b/graft/subnet-evm/params/extras/precompiles.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/rules.go
+++ b/graft/subnet-evm/params/extras/rules.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/state_upgrade.go
+++ b/graft/subnet-evm/params/extras/state_upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/extras/state_upgrade_test.go
+++ b/graft/subnet-evm/params/extras/state_upgrade_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extras

--- a/graft/subnet-evm/params/hooks_libevm.go
+++ b/graft/subnet-evm/params/hooks_libevm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/subnet-evm/params/network_params.go
+++ b/graft/subnet-evm/params/network_params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/params/paramstest/forks.go
+++ b/graft/subnet-evm/params/paramstest/forks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package paramstest

--- a/graft/subnet-evm/params/protocol_params_test.go
+++ b/graft/subnet-evm/params/protocol_params_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package params

--- a/graft/subnet-evm/params/version.go
+++ b/graft/subnet-evm/params/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/plugin/evm/admin.go
+++ b/graft/subnet-evm/plugin/evm/admin.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/block_builder.go
+++ b/graft/subnet-evm/plugin/evm/block_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/block_builder_test.go
+++ b/graft/subnet-evm/plugin/evm/block_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/block_test.go
+++ b/graft/subnet-evm/plugin/evm/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/blockgascost/cost.go
+++ b/graft/subnet-evm/plugin/evm/blockgascost/cost.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // blockgascost implements the block gas cost logic

--- a/graft/subnet-evm/plugin/evm/blockgascost/cost_test.go
+++ b/graft/subnet-evm/plugin/evm/blockgascost/cost_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockgascost

--- a/graft/subnet-evm/plugin/evm/client/client.go
+++ b/graft/subnet-evm/plugin/evm/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package client

--- a/graft/subnet-evm/plugin/evm/config/config.go
+++ b/graft/subnet-evm/plugin/evm/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/subnet-evm/plugin/evm/config/config_test.go
+++ b/graft/subnet-evm/plugin/evm/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/subnet-evm/plugin/evm/config/constants.go
+++ b/graft/subnet-evm/plugin/evm/config/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/subnet-evm/plugin/evm/config/default_config.go
+++ b/graft/subnet-evm/plugin/evm/config/default_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/graft/subnet-evm/plugin/evm/customheader/base_fee.go
+++ b/graft/subnet-evm/plugin/evm/customheader/base_fee.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/base_fee_test.go
+++ b/graft/subnet-evm/plugin/evm/customheader/base_fee_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/block_gas_cost.go
+++ b/graft/subnet-evm/plugin/evm/customheader/block_gas_cost.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/block_gas_cost_test.go
+++ b/graft/subnet-evm/plugin/evm/customheader/block_gas_cost_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/dynamic_fee_windower.go
+++ b/graft/subnet-evm/plugin/evm/customheader/dynamic_fee_windower.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/dynamic_fee_windower_test.go
+++ b/graft/subnet-evm/plugin/evm/customheader/dynamic_fee_windower_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/extra.go
+++ b/graft/subnet-evm/plugin/evm/customheader/extra.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/extra_test.go
+++ b/graft/subnet-evm/plugin/evm/customheader/extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/gas_limit.go
+++ b/graft/subnet-evm/plugin/evm/customheader/gas_limit.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/gas_limit_test.go
+++ b/graft/subnet-evm/plugin/evm/customheader/gas_limit_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/min_delay_excess.go
+++ b/graft/subnet-evm/plugin/evm/customheader/min_delay_excess.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/min_delay_excess_test.go
+++ b/graft/subnet-evm/plugin/evm/customheader/min_delay_excess_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/time.go
+++ b/graft/subnet-evm/plugin/evm/customheader/time.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customheader/time_test.go
+++ b/graft/subnet-evm/plugin/evm/customheader/time_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customheader

--- a/graft/subnet-evm/plugin/evm/customrawdb/accessors_metadata_ext.go
+++ b/graft/subnet-evm/plugin/evm/customrawdb/accessors_metadata_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/graft/subnet-evm/plugin/evm/customrawdb/accessors_snapshot_ext.go
+++ b/graft/subnet-evm/plugin/evm/customrawdb/accessors_snapshot_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/graft/subnet-evm/plugin/evm/customrawdb/accessors_state_sync.go
+++ b/graft/subnet-evm/plugin/evm/customrawdb/accessors_state_sync.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/graft/subnet-evm/plugin/evm/customrawdb/accessors_state_sync_test.go
+++ b/graft/subnet-evm/plugin/evm/customrawdb/accessors_state_sync_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/graft/subnet-evm/plugin/evm/customrawdb/database_ext.go
+++ b/graft/subnet-evm/plugin/evm/customrawdb/database_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/graft/subnet-evm/plugin/evm/customrawdb/database_ext_test.go
+++ b/graft/subnet-evm/plugin/evm/customrawdb/database_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/graft/subnet-evm/plugin/evm/customrawdb/schema_ext.go
+++ b/graft/subnet-evm/plugin/evm/customrawdb/schema_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/graft/subnet-evm/plugin/evm/customtypes/aliases_test.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/aliases_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/subnet-evm/plugin/evm/customtypes/block_ext.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/block_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/subnet-evm/plugin/evm/customtypes/block_ext_test.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/block_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/subnet-evm/plugin/evm/customtypes/block_test.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/plugin/evm/customtypes/hashing_test.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/hashing_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/plugin/evm/customtypes/header_ext.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/header_ext.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/subnet-evm/plugin/evm/customtypes/header_ext_test.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/header_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/subnet-evm/plugin/evm/customtypes/libevm.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/libevm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customtypes

--- a/graft/subnet-evm/plugin/evm/customtypes/rlp_fuzzer_test.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/rlp_fuzzer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/plugin/evm/customtypes/types_test.go
+++ b/graft/subnet-evm/plugin/evm/customtypes/types_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/plugin/evm/eth_gossiper.go
+++ b/graft/subnet-evm/plugin/evm/eth_gossiper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // TODO: move to network

--- a/graft/subnet-evm/plugin/evm/extension/config.go
+++ b/graft/subnet-evm/plugin/evm/extension/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package extension

--- a/graft/subnet-evm/plugin/evm/factory.go
+++ b/graft/subnet-evm/plugin/evm/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/gossip/handler.go
+++ b/graft/subnet-evm/plugin/evm/gossip/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/graft/subnet-evm/plugin/evm/gossip_test.go
+++ b/graft/subnet-evm/plugin/evm/gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/health.go
+++ b/graft/subnet-evm/plugin/evm/health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/libevm.go
+++ b/graft/subnet-evm/plugin/evm/libevm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/log/log.go
+++ b/graft/subnet-evm/plugin/evm/log/log.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package log

--- a/graft/subnet-evm/plugin/evm/log/log_test.go
+++ b/graft/subnet-evm/plugin/evm/log/log_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package log

--- a/graft/subnet-evm/plugin/evm/message/block_request.go
+++ b/graft/subnet-evm/plugin/evm/message/block_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/block_request_test.go
+++ b/graft/subnet-evm/plugin/evm/message/block_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/block_sync_summary.go
+++ b/graft/subnet-evm/plugin/evm/message/block_sync_summary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/block_sync_summary_parser.go
+++ b/graft/subnet-evm/plugin/evm/message/block_sync_summary_parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/block_sync_summary_provider.go
+++ b/graft/subnet-evm/plugin/evm/message/block_sync_summary_provider.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/block_sync_summary_test.go
+++ b/graft/subnet-evm/plugin/evm/message/block_sync_summary_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/code_request.go
+++ b/graft/subnet-evm/plugin/evm/message/code_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/code_request_test.go
+++ b/graft/subnet-evm/plugin/evm/message/code_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/codec.go
+++ b/graft/subnet-evm/plugin/evm/message/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/handler.go
+++ b/graft/subnet-evm/plugin/evm/message/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/leafs_request.go
+++ b/graft/subnet-evm/plugin/evm/message/leafs_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/leafs_request_test.go
+++ b/graft/subnet-evm/plugin/evm/message/leafs_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/request.go
+++ b/graft/subnet-evm/plugin/evm/message/request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/message/syncable.go
+++ b/graft/subnet-evm/plugin/evm/message/syncable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/graft/subnet-evm/plugin/evm/network_handler.go
+++ b/graft/subnet-evm/plugin/evm/network_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/service.go
+++ b/graft/subnet-evm/plugin/evm/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/status.go
+++ b/graft/subnet-evm/plugin/evm/status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/sync/client.go
+++ b/graft/subnet-evm/plugin/evm/sync/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/subnet-evm/plugin/evm/sync/executor_static.go
+++ b/graft/subnet-evm/plugin/evm/sync/executor_static.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/subnet-evm/plugin/evm/sync/server.go
+++ b/graft/subnet-evm/plugin/evm/sync/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/graft/subnet-evm/plugin/evm/syncervm_test.go
+++ b/graft/subnet-evm/plugin/evm/syncervm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/tempextrastest/tempextras_test.go
+++ b/graft/subnet-evm/plugin/evm/tempextrastest/tempextras_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package tempextrastest exists solely to test [evm.WithTempRegisteredLibEVMExtras]

--- a/graft/subnet-evm/plugin/evm/tx_gossip_test.go
+++ b/graft/subnet-evm/plugin/evm/tx_gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/upgrade/legacy/params.go
+++ b/graft/subnet-evm/plugin/evm/upgrade/legacy/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package legacy

--- a/graft/subnet-evm/plugin/evm/upgrade/subnetevm/window.go
+++ b/graft/subnet-evm/plugin/evm/upgrade/subnetevm/window.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // subnetevm defines the dynamic fee window used after subnetevm upgrade.

--- a/graft/subnet-evm/plugin/evm/upgrade/subnetevm/window_test.go
+++ b/graft/subnet-evm/plugin/evm/upgrade/subnetevm/window_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subnetevm

--- a/graft/subnet-evm/plugin/evm/version.go
+++ b/graft/subnet-evm/plugin/evm/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/version_test.go
+++ b/graft/subnet-evm/plugin/evm/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/vm.go
+++ b/graft/subnet-evm/plugin/evm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/vm_database.go
+++ b/graft/subnet-evm/plugin/evm/vm_database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/vm_extensible.go
+++ b/graft/subnet-evm/plugin/evm/vm_extensible.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/vm_test.go
+++ b/graft/subnet-evm/plugin/evm/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/vm_upgrade_bytes_test.go
+++ b/graft/subnet-evm/plugin/evm/vm_upgrade_bytes_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/vm_uptime_test.go
+++ b/graft/subnet-evm/plugin/evm/vm_uptime_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/vm_warp_test.go
+++ b/graft/subnet-evm/plugin/evm/vm_warp_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/evm/vmerrors/errors.go
+++ b/graft/subnet-evm/plugin/evm/vmerrors/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vmerrors

--- a/graft/subnet-evm/plugin/evm/wrapped_block.go
+++ b/graft/subnet-evm/plugin/evm/wrapped_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/graft/subnet-evm/plugin/main.go
+++ b/graft/subnet-evm/plugin/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/subnet-evm/plugin/runner/keys.go
+++ b/graft/subnet-evm/plugin/runner/keys.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package runner

--- a/graft/subnet-evm/plugin/runner/params.go
+++ b/graft/subnet-evm/plugin/runner/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package runner

--- a/graft/subnet-evm/plugin/runner/runner.go
+++ b/graft/subnet-evm/plugin/runner/runner.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package runner

--- a/graft/subnet-evm/precompile/allowlist/allowlist.go
+++ b/graft/subnet-evm/precompile/allowlist/allowlist.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlist

--- a/graft/subnet-evm/precompile/allowlist/allowlist_test.go
+++ b/graft/subnet-evm/precompile/allowlist/allowlist_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlist_test

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/bindings/compile.go
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/bindings/compile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bindings

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/test_allowlist.go
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/test_allowlist.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlisttest

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/test_allowlist_config.go
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/test_allowlist_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlisttest

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/test_allowlist_events.go
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/test_allowlist_events.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlisttest

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/test_allowlist_helpers.go
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/test_allowlist_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlisttest

--- a/graft/subnet-evm/precompile/allowlist/config.go
+++ b/graft/subnet-evm/precompile/allowlist/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlist

--- a/graft/subnet-evm/precompile/allowlist/config_test.go
+++ b/graft/subnet-evm/precompile/allowlist/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlist_test

--- a/graft/subnet-evm/precompile/allowlist/event.go
+++ b/graft/subnet-evm/precompile/allowlist/event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Code generated

--- a/graft/subnet-evm/precompile/allowlist/role.go
+++ b/graft/subnet-evm/precompile/allowlist/role.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlist

--- a/graft/subnet-evm/precompile/allowlist/role_test.go
+++ b/graft/subnet-evm/precompile/allowlist/role_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlist

--- a/graft/subnet-evm/precompile/allowlist/unpack_pack_test.go
+++ b/graft/subnet-evm/precompile/allowlist/unpack_pack_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package allowlist

--- a/graft/subnet-evm/precompile/contract/contract.go
+++ b/graft/subnet-evm/precompile/contract/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contract

--- a/graft/subnet-evm/precompile/contract/interfaces.go
+++ b/graft/subnet-evm/precompile/contract/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Defines the interface for the configuration and execution of a precompile contract

--- a/graft/subnet-evm/precompile/contract/test_utils.go
+++ b/graft/subnet-evm/precompile/contract/test_utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contract

--- a/graft/subnet-evm/precompile/contract/utils.go
+++ b/graft/subnet-evm/precompile/contract/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contract

--- a/graft/subnet-evm/precompile/contract/utils_test.go
+++ b/graft/subnet-evm/precompile/contract/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contract

--- a/graft/subnet-evm/precompile/contracts/deployerallowlist/config.go
+++ b/graft/subnet-evm/precompile/contracts/deployerallowlist/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deployerallowlist

--- a/graft/subnet-evm/precompile/contracts/deployerallowlist/config_test.go
+++ b/graft/subnet-evm/precompile/contracts/deployerallowlist/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deployerallowlist_test

--- a/graft/subnet-evm/precompile/contracts/deployerallowlist/contract.go
+++ b/graft/subnet-evm/precompile/contracts/deployerallowlist/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deployerallowlist

--- a/graft/subnet-evm/precompile/contracts/deployerallowlist/contract_test.go
+++ b/graft/subnet-evm/precompile/contracts/deployerallowlist/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deployerallowlist_test

--- a/graft/subnet-evm/precompile/contracts/deployerallowlist/module.go
+++ b/graft/subnet-evm/precompile/contracts/deployerallowlist/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deployerallowlist

--- a/graft/subnet-evm/precompile/contracts/deployerallowlist/simulated_test.go
+++ b/graft/subnet-evm/precompile/contracts/deployerallowlist/simulated_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deployerallowlist_test

--- a/graft/subnet-evm/precompile/contracts/feemanager/config.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package feemanager

--- a/graft/subnet-evm/precompile/contracts/feemanager/config_test.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package feemanager_test

--- a/graft/subnet-evm/precompile/contracts/feemanager/contract.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package feemanager

--- a/graft/subnet-evm/precompile/contracts/feemanager/contract_test.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package feemanager_test

--- a/graft/subnet-evm/precompile/contracts/feemanager/event.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Code generated

--- a/graft/subnet-evm/precompile/contracts/feemanager/feemanagertest/bindings/compile.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/feemanagertest/bindings/compile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bindings

--- a/graft/subnet-evm/precompile/contracts/feemanager/module.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package feemanager

--- a/graft/subnet-evm/precompile/contracts/feemanager/simulated_test.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/simulated_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package feemanager_test

--- a/graft/subnet-evm/precompile/contracts/feemanager/unpack_pack_test.go
+++ b/graft/subnet-evm/precompile/contracts/feemanager/unpack_pack_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package feemanager

--- a/graft/subnet-evm/precompile/contracts/nativeminter/config.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeminter

--- a/graft/subnet-evm/precompile/contracts/nativeminter/config_test.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeminter_test

--- a/graft/subnet-evm/precompile/contracts/nativeminter/contract.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeminter

--- a/graft/subnet-evm/precompile/contracts/nativeminter/contract_test.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeminter_test

--- a/graft/subnet-evm/precompile/contracts/nativeminter/event.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Code generated

--- a/graft/subnet-evm/precompile/contracts/nativeminter/module.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeminter

--- a/graft/subnet-evm/precompile/contracts/nativeminter/nativemintertest/bindings/compile.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/nativemintertest/bindings/compile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bindings

--- a/graft/subnet-evm/precompile/contracts/nativeminter/simulated_test.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/simulated_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeminter_test

--- a/graft/subnet-evm/precompile/contracts/nativeminter/unpack_pack_test.go
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/unpack_pack_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nativeminter

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/config.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Code generated

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/config_test.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rewardmanager_test

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/contract.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Code generated

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/contract_test.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rewardmanager_test

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/event.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Code generated

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/module.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rewardmanager

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/rewardmanagertest/bindings/compile.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/rewardmanagertest/bindings/compile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bindings

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/simulated_test.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/simulated_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rewardmanager_test

--- a/graft/subnet-evm/precompile/contracts/txallowlist/config.go
+++ b/graft/subnet-evm/precompile/contracts/txallowlist/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txallowlist

--- a/graft/subnet-evm/precompile/contracts/txallowlist/config_test.go
+++ b/graft/subnet-evm/precompile/contracts/txallowlist/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txallowlist_test

--- a/graft/subnet-evm/precompile/contracts/txallowlist/contract.go
+++ b/graft/subnet-evm/precompile/contracts/txallowlist/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txallowlist

--- a/graft/subnet-evm/precompile/contracts/txallowlist/contract_test.go
+++ b/graft/subnet-evm/precompile/contracts/txallowlist/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txallowlist_test

--- a/graft/subnet-evm/precompile/contracts/txallowlist/module.go
+++ b/graft/subnet-evm/precompile/contracts/txallowlist/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txallowlist

--- a/graft/subnet-evm/precompile/contracts/txallowlist/simulated_test.go
+++ b/graft/subnet-evm/precompile/contracts/txallowlist/simulated_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txallowlist_test

--- a/graft/subnet-evm/precompile/contracts/utilstest/simulated_helpers.go
+++ b/graft/subnet-evm/precompile/contracts/utilstest/simulated_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/subnet-evm/precompile/contracts/warp/config.go
+++ b/graft/subnet-evm/precompile/contracts/warp/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/precompile/contracts/warp/config_test.go
+++ b/graft/subnet-evm/precompile/contracts/warp/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/precompile/contracts/warp/contract.go
+++ b/graft/subnet-evm/precompile/contracts/warp/contract.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/precompile/contracts/warp/contract_test.go
+++ b/graft/subnet-evm/precompile/contracts/warp/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/precompile/contracts/warp/contract_warp_handler.go
+++ b/graft/subnet-evm/precompile/contracts/warp/contract_warp_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/precompile/contracts/warp/module.go
+++ b/graft/subnet-evm/precompile/contracts/warp/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/precompile/contracts/warp/predicate_test.go
+++ b/graft/subnet-evm/precompile/contracts/warp/predicate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/precompile/contracts/warp/warpbindings/compile.go
+++ b/graft/subnet-evm/precompile/contracts/warp/warpbindings/compile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warpbindings

--- a/graft/subnet-evm/precompile/contracts/warp/warptest/bindings/compile.go
+++ b/graft/subnet-evm/precompile/contracts/warp/warptest/bindings/compile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bindings

--- a/graft/subnet-evm/precompile/modules/module.go
+++ b/graft/subnet-evm/precompile/modules/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package modules

--- a/graft/subnet-evm/precompile/modules/registerer.go
+++ b/graft/subnet-evm/precompile/modules/registerer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package modules

--- a/graft/subnet-evm/precompile/modules/registerer_test.go
+++ b/graft/subnet-evm/precompile/modules/registerer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package modules

--- a/graft/subnet-evm/precompile/precompileconfig/config.go
+++ b/graft/subnet-evm/precompile/precompileconfig/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Defines the stateless interface for unmarshalling an arbitrary config of a precompile

--- a/graft/subnet-evm/precompile/precompileconfig/upgradeable.go
+++ b/graft/subnet-evm/precompile/precompileconfig/upgradeable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompileconfig

--- a/graft/subnet-evm/precompile/precompiletest/test_config.go
+++ b/graft/subnet-evm/precompile/precompiletest/test_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompiletest

--- a/graft/subnet-evm/precompile/precompiletest/test_precompile.go
+++ b/graft/subnet-evm/precompile/precompiletest/test_precompile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompiletest

--- a/graft/subnet-evm/precompile/precompiletest/test_predicate.go
+++ b/graft/subnet-evm/precompile/precompiletest/test_predicate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package precompiletest

--- a/graft/subnet-evm/precompile/registry/registry.go
+++ b/graft/subnet-evm/precompile/registry/registry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Module to facilitate the registration of precompiles and their configuration.

--- a/graft/subnet-evm/rpc/client.go
+++ b/graft/subnet-evm/rpc/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/client_opt.go
+++ b/graft/subnet-evm/rpc/client_opt.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/client_opt_test.go
+++ b/graft/subnet-evm/rpc/client_opt_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/client_test.go
+++ b/graft/subnet-evm/rpc/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/context_headers.go
+++ b/graft/subnet-evm/rpc/context_headers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/doc.go
+++ b/graft/subnet-evm/rpc/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/errors.go
+++ b/graft/subnet-evm/rpc/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/handler.go
+++ b/graft/subnet-evm/rpc/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/http.go
+++ b/graft/subnet-evm/rpc/http.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/http_test.go
+++ b/graft/subnet-evm/rpc/http_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/inproc.go
+++ b/graft/subnet-evm/rpc/inproc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/json.go
+++ b/graft/subnet-evm/rpc/json.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/metrics.go
+++ b/graft/subnet-evm/rpc/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/server.go
+++ b/graft/subnet-evm/rpc/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/server_test.go
+++ b/graft/subnet-evm/rpc/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/service.go
+++ b/graft/subnet-evm/rpc/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/subscription.go
+++ b/graft/subnet-evm/rpc/subscription.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/subscription_test.go
+++ b/graft/subnet-evm/rpc/subscription_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/testservice_test.go
+++ b/graft/subnet-evm/rpc/testservice_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/types.go
+++ b/graft/subnet-evm/rpc/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/types_test.go
+++ b/graft/subnet-evm/rpc/types_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/websocket.go
+++ b/graft/subnet-evm/rpc/websocket.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/rpc/websocket_test.go
+++ b/graft/subnet-evm/rpc/websocket_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/stateupgrade/interfaces.go
+++ b/graft/subnet-evm/stateupgrade/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stateupgrade

--- a/graft/subnet-evm/stateupgrade/state_upgrade.go
+++ b/graft/subnet-evm/stateupgrade/state_upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stateupgrade

--- a/graft/subnet-evm/sync/client/client.go
+++ b/graft/subnet-evm/sync/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/subnet-evm/sync/client/client_test.go
+++ b/graft/subnet-evm/sync/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/subnet-evm/sync/client/leaf_syncer.go
+++ b/graft/subnet-evm/sync/client/leaf_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/subnet-evm/sync/client/mock_network.go
+++ b/graft/subnet-evm/sync/client/mock_network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/subnet-evm/sync/client/stats/stats.go
+++ b/graft/subnet-evm/sync/client/stats/stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stats

--- a/graft/subnet-evm/sync/client/test_client.go
+++ b/graft/subnet-evm/sync/client/test_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesyncclient

--- a/graft/subnet-evm/sync/handlers/block_request.go
+++ b/graft/subnet-evm/sync/handlers/block_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/subnet-evm/sync/handlers/block_request_test.go
+++ b/graft/subnet-evm/sync/handlers/block_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/subnet-evm/sync/handlers/code_request.go
+++ b/graft/subnet-evm/sync/handlers/code_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/subnet-evm/sync/handlers/code_request_test.go
+++ b/graft/subnet-evm/sync/handlers/code_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/subnet-evm/sync/handlers/handler.go
+++ b/graft/subnet-evm/sync/handlers/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/subnet-evm/sync/handlers/leafs_request.go
+++ b/graft/subnet-evm/sync/handlers/leafs_request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/subnet-evm/sync/handlers/leafs_request_test.go
+++ b/graft/subnet-evm/sync/handlers/leafs_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/subnet-evm/sync/handlers/stats/stats.go
+++ b/graft/subnet-evm/sync/handlers/stats/stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stats

--- a/graft/subnet-evm/sync/handlers/stats/statstest/test_stats.go
+++ b/graft/subnet-evm/sync/handlers/stats/statstest/test_stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statstest

--- a/graft/subnet-evm/sync/handlers/test_providers.go
+++ b/graft/subnet-evm/sync/handlers/test_providers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/graft/subnet-evm/sync/statesync/code_syncer.go
+++ b/graft/subnet-evm/sync/statesync/code_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/code_syncer_test.go
+++ b/graft/subnet-evm/sync/statesync/code_syncer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/state_syncer.go
+++ b/graft/subnet-evm/sync/statesync/state_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/statesynctest/test_sync.go
+++ b/graft/subnet-evm/sync/statesync/statesynctest/test_sync.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesynctest

--- a/graft/subnet-evm/sync/statesync/statesynctest/test_trie.go
+++ b/graft/subnet-evm/sync/statesync/statesynctest/test_trie.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesynctest

--- a/graft/subnet-evm/sync/statesync/sync_helpers.go
+++ b/graft/subnet-evm/sync/statesync/sync_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/sync_test.go
+++ b/graft/subnet-evm/sync/statesync/sync_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/trie_queue.go
+++ b/graft/subnet-evm/sync/statesync/trie_queue.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/trie_segments.go
+++ b/graft/subnet-evm/sync/statesync/trie_segments.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/trie_sync_stats.go
+++ b/graft/subnet-evm/sync/statesync/trie_sync_stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/trie_sync_stats_test.go
+++ b/graft/subnet-evm/sync/statesync/trie_sync_stats_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/statesync/trie_sync_tasks.go
+++ b/graft/subnet-evm/sync/statesync/trie_sync_tasks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statesync

--- a/graft/subnet-evm/sync/syncutils/iterators.go
+++ b/graft/subnet-evm/sync/syncutils/iterators.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncutils

--- a/graft/subnet-evm/tests/antithesis/gencomposeconfig/main.go
+++ b/graft/subnet-evm/tests/antithesis/gencomposeconfig/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/subnet-evm/tests/antithesis/main.go
+++ b/graft/subnet-evm/tests/antithesis/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/graft/subnet-evm/tests/load/load_test.go
+++ b/graft/subnet-evm/tests/load/load_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/graft/subnet-evm/tests/state_test_util.go
+++ b/graft/subnet-evm/tests/state_test_util.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/tests/utils/command.go
+++ b/graft/subnet-evm/tests/utils/command.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/tests/utils/constants.go
+++ b/graft/subnet-evm/tests/utils/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/tests/utils/proposervm.go
+++ b/graft/subnet-evm/tests/utils/proposervm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/tests/utils/subnet.go
+++ b/graft/subnet-evm/tests/utils/subnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/tests/utils/tmpnet.go
+++ b/graft/subnet-evm/tests/utils/tmpnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/tests/warp/warp_test.go
+++ b/graft/subnet-evm/tests/warp/warp_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Implements solidity tests.

--- a/graft/subnet-evm/triedb/hashdb/database.go
+++ b/graft/subnet-evm/triedb/hashdb/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/database.go
+++ b/graft/subnet-evm/triedb/pathdb/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/database_test.go
+++ b/graft/subnet-evm/triedb/pathdb/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/difflayer.go
+++ b/graft/subnet-evm/triedb/pathdb/difflayer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/difflayer_test.go
+++ b/graft/subnet-evm/triedb/pathdb/difflayer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/disklayer.go
+++ b/graft/subnet-evm/triedb/pathdb/disklayer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/errors.go
+++ b/graft/subnet-evm/triedb/pathdb/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/history.go
+++ b/graft/subnet-evm/triedb/pathdb/history.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/history_test.go
+++ b/graft/subnet-evm/triedb/pathdb/history_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/journal.go
+++ b/graft/subnet-evm/triedb/pathdb/journal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/layertree.go
+++ b/graft/subnet-evm/triedb/pathdb/layertree.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/metrics.go
+++ b/graft/subnet-evm/triedb/pathdb/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/nodebuffer.go
+++ b/graft/subnet-evm/triedb/pathdb/nodebuffer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/triedb/pathdb/testutils.go
+++ b/graft/subnet-evm/triedb/pathdb/testutils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 //
 // This file is a derived work, based on the go-ethereum library whose original

--- a/graft/subnet-evm/utils/address_range.go
+++ b/graft/subnet-evm/utils/address_range.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/utils/bounded_workers.go
+++ b/graft/subnet-evm/utils/bounded_workers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/utils/bytes.go
+++ b/graft/subnet-evm/utils/bytes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/utils/bytes_test.go
+++ b/graft/subnet-evm/utils/bytes_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/utils/denomination.go
+++ b/graft/subnet-evm/utils/denomination.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/utils/metered_cache.go
+++ b/graft/subnet-evm/utils/metered_cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/utils/numbers.go
+++ b/graft/subnet-evm/utils/numbers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/utils/numbers_test.go
+++ b/graft/subnet-evm/utils/numbers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/graft/subnet-evm/utils/rand/rand.go
+++ b/graft/subnet-evm/utils/rand/rand.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rand

--- a/graft/subnet-evm/utils/utilstest/context_test.go
+++ b/graft/subnet-evm/utils/utilstest/context_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/subnet-evm/utils/utilstest/key.go
+++ b/graft/subnet-evm/utils/utilstest/key.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/subnet-evm/utils/utilstest/pointer.go
+++ b/graft/subnet-evm/utils/utilstest/pointer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/subnet-evm/utils/utilstest/snow.go
+++ b/graft/subnet-evm/utils/utilstest/snow.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utilstest

--- a/graft/subnet-evm/warp/backend.go
+++ b/graft/subnet-evm/warp/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/warp/backend_test.go
+++ b/graft/subnet-evm/warp/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/warp/client.go
+++ b/graft/subnet-evm/warp/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/warp/messages/codec.go
+++ b/graft/subnet-evm/warp/messages/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messages

--- a/graft/subnet-evm/warp/messages/payload.go
+++ b/graft/subnet-evm/warp/messages/payload.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messages

--- a/graft/subnet-evm/warp/messages/validator_uptime.go
+++ b/graft/subnet-evm/warp/messages/validator_uptime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messages

--- a/graft/subnet-evm/warp/service.go
+++ b/graft/subnet-evm/warp/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/warp/verifier_backend.go
+++ b/graft/subnet-evm/warp/verifier_backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/warp/verifier_backend_test.go
+++ b/graft/subnet-evm/warp/verifier_backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/warp/verifier_stats.go
+++ b/graft/subnet-evm/warp/verifier_stats.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/graft/subnet-evm/warp/warptest/block_client.go
+++ b/graft/subnet-evm/warp/warptest/block_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // warptest exposes common functionality for testing the warp package.

--- a/header.yml
+++ b/header.yml
@@ -1,3 +1,3 @@
 header: |
-  // Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+  // Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
   // See the file LICENSE for licensing terms.

--- a/header_upstream.yml
+++ b/header_upstream.yml
@@ -1,5 +1,5 @@
 header: |
-  // Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+  // Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
   // See the file LICENSE for licensing terms.
   //
   // This file is a derived work, based on the go-ethereum library whose original

--- a/ids/aliases.go
+++ b/ids/aliases.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/aliases_test.go
+++ b/ids/aliases_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids_test

--- a/ids/bits.go
+++ b/ids/bits.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/bits_test.go
+++ b/ids/bits_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/galiasreader/alias_reader_client.go
+++ b/ids/galiasreader/alias_reader_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package galiasreader

--- a/ids/galiasreader/alias_reader_server.go
+++ b/ids/galiasreader/alias_reader_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package galiasreader

--- a/ids/galiasreader/alias_reader_test.go
+++ b/ids/galiasreader/alias_reader_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package galiasreader

--- a/ids/id.go
+++ b/ids/id.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/id_test.go
+++ b/ids/id_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/idstest/aliases.go
+++ b/ids/idstest/aliases.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package codectest provides a test suite for testing functionality related to

--- a/ids/node_id.go
+++ b/ids/node_id.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/node_id_test.go
+++ b/ids/node_id_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/request_id.go
+++ b/ids/request_id.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/short.go
+++ b/ids/short.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/ids/test_generator.go
+++ b/ids/test_generator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ids

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/indexer/client_test.go
+++ b/indexer/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/indexer/codec.go
+++ b/indexer/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/indexer/container.go
+++ b/indexer/container.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/indexer/examples/p-chain/main.go
+++ b/indexer/examples/p-chain/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/indexer/examples/x-chain-blocks/main.go
+++ b/indexer/examples/x-chain-blocks/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/indexer/index.go
+++ b/indexer/index.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/indexer/index_test.go
+++ b/indexer/index_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/indexer/service.go
+++ b/indexer/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package indexer

--- a/main/main.go
+++ b/main/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/message/creator.go
+++ b/message/creator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/fields.go
+++ b/message/fields.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/inbound_msg_builder.go
+++ b/message/inbound_msg_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/inbound_msg_builder_test.go
+++ b/message/inbound_msg_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/internal_msg_builder.go
+++ b/message/internal_msg_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //nolint:staticcheck // proto generates interfaces that fail linting

--- a/message/messages.go
+++ b/message/messages.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/messages_benchmark_test.go
+++ b/message/messages_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/messages_test.go
+++ b/message/messages_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/mocks_generate_test.go
+++ b/message/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/ops.go
+++ b/message/ops.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/outbound_msg_builder.go
+++ b/message/outbound_msg_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/message/outbound_msg_builder_test.go
+++ b/message/outbound_msg_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/nat/nat.go
+++ b/nat/nat.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nat

--- a/nat/no_router.go
+++ b/nat/no_router.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nat

--- a/nat/pmp.go
+++ b/nat/pmp.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nat

--- a/nat/upnp.go
+++ b/nat/upnp.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nat

--- a/network/config.go
+++ b/network/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/conn_test.go
+++ b/network/conn_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/dialer/dialer.go
+++ b/network/dialer/dialer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dialer

--- a/network/dialer/dialer_test.go
+++ b/network/dialer/dialer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dialer

--- a/network/dialer_test.go
+++ b/network/dialer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/example_test.go
+++ b/network/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/handler_test.go
+++ b/network/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/ip_tracker.go
+++ b/network/ip_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/ip_tracker_test.go
+++ b/network/ip_tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/listener_test.go
+++ b/network/listener_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/metrics.go
+++ b/network/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/network.go
+++ b/network/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/no_ingress_conn_alert.go
+++ b/network/no_ingress_conn_alert.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/no_ingress_conn_alert_test.go
+++ b/network/no_ingress_conn_alert_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/p2p/acp118/aggregator.go
+++ b/network/p2p/acp118/aggregator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package acp118

--- a/network/p2p/acp118/aggregator_test.go
+++ b/network/p2p/acp118/aggregator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package acp118

--- a/network/p2p/acp118/handler.go
+++ b/network/p2p/acp118/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package acp118

--- a/network/p2p/acp118/handler_test.go
+++ b/network/p2p/acp118/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package acp118

--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/error.go
+++ b/network/p2p/error.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/gossip/bloom.go
+++ b/network/p2p/gossip/bloom.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/network/p2p/gossip/bloom_test.go
+++ b/network/p2p/gossip/bloom_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/network/p2p/gossip/message.go
+++ b/network/p2p/gossip/message.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/network/p2p/gossip/set.go
+++ b/network/p2p/gossip/set.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/network/p2p/gossip/set_test.go
+++ b/network/p2p/gossip/set_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gossip

--- a/network/p2p/handler.go
+++ b/network/p2p/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/handler_test.go
+++ b/network/p2p/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/network_test.go
+++ b/network/p2p/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/node_sampler.go
+++ b/network/p2p/node_sampler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/p2ptest/client.go
+++ b/network/p2p/p2ptest/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2ptest

--- a/network/p2p/p2ptest/client_test.go
+++ b/network/p2p/p2ptest/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2ptest

--- a/network/p2p/peer_tracker.go
+++ b/network/p2p/peer_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/peer_tracker_test.go
+++ b/network/p2p/peer_tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/router.go
+++ b/network/p2p/router.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/throttler.go
+++ b/network/p2p/throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/throttler_handler.go
+++ b/network/p2p/throttler_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/throttler_handler_test.go
+++ b/network/p2p/throttler_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/throttler_test.go
+++ b/network/p2p/throttler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/validators.go
+++ b/network/p2p/validators.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/p2p/validators_test.go
+++ b/network/p2p/validators_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p2p

--- a/network/peer/config.go
+++ b/network/peer/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/example_test.go
+++ b/network/peer/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/info.go
+++ b/network/peer/info.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/ip.go
+++ b/network/peer/ip.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/ip_signer.go
+++ b/network/peer/ip_signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/ip_signer_test.go
+++ b/network/peer/ip_signer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/ip_test.go
+++ b/network/peer/ip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/message_queue.go
+++ b/network/peer/message_queue.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/message_queue_test.go
+++ b/network/peer/message_queue_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/metrics.go
+++ b/network/peer/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/msg_length.go
+++ b/network/peer/msg_length.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/msg_length_test.go
+++ b/network/peer/msg_length_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/network.go
+++ b/network/peer/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/peer_test.go
+++ b/network/peer/peer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/set.go
+++ b/network/peer/set.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/set_test.go
+++ b/network/peer/set_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/test_network.go
+++ b/network/peer/test_network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/test_peer.go
+++ b/network/peer/test_peer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/tls_config.go
+++ b/network/peer/tls_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/tls_config_test.go
+++ b/network/peer/tls_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer_test

--- a/network/peer/upgrader.go
+++ b/network/peer/upgrader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer

--- a/network/peer/upgrader_test.go
+++ b/network/peer/upgrader_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package peer_test

--- a/network/test_network.go
+++ b/network/test_network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/throttling/bandwidth_throttler.go
+++ b/network/throttling/bandwidth_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/bandwidth_throttler_test.go
+++ b/network/throttling/bandwidth_throttler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/common.go
+++ b/network/throttling/common.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/dial_throttler.go
+++ b/network/throttling/dial_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_conn_throttler.go
+++ b/network/throttling/inbound_conn_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_conn_throttler_test.go
+++ b/network/throttling/inbound_conn_throttler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_conn_upgrade_throttler.go
+++ b/network/throttling/inbound_conn_upgrade_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_conn_upgrade_throttler_test.go
+++ b/network/throttling/inbound_conn_upgrade_throttler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_msg_buffer_throttler.go
+++ b/network/throttling/inbound_msg_buffer_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_msg_buffer_throttler_test.go
+++ b/network/throttling/inbound_msg_buffer_throttler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_msg_byte_throttler.go
+++ b/network/throttling/inbound_msg_byte_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_msg_byte_throttler_test.go
+++ b/network/throttling/inbound_msg_byte_throttler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_msg_throttler.go
+++ b/network/throttling/inbound_msg_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_resource_throttler.go
+++ b/network/throttling/inbound_resource_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/inbound_resource_throttler_test.go
+++ b/network/throttling/inbound_resource_throttler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/no_inbound_msg_throttler.go
+++ b/network/throttling/no_inbound_msg_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/outbound_msg_throttler.go
+++ b/network/throttling/outbound_msg_throttler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/outbound_msg_throttler_test.go
+++ b/network/throttling/outbound_msg_throttler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/throttling/release_func.go
+++ b/network/throttling/release_func.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package throttling

--- a/network/tracked_ip.go
+++ b/network/tracked_ip.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/network/tracked_ip_test.go
+++ b/network/tracked_ip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/node/beacon_manager.go
+++ b/node/beacon_manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/node/beacon_manager_test.go
+++ b/node/beacon_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/node/insecure_validator_manager.go
+++ b/node/insecure_validator_manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/node/node.go
+++ b/node/node.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/node/overridden_manager.go
+++ b/node/overridden_manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/node/overridden_manager_test.go
+++ b/node/overridden_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package node

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Based on https://raw.githubusercontent.com/kubernetes-sigs/kind/7cb9e6be25b48a0e248097eef29d496ab1a044d0/site/static/examples/kind-with-registry.sh
 # Original work Copyright 2019 The Kubernetes Authors
-# Modifications Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+# Modifications Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/simplex/block.go
+++ b/simplex/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/block_builder.go
+++ b/simplex/block_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/block_builder_test.go
+++ b/simplex/block_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/block_test.go
+++ b/simplex/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/bls.go
+++ b/simplex/bls.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/bls_test.go
+++ b/simplex/bls_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/codec.go
+++ b/simplex/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/comm.go
+++ b/simplex/comm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/comm_test.go
+++ b/simplex/comm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/config.go
+++ b/simplex/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/messages.go
+++ b/simplex/messages.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/qc.go
+++ b/simplex/qc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/qc_test.go
+++ b/simplex/qc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/storage.go
+++ b/simplex/storage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/storage_test.go
+++ b/simplex/storage_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/simplex/util_test.go
+++ b/simplex/util_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package simplex

--- a/snow/acceptor.go
+++ b/snow/acceptor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snow

--- a/snow/choices/decidable.go
+++ b/snow/choices/decidable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package choices

--- a/snow/choices/status.go
+++ b/snow/choices/status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package choices

--- a/snow/choices/status_test.go
+++ b/snow/choices/status_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package choices

--- a/snow/choices/test_decidable.go
+++ b/snow/choices/test_decidable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package choices

--- a/snow/consensus/avalanche/test_vertex.go
+++ b/snow/consensus/avalanche/test_vertex.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avalanche

--- a/snow/consensus/avalanche/vertex.go
+++ b/snow/consensus/avalanche/vertex.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avalanche

--- a/snow/consensus/snowball/binary_slush.go
+++ b/snow/consensus/snowball/binary_slush.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/binary_snowball.go
+++ b/snow/consensus/snowball/binary_snowball.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/binary_snowball_test.go
+++ b/snow/consensus/snowball/binary_snowball_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/binary_snowflake.go
+++ b/snow/consensus/snowball/binary_snowflake.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/binary_snowflake_test.go
+++ b/snow/consensus/snowball/binary_snowflake_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/consensus.go
+++ b/snow/consensus/snowball/consensus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/consensus_performance_test.go
+++ b/snow/consensus/snowball/consensus_performance_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/consensus_reversibility_test.go
+++ b/snow/consensus/snowball/consensus_reversibility_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/consensus_test.go
+++ b/snow/consensus/snowball/consensus_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/factory.go
+++ b/snow/consensus/snowball/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/flat.go
+++ b/snow/consensus/snowball/flat.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/flat_test.go
+++ b/snow/consensus/snowball/flat_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/network_test.go
+++ b/snow/consensus/snowball/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/nnary_slush.go
+++ b/snow/consensus/snowball/nnary_slush.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/nnary_snowball.go
+++ b/snow/consensus/snowball/nnary_snowball.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/nnary_snowball_test.go
+++ b/snow/consensus/snowball/nnary_snowball_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/nnary_snowflake.go
+++ b/snow/consensus/snowball/nnary_snowflake.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/nnary_snowflake_test.go
+++ b/snow/consensus/snowball/nnary_snowflake_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/parameters.go
+++ b/snow/consensus/snowball/parameters.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/parameters_test.go
+++ b/snow/consensus/snowball/parameters_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/snowflake_test.go
+++ b/snow/consensus/snowball/snowflake_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/tree.go
+++ b/snow/consensus/snowball/tree.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/tree_test.go
+++ b/snow/consensus/snowball/tree_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //nolint:goconst

--- a/snow/consensus/snowball/unary_snowball.go
+++ b/snow/consensus/snowball/unary_snowball.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/unary_snowball_test.go
+++ b/snow/consensus/snowball/unary_snowball_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/unary_snowflake.go
+++ b/snow/consensus/snowball/unary_snowflake.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowball/unary_snowflake_test.go
+++ b/snow/consensus/snowball/unary_snowflake_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowball

--- a/snow/consensus/snowman/block.go
+++ b/snow/consensus/snowman/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/bootstrapper/majority.go
+++ b/snow/consensus/snowman/bootstrapper/majority.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/majority_test.go
+++ b/snow/consensus/snowman/bootstrapper/majority_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/minority.go
+++ b/snow/consensus/snowman/bootstrapper/minority.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/minority_test.go
+++ b/snow/consensus/snowman/bootstrapper/minority_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/noop.go
+++ b/snow/consensus/snowman/bootstrapper/noop.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/noop_test.go
+++ b/snow/consensus/snowman/bootstrapper/noop_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/poll.go
+++ b/snow/consensus/snowman/bootstrapper/poll.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/poll_test.go
+++ b/snow/consensus/snowman/bootstrapper/poll_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/requests.go
+++ b/snow/consensus/snowman/bootstrapper/requests.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/sampler.go
+++ b/snow/consensus/snowman/bootstrapper/sampler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/bootstrapper/sampler_test.go
+++ b/snow/consensus/snowman/bootstrapper/sampler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapper

--- a/snow/consensus/snowman/consensus.go
+++ b/snow/consensus/snowman/consensus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/factory.go
+++ b/snow/consensus/snowman/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/metrics.go
+++ b/snow/consensus/snowman/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/mixed_test.go
+++ b/snow/consensus/snowman/mixed_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/mocks_generate_test.go
+++ b/snow/consensus/snowman/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/network_test.go
+++ b/snow/consensus/snowman/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/oracle_block.go
+++ b/snow/consensus/snowman/oracle_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/poll/early_term_traversal.go
+++ b/snow/consensus/snowman/poll/early_term_traversal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/poll/early_term_traversal_test.go
+++ b/snow/consensus/snowman/poll/early_term_traversal_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/poll/graph.go
+++ b/snow/consensus/snowman/poll/graph.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/poll/graph_test.go
+++ b/snow/consensus/snowman/poll/graph_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/poll/interfaces.go
+++ b/snow/consensus/snowman/poll/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/poll/prefix.go
+++ b/snow/consensus/snowman/poll/prefix.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/poll/prefix_test.go
+++ b/snow/consensus/snowman/poll/prefix_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/poll/set.go
+++ b/snow/consensus/snowman/poll/set.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/poll/set_test.go
+++ b/snow/consensus/snowman/poll/set_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package poll

--- a/snow/consensus/snowman/snowman_block.go
+++ b/snow/consensus/snowman/snowman_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/snowmantest/block.go
+++ b/snow/consensus/snowman/snowmantest/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowmantest

--- a/snow/consensus/snowman/snowmantest/engine.go
+++ b/snow/consensus/snowman/snowmantest/engine.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowmantest

--- a/snow/consensus/snowman/snowmantest/require.go
+++ b/snow/consensus/snowman/snowmantest/require.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowmantest

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/topological_test.go
+++ b/snow/consensus/snowman/topological_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowman/traced_consensus.go
+++ b/snow/consensus/snowman/traced_consensus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/consensus/snowstorm/test_tx.go
+++ b/snow/consensus/snowstorm/test_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowstorm

--- a/snow/consensus/snowstorm/tx.go
+++ b/snow/consensus/snowstorm/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowstorm

--- a/snow/context.go
+++ b/snow/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snow

--- a/snow/decidable.go
+++ b/snow/decidable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snow

--- a/snow/engine/avalanche/bootstrap/bootstrapper.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/avalanche/bootstrap/bootstrapper_test.go
+++ b/snow/engine/avalanche/bootstrap/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/avalanche/bootstrap/config.go
+++ b/snow/engine/avalanche/bootstrap/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/avalanche/bootstrap/metrics.go
+++ b/snow/engine/avalanche/bootstrap/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/avalanche/bootstrap/queue/job.go
+++ b/snow/engine/avalanche/bootstrap/queue/job.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package queue

--- a/snow/engine/avalanche/bootstrap/queue/job_test.go
+++ b/snow/engine/avalanche/bootstrap/queue/job_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package queue

--- a/snow/engine/avalanche/bootstrap/queue/jobs.go
+++ b/snow/engine/avalanche/bootstrap/queue/jobs.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package queue

--- a/snow/engine/avalanche/bootstrap/queue/jobs_test.go
+++ b/snow/engine/avalanche/bootstrap/queue/jobs_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package queue

--- a/snow/engine/avalanche/bootstrap/queue/parser.go
+++ b/snow/engine/avalanche/bootstrap/queue/parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package queue

--- a/snow/engine/avalanche/bootstrap/queue/parser_test.go
+++ b/snow/engine/avalanche/bootstrap/queue/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package queue

--- a/snow/engine/avalanche/bootstrap/queue/state.go
+++ b/snow/engine/avalanche/bootstrap/queue/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package queue

--- a/snow/engine/avalanche/bootstrap/tx_job.go
+++ b/snow/engine/avalanche/bootstrap/tx_job.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/avalanche/bootstrap/vertex_job.go
+++ b/snow/engine/avalanche/bootstrap/vertex_job.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/avalanche/engine.go
+++ b/snow/engine/avalanche/engine.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avalanche

--- a/snow/engine/avalanche/getter/getter.go
+++ b/snow/engine/avalanche/getter/getter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package getter

--- a/snow/engine/avalanche/state/prefixed_state.go
+++ b/snow/engine/avalanche/state/prefixed_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/snow/engine/avalanche/state/serializer.go
+++ b/snow/engine/avalanche/state/serializer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package state manages the meta-data required by consensus for an avalanche

--- a/snow/engine/avalanche/state/state.go
+++ b/snow/engine/avalanche/state/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/snow/engine/avalanche/state/unique_vertex.go
+++ b/snow/engine/avalanche/state/unique_vertex.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/snow/engine/avalanche/state/unique_vertex_test.go
+++ b/snow/engine/avalanche/state/unique_vertex_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/snow/engine/avalanche/vertex/builder.go
+++ b/snow/engine/avalanche/vertex/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/builder_test.go
+++ b/snow/engine/avalanche/vertex/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/codec.go
+++ b/snow/engine/avalanche/vertex/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/manager.go
+++ b/snow/engine/avalanche/vertex/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/mocks_generate_test.go
+++ b/snow/engine/avalanche/vertex/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/parser.go
+++ b/snow/engine/avalanche/vertex/parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/parser_test.go
+++ b/snow/engine/avalanche/vertex/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/stateless_vertex.go
+++ b/snow/engine/avalanche/vertex/stateless_vertex.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/stateless_vertex_test.go
+++ b/snow/engine/avalanche/vertex/stateless_vertex_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/storage.go
+++ b/snow/engine/avalanche/vertex/storage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/avalanche/vertex/vertextest/builder.go
+++ b/snow/engine/avalanche/vertex/vertextest/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertextest

--- a/snow/engine/avalanche/vertex/vertextest/manager.go
+++ b/snow/engine/avalanche/vertex/vertextest/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertextest

--- a/snow/engine/avalanche/vertex/vertextest/parser.go
+++ b/snow/engine/avalanche/vertex/vertextest/parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertextest

--- a/snow/engine/avalanche/vertex/vertextest/storage.go
+++ b/snow/engine/avalanche/vertex/vertextest/storage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertextest

--- a/snow/engine/avalanche/vertex/vertextest/vm.go
+++ b/snow/engine/avalanche/vertex/vertextest/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertextest

--- a/snow/engine/avalanche/vertex/vm.go
+++ b/snow/engine/avalanche/vertex/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vertex

--- a/snow/engine/common/appsender/appsender_client.go
+++ b/snow/engine/common/appsender/appsender_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package appsender

--- a/snow/engine/common/appsender/appsender_server.go
+++ b/snow/engine/common/appsender/appsender_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package appsender

--- a/snow/engine/common/bootstrap_tracker.go
+++ b/snow/engine/common/bootstrap_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/bootstrapable.go
+++ b/snow/engine/common/bootstrapable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/engine.go
+++ b/snow/engine/common/engine.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/error.go
+++ b/snow/engine/common/error.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/error_test.go
+++ b/snow/engine/common/error_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/fx.go
+++ b/snow/engine/common/fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/halter.go
+++ b/snow/engine/common/halter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/message.go
+++ b/snow/engine/common/message.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/mocks_generate_test.go
+++ b/snow/engine/common/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/no_ops_handlers.go
+++ b/snow/engine/common/no_ops_handlers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/notifier.go
+++ b/snow/engine/common/notifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/notifier_test.go
+++ b/snow/engine/common/notifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/request.go
+++ b/snow/engine/common/request.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/request_test.go
+++ b/snow/engine/common/request_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/sender.go
+++ b/snow/engine/common/sender.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/state_syncer.go
+++ b/snow/engine/common/state_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/timer.go
+++ b/snow/engine/common/timer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/timer_test.go
+++ b/snow/engine/common/timer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/traced_bootstrapable_engine.go
+++ b/snow/engine/common/traced_bootstrapable_engine.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/traced_engine.go
+++ b/snow/engine/common/traced_engine.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/traced_state_syncer.go
+++ b/snow/engine/common/traced_state_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/common/tracker/accepted.go
+++ b/snow/engine/common/tracker/accepted.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/engine/common/tracker/accepted_test.go
+++ b/snow/engine/common/tracker/accepted_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/engine/common/tracker/peers.go
+++ b/snow/engine/common/tracker/peers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/engine/common/tracker/peers_test.go
+++ b/snow/engine/common/tracker/peers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/engine/common/tracker/startup.go
+++ b/snow/engine/common/tracker/startup.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/engine/common/vm.go
+++ b/snow/engine/common/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/snow/engine/enginetest/bootstrap_tracker.go
+++ b/snow/engine/enginetest/bootstrap_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package enginetest

--- a/snow/engine/enginetest/bootstrapper.go
+++ b/snow/engine/enginetest/bootstrapper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package enginetest

--- a/snow/engine/enginetest/engine.go
+++ b/snow/engine/enginetest/engine.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package enginetest

--- a/snow/engine/enginetest/sender.go
+++ b/snow/engine/enginetest/sender.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package enginetest

--- a/snow/engine/enginetest/timer.go
+++ b/snow/engine/enginetest/timer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package enginetest

--- a/snow/engine/enginetest/vm.go
+++ b/snow/engine/enginetest/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package enginetest

--- a/snow/engine/snowman/ancestor/tree.go
+++ b/snow/engine/snowman/ancestor/tree.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ancestor

--- a/snow/engine/snowman/ancestor/tree_test.go
+++ b/snow/engine/snowman/ancestor/tree_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ancestor

--- a/snow/engine/snowman/block/batched_vm.go
+++ b/snow/engine/snowman/block/batched_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/snow/engine/snowman/block/batched_vm_test.go
+++ b/snow/engine/snowman/block/batched_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block_test

--- a/snow/engine/snowman/block/block_context_vm.go
+++ b/snow/engine/snowman/block/block_context_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/snow/engine/snowman/block/blocktest/batched_vm.go
+++ b/snow/engine/snowman/block/blocktest/batched_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocktest

--- a/snow/engine/snowman/block/blocktest/set_preference_vm.go
+++ b/snow/engine/snowman/block/blocktest/set_preference_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocktest

--- a/snow/engine/snowman/block/blocktest/state_summary.go
+++ b/snow/engine/snowman/block/blocktest/state_summary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocktest

--- a/snow/engine/snowman/block/blocktest/state_syncable_vm.go
+++ b/snow/engine/snowman/block/blocktest/state_syncable_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocktest

--- a/snow/engine/snowman/block/blocktest/vm.go
+++ b/snow/engine/snowman/block/blocktest/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocktest

--- a/snow/engine/snowman/block/mocks_generate_test.go
+++ b/snow/engine/snowman/block/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/snow/engine/snowman/block/notifier.go
+++ b/snow/engine/snowman/block/notifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/snow/engine/snowman/block/notifier_test.go
+++ b/snow/engine/snowman/block/notifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block_test

--- a/snow/engine/snowman/block/state_summary.go
+++ b/snow/engine/snowman/block/state_summary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/snow/engine/snowman/block/state_sync_mode.go
+++ b/snow/engine/snowman/block/state_sync_mode.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/snow/engine/snowman/block/state_syncable_vm.go
+++ b/snow/engine/snowman/block/state_syncable_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/snow/engine/snowman/block/vm.go
+++ b/snow/engine/snowman/block/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/snow/engine/snowman/bootstrap/acceptor.go
+++ b/snow/engine/snowman/bootstrap/acceptor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/snowman/bootstrap/bootstrapper_test.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/snowman/bootstrap/config.go
+++ b/snow/engine/snowman/bootstrap/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/snowman/bootstrap/interval/blocks.go
+++ b/snow/engine/snowman/bootstrap/interval/blocks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interval

--- a/snow/engine/snowman/bootstrap/interval/blocks_test.go
+++ b/snow/engine/snowman/bootstrap/interval/blocks_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interval

--- a/snow/engine/snowman/bootstrap/interval/interval.go
+++ b/snow/engine/snowman/bootstrap/interval/interval.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interval

--- a/snow/engine/snowman/bootstrap/interval/interval_test.go
+++ b/snow/engine/snowman/bootstrap/interval/interval_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interval

--- a/snow/engine/snowman/bootstrap/interval/state.go
+++ b/snow/engine/snowman/bootstrap/interval/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interval

--- a/snow/engine/snowman/bootstrap/interval/tree.go
+++ b/snow/engine/snowman/bootstrap/interval/tree.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interval

--- a/snow/engine/snowman/bootstrap/interval/tree_test.go
+++ b/snow/engine/snowman/bootstrap/interval/tree_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package interval

--- a/snow/engine/snowman/bootstrap/metrics.go
+++ b/snow/engine/snowman/bootstrap/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/snowman/bootstrap/storage.go
+++ b/snow/engine/snowman/bootstrap/storage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/snowman/bootstrap/storage_test.go
+++ b/snow/engine/snowman/bootstrap/storage_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrap

--- a/snow/engine/snowman/config.go
+++ b/snow/engine/snowman/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/engine/snowman/config_test.go
+++ b/snow/engine/snowman/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/engine/snowman/engine.go
+++ b/snow/engine/snowman/engine.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/engine/snowman/engine_test.go
+++ b/snow/engine/snowman/engine_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/engine/snowman/getter/getter.go
+++ b/snow/engine/snowman/getter/getter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package getter

--- a/snow/engine/snowman/getter/getter_test.go
+++ b/snow/engine/snowman/getter/getter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package getter

--- a/snow/engine/snowman/issuer.go
+++ b/snow/engine/snowman/issuer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/engine/snowman/job/scheduler.go
+++ b/snow/engine/snowman/job/scheduler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package job provides a Scheduler to manage and execute Jobs with

--- a/snow/engine/snowman/job/scheduler_test.go
+++ b/snow/engine/snowman/job/scheduler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package job

--- a/snow/engine/snowman/memory_block.go
+++ b/snow/engine/snowman/memory_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/engine/snowman/metrics.go
+++ b/snow/engine/snowman/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/engine/snowman/syncer/config.go
+++ b/snow/engine/snowman/syncer/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncer

--- a/snow/engine/snowman/syncer/state_syncer.go
+++ b/snow/engine/snowman/syncer/state_syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncer

--- a/snow/engine/snowman/syncer/state_syncer_test.go
+++ b/snow/engine/snowman/syncer/state_syncer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncer

--- a/snow/engine/snowman/syncer/utils_test.go
+++ b/snow/engine/snowman/syncer/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package syncer

--- a/snow/engine/snowman/voter.go
+++ b/snow/engine/snowman/voter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowman

--- a/snow/networking/benchlist/benchable.go
+++ b/snow/networking/benchlist/benchable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package benchlist

--- a/snow/networking/benchlist/benchable_test.go
+++ b/snow/networking/benchlist/benchable_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package benchlist

--- a/snow/networking/benchlist/benchlist.go
+++ b/snow/networking/benchlist/benchlist.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package benchlist

--- a/snow/networking/benchlist/benchlist_test.go
+++ b/snow/networking/benchlist/benchlist_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package benchlist

--- a/snow/networking/benchlist/manager.go
+++ b/snow/networking/benchlist/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package benchlist

--- a/snow/networking/handler/engine.go
+++ b/snow/networking/handler/engine.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/engine_test.go
+++ b/snow/networking/handler/engine_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/handler_test.go
+++ b/snow/networking/handler/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/health.go
+++ b/snow/networking/handler/health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/health_test.go
+++ b/snow/networking/handler/health_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/message_queue.go
+++ b/snow/networking/handler/message_queue.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/message_queue_metrics.go
+++ b/snow/networking/handler/message_queue_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/message_queue_test.go
+++ b/snow/networking/handler/message_queue_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/metrics.go
+++ b/snow/networking/handler/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/mocks_generate_test.go
+++ b/snow/networking/handler/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/handler/parser.go
+++ b/snow/networking/handler/parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handler

--- a/snow/networking/router/chain_router.go
+++ b/snow/networking/router/chain_router.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/router/chain_router_metrics.go
+++ b/snow/networking/router/chain_router_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/router/health.go
+++ b/snow/networking/router/health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/router/inbound_handler.go
+++ b/snow/networking/router/inbound_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/router/main_test.go
+++ b/snow/networking/router/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/router/mocks_generate_test.go
+++ b/snow/networking/router/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/router/router.go
+++ b/snow/networking/router/router.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/router/traced_router.go
+++ b/snow/networking/router/traced_router.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package router

--- a/snow/networking/sender/external_sender.go
+++ b/snow/networking/sender/external_sender.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sender

--- a/snow/networking/sender/mocks_generate_test.go
+++ b/snow/networking/sender/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sender

--- a/snow/networking/sender/sender.go
+++ b/snow/networking/sender/sender.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sender

--- a/snow/networking/sender/sender_test.go
+++ b/snow/networking/sender/sender_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sender_test

--- a/snow/networking/sender/sendertest/external.go
+++ b/snow/networking/sender/sendertest/external.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sendertest

--- a/snow/networking/sender/traced_sender.go
+++ b/snow/networking/sender/traced_sender.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sender

--- a/snow/networking/timeout/main_test.go
+++ b/snow/networking/timeout/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timeout

--- a/snow/networking/timeout/manager.go
+++ b/snow/networking/timeout/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timeout

--- a/snow/networking/timeout/manager_test.go
+++ b/snow/networking/timeout/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timeout

--- a/snow/networking/timeout/metrics.go
+++ b/snow/networking/timeout/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timeout

--- a/snow/networking/timeout/mocks_generate_test.go
+++ b/snow/networking/timeout/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timeout

--- a/snow/networking/tracker/mocks_generate_test.go
+++ b/snow/networking/tracker/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/networking/tracker/resource_tracker.go
+++ b/snow/networking/tracker/resource_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/networking/tracker/resource_tracker_test.go
+++ b/snow/networking/tracker/resource_tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/networking/tracker/targeter.go
+++ b/snow/networking/tracker/targeter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/networking/tracker/targeter_test.go
+++ b/snow/networking/tracker/targeter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracker

--- a/snow/snowtest/context.go
+++ b/snow/snowtest/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowtest

--- a/snow/snowtest/decidable.go
+++ b/snow/snowtest/decidable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowtest

--- a/snow/snowtest/status.go
+++ b/snow/snowtest/status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snowtest

--- a/snow/state.go
+++ b/snow/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package snow

--- a/snow/uptime/locked_calculator.go
+++ b/snow/uptime/locked_calculator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptime

--- a/snow/uptime/locked_calculator_test.go
+++ b/snow/uptime/locked_calculator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptime

--- a/snow/uptime/manager.go
+++ b/snow/uptime/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptime

--- a/snow/uptime/manager_test.go
+++ b/snow/uptime/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptime

--- a/snow/uptime/mocks_generate_test.go
+++ b/snow/uptime/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptime

--- a/snow/uptime/no_op_calculator.go
+++ b/snow/uptime/no_op_calculator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptime

--- a/snow/uptime/state.go
+++ b/snow/uptime/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptime

--- a/snow/uptime/test_state.go
+++ b/snow/uptime/test_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptime

--- a/snow/validators/connector.go
+++ b/snow/validators/connector.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/gvalidators/validator_state_client.go
+++ b/snow/validators/gvalidators/validator_state_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gvalidators

--- a/snow/validators/gvalidators/validator_state_server.go
+++ b/snow/validators/gvalidators/validator_state_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gvalidators

--- a/snow/validators/gvalidators/validator_state_test.go
+++ b/snow/validators/gvalidators/validator_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gvalidators

--- a/snow/validators/logger.go
+++ b/snow/validators/logger.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/manager.go
+++ b/snow/validators/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/manager_test.go
+++ b/snow/validators/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/mocks_generate_test.go
+++ b/snow/validators/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/set.go
+++ b/snow/validators/set.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/set_test.go
+++ b/snow/validators/set_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/state.go
+++ b/snow/validators/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/state_test.go
+++ b/snow/validators/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators_test

--- a/snow/validators/traced_state.go
+++ b/snow/validators/traced_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/validator.go
+++ b/snow/validators/validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/validatorstest/state.go
+++ b/snow/validators/validatorstest/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validatorstest

--- a/snow/validators/validatorstest/warp.go
+++ b/snow/validators/validatorstest/warp.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validatorstest

--- a/snow/validators/warp.go
+++ b/snow/validators/warp.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/snow/validators/warp_test.go
+++ b/snow/validators/warp_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators_test

--- a/staking/asn1.go
+++ b/staking/asn1.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package staking

--- a/staking/certificate.go
+++ b/staking/certificate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package staking

--- a/staking/parse.go
+++ b/staking/parse.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package staking

--- a/staking/parse_test.go
+++ b/staking/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package staking

--- a/staking/tls.go
+++ b/staking/tls.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package staking

--- a/staking/tls_test.go
+++ b/staking/tls_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package staking

--- a/staking/verify.go
+++ b/staking/verify.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package staking

--- a/staking/verify_test.go
+++ b/staking/verify_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package staking

--- a/subnets/config.go
+++ b/subnets/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subnets

--- a/subnets/config_test.go
+++ b/subnets/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subnets

--- a/subnets/no_op_allower.go
+++ b/subnets/no_op_allower.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subnets

--- a/subnets/subnet.go
+++ b/subnets/subnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subnets

--- a/subnets/subnet_test.go
+++ b/subnets/subnet_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subnets

--- a/tests/antithesis/avalanchego/gencomposeconfig/main.go
+++ b/tests/antithesis/avalanchego/gencomposeconfig/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/antithesis/compose.go
+++ b/tests/antithesis/compose.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package antithesis

--- a/tests/antithesis/config.go
+++ b/tests/antithesis/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package antithesis

--- a/tests/antithesis/context.go
+++ b/tests/antithesis/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package antithesis

--- a/tests/antithesis/init_db.go
+++ b/tests/antithesis/init_db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package antithesis

--- a/tests/antithesis/node_health.go
+++ b/tests/antithesis/node_health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package antithesis

--- a/tests/antithesis/xsvm/gencomposeconfig/main.go
+++ b/tests/antithesis/xsvm/gencomposeconfig/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/antithesis/xsvm/main.go
+++ b/tests/antithesis/xsvm/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/context_helpers.go
+++ b/tests/context_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tests

--- a/tests/e2e/banff/suites.go
+++ b/tests/e2e/banff/suites.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Implements tests for the banff network upgrade.

--- a/tests/e2e/c/api.go
+++ b/tests/e2e/c/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/tests/e2e/c/consume_gas.go
+++ b/tests/e2e/c/consume_gas.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/tests/e2e/c/proposervm_epoch.go
+++ b/tests/e2e/c/proposervm_epoch.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e_test

--- a/tests/e2e/faultinjection/duplicate_node_id.go
+++ b/tests/e2e/faultinjection/duplicate_node_id.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package faultinjection

--- a/tests/e2e/ignore.go
+++ b/tests/e2e/ignore.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/tests/e2e/p/l1.go
+++ b/tests/e2e/p/l1.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/tests/e2e/p/owner_retrieval.go
+++ b/tests/e2e/p/owner_retrieval.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/tests/e2e/p/validator_sets.go
+++ b/tests/e2e/p/validator_sets.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/tests/e2e/p/workflow.go
+++ b/tests/e2e/p/workflow.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/tests/e2e/vms/xsvm.go
+++ b/tests/e2e/vms/xsvm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vms

--- a/tests/e2e/x/interchain_workflow.go
+++ b/tests/e2e/x/interchain_workflow.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package x

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Implements X-chain transfer tests.

--- a/tests/fixture/bootstrapmonitor/bootstrap_test_config.go
+++ b/tests/fixture/bootstrapmonitor/bootstrap_test_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapmonitor

--- a/tests/fixture/bootstrapmonitor/bootstrap_test_config_test.go
+++ b/tests/fixture/bootstrapmonitor/bootstrap_test_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapmonitor

--- a/tests/fixture/bootstrapmonitor/cmd/main.go
+++ b/tests/fixture/bootstrapmonitor/cmd/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/fixture/bootstrapmonitor/common.go
+++ b/tests/fixture/bootstrapmonitor/common.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapmonitor

--- a/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
+++ b/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/fixture/bootstrapmonitor/init.go
+++ b/tests/fixture/bootstrapmonitor/init.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapmonitor

--- a/tests/fixture/bootstrapmonitor/wait.go
+++ b/tests/fixture/bootstrapmonitor/wait.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bootstrapmonitor

--- a/tests/fixture/e2e/apitest.go
+++ b/tests/fixture/e2e/apitest.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/fixture/e2e/describe.go
+++ b/tests/fixture/e2e/describe.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/fixture/e2e/ginkgo_test_context.go
+++ b/tests/fixture/e2e/ginkgo_test_context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/fixture/e2e/metrics_link.go
+++ b/tests/fixture/e2e/metrics_link.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package e2e

--- a/tests/fixture/stacktrace/stacktrace.go
+++ b/tests/fixture/stacktrace/stacktrace.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stacktrace

--- a/tests/fixture/subnet/xsvm.go
+++ b/tests/fixture/subnet/xsvm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subnet

--- a/tests/fixture/tmpnet/check_monitoring.go
+++ b/tests/fixture/tmpnet/check_monitoring.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/detached_process_default.go
+++ b/tests/fixture/tmpnet/detached_process_default.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build linux || darwin || unix

--- a/tests/fixture/tmpnet/flags/collector.go
+++ b/tests/fixture/tmpnet/flags/collector.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package flags

--- a/tests/fixture/tmpnet/flags/common.go
+++ b/tests/fixture/tmpnet/flags/common.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package flags

--- a/tests/fixture/tmpnet/flags/kube_runtime.go
+++ b/tests/fixture/tmpnet/flags/kube_runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package flags

--- a/tests/fixture/tmpnet/flags/kubeconfig.go
+++ b/tests/fixture/tmpnet/flags/kubeconfig.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package flags

--- a/tests/fixture/tmpnet/flags/process_runtime.go
+++ b/tests/fixture/tmpnet/flags/process_runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package flags

--- a/tests/fixture/tmpnet/flags/runtime.go
+++ b/tests/fixture/tmpnet/flags/runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package flags

--- a/tests/fixture/tmpnet/flags/start_network.go
+++ b/tests/fixture/tmpnet/flags/start_network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package flags

--- a/tests/fixture/tmpnet/flagsmap.go
+++ b/tests/fixture/tmpnet/flagsmap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/genesis.go
+++ b/tests/fixture/tmpnet/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/kube.go
+++ b/tests/fixture/tmpnet/kube.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/kube_runtime.go
+++ b/tests/fixture/tmpnet/kube_runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/local_network.go
+++ b/tests/fixture/tmpnet/local_network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/monitor_kube.go
+++ b/tests/fixture/tmpnet/monitor_kube.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/monitor_processes.go
+++ b/tests/fixture/tmpnet/monitor_processes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/network.go
+++ b/tests/fixture/tmpnet/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/network_config.go
+++ b/tests/fixture/tmpnet/network_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/network_test.go
+++ b/tests/fixture/tmpnet/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/node_config.go
+++ b/tests/fixture/tmpnet/node_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/process_runtime.go
+++ b/tests/fixture/tmpnet/process_runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/start_kind_cluster.go
+++ b/tests/fixture/tmpnet/start_kind_cluster.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/subnet.go
+++ b/tests/fixture/tmpnet/subnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/fixture/tmpnet/tmpnetctl/main.go
+++ b/tests/fixture/tmpnet/tmpnetctl/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/fixture/tmpnet/utils.go
+++ b/tests/fixture/tmpnet/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tmpnet

--- a/tests/load/contracts/generate.go
+++ b/tests/load/contracts/generate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contracts

--- a/tests/load/generator.go
+++ b/tests/load/generator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/tests/load/main/main.go
+++ b/tests/load/main/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/load/metrics.go
+++ b/tests/load/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/tests/load/tests.go
+++ b/tests/load/tests.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/tests/load/wallet.go
+++ b/tests/load/wallet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package load

--- a/tests/log.go
+++ b/tests/log.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tests

--- a/tests/metrics.go
+++ b/tests/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tests

--- a/tests/notify_context.go
+++ b/tests/notify_context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tests

--- a/tests/prometheus_server.go
+++ b/tests/prometheus_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tests

--- a/tests/reexecute/blockexport/main.go
+++ b/tests/reexecute/blockexport/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/reexecute/c/metrics.go
+++ b/tests/reexecute/c/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/reexecute/c/vm_reexecute.go
+++ b/tests/reexecute/c/vm_reexecute.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tests/reexecute/db.go
+++ b/tests/reexecute/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package reexecute

--- a/tests/reexecute/vm.go
+++ b/tests/reexecute/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package reexecute

--- a/tests/simple_test_context.go
+++ b/tests/simple_test_context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tests

--- a/tests/test_context.go
+++ b/tests/test_context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tests

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package upgrade

--- a/trace/exporter.go
+++ b/trace/exporter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package trace

--- a/trace/exporter_type.go
+++ b/trace/exporter_type.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package trace

--- a/trace/exporter_type_test.go
+++ b/trace/exporter_type_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package trace

--- a/trace/noop.go
+++ b/trace/noop.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package trace

--- a/trace/tracer.go
+++ b/trace/tracer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package trace

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package upgrade

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package upgrade

--- a/upgrade/upgradetest/config.go
+++ b/upgrade/upgradetest/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package upgradetest

--- a/upgrade/upgradetest/fork.go
+++ b/upgrade/upgradetest/fork.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package upgradetest

--- a/utils/atomic.go
+++ b/utils/atomic.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/atomic_test.go
+++ b/utils/atomic_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/bag/bag.go
+++ b/utils/bag/bag.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bag

--- a/utils/bag/bag_benchmark_test.go
+++ b/utils/bag/bag_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bag

--- a/utils/bag/bag_test.go
+++ b/utils/bag/bag_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bag

--- a/utils/bag/unique_bag.go
+++ b/utils/bag/unique_bag.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bag

--- a/utils/bag/unique_bag_test.go
+++ b/utils/bag/unique_bag_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bag

--- a/utils/beacon/beacon.go
+++ b/utils/beacon/beacon.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package beacon

--- a/utils/beacon/set.go
+++ b/utils/beacon/set.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package beacon

--- a/utils/beacon/set_test.go
+++ b/utils/beacon/set_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package beacon

--- a/utils/bimap/bimap.go
+++ b/utils/bimap/bimap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bimap

--- a/utils/bimap/bimap_test.go
+++ b/utils/bimap/bimap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bimap

--- a/utils/bloom/filter.go
+++ b/utils/bloom/filter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/bloom/filter_test.go
+++ b/utils/bloom/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/bloom/hasher.go
+++ b/utils/bloom/hasher.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/bloom/hasher_test.go
+++ b/utils/bloom/hasher_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/bloom/metrics.go
+++ b/utils/bloom/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/bloom/optimal.go
+++ b/utils/bloom/optimal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/bloom/optimal_test.go
+++ b/utils/bloom/optimal_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/bloom/read_filter.go
+++ b/utils/bloom/read_filter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/bloom/read_filter_test.go
+++ b/utils/bloom/read_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bloom

--- a/utils/buffer/bounded_nonblocking_queue.go
+++ b/utils/buffer/bounded_nonblocking_queue.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package buffer

--- a/utils/buffer/bounded_nonblocking_queue_test.go
+++ b/utils/buffer/bounded_nonblocking_queue_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package buffer

--- a/utils/buffer/unbounded_blocking_deque.go
+++ b/utils/buffer/unbounded_blocking_deque.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package buffer

--- a/utils/buffer/unbounded_blocking_deque_test.go
+++ b/utils/buffer/unbounded_blocking_deque_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package buffer

--- a/utils/buffer/unbounded_deque.go
+++ b/utils/buffer/unbounded_deque.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package buffer

--- a/utils/buffer/unbounded_deque_test.go
+++ b/utils/buffer/unbounded_deque_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package buffer

--- a/utils/bytes.go
+++ b/utils/bytes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/bytes_test.go
+++ b/utils/bytes_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/cb58/cb58.go
+++ b/utils/cb58/cb58.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cb58

--- a/utils/cb58/cb58_test.go
+++ b/utils/cb58/cb58_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cb58

--- a/utils/compression/compressor.go
+++ b/utils/compression/compressor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/utils/compression/compressor_test.go
+++ b/utils/compression/compressor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/utils/compression/no_compressor.go
+++ b/utils/compression/no_compressor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/utils/compression/no_compressor_test.go
+++ b/utils/compression/no_compressor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/utils/compression/type.go
+++ b/utils/compression/type.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/utils/compression/type_test.go
+++ b/utils/compression/type_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/utils/compression/zstd_compressor.go
+++ b/utils/compression/zstd_compressor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/utils/constants/acps.go
+++ b/utils/constants/acps.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/constants/aliases.go
+++ b/utils/constants/aliases.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/constants/application.go
+++ b/utils/constants/application.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/constants/memory.go
+++ b/utils/constants/memory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/constants/network_ids.go
+++ b/utils/constants/network_ids.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/constants/network_ids_test.go
+++ b/utils/constants/network_ids_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/constants/networking.go
+++ b/utils/constants/networking.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/constants/vm_ids.go
+++ b/utils/constants/vm_ids.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/crypto/bls/bls_benchmark_test.go
+++ b/utils/crypto/bls/bls_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bls

--- a/utils/crypto/bls/bls_test.go
+++ b/utils/crypto/bls/bls_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bls

--- a/utils/crypto/bls/blstest/benchmark.go
+++ b/utils/crypto/bls/blstest/benchmark.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blstest

--- a/utils/crypto/bls/ciphersuite.go
+++ b/utils/crypto/bls/ciphersuite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bls

--- a/utils/crypto/bls/public.go
+++ b/utils/crypto/bls/public.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bls

--- a/utils/crypto/bls/public_test.go
+++ b/utils/crypto/bls/public_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bls

--- a/utils/crypto/bls/signature.go
+++ b/utils/crypto/bls/signature.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bls

--- a/utils/crypto/bls/signature_test.go
+++ b/utils/crypto/bls/signature_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bls

--- a/utils/crypto/bls/signer.go
+++ b/utils/crypto/bls/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package bls

--- a/utils/crypto/bls/signer/localsigner/benchmark_test.go
+++ b/utils/crypto/bls/signer/localsigner/benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package localsigner

--- a/utils/crypto/bls/signer/localsigner/bls_test.go
+++ b/utils/crypto/bls/signer/localsigner/bls_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package localsigner

--- a/utils/crypto/bls/signer/localsigner/localsigner.go
+++ b/utils/crypto/bls/signer/localsigner/localsigner.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package localsigner

--- a/utils/crypto/bls/signer/localsigner/serialization_test.go
+++ b/utils/crypto/bls/signer/localsigner/serialization_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package localsigner

--- a/utils/crypto/bls/signer/rpcsigner/client.go
+++ b/utils/crypto/bls/signer/rpcsigner/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcsigner

--- a/utils/crypto/bls/signer/rpcsigner/client_test.go
+++ b/utils/crypto/bls/signer/rpcsigner/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcsigner

--- a/utils/crypto/keychain/keychain.go
+++ b/utils/crypto/keychain/keychain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package keychain

--- a/utils/crypto/secp256k1/rfc6979_test.go
+++ b/utils/crypto/secp256k1/rfc6979_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1

--- a/utils/crypto/secp256k1/secp256k1.go
+++ b/utils/crypto/secp256k1/secp256k1.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1

--- a/utils/crypto/secp256k1/secp256k1_benchmark_test.go
+++ b/utils/crypto/secp256k1/secp256k1_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1

--- a/utils/crypto/secp256k1/secp256k1_test.go
+++ b/utils/crypto/secp256k1/secp256k1_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1

--- a/utils/crypto/secp256k1/test_keys.go
+++ b/utils/crypto/secp256k1/test_keys.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1

--- a/utils/dynamicip/ifconfig_resolver.go
+++ b/utils/dynamicip/ifconfig_resolver.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dynamicip

--- a/utils/dynamicip/no_updater.go
+++ b/utils/dynamicip/no_updater.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dynamicip

--- a/utils/dynamicip/opendns_resolver.go
+++ b/utils/dynamicip/opendns_resolver.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dynamicip

--- a/utils/dynamicip/resolver.go
+++ b/utils/dynamicip/resolver.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dynamicip

--- a/utils/dynamicip/resolver_test.go
+++ b/utils/dynamicip/resolver_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dynamicip

--- a/utils/dynamicip/updater.go
+++ b/utils/dynamicip/updater.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dynamicip

--- a/utils/dynamicip/updater_test.go
+++ b/utils/dynamicip/updater_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dynamicip

--- a/utils/filesystem/io.go
+++ b/utils/filesystem/io.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package filesystem

--- a/utils/filesystem/mock_file.go
+++ b/utils/filesystem/mock_file.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package filesystem

--- a/utils/filesystem/mocks_generate_test.go
+++ b/utils/filesystem/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package filesystem

--- a/utils/filesystem/rename.go
+++ b/utils/filesystem/rename.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package filesystem

--- a/utils/filesystem/rename_test.go
+++ b/utils/filesystem/rename_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package filesystem

--- a/utils/formatting/address/address.go
+++ b/utils/formatting/address/address.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package address

--- a/utils/formatting/address/converter.go
+++ b/utils/formatting/address/converter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package address

--- a/utils/formatting/encoding.go
+++ b/utils/formatting/encoding.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package formatting

--- a/utils/formatting/encoding_benchmark_test.go
+++ b/utils/formatting/encoding_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package formatting

--- a/utils/formatting/encoding_test.go
+++ b/utils/formatting/encoding_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package formatting

--- a/utils/formatting/int_format.go
+++ b/utils/formatting/int_format.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package formatting

--- a/utils/formatting/int_format_test.go
+++ b/utils/formatting/int_format_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package formatting

--- a/utils/formatting/prefixed_stringer.go
+++ b/utils/formatting/prefixed_stringer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package formatting

--- a/utils/hashing/consistent/hashable.go
+++ b/utils/hashing/consistent/hashable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package consistent

--- a/utils/hashing/consistent/ring.go
+++ b/utils/hashing/consistent/ring.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package consistent

--- a/utils/hashing/consistent/ring_test.go
+++ b/utils/hashing/consistent/ring_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package consistent

--- a/utils/hashing/hasher.go
+++ b/utils/hashing/hasher.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package hashing

--- a/utils/hashing/hashing.go
+++ b/utils/hashing/hashing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package hashing

--- a/utils/hashing/mocks_generate_test.go
+++ b/utils/hashing/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package hashing

--- a/utils/heap/map.go
+++ b/utils/heap/map.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package heap

--- a/utils/heap/map_test.go
+++ b/utils/heap/map_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package heap

--- a/utils/heap/queue.go
+++ b/utils/heap/queue.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package heap

--- a/utils/heap/queue_test.go
+++ b/utils/heap/queue_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package heap

--- a/utils/heap/set.go
+++ b/utils/heap/set.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package heap

--- a/utils/heap/set_test.go
+++ b/utils/heap/set_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package heap

--- a/utils/ips/claimed_ip_port.go
+++ b/utils/ips/claimed_ip_port.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ips

--- a/utils/ips/ip.go
+++ b/utils/ips/ip.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ips

--- a/utils/ips/lookup.go
+++ b/utils/ips/lookup.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ips

--- a/utils/ips/lookup_test.go
+++ b/utils/ips/lookup_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ips

--- a/utils/iterator/empty.go
+++ b/utils/iterator/empty.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator

--- a/utils/iterator/empty_test.go
+++ b/utils/iterator/empty_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator

--- a/utils/iterator/filter.go
+++ b/utils/iterator/filter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator

--- a/utils/iterator/filter_test.go
+++ b/utils/iterator/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator_test

--- a/utils/iterator/iterator.go
+++ b/utils/iterator/iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator

--- a/utils/iterator/merge.go
+++ b/utils/iterator/merge.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator

--- a/utils/iterator/merge_test.go
+++ b/utils/iterator/merge_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator_test

--- a/utils/iterator/slice.go
+++ b/utils/iterator/slice.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator

--- a/utils/iterator/tree.go
+++ b/utils/iterator/tree.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator

--- a/utils/iterator/tree_test.go
+++ b/utils/iterator/tree_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package iterator_test

--- a/utils/json/codec.go
+++ b/utils/json/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/json/float32.go
+++ b/utils/json/float32.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/json/float32_test.go
+++ b/utils/json/float32_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/json/float64.go
+++ b/utils/json/float64.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/json/uint16.go
+++ b/utils/json/uint16.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/json/uint32.go
+++ b/utils/json/uint32.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/json/uint64.go
+++ b/utils/json/uint64.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/json/uint8.go
+++ b/utils/json/uint8.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/linked/hashmap.go
+++ b/utils/linked/hashmap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linked

--- a/utils/linked/hashmap_test.go
+++ b/utils/linked/hashmap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linked

--- a/utils/linked/list.go
+++ b/utils/linked/list.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linked

--- a/utils/linked/list_test.go
+++ b/utils/linked/list_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linked

--- a/utils/lock/cond.go
+++ b/utils/lock/cond.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package lock

--- a/utils/lock/cond_test.go
+++ b/utils/lock/cond_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package lock

--- a/utils/logging/color.go
+++ b/utils/logging/color.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/config.go
+++ b/utils/logging/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/factory.go
+++ b/utils/logging/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/format.go
+++ b/utils/logging/format.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/level.go
+++ b/utils/logging/level.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/log.go
+++ b/utils/logging/log.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/log_test.go
+++ b/utils/logging/log_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/sanitize.go
+++ b/utils/logging/sanitize.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/logging/test_log.go
+++ b/utils/logging/test_log.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package logging

--- a/utils/math/averager.go
+++ b/utils/math/averager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/math/averager_heap.go
+++ b/utils/math/averager_heap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/math/averager_heap_test.go
+++ b/utils/math/averager_heap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/math/continuous_averager.go
+++ b/utils/math/continuous_averager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/math/continuous_averager_benchmark_test.go
+++ b/utils/math/continuous_averager_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/math/continuous_averager_test.go
+++ b/utils/math/continuous_averager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/math/meter/continuous_meter.go
+++ b/utils/math/meter/continuous_meter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meter

--- a/utils/math/meter/factory.go
+++ b/utils/math/meter/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meter

--- a/utils/math/meter/meter.go
+++ b/utils/math/meter/meter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meter

--- a/utils/math/meter/meter_benchmark_test.go
+++ b/utils/math/meter/meter_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meter

--- a/utils/math/meter/meter_test.go
+++ b/utils/math/meter/meter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package meter

--- a/utils/math/safe_math.go
+++ b/utils/math/safe_math.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/math/safe_math_test.go
+++ b/utils/math/safe_math_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/math/sync_averager.go
+++ b/utils/math/sync_averager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package math

--- a/utils/maybe/maybe.go
+++ b/utils/maybe/maybe.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package maybe

--- a/utils/maybe/maybe_test.go
+++ b/utils/maybe/maybe_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package maybe

--- a/utils/metric/api_interceptor.go
+++ b/utils/metric/api_interceptor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metric

--- a/utils/metric/averager.go
+++ b/utils/metric/averager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metric

--- a/utils/metric/namespace.go
+++ b/utils/metric/namespace.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metric

--- a/utils/metric/namespace_test.go
+++ b/utils/metric/namespace_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metric

--- a/utils/packages/dependencies.go
+++ b/utils/packages/dependencies.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package packages

--- a/utils/password/hash.go
+++ b/utils/password/hash.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package password

--- a/utils/password/hash_test.go
+++ b/utils/password/hash_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package password

--- a/utils/password/password.go
+++ b/utils/password/password.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package password

--- a/utils/password/password_test.go
+++ b/utils/password/password_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package password

--- a/utils/perms/chmod.go
+++ b/utils/perms/chmod.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package perms

--- a/utils/perms/create.go
+++ b/utils/perms/create.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package perms

--- a/utils/perms/perms.go
+++ b/utils/perms/perms.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package perms

--- a/utils/perms/write_file.go
+++ b/utils/perms/write_file.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package perms

--- a/utils/profiler/continuous.go
+++ b/utils/profiler/continuous.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package profiler

--- a/utils/profiler/profiler.go
+++ b/utils/profiler/profiler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package profiler

--- a/utils/profiler/profiler_test.go
+++ b/utils/profiler/profiler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package profiler

--- a/utils/resource/metrics.go
+++ b/utils/resource/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package resource

--- a/utils/resource/mocks_generate_test.go
+++ b/utils/resource/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package resource

--- a/utils/resource/no_usage.go
+++ b/utils/resource/no_usage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package resource

--- a/utils/resource/usage.go
+++ b/utils/resource/usage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package resource

--- a/utils/resource/usage_test.go
+++ b/utils/resource/usage_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package resource

--- a/utils/rpc/json.go
+++ b/utils/rpc/json.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/utils/rpc/options.go
+++ b/utils/rpc/options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/utils/rpc/requester.go
+++ b/utils/rpc/requester.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/utils/sampler/rand.go
+++ b/utils/sampler/rand.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/rand_test.go
+++ b/utils/sampler/rand_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/uniform.go
+++ b/utils/sampler/uniform.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/uniform_benchmark_test.go
+++ b/utils/sampler/uniform_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/uniform_replacer.go
+++ b/utils/sampler/uniform_replacer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/uniform_test.go
+++ b/utils/sampler/uniform_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted.go
+++ b/utils/sampler/weighted.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted_benchmark_test.go
+++ b/utils/sampler/weighted_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted_heap.go
+++ b/utils/sampler/weighted_heap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted_heap_test.go
+++ b/utils/sampler/weighted_heap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted_test.go
+++ b/utils/sampler/weighted_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted_without_replacement.go
+++ b/utils/sampler/weighted_without_replacement.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted_without_replacement_benchmark_test.go
+++ b/utils/sampler/weighted_without_replacement_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted_without_replacement_generic.go
+++ b/utils/sampler/weighted_without_replacement_generic.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/sampler/weighted_without_replacement_test.go
+++ b/utils/sampler/weighted_without_replacement_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sampler

--- a/utils/set/bits.go
+++ b/utils/set/bits.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/set/bits_64.go
+++ b/utils/set/bits_64.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/set/bits_64_test.go
+++ b/utils/set/bits_64_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/set/bits_test.go
+++ b/utils/set/bits_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/set/sampleable_set.go
+++ b/utils/set/sampleable_set.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/set/sampleable_set_test.go
+++ b/utils/set/sampleable_set_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/set/set_benchmark_test.go
+++ b/utils/set/set_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/set/set_test.go
+++ b/utils/set/set_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package set

--- a/utils/setmap/setmap.go
+++ b/utils/setmap/setmap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package setmap

--- a/utils/setmap/setmap_test.go
+++ b/utils/setmap/setmap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package setmap

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/slice_test.go
+++ b/utils/slice_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/sorting.go
+++ b/utils/sorting.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/sorting_test.go
+++ b/utils/sorting_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/stacktrace.go
+++ b/utils/stacktrace.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/utils/storage/storage_common.go
+++ b/utils/storage/storage_common.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package storage

--- a/utils/storage/storage_openbsd.go
+++ b/utils/storage/storage_openbsd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build openbsd

--- a/utils/storage/storage_unix.go
+++ b/utils/storage/storage_unix.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build !windows && !openbsd

--- a/utils/timer/adaptive_timeout_manager.go
+++ b/utils/timer/adaptive_timeout_manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timer

--- a/utils/timer/adaptive_timeout_manager_test.go
+++ b/utils/timer/adaptive_timeout_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timer

--- a/utils/timer/eta.go
+++ b/utils/timer/eta.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timer

--- a/utils/timer/eta_test.go
+++ b/utils/timer/eta_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timer

--- a/utils/timer/meter.go
+++ b/utils/timer/meter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timer

--- a/utils/timer/mockable/clock.go
+++ b/utils/timer/mockable/clock.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mockable

--- a/utils/timer/mockable/clock_test.go
+++ b/utils/timer/mockable/clock_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mockable

--- a/utils/timer/stopped_timer.go
+++ b/utils/timer/stopped_timer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timer

--- a/utils/timer/timer.go
+++ b/utils/timer/timer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timer

--- a/utils/timer/timer_test.go
+++ b/utils/timer/timer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package timer

--- a/utils/tree/tree.go
+++ b/utils/tree/tree.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tree

--- a/utils/tree/tree_test.go
+++ b/utils/tree/tree_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tree

--- a/utils/ulimit/ulimit_bsd.go
+++ b/utils/ulimit/ulimit_bsd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build freebsd

--- a/utils/ulimit/ulimit_darwin.go
+++ b/utils/ulimit/ulimit_darwin.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build darwin

--- a/utils/ulimit/ulimit_unix.go
+++ b/utils/ulimit/ulimit_unix.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build linux || netbsd || openbsd

--- a/utils/units/avax.go
+++ b/utils/units/avax.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package units

--- a/utils/units/bytes.go
+++ b/utils/units/bytes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package units

--- a/utils/window/window.go
+++ b/utils/window/window.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package window

--- a/utils/window/window_test.go
+++ b/utils/window/window_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package window

--- a/utils/wrappers/closers.go
+++ b/utils/wrappers/closers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wrappers

--- a/utils/wrappers/errors.go
+++ b/utils/wrappers/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wrappers

--- a/utils/wrappers/packing.go
+++ b/utils/wrappers/packing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wrappers

--- a/utils/wrappers/packing_test.go
+++ b/utils/wrappers/packing_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wrappers

--- a/utils/zero.go
+++ b/utils/zero.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/version/application.go
+++ b/version/application.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/version/application_test.go
+++ b/version/application_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/version/compatibility.go
+++ b/version/compatibility.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/version/compatibility_test.go
+++ b/version/compatibility_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/version/constants.go
+++ b/version/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/version/constants_test.go
+++ b/version/constants_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/version/string.go
+++ b/version/string.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/version/string_test.go
+++ b/version/string_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/vms/avm/block/block.go
+++ b/vms/avm/block/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/avm/block/block_test.go
+++ b/vms/avm/block/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/avm/block/builder/builder.go
+++ b/vms/avm/block/builder/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/avm/block/builder/builder_test.go
+++ b/vms/avm/block/builder/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/avm/block/executor/block.go
+++ b/vms/avm/block/executor/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/block/executor/block_test.go
+++ b/vms/avm/block/executor/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/block/executor/manager.go
+++ b/vms/avm/block/executor/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/block/executor/manager_test.go
+++ b/vms/avm/block/executor/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/block/executor/mocks_generate_test.go
+++ b/vms/avm/block/executor/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/block/mocks_generate_test.go
+++ b/vms/avm/block/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/avm/block/parser.go
+++ b/vms/avm/block/parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/avm/block/standard_block.go
+++ b/vms/avm/block/standard_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/avm/client.go
+++ b/vms/avm/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/config.go
+++ b/vms/avm/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/config/config.go
+++ b/vms/avm/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/vms/avm/config_test.go
+++ b/vms/avm/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/environment_test.go
+++ b/vms/avm/environment_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/factory.go
+++ b/vms/avm/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/fx_test.go
+++ b/vms/avm/fx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/fxs/fx.go
+++ b/vms/avm/fxs/fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fxs

--- a/vms/avm/genesis.go
+++ b/vms/avm/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/genesis_test.go
+++ b/vms/avm/genesis_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/health.go
+++ b/vms/avm/health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/metrics/metrics.go
+++ b/vms/avm/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/vms/avm/metrics/mocks_generate_test.go
+++ b/vms/avm/metrics/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/vms/avm/metrics/tx_metrics.go
+++ b/vms/avm/metrics/tx_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/vms/avm/network/atomic.go
+++ b/vms/avm/network/atomic.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/avm/network/config.go
+++ b/vms/avm/network/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/avm/network/gossip.go
+++ b/vms/avm/network/gossip.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/avm/network/gossip_test.go
+++ b/vms/avm/network/gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/avm/network/network.go
+++ b/vms/avm/network/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/avm/network/network_test.go
+++ b/vms/avm/network/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/avm/network/tx_verifier.go
+++ b/vms/avm/network/tx_verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/avm/service.go
+++ b/vms/avm/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/service_test.go
+++ b/vms/avm/service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/state/diff.go
+++ b/vms/avm/state/diff.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/avm/state/mocks_generate_test.go
+++ b/vms/avm/state/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/avm/state/state.go
+++ b/vms/avm/state/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/avm/state/state_test.go
+++ b/vms/avm/state/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/avm/state/versions.go
+++ b/vms/avm/state/versions.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/avm/state_test.go
+++ b/vms/avm/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/tx.go
+++ b/vms/avm/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/tx_init.go
+++ b/vms/avm/tx_init.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/txs/base_tx.go
+++ b/vms/avm/txs/base_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/base_tx_test.go
+++ b/vms/avm/txs/base_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/codec.go
+++ b/vms/avm/txs/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/create_asset_tx.go
+++ b/vms/avm/txs/create_asset_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/create_asset_tx_test.go
+++ b/vms/avm/txs/create_asset_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/executor/backend.go
+++ b/vms/avm/txs/executor/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/txs/executor/executor.go
+++ b/vms/avm/txs/executor/executor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/txs/executor/executor_test.go
+++ b/vms/avm/txs/executor/executor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/txs/executor/semantic_verifier.go
+++ b/vms/avm/txs/executor/semantic_verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/txs/executor/semantic_verifier_test.go
+++ b/vms/avm/txs/executor/semantic_verifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/txs/executor/syntactic_verifier.go
+++ b/vms/avm/txs/executor/syntactic_verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/txs/executor/syntactic_verifier_test.go
+++ b/vms/avm/txs/executor/syntactic_verifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/avm/txs/export_tx.go
+++ b/vms/avm/txs/export_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/export_tx_test.go
+++ b/vms/avm/txs/export_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/import_tx.go
+++ b/vms/avm/txs/import_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/import_tx_test.go
+++ b/vms/avm/txs/import_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/initial_state.go
+++ b/vms/avm/txs/initial_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/initial_state_test.go
+++ b/vms/avm/txs/initial_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/mempool/mempool.go
+++ b/vms/avm/txs/mempool/mempool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mempool

--- a/vms/avm/txs/mocks_generate_test.go
+++ b/vms/avm/txs/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/operation.go
+++ b/vms/avm/txs/operation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/operation_test.go
+++ b/vms/avm/txs/operation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/operation_tx.go
+++ b/vms/avm/txs/operation_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/parser.go
+++ b/vms/avm/txs/parser.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/tx.go
+++ b/vms/avm/txs/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/txs/txstest/builder.go
+++ b/vms/avm/txs/txstest/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txstest

--- a/vms/avm/txs/txstest/context.go
+++ b/vms/avm/txs/txstest/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txstest

--- a/vms/avm/txs/txstest/utxos.go
+++ b/vms/avm/txs/txstest/utxos.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txstest

--- a/vms/avm/txs/visitor.go
+++ b/vms/avm/txs/visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/avm/utxo/spender.go
+++ b/vms/avm/utxo/spender.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/vm_benchmark_test.go
+++ b/vms/avm/vm_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/vm_regression_test.go
+++ b/vms/avm/vm_regression_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/vm_test.go
+++ b/vms/avm/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/wallet_client.go
+++ b/vms/avm/wallet_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/wallet_service.go
+++ b/vms/avm/wallet_service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/components/avax/addresses.go
+++ b/vms/components/avax/addresses.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/asset.go
+++ b/vms/components/avax/asset.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/asset_test.go
+++ b/vms/components/avax/asset_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/atomic_utxos.go
+++ b/vms/components/avax/atomic_utxos.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/base_tx.go
+++ b/vms/components/avax/base_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/flow_checker.go
+++ b/vms/components/avax/flow_checker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/mocks_generate_test.go
+++ b/vms/components/avax/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/state.go
+++ b/vms/components/avax/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/test_verifiable.go
+++ b/vms/components/avax/test_verifiable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/transferables.go
+++ b/vms/components/avax/transferables.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/transferables_test.go
+++ b/vms/components/avax/transferables_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo.go
+++ b/vms/components/avax/utxo.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo_fetching.go
+++ b/vms/components/avax/utxo_fetching.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo_fetching_test.go
+++ b/vms/components/avax/utxo_fetching_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo_handler.go
+++ b/vms/components/avax/utxo_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo_id.go
+++ b/vms/components/avax/utxo_id.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo_id_test.go
+++ b/vms/components/avax/utxo_id_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo_state.go
+++ b/vms/components/avax/utxo_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo_state_test.go
+++ b/vms/components/avax/utxo_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/utxo_test.go
+++ b/vms/components/avax/utxo_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/chain/block.go
+++ b/vms/components/chain/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chain

--- a/vms/components/chain/state.go
+++ b/vms/components/chain/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chain

--- a/vms/components/chain/state_test.go
+++ b/vms/components/chain/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chain

--- a/vms/components/gas/config.go
+++ b/vms/components/gas/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // The gas package implements dynamic gas pricing specified in ACP-103:

--- a/vms/components/gas/dimensions.go
+++ b/vms/components/gas/dimensions.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gas

--- a/vms/components/gas/dimensions_test.go
+++ b/vms/components/gas/dimensions_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gas

--- a/vms/components/gas/gas.go
+++ b/vms/components/gas/gas.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gas

--- a/vms/components/gas/gas_test.go
+++ b/vms/components/gas/gas_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gas

--- a/vms/components/gas/state.go
+++ b/vms/components/gas/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gas

--- a/vms/components/gas/state_test.go
+++ b/vms/components/gas/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gas

--- a/vms/components/verify/mocks_generate_test.go
+++ b/vms/components/verify/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package verify

--- a/vms/components/verify/subnet.go
+++ b/vms/components/verify/subnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package verify

--- a/vms/components/verify/subnet_test.go
+++ b/vms/components/verify/subnet_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package verify

--- a/vms/components/verify/verification.go
+++ b/vms/components/verify/verification.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package verify

--- a/vms/components/verify/verification_test.go
+++ b/vms/components/verify/verification_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package verify

--- a/vms/evm/acp176/acp176.go
+++ b/vms/evm/acp176/acp176.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // ACP176 implements the fee logic specified here:

--- a/vms/evm/acp176/acp176_test.go
+++ b/vms/evm/acp176/acp176_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package acp176

--- a/vms/evm/acp226/acp226.go
+++ b/vms/evm/acp226/acp226.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // ACP-226 implements the dynamic minimum block delay mechanism specified here:

--- a/vms/evm/acp226/acp226_test.go
+++ b/vms/evm/acp226/acp226_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package acp226

--- a/vms/evm/database/database.go
+++ b/vms/evm/database/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package database

--- a/vms/evm/database/database_test.go
+++ b/vms/evm/database/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package database

--- a/vms/evm/emulate/emulate.go
+++ b/vms/evm/emulate/emulate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package emulate provides temporary emulation of coreth (C-Chain) and

--- a/vms/evm/emulate/emulate_test.go
+++ b/vms/evm/emulate/emulate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package emulate

--- a/vms/evm/imports_test.go
+++ b/vms/evm/imports_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package evm

--- a/vms/evm/metrics/metricstest/metrics.go
+++ b/vms/evm/metrics/metricstest/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metricstest

--- a/vms/evm/metrics/prometheus/enabled_test.go
+++ b/vms/evm/metrics/prometheus/enabled_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package prometheus_test

--- a/vms/evm/metrics/prometheus/interfaces.go
+++ b/vms/evm/metrics/prometheus/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package prometheus

--- a/vms/evm/metrics/prometheus/prometheus.go
+++ b/vms/evm/metrics/prometheus/prometheus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package prometheus

--- a/vms/evm/metrics/prometheus/prometheus_test.go
+++ b/vms/evm/metrics/prometheus/prometheus_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package prometheus

--- a/vms/evm/predicate/predicate.go
+++ b/vms/evm/predicate/predicate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package predicate

--- a/vms/evm/predicate/predicate_test.go
+++ b/vms/evm/predicate/predicate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package predicate

--- a/vms/evm/predicate/results.go
+++ b/vms/evm/predicate/results.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package predicate

--- a/vms/evm/predicate/results_test.go
+++ b/vms/evm/predicate/results_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package predicate

--- a/vms/evm/sync/customrawdb/db.go
+++ b/vms/evm/sync/customrawdb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/vms/evm/sync/customrawdb/db_test.go
+++ b/vms/evm/sync/customrawdb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/vms/evm/sync/customrawdb/markers.go
+++ b/vms/evm/sync/customrawdb/markers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/vms/evm/sync/customrawdb/markers_test.go
+++ b/vms/evm/sync/customrawdb/markers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/vms/evm/sync/customrawdb/sync_progress.go
+++ b/vms/evm/sync/customrawdb/sync_progress.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/vms/evm/sync/customrawdb/sync_progress_test.go
+++ b/vms/evm/sync/customrawdb/sync_progress_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package customrawdb

--- a/vms/evm/uptimetracker/state.go
+++ b/vms/evm/uptimetracker/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptimetracker

--- a/vms/evm/uptimetracker/uptime_tracker.go
+++ b/vms/evm/uptimetracker/uptime_tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptimetracker

--- a/vms/evm/uptimetracker/uptime_tracker_test.go
+++ b/vms/evm/uptimetracker/uptime_tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package uptimetracker

--- a/vms/example/xsvm/api/client.go
+++ b/vms/example/xsvm/api/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/vms/example/xsvm/api/ping.go
+++ b/vms/example/xsvm/api/ping.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/vms/example/xsvm/api/server.go
+++ b/vms/example/xsvm/api/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/vms/example/xsvm/block/block.go
+++ b/vms/example/xsvm/block/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/example/xsvm/block/codec.go
+++ b/vms/example/xsvm/block/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/example/xsvm/builder/builder.go
+++ b/vms/example/xsvm/builder/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/example/xsvm/chain/block.go
+++ b/vms/example/xsvm/chain/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chain

--- a/vms/example/xsvm/chain/chain.go
+++ b/vms/example/xsvm/chain/chain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chain

--- a/vms/example/xsvm/cmd/account/cmd.go
+++ b/vms/example/xsvm/cmd/account/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package account

--- a/vms/example/xsvm/cmd/account/flags.go
+++ b/vms/example/xsvm/cmd/account/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package account

--- a/vms/example/xsvm/cmd/chain/cmd.go
+++ b/vms/example/xsvm/cmd/chain/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chain

--- a/vms/example/xsvm/cmd/chain/create/cmd.go
+++ b/vms/example/xsvm/cmd/chain/create/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package create

--- a/vms/example/xsvm/cmd/chain/create/flags.go
+++ b/vms/example/xsvm/cmd/chain/create/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package create

--- a/vms/example/xsvm/cmd/chain/genesis/cmd.go
+++ b/vms/example/xsvm/cmd/chain/genesis/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/example/xsvm/cmd/chain/genesis/flags.go
+++ b/vms/example/xsvm/cmd/chain/genesis/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/example/xsvm/cmd/issue/cmd.go
+++ b/vms/example/xsvm/cmd/issue/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package issue

--- a/vms/example/xsvm/cmd/issue/export/cmd.go
+++ b/vms/example/xsvm/cmd/issue/export/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package export

--- a/vms/example/xsvm/cmd/issue/export/flags.go
+++ b/vms/example/xsvm/cmd/issue/export/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package export

--- a/vms/example/xsvm/cmd/issue/importtx/cmd.go
+++ b/vms/example/xsvm/cmd/issue/importtx/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package importtx

--- a/vms/example/xsvm/cmd/issue/importtx/flags.go
+++ b/vms/example/xsvm/cmd/issue/importtx/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package importtx

--- a/vms/example/xsvm/cmd/issue/status/status.go
+++ b/vms/example/xsvm/cmd/issue/status/status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package status

--- a/vms/example/xsvm/cmd/issue/transfer/cmd.go
+++ b/vms/example/xsvm/cmd/issue/transfer/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package transfer

--- a/vms/example/xsvm/cmd/issue/transfer/flags.go
+++ b/vms/example/xsvm/cmd/issue/transfer/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package transfer

--- a/vms/example/xsvm/cmd/run/cmd.go
+++ b/vms/example/xsvm/cmd/run/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package run

--- a/vms/example/xsvm/cmd/version/cmd.go
+++ b/vms/example/xsvm/cmd/version/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/vms/example/xsvm/cmd/versionjson/cmd.go
+++ b/vms/example/xsvm/cmd/versionjson/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package versionjson

--- a/vms/example/xsvm/cmd/xsvm/main.go
+++ b/vms/example/xsvm/cmd/xsvm/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/vms/example/xsvm/constants.go
+++ b/vms/example/xsvm/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package xsvm

--- a/vms/example/xsvm/execute/block.go
+++ b/vms/example/xsvm/execute/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package execute

--- a/vms/example/xsvm/execute/expects_context.go
+++ b/vms/example/xsvm/execute/expects_context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package execute

--- a/vms/example/xsvm/execute/genesis.go
+++ b/vms/example/xsvm/execute/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package execute

--- a/vms/example/xsvm/execute/tx.go
+++ b/vms/example/xsvm/execute/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package execute

--- a/vms/example/xsvm/factory.go
+++ b/vms/example/xsvm/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package xsvm

--- a/vms/example/xsvm/genesis/codec.go
+++ b/vms/example/xsvm/genesis/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/example/xsvm/genesis/genesis.go
+++ b/vms/example/xsvm/genesis/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/example/xsvm/genesis/genesis_test.go
+++ b/vms/example/xsvm/genesis/genesis_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/example/xsvm/state/keys.go
+++ b/vms/example/xsvm/state/keys.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/example/xsvm/state/storage.go
+++ b/vms/example/xsvm/state/storage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/example/xsvm/tx/codec.go
+++ b/vms/example/xsvm/tx/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tx

--- a/vms/example/xsvm/tx/export.go
+++ b/vms/example/xsvm/tx/export.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tx

--- a/vms/example/xsvm/tx/import.go
+++ b/vms/example/xsvm/tx/import.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tx

--- a/vms/example/xsvm/tx/payload.go
+++ b/vms/example/xsvm/tx/payload.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tx

--- a/vms/example/xsvm/tx/transfer.go
+++ b/vms/example/xsvm/tx/transfer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tx

--- a/vms/example/xsvm/tx/tx.go
+++ b/vms/example/xsvm/tx/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tx

--- a/vms/example/xsvm/tx/unsigned.go
+++ b/vms/example/xsvm/tx/unsigned.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tx

--- a/vms/example/xsvm/tx/visitor.go
+++ b/vms/example/xsvm/tx/visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tx

--- a/vms/example/xsvm/vm.go
+++ b/vms/example/xsvm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package xsvm

--- a/vms/example/xsvm/warp.go
+++ b/vms/example/xsvm/warp.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package xsvm

--- a/vms/fx/factory.go
+++ b/vms/fx/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fx

--- a/vms/manager.go
+++ b/vms/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vms

--- a/vms/metervm/batched_vm.go
+++ b/vms/metervm/batched_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/block.go
+++ b/vms/metervm/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/block_metrics.go
+++ b/vms/metervm/block_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/block_vm.go
+++ b/vms/metervm/block_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/build_block_with_context_vm.go
+++ b/vms/metervm/build_block_with_context_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/metrics.go
+++ b/vms/metervm/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/set_preference_with_context_vm.go
+++ b/vms/metervm/set_preference_with_context_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/state_syncable_vm.go
+++ b/vms/metervm/state_syncable_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/vertex_metrics.go
+++ b/vms/metervm/vertex_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/metervm/vertex_vm.go
+++ b/vms/metervm/vertex_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metervm

--- a/vms/mocks_generate_test.go
+++ b/vms/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package vms

--- a/vms/nftfx/credential.go
+++ b/vms/nftfx/credential.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/credential_test.go
+++ b/vms/nftfx/credential_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/factory.go
+++ b/vms/nftfx/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/factory_test.go
+++ b/vms/nftfx/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/fx.go
+++ b/vms/nftfx/fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/fx_test.go
+++ b/vms/nftfx/fx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/mint_operation.go
+++ b/vms/nftfx/mint_operation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/mint_operation_test.go
+++ b/vms/nftfx/mint_operation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/mint_output.go
+++ b/vms/nftfx/mint_output.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/mint_output_test.go
+++ b/vms/nftfx/mint_output_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/transfer_operation.go
+++ b/vms/nftfx/transfer_operation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/transfer_operation_test.go
+++ b/vms/nftfx/transfer_operation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/transfer_output.go
+++ b/vms/nftfx/transfer_output.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/nftfx/transfer_output_test.go
+++ b/vms/nftfx/transfer_output_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package nftfx

--- a/vms/platformvm/api/height.go
+++ b/vms/platformvm/api/height.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/vms/platformvm/api/height_test.go
+++ b/vms/platformvm/api/height_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/vms/platformvm/api/validator.go
+++ b/vms/platformvm/api/validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/vms/platformvm/block/abort_block.go
+++ b/vms/platformvm/block/abort_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/abort_block_test.go
+++ b/vms/platformvm/block/abort_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/atomic_block.go
+++ b/vms/platformvm/block/atomic_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/atomic_block_test.go
+++ b/vms/platformvm/block/atomic_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/block.go
+++ b/vms/platformvm/block/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/block/builder/main_test.go
+++ b/vms/platformvm/block/builder/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/block/builder/standard_block_test.go
+++ b/vms/platformvm/block/builder/standard_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/commit_block.go
+++ b/vms/platformvm/block/commit_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/commit_block_test.go
+++ b/vms/platformvm/block/commit_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/common_block.go
+++ b/vms/platformvm/block/common_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/executor/acceptor.go
+++ b/vms/platformvm/block/executor/acceptor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/acceptor_test.go
+++ b/vms/platformvm/block/executor/acceptor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/backend.go
+++ b/vms/platformvm/block/executor/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/backend_test.go
+++ b/vms/platformvm/block/executor/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/block.go
+++ b/vms/platformvm/block/executor/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/block_state.go
+++ b/vms/platformvm/block/executor/block_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/block_test.go
+++ b/vms/platformvm/block/executor/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/manager.go
+++ b/vms/platformvm/block/executor/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/manager_test.go
+++ b/vms/platformvm/block/executor/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/mocks_generate_test.go
+++ b/vms/platformvm/block/executor/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/options.go
+++ b/vms/platformvm/block/executor/options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/options_test.go
+++ b/vms/platformvm/block/executor/options_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/rejector.go
+++ b/vms/platformvm/block/executor/rejector.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/rejector_test.go
+++ b/vms/platformvm/block/executor/rejector_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/warp_verifier.go
+++ b/vms/platformvm/block/executor/warp_verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/executor/warp_verifier_test.go
+++ b/vms/platformvm/block/executor/warp_verifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/block/mocks_generate_test.go
+++ b/vms/platformvm/block/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/parse.go
+++ b/vms/platformvm/block/parse.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/parse_test.go
+++ b/vms/platformvm/block/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/proposal_block.go
+++ b/vms/platformvm/block/proposal_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/proposal_block_test.go
+++ b/vms/platformvm/block/proposal_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/serialization_test.go
+++ b/vms/platformvm/block/serialization_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/standard_block.go
+++ b/vms/platformvm/block/standard_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/standard_block_test.go
+++ b/vms/platformvm/block/standard_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/block/visitor.go
+++ b/vms/platformvm/block/visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/client_permissionless_validator.go
+++ b/vms/platformvm/client_permissionless_validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/config/config.go
+++ b/vms/platformvm/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/vms/platformvm/config/config_test.go
+++ b/vms/platformvm/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/vms/platformvm/config/internal.go
+++ b/vms/platformvm/config/internal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/vms/platformvm/config/network.go
+++ b/vms/platformvm/config/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/vms/platformvm/factory.go
+++ b/vms/platformvm/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/fx/fx.go
+++ b/vms/platformvm/fx/fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fx

--- a/vms/platformvm/fx/mocks_generate_test.go
+++ b/vms/platformvm/fx/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fx

--- a/vms/platformvm/genesis/codec.go
+++ b/vms/platformvm/genesis/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/platformvm/genesis/genesis.go
+++ b/vms/platformvm/genesis/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/platformvm/genesis/genesis_test.go
+++ b/vms/platformvm/genesis/genesis_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/platformvm/genesis/genesistest/genesis.go
+++ b/vms/platformvm/genesis/genesistest/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesistest

--- a/vms/platformvm/health.go
+++ b/vms/platformvm/health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/main_test.go
+++ b/vms/platformvm/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/metrics/block_metrics.go
+++ b/vms/platformvm/metrics/block_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/vms/platformvm/metrics/metrics.go
+++ b/vms/platformvm/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/vms/platformvm/metrics/no_op.go
+++ b/vms/platformvm/metrics/no_op.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/vms/platformvm/metrics/tx_metrics.go
+++ b/vms/platformvm/metrics/tx_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/vms/platformvm/network/gossip.go
+++ b/vms/platformvm/network/gossip.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/platformvm/network/gossip_test.go
+++ b/vms/platformvm/network/gossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/platformvm/network/main_test.go
+++ b/vms/platformvm/network/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/platformvm/network/tx_verifier.go
+++ b/vms/platformvm/network/tx_verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/platformvm/network/warp.go
+++ b/vms/platformvm/network/warp.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/platformvm/network/warp_test.go
+++ b/vms/platformvm/network/warp_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package network

--- a/vms/platformvm/reward/calculator.go
+++ b/vms/platformvm/reward/calculator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package reward

--- a/vms/platformvm/reward/calculator_test.go
+++ b/vms/platformvm/reward/calculator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package reward

--- a/vms/platformvm/reward/config.go
+++ b/vms/platformvm/reward/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package reward

--- a/vms/platformvm/reward/example_test.go
+++ b/vms/platformvm/reward/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package reward

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/signer/empty.go
+++ b/vms/platformvm/signer/empty.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/vms/platformvm/signer/empty_test.go
+++ b/vms/platformvm/signer/empty_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/vms/platformvm/signer/mocks_generate_test.go
+++ b/vms/platformvm/signer/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/vms/platformvm/signer/proof_of_possession.go
+++ b/vms/platformvm/signer/proof_of_possession.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/vms/platformvm/signer/proof_of_possession_test.go
+++ b/vms/platformvm/signer/proof_of_possession_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/vms/platformvm/signer/signer.go
+++ b/vms/platformvm/signer/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/vms/platformvm/stakeable/stakeable_lock.go
+++ b/vms/platformvm/stakeable/stakeable_lock.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stakeable

--- a/vms/platformvm/stakeable/stakeable_lock_test.go
+++ b/vms/platformvm/stakeable/stakeable_lock_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package stakeable

--- a/vms/platformvm/state/chain_time_helpers.go
+++ b/vms/platformvm/state/chain_time_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/chain_time_helpers_test.go
+++ b/vms/platformvm/state/chain_time_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/disk_staker_diff_iterator.go
+++ b/vms/platformvm/state/disk_staker_diff_iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/disk_staker_diff_iterator_test.go
+++ b/vms/platformvm/state/disk_staker_diff_iterator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/expiry.go
+++ b/vms/platformvm/state/expiry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/expiry_test.go
+++ b/vms/platformvm/state/expiry_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/l1_validator.go
+++ b/vms/platformvm/state/l1_validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/l1_validator_test.go
+++ b/vms/platformvm/state/l1_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/metadata_codec.go
+++ b/vms/platformvm/state/metadata_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/metadata_delegator.go
+++ b/vms/platformvm/state/metadata_delegator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/metadata_delegator_test.go
+++ b/vms/platformvm/state/metadata_delegator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/metadata_validator.go
+++ b/vms/platformvm/state/metadata_validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/metadata_validator_test.go
+++ b/vms/platformvm/state/metadata_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/mocks_generate_test.go
+++ b/vms/platformvm/state/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/staker.go
+++ b/vms/platformvm/state/staker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/staker_diff_iterator.go
+++ b/vms/platformvm/state/staker_diff_iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/staker_diff_iterator_test.go
+++ b/vms/platformvm/state/staker_diff_iterator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/staker_status.go
+++ b/vms/platformvm/state/staker_status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/staker_test.go
+++ b/vms/platformvm/state/staker_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/statetest/state.go
+++ b/vms/platformvm/state/statetest/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package statetest

--- a/vms/platformvm/state/subnet_id_node_id.go
+++ b/vms/platformvm/state/subnet_id_node_id.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/subnet_id_node_id_test.go
+++ b/vms/platformvm/state/subnet_id_node_id_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/versions.go
+++ b/vms/platformvm/state/versions.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/status/blockchain_status.go
+++ b/vms/platformvm/status/blockchain_status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package status

--- a/vms/platformvm/status/blockchain_status_test.go
+++ b/vms/platformvm/status/blockchain_status_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package status

--- a/vms/platformvm/status/status.go
+++ b/vms/platformvm/status/status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package status

--- a/vms/platformvm/status/status_test.go
+++ b/vms/platformvm/status/status_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package status

--- a/vms/platformvm/txs/add_delegator_test.go
+++ b/vms/platformvm/txs/add_delegator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_delegator_tx.go
+++ b/vms/platformvm/txs/add_delegator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_permissionless_delegator_tx.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_permissionless_validator_tx.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_permissionless_validator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_subnet_validator_test.go
+++ b/vms/platformvm/txs/add_subnet_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_subnet_validator_tx.go
+++ b/vms/platformvm/txs/add_subnet_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_validator_test.go
+++ b/vms/platformvm/txs/add_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/add_validator_tx.go
+++ b/vms/platformvm/txs/add_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/advance_time_tx.go
+++ b/vms/platformvm/txs/advance_time_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/base_tx.go
+++ b/vms/platformvm/txs/base_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/base_tx_test.go
+++ b/vms/platformvm/txs/base_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/convert_subnet_to_l1_tx.go
+++ b/vms/platformvm/txs/convert_subnet_to_l1_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/convert_subnet_to_l1_tx_test.go
+++ b/vms/platformvm/txs/convert_subnet_to_l1_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/create_chain_test.go
+++ b/vms/platformvm/txs/create_chain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/create_chain_tx.go
+++ b/vms/platformvm/txs/create_chain_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/create_subnet_tx.go
+++ b/vms/platformvm/txs/create_subnet_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/disable_l1_validator_tx.go
+++ b/vms/platformvm/txs/disable_l1_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/disable_l1_validator_tx_test.go
+++ b/vms/platformvm/txs/disable_l1_validator_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/atomic_tx_executor.go
+++ b/vms/platformvm/txs/executor/atomic_tx_executor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/backend.go
+++ b/vms/platformvm/txs/executor/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/create_chain_test.go
+++ b/vms/platformvm/txs/executor/create_chain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/export_test.go
+++ b/vms/platformvm/txs/executor/export_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/helpers_test.go
+++ b/vms/platformvm/txs/executor/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/import_test.go
+++ b/vms/platformvm/txs/executor/import_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/proposal_tx_executor.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/proposal_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/staker_tx_verification.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/staker_tx_verification_test.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/standard_tx_executor.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/state_changes_test.go
+++ b/vms/platformvm/txs/executor/state_changes_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/subnet_tx_verification.go
+++ b/vms/platformvm/txs/executor/subnet_tx_verification.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/warp_verifier.go
+++ b/vms/platformvm/txs/executor/warp_verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/warp_verifier_test.go
+++ b/vms/platformvm/txs/executor/warp_verifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/export_tx.go
+++ b/vms/platformvm/txs/export_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/fee/calculator.go
+++ b/vms/platformvm/txs/fee/calculator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fee

--- a/vms/platformvm/txs/fee/calculator_test.go
+++ b/vms/platformvm/txs/fee/calculator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fee

--- a/vms/platformvm/txs/fee/complexity.go
+++ b/vms/platformvm/txs/fee/complexity.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // TODO: Before Etna, address all TODOs in this package and ensure ACP-103

--- a/vms/platformvm/txs/fee/complexity_test.go
+++ b/vms/platformvm/txs/fee/complexity_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fee

--- a/vms/platformvm/txs/fee/dynamic_calculator.go
+++ b/vms/platformvm/txs/fee/dynamic_calculator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fee

--- a/vms/platformvm/txs/fee/dynamic_calculator_test.go
+++ b/vms/platformvm/txs/fee/dynamic_calculator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fee

--- a/vms/platformvm/txs/fee/simple_calculator.go
+++ b/vms/platformvm/txs/fee/simple_calculator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fee

--- a/vms/platformvm/txs/import_tx.go
+++ b/vms/platformvm/txs/import_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/increase_l1_validator_balance_tx.go
+++ b/vms/platformvm/txs/increase_l1_validator_balance_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/increase_l1_validator_balance_tx_test.go
+++ b/vms/platformvm/txs/increase_l1_validator_balance_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mempool

--- a/vms/platformvm/txs/mempool/mempool_test.go
+++ b/vms/platformvm/txs/mempool/mempool_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mempool

--- a/vms/platformvm/txs/priorities.go
+++ b/vms/platformvm/txs/priorities.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/priorities_test.go
+++ b/vms/platformvm/txs/priorities_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/register_l1_validator_tx.go
+++ b/vms/platformvm/txs/register_l1_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/register_l1_validator_tx_test.go
+++ b/vms/platformvm/txs/register_l1_validator_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/remove_subnet_validator_tx.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/remove_subnet_validator_tx_test.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/reward_validator_tx.go
+++ b/vms/platformvm/txs/reward_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/set_l1_validator_weight_tx.go
+++ b/vms/platformvm/txs/set_l1_validator_weight_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/set_l1_validator_weight_tx_test.go
+++ b/vms/platformvm/txs/set_l1_validator_weight_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/staker_tx.go
+++ b/vms/platformvm/txs/staker_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/subnet_validator.go
+++ b/vms/platformvm/txs/subnet_validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/subnet_validator_test.go
+++ b/vms/platformvm/txs/subnet_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/transfer_subnet_ownership_tx.go
+++ b/vms/platformvm/txs/transfer_subnet_ownership_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/transfer_subnet_ownership_tx_test.go
+++ b/vms/platformvm/txs/transfer_subnet_ownership_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/transform_subnet_tx.go
+++ b/vms/platformvm/txs/transform_subnet_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/transform_subnet_tx_test.go
+++ b/vms/platformvm/txs/transform_subnet_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/tx.go
+++ b/vms/platformvm/txs/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/txheap/by_end_time.go
+++ b/vms/platformvm/txs/txheap/by_end_time.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txheap

--- a/vms/platformvm/txs/txheap/by_end_time_test.go
+++ b/vms/platformvm/txs/txheap/by_end_time_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txheap

--- a/vms/platformvm/txs/txheap/heap.go
+++ b/vms/platformvm/txs/txheap/heap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txheap

--- a/vms/platformvm/txs/txstest/context.go
+++ b/vms/platformvm/txs/txstest/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txstest

--- a/vms/platformvm/txs/txstest/wallet.go
+++ b/vms/platformvm/txs/txstest/wallet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txstest

--- a/vms/platformvm/txs/unsigned_tx.go
+++ b/vms/platformvm/txs/unsigned_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/validator.go
+++ b/vms/platformvm/txs/validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/validator_test.go
+++ b/vms/platformvm/txs/validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/visitor.go
+++ b/vms/platformvm/txs/visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/utxo/mocks_generate_test.go
+++ b/vms/platformvm/utxo/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/platformvm/utxo/verifier.go
+++ b/vms/platformvm/utxo/verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/platformvm/utxo/verifier_test.go
+++ b/vms/platformvm/utxo/verifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/platformvm/validator_set_property_test.go
+++ b/vms/platformvm/validator_set_property_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/validators/fee/fee.go
+++ b/vms/platformvm/validators/fee/fee.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fee

--- a/vms/platformvm/validators/fee/fee_test.go
+++ b/vms/platformvm/validators/fee/fee_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fee

--- a/vms/platformvm/validators/manager.go
+++ b/vms/platformvm/validators/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators

--- a/vms/platformvm/validators/manager_test.go
+++ b/vms/platformvm/validators/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validators_test

--- a/vms/platformvm/validators/validatorstest/manager.go
+++ b/vms/platformvm/validators/validatorstest/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package validatorstest

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/warp/codec.go
+++ b/vms/platformvm/warp/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/constants.go
+++ b/vms/platformvm/warp/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/gwarp/client.go
+++ b/vms/platformvm/warp/gwarp/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gwarp

--- a/vms/platformvm/warp/gwarp/server.go
+++ b/vms/platformvm/warp/gwarp/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gwarp

--- a/vms/platformvm/warp/gwarp/signer_test.go
+++ b/vms/platformvm/warp/gwarp/signer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gwarp

--- a/vms/platformvm/warp/message.go
+++ b/vms/platformvm/warp/message.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/message/codec.go
+++ b/vms/platformvm/warp/message/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/l1_validator_registration.go
+++ b/vms/platformvm/warp/message/l1_validator_registration.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/l1_validator_registration_test.go
+++ b/vms/platformvm/warp/message/l1_validator_registration_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/l1_validator_weight.go
+++ b/vms/platformvm/warp/message/l1_validator_weight.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/l1_validator_weight_test.go
+++ b/vms/platformvm/warp/message/l1_validator_weight_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/payload.go
+++ b/vms/platformvm/warp/message/payload.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/payload_test.go
+++ b/vms/platformvm/warp/message/payload_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/register_l1_validator.go
+++ b/vms/platformvm/warp/message/register_l1_validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/register_l1_validator_test.go
+++ b/vms/platformvm/warp/message/register_l1_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/subnet_to_l1_conversion.go
+++ b/vms/platformvm/warp/message/subnet_to_l1_conversion.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message/subnet_to_l1_conversion_test.go
+++ b/vms/platformvm/warp/message/subnet_to_l1_conversion_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/platformvm/warp/message_test.go
+++ b/vms/platformvm/warp/message_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/payload/addressed_call.go
+++ b/vms/platformvm/warp/payload/addressed_call.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package payload

--- a/vms/platformvm/warp/payload/addressed_call_test.go
+++ b/vms/platformvm/warp/payload/addressed_call_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package payload

--- a/vms/platformvm/warp/payload/codec.go
+++ b/vms/platformvm/warp/payload/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package payload

--- a/vms/platformvm/warp/payload/hash.go
+++ b/vms/platformvm/warp/payload/hash.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package payload

--- a/vms/platformvm/warp/payload/hash_test.go
+++ b/vms/platformvm/warp/payload/hash_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package payload

--- a/vms/platformvm/warp/payload/payload.go
+++ b/vms/platformvm/warp/payload/payload.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package payload

--- a/vms/platformvm/warp/payload/payload_test.go
+++ b/vms/platformvm/warp/payload/payload_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package payload

--- a/vms/platformvm/warp/signature.go
+++ b/vms/platformvm/warp/signature.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/signature_test.go
+++ b/vms/platformvm/warp/signature_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/signer.go
+++ b/vms/platformvm/warp/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/signer_test.go
+++ b/vms/platformvm/warp/signer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp_test

--- a/vms/platformvm/warp/signertest/signertest.go
+++ b/vms/platformvm/warp/signertest/signertest.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signertest

--- a/vms/platformvm/warp/unsigned_message.go
+++ b/vms/platformvm/warp/unsigned_message.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/unsigned_message_test.go
+++ b/vms/platformvm/warp/unsigned_message_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/validator.go
+++ b/vms/platformvm/warp/validator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/platformvm/warp/validator_test.go
+++ b/vms/platformvm/warp/validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package warp

--- a/vms/propertyfx/burn_operation.go
+++ b/vms/propertyfx/burn_operation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/burn_operation_test.go
+++ b/vms/propertyfx/burn_operation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/credential.go
+++ b/vms/propertyfx/credential.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/credential_test.go
+++ b/vms/propertyfx/credential_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/factory.go
+++ b/vms/propertyfx/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/factory_test.go
+++ b/vms/propertyfx/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/fx.go
+++ b/vms/propertyfx/fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/fx_test.go
+++ b/vms/propertyfx/fx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/mint_operation.go
+++ b/vms/propertyfx/mint_operation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/mint_operation_test.go
+++ b/vms/propertyfx/mint_operation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/mint_output.go
+++ b/vms/propertyfx/mint_output.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/mint_output_test.go
+++ b/vms/propertyfx/mint_output_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/owned_output.go
+++ b/vms/propertyfx/owned_output.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/propertyfx/owned_output_test.go
+++ b/vms/propertyfx/owned_output_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package propertyfx

--- a/vms/proposervm/acp181/epoch.go
+++ b/vms/proposervm/acp181/epoch.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // ACP181 implements the epoch logic specified here:

--- a/vms/proposervm/acp181/epoch_test.go
+++ b/vms/proposervm/acp181/epoch_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package acp181

--- a/vms/proposervm/batched_vm.go
+++ b/vms/proposervm/batched_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/batched_vm_test.go
+++ b/vms/proposervm/batched_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/block/block.go
+++ b/vms/proposervm/block/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/block_test.go
+++ b/vms/proposervm/block/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/build.go
+++ b/vms/proposervm/block/build.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/build_test.go
+++ b/vms/proposervm/block/build_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/codec.go
+++ b/vms/proposervm/block/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/header.go
+++ b/vms/proposervm/block/header.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/header_test.go
+++ b/vms/proposervm/block/header_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/option.go
+++ b/vms/proposervm/block/option.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/parse.go
+++ b/vms/proposervm/block/parse.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block/parse_test.go
+++ b/vms/proposervm/block/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package block

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/client_jsonrpc.go
+++ b/vms/proposervm/client_jsonrpc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/config.go
+++ b/vms/proposervm/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/height_indexed_vm.go
+++ b/vms/proposervm/height_indexed_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/main_test.go
+++ b/vms/proposervm/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/mocks_generate_test.go
+++ b/vms/proposervm/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/post_fork_block.go
+++ b/vms/proposervm/post_fork_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/post_fork_block_test.go
+++ b/vms/proposervm/post_fork_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/post_fork_option.go
+++ b/vms/proposervm/post_fork_option.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/post_fork_option_test.go
+++ b/vms/proposervm/post_fork_option_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/pre_fork_block.go
+++ b/vms/proposervm/pre_fork_block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/pre_fork_block_test.go
+++ b/vms/proposervm/pre_fork_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/proposer/mocks_generate_test.go
+++ b/vms/proposervm/proposer/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposer

--- a/vms/proposervm/proposer/validators.go
+++ b/vms/proposervm/proposer/validators.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposer

--- a/vms/proposervm/proposer/validators_test.go
+++ b/vms/proposervm/proposer/validators_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposer

--- a/vms/proposervm/proposer/windower.go
+++ b/vms/proposervm/proposer/windower.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposer

--- a/vms/proposervm/proposer/windower_test.go
+++ b/vms/proposervm/proposer/windower_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposer

--- a/vms/proposervm/service.go
+++ b/vms/proposervm/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/service_test.go
+++ b/vms/proposervm/service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/state/block_height_index.go
+++ b/vms/proposervm/state/block_height_index.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/proposervm/state/block_state_test.go
+++ b/vms/proposervm/state/block_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/proposervm/state/chain_state.go
+++ b/vms/proposervm/state/chain_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/proposervm/state/chain_state_test.go
+++ b/vms/proposervm/state/chain_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/proposervm/state/codec.go
+++ b/vms/proposervm/state/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/proposervm/state/state.go
+++ b/vms/proposervm/state/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/proposervm/state/state_test.go
+++ b/vms/proposervm/state/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/proposervm/state_summary.go
+++ b/vms/proposervm/state_summary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/state_syncable_vm.go
+++ b/vms/proposervm/state_syncable_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/summary/build.go
+++ b/vms/proposervm/summary/build.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package summary

--- a/vms/proposervm/summary/build_test.go
+++ b/vms/proposervm/summary/build_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package summary

--- a/vms/proposervm/summary/codec.go
+++ b/vms/proposervm/summary/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package summary

--- a/vms/proposervm/summary/parse.go
+++ b/vms/proposervm/summary/parse.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package summary

--- a/vms/proposervm/summary/parse_test.go
+++ b/vms/proposervm/summary/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package summary

--- a/vms/proposervm/summary/state_summary.go
+++ b/vms/proposervm/summary/state_summary.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package summary

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/vm_byzantine_test.go
+++ b/vms/proposervm/vm_byzantine_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proposervm

--- a/vms/registry/mocks_generate_test.go
+++ b/vms/registry/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package registry

--- a/vms/registry/vm_getter.go
+++ b/vms/registry/vm_getter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package registry

--- a/vms/registry/vm_getter_test.go
+++ b/vms/registry/vm_getter_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package registry

--- a/vms/registry/vm_registry.go
+++ b/vms/registry/vm_registry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package registry

--- a/vms/registry/vm_registry_test.go
+++ b/vms/registry/vm_registry_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package registry

--- a/vms/rpcchainvm/batched_vm_test.go
+++ b/vms/rpcchainvm/batched_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/rpcchainvm/errors.go
+++ b/vms/rpcchainvm/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/rpcchainvm/factory.go
+++ b/vms/rpcchainvm/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/rpcchainvm/ghttp/gconn/conn_client.go
+++ b/vms/rpcchainvm/ghttp/gconn/conn_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gconn

--- a/vms/rpcchainvm/ghttp/gconn/conn_server.go
+++ b/vms/rpcchainvm/ghttp/gconn/conn_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gconn

--- a/vms/rpcchainvm/ghttp/gconn/gconn_test.go
+++ b/vms/rpcchainvm/ghttp/gconn/gconn_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gconn

--- a/vms/rpcchainvm/ghttp/greader/greader_test.go
+++ b/vms/rpcchainvm/ghttp/greader/greader_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package greader

--- a/vms/rpcchainvm/ghttp/greader/reader_client.go
+++ b/vms/rpcchainvm/ghttp/greader/reader_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package greader

--- a/vms/rpcchainvm/ghttp/greader/reader_server.go
+++ b/vms/rpcchainvm/ghttp/greader/reader_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package greader

--- a/vms/rpcchainvm/ghttp/gresponsewriter/locked_writer.go
+++ b/vms/rpcchainvm/ghttp/gresponsewriter/locked_writer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gresponsewriter

--- a/vms/rpcchainvm/ghttp/gresponsewriter/writer_client.go
+++ b/vms/rpcchainvm/ghttp/gresponsewriter/writer_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gresponsewriter

--- a/vms/rpcchainvm/ghttp/gresponsewriter/writer_server.go
+++ b/vms/rpcchainvm/ghttp/gresponsewriter/writer_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gresponsewriter

--- a/vms/rpcchainvm/ghttp/gwriter/writer_client.go
+++ b/vms/rpcchainvm/ghttp/gwriter/writer_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gwriter

--- a/vms/rpcchainvm/ghttp/gwriter/writer_server.go
+++ b/vms/rpcchainvm/ghttp/gwriter/writer_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gwriter

--- a/vms/rpcchainvm/ghttp/http_client.go
+++ b/vms/rpcchainvm/ghttp/http_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ghttp

--- a/vms/rpcchainvm/ghttp/http_server.go
+++ b/vms/rpcchainvm/ghttp/http_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ghttp

--- a/vms/rpcchainvm/ghttp/http_test.go
+++ b/vms/rpcchainvm/ghttp/http_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package ghttp

--- a/vms/rpcchainvm/grpcutils/client.go
+++ b/vms/rpcchainvm/grpcutils/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package grpcutils

--- a/vms/rpcchainvm/grpcutils/client_test.go
+++ b/vms/rpcchainvm/grpcutils/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package grpcutils

--- a/vms/rpcchainvm/grpcutils/server.go
+++ b/vms/rpcchainvm/grpcutils/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package grpcutils

--- a/vms/rpcchainvm/grpcutils/server_closer.go
+++ b/vms/rpcchainvm/grpcutils/server_closer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package grpcutils

--- a/vms/rpcchainvm/grpcutils/util.go
+++ b/vms/rpcchainvm/grpcutils/util.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package grpcutils

--- a/vms/rpcchainvm/gruntime/runtime_client.go
+++ b/vms/rpcchainvm/gruntime/runtime_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gruntime

--- a/vms/rpcchainvm/gruntime/runtime_server.go
+++ b/vms/rpcchainvm/gruntime/runtime_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gruntime

--- a/vms/rpcchainvm/runtime/manager.go
+++ b/vms/rpcchainvm/runtime/manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package runtime

--- a/vms/rpcchainvm/runtime/runtime.go
+++ b/vms/rpcchainvm/runtime/runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package runtime

--- a/vms/rpcchainvm/runtime/subprocess/initializer.go
+++ b/vms/rpcchainvm/runtime/subprocess/initializer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subprocess

--- a/vms/rpcchainvm/runtime/subprocess/linux_stopper.go
+++ b/vms/rpcchainvm/runtime/subprocess/linux_stopper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build linux

--- a/vms/rpcchainvm/runtime/subprocess/non_linux_stopper.go
+++ b/vms/rpcchainvm/runtime/subprocess/non_linux_stopper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build !linux

--- a/vms/rpcchainvm/runtime/subprocess/runtime.go
+++ b/vms/rpcchainvm/runtime/subprocess/runtime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subprocess

--- a/vms/rpcchainvm/runtime/subprocess/stopper.go
+++ b/vms/rpcchainvm/runtime/subprocess/stopper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package subprocess

--- a/vms/rpcchainvm/state_syncable_vm_test.go
+++ b/vms/rpcchainvm/state_syncable_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/rpcchainvm/vm.go
+++ b/vms/rpcchainvm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/rpcchainvm/vm_server.go
+++ b/vms/rpcchainvm/vm_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/rpcchainvm/vm_test.go
+++ b/vms/rpcchainvm/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/rpcchainvm/with_context_vm_test.go
+++ b/vms/rpcchainvm/with_context_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpcchainvm

--- a/vms/secp256k1fx/credential.go
+++ b/vms/secp256k1fx/credential.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/credential_test.go
+++ b/vms/secp256k1fx/credential_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/factory.go
+++ b/vms/secp256k1fx/factory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/factory_test.go
+++ b/vms/secp256k1fx/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/fx.go
+++ b/vms/secp256k1fx/fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/fx_test.go
+++ b/vms/secp256k1fx/fx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/input.go
+++ b/vms/secp256k1fx/input.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/input_test.go
+++ b/vms/secp256k1fx/input_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/keychain.go
+++ b/vms/secp256k1fx/keychain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/keychain_test.go
+++ b/vms/secp256k1fx/keychain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/mint_operation.go
+++ b/vms/secp256k1fx/mint_operation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/mint_operation_test.go
+++ b/vms/secp256k1fx/mint_operation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/mint_output.go
+++ b/vms/secp256k1fx/mint_output.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/mint_output_test.go
+++ b/vms/secp256k1fx/mint_output_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/output_owners.go
+++ b/vms/secp256k1fx/output_owners.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/output_owners_test.go
+++ b/vms/secp256k1fx/output_owners_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/transfer_input.go
+++ b/vms/secp256k1fx/transfer_input.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/transfer_input_test.go
+++ b/vms/secp256k1fx/transfer_input_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/transfer_output.go
+++ b/vms/secp256k1fx/transfer_output.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/transfer_output_test.go
+++ b/vms/secp256k1fx/transfer_output_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/tx.go
+++ b/vms/secp256k1fx/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/vm.go
+++ b/vms/secp256k1fx/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/tracedvm/batched_vm.go
+++ b/vms/tracedvm/batched_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracedvm

--- a/vms/tracedvm/block.go
+++ b/vms/tracedvm/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracedvm

--- a/vms/tracedvm/block_vm.go
+++ b/vms/tracedvm/block_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracedvm

--- a/vms/tracedvm/build_block_with_context_vm.go
+++ b/vms/tracedvm/build_block_with_context_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracedvm

--- a/vms/tracedvm/set_preference_with_context_vm.go
+++ b/vms/tracedvm/set_preference_with_context_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracedvm

--- a/vms/tracedvm/state_syncable_vm.go
+++ b/vms/tracedvm/state_syncable_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracedvm

--- a/vms/tracedvm/tx.go
+++ b/vms/tracedvm/tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracedvm

--- a/vms/tracedvm/vertex_vm.go
+++ b/vms/tracedvm/vertex_vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracedvm

--- a/vms/txs/mempool/mempool.go
+++ b/vms/txs/mempool/mempool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mempool

--- a/vms/txs/mempool/mempool_test.go
+++ b/vms/txs/mempool/mempool_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mempool

--- a/vms/txs/mempool/metrics.go
+++ b/vms/txs/mempool/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mempool

--- a/vms/types/blob_data.go
+++ b/vms/types/blob_data.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package types

--- a/vms/types/blob_data_test.go
+++ b/vms/types/blob_data_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package types

--- a/wallet/chain/c/backend.go
+++ b/wallet/chain/c/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/wallet/chain/c/builder.go
+++ b/wallet/chain/c/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/wallet/chain/c/builder_with_options.go
+++ b/wallet/chain/c/builder_with_options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/wallet/chain/c/context.go
+++ b/wallet/chain/c/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/wallet/chain/c/signer.go
+++ b/wallet/chain/c/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/wallet/chain/c/wallet_with_options.go
+++ b/wallet/chain/c/wallet_with_options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package c

--- a/wallet/chain/p/builder/builder.go
+++ b/wallet/chain/p/builder/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/wallet/chain/p/builder/builder_test.go
+++ b/wallet/chain/p/builder/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/wallet/chain/p/builder/context.go
+++ b/wallet/chain/p/builder/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/wallet/chain/p/builder/with_options.go
+++ b/wallet/chain/p/builder/with_options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/wallet/chain/p/builder_test.go
+++ b/wallet/chain/p/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/wallet/chain/p/client.go
+++ b/wallet/chain/p/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/wallet/chain/p/context.go
+++ b/wallet/chain/p/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/wallet/chain/p/signer/signer.go
+++ b/wallet/chain/p/signer/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/wallet/chain/p/signer/visitor.go
+++ b/wallet/chain/p/signer/visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/wallet/chain/p/wallet/backend.go
+++ b/wallet/chain/p/wallet/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wallet

--- a/wallet/chain/p/wallet/backend_visitor.go
+++ b/wallet/chain/p/wallet/backend_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wallet

--- a/wallet/chain/p/wallet/wallet.go
+++ b/wallet/chain/p/wallet/wallet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wallet

--- a/wallet/chain/p/wallet/with_options.go
+++ b/wallet/chain/p/wallet/with_options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wallet

--- a/wallet/chain/x/backend.go
+++ b/wallet/chain/x/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package x

--- a/wallet/chain/x/backend_visitor.go
+++ b/wallet/chain/x/backend_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package x

--- a/wallet/chain/x/builder/builder.go
+++ b/wallet/chain/x/builder/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/wallet/chain/x/builder/builder_with_options.go
+++ b/wallet/chain/x/builder/builder_with_options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/wallet/chain/x/builder/constants.go
+++ b/wallet/chain/x/builder/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/wallet/chain/x/builder/context.go
+++ b/wallet/chain/x/builder/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/wallet/chain/x/builder_test.go
+++ b/wallet/chain/x/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package x

--- a/wallet/chain/x/context.go
+++ b/wallet/chain/x/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package x

--- a/wallet/chain/x/signer/signer.go
+++ b/wallet/chain/x/signer/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/wallet/chain/x/signer/visitor.go
+++ b/wallet/chain/x/signer/visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package signer

--- a/wallet/chain/x/wallet.go
+++ b/wallet/chain/x/wallet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package x

--- a/wallet/chain/x/wallet_with_options.go
+++ b/wallet/chain/x/wallet_with_options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package x

--- a/wallet/subnet/primary/api.go
+++ b/wallet/subnet/primary/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package primary

--- a/wallet/subnet/primary/common/options.go
+++ b/wallet/subnet/primary/common/options.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/wallet/subnet/primary/common/spend.go
+++ b/wallet/subnet/primary/common/spend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/wallet/subnet/primary/common/utxos.go
+++ b/wallet/subnet/primary/common/utxos.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/wallet/subnet/primary/common/utxotest/utxotest.go
+++ b/wallet/subnet/primary/common/utxotest/utxotest.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxotest

--- a/wallet/subnet/primary/example_test.go
+++ b/wallet/subnet/primary/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package primary

--- a/wallet/subnet/primary/examples/add-permissioned-subnet-validator/main.go
+++ b/wallet/subnet/primary/examples/add-permissioned-subnet-validator/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/add-primary-validator/main.go
+++ b/wallet/subnet/primary/examples/add-primary-validator/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/c-chain-export/main.go
+++ b/wallet/subnet/primary/examples/c-chain-export/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/c-chain-import/main.go
+++ b/wallet/subnet/primary/examples/c-chain-import/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/convert-subnet-to-l1/main.go
+++ b/wallet/subnet/primary/examples/convert-subnet-to-l1/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/create-asset/main.go
+++ b/wallet/subnet/primary/examples/create-asset/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/create-chain/main.go
+++ b/wallet/subnet/primary/examples/create-chain/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/create-locked-stakeable/main.go
+++ b/wallet/subnet/primary/examples/create-locked-stakeable/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/create-subnet/main.go
+++ b/wallet/subnet/primary/examples/create-subnet/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/disable-l1-validator/main.go
+++ b/wallet/subnet/primary/examples/disable-l1-validator/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/get-p-chain-balance/main.go
+++ b/wallet/subnet/primary/examples/get-p-chain-balance/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/get-x-chain-balance/main.go
+++ b/wallet/subnet/primary/examples/get-x-chain-balance/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/increase-l1-validator-balance/main.go
+++ b/wallet/subnet/primary/examples/increase-l1-validator-balance/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/register-l1-validator/main.go
+++ b/wallet/subnet/primary/examples/register-l1-validator/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/remove-subnet-validator/main.go
+++ b/wallet/subnet/primary/examples/remove-subnet-validator/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/set-l1-validator-weight/main.go
+++ b/wallet/subnet/primary/examples/set-l1-validator-weight/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/sign-l1-validator-registration/main.go
+++ b/wallet/subnet/primary/examples/sign-l1-validator-registration/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/sign-l1-validator-removal-genesis/main.go
+++ b/wallet/subnet/primary/examples/sign-l1-validator-removal-genesis/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/sign-l1-validator-removal-registration/main.go
+++ b/wallet/subnet/primary/examples/sign-l1-validator-removal-registration/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/sign-l1-validator-weight/main.go
+++ b/wallet/subnet/primary/examples/sign-l1-validator-weight/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/examples/sign-subnet-to-l1-conversion/main.go
+++ b/wallet/subnet/primary/examples/sign-subnet-to-l1-conversion/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/wallet/subnet/primary/wallet.go
+++ b/wallet/subnet/primary/wallet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package primary

--- a/x/archivedb/batch.go
+++ b/x/archivedb/batch.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package archivedb

--- a/x/archivedb/db.go
+++ b/x/archivedb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package archivedb

--- a/x/archivedb/db_test.go
+++ b/x/archivedb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package archivedb

--- a/x/archivedb/key.go
+++ b/x/archivedb/key.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package archivedb

--- a/x/archivedb/key_test.go
+++ b/x/archivedb/key_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package archivedb

--- a/x/archivedb/prefix_test.go
+++ b/x/archivedb/prefix_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package archivedb

--- a/x/archivedb/reader.go
+++ b/x/archivedb/reader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package archivedb

--- a/x/archivedb/value.go
+++ b/x/archivedb/value.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package archivedb

--- a/x/blockdb/cache_db.go
+++ b/x/blockdb/cache_db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/cache_db_test.go
+++ b/x/blockdb/cache_db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/config.go
+++ b/x/blockdb/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/database_test.go
+++ b/x/blockdb/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/datasplit_test.go
+++ b/x/blockdb/datasplit_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/errors.go
+++ b/x/blockdb/errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/helpers_test.go
+++ b/x/blockdb/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/readblock_test.go
+++ b/x/blockdb/readblock_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/recovery_test.go
+++ b/x/blockdb/recovery_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/blockdb/writeblock_test.go
+++ b/x/blockdb/writeblock_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockdb

--- a/x/merkledb/batch.go
+++ b/x/merkledb/batch.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/bytes_pool.go
+++ b/x/merkledb/bytes_pool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/bytes_pool_test.go
+++ b/x/merkledb/bytes_pool_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/cache.go
+++ b/x/merkledb/cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/cache_test.go
+++ b/x/merkledb/cache_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/client_test.go
+++ b/x/merkledb/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/codec.go
+++ b/x/merkledb/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/codec_test.go
+++ b/x/merkledb/codec_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/db.go
+++ b/x/merkledb/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/db_test.go
+++ b/x/merkledb/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/hashing.go
+++ b/x/merkledb/hashing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/hashing_test.go
+++ b/x/merkledb/hashing_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/helpers_test.go
+++ b/x/merkledb/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/history.go
+++ b/x/merkledb/history.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/history_test.go
+++ b/x/merkledb/history_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/intermediate_node_db.go
+++ b/x/merkledb/intermediate_node_db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/intermediate_node_db_test.go
+++ b/x/merkledb/intermediate_node_db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/key.go
+++ b/x/merkledb/key.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/key_test.go
+++ b/x/merkledb/key_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/metrics.go
+++ b/x/merkledb/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/metrics_test.go
+++ b/x/merkledb/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/network_server_test.go
+++ b/x/merkledb/network_server_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/node.go
+++ b/x/merkledb/node.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/node_test.go
+++ b/x/merkledb/node_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/proof_test.go
+++ b/x/merkledb/proof_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/sync_test.go
+++ b/x/merkledb/sync_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/tracer.go
+++ b/x/merkledb/tracer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/trie.go
+++ b/x/merkledb/trie.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/trie_test.go
+++ b/x/merkledb/trie_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/value_node_db.go
+++ b/x/merkledb/value_node_db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/value_node_db_test.go
+++ b/x/merkledb/value_node_db_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/view.go
+++ b/x/merkledb/view.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/view_iterator.go
+++ b/x/merkledb/view_iterator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/view_iterator_test.go
+++ b/x/merkledb/view_iterator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/view_test.go
+++ b/x/merkledb/view_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/wait_group.go
+++ b/x/merkledb/wait_group.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/merkledb/wait_group_test.go
+++ b/x/merkledb/wait_group_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package merkledb

--- a/x/sync/db.go
+++ b/x/sync/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/x/sync/metrics.go
+++ b/x/sync/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/x/sync/network_server.go
+++ b/x/sync/network_server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/x/sync/protoutils/utils.go
+++ b/x/sync/protoutils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package protoutils

--- a/x/sync/sync_test.go
+++ b/x/sync/sync_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/x/sync/syncer.go
+++ b/x/sync/syncer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/x/sync/workheap.go
+++ b/x/sync/workheap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync

--- a/x/sync/workheap_test.go
+++ b/x/sync/workheap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sync


### PR DESCRIPTION
## Why this should be merged
Updating the year every year is slightly annoying and unnecessary. Our legal department has confirmed that updating the end year doesn't actually do anything to update our copyright, and is thus unnecessary. 

## How this was tested
CI

## Need to be documented in RELEASES.md?
No 