### PR TITLE
[ci] Configure dir exclusion from linting via .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,7 @@ linters:
     - govet
     - importas
     - ineffassign
-    - mirror
+    - mirror 
     - misspell
     - nakedret
     - nilerr


### PR DESCRIPTION
## Why this should be merged

The need to exclude new directories from linting for Goland and soon Bazel suggested a simple way of maintaining a list of such directories.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A