### PR TITLE
refactor: use WaitGroup.Go to simplify code

### DIFF
--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -44,12 +44,10 @@ func TestGossiperShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	wg := &sync.WaitGroup{}
-	wg.Add(1)
 
-	go func() {
+	wg.Go(func() {
 		Every(ctx, logging.NoLog{}, gossiper, time.Second)
-		wg.Done()
-	}()
+	})
 
 	cancel()
 	wg.Wait()

--- a/utils/buffer/unbounded_blocking_deque_test.go
+++ b/utils/buffer/unbounded_blocking_deque_test.go
@@ -70,11 +70,9 @@ func TestUnboundedBlockingDequePop(t *testing.T) {
 	)
 
 	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		gotCh, gotOk = deque.PopLeft()
-		wg.Done()
-	}()
+	})
 
 	ok = deque.PushRight(2)
 	require.True(ok)

--- a/utils/iterator/tree.go
+++ b/utils/iterator/tree.go
@@ -29,9 +29,7 @@ func FromTree[T any](btree *btree.BTreeG[T]) Iterator[T] {
 		next:    make(chan T),
 		release: make(chan struct{}),
 	}
-	it.wg.Add(1)
-	go func() {
-		defer it.wg.Done()
+	it.wg.Go(func() {
 		btree.Ascend(func(i T) bool {
 			select {
 			case it.next <- i:
@@ -41,7 +39,7 @@ func FromTree[T any](btree *btree.BTreeG[T]) Iterator[T] {
 			}
 		})
 		close(it.next)
-	}()
+	})
 	return it
 }
 


### PR DESCRIPTION
## Why this should be merged

use WaitGroup.Go to simplify code. More info: https://github.com/golang/go/issues/63796


## How this works

## How this was tested

## Need to be documented in RELEASES.md?
