### PR TITLE
version: prevent panic on nil peer in Compatible and add test

### DIFF
--- a/version/compatibility.go
+++ b/version/compatibility.go
@@ -28,6 +28,10 @@ type Compatibility struct {
 // This means that the version is connectable and that consensus messages can be
 // made to the peer.
 func (c *Compatibility) Compatible(peer *Application) bool {
+	if peer == nil {
+		return false
+	}
+
 	if c.Current.Major < peer.Major {
 		return false // If we are on an older major version, we are incompatible.
 	}

--- a/version/compatibility_test.go
+++ b/version/compatibility_test.go
@@ -122,4 +122,8 @@ func TestCompatibility(t *testing.T) {
 			require.Equal(t, test.expected, compatibility.Compatible(peer))
 		})
 	}
+	t.Run("nil_peer_after_upgrade", func(t *testing.T) {
+		compatibility.clock.Set(upgradeTime)
+		require.False(t, compatibility.Compatible(nil), "nil peer should return false, not panic")
+	})
 }


### PR DESCRIPTION
Prevent panic when Compatible is called with a nil peer. Adds a defensive nil check and a unit test to ensure nil peer is treated as incompatible and does not cause a panic.

