### PR TITLE
chore: sync Go 1.25.7 toolchain across modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ module github.com/ava-labs/avalanchego
 //
 // - If updating between minor versions (e.g. 1.24.x -> 1.25.x):
 //   - Consider updating the version of golangci-lint (see tools/external/go.mod)
-go 1.24.12
+go 1.25.7
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -5,7 +5,7 @@ module github.com/ava-labs/avalanchego/graft/coreth
 // CONTRIBUTING.md for more details.
 
 // See ../../go.mod for guidelines on updating the Go version.
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/ava-labs/avalanchego v1.14.1-0.20251120155522-df4a8e531761

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/avalanchego/graft/evm
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -11,7 +11,7 @@ module github.com/ava-labs/avalanchego/graft/subnet-evm
 //
 // - If updating between minor versions (e.g. 1.24.x -> 1.25.x):
 //   - Consider updating the version of golangci-lint (see tools/external/go.mod)
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.3.8

--- a/tools/external/go.mod
+++ b/tools/external/go.mod
@@ -13,7 +13,7 @@ module github.com/ava-labs/avalanchego/tools/external
 //   - go tool -modfile=tools/external/go.mod [tool] [args]
 //   - ./scripts/run_tool.sh [tool] [args]
 
-go 1.24.12
+go 1.25.7
 
 tool (
 	github.com/fjl/gencodec


### PR DESCRIPTION
Sync Go version to 1.25.7 and add toolchain directive across all modules to keep the workspace consistent and aligned with the latest stable patch release. This ensures reproducible builds and prevents version drift between modules.

