### PR TITLE
[migrate-strevm][3] rewrite strevm imports

### DIFF
--- a/graft/scripts/rewrite-imports.sh
+++ b/graft/scripts/rewrite-imports.sh
@@ -41,8 +41,11 @@ echo "rewriting ${ORIGINAL_IMPORT} imports to ${TARGET_IMPORT} in all golang fil
 # Escape dots in the original import path for regex use
 ESCAPED_ORIGINAL="${ORIGINAL_IMPORT//./\\.}"
 
+# The negative lookbehind (?<!://) ensures we only rewrite Go import paths
+# and not GitHub URLs (e.g. https://github.com/.../issues/123) in comments
+# or string literals.
 rg "${ESCAPED_ORIGINAL}" -t go --files-with-matches --null | \
-  xargs -0 perl -i -pe "s|\\Q${ORIGINAL_IMPORT}\\E|${TARGET_IMPORT}|g"
+  xargs -0 perl -i -pe "s|(?<!://)\\Q${ORIGINAL_IMPORT}\\E|${TARGET_IMPORT}|g"
 
 echo "import rewrite completed successfully"
 

--- a/vms/saevm/blocks/access.go
+++ b/vms/saevm/blocks/access.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 type (

--- a/vms/saevm/blocks/block.go
+++ b/vms/saevm/blocks/block.go
@@ -21,8 +21,8 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/proxytime"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // A Block extends a [types.Block] to track SAE-defined concepts of async

--- a/vms/saevm/blocks/block_test.go
+++ b/vms/saevm/blocks/block_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/hook/hookstest"
-	"github.com/ava-labs/strevm/saetest"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 func newEthBlock(num, time uint64, parent *types.Block) *types.Block {

--- a/vms/saevm/blocks/blockstest/blocks.go
+++ b/vms/saevm/blocks/blockstest/blocks.go
@@ -25,10 +25,10 @@ import (
 	"github.com/ava-labs/libevm/triedb"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/hook/hookstest"
-	"github.com/ava-labs/strevm/saetest"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // An EthBlockOption configures the default block properties created by

--- a/vms/saevm/blocks/blockstest/blocks_test.go
+++ b/vms/saevm/blocks/blockstest/blocks_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/cmputils"
-	"github.com/ava-labs/strevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
 
 func TestIntegration(t *testing.T) {

--- a/vms/saevm/blocks/blockstest/chain.go
+++ b/vms/saevm/blocks/blockstest/chain.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 )
 
 // A ChainBuilder builds a chain of blocks, maintaining necessary invariants.

--- a/vms/saevm/blocks/cmpopt.go
+++ b/vms/saevm/blocks/cmpopt.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/ava-labs/strevm/cmputils"
-	"github.com/ava-labs/strevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
 
 // CmpOpt returns a configuration for [cmp.Diff] to compare [Block] instances in

--- a/vms/saevm/blocks/execution.go
+++ b/vms/saevm/blocks/execution.go
@@ -22,10 +22,10 @@ import (
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/gastime"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/proxytime"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // SetInterimExecutionTime is expected to be called during execution of b's

--- a/vms/saevm/blocks/execution_test.go
+++ b/vms/saevm/blocks/execution_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/cmputils"
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/saetest"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // markExecutedForTests calls [Block.MarkExecuted] with zero-value

--- a/vms/saevm/blocks/invariants.go
+++ b/vms/saevm/blocks/invariants.go
@@ -16,8 +16,8 @@ import (
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 
 // WorstCaseBounds define the limits of certain values, predicted by the block

--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -15,10 +15,10 @@ import (
 	"github.com/ava-labs/libevm/ethdb"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/proxytime"
-	"github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 type ancestry struct {

--- a/vms/saevm/blocks/settlement_test.go
+++ b/vms/saevm/blocks/settlement_test.go
@@ -17,13 +17,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/cmputils"
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/hook/hookstest"
-	"github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/proxytime"
-	"github.com/ava-labs/strevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
 
 //nolint:testableexamples // Output is meaningless

--- a/vms/saevm/blocks/snow.go
+++ b/vms/saevm/blocks/snow.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ava-labs/libevm/rlp"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/adaptor"
+	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 
 	// Imported to allow IDE resolution of comments like [types.Block]. The
 	// package is imported in other files so this is a no-op beyond devex.

--- a/vms/saevm/blocks/time.go
+++ b/vms/saevm/blocks/time.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/core/types"
 
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
 // PreciseTime calls [hook.Points.SubSecondBlockTime] on the header and returns

--- a/vms/saevm/blocks/time_test.go
+++ b/vms/saevm/blocks/time_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook/hookstest"
-	"github.com/ava-labs/strevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
 func TestGasTime(t *testing.T) {

--- a/vms/saevm/gasprice/estimator.go
+++ b/vms/saevm/gasprice/estimator.go
@@ -23,8 +23,8 @@ import (
 	"github.com/ava-labs/libevm/rpc"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/intmath"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
 )
 
 // Backend that the [Estimator] depends on for chain data.

--- a/vms/saevm/gasprice/estimator_test.go
+++ b/vms/saevm/gasprice/estimator_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/blocks/blockstest"
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
 
 func TestMain(m *testing.M) {

--- a/vms/saevm/gastime/acp176.go
+++ b/vms/saevm/gastime/acp176.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/core/types"
 
-	"github.com/ava-labs/strevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 
 // BeforeBlock is intended to be called before processing a block, with the

--- a/vms/saevm/gastime/acp176_test.go
+++ b/vms/saevm/gastime/acp176_test.go
@@ -17,8 +17,8 @@ import (
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 )
 
 // TestInvalidConfigRejected verifies that zero values for TargetToExcessScaling

--- a/vms/saevm/gastime/cmpopt.go
+++ b/vms/saevm/gastime/cmpopt.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/ava-labs/strevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
 // CmpOpt returns a configuration for [cmp.Diff] to compare [Time] instances in

--- a/vms/saevm/gastime/config.go
+++ b/vms/saevm/gastime/config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 
-	"github.com/ava-labs/strevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE

--- a/vms/saevm/gastime/gastime.go
+++ b/vms/saevm/gastime/gastime.go
@@ -12,9 +12,9 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/holiman/uint256"
 
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/intmath"
-	"github.com/ava-labs/strevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE

--- a/vms/saevm/gastime/gastime_test.go
+++ b/vms/saevm/gastime/gastime_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/intmath"
-	"github.com/ava-labs/strevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
 func mustNew(tb testing.TB, at time.Time, target, startingExcess gas.Gas, gasPriceConfig hook.GasPriceConfig) *Time {

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -26,9 +26,9 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
-	"github.com/ava-labs/strevm/intmath"
-	saeparams "github.com/ava-labs/strevm/params"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // PointsG define user-injected hook points.

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -22,9 +22,9 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/saetest"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // Stub implements [hook.PointsG] parameterized by [Op].

--- a/vms/saevm/proxytime/proxytime.go
+++ b/vms/saevm/proxytime/proxytime.go
@@ -12,7 +12,7 @@ import (
 	"math/bits"
 	"time"
 
-	"github.com/ava-labs/strevm/intmath"
+	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
 )
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE

--- a/vms/saevm/sae/always.go
+++ b/vms/saevm/sae/always.go
@@ -14,9 +14,9 @@ import (
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/triedb"
 
-	"github.com/ava-labs/strevm/adaptor"
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 
 var _ adaptor.ChainVM[*blocks.Block] = (*SinceGenesis[hook.Transaction])(nil)

--- a/vms/saevm/sae/always_test.go
+++ b/vms/saevm/sae/always_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 )
 
 func TestSinceGenesisBeforeInit(t *testing.T) {

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -18,13 +18,13 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/hook"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/saexec"
-	"github.com/ava-labs/strevm/txgossip"
-	saetypes "github.com/ava-labs/strevm/types"
-	"github.com/ava-labs/strevm/worstcase"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
+	"github.com/ava-labs/avalanchego/vms/saevm/txgossip"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/worstcase"
 )
 
 // blockBuilder hides [blockBuilderG]'s generic type behind non-generic methods.

--- a/vms/saevm/sae/blocks.go
+++ b/vms/saevm/sae/blocks.go
@@ -21,8 +21,8 @@ import (
 	"github.com/ava-labs/libevm/rlp"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/blocks"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // maxFutureBlockDuration is the maximum time from the current time allowed for

--- a/vms/saevm/sae/consensus.go
+++ b/vms/saevm/sae/consensus.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ava-labs/libevm/event"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 )
 
 // SetPreference updates the VM's currently [preferred block] with the given block context,

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -16,13 +16,13 @@ import (
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/params"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/hook"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/proxytime"
-	"github.com/ava-labs/strevm/saedb"
-	"github.com/ava-labs/strevm/saexec"
-	"github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
+	"github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 type recovery struct {

--- a/vms/saevm/sae/recovery_test.go
+++ b/vms/saevm/sae/recovery_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/cmputils"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/saedb"
-	"github.com/ava-labs/strevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
 
 func TestRecoverFromDatabase(t *testing.T) {

--- a/vms/saevm/sae/rpc.go
+++ b/vms/saevm/sae/rpc.go
@@ -11,12 +11,12 @@ import (
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/event"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/hook"
-	saerpc "github.com/ava-labs/strevm/sae/rpc"
-	"github.com/ava-labs/strevm/saexec"
-	"github.com/ava-labs/strevm/txgossip"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	saerpc "github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
+	"github.com/ava-labs/avalanchego/vms/saevm/txgossip"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // GethRPCBackends returns the backing infrastructure for geth's implementations

--- a/vms/saevm/sae/rpc/backend.go
+++ b/vms/saevm/sae/rpc/backend.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ava-labs/libevm/eth/tracers"
 	"github.com/ava-labs/libevm/libevm/ethapi"
 
-	"github.com/ava-labs/strevm/gasprice"
-	"github.com/ava-labs/strevm/txgossip"
+	"github.com/ava-labs/avalanchego/vms/saevm/gasprice"
+	"github.com/ava-labs/avalanchego/vms/saevm/txgossip"
 )
 
 // The GethBackends interface is the union of geth interfaces required by

--- a/vms/saevm/sae/rpc/blocks.go
+++ b/vms/saevm/sae/rpc/blocks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 )
 
 func (b *backend) CurrentBlock() *types.Header {

--- a/vms/saevm/sae/rpc/custom.go
+++ b/vms/saevm/sae/rpc/custom.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 )
 
 // customAPI implements Avalanche-custom RPCs. These are not part of the

--- a/vms/saevm/sae/rpc/gasprice.go
+++ b/vms/saevm/sae/rpc/gasprice.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ava-labs/libevm/event"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/gasprice"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/gasprice"
 )
 
 type estimatorBackend struct {

--- a/vms/saevm/sae/rpc/readers.go
+++ b/vms/saevm/sae/rpc/readers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 )
 
 // neverErrs is a convenience wrapper, intended for use with [rawdb] Read*()

--- a/vms/saevm/sae/rpc/receipts.go
+++ b/vms/saevm/sae/rpc/receipts.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ava-labs/libevm/libevm/ethapi"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/saexec"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
 )
 
 func (b *backend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {

--- a/vms/saevm/sae/rpc/rpc.go
+++ b/vms/saevm/sae/rpc/rpc.go
@@ -24,12 +24,12 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/gasprice"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/saedb"
-	"github.com/ava-labs/strevm/saexec"
-	"github.com/ava-labs/strevm/txgossip"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/gasprice"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
+	"github.com/ava-labs/avalanchego/vms/saevm/txgossip"
 )
 
 // A Chain provides the consensus and execution state required to serve RPC

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -19,9 +19,9 @@ import (
 	"github.com/ava-labs/libevm/eth/tracers"
 	"github.com/ava-labs/libevm/rpc"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/saexec"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
 )
 
 var noopRelease tracers.StateReleaseFunc = func() {}

--- a/vms/saevm/sae/rpc_custom_test.go
+++ b/vms/saevm/sae/rpc_custom_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/cmputils"
-	saerpc "github.com/ava-labs/strevm/sae/rpc"
-	"github.com/ava-labs/strevm/saetest"
-	"github.com/ava-labs/strevm/saetest/escrow"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	saerpc "github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
 )
 
 func TestGetChainConfig(t *testing.T) {

--- a/vms/saevm/sae/rpc_gasprice_test.go
+++ b/vms/saevm/sae/rpc_gasprice_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/ava-labs/libevm/rpc"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/gastime"
-	saeparams "github.com/ava-labs/strevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 )
 
 func TestGasPriceAPIs(t *testing.T) {

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/blocks"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/saetest/escrow"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
 )
 
 // TestStateQueryOnNonCanonicalBlock verifies that state-dependent RPC calls

--- a/vms/saevm/sae/rpc_test.go
+++ b/vms/saevm/sae/rpc_test.go
@@ -36,11 +36,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/cmputils"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/saetest"
-	"github.com/ava-labs/strevm/saetest/escrow"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
 )
 
 var zeroAddr common.Address

--- a/vms/saevm/sae/vm.go
+++ b/vms/saevm/sae/vm.go
@@ -34,13 +34,13 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/sae/rpc"
-	"github.com/ava-labs/strevm/saedb"
-	"github.com/ava-labs/strevm/saexec"
-	"github.com/ava-labs/strevm/txgossip"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
+	"github.com/ava-labs/avalanchego/vms/saevm/txgossip"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // VM implements all of [adaptor.ChainVM] except for the `Initialize` method,

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -52,16 +52,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/ava-labs/strevm/adaptor"
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/blocks/blockstest"
-	"github.com/ava-labs/strevm/cmputils"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/hook/hookstest"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/saetest"
-	"github.com/ava-labs/strevm/txgossip/txgossiptest"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/txgossip/txgossiptest"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 func TestMain(m *testing.M) {

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/intmath"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/worstcase"
+	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/worstcase"
 )
 
 var worstCaseFuzzFlags struct {

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ava-labs/libevm/triedb"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 
 // Config allows parameterization of the TrieDB and when state is committed.

--- a/vms/saevm/saetest/heightdb.go
+++ b/vms/saevm/saetest/heightdb.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 
-	"github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // A ClonableHeightIndex extends [database.HeightIndex] with the ability to

--- a/vms/saevm/saetest/saetest.go
+++ b/vms/saevm/saetest/saetest.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ava-labs/libevm/trie"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/ava-labs/strevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 )
 
 var _ saedb.StateDBOpener = (*stateDBOpener)(nil)

--- a/vms/saevm/saexec/context.go
+++ b/vms/saevm/saexec/context.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/types"
 
-	saetypes "github.com/ava-labs/strevm/types"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 var _ core.ChainContext = (*chainContext)(nil)

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -22,10 +22,10 @@ import (
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 )
 
 var errExecutorClosed = errors.New("saexec.Executor closed")

--- a/vms/saevm/saexec/receipts.go
+++ b/vms/saevm/saexec/receipts.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/libevm/eventual"
 
-	"github.com/ava-labs/strevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 )
 
 func (e *Executor) createReceiptBuffers(b *blocks.Block) {

--- a/vms/saevm/saexec/saexec.go
+++ b/vms/saevm/saexec/saexec.go
@@ -21,10 +21,10 @@ import (
 	"github.com/ava-labs/libevm/libevm/eventual"
 	"github.com/ava-labs/libevm/params"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/saedb"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 var _ saedb.StateDBOpener = (*Executor)(nil)

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -38,15 +38,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/blocks/blockstest"
-	"github.com/ava-labs/strevm/cmputils"
-	"github.com/ava-labs/strevm/gastime"
-	saehookstest "github.com/ava-labs/strevm/hook/hookstest"
-	"github.com/ava-labs/strevm/proxytime"
-	"github.com/ava-labs/strevm/saedb"
-	"github.com/ava-labs/strevm/saetest"
-	"github.com/ava-labs/strevm/saetest/escrow"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	saehookstest "github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
 )
 
 func TestMain(m *testing.M) {

--- a/vms/saevm/txgossip/blockchain.go
+++ b/vms/saevm/txgossip/blockchain.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/params"
 
-	"github.com/ava-labs/strevm/saexec"
-	saetypes "github.com/ava-labs/strevm/types"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 
 	// Imported for [core.ChainHeadEvent] comment resolution. Already a
 	// downstream dependency.

--- a/vms/saevm/txgossip/txgossip_test.go
+++ b/vms/saevm/txgossip/txgossip_test.go
@@ -35,14 +35,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/blocks/blockstest"
-	"github.com/ava-labs/strevm/cmputils"
-	"github.com/ava-labs/strevm/hook/hookstest"
-	"github.com/ava-labs/strevm/saedb"
-	"github.com/ava-labs/strevm/saetest"
-	"github.com/ava-labs/strevm/saexec"
-	"github.com/ava-labs/strevm/txgossip/txgossiptest"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
+	"github.com/ava-labs/avalanchego/vms/saevm/txgossip/txgossiptest"
 )
 
 func TestMain(m *testing.M) {

--- a/vms/saevm/worstcase/state.go
+++ b/vms/saevm/worstcase/state.go
@@ -22,11 +22,11 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 )
 
 // State tracks the worst-case gas price and account state as operations are

--- a/vms/saevm/worstcase/state_benchmark_test.go
+++ b/vms/saevm/worstcase/state_benchmark_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/saedb"
-	"github.com/ava-labs/strevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
 
 func BenchmarkApplyTxWithSnapshot(b *testing.B) {

--- a/vms/saevm/worstcase/state_test.go
+++ b/vms/saevm/worstcase/state_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/blocks"
-	"github.com/ava-labs/strevm/blocks/blockstest"
-	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
-	"github.com/ava-labs/strevm/hook/hookstest"
-	"github.com/ava-labs/strevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
 
 type SUT struct {


### PR DESCRIPTION
## Why this should be merged

Rewrites all Go import statements from external package github.com/ava-labs/strevm to internal graft subdirectory `github.com/ava-labs/avalanchego/vms/saevm`.

Reviewers are encouraged to review the script that performed the rewrite and to reproduce the branch locally to gain confidence that this PR represents the results of that script.

```bash
cd graft
task strevm-rewrite-imports
```

## How this was tested

 - [ ] CI will pass only once child PRs are merged into this one
 
## Need to be documented in RELEASES.md?

N/A


(this PR description was taken from @maru-ava -- I did not write it). 