### PR TITLE
 Replace DelegateeReward API with generalized API

### DIFF
--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -107,7 +107,7 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 	)
 	onParentAccept.EXPECT().GetTx(addValTx.ID()).Return(addValTx, status.Committed, nil)
 	onParentAccept.EXPECT().GetCurrentSupply(constants.PrimaryNetworkID).Return(uint64(1000), nil).AnyTimes()
-	onParentAccept.EXPECT().GetDelegateeReward(constants.PrimaryNetworkID, utx.NodeID()).Return(uint64(0), nil).AnyTimes()
+	onParentAccept.EXPECT().GetStakingInfo(constants.PrimaryNetworkID, utx.NodeID()).Return(state.StakingInfo{}, nil).AnyTimes()
 
 	env.mockedState.EXPECT().GetUptime(gomock.Any()).Return(
 		time.Microsecond, /*upDuration*/
@@ -221,7 +221,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	onParentAccept.EXPECT().GetActiveL1ValidatorsIterator().Return(iterator.Empty[state.L1Validator]{}, nil).AnyTimes()
 	onParentAccept.EXPECT().GetExpiryIterator().Return(iterator.Empty[state.ExpiryEntry]{}, nil).AnyTimes()
 
-	onParentAccept.EXPECT().GetDelegateeReward(constants.PrimaryNetworkID, unsignedNextStakerTx.NodeID()).Return(uint64(0), nil).AnyTimes()
+	onParentAccept.EXPECT().GetStakingInfo(constants.PrimaryNetworkID, unsignedNextStakerTx.NodeID()).Return(state.StakingInfo{}, nil).AnyTimes()
 
 	env.mockedState.EXPECT().GetUptime(gomock.Any).Return(
 		time.Microsecond, /*upDuration*/

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -838,11 +838,11 @@ func (s *Service) getPrimaryOrSubnetValidators(subnetID ids.ID, nodeIDs set.Set[
 		apiStaker := toPlatformStaker(currentStaker)
 		potentialReward := avajson.Uint64(currentStaker.PotentialReward)
 
-		delegateeReward, err := s.vm.state.GetDelegateeReward(currentStaker.SubnetID, currentStaker.NodeID)
+		stakingInfo, err := s.vm.state.GetStakingInfo(currentStaker.SubnetID, currentStaker.NodeID)
 		if err != nil {
 			return nil, err
 		}
-		jsonDelegateeReward := avajson.Uint64(delegateeReward)
+		jsonDelegateeReward := avajson.Uint64(stakingInfo.DelegateeReward)
 
 		switch currentStaker.Priority {
 		case txs.PrimaryNetworkValidatorCurrentPriority, txs.SubnetPermissionlessValidatorCurrentPriority:

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -751,7 +751,7 @@ func TestGetCurrentValidators(t *testing.T) {
 	require.NoError(err)
 	service.vm.state.AddTx(tx, status.Committed)
 	service.vm.state.DeleteCurrentDelegator(staker)
-	require.NoError(service.vm.state.SetDelegateeReward(staker.SubnetID, staker.NodeID, 100000))
+	require.NoError(service.vm.state.SetStakingInfo(staker.SubnetID, staker.NodeID, state.StakingInfo{DelegateeReward: 100000}))
 	require.NoError(service.vm.state.Commit())
 
 	service.vm.ctx.Lock.Unlock()

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -48,9 +48,9 @@ type diff struct {
 	l1ValidatorsDiff *l1ValidatorsDiff
 
 	currentStakerDiffs diffStakers
-	// map of subnetID -> nodeID -> total accrued delegatee rewards
-	modifiedDelegateeRewards map[ids.ID]map[ids.NodeID]uint64
-	pendingStakerDiffs       diffStakers
+	// map of subnetID -> nodeID -> staking info
+	modifiedStakingInfo map[ids.ID]map[ids.NodeID]StakingInfo
+	pendingStakerDiffs  diffStakers
 
 	addedSubnetIDs []ids.ID
 	// Subnet ID --> Owner of the subnet
@@ -281,29 +281,28 @@ func (d *diff) GetCurrentValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker,
 	}
 }
 
-func (d *diff) SetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID, amount uint64) error {
-	if d.modifiedDelegateeRewards == nil {
-		d.modifiedDelegateeRewards = make(map[ids.ID]map[ids.NodeID]uint64)
+func (d *diff) SetStakingInfo(subnetID ids.ID, nodeID ids.NodeID, stakingInfo StakingInfo) error {
+	if d.modifiedStakingInfo == nil {
+		d.modifiedStakingInfo = make(map[ids.ID]map[ids.NodeID]StakingInfo)
 	}
-	nodes, ok := d.modifiedDelegateeRewards[subnetID]
+	nodes, ok := d.modifiedStakingInfo[subnetID]
 	if !ok {
-		nodes = make(map[ids.NodeID]uint64)
-		d.modifiedDelegateeRewards[subnetID] = nodes
+		nodes = make(map[ids.NodeID]StakingInfo)
+		d.modifiedStakingInfo[subnetID] = nodes
 	}
-	nodes[nodeID] = amount
+	nodes[nodeID] = stakingInfo
 	return nil
 }
 
-func (d *diff) GetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID) (uint64, error) {
-	amount, modified := d.modifiedDelegateeRewards[subnetID][nodeID]
-	if modified {
-		return amount, nil
+func (d *diff) GetStakingInfo(subnetID ids.ID, nodeID ids.NodeID) (StakingInfo, error) {
+	if stakingInfo, ok := d.modifiedStakingInfo[subnetID][nodeID]; ok {
+		return stakingInfo, nil
 	}
 	parentState, ok := d.stateVersions.GetState(d.parentID)
 	if !ok {
-		return 0, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
+		return StakingInfo{}, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
 	}
-	return parentState.GetDelegateeReward(subnetID, nodeID)
+	return parentState.GetStakingInfo(subnetID, nodeID)
 }
 
 func (d *diff) PutCurrentValidator(staker *Staker) error {
@@ -614,9 +613,9 @@ func (d *diff) Apply(baseState Chain) error {
 			}
 		}
 	}
-	for subnetID, nodes := range d.modifiedDelegateeRewards {
-		for nodeID, amount := range nodes {
-			if err := baseState.SetDelegateeReward(subnetID, nodeID, amount); err != nil {
+	for subnetID, nodes := range d.modifiedStakingInfo {
+		for nodeID, stakingInfo := range nodes {
+			if err := baseState.SetStakingInfo(subnetID, nodeID, stakingInfo); err != nil {
 				return err
 			}
 		}

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -1040,3 +1040,35 @@ func TestDiffStacking(t *testing.T) {
 	require.NoError(err)
 	require.Equal(owner3, owner)
 }
+
+func TestDiffStakingInfo(t *testing.T) {
+	state := newTestState(t, memdb.New())
+
+	d, err := NewDiffOn(state)
+	require.NoError(t, err)
+
+	// Get falls through to parent when not set in diff
+	initialStakingInfo, err := d.GetStakingInfo(constants.PrimaryNetworkID, defaultValidatorNodeID)
+	require.NoError(t, err)
+
+	// Set then Get returns the diff value
+	wantStakingInfo := StakingInfo{DelegateeReward: 200}
+	require.NoError(t, d.SetStakingInfo(constants.PrimaryNetworkID, defaultValidatorNodeID, wantStakingInfo))
+
+	gotStakingInfo, err := d.GetStakingInfo(constants.PrimaryNetworkID, defaultValidatorNodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantStakingInfo, gotStakingInfo)
+
+	// Parent state unchanged
+	parentStakingInfo, err := state.GetStakingInfo(constants.PrimaryNetworkID, defaultValidatorNodeID)
+	require.NoError(t, err)
+	require.Equal(t, initialStakingInfo, parentStakingInfo)
+
+	// Overwrite works correctly
+	wantStakingInfo = StakingInfo{DelegateeReward: 300}
+	require.NoError(t, d.SetStakingInfo(constants.PrimaryNetworkID, defaultValidatorNodeID, wantStakingInfo))
+
+	gotStakingInfo, err = d.GetStakingInfo(constants.PrimaryNetworkID, defaultValidatorNodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantStakingInfo, gotStakingInfo)
+}

--- a/vms/platformvm/state/metadata_validator.go
+++ b/vms/platformvm/state/metadata_validator.go
@@ -75,6 +75,17 @@ func parseValidatorMetadata(bytes []byte, metadata *validatorMetadata) error {
 	return nil
 }
 
+// StakingInfo holds mutable validator data that can be modified.
+type StakingInfo struct {
+	DelegateeReward uint64
+}
+
+func stakingInfoFromMetadata(vdrMetadata *validatorMetadata) StakingInfo {
+	return StakingInfo{
+		DelegateeReward: vdrMetadata.PotentialDelegateeReward,
+	}
+}
+
 type validatorState struct {
 	metadata map[ids.NodeID]map[ids.ID]*validatorMetadata // vdrID -> subnetID -> metadata
 	// updatedMetadata tracks (vdrID, subnetID) -> txIDs needing DB sync since the
@@ -133,6 +144,8 @@ func (vs *validatorState) GetUptime(
 // SetUptime updates the uptime measurements of `vdrID` on `subnetID`.
 // Unless these measurements are deleted first, the next call to
 // [WriteValidatorMetadata] will write this update to disk.
+//
+// This is called by the consensus layer to track validator connection times.
 func (vs *validatorState) SetUptime(
 	vdrID ids.NodeID,
 	subnetID ids.ID,
@@ -150,32 +163,32 @@ func (vs *validatorState) SetUptime(
 	return nil
 }
 
-// GetDelegateeReward returns the current rewards accrued to `vdrID` on
-// `subnetID`.
-func (vs *validatorState) GetDelegateeReward(
+// GetStakingInfo returns the mutable staking info for the validator on [subnetID] with [vdrID].
+func (vs *validatorState) GetStakingInfo(
 	subnetID ids.ID,
 	vdrID ids.NodeID,
-) (uint64, error) {
+) (StakingInfo, error) {
 	metadata, exists := vs.metadata[vdrID][subnetID]
 	if !exists {
-		return 0, database.ErrNotFound
+		return StakingInfo{}, database.ErrNotFound
 	}
-	return metadata.PotentialDelegateeReward, nil
+	return stakingInfoFromMetadata(metadata), nil
 }
 
-// SetDelegateeReward updates the rewards accrued to `vdrID` on `subnetID`.
-// Unless these measurements are deleted first, the next call to
-// [WriteValidatorMetadata] will write this update to disk.
-func (vs *validatorState) SetDelegateeReward(
+// SetStakingInfo updates the mutable staking info of `vdrID` on `subnetID`.
+// Unless deleted first, the next call to [WriteValidatorMetadata] will write this update to disk.
+//
+// This is called by execution layer to update mutable staking info.
+func (vs *validatorState) SetStakingInfo(
 	subnetID ids.ID,
 	vdrID ids.NodeID,
-	amount uint64,
+	stakingInfo StakingInfo,
 ) error {
 	metadata, exists := vs.metadata[vdrID][subnetID]
 	if !exists {
 		return database.ErrNotFound
 	}
-	metadata.PotentialDelegateeReward = amount
+	metadata.PotentialDelegateeReward = stakingInfo.DelegateeReward
 
 	vs.addUpdatedTxID(vdrID, subnetID, metadata.txID)
 	return nil
@@ -184,7 +197,7 @@ func (vs *validatorState) SetDelegateeReward(
 // DeleteValidatorMetadata removes in-memory references to the metadata of
 // `vdrID` on `subnetID`. The txID is recorded for deletion from disk on the
 // next [WriteValidatorMetadata]. Any staged updates from [SetUptime] or
-// [SetDelegateeReward] are dropped.
+// [SetStakingInfo] are dropped.
 func (vs *validatorState) DeleteValidatorMetadata(vdrID ids.NodeID, subnetID ids.ID) {
 	subnetMetadata := vs.metadata[vdrID]
 	md, exists := subnetMetadata[subnetID]

--- a/vms/platformvm/state/metadata_validator_test.go
+++ b/vms/platformvm/state/metadata_validator_test.go
@@ -119,57 +119,56 @@ func TestWriteValidatorMetadata(t *testing.T) {
 	require.True(subnetDB.Has(testUptimeReward.txID[:]))
 }
 
-func TestValidatorDelegateeRewards(t *testing.T) {
-	require := require.New(t)
+func TestValidatorStakingInfo(t *testing.T) {
 	state := newValidatorState()
 
-	// get non-existent delegatee reward
+	// get non-existent staking info
 	nodeID := ids.GenerateTestNodeID()
 	subnetID := ids.GenerateTestID()
-	_, err := state.GetDelegateeReward(subnetID, nodeID)
-	require.ErrorIs(err, database.ErrNotFound)
+	_, err := state.GetStakingInfo(subnetID, nodeID)
+	require.ErrorIs(t, err, database.ErrNotFound)
 
-	// set non-existent delegatee reward
-	err = state.SetDelegateeReward(subnetID, nodeID, 100000)
-	require.ErrorIs(err, database.ErrNotFound)
+	// set non-existent staking info
+	err = state.SetStakingInfo(subnetID, nodeID, StakingInfo{DelegateeReward: 100000})
+	require.ErrorIs(t, err, database.ErrNotFound)
 
 	testMetadata := &validatorMetadata{
 		PotentialDelegateeReward: 100000,
 	}
-	// load delegatee reward
+	// load staking info
 	state.LoadValidatorMetadata(nodeID, subnetID, testMetadata)
 
-	// get delegatee reward
-	delegateeReward, err := state.GetDelegateeReward(subnetID, nodeID)
-	require.NoError(err)
-	require.Equal(testMetadata.PotentialDelegateeReward, delegateeReward)
+	// get staking info
+	stakingInfo, err := state.GetStakingInfo(subnetID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, testMetadata.PotentialDelegateeReward, stakingInfo.DelegateeReward)
 
-	// set delegatee reward
-	newDelegateeReward := testMetadata.PotentialDelegateeReward + 100000
-	require.NoError(state.SetDelegateeReward(subnetID, nodeID, newDelegateeReward))
+	// set staking info
+	wantDelegateeReward := testMetadata.PotentialDelegateeReward + 100000
+	require.NoError(t, state.SetStakingInfo(subnetID, nodeID, StakingInfo{DelegateeReward: wantDelegateeReward}))
 
-	// get new delegatee reward
-	delegateeReward, err = state.GetDelegateeReward(subnetID, nodeID)
-	require.NoError(err)
-	require.Equal(newDelegateeReward, delegateeReward)
+	// get new staking info
+	stakingInfo, err = state.GetStakingInfo(subnetID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantDelegateeReward, stakingInfo.DelegateeReward)
 
-	// load delegatee reward changes
+	// load staking info changes
 	newTestMetadata := &validatorMetadata{
 		PotentialDelegateeReward: testMetadata.PotentialDelegateeReward + 100000,
 	}
 	state.LoadValidatorMetadata(nodeID, subnetID, newTestMetadata)
 
-	// get new delegatee reward
-	delegateeReward, err = state.GetDelegateeReward(subnetID, nodeID)
-	require.NoError(err)
-	require.Equal(newTestMetadata.PotentialDelegateeReward, delegateeReward)
+	// get new staking info
+	stakingInfo, err = state.GetStakingInfo(subnetID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, newTestMetadata.PotentialDelegateeReward, stakingInfo.DelegateeReward)
 
-	// delete delegatee reward
+	// delete staking info
 	state.DeleteValidatorMetadata(nodeID, subnetID)
 
-	// get deleted delegatee reward
+	// get deleted staking info
 	_, _, err = state.GetUptime(nodeID, subnetID)
-	require.ErrorIs(err, database.ErrNotFound)
+	require.ErrorIs(t, err, database.ErrNotFound)
 }
 
 func TestAddValidatorMetadataWrite(t *testing.T) {

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -280,21 +280,6 @@ func (mr *MockChainMockRecorder) GetCurrentValidator(subnetID, nodeID any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentValidator", reflect.TypeOf((*MockChain)(nil).GetCurrentValidator), subnetID, nodeID)
 }
 
-// GetDelegateeReward mocks base method.
-func (m *MockChain) GetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDelegateeReward", subnetID, nodeID)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDelegateeReward indicates an expected call of GetDelegateeReward.
-func (mr *MockChainMockRecorder) GetDelegateeReward(subnetID, nodeID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDelegateeReward", reflect.TypeOf((*MockChain)(nil).GetDelegateeReward), subnetID, nodeID)
-}
-
 // GetExpiryIterator mocks base method.
 func (m *MockChain) GetExpiryIterator() (iterator.Iterator[ExpiryEntry], error) {
 	m.ctrl.T.Helper()
@@ -396,6 +381,21 @@ func (m *MockChain) GetPendingValidator(subnetID ids.ID, nodeID ids.NodeID) (*St
 func (mr *MockChainMockRecorder) GetPendingValidator(subnetID, nodeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockChain)(nil).GetPendingValidator), subnetID, nodeID)
+}
+
+// GetStakingInfo mocks base method.
+func (m *MockChain) GetStakingInfo(subnetID ids.ID, nodeID ids.NodeID) (StakingInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStakingInfo", subnetID, nodeID)
+	ret0, _ := ret[0].(StakingInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStakingInfo indicates an expected call of GetStakingInfo.
+func (mr *MockChainMockRecorder) GetStakingInfo(subnetID, nodeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStakingInfo", reflect.TypeOf((*MockChain)(nil).GetStakingInfo), subnetID, nodeID)
 }
 
 // GetSubnetOwner mocks base method.
@@ -634,20 +634,6 @@ func (mr *MockChainMockRecorder) SetCurrentSupply(subnetID, cs any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentSupply", reflect.TypeOf((*MockChain)(nil).SetCurrentSupply), subnetID, cs)
 }
 
-// SetDelegateeReward mocks base method.
-func (m *MockChain) SetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID, amount uint64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDelegateeReward", subnetID, nodeID, amount)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetDelegateeReward indicates an expected call of SetDelegateeReward.
-func (mr *MockChainMockRecorder) SetDelegateeReward(subnetID, nodeID, amount any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDelegateeReward", reflect.TypeOf((*MockChain)(nil).SetDelegateeReward), subnetID, nodeID, amount)
-}
-
 // SetFeeState mocks base method.
 func (m *MockChain) SetFeeState(f gas.State) {
 	m.ctrl.T.Helper()
@@ -670,6 +656,20 @@ func (m *MockChain) SetL1ValidatorExcess(e gas.Gas) {
 func (mr *MockChainMockRecorder) SetL1ValidatorExcess(e any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetL1ValidatorExcess", reflect.TypeOf((*MockChain)(nil).SetL1ValidatorExcess), e)
+}
+
+// SetStakingInfo mocks base method.
+func (m *MockChain) SetStakingInfo(subnetID ids.ID, nodeID ids.NodeID, stakingInfo StakingInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetStakingInfo", subnetID, nodeID, stakingInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetStakingInfo indicates an expected call of SetStakingInfo.
+func (mr *MockChainMockRecorder) SetStakingInfo(subnetID, nodeID, stakingInfo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStakingInfo", reflect.TypeOf((*MockChain)(nil).SetStakingInfo), subnetID, nodeID, stakingInfo)
 }
 
 // SetSubnetOwner mocks base method.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -294,21 +294,6 @@ func (mr *MockDiffMockRecorder) GetCurrentValidator(subnetID, nodeID any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentValidator", reflect.TypeOf((*MockDiff)(nil).GetCurrentValidator), subnetID, nodeID)
 }
 
-// GetDelegateeReward mocks base method.
-func (m *MockDiff) GetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDelegateeReward", subnetID, nodeID)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDelegateeReward indicates an expected call of GetDelegateeReward.
-func (mr *MockDiffMockRecorder) GetDelegateeReward(subnetID, nodeID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDelegateeReward", reflect.TypeOf((*MockDiff)(nil).GetDelegateeReward), subnetID, nodeID)
-}
-
 // GetExpiryIterator mocks base method.
 func (m *MockDiff) GetExpiryIterator() (iterator.Iterator[ExpiryEntry], error) {
 	m.ctrl.T.Helper()
@@ -410,6 +395,21 @@ func (m *MockDiff) GetPendingValidator(subnetID ids.ID, nodeID ids.NodeID) (*Sta
 func (mr *MockDiffMockRecorder) GetPendingValidator(subnetID, nodeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockDiff)(nil).GetPendingValidator), subnetID, nodeID)
+}
+
+// GetStakingInfo mocks base method.
+func (m *MockDiff) GetStakingInfo(subnetID ids.ID, nodeID ids.NodeID) (StakingInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStakingInfo", subnetID, nodeID)
+	ret0, _ := ret[0].(StakingInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStakingInfo indicates an expected call of GetStakingInfo.
+func (mr *MockDiffMockRecorder) GetStakingInfo(subnetID, nodeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStakingInfo", reflect.TypeOf((*MockDiff)(nil).GetStakingInfo), subnetID, nodeID)
 }
 
 // GetSubnetOwner mocks base method.
@@ -648,20 +648,6 @@ func (mr *MockDiffMockRecorder) SetCurrentSupply(subnetID, cs any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentSupply", reflect.TypeOf((*MockDiff)(nil).SetCurrentSupply), subnetID, cs)
 }
 
-// SetDelegateeReward mocks base method.
-func (m *MockDiff) SetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID, amount uint64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDelegateeReward", subnetID, nodeID, amount)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetDelegateeReward indicates an expected call of SetDelegateeReward.
-func (mr *MockDiffMockRecorder) SetDelegateeReward(subnetID, nodeID, amount any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDelegateeReward", reflect.TypeOf((*MockDiff)(nil).SetDelegateeReward), subnetID, nodeID, amount)
-}
-
 // SetFeeState mocks base method.
 func (m *MockDiff) SetFeeState(f gas.State) {
 	m.ctrl.T.Helper()
@@ -684,6 +670,20 @@ func (m *MockDiff) SetL1ValidatorExcess(e gas.Gas) {
 func (mr *MockDiffMockRecorder) SetL1ValidatorExcess(e any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetL1ValidatorExcess", reflect.TypeOf((*MockDiff)(nil).SetL1ValidatorExcess), e)
+}
+
+// SetStakingInfo mocks base method.
+func (m *MockDiff) SetStakingInfo(subnetID ids.ID, nodeID ids.NodeID, stakingInfo StakingInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetStakingInfo", subnetID, nodeID, stakingInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetStakingInfo indicates an expected call of SetStakingInfo.
+func (mr *MockDiffMockRecorder) SetStakingInfo(subnetID, nodeID, stakingInfo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStakingInfo", reflect.TypeOf((*MockDiff)(nil).SetStakingInfo), subnetID, nodeID, stakingInfo)
 }
 
 // SetSubnetOwner mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -470,21 +470,6 @@ func (mr *MockStateMockRecorder) GetCurrentValidators(ctx, subnetID any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentValidators", reflect.TypeOf((*MockState)(nil).GetCurrentValidators), ctx, subnetID)
 }
 
-// GetDelegateeReward mocks base method.
-func (m *MockState) GetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDelegateeReward", subnetID, nodeID)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDelegateeReward indicates an expected call of GetDelegateeReward.
-func (mr *MockStateMockRecorder) GetDelegateeReward(subnetID, nodeID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDelegateeReward", reflect.TypeOf((*MockState)(nil).GetDelegateeReward), subnetID, nodeID)
-}
-
 // GetExpiryIterator mocks base method.
 func (m *MockState) GetExpiryIterator() (iterator.Iterator[ExpiryEntry], error) {
 	m.ctrl.T.Helper()
@@ -615,6 +600,21 @@ func (m *MockState) GetRewardUTXOs(txID ids.ID) ([]*avax.UTXO, error) {
 func (mr *MockStateMockRecorder) GetRewardUTXOs(txID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRewardUTXOs", reflect.TypeOf((*MockState)(nil).GetRewardUTXOs), txID)
+}
+
+// GetStakingInfo mocks base method.
+func (m *MockState) GetStakingInfo(subnetID ids.ID, nodeID ids.NodeID) (StakingInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStakingInfo", subnetID, nodeID)
+	ret0, _ := ret[0].(StakingInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStakingInfo indicates an expected call of GetStakingInfo.
+func (mr *MockStateMockRecorder) GetStakingInfo(subnetID, nodeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStakingInfo", reflect.TypeOf((*MockState)(nil).GetStakingInfo), subnetID, nodeID)
 }
 
 // GetStartTime mocks base method.
@@ -928,20 +928,6 @@ func (mr *MockStateMockRecorder) SetCurrentSupply(subnetID, cs any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentSupply", reflect.TypeOf((*MockState)(nil).SetCurrentSupply), subnetID, cs)
 }
 
-// SetDelegateeReward mocks base method.
-func (m *MockState) SetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID, amount uint64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDelegateeReward", subnetID, nodeID, amount)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetDelegateeReward indicates an expected call of SetDelegateeReward.
-func (mr *MockStateMockRecorder) SetDelegateeReward(subnetID, nodeID, amount any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDelegateeReward", reflect.TypeOf((*MockState)(nil).SetDelegateeReward), subnetID, nodeID, amount)
-}
-
 // SetFeeState mocks base method.
 func (m *MockState) SetFeeState(f gas.State) {
 	m.ctrl.T.Helper()
@@ -988,6 +974,20 @@ func (m *MockState) SetLastAccepted(blkID ids.ID) {
 func (mr *MockStateMockRecorder) SetLastAccepted(blkID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAccepted", reflect.TypeOf((*MockState)(nil).SetLastAccepted), blkID)
+}
+
+// SetStakingInfo mocks base method.
+func (m *MockState) SetStakingInfo(subnetID ids.ID, nodeID ids.NodeID, stakingInfo StakingInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetStakingInfo", subnetID, nodeID, stakingInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetStakingInfo indicates an expected call of SetStakingInfo.
+func (mr *MockStateMockRecorder) SetStakingInfo(subnetID, nodeID, stakingInfo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStakingInfo", reflect.TypeOf((*MockState)(nil).SetStakingInfo), subnetID, nodeID, stakingInfo)
 }
 
 // SetSubnetOwner mocks base method.

--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -39,13 +39,11 @@ type CurrentStakers interface {
 	// Invariant: [staker] is currently a CurrentValidator
 	DeleteCurrentValidator(staker *Staker)
 
-	// SetDelegateeReward sets the accrued delegation rewards for [nodeID] on
-	// [subnetID] to [amount].
-	SetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID, amount uint64) error
+	// SetStakingInfo updates the mutable staking info for [nodeID] on [subnetID].
+	SetStakingInfo(subnetID ids.ID, nodeID ids.NodeID, stakingInfo StakingInfo) error
 
-	// GetDelegateeReward returns the accrued delegation rewards for [nodeID] on
-	// [subnetID].
-	GetDelegateeReward(subnetID ids.ID, nodeID ids.NodeID) (uint64, error)
+	// GetStakingInfo returns the mutable staking info for [nodeID] on [subnetID].
+	GetStakingInfo(subnetID ids.ID, nodeID ids.NodeID) (StakingInfo, error)
 
 	// GetCurrentDelegatorIterator returns the delegators associated with the
 	// validator on [subnetID] with [nodeID]. Delegators are sorted by their

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -864,12 +864,12 @@ func New(
 	return s, nil
 }
 
-func (s *state) GetDelegateeReward(subnetID ids.ID, vdrID ids.NodeID) (uint64, error) {
-	return s.validatorState.GetDelegateeReward(subnetID, vdrID)
+func (s *state) GetStakingInfo(subnetID ids.ID, vdrID ids.NodeID) (StakingInfo, error) {
+	return s.validatorState.GetStakingInfo(subnetID, vdrID)
 }
 
-func (s *state) SetDelegateeReward(subnetID ids.ID, vdrID ids.NodeID, reward uint64) error {
-	return s.validatorState.SetDelegateeReward(subnetID, vdrID, reward)
+func (s *state) SetStakingInfo(subnetID ids.ID, vdrID ids.NodeID, stakingInfo StakingInfo) error {
+	return s.validatorState.SetStakingInfo(subnetID, vdrID, stakingInfo)
 }
 
 func (s *state) GetExpiryIterator() (iterator.Iterator[ExpiryEntry], error) {

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -2404,3 +2404,92 @@ func TestGetCurrentValidators(t *testing.T) {
 		})
 	}
 }
+
+func TestSetUptimeAndSetStakingInfoBothPersist(t *testing.T) {
+	db := memdb.New()
+	state := newTestState(t, db)
+
+	// Use the default validator from genesis
+	nodeID := defaultValidatorNodeID
+
+	// Get initial uptime values
+	initialUpDuration, initialLastUpdated, err := state.GetUptime(nodeID)
+	require.NoError(t, err)
+
+	// Get initial staking info
+	initialStakingInfo, err := state.GetStakingInfo(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+
+	// Update uptime first, then staking info
+	wantUpDuration := initialUpDuration + 2*time.Hour
+	wantLastUpdated := initialLastUpdated.Add(time.Hour)
+	require.NoError(t, state.SetUptime(nodeID, wantUpDuration, wantLastUpdated))
+
+	wantDelegateeReward := initialStakingInfo.DelegateeReward + 100000
+	require.NoError(t, state.SetStakingInfo(
+		constants.PrimaryNetworkID,
+		nodeID,
+		StakingInfo{DelegateeReward: wantDelegateeReward},
+	))
+
+	// Commit and verify both changes persisted
+	require.NoError(t, state.Commit())
+
+	// Verify immediately after commit
+	upDuration, lastUpdated, err := state.GetUptime(nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantUpDuration, upDuration)
+	require.Equal(t, wantLastUpdated, lastUpdated)
+
+	stakingInfo, err := state.GetStakingInfo(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantDelegateeReward, stakingInfo.DelegateeReward)
+
+	// Reload state from DB and verify persistence
+	state = newTestState(t, db)
+
+	upDuration, lastUpdated, err = state.GetUptime(nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantUpDuration, upDuration)
+	require.Equal(t, wantLastUpdated, lastUpdated)
+
+	stakingInfo, err = state.GetStakingInfo(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantDelegateeReward, stakingInfo.DelegateeReward)
+
+	// Now test reverse order: staking info first, then uptime
+	wantDelegateeReward2 := wantDelegateeReward + 200000
+	require.NoError(t, state.SetStakingInfo(
+		constants.PrimaryNetworkID,
+		nodeID,
+		StakingInfo{DelegateeReward: wantDelegateeReward2},
+	))
+
+	wantUpDuration2 := wantUpDuration + 3*time.Hour
+	wantLastUpdated2 := wantLastUpdated.Add(2 * time.Hour)
+	require.NoError(t, state.SetUptime(nodeID, wantUpDuration2, wantLastUpdated2))
+
+	// Commit and verify both changes persisted
+	require.NoError(t, state.Commit())
+
+	upDuration, lastUpdated, err = state.GetUptime(nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantUpDuration2, upDuration)
+	require.Equal(t, wantLastUpdated2, lastUpdated)
+
+	stakingInfo, err = state.GetStakingInfo(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantDelegateeReward2, stakingInfo.DelegateeReward)
+
+	// Reload state from DB and verify persistence
+	state = newTestState(t, db)
+
+	upDuration, lastUpdated, err = state.GetUptime(nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantUpDuration2, upDuration)
+	require.Equal(t, wantLastUpdated2, lastUpdated)
+
+	stakingInfo, err = state.GetStakingInfo(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantDelegateeReward2, stakingInfo.DelegateeReward)
+}

--- a/vms/platformvm/txs/executor/proposal_tx_executor.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor.go
@@ -468,13 +468,14 @@ func (e *proposalTxExecutor) rewardValidatorTx(uValidatorTx txs.ValidatorTx, val
 	}
 
 	// Provide the accrued delegatee rewards from successful delegations here.
-	delegateeReward, err := e.onCommitState.GetDelegateeReward(
+	stakingInfo, err := e.onCommitState.GetStakingInfo(
 		validator.SubnetID,
 		validator.NodeID,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to fetch accrued delegatee rewards: %w", err)
 	}
+	delegateeReward := stakingInfo.DelegateeReward
 
 	if delegateeReward == 0 {
 		return nil
@@ -599,25 +600,25 @@ func (e *proposalTxExecutor) rewardDelegatorTx(uDelegatorTx txs.DelegatorTx, del
 
 	// Reward the delegatee here
 	if e.backend.Config.UpgradeConfig.IsCortinaActivated(validator.StartTime) {
-		previousDelegateeReward, err := e.onCommitState.GetDelegateeReward(
+		stakingInfo, err := e.onCommitState.GetStakingInfo(
 			validator.SubnetID,
 			validator.NodeID,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to get delegatee reward: %w", err)
+			return fmt.Errorf("failed to get staking info: %w", err)
 		}
 
 		// Invariant: The rewards calculator can never return a
 		//            [potentialReward] that would overflow the
 		//            accumulated rewards.
-		newDelegateeReward := previousDelegateeReward + delegateeReward
+		stakingInfo.DelegateeReward += delegateeReward
 
 		// For any validators starting after [CortinaTime], we defer rewarding the
 		// [reward] until their staking period is over.
-		err = e.onCommitState.SetDelegateeReward(
+		err = e.onCommitState.SetStakingInfo(
 			validator.SubnetID,
 			validator.NodeID,
-			newDelegateeReward,
+			stakingInfo,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to update delegatee reward: %w", err)


### PR DESCRIPTION
## Why this should be merged
Replaces the existing `GetDelegateeReward/SetDelegateeReward` API with a generalized struct.

This prepares for ACP-236 which will introduce additional mutable validator fields that need to be modified during block execution.

## How this works
Introduces new struct containing `DelegateeReward` (with room for future fields)

By grouping mutable fields into a single struct, future additions require minimal API changes - just adding new fields to ValidatorMutables.

## How this was tested
New and existing unit tests

## Need to be documented in RELEASES.md?
No
