### PR TITLE
[bazel] Fix metadata generation on macos

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 # Keep MODULE.bazel.lock up to date automatically
 common --lockfile_mode=update
 
+# Enable platform-specific config sections (build:macos, build:linux, etc.)
+common --enable_platform_specific_config
+
 # Go settings - match scripts/build_test.sh defaults
 
 # Test settings (match scripts/build_test.sh)
@@ -39,6 +42,12 @@ test:norace --@io_bazel_rules_go//go/config:race=false
 # The BLST library requires -D__BLST_PORTABLE__ for portable builds across CPU architectures.
 build --action_env=CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"
 build --action_env=CGO_ENABLED=1
+
+# macOS: Prevent nix dev shell env vars from breaking CGO sandbox builds.
+# Bazel discovers Xcode natively; the nix SDK may lack headers like resolv.h.
+build:macos --action_env=DEVELOPER_DIR=
+build:macos --action_env=CC=
+build:macos --action_env=CXX=
 
 # Cache for faster builds
 build --disk_cache=~/.cache/bazel-disk-cache

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -25,7 +25,7 @@ jobs:
   # failures. This is especially important when PRs are tested against
   # the current base branch and the metadata included in the PR is stale
   # relative to it.
-  check-metadata:
+  check-metadata-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,18 +34,28 @@ jobs:
         with:
           prune_runner_disk: 'false'
           task: bazel-check-metadata
+  # Not a dependency of other jobs but intended to ensure that
+  # developers on macos are able to maintain bazel metadata.
+  check-metadata-darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Bazel metadata
+        uses: ./.github/actions/run-bazel-task
+        with:
+          prune_runner_disk: 'false'
+          task: bazel-check-metadata
   unit-main:
-    needs: check-metadata
+    needs: check-metadata-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run unit tests with Bazel
         uses: ./.github/actions/run-bazel-task
         with:
-          prune_runner_disk: 'false'
           task: bazel-test-main
   unit-coreth:
-    needs: check-metadata
+    needs: check-metadata-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +65,7 @@ jobs:
           prune_runner_disk: 'false'
           task: bazel-test-coreth
   unit-subnet-evm:
-    needs: check-metadata
+    needs: check-metadata-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +74,7 @@ jobs:
         with:
           task: bazel-test-subnet-evm
   e2e:
-    needs: check-metadata
+    needs: check-metadata-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/vms/proposervm/BUILD.bazel
+++ b/vms/proposervm/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//snow/consensus/snowman",
         "//snow/engine/common",
         "//snow/engine/snowman/block",
+        "//snow/validators",
         "//staking",
         "//upgrade",
         "//utils/constants",
@@ -115,5 +116,7 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
         "@org_uber_go_mock//gomock",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zapcore",
     ],
 )


### PR DESCRIPTION
## Why this should be merged

Bazel support was merged without validating usage on darwin which ended up broken. This change ensures metadata generation is possible and adds a check job to ensure it stays that way.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A