### PR TITLE
bug(initialization): Add lock around metric registration

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -287,42 +287,42 @@ type manager struct {
 func New(config *ManagerConfig) (Manager, error) {
 	avalancheGatherer := metrics.NewLabelGatherer(ChainLabel)
 	if err := config.Metrics.Register(avalancheNamespace, avalancheGatherer); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register metrics namespace %q: %w", avalancheNamespace, err)
 	}
 
 	handlerGatherer := metrics.NewLabelGatherer(ChainLabel)
 	if err := config.Metrics.Register(handlerNamespace, handlerGatherer); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register metrics namespace %q: %w", handlerNamespace, err)
 	}
 
 	meterChainVMGatherer := metrics.NewLabelGatherer(ChainLabel)
 	if err := config.Metrics.Register(meterchainvmNamespace, meterChainVMGatherer); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register metrics namespace %q: %w", meterchainvmNamespace, err)
 	}
 
 	meterDAGVMGatherer := metrics.NewLabelGatherer(ChainLabel)
 	if err := config.Metrics.Register(meterdagvmNamespace, meterDAGVMGatherer); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register metrics namespace %q: %w", meterdagvmNamespace, err)
 	}
 
 	proposervmGatherer := metrics.NewLabelGatherer(ChainLabel)
 	if err := config.Metrics.Register(proposervmNamespace, proposervmGatherer); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register metrics namespace %q: %w", proposervmNamespace, err)
 	}
 
 	p2pGatherer := metrics.NewLabelGatherer(ChainLabel)
 	if err := config.Metrics.Register(p2pNamespace, p2pGatherer); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register metrics namespace %q: %w", p2pNamespace, err)
 	}
 
 	snowmanGatherer := metrics.NewLabelGatherer(ChainLabel)
 	if err := config.Metrics.Register(snowmanNamespace, snowmanGatherer); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register metrics namespace %q: %w", snowmanNamespace, err)
 	}
 
 	stakeGatherer := metrics.NewLabelGatherer(ChainLabel)
 	if err := config.Metrics.Register(stakeNamespace, stakeGatherer); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register metrics namespace %q: %w", stakeNamespace, err)
 	}
 
 	return &manager{

--- a/node/metrics_helpers.go
+++ b/node/metrics_helpers.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package node
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func describeCollector(collector prometheus.Collector) string {
+	descs := make(chan *prometheus.Desc, 16)
+	go func() {
+		collector.Describe(descs)
+		close(descs)
+	}()
+
+	parts := make([]string, 0, 4)
+	for desc := range descs {
+		parts = append(parts, desc.String())
+	}
+	return strings.Join(parts, ", ")
+}

--- a/vms/rpcchainvm/metrics_helpers.go
+++ b/vms/rpcchainvm/metrics_helpers.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package rpcchainvm
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func describeCollector(collector prometheus.Collector) string {
+	descs := make(chan *prometheus.Desc, 16)
+	go func() {
+		collector.Describe(descs)
+		close(descs)
+	}()
+
+	parts := make([]string, 0, 4)
+	for desc := range descs {
+		parts = append(parts, desc.String())
+	}
+	return strings.Join(parts, ", ")
+}


### PR DESCRIPTION
## Why this should be merged

We occasionally see duplicate prometheus metric registration while processing an Ancestors sync message.
[Example](https://avalabs.grafana.net/a/grafana-lokiexplore-app/explore/pod/achilles-validator-val-ldb-scratch-us-east-2-mainnet-0/logs?patterns=%5B%5D&from=2026-02-25T00:15:01.280Z&to=2026-02-25T00:24:59.569Z&var-lineFormat=&var-ds=grafanacloud-logs&var-filters=pod%7C%3D%7Cachilles-validator-val-ldb-scratch-us-east-2-mainnet-0&var-fields=&var-levels=detected_level%7C%3D%7Cfatal&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&timezone=browser&var-all-fields=&userDisplayedFields=false&displayedFields=%5B%5D&urlColumns=%5B%5D&visualizationType=%22logs%22&prettifyLogMessage=false&sortOrder=%22Descending%22&wrapLogMessage=false)

There doesn't appear to be any lock around the getOrMakeVMGatherer, which might get called concurrently. This could cause a duplicate metrics registration fatal error.

## How this works

Adds a RWLock around the operation

## How this was tested

Unit tests only, it's not clear if we can reproduce this at will, but accessing a map without a lock around it is a potential source of this kind of bug.

## Need to be documented in RELEASES.md?

No
