### PR TITLE
test(sync/evmstate): add storage verification to Firewood sync tests

### DIFF
--- a/graft/evm/sync/evmstate/firewood_syncer_test.go
+++ b/graft/evm/sync/evmstate/firewood_syncer_test.go
@@ -250,8 +250,10 @@ func assertFirewoodAllKeysConsistency(t *testing.T, clientState, serverState sta
 
 	clientRev, err := clientDB.Revision(clientRoot)
 	require.NoError(t, err, "client Revision()")
+	defer func() { require.NoError(t, clientRev.Drop()) }()
 	serverRev, err := serverDB.Revision(serverRoot)
 	require.NoError(t, err, "server Revision()")
+	defer func() { require.NoError(t, serverRev.Drop()) }()
 
 	clientIt, err := clientRev.Iter(nil)
 	require.NoError(t, err, "client Iter()")


### PR DESCRIPTION
## Why this should be merged

Check #5012 

## How this works

`assertFirewoodConsistency` only verified account leaves and code hashes, leaving all storage entries (64-byte combined keys) unchecked. Add `assertFirewoodAllKeysConsistency` which uses the raw FFI iterator to compare every key-value pair between client and server in lockstep, bypassing the 32-byte account filter that hides storage entries.

## How this was tested

enhancing the current Firewood sync tests

## Need to be documented in RELEASES.md?

no

resolves #5012

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)