### PR TITLE
Downgrade proposervm ErrClosed log to Warn during shutdown

### DIFF
--- a/vms/proposervm/BUILD.bazel
+++ b/vms/proposervm/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//upgrade",
         "//utils/constants",
         "//utils/json",
+        "//utils/logging",
         "//utils/math",
         "//utils/metric",
         "//utils/rpc",
@@ -118,5 +119,6 @@ go_test(
         "@org_uber_go_mock//gomock",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -143,7 +143,7 @@ func (p *postForkCommonComponents) Verify(
 		// has been synced up to this point yet.
 		currentPChainHeight, err := p.vm.ctx.ValidatorState.GetCurrentHeight(ctx)
 		if err != nil {
-			p.logErrorUnlessDBClosed(err, "block verification failed",
+			p.logErrorUnlessDBClosed(err)("block verification failed",
 				zap.String("reason", "failed to get current P-Chain height"),
 				zap.Stringer("blkID", child.ID()),
 				zap.Error(err),
@@ -217,7 +217,7 @@ func (p *postForkCommonComponents) buildChild(
 	// is at least the parent's P-Chain height
 	pChainHeight, err := p.vm.selectChildPChainHeight(ctx, parentPChainHeight)
 	if err != nil {
-		p.logErrorUnlessDBClosed(err, "unexpected build block failure",
+		p.logErrorUnlessDBClosed(err)("unexpected build block failure",
 			zap.String("reason", "failed to calculate optimal P-chain height"),
 			zap.Stringer("parentID", parentID),
 			zap.Error(err),
@@ -423,7 +423,7 @@ func (p *postForkCommonComponents) verifyPostDurangoBlockDelay(
 	case errors.Is(err, proposer.ErrAnyoneCanPropose):
 		return false, nil // block should be unsigned
 	case err != nil:
-		p.logErrorUnlessDBClosed(err, "unexpected block verification failure",
+		p.logErrorUnlessDBClosed(err)("unexpected block verification failure",
 			zap.String("reason", "failed to calculate expected proposer"),
 			zap.Stringer("blkID", blk.ID()),
 			zap.Error(err),
@@ -463,7 +463,7 @@ func (p *postForkCommonComponents) shouldBuildSignedBlockPostDurango(
 		)
 		return false, err
 	case err != nil:
-		p.logErrorUnlessDBClosed(err, "unexpected build block failure",
+		p.logErrorUnlessDBClosed(err)("unexpected build block failure",
 			zap.String("reason", "failed to calculate expected proposer"),
 			zap.Stringer("parentID", parentID),
 			zap.Error(err),
@@ -534,13 +534,13 @@ func (p *postForkCommonComponents) logWarnOrError() func(msg string, fields ...z
 	return p.vm.ctx.Log.Error
 }
 
-// logErrorUnlessDBClosed logs at Error unless err wraps database.ErrClosed,
-// in which case it logs at Warn. A closed database is expected during
-// graceful shutdown when the P-chain tears down before the C-chain.
-func (p *postForkCommonComponents) logErrorUnlessDBClosed(err error, msg string, fields ...zap.Field) {
+// logErrorUnlessDBClosed returns a Warn-level logger if err wraps
+// database.ErrClosed, otherwise an Error-level logger. A closed database is
+// expected during graceful shutdown when the P-chain tears down before the
+// C-chain.
+func (p *postForkCommonComponents) logErrorUnlessDBClosed(err error) func(msg string, fields ...zap.Field) {
 	if errors.Is(err, database.ErrClosed) {
-		p.vm.ctx.Log.Warn(msg, fields...)
-		return
+		return p.vm.ctx.Log.Warn
 	}
-	p.vm.ctx.Log.Error(msg, fields...)
+	return p.vm.ctx.Log.Error
 }

--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
@@ -142,7 +143,7 @@ func (p *postForkCommonComponents) Verify(
 		// has been synced up to this point yet.
 		currentPChainHeight, err := p.vm.ctx.ValidatorState.GetCurrentHeight(ctx)
 		if err != nil {
-			p.vm.ctx.Log.Error("block verification failed",
+			p.logErrorUnlessDBClosed(err, "block verification failed",
 				zap.String("reason", "failed to get current P-Chain height"),
 				zap.Stringer("blkID", child.ID()),
 				zap.Error(err),
@@ -216,7 +217,7 @@ func (p *postForkCommonComponents) buildChild(
 	// is at least the parent's P-Chain height
 	pChainHeight, err := p.vm.selectChildPChainHeight(ctx, parentPChainHeight)
 	if err != nil {
-		p.vm.ctx.Log.Error("unexpected build block failure",
+		p.logErrorUnlessDBClosed(err, "unexpected build block failure",
 			zap.String("reason", "failed to calculate optimal P-chain height"),
 			zap.Stringer("parentID", parentID),
 			zap.Error(err),
@@ -422,7 +423,7 @@ func (p *postForkCommonComponents) verifyPostDurangoBlockDelay(
 	case errors.Is(err, proposer.ErrAnyoneCanPropose):
 		return false, nil // block should be unsigned
 	case err != nil:
-		p.vm.ctx.Log.Error("unexpected block verification failure",
+		p.logErrorUnlessDBClosed(err, "unexpected block verification failure",
 			zap.String("reason", "failed to calculate expected proposer"),
 			zap.Stringer("blkID", blk.ID()),
 			zap.Error(err),
@@ -462,7 +463,7 @@ func (p *postForkCommonComponents) shouldBuildSignedBlockPostDurango(
 		)
 		return false, err
 	case err != nil:
-		p.vm.ctx.Log.Error("unexpected build block failure",
+		p.logErrorUnlessDBClosed(err, "unexpected build block failure",
 			zap.String("reason", "failed to calculate expected proposer"),
 			zap.Stringer("parentID", parentID),
 			zap.Error(err),
@@ -531,4 +532,15 @@ func (p *postForkCommonComponents) logWarnOrError() func(msg string, fields ...z
 		return p.vm.ctx.Log.Warn
 	}
 	return p.vm.ctx.Log.Error
+}
+
+// logErrorUnlessDBClosed logs at Error unless err wraps database.ErrClosed,
+// in which case it logs at Warn. A closed database is expected during
+// graceful shutdown when the P-chain tears down before the C-chain.
+func (p *postForkCommonComponents) logErrorUnlessDBClosed(err error, msg string, fields ...zap.Field) {
+	if errors.Is(err, database.ErrClosed) {
+		p.vm.ctx.Log.Warn(msg, fields...)
+		return
+	}
+	p.vm.ctx.Log.Error(msg, fields...)
 }

--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/proposervm/acp181"
 	"github.com/ava-labs/avalanchego/vms/proposervm/block"
 	"github.com/ava-labs/avalanchego/vms/proposervm/proposer"
@@ -143,10 +144,9 @@ func (p *postForkCommonComponents) Verify(
 		// has been synced up to this point yet.
 		currentPChainHeight, err := p.vm.ctx.ValidatorState.GetCurrentHeight(ctx)
 		if err != nil {
-			p.logErrorUnlessDBClosed(err)("block verification failed",
+			logUnexpectedPChainError(p.vm.ctx.Log, err, "block verification failed",
 				zap.String("reason", "failed to get current P-Chain height"),
 				zap.Stringer("blkID", child.ID()),
-				zap.Error(err),
 			)
 			return err
 		}
@@ -217,10 +217,9 @@ func (p *postForkCommonComponents) buildChild(
 	// is at least the parent's P-Chain height
 	pChainHeight, err := p.vm.selectChildPChainHeight(ctx, parentPChainHeight)
 	if err != nil {
-		p.logErrorUnlessDBClosed(err)("unexpected build block failure",
+		logUnexpectedPChainError(p.vm.ctx.Log, err, "unexpected build block failure",
 			zap.String("reason", "failed to calculate optimal P-chain height"),
 			zap.Stringer("parentID", parentID),
-			zap.Error(err),
 		)
 		return nil, err
 	}
@@ -423,10 +422,9 @@ func (p *postForkCommonComponents) verifyPostDurangoBlockDelay(
 	case errors.Is(err, proposer.ErrAnyoneCanPropose):
 		return false, nil // block should be unsigned
 	case err != nil:
-		p.logErrorUnlessDBClosed(err)("unexpected block verification failure",
+		logUnexpectedPChainError(p.vm.ctx.Log, err, "unexpected block verification failure",
 			zap.String("reason", "failed to calculate expected proposer"),
 			zap.Stringer("blkID", blk.ID()),
-			zap.Error(err),
 		)
 		return false, err
 	case expectedProposerID == proposerID:
@@ -463,10 +461,9 @@ func (p *postForkCommonComponents) shouldBuildSignedBlockPostDurango(
 		)
 		return false, err
 	case err != nil:
-		p.logErrorUnlessDBClosed(err)("unexpected build block failure",
+		logUnexpectedPChainError(p.vm.ctx.Log, err, "unexpected build block failure",
 			zap.String("reason", "failed to calculate expected proposer"),
 			zap.Stringer("parentID", parentID),
-			zap.Error(err),
 		)
 		return false, err
 	case expectedProposerID == p.vm.ctx.NodeID:
@@ -534,13 +531,20 @@ func (p *postForkCommonComponents) logWarnOrError() func(msg string, fields ...z
 	return p.vm.ctx.Log.Error
 }
 
-// logErrorUnlessDBClosed returns a Warn-level logger if err wraps
-// database.ErrClosed, otherwise an Error-level logger. A closed database is
-// expected during graceful shutdown when the P-chain tears down before the
-// C-chain.
-func (p *postForkCommonComponents) logErrorUnlessDBClosed(err error) func(msg string, fields ...zap.Field) {
+// logUnexpectedPChainError logs an unexpected P-chain failure: Warn when err
+// wraps database.ErrClosed, Error otherwise.
+//
+// ErrClosed is expected during VM shutdown because the P-chain can stop and
+// close its DB before chains that consult it finish stopping. Logging at Warn
+// avoids noise in that normal path. If ErrClosed happens during normal
+// operation, the failure will still be surfaced elsewhere.
+func logUnexpectedPChainError(log logging.Logger, err error, msg string, fields ...zap.Field) {
+	// Caller skip so the caller field points at the call site, not here.
+	log = log.WithOptions(zap.AddCallerSkip(1))
+	fields = append(fields, zap.Error(err))
 	if errors.Is(err, database.ErrClosed) {
-		return p.vm.ctx.Log.Warn
+		log.Warn(msg, fields...)
+		return
 	}
-	return p.vm.ctx.Log.Error
+	log.Error(msg, fields...)
 }

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -731,70 +731,86 @@ func TestBuildBlockErrClosedLogsWarn(t *testing.T) {
 }
 
 func TestVerifyBlockErrClosedLogsWarn(t *testing.T) {
-	ctx := t.Context()
-
-	coreVM, valState, proVM, _ := initTestProposerVM(t, upgradetest.Latest, 0)
-	t.Cleanup(func() {
-		require.NoError(t, proVM.Shutdown(ctx))
-	})
-
-	coreParentBlk := snowmantest.BuildChild(snowmantest.Genesis)
-	coreChildBlk := snowmantest.BuildChild(coreParentBlk)
-	coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
-		return coreParentBlk, nil
-	}
-	coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
-		switch {
-		case bytes.Equal(b, coreParentBlk.Bytes()):
-			return coreParentBlk, nil
-		case bytes.Equal(b, coreChildBlk.Bytes()):
-			return coreChildBlk, nil
-		case bytes.Equal(b, snowmantest.GenesisBytes):
-			return snowmantest.Genesis, nil
-		default:
-			return nil, errUnknownBlock
-		}
-	}
-
-	parentBlk, err := proVM.BuildBlock(ctx)
-	require.NoError(t, err)
-	require.NoError(t, parentBlk.Verify(ctx))
-	require.NoError(t, parentBlk.Accept(ctx))
-	require.NoError(t, proVM.SetPreference(ctx, parentBlk.ID()))
-
-	valState.GetCurrentHeightF = func(context.Context) (uint64, error) {
-		return 0, database.ErrClosed
+	testCases := []struct {
+		name            string
+		setupMock       func(*validatorstest.State)
+		expectedMessage string
+	}{
+		{
+			name: "GetCurrentHeight returns ErrClosed",
+			setupMock: func(valState *validatorstest.State) {
+				valState.GetCurrentHeightF = func(context.Context) (uint64, error) {
+					return 0, database.ErrClosed
+				}
+			},
+			expectedMessage: "block verification failed",
+		},
+		{
+			name: "ExpectedProposer returns ErrClosed",
+			setupMock: func(valState *validatorstest.State) {
+				valState.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+					return nil, database.ErrClosed
+				}
+			},
+			expectedMessage: "unexpected block verification failure",
+		},
 	}
 
-	coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
-		return coreChildBlk, nil
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			coreVM, valState, proVM, _ := initTestProposerVM(t, upgradetest.Latest, 0)
+			t.Cleanup(func() {
+				require.NoError(t, proVM.Shutdown(ctx))
+			})
+
+			coreParentBlk := snowmantest.BuildChild(snowmantest.Genesis)
+			coreChildBlk := snowmantest.BuildChild(coreParentBlk)
+			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
+				return coreParentBlk, nil
+			}
+			coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
+				switch {
+				case bytes.Equal(b, coreParentBlk.Bytes()):
+					return coreParentBlk, nil
+				case bytes.Equal(b, coreChildBlk.Bytes()):
+					return coreChildBlk, nil
+				case bytes.Equal(b, snowmantest.GenesisBytes):
+					return snowmantest.Genesis, nil
+				default:
+					return nil, errUnknownBlock
+				}
+			}
+
+			parentBlk, err := proVM.BuildBlock(ctx)
+			require.NoError(t, err)
+			require.NoError(t, parentBlk.Verify(ctx))
+			require.NoError(t, parentBlk.Accept(ctx))
+			require.NoError(t, proVM.SetPreference(ctx, parentBlk.ID()))
+
+			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
+				return coreChildBlk, nil
+			}
+
+			childBlk, err := proVM.BuildBlock(ctx)
+			require.NoError(t, err)
+
+			test.setupMock(valState)
+
+			var logged bool
+			loggingCore := logging.NewWrappedCore(logging.Warn, logging.Discard, logging.Plain.ConsoleEncoder())
+			proVM.ctx.Log = logging.NewLogger("", loggingCore).WithOptions(zap.Hooks(func(e zapcore.Entry) error {
+				require.False(t, logged, "expected exactly one log entry")
+				logged = true
+				require.Equal(t, zapcore.Level(logging.Warn), e.Level)
+				require.Equal(t, test.expectedMessage, e.Message)
+				return nil
+			}))
+
+			err = childBlk.Verify(ctx)
+			require.ErrorIs(t, err, database.ErrClosed)
+			require.True(t, logged, "expected log entry was not emitted")
+		})
 	}
-
-	// Build a child block so we can parse and verify it.
-	// GetCurrentHeight is called during verification, not building,
-	// so we need to temporarily restore it for the build step.
-	savedGetCurrentHeightF := valState.GetCurrentHeightF
-	valState.GetCurrentHeightF = func(context.Context) (uint64, error) {
-		return defaultPChainHeight, nil
-	}
-
-	childBlk, err := proVM.BuildBlock(ctx)
-	require.NoError(t, err)
-
-	// Now break GetCurrentHeight and verify the built block
-	valState.GetCurrentHeightF = savedGetCurrentHeightF
-
-	var logged bool
-	loggingCore := logging.NewWrappedCore(logging.Warn, logging.Discard, logging.Plain.ConsoleEncoder())
-	proVM.ctx.Log = logging.NewLogger("", loggingCore).WithOptions(zap.Hooks(func(e zapcore.Entry) error {
-		require.False(t, logged, "expected exactly one log entry")
-		logged = true
-		require.Equal(t, zapcore.Level(logging.Warn), e.Level)
-		require.Equal(t, "block verification failed", e.Message)
-		return nil
-	}))
-
-	err = childBlk.Verify(ctx)
-	require.ErrorIs(t, err, database.ErrClosed)
-	require.True(t, logged, "expected log entry was not emitted")
 }

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
@@ -27,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block/blockmock"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/snow/validators/validatorsmock"
+	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
@@ -646,4 +648,155 @@ func TestFailedToCalculateExpectedProposerLogLevel(t *testing.T) {
 			require.True(logged, "expected log entry was not emitted")
 		})
 	}
+}
+
+func TestBuildBlockErrClosedLogsWarn(t *testing.T) {
+	testCases := []struct {
+		name            string
+		setupMock       func(*validatorstest.State)
+		expectedMessage string
+	}{
+		{
+			name: "GetMinimumHeight returns ErrClosed",
+			setupMock: func(valState *validatorstest.State) {
+				valState.GetMinimumHeightF = func(context.Context) (uint64, error) {
+					return 0, database.ErrClosed
+				}
+			},
+			expectedMessage: "unexpected build block failure",
+		},
+		{
+			name: "ExpectedProposer returns ErrClosed",
+			setupMock: func(valState *validatorstest.State) {
+				valState.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+					return nil, database.ErrClosed
+				}
+			},
+			expectedMessage: "unexpected build block failure",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			ctx := t.Context()
+
+			coreVM, valState, proVM, _ := initTestProposerVM(t, upgradetest.Latest, 0)
+			defer func() {
+				require.NoError(proVM.Shutdown(ctx))
+			}()
+
+			coreParentBlk := snowmantest.BuildChild(snowmantest.Genesis)
+			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
+				return coreParentBlk, nil
+			}
+			coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
+				switch {
+				case bytes.Equal(b, coreParentBlk.Bytes()):
+					return coreParentBlk, nil
+				case bytes.Equal(b, snowmantest.GenesisBytes):
+					return snowmantest.Genesis, nil
+				default:
+					return nil, errUnknownBlock
+				}
+			}
+
+			parentBlk, err := proVM.BuildBlock(ctx)
+			require.NoError(err)
+			require.NoError(parentBlk.Verify(ctx))
+			require.NoError(parentBlk.Accept(ctx))
+			require.NoError(proVM.SetPreference(ctx, parentBlk.ID()))
+
+			test.setupMock(valState)
+
+			coreChildBlk := snowmantest.BuildChild(coreParentBlk)
+			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
+				return coreChildBlk, nil
+			}
+
+			var logged bool
+			loggingCore := logging.NewWrappedCore(logging.Warn, logging.Discard, logging.Plain.ConsoleEncoder())
+			proVM.ctx.Log = logging.NewLogger("", loggingCore).WithOptions(zap.Hooks(func(e zapcore.Entry) error {
+				require.False(logged, "expected exactly one log entry")
+				logged = true
+				require.Equal(zapcore.Level(logging.Warn), e.Level)
+				require.Equal(test.expectedMessage, e.Message)
+				return nil
+			}))
+
+			_, err = proVM.BuildBlock(ctx)
+			require.ErrorIs(err, database.ErrClosed)
+			require.True(logged, "expected log entry was not emitted")
+		})
+	}
+}
+
+func TestVerifyBlockErrClosedLogsWarn(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+
+	coreVM, valState, proVM, _ := initTestProposerVM(t, upgradetest.Latest, 0)
+	defer func() {
+		require.NoError(proVM.Shutdown(ctx))
+	}()
+
+	coreParentBlk := snowmantest.BuildChild(snowmantest.Genesis)
+	coreChildBlk := snowmantest.BuildChild(coreParentBlk)
+	coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
+		return coreParentBlk, nil
+	}
+	coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
+		switch {
+		case bytes.Equal(b, coreParentBlk.Bytes()):
+			return coreParentBlk, nil
+		case bytes.Equal(b, coreChildBlk.Bytes()):
+			return coreChildBlk, nil
+		case bytes.Equal(b, snowmantest.GenesisBytes):
+			return snowmantest.Genesis, nil
+		default:
+			return nil, errUnknownBlock
+		}
+	}
+
+	parentBlk, err := proVM.BuildBlock(ctx)
+	require.NoError(err)
+	require.NoError(parentBlk.Verify(ctx))
+	require.NoError(parentBlk.Accept(ctx))
+	require.NoError(proVM.SetPreference(ctx, parentBlk.ID()))
+
+	valState.GetCurrentHeightF = func(context.Context) (uint64, error) {
+		return 0, database.ErrClosed
+	}
+
+	coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
+		return coreChildBlk, nil
+	}
+
+	// Build a child block so we can parse and verify it.
+	// GetCurrentHeight is called during verification, not building,
+	// so we need to temporarily restore it for the build step.
+	savedGetCurrentHeightF := valState.GetCurrentHeightF
+	valState.GetCurrentHeightF = func(context.Context) (uint64, error) {
+		return defaultPChainHeight, nil
+	}
+
+	childBlk, err := proVM.BuildBlock(ctx)
+	require.NoError(err)
+
+	// Now break GetCurrentHeight and verify the built block
+	valState.GetCurrentHeightF = savedGetCurrentHeightF
+
+	var logged bool
+	loggingCore := logging.NewWrappedCore(logging.Warn, logging.Discard, logging.Plain.ConsoleEncoder())
+	proVM.ctx.Log = logging.NewLogger("", loggingCore).WithOptions(zap.Hooks(func(e zapcore.Entry) error {
+		require.False(logged, "expected exactly one log entry")
+		logged = true
+		require.Equal(zapcore.Level(logging.Warn), e.Level)
+		require.Equal("block verification failed", e.Message)
+		return nil
+	}))
+
+	err = childBlk.Verify(ctx)
+	require.ErrorIs(err, database.ErrClosed)
+	require.True(logged, "expected log entry was not emitted")
 }

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -678,13 +678,12 @@ func TestBuildBlockErrClosedLogsWarn(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			require := require.New(t)
 			ctx := t.Context()
 
 			coreVM, valState, proVM, _ := initTestProposerVM(t, upgradetest.Latest, 0)
-			defer func() {
-				require.NoError(proVM.Shutdown(ctx))
-			}()
+			t.Cleanup(func() {
+				require.NoError(t, proVM.Shutdown(ctx))
+			})
 
 			coreParentBlk := snowmantest.BuildChild(snowmantest.Genesis)
 			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
@@ -702,10 +701,10 @@ func TestBuildBlockErrClosedLogsWarn(t *testing.T) {
 			}
 
 			parentBlk, err := proVM.BuildBlock(ctx)
-			require.NoError(err)
-			require.NoError(parentBlk.Verify(ctx))
-			require.NoError(parentBlk.Accept(ctx))
-			require.NoError(proVM.SetPreference(ctx, parentBlk.ID()))
+			require.NoError(t, err)
+			require.NoError(t, parentBlk.Verify(ctx))
+			require.NoError(t, parentBlk.Accept(ctx))
+			require.NoError(t, proVM.SetPreference(ctx, parentBlk.ID()))
 
 			test.setupMock(valState)
 
@@ -717,28 +716,27 @@ func TestBuildBlockErrClosedLogsWarn(t *testing.T) {
 			var logged bool
 			loggingCore := logging.NewWrappedCore(logging.Warn, logging.Discard, logging.Plain.ConsoleEncoder())
 			proVM.ctx.Log = logging.NewLogger("", loggingCore).WithOptions(zap.Hooks(func(e zapcore.Entry) error {
-				require.False(logged, "expected exactly one log entry")
+				require.False(t, logged, "expected exactly one log entry")
 				logged = true
-				require.Equal(zapcore.Level(logging.Warn), e.Level)
-				require.Equal(test.expectedMessage, e.Message)
+				require.Equal(t, zapcore.Level(logging.Warn), e.Level)
+				require.Equal(t, test.expectedMessage, e.Message)
 				return nil
 			}))
 
 			_, err = proVM.BuildBlock(ctx)
-			require.ErrorIs(err, database.ErrClosed)
-			require.True(logged, "expected log entry was not emitted")
+			require.ErrorIs(t, err, database.ErrClosed)
+			require.True(t, logged, "expected log entry was not emitted")
 		})
 	}
 }
 
 func TestVerifyBlockErrClosedLogsWarn(t *testing.T) {
-	require := require.New(t)
 	ctx := t.Context()
 
 	coreVM, valState, proVM, _ := initTestProposerVM(t, upgradetest.Latest, 0)
-	defer func() {
-		require.NoError(proVM.Shutdown(ctx))
-	}()
+	t.Cleanup(func() {
+		require.NoError(t, proVM.Shutdown(ctx))
+	})
 
 	coreParentBlk := snowmantest.BuildChild(snowmantest.Genesis)
 	coreChildBlk := snowmantest.BuildChild(coreParentBlk)
@@ -759,10 +757,10 @@ func TestVerifyBlockErrClosedLogsWarn(t *testing.T) {
 	}
 
 	parentBlk, err := proVM.BuildBlock(ctx)
-	require.NoError(err)
-	require.NoError(parentBlk.Verify(ctx))
-	require.NoError(parentBlk.Accept(ctx))
-	require.NoError(proVM.SetPreference(ctx, parentBlk.ID()))
+	require.NoError(t, err)
+	require.NoError(t, parentBlk.Verify(ctx))
+	require.NoError(t, parentBlk.Accept(ctx))
+	require.NoError(t, proVM.SetPreference(ctx, parentBlk.ID()))
 
 	valState.GetCurrentHeightF = func(context.Context) (uint64, error) {
 		return 0, database.ErrClosed
@@ -781,7 +779,7 @@ func TestVerifyBlockErrClosedLogsWarn(t *testing.T) {
 	}
 
 	childBlk, err := proVM.BuildBlock(ctx)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// Now break GetCurrentHeight and verify the built block
 	valState.GetCurrentHeightF = savedGetCurrentHeightF
@@ -789,14 +787,14 @@ func TestVerifyBlockErrClosedLogsWarn(t *testing.T) {
 	var logged bool
 	loggingCore := logging.NewWrappedCore(logging.Warn, logging.Discard, logging.Plain.ConsoleEncoder())
 	proVM.ctx.Log = logging.NewLogger("", loggingCore).WithOptions(zap.Hooks(func(e zapcore.Entry) error {
-		require.False(logged, "expected exactly one log entry")
+		require.False(t, logged, "expected exactly one log entry")
 		logged = true
-		require.Equal(zapcore.Level(logging.Warn), e.Level)
-		require.Equal("block verification failed", e.Message)
+		require.Equal(t, zapcore.Level(logging.Warn), e.Level)
+		require.Equal(t, "block verification failed", e.Message)
 		return nil
 	}))
 
 	err = childBlk.Verify(ctx)
-	require.ErrorIs(err, database.ErrClosed)
-	require.True(logged, "expected log entry was not emitted")
+	require.ErrorIs(t, err, database.ErrClosed)
+	require.True(t, logged, "expected log entry was not emitted")
 }

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -9,6 +9,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
@@ -28,7 +31,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block/blockmock"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/snow/validators/validatorsmock"
-	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
@@ -650,167 +652,42 @@ func TestFailedToCalculateExpectedProposerLogLevel(t *testing.T) {
 	}
 }
 
-func TestBuildBlockErrClosedLogsWarn(t *testing.T) {
-	testCases := []struct {
-		name            string
-		setupMock       func(*validatorstest.State)
-		expectedMessage string
+func TestLogUnexpectedPChainError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantLevel logging.Level
 	}{
 		{
-			name: "GetMinimumHeight returns ErrClosed",
-			setupMock: func(valState *validatorstest.State) {
-				valState.GetMinimumHeightF = func(context.Context) (uint64, error) {
-					return 0, database.ErrClosed
-				}
-			},
-			expectedMessage: "unexpected build block failure",
+			name:      "ErrClosed logs at Warn",
+			err:       database.ErrClosed,
+			wantLevel: logging.Warn,
 		},
 		{
-			name: "ExpectedProposer returns ErrClosed",
-			setupMock: func(valState *validatorstest.State) {
-				valState.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
-					return nil, database.ErrClosed
-				}
-			},
-			expectedMessage: "unexpected build block failure",
+			name:      "wrapped ErrClosed logs at Warn",
+			err:       fmt.Errorf("getting height: %w", database.ErrClosed),
+			wantLevel: logging.Warn,
+		},
+		{
+			name:      "unrelated error logs at Error",
+			err:       errors.New("boom"),
+			wantLevel: logging.Error,
 		},
 	}
-
-	for _, test := range testCases {
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := t.Context()
+			l, logs := newObservedLogger()
+			logUnexpectedPChainError(l, test.err, "msg")
 
-			coreVM, valState, proVM, _ := initTestProposerVM(t, upgradetest.Latest, 0)
-			t.Cleanup(func() {
-				require.NoError(t, proVM.Shutdown(ctx))
-			})
-
-			coreParentBlk := snowmantest.BuildChild(snowmantest.Genesis)
-			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
-				return coreParentBlk, nil
-			}
-			coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
-				switch {
-				case bytes.Equal(b, coreParentBlk.Bytes()):
-					return coreParentBlk, nil
-				case bytes.Equal(b, snowmantest.GenesisBytes):
-					return snowmantest.Genesis, nil
-				default:
-					return nil, errUnknownBlock
-				}
-			}
-
-			parentBlk, err := proVM.BuildBlock(ctx)
-			require.NoError(t, err)
-			require.NoError(t, parentBlk.Verify(ctx))
-			require.NoError(t, parentBlk.Accept(ctx))
-			require.NoError(t, proVM.SetPreference(ctx, parentBlk.ID()))
-
-			test.setupMock(valState)
-
-			coreChildBlk := snowmantest.BuildChild(coreParentBlk)
-			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
-				return coreChildBlk, nil
-			}
-
-			var logged bool
-			loggingCore := logging.NewWrappedCore(logging.Warn, logging.Discard, logging.Plain.ConsoleEncoder())
-			proVM.ctx.Log = logging.NewLogger("", loggingCore).WithOptions(zap.Hooks(func(e zapcore.Entry) error {
-				require.False(t, logged, "expected exactly one log entry")
-				logged = true
-				require.Equal(t, zapcore.Level(logging.Warn), e.Level)
-				require.Equal(t, test.expectedMessage, e.Message)
-				return nil
-			}))
-
-			_, err = proVM.BuildBlock(ctx)
-			require.ErrorIs(t, err, database.ErrClosed)
-			require.True(t, logged, "expected log entry was not emitted")
+			require.Equal(t, 1, logs.Len())
+			entry := logs.All()[0]
+			require.Equal(t, zapcore.Level(test.wantLevel), entry.Level)
+			require.Equal(t, "msg", entry.Message)
 		})
 	}
 }
 
-func TestVerifyBlockErrClosedLogsWarn(t *testing.T) {
-	testCases := []struct {
-		name            string
-		setupMock       func(*validatorstest.State)
-		expectedMessage string
-	}{
-		{
-			name: "GetCurrentHeight returns ErrClosed",
-			setupMock: func(valState *validatorstest.State) {
-				valState.GetCurrentHeightF = func(context.Context) (uint64, error) {
-					return 0, database.ErrClosed
-				}
-			},
-			expectedMessage: "block verification failed",
-		},
-		{
-			name: "ExpectedProposer returns ErrClosed",
-			setupMock: func(valState *validatorstest.State) {
-				valState.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
-					return nil, database.ErrClosed
-				}
-			},
-			expectedMessage: "unexpected block verification failure",
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			ctx := t.Context()
-
-			coreVM, valState, proVM, _ := initTestProposerVM(t, upgradetest.Latest, 0)
-			t.Cleanup(func() {
-				require.NoError(t, proVM.Shutdown(ctx))
-			})
-
-			coreParentBlk := snowmantest.BuildChild(snowmantest.Genesis)
-			coreChildBlk := snowmantest.BuildChild(coreParentBlk)
-			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
-				return coreParentBlk, nil
-			}
-			coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
-				switch {
-				case bytes.Equal(b, coreParentBlk.Bytes()):
-					return coreParentBlk, nil
-				case bytes.Equal(b, coreChildBlk.Bytes()):
-					return coreChildBlk, nil
-				case bytes.Equal(b, snowmantest.GenesisBytes):
-					return snowmantest.Genesis, nil
-				default:
-					return nil, errUnknownBlock
-				}
-			}
-
-			parentBlk, err := proVM.BuildBlock(ctx)
-			require.NoError(t, err)
-			require.NoError(t, parentBlk.Verify(ctx))
-			require.NoError(t, parentBlk.Accept(ctx))
-			require.NoError(t, proVM.SetPreference(ctx, parentBlk.ID()))
-
-			coreVM.BuildBlockF = func(context.Context) (snowman.Block, error) {
-				return coreChildBlk, nil
-			}
-
-			childBlk, err := proVM.BuildBlock(ctx)
-			require.NoError(t, err)
-
-			test.setupMock(valState)
-
-			var logged bool
-			loggingCore := logging.NewWrappedCore(logging.Warn, logging.Discard, logging.Plain.ConsoleEncoder())
-			proVM.ctx.Log = logging.NewLogger("", loggingCore).WithOptions(zap.Hooks(func(e zapcore.Entry) error {
-				require.False(t, logged, "expected exactly one log entry")
-				logged = true
-				require.Equal(t, zapcore.Level(logging.Warn), e.Level)
-				require.Equal(t, test.expectedMessage, e.Message)
-				return nil
-			}))
-
-			err = childBlk.Verify(ctx)
-			require.ErrorIs(t, err, database.ErrClosed)
-			require.True(t, logged, "expected log entry was not emitted")
-		})
-	}
+func newObservedLogger() (logging.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zapcore.Level(logging.Verbo))
+	return logging.NewLogger("", logging.WrappedCore{Core: core}), logs
 }


### PR DESCRIPTION
## Why this should be merged

Antithesis runs are reporting recurring error-level log entries like:

```
level: error
msg: "block verification failed"
reason: "failed to get current P-Chain height"
error: "closed"
```

This is from a shutdown race condition. All chains receive the stop signal concurrently via `ChainRouter.Shutdown`, but the P-chain finishes draining and closes its database before the C-chain is done. Any in-flight block verification or build on the C-chain that calls `ValidatorState.GetCurrentHeight` or `Windower.ExpectedProposer` hits the closed P-chain DB and gets `database.ErrClosed`. This is expected and benign (the node is shutting down anyway), but the Error-level log creates noise in Antithesis reports and can also trigger oncall alerts.

## How this works

Add a `logErrorUnlessDBClosed` helper on `postForkCommonComponents` (alongside the existing `logWarnOrError`). It logs at Error unless the error wraps `database.ErrClosed`, in which case it logs at Warn.

Applied at four call sites in `proposervm/block.go`, two on the verify path and two on the build path:
- `Verify` -> `GetCurrentHeight` (P-chain height lookup)
- `buildChild` -> `selectChildPChainHeight` (optimal P-chain height selection)
- `verifyPostDurangoBlockDelay` -> `ExpectedProposer` (validator set lookup)
- `shouldBuildSignedBlockPostDurango` -> `ExpectedProposer` (validator set lookup)

Note: we use `database.ErrClosed` as a proxy for "shutting down" since there is no pchain shutdown signal accessible from within the proposalvm layer. This means if the P-chain DB were somehow closed during normal operation, these sites would incorrectly log at Warn instead of Error. In practice this is safe: the P-chain DB is only closed in `VM.Shutdown`, and if it closed during normal operation the P-chain would hit the closed DB on its own operations first, logging errors and crashing independently of the C-chain.

## How this was tested

Validated with a 10-hour Antithesis run. The error-level "block verification failed" / "closed" log entries were eliminated.

## Need to be documented in RELEASES.md?

No. Log level change only, no behavioral difference.