### PR TITLE
feat: ACP-267 90% uptime requirement activation

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,7 @@
 
 - Removed `pull-gossip-poll-size` from the X-chain and P-chain configs.
 - Removed `proposerMinBlockDelay` from subnet configs.
+- Increases Primary Network Validator uptime requirement to 90% for validators starting on or after February 15th, 2026.
 
 ### Fixes
 

--- a/genesis/genesis_fuji.go
+++ b/genesis/genesis_fuji.go
@@ -54,6 +54,12 @@ var (
 		StakingConfig: StakingConfig{
 			UptimeRequirementConfig: UptimeRequirementConfig{
 				DefaultRequiredUptimePercentage: .8, // 80%
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, time.February, 15, 0, 0, 0, 0, time.UTC),
+						Requirement: .9, // 90%
+					},
+				},
 			},
 			MinValidatorStake: 1 * units.Avax,
 			MaxValidatorStake: 3 * units.MegaAvax,

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -72,6 +72,12 @@ var (
 		StakingConfig: StakingConfig{
 			UptimeRequirementConfig: UptimeRequirementConfig{
 				DefaultRequiredUptimePercentage: .8, // 80%
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, time.February, 15, 0, 0, 0, 0, time.UTC),
+						Requirement: .9, // 90%
+					},
+				},
 			},
 			MinValidatorStake: 2 * units.KiloAvax,
 			MaxValidatorStake: 3 * units.MegaAvax,

--- a/genesis/genesis_mainnet.go
+++ b/genesis/genesis_mainnet.go
@@ -54,6 +54,12 @@ var (
 		StakingConfig: StakingConfig{
 			UptimeRequirementConfig: UptimeRequirementConfig{
 				DefaultRequiredUptimePercentage: .8, // 80%
+				RequiredUptimePercentageSchedule: []UptimeRequirementUpdate{
+					{
+						Time:        time.Date(2026, time.February, 15, 0, 0, 0, 0, time.UTC),
+						Requirement: .9, // 90%
+					},
+				},
 			},
 			MinValidatorStake: 2 * units.KiloAvax,
 			MaxValidatorStake: 3 * units.MegaAvax,


### PR DESCRIPTION
Blocked by #4987 

## Why this should be merged
- Closes https://github.com/ava-labs/avalanchego/issues/4977
- Increases the primary network validator uptime requirement on Fuji, Mainnet, and default local networks for validators starting on or after 2026-02-15

## How this works
Sets the uptime requirement update configuration.

## How this was tested
Existing UT added in #4987 

## Need to be documented in RELEASES.md?
Yes, done.