### PR TITLE
fix: warp e2e flake

### DIFF
--- a/graft/coreth/tests/utils/proposervm.go
+++ b/graft/coreth/tests/utils/proposervm.go
@@ -21,7 +21,9 @@ import (
 	ethparams "github.com/ava-labs/libevm/params"
 )
 
-const numTriggerTxs = 2 // Number of txs needed to activate the proposer VM fork
+// expectedBlockHeight is the block height that activates the proposerVM fork.
+// We issue 2 txs (one per block) to reach block height 2.
+const expectedBlockHeight = 2
 
 // IssueTxsToActivateProposerVMFork issues transactions at the current
 // timestamp, which should be after the ProposerVM activation time (aka
@@ -39,11 +41,11 @@ func IssueTxsToActivateProposerVMFork(
 		return err
 	}
 
-	gasPrice := big.NewInt(ap1.MinGasPrice)
+	gasPrice := big.NewInt(ap1.MinGasPrice) // should be pretty generous for c-chain and subnets
 	txSigner := types.LatestSignerForChainID(chainID)
 
 	// Send exactly 2 transactions, waiting for each to be included in a block
-	for i := 0; i < numTriggerTxs; i++ {
+	for i := 0; i < expectedBlockHeight; i++ {
 		tx := types.NewTransaction(
 			nonce, addr, common.Big1, ethparams.TxGas, gasPrice, nil)
 		triggerTx, err := types.SignTx(tx, txSigner, fundedKey)
@@ -66,7 +68,7 @@ func IssueTxsToActivateProposerVMFork(
 
 	log.Info(
 		"Built sufficient blocks to activate proposerVM fork",
-		"txCount", numTriggerTxs,
+		"blockHeight", expectedBlockHeight,
 	)
 	return nil
 }

--- a/graft/subnet-evm/tests/utils/proposervm.go
+++ b/graft/subnet-evm/tests/utils/proposervm.go
@@ -21,7 +21,9 @@ import (
 	ethparams "github.com/ava-labs/libevm/params"
 )
 
-const numTriggerTxs = 2 // Number of txs needed to activate the proposer VM fork
+// expectedBlockHeight is the block height that activates the proposerVM fork.
+// We issue 2 txs (one per block) to reach block height 2.
+const expectedBlockHeight = 2
 
 // IssueTxsToActivateProposerVMFork issues transactions at the current
 // timestamp, which should be after the ProposerVM activation time (aka
@@ -43,7 +45,7 @@ func IssueTxsToActivateProposerVMFork(
 	txSigner := types.LatestSignerForChainID(chainID)
 
 	// Send exactly 2 transactions, waiting for each to be included in a block
-	for i := 0; i < numTriggerTxs; i++ {
+	for i := 0; i < expectedBlockHeight; i++ {
 		tx := types.NewTransaction(
 			nonce, addr, common.Big1, ethparams.TxGas, gasPrice, nil)
 		triggerTx, err := types.SignTx(tx, txSigner, fundedKey)
@@ -66,7 +68,7 @@ func IssueTxsToActivateProposerVMFork(
 
 	log.Info(
 		"Built sufficient blocks to activate proposerVM fork",
-		"txCount", numTriggerTxs,
+		"blockHeight", expectedBlockHeight,
 	)
 	return nil
 }


### PR DESCRIPTION
## Why this should be merged

The EVM warp E2E tests have been flaky since the monorepo because of time outs -- sometimes transactions take more than 30 seconds to get included, and it fails. See this for a recent flake: https://github.com/ava-labs/avalanchego/actions/runs/20761939951/job/59618890988?pr=4816

## How this works
I extended the timeout to 60 seconds, and immediately canceled, rather than lettering them accumulate via defer in the loop.  From reading online, it's generally not recommended to defer within loops, unless under closure, as it adds additional overhead. (and we're only 0.009s over the threshold in the example linked above). 

I also aligned subnet-evm and coreth's implementation of this file. 

## How this was tested
CI

## Need to be documented in RELEASES.md?
No