### PR TITLE
chore: increase Firewood commit interval

### DIFF
--- a/tests/reexecute/c/vm_reexecute.go
+++ b/tests/reexecute/c/vm_reexecute.go
@@ -70,7 +70,9 @@ var (
 			"state-scheme": "firewood",
 			"snapshot-cache": 0,
 			"pruning-enabled": true,
-			"state-sync-enabled": false
+			"state-sync-enabled": false,
+			"commit-interval": 4096,
+			"state-history": 8192
 		}`,
 		"firewood-archive": `{
 			"state-scheme": "firewood",


### PR DESCRIPTION
## Why this should be merged

Builds on #5022; the current Firewood `commit-interval` is set to `31` by default, but we can push this number to be much higher.

## How this works

If using Firewood (w/o archive mode), sets `state-history` to `8192` and `commit-interval` to `4096`.

## How this was tested

CI + ran workflow manually: https://github.com/ava-labs/avalanchego/actions/runs/23202474500

## Need to be documented in RELEASES.md?

No