### PR TITLE
fix: only ignore specific firewood directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ __debug_*
 
 # polyrepo
 polyrepo.log
-firewood
+/firewood/


### PR DESCRIPTION
## Why this should be merged

When trying to create a new file in `graft/evm/firewood`, I noticed that the file was being ignored. After further inspection, this occurs because `firewood` is specified in the `.gitignore`, and git is now ignoring all files directories named `firewood`.

## How this works

Changes `firewood` ignore rule to `/firewood/`, as we just need to ignore the top-level `firewood` directory when using the `polyrepo` tool

## How this was tested

- Created a file in `graft/evm/firewood` after this fix => the file is recognized.
- Created a directory named `firewood` => the directory is ignored.

## Need to be documented in RELEASES.md?

No