### PR TITLE
ci: just fuzz a single test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -291,7 +291,8 @@ tasks:
     cmds:
       - cmd: bash -x ./scripts/tests.e2e.kube.sh --ginkgo.focus-file=xsvm.go {{.CLI_ARGS}}
 
-  # To use a different fuzz time, run `task test-fuzz FUZZTIME=[value in seconds]`.
+  # test-fuzz targets a single package as a smoke test for fuzz infrastructure.
+  # For comprehensive fuzzing, use test-fuzz-long FUZZTIME=[value in seconds].
   # A value of `-1` will run until it encounters a failing output.
 
   test-fuzz:


### PR DESCRIPTION
## Why this should be merged

The fuzz test seems to be even flakier now. To fix this, we change it so the pre-merge job now acts as a smoke test (validates the fuzz infrastructure works) while the scheduled job do the real fuzzing. I also bumped fuzz time back to 10s — since we're only running one test in one package now, this should still be fast. 

## How this was tested
CI

## Need to be documented in RELEASES.md?
No 