### PR TITLE
[direnv] Enable global envrc customization

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -26,3 +26,15 @@ export TMPNET_NETWORK_DIR="${TMPNET_NETWORK_DIR:-${HOME}/.tmpnet/networks/latest
 
 # Allow individuals to add their own customisation
 source_env_if_exists .envrc.local
+
+# Allow individuals to add global customization without requiring .envrc.local files in each one
+#
+# Example usage:
+#
+# - Add to shell profile (~/.bashrc, ~/.zshrc, etc.)
+#
+#   export GLOBAL_ENVRC="$HOME/.envrc_global"
+#
+export ENVRC_GIT_REPO=avalanchego # Enables configuring the global behavior by repo
+export ENVRC_PROJECT_DIR="$PWD" # Enables targeting the current project directory
+[[ -n "$GLOBAL_ENVRC" ]] && source_env_if_exists "$GLOBAL_ENVRC"


### PR DESCRIPTION
## Why this should be merged

Previously .envrc customization required adding a .envrc.local file to a given git clone. This change adds support for setting GLOBAL_ENVRC to the path of a bash script to source and sets:

 - ENVRC_GIT_REPO=avalanchego so that the script can configure itself specifically for avalanchego.
   - This supports configuring developer-local LLM tooling like [beads](https://github.com/steveyegge/beads).
 - ENVRC_PROJECT_DIR=$PWD so that the script can target the project path
   - This supports symlinking a common CLAUDE.local.md across worktrees

## How this was tested

 - After creating the beads repo as per the example location, was able to create issues
 - After creating AGENTS-avalanchego.md file with instructions to answer 'blue cheese' to the question of 'what is the moon made of', the file was symlinked to ./CLAUDE.local.md after direnv loaded and claude answered as expected.

## Need to be documented in RELEASES.md?

N/A