### PR TITLE
refactor: granite cleanup - remove pre-granite test-cases

### DIFF
--- a/graft/coreth/plugin/evm/vm_test.go
+++ b/graft/coreth/plugin/evm/vm_test.go
@@ -1544,7 +1544,6 @@ func TestWaitForEvent(t *testing.T) {
 		err error
 	}
 
-	fortunaFork := upgradetest.Fortuna
 	for _, testCase := range []struct {
 		name     string
 		Fork     *upgradetest.Fork
@@ -1709,48 +1708,6 @@ func TestWaitForEvent(t *testing.T) {
 				res := <-results
 				require.NoError(t, res.err)
 				require.Equal(t, commonEng.PendingTxs, res.msg)
-			},
-		},
-		// TODO (ceyonur): remove this test after Granite is activated. (See https://github.com/ava-labs/avalanchego/graft/coreth/issues/1318)
-		{
-			name: "WaitForEvent does not wait for new block to be built in fortuna",
-			Fork: &fortunaFork,
-			testCase: func(t *testing.T, vm *VM) {
-				t.Parallel()
-				signedTx := newSignedLegacyTx(t, vm.chainConfig, vmtest.TestKeys[0].ToECDSA(), 0, &vmtest.TestEthAddrs[1], big.NewInt(1), 21000, vmtest.InitialBaseFee, nil)
-				blk, err := vmtest.IssueTxsAndSetPreference([]*types.Transaction{signedTx}, vm)
-				require.NoError(t, err)
-				require.NoError(t, blk.Accept(t.Context()))
-				signedTx = newSignedLegacyTx(t, vm.chainConfig, vmtest.TestKeys[0].ToECDSA(), 1, &vmtest.TestEthAddrs[1], big.NewInt(1), 21000, vmtest.InitialBaseFee, nil)
-
-				for _, err := range vm.txPool.AddRemotesSync([]*types.Transaction{signedTx}) {
-					require.NoError(t, err)
-				}
-
-				msg, err := vm.WaitForEvent(t.Context())
-				require.NoError(t, err)
-				require.Equal(t, commonEng.PendingTxs, msg)
-			},
-		},
-		// TODO (ceyonur): remove this test after Granite is activated. (See https://github.com/ava-labs/avalanchego/graft/coreth/issues/1318)
-		{
-			name: "WaitForEvent waits for a delay with a retry in fortuna",
-			Fork: &fortunaFork,
-			testCase: func(t *testing.T, vm *VM) {
-				t.Parallel()
-				lastBuildBlockTime := time.Now()
-				_, err := vm.BuildBlock(t.Context())
-				require.NoError(t, err)
-				// we haven't accepted the previous built block, so this should be a retry
-				signedTx := newSignedLegacyTx(t, vm.chainConfig, vmtest.TestKeys[0].ToECDSA(), 0, &vmtest.TestEthAddrs[1], big.NewInt(1), 21000, vmtest.InitialBaseFee, nil)
-				for _, err := range vm.txPool.AddRemotesSync([]*types.Transaction{signedTx}) {
-					require.NoError(t, err)
-				}
-
-				msg, err := vm.WaitForEvent(t.Context())
-				require.NoError(t, err)
-				require.Equal(t, commonEng.PendingTxs, msg)
-				require.GreaterOrEqual(t, time.Since(lastBuildBlockTime), RetryDelay)
 			},
 		},
 	} {

--- a/graft/subnet-evm/plugin/evm/vm_test.go
+++ b/graft/subnet-evm/plugin/evm/vm_test.go
@@ -2912,7 +2912,6 @@ func TestWaitForEvent(t *testing.T) {
 		err error
 	}
 
-	fortunaFork := upgradetest.Fortuna
 	for _, testCase := range []struct {
 		name     string
 		Fork     *upgradetest.Fork
@@ -3095,52 +3094,6 @@ func TestWaitForEvent(t *testing.T) {
 				res := <-results
 				require.NoError(t, res.err)
 				require.Equal(t, commonEng.PendingTxs, res.msg)
-			},
-		},
-		// TODO (ceyonur): remove this test after Granite is activated. (See https://github.com/ava-labs/coreth/issues/1318)
-		{
-			name: "WaitForEvent does not wait for new block to be built in fortuna",
-			Fork: &fortunaFork,
-			testCase: func(t *testing.T, vm *VM) {
-				t.Parallel()
-
-				signedTx := newSignedLegacyTx(t, vm.chainConfig, testKeys[0].ToECDSA(), 0, &testEthAddrs[1], big.NewInt(1), 21000, big.NewInt(testMinGasPrice), nil)
-				blk, err := IssueTxsAndSetPreference([]*types.Transaction{signedTx}, vm)
-				require.NoError(t, err)
-				require.NoError(t, blk.Accept(t.Context()))
-				signedTx = newSignedLegacyTx(t, vm.chainConfig, testKeys[0].ToECDSA(), 1, &testEthAddrs[1], big.NewInt(1), 21000, big.NewInt(testMinGasPrice), nil)
-
-				for _, err := range vm.txPool.AddRemotesSync([]*types.Transaction{signedTx}) {
-					require.NoError(t, err)
-				}
-
-				msg, err := vm.WaitForEvent(t.Context())
-				require.NoError(t, err)
-				require.Equal(t, commonEng.PendingTxs, msg)
-			},
-		},
-		// TODO (ceyonur): remove this test after Granite is activated. (See https://github.com/ava-labs/coreth/issues/1318)
-		{
-			name: "WaitForEvent waits for a delay with a retry in fortuna",
-			Fork: &fortunaFork,
-			testCase: func(t *testing.T, vm *VM) {
-				lastBuildBlockTime := time.Now()
-				signedTx := newSignedLegacyTx(t, vm.chainConfig, testKeys[0].ToECDSA(), 0, &testEthAddrs[1], big.NewInt(1), 21000, big.NewInt(testMinGasPrice), nil)
-				for _, err := range vm.txPool.AddRemotesSync([]*types.Transaction{signedTx}) {
-					require.NoError(t, err)
-				}
-				_, err := vm.BuildBlock(t.Context())
-				require.NoError(t, err)
-				// we haven't advanced the tip to include the previous built block, so this is a retry
-				signedTx = newSignedLegacyTx(t, vm.chainConfig, testKeys[1].ToECDSA(), 0, &testEthAddrs[0], big.NewInt(2), 21000, big.NewInt(testMinGasPrice), nil)
-				for _, err := range vm.txPool.AddRemotesSync([]*types.Transaction{signedTx}) {
-					require.NoError(t, err)
-				}
-
-				msg, err := vm.WaitForEvent(t.Context())
-				require.NoError(t, err)
-				require.Equal(t, commonEng.PendingTxs, msg)
-				require.GreaterOrEqual(t, time.Since(lastBuildBlockTime), RetryDelay)
 			},
 		},
 	} {


### PR DESCRIPTION
## Why this should be merged
Granite has been activated for several months now and we can clean up pre-Granite test code. This PR removes test cases that were specifically testing pre-Granite behavior, which is no longer relevant.

## How this works
- Remove pre-Granite test cases from `vm_test.go` in both coreth and subnet-evm
   - With Granite always active, these test cases are no longer meaningful

## How this was tested
CI

## Need to be documented in RELEASES.md?
No
