### PR TITLE
Fix race in tests on VM Shutdown

### DIFF
--- a/graft/coreth/plugin/evm/vm_test.go
+++ b/graft/coreth/plugin/evm/vm_test.go
@@ -2218,7 +2218,9 @@ func TestInspectDatabases(t *testing.T) {
 // Querying for the nonce of the zero address at various heights is sufficient
 // as this succeeds only if the EVM has the matching trie at each height.
 func TestArchivalQueries(t *testing.T) {
-	for _, scheme := range vmtest.Schemes {
+	schemes := []string{customrawdb.FirewoodScheme, rawdb.HashScheme}
+
+	for _, scheme := range schemes {
 		t.Run(scheme, func(t *testing.T) {
 			require := require.New(t)
 			ctx := t.Context()
@@ -2236,9 +2238,9 @@ func TestArchivalQueries(t *testing.T) {
 				}`,
 				Scheme: scheme,
 			})
-			defer func() {
+			t.Cleanup(func() {
 				require.NoError(vm.Shutdown(ctx))
-			}()
+			})
 
 			numBlocks := 10
 			for range numBlocks {

--- a/graft/subnet-evm/plugin/evm/vm_test.go
+++ b/graft/subnet-evm/plugin/evm/vm_test.go
@@ -3655,11 +3655,11 @@ func TestArchivalQueries(t *testing.T) {
 	//	- Tries 0-5: on-disk
 	// 	- Tries 6-10: in-memory
 	tests := []struct {
-		scheme string
+		name   string
 		config string
 	}{
 		{
-			scheme: "firewood",
+			name: "firewood",
 			config: `{
 				"state-scheme": "firewood",
 				"snapshot-cache": 0,
@@ -3669,7 +3669,7 @@ func TestArchivalQueries(t *testing.T) {
 			}`,
 		},
 		{
-			scheme: "hashdb",
+			name: "hashdb",
 			config: `{
 				"state-scheme": "hash",
 				"pruning-enabled": false,
@@ -3679,14 +3679,14 @@ func TestArchivalQueries(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.scheme, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctx := t.Context()
 
 			vm := newVM(t, testVMConfig{configJSON: tt.config})
-			defer func() {
+			t.Cleanup(func() {
 				require.NoError(vm.vm.Shutdown(ctx))
-			}()
+			})
 
 			numBlocks := 10
 			for range numBlocks {


### PR DESCRIPTION
## Why this should be merged

Data race: see https://github.com/ava-labs/avalanchego/actions/runs/20971917102/job/60277170521?pr=4851

## How this works

The VM was never shutdown, so it didn't clean up any of the threads it started up (including the txpool, which is the race seen)

## How this was tested

Look at the thread numbers in the test run above. The reading thread is less than the writing thread, prior to the txpool being created. This means that it's from the previous test.

## Need to be documented in RELEASES.md?

No
