### PR TITLE
[ci] add KMS-backed package signing flow

### DIFF
--- a/.github/packaging/Dockerfile
+++ b/.github/packaging/Dockerfile
@@ -18,7 +18,6 @@ ARG TARGETARCH
 # - gnupg2: GPG signing of RPM packages
 # - git: version detection in build scripts
 RUN dnf install -y \
-        curl \
         'dnf-command(config-manager)' \
         gcc \
         gnupg2 \

--- a/.github/packaging/Dockerfile
+++ b/.github/packaging/Dockerfile
@@ -18,9 +18,12 @@ ARG TARGETARCH
 # - gnupg2: GPG signing of RPM packages
 # - git: version detection in build scripts
 RUN dnf install -y \
+        curl \
         gcc \
         gnupg2 \
+        gnupg-pkcs11-scd \
         git \
+        rpm-sign \
     && dnf clean all
 
 # Install Go (with SHA256 verification)

--- a/.github/packaging/Dockerfile
+++ b/.github/packaging/Dockerfile
@@ -19,11 +19,14 @@ ARG TARGETARCH
 # - git: version detection in build scripts
 RUN dnf install -y \
         curl \
+        'dnf-command(config-manager)' \
         gcc \
         gnupg2 \
-        gnupg-pkcs11-scd \
         git \
         rpm-sign \
+    && dnf config-manager --set-enabled crb \
+    && dnf install -y epel-release \
+    && dnf install -y gnupg-pkcs11-scd \
     && dnf clean all
 
 # Install Go (with SHA256 verification)

--- a/.github/packaging/Taskfile.yml
+++ b/.github/packaging/Taskfile.yml
@@ -37,6 +37,21 @@ tasks:
     silent: true
     cmd: task --list | grep packaging
 
+  setup-kms-gpg:
+    desc: Configures KMS-backed GPG for package signing
+    cmds:
+      - cmd: '{{.REPO_ROOT}}/.github/packaging/scripts/setup-kms-gpg.sh'
+
+  sign-deb:
+    desc: Signs a DEB package with the configured GPG identity
+    cmds:
+      - cmd: '{{.REPO_ROOT}}/.github/packaging/scripts/sign-deb.sh'
+
+  validate-deb:
+    desc: Validates a DEB package in a fresh container
+    cmds:
+      - cmd: '{{.REPO_ROOT}}/.github/packaging/scripts/validate-deb.sh'
+
   build-rpms:
     desc: Builds RPMs for both avalanchego and subnet-evm
     cmds:

--- a/.github/packaging/Taskfile.yml
+++ b/.github/packaging/Taskfile.yml
@@ -66,6 +66,7 @@ tasks:
           -v {{.REPO_ROOT}}:/build
           -v {{.PACKAGING_OUTPUT_DIR}}:/output
           {{if .RPM_GPG_KEY_FILE}}-v {{.RPM_GPG_KEY_FILE}}:{{.RPM_GPG_KEY_FILE}}:ro{{end}}
+          {{if .PACKAGE_SIGNING_X509_CERT_PATH}}-v {{.PACKAGE_SIGNING_X509_CERT_PATH}}:{{.PACKAGE_SIGNING_X509_CERT_PATH}}:ro{{end}}
           -e PACKAGE=avalanchego
           -e VERSION={{trimPrefix "v" .RPM_TAG}}
           -e TAG={{.RPM_TAG}}
@@ -74,6 +75,16 @@ tasks:
           -e AVALANCHEGO_COMMIT={{.PACKAGING_GIT_COMMIT}}
           {{if .RPM_GPG_KEY_FILE}}-e RPM_GPG_KEY_FILE={{.RPM_GPG_KEY_FILE}}{{end}}
           {{if .NFPM_RPM_PASSPHRASE}}-e NFPM_RPM_PASSPHRASE={{.NFPM_RPM_PASSPHRASE}}{{end}}
+          {{if .PACKAGE_SIGNING_KMS_KEY_ID}}-e PACKAGE_SIGNING_KMS_KEY_ID={{.PACKAGE_SIGNING_KMS_KEY_ID}}{{end}}
+          {{if .PACKAGE_SIGNING_OPENPGP_KEY_SHA1}}-e PACKAGE_SIGNING_OPENPGP_KEY_SHA1={{.PACKAGE_SIGNING_OPENPGP_KEY_SHA1}}{{end}}
+          {{if .PACKAGE_SIGNING_X509_CERT_PATH}}-e PACKAGE_SIGNING_X509_CERT_PATH={{.PACKAGE_SIGNING_X509_CERT_PATH}}{{end}}
+          {{if .PACKAGE_SIGNING_X509_CERT_PEM_BASE64}}-e PACKAGE_SIGNING_X509_CERT_PEM_BASE64={{.PACKAGE_SIGNING_X509_CERT_PEM_BASE64}}{{end}}
+          {{if .AWS_KMS_PKCS11_DOWNLOAD_URL}}-e AWS_KMS_PKCS11_DOWNLOAD_URL={{.AWS_KMS_PKCS11_DOWNLOAD_URL}}{{end}}
+          {{if .AWS_KMS_PKCS11_LIBRARY_PATH}}-e AWS_KMS_PKCS11_LIBRARY_PATH={{.AWS_KMS_PKCS11_LIBRARY_PATH}}{{end}}
+          {{if .AWS_ACCESS_KEY_ID}}-e AWS_ACCESS_KEY_ID={{.AWS_ACCESS_KEY_ID}}{{end}}
+          {{if .AWS_SECRET_ACCESS_KEY}}-e AWS_SECRET_ACCESS_KEY={{.AWS_SECRET_ACCESS_KEY}}{{end}}
+          {{if .AWS_SESSION_TOKEN}}-e AWS_SESSION_TOKEN={{.AWS_SESSION_TOKEN}}{{end}}
+          {{if .AWS_REGION}}-e AWS_REGION={{.AWS_REGION}}{{end}}
           {{.PACKAGING_DOCKER_IMAGE}}
           .github/packaging/scripts/build-rpm.sh
 
@@ -90,6 +101,7 @@ tasks:
           -v {{.REPO_ROOT}}:/build
           -v {{.PACKAGING_OUTPUT_DIR}}:/output
           {{if .RPM_GPG_KEY_FILE}}-v {{.RPM_GPG_KEY_FILE}}:{{.RPM_GPG_KEY_FILE}}:ro{{end}}
+          {{if .PACKAGE_SIGNING_X509_CERT_PATH}}-v {{.PACKAGE_SIGNING_X509_CERT_PATH}}:{{.PACKAGE_SIGNING_X509_CERT_PATH}}:ro{{end}}
           -e PACKAGE=subnet-evm
           -e VERSION={{trimPrefix "v" .RPM_TAG}}
           -e TAG={{.RPM_TAG}}
@@ -98,6 +110,16 @@ tasks:
           -e AVALANCHEGO_COMMIT={{.PACKAGING_GIT_COMMIT}}
           {{if .RPM_GPG_KEY_FILE}}-e RPM_GPG_KEY_FILE={{.RPM_GPG_KEY_FILE}}{{end}}
           {{if .NFPM_RPM_PASSPHRASE}}-e NFPM_RPM_PASSPHRASE={{.NFPM_RPM_PASSPHRASE}}{{end}}
+          {{if .PACKAGE_SIGNING_KMS_KEY_ID}}-e PACKAGE_SIGNING_KMS_KEY_ID={{.PACKAGE_SIGNING_KMS_KEY_ID}}{{end}}
+          {{if .PACKAGE_SIGNING_OPENPGP_KEY_SHA1}}-e PACKAGE_SIGNING_OPENPGP_KEY_SHA1={{.PACKAGE_SIGNING_OPENPGP_KEY_SHA1}}{{end}}
+          {{if .PACKAGE_SIGNING_X509_CERT_PATH}}-e PACKAGE_SIGNING_X509_CERT_PATH={{.PACKAGE_SIGNING_X509_CERT_PATH}}{{end}}
+          {{if .PACKAGE_SIGNING_X509_CERT_PEM_BASE64}}-e PACKAGE_SIGNING_X509_CERT_PEM_BASE64={{.PACKAGE_SIGNING_X509_CERT_PEM_BASE64}}{{end}}
+          {{if .AWS_KMS_PKCS11_DOWNLOAD_URL}}-e AWS_KMS_PKCS11_DOWNLOAD_URL={{.AWS_KMS_PKCS11_DOWNLOAD_URL}}{{end}}
+          {{if .AWS_KMS_PKCS11_LIBRARY_PATH}}-e AWS_KMS_PKCS11_LIBRARY_PATH={{.AWS_KMS_PKCS11_LIBRARY_PATH}}{{end}}
+          {{if .AWS_ACCESS_KEY_ID}}-e AWS_ACCESS_KEY_ID={{.AWS_ACCESS_KEY_ID}}{{end}}
+          {{if .AWS_SECRET_ACCESS_KEY}}-e AWS_SECRET_ACCESS_KEY={{.AWS_SECRET_ACCESS_KEY}}{{end}}
+          {{if .AWS_SESSION_TOKEN}}-e AWS_SESSION_TOKEN={{.AWS_SESSION_TOKEN}}{{end}}
+          {{if .AWS_REGION}}-e AWS_REGION={{.AWS_REGION}}{{end}}
           {{.PACKAGING_DOCKER_IMAGE}}
           .github/packaging/scripts/build-rpm.sh
 
@@ -112,5 +134,6 @@ tasks:
     env:
       TAG: '{{.PACKAGING_TAG}}'
       GIT_COMMIT: '{{.PACKAGING_GIT_COMMIT}}'
+      REQUIRE_SIGNATURE: '{{.REQUIRE_SIGNATURE | default "0"}}'
     cmds:
       - cmd: '{{.REPO_ROOT}}/.github/packaging/scripts/validate-rpm.sh'

--- a/.github/packaging/keys/README.md
+++ b/.github/packaging/keys/README.md
@@ -1,0 +1,7 @@
+Place the committed armored package-signing public key here as
+`avalanchego-signing-public.asc` once the AWS KMS-backed signing identity
+has been provisioned.
+
+Until that key is committed, the workflows export a runtime copy of the
+public key generated from the configured signer and use that for
+validation and artifacts.

--- a/.github/packaging/nfpm/avalanchego-unsigned.yml
+++ b/.github/packaging/nfpm/avalanchego-unsigned.yml
@@ -1,0 +1,18 @@
+name: avalanchego
+arch: "${RPM_ARCH}"
+version: "${VERSION}"
+maintainer: "Ava Labs <security@avalabs.org>"
+description: "AvalancheGo node — the official Avalanche protocol implementation"
+homepage: "https://github.com/ava-labs/avalanchego"
+license: "BSD-3-Clause"
+depends:
+  - "glibc >= 2.34"
+contents:
+  - src: "${AVALANCHEGO_BINARY}"
+    dst: /var/opt/avalanchego/bin/avalanchego
+    expand: true
+    file_info:
+      mode: 0755
+changelog: "/build/build/nfpm-changelog.yml"
+rpm:
+  compression: zstd

--- a/.github/packaging/nfpm/subnet-evm-unsigned.yml
+++ b/.github/packaging/nfpm/subnet-evm-unsigned.yml
@@ -1,0 +1,18 @@
+name: subnet-evm
+arch: "${RPM_ARCH}"
+version: "${VERSION}"
+maintainer: "Ava Labs <security@avalabs.org>"
+description: "Subnet-EVM plugin for AvalancheGo"
+homepage: "https://github.com/ava-labs/avalanchego"
+license: "BSD-3-Clause"
+depends:
+  - "glibc >= 2.34"
+contents:
+  - src: "${SUBNET_EVM_BINARY}"
+    dst: /var/opt/avalanchego/plugins/${SUBNET_EVM_VM_ID}
+    expand: true
+    file_info:
+      mode: 0755
+changelog: "/build/build/nfpm-changelog.yml"
+rpm:
+  compression: zstd

--- a/.github/packaging/scripts/build-rpm.sh
+++ b/.github/packaging/scripts/build-rpm.sh
@@ -13,6 +13,7 @@
 #   RPM_GPG_KEY_FILE      - Path to GPG private key for signing
 #   NFPM_RPM_PASSPHRASE   - Passphrase for the GPG key
 #   AVALANCHEGO_COMMIT    - Git commit hash (auto-detected if not set)
+#   PACKAGE_SIGNING_KMS_KEY_ID - AWS KMS key identifier for PKCS#11-backed signing
 
 set -euo pipefail
 
@@ -98,8 +99,26 @@ EOF
 GPG_WORKDIR="${REPO_ROOT}/build/gpg"
 mkdir -p "${GPG_WORKDIR}"
 GPG_PUBLIC_KEY="${OUTPUT_DIR}/RPM-GPG-KEY-avalanchego"
+NFPM_CONFIG="${PACKAGING_DIR}/nfpm/${PACKAGE}.yml"
+KMS_SIGNING_ENABLED=0
 
-if [[ -n "${RPM_GPG_KEY_FILE:-}" ]]; then
+if [[ -n "${PACKAGE_SIGNING_KMS_KEY_ID:-}" ]]; then
+    echo "Using AWS KMS-backed GPG signing"
+    KMS_SIGNING_ENABLED=1
+    export PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH="${GPG_PUBLIC_KEY}"
+    "${PACKAGING_DIR}/scripts/setup-kms-gpg.sh"
+    PACKAGE_SIGNING_GPG_FINGERPRINT="${PACKAGE_SIGNING_GPG_FINGERPRINT:-$(
+        gpg --batch --with-colons --list-secret-keys 2>/dev/null \
+            | awk -F: '$1 == "fpr" { print $10; exit }'
+    )}"
+    : "${PACKAGE_SIGNING_GPG_FINGERPRINT:?PACKAGE_SIGNING_GPG_FINGERPRINT could not be derived for KMS signing}"
+    cat > "${HOME}/.rpmmacros" <<EOF
+%_signature gpg
+%_gpg_name ${PACKAGE_SIGNING_GPG_FINGERPRINT}
+%__gpg /usr/bin/gpg
+EOF
+    NFPM_CONFIG="${PACKAGING_DIR}/nfpm/${PACKAGE}-unsigned.yml"
+elif [[ -n "${RPM_GPG_KEY_FILE:-}" ]]; then
     echo "Using provided GPG key for signing"
     gpg --batch --import "${RPM_GPG_KEY_FILE}"
     # Copy to well-known path for nfpm config
@@ -129,9 +148,11 @@ GPGEOF
     export NFPM_RPM_PASSPHRASE=""
 fi
 
-# Export public key for verification
-gpg --batch --armor --export "security@avalabs.org" > "${GPG_PUBLIC_KEY}"
-echo "GPG public key exported to: ${GPG_PUBLIC_KEY}"
+if [[ "${KMS_SIGNING_ENABLED}" -eq 0 ]]; then
+    # Export public key for verification
+    gpg --batch --armor --export "security@avalabs.org" > "${GPG_PUBLIC_KEY}"
+    echo "GPG public key exported to: ${GPG_PUBLIC_KEY}"
+fi
 
 # ── Step 4: Package with nfpm ─────────────────────────────────────
 
@@ -149,8 +170,13 @@ export VERSION RPM_ARCH
 
 echo "Packaging ${RPM_FILENAME}..."
 nfpm package \
-    --config "${PACKAGING_DIR}/nfpm/${PACKAGE}.yml" \
+    --config "${NFPM_CONFIG}" \
     --packager rpm \
     --target "${RPM_PATH}"
+
+if [[ "${KMS_SIGNING_ENABLED}" -eq 1 ]]; then
+    echo "Signing ${RPM_FILENAME} with rpmsign..."
+    rpmsign --addsign "${RPM_PATH}"
+fi
 
 echo "RPM built: ${RPM_PATH}"

--- a/.github/packaging/scripts/install-aws-kms-pkcs11.sh
+++ b/.github/packaging/scripts/install-aws-kms-pkcs11.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LIBRARY_PATH="${1:-${AWS_KMS_PKCS11_LIBRARY_PATH:-${HOME}/.local/lib/pkcs11/aws_kms_pkcs11.so}}"
+
+if [[ -f "${LIBRARY_PATH}" ]]; then
+    exit 0
+fi
+
+: "${AWS_KMS_PKCS11_DOWNLOAD_URL:?AWS_KMS_PKCS11_DOWNLOAD_URL must be set when aws_kms_pkcs11.so is not already present}"
+
+mkdir -p "$(dirname "${LIBRARY_PATH}")"
+curl -fsSL -o "${LIBRARY_PATH}" "${AWS_KMS_PKCS11_DOWNLOAD_URL}"
+chmod 0755 "${LIBRARY_PATH}"

--- a/.github/packaging/scripts/setup-kms-gpg.sh
+++ b/.github/packaging/scripts/setup-kms-gpg.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${PACKAGE_SIGNING_KMS_KEY_ID:?PACKAGE_SIGNING_KMS_KEY_ID must be set}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GPG_HOME="${PACKAGE_SIGNING_GPG_HOME:-${GNUPGHOME:-${HOME}/.gnupg}}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+AWS_KMS_PKCS11_LIBRARY_PATH="${AWS_KMS_PKCS11_LIBRARY_PATH:-${HOME}/.local/lib/pkcs11/aws_kms_pkcs11.so}"
+PACKAGE_SIGNING_LABEL="${PACKAGE_SIGNING_LABEL:-avalanchego-package-signing}"
+PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH="${PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH:-${PWD}/avalanchego-signing-public.asc}"
+AWS_KMS_PKCS11_CONFIG_DIR="${AWS_KMS_PKCS11_CONFIG_DIR:-${HOME}/.config/aws-kms-pkcs11}"
+AWS_KMS_PKCS11_CONFIG_PATH="${AWS_KMS_PKCS11_CONFIG_PATH:-${AWS_KMS_PKCS11_CONFIG_DIR}/config.json}"
+
+"${SCRIPT_DIR}/install-aws-kms-pkcs11.sh" "${AWS_KMS_PKCS11_LIBRARY_PATH}"
+
+mkdir -p "${GPG_HOME}" "${AWS_KMS_PKCS11_CONFIG_DIR}" "$(dirname "${PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH}")"
+chmod 700 "${GPG_HOME}"
+export GNUPGHOME="${GPG_HOME}"
+
+CERT_PATH=""
+if [[ -n "${PACKAGE_SIGNING_X509_CERT_PEM_BASE64:-}" ]]; then
+    CERT_PATH="${AWS_KMS_PKCS11_CONFIG_DIR}/signing-cert.pem"
+    printf '%s' "${PACKAGE_SIGNING_X509_CERT_PEM_BASE64}" | base64 --decode > "${CERT_PATH}"
+elif [[ -n "${PACKAGE_SIGNING_X509_CERT_PEM:-}" ]]; then
+    CERT_PATH="${AWS_KMS_PKCS11_CONFIG_DIR}/signing-cert.pem"
+    printf '%s\n' "${PACKAGE_SIGNING_X509_CERT_PEM}" > "${CERT_PATH}"
+elif [[ -n "${PACKAGE_SIGNING_X509_CERT_PATH:-}" ]]; then
+    CERT_PATH="${PACKAGE_SIGNING_X509_CERT_PATH}"
+fi
+
+json_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+cat > "${AWS_KMS_PKCS11_CONFIG_PATH}" <<EOF
+{
+  "slots": [
+    {
+      "label": "$(json_escape "${PACKAGE_SIGNING_LABEL}")",
+      "kms_key_id": "$(json_escape "${PACKAGE_SIGNING_KMS_KEY_ID}")",
+      "aws_region": "$(json_escape "${AWS_REGION}")"$(if [[ -n "${CERT_PATH}" ]]; then printf ',\n      "certificate_path": "%s"' "$(json_escape "${CERT_PATH}")"; fi)
+    }
+  ]
+}
+EOF
+
+cat > "${GPG_HOME}/gnupg-pkcs11-scd.conf" <<EOF
+providers kms
+provider-kms-library ${AWS_KMS_PKCS11_LIBRARY_PATH}
+use-gnupg-pin-cache
+EOF
+
+if [[ -n "${PACKAGE_SIGNING_OPENPGP_KEY_SHA1:-}" ]]; then
+    cat >> "${GPG_HOME}/gnupg-pkcs11-scd.conf" <<EOF
+emulate-openpgp
+openpgp-sign ${PACKAGE_SIGNING_OPENPGP_KEY_SHA1}
+EOF
+fi
+
+cat > "${GPG_HOME}/gpg-agent.conf" <<EOF
+scdaemon-program $(command -v gnupg-pkcs11-scd)
+EOF
+
+gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+gpgconf --launch gpg-agent
+
+gpg-connect-agent "SCD LEARN --force" /bye >/dev/null 2>&1 || true
+gpg --batch --card-status >/dev/null 2>&1 || true
+
+PACKAGE_SIGNING_GPG_FINGERPRINT="$(
+    gpg --batch --with-colons --list-secret-keys 2>/dev/null \
+        | awk -F: '$1 == "fpr" { print $10; exit }'
+)"
+
+if [[ -z "${PACKAGE_SIGNING_GPG_FINGERPRINT}" ]]; then
+    echo "Failed to discover a KMS-backed GPG fingerprint. If gnupg-pkcs11-scd requires OpenPGP emulation for this key, set PACKAGE_SIGNING_OPENPGP_KEY_SHA1 and provide a certificate via PACKAGE_SIGNING_X509_CERT_*." >&2
+    exit 1
+fi
+
+gpg --batch --yes --armor --export "${PACKAGE_SIGNING_GPG_FINGERPRINT}" > "${PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH}"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+    {
+        printf 'PACKAGE_SIGNING_GPG_FINGERPRINT=%s\n' "${PACKAGE_SIGNING_GPG_FINGERPRINT}"
+        printf 'PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH=%s\n' "${PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH}"
+    } >> "${GITHUB_ENV}"
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+        printf 'fingerprint=%s\n' "${PACKAGE_SIGNING_GPG_FINGERPRINT}"
+        printf 'public_key_path=%s\n' "${PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH}"
+    } >> "${GITHUB_OUTPUT}"
+fi
+
+echo "Configured KMS-backed GPG fingerprint: ${PACKAGE_SIGNING_GPG_FINGERPRINT}"
+echo "Exported public key to: ${PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH}"

--- a/.github/packaging/scripts/sign-deb.sh
+++ b/.github/packaging/scripts/sign-deb.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DEB_PATH:?DEB_PATH must be set}"
+
+if [[ ! -f "${DEB_PATH}" ]]; then
+    echo "Missing DEB package: ${DEB_PATH}" >&2
+    exit 1
+fi
+
+PACKAGE_SIGNING_GPG_FINGERPRINT="${PACKAGE_SIGNING_GPG_FINGERPRINT:-$(
+    gpg --batch --with-colons --list-secret-keys 2>/dev/null \
+        | awk -F: '$1 == "fpr" { print $10; exit }'
+)}"
+
+: "${PACKAGE_SIGNING_GPG_FINGERPRINT:?PACKAGE_SIGNING_GPG_FINGERPRINT could not be derived}"
+
+dpkg-sig --sign builder -k "${PACKAGE_SIGNING_GPG_FINGERPRINT}" "${DEB_PATH}"

--- a/.github/packaging/scripts/validate-deb.sh
+++ b/.github/packaging/scripts/validate-deb.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DEB_PATH:?DEB_PATH must be set}"
+: "${PUBLIC_KEY_PATH:?PUBLIC_KEY_PATH must be set}"
+: "${GIT_COMMIT:?GIT_COMMIT must be set}"
+: "${RELEASE:?RELEASE must be set}"
+
+if [[ ! -f "${DEB_PATH}" ]]; then
+    echo "Missing DEB package: ${DEB_PATH}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${PUBLIC_KEY_PATH}" ]]; then
+    echo "Missing package signing public key: ${PUBLIC_KEY_PATH}" >&2
+    exit 1
+fi
+
+case "${RELEASE}" in
+    jammy) UBUNTU_IMAGE="ubuntu:22.04" ;;
+    noble) UBUNTU_IMAGE="ubuntu:24.04" ;;
+    *)
+        echo "Unsupported Ubuntu release: ${RELEASE}" >&2
+        exit 1
+        ;;
+esac
+
+DEB_DIR="$(cd "$(dirname "${DEB_PATH}")" && pwd)"
+DEB_NAME="$(basename "${DEB_PATH}")"
+PUBLIC_KEY_NAME="$(basename "${PUBLIC_KEY_PATH}")"
+
+echo "=== Validating ${DEB_NAME} in fresh ${UBUNTU_IMAGE} container ==="
+docker run --rm \
+    -v "${DEB_DIR}:/input:ro" \
+    "${UBUNTU_IMAGE}" \
+    bash -euxo pipefail -c '
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y ca-certificates dpkg-sig gnupg
+
+        gpg --batch --import "/input/'"${PUBLIC_KEY_NAME}"'"
+        dpkg-sig --verify "/input/'"${DEB_NAME}"'"
+        apt-get install -y "/input/'"${DEB_NAME}"'"
+
+        output=$(/usr/local/bin/avalanchego --version)
+        echo "avalanchego --version: ${output}"
+        if [[ "${output}" != avalanchego/* ]]; then
+            echo "ERROR: --version output does not start with avalanchego/" >&2
+            exit 1
+        fi
+        if [[ "${output}" != *"'"${GIT_COMMIT}"'"* ]]; then
+            echo "ERROR: --version output does not contain expected commit '"${GIT_COMMIT}"'" >&2
+            exit 1
+        fi
+    '
+
+echo "=== DEB validation complete ==="

--- a/.github/packaging/scripts/validate-rpm.sh
+++ b/.github/packaging/scripts/validate-rpm.sh
@@ -11,6 +11,7 @@
 #
 # Optional env vars:
 #   RPM_ARCH       - RPM architecture ("x86_64" or "aarch64"), defaults to host
+#   REQUIRE_SIGNATURE - "1" to fail if the RPM public key is absent
 
 set -euo pipefail
 
@@ -28,6 +29,7 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 RPM_DIR="${REPO_ROOT}/build/rpm"
+REQUIRE_SIGNATURE="${REQUIRE_SIGNATURE:-0}"
 
 # Source VM ID from constants.sh (canonical definition)
 SUBNET_EVM_VM_ID=$(
@@ -56,6 +58,9 @@ docker run --rm \
             rpm --import /rpms/RPM-GPG-KEY-avalanchego
             rpm -K "/rpms/avalanchego-'"${TAG}"'-'"${RPM_ARCH}"'.rpm"
             rpm -K "/rpms/subnet-evm-'"${TAG}"'-'"${RPM_ARCH}"'.rpm"
+        elif [[ "'"${REQUIRE_SIGNATURE}"'" == "1" ]]; then
+            echo "ERROR: required RPM signing public key is missing" >&2
+            exit 1
         else
             echo "Skipping GPG verification (unsigned build)"
         fi

--- a/.github/workflows/build-deb-pkg.sh
+++ b/.github/workflows/build-deb-pkg.sh
@@ -2,25 +2,23 @@
 
 set -euo pipefail
 
-DEBIAN_BASE_DIR=$PKG_ROOT/debian
-AVALANCHE_BUILD_BIN_DIR=$DEBIAN_BASE_DIR/usr/local/bin
+: "${PKG_ROOT:?PKG_ROOT must be set}"
+: "${TAG:?TAG must be set}"
+: "${ARCH:?ARCH must be set}"
+
+DEBIAN_BASE_DIR="${PKG_ROOT}/debian"
+AVALANCHE_BUILD_BIN_DIR="${DEBIAN_BASE_DIR}/usr/local/bin"
 TEMPLATE=.github/workflows/debian/template
-DEBIAN_CONF=$DEBIAN_BASE_DIR/DEBIAN
+DEBIAN_CONF="${DEBIAN_BASE_DIR}/DEBIAN"
+DEB_PATH="${PKG_ROOT}/avalanchego-${TAG}-${ARCH}.deb"
 
 mkdir -p "$DEBIAN_BASE_DIR"
 mkdir -p "$DEBIAN_CONF"
 mkdir -p "$AVALANCHE_BUILD_BIN_DIR"
 
 # Assume binaries are at default locations
-OK=$(cp ./build/avalanchego "$AVALANCHE_BUILD_BIN_DIR")
-if [[ $OK -ne 0 ]]; then
-  exit "$OK";
-fi
-
-OK=$(cp $TEMPLATE/control "$DEBIAN_CONF"/control)
-if [[ $OK -ne 0 ]]; then
-  exit "$OK";
-fi
+cp ./build/avalanchego "$AVALANCHE_BUILD_BIN_DIR"
+cp "$TEMPLATE/control" "$DEBIAN_CONF/control"
 
 echo "Build debian package..."
 cd "$PKG_ROOT"
@@ -33,5 +31,10 @@ NEW_VERSION_STRING="Version: $VER"
 NEW_ARCH_STRING="Architecture: $ARCH"
 sed -i "s/Version.*/$NEW_VERSION_STRING/g" debian/DEBIAN/control
 sed -i "s/Architecture.*/$NEW_ARCH_STRING/g" debian/DEBIAN/control
-dpkg-deb --build debian "avalanchego-$TAG-$ARCH.deb"
-aws s3 cp "avalanchego-$TAG-$ARCH.deb" "s3://${BUCKET}/linux/debs/ubuntu/$RELEASE/$ARCH/"
+dpkg-deb --build debian "$(basename "${DEB_PATH}")"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  printf 'deb_path=%s\n' "${DEB_PATH}" >> "${GITHUB_OUTPUT}"
+fi
+
+echo "Built DEB: ${DEB_PATH}"

--- a/.github/workflows/build-rpm-release.yml
+++ b/.github/workflows/build-rpm-release.yml
@@ -27,6 +27,7 @@ jobs:
             rpm_arch: aarch64
     runs-on: ${{ matrix.runner }}
     permissions:
+      id-token: write
       contents: read
 
     steps:
@@ -64,21 +65,23 @@ jobs:
           fi
         shell: bash
 
-      - name: Import GPG key
+      - name: Configure AWS credentials
         if: github.event_name != 'pull_request'
-        run: |
-          GPG_KEY_FILE="$(mktemp)"
-          chmod 600 "${GPG_KEY_FILE}"
-          printf '%s' "${{ secrets.RPM_GPG_PRIVATE_KEY }}" > "${GPG_KEY_FILE}"
-          printf 'GPG_KEY_FILE=%s\n' "${GPG_KEY_FILE}" >> "$GITHUB_ENV"
-        shell: bash
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
+          role-session-name: githubrolesession
+          aws-region: us-east-1
 
       - name: Build and validate RPMs
         run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml test-build-rpms
         env:
           PACKAGING_TAG: ${{ env.TAG }}
-          RPM_GPG_KEY_FILE: ${{ env.GPG_KEY_FILE }}
-          NFPM_RPM_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
+          PACKAGE_SIGNING_KMS_KEY_ID: ${{ github.event_name != 'pull_request' && vars.PACKAGE_SIGNING_KMS_KEY_ID || '' }}
+          PACKAGE_SIGNING_X509_CERT_PEM_BASE64: ${{ github.event_name != 'pull_request' && secrets.PACKAGE_SIGNING_X509_CERT_PEM_BASE64 || '' }}
+          PACKAGE_SIGNING_OPENPGP_KEY_SHA1: ${{ github.event_name != 'pull_request' && vars.PACKAGE_SIGNING_OPENPGP_KEY_SHA1 || '' }}
+          AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ github.event_name != 'pull_request' && vars.AWS_KMS_PKCS11_DOWNLOAD_URL || '' }}
+          REQUIRE_SIGNATURE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
 
       - name: Upload RPMs as artifacts
         if: github.event_name != 'pull_request'
@@ -93,8 +96,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          if [[ -n "${GPG_KEY_FILE:-}" ]]; then
-            rm -f "${GPG_KEY_FILE}"
-          fi
           rm -rf build/rpm
         shell: bash

--- a/.github/workflows/build-ubuntu-amd64-release.yml
+++ b/.github/workflows/build-ubuntu-amd64-release.yml
@@ -62,7 +62,7 @@ jobs:
           ARCH: "amd64"
 
       - name: Configure KMS GPG signing
-        run: ./.github/packaging/scripts/setup-kms-gpg.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml setup-kms-gpg
         env:
           PACKAGE_SIGNING_KMS_KEY_ID: ${{ vars.PACKAGE_SIGNING_KMS_KEY_ID }}
           PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
@@ -71,7 +71,7 @@ jobs:
           AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ vars.AWS_KMS_PKCS11_DOWNLOAD_URL }}
 
       - name: Sign debian package
-        run: ./.github/packaging/scripts/sign-deb.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml sign-deb
         env:
           DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
 
@@ -79,7 +79,7 @@ jobs:
         run: dpkg-sig --verify /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
 
       - name: Validate debian package in fresh container
-        run: ./.github/packaging/scripts/validate-deb.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml validate-deb
         env:
           DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
           PUBLIC_KEY_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
@@ -153,7 +153,7 @@ jobs:
           ARCH: "amd64"
 
       - name: Configure KMS GPG signing
-        run: ./.github/packaging/scripts/setup-kms-gpg.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml setup-kms-gpg
         env:
           PACKAGE_SIGNING_KMS_KEY_ID: ${{ vars.PACKAGE_SIGNING_KMS_KEY_ID }}
           PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
@@ -162,7 +162,7 @@ jobs:
           AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ vars.AWS_KMS_PKCS11_DOWNLOAD_URL }}
 
       - name: Sign debian package
-        run: ./.github/packaging/scripts/sign-deb.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml sign-deb
         env:
           DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
 
@@ -170,7 +170,7 @@ jobs:
         run: dpkg-sig --verify /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
 
       - name: Validate debian package in fresh container
-        run: ./.github/packaging/scripts/validate-deb.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml validate-deb
         env:
           DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
           PUBLIC_KEY_PATH: /tmp/avalanchego/avalanchego-signing-public.asc

--- a/.github/workflows/build-ubuntu-amd64-release.yml
+++ b/.github/workflows/build-ubuntu-amd64-release.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Install aws cli
         run: sudo snap install aws-cli --classic
 
+      - name: Install DEB signing dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl dpkg-sig gnupg gnupg-pkcs11-scd
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -54,15 +59,43 @@ jobs:
         env:
           PKG_ROOT: /tmp/avalanchego
           TAG: ${{ env.TAG }}
-          BUCKET: ${{ secrets.BUCKET }}
           ARCH: "amd64"
+
+      - name: Configure KMS GPG signing
+        run: ./.github/packaging/scripts/setup-kms-gpg.sh
+        env:
+          PACKAGE_SIGNING_KMS_KEY_ID: ${{ vars.PACKAGE_SIGNING_KMS_KEY_ID }}
+          PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
+          PACKAGE_SIGNING_X509_CERT_PEM_BASE64: ${{ secrets.PACKAGE_SIGNING_X509_CERT_PEM_BASE64 }}
+          PACKAGE_SIGNING_OPENPGP_KEY_SHA1: ${{ vars.PACKAGE_SIGNING_OPENPGP_KEY_SHA1 }}
+          AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ vars.AWS_KMS_PKCS11_DOWNLOAD_URL }}
+
+      - name: Sign debian package
+        run: ./.github/packaging/scripts/sign-deb.sh
+        env:
+          DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+
+      - name: Verify debian signature on runner
+        run: dpkg-sig --verify /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+
+      - name: Validate debian package in fresh container
+        run: ./.github/packaging/scripts/validate-deb.sh
+        env:
+          DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+          PUBLIC_KEY_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
+          GIT_COMMIT: ${{ github.sha }}
           RELEASE: "jammy"
 
       - name: Save as Github artifact
         uses: actions/upload-artifact@v4
         with:
-          name: jammy
-          path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+          name: jammy-amd64
+          path: |
+            /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+            /tmp/avalanchego/avalanchego-signing-public.asc
+
+      - name: Publish to S3
+        run: aws s3 cp /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb s3://${{ secrets.BUCKET }}/linux/debs/ubuntu/jammy/amd64/
 
       - name: Cleanup
         run: |
@@ -86,6 +119,11 @@ jobs:
       - name: Install aws cli
         run: sudo snap install aws-cli --classic
 
+      - name: Install DEB signing dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl dpkg-sig gnupg gnupg-pkcs11-scd
+
       - name: Try to get tag from git
         if: "${{ github.event.inputs.tag == '' }}"
         id: get_tag_from_git
@@ -112,15 +150,43 @@ jobs:
         env:
           PKG_ROOT: /tmp/avalanchego
           TAG: ${{ env.TAG }}
-          BUCKET: ${{ secrets.BUCKET }}
           ARCH: "amd64"
+
+      - name: Configure KMS GPG signing
+        run: ./.github/packaging/scripts/setup-kms-gpg.sh
+        env:
+          PACKAGE_SIGNING_KMS_KEY_ID: ${{ vars.PACKAGE_SIGNING_KMS_KEY_ID }}
+          PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
+          PACKAGE_SIGNING_X509_CERT_PEM_BASE64: ${{ secrets.PACKAGE_SIGNING_X509_CERT_PEM_BASE64 }}
+          PACKAGE_SIGNING_OPENPGP_KEY_SHA1: ${{ vars.PACKAGE_SIGNING_OPENPGP_KEY_SHA1 }}
+          AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ vars.AWS_KMS_PKCS11_DOWNLOAD_URL }}
+
+      - name: Sign debian package
+        run: ./.github/packaging/scripts/sign-deb.sh
+        env:
+          DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+
+      - name: Verify debian signature on runner
+        run: dpkg-sig --verify /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+
+      - name: Validate debian package in fresh container
+        run: ./.github/packaging/scripts/validate-deb.sh
+        env:
+          DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+          PUBLIC_KEY_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
+          GIT_COMMIT: ${{ github.sha }}
           RELEASE: "noble"
 
       - name: Save as Github artifact
         uses: actions/upload-artifact@v4
         with:
-          name: noble
-          path:  /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+          name: noble-amd64
+          path: |
+            /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
+            /tmp/avalanchego/avalanchego-signing-public.asc
+
+      - name: Publish to S3
+        run: aws s3 cp /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb s3://${{ secrets.BUCKET }}/linux/debs/ubuntu/noble/amd64/
 
       - name: Cleanup
         run: |

--- a/.github/workflows/build-ubuntu-arm64-release.yml
+++ b/.github/workflows/build-ubuntu-arm64-release.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Install aws cli
         run: sudo snap install aws-cli --classic
 
+      - name: Install DEB signing dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl dpkg-sig gnupg gnupg-pkcs11-scd
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -54,15 +59,43 @@ jobs:
         env:
           PKG_ROOT: /tmp/avalanchego
           TAG: ${{ env.TAG }}
-          BUCKET: ${{ secrets.BUCKET }}
           ARCH: "arm64"
+
+      - name: Configure KMS GPG signing
+        run: ./.github/packaging/scripts/setup-kms-gpg.sh
+        env:
+          PACKAGE_SIGNING_KMS_KEY_ID: ${{ vars.PACKAGE_SIGNING_KMS_KEY_ID }}
+          PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
+          PACKAGE_SIGNING_X509_CERT_PEM_BASE64: ${{ secrets.PACKAGE_SIGNING_X509_CERT_PEM_BASE64 }}
+          PACKAGE_SIGNING_OPENPGP_KEY_SHA1: ${{ vars.PACKAGE_SIGNING_OPENPGP_KEY_SHA1 }}
+          AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ vars.AWS_KMS_PKCS11_DOWNLOAD_URL }}
+
+      - name: Sign debian package
+        run: ./.github/packaging/scripts/sign-deb.sh
+        env:
+          DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+
+      - name: Verify debian signature on runner
+        run: dpkg-sig --verify /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+
+      - name: Validate debian package in fresh container
+        run: ./.github/packaging/scripts/validate-deb.sh
+        env:
+          DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+          PUBLIC_KEY_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
+          GIT_COMMIT: ${{ github.sha }}
           RELEASE: "jammy"
 
       - name: Save as Github artifact
         uses: actions/upload-artifact@v4
         with:
-          name: jammy
-          path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+          name: jammy-arm64
+          path: |
+            /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+            /tmp/avalanchego/avalanchego-signing-public.asc
+
+      - name: Publish to S3
+        run: aws s3 cp /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb s3://${{ secrets.BUCKET }}/linux/debs/ubuntu/jammy/arm64/
 
       - name: Cleanup
         run: |
@@ -86,6 +119,11 @@ jobs:
       - name: Install aws cli
         run: sudo snap install aws-cli --classic
 
+      - name: Install DEB signing dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl dpkg-sig gnupg gnupg-pkcs11-scd
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -112,15 +150,43 @@ jobs:
         env:
           PKG_ROOT: /tmp/avalanchego
           TAG: ${{ env.TAG }}
-          BUCKET: ${{ secrets.BUCKET }}
           ARCH: "arm64"
+
+      - name: Configure KMS GPG signing
+        run: ./.github/packaging/scripts/setup-kms-gpg.sh
+        env:
+          PACKAGE_SIGNING_KMS_KEY_ID: ${{ vars.PACKAGE_SIGNING_KMS_KEY_ID }}
+          PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
+          PACKAGE_SIGNING_X509_CERT_PEM_BASE64: ${{ secrets.PACKAGE_SIGNING_X509_CERT_PEM_BASE64 }}
+          PACKAGE_SIGNING_OPENPGP_KEY_SHA1: ${{ vars.PACKAGE_SIGNING_OPENPGP_KEY_SHA1 }}
+          AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ vars.AWS_KMS_PKCS11_DOWNLOAD_URL }}
+
+      - name: Sign debian package
+        run: ./.github/packaging/scripts/sign-deb.sh
+        env:
+          DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+
+      - name: Verify debian signature on runner
+        run: dpkg-sig --verify /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+
+      - name: Validate debian package in fresh container
+        run: ./.github/packaging/scripts/validate-deb.sh
+        env:
+          DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+          PUBLIC_KEY_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
+          GIT_COMMIT: ${{ github.sha }}
           RELEASE: "noble"
 
       - name: Save as Github artifact
         uses: actions/upload-artifact@v4
         with:
-          name: noble
-          path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+          name: noble-arm64
+          path: |
+            /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
+            /tmp/avalanchego/avalanchego-signing-public.asc
+
+      - name: Publish to S3
+        run: aws s3 cp /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb s3://${{ secrets.BUCKET }}/linux/debs/ubuntu/noble/arm64/
 
       - name: Cleanup
         run: |

--- a/.github/workflows/build-ubuntu-arm64-release.yml
+++ b/.github/workflows/build-ubuntu-arm64-release.yml
@@ -62,7 +62,7 @@ jobs:
           ARCH: "arm64"
 
       - name: Configure KMS GPG signing
-        run: ./.github/packaging/scripts/setup-kms-gpg.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml setup-kms-gpg
         env:
           PACKAGE_SIGNING_KMS_KEY_ID: ${{ vars.PACKAGE_SIGNING_KMS_KEY_ID }}
           PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
@@ -71,7 +71,7 @@ jobs:
           AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ vars.AWS_KMS_PKCS11_DOWNLOAD_URL }}
 
       - name: Sign debian package
-        run: ./.github/packaging/scripts/sign-deb.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml sign-deb
         env:
           DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
 
@@ -79,7 +79,7 @@ jobs:
         run: dpkg-sig --verify /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
 
       - name: Validate debian package in fresh container
-        run: ./.github/packaging/scripts/validate-deb.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml validate-deb
         env:
           DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
           PUBLIC_KEY_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
@@ -153,7 +153,7 @@ jobs:
           ARCH: "arm64"
 
       - name: Configure KMS GPG signing
-        run: ./.github/packaging/scripts/setup-kms-gpg.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml setup-kms-gpg
         env:
           PACKAGE_SIGNING_KMS_KEY_ID: ${{ vars.PACKAGE_SIGNING_KMS_KEY_ID }}
           PACKAGE_SIGNING_PUBLIC_KEY_OUTPUT_PATH: /tmp/avalanchego/avalanchego-signing-public.asc
@@ -162,7 +162,7 @@ jobs:
           AWS_KMS_PKCS11_DOWNLOAD_URL: ${{ vars.AWS_KMS_PKCS11_DOWNLOAD_URL }}
 
       - name: Sign debian package
-        run: ./.github/packaging/scripts/sign-deb.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml sign-deb
         env:
           DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
 
@@ -170,7 +170,7 @@ jobs:
         run: dpkg-sig --verify /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
 
       - name: Validate debian package in fresh container
-        run: ./.github/packaging/scripts/validate-deb.sh
+        run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml validate-deb
         env:
           DEB_PATH: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
           PUBLIC_KEY_PATH: /tmp/avalanchego/avalanchego-signing-public.asc

--- a/docs/design/rpm-packaging.md
+++ b/docs/design/rpm-packaging.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-Ship signed RPM packages for avalanchego and subnet-evm targeting
-RHEL 9.x customers. Packages are built inside a Rocky Linux 9 container
-(glibc 2.34), signed with GPG, and published as GitHub Actions artifacts.
+Ship signed Linux packages for avalanchego and subnet-evm targeting
+RHEL 9.x and Ubuntu customers. RPMs are built inside a Rocky Linux 9
+container (glibc 2.34), DEBs are built on the Ubuntu release runners,
+and release signing is moving to a single AWS KMS-backed GPG identity.
 
 ## Decisions
 
@@ -35,12 +36,24 @@ Rocky Linux 9 container. The build is orchestrated by a Taskfile at
 `.github/packaging/Taskfile.yml`, included from the root Taskfile as
 `packaging:`.
 
-### GPG signing
+### Package signing
 
-RPMs are always signed. In CI, a real GPG key is provided via
-`secrets.RPM_GPG_PRIVATE_KEY`. For local builds, an ephemeral GPG key
-(RSA 4096, no passphrase, 1-day expiry) is generated to exercise the
-signing pipeline without requiring a real key.
+Release signing uses a single AWS KMS-backed GPG identity exposed to CI
+as metadata only (`PACKAGE_SIGNING_KMS_KEY_ID`) plus AWS OIDC-issued
+credentials. The GPG private key never lives in GitHub secrets, runner
+disk, or container volumes.
+
+The bridge from GPG to KMS is:
+- `gnupg-pkcs11-scd`
+- `aws-kms-pkcs11`
+
+DEBs are signed after `dpkg-deb --build` with `dpkg-sig`. RPMs are built
+first and then signed with `rpmsign --addsign` in the Rocky container.
+Both release paths export the public key used for verification and gate
+artifact publication on successful signature verification.
+
+PR RPM builds still use the ephemeral GPG path so the packaging pipeline
+can be exercised without AWS credentials. DEB workflows do not run on PRs.
 
 ### Version smoke test
 
@@ -54,16 +67,29 @@ not the git tag, so it may not match RC tags. The smoke test verifies:
 
 ### CI workflow
 
-`.github/workflows/build-rpm-release.yml` triggers on tag push,
-`workflow_dispatch`, and `pull_request` (for paths under `.github/packaging/`
-and the workflow file itself). On PRs, the full build runs as a smoke test
-with an ephemeral GPG key and synthetic tag. Matrix strategy covers x86_64 and
-aarch64. Steps:
+RPM releases use `.github/workflows/build-rpm-release.yml` and DEB releases
+use `.github/workflows/build-ubuntu-amd64-release.yml` plus
+`.github/workflows/build-ubuntu-arm64-release.yml`.
 
-1. Build and validate RPMs via `scripts/run_task.sh packaging:test-build-rpms`
-   (builds both packages, then validates in a fresh `rockylinux:9`
-   container: signature verification, installation, smoke test)
-2. Upload RPMs and GPG public key as GitHub artifacts
+RPM workflow behavior:
+1. On tag push and `workflow_dispatch`, configure AWS credentials via OIDC
+2. Build RPMs in the Rocky container
+3. Use the KMS-backed GPG bridge to sign finished RPMs
+4. Validate in a fresh `rockylinux:9` container with `rpm -K`, install,
+   and smoke tests
+5. Upload RPMs plus the exported public key as artifacts
+
+On PRs, the same RPM workflow keeps the existing ephemeral signing path and
+synthetic tag so packaging changes still get end-to-end coverage.
+
+DEB workflow behavior:
+1. Build the `.deb` on the matching Ubuntu runner
+2. Configure the KMS-backed GPG bridge on that runner
+3. Sign the finished `.deb` with `dpkg-sig`
+4. Verify on the runner, then verify/install/smoke-test in a fresh Ubuntu
+   container matching the target release
+5. Upload the signed `.deb` plus public key artifact and only then publish
+   to S3
 
 ### Architecture mapping
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,6 +9,7 @@ fi
 
 # Root-level directories to exclude from linting
 EXCLUDE_DIRS=(
+  .claude  # local Codex agent worktrees/cache
   graft    # Grafted modules have their own lint config
   .direnv  # direnv cache
   .idea    # GoLand


### PR DESCRIPTION
## Why this should be merged

This moves Linux package signing toward a single AWS KMS-backed GPG identity so private signing material no longer needs to live in GitHub secrets or on CI runners. It also closes the current DEB gap where packages are built and uploaded without a signing or validation gate.

## How this works

DEB release jobs now split packaging from publication: they build the `.deb`, configure a KMS-backed GPG bridge, sign with `dpkg-sig`, verify on the runner, validate in a fresh Ubuntu container, and only then upload artifacts and publish to S3.

RPM packaging keeps the current container-based build flow, but adds a KMS-aware signing path that builds unsigned RPMs with nfpm and then signs them with `rpmsign --addsign`. The existing ephemeral signing path remains available for PR packaging tests.

The shared KMS/GPG setup lives under `.github/packaging/scripts/` and the packaging docs were updated to describe the new release-signing flow and the transitional PR behavior.

## How this was tested

- `bash -n` on the updated packaging and signing scripts
- `./scripts/run_task.sh lint-shell`
- `actionlint .github/workflows/build-rpm-release.yml .github/workflows/build-ubuntu-amd64-release.yml .github/workflows/build-ubuntu-arm64-release.yml`
- `task --taskfile .github/packaging/Taskfile.yml --list`
- `git diff --check`

I did not run end-to-end DEB or RPM signing locally because that requires real AWS OIDC/KMS configuration and signing material.

## Need to be documented in RELEASES.md?

No. This changes release packaging and CI wiring, not a runtime or API behavior exposed to node operators.
