### PR TITLE
Fix coreth and subnet-evm flaky tests

### DIFF
--- a/graft/coreth/plugin/evm/vm_test.go
+++ b/graft/coreth/plugin/evm/vm_test.go
@@ -2216,6 +2216,7 @@ func TestArchivalQueries(t *testing.T) {
 
 				require.NoError(blk.Accept(ctx))
 			}
+			vm.blockChain.DrainAcceptorQueue()
 
 			handlers, err := vm.CreateHandlers(ctx)
 			require.NoError(err)

--- a/graft/subnet-evm/plugin/evm/vm_test.go
+++ b/graft/subnet-evm/plugin/evm/vm_test.go
@@ -3662,6 +3662,7 @@ func TestArchivalQueries(t *testing.T) {
 
 				require.NoError(blk.Accept(ctx))
 			}
+			vm.vm.blockChain.DrainAcceptorQueue()
 
 			handlers, err := vm.vm.CreateHandlers(ctx)
 			require.NoError(err)


### PR DESCRIPTION
## Why this should be merged
Fix flaky test in coreth and subnet-evm (`TestArchivalQueries`).

## How this works
This test was flaky because after blocks were accepted, it could happen that the `acceptorQueue` wasn't empty at the moment of querying.

The fix adds `DrainAcceptorQueue()` after accepting all blocks to ensure the queue is empty.

## How this was tested
Existing tests.

## Need to be documented in RELEASES.md?
No.