### PR TITLE
Remove legacy golang build tags

### DIFF
--- a/graft/coreth/core/mkalloc.go
+++ b/graft/coreth/core/mkalloc.go
@@ -26,7 +26,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build none
-// +build none
 
 /*
 The mkalloc tool creates the genesis allocation constants in genesis_alloc.go

--- a/graft/subnet-evm/core/mkalloc.go
+++ b/graft/subnet-evm/core/mkalloc.go
@@ -26,7 +26,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build none
-// +build none
 
 /*
 The mkalloc tool creates the genesis allocation constants in genesis_alloc.go

--- a/utils/storage/storage_openbsd.go
+++ b/utils/storage/storage_openbsd.go
@@ -2,7 +2,6 @@
 // See the file LICENSE for licensing terms.
 
 //go:build openbsd
-// +build openbsd
 
 package storage
 

--- a/utils/storage/storage_unix.go
+++ b/utils/storage/storage_unix.go
@@ -2,7 +2,6 @@
 // See the file LICENSE for licensing terms.
 
 //go:build !windows && !openbsd
-// +build !windows,!openbsd
 
 package storage
 

--- a/utils/ulimit/ulimit_bsd.go
+++ b/utils/ulimit/ulimit_bsd.go
@@ -2,7 +2,6 @@
 // See the file LICENSE for licensing terms.
 
 //go:build freebsd
-// +build freebsd
 
 package ulimit
 

--- a/utils/ulimit/ulimit_darwin.go
+++ b/utils/ulimit/ulimit_darwin.go
@@ -2,7 +2,6 @@
 // See the file LICENSE for licensing terms.
 
 //go:build darwin
-// +build darwin
 
 package ulimit
 

--- a/utils/ulimit/ulimit_unix.go
+++ b/utils/ulimit/ulimit_unix.go
@@ -2,7 +2,6 @@
 // See the file LICENSE for licensing terms.
 
 //go:build linux || netbsd || openbsd
-// +build linux netbsd openbsd
 
 package ulimit
 

--- a/vms/rpcchainvm/runtime/subprocess/linux_stopper.go
+++ b/vms/rpcchainvm/runtime/subprocess/linux_stopper.go
@@ -2,7 +2,6 @@
 // See the file LICENSE for licensing terms.
 
 //go:build linux
-// +build linux
 
 // ^ SIGTERM signal is not available on Windows
 // ^ syscall.SysProcAttr only has field Pdeathsig on Linux

--- a/vms/rpcchainvm/runtime/subprocess/non_linux_stopper.go
+++ b/vms/rpcchainvm/runtime/subprocess/non_linux_stopper.go
@@ -2,7 +2,6 @@
 // See the file LICENSE for licensing terms.
 
 //go:build !linux
-// +build !linux
 
 package subprocess
 


### PR DESCRIPTION
## Why this should be merged

As of 1.18 the format is `//go:build`, no need to continue including the legacy `// +build` format.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A