### PR TITLE
chore(chaos): remove chaos test from PR CI

### DIFF
--- a/.github/workflows/firewood-chaos-test.yml
+++ b/.github/workflows/firewood-chaos-test.yml
@@ -35,8 +35,6 @@ on:
       timeout-minutes:
         description: 'Timeout in minutes for the job.'
         default: '60'
-  # XXX: remove this before merging
-  pull_request:
   schedule:
     - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 


### PR DESCRIPTION
## Why this should be merged

In https://github.com/ava-labs/avalanchego/pull/4695#discussion_r2624919987, it was noted that running the Firewood chaos test on PRs was only for testing #4695. However, this PR was merged in prior to this setting being removed (there's no need ATM to run the chaos test on every PR).

## How this works

Removes the chaos test job from being run on PRs.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
