### PR TITLE
[ci] Skip RPM upload for PRs

### DIFF
--- a/.github/workflows/build-rpm-release.yml
+++ b/.github/workflows/build-rpm-release.yml
@@ -81,6 +81,7 @@ jobs:
           NFPM_RPM_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
 
       - name: Upload RPMs as artifacts
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: rpms-${{ matrix.rpm_arch }}


### PR DESCRIPTION
## Why this should be merged

RPM archives are 70MB per arch, and there's not much value in retaining them for every PR run given that we only want RPM consumers to be using stable versions.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A