### PR TITLE
refactor: introduce base trie

### DIFF
--- a/graft/evm/firewood/BUILD.bazel
+++ b/graft/evm/firewood/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "firewood",
     srcs = [
         "account_trie.go",
+        "base_trie.go",
         "metrics.go",
         "state.go",
         "storage_trie.go",

--- a/graft/evm/firewood/account_trie.go
+++ b/graft/evm/firewood/account_trie.go
@@ -4,20 +4,10 @@
 package firewood
 
 import (
-	"errors"
-	"slices"
-
-	"github.com/ava-labs/firewood-go-ethhash/ffi"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
-	"github.com/ava-labs/libevm/core/types"
-	"github.com/ava-labs/libevm/crypto"
-	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/log"
-	"github.com/ava-labs/libevm/rlp"
-	"github.com/ava-labs/libevm/trie"
 	"github.com/ava-labs/libevm/trie/trienode"
-	"github.com/ava-labs/libevm/triedb/database"
 )
 
 var _ state.Trie = (*accountTrie)(nil)
@@ -33,13 +23,9 @@ var _ state.Trie = (*accountTrie)(nil)
 //
 // Note this is not concurrent safe.
 type accountTrie struct {
+	*baseTrie
 	fw         *TrieDB
 	parentRoot common.Hash
-	root       common.Hash
-	reader     database.Reader
-	dirtyKeys  map[string][]byte // Store dirty changes
-	updateOps  []ffi.BatchOp
-	hasChanges bool
 }
 
 func newAccountTrie(root common.Hash, db *TrieDB) (*accountTrie, error) {
@@ -48,147 +34,14 @@ func newAccountTrie(root common.Hash, db *TrieDB) (*accountTrie, error) {
 		return nil, err
 	}
 	return &accountTrie{
+		baseTrie: &baseTrie{
+			reader:     reader,
+			dirtyKeys:  make(map[string][]byte),
+			hasChanges: true, // Start with hasChanges true to allow computing the proposal hash
+		},
 		fw:         db,
 		parentRoot: root,
-		reader:     reader,
-		dirtyKeys:  make(map[string][]byte),
-		hasChanges: true, // Start with hasChanges true to allow computing the proposal hash
 	}, nil
-}
-
-// GetAccount returns the state account associated with an address.
-// - If the account has been updated, the new value is returned.
-// - If the account has been deleted, (nil, nil) is returned.
-// - If the account does not exist, (nil, nil) is returned.
-func (a *accountTrie) GetAccount(addr common.Address) (*types.StateAccount, error) {
-	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-
-	// First check if there's a pending update for this account
-	if updateValue, exists := a.dirtyKeys[string(key)]; exists {
-		// If the value is empty, it indicates deletion
-		// Invariant: All encoded values have length > 0
-		if len(updateValue) == 0 {
-			return nil, nil
-		}
-		// Decode and return the updated account
-		account := new(types.StateAccount)
-		err := rlp.DecodeBytes(updateValue, account)
-		return account, err
-	}
-
-	// No pending update found, read from the underlying reader
-	accountBytes, err := a.reader.Node(common.Hash{}, key, common.Hash{})
-	if err != nil {
-		return nil, err
-	}
-
-	if accountBytes == nil {
-		return nil, nil
-	}
-
-	// Decode the account node
-	account := new(types.StateAccount)
-	err = rlp.DecodeBytes(accountBytes, account)
-	return account, err
-}
-
-// GetStorage returns the value associated with a storage key for a given account address.
-// - If the storage slot has been updated, the new value is returned.
-// - If the storage slot has been deleted, (nil, nil) is returned.
-// - If the storage slot does not exist, (nil, nil) is returned.
-func (a *accountTrie) GetStorage(addr common.Address, key []byte) ([]byte, error) {
-	// If the account has been deleted, we should return nil
-	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	if val, exists := a.dirtyKeys[string(accountKey)]; exists && len(val) == 0 {
-		return nil, nil
-	}
-
-	var combinedKey [2 * common.HashLength]byte
-	storageKey := crypto.Keccak256Hash(key).Bytes()
-	copy(combinedKey[:common.HashLength], accountKey)
-	copy(combinedKey[common.HashLength:], storageKey)
-
-	// Check if there's a pending update for this storage slot
-	if updateValue, exists := a.dirtyKeys[string(combinedKey[:])]; exists {
-		// If the value is empty, it indicates deletion
-		if len(updateValue) == 0 {
-			return nil, nil
-		}
-		// Decode and return the updated storage value
-		_, decoded, _, err := rlp.Split(updateValue)
-		return decoded, err
-	}
-
-	// No pending update found, read from the underlying reader
-	storageBytes, err := a.reader.Node(common.Hash{}, combinedKey[:], common.Hash{})
-	if err != nil || storageBytes == nil {
-		return nil, err
-	}
-
-	// Decode the storage value
-	_, decoded, _, err := rlp.Split(storageBytes)
-	return decoded, err
-}
-
-// UpdateAccount replaces or creates the state account associated with an address.
-// This new value will be returned for subsequent `GetAccount` calls.
-func (a *accountTrie) UpdateAccount(addr common.Address, account *types.StateAccount) error {
-	// Queue the keys and values for later commit
-	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	data, err := rlp.EncodeToBytes(account)
-	if err != nil {
-		return err
-	}
-	a.dirtyKeys[string(key)] = data
-	a.updateOps = append(a.updateOps, ffi.Put(key, data))
-	a.hasChanges = true // Mark that there are changes to commit
-	return nil
-}
-
-// UpdateStorage replaces or creates the value associated with a storage key for a given account address.
-// This new value will be returned for subsequent `GetStorage` calls.
-func (a *accountTrie) UpdateStorage(addr common.Address, key []byte, value []byte) error {
-	var combinedKey [2 * common.HashLength]byte
-	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	storageKey := crypto.Keccak256Hash(key).Bytes()
-	copy(combinedKey[:common.HashLength], accountKey)
-	copy(combinedKey[common.HashLength:], storageKey)
-
-	data, err := rlp.EncodeToBytes(value)
-	if err != nil {
-		return err
-	}
-
-	// Queue the keys and values for later commit
-	a.dirtyKeys[string(combinedKey[:])] = data
-	a.updateOps = append(a.updateOps, ffi.Put(combinedKey[:], data))
-	a.hasChanges = true // Mark that there are changes to commit
-	return nil
-}
-
-// DeleteAccount removes the state account associated with an address.
-func (a *accountTrie) DeleteAccount(addr common.Address) error {
-	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	// Queue the key for deletion
-	a.dirtyKeys[string(key)] = nil
-	a.updateOps = append(a.updateOps, ffi.PrefixDelete(key)) // Remove all storage
-	a.hasChanges = true                                      // Mark that there are changes to commit
-	return nil
-}
-
-// DeleteStorage removes the value associated with a storage key for a given account address.
-func (a *accountTrie) DeleteStorage(addr common.Address, key []byte) error {
-	var combinedKey [2 * common.HashLength]byte
-	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	storageKey := crypto.Keccak256Hash(key).Bytes()
-	copy(combinedKey[:common.HashLength], accountKey)
-	copy(combinedKey[common.HashLength:], storageKey)
-
-	// Queue the key for deletion
-	a.dirtyKeys[string(combinedKey[:])] = nil
-	a.updateOps = append(a.updateOps, ffi.Delete(combinedKey[:]))
-	a.hasChanges = true // Mark that there are changes to commit
-	return nil
 }
 
 // Hash returns the current hash of the state trie.
@@ -233,52 +86,12 @@ func (a *accountTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
 	return hash, set, nil
 }
 
-// UpdateContractCode implements state.Trie.
-// Contract code is controlled by `rawdb`, so we don't need to do anything here.
-// This always returns nil.
-func (*accountTrie) UpdateContractCode(common.Address, common.Hash, []byte) error {
-	return nil
-}
-
-// GetKey implements state.Trie.
-// Preimages are not yet supported in Firewood.
-// It always returns nil.
-func (*accountTrie) GetKey([]byte) []byte {
-	return nil
-}
-
-// NodeIterator implements state.Trie.
-// Firewood does not support iterating over internal nodes.
-// This always returns an error.
-func (*accountTrie) NodeIterator([]byte) (trie.NodeIterator, error) {
-	return nil, errors.New("NodeIterator not implemented for Firewood")
-}
-
-// Prove implements state.Trie.
-// Firewood does not support providing key proofs.
-// This always returns an error.
-func (*accountTrie) Prove([]byte, ethdb.KeyValueWriter) error {
-	return errors.New("Prove not implemented for Firewood")
-}
-
 // Copy creates a deep copy of the [accountTrie].
 // The [database.Reader] is shared, since it is read-only.
 func (a *accountTrie) Copy() *accountTrie {
-	// Create a new AccountTrie with the same root and reader
-	newTrie := &accountTrie{
+	return &accountTrie{
+		baseTrie:   a.baseTrie.copy(),
 		fw:         a.fw,
 		parentRoot: a.parentRoot,
-		root:       a.root,
-		reader:     a.reader, // Share the same reader
-		hasChanges: a.hasChanges,
-		dirtyKeys:  make(map[string][]byte, len(a.dirtyKeys)),
-		updateOps:  slices.Clone(a.updateOps), // each ffi.BatchOp is read-only, safe to shallow copy
 	}
-
-	// Deep copy dirtyKeys map
-	for k, v := range a.dirtyKeys {
-		newTrie.dirtyKeys[k] = slices.Clone(v)
-	}
-
-	return newTrie
 }

--- a/graft/evm/firewood/base_trie.go
+++ b/graft/evm/firewood/base_trie.go
@@ -1,0 +1,215 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"errors"
+	"slices"
+
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/rlp"
+	"github.com/ava-labs/libevm/trie"
+	"github.com/ava-labs/libevm/triedb/database"
+)
+
+var (
+	errNodeIteratorNotImplemented = errors.New("NodeIterator not implemented for Firewood")
+	errProveNotImplemented        = errors.New("Prove not implemented for Firewood")
+)
+
+// baseTrie contains the shared state and methods for all Firewood
+// trie implementations. It provides the read/write operations that are
+// identical between [accountTrie] and [reconstructedAccountTrie].
+//
+// Not concurrent-safe.
+type baseTrie struct {
+	reader     database.Reader
+	root       common.Hash
+	dirtyKeys  map[string][]byte
+	updateOps  []ffi.BatchOp
+	hasChanges bool
+}
+
+// GetAccount returns the state account associated with an address.
+// - If the account has been updated, the new value is returned.
+// - If the account has been deleted, (nil, nil) is returned.
+// - If the account does not exist, (nil, nil) is returned.
+func (a *baseTrie) GetAccount(addr common.Address) (*types.StateAccount, error) {
+	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+
+	// First check if there's a pending update for this account
+	if updateValue, exists := a.dirtyKeys[string(key)]; exists {
+		// If the value is empty, it indicates deletion
+		// Invariant: All encoded values have length > 0
+		if len(updateValue) == 0 {
+			return nil, nil
+		}
+		// Decode and return the updated account
+		account := new(types.StateAccount)
+		err := rlp.DecodeBytes(updateValue, account)
+		return account, err
+	}
+
+	// No pending update found, read from the underlying reader
+	accountBytes, err := a.reader.Node(common.Hash{}, key, common.Hash{})
+	if err != nil {
+		return nil, err
+	}
+
+	if accountBytes == nil {
+		return nil, nil
+	}
+
+	// Decode the account node
+	account := new(types.StateAccount)
+	err = rlp.DecodeBytes(accountBytes, account)
+	return account, err
+}
+
+// GetStorage returns the value associated with a storage key for a given account address.
+// - If the storage slot has been updated, the new value is returned.
+// - If the storage slot has been deleted, (nil, nil) is returned.
+// - If the storage slot does not exist, (nil, nil) is returned.
+func (a *baseTrie) GetStorage(addr common.Address, key []byte) ([]byte, error) {
+	// If the account has been deleted, we should return nil
+	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	if val, exists := a.dirtyKeys[string(accountKey)]; exists && len(val) == 0 {
+		return nil, nil
+	}
+
+	var combinedKey [2 * common.HashLength]byte
+	storageKey := crypto.Keccak256Hash(key).Bytes()
+	copy(combinedKey[:common.HashLength], accountKey)
+	copy(combinedKey[common.HashLength:], storageKey)
+
+	// Check if there's a pending update for this storage slot
+	if updateValue, exists := a.dirtyKeys[string(combinedKey[:])]; exists {
+		// If the value is empty, it indicates deletion
+		if len(updateValue) == 0 {
+			return nil, nil
+		}
+		// Decode and return the updated storage value
+		_, decoded, _, err := rlp.Split(updateValue)
+		return decoded, err
+	}
+
+	// No pending update found, read from the underlying reader
+	storageBytes, err := a.reader.Node(common.Hash{}, combinedKey[:], common.Hash{})
+	if err != nil || storageBytes == nil {
+		return nil, err
+	}
+
+	// Decode the storage value
+	_, decoded, _, err := rlp.Split(storageBytes)
+	return decoded, err
+}
+
+// UpdateAccount replaces or creates the state account associated with an address.
+// This new value will be returned for subsequent `GetAccount` calls.
+func (a *baseTrie) UpdateAccount(addr common.Address, account *types.StateAccount) error {
+	// Queue the keys and values for later commit
+	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	data, err := rlp.EncodeToBytes(account)
+	if err != nil {
+		return err
+	}
+	a.dirtyKeys[string(key)] = data
+	a.updateOps = append(a.updateOps, ffi.Put(key, data))
+	a.hasChanges = true // Mark that there are changes to commit
+	return nil
+}
+
+// UpdateStorage replaces or creates the value associated with a storage key for a given account address.
+// This new value will be returned for subsequent `GetStorage` calls.
+func (a *baseTrie) UpdateStorage(addr common.Address, key []byte, value []byte) error {
+	var combinedKey [2 * common.HashLength]byte
+	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	storageKey := crypto.Keccak256Hash(key).Bytes()
+	copy(combinedKey[:common.HashLength], accountKey)
+	copy(combinedKey[common.HashLength:], storageKey)
+
+	data, err := rlp.EncodeToBytes(value)
+	if err != nil {
+		return err
+	}
+
+	// Queue the keys and values for later commit
+	a.dirtyKeys[string(combinedKey[:])] = data
+	a.updateOps = append(a.updateOps, ffi.Put(combinedKey[:], data))
+	a.hasChanges = true // Mark that there are changes to commit
+	return nil
+}
+
+// DeleteAccount removes the state account associated with an address.
+func (a *baseTrie) DeleteAccount(addr common.Address) error {
+	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	// Queue the key for deletion
+	a.dirtyKeys[string(key)] = nil
+	a.updateOps = append(a.updateOps, ffi.PrefixDelete(key)) // Remove all storage
+	a.hasChanges = true                                      // Mark that there are changes to commit
+	return nil
+}
+
+// DeleteStorage removes the value associated with a storage key for a given account address.
+func (a *baseTrie) DeleteStorage(addr common.Address, key []byte) error {
+	var combinedKey [2 * common.HashLength]byte
+	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	storageKey := crypto.Keccak256Hash(key).Bytes()
+	copy(combinedKey[:common.HashLength], accountKey)
+	copy(combinedKey[common.HashLength:], storageKey)
+
+	// Queue the key for deletion
+	a.dirtyKeys[string(combinedKey[:])] = nil
+	a.updateOps = append(a.updateOps, ffi.Delete(combinedKey[:]))
+	a.hasChanges = true // Mark that there are changes to commit
+	return nil
+}
+
+// UpdateContractCode implements state.Trie.
+// Contract code is controlled by `rawdb`, so we don't need to do anything here.
+// This always returns nil.
+func (*baseTrie) UpdateContractCode(common.Address, common.Hash, []byte) error {
+	return nil
+}
+
+// GetKey implements state.Trie.
+// Preimages are not yet supported in Firewood.
+// It always returns nil.
+func (*baseTrie) GetKey([]byte) []byte {
+	return nil
+}
+
+// NodeIterator implements state.Trie.
+// Firewood does not support iterating over internal nodes.
+// This always returns an error.
+func (*baseTrie) NodeIterator([]byte) (trie.NodeIterator, error) {
+	return nil, errNodeIteratorNotImplemented
+}
+
+// Prove implements state.Trie.
+// Firewood does not support providing key proofs.
+// This always returns an error.
+func (*baseTrie) Prove([]byte, ethdb.KeyValueWriter) error {
+	return errProveNotImplemented
+}
+
+// copy creates a deep copy of the baseTrie fields.
+// The [database.Reader] is shared, since it is read-only.
+func (a *baseTrie) copy() *baseTrie {
+	newBase := &baseTrie{
+		reader:     a.reader,
+		root:       a.root,
+		hasChanges: a.hasChanges,
+		dirtyKeys:  make(map[string][]byte, len(a.dirtyKeys)),
+		updateOps:  slices.Clone(a.updateOps), // each ffi.BatchOp is read-only, safe to shallow copy
+	}
+	for k, v := range a.dirtyKeys {
+		newBase.dirtyKeys[k] = slices.Clone(v)
+	}
+	return newBase
+}

--- a/graft/evm/firewood/state.go
+++ b/graft/evm/firewood/state.go
@@ -37,7 +37,7 @@ func (*stateAccessor) OpenStorageTrie(stateRoot common.Hash, addr common.Address
 	if !ok {
 		return nil, fmt.Errorf("invalid account trie type: %T", self)
 	}
-	return newStorageTrie(accountTrie), nil
+	return newStorageTrie(accountTrie.baseTrie), nil
 }
 
 // CopyTrie returns a deep copy of the given trie.

--- a/graft/evm/firewood/storage_trie.go
+++ b/graft/evm/firewood/storage_trie.go
@@ -12,18 +12,19 @@ import (
 var _ state.Trie = (*storageTrie)(nil)
 
 type storageTrie struct {
-	*accountTrie
+	*baseTrie
 }
 
-// `newStorageTrie` returns a wrapper around an `accountTrie` since Firewood
-// does not require a separate storage trie. All changes are managed by the account trie.
-func newStorageTrie(accountTrie *accountTrie) *storageTrie {
+// newStorageTrie returns a wrapper around a [baseTrie] since Firewood
+// does not require a separate storage trie. All changes are tracked by the base
+// trie.
+func newStorageTrie(base *baseTrie) *storageTrie {
 	return &storageTrie{
-		accountTrie: accountTrie,
+		baseTrie: base,
 	}
 }
 
-// Commit is a no-op for storage tries, as all changes are managed by the account trie.
+// Commit is a no-op for storage tries, as all changes are tracked by the base trie.
 // It always returns a nil NodeSet and zero hash.
 func (*storageTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
 	return common.Hash{}, nil, nil


### PR DESCRIPTION
## Why this should be merged

Part of enabling Firewood archival nodes to use deferred persistence is to add a `state.Trie` implementation that uses  `ffi.Reconstructed` rather than `*TrieDB` for use with `*state.StateDB`. Since this new implementation is mostly a copy-and-paste of `accountTrie`, I created a new `baseTrie` which both trie implementations will use.

This PR is followed by:

- Add reconstructed types (https://github.com/ava-labs/avalanchego/pull/5114)
- Enable deferred persistence for Firewood archive nodes (https://github.com/ava-labs/avalanchego/pull/5115)

## How this works

Refactors common code between `accountTrie` and `reconstructedAccountTrie` into a common type `baseTrie`

## How this was tested

CI

## Need to be documented in RELEASES.md?

No