### PR TITLE
feat: Remove FreeListCache from Firewood config

### DIFF
--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -231,12 +231,11 @@ func (c *CacheConfig) triedbConfig() *triedb.Config {
 		}
 
 		config.DBOverride = firewood.TrieDBConfig{
-			DatabaseDir:          c.ChainDataDir,
-			CacheSizeBytes:       uint(c.TrieCleanLimit * 1024 * 1024),
-			FreeListCacheEntries: 1_000_000,
-			RevisionsInMemory:    uint(c.StateHistory), // must be at least 2
-			CacheStrategy:        ffi.CacheAllReads,
-			Archive:              !c.Pruning,
+			DatabaseDir:       c.ChainDataDir,
+			CacheSizeBytes:    uint(c.TrieCleanLimit * 1024 * 1024),
+			RevisionsInMemory: uint(c.StateHistory), // must be at least 2
+			CacheStrategy:     ffi.CacheAllReads,
+			Archive:           !c.Pruning,
 		}.BackendConstructor
 	}
 	return config

--- a/graft/evm/firewood/triedb.go
+++ b/graft/evm/firewood/triedb.go
@@ -95,27 +95,24 @@ type proposalMeta struct {
 }
 
 type TrieDBConfig struct {
-	DatabaseDir          string
-	CacheSizeBytes       uint
-	FreeListCacheEntries uint
-	RevisionsInMemory    uint // must be >= 2
-	CacheStrategy        ffi.CacheStrategy
-	Archive              bool
+	DatabaseDir       string
+	CacheSizeBytes    uint
+	RevisionsInMemory uint // must be >= 2
+	CacheStrategy     ffi.CacheStrategy
+	Archive           bool
 }
 
 // DefaultConfig returns a sensible TrieDBConfig with the given directory.
 // The default config is:
 //   - CacheSizeBytes: 1MB
-//   - FreeListCacheEntries: 40,000
 //   - RevisionsInMemory: 100
 //   - CacheStrategy: [ffi.CacheAllReads]
 func DefaultConfig(dir string) TrieDBConfig {
 	return TrieDBConfig{
-		DatabaseDir:          dir,
-		CacheSizeBytes:       1024 * 1024, // 1MB
-		FreeListCacheEntries: 40_000,
-		RevisionsInMemory:    100,
-		CacheStrategy:        ffi.CacheAllReads,
+		DatabaseDir:       dir,
+		CacheSizeBytes:    1024 * 1024, // 1MB
+		RevisionsInMemory: 100,
+		CacheStrategy:     ffi.CacheAllReads,
 	}
 }
 
@@ -139,7 +136,6 @@ func New(config TrieDBConfig) (*TrieDB, error) {
 	path := filepath.Join(config.DatabaseDir, firewoodDir)
 	options := []ffi.Option{
 		ffi.WithNodeCacheEntries(config.CacheSizeBytes / 256), // TODO(#4750): is 256 bytes per node a good estimate?
-		ffi.WithFreeListCacheEntries(config.FreeListCacheEntries),
 		ffi.WithRevisions(config.RevisionsInMemory),
 		ffi.WithReadCacheStrategy(config.CacheStrategy),
 	}

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -244,12 +244,11 @@ func (c *CacheConfig) triedbConfig() *triedb.Config {
 		}
 
 		config.DBOverride = firewood.TrieDBConfig{
-			DatabaseDir:          c.ChainDataDir,
-			CacheSizeBytes:       uint(c.TrieCleanLimit * 1024 * 1024),
-			FreeListCacheEntries: 1_000_000,
-			RevisionsInMemory:    uint(c.StateHistory), // must be at least 2
-			CacheStrategy:        ffi.CacheAllReads,
-			Archive:              !c.Pruning,
+			DatabaseDir:       c.ChainDataDir,
+			CacheSizeBytes:    uint(c.TrieCleanLimit * 1024 * 1024),
+			RevisionsInMemory: uint(c.StateHistory), // must be at least 2
+			CacheStrategy:     ffi.CacheAllReads,
+			Archive:           !c.Pruning,
 		}.BackendConstructor
 	}
 	return config


### PR DESCRIPTION
## Why this should be merged

I very lazily estimated cache sizes to match Firewood, but since it's not exposed to the user, what's the point

## How this works

Allows default firewood setting

## How this was tested

CI

## Need to be documented in RELEASES.md?

No?
