### PR TITLE
feat: uptime requirement updates configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -664,7 +664,7 @@ func getStakingConfig(v *viper.Viper, networkID uint32) (node.StakingConfig, err
 	}
 
 	if networkID != constants.MainnetID && networkID != constants.FujiID {
-		config.UptimeRequirement = v.GetFloat64(UptimeRequirementKey)
+		config.UptimeRequirementConfig.DefaultRequiredUptimePercentage = v.GetFloat64(UptimeRequirementKey)
 		config.MinValidatorStake = v.GetUint64(MinValidatorStakeKey)
 		config.MaxValidatorStake = v.GetUint64(MaxValidatorStakeKey)
 		config.MinDelegatorStake = v.GetUint64(MinDelegatorStakeKey)

--- a/config/config.md
+++ b/config/config.md
@@ -346,7 +346,7 @@ Some of these parameters can only be set on a local or private network, not on F
 | `--consensus-shutdown-timeout` | `AVAGO_CONSENSUS_SHUTDOWN_TIMEOUT` | duration | `5s` | Timeout before killing an unresponsive chain. |
 | `--create-asset-tx-fee` | `AVAGO_CREATE_ASSET_TX_FEE` | int | `10000000` | Transaction fee, in nAVAX, for transactions that create new assets. This can only be changed on a local network. |
 | `--tx-fee` | `AVAGO_TX_FEE` | int | `1000000` | The required amount of nAVAX to be burned for a transaction to be valid on the X-Chain, and for import/export transactions on the P-Chain. This parameter requires network agreement in its current form. Changing this value from the default should only be done on private networks or local network. |
-| `--uptime-requirement` | `AVAGO_UPTIME_REQUIREMENT` | float | `0.8` | Fraction of time a validator must be online to receive rewards. This can only be changed on a local network. |
+| `--uptime-requirement` | `AVAGO_UPTIME_REQUIREMENT` | float | `0.8` | Default fraction of time a validator must be online to receive rewards. This can only be changed on a local network. |
 | `--uptime-metric-freq` | `AVAGO_UPTIME_METRIC_FREQ` | duration | `30s` | Frequency of renewing this node's average uptime metric. |
 
 ### Staking Parameters

--- a/config/flags.go
+++ b/config/flags.go
@@ -269,7 +269,7 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Uint64(SybilProtectionDisabledWeightKey, 100, "Weight to provide to each peer when sybil protection is disabled")
 	fs.Bool(PartialSyncPrimaryNetworkKey, false, "Only sync the P-chain on the Primary Network. If the node is a Primary Network validator, it will report unhealthy")
 	// Uptime Requirement
-	fs.Float64(UptimeRequirementKey, genesis.LocalParams.UptimeRequirement, "Fraction of time a validator must be online to receive rewards")
+	fs.Float64(UptimeRequirementKey, genesis.LocalParams.UptimeRequirementConfig.DefaultRequiredUptimePercentage, "Fraction of time a validator must be online to receive rewards")
 	// Minimum Stake required to validate the Primary Network
 	fs.Uint64(MinValidatorStakeKey, genesis.LocalParams.MinValidatorStake, "Minimum stake, in nAVAX, required to validate the primary network")
 	// Maximum Stake that can be staked and delegated to a validator on the Primary Network

--- a/config/node/config.go
+++ b/config/node/config.go
@@ -29,7 +29,6 @@ import (
 )
 
 var (
-	errInvalidUptimeRequirement    = errors.New("uptime requirement must be in the range [0, 1]")
 	errMinValidatorStakeAboveMax   = errors.New("minimum validator stake can't be greater than maximum validator stake")
 	errInvalidDelegationFee        = errors.New("delegation fee must be in the range [0, 1,000,000]")
 	errInvalidMinStakeDuration     = errors.New("min stake duration must be > 0")
@@ -97,8 +96,6 @@ type StakingConfig struct {
 
 func (c *StakingConfig) Verify() error {
 	switch {
-	case c.UptimeRequirement < 0 || c.UptimeRequirement > 1:
-		return errInvalidUptimeRequirement
 	case c.MinValidatorStake > c.MaxValidatorStake:
 		return errMinValidatorStakeAboveMax
 	case c.MinDelegationFee > 1_000_000:
@@ -114,7 +111,7 @@ func (c *StakingConfig) Verify() error {
 	case c.RewardConfig.MintingPeriod < c.MaxStakeDuration:
 		return errStakeMintingPeriodBelowMin
 	}
-	return nil
+	return c.StakingConfig.UptimeRequirementConfig.Verify()
 }
 
 type StakingSignerConfig struct {

--- a/genesis/README.md
+++ b/genesis/README.md
@@ -30,3 +30,39 @@ Each allocation contains the following fields:
 Note: if an `avaxAddr` from allocations is included in `initialStakers`, the genesis includes
 all the UTXOs specified in the `unlockSchedule` as part of the locked stake of the corresponding
 genesis validator. Otherwise, the locked UTXO is created directly on the P-Chain.
+
+## Primary Network Validator Uptime Requirements
+
+The Primary Network uses an uptime requirement configuration to determine whether validators should be rewarded based on their observed uptime during their validation period.
+
+### Configuration
+
+The uptime requirement consists of:
+- A default percentage (e.g., 80%) that applies to all validators by default
+- An optional schedule of requirement updates, each specifying a timestamp and a new requirement percentage
+
+When a validator's staking period begins, the applicable uptime requirement is determined by finding the most recent update in the schedule whose timestamp is at or before the validator's start time. If no such update exists, the default percentage is used. This means validators that start staking after a scheduled increase will be subject to the updated requirement.
+
+The schedule must have strictly increasing timestamps - each update must occur after all previous updates. All requirement percentages must be in the range [0, 1].
+
+#### Example Configuration
+
+```go
+UptimeRequirementConfig: UptimeRequirementConfig{
+    DefaultRequiredUptimePercentage: 0.8, // 80%
+    RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+        {
+            Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+            Requirement: 0.9, // 90%
+        },
+    },
+}
+```
+
+This configuration sets the default requirement at 80% and schedules an increase to 90% effective February 12, 2026 at 00:00:00 UTC. Validators whose staking period begins before this date will be subject to the 80% requirement, while those starting on or after this date will need to maintain 90% uptime to be rewarded.
+
+### Consensus and Preference
+
+The uptime requirement determines each validator's **initial preference** for whether to reward a fellow validator when their staking period ends. If the validator's observed uptime meets or exceeds the applicable requirement, the validator initially prefers to issue the reward (commit). Otherwise, it initially prefers to deny the reward (abort).
+
+However, the **final decision on whether to reward a validator is determined through Snowman consensus**. All validators vote on whether to commit (reward) or abort (deny reward) the validator's staking transaction. The uptime requirement only influences each validator's initial preference - the network reaches agreement through the standard consensus process, ensuring that the majority decision prevails regardless of individual preferences.

--- a/genesis/genesis_fuji.go
+++ b/genesis/genesis_fuji.go
@@ -52,7 +52,9 @@ var (
 			},
 		},
 		StakingConfig: StakingConfig{
-			UptimeRequirement: .8, // 80%
+			UptimeRequirementConfig: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: .8, // 80%
+			},
 			MinValidatorStake: 1 * units.Avax,
 			MaxValidatorStake: 3 * units.MegaAvax,
 			MinDelegatorStake: 1 * units.Avax,

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -70,7 +70,9 @@ var (
 			},
 		},
 		StakingConfig: StakingConfig{
-			UptimeRequirement: .8, // 80%
+			UptimeRequirementConfig: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: .8, // 80%
+			},
 			MinValidatorStake: 2 * units.KiloAvax,
 			MaxValidatorStake: 3 * units.MegaAvax,
 			MinDelegatorStake: 25 * units.Avax,

--- a/genesis/genesis_mainnet.go
+++ b/genesis/genesis_mainnet.go
@@ -52,7 +52,9 @@ var (
 			},
 		},
 		StakingConfig: StakingConfig{
-			UptimeRequirement: .8, // 80%
+			UptimeRequirementConfig: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: .8, // 80%
+			},
 			MinValidatorStake: 2 * units.KiloAvax,
 			MaxValidatorStake: 3 * units.MegaAvax,
 			MinDelegatorStake: 25 * units.Avax,

--- a/genesis/params_test.go
+++ b/genesis/params_test.go
@@ -1,0 +1,260 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUptimeRequirementConfigVerify(t *testing.T) {
+	tests := map[string]struct {
+		config      UptimeRequirementConfig
+		expectedErr error
+	}{
+		"valid - default only": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage:  0.8,
+				RequiredUptimePercentageSchedule: nil,
+			},
+			expectedErr: nil,
+		},
+		"valid - default with single update": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		"valid - default with multiple updates": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+					{
+						Time:        time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.95,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		"valid - zero default": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage:  0,
+				RequiredUptimePercentageSchedule: nil,
+			},
+			expectedErr: nil,
+		},
+		"valid - one default": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage:  1,
+				RequiredUptimePercentageSchedule: nil,
+			},
+			expectedErr: nil,
+		},
+		"invalid - negative default": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage:  -0.1,
+				RequiredUptimePercentageSchedule: nil,
+			},
+			expectedErr: errInvalidUptimeRequirement,
+		},
+		"invalid - default above 1": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage:  1.1,
+				RequiredUptimePercentageSchedule: nil,
+			},
+			expectedErr: errInvalidUptimeRequirement,
+		},
+		"invalid - negative requirement in schedule": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: -0.1,
+					},
+				},
+			},
+			expectedErr: errInvalidUptimeRequirement,
+		},
+		"invalid - requirement above 1 in schedule": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 1.5,
+					},
+				},
+			},
+			expectedErr: errInvalidUptimeRequirement,
+		},
+		"invalid - non-increasing times (equal)": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.95,
+					},
+				},
+			},
+			expectedErr: errUptimeRequirementTimeNotIncreasing,
+		},
+		"invalid - non-increasing times (decreasing)": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.95,
+					},
+				},
+			},
+			expectedErr: errUptimeRequirementTimeNotIncreasing,
+		},
+		"invalid - second requirement negative in multiple updates": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+					{
+						Time:        time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+						Requirement: -0.5,
+					},
+				},
+			},
+			expectedErr: errInvalidUptimeRequirement,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.config.Verify()
+			require.ErrorIs(t, err, test.expectedErr)
+		})
+	}
+}
+
+func TestUptimeRequirementConfigRequiredUptime(t *testing.T) {
+	tests := map[string]struct {
+		config              UptimeRequirementConfig
+		stakerStartTime     time.Time
+		expectedRequirement float64
+	}{
+		"default - no schedule": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage:  0.8,
+				RequiredUptimePercentageSchedule: nil,
+			},
+			stakerStartTime:     time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			expectedRequirement: 0.8,
+		},
+		"default - staker started before first update": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+				},
+			},
+			stakerStartTime:     time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC),
+			expectedRequirement: 0.8,
+		},
+		"updated - staker started on update time": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+				},
+			},
+			stakerStartTime:     time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+			expectedRequirement: 0.9,
+		},
+		"updated - staker started after update time": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+				},
+			},
+			stakerStartTime:     time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
+			expectedRequirement: 0.9,
+		},
+		"first update - staker started before second update": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+					{
+						Time:        time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.95,
+					},
+				},
+			},
+			stakerStartTime:     time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			expectedRequirement: 0.9,
+		},
+		"second update - staker started after second update": {
+			config: UptimeRequirementConfig{
+				DefaultRequiredUptimePercentage: 0.8,
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.9,
+					},
+					{
+						Time:        time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+						Requirement: 0.95,
+					},
+				},
+			},
+			stakerStartTime:     time.Date(2027, 6, 1, 0, 0, 0, 0, time.UTC),
+			expectedRequirement: 0.95,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			actual := test.config.RequiredUptime(test.stakerStartTime)
+			require.Equal(test.expectedRequirement, actual)
+		})
+	}
+}

--- a/network/config.go
+++ b/network/config.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 	"time"
 
+	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/dialer"
 	"github.com/ava-labs/avalanchego/network/throttling"
@@ -148,9 +149,9 @@ type Config struct {
 	// observed average uptime metrics.
 	UptimeMetricFreq time.Duration `json:"uptimeMetricFreq"`
 
-	// UptimeRequirement is the fraction of time a validator must be online and
-	// responsive for us to vote that they should receive a staking reward.
-	UptimeRequirement float64 `json:"-"`
+	// UptimeRequirementConfig defines the required uptime percentages to
+	// reward primary network validators based on their start time.
+	genesis.UptimeRequirementConfig `json:"-"`
 
 	// RequireValidatorToConnect require that all connections must have at least
 	// one validator between the 2 peers. This can be useful to enable if the

--- a/network/network.go
+++ b/network/network.go
@@ -1205,8 +1205,10 @@ func (n *network) NodeUptime() (UptimeResult, error) {
 		weightFloat := float64(weight)
 		totalWeightedPercent += percent * weightFloat
 
-		// if this peer thinks we're above requirement add the weight
-		if percent/100 >= n.config.UptimeRequirement {
+		// if this peer thinks we're above latest requirement, add the weight.
+		// the actual requirement may vary if our staking start time was before
+		// the latest required uptime update.
+		if percent/100 >= n.config.RequiredUptime(time.Now()) {
 			rewardingStake += weightFloat
 		}
 	}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"
 	"github.com/ava-labs/avalanchego/network/dialer"
@@ -115,9 +116,11 @@ var (
 
 		CompressionType: constants.DefaultNetworkCompressionType,
 
-		UptimeCalculator:  uptime.NewManager(uptime.NewTestState(), &mockable.Clock{}),
-		UptimeMetricFreq:  30 * time.Second,
-		UptimeRequirement: .8,
+		UptimeCalculator: uptime.NewManager(uptime.NewTestState(), &mockable.Clock{}),
+		UptimeMetricFreq: 30 * time.Second,
+		UptimeRequirementConfig: genesis.UptimeRequirementConfig{
+			DefaultRequiredUptimePercentage: .8, // 80%
+		},
 
 		RequireValidatorToConnect: false,
 

--- a/node/node.go
+++ b/node/node.go
@@ -630,7 +630,7 @@ func (n *Node) initNetworking(reg prometheus.Registerer) error {
 	n.Config.NetworkConfig.BLSKey = n.StakingSigner
 	n.Config.NetworkConfig.TrackedSubnets = n.Config.TrackedSubnets
 	n.Config.NetworkConfig.UptimeCalculator = n.uptimeCalculator
-	n.Config.NetworkConfig.UptimeRequirement = n.Config.UptimeRequirement
+	n.Config.NetworkConfig.UptimeRequirementConfig = n.Config.UptimeRequirementConfig
 	n.Config.NetworkConfig.ResourceTracker = n.resourceTracker
 	n.Config.NetworkConfig.CPUTargeter = n.cpuTargeter
 	n.Config.NetworkConfig.DiskTargeter = n.diskTargeter
@@ -1213,7 +1213,7 @@ func (n *Node) initVMs() error {
 				TrackedSubnets:            n.Config.TrackedSubnets,
 				DynamicFeeConfig:          n.Config.DynamicFeeConfig,
 				ValidatorFeeConfig:        n.Config.ValidatorFeeConfig,
-				UptimePercentage:          n.Config.UptimeRequirement,
+				UptimeRequirementConfig:   n.Config.UptimeRequirementConfig,
 				MinValidatorStake:         n.Config.MinValidatorStake,
 				MaxValidatorStake:         n.Config.MaxValidatorStake,
 				MinDelegatorStake:         n.Config.MinDelegatorStake,

--- a/vms/platformvm/block/executor/block.go
+++ b/vms/platformvm/block/executor/block.go
@@ -89,7 +89,7 @@ func (b *Block) Timestamp() time.Time {
 func (b *Block) Options(context.Context) ([2]snowman.Block, error) {
 	options := options{
 		log:                     b.manager.ctx.Log,
-		primaryUptimePercentage: b.manager.txExecutorBackend.Config.UptimePercentage,
+		primaryUptimePercentage: b.manager.txExecutorBackend.Config.RequiredUptime,
 		uptimes:                 b.manager.txExecutorBackend.Uptimes,
 		state:                   b.manager.backend.state,
 	}

--- a/vms/platformvm/block/executor/block_test.go
+++ b/vms/platformvm/block/executor/block_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/snow/uptime/uptimemock"
@@ -22,6 +23,15 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
+)
+
+var (
+	zeroRequiredUptimeConfig = genesis.UptimeRequirementConfig{
+		DefaultRequiredUptimePercentage: 0,
+	}
+	eightyRequiredUptimeConfig = genesis.UptimeRequirementConfig{
+		DefaultRequiredUptimePercentage: .8,
+	}
 )
 
 func TestBlockOptions(t *testing.T) {
@@ -46,7 +56,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: 0,
+							UptimeRequirementConfig: zeroRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -73,7 +83,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: 0,
+							UptimeRequirementConfig: zeroRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -109,7 +119,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: 0,
+							UptimeRequirementConfig: zeroRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -147,7 +157,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: 0,
+							UptimeRequirementConfig: zeroRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -188,7 +198,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: 0,
+							UptimeRequirementConfig: zeroRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -239,7 +249,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: 0,
+							UptimeRequirementConfig: zeroRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -295,7 +305,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: 0,
+							UptimeRequirementConfig: zeroRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -351,7 +361,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: 0,
+							UptimeRequirementConfig: zeroRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -413,7 +423,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: .8,
+							UptimeRequirementConfig: eightyRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},
@@ -475,7 +485,7 @@ func TestBlockOptions(t *testing.T) {
 					},
 					txExecutorBackend: &executor.Backend{
 						Config: &config.Internal{
-							UptimePercentage: .8,
+							UptimeRequirementConfig: eightyRequiredUptimeConfig,
 						},
 						Uptimes: uptimes,
 					},

--- a/vms/platformvm/block/executor/options.go
+++ b/vms/platformvm/block/executor/options.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -34,8 +35,9 @@ var (
 // options supports build new option blocks
 type options struct {
 	// inputs populated before calling this struct's methods:
-	log                     logging.Logger
-	primaryUptimePercentage float64
+	log logging.Logger
+	// determines required uptime percentage based on validator start time
+	primaryUptimePercentage func(time.Time) float64
 	uptimes                 uptime.Calculator
 	state                   state.Chain
 
@@ -165,7 +167,7 @@ func (o *options) prefersCommit(tx *txs.Tx) (bool, error) {
 		return false, fmt.Errorf("%w: %w", errFailedFetchingPrimaryStaker, err)
 	}
 
-	expectedUptimePercentage := o.primaryUptimePercentage
+	expectedUptimePercentage := o.primaryUptimePercentage(primaryNetworkValidator.StartTime)
 	if subnetID := staker.SubnetID(); subnetID != constants.PrimaryNetworkID {
 		transformSubnet, err := executor.GetTransformSubnetTx(o.state, subnetID)
 		if err != nil {

--- a/vms/platformvm/config/internal.go
+++ b/vms/platformvm/config/internal.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/chains"
+	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/uptime"
 	"github.com/ava-labs/avalanchego/snow/validators"
@@ -63,8 +64,9 @@ type Internal struct {
 	// Minimum fee that can be charged for delegation
 	MinDelegationFee uint32
 
-	// UptimePercentage is the minimum uptime required to be rewarded for staking
-	UptimePercentage float64
+	// UptimeRequirementConfig defines the uptime requirements for stakers
+	// to receive rewards.
+	genesis.UptimeRequirementConfig
 
 	// Minimum amount of time to allow a staker to stake
 	MinStakeDuration time.Duration

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
@@ -63,7 +64,7 @@ var encodings = []formatting.Encoding{
 }
 
 func defaultService(t *testing.T) (*Service, *mutableSharedMemory) {
-	vm, _, mutableSharedMemory := setupVM(t, nil, upgradetest.Latest, 0)
+	vm, _, mutableSharedMemory := setupVM(t, nil, upgradetest.Latest, genesis.UptimeRequirementConfig{})
 	initializeTestSubnet(t, vm)
 	return &Service{
 		vm:                    vm,

--- a/vms/platformvm/vm_regression_test.go
+++ b/vms/platformvm/vm_regression_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
@@ -516,7 +517,7 @@ func TestUnverifiedParentPanicRegression(t *testing.T) {
 func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 	require := require.New(t)
 
-	vm, baseDB, mutableSharedMemory := setupVM(t, nil, upgradetest.Cortina, 0)
+	vm, baseDB, mutableSharedMemory := setupVM(t, nil, upgradetest.Cortina, genesis.UptimeRequirementConfig{})
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 
@@ -709,7 +710,7 @@ func TestRejectedStateRegressionInvalidValidatorTimestamp(t *testing.T) {
 func TestRejectedStateRegressionInvalidValidatorReward(t *testing.T) {
 	require := require.New(t)
 
-	vm, baseDB, mutableSharedMemory := setupVM(t, nil, upgradetest.Cortina, 0)
+	vm, baseDB, mutableSharedMemory := setupVM(t, nil, upgradetest.Cortina, genesis.UptimeRequirementConfig{})
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
 


### PR DESCRIPTION
Blocked by https://github.com/ava-labs/avalanchego/pull/4985 and https://github.com/ava-labs/avalanchego/pull/4986

## Why this should be merged
Adds the framework for https://github.com/ava-labs/avalanchego/issues/4977 to allow for straightforward updates to the primary network validator uptime requirements as of a specified start time.

No functional changes are made yet in this PR. The uptime requirements are kept equivalent as before (static 80%). This PR just includes the framework to easily update it via configuration.

## How this works
Documentation added in PR [here](https://github.com/ava-labs/avalanchego/blob/c4fea96dac8a9f207dbc0944756abbd3589e437a/genesis/README.md#primary-network-validator-uptime-requirements).

## How this was tested
New unit tests in `genesis/params_test.go` and `platformvm/vm_test.go`

## Need to be documented in RELEASES.md?
No, not until a new uptime requirement is added.