### PR TITLE
Dump heap and allocated memory in case free memory is low

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ava-labs/avalanchego/profiling"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -1444,6 +1445,11 @@ func (n *Node) initHealthAPI() error {
 	err = n.health.RegisterHealthCheck("router", n.chainRouter, health.ApplicationTag)
 	if err != nil {
 		return fmt.Errorf("couldn't register router health check: %w", err)
+	}
+
+	err = n.health.RegisterHealthCheck("memory", &profiling.MemHealthCheck{Logger: n.Log}, health.ApplicationTag)
+	if err != nil {
+		return fmt.Errorf("couldn't register memory health check: %w", err)
 	}
 
 	// TODO: add database health to liveness check

--- a/profiling/mem.go
+++ b/profiling/mem.go
@@ -1,0 +1,99 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package profiling
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"runtime"
+	"runtime/pprof"
+	"time"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"go.uber.org/zap"
+)
+
+type MemHealthCheck struct{
+	LastScanTime time.Time
+	Logger logging.Logger
+}
+
+func (m *MemHealthCheck) HealthCheck(ctx context.Context) (interface{}, error) {
+	if ! m.LastScanTime.IsZero() && time.Since(m.LastScanTime) < 10*time.Minute {
+		return nil, nil
+	}
+	m.LastScanTime = time.Now()
+
+	percent, ok := getAvailableMem(m.Logger)
+	if ! ok || percent > 10 {
+		return nil, nil
+	}
+
+	runtime.GC()
+	var allocs bytes.Buffer
+	if err := pprof.Lookup("allocs").WriteTo(&allocs, 0); err != nil {
+		m.Logger.Warn("Failed writing memory profile", zap.Error(err))
+		return nil, err
+	}
+
+	var heap bytes.Buffer
+	if err := pprof.Lookup("heap").WriteTo(&heap, 0); err != nil {
+		m.Logger.Warn("Failed writing memory profile", zap.Error(err))
+		return nil, err
+	}
+
+	m.Logger.Warn("Low memory available, outputting profile",
+		zap.Float64("percent", percent),
+		zap.String("allocs", base64.StdEncoding.EncodeToString(allocs.Bytes())))
+
+	m.Logger.Warn("Low memory available, outputting profile",
+		zap.Float64("percent", percent),
+		zap.String("heap", base64.StdEncoding.EncodeToString(heap.Bytes())))
+
+	return nil, nil
+}
+
+func getAvailableMem(logger logging.Logger) (float64, bool){
+	client, err := api.NewClient(api.Config{
+		Address: "http://localhost:9090",
+	})
+	if err != nil {
+		logger.Warn("Failed creating Prometheus client", zap.Error(err))
+		return 0, false
+	}
+
+	v1api := v1.NewAPI(client)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Query: (Available / Total) * 100
+	query := `(node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100`
+
+	result, _, err := v1api.Query(ctx, query, time.Now())
+	if err != nil {
+		logger.Warn("Failed querying Prometheus", zap.Error(err))
+		return 0, false
+	}
+	// Cast the result to a Vector (standard for instant queries)
+	vector, ok := result.(model.Vector)
+	if !ok || len(vector) == 0 {
+		logger.Warn("No data found for the query")
+		return 0, false
+	}
+
+	// Print the percentage for each instance (host)
+	for _, sample := range vector {
+		instance := sample.Metric["instance"]
+		percent := float64(sample.Value)
+		logger.Debug(fmt.Sprintf("Instance %s has %.2f%% available memory", instance, percent))
+		return percent, true
+	}
+
+	return 0, false
+}


### PR DESCRIPTION



## Why this should be merged

This commit adds a fake health check that checks if the free memory is too low and if it is, then it dumps a memory profile to the log in the form of base64 encoded strings.

The strings can then be made into PNG via `go tool pprof -png <file>.pprof > <file>.png` after base64 decoding them.

This can be useful to debug nodes that occasionally have high memory. 


## How this works

Adds a health check that queries prometheus via the loopback interface and if it reports the free memory is too low, it creates memory profiles and logs them.

## How this was tested

I ran my own node and just changed the memory threshold to alert if we have less than 95% free memory instead of 10%:

```
diff --git a/profiling/mem.go b/profiling/mem.go
index c0ee1d834d..3005821f3f 100644
--- a/profiling/mem.go
+++ b/profiling/mem.go
@@ -31,7 +31,7 @@ func (m *MemHealthCheck) HealthCheck(ctx context.Context) (interface{}, error) {
        m.LastScanTime = time.Now()
 
        percent, ok := getAvailableMem(m.Logger)
-       if ! ok || percent > 10 {
+       if ! ok || percent > 95 {
                return nil, nil
        }
 ```

Waited 10 minutes and the logs printed: `[01-14|20:40:27.150] WARN profiling/mem.go:51 Low memory available, outputting profile {"percent": 89.74091114528836, "allocs": "H4sIAAAAAAAE/7T9B3...=="}`.

I took the log entries and base64 decoded them and converted them to PNG using `go tool` and then observed it works:

<img width="1177" height="413" alt="image" src="https://github.com/user-attachments/assets/53dae6b6-79cf-4c1a-a6fa-18a4deee7e39" />



## Need to be documented in RELEASES.md?
