### PR TITLE
Use clock time instead of time.Until in proposerVM

### DIFF
--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -450,7 +450,8 @@ func (vm *VM) WaitForEvent(ctx context.Context) (common.Message, error) {
 			return vm.ChainVM.WaitForEvent(ctx)
 		}
 
-		duration := time.Until(timeToBuild)
+		now := vm.Clock.Time()
+		duration := timeToBuild.Sub(now)
 		if duration <= 0 {
 			vm.ctx.Log.Debug("Can build a block without waiting")
 			return vm.ChainVM.WaitForEvent(ctx)


### PR DESCRIPTION

## Why this should be merged

We should be using the clock time consistently in all places in the proposerVM, and not the system time at some places and the clock time in others.

## How this works

Uses the clock time instead of the system time.

## How this was tested

CI

## Need to be documented in RELEASES.md?
