### PR TITLE
chore(reexecution): add pathdb config

### DIFF
--- a/tests/reexecute/c/vm_reexecute.go
+++ b/tests/reexecute/c/vm_reexecute.go
@@ -66,6 +66,10 @@ var (
 		"archive": `{
 			"pruning-enabled": false
 		}`,
+		"pathdb": `{
+			"state-scheme": "path",
+			"state-sync-enabled": false
+		}`,
 		"firewood": `{
 			"state-scheme": "firewood",
 			"snapshot-cache": 0,


### PR DESCRIPTION
## Why this should be merged

We want to start testing Firewood's performance against PathDB. The first step to enable this is to add a PathDB VM config in the reexecution test.

## How this works

Adds `pathdb` VM config

## How this was tested

Ran reexecution test up to block 250k with PathDB: https://github.com/ava-labs/avalanchego/actions/runs/23808244131/job/69387757290

## Need to be documented in RELEASES.md?

No