### PR TITLE
test: Ensure code hashes are synced in Firewood

### DIFF
--- a/graft/coreth/sync/evmstate/firewood_syncer_test.go
+++ b/graft/coreth/sync/evmstate/firewood_syncer_test.go
@@ -194,7 +194,7 @@ func createDB(t *testing.T) state.Database {
 func assertFirewoodConsistency(t *testing.T, root common.Hash, serverState, clientState state.Database) {
 	t.Helper()
 
-	synctest.AssertTrieConsistency(t, root, clientState, serverState, func(key, val []byte) {
+	synctest.AssertTrieConsistency(t, root, clientState, serverState, func(_, val []byte) {
 		var acc types.StateAccount
 		require.NoError(t, rlp.DecodeBytes(val, &acc))
 

--- a/graft/coreth/sync/evmstate/firewood_syncer_test.go
+++ b/graft/coreth/sync/evmstate/firewood_syncer_test.go
@@ -191,7 +191,7 @@ func createDB(t *testing.T) state.Database {
 	return db
 }
 
-func assertFirewoodConsistency(t *testing.T, root common.Hash, serverState, clientState state.Database) {
+func assertFirewoodConsistency(t *testing.T, root common.Hash, clientState, serverState state.Database) {
 	t.Helper()
 
 	synctest.AssertTrieConsistency(t, root, clientState, serverState, func(_, val []byte) {

--- a/graft/coreth/sync/evmstate/sync_test.go
+++ b/graft/coreth/sync/evmstate/sync_test.go
@@ -573,11 +573,9 @@ func assertDBConsistency(t testing.TB, root common.Hash, clientDB, serverDB stat
 			storageTrieLeavesCount++
 			snapshotVal := rawdb.ReadStorageSnapshot(clientDB.DiskDB(), accHash, common.BytesToHash(key))
 			require.Equal(t, val, snapshotVal)
-			return
 		})
 
 		require.Equal(t, storageTrieLeavesCount, snapshotStorageKeysCount)
-		return
 	})
 
 	// Check that the number of accounts in the snapshot matches the number of leaves in the accounts trie

--- a/graft/evm/firewood/account_it.go
+++ b/graft/evm/firewood/account_it.go
@@ -51,7 +51,7 @@ func (a *accountIt) Error() error {
 }
 
 // Leaf always returns true since Firewood only iterates over leaf nodes.
-func (a *accountIt) Leaf() bool {
+func (*accountIt) Leaf() bool {
 	return true
 }
 
@@ -66,17 +66,17 @@ func (a *accountIt) LeafBlob() []byte {
 }
 
 // LeafProof returns nil since Firewood does not support proofs.
-func (a *accountIt) LeafProof() [][]byte {
+func (*accountIt) LeafProof() [][]byte {
 	return nil
 }
 
 // Hash is unused since Firewood does not expose internal hashes.
-func (a *accountIt) Hash() common.Hash {
+func (*accountIt) Hash() common.Hash {
 	return common.Hash{}
 }
 
 // NodeBlob is unused since Firewood does not expose internal nodes.
-func (a *accountIt) NodeBlob() []byte {
+func (*accountIt) NodeBlob() []byte {
 	return nil
 }
 
@@ -84,8 +84,8 @@ func (a *accountIt) Path() []byte {
 	return a.it.Key()
 }
 
-func (a *accountIt) AddResolver(trie.NodeResolver) {}
+func (*accountIt) AddResolver(trie.NodeResolver) {}
 
-func (a *accountIt) Parent() common.Hash {
+func (*accountIt) Parent() common.Hash {
 	return common.Hash{}
 }

--- a/graft/evm/firewood/account_it.go
+++ b/graft/evm/firewood/account_it.go
@@ -1,5 +1,6 @@
-// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
+
 package firewood
 
 import (

--- a/graft/evm/firewood/account_it.go
+++ b/graft/evm/firewood/account_it.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ava-labs/firewood-go-ethhash/ffi"
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/trie"
 )
 
@@ -30,7 +31,9 @@ func newAccountIt(rev *ffi.Revision, start []byte) (*accountIt, error) {
 	// that the underlying resources are freed when the iterator is garbage
 	// collected.
 	runtime.AddCleanup(a, func(it *ffi.Iterator) {
-		_ = it.Drop()
+		if err := it.Drop(); err != nil {
+			log.Warn("failed to drop iterator: %w, Firewood may leak resources", err)
+		}
 	}, it)
 	return a, nil
 }

--- a/graft/evm/firewood/account_it.go
+++ b/graft/evm/firewood/account_it.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package firewood
+
+import (
+	"runtime"
+
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/trie"
+)
+
+var _ trie.NodeIterator = (*accountIt)(nil)
+
+type accountIt struct {
+	it *ffi.Iterator
+}
+
+func newAccountIt(rev *ffi.Revision, start []byte) (*accountIt, error) {
+	it, err := rev.Iter(start)
+	if err != nil {
+		return nil, err
+	}
+	a := &accountIt{
+		it: it,
+	}
+
+	// Because the user manages the lifetime of the iterator, we must guarantee
+	// that the underlying resources are freed when the iterator is garbage
+	// collected.
+	runtime.AddCleanup(a, func(it *ffi.Iterator) {
+		_ = it.Drop()
+	}, it)
+	return a, nil
+}
+
+// Next advances the iterator to the next account.
+func (a *accountIt) Next(bool) bool {
+	next := a.it.Next()
+	for ; next; next = a.it.Next() {
+		if len(a.it.Key()) == common.HashLength {
+			return true
+		}
+	}
+	return false
+}
+
+// Error returns any error that occurred during iteration.
+func (a *accountIt) Error() error {
+	return a.it.Err()
+}
+
+// Leaf always returns true since Firewood only iterates over leaf nodes.
+func (a *accountIt) Leaf() bool {
+	return true
+}
+
+// LeafKey returns the key of the account.
+func (a *accountIt) LeafKey() []byte {
+	return a.it.Key()
+}
+
+// LeafBlob returns the RLP encoded account data.
+func (a *accountIt) LeafBlob() []byte {
+	return a.it.Value()
+}
+
+// LeafProof returns nil since Firewood does not support proofs.
+func (a *accountIt) LeafProof() [][]byte {
+	return nil
+}
+
+// Hash is unused since Firewood does not expose internal hashes.
+func (a *accountIt) Hash() common.Hash {
+	return common.Hash{}
+}
+
+// NodeBlob is unused since Firewood does not expose internal nodes.
+func (a *accountIt) NodeBlob() []byte {
+	return nil
+}
+
+func (a *accountIt) Path() []byte {
+	return a.it.Key()
+}
+
+func (a *accountIt) AddResolver(trie.NodeResolver) {}
+
+func (a *accountIt) Parent() common.Hash {
+	return common.Hash{}
+}

--- a/graft/evm/firewood/account_trie.go
+++ b/graft/evm/firewood/account_trie.go
@@ -248,10 +248,14 @@ func (*accountTrie) GetKey([]byte) []byte {
 }
 
 // NodeIterator implements state.Trie.
-// Firewood does not support iterating over internal nodes.
-// This always returns an error.
-func (*accountTrie) NodeIterator([]byte) (trie.NodeIterator, error) {
-	return nil, errors.New("NodeIterator not implemented for Firewood")
+// It iterates only over account nodes, so all nodes are leaf nodes.
+// The first key yielded will be >= [start].
+func (a *accountTrie) NodeIterator(start []byte) (trie.NodeIterator, error) {
+	r, ok := a.reader.(*reader)
+	if !ok {
+		return nil, errors.New("invalid reader type for account trie")
+	}
+	return newAccountIt(r.revision, start)
 }
 
 // Prove implements state.Trie.

--- a/graft/evm/firewood/account_trie.go
+++ b/graft/evm/firewood/account_trie.go
@@ -255,7 +255,7 @@ func (a *accountTrie) NodeIterator(start []byte) (trie.NodeIterator, error) {
 	if !ok {
 		return nil, errors.New("invalid reader type for account trie")
 	}
-	return newAccountIt(r.revision, start)
+	return newAccountIterator(r.revision, start)
 }
 
 // Prove implements state.Trie.

--- a/graft/evm/firewood/account_trie.go
+++ b/graft/evm/firewood/account_trie.go
@@ -5,6 +5,7 @@ package firewood
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/ava-labs/firewood-go-ethhash/ffi"
@@ -247,13 +248,15 @@ func (*accountTrie) GetKey([]byte) []byte {
 	return nil
 }
 
+var errInvalidReader = errors.New("invalid reader type")
+
 // NodeIterator implements state.Trie.
 // It iterates only over account nodes, so all nodes are leaf nodes.
 // The first key yielded will be >= [start].
 func (a *accountTrie) NodeIterator(start []byte) (trie.NodeIterator, error) {
 	r, ok := a.reader.(*reader)
 	if !ok {
-		return nil, errors.New("invalid reader type for account trie")
+		return nil, fmt.Errorf("%w: got %T", errInvalidReader, a.reader)
 	}
 	return newAccountIterator(r.revision, start)
 }

--- a/graft/evm/firewood/iterator.go
+++ b/graft/evm/firewood/iterator.go
@@ -12,18 +12,18 @@ import (
 	"github.com/ava-labs/libevm/trie"
 )
 
-var _ trie.NodeIterator = (*accountIt)(nil)
+var _ trie.NodeIterator = (*accountIterator)(nil)
 
-type accountIt struct {
+type accountIterator struct {
 	it *ffi.Iterator
 }
 
-func newAccountIt(rev *ffi.Revision, start []byte) (*accountIt, error) {
+func newAccountIterator(rev *ffi.Revision, start []byte) (*accountIterator, error) {
 	it, err := rev.Iter(start)
 	if err != nil {
 		return nil, err
 	}
-	a := &accountIt{
+	a := &accountIterator{
 		it: it,
 	}
 
@@ -39,7 +39,7 @@ func newAccountIt(rev *ffi.Revision, start []byte) (*accountIt, error) {
 }
 
 // Next advances the iterator to the next account.
-func (a *accountIt) Next(bool) bool {
+func (a *accountIterator) Next(bool) bool {
 	next := a.it.Next()
 	for ; next; next = a.it.Next() {
 		if len(a.it.Key()) == common.HashLength {
@@ -50,46 +50,46 @@ func (a *accountIt) Next(bool) bool {
 }
 
 // Error returns any error that occurred during iteration.
-func (a *accountIt) Error() error {
+func (a *accountIterator) Error() error {
 	return a.it.Err()
 }
 
 // Leaf always returns true since Firewood only iterates over leaf nodes.
-func (*accountIt) Leaf() bool {
+func (*accountIterator) Leaf() bool {
 	return true
 }
 
 // LeafKey returns the key of the account.
-func (a *accountIt) LeafKey() []byte {
+func (a *accountIterator) LeafKey() []byte {
 	return a.it.Key()
 }
 
 // LeafBlob returns the RLP encoded account data.
-func (a *accountIt) LeafBlob() []byte {
+func (a *accountIterator) LeafBlob() []byte {
 	return a.it.Value()
 }
 
 // LeafProof returns nil since Firewood does not support proofs.
-func (*accountIt) LeafProof() [][]byte {
+func (*accountIterator) LeafProof() [][]byte {
 	return nil
 }
 
 // Hash is unused since Firewood does not expose internal hashes.
-func (*accountIt) Hash() common.Hash {
+func (*accountIterator) Hash() common.Hash {
 	return common.Hash{}
 }
 
 // NodeBlob is unused since Firewood does not expose internal nodes.
-func (*accountIt) NodeBlob() []byte {
+func (*accountIterator) NodeBlob() []byte {
 	return nil
 }
 
-func (a *accountIt) Path() []byte {
+func (a *accountIterator) Path() []byte {
 	return a.it.Key()
 }
 
-func (*accountIt) AddResolver(trie.NodeResolver) {}
+func (*accountIterator) AddResolver(trie.NodeResolver) {}
 
-func (*accountIt) Parent() common.Hash {
+func (*accountIterator) Parent() common.Hash {
 	return common.Hash{}
 }

--- a/graft/evm/firewood/iterator.go
+++ b/graft/evm/firewood/iterator.go
@@ -32,7 +32,7 @@ func newAccountIterator(rev *ffi.Revision, start []byte) (*accountIterator, erro
 	// collected.
 	runtime.AddCleanup(a, func(it *ffi.Iterator) {
 		if err := it.Drop(); err != nil {
-			log.Warn("failed to drop iterator: %w, Firewood may leak resources", err)
+			log.Warn("failed to drop iterator, Firewood may leak resources", "error", err)
 		}
 	}, it)
 	return a, nil
@@ -42,6 +42,7 @@ func newAccountIterator(rev *ffi.Revision, start []byte) (*accountIterator, erro
 func (a *accountIterator) Next(bool) bool {
 	next := a.it.Next()
 	for ; next; next = a.it.Next() {
+		// Account keys are 32 bytes
 		if len(a.it.Key()) == common.HashLength {
 			return true
 		}

--- a/graft/evm/firewood/iterator.go
+++ b/graft/evm/firewood/iterator.go
@@ -44,7 +44,7 @@ func newAccountIterator(rev *ffi.Revision, start []byte) (*accountIterator, erro
 func (a *accountIterator) Next(bool) bool {
 	next := a.it.Next()
 	for ; next; next = a.it.Next() {
-		// Account keys are 32 bytes
+		// Is an account if and only if the key length is 32 bytes
 		if len(a.it.Key()) == common.HashLength {
 			return true
 		}

--- a/graft/evm/firewood/iterator.go
+++ b/graft/evm/firewood/iterator.go
@@ -32,6 +32,8 @@ func newAccountIterator(rev *ffi.Revision, start []byte) (*accountIterator, erro
 	// collected.
 	runtime.AddCleanup(a, func(it *ffi.Iterator) {
 		if err := it.Drop(); err != nil {
+			// Best-effort GC cleanup: there is no safe way to surface or recover from
+			// Drop errors here, and at this point the iterator is already unreachable.
 			log.Warn("failed to drop iterator, Firewood may leak resources", "error", err)
 		}
 	}, it)

--- a/graft/evm/firewood/storage_trie.go
+++ b/graft/evm/firewood/storage_trie.go
@@ -37,8 +37,10 @@ func (*storageTrie) Hash() common.Hash {
 	return common.Hash{}
 }
 
+var errStorageIteratorNotSupported = errors.New("storage trie does not support node iteration")
+
 func (*storageTrie) NodeIterator([]byte) (trie.NodeIterator, error) {
-	return nil, errors.New("storage trie does not support node iteration")
+	return nil, errStorageIteratorNotSupported
 }
 
 // Copy returns nil, as storage tries do not need to be copied separately.

--- a/graft/evm/firewood/storage_trie.go
+++ b/graft/evm/firewood/storage_trie.go
@@ -4,8 +4,11 @@
 package firewood
 
 import (
+	"errors"
+
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/trie"
 	"github.com/ava-labs/libevm/trie/trienode"
 )
 
@@ -32,6 +35,10 @@ func (*storageTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
 // Hash returns an empty hash, as the storage roots are managed internally to Firewood.
 func (*storageTrie) Hash() common.Hash {
 	return common.Hash{}
+}
+
+func (*storageTrie) NodeIterator([]byte) (trie.NodeIterator, error) {
+	return nil, errors.New("storage trie does not support node iteration")
 }
 
 // Copy returns nil, as storage tries do not need to be copied separately.

--- a/graft/evm/sync/synctest/test_trie.go
+++ b/graft/evm/sync/synctest/test_trie.go
@@ -105,7 +105,7 @@ func FillIndependentTrie(t *testing.T, r *rand.Rand, start, numKeys int, keySize
 // AssertTrieConsistency ensures given trieDB [a] and [b] both have the same
 // non-empty trie at [root]. (all key/value pairs must be equal)
 //
-// This is only safe for HashDB or PathDB, since Firewood doesn't store trie nodes individually.
+// Firewood storage tries are not supported.
 func AssertTrieConsistency(t testing.TB, root common.Hash, a, b state.Database, onLeaf func(key, val []byte)) {
 	trieA, err := a.OpenTrie(root)
 	require.NoError(t, err)

--- a/graft/subnet-evm/sync/statesync/sync_test.go
+++ b/graft/subnet-evm/sync/statesync/sync_test.go
@@ -530,13 +530,12 @@ func assertDBConsistency(t testing.TB, root common.Hash, clientDB state.Database
 	require.NoError(t, accountIt.Error())
 	trieAccountLeaves := 0
 
-	synctest.AssertTrieConsistency(t, root, serverDB.TrieDB(), clientDB.TrieDB(), func(key, val []byte) error {
+	synctest.AssertTrieConsistency(t, root, serverDB, clientDB, func(key, val []byte) {
 		trieAccountLeaves++
 		accHash := common.BytesToHash(key)
 		var acc types.StateAccount
-		if err := rlp.DecodeBytes(val, &acc); err != nil {
-			return err
-		}
+		require.NoError(t, rlp.DecodeBytes(val, &acc))
+
 		// check snapshot consistency
 		snapshotVal := rawdb.ReadAccountSnapshot(clientDB.DiskDB(), accHash)
 		expectedSnapshotVal := types.SlimAccountRLP(acc)
@@ -551,7 +550,7 @@ func assertDBConsistency(t testing.TB, root common.Hash, clientDB state.Database
 			require.Equal(t, codeHash, actualHash)
 		}
 		if acc.Root == types.EmptyRootHash {
-			return nil
+			return
 		}
 
 		storageIt := rawdb.IterateStorageSnapshots(clientDB.DiskDB(), accHash)
@@ -565,15 +564,13 @@ func assertDBConsistency(t testing.TB, root common.Hash, clientDB state.Database
 		storageTrieLeavesCount := 0
 
 		// check storage trie and storage snapshot consistency
-		synctest.AssertTrieConsistency(t, acc.Root, serverDB.TrieDB(), clientDB.TrieDB(), func(key, val []byte) error {
+		synctest.AssertTrieConsistency(t, acc.Root, serverDB, clientDB, func(key, val []byte) {
 			storageTrieLeavesCount++
 			snapshotVal := rawdb.ReadStorageSnapshot(clientDB.DiskDB(), accHash, common.BytesToHash(key))
 			require.Equal(t, val, snapshotVal)
-			return nil
 		})
 
 		require.Equal(t, storageTrieLeavesCount, snapshotStorageKeysCount)
-		return nil
 	})
 
 	// Check that the number of accounts in the snapshot matches the number of leaves in the accounts trie


### PR DESCRIPTION
## Why this should be merged

Although Firewood does properly sync all code hashes, it wasn't tested. Now it is!

## How this works

Adds the minimum iterating functionality through the geth interface to check all accounts. I had to refactor quite a bit though

## How this was tested

It is the test!

## Need to be documented in RELEASES.md?

No