### PR TITLE
[ci] Ensure rpm packaging compatibility with legacy subnet-evm

### DIFF
--- a/.github/packaging/scripts/build-rpm.sh
+++ b/.github/packaging/scripts/build-rpm.sh
@@ -33,6 +33,13 @@ echo "=== Building ${PACKAGE} RPM for ${RPM_ARCH} (tag: ${TAG}) ==="
 
 # ── Step 1: Build binary ──────────────────────────────────────────
 
+# In CI, the bind-mounted source tree is owned by the host user. Mark it
+# as safe so that git works inside the container (needed by older build
+# scripts that resolve the commit hash via git rather than AVALANCHEGO_COMMIT).
+if ! git -C "${REPO_ROOT}" rev-parse HEAD &>/dev/null; then
+    git config --global --add safe.directory "${REPO_ROOT}"
+fi
+
 # shellcheck disable=SC1091
 source "${REPO_ROOT}/scripts/constants.sh"
 # shellcheck disable=SC1091
@@ -41,9 +48,8 @@ source "${REPO_ROOT}/scripts/git_commit.sh"
 # shellcheck disable=SC2154
 echo "Git commit: ${git_commit}"
 
-# Disable Go's automatic VCS stamping — the bind-mounted .git is owned by
-# the host user, causing git to fail inside the container. The commit hash
-# is passed explicitly via AVALANCHEGO_COMMIT and -ldflags instead.
+# Disable Go's automatic VCS stamping — the commit hash is passed
+# explicitly via AVALANCHEGO_COMMIT and -ldflags instead.
 export GOFLAGS="${GOFLAGS:-} -buildvcs=false"
 
 case "${PACKAGE}" in

--- a/.github/packaging/scripts/validate-rpm.sh
+++ b/.github/packaging/scripts/validate-rpm.sh
@@ -65,17 +65,15 @@ docker run --rm \
         rpm -ivh "/rpms/subnet-evm-'"${TAG}"'-'"${RPM_ARCH}"'.rpm"
 
         # Smoke test avalanchego
+        full_commit="'"${GIT_COMMIT}"'"
         output=$(/var/opt/avalanchego/bin/avalanchego --version)
         echo "avalanchego --version: ${output}"
         if [[ "${output}" != avalanchego/* ]]; then
             echo "ERROR: --version output does not start with avalanchego/" >&2
             exit 1
         fi
-
-        # Verify git commit hash is present in output
-        short_commit="'"${GIT_COMMIT::8}"'"
-        if [[ "${output}" != *"commit=${short_commit}"* ]]; then
-            echo "ERROR: --version output does not contain expected commit=${short_commit}" >&2
+        if [[ "${output}" != *"${full_commit}"* ]]; then
+            echo "ERROR: avalanchego --version output does not contain expected commit ${full_commit}" >&2
             echo "Output: ${output}" >&2
             exit 1
         fi
@@ -90,8 +88,8 @@ docker run --rm \
         # Smoke test subnet-evm version and commit
         evm_output=$("${plugin}" --version)
         echo "subnet-evm --version: ${evm_output}"
-        if [[ "${evm_output}" != *"@${short_commit}"* ]]; then
-            echo "ERROR: subnet-evm --version output does not contain expected @${short_commit}" >&2
+        if [[ "${evm_output}" != *"${full_commit}"* ]]; then
+            echo "ERROR: subnet-evm --version output does not contain expected commit ${full_commit}" >&2
             echo "Output: ${evm_output}" >&2
             exit 1
         fi


### PR DESCRIPTION
## Why this should be merged

Fix subnet-evm RPM build to include the git commit hash in the version output. The container's git couldn't access the bind-mounted repo, so the hash was silently empty. Add safe.directory config to fix that, and validate the full hash in both avalanchego and subnet-evm after install.

## How this was tested

CI.

## Need to be documented in RELEASES.md?

N/A