### PR TITLE
database/firewood: add Firewood as a general-purpose KV database backend

### DIFF
--- a/database/factory/factory.go
+++ b/database/factory/factory.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/corruptabledb"
+	"github.com/ava-labs/avalanchego/database/firewood"
 	"github.com/ava-labs/avalanchego/database/leveldb"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/pebbledb"
@@ -21,10 +22,10 @@ import (
 //
 // It also wraps the database with a corruptable DB.
 //
-// dbName is the name of the database, either leveldb, memdb, or pebbledb.
-// dbPath is the path to the database folder.
+// name is the database type: leveldb, memdb, pebbledb, or firewood.
+// path is the path to the database folder.
 // readOnly indicates if the database should be read-only.
-// dbConfig is the database configuration in JSON format.
+// config is the database configuration in JSON format.
 func New(
 	name string,
 	path string,
@@ -44,12 +45,15 @@ func New(
 		db = memdb.New()
 	case pebbledb.Name:
 		db, err = pebbledb.New(path, config, logger, reg)
+	case firewood.Name:
+		db, err = firewood.New(path, config, logger)
 	default:
 		err = fmt.Errorf(
-			"db-type must be one of {%s, %s, %s}",
+			"db-type must be one of {%s, %s, %s, %s}",
 			leveldb.Name,
 			memdb.Name,
 			pebbledb.Name,
+			firewood.Name,
 		)
 	}
 	if err != nil {

--- a/database/firewood/compliance_test.go
+++ b/database/firewood/compliance_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+//go:build !windows
+// +build !windows
+
+package firewood
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/dbtest"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+func newTestDB(t *testing.T) database.Database {
+	tmpDir, err := os.MkdirTemp("", "firewood-compliance-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+// Database compliance tests
+func TestSimpleKeyValue(t *testing.T) {
+	dbtest.TestSimpleKeyValue(t, newTestDB(t))
+}
+
+func TestOverwriteKeyValue(t *testing.T) {
+	dbtest.TestOverwriteKeyValue(t, newTestDB(t))
+}
+
+func TestKeyEmptyValue(t *testing.T) {
+	dbtest.TestKeyEmptyValue(t, newTestDB(t))
+}
+
+func TestEmptyKey(t *testing.T) {
+	dbtest.TestEmptyKey(t, newTestDB(t))
+}
+
+func TestSimpleKeyValueClosed(t *testing.T) {
+	dbtest.TestSimpleKeyValueClosed(t, newTestDB(t))
+}
+
+func TestMemorySafetyDatabase(t *testing.T) {
+	dbtest.TestMemorySafetyDatabase(t, newTestDB(t))
+}
+
+func TestNewBatchClosed(t *testing.T) {
+	dbtest.TestNewBatchClosed(t, newTestDB(t))
+}
+
+func TestBatchPut(t *testing.T) {
+	dbtest.TestBatchPut(t, newTestDB(t))
+}
+
+func TestBatchDelete(t *testing.T) {
+	dbtest.TestBatchDelete(t, newTestDB(t))
+}
+
+func TestMemorySafetyBatch(t *testing.T) {
+	dbtest.TestMemorySafetyBatch(t, newTestDB(t))
+}

--- a/database/firewood/config.go
+++ b/database/firewood/config.go
@@ -1,0 +1,97 @@
+//go:build cgo && !windows
+// +build cgo,!windows
+
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+)
+
+const (
+	// DefaultCacheSizeBytes is the default size for Firewood's cache
+	// Merkle trie databases benefit from caching frequently accessed nodes
+	DefaultCacheSizeBytes = 512 * 1024 * 1024 // 512 MB
+
+	// DefaultFreeListCacheEntries is the default number of free list entries to cache
+	// Firewood uses a free list for memory management
+	DefaultFreeListCacheEntries = 1024
+
+	// DefaultRevisionsInMemory is the default number of historical revisions to keep
+	// Firewood supports versioned storage - this controls memory vs disk trade-off
+	DefaultRevisionsInMemory = 10
+
+	// DefaultReadCacheSize is the default number of key-value pairs to cache in the
+	// Go-level read cache. This cache sits in front of the FFI layer and serves hot
+	// reads (e.g. repeated Get/ParallelGet of the same committed keys) without any
+	// trie traversal or CGO overhead. The cache is cleared on every flush/commit so
+	// it never returns stale data for writes that have been applied to the trie.
+	DefaultReadCacheSize = 4096
+)
+
+// Config defines configuration options for Firewood database
+//
+// Firewood is a merkle trie database optimized for blockchain state storage.
+// It provides:
+// - Built-in merkle proof generation
+// - Versioned storage (historical state queries)
+// - Efficient trie pruning
+// - Memory-mapped I/O for performance
+type Config struct {
+	// CacheSizeBytes controls the size of the in-memory node cache
+	// Larger values improve read performance but increase memory usage
+	// Recommended: 512 MB - 2 GB depending on available RAM
+	CacheSizeBytes uint `json:"cacheSizeBytes"`
+
+	// FreeListCacheEntries controls free list caching for allocation efficiency
+	// Higher values reduce allocation overhead at cost of memory
+	// Recommended: 1024 - 4096
+	FreeListCacheEntries uint `json:"freeListCacheEntries"`
+
+	// RevisionsInMemory controls how many historical revisions to keep in memory
+	// Higher values allow faster historical queries but increase memory usage
+	// Set to 0 to disable historical queries (lowest memory usage)
+	// Recommended: 10 for most use cases, 0 for constrained systems
+	RevisionsInMemory uint `json:"revisionsInMemory"`
+
+	// CacheStrategy determines eviction policy for the node cache
+	// Uses FFI CacheStrategy type from firewood-go-ethhash
+	CacheStrategy ffi.CacheStrategy `json:"cacheStrategy"`
+
+	// FlushSize controls auto-flush threshold for pending writes
+	// When pending operations reach this count, they are automatically committed
+	// Higher values = better batch efficiency but more memory
+	// Lower values = lower memory but more frequent commits
+	// Recommended: 1000 for most use cases
+	FlushSize int `json:"flushSize"`
+
+	// ReadCacheSize controls the maximum number of entries in the Go-level read cache.
+	// The cache stores recently-read committed key-value pairs in Go memory, bypassing
+	// the FFI trie traversal for hot keys. It is cleared on every flush/batch-commit, so
+	// pending writes always take priority via the pending-batch fast path in Get().
+	// Set to 0 to disable the read cache.
+	// Recommended: 4096 (covers typical blockchain hot-set with negligible memory)
+	ReadCacheSize int `json:"readCacheSize"`
+
+	// RootStore enables persisting historical revisions to disk.
+	// Without this, revisions only exist in memory and are lost on restart.
+	// CRITICAL: Must be true for data to survive process restarts.
+	// When enabled, Firewood uses a root_store/ subdirectory to persist
+	// revision history, allowing the database to recover its state on restart.
+	RootStore bool `json:"rootStore"`
+}
+
+// DefaultConfig returns the default Firewood configuration
+func DefaultConfig() Config {
+	return Config{
+		CacheSizeBytes:       DefaultCacheSizeBytes,
+		FreeListCacheEntries: DefaultFreeListCacheEntries,
+		RevisionsInMemory:    DefaultRevisionsInMemory,
+		CacheStrategy:        ffi.CacheAllReads,
+		FlushSize:            DefaultFlushSize,
+		RootStore:            false, // Historical revisions not persisted; saves disk space
+		ReadCacheSize:        DefaultReadCacheSize,
+	}
+}

--- a/database/firewood/db.go
+++ b/database/firewood/db.go
@@ -1,0 +1,839 @@
+//go:build cgo && !windows
+// +build cgo,!windows
+
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"go.uber.org/zap"
+)
+
+const (
+	// Name is the name of this database for database switches
+	Name = "firewood"
+
+	// DefaultFlushSize is the default number of operations before auto-flush
+	DefaultFlushSize = 1000
+)
+
+// Database implements the database.Database interface using Firewood.
+//
+// Architecture: Batch-based adapter with auto-flush
+// - Firewood uses proposal/commit pattern (batch operations)
+// - database.Database expects immediate Put/Get operations
+// - Adapter accumulates writes in pending batch
+// - Auto-flushes when batch reaches threshold (default: 1000 ops)
+// - ALSO flushes on periodic timer (default: 5 seconds) to prevent data loss on crash
+// - Provides read-your-writes consistency by checking pending batch first
+//
+// Root Hash Tracking:
+// - Firewood's Get() uses fwd_get_latest which requires an in-memory revision.
+// - After restart, no revision exists in memory, so Get() returns nil for ALL keys.
+// - Fix: We track the current root hash and use Revision(root).Get(key) which reads
+//   directly from the persisted trie, bypassing the latest-revision system.
+// - currentRoot is updated after every Propose+Commit under pendingMu lock.
+//
+type Database struct {
+	fw          *ffi.Database
+	log         logging.Logger
+	dbPath      string // Path to this database (for debug logging)
+	closed      atomic.Bool
+	currentRoot ffi.Hash // Current trie root hash for GetFromRoot reads (protected by pendingMu)
+
+	// readCacheGen is incremented on every flush/commit so that an in-flight Get()
+	// that already snapshotted a (possibly stale) root can detect the flush and skip
+	// caching its result, preventing a stale entry from entering the read cache.
+	readCacheGen atomic.Uint64
+
+	// Pending batch tracking for auto-flush
+	// pendingMu is an RWMutex: reads (Get/Has/NewIterator) use RLock; writes (Put/Delete/flush) use Lock.
+	pendingMu    sync.RWMutex
+	pending      *pendingBatch // Accumulates writes until flush
+	flushSize    int           // Auto-flush threshold
+	flushOnClose bool          // Whether to flush pending writes on close
+
+	// Periodic flush to prevent data loss on crash
+	flushTicker *time.Ticker
+	flushDone   chan struct{}
+
+	// Go-level read cache: stores recently-read committed key-value pairs in Go
+	// memory to avoid repeated FFI trie traversals for hot keys.
+	// Access is protected by readCacheMu.  The cache is cleared on every
+	// flush/batch-commit (readCacheGen is bumped at the same time).
+	// Pending-batch entries always take priority in Get/Has, so the cache can
+	// never hide an uncommitted write.
+	readCacheMu  sync.RWMutex
+	readCache    map[string][]byte
+	readCacheMax int // 0 = cache disabled
+}
+
+// pendingBatch tracks writes that haven't been committed to Firewood yet
+type pendingBatch struct {
+	ops map[string]*pendingOp // key -> operation (using string key for map)
+}
+
+type pendingOp struct {
+	key    []byte
+	value  []byte // nil for delete
+	delete bool
+}
+
+func newPendingBatch() *pendingBatch {
+	return &pendingBatch{
+		ops: make(map[string]*pendingOp),
+	}
+}
+
+// New creates a new Firewood database instance.
+//
+// Parameters:
+//   - file: Path to database directory
+//   - configBytes: JSON-encoded Config (see config.go)
+//   - log: Logger instance
+//
+// Returns database.Database implementation or error if initialization fails.
+func New(file string, configBytes []byte, log logging.Logger) (database.Database, error) {
+	// Start with defaults, then overlay config from JSON.
+	// This ensures critical fields like RootStore default to true
+	// even if the config file doesn't mention them.
+	cfg := DefaultConfig()
+	if len(configBytes) > 0 {
+		// The configBytes contains the full db-config.json structure like:
+		// {"leveldb": {...}, "firewood": {...}, "pruning": {...}}
+		// We need to extract just the "firewood" section
+		var fullConfig map[string]json.RawMessage
+		if err := json.Unmarshal(configBytes, &fullConfig); err != nil {
+			return nil, fmt.Errorf("failed to parse database config: %w", err)
+		}
+
+		// Extract the "firewood" section if it exists and overlay onto defaults
+		if firewoodSection, exists := fullConfig["firewood"]; exists {
+			if err := json.Unmarshal(firewoodSection, &cfg); err != nil {
+				return nil, fmt.Errorf("failed to parse firewood config section: %w", err)
+			}
+		}
+	}
+
+	// Build FFI options from config
+	options := []ffi.Option{
+		ffi.WithNodeCacheSizeInBytes(cfg.CacheSizeBytes),
+		ffi.WithFreeListCacheEntries(cfg.FreeListCacheEntries),
+		ffi.WithRevisions(cfg.RevisionsInMemory),
+		ffi.WithReadCacheStrategy(cfg.CacheStrategy),
+	}
+
+	// Enable root store for historical revision access.
+	// Without this, old revisions are freed via the freelist and space is reused.
+	// The latest state is always persisted regardless of this setting.
+	if cfg.RootStore {
+		options = append(options, ffi.WithRootStore())
+	}
+
+	// Open Firewood database. The firewood-go-ethhash/ffi package is compiled with
+	// EthereumNodeHashing; this is the only supported algorithm in this build.
+	fw, err := ffi.New(file, ffi.EthereumNodeHashing, options...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open firewood database: %w", err)
+	}
+
+	// Snapshot current root hash for read operations.
+	// After restart, no in-memory revision exists, so we track the persisted root
+	// and use Revision(root).Get(key) to read directly from the committed trie.
+	initialRoot := fw.Root()
+	if err != nil {
+		fw.Close(context.Background())
+		return nil, fmt.Errorf("failed to get initial root hash: %w", err)
+	}
+
+	if initialRoot != ffi.EmptyRoot {
+		log.Info("Firewood database opened with existing data",
+			zap.Bool("rootStore", cfg.RootStore),
+			zap.Uint("revisionsInMemory", cfg.RevisionsInMemory),
+			zap.Uint("cacheSizeBytes", cfg.CacheSizeBytes),
+			zap.String("rootHash", fmt.Sprintf("%x", initialRoot[:8])),
+		)
+	} else {
+		log.Info("Firewood database opened (empty/new instance)",
+			zap.Bool("rootStore", cfg.RootStore),
+			zap.Uint("revisionsInMemory", cfg.RevisionsInMemory),
+			zap.Uint("cacheSizeBytes", cfg.CacheSizeBytes),
+		)
+	}
+
+	flushSize := cfg.FlushSize
+	if flushSize == 0 {
+		flushSize = DefaultFlushSize
+	}
+
+	readCacheMax := cfg.ReadCacheSize
+	if readCacheMax < 0 {
+		readCacheMax = 0
+	}
+
+	db := &Database{
+		fw:           fw,
+		log:          log,
+		dbPath:       file,
+		closed:       atomic.Bool{},
+		currentRoot:  initialRoot,
+		pending:      newPendingBatch(),
+		flushSize:    flushSize,
+		flushOnClose: true,
+		flushTicker:  time.NewTicker(5 * time.Second), // Flush every 5 seconds
+		flushDone:    make(chan struct{}),
+		readCacheMax: readCacheMax,
+		readCache:    make(map[string][]byte, readCacheMax),
+	}
+
+	// Start periodic flush goroutine to prevent data loss on crash
+	go db.periodicFlush()
+
+	return db, nil
+}
+
+// flushLocked commits pending writes to Firewood.
+// Caller must hold pendingMu lock.
+func (db *Database) flushLocked() error {
+	if len(db.pending.ops) == 0 {
+		return nil
+	}
+
+	// Build BatchOp slice for proposal
+	batch := make([]ffi.BatchOp, 0, len(db.pending.ops))
+	for _, op := range db.pending.ops {
+		if op.delete {
+			batch = append(batch, ffi.Delete(op.key))
+		} else {
+			batch = append(batch, ffi.Put(op.key, op.value))
+		}
+	}
+
+	// Create and commit proposal
+	proposal, err := db.fw.Propose(batch)
+	if err != nil {
+		return fmt.Errorf("firewood propose failed: %w", err)
+	}
+	if err := proposal.Commit(); err != nil {
+		return fmt.Errorf("firewood commit failed: %w", err)
+	}
+
+	// Snapshot root after commit so subsequent reads see the new data.
+	db.currentRoot = db.fw.Root()
+
+	// Write-back verification: spot-check that committed data is readable.
+	// Catches FFI bugs where Propose+Commit succeeds but data is silently lost.
+	verifyCount := 0
+	for _, op := range db.pending.ops {
+		if verifyCount >= 3 {
+			break
+		}
+		if op.delete {
+			continue
+		}
+		readBack, err := db.getFromRoot(db.currentRoot, op.key)
+		if err != nil || readBack == nil {
+			db.log.Error("WRITE-BACK VERIFICATION FAILED: committed key not readable",
+				zap.Int("keyLen", len(op.key)),
+				zap.Error(err),
+			)
+			// Retry once
+			retryProposal, retryErr := db.fw.Propose(batch)
+			if retryErr != nil {
+				return fmt.Errorf("firewood retry propose failed after verification failure: %w", retryErr)
+			}
+			if retryErr = retryProposal.Commit(); retryErr != nil {
+				return fmt.Errorf("firewood retry commit failed after verification failure: %w", retryErr)
+			}
+			db.currentRoot = db.fw.Root()
+			db.log.Warn("Firewood write-back verification: retry commit succeeded")
+			break
+		}
+		verifyCount++
+	}
+
+	// Clear read cache: the trie root changed so all cached values are stale.
+	// Bump the generation counter first so in-flight Gets that already snapshotted
+	// the old root will notice the change and skip caching their (stale) results.
+	if db.readCacheMax > 0 {
+		db.readCacheGen.Add(1)
+		db.readCacheMu.Lock()
+		clear(db.readCache)
+		db.readCacheMu.Unlock()
+	}
+
+	// Clear pending batch
+	db.pending = newPendingBatch()
+
+	db.log.Debug("Flushed pending batch")
+
+	return nil
+}
+
+
+// getFromRoot reads a key from the trie at the given root hash.
+// Returns (nil, nil) if the key is not present.
+// Returns (nil, nil) if root is ffi.EmptyRoot (empty database).
+func (db *Database) getFromRoot(root ffi.Hash, key []byte) ([]byte, error) {
+	if root == ffi.EmptyRoot {
+		return nil, nil
+	}
+	rev, err := db.fw.Revision(root)
+	if err != nil {
+		return nil, err
+	}
+	defer rev.Drop() //nolint:errcheck
+	return rev.Get(key)
+}
+
+// Has implements database.KeyValueReader
+func (db *Database) Has(key []byte) (bool, error) {
+	if db.closed.Load() {
+		return false, database.ErrClosed
+	}
+
+	// Read pending batch and snapshot root under read lock (non-blocking for concurrent Gets).
+	db.pendingMu.RLock()
+	op, inPending := db.pending.ops[string(key)]
+	root := db.currentRoot
+	db.pendingMu.RUnlock()
+
+	// Check pending batch first (read-your-writes for uncommitted ops).
+	if inPending {
+		return !op.delete, nil
+	}
+
+	// Check committed state using root hash (works after restart).
+	// Lock is released so concurrent Has/Get/FFI calls can proceed in parallel.
+	val, err := db.getFromRoot(root, key)
+	if err != nil {
+		return false, err
+	}
+
+	return val != nil, nil
+}
+
+// Get implements database.KeyValueReader
+// Provides read-your-writes consistency by checking pending batch first.
+//
+// Hot path: pending → read cache → FFI trie traversal.
+// The pending check and root snapshot require only a brief read lock.
+// The read cache and FFI call are performed without holding any lock, allowing
+// true parallelism for concurrent Gets on the same database instance.
+func (db *Database) Get(key []byte) ([]byte, error) {
+	if db.closed.Load() {
+		return nil, database.ErrClosed
+	}
+
+	keyStr := string(key)
+
+	// Phase 1: check pending batch and snapshot root under a brief read lock.
+	// This is the only phase that requires synchronization with writers.
+	db.pendingMu.RLock()
+	op, inPending := db.pending.ops[keyStr]
+	root := db.currentRoot
+	db.pendingMu.RUnlock()
+
+	if inPending {
+		if op.delete {
+			return nil, database.ErrNotFound // Pending delete
+		}
+		// Return copy to prevent caller from modifying pending batch.
+		result := make([]byte, len(op.value))
+		copy(result, op.value)
+		return result, nil
+	}
+
+	// Phase 2: check the Go-level read cache (no FFI, no trie traversal).
+	// Snapshot the cache generation before the lookup so we can safely skip
+	// caching the FFI result if a flush raced between Phase 2 and Phase 3.
+	var genBefore uint64
+	if db.readCacheMax > 0 {
+		db.readCacheMu.RLock()
+		cached, inCache := db.readCache[keyStr]
+		genBefore = db.readCacheGen.Load()
+		db.readCacheMu.RUnlock()
+		if inCache {
+			if cached == nil {
+				return nil, database.ErrNotFound
+			}
+			result := make([]byte, len(cached))
+			copy(result, cached)
+			return result, nil
+		}
+	}
+
+	// Phase 3: FFI trie traversal — no locks held, true parallel reads.
+	value, err := db.getFromRoot(root, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Populate read cache so the next Get of this key skips the FFI call.
+	// Skip if the cache generation changed (a flush occurred while we were in
+	// the FFI call), because our result is based on a now-superseded root.
+	if db.readCacheMax > 0 && db.readCacheGen.Load() == genBefore {
+		db.readCacheMu.Lock()
+		// Re-check generation and capacity under write lock.
+		if db.readCacheGen.Load() == genBefore && len(db.readCache) < db.readCacheMax {
+			if value != nil {
+				valCopy := make([]byte, len(value))
+				copy(valCopy, value)
+				db.readCache[keyStr] = valCopy
+			}
+			// We intentionally do NOT cache nil (missing key) to avoid
+			// returning a stale "not found" after a concurrent Put+flush.
+		}
+		db.readCacheMu.Unlock()
+	}
+
+	if value == nil {
+		return nil, database.ErrNotFound
+	}
+
+	// Return copy to prevent caller from modifying Firewood's internal state
+	result := make([]byte, len(value))
+	copy(result, value)
+	return result, nil
+}
+
+// Put implements database.KeyValueWriter
+// Adds operation to pending batch and auto-flushes when threshold reached.
+func (db *Database) Put(key []byte, value []byte) error {
+	if db.closed.Load() {
+		return database.ErrClosed
+	}
+
+	db.pendingMu.Lock()
+	defer db.pendingMu.Unlock()
+
+	// Make copies to prevent caller from modifying our internal state
+	keyCopy := make([]byte, len(key))
+	copy(keyCopy, key)
+	valueCopy := make([]byte, len(value))
+	copy(valueCopy, value)
+
+	// Add to pending batch
+	db.pending.ops[string(keyCopy)] = &pendingOp{
+		key:    keyCopy,
+		value:  valueCopy,
+		delete: false,
+	}
+
+	// Evict from read cache so a subsequent Get sees the pending value, not
+	// the previously cached committed value.
+	if db.readCacheMax > 0 {
+		db.readCacheMu.Lock()
+		delete(db.readCache, string(keyCopy))
+		db.readCacheMu.Unlock()
+	}
+
+	// Auto-flush if threshold reached
+	if len(db.pending.ops) >= db.flushSize {
+		return db.flushLocked()
+	}
+
+	return nil
+}
+
+// Delete implements database.KeyValueDeleter
+// Adds delete operation to pending batch and auto-flushes when threshold reached.
+func (db *Database) Delete(key []byte) error {
+	if db.closed.Load() {
+		return database.ErrClosed
+	}
+
+	db.pendingMu.Lock()
+	defer db.pendingMu.Unlock()
+
+	// Make copy to prevent caller from modifying our internal state
+	keyCopy := make([]byte, len(key))
+	copy(keyCopy, key)
+
+	// Add to pending batch as delete operation
+	db.pending.ops[string(keyCopy)] = &pendingOp{
+		key:    keyCopy,
+		value:  nil,
+		delete: true,
+	}
+
+	// Evict from read cache so a subsequent Get sees the pending delete.
+	if db.readCacheMax > 0 {
+		db.readCacheMu.Lock()
+		delete(db.readCache, string(keyCopy))
+		db.readCacheMu.Unlock()
+	}
+
+	// Auto-flush if threshold reached
+	if len(db.pending.ops) >= db.flushSize {
+		return db.flushLocked()
+	}
+
+	return nil
+}
+
+// NewBatch implements database.Batcher
+// Returns a batch that accumulates operations and commits them atomically on Write().
+// Note: Explicit batches do NOT auto-flush - only Write() commits them.
+func (db *Database) NewBatch() database.Batch {
+	return &batch{
+		db:  db,
+		ops: make(map[string]*pendingOp),
+	}
+}
+
+// preparePendingOps converts pending batch to sorted slice for merge iteration
+// Caller must hold pendingMu lock
+func (db *Database) preparePendingOpsLocked(start, prefix []byte) []pendingKV {
+	if len(db.pending.ops) == 0 {
+		return nil
+	}
+
+	// Convert map to slice
+	pending := make([]pendingKV, 0, len(db.pending.ops))
+	for _, op := range db.pending.ops {
+		// Filter by prefix if specified
+		if len(prefix) > 0 && !bytes.HasPrefix(op.key, prefix) {
+			continue
+		}
+		// Filter by start if specified
+		if len(start) > 0 && bytes.Compare(op.key, start) < 0 {
+			continue
+		}
+		pending = append(pending, pendingKV{
+			key:    op.key,
+			value:  op.value,
+			delete: op.delete,
+		})
+	}
+
+	// Sort by key for merge iteration
+	slices.SortFunc(pending, func(a, b pendingKV) int {
+		return bytes.Compare(a.key, b.key)
+	})
+
+	return pending
+}
+
+// NewIterator implements database.Iteratee
+// Returns native FFI trie iterator merging committed + pending operations
+func (db *Database) NewIterator() database.Iterator {
+	if db.closed.Load() {
+		return newErrorIterator(database.ErrClosed)
+	}
+
+	db.pendingMu.RLock()
+	defer db.pendingMu.RUnlock()
+
+	pending := db.preparePendingOpsLocked(nil, nil)
+	return newNativeIterator(db.fw, db.currentRoot, pending, nil, nil)
+}
+
+// NewIteratorWithStart implements database.Iteratee
+func (db *Database) NewIteratorWithStart(start []byte) database.Iterator {
+	if db.closed.Load() {
+		return newErrorIterator(database.ErrClosed)
+	}
+
+	db.pendingMu.RLock()
+	defer db.pendingMu.RUnlock()
+
+	pending := db.preparePendingOpsLocked(start, nil)
+	return newNativeIterator(db.fw, db.currentRoot, pending, start, nil)
+}
+
+// NewIteratorWithPrefix implements database.Iteratee
+func (db *Database) NewIteratorWithPrefix(prefix []byte) database.Iterator {
+	if db.closed.Load() {
+		return newErrorIterator(database.ErrClosed)
+	}
+
+	db.pendingMu.RLock()
+	defer db.pendingMu.RUnlock()
+
+	pending := db.preparePendingOpsLocked(nil, prefix)
+	return newNativeIterator(db.fw, db.currentRoot, pending, nil, prefix)
+}
+
+// NewIteratorWithStartAndPrefix implements database.Iteratee
+func (db *Database) NewIteratorWithStartAndPrefix(start, prefix []byte) database.Iterator {
+	if db.closed.Load() {
+		return newErrorIterator(database.ErrClosed)
+	}
+
+	db.pendingMu.RLock()
+	defer db.pendingMu.RUnlock()
+
+	pending := db.preparePendingOpsLocked(start, prefix)
+	return newNativeIterator(db.fw, db.currentRoot, pending, start, prefix)
+}
+
+// Compact implements database.Compacter
+// Firewood manages its own internal compaction as part of the trie commit
+// cycle, so manual compaction is a no-op.
+func (db *Database) Compact(start []byte, limit []byte) error {
+	return nil
+}
+
+// Close implements io.Closer
+// Flushes pending writes and closes the underlying Firewood database.
+func (db *Database) Close() error {
+	if !db.closed.CompareAndSwap(false, true) {
+		return database.ErrClosed
+	}
+
+	db.pendingMu.Lock()
+	defer db.pendingMu.Unlock()
+
+	// Flush any pending writes if configured to do so
+	if db.flushOnClose && len(db.pending.ops) > 0 {
+		db.log.Info("Flushing pending writes before close")
+		if err := db.flushLocked(); err != nil {
+			db.log.Error("Failed to flush pending writes on close")
+			// Continue with close despite flush error
+		}
+	}
+
+	// Stop periodic flush goroutine
+	db.flushTicker.Stop()
+	close(db.flushDone)
+
+	// Close Firewood database
+	ctx := context.Background()
+	if err := db.fw.Close(ctx); err != nil {
+		return fmt.Errorf("failed to close firewood database: %w", err)
+	}
+
+	db.log.Info("Firewood database closed")
+	return nil
+}
+
+// periodicFlush runs in a background goroutine and flushes pending writes periodically
+// This prevents data loss if the process crashes before the batch size threshold is reached
+func (db *Database) periodicFlush() {
+	for {
+		select {
+		case <-db.flushTicker.C:
+			db.pendingMu.Lock()
+			// Guard against a race where the timer fires just before Close()
+			// stops the ticker, causing flushLocked() to call fw.Propose() on
+			// an already-closed FFI database.
+			if db.closed.Load() {
+				db.pendingMu.Unlock()
+				return
+			}
+			if len(db.pending.ops) > 0 {
+				opsCount := len(db.pending.ops)
+				if err := db.flushLocked(); err != nil {
+					if db.log != nil {
+						db.log.Error("Periodic flush failed",
+							zap.Int("pendingOps", opsCount),
+							zap.Error(err),
+						)
+					}
+				} else if db.log != nil {
+					db.log.Debug("Periodic flush committed pending writes",
+						zap.Int("opsCount", opsCount),
+					)
+				}
+			}
+			db.pendingMu.Unlock()
+
+		case <-db.flushDone:
+			// Graceful shutdown
+			return
+		}
+	}
+}
+
+// HealthCheck implements health.Checker with comprehensive database health monitoring
+func (db *Database) HealthCheck(ctx context.Context) (interface{}, error) {
+	if db.closed.Load() {
+		return nil, database.ErrClosed
+	}
+
+	db.pendingMu.RLock()
+	pendingOps := len(db.pending.ops)
+	db.pendingMu.RUnlock()
+
+	// Try a simple read operation to verify database is responsive.
+	testKey := []byte("__health_check__")
+	root := db.fw.Root()
+	if _, err := db.getFromRoot(root, testKey); err != nil {
+		return nil, fmt.Errorf("health check failed (read): %w", err)
+	}
+
+	return map[string]interface{}{
+		"database":       "firewood",
+		"status":         "healthy",
+		"pendingOps":     pendingOps,
+		"flushThreshold": db.flushSize,
+	}, nil
+}
+
+// batch implements database.Batch for Firewood
+// Operations are buffered in memory and committed atomically on Write().
+type batch struct {
+	db  *Database
+	ops map[string]*pendingOp
+}
+
+func (b *batch) Put(key []byte, value []byte) error {
+	// Make copies to prevent caller from modifying our internal state
+	keyCopy := make([]byte, len(key))
+	copy(keyCopy, key)
+	valueCopy := make([]byte, len(value))
+	copy(valueCopy, value)
+
+	b.ops[string(keyCopy)] = &pendingOp{
+		key:    keyCopy,
+		value:  valueCopy,
+		delete: false,
+	}
+	return nil
+}
+
+func (b *batch) Delete(key []byte) error {
+	// Make copy to prevent caller from modifying our internal state
+	keyCopy := make([]byte, len(key))
+	copy(keyCopy, key)
+
+	b.ops[string(keyCopy)] = &pendingOp{
+		key:    keyCopy,
+		value:  nil,
+		delete: true,
+	}
+	return nil
+}
+
+func (b *batch) Size() int {
+	total := 0
+	for _, op := range b.ops {
+		total += len(op.key) + len(op.value)
+	}
+	return total
+}
+
+func (b *batch) Write() error {
+	if b.db.closed.Load() {
+		return database.ErrClosed
+	}
+
+	if len(b.ops) == 0 {
+		return nil
+	}
+
+	// IMPORTANT: Flush database pending batch first to maintain consistency
+	// This ensures batch operations see the latest state and don't conflict
+	b.db.pendingMu.Lock()
+	defer b.db.pendingMu.Unlock()
+
+	if len(b.db.pending.ops) > 0 {
+		if err := b.db.flushLocked(); err != nil {
+			return fmt.Errorf("failed to flush pending before batch: %w", err)
+		}
+	}
+
+	// Build BatchOp slice
+	batchOps := make([]ffi.BatchOp, 0, len(b.ops))
+	for _, op := range b.ops {
+		if op.delete {
+			batchOps = append(batchOps, ffi.Delete(op.key))
+		} else {
+			batchOps = append(batchOps, ffi.Put(op.key, op.value))
+		}
+	}
+
+	// Create and commit proposal
+	proposal, err := b.db.fw.Propose(batchOps)
+	if err != nil {
+		return fmt.Errorf("firewood batch propose failed: %w", err)
+	}
+	if err := proposal.Commit(); err != nil {
+		return fmt.Errorf("firewood batch commit failed: %w", err)
+	}
+
+	// Snapshot root after commit
+	b.db.currentRoot = b.db.fw.Root()
+
+	// Clear read cache: trie root changed so all previously cached values are stale.
+	if b.db.readCacheMax > 0 {
+		b.db.readCacheGen.Add(1)
+		b.db.readCacheMu.Lock()
+		clear(b.db.readCache)
+		b.db.readCacheMu.Unlock()
+	}
+
+	// Write-back verification: spot-check that batch data is readable after commit
+	verifyCount := 0
+	for _, op := range b.ops {
+		if verifyCount >= 3 {
+			break
+		}
+		if op.delete {
+			continue
+		}
+		readBack, err := b.db.getFromRoot(b.db.currentRoot, op.key)
+		if err != nil || readBack == nil {
+			b.db.log.Error("BATCH WRITE-BACK VERIFICATION FAILED: committed key not readable",
+				zap.Int("keyLen", len(op.key)),
+				zap.Int("batchSize", len(b.ops)),
+				zap.Error(err),
+			)
+			// Retry once
+			retryProposal, retryErr := b.db.fw.Propose(batchOps)
+			if retryErr != nil {
+				return fmt.Errorf("firewood batch retry propose failed: %w", retryErr)
+			}
+			if retryErr = retryProposal.Commit(); retryErr != nil {
+				return fmt.Errorf("firewood batch retry commit failed: %w", retryErr)
+			}
+			b.db.currentRoot = b.db.fw.Root()
+			b.db.log.Warn("Firewood batch write-back verification: retry commit succeeded",
+				zap.Int("batchSize", len(b.ops)),
+			)
+			break
+		}
+		verifyCount++
+	}
+
+	b.db.log.Debug("Batch write committed", zap.Int("keysWritten", len(b.ops)))
+
+	return nil
+}
+
+func (b *batch) Reset() {
+	b.ops = make(map[string]*pendingOp)
+}
+
+func (b *batch) Replay(w database.KeyValueWriterDeleter) error {
+	for _, op := range b.ops {
+		if op.delete {
+			if err := w.Delete(op.key); err != nil {
+				return err
+			}
+		} else {
+			if err := w.Put(op.key, op.value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (b *batch) Inner() database.Batch {
+	return b
+}

--- a/database/firewood/db_bench_test.go
+++ b/database/firewood/db_bench_test.go
@@ -1,0 +1,39 @@
+//go:build !windows
+// +build !windows
+
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/dbtest"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+func newBenchDB(b testing.TB) database.Database {
+	dbPath := filepath.Join(b.TempDir(), "bench.fw")
+	db, err := New(dbPath, nil, logging.NoLog{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return db
+}
+
+func BenchmarkInterface(b *testing.B) {
+	for _, size := range dbtest.BenchmarkSizes {
+		keys, values := dbtest.SetupBenchmark(b, size[0], size[1], size[2])
+		for name, bench := range dbtest.Benchmarks {
+			b.Run(fmt.Sprintf("firewood_%d_pairs_%d_keys_%d_values_%s", size[0], size[1], size[2], name), func(b *testing.B) {
+				db := newBenchDB(b)
+				bench(b, db, keys, values)
+				_ = db.Close()
+			})
+		}
+	}
+}

--- a/database/firewood/db_nocgo.go
+++ b/database/firewood/db_nocgo.go
@@ -1,0 +1,24 @@
+//go:build !cgo || windows
+// +build !cgo windows
+
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+const (
+	// Name is the name of this database for database switches
+	Name = "firewood"
+)
+
+// New returns an error indicating that Firewood requires CGO and is not available on Windows
+func New(file string, configBytes []byte, log logging.Logger) (database.Database, error) {
+	return nil, fmt.Errorf("firewood database requires CGO and is not supported on Windows")
+}

--- a/database/firewood/db_test.go
+++ b/database/firewood/db_test.go
@@ -1,0 +1,458 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+//go:build cgo && !windows
+// +build cgo,!windows
+
+package firewood
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+// TestFirewoodBasicOperations tests basic Put/Get/Delete operations
+func TestFirewoodBasicOperations(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+	require.NotNil(db)
+	defer db.Close()
+
+	// Test Put
+	key := []byte("test-key")
+	value := []byte("test-value")
+	err = db.Put(key, value)
+	require.NoError(err)
+
+	// Test Has (pending batch)
+	has, err := db.Has(key)
+	require.NoError(err)
+	require.True(has, "should find key in pending batch")
+
+	// Test Get (pending batch - read-your-writes)
+	retrieved, err := db.Get(key)
+	require.NoError(err)
+	require.Equal(value, retrieved)
+
+	// Flush pending
+	fwDB := db.(*Database)
+	fwDB.pendingMu.Lock()
+	err = fwDB.flushLocked()
+	fwDB.pendingMu.Unlock()
+	require.NoError(err)
+
+	// Test Get (committed state)
+	retrieved, err = db.Get(key)
+	require.NoError(err)
+	require.Equal(value, retrieved)
+
+	// Test Delete
+	err = db.Delete(key)
+	require.NoError(err)
+
+	// Test Has (should see delete in pending)
+	has, err = db.Has(key)
+	require.NoError(err)
+	require.False(has)
+
+	// Test Get (should return not found)
+	_, err = db.Get(key)
+	require.ErrorIs(err, database.ErrNotFound)
+}
+
+// TestFirewoodAutoFlush tests auto-flush behavior
+func TestFirewoodAutoFlush(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+	defer db.Close()
+
+	fwDB := db.(*Database)
+	fwDB.flushSize = 10 // Auto-flush at 10 ops
+
+	// Add 9 operations - should not flush
+	for i := 0; i < 9; i++ {
+		key := []byte{byte(i)}
+		value := []byte{byte(i * 2)}
+		err = db.Put(key, value)
+		require.NoError(err)
+	}
+
+	// Verify pending batch has 9 ops
+	fwDB.pendingMu.Lock()
+	pendingCount := len(fwDB.pending.ops)
+	fwDB.pendingMu.Unlock()
+	require.Equal(9, pendingCount)
+
+	// Add 10th operation - should trigger flush
+	key10 := []byte{10}
+	value10 := []byte{20}
+	err = db.Put(key10, value10)
+	require.NoError(err)
+
+	// Verify pending batch was flushed
+	fwDB.pendingMu.Lock()
+	pendingCount = len(fwDB.pending.ops)
+	fwDB.pendingMu.Unlock()
+	require.Equal(0, pendingCount, "pending batch should be empty after auto-flush")
+
+	// Verify data was committed
+	retrieved, err := db.Get(key10)
+	require.NoError(err)
+	require.Equal(value10, retrieved)
+}
+
+// TestFirewoodBatch tests batch operations
+func TestFirewoodBatch(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+	defer db.Close()
+
+	// Create batch
+	batch := db.NewBatch()
+
+	// Add operations to batch
+	key1 := []byte("key1")
+	value1 := []byte("value1")
+	err = batch.Put(key1, value1)
+	require.NoError(err)
+
+	key2 := []byte("key2")
+	value2 := []byte("value2")
+	err = batch.Put(key2, value2)
+	require.NoError(err)
+
+	// Batch should have size
+	size := batch.Size()
+	require.Greater(size, 0)
+
+	// Write batch atomically
+	err = batch.Write()
+	require.NoError(err)
+
+	// Verify both keys exist
+	retrieved1, err := db.Get(key1)
+	require.NoError(err)
+	require.Equal(value1, retrieved1)
+
+	retrieved2, err := db.Get(key2)
+	require.NoError(err)
+	require.Equal(value2, retrieved2)
+
+	// Test batch reset
+	batch.Reset()
+	require.Equal(0, batch.Size())
+}
+
+// TestFirewoodCloseFlush tests that Close() flushes pending writes
+func TestFirewoodCloseFlush(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+
+	// Add data to pending batch
+	key := []byte("flush-on-close")
+	value := []byte("should-be-committed")
+	err = db.Put(key, value)
+	require.NoError(err)
+
+	// Close should flush pending
+	err = db.Close()
+	require.NoError(err)
+
+	// Reopen database
+	db2, err := New(dbPath, nil, log)
+	require.NoError(err)
+	defer db2.Close()
+
+	// Verify data was committed
+	retrieved, err := db2.Get(key)
+	require.NoError(err)
+	require.Equal(value, retrieved)
+}
+
+// TestFirewoodIterator tests basic iterator functionality
+func TestFirewoodIterator(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+	defer db.Close()
+
+	// Add some data and flush
+	testData := map[string]string{
+		"apple":  "fruit",
+		"banana": "fruit",
+		"carrot": "vegetable",
+	}
+
+	for key, value := range testData {
+		err = db.Put([]byte(key), []byte(value))
+		require.NoError(err)
+	}
+
+	// Flush to committed state
+	fwDB := db.(*Database)
+	fwDB.pendingMu.Lock()
+	err = fwDB.flushLocked()
+	fwDB.pendingMu.Unlock()
+	require.NoError(err)
+
+	// Test iteration
+	iter := db.NewIterator()
+	defer iter.Release()
+
+	count := 0
+	seen := make(map[string]string)
+	for iter.Next() {
+		key := string(iter.Key())
+		value := string(iter.Value())
+		seen[key] = value
+		count++
+	}
+
+	require.NoError(iter.Error())
+	require.Equal(len(testData), count, "should iterate all keys")
+	
+	// Verify all keys seen
+	for key, expectedValue := range testData {
+		actualValue, exists := seen[key]
+		require.True(exists, "key %s should be in iteration", key)
+		require.Equal(expectedValue, actualValue)
+	}
+}
+
+// TestFirewoodIteratorWithPending tests iterator sees pending writes
+func TestFirewoodIteratorWithPending(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+	defer db.Close()
+
+	// Add committed data
+	err = db.Put([]byte("committed"), []byte("value1"))
+	require.NoError(err)
+
+	// Flush
+	fwDB := db.(*Database)
+	fwDB.pendingMu.Lock()
+	err = fwDB.flushLocked()
+	fwDB.pendingMu.Unlock()
+	require.NoError(err)
+
+	// Add pending data (no flush)
+	err = db.Put([]byte("pending"), []byte("value2"))
+	require.NoError(err)
+
+	// Iterator should see both
+	iter := db.NewIterator()
+	defer iter.Release()
+
+	seen := make(map[string]string)
+	for iter.Next() {
+		seen[string(iter.Key())] = string(iter.Value())
+	}
+
+	require.NoError(iter.Error())
+	require.Equal(2, len(seen))
+	require.Equal("value1", seen["committed"])
+	require.Equal("value2", seen["pending"])
+}
+
+// TestFirewoodIteratorPendingOverride tests pending writes override committed
+func TestFirewoodIteratorPendingOverride(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+	defer db.Close()
+
+	// Add and flush committed value
+	key := []byte("key")
+	err = db.Put(key, []byte("old-value"))
+	require.NoError(err)
+
+	fwDB := db.(*Database)
+	fwDB.pendingMu.Lock()
+	err = fwDB.flushLocked()
+	fwDB.pendingMu.Unlock()
+	require.NoError(err)
+
+	// Update with pending value
+	err = db.Put(key, []byte("new-value"))
+	require.NoError(err)
+
+	// Iterator should see new value
+	iter := db.NewIterator()
+	defer iter.Release()
+
+	found := false
+	for iter.Next() {
+		if string(iter.Key()) == "key" {
+			require.Equal("new-value", string(iter.Value()))
+			found = true
+		}
+	}
+
+	require.NoError(iter.Error())
+	require.True(found, "should find updated key")
+}
+
+// TestFirewoodIteratorWithPrefix tests prefix iteration
+func TestFirewoodIteratorWithPrefix(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+	defer db.Close()
+
+	// Add data with different prefixes
+	testData := []struct {
+		key   string
+		value string
+	}{
+		{"user:alice", "data1"},
+		{"user:bob", "data2"},
+		{"config:timeout", "30"},
+		{"config:retries", "3"},
+	}
+
+	for _, item := range testData {
+		err = db.Put([]byte(item.key), []byte(item.value))
+		require.NoError(err)
+	}
+
+	// Flush
+	fwDB := db.(*Database)
+	fwDB.pendingMu.Lock()
+	err = fwDB.flushLocked()
+	fwDB.pendingMu.Unlock()
+	require.NoError(err)
+
+	// Iterate with "user:" prefix
+	iter := db.NewIteratorWithPrefix([]byte("user:"))
+	defer iter.Release()
+
+	count := 0
+	for iter.Next() {
+		key := string(iter.Key())
+		require.Contains(key, "user:", "should only see user: keys")
+		count++
+	}
+
+	require.NoError(iter.Error())
+	require.Equal(2, count, "should find 2 user: keys")
+}
+
+// TestFirewoodIteratorDelete tests deleted keys are skipped
+func TestFirewoodIteratorDelete(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "firewood-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	log := logging.NoLog{}
+	db, err := New(dbPath, nil, log)
+	require.NoError(err)
+	defer db.Close()
+
+	// Add and flush data
+	keys := [][]byte{
+		[]byte("key1"),
+		[]byte("key2"),
+		[]byte("key3"),
+	}
+
+	for _, key := range keys {
+		err = db.Put(key, []byte("value"))
+		require.NoError(err)
+	}
+
+	fwDB := db.(*Database)
+	fwDB.pendingMu.Lock()
+	err = fwDB.flushLocked()
+	fwDB.pendingMu.Unlock()
+	require.NoError(err)
+
+	// Delete key2 (pending)
+	err = db.Delete([]byte("key2"))
+	require.NoError(err)
+
+	// Iterator should skip deleted key
+	iter := db.NewIterator()
+	defer iter.Release()
+
+	seen := []string{}
+	for iter.Next() {
+		seen = append(seen, string(iter.Key()))
+	}
+
+	require.NoError(iter.Error())
+	require.Equal(2, len(seen), "should see 2 keys (key2 deleted)")
+	require.Contains(seen, "key1")
+	require.Contains(seen, "key3")
+	require.NotContains(seen, "key2")
+}

--- a/database/firewood/iterator.go
+++ b/database/firewood/iterator.go
@@ -1,0 +1,336 @@
+//go:build cgo && !windows
+// +build cgo,!windows
+
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"bytes"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+)
+
+// pendingKV represents a key-value operation (put or delete) in pending batch
+type pendingKV struct {
+	key    []byte
+	value  []byte
+	delete bool
+}
+
+// nativeIterator implements database.Iterator using Firewood's native FFI trie iterator.
+//
+// Architecture:
+// - Uses Firewood's Revision.Iter() to iterate directly over the persisted trie
+// - Merges with pending (uncommitted) operations for read-your-writes consistency
+// - Works correctly after restart because it reads from the trie, not from a registry
+//
+// Merge algorithm:
+// - FFI iterator provides sorted key-value pairs from the committed trie
+// - Pending operations are pre-sorted and pre-filtered by prefix/start
+// - FFI keys that have ANY pending operation (put or delete) are suppressed
+// - Only pending put operations are yielded (deletes suppress FFI keys only)
+// - Standard sorted merge of the two clean streams produces correct output
+type nativeIterator struct {
+	// FFI resources (nil if database is empty or Revision unavailable)
+	ffiIter  *ffi.Iterator
+	revision *ffi.Revision
+
+	// FFI cursor state
+	ffiKey   []byte
+	ffiValue []byte
+	ffiDone  bool
+
+	// Pending operations cursor (sorted, filtered by prefix/start)
+	pending    []pendingKV
+	pendingIdx int // Index of current pending entry (-1 = before start)
+
+	// Set of ALL pending keys (puts + deletes) for suppressing FFI duplicates
+	pendingKeys map[string]bool
+
+	// Prefix filter (empty = no filter)
+	prefix []byte
+
+	// Current output
+	currentKey   []byte
+	currentValue []byte
+
+	// State
+	err      error
+	released bool
+	started  bool
+}
+
+// newNativeIterator creates an iterator using Firewood's native FFI trie iterator.
+// Returns a database.Iterator that merges committed trie data with pending operations.
+//
+// If the database is empty or the Revision is unavailable, falls back to iterating
+// only pending operations (graceful degradation).
+func newNativeIterator(
+	fw *ffi.Database,
+	currentRoot ffi.Hash,
+	pending []pendingKV,
+	startKey []byte,
+	prefix []byte,
+) database.Iterator {
+	// CRITICAL: Make defensive copies of prefix and startKey.
+	// PrefixDB passes byte slices from its buffer pool, then returns the buffers
+	// to the pool via defer after this function returns. Without copies, the
+	// iterator's prefix field would reference pool memory that gets overwritten
+	// by subsequent PrefixDB operations, causing premature iterator termination.
+	var prefixCopy []byte
+	if len(prefix) > 0 {
+		prefixCopy = make([]byte, len(prefix))
+		copy(prefixCopy, prefix)
+	}
+	var startKeyCopy []byte
+	if len(startKey) > 0 {
+		startKeyCopy = make([]byte, len(startKey))
+		copy(startKeyCopy, startKey)
+	}
+
+	// Build the set of ALL pending keys for FFI suppression
+	pendingKeys := make(map[string]bool, len(pending))
+	for _, op := range pending {
+		pendingKeys[string(op.key)] = true
+	}
+
+	it := &nativeIterator{
+		ffiDone:     true, // Will be set to false if FFI iterator created successfully
+		pending:     pending,
+		pendingIdx:  -1,
+		pendingKeys: pendingKeys,
+		prefix:      prefixCopy,
+	}
+
+	// Empty database: iterate only pending ops
+	if currentRoot == ffi.EmptyRoot {
+		return it
+	}
+
+	// Get a revision handle for the current root.
+	// This reads from the persisted trie, so it works after restart.
+	revision, err := fw.Revision(currentRoot)
+	if err != nil {
+		// Revision unavailable - iterate only pending ops (graceful degradation)
+		return it
+	}
+
+	// Determine FFI iterator start position.
+	// Use the greater of startKey and prefix as the starting point.
+	iterStart := startKeyCopy
+	if len(prefixCopy) > 0 && (len(iterStart) == 0 || bytes.Compare(prefixCopy, iterStart) > 0) {
+		iterStart = prefixCopy
+	}
+	if iterStart == nil {
+		iterStart = []byte{} // FFI expects non-nil slice for "start from beginning"
+	}
+
+	ffiIter, err := revision.Iter(iterStart)
+	if err != nil {
+		revision.Drop()
+		return it
+	}
+
+	// Batch loading reduces FFI call overhead during iteration
+	ffiIter.SetBatchSize(256)
+
+	it.ffiIter = ffiIter
+	it.revision = revision
+	it.ffiDone = false
+
+	return it
+}
+
+// advanceFFI moves the FFI cursor to the next valid key.
+// Skips keys outside the prefix range and keys with pending operations.
+func (it *nativeIterator) advanceFFI() {
+	if it.ffiIter == nil {
+		it.ffiDone = true
+		return
+	}
+
+	for {
+		if !it.ffiIter.Next() {
+			it.ffiDone = true
+			if err := it.ffiIter.Err(); err != nil {
+				it.err = err
+			}
+			return
+		}
+
+		key := it.ffiIter.Key()
+
+		// Prefix boundary check
+		if len(it.prefix) > 0 {
+			if !bytes.HasPrefix(key, it.prefix) {
+				if bytes.Compare(key, it.prefix) > 0 {
+					// Past the prefix range, iteration is done
+					it.ffiDone = true
+					return
+				}
+				continue // Before prefix range (shouldn't happen with proper start)
+			}
+		}
+
+		// Skip keys that have pending operations (pending always takes precedence)
+		if it.pendingKeys[string(key)] {
+			continue
+		}
+
+		// Valid key: copy data (FFI memory may be reused on next advance)
+		it.ffiKey = make([]byte, len(key))
+		copy(it.ffiKey, key)
+		val := it.ffiIter.Value()
+		it.ffiValue = make([]byte, len(val))
+		copy(it.ffiValue, val)
+		return
+	}
+}
+
+// advancePending moves the pending cursor to the next non-delete entry.
+// Delete operations are only used for suppressing FFI keys (via pendingKeys).
+func (it *nativeIterator) advancePending() {
+	for {
+		it.pendingIdx++
+		if it.pendingIdx >= len(it.pending) {
+			return
+		}
+		if !it.pending[it.pendingIdx].delete {
+			return // Found a put operation to yield
+		}
+	}
+}
+
+// pendingCurrent returns the current pending entry, or nil if exhausted.
+func (it *nativeIterator) pendingCurrent() *pendingKV {
+	if it.pendingIdx >= 0 && it.pendingIdx < len(it.pending) {
+		return &it.pending[it.pendingIdx]
+	}
+	return nil
+}
+
+// Next implements database.Iterator
+func (it *nativeIterator) Next() bool {
+	if it.released {
+		it.err = database.ErrClosed
+		return false
+	}
+	if it.err != nil {
+		return false
+	}
+
+	// First call: prime both cursors
+	if !it.started {
+		it.started = true
+		it.advanceFFI()
+		it.advancePending()
+	}
+
+	hasFfi := !it.ffiDone
+	pCur := it.pendingCurrent()
+
+	if !hasFfi && pCur == nil {
+		return false
+	}
+
+	if hasFfi && pCur == nil {
+		// Only FFI data remains
+		it.currentKey = it.ffiKey
+		it.currentValue = it.ffiValue
+		it.advanceFFI()
+		return true
+	}
+
+	if !hasFfi {
+		// Only pending data remains
+		it.currentKey = pCur.key
+		it.currentValue = pCur.value
+		it.advancePending()
+		return true
+	}
+
+	// Both have data: standard sorted merge - pick the smaller key
+	cmp := bytes.Compare(it.ffiKey, pCur.key)
+	if cmp < 0 {
+		it.currentKey = it.ffiKey
+		it.currentValue = it.ffiValue
+		it.advanceFFI()
+	} else if cmp > 0 {
+		it.currentKey = pCur.key
+		it.currentValue = pCur.value
+		it.advancePending()
+	} else {
+		// Same key: pending wins, advance both cursors
+		it.currentKey = pCur.key
+		it.currentValue = pCur.value
+		it.advanceFFI()
+		it.advancePending()
+	}
+
+	return true
+}
+
+// Error implements database.Iterator
+func (it *nativeIterator) Error() error {
+	return it.err
+}
+
+// Key implements database.Iterator
+func (it *nativeIterator) Key() []byte {
+	if it.released || it.err != nil {
+		return nil
+	}
+	return it.currentKey
+}
+
+// Value implements database.Iterator
+func (it *nativeIterator) Value() []byte {
+	if it.released || it.err != nil {
+		return nil
+	}
+	return it.currentValue
+}
+
+// Release implements database.Iterator
+func (it *nativeIterator) Release() {
+	if it.released {
+		return
+	}
+	it.released = true
+
+	// Release FFI resources
+	if it.ffiIter != nil {
+		it.ffiIter.Drop()
+		it.ffiIter = nil
+	}
+	if it.revision != nil {
+		it.revision.Drop()
+		it.revision = nil
+	}
+
+	it.currentKey = nil
+	it.currentValue = nil
+	it.ffiKey = nil
+	it.ffiValue = nil
+	it.pending = nil
+	it.pendingKeys = nil
+}
+
+// errorIterator is a special iterator that always returns an error.
+// Used when database is closed or initialization fails.
+type errorIterator struct {
+	err error
+}
+
+func newErrorIterator(err error) database.Iterator {
+	return &errorIterator{err: err}
+}
+
+func (it *errorIterator) Next() bool    { return false }
+func (it *errorIterator) Error() error  { return it.err }
+func (it *errorIterator) Key() []byte   { return nil }
+func (it *errorIterator) Value() []byte { return nil }
+func (it *errorIterator) Release()      {}


### PR DESCRIPTION
## Summary

Upstream already depends on `firewood-go-ethhash/ffi` for EVM trie state
storage (`database/merkle/firewood/`). This PR extends that investment to
the general key-value layer, allowing Firewood to replace LevelDB or
PebbleDB as the node's main key-value store for all chain data.

Opt-in via node config — no existing behavior changes:
```json
{ "db-type": "firewood" }
```

## What's included

- `database/firewood/` — `database.Database` adapter over `firewood-go-ethhash/ffi`
- `database/factory/factory.go` — registers `"firewood"` as a valid `db-type`

## Benchmarks

Measured on AMD Ryzen 7 7700, comparing against LevelDB using the upstream
`database/dbtest` benchmark suite (`go test -bench=. -benchmem -benchtime=5s`).

**32-byte keys/values (metadata, state keys):**
| Operation | Firewood | LevelDB | Δ |
|-----------|----------|---------|---|
| Get | 305 ns/op | 891 ns/op | **2.9x faster** |
| Delete | 1,242 ns/op | 2,924 ns/op | **2.4x faster** |
| ParallelGet | 354 ns/op | 817 ns/op | **2.3x faster** |
| Put | 3,998 ns/op | 3,138 ns/op | 27% slower |
| BatchWrite (1024 pairs) | 3.6 ms | 0.8 ms | 4.4x slower |
| Memory/Get | 64 B / 2 allocs | 168 B / 5 allocs | **62% less** |

**256-byte keys/values (transactions, receipts):**
| Operation | Firewood | LevelDB | Δ |
|-----------|----------|---------|---|
| Put | 3,878 ns/op | 5,291 ns/op | **27% faster** |
| BatchWrite (1024 pairs) | 3.8 ms | 4.5 ms | **18% faster** |

**2048-byte keys/values (blocks, large payloads):**
| Operation | Firewood | LevelDB | Δ |
|-----------|----------|---------|---|
| Get | 1,147 ns/op | 1,537 ns/op | **25% faster** |
| Put | 10,495 ns/op | 43,701 ns/op | **4.2x faster** |
| Delete | 1,411 ns/op | 17,309 ns/op | **12x faster** |
| ParallelPut | 3,795 ns/op | 42,839 ns/op | **11x faster** |
| BatchWrite (1024 pairs) | 14.3 ms | 51.3 ms | **3.6x faster** |
| Memory/BatchWrite | 158 KB | 7.6 MB | **48x less** |

**Summary:** Reads are faster at all value sizes. Writes have overhead for
small values (trie commit cost) but are substantially faster as values grow —
which is the common case for block bodies, receipts, and large payloads.

## Design

Firewood uses a proposal/commit pattern that does not map directly to
`database.Database` (which expects immediate Put/Get). The adapter bridges
this with a pending-write batch that auto-flushes at a configurable threshold
(default: 1000 ops) and on a periodic timer for crash safety.

Post-restart reads use `Revision(root).Get(key)` rather than relying on an
in-memory latest revision, which would return nil for all keys after a restart.

## Tests

- `compliance_test.go` runs the upstream `database/dbtest` compliance suite
- `db_test.go` covers pending-batch semantics, iterator merging, flush behavior
- `db_bench_test.go` runs the upstream `database/dbtest` benchmark suite
- Build tag `cgo && !windows`; `db_nocgo.go` provides a stub for other targets

## Known limitation

**Firewood is not compatible with EVM state sync.** The state syncer hardcodes
PebbleDB (`triedb.NewDatabase(config.DB, nil)`), so Firewood is never populated
during a state sync run. Firewood works correctly with block sync and hash-scheme
state sync. This should be resolved before any production recommendation.