### PR TITLE
Remove benchlist timeout override for tmpnet in favor of relying on o…

### DIFF
--- a/tests/fixture/tmpnet/defaults.go
+++ b/tests/fixture/tmpnet/defaults.go
@@ -47,9 +47,6 @@ func DefaultTmpnetFlags() FlagsMap {
 		// resource-constrained environments that commonly have low disk space.
 		config.SystemTrackerRequiredAvailableDiskSpacePercentageKey: "0",
 		config.SystemTrackerWarningAvailableDiskSpacePercentageKey:  "0",
-		// Reduce benchlist duration from the 5m default to avoid
-		// benching nodes that are slow to start in test environments.
-		config.BenchlistDurationKey: "5s",
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

This PR removes the benchlist timeout override for tmpnet. Previously, the timeout was set to a lower value so that nodes could unbench nodes that got benched during bootstrapping and pass the e2e tests within the timeout (5s instead of 5min). This should no longer be necessary with the overbench protection added in https://github.com/ava-labs/avalanchego/pull/5010.

ref https://github.com/ava-labs/avalanchego/pull/5010#issuecomment-3929663762

## How this works

Removes tmpnet override for benchlist timeout.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No - this should be collapsed with other benchlist changes and included as a single entry in RELEASES.md.