### PR TITLE
[nix] Switch to direct import of golang to fix relative path bug

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "go-flake": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1,
-        "narHash": "sha256-PPX4of5NK7HA4g4MMT1xYHjgpHYotB+uAA4Oh9sLhpI=",
-        "path": "./nix/go",
-        "type": "path"
-      },
-      "original": {
-        "path": "./nix/go",
-        "type": "path"
-      },
-      "parent": []
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1765838191,
@@ -36,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "go-flake": "go-flake",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -9,12 +9,10 @@
   # Flake inputs
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    go-flake.url = "path:./nix/go";
-    go-flake.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs, go-flake }:
+  outputs = { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -41,8 +39,8 @@
             # Task runner
             go-task
 
-            # Local Go package from nested flake
-            go-flake.packages.${pkgs.stdenv.hostPlatform.system}.default
+            # Local Go package
+            (import ./nix/go { inherit pkgs; })
 
             # Monitoring tools
             promtail                                   # Loki log shipper


### PR DESCRIPTION
## Why this should be merged

lix (our recommended nix distro for macos) doesn't support relative flake references. Switching to a direct import is intended to ensure that our flake is compatible with lix on macos.

## How this was tested

- CI
- Locally ran `nix develop` without error

## Need to be documented in RELEASES.md?

N/A