### PR TITLE
feat(sync): finalize firewood syncer and add finalization tests

### DIFF
--- a/firewood/syncer/evm_syncer.go
+++ b/firewood/syncer/evm_syncer.go
@@ -66,7 +66,6 @@ func (e *evmDB) CommitRangeProof(ctx context.Context, start, end maybe.Maybe[[]b
 	if err != nil {
 		return maybe.Nothing[[]byte](), err
 	}
-
 	return nextKey, nil
 }
 

--- a/graft/coreth/sync/code/queue.go
+++ b/graft/coreth/sync/code/queue.go
@@ -23,7 +23,7 @@ const defaultQueueCapacity = 5000
 var (
 	_ types.Finalizer = (*Queue)(nil)
 
-	errFailedToAddCodeHashesToQueue = errors.New("failed to add code hashes to queue")
+	ErrFailedToAddCodeHashesToQueue = errors.New("failed to add code hashes to queue")
 	errFailedToFinalizeCodeQueue    = errors.New("failed to finalize code queue")
 )
 
@@ -129,7 +129,7 @@ func (q *Queue) AddCode(ctx context.Context, codeHashes []common.Hash) error {
 	if q.in == nil {
 		// Although this will happen anyway once the `select` is reached,
 		// bailing early avoids unnecessary database writes.
-		return errFailedToAddCodeHashesToQueue
+		return ErrFailedToAddCodeHashesToQueue
 	}
 
 	batch := q.db.NewBatch()
@@ -152,7 +152,7 @@ func (q *Queue) AddCode(ctx context.Context, codeHashes []common.Hash) error {
 		select {
 		case q.in <- h: // guaranteed to be open or nil, but never closed
 		case <-q.quit:
-			return errFailedToAddCodeHashesToQueue
+			return ErrFailedToAddCodeHashesToQueue
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/graft/coreth/sync/code/queue_test.go
+++ b/graft/coreth/sync/code/queue_test.go
@@ -103,7 +103,7 @@ func TestCodeQueue(t *testing.T) {
 					close(quit)
 					<-recvDone
 					err := q.AddCode(t.Context(), tt.addCodeAfter)
-					require.ErrorIsf(t, err, errFailedToAddCodeHashesToQueue, "%T.AddCode() after `quit` channel closed", q)
+					require.ErrorIsf(t, err, ErrFailedToAddCodeHashesToQueue, "%T.AddCode() after `quit` channel closed", q)
 				} else {
 					require.NoErrorf(t, q.Finalize(), "%T.Finalize()", q)
 					// Avoid leaking the internal goroutine


### PR DESCRIPTION
## Why this should be merged

Enable correct finalization support for `FirewoodSyncer` that is idempotent and disallow hanging issues on code syncing.

## How this works

- Close code queue via Finalize (idempotent) and call from Sync.
- Enqueue code hashes before committing range proofs.
- Add finalize scenarios and registry finalize tests.

## How this was tested

added UT testing finalization logic

## Need to be documented in RELEASES.md?

no

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)