### PR TITLE
snow/engine/snowman/bootstrap: fix spurious %w verb in zap log call

### DIFF
--- a/snow/engine/snowman/bootstrap/bootstrapper.go
+++ b/snow/engine/snowman/bootstrap/bootstrapper.go
@@ -155,7 +155,7 @@ func New(config Config, onFinished func(ctx context.Context, lastReqID uint32) e
 		defer config.Ctx.Lock.Unlock()
 
 		if err := bs.Timeout(); err != nil {
-			bs.Config.Ctx.Log.Warn("Encountered error during bootstrapping: %w", zap.Error(err))
+			bs.Config.Ctx.Log.Warn("Encountered error during bootstrapping", zap.Error(err))
 		}
 	}
 	bs.TimeoutRegistrar = common.NewTimeoutScheduler(timeout, config.BootstrapTracker.AllBootstrapped())


### PR DESCRIPTION
## Summary

In `bootstrapper.go`, the `Warn` call passes `%w` as a format string to zap, but zap's `Warn` does not support `fmt`-style format verbs — errors are attached via `zap.Error(err)`. The `%w` is emitted literally in the log output (as the string `"%!w(<nil>)"` or similar), which is noise.

**Before:**
```go
bs.Config.Ctx.Log.Warn("Encountered error during bootstrapping: %w", zap.Error(err))
```

**After:**
```go
bs.Config.Ctx.Log.Warn("Encountered error during bootstrapping", zap.Error(err))
```

## Test plan

- [ ] `go build ./snow/engine/snowman/bootstrap/...` passes
- [ ] `go vet ./snow/engine/snowman/bootstrap/...` passes
- [ ] Log output no longer contains literal `%w` in the warning message