### PR TITLE
build: bump to go 1.24.12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 To start developing on AvalancheGo, you'll need a few things installed.
 
-- Golang version >= 1.24.11
+- Golang version >= 1.24.12
 - gcc
 - g++
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The minimum recommended hardware specification for nodes connected to Mainnet is
 
 If you plan to build AvalancheGo from source, you will also need the following software:
 
-- [Go](https://golang.org/doc/install) version >= 1.24.11
+- [Go](https://golang.org/doc/install) version >= 1.24.12
 - [gcc](https://gcc.gnu.org/)
 - g++
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ module github.com/ava-labs/avalanchego
 //
 // - If updating between minor versions (e.g. 1.24.x -> 1.25.x):
 //   - Consider updating the version of golangci-lint (see tools/go.mod)
-go 1.24.11
+go 1.24.12
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -5,7 +5,7 @@ module github.com/ava-labs/avalanchego/graft/coreth
 // CONTRIBUTING.md for more details.
 
 // See ../../go.mod for guidelines on updating the Go version.
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/ava-labs/avalanchego v1.14.1-0.20251120155522-df4a8e531761

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/avalanchego/graft/evm
 
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -11,7 +11,7 @@ module github.com/ava-labs/avalanchego/graft/subnet-evm
 //
 // - If updating between minor versions (e.g. 1.24.x -> 1.25.x):
 //   - Consider updating the version of golangci-lint (see tools/go.mod)
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.3.8

--- a/nix/go/default.nix
+++ b/nix/go/default.nix
@@ -19,13 +19,13 @@ let
     };
 
   # Update the following to change the version:
-  goVersion = "1.24.11";
+  goVersion = "1.24.12";
   # The sha256 checksums can fetched from https://go.dev/dl/ for new versions.
   goSHA256s = {
-    "linux-amd64" = "bceca00afaac856bc48b4cc33db7cd9eb383c81811379faed3bdbc80edb0af65";
-    "linux-arm64" = "beaf0f51cbe0bd71b8289b2b6fa96c0b11cd86aa58672691ef2f1de88eb621de";
-    "darwin-amd64" = "c45566cf265e2083cd0324e88648a9c28d0edede7b5fd12f8dc6932155a344c5";
-    "darwin-arm64" = "a9c90c786e75d5d1da0547de2d1199034df6a4b163af2fa91b9168c65f229c12";
+    "linux-amd64" = "bddf8e653c82429aea7aec2520774e79925d4bb929fe20e67ecc00dd5af44c50";
+    "linux-arm64" = "4e02e2979e53b40f3666bba9f7e5ea0b99ea5156e0824b343fd054742c25498d";
+    "darwin-amd64" = "4b9cc6771b56645da35a83a5424ae507f3250829b0d227e75f57b73e72da1f76";
+    "darwin-arm64" = "098d0c039357c3652ec6c97d5451bc4dc24f7cf30ed902373ed9a8134aab2d29";
   };
 
   targetSystem = parseSystem pkgs.stdenv.hostPlatform.system;

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -13,7 +13,7 @@ module github.com/ava-labs/avalanchego/tools
 //   - go tool -modfile=tools/go.mod [tool] [args]
 //   - ./scripts/run_tool.sh [tool] [args]
 
-go 1.24.9
+go 1.24.12
 
 tool (
 	github.com/fjl/gencodec


### PR DESCRIPTION
## Why this should be merged

There are security vulnerabilities addressed in go 1.24.12 

## How this works

## How this was tested
CI

## Need to be documented in RELEASES.md?
No