### PR TITLE
chore: bump commit count for Firewood archival nodes

### DIFF
--- a/tests/reexecute/c/vm_reexecute.go
+++ b/tests/reexecute/c/vm_reexecute.go
@@ -82,7 +82,9 @@ var (
 			"state-scheme": "firewood",
 			"snapshot-cache": 0,
 			"pruning-enabled": false,
-			"state-sync-enabled": false
+			"state-sync-enabled": false,
+			"commit-interval": 4096,
+			"state-history": 8192
 		}`,
 	}
 


### PR DESCRIPTION
## Why this should be merged

With Firewood archival nodes now able to utilize deferred persistence, we can now reduce how often we commit similar to what we already do for non-archival nodes. 

## How this works

Sets `"commit-interval": 4096` and `"state-history": 8192`.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No