### PR TITLE
Unskip tests skipped due to firewood stack corruption issue

### DIFF
--- a/graft/coreth/core/blockchain_test.go
+++ b/graft/coreth/core/blockchain_test.go
@@ -736,11 +736,6 @@ func TestCanonicalHashMarker(t *testing.T) {
 }
 
 func testCanonicalHashMarker(t *testing.T, scheme string) {
-	// TODO: https://github.com/ava-labs/firewood/issues/1679
-	if scheme == customrawdb.FirewoodScheme {
-		t.Skip("firewood currently fails due to a stack corruption issue")
-	}
-
 	var cases = []struct {
 		forkA int
 		forkB int

--- a/graft/coreth/plugin/evm/atomic/vm/vm_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/chain"
-	"github.com/ava-labs/avalanchego/vms/evm/sync/customrawdb"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
 	avalancheatomic "github.com/ava-labs/avalanchego/chains/atomic"
@@ -264,11 +263,6 @@ func testIssueAtomicTxs(t *testing.T, scheme string) {
 }
 
 func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork, scheme string) {
-	// TODO: https://github.com/ava-labs/firewood/issues/1679
-	if scheme == customrawdb.FirewoodScheme {
-		t.Skip("firewood currently fails due to a stack corruption issue")
-	}
-
 	require := require.New(t)
 	importAmount := uint64(10000000)
 	vm := newAtomicTestVM()

--- a/graft/evm/firewood/triedb.go
+++ b/graft/evm/firewood/triedb.go
@@ -257,10 +257,15 @@ func (t *TrieDB) Close() error {
 	p.byStateRoot = nil
 	t.possible = nil
 
-	// We must provide a context to close since it may hang while waiting for the finalizers to complete.
-	runtime.GC() // encourage finalizers to run before we wait, otherwise the database won't close properly.
+	// encourage finalizers to run before we wait, otherwise the database won't close properly.
+	// N.B.: this is wrapped in a user-defined function as a workaround for
+	// https://github.com/golang/go/issues/78059.
+	// See https://github.com/ava-labs/firewood/issues/1679 for full details.
+	go func() { runtime.GC() }()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	// We must provide a context to close since it may hang while waiting for the finalizers to complete.
 	return t.Firewood.Close(ctx)
 }
 

--- a/graft/subnet-evm/core/blockchain_test.go
+++ b/graft/subnet-evm/core/blockchain_test.go
@@ -687,11 +687,6 @@ func TestCanonicalHashMarker(t *testing.T) {
 }
 
 func testCanonicalHashMarker(t *testing.T, scheme string) {
-	// TODO: https://github.com/ava-labs/firewood/issues/1679
-	if scheme == customrawdb.FirewoodScheme {
-		t.Skip("firewood currently fails due to a stack corruption issue")
-	}
-
 	cases := []struct {
 		forkA int
 		forkB int


### PR DESCRIPTION
## Why this should be merged

This works around the crashes in our tests and removes the skip.

Closes: https://github.com/ava-labs/firewood/issues/1679

Related: https://github.com/golang/go/issues/78059

## How this works

The crux of the issue is an upstream llvm bug that has been fixed but not yet released with the Go toolchain.

The llvm bug is that a field in the `ThreadContext` struct that is created for each goroutine does not initialize its `Trace.local_head` field. For goroutines that do not emit any tracing events, such as one spawned by `go runtime.GC()`, this field is left uninitialized and contains garbage data. When the goroutine exits, the tsan context can cause a segmentation fault when it tries to use the uninitialized `Trace.local_head` field.

This only impacts `-race` builds. However, it is extremely easy for our tests to trigger this issue. A workaround is to call `runtime.GC()` inside a user-defined function which automatically emits a tracing event on entry and before calling `runtime.GC()` which ensures that the `Trace.local_head` field is initialized and prevents the segmentation fault.

## How this was tested

CI, unskipped tests.

## Need to be documented in RELEASES.md?

No.