### PR TITLE
Introduce Simplex Engine Struct

### DIFF
--- a/simplex/block.go
+++ b/simplex/block.go
@@ -24,9 +24,10 @@ var (
 	_ simplex.Block             = (*Block)(nil)
 	_ simplex.VerifiedBlock     = (*Block)(nil)
 
-	errDigestNotFound       = errors.New("digest not found in block tracker")
-	errMismatchedPrevDigest = errors.New("prev digest does not match block parent")
-	errGenesisVerification  = errors.New("genesis block should not be verified")
+	errDigestNotFound        = errors.New("digest not found in block tracker")
+	errMismatchedPrevDigest  = errors.New("prev digest does not match block parent")
+	errGenesisVerification   = errors.New("genesis block should not be verified")
+	errFailedToParseMetadata = errors.New("failed to parse protocol metadata")
 )
 
 type Block struct {
@@ -132,7 +133,7 @@ func (d *blockDeserializer) DeserializeBlock(ctx context.Context, bytes []byte) 
 
 	md, err := simplex.ProtocolMetadataFromBytes(canotoBlock.Metadata)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse protocol metadata: %w", err)
+		return nil, fmt.Errorf("%w: %w", errFailedToParseMetadata, err)
 	}
 
 	vmblock, err := d.parser.ParseBlock(ctx, canotoBlock.InnerBlock)

--- a/simplex/config.go
+++ b/simplex/config.go
@@ -4,6 +4,8 @@
 package simplex
 
 import (
+	"github.com/ava-labs/simplex"
+
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"
@@ -25,6 +27,9 @@ type Config struct {
 	VM block.ChainVM
 
 	DB database.KeyValueReaderWriter
+
+	// In the case of a crash, Simplex uses the WAL to recover its state and resume consensus.
+	WAL simplex.WriteAheadLog
 
 	// SignBLS is the signing function used for this node to sign messages.
 	SignBLS SignFunc

--- a/simplex/engine.go
+++ b/simplex/engine.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package simplex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ava-labs/simplex"
+	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/proto/pb/p2p"
+	"github.com/ava-labs/avalanchego/utils/logging"
+
+	simplexparams "github.com/ava-labs/avalanchego/snow/consensus/simplex"
+)
+
+var (
+	errUnknownMessageType   = errors.New("unknown message type")
+	errNilSimplexParameters = errors.New("simplex parameters cannot be nil")
+)
+
+type Engine struct {
+	epoch              *simplex.Epoch
+	blockDeserializer  *blockDeserializer
+	quorumDeserializer *QCDeserializer
+	logger             logging.Logger
+
+	tickInterval time.Duration
+	shutdown     chan struct{}
+	shutdownOnce sync.Once
+}
+
+// The VM must be initialized before creating the engine
+func NewEngine(ctx context.Context, config *Config) (*Engine, error) {
+	if config.Params == nil {
+		return nil, errNilSimplexParameters
+	}
+
+	signer, verifier, err := NewBLSAuth(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create BLS auth: %w", err)
+	}
+
+	qcDeserializer := &QCDeserializer{
+		verifier: &verifier,
+	}
+
+	signatureAggregator := &SignatureAggregator{
+		verifier: &verifier,
+	}
+	comm, err := NewComm(config)
+	if err != nil {
+		return nil, err
+	}
+
+	storage, err := newStorage(ctx, config, qcDeserializer, &blockTracker{})
+	if err != nil {
+		return nil, err
+	}
+
+	if storage.NumBlocks() == 0 {
+		return nil, errors.New("storage has no blocks")
+	}
+
+	lastBlock, _, err := storage.Retrieve(storage.NumBlocks() - 1)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't find last block at height %d: %w", storage.NumBlocks()-1, err)
+	}
+
+	simplexBlock, ok := lastBlock.(*Block)
+	if !ok {
+		return nil, fmt.Errorf("expected last block to be of type *Block but got %T", lastBlock)
+	}
+
+	blockTracker := newBlockTracker(simplexBlock)
+	blockBuilder := &BlockBuilder{
+		vm:           config.VM,
+		blockTracker: blockTracker,
+		log:          config.Log,
+	}
+	storage.blockTracker = blockTracker
+
+	blockDeserializer := &blockDeserializer{
+		parser:       config.VM,
+		blockTracker: blockTracker,
+	}
+
+	epochConfig := simplex.EpochConfig{
+		MaxProposalWait:     config.Params.MaxNetworkDelay,
+		MaxRebroadcastWait:  config.Params.MaxRebroadcastWait,
+		QCDeserializer:      qcDeserializer,
+		Logger:              config.Log,
+		ID:                  config.Ctx.NodeID[:],
+		Signer:              &signer,
+		Verifier:            &verifier,
+		BlockDeserializer:   blockDeserializer,
+		SignatureAggregator: signatureAggregator,
+		Comm:                comm,
+		Storage:             storage,
+		WAL:                 config.WAL,
+		BlockBuilder:        blockBuilder,
+		Epoch:               simplexBlock.metadata.Epoch,
+		StartTime:           time.Now(),
+		ReplicationEnabled:  true,
+	}
+
+	epoch, err := simplex.NewEpoch(epochConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Engine{
+		epoch:              epoch,
+		blockDeserializer:  blockDeserializer,
+		quorumDeserializer: qcDeserializer,
+		logger:             config.Log,
+
+		tickInterval: getTickInterval(config.Params),
+		shutdown:     make(chan struct{}, 1),
+	}, nil
+}
+
+func (e *Engine) Start(_ context.Context, _ uint32) error {
+	e.logger.Info("Starting simplex engine")
+	if err := e.epoch.Start(); err != nil {
+		return fmt.Errorf("failed to start simplex epoch: %w", err)
+	}
+
+	go e.tick()
+	return nil
+}
+
+// getTickInterval defines a reasonable tick interval for simplex to advance time.
+func getTickInterval(params *simplexparams.Parameters) time.Duration {
+	tick := min(int64(params.MaxNetworkDelay), int64(params.MaxRebroadcastWait)) / 10
+	return time.Duration(tick)
+}
+
+// tick periodically advances the engine's time.
+func (e *Engine) tick() {
+	ticker := time.NewTicker(e.tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case tick := <-ticker.C:
+			e.epoch.AdvanceTime(tick)
+		case <-e.shutdown:
+			return
+		}
+	}
+}
+
+func (e *Engine) Simplex(ctx context.Context, nodeID ids.NodeID, msg *p2p.Simplex) error {
+	simplexMsg, err := e.p2pToSimplexMessage(ctx, msg)
+	if err != nil {
+		e.logger.Debug("failed to convert p2p message to simplex message", zap.Error(err))
+		return nil
+	}
+
+	return e.epoch.HandleMessage(simplexMsg, nodeID[:])
+}
+
+func (e *Engine) p2pToSimplexMessage(ctx context.Context, msg *p2p.Simplex) (*simplex.Message, error) {
+	if msg == nil {
+		return nil, errNilField
+	}
+
+	switch {
+	case msg.GetBlockProposal() != nil:
+		return blockProposalFromP2P(ctx, msg.GetBlockProposal(), e.blockDeserializer)
+	case msg.GetEmptyNotarization() != nil:
+		return emptyNotarizationMessageFromP2P(msg.GetEmptyNotarization(), e.quorumDeserializer)
+	case msg.GetVote() != nil:
+		return voteFromP2P(msg.GetVote())
+	case msg.GetEmptyVote() != nil:
+		return emptyVoteFromP2P(msg.GetEmptyVote())
+	case msg.GetNotarization() != nil:
+		return notarizationMessageFromP2P(msg.GetNotarization(), e.quorumDeserializer)
+	case msg.GetFinalizeVote() != nil:
+		return finalizeVoteFromP2P(msg.GetFinalizeVote())
+	case msg.GetFinalization() != nil:
+		return finalizationMessageFromP2P(msg.GetFinalization(), e.quorumDeserializer)
+	case msg.GetReplicationRequest() != nil:
+		return replicationRequestFromP2P(msg.GetReplicationRequest()), nil
+	case msg.GetReplicationResponse() != nil:
+		return replicationResponseFromP2P(ctx, msg.GetReplicationResponse(), e.blockDeserializer, e.quorumDeserializer)
+	default:
+		return nil, errUnknownMessageType
+	}
+}
+
+func (e *Engine) Shutdown(_ context.Context) error {
+	e.shutdownOnce.Do(func() {
+		e.epoch.Stop()
+		e.logger.Info("Stopped simplex engine")
+		close(e.shutdown)
+	})
+	return nil
+}

--- a/simplex/engine_test.go
+++ b/simplex/engine_test.go
@@ -1,0 +1,767 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package simplex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/simplex"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/proto/pb/p2p"
+	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	"github.com/ava-labs/avalanchego/snow/networking/sender/sendermock"
+
+	simplexparams "github.com/ava-labs/avalanchego/snow/consensus/simplex"
+)
+
+// TestSimplexEngineHandlesSimplexMessages tests that the Simplex engine can handle
+// various types of Simplex messages without errors. The contents of the messages do not have
+// to be valid, as long as they can be parsed and processed by the engine.
+func TestSimplexEngineHandlesSimplexMessages(t *testing.T) {
+	ctx := t.Context()
+	engine, configs := setupEngine(t)
+
+	qcBytes := buildQCBytes(t, configs)
+
+	allSimplexMessages := []*p2p.Simplex{
+		simplexBlockProposal,
+		simplexVote,
+		simplexEmptyVote,
+		simplexFinalizeVote,
+		NewNotarizationMessage(qcBytes),
+		NewEmptyNotarizationMessage(qcBytes),
+		NewFinalizationMessage(qcBytes),
+		simplexReplicationRequest,
+		NewReplicationResponseMessage(qcBytes),
+	}
+
+	for _, msg := range allSimplexMessages {
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	}
+}
+
+func TestSimplexEngineNilParameters(t *testing.T) {
+	configs := newNetworkConfigs(t, 4)
+	ctx := t.Context()
+
+	config := configs[0]
+	config.Params = nil
+	_, err := NewEngine(ctx, config)
+	require.ErrorIs(t, err, errNilSimplexParameters)
+}
+
+func TestSimplexEngineShutdown(t *testing.T) {
+	engine, _ := setupEngine(t)
+	require.NotPanics(t, func() {
+		require.NoError(t, engine.Shutdown(t.Context()))
+	})
+}
+
+func TestGetTickInterval(t *testing.T) {
+	maxNetworkDelay := 2 * time.Second
+	params := &simplexparams.Parameters{
+		MaxNetworkDelay:    5 * time.Second,
+		MaxRebroadcastWait: 2 * time.Second,
+	}
+	tick := getTickInterval(params)
+	require.Equal(t, maxNetworkDelay/10, tick)
+}
+
+func TestSimplexEngineRejectsMalformedSimplexMessages(t *testing.T) {
+	configs := newNetworkConfigs(t, 4)
+	ctx := t.Context()
+
+	config := configs[0]
+	config.Sender.(*sendermock.ExternalSender).
+		EXPECT().
+		Send(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes()
+
+	engine, err := NewEngine(ctx, config)
+	require.NoError(t, err)
+
+	config.VM.(*wrappedVM).ParseBlockF = func(_ context.Context, _ []byte) (snowman.Block, error) {
+		return newTestBlock(t, newBlockConfig{round: 1}).vmBlock, nil
+	}
+
+	require.NoError(t, engine.Start(ctx, 1))
+
+	tests := []struct {
+		name        string
+		msg         *p2p.Simplex
+		expectedErr error
+	}{
+		// --- BlockProposal ---
+		{
+			name: "BlockProposal missing block",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_BlockProposal{
+					BlockProposal: &p2p.BlockProposal{},
+				},
+			},
+			expectedErr: errFailedToParseMetadata,
+		},
+		{
+			name: "BlockProposal missing vote",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_BlockProposal{
+					BlockProposal: &p2p.BlockProposal{
+						Block: blockBytes,
+					},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		// --- Vote ---
+		{
+			name: "Vote with nil header",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_Vote{
+					Vote: &p2p.Vote{},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		// --- EmptyVote ---
+		{
+			name: "EmptyVote with nil metadata",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_EmptyVote{
+					EmptyVote: &p2p.EmptyVote{},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		{
+			name: "EmptyVote with nil signature",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_EmptyVote{
+					EmptyVote: &p2p.EmptyVote{
+						Metadata: &p2p.EmptyVoteMetadata{
+							Epoch: 1, Round: 1,
+						},
+					},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		// --- FinalizeVote ---
+		{
+			name: "FinalizeVote missing header + sig",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_FinalizeVote{
+					FinalizeVote: &p2p.Vote{},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		// --- Notarization ---
+		{
+			name: "Notarization with nil BlockHeader",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_Notarization{
+					Notarization: &p2p.QuorumCertificate{},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		{
+			name: "Notarization with nil QC",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_Notarization{
+					Notarization: &p2p.QuorumCertificate{
+						BlockHeader: &p2p.BlockHeader{
+							Metadata: p2pProtocolMetadata,
+							Digest:   digest[:],
+						},
+					},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		// --- EmptyNotarization ---
+		{
+			name: "EmptyNotarization with nil metadata",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_EmptyNotarization{
+					EmptyNotarization: &p2p.EmptyNotarization{},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		{
+			name: "EmptyNotarization with nil QC",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_EmptyNotarization{
+					EmptyNotarization: &p2p.EmptyNotarization{
+						Metadata: &p2p.EmptyVoteMetadata{
+							Epoch: 1, Round: 1,
+						},
+					},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		// --- Finalization ---
+		{
+			name: "Finalization with nil BlockHeader",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_Finalization{
+					Finalization: &p2p.QuorumCertificate{},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		{
+			name: "Finalization with nil QC",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_Finalization{
+					Finalization: &p2p.QuorumCertificate{
+						BlockHeader: &p2p.BlockHeader{
+							Metadata: p2pProtocolMetadata,
+							Digest:   digest[:],
+						},
+					},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		// --- ReplicationRequest ---
+		{
+			name: "ReplicationRequest missing seqs/round (allowed)",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_ReplicationRequest{
+					ReplicationRequest: &p2p.ReplicationRequest{},
+				},
+			},
+			expectedErr: nil,
+		},
+		// --- ReplicationResponse ---
+		{
+			name: "ReplicationResponse with nil latest_round",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_ReplicationResponse{
+					ReplicationResponse: &p2p.ReplicationResponse{},
+				},
+			},
+			expectedErr: errNilField,
+		},
+		// --- Edge case: invalid digest ---
+		{
+			name: "Vote with invalid digest length",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_Vote{
+					Vote: &p2p.Vote{
+						BlockHeader: &p2p.BlockHeader{
+							Metadata: &p2p.ProtocolMetadata{},
+						},
+						Signature: &p2p.Signature{
+							Signer: []byte{1, 2, 3}, Value: []byte{4},
+						},
+					},
+				},
+			},
+			expectedErr: errInvalidDigestLength,
+		},
+		{
+			name: "Vote with invalid signer",
+			msg: &p2p.Simplex{
+				Message: &p2p.Simplex_Vote{
+					Vote: &p2p.Vote{
+						BlockHeader: &p2p.BlockHeader{
+							Metadata: p2pProtocolMetadata,
+							Digest:   digest[:],
+						},
+						Signature: &p2p.Signature{
+							Signer: []byte{1, 2, 3}, Value: []byte{4},
+						},
+					},
+				},
+			},
+			expectedErr: errInvalidSigner,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := engine.p2pToSimplexMessage(ctx, tt.msg)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Shared Test Data
+// -----------------------------------------------------------------------------
+
+var (
+	blockMetadata = &simplex.ProtocolMetadata{
+		Version: 1,
+		Epoch:   2,
+		Round:   3,
+		Seq:     4,
+		Prev:    simplex.Digest{0x1, 0x2, 0x3, 0x4},
+	}
+
+	canotoBlock = &canotoSimplexBlock{
+		Metadata:   blockMetadata.Bytes(),
+		InnerBlock: []byte("inner-block"),
+	}
+
+	blockBytes = canotoBlock.MarshalCanoto()
+	digest     = computeDigest(blockBytes)
+	nodeID     = ids.GenerateTestNodeID()
+	signer     = nodeID[:]
+)
+
+// -----------------------------------------------------------------------------
+// Predefined Messages (no QC dependency)
+// -----------------------------------------------------------------------------
+
+var (
+	p2pProtocolMetadata = &p2p.ProtocolMetadata{
+		Version: 1,
+		Epoch:   42,
+		Round:   7,
+		Seq:     100,
+		Prev:    digest[:],
+	}
+	// BlockProposal
+	simplexBlockProposal = &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_BlockProposal{
+			BlockProposal: &p2p.BlockProposal{
+				Block: blockBytes,
+				Vote: &p2p.Vote{
+					BlockHeader: &p2p.BlockHeader{
+						Metadata: p2pProtocolMetadata,
+						Digest:   digest[:],
+					},
+					Signature: &p2p.Signature{Signer: signer, Value: []byte("signature")},
+				},
+			},
+		},
+	}
+
+	// Vote
+	simplexVote = &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_Vote{
+			Vote: &p2p.Vote{
+				BlockHeader: &p2p.BlockHeader{
+					Metadata: &p2p.ProtocolMetadata{
+						Version: 1, Epoch: 1, Round: 1, Seq: 1, Prev: digest[:],
+					},
+					Digest: digest[:],
+				},
+				Signature: &p2p.Signature{Signer: signer, Value: []byte("vote-sig")},
+			},
+		},
+	}
+
+	// EmptyVote
+	simplexEmptyVote = &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_EmptyVote{
+			EmptyVote: &p2p.EmptyVote{
+				Metadata:  &p2p.EmptyVoteMetadata{Epoch: 1, Round: 1},
+				Signature: &p2p.Signature{Signer: signer, Value: []byte("emptyvote-sig")},
+			},
+		},
+	}
+
+	// FinalizeVote
+	simplexFinalizeVote = &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_FinalizeVote{
+			FinalizeVote: &p2p.Vote{
+				BlockHeader: &p2p.BlockHeader{
+					Metadata: &p2p.ProtocolMetadata{
+						Version: 1, Epoch: 2, Round: 5, Seq: 50, Prev: digest[:],
+					},
+					Digest: digest[:],
+				},
+				Signature: &p2p.Signature{Signer: signer, Value: []byte("finalize-sig")},
+			},
+		},
+	}
+
+	// ReplicationRequest
+	simplexReplicationRequest = &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_ReplicationRequest{
+			ReplicationRequest: &p2p.ReplicationRequest{
+				Seqs:        []uint64{1, 2, 3},
+				LatestRound: 42,
+			},
+		},
+	}
+)
+
+// -----------------------------------------------------------------------------
+// QC Builder
+// -----------------------------------------------------------------------------
+
+func buildQCWithBytes(t testing.TB, configs []*Config, msg []byte) []byte {
+	t.Helper()
+
+	sigs := make([]simplex.Signature, 0, len(configs))
+
+	for _, config := range configs {
+		signer, _, err := NewBLSAuth(config)
+		require.NoError(t, err)
+		sig, _ := signer.Sign(msg)
+		sigs = append(sigs, simplex.Signature{
+			Signer: config.Ctx.NodeID[:],
+			Value:  sig,
+		})
+	}
+
+	_, verifier, err := NewBLSAuth(configs[0])
+	require.NoError(t, err)
+	agg := SignatureAggregator{verifier: &verifier}
+
+	qc, err := agg.Aggregate(sigs)
+	require.NoError(t, err)
+	return qc.Bytes()
+}
+
+func buildQCBytes(t testing.TB, configs []*Config) []byte {
+	return buildQCWithBytes(t, configs, []byte("test message"))
+}
+
+// -----------------------------------------------------------------------------
+// QC-Dependent Message Constructors
+// -----------------------------------------------------------------------------
+
+func NewNotarizationMessage(qcBytes []byte) *p2p.Simplex {
+	return &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_Notarization{
+			Notarization: &p2p.QuorumCertificate{
+				BlockHeader: &p2p.BlockHeader{
+					Metadata: &p2p.ProtocolMetadata{
+						Version: 1, Epoch: 3, Round: 8, Seq: 75, Prev: digest[:],
+					},
+					Digest: digest[:],
+				},
+				QuorumCertificate: qcBytes,
+			},
+		},
+	}
+}
+
+func NewEmptyNotarizationMessage(qcBytes []byte) *p2p.Simplex {
+	return &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_EmptyNotarization{
+			EmptyNotarization: &p2p.EmptyNotarization{
+				Metadata:          &p2p.EmptyVoteMetadata{Epoch: 1, Round: 1},
+				QuorumCertificate: qcBytes,
+			},
+		},
+	}
+}
+
+func NewFinalizationMessage(qcBytes []byte) *p2p.Simplex {
+	return &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_Finalization{
+			Finalization: &p2p.QuorumCertificate{
+				BlockHeader: &p2p.BlockHeader{
+					Metadata: &p2p.ProtocolMetadata{
+						Version: 1, Epoch: 5, Round: 11, Seq: 120, Prev: digest[:],
+					},
+					Digest: digest[:],
+				},
+				QuorumCertificate: qcBytes,
+			},
+		},
+	}
+}
+
+func NewReplicationResponseMessage(qcBytes []byte) *p2p.Simplex {
+	return &p2p.Simplex{
+		ChainId: []byte("chain-1"),
+		Message: &p2p.Simplex_ReplicationResponse{
+			ReplicationResponse: &p2p.ReplicationResponse{
+				Data: []*p2p.QuorumRound{
+					{
+						Block: blockBytes,
+						Notarization: &p2p.QuorumCertificate{
+							BlockHeader: &p2p.BlockHeader{
+								Metadata: &p2p.ProtocolMetadata{
+									Version: 1, Epoch: 6, Round: 13, Seq: 150, Prev: digest[:],
+								},
+								Digest: digest[:],
+							},
+							QuorumCertificate: qcBytes,
+						},
+					},
+				},
+				LatestRound: &p2p.QuorumRound{Block: blockBytes},
+			},
+		},
+	}
+}
+
+func FuzzSimplexVotes(f *testing.F) {
+	f.Fuzz(func(t *testing.T, blockDigest []byte, signer []byte, epoch, round, seq uint64, version uint32) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+
+		msg := &p2p.Simplex{
+			Message: &p2p.Simplex_Vote{
+				Vote: &p2p.Vote{
+					BlockHeader: &p2p.BlockHeader{
+						Metadata: &p2p.ProtocolMetadata{
+							Version: version,
+							Epoch:   epoch,
+							Round:   round,
+							Seq:     seq,
+							Prev:    blockDigest,
+						},
+						Digest: blockDigest,
+					},
+					Signature: &p2p.Signature{Signer: signer, Value: []byte("vote-sig")},
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func FuzzSimplexEmptyVotes(f *testing.F) {
+	f.Fuzz(func(t *testing.T, signer []byte, epoch, round uint64, signerValue []byte) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+
+		msg := &p2p.Simplex{
+			Message: &p2p.Simplex_EmptyVote{
+				EmptyVote: &p2p.EmptyVote{
+					Metadata:  &p2p.EmptyVoteMetadata{Epoch: epoch, Round: round},
+					Signature: &p2p.Signature{Signer: signer, Value: signerValue},
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func FuzzSimplexFinalizeVotes(f *testing.F) {
+	f.Fuzz(func(t *testing.T, signer []byte, signerValue []byte, blockDigest []byte, epoch, round, seq uint64, version uint32) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+
+		msg := &p2p.Simplex{
+			Message: &p2p.Simplex_FinalizeVote{
+				FinalizeVote: &p2p.Vote{
+					BlockHeader: &p2p.BlockHeader{
+						Metadata: &p2p.ProtocolMetadata{
+							Version: version,
+							Epoch:   epoch,
+							Round:   round,
+							Seq:     seq,
+							Prev:    blockDigest,
+						},
+						Digest: blockDigest,
+					},
+					Signature: &p2p.Signature{Signer: signer, Value: signerValue},
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func FuzzSimplexNotarizations(f *testing.F) {
+	f.Fuzz(func(t *testing.T, qcData, blockDigest []byte, epoch, round, seq uint64, version uint32) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+		qc := buildQCWithBytes(t, configs, qcData)
+
+		msg := &p2p.Simplex{
+			Message: &p2p.Simplex_Notarization{
+				Notarization: &p2p.QuorumCertificate{
+					BlockHeader: &p2p.BlockHeader{
+						Metadata: &p2p.ProtocolMetadata{
+							Version: version,
+							Epoch:   epoch,
+							Round:   round,
+							Seq:     seq,
+							Prev:    blockDigest,
+						},
+						Digest: blockDigest,
+					},
+					QuorumCertificate: qc,
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func FuzzSimplexFinalizations(f *testing.F) {
+	f.Fuzz(func(t *testing.T, qcData, blockDigest []byte, epoch, round, seq uint64, version uint32) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+		qc := buildQCWithBytes(t, configs, qcData)
+
+		msg := &p2p.Simplex{
+			Message: &p2p.Simplex_Finalization{
+				Finalization: &p2p.QuorumCertificate{
+					BlockHeader: &p2p.BlockHeader{
+						Metadata: &p2p.ProtocolMetadata{
+							Version: version,
+							Epoch:   epoch,
+							Round:   round,
+							Seq:     seq,
+							Prev:    blockDigest,
+						},
+						Digest: blockDigest,
+					},
+					QuorumCertificate: qc,
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func FuzzSimplexReplicationRequests(f *testing.F) {
+	f.Fuzz(func(t *testing.T, seq1, seq2, seq3, latestRound uint64) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+
+		msg := &p2p.Simplex{
+			Message: &p2p.Simplex_ReplicationRequest{
+				ReplicationRequest: &p2p.ReplicationRequest{
+					Seqs:        []uint64{seq1, seq2, seq3},
+					LatestRound: latestRound,
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func FuzzSimplexReplicationResponses(f *testing.F) {
+	f.Fuzz(func(t *testing.T, qcData, blockDigest []byte, epoch, round, seq uint64, version uint32) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+		qc := buildQCWithBytes(t, configs, qcData)
+
+		msg := &p2p.Simplex{
+			Message: &p2p.Simplex_ReplicationResponse{
+				ReplicationResponse: &p2p.ReplicationResponse{
+					Data: []*p2p.QuorumRound{
+						{
+							Block: blockBytes,
+							Notarization: &p2p.QuorumCertificate{
+								BlockHeader: &p2p.BlockHeader{
+									Metadata: &p2p.ProtocolMetadata{
+										Version: version,
+										Epoch:   epoch,
+										Round:   round,
+										Seq:     seq,
+										Prev:    blockDigest,
+									},
+									Digest: blockDigest,
+								},
+								QuorumCertificate: qc,
+							},
+						},
+					},
+					LatestRound: &p2p.QuorumRound{Block: blockBytes},
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func FuzzSimplexBlockProposals(f *testing.F) {
+	f.Fuzz(func(t *testing.T, blockBytes []byte, blockDigest []byte, round, epoch, seq uint64, version uint32) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+		msg := &p2p.Simplex{
+			ChainId: []byte("chain-1"),
+			Message: &p2p.Simplex_BlockProposal{
+				BlockProposal: &p2p.BlockProposal{
+					Block: blockBytes,
+					Vote: &p2p.Vote{
+						BlockHeader: &p2p.BlockHeader{
+							Metadata: &p2p.ProtocolMetadata{
+								Version: version,
+								Epoch:   epoch,
+								Round:   round,
+								Seq:     seq,
+								Prev:    blockDigest,
+							},
+							Digest: blockDigest,
+						},
+						Signature: &p2p.Signature{Signer: signer, Value: []byte("signature")},
+					},
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func FuzzSimplexEmptyNotarizations(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte, round uint64, epoch uint64) {
+		ctx := t.Context()
+		engine, configs := setupEngine(t)
+		qc := buildQCWithBytes(t, configs, data)
+		msg := &p2p.Simplex{
+			Message: &p2p.Simplex_EmptyNotarization{
+				EmptyNotarization: &p2p.EmptyNotarization{
+					Metadata:          &p2p.EmptyVoteMetadata{Epoch: epoch, Round: round},
+					QuorumCertificate: qc,
+				},
+			},
+		}
+
+		require.NoError(t, engine.Simplex(ctx, configs[1].Ctx.NodeID, msg))
+	})
+}
+
+func setupEngine(t *testing.T) (*Engine, []*Config) {
+	configs := newNetworkConfigs(t, 4)
+	ctx := t.Context()
+
+	config := configs[0]
+	config.Sender.(*sendermock.ExternalSender).EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	engine, err := NewEngine(ctx, config)
+	require.NoError(t, err)
+
+	// ensure any go-routines started by the engine are cleaned up after the test finishes
+	t.Cleanup(func() {
+		require.NoError(t, engine.Shutdown(ctx))
+	})
+
+	config.VM.(*wrappedVM).ParseBlockF = func(_ context.Context, _ []byte) (snowman.Block, error) {
+		return newTestBlock(t, newBlockConfig{round: 1}).vmBlock, nil
+	}
+
+	require.NoError(t, engine.Start(ctx, 1))
+	md := engine.epoch.Metadata()
+	require.Equal(t, uint64(1), md.Seq)
+	require.Equal(t, uint64(1), md.Round)
+	return engine, configs
+}

--- a/simplex/inbound.go
+++ b/simplex/inbound.go
@@ -1,0 +1,387 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package simplex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/ava-labs/simplex"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/proto/pb/p2p"
+)
+
+var (
+	errNilField            = errors.New("nil field")
+	errInvalidDigestLength = errors.New("invalid digest length")
+	errInvalidSigner       = errors.New("invalid signer")
+)
+
+func emptyNotarizationMessageFromP2P(emptyNotarization *p2p.EmptyNotarization, qcDeserializer *QCDeserializer) (*simplex.Message, error) {
+	notarization, err := emptyNotarizationFromP2P(emptyNotarization, qcDeserializer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert empty notarization: %w", err)
+	}
+
+	return &simplex.Message{
+		EmptyNotarization: notarization,
+	}, nil
+}
+
+func notarizationMessageFromP2P(notarization *p2p.QuorumCertificate, qcDeserializer *QCDeserializer) (*simplex.Message, error) {
+	note, err := notarizationFromP2P(notarization, qcDeserializer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert notarization: %w", err)
+	}
+
+	return &simplex.Message{
+		Notarization: note,
+	}, nil
+}
+
+func finalizationMessageFromP2P(finalization *p2p.QuorumCertificate, qcDeserializer *QCDeserializer) (*simplex.Message, error) {
+	finalizationMsg, err := finalizationFromP2P(finalization, qcDeserializer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert finalization: %w", err)
+	}
+
+	return &simplex.Message{
+		Finalization: finalizationMsg,
+	}, nil
+}
+
+func blockProposalFromP2P(ctx context.Context, blockProposal *p2p.BlockProposal, deserializer *blockDeserializer) (*simplex.Message, error) {
+	block, err := deserializer.DeserializeBlock(ctx, blockProposal.Block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize block: %w", err)
+	}
+
+	vote, err := p2pVoteToSimplexVote(blockProposal.Vote)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize vote: %w", err)
+	}
+
+	return &simplex.Message{
+		BlockMessage: &simplex.BlockMessage{
+			Block: block,
+			Vote:  vote,
+		},
+	}, nil
+}
+
+func voteFromP2P(vote *p2p.Vote) (*simplex.Message, error) {
+	simplexVote, err := p2pVoteToSimplexVote(vote)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert p2p vote to simplex vote: %w", err)
+	}
+	return &simplex.Message{
+		VoteMessage: &simplexVote,
+	}, nil
+}
+
+func emptyVoteFromP2P(emptyVote *p2p.EmptyVote) (*simplex.Message, error) {
+	vote, err := emptyVoteMetadataFromP2P(emptyVote.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := p2pSignatureToSimplexSignature(emptyVote.Signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return &simplex.Message{
+		EmptyVoteMessage: &simplex.EmptyVote{
+			Vote: simplex.ToBeSignedEmptyVote{
+				EmptyVoteMetadata: vote,
+			},
+			Signature: sig,
+		},
+	}, nil
+}
+
+func finalizeVoteFromP2P(finalizeVote *p2p.Vote) (*simplex.Message, error) {
+	bh, err := p2pBlockHeaderToSimplexBlockHeader(finalizeVote.BlockHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := p2pSignatureToSimplexSignature(finalizeVote.Signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return &simplex.Message{
+		FinalizeVote: &simplex.FinalizeVote{
+			Finalization: simplex.ToBeSignedFinalization{
+				BlockHeader: bh,
+			},
+			Signature: sig,
+		},
+	}, nil
+}
+
+func replicationRequestFromP2P(replicationRequest *p2p.ReplicationRequest) *simplex.Message {
+	return &simplex.Message{
+		ReplicationRequest: &simplex.ReplicationRequest{
+			Seqs:        replicationRequest.Seqs,
+			LatestRound: replicationRequest.LatestRound,
+		},
+	}
+}
+
+func replicationResponseFromP2P(ctx context.Context, replicationResponse *p2p.ReplicationResponse, blockDeserializer *blockDeserializer, qcDeserializer *QCDeserializer) (*simplex.Message, error) {
+	latestRound, err := quorumRoundFromP2P(ctx, replicationResponse.LatestRound, blockDeserializer, qcDeserializer)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]simplex.QuorumRound, 0, len(replicationResponse.Data))
+	for _, qr := range replicationResponse.Data {
+		converted, err := quorumRoundFromP2P(ctx, qr, blockDeserializer, qcDeserializer)
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, *converted)
+	}
+
+	return &simplex.Message{
+		ReplicationResponse: &simplex.ReplicationResponse{
+			LatestRound: latestRound,
+			Data:        data,
+		},
+	}, nil
+}
+
+// HELPERS -----------------
+func p2pVoteToSimplexVote(p2pVote *p2p.Vote) (simplex.Vote, error) {
+	if p2pVote == nil {
+		return simplex.Vote{}, errNilField
+	}
+
+	bh, err := p2pBlockHeaderToSimplexBlockHeader(p2pVote.BlockHeader)
+	if err != nil {
+		return simplex.Vote{}, err
+	}
+
+	signature, err := p2pSignatureToSimplexSignature(p2pVote.Signature)
+	if err != nil {
+		return simplex.Vote{}, err
+	}
+
+	v := simplex.Vote{
+		Vote: simplex.ToBeSignedVote{
+			BlockHeader: bh,
+		},
+		Signature: signature,
+	}
+
+	return v, nil
+}
+
+func p2pSignatureToSimplexSignature(p2pSig *p2p.Signature) (simplex.Signature, error) {
+	if p2pSig == nil {
+		return simplex.Signature{}, errNilField
+	}
+
+	nodeID, err := ids.ToNodeID(p2pSig.Signer)
+	if err != nil {
+		return simplex.Signature{}, fmt.Errorf("%w: %w", errInvalidSigner, err)
+	}
+
+	return simplex.Signature{
+		Signer: nodeID[:],
+		Value:  p2pSig.Value,
+	}, nil
+}
+
+func p2pBlockHeaderToSimplexBlockHeader(p2pHeader *p2p.BlockHeader) (simplex.BlockHeader, error) {
+	if p2pHeader == nil {
+		return simplex.BlockHeader{}, errNilField
+	}
+
+	md, err := p2pMetadataToSimplexMetadata(p2pHeader.Metadata)
+	if err != nil {
+		return simplex.BlockHeader{}, fmt.Errorf("failed to convert previous metadata: %w", err)
+	}
+
+	digest, err := digestFromP2P(p2pHeader.Digest)
+	if err != nil {
+		return simplex.BlockHeader{}, fmt.Errorf("failed to convert digest: %w", err)
+	}
+
+	return simplex.BlockHeader{
+		ProtocolMetadata: md,
+		Digest:           digest,
+	}, nil
+}
+
+func p2pMetadataToSimplexMetadata(p2pMetadata *p2p.ProtocolMetadata) (simplex.ProtocolMetadata, error) {
+	if p2pMetadata == nil {
+		return simplex.ProtocolMetadata{}, errNilField
+	}
+
+	if p2pMetadata.Version > math.MaxUint8 {
+		return simplex.ProtocolMetadata{}, fmt.Errorf("version %d exceeds maximum value %d", p2pMetadata.Version, math.MaxUint8)
+	}
+	prev, err := digestFromP2P(p2pMetadata.Prev)
+	if err != nil {
+		return simplex.ProtocolMetadata{}, err
+	}
+
+	return simplex.ProtocolMetadata{
+		Version: uint8(p2pMetadata.Version),
+		Epoch:   p2pMetadata.Epoch,
+		Round:   p2pMetadata.Round,
+		Seq:     p2pMetadata.Seq,
+		Prev:    prev,
+	}, nil
+}
+
+func emptyVoteMetadataFromP2P(emptyVote *p2p.EmptyVoteMetadata) (simplex.EmptyVoteMetadata, error) {
+	if emptyVote == nil {
+		return simplex.EmptyVoteMetadata{}, errNilField
+	}
+
+	return simplex.EmptyVoteMetadata{
+		Round: emptyVote.Round,
+		Epoch: emptyVote.Epoch,
+	}, nil
+}
+
+func digestFromP2P(p2pDigest []byte) (simplex.Digest, error) {
+	if len(p2pDigest) != 32 {
+		return simplex.Digest{}, fmt.Errorf("%w: got %d, expected %d", errInvalidDigestLength, len(p2pDigest), 32)
+	}
+
+	var digest simplex.Digest
+	copy(digest[:], p2pDigest)
+	return digest, nil
+}
+
+func quorumCertificateFromP2P(qcBytes []byte, qcDeserializer *QCDeserializer) (simplex.QuorumCertificate, error) {
+	if qcBytes == nil {
+		return nil, errNilField
+	}
+
+	simplexQC, err := qcDeserializer.DeserializeQuorumCertificate(qcBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return simplexQC, nil
+}
+
+func notarizationFromP2P(notarization *p2p.QuorumCertificate, qcDeserializer *QCDeserializer) (*simplex.Notarization, error) {
+	bh, err := p2pBlockHeaderToSimplexBlockHeader(notarization.BlockHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	qc, err := quorumCertificateFromP2P(notarization.QuorumCertificate, qcDeserializer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert quorum certificate: %w", err)
+	}
+
+	return &simplex.Notarization{
+		Vote: simplex.ToBeSignedVote{
+			BlockHeader: bh,
+		},
+		QC: qc,
+	}, nil
+}
+
+func emptyNotarizationFromP2P(emptyNotarization *p2p.EmptyNotarization, qcDeserializer *QCDeserializer) (*simplex.EmptyNotarization, error) {
+	if emptyNotarization == nil {
+		return nil, errNilField
+	}
+
+	md, err := emptyVoteMetadataFromP2P(emptyNotarization.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert metadata: %w", err)
+	}
+
+	qc, err := quorumCertificateFromP2P(emptyNotarization.QuorumCertificate, qcDeserializer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert quorum certificate: %w", err)
+	}
+
+	return &simplex.EmptyNotarization{
+		Vote: simplex.ToBeSignedEmptyVote{
+			EmptyVoteMetadata: md,
+		},
+		QC: qc,
+	}, nil
+}
+
+func finalizationFromP2P(finalization *p2p.QuorumCertificate, qcDeserializer *QCDeserializer) (*simplex.Finalization, error) {
+	bh, err := p2pBlockHeaderToSimplexBlockHeader(finalization.BlockHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	qc, err := quorumCertificateFromP2P(finalization.QuorumCertificate, qcDeserializer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert quorum certificate: %w", err)
+	}
+
+	return &simplex.Finalization{
+		Finalization: simplex.ToBeSignedFinalization{
+			BlockHeader: bh,
+		},
+		QC: qc,
+	}, nil
+}
+
+func quorumRoundFromP2P(ctx context.Context, qr *p2p.QuorumRound, blockDeserializer *blockDeserializer, qcDeserializer *QCDeserializer) (*simplex.QuorumRound, error) {
+	if qr == nil {
+		return nil, errNilField
+	}
+
+	var block simplex.Block
+	if qr.Block != nil {
+		dBlock, err := blockDeserializer.DeserializeBlock(ctx, qr.Block)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert block: %w", err)
+		}
+		block = dBlock
+	}
+
+	var emptyNotarization *simplex.EmptyNotarization
+	if qr.EmptyNotarization != nil {
+		eNote, err := emptyNotarizationFromP2P(qr.EmptyNotarization, qcDeserializer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert empty notarization: %w", err)
+		}
+		emptyNotarization = eNote
+	}
+
+	var notarization *simplex.Notarization
+	if qr.Notarization != nil {
+		note, err := notarizationFromP2P(qr.Notarization, qcDeserializer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert notarization: %w", err)
+		}
+		notarization = note
+	}
+
+	var finalization *simplex.Finalization
+	if qr.Finalization != nil {
+		finalize, err := finalizationFromP2P(qr.Finalization, qcDeserializer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert finalization: %w", err)
+		}
+		finalization = finalize
+	}
+
+	return &simplex.QuorumRound{
+		Block:             block,
+		EmptyNotarization: emptyNotarization,
+		Notarization:      notarization,
+		Finalization:      finalization,
+	}, nil
+}

--- a/simplex/util_test.go
+++ b/simplex/util_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/simplex"
+	"github.com/ava-labs/simplex/wal"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -122,6 +123,7 @@ func newNetworkConfigs(t *testing.T, numNodes uint64) []*Config {
 			OutboundMsgBuilder: mc,
 			VM:                 newTestVM(),
 			DB:                 memdb.New(),
+			WAL:                wal.NewMemWAL(t),
 			SignBLS:            node.signFunc,
 			Params:             chainParameters,
 		}


### PR DESCRIPTION
## Why this should be merged

This PR introduces the Simplex Consensus Engine which will be responsible for running simplex consensus. For now, we do not implement the entire `common.Engine` interface in order to break apart the simplex integration into bite sized & reviewable PRs. In future PRs we will complete the `common.Engine` interface and introduce the `Simplex()` method as a required part of AppHandlers.

## How this works

This version of the simplex engine initializes the simplex `Epoch` struct and all relevant internal structs of the epoch. We also create public `Start`, `Simplex`, and `Shutdown` methods. The `Start` method is required by the simplex.Engine interface and starts the simplex epoch. It also starts a goroutine to periodically update the epochs time which is important for simplex timeouts, replication and more. 

The `Simplex` converts `p2p.Simplex` messages to simplex ones and processes them via the epoch struct. 

`Shutdown` stops the simplex epoch and any goroutines related to simplex.

## How this was tested

Most of the code diff for this PR(around 1000 out of the 1300 lines) revolve around converting `p2p.Simplex` messages to `simplex.Message`. I created fuzz tests for each of the conversions as well as other unit tests revolving around initializing the simplex engine. 

## Need to be documented in RELEASES.md?

No