### PR TITLE
test: skip StateSyncToggleEnabledToDisabledTest flake

### DIFF
--- a/graft/coreth/plugin/evm/vmtest/test_syncervm.go
+++ b/graft/coreth/plugin/evm/vmtest/test_syncervm.go
@@ -116,6 +116,8 @@ func StateSyncFromScratchExceedParentTest(t *testing.T, testSetup *SyncTestSetup
 }
 
 func StateSyncToggleEnabledToDisabledTest(t *testing.T, testSetup *SyncTestSetup) {
+	t.Skip("Flaky test - tracked in #4968")
+
 	var lock sync.Mutex
 	require := require.New(t)
 	reqCount := 0


### PR DESCRIPTION
## Why this should be merged

Skips a flake
