### PR TITLE
test: blockchain test cleanup

### DIFF
--- a/graft/coreth/core/blockchain_ext_test.go
+++ b/graft/coreth/core/blockchain_ext_test.go
@@ -157,6 +157,7 @@ var reexecTests = []ReexecTest{
 // Additionally, create another BlockChain instance from its databases to ensure that BlockChain is
 // persisted correctly through a restart.
 // checkBlockChainState consumes `bc` and all database references, and it cannot be used afterwards.
+// Note: [BlockChain.Stop] is safe to be called multiple times.
 func checkBlockChainState(
 	t *testing.T,
 	bc *BlockChain,

--- a/graft/subnet-evm/core/blockchain_ext_test.go
+++ b/graft/subnet-evm/core/blockchain_ext_test.go
@@ -131,6 +131,7 @@ var reexecTests = []ReexecTest{
 // Additionally, create another BlockChain instance from its databases to ensure that BlockChain is
 // persisted correctly through a restart.
 // checkBlockChainState consumes `bc` and all database references, and it cannot be used afterwards.
+// Note: [BlockChain.Stop] is safe to be called multiple times.
 func checkBlockChainState(
 	t *testing.T,
 	bc *BlockChain,


### PR DESCRIPTION
## Why this should be merged

There were some weird situations with the databases in these tests. They were copied while their state isn't deterministic, which caused failures in #5022. The blockchain, after closed, shouldn't be used anymore. 

Although subtle database corruption like this should be tested, it should not be tested in our basic start/stop tests here., and added in #5022.

## How this works

This refactors the tests to consume the blockchain provided.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
