### PR TITLE
fix: use `setstate` context

### DIFF
--- a/graft/coreth/plugin/evm/atomic/vm/vm.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm.go
@@ -264,7 +264,7 @@ func (vm *VM) SetState(ctx context.Context, state snow.State) error {
 			return err
 		}
 	case snow.NormalOp:
-		if err := vm.onNormalOperationsStarted(); err != nil {
+		if err := vm.onNormalOperationsStarted(ctx); err != nil {
 			return err
 		}
 	}
@@ -277,7 +277,7 @@ func (vm *VM) onBootstrapStarted() error {
 	return vm.Fx.Bootstrapping()
 }
 
-func (vm *VM) onNormalOperationsStarted() error {
+func (vm *VM) onNormalOperationsStarted(ctx context.Context) error {
 	if vm.bootstrapped.Get() {
 		return nil
 	}
@@ -290,7 +290,7 @@ func (vm *VM) onNormalOperationsStarted() error {
 		return fmt.Errorf("failed to add atomic tx gossip handler: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(ctx)
 	vm.cancel = cancel
 
 	vm.shutdownWg.Add(1)

--- a/graft/subnet-evm/plugin/evm/vm.go
+++ b/graft/subnet-evm/plugin/evm/vm.go
@@ -766,7 +766,7 @@ func (vm *VM) initChainState(lastAcceptedBlock *types.Block) error {
 	return vm.ctx.Metrics.Register(chainStateMetricsPrefix, chainStateRegisterer)
 }
 
-func (vm *VM) SetState(_ context.Context, state snow.State) error {
+func (vm *VM) SetState(ctx context.Context, state snow.State) error {
 	vm.vmLock.Lock()
 	defer vm.vmLock.Unlock()
 	switch state {
@@ -776,7 +776,7 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 	case snow.Bootstrapping:
 		return vm.onBootstrapStarted()
 	case snow.NormalOp:
-		return vm.onNormalOperationsStarted()
+		return vm.onNormalOperationsStarted(ctx)
 	default:
 		return snow.ErrUnknownState
 	}
@@ -799,13 +799,13 @@ func (vm *VM) onBootstrapStarted() error {
 }
 
 // onNormalOperationsStarted marks this VM as bootstrapped
-func (vm *VM) onNormalOperationsStarted() error {
+func (vm *VM) onNormalOperationsStarted(ctx context.Context) error {
 	if vm.bootstrapped.Get() {
 		return nil
 	}
 	vm.bootstrapped.Set(true)
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(ctx)
 	vm.cancel = cancel
 
 	// Initially sync the uptime tracker so that APIs expose recent data even if


### PR DESCRIPTION
## Why this should be merged

Closes #4708. The `SetState` method receives a context parameter from the caller but was ignoring it and creating a new context with context.TODO() instead. This PR addresses that strange choice. 

## How this was tested
CI

## Need to be documented in RELEASES.md?
No 