### PR TITLE
test: Add test logger

### DIFF
--- a/database/merkle/firewood/syncer/syncer_test.go
+++ b/database/merkle/firewood/syncer/syncer_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/ava-labs/avalanchego/database/merkle/sync/synctest"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p/p2ptest"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
 )
 
 func Test_Firewood_Sync(t *testing.T) {
@@ -81,7 +83,9 @@ func testSync(t *testing.T, clientKeys int, serverKeys int) {
 	}()
 
 	syncer, err := New(
-		Config{},
+		Config{
+			Log: loggingtest.NewLogger(t, logging.Info),
+		},
 		clientDB,
 		root,
 		p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, NewGetRangeProofHandler(serverDB)),
@@ -158,7 +162,9 @@ func testSyncWithUpdate(t *testing.T, clientKeys int, serverKeys int, numRequest
 		}
 	}, numRequestsBeforeUpdate)
 	syncer, err := New(
-		Config{},
+		Config{
+			Log: loggingtest.NewLogger(t, logging.Info),
+		},
 		clientDB,
 		firstRoot,
 		p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, rangeProofHandler),

--- a/graft/coreth/sync/evmstate/firewood_syncer_test.go
+++ b/graft/coreth/sync/evmstate/firewood_syncer_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/ava-labs/avalanchego/graft/evm/utils/utilstest"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p/p2ptest"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
 	"github.com/ava-labs/avalanchego/vms/evm/sync/customrawdb"
 
 	statesyncclient "github.com/ava-labs/avalanchego/graft/coreth/sync/client"
@@ -162,7 +164,9 @@ func createSyncers(t *testing.T, clientState, serverState state.Database, root c
 
 	// Create the firewood syncer.
 	firewoodSyncer, err := NewFirewoodSyncer(
-		syncer.Config{},
+		syncer.Config{
+			Log: loggingtest.NewLogger(t, logging.Info),
+		},
 		dbFromState(t, clientState),
 		root,
 		codeQueue,

--- a/snow/networking/router/chain_router_test.go
+++ b/snow/networking/router/chain_router_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
 	"github.com/ava-labs/avalanchego/utils/math/meter"
 	"github.com/ava-labs/avalanchego/utils/resource"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -204,7 +205,7 @@ func TestConnectedAfterShutdownErrorLogRegression(t *testing.T) {
 	chainRouter := ChainRouter{}
 	require.NoError(chainRouter.Initialize(
 		ids.EmptyNodeID,
-		logging.NoWarn{}, // If an error log is emitted, the test will fail
+		loggingtest.NewLogger(t, logging.Warn),
 		nil,
 		time.Second,
 		set.Set[ids.ID]{},

--- a/utils/logging/loggingtest/logger.go
+++ b/utils/logging/loggingtest/logger.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package loggingtest
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+var _ io.WriteCloser = (*testWriter)(nil)
+
+type testWriter struct {
+	zaptest.TestingWriter
+}
+
+func (testWriter) Close() error {
+	return nil
+}
+
+type testLogger struct {
+	logging.Logger
+	t testing.TB
+}
+
+// NewLogger returns a logger that writes to the provided testing.TB.
+// Any logs will only be shown if the test fails.
+// If Fatal is called, the test will be failed immediately.
+// If Error or Warn are called, the test will be marked as failed, but will continue running.
+func NewLogger(t testing.TB, logLevel logging.Level) logging.Logger {
+	t.Helper()
+
+	require.LessOrEqualf(t, logLevel, logging.Warn, "TestLogger will fail the test on Warn, but user asked to ignore %s logs", (logLevel - 1).String())
+
+	w := testWriter{TestingWriter: zaptest.NewTestingWriter(t)}
+	core := logging.NewWrappedCore(logLevel, w, logging.Plain.ConsoleEncoder())
+	return &testLogger{
+		Logger: logging.NewLogger("", core),
+		t:      t,
+	}
+}
+
+func (l *testLogger) Fatal(msg string, fields ...zap.Field) {
+	l.Logger.Fatal(msg, fields...)
+	l.t.Fatal("Fatal")
+}
+
+func (l *testLogger) Error(msg string, fields ...zap.Field) {
+	l.Logger.Error(msg, fields...)
+	l.t.Error("Error")
+}
+
+func (l *testLogger) Warn(msg string, fields ...zap.Field) {
+	l.Logger.Warn(msg, fields...)
+	l.t.Error("Warn")
+}

--- a/utils/logging/loggingtest/logger_test.go
+++ b/utils/logging/loggingtest/logger_test.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package loggingtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+// mockT is a *testing.T that records whether certain methods were called, rather than actually
+// marking the test as failed or logging anything.
+type mockT struct {
+	*testing.T
+	failed  bool
+	errored bool
+	logged  bool
+}
+
+func (t *mockT) Clear() {
+	t.failed = false
+	t.errored = false
+	t.logged = false
+}
+
+func (t *mockT) Fail() {
+	t.errored = true
+}
+
+func (t *mockT) FailNow() {
+	t.failed = true
+}
+
+func (t *mockT) Fatal(...interface{}) {
+	t.failed = true
+}
+
+func (t *mockT) Fatalf(string, ...interface{}) {
+	t.failed = true
+}
+
+func (t *mockT) Error(...interface{}) {
+	t.errored = true
+}
+
+func (t *mockT) Errorf(string, ...interface{}) {
+	t.errored = true
+}
+
+func (t *mockT) Log(...interface{}) {
+	t.logged = true
+}
+
+func (t *mockT) Logf(string, ...interface{}) {
+	t.logged = true
+}
+
+func TestTestLog(t *testing.T) {
+	tests := []struct {
+		name   string
+		level  logging.Level
+		call   func(logger logging.Logger)
+		checkT func(t *mockT)
+	}{
+		{
+			name: "Fatal",
+			call: func(logger logging.Logger) {
+				logger.Fatal("fatal message")
+			},
+			checkT: func(t *mockT) {
+				require.True(t, t.failed)
+			},
+		},
+		{
+			name: "Error",
+			call: func(logger logging.Logger) {
+				logger.Error("error message")
+			},
+			checkT: func(t *mockT) {
+				require.True(t, t.errored)
+				require.False(t, t.failed)
+			},
+		},
+		{
+			name: "Warn",
+			call: func(logger logging.Logger) {
+				logger.Warn("warn message")
+			},
+			checkT: func(t *mockT) {
+				require.True(t, t.errored)
+				require.False(t, t.failed)
+			},
+		},
+		{
+			name: "Info",
+			call: func(logger logging.Logger) {
+				logger.Info("info message")
+			},
+			checkT: func(t *mockT) {
+				require.True(t, t.logged)
+				require.False(t, t.errored)
+				require.False(t, t.failed)
+			},
+		},
+		{
+			name: "Debug",
+			call: func(logger logging.Logger) {
+				logger.Debug("debug message")
+			},
+			checkT: func(t *mockT) {
+				require.False(t, t.logged)
+				require.False(t, t.errored)
+				require.False(t, t.failed)
+			},
+		},
+		{
+			name:  "Reduced level",
+			level: logging.Debug,
+			call: func(logger logging.Logger) {
+				logger.Debug("debug message")
+			},
+			checkT: func(t *mockT) {
+				require.True(t, t.logged)
+				require.False(t, t.errored)
+				require.False(t, t.failed)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockT{T: t}
+			logger := NewLogger(mock, tt.level)
+			tt.call(logger)
+			tt.checkT(mock)
+		})
+	}
+}

--- a/utils/logging/no_log.go
+++ b/utils/logging/no_log.go
@@ -63,20 +63,6 @@ func (NoLog) RecoverAndExit(f, exit func()) {
 
 func (NoLog) Stop() {}
 
-type NoWarn struct{ NoLog }
-
-func (NoWarn) Fatal(string, ...zap.Field) {
-	panic("unexpected Fatal")
-}
-
-func (NoWarn) Error(string, ...zap.Field) {
-	panic("unexpected Error")
-}
-
-func (NoWarn) Warn(string, ...zap.Field) {
-	panic("unexpected Warn")
-}
-
 type discard struct{}
 
 func (discard) Write(p []byte) (int, error) {

--- a/vms/avm/txs/executor/semantic_verifier_test.go
+++ b/vms/avm/txs/executor/semantic_verifier_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/avm/fxs"
 	"github.com/ava-labs/avalanchego/vms/avm/state"
@@ -38,7 +39,7 @@ func TestSemanticVerifierBaseTx(t *testing.T) {
 	parser, err := txs.NewCustomParser(
 		typeToFxIndex,
 		new(mockable.Clock),
-		logging.NoWarn{},
+		loggingtest.NewLogger(t, logging.Warn),
 		[]fxs.Fx{
 			secpFx,
 		},
@@ -395,7 +396,7 @@ func TestSemanticVerifierExportTx(t *testing.T) {
 	parser, err := txs.NewCustomParser(
 		typeToFxIndex,
 		new(mockable.Clock),
-		logging.NoWarn{},
+		loggingtest.NewLogger(t, logging.Warn),
 		[]fxs.Fx{
 			secpFx,
 		},
@@ -763,7 +764,7 @@ func TestSemanticVerifierExportTxDifferentSubnet(t *testing.T) {
 	parser, err := txs.NewCustomParser(
 		typeToFxIndex,
 		new(mockable.Clock),
-		logging.NoWarn{},
+		loggingtest.NewLogger(t, logging.Warn),
 		[]fxs.Fx{
 			secpFx,
 		},
@@ -879,7 +880,7 @@ func TestSemanticVerifierImportTx(t *testing.T) {
 	parser, err := txs.NewCustomParser(
 		typeToFxIndex,
 		new(mockable.Clock),
-		logging.NoWarn{},
+		loggingtest.NewLogger(t, logging.Warn),
 		[]fxs.Fx{
 			fx,
 		},

--- a/x/merkledb/sync_test.go
+++ b/x/merkledb/sync_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/p2ptest"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
 	"github.com/ava-labs/avalanchego/utils/maybe"
 )
 
@@ -48,7 +49,7 @@ func Test_Creation(t *testing.T) {
 			RangeProofClient:      p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, sync.NewGetRangeProofHandler(db, rangeProofMarshaler)),
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, sync.NewGetChangeProofHandler(db, rangeProofMarshaler, changeProofMarshaler)),
 			SimultaneousWorkLimit: 5,
-			Log:                   logging.NoLog{},
+			Log:                   loggingtest.NewLogger(t, logging.Info),
 		},
 		prometheus.NewRegistry(),
 	)
@@ -268,7 +269,7 @@ func Test_Sync_Result_Correct_Root(t *testing.T) {
 					ChangeProofClient:     changeProofClient,
 					TargetRoot:            syncRoot,
 					SimultaneousWorkLimit: 5,
-					Log:                   logging.NoLog{},
+					Log:                   loggingtest.NewLogger(t, logging.Info),
 				},
 				prometheus.NewRegistry(),
 			)
@@ -348,7 +349,7 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, sync.NewGetChangeProofHandler(dbToSync, rangeProofMarshaler, changeProofMarshaler)),
 			TargetRoot:            syncRoot,
 			SimultaneousWorkLimit: 5,
-			Log:                   logging.NoLog{},
+			Log:                   loggingtest.NewLogger(t, logging.Info),
 		},
 		prometheus.NewRegistry(),
 	)
@@ -374,7 +375,7 @@ func Test_Sync_Result_Correct_Root_With_Sync_Restart(t *testing.T) {
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, sync.NewGetChangeProofHandler(dbToSync, rangeProofMarshaler, changeProofMarshaler)),
 			TargetRoot:            syncRoot,
 			SimultaneousWorkLimit: 5,
-			Log:                   logging.NoLog{},
+			Log:                   loggingtest.NewLogger(t, logging.Info),
 		},
 		prometheus.NewRegistry(),
 	)
@@ -457,7 +458,7 @@ func Test_Sync_Result_Correct_Root_Update_Root_During(t *testing.T) {
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, sync.NewGetChangeProofHandler(dbToSync, rangeProofMarshaler, changeProofMarshaler)),
 			TargetRoot:            firstSyncRoot,
 			SimultaneousWorkLimit: 5,
-			Log:                   logging.NoLog{},
+			Log:                   loggingtest.NewLogger(t, logging.Info),
 		},
 		prometheus.NewRegistry(),
 	)
@@ -514,7 +515,7 @@ func Test_Sync_UpdateSyncTarget(t *testing.T) {
 			ChangeProofClient:     p2ptest.NewSelfClient(t, ctx, ids.EmptyNodeID, sync.NewGetChangeProofHandler(dbToSync, rangeProofMarshaler, changeProofMarshaler)),
 			TargetRoot:            root1,
 			SimultaneousWorkLimit: 5,
-			Log:                   logging.NoLog{},
+			Log:                   loggingtest.NewLogger(t, logging.Info),
 		},
 		prometheus.NewRegistry(),
 	)


### PR DESCRIPTION
## Why this should be merged

I often find myself adding copious print statements to test logging details when my test fails. However, zap provides a testing helper that only logs if the test fails or if verbose. We can use this, and even add to it if one needs to verify log output.

## How this works

Adds a wrapper for the `logging.Logger` that logs to `t`, and fails if there are any warnings. Also removes `logger.NoWarn`, since this implements the same functionality essentially, but also reports what the failure is.

## How this was tested

Added a unit test, as well as used in many places.

## Need to be documented in RELEASES.md?

No