### PR TITLE
docs: fix getutxos incorrect type 

### DIFF
--- a/graft/coreth/plugin/evm/api.md
+++ b/graft/coreth/plugin/evm/api.md
@@ -335,7 +335,7 @@ avax.getUTXOs({
         address: string,
         utxo: string
     },
-    numFetched: number,
+    numFetched: string,
     encoding: string
 }
 ```

--- a/vms/avm/service.md
+++ b/vms/avm/service.md
@@ -565,7 +565,7 @@ avm.getUTXOs({
     sourceChain: string, //optional
     encoding: string //optional
 }) -> {
-    numFetched: int,
+    numFetched: string,
     utxos: []string,
     endIndex: {
         address: string,

--- a/vms/platformvm/service.md
+++ b/vms/platformvm/service.md
@@ -1647,7 +1647,7 @@ platform.getUTXOs(
     },
 ) ->
 {
-    numFetched: int,
+    numFetched: string,
     utxos: []string,
     endIndex: {
         address: string,


### PR DESCRIPTION
## Why this should be merged

Closes #4682. Corrects the API documentation for `getUTXOs` across all three chains to accurately reflect that numFetched returns as a JSON string, not a number.