### PR TITLE
chore: fix network logs typo 

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -1096,7 +1096,7 @@ func (n *network) upgrade(conn net.Conn, upgrader peer.Upgrader, isIngress bool)
 		_ = tlsConn.Close()
 		n.peerConfig.Log.Verbo(
 			"dropping connection",
-			zap.String("reason", "already connecting to peer"),
+			zap.String("reason", "already connected to peer"),
 			zap.Stringer("nodeID", nodeID),
 		)
 		return nil


### PR DESCRIPTION
## Why this should be merged

Closes #4487. Fixes the verbose log message at o say "already connected to peer" instead of "already connecting to peer". The check is against connectedPeers, not connectingPeers.