### PR TITLE
test: fix `TestUptimeSignatures` flake

### DIFF
--- a/graft/subnet-evm/warp/verifier_backend_test.go
+++ b/graft/subnet-evm/warp/verifier_backend_test.go
@@ -259,7 +259,8 @@ func TestUptimeSignatures(t *testing.T) {
 
 	validationID := ids.GenerateTestID()
 	nodeID := ids.GenerateTestNodeID()
-	startTime := uint64(time.Now().Unix())
+	start := time.Now()
+	startTime := uint64(start.Unix())
 
 	getUptimeMessageBytes := func(sourceAddress []byte, vID ids.ID) ([]byte, *avalancheWarp.UnsignedMessage) {
 		uptimePayload, err := messages.NewValidatorUptime(vID, 80)
@@ -302,6 +303,7 @@ func TestUptimeSignatures(t *testing.T) {
 		}
 
 		clk := &mockable.Clock{}
+		clk.Set(start)
 		uptimeTracker, err := uptimetracker.New(
 			validatorState,
 			snowCtx.SubnetID,


### PR DESCRIPTION
## Why this should be merged

This closes #4706. 

## How this works 

The test flakes were off by a single second: 

```
expected: "2: current uptime 0 is less than queried uptime 80 for validationID 2MiEo2BzNcA4muUMhYeEjsbzbo16eHF5zFknxQbzJqf1LurbD4"
actual  : "2: current uptime 1 is less than queried uptime 80 for validationID 2MiEo2BzNcA4muUMhYeEjsbzbo16eHF5zFknxQbzJqf1LurbD4"
```

The root cause of this issue is when `startTime` was captured using `time.Now().Unix()` for the `validatorState`, work is done and time elapses between the creation of the mockable clock used in tests. That clock can then be ever so slightly ahead of `startTime`, depending on the execution time, as it defaults to `time.Now`. This can lead to test failures if things are exceptionally slow (on the order of one second) between the test really starting. To fix this, I set the mockable clock the same originally captured start time. 

## How this was tested
Ran the test repeatedly 

## Need to be documented in RELEASES.md?
No