### PR TITLE
fix: remove build arguement

### DIFF
--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build subnet-evm plugin
         working-directory: ./graft/subnet-evm
-        run: ./scripts/run_task.sh build "${GITHUB_WORKSPACE}/build/subnet-evm"
+        run: ./scripts/run_task.sh build
 
       - name: Try to get tag from git
         if: "${{ github.event.inputs.tag == '' }}"


### PR DESCRIPTION
## Why this should be merged

This removes the faulty argument to build from the MacOS build, bringing it in line with the linux builds. See https://github.com/ava-labs/avalanchego/pull/4675#discussion_r2620406077

## How this was tested
Manual CI job for the mac build -- see [the build run](https://github.com/ava-labs/avalanchego/actions/runs/22459036032/job/65047997114)

## Need to be documented in RELEASES.md?
No 