### PR TITLE
ci: change PR fuzz tests timing and bump fuzz test timeout 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
         run: ./scripts/run_task.sh test-unit
         env:
           TIMEOUT: ${{ env.TIMEOUT }}
+  Fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go-for-project
+      - name: test-fuzz
+        shell: bash
+        run: ./scripts/run_task.sh test-fuzz
   e2e:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -291,8 +291,14 @@ tasks:
     cmds:
       - cmd: bash -x ./scripts/tests.e2e.kube.sh --ginkgo.focus-file=xsvm.go {{.CLI_ARGS}}
 
-  # To use a different fuzz time, run `task test-fuzz-long FUZZTIME=[value in seconds]`.
+  # To use a different fuzz time, run `task test-fuzz FUZZTIME=[value in seconds]`.
   # A value of `-1` will run until it encounters a failing output.
+
+  test-fuzz:
+    desc: Runs each fuzz test for 1 second
+    vars:
+      FUZZTIME: '{{.FUZZTIME| default "1"}}'
+    cmd: ./scripts/build_fuzz.sh {{.FUZZTIME}}
 
   test-fuzz-long:
     desc: Runs each fuzz test for 180 seconds


### PR DESCRIPTION
## Why this should be merged

GitHub seems to have reduced the compute available for these jobs, and we observed "FAIL, ... context deadline exceeded" repeatedly. This PR changes the test-fuzz task to a 1 second fuzz time to reduce the time spent in fuzz tests, and the timeout is increased. 

## How this works

To increase the timeout for the go tests (beyond the 10m default), I added an `explicit -timeout` flag to go test in `build_fuzz.sh`. 

## How this was tested
CI

## Need to be documented in RELEASES.md?
No 