### PR TITLE
Update Firewoods metrics namespace 

### DIFF
--- a/graft/coreth/plugin/evm/vm.go
+++ b/graft/coreth/plugin/evm/vm.go
@@ -511,7 +511,8 @@ func (vm *VM) initializeMetrics() error {
 	}
 
 	if vm.config.StateScheme == customrawdb.FirewoodScheme {
-		if err := vm.ctx.Metrics.Register(customrawdb.FirewoodScheme, ffi.Gatherer{}); err != nil {
+		// Registers and exposes Firewood's internal metrics, which are exposed via FFI
+		if err := vm.ctx.Metrics.Register(customrawdb.FirewoodMetricsPrefix, ffi.Gatherer{}); err != nil {
 			return fmt.Errorf("registering firewood metrics: %w", err)
 		}
 	}

--- a/graft/subnet-evm/plugin/evm/vm.go
+++ b/graft/subnet-evm/plugin/evm/vm.go
@@ -580,7 +580,8 @@ func (vm *VM) initializeMetrics() error {
 	}
 
 	if vm.config.StateScheme == customrawdb.FirewoodScheme {
-		if err := vm.ctx.Metrics.Register(customrawdb.FirewoodScheme, ffi.Gatherer{}); err != nil {
+		// Registers and exposes Firewood's internal metrics, which are exposed via FFI
+		if err := vm.ctx.Metrics.Register(customrawdb.FirewoodMetricsPrefix, ffi.Gatherer{}); err != nil {
 			return fmt.Errorf("registering firewood metrics: %w", err)
 		}
 	}

--- a/vms/evm/sync/customrawdb/BUILD.bazel
+++ b/vms/evm/sync/customrawdb/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//database",
+        "//utils/metric",
         "//utils/wrappers",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/rawdb",

--- a/vms/evm/sync/customrawdb/db.go
+++ b/vms/evm/sync/customrawdb/db.go
@@ -6,9 +6,10 @@ package customrawdb
 import (
 	"errors"
 
-	"github.com/ava-labs/avalanchego/utils/metric"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/ethdb"
+
+	"github.com/ava-labs/avalanchego/utils/metric"
 )
 
 // FirewoodScheme is the scheme for the Firewood storage scheme.

--- a/vms/evm/sync/customrawdb/db.go
+++ b/vms/evm/sync/customrawdb/db.go
@@ -6,12 +6,17 @@ package customrawdb
 import (
 	"errors"
 
+	"github.com/ava-labs/avalanchego/utils/metric"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/ethdb"
 )
 
 // FirewoodScheme is the scheme for the Firewood storage scheme.
 const FirewoodScheme = "firewood"
+
+// FirewoodMetricsPrefix is the vm metrics gatherer prefix for Firewood both internal and FFI metrics.
+// It is derived from [FirewoodScheme] so the exported namespace stays aligned with the state scheme name.
+const FirewoodMetricsPrefix = FirewoodScheme + metric.NamespaceSeparator + "db"
 
 // errStateSchemeConflict indicates the provided state scheme conflicts with
 // what is on disk.


### PR DESCRIPTION
## Why this should be merged

Renames the VM gatherer prefix for Firewood metrics to `firewood_db` so exported names stay consistent and `coreth/subnet-evm` share one constant (FirewoodMetricsPrefix in customrawdb). Breaking for anyone already scraping the old *_firewood_* FFI series (Grafana/Prometheus); Firewood is not production-ready yet.

## How this works

Prepends `db` to previously namespaced `firewood`. This is expected to break Firewood dashboards.

## How this was tested

gh workflow run "C-Chain Re-Execution Benchmark w/ Container" \
  --ref es/update-firewood-metrics-namespace \
  -f test="firewood-101-250k" \
  -f config=firewood \
  -f runner=avago-runner-i4i-2xlarge-local-ssd \
  -f timeout-minutes=25
  
<img width="2073" height="816" alt="Screenshot 2026-03-27 at 18 51 20" src="https://github.com/user-attachments/assets/899134ac-c310-4ca0-a9db-b7b7ac92d782" />

## Need to be documented in RELEASES.md?

No, Firewood is not production reayd. 
