### PR TITLE
feat: add reconstructed types

### DIFF
--- a/graft/evm/firewood/BUILD.bazel
+++ b/graft/evm/firewood/BUILD.bazel
@@ -7,6 +7,8 @@ go_library(
         "account_trie.go",
         "base_trie.go",
         "metrics.go",
+        "reconstructed_state.go",
+        "reconstructed_trie.go",
         "state.go",
         "storage_trie.go",
         "triedb.go",
@@ -37,6 +39,7 @@ graft_go_test(
     name = "firewood_test",
     srcs = [
         "hash_test.go",
+        "reconstructed_state_test.go",
         "triedb_test.go",
     ],
     embed = [":firewood"],

--- a/graft/evm/firewood/reconstructed_state.go
+++ b/graft/evm/firewood/reconstructed_state.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/state"
+)
+
+var _ state.Database = (*reconstructedStateAccessor)(nil)
+
+// reconstructedStateAccessor wraps a [state.Database] and overrides OpenTrie
+// and OpenStorageTrie to return reconstructed tries backed by an [ffi.Reconstructed].
+type reconstructedStateAccessor struct {
+	state.Database
+	recon *ffi.Reconstructed
+}
+
+// NewReconstructedStateAccessor creates a [state.Database] that opens tries
+// backed by the given [ffi.Reconstructed] view. The [ffi.Reconstructed] view is
+// mutated in place by trie operations, so the caller must not use it concurrently.
+//
+// The provided db must have been returned by [NewStateAccessor].
+func NewReconstructedStateAccessor(db state.Database, recon *ffi.Reconstructed) (state.Database, error) {
+	if _, ok := db.(*stateAccessor); !ok {
+		return nil, fmt.Errorf("expected *stateAccessor, got %T", db)
+	}
+	return &reconstructedStateAccessor{
+		Database: db,
+		recon:    recon,
+	}, nil
+}
+
+// OpenTrie opens an account trie backed by the [ffi.Reconstructed] view.
+// Only the view's current root is accepted; passing an arbitrary root will
+// return an error.
+func (s *reconstructedStateAccessor) OpenTrie(hash common.Hash) (state.Trie, error) {
+	currRoot := common.Hash(s.recon.Root())
+	if currRoot != hash {
+		return nil, fmt.Errorf("expected root hash %s but got %s", hash, currRoot)
+	}
+
+	t, err := newReconstructedAccountTrie(s.recon)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// OpenStorageTrie opens a reconstructed storage trie wrapping the account trie.
+//
+//nolint:revive // removing names loses context.
+func (*reconstructedStateAccessor) OpenStorageTrie(stateRoot common.Hash, addr common.Address, accountRoot common.Hash, self state.Trie) (state.Trie, error) {
+	accountTrie, ok := self.(*reconstructedAccountTrie)
+	if !ok {
+		return nil, fmt.Errorf("invalid account trie type for reconstructed storage: %T", self)
+	}
+	return newStorageTrie(&accountTrie.baseTrie), nil
+}
+
+// CopyTrie returns a deep copy of the given trie.
+func (*reconstructedStateAccessor) CopyTrie(t state.Trie) state.Trie {
+	switch t := t.(type) {
+	case *reconstructedAccountTrie:
+		// reconstructedAccountTrie is not concurrent-safe
+		return nil
+	case *storageTrie:
+		return nil
+	default:
+		panic(fmt.Errorf("unknown trie type %T", t))
+	}
+}

--- a/graft/evm/firewood/reconstructed_state_test.go
+++ b/graft/evm/firewood/reconstructed_state_test.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/libevm/stateconf"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconstructedRevisions(t *testing.T) {
+	r := require.New(t)
+
+	dbDir := t.TempDir()
+	cfg := DefaultConfig(dbDir)
+
+	// Set commitInterval high to persist only on shutdown
+	commitInterval := uint64(500)
+	cfg.DeferredCommitInterval = commitInterval
+	cfg.RevisionsInMemory = uint(commitInterval)
+
+	db := newTestDatabaseWithConfig(t, cfg)
+	trie, err := db.OpenTrie(types.EmptyRootHash)
+	r.NoError(err)
+
+	var (
+		addr           = common.HexToAddress("1234")
+		initialBalance = uint256.NewInt(100)
+	)
+
+	r.NoError(trie.UpdateAccount(addr, &types.StateAccount{Balance: initialBalance}))
+
+	// Commit and persist initial revision (R1)
+	initialRoot, _, err := trie.Commit(true)
+	r.NoError(err)
+	r.NoError(db.TrieDB().Update(
+		initialRoot,
+		types.EmptyRootHash,
+		0,
+		nil,
+		nil,
+		stateconf.WithTrieDBUpdatePayload(common.Hash{}, common.Hash{1})),
+	)
+	r.NoError(db.TrieDB().Commit(initialRoot, true))
+	r.NoError(db.TrieDB().Backend().Close())
+
+	// Reopen the database
+	db = newTestDatabaseWithConfig(t, cfg)
+
+	// Create a reconstructed view starting from R1 (the latest persisted revision)
+	tdb := db.TrieDB().Backend().(*TrieDB)
+	rev, err := tdb.Firewood.LatestRevision()
+	r.NoError(err)
+	recon, err := rev.Reconstruct(nil)
+	r.NoError(err)
+	r.NoError(rev.Drop())
+	t.Cleanup(func() {
+		r.NoError(recon.Drop())
+	})
+
+	reconDB, err := NewReconstructedStateAccessor(db, recon)
+	r.NoError(err)
+
+	var (
+		newBalances = []*uint256.Int{
+			uint256.NewInt(200),
+			uint256.NewInt(300),
+			uint256.NewInt(400),
+		}
+		prevRoot      = initialRoot
+		prevBlockHash = common.Hash{} // After reopen, TrieDB only knows the empty block hash.
+	)
+
+	// Commit 3 more times (R2, R3, R4)
+	// Afterwards, reconstruct R2, R3, R4 from R1 and verify the roots match.
+	for i, balance := range newBalances {
+		// Commit normal revision.
+		trie, err = db.OpenTrie(prevRoot)
+		r.NoError(err)
+
+		r.NoError(trie.UpdateAccount(addr, &types.StateAccount{Balance: balance}))
+		normalRoot := trie.Hash()
+		_, _, err = trie.Commit(true)
+		r.NoError(err)
+
+		blockHash := common.Hash{byte(i + 1)}
+		r.NoError(db.TrieDB().Update(
+			normalRoot,
+			prevRoot,
+			uint64(i),
+			nil,
+			nil,
+			stateconf.WithTrieDBUpdatePayload(prevBlockHash, blockHash)),
+		)
+		r.NoError(db.TrieDB().Commit(normalRoot, true))
+		prevRoot = normalRoot
+		prevBlockHash = blockHash
+
+		// Create reconstructed revision and verify root matches.
+		reconTrie, err := reconDB.OpenTrie(common.Hash(recon.Root()))
+		r.NoError(err)
+		r.NoError(reconTrie.UpdateAccount(addr, &types.StateAccount{Balance: balance}))
+		r.Equal(normalRoot, reconTrie.Hash(), "reconstructed root mismatch for R%d", i+2)
+	}
+}

--- a/graft/evm/firewood/reconstructed_trie.go
+++ b/graft/evm/firewood/reconstructed_trie.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"errors"
+
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/log"
+	"github.com/ava-labs/libevm/trie/trienode"
+	"github.com/ava-labs/libevm/triedb/database"
+)
+
+var (
+	_ state.Trie = (*reconstructedAccountTrie)(nil)
+
+	errNilReconstructed = errors.New("nil Reconstructed")
+)
+
+// reconstructedAccountTrie implements [state.Trie] backed by an [ffi.Reconstructed] view.
+// Like [accountTrie], it accumulates BatchOps from writes. Unlike [accountTrie],
+// Hash() chains Reconstruct() calls instead of creating proposals.
+//
+// Not concurrent-safe (matching Reconstructed's guarantees).
+type reconstructedAccountTrie struct {
+	baseTrie
+	recon *ffi.Reconstructed
+}
+
+// newReconstructedAccountTrie creates a new reconstructed account trie.
+// The caller retains ownership of the [ffi.Reconstructed] handle and must ensure
+// it outlives the trie.
+func newReconstructedAccountTrie(recon *ffi.Reconstructed) (*reconstructedAccountTrie, error) {
+	if recon == nil {
+		return nil, errNilReconstructed
+	}
+	return &reconstructedAccountTrie{
+		baseTrie: baseTrie{
+			reader:    &reconstructedReader{reconstructed: recon},
+			root:      common.Hash(recon.Root()),
+			dirtyKeys: make(map[string][]byte),
+		},
+		recon: recon,
+	}, nil
+}
+
+// Hash returns the current hash of the reconstructed trie.
+// This will chain Reconstruct() with the accumulated ops to compute the new root.
+// If there are no changes since the last call, the cached root is returned.
+// On error, the zero hash is returned.
+func (r *reconstructedAccountTrie) Hash() common.Hash {
+	hash, err := r.hash()
+	if err != nil {
+		log.Error("Failed to hash reconstructed trie", "error", err)
+		return common.Hash{}
+	}
+	return hash
+}
+
+func (r *reconstructedAccountTrie) hash() (common.Hash, error) {
+	if r.hasChanges {
+		// Reconstruct() mutates the receiver in place with the new state.
+		if err := r.recon.Reconstruct(r.updateOps); err != nil {
+			return common.Hash{}, err
+		}
+		r.root = common.Hash(r.recon.Root())
+		// Unlike accountTrie, updateOps must be cleared because Reconstruct()
+		// is incremental (mutates in place), whereas createProposals() replays
+		// all ops from the parent root each time.
+		r.updateOps = nil
+		r.dirtyKeys = make(map[string][]byte)
+		r.hasChanges = false
+	}
+	return r.root, nil
+}
+
+// Commit returns the new root hash of the trie and an empty [trienode.NodeSet].
+// No persistence occurs; reconstructed views exist only in memory and are not
+// committed to the Firewood database.
+func (r *reconstructedAccountTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
+	hash, err := r.hash()
+	if err != nil {
+		return common.Hash{}, nil, err
+	}
+	return hash, trienode.NewNodeSet(common.Hash{}), nil
+}
+
+var _ database.Reader = (*reconstructedReader)(nil)
+
+// reconstructedReader adapts an [ffi.Reconstructed] to the [database.Reader] interface.
+// The underlying [ffi.Reconstructed] may be mutated by Reconstruct() calls, which
+// changes what Get() returns.
+type reconstructedReader struct {
+	reconstructed *ffi.Reconstructed
+}
+
+// Node retrieves the value at the given path from the reconstructed view.
+func (r *reconstructedReader) Node(_ common.Hash, path []byte, _ common.Hash) ([]byte, error) {
+	return r.reconstructed.Get(path)
+}

--- a/graft/evm/firewood/triedb_test.go
+++ b/graft/evm/firewood/triedb_test.go
@@ -19,8 +19,14 @@ import (
 func newTestDatabase(t *testing.T) state.Database {
 	t.Helper()
 	fwConfig := DefaultConfig(t.TempDir())
+
+	return newTestDatabaseWithConfig(t, fwConfig)
+}
+
+func newTestDatabaseWithConfig(t *testing.T, cfg TrieDBConfig) state.Database {
+	t.Helper()
 	triedbConfig := &triedb.Config{
-		DBOverride: fwConfig.BackendConstructor,
+		DBOverride: cfg.BackendConstructor,
 	}
 	internalState := state.NewDatabaseWithConfig(
 		rawdb.NewMemoryDatabase(),


### PR DESCRIPTION
## Why this should be merged

Add a `state.Trie` implementation that uses `ffi.Reconstructed` rather than `*TrieDB` for use with `*state.StateDB`.

This PR builds on #5113 and is followed by #5115.

## How this works

Adds the following types:
- `reconstructedStateAccessor`
- `reconstructedAccountTrie`
- `reconstructedReader`

## How this was tested

Added UT for verifying that reconstructed account tries behave the same as regular account tries.

## Need to be documented in RELEASES.md?

No