### PR TITLE
Simplify go version maintenance

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -100,6 +100,10 @@ tasks:
       - task: go-mod-tidy
       - task: check-clean-branch
 
+  check-go-version:
+    desc: Checks that go version directives are consistent across all modules
+    cmd: ./scripts/check_go_version.sh
+
   create-kind-cluster:
     desc: Creates the default kind cluster
     cmd: bash -x ./scripts/start_kind_cluster.sh {{.CLI_ARGS}}
@@ -178,6 +182,7 @@ tasks:
       - lint-action
       - lint-shell
       - check-go-mod-tidy
+      - check-go-version
 
   lint-all-ci:
     desc: Runs all lint checks one-by-one
@@ -186,6 +191,7 @@ tasks:
       - task: lint-action
       - task: lint-shell
       - task: check-go-mod-tidy
+      - task: check-go-version
 
   lint-fix:
     desc: Runs automated fixing for failing static analysis of golang code
@@ -348,3 +354,9 @@ tasks:
     cmds:
       - task: build
       - cmd: bash -x ./scripts/tests.upgrade.sh {{.CLI_ARGS}}
+
+  update-go-version:
+    desc: "Updates go version directives across all modules. Usage: task update-go-version -- <version> (e.g. 1.24.12)"
+    cmds:
+      - cmd: ./scripts/set_go_version.sh {{.CLI_ARGS}}
+      - task: go-mod-tidy

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,9 @@
             kind                                       # Kubernetes-in-Docker
             kubernetes-helm                            # Helm CLI (Kubernetes package manager)
 
+            # JSON processing
+            jq
+
             # Linters
             shellcheck
 

--- a/go.mod
+++ b/go.mod
@@ -4,16 +4,10 @@ module github.com/ava-labs/avalanchego
 // tools/external/go.mod to avoid polluting the main module's dependencies. See
 // tools/external/go.mod for usage details.
 
-// - Changes to the minimum golang version must also be replicated in:
+// - To update the go version across all go.mod and go.work files:
+//     task update-go-version -- <version>
 //
-// The following go.mod files:
-//   - go.mod (here)
-//   - tools/external/go.mod
-//   - graft/evm/go.mod
-//   - graft/coreth/go.mod
-//   - graft/subnet-evm/go.mod
-//
-// and
+// - The following files must also be updated manually:
 //   - CONTRIBUTING.md
 //   - README.md
 //   - RELEASES.md

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -1,5 +1,6 @@
 module github.com/ava-labs/avalanchego/graft/evm
 
+// See ../../go.mod for guidelines on updating the Go version.
 go 1.24.12
 
 require (

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -4,13 +4,7 @@ module github.com/ava-labs/avalanchego/graft/subnet-evm
 // tools/external/go.mod to avoid polluting the main module's dependencies. See
 // CONTRIBUTING.md for more details.
 
-// - Changes to the minimum golang version must also be replicated in:
-//   - go.mod (here)
-//   - tools/external/go.mod
-//   - RELEASES.md
-//
-// - If updating between minor versions (e.g. 1.24.x -> 1.25.x):
-//   - Consider updating the version of golangci-lint (see tools/external/go.mod)
+// See ../../go.mod for guidelines on updating the Go version.
 go 1.24.12
 
 require (

--- a/scripts/check_go_version.sh
+++ b/scripts/check_go_version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Checks that go version directives are consistent across all go.mod, go.work,
+# and nix/go/default.nix.
+
+if ! [[ "$0" =~ scripts/check_go_version.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+# Reference version from go.work
+reference=$(go work edit -json go.work | jq -r .Go)
+
+mismatches=()
+
+# Check all go.mod files
+while IFS= read -r -d '' mod_file; do
+  version=$(go mod edit -json "$mod_file" | jq -r .Go)
+  if [[ "$version" != "$reference" ]]; then
+    mismatches+=("$mod_file: $version")
+  fi
+done < <(git ls-files -z 'go.mod' '*/go.mod')
+
+# Check nix version
+nix_file="nix/go/default.nix"
+nix_version=$(sed -n 's/^[[:space:]]*goVersion = "\(.*\)";$/\1/p' "$nix_file")
+if [[ -z "$nix_version" ]]; then
+  echo "error: failed to parse goVersion from $nix_file"
+  exit 1
+elif [[ "$nix_version" != "$reference" ]]; then
+  mismatches+=("$nix_file: $nix_version")
+fi
+
+if [[ ${#mismatches[@]} -gt 0 ]]; then
+  echo "go version mismatch (expected $reference from go.work):"
+  for m in "${mismatches[@]}"; do
+    echo "  $m"
+  done
+  exit 1
+fi
+
+echo "All go version directives are consistent: $reference"

--- a/scripts/set_go_version.sh
+++ b/scripts/set_go_version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Updates go version directives across all go.mod and go.work files.
+# Does NOT update nix/go/default.nix (requires SHA changes).
+
+if ! [[ "$0" =~ scripts/set_go_version.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <go-version>"
+  echo "Example: $0 1.24.12"
+  exit 1
+fi
+
+version="$1"
+
+go work edit -go="$version" go.work
+echo "updated go.work"
+
+while IFS= read -r -d '' mod_file; do
+  go mod edit -go="$version" "$mod_file"
+  echo "updated $mod_file"
+done < <(git ls-files -z 'go.mod' '*/go.mod')
+
+echo ""
+echo "NOTE: nix/go/default.nix requires manual update (version + SHA256 checksums)."

--- a/tools/external/go.mod
+++ b/tools/external/go.mod
@@ -12,7 +12,8 @@ module github.com/ava-labs/avalanchego/tools/external
 // - Run a tool
 //   - go tool -modfile=tools/external/go.mod [tool] [args]
 //   - ./scripts/run_tool.sh [tool] [args]
-
+//
+// See ../../go.mod for guidelines on updating the Go version.
 go 1.24.12
 
 tool (


### PR DESCRIPTION
## Why this should be merged

Adds the check-go-version and update-go-version tasks to simplify maintenance of the go version across nix, go.work, go.mod files and ensures that the check task is invoked by the lint CI job.

## How this was tested

- CI

- Manually verified `task check-go-version` with go.work manually updated to `1.24.13`:

```
$ task check-go-version
task: [check-go-version] ./scripts/check_go_version.sh
go: downloading go1.24.13 (darwin/arm64)
go version mismatch (expected 1.24.13 from go.work):
  go.mod: 1.24.12
  graft/coreth/go.mod: 1.24.12
  graft/evm/go.mod: 1.24.12
  graft/subnet-evm/go.mod: 1.24.12
  tools/external/go.mod: 1.24.12
  nix/go/default.nix: 1.24.12
task: Failed to run task "check-go-version": exit status 1
```

- Manually verified `task update-go-version`

```
$ task update-go-version -- 1.24.13
task: [update-go-version] ./scripts/set_go_version.sh 1.24.13
updated go.work
updated go.mod
updated graft/coreth/go.mod
updated graft/evm/go.mod
updated graft/subnet-evm/go.mod
updated tools/external/go.mod

NOTE: nix/go/default.nix requires manual update (version + SHA256 checksums).
task: [go-mod-tidy] GOWORK=off go mod tidy
task: [go-mod-tidy] cd tools/external && GOWORK=off go mod tidy
task: [go-mod-tidy] cd graft/evm && GOWORK=off go mod tidy
task: [go-mod-tidy] cd graft/coreth && GOWORK=off go mod tidy
task: [go-mod-tidy] cd graft/subnet-evm && GOWORK=off go mod tidy
task: [sync-go-work] go mod download
task: [sync-go-work] GOWORK="" go work sync

# This error is expected since nix needs to be updated manually
$ task check-go-version
task: [check-go-version] ./scripts/check_go_version.sh
go version mismatch (expected 1.24.13 from go.work):
  nix/go/default.nix: 1.24.12
task: Failed to run task "check-go-version": exit status 1
```

## Need to be documented in RELEASES.md?

N/A