### PR TITLE
database/migrate: add per-chain database migration utility

### DIFF
--- a/database/migrate/per_chain.go
+++ b/database/migrate/per_chain.go
@@ -1,0 +1,291 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package migrate
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+
+	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+const (
+	// chainIDPrefixLen is the length of the chain ID prefix (32 bytes)
+	chainIDPrefixLen = 32
+
+	// migrateBatchFlushSize is the byte threshold at which a write batch is
+	// flushed to the target database during migration (~16 MB, matching
+	// LevelDB's default write-buffer size).
+	migrateBatchFlushSize = 16 * 1024 * 1024
+)
+
+// PerChainMigrator handles migration from monolithic database to per-chain databases.
+type PerChainMigrator struct {
+	sourceDB database.Database
+	log      logging.Logger
+
+	// chainDBs maps chain IDs to their target databases
+	chainDBs map[ids.ID]database.Database
+
+	// Statistics
+	keysProcessed int
+	keysCopied    int
+	keysSkipped   int
+}
+
+// NewPerChainMigrator creates a new migrator for per-chain database separation.
+func NewPerChainMigrator(sourceDB database.Database, log logging.Logger) *PerChainMigrator {
+	return &PerChainMigrator{
+		sourceDB: sourceDB,
+		log:      log,
+		chainDBs: make(map[ids.ID]database.Database),
+	}
+}
+
+// RegisterChainDB registers a target database for a specific chain.
+// Keys with this chain's prefix will be migrated to this database.
+// Note: P-chain uses ids.Empty as its chain ID, which is valid.
+func (m *PerChainMigrator) RegisterChainDB(chainID ids.ID, targetDB database.Database) error {
+	if targetDB == nil {
+		return fmt.Errorf("target database cannot be nil")
+	}
+
+	if _, exists := m.chainDBs[chainID]; exists {
+		return fmt.Errorf("database already registered for chain %s", chainID)
+	}
+
+	m.chainDBs[chainID] = targetDB
+	m.log.Info("registered target database for chain migration",
+		zap.Stringer("chainID", chainID),
+	)
+	return nil
+}
+
+// Migrate performs the migration from monolithic to per-chain databases.
+//
+// Process:
+//  1. Iterates through all keys in source database
+//  2. Extracts chain ID from first 32 bytes of key
+//  3. Copies key/value to appropriate chain database (stripping chain ID prefix)
+//  4. Returns statistics about the migration
+//
+// NOTE: This does NOT delete keys from source database (non-destructive migration).
+// The source database should be backed up and deleted manually after verification.
+func (m *PerChainMigrator) Migrate() error {
+	if len(m.chainDBs) == 0 {
+		return fmt.Errorf("no target databases registered")
+	}
+
+	// Reset statistics for this migration run
+	m.keysProcessed = 0
+	m.keysCopied = 0
+	m.keysSkipped = 0
+
+	m.log.Info("starting per-chain database migration",
+		zap.Int("targetChains", len(m.chainDBs)),
+	)
+
+	// One write batch per target chain DB for efficient bulk writes.
+	batches := make(map[ids.ID]database.Batch, len(m.chainDBs))
+	for chainID, db := range m.chainDBs {
+		batches[chainID] = db.NewBatch()
+	}
+	flushBatch := func(chainID ids.ID) error {
+		b := batches[chainID]
+		if err := b.Write(); err != nil {
+			return fmt.Errorf("failed to flush batch for chain %s: %w", chainID, err)
+		}
+		b.Reset()
+		return nil
+	}
+	// On error paths, flush any remaining (unflushed) batch data best-effort.
+	// The success path uses the explicit final flush loop below and sets this flag.
+	var allFlushed bool
+	defer func() {
+		if allFlushed {
+			return
+		}
+		for chainID := range batches {
+			_ = flushBatch(chainID)
+		}
+	}()
+
+	// Create iterator for entire source database
+	iterator := m.sourceDB.NewIterator()
+	defer iterator.Release()
+
+	for iterator.Next() {
+		m.keysProcessed++
+
+		// Log progress every 10000 keys
+		if m.keysProcessed%10000 == 0 {
+			m.log.Info("migration progress",
+				zap.Int("keysProcessed", m.keysProcessed),
+				zap.Int("keysCopied", m.keysCopied),
+				zap.Int("keysSkipped", m.keysSkipped),
+			)
+		}
+
+		// Check key length before copying — short keys are skipped immediately.
+		// iterator.Key() and iterator.Value() are only valid until the next Next() call.
+		rawKey := iterator.Key()
+		if len(rawKey) < chainIDPrefixLen {
+			m.keysSkipped++
+			m.log.Debug("skipping key without chain ID prefix",
+				zap.Int("keyLength", len(rawKey)),
+			)
+			continue
+		}
+
+		// Extract chain ID from first 32 bytes
+		chainID, err := ids.ToID(rawKey[:chainIDPrefixLen])
+		if err != nil {
+			m.keysSkipped++
+			m.log.Debug("skipping key with invalid chain ID prefix",
+				zap.Binary("prefix", rawKey[:chainIDPrefixLen]),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// Check if we have a target database for this chain
+		if _, exists := m.chainDBs[chainID]; !exists {
+			m.keysSkipped++
+			if m.keysSkipped%10000 == 0 {
+				m.log.Debug("skipping key for unregistered chain",
+					zap.Stringer("chainID", chainID),
+				)
+			}
+			continue
+		}
+
+		// Now that we know this key will be written, copy key and value.
+		keyWithoutPrefix := slices.Clone(rawKey[chainIDPrefixLen:])
+		value := slices.Clone(iterator.Value())
+
+		batch := batches[chainID]
+		if err := batch.Put(keyWithoutPrefix, value); err != nil {
+			return fmt.Errorf("failed to stage key for chain %s: %w", chainID, err)
+		}
+		m.keysCopied++
+
+		// Flush batch when it reaches the size threshold
+		if batch.Size() >= migrateBatchFlushSize {
+			if err := flushBatch(chainID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := iterator.Error(); err != nil {
+		return fmt.Errorf("iterator error during migration: %w", err)
+	}
+
+	// Flush all remaining batches
+	for chainID := range batches {
+		if err := flushBatch(chainID); err != nil {
+			return err
+		}
+	}
+	allFlushed = true
+
+	m.log.Info("per-chain database migration completed",
+		zap.Int("keysProcessed", m.keysProcessed),
+		zap.Int("keysCopied", m.keysCopied),
+		zap.Int("keysSkipped", m.keysSkipped),
+	)
+
+	return nil
+}
+
+// VerifyMigration checks that all migrated keys are present in target databases.
+//
+// This is a read-only verification step that should be run after Migrate()
+// to ensure data integrity before deleting the source database.
+func (m *PerChainMigrator) VerifyMigration() error {
+	m.log.Info("verifying per-chain database migration")
+
+	verified := 0
+	errCount := 0
+
+	iterator := m.sourceDB.NewIterator()
+	defer iterator.Release()
+
+	for iterator.Next() {
+		rawKey := iterator.Key()
+
+		// Skip keys without chain ID prefix
+		if len(rawKey) < chainIDPrefixLen {
+			continue
+		}
+
+		chainID, err := ids.ToID(rawKey[:chainIDPrefixLen])
+		if err != nil {
+			continue
+		}
+
+		targetDB, exists := m.chainDBs[chainID]
+		if !exists {
+			continue
+		}
+
+		// Copy key since we need it past the next iterator.Next() call.
+		// Value is only needed for comparison; copy only if Get succeeds.
+		keyWithoutPrefix := slices.Clone(rawKey[chainIDPrefixLen:])
+		targetValue, err := targetDB.Get(keyWithoutPrefix)
+		if err != nil {
+			m.log.Error("verification failed: key missing in target database",
+				zap.Stringer("chainID", chainID),
+				zap.Binary("key", keyWithoutPrefix[:min(32, len(keyWithoutPrefix))]),
+				zap.Error(err),
+			)
+			errCount++
+			continue
+		}
+
+		// Compare directly against the iterator's value buffer — no copy needed here.
+		if !bytes.Equal(iterator.Value(), targetValue) {
+			m.log.Error("verification failed: value mismatch",
+				zap.Stringer("chainID", chainID),
+				zap.Binary("key", keyWithoutPrefix[:min(32, len(keyWithoutPrefix))]),
+			)
+			errCount++
+			continue
+		}
+
+		verified++
+
+		if verified%10000 == 0 {
+			m.log.Info("verification progress",
+				zap.Int("verified", verified),
+				zap.Int("errors", errCount),
+			)
+		}
+	}
+
+	if err := iterator.Error(); err != nil {
+		return fmt.Errorf("iterator error during verification: %w", err)
+	}
+
+	m.log.Info("migration verification completed",
+		zap.Int("verified", verified),
+		zap.Int("errors", errCount),
+	)
+
+	if errCount > 0 {
+		return fmt.Errorf("verification failed with %d errors", errCount)
+	}
+
+	return nil
+}
+
+// GetStatistics returns migration statistics.
+func (m *PerChainMigrator) GetStatistics() (keysProcessed, keysCopied, keysSkipped int) {
+	return m.keysProcessed, m.keysCopied, m.keysSkipped
+}

--- a/database/migrate/per_chain_test.go
+++ b/database/migrate/per_chain_test.go
@@ -1,0 +1,361 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+func TestPerChainMigrator_BasicMigration(t *testing.T) {
+	require := require.New(t)
+
+	// Create source database with data for multiple chains
+	sourceDB := memdb.New()
+
+	// Create test chain IDs
+	chainID1 := ids.GenerateTestID()
+	chainID2 := ids.GenerateTestID()
+
+	// Add keys with chain ID prefixes
+	key1 := append(chainID1[:], []byte("key1")...)
+	key2 := append(chainID1[:], []byte("key2")...)
+	key3 := append(chainID2[:], []byte("key3")...)
+
+	require.NoError(sourceDB.Put(key1, []byte("value1")))
+	require.NoError(sourceDB.Put(key2, []byte("value2")))
+	require.NoError(sourceDB.Put(key3, []byte("value3")))
+
+	// Create target databases
+	targetDB1 := memdb.New()
+	targetDB2 := memdb.New()
+
+	// Create migrator
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID1, targetDB1))
+	require.NoError(migrator.RegisterChainDB(chainID2, targetDB2))
+
+	// Perform migration
+	require.NoError(migrator.Migrate())
+
+	// Verify keys were copied without chain ID prefix
+	val1, err := targetDB1.Get([]byte("key1"))
+	require.NoError(err)
+	require.Equal([]byte("value1"), val1)
+
+	val2, err := targetDB1.Get([]byte("key2"))
+	require.NoError(err)
+	require.Equal([]byte("value2"), val2)
+
+	val3, err := targetDB2.Get([]byte("key3"))
+	require.NoError(err)
+	require.Equal([]byte("value3"), val3)
+
+	// Verify statistics
+	keysProcessed, keysCopied, keysSkipped := migrator.GetStatistics()
+	require.Equal(3, keysProcessed)
+	require.Equal(3, keysCopied)
+	require.Equal(0, keysSkipped)
+}
+
+func TestPerChainMigrator_SkipsUnregisteredChains(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+
+	chainID1 := ids.GenerateTestID()
+	chainID2 := ids.GenerateTestID()
+
+	// Add keys for two chains, but only register one
+	key1 := append(chainID1[:], []byte("key1")...)
+	key2 := append(chainID2[:], []byte("key2")...)
+
+	require.NoError(sourceDB.Put(key1, []byte("value1")))
+	require.NoError(sourceDB.Put(key2, []byte("value2")))
+
+	targetDB1 := memdb.New()
+
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID1, targetDB1))
+
+	require.NoError(migrator.Migrate())
+
+	// Verify only chain1 keys were copied
+	val1, err := targetDB1.Get([]byte("key1"))
+	require.NoError(err)
+	require.Equal([]byte("value1"), val1)
+
+	// Verify statistics
+	keysProcessed, keysCopied, keysSkipped := migrator.GetStatistics()
+	require.Equal(2, keysProcessed)
+	require.Equal(1, keysCopied)
+	require.Equal(1, keysSkipped)
+}
+
+func TestPerChainMigrator_SkipsShortKeys(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+	chainID := ids.GenerateTestID()
+
+	// Add a key that's too short to have a chain ID prefix
+	shortKey := []byte("short")
+	require.NoError(sourceDB.Put(shortKey, []byte("value")))
+
+	// Add a valid key
+	validKey := append(chainID[:], []byte("key")...)
+	require.NoError(sourceDB.Put(validKey, []byte("validvalue")))
+
+	targetDB := memdb.New()
+
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID, targetDB))
+
+	require.NoError(migrator.Migrate())
+
+	// Verify valid key was copied
+	val, err := targetDB.Get([]byte("key"))
+	require.NoError(err)
+	require.Equal([]byte("validvalue"), val)
+
+	// Verify statistics
+	keysProcessed, keysCopied, keysSkipped := migrator.GetStatistics()
+	require.Equal(2, keysProcessed)
+	require.Equal(1, keysCopied)
+	require.Equal(1, keysSkipped)
+}
+
+func TestPerChainMigrator_Verification(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+	chainID := ids.GenerateTestID()
+
+	// Add test data
+	key := append(chainID[:], []byte("key")...)
+	require.NoError(sourceDB.Put(key, []byte("value")))
+
+	targetDB := memdb.New()
+
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID, targetDB))
+
+	require.NoError(migrator.Migrate())
+
+	// Verification should pass
+	require.NoError(migrator.VerifyMigration())
+}
+
+func TestPerChainMigrator_VerificationDetectsMissingKey(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+	chainID := ids.GenerateTestID()
+
+	// Add test data
+	key := append(chainID[:], []byte("key")...)
+	require.NoError(sourceDB.Put(key, []byte("value")))
+
+	targetDB := memdb.New()
+
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID, targetDB))
+
+	// Migrate
+	require.NoError(migrator.Migrate())
+
+	// Delete key from target to simulate incomplete migration
+	require.NoError(targetDB.Delete([]byte("key")))
+
+	// Verification should fail
+	err := migrator.VerifyMigration()
+	require.Error(err)
+	require.Contains(err.Error(), "verification failed")
+}
+
+func TestPerChainMigrator_VerificationDetectsValueMismatch(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+	chainID := ids.GenerateTestID()
+
+	// Add test data
+	key := append(chainID[:], []byte("key")...)
+	require.NoError(sourceDB.Put(key, []byte("value")))
+
+	targetDB := memdb.New()
+
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID, targetDB))
+
+	// Migrate
+	require.NoError(migrator.Migrate())
+
+	// Modify value in target to simulate corruption
+	require.NoError(targetDB.Put([]byte("key"), []byte("wrong_value")))
+
+	// Verification should fail
+	err := migrator.VerifyMigration()
+	require.Error(err)
+	require.Contains(err.Error(), "verification failed")
+}
+
+func TestPerChainMigrator_RegisterChainDB_Errors(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+
+	// Error on nil database
+	chainID := ids.GenerateTestID()
+	err := migrator.RegisterChainDB(chainID, nil)
+	require.Error(err)
+	require.Contains(err.Error(), "cannot be nil")
+
+	// Error on duplicate registration
+	db := memdb.New()
+	require.NoError(migrator.RegisterChainDB(chainID, db))
+	err = migrator.RegisterChainDB(chainID, db)
+	require.Error(err)
+	require.Contains(err.Error(), "already registered")
+}
+
+func TestPerChainMigrator_Migrate_NoTargetDatabases(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+
+	// Error when no target databases registered
+	err := migrator.Migrate()
+	require.Error(err)
+	require.Contains(err.Error(), "no target databases")
+}
+
+func TestPerChainMigrator_LargeDataset(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+	chainID := ids.GenerateTestID()
+
+	// Add many keys
+	numKeys := 1000
+	for i := 0; i < numKeys; i++ {
+		key := append(chainID[:], []byte{byte(i / 256), byte(i % 256)}...)
+		value := []byte{byte(i), byte(i >> 8)}
+		require.NoError(sourceDB.Put(key, value))
+	}
+
+	targetDB := memdb.New()
+
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID, targetDB))
+
+	require.NoError(migrator.Migrate())
+
+	// Verify all keys were copied
+	keysProcessed, keysCopied, _ := migrator.GetStatistics()
+	require.Equal(numKeys, keysProcessed)
+	require.Equal(numKeys, keysCopied)
+
+	// Spot check some values
+	for i := 0; i < numKeys; i += 100 {
+		key := []byte{byte(i / 256), byte(i % 256)}
+		val, err := targetDB.Get(key)
+		require.NoError(err)
+		require.Equal([]byte{byte(i), byte(i >> 8)}, val)
+	}
+
+	// Verify migration
+	require.NoError(migrator.VerifyMigration())
+}
+
+func TestPerChainMigrator_EmptySourceDatabase(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+	chainID := ids.GenerateTestID()
+	targetDB := memdb.New()
+
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID, targetDB))
+
+	// Should succeed with empty database
+	require.NoError(migrator.Migrate())
+
+	keysProcessed, keysCopied, keysSkipped := migrator.GetStatistics()
+	require.Equal(0, keysProcessed)
+	require.Equal(0, keysCopied)
+	require.Equal(0, keysSkipped)
+}
+
+func TestPerChainMigrator_MultipleChains(t *testing.T) {
+	require := require.New(t)
+
+	sourceDB := memdb.New()
+
+	// Create 3 chains with different amounts of data
+	chainID1 := ids.GenerateTestID()
+	chainID2 := ids.GenerateTestID()
+	chainID3 := ids.GenerateTestID()
+
+	// Chain 1: 100 keys
+	for i := 0; i < 100; i++ {
+		key := append(chainID1[:], []byte{byte(i)}...)
+		require.NoError(sourceDB.Put(key, []byte{byte(i)}))
+	}
+
+	// Chain 2: 200 keys
+	for i := 0; i < 200; i++ {
+		key := append(chainID2[:], []byte{byte(i / 256), byte(i % 256)}...)
+		require.NoError(sourceDB.Put(key, []byte{byte(i)}))
+	}
+
+	// Chain 3: 50 keys
+	for i := 0; i < 50; i++ {
+		key := append(chainID3[:], []byte{byte(i)}...)
+		require.NoError(sourceDB.Put(key, []byte{byte(i)}))
+	}
+
+	// Create target databases
+	targetDB1 := memdb.New()
+	targetDB2 := memdb.New()
+	targetDB3 := memdb.New()
+
+	migrator := NewPerChainMigrator(sourceDB, logging.NoLog{})
+	require.NoError(migrator.RegisterChainDB(chainID1, targetDB1))
+	require.NoError(migrator.RegisterChainDB(chainID2, targetDB2))
+	require.NoError(migrator.RegisterChainDB(chainID3, targetDB3))
+
+	require.NoError(migrator.Migrate())
+
+	// Verify statistics
+	keysProcessed, keysCopied, keysSkipped := migrator.GetStatistics()
+	require.Equal(350, keysProcessed)
+	require.Equal(350, keysCopied)
+	require.Equal(0, keysSkipped)
+
+	// Verify each database has correct number of keys
+	count1, err := database.Count(targetDB1)
+	require.NoError(err)
+	require.Equal(100, count1)
+
+	count2, err := database.Count(targetDB2)
+	require.NoError(err)
+	require.Equal(200, count2)
+
+	count3, err := database.Count(targetDB3)
+	require.NoError(err)
+	require.Equal(50, count3)
+
+	// Verify migration
+	require.NoError(migrator.VerifyMigration())
+}
+


### PR DESCRIPTION
## Summary

Adds `database/migrate.PerChainMigrator` — a utility for copying entries from a monolithic source database into separate per-chain target databases. Useful for splitting a combined database across chains (e.g. when adopting per-chain storage backends).

## Design

**Key extraction:** The first 32 bytes of each key are treated as the chain ID prefix. Matching entries are written to the registered target database with the prefix stripped.

**Batched writes:** Accumulates up to 16MB of writes per target chain before flushing. This matches LevelDB's default write-buffer size and reduces I/O pressure significantly compared to one `Put()` per key.

```
Before: Put() × N   → N individual write amplifications
After:  Batch(16MB) → ~1 flush per 16MB of data per chain
```

**Non-destructive:** The source database is never modified. The caller is expected to verify and then delete the source after migration.

**Safe byte handling:** Uses `slices.Clone()` for all key/value copies — iterator-owned byte slices are only valid until the next `Next()` call.

## API

```go
m := migrate.NewPerChainMigrator(sourceDB, log)
m.RegisterChainDB(chainID, targetDB)
err := m.Migrate()           // copy all matching keys
err  = m.VerifyMigration()   // read-only integrity check
keys, copied, skipped := m.GetStatistics()
```

## Tests

```
ok  github.com/ava-labs/avalanchego/database/migrate  1.019s
```

All tests pass with `-race`. Covers: basic migration, multi-chain routing, batch flush threshold, prefix stripping, short-key skipping, empty source, and verification pass/fail.

## Files

- `database/migrate/per_chain.go` — new, 291 lines
- `database/migrate/per_chain_test.go` — new, 361 lines