### PR TITLE
refactor: platform vm tests initialization

### DIFF
--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -63,7 +63,8 @@ var encodings = []formatting.Encoding{
 }
 
 func defaultService(t *testing.T) (*Service, *mutableSharedMemory) {
-	vm, _, mutableSharedMemory := defaultVM(t, upgradetest.Latest)
+	vm, _, mutableSharedMemory := setupVM(t, nil, upgradetest.Latest, 0)
+	initializeTestSubnet(t, vm)
 	return &Service{
 		vm:                    vm,
 		addrManager:           avax.NewAddressManager(vm.ctx),


### PR DESCRIPTION
## Why this should be merged
- Reduces duplicate/brittle platformvm test set up. Reducing ~180 lines of code and aiming to make the test more easily readable.
- Prepares for additional tests in `vm_test.go` to be added for https://github.com/ava-labs/avalanchego/issues/4977.

## How this works
- Adds common helpers for platform VM initialization and proposal/option block creation and preference.

## How this was tested
N/A

## Need to be documented in RELEASES.md?
No
