### PR TITLE
fix: skip TestConflictingImportTxsAcrossBlocks if using Firewood

### DIFF
--- a/graft/coreth/plugin/evm/atomic/vm/vm_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/chain"
+	"github.com/ava-labs/avalanchego/vms/evm/sync/customrawdb"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
 	avalancheatomic "github.com/ava-labs/avalanchego/chains/atomic"
@@ -263,6 +264,11 @@ func testIssueAtomicTxs(t *testing.T, scheme string) {
 }
 
 func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork, scheme string) {
+	// TODO: https://github.com/ava-labs/firewood/issues/1679
+	if scheme == customrawdb.FirewoodScheme {
+		t.Skip("firewood currently fails due to a stack corruption issue")
+	}
+
 	require := require.New(t)
 	importAmount := uint64(10000000)
 	vm := newAtomicTestVM()


### PR DESCRIPTION
## Why this should be merged

Similar to #5001, bumping the go version to 1.25 has resulted in this additional test flake: https://github.com/ava-labs/avalanchego/actions/runs/22294384926/job/64487963219?pr=4942#step:4:20738. This flake was observed with the test `TestConflictingImportTxsAcrossBlocks`.

## How this works

Skips `TestConflictingImportTxsAcrossBlocks` if using Firewood.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No