### PR TITLE
refactor: remove UnpackInput

### DIFF
--- a/graft/coreth/accounts/abi/abi.go
+++ b/graft/coreth/accounts/abi/abi.go
@@ -194,17 +194,6 @@ func (abi ABI) getArguments(name string, data []byte) (Arguments, error) {
 	return args, nil
 }
 
-// UnpackInput unpacks the input according to the ABI specification.
-// No length check is performed, so if the data is expected to be padded by a multiple of 32,
-// this check must be performed by the caller.
-func (abi ABI) UnpackInput(name string, data []byte) ([]interface{}, error) {
-	args, err := abi.getInputs(name)
-	if err != nil {
-		return nil, err
-	}
-	return args.Unpack(data)
-}
-
 // Unpack unpacks the output according to the abi specification.
 func (abi ABI) Unpack(name string, data []byte) ([]interface{}, error) {
 	args, err := abi.getArguments(name, data)

--- a/graft/coreth/precompile/contracts/warp/contract.go
+++ b/graft/coreth/precompile/contracts/warp/contract.go
@@ -155,11 +155,10 @@ func getBlockchainID(accessibleState contract.AccessibleState, caller common.Add
 func UnpackGetVerifiedWarpBlockHashInput(input []byte) (uint32, error) {
 	// We don't use strict mode here because it was disabled with Durango.
 	// Since Warp will be deployed after Durango, we don't need to validate padding length.
-	res, err := WarpABI.UnpackInput("getVerifiedWarpBlockHash", input)
-	if err != nil {
+	var unpacked uint32
+	if err := WarpABI.UnpackInputIntoInterface(&unpacked, "getVerifiedWarpBlockHash", input); err != nil {
 		return 0, err
 	}
-	unpacked := *abi.ConvertType(res[0], new(uint32)).(*uint32)
 	return unpacked, nil
 }
 
@@ -198,11 +197,10 @@ func getVerifiedWarpBlockHash(accessibleState contract.AccessibleState, caller c
 func UnpackGetVerifiedWarpMessageInput(input []byte) (uint32, error) {
 	// We don't use strict mode here because it was disabled with Durango.
 	// Since Warp will be deployed after Durango, we don't need to validate padding length.
-	res, err := WarpABI.UnpackInput("getVerifiedWarpMessage", input)
-	if err != nil {
+	var unpacked uint32
+	if err := WarpABI.UnpackInputIntoInterface(&unpacked, "getVerifiedWarpMessage", input); err != nil {
 		return 0, err
 	}
-	unpacked := *abi.ConvertType(res[0], new(uint32)).(*uint32)
 	return unpacked, nil
 }
 
@@ -244,11 +242,10 @@ func getVerifiedWarpMessage(accessibleState contract.AccessibleState, caller com
 func UnpackSendWarpMessageInput(input []byte) ([]byte, error) {
 	// We don't use strict mode here because it was disabled with Durango.
 	// Since Warp will be deployed after Durango, we don't need to validate padding length.
-	res, err := WarpABI.UnpackInput("sendWarpMessage", input)
-	if err != nil {
+	var unpacked []byte
+	if err := WarpABI.UnpackInputIntoInterface(&unpacked, "sendWarpMessage", input); err != nil {
 		return []byte{}, err
 	}
-	unpacked := *abi.ConvertType(res[0], new([]byte)).(*[]byte)
 	return unpacked, nil
 }
 

--- a/graft/subnet-evm/accounts/abi/abi.go
+++ b/graft/subnet-evm/accounts/abi/abi.go
@@ -194,17 +194,6 @@ func (abi ABI) getArguments(name string, data []byte) (Arguments, error) {
 	return args, nil
 }
 
-// UnpackInput unpacks the input according to the ABI specification.
-// No length check is performed, so if the data is expected to be padded by a multiple of 32,
-// this check must be performed by the caller.
-func (abi ABI) UnpackInput(name string, data []byte) ([]interface{}, error) {
-	args, err := abi.getInputs(name)
-	if err != nil {
-		return nil, err
-	}
-	return args.Unpack(data)
-}
-
 // Unpack unpacks the output according to the abi specification.
 func (abi ABI) Unpack(name string, data []byte) ([]interface{}, error) {
 	args, err := abi.getArguments(name, data)

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_contract_template.go
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/precompile_contract_template.go
@@ -162,11 +162,10 @@ func Pack{{.Normalized.Name}}(inputStruct {{capitalise .Normalized.Name}}Input) 
 // Unpack{{capitalise .Normalized.Name}}Input attempts to unpack [input] into the {{$bindedType}} type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func Unpack{{capitalise .Normalized.Name}}Input(input []byte)({{$bindedType}}, error) {
-res, err := {{$contract.Type}}ABI.UnpackInput("{{$method.Original.Name}}", input)
-if err != nil {
+var unpacked {{$bindedType}}
+if err := {{$contract.Type}}ABI.UnpackInputIntoInterface(&unpacked, "{{$method.Original.Name}}", input); err != nil {
 	return {{bindtypenew $input.Type $structs}}, err
 }
-unpacked := *abi.ConvertType(res[0], new({{$bindedType}})).(*{{$bindedType}})
 return unpacked, nil
 }
 

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/contract.go
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/contract.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/graft/evm/constants"
-	"github.com/ava-labs/avalanchego/graft/subnet-evm/accounts/abi"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/allowlist"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contract"
 	"github.com/ava-labs/libevm/core/types"
@@ -193,11 +192,10 @@ func UnpackSetRewardAddressInput(input []byte, useStrictMode bool) (common.Addre
 	if useStrictMode && len(input)%32 != 0 {
 		return common.Address{}, fmt.Errorf("%w: %d", ErrInvalidLen, len(input))
 	}
-	res, err := RewardManagerABI.UnpackInput("setRewardAddress", input)
-	if err != nil {
+	var unpacked common.Address
+	if err := RewardManagerABI.UnpackInputIntoInterface(&unpacked, "setRewardAddress", input); err != nil {
 		return common.Address{}, err
 	}
-	unpacked := *abi.ConvertType(res[0], new(common.Address)).(*common.Address)
 	return unpacked, nil
 }
 

--- a/graft/subnet-evm/precompile/contracts/warp/contract.go
+++ b/graft/subnet-evm/precompile/contracts/warp/contract.go
@@ -155,11 +155,10 @@ func getBlockchainID(accessibleState contract.AccessibleState, caller common.Add
 func UnpackGetVerifiedWarpBlockHashInput(input []byte) (uint32, error) {
 	// We don't use strict mode here because it was disabled with Durango.
 	// Since Warp will be deployed after Durango, we don't need to validate padding length.
-	res, err := WarpABI.UnpackInput("getVerifiedWarpBlockHash", input)
-	if err != nil {
+	var unpacked uint32
+	if err := WarpABI.UnpackInputIntoInterface(&unpacked, "getVerifiedWarpBlockHash", input); err != nil {
 		return 0, err
 	}
-	unpacked := *abi.ConvertType(res[0], new(uint32)).(*uint32)
 	return unpacked, nil
 }
 
@@ -198,11 +197,10 @@ func getVerifiedWarpBlockHash(accessibleState contract.AccessibleState, caller c
 func UnpackGetVerifiedWarpMessageInput(input []byte) (uint32, error) {
 	// We don't use strict mode here because it was disabled with Durango.
 	// Since Warp will be deployed after Durango, we don't need to validate padding length.
-	res, err := WarpABI.UnpackInput("getVerifiedWarpMessage", input)
-	if err != nil {
+	var unpacked uint32
+	if err := WarpABI.UnpackInputIntoInterface(&unpacked, "getVerifiedWarpMessage", input); err != nil {
 		return 0, err
 	}
-	unpacked := *abi.ConvertType(res[0], new(uint32)).(*uint32)
 	return unpacked, nil
 }
 
@@ -244,11 +242,10 @@ func getVerifiedWarpMessage(accessibleState contract.AccessibleState, caller com
 func UnpackSendWarpMessageInput(input []byte) ([]byte, error) {
 	// We don't use strict mode here because it was disabled with Durango.
 	// Since Warp will be deployed after Durango, we don't need to validate padding length.
-	res, err := WarpABI.UnpackInput("sendWarpMessage", input)
-	if err != nil {
+	var unpacked []byte
+	if err := WarpABI.UnpackInputIntoInterface(&unpacked, "sendWarpMessage", input); err != nil {
 		return []byte{}, err
 	}
-	unpacked := *abi.ConvertType(res[0], new([]byte)).(*[]byte)
 	return unpacked, nil
 }
 


### PR DESCRIPTION
## Why this should be merged

Migrating this to libevm requires removing this unnecessary function. We can use a more type-safe alternative at a slight performance cost

## How this works

Removes a function for a preferred alternative.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
