### PR TITLE
[migrate-strevm][1] Add tooling enabling repo migration

### DIFF
--- a/graft/Taskfile.yml
+++ b/graft/Taskfile.yml
@@ -25,9 +25,9 @@ tasks:
   #   cmd: bash ./scripts/subtree-merge.sh {{.REPO_MODULE}} BRANCH
 
   strevm-rewrite-imports:
-    desc: Rewrite imports of out-of-tree strevm ({{.STREVM_MODULE}}) to in-tree strevm
-    cmd: bash ./scripts/rewrite-imports.sh {{.STREVM_MODULE}}
+    desc: Rewrite imports of out-of-tree strevm ({{.STREVM_MODULE}}) to in-tree saevm
+    cmd: bash ./scripts/rewrite-imports.sh {{.STREVM_MODULE}} github.com/ava-labs/avalanchego/vms/saevm
 
   strevm-subtree-merge:
-    desc: Perform git subtree merge of strevm into graft/strevm (commits)
-    cmd: bash ./scripts/subtree-merge.sh {{.STREVM_MODULE}} main
+    desc: Perform git subtree merge of strevm into vms/saevm (commits)
+    cmd: bash ./scripts/subtree-merge.sh {{.STREVM_MODULE}} main vms/saevm


### PR DESCRIPTION
## Why this should be merged

This adds the tooling to execute the strevm subtree merge via a task so it is repeatable and verifiable. 

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A