### PR TITLE
[ci] Free up space to get the subnet evm antithesis test job passing

### DIFF
--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -111,6 +111,10 @@ jobs:
       run:
         working-directory: ./graft/subnet-evm
     steps:
+      - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
+        with:
+          tool-cache: true
+          docker-images: true
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Why this should be merged

The CI job validating image build for subnet-evm antithesis testing has started failing due to lack of space. This change uses a github action to trim down unused content from the image to try to avoid this failure mode.
 
## Safety Assessment: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

```
  Verdict: Safe to use.

  Key Findings

  Commit verification: The pinned SHA matches tag v1.3.1 (latest release). The commit is GPG-signed by the repo
  owner.

  Minimal attack surface: The entire action is a single inline bash script in action.yml — no external scripts, no
  dependencies, no node_modules, no compiled code. The repo contains only 4 files.

  No network activity or data exfiltration: Zero curl/wget calls, no artifact uploads, no GITHUB_OUTPUT/GITHUB_ENV
  writes, no secrets access, no GITHUB_TOKEN usage.

  What it actually does (all gated by configurable inputs):
  - sudo rm -rf on Android SDK, .NET runtime, Haskell toolchain directories
  - sudo apt-get remove of large packages (LLVM, PHP, MongoDB, MySQL, Chrome, Firefox, etc.)
  - sudo docker image prune --all --force
  - Swap disable/removal
  - Diagnostic df output before/after

  Author credibility: Jeremie Lumbroso, UPenn CS faculty. 632 stars, 112 forks, 8 contributors.

  Minor Concerns (not security-related)

  - Low maintenance — last push Aug 2024, several unanswered issues. Since you're pinning by SHA, this is a
  maintenance risk, not a security risk.
  - Known bug (#33): Setting dotnet: false may still delete dotnet via the large-packages removal. Worth noting if
  you depend on dotnet.
  - The large-packages option uses apt glob patterns ('^dotnet-.*') which could match unexpected packages if runner
  images change — a stability concern.

  Bottom line: Pin-by-SHA eliminates tag-reassignment risk, the code does exactly what it claims with no hidden
  behavior, and the author is credible. Safe to adopt.
```

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A