### PR TITLE
vms/platformvm: increase MaxValidatorWeightFactor to 25 (ACP-247)

### DIFF
--- a/vms/platformvm/txs/executor/proposal_tx_executor.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor.go
@@ -26,7 +26,12 @@ const (
 	// SyncBound is the synchrony bound used for safe decision making
 	SyncBound = 10 * time.Second
 
-	MaxValidatorWeightFactor = 5
+	// MaxValidatorWeightFactor is the maximum ratio of total validator weight
+	// (self-stake + delegations) to self-stake for Primary Network validators.
+	// A value of 25 means a validator can accept up to 24x its self-stake in
+	// delegations (e.g. 2,000 AVAX self-stake → up to 48,000 AVAX delegated).
+	// Implements ACP-247 (Delegation Multiplier Increase).
+	MaxValidatorWeightFactor = 25
 )
 
 var (


### PR DESCRIPTION
## Summary

Implements [ACP-247: Delegation Multiplier Increase](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/247-delegation-multiplier-increase/README.md), which is currently in **Implementable** status.

### Change

Increases `MaxValidatorWeightFactor` from `5` to `25` in `vms/platformvm/txs/executor/proposal_tx_executor.go`.

This raises the effective delegation multiplier from **4x → 24x** for Primary Network validators.

| | Current (4x / factor=5) | Proposed (24x / factor=25) |
|---|---|---|
| Max delegations (2,000 AVAX self-stake) | 8,000 AVAX | 48,000 AVAX |
| Max total weight | 10,000 AVAX | 50,000 AVAX |
| Monthly net profit (est.) | $180 | $455 |

### Motivation

- **52.8% of validators have zero delegations** under the current 4x constraint (854 validators, data from Oct 28, 2025)
- Current economics ($180/mo net at 2k AVAX self-stake) are marginal; many validators are forced to run multiple nodes
- Increasing to 24x unlocks dormant capacity and makes single-node operations economically sustainable at scale

### Implementation Notes

- Non-breaking for existing delegation relationships (existing delegations remain valid)
- Only validators with 120,000+ AVAX self-stake cannot fully utilize 24x due to the existing 3M AVAX weight cap
- All 2,000 AVAX validators can deploy the full 24x multiplier
- No changes to minimum validator/delegator stake, staking duration, uptime requirements, or reward formula

### References

- ACP-247 discussion: https://github.com/avalanche-foundation/ACPs/discussions/248
- ACP-247 text: https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/247-delegation-multiplier-increase/README.md