### PR TITLE
[migrate-strevm][7] lint

### DIFF
--- a/.gosec-golangci.yml
+++ b/.gosec-golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - gosec

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -320,10 +320,15 @@ tasks:
       - task: check-require-directives-round-trip
       - task: bazel-check-metadata
 
+  lint-saevm:
+    desc: Runs gosec with G115 enabled on vms/saevm
+    cmd: '{{.NIX_RUN}} ./scripts/run_tool.sh golangci-lint run --config .gosec-golangci.yml ./vms/saevm/...'
+
   _lint-readonly:
     internal: true
     deps:
       - lint
+      - lint-saevm
       - lint-action
       - lint-shell
       - check-go-version
@@ -333,6 +338,7 @@ tasks:
     desc: Runs all lint checks one-by-one
     cmds:
       - task: lint
+      - task: lint-saevm
       - task: lint-action
       - task: lint-shell
       - task: check-yaml-fmt

--- a/vms/saevm/adaptor/adaptor.go
+++ b/vms/saevm/adaptor/adaptor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package adaptor provides a generic alternative to the Snowman [block.ChainVM]
@@ -123,7 +123,7 @@ func (b Block[BP]) Reject(ctx context.Context) error { return b.vm.RejectBlock(c
 
 // ShouldVerifyWithContext returns true, indicating that the block
 // SHOULD be verified with [VerifyWithContext].
-func (b Block[BP]) ShouldVerifyWithContext(ctx context.Context) (bool, error) {
+func (Block[BP]) ShouldVerifyWithContext(ctx context.Context) (bool, error) {
 	return true, nil
 }
 

--- a/vms/saevm/blocks/BUILD.bazel
+++ b/vms/saevm/blocks/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//vms/saevm/hook",
         "//vms/saevm/params",
         "//vms/saevm/proxytime",
-        "//vms/saevm/saetest",
         "//vms/saevm/types",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/rawdb",

--- a/vms/saevm/blocks/access.go
+++ b/vms/saevm/blocks/access.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -126,7 +126,7 @@ func ResolveRPCNumber(f Frontier, bn rpc.BlockNumber) (uint64, error) {
 	if bn < 0 {
 		return 0, fmt.Errorf("%s block unsupported", bn.String())
 	}
-	n := uint64(bn) //nolint:gosec // Non-negative check performed above
+	n := uint64(bn) //#nosec G115 -- Non-negative check performed above
 	if n > tip {
 		return 0, fmt.Errorf("%w: block %d", ErrFutureBlockNotResolved, n)
 	}
@@ -265,7 +265,7 @@ func FromNumberAndHash[T any](c Chain, hash common.Hash, rpcNum rpc.BlockNumber,
 	if rpcNum < 0 {
 		return nil, errors.New("named blocks not supported")
 	}
-	n := uint64(rpcNum) //nolint:gosec // Non-negative check performed above
+	n := uint64(rpcNum) //#nosec G115 -- Non-negative check performed above
 	if b, ok := c.ConsensusCriticalBlock(hash); ok {
 		if b.NumberU64() != n {
 			return nil, fmt.Errorf("%w: found block number %d for hash %#x, expected %d", ErrNotFound, b.NumberU64(), hash, n)

--- a/vms/saevm/blocks/block.go
+++ b/vms/saevm/blocks/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package blocks defines [Streaming Asynchronous Execution] (SAE) blocks.
@@ -13,15 +13,16 @@ import (
 	"runtime"
 	"sync/atomic"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/params"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 

--- a/vms/saevm/blocks/block_test.go
+++ b/vms/saevm/blocks/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -7,15 +7,16 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 

--- a/vms/saevm/blocks/blockstest/blocks.go
+++ b/vms/saevm/blocks/blockstest/blocks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package blockstest provides test helpers for constructing [Streaming
@@ -13,8 +13,6 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
@@ -25,9 +23,12 @@ import (
 	"github.com/ava-labs/libevm/triedb"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 

--- a/vms/saevm/blocks/blockstest/blocks_test.go
+++ b/vms/saevm/blocks/blockstest/blocks_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockstest
@@ -60,11 +60,11 @@ func TestIntegration(t *testing.T) {
 	sdb, err := state.New(bc.Genesis().Root(), state.NewDatabase(db), nil)
 	require.NoError(t, err, "state.New(%T.Genesis().Root())", bc)
 
-	build := NewChainBuilder(config, NewBlock(t, bc.Genesis(), nil, nil))
+	build := NewChainBuilder(NewBlock(t, bc.Genesis(), nil, nil))
 	dest := common.Address{'d', 'e', 's', 't'}
 	for i := range numBlocks {
 		// Genesis is block 0
-		blockNum := uint64(i + 1) //nolint:gosec // Known to not overflow
+		blockNum := uint64(i + 1) //#nosec G115 -- Known to not overflow
 
 		var txs types.Transactions
 		for range txsPerAccountPerBlock {
@@ -127,7 +127,7 @@ func TestNewGenesis(t *testing.T) {
 	gen := NewGenesis(t, db, xdb, config, alloc)
 
 	assert.True(t, gen.Executed(), "genesis.Executed()")
-	assert.NoError(t, gen.WaitUntilSettled(t.Context()), "genesis.WaitUntilSettled()")
+	require.NoError(t, gen.WaitUntilSettled(t.Context()), "genesis.WaitUntilSettled()")
 	assert.Equal(t, gen.Hash(), gen.LastSettled().Hash(), "genesis.LastSettled().Hash() is self")
 
 	t.Run("alloc", func(t *testing.T) {

--- a/vms/saevm/blocks/blockstest/chain.go
+++ b/vms/saevm/blocks/blockstest/chain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blockstest
@@ -14,7 +14,6 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/event"
 	"github.com/ava-labs/libevm/libevm/options"
-	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/rpc"
 
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
@@ -24,7 +23,6 @@ import (
 //
 // It is not safe for concurrent use.
 type ChainBuilder struct {
-	config         *params.ChainConfig
 	chain          []*blocks.Block
 	blocksByHash   sync.Map
 	acceptedBlocks event.FeedOf[*blocks.Block]
@@ -34,10 +32,9 @@ type ChainBuilder struct {
 
 // NewChainBuilder returns a new ChainBuilder starting from the provided block,
 // which MUST NOT be nil.
-func NewChainBuilder(config *params.ChainConfig, genesis *blocks.Block, defaultOpts ...ChainOption) *ChainBuilder {
+func NewChainBuilder(genesis *blocks.Block, defaultOpts ...ChainOption) *ChainBuilder {
 	c := &ChainBuilder{
-		config: config,
-		chain:  []*blocks.Block{genesis},
+		chain: []*blocks.Block{genesis},
 	}
 	c.SetDefaultOptions(defaultOpts...)
 	return c
@@ -151,7 +148,7 @@ func (cb *ChainBuilder) ResolveBlockNumber(bn rpc.BlockNumber) (uint64, error) {
 		if bn < 0 {
 			return 0, fmt.Errorf("%s block unsupported", bn)
 		}
-		n := uint64(bn) //nolint:gosec // Non-negative checked above
+		n := uint64(bn) //#nosec G115 -- Non-negative checked above
 		if n > head {
 			return 0, fmt.Errorf("%w: %d", ErrBlockNotFound, n)
 		}

--- a/vms/saevm/blocks/cmpopt.go
+++ b/vms/saevm/blocks/cmpopt.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build !prod && !nocmpopts
@@ -6,13 +6,12 @@
 package blocks
 
 import (
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
-	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
 
 // CmpOpt returns a configuration for [cmp.Diff] to compare [Block] instances in
@@ -43,11 +42,10 @@ func CmpOpt() cmp.Option {
 
 func (e *executionResults) equalForTests(f *executionResults) bool {
 	fn := cmputils.WithNilCheck(func(e, f *executionResults) bool {
-		return true &&
-			e.byGas.Rate() == f.byGas.Rate() &&
+		return e.byGas.Rate() == f.byGas.Rate() &&
 			e.byGas.Compare(f.byGas.Time) == 0 &&
 			e.receiptRoot == f.receiptRoot &&
-			saetest.MerkleRootsEqual(e.receipts, f.receipts) &&
+			cmp.Equal(e.receipts, f.receipts, cmputils.CmpByMerkleRoots[types.Receipts]()) &&
 			e.stateRootPost == f.stateRootPost
 	})
 	return fn(e, f)

--- a/vms/saevm/blocks/execution.go
+++ b/vms/saevm/blocks/execution.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
@@ -22,9 +21,11 @@ import (
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
@@ -37,6 +38,7 @@ func (b *Block) SetInterimExecutionTime(t *proxytime.Time[gas.Gas]) {
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE
 
+//nolint:revive // struct-tag: canoto allows unexported fields
 type executionResults struct {
 	byGas         gastime.Time `canoto:"value,1"`
 	baseFee       uint256.Int  `canoto:"fixed repeated uint,2"`

--- a/vms/saevm/blocks/execution_test.go
+++ b/vms/saevm/blocks/execution_test.go
@@ -1,18 +1,15 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
@@ -23,10 +20,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
@@ -42,7 +42,7 @@ func TestMarkExecuted(t *testing.T) {
 	txs := make(types.Transactions, 10)
 	for i := range txs {
 		txs[i] = types.NewTx(&types.LegacyTx{
-			Nonce:    uint64(i), //nolint:gosec // Won't overflow
+			Nonce:    uint64(i), //#nosec G115 -- Won't overflow
 			GasPrice: big.NewInt(gasPrice),
 			Gas:      params.TxGas,
 			To:       &common.Address{},
@@ -71,9 +71,9 @@ func TestMarkExecuted(t *testing.T) {
 		require.False(t, b.Executed(), "Executed()")
 		require.NoError(t, b.CheckInvariants(NotExecuted), "CheckInvariants(NotExecuted)")
 
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 		defer cancel()
-		require.ErrorIs(t, context.DeadlineExceeded, b.WaitUntilExecuted(ctx), "WaitUntilExecuted()")
+		require.ErrorIs(t, b.WaitUntilExecuted(ctx), context.DeadlineExceeded, "WaitUntilExecuted()")
 	})
 
 	gasTime := mustNewGasTime(t, time.Unix(42, 0), 1e6, 42, gastime.DefaultGasPriceConfig())
@@ -95,7 +95,7 @@ func TestMarkExecuted(t *testing.T) {
 			EffectiveGasPrice: big.NewInt(gasPrice),
 			BlockHash:         ethB.Hash(),
 			BlockNumber:       new(big.Int).Set(ethB.Number()),
-			TransactionIndex:  uint(i), //nolint:gosec // Won't overflow
+			TransactionIndex:  uint(i), //#nosec G115 -- Won't overflow
 		})
 	}
 	lastExecuted := new(atomic.Pointer[Block])
@@ -125,7 +125,7 @@ func TestMarkExecuted(t *testing.T) {
 			require.True(t, b.Executed(), "Executed()")
 			assert.NoError(t, b.CheckInvariants(Executed), "CheckInvariants(Executed)")
 
-			require.NoError(t, b.WaitUntilExecuted(context.Background()), "WaitUntilExecuted()")
+			require.NoError(t, b.WaitUntilExecuted(t.Context()), "WaitUntilExecuted()")
 
 			assert.Zero(t, b.ExecutedByGasTime().Compare(gasTime.Time), "ExecutedByGasTime().Compare([original input])")
 			assert.Zero(t, b.ExecutedBaseFee().Cmp(baseFee), "ExecutedBaseFee().Cmp([original input])")
@@ -144,7 +144,7 @@ func TestMarkExecuted(t *testing.T) {
 			t.Run("MarkExecuted_again", func(t *testing.T) {
 				rec := saetest.NewLogRecorder(logging.Warn)
 				b.log = rec
-				assert.ErrorIs(t, b.MarkExecuted(db, xdb, gasTime, wallTime, baseFee.ToBig(), receipts, stateRoot, lastExecuted), errMarkBlockExecutedAgain)
+				require.ErrorIs(t, b.MarkExecuted(db, xdb, gasTime, wallTime, baseFee.ToBig(), receipts, stateRoot, lastExecuted), errMarkBlockExecutedAgain)
 				// The database's head block might have been corrupted so this MUST
 				// be a fatal action.
 				assert.Len(t, rec.At(logging.Fatal), 1, "FATAL logs")
@@ -160,7 +160,7 @@ func TestMarkExecuted(t *testing.T) {
 				"ReadHeadBlock":      rawdb.ReadHeadBlock(db),
 				"ReadHeadHeader":     rawdb.ReadHeadHeader(db),
 			} {
-				t.Run(fmt.Sprintf("rawdb.%s", fn), func(t *testing.T) {
+				t.Run("rawdb."+fn, func(t *testing.T) {
 					require.NotNil(t, got)
 					assert.Equalf(t, b.Hash(), got.Hash(), "rawdb.%s()", fn)
 				})

--- a/vms/saevm/blocks/export.go
+++ b/vms/saevm/blocks/export.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks

--- a/vms/saevm/blocks/invariants.go
+++ b/vms/saevm/blocks/invariants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -8,7 +8,6 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
@@ -16,6 +15,7 @@ import (
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )

--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -11,10 +11,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/ethdb"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"

--- a/vms/saevm/blocks/settlement_test.go
+++ b/vms/saevm/blocks/settlement_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
@@ -65,9 +65,9 @@ func TestSettlementInvariants(t *testing.T) {
 
 	t.Run("before_MarkSettled", func(t *testing.T) {
 		require.False(t, b.Settled(), "Settled()")
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 		defer cancel()
-		assert.ErrorIs(t, b.WaitUntilSettled(ctx), context.DeadlineExceeded, "WaitUntilSettled()")
+		require.ErrorIs(t, b.WaitUntilSettled(ctx), context.DeadlineExceeded, "WaitUntilSettled()")
 
 		if diff := cmp.Diff(parent, b.ParentBlock(), CmpOpt()); diff != "" {
 			t.Errorf("ParentBlock() diff (-constructor arg +got):\n%s", diff)
@@ -87,7 +87,7 @@ func TestSettlementInvariants(t *testing.T) {
 	t.Run("after_MarkSettled", func(t *testing.T) {
 		assert.Equal(t, b, lastSettledPtr.Load(), "Atomic pointer to last-settled block")
 		require.True(t, b.Settled(), "Settled()")
-		assert.NoError(t, b.WaitUntilSettled(context.Background()), "WaitUntilSettled()")
+		assert.NoError(t, b.WaitUntilSettled(t.Context()), "WaitUntilSettled()")
 		assert.NoError(t, b.CheckInvariants(Settled), "CheckInvariants(Settled)")
 
 		rec := saetest.NewLogRecorder(logging.Warn)
@@ -101,7 +101,7 @@ func TestSettlementInvariants(t *testing.T) {
 		assertNumErrorLogs(t, 1)
 		assert.Nil(t, b.LastSettled(), "LastSettled()")
 		assertNumErrorLogs(t, 2)
-		assert.ErrorIs(t, b.MarkSettled(&lastSettledPtr), errBlockResettled, "second call to MarkSettled()")
+		require.ErrorIs(t, b.MarkSettled(&lastSettledPtr), errBlockResettled, "second call to MarkSettled()")
 		assertNumErrorLogs(t, 3)
 		if t.Failed() {
 			t.FailNow()
@@ -222,7 +222,7 @@ func TestLastToSettleAt(t *testing.T) {
 	blocks := newChain(t, db, xdb, 0, 30, nil)
 	t.Run("helper_invariants", func(t *testing.T) {
 		for i, b := range blocks {
-			require.Equal(t, uint64(i), b.Height()) //nolint:gosec // Slice index won't overflow
+			require.Equal(t, uint64(i), b.Height()) //#nosec G115 -- Slice index won't overflow
 			require.Equal(t, b.BuildTime(), b.Height())
 		}
 	})
@@ -365,7 +365,7 @@ func TestLastToSettleAt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			settleAt := time.Unix(int64(tt.settleAt), 0) //nolint:gosec // Hard-coded, non-overflowing values
+			settleAt := time.Unix(int64(tt.settleAt), 0) //#nosec G115 -- Hard-coded, non-overflowing values
 			got, gotOK, err := LastToSettleAt(hookstest.NewStub(0), settleAt, tt.parent)
 			if err != nil || gotOK != tt.wantOK {
 				t.Fatalf("LastToSettleAt(%d, [parent height %d]) got (_, %t, %v); want (_, %t, nil)", tt.settleAt, tt.parent.Height(), gotOK, err, tt.wantOK)

--- a/vms/saevm/blocks/snow.go
+++ b/vms/saevm/blocks/snow.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -6,15 +6,15 @@ package blocks
 import (
 	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/libevm/rlp"
 	"go.uber.org/zap"
-
-	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 
 	// Imported to allow IDE resolution of comments like [types.Block]. The
 	// package is imported in other files so this is a no-op beyond devex.
 	_ "github.com/ava-labs/libevm/core/types"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 )
 
 var _ adaptor.BlockProperties = (*Block)(nil)
@@ -49,5 +49,5 @@ func (b *Block) Height() uint64 {
 // Timestamp returns the timestamp of the wrapped [types.Block], at
 // [time.Second] resolution.
 func (b *Block) Timestamp() time.Time {
-	return time.Unix(int64(b.BuildTime()), 0) //nolint:gosec // Won't be a problem for a few millennia
+	return time.Unix(int64(b.BuildTime()), 0) //#nosec G115 -- Won't overflow for a few millennia
 }

--- a/vms/saevm/blocks/time.go
+++ b/vms/saevm/blocks/time.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -6,9 +6,9 @@ package blocks
 import (
 	"time"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/core/types"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
@@ -23,7 +23,7 @@ func PreciseTime(hooks hook.Points, hdr *types.Header) time.Time {
 
 func preciseTime(hdr *types.Header, subSec time.Duration) time.Time { //nolint:staticcheck // subSec intentionally communicates that the value is < time.Second
 	return time.Unix(
-		int64(hdr.Time), //nolint:gosec // Won't overflow for a few millennia
+		int64(hdr.Time), //#nosec G115 -- Won't overflow for a few millennia
 		subSec.Nanoseconds(),
 	)
 }

--- a/vms/saevm/blocks/time_test.go
+++ b/vms/saevm/blocks/time_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package blocks
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"

--- a/vms/saevm/cmputils/BUILD.bazel
+++ b/vms/saevm/cmputils/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "@com_github_ava_labs_libevm//common/hexutil",
         "@com_github_ava_labs_libevm//core/state",
         "@com_github_ava_labs_libevm//core/types",
+        "@com_github_ava_labs_libevm//trie",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
     ],

--- a/vms/saevm/cmputils/cmputils.go
+++ b/vms/saevm/cmputils/cmputils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build !prod && !nocmpopts

--- a/vms/saevm/cmputils/types.go
+++ b/vms/saevm/cmputils/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build !prod && !nocmpopts
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/trie"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -65,6 +66,14 @@ func ReceiptsByTxHash() cmp.Option {
 	})
 }
 
+// CmpByMerkleRoots returns a [cmp.Comparer] for [types.DerivableList] values,
+// equating them by their Merkle roots.
+func CmpByMerkleRoots[T types.DerivableList]() cmp.Option {
+	return cmp.Comparer(func(a, b T) bool {
+		return types.DeriveSha(a, trie.NewStackTrie(nil)) == types.DeriveSha(b, trie.NewStackTrie(nil))
+	})
+}
+
 // Blocks returns a set of [cmp.Options] for comparing [types.Block] values.
 // The [Headers] option MUST be used alongside this but isn't included
 // automatically, to avoid duplication.
@@ -96,10 +105,10 @@ func LoadAtomicPointers[T any]() cmp.Options {
 		// Although accepting an [atomic.Pointer] value copies a lock, this is
 		// unavoidable but OK in tests given the non-concurrency documentation
 		// above.
-		cmp.Transformer(fmt.Sprintf("atomicOf_%s", typeName[T]()), func(p atomic.Pointer[T]) *T { //nolint:govet
+		cmp.Transformer("atomicOf_"+typeName[T](), func(p atomic.Pointer[T]) *T { //nolint:govet
 			return p.Load()
 		}),
-		cmp.Transformer(fmt.Sprintf("pointerOfAtomicOf_%s", typeName[T]()), func(p *atomic.Pointer[T]) *T {
+		cmp.Transformer("pointerOfAtomicOf_"+typeName[T](), func(p *atomic.Pointer[T]) *T {
 			return p.Load()
 		}),
 	}
@@ -120,7 +129,7 @@ func NilSlicesAreEmpty[S ~[]E, E any]() cmp.Option {
 func typeName[T any]() string {
 	t := reflect.TypeFor[T]()
 	if t.Kind() == reflect.Pointer {
-		return fmt.Sprintf("pointerTo_%s", t.Elem().String())
+		return "pointerTo_" + t.Elem().String()
 	}
 	return t.String()
 }

--- a/vms/saevm/gasprice/block_cache.go
+++ b/vms/saevm/gasprice/block_cache.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gasprice
@@ -7,11 +7,12 @@ import (
 	"math/big"
 	"slices"
 
-	"github.com/ava-labs/avalanchego/cache/lru"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/rpc"
 	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanchego/cache/lru"
+	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
 type transaction struct {
@@ -112,7 +113,7 @@ func (b *blockCache) getBlock(n uint64) *block {
 		return blk
 	}
 
-	blk, err := b.backend.BlockByNumber(rpc.BlockNumber(n)) //nolint:gosec // block numbers were previously resolved
+	blk, err := b.backend.BlockByNumber(rpc.BlockNumber(n)) //#nosec G115 -- Block numbers were previously resolved
 	if err != nil {
 		b.log.Error("fetching BlockByNumber",
 			zap.Uint64("number", n),

--- a/vms/saevm/gasprice/estimator.go
+++ b/vms/saevm/gasprice/estimator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package gasprice provides gas price statistics and suggestions for timely
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common/math"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/event"
@@ -23,6 +22,7 @@ import (
 	"github.com/ava-labs/libevm/rpc"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
 )
@@ -138,7 +138,7 @@ func NewEstimator(backend Backend, log logging.Logger, c Config) (*Estimator, er
 	// blocks while new blocks are added concurrently.
 	const extraSlots = 5
 	size := max(c.SuggestedTipMaxBlocks, c.HistoryMaxBlocksFromHead+c.HistoryMaxBlocks) + extraSlots
-	cache := newBlockCache(log, backend, int(size)) //nolint:gosec // Overflow would require misconfiguration
+	cache := newBlockCache(log, backend, int(size)) //#nosec G115 -- Overflow would require misconfiguration
 	go func() {
 		defer sub.Unsubscribe() // `Unsubscribe` can fire twice on Close(), but it's safe to call multiple times.
 		for {
@@ -197,7 +197,7 @@ func (e *Estimator) SuggestGasTipCap(ctx context.Context) (tip *big.Int, _ error
 	var (
 		newest     = lastAcceptedNumber
 		tooOld     = intmath.BoundedSubtract(newest, e.c.SuggestedTipMaxBlocks, 0)
-		recentUnix = uint64(e.c.Now().Add(-e.c.SuggestedTipMaxDuration).Unix()) //nolint:gosec // Known non-negative
+		recentUnix = uint64(e.c.Now().Add(-e.c.SuggestedTipMaxDuration).Unix()) //#nosec G115 -- Known non-negative
 		tips       []transaction
 	)
 	for n := newest; n > tooOld; n-- {
@@ -215,7 +215,7 @@ func (e *Estimator) SuggestGasTipCap(ctx context.Context) (tip *big.Int, _ error
 	if n := len(tips); n > 0 {
 		slices.SortFunc(tips, transaction.Compare)
 
-		i := (n - 1) * int(e.c.SuggestedTipPercentile) / 100 //nolint:gosec // Known to be between (0, 100]
+		i := (n - 1) * int(e.c.SuggestedTipPercentile) / 100 //#nosec G115 -- Known to be between (0, 100]
 		price = tips[i].tip
 		price = math.BigMax(price, e.c.MinSuggestedTip)
 		price = math.BigMin(price, e.c.MaxSuggestedTip)

--- a/vms/saevm/gasprice/estimator_test.go
+++ b/vms/saevm/gasprice/estimator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gasprice
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/math"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -19,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
@@ -99,7 +99,7 @@ func newSUT(tb testing.TB, c Config) *SUT {
 	xdb := saetest.NewExecutionResultsDB()
 	config := saetest.ChainConfig()
 	genesis := blockstest.NewGenesis(tb, db, xdb, config, types.GenesisAlloc{})
-	chain := blockstest.NewChainBuilder(config, genesis)
+	chain := blockstest.NewChainBuilder(genesis)
 
 	log := saetest.NewTBLogger(tb, logging.Debug)
 	e, err := NewEstimator(chain, log, c)
@@ -116,7 +116,7 @@ func newSUT(tb testing.TB, c Config) *SUT {
 
 const gasLimit = 1_000_000
 
-func (s *SUT) newBlock(tb testing.TB, time uint64, bounds *blocks.WorstCaseBounds, txs ...*types.Transaction) *blocks.Block {
+func (s *SUT) addBlock(tb testing.TB, time uint64, bounds *blocks.WorstCaseBounds, txs ...*types.Transaction) {
 	tb.Helper()
 	blk := s.chain.NewBlock(tb, txs, blockstest.WithEthBlockOptions(
 		blockstest.ModifyHeader(func(h *types.Header) {
@@ -130,7 +130,6 @@ func (s *SUT) newBlock(tb testing.TB, time uint64, bounds *blocks.WorstCaseBound
 		}),
 	))
 	blk.SetWorstCaseBounds(bounds)
-	return blk
 }
 
 func newDynamicFeeTx(gas, price uint64) *types.Transaction {
@@ -157,7 +156,7 @@ func TestSuggestTipCap(t *testing.T) {
 	cfg.Now = func() time.Time {
 		return clk
 	}
-	nowSec := uint64(clk.Unix()) //nolint:gosec // Guaranteed to be positive
+	nowSec := uint64(clk.Unix()) //#nosec G115 -- Known non-negative
 
 	type blockSpec struct {
 		time   uint64
@@ -277,7 +276,7 @@ func TestSuggestTipCap(t *testing.T) {
 				for i, price := range spec.txTips {
 					txs[i] = newDynamicFeeTx(1, price)
 				}
-				sut.newBlock(t, spec.time, nil, txs...)
+				sut.addBlock(t, spec.time, nil, txs...)
 			}
 
 			got, err := sut.SuggestGasTipCap(t.Context())
@@ -519,7 +518,7 @@ func TestFeeHistory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sut := newSUT(t, cfg)
 			for _, spec := range tt.blocks {
-				sut.newBlock(t, 0, spec.bounds, spec.txs...)
+				sut.addBlock(t, 0, spec.bounds, spec.txs...)
 			}
 
 			a := tt.args

--- a/vms/saevm/gastime/acp176.go
+++ b/vms/saevm/gastime/acp176.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gastime
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/core/types"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 

--- a/vms/saevm/gastime/acp176_test.go
+++ b/vms/saevm/gastime/acp176_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gastime
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/params"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +16,7 @@ import (
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 )
@@ -117,7 +117,7 @@ func FuzzWorstCasePrice(f *testing.F) {
 	) {
 		initTarget = max(initTarget, 1)
 
-		initUnix := int64(min(initTimestamp, math.MaxInt64)) //nolint:gosec // I can't believe I have to be explicit about this!
+		initUnix := int64(min(initTimestamp, math.MaxInt64)) //#nosec G115 -- Clamped to MaxInt64
 		worstcase := mustNew(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
 		actual := mustNew(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
 
@@ -130,28 +130,28 @@ func FuzzWorstCasePrice(f *testing.F) {
 		}{
 			{
 				time:   time0,
-				nanos:  time.Duration(nanos0 % 1e9), //nolint:gosec
+				nanos:  time.Duration(nanos0 % 1e9), //#nosec G115
 				used:   gas.Gas(used0),
 				limit:  gas.Gas(limit0),
 				target: gas.Gas(target0),
 			},
 			{
 				time:   time1,
-				nanos:  time.Duration(nanos1 % 1e9), //nolint:gosec
+				nanos:  time.Duration(nanos1 % 1e9), //#nosec G115
 				used:   gas.Gas(used1),
 				limit:  gas.Gas(limit1),
 				target: gas.Gas(target1),
 			},
 			{
 				time:   time2,
-				nanos:  time.Duration(nanos2 % 1e9), //nolint:gosec
+				nanos:  time.Duration(nanos2 % 1e9), //#nosec G115
 				used:   gas.Gas(used2),
 				limit:  gas.Gas(limit2),
 				target: gas.Gas(target2),
 			},
 			{
 				time:   time3,
-				nanos:  time.Duration(nanos3 % 1e9), //nolint:gosec
+				nanos:  time.Duration(nanos3 % 1e9), //#nosec G115
 				used:   gas.Gas(used3),
 				limit:  gas.Gas(limit3),
 				target: gas.Gas(target3),
@@ -166,7 +166,7 @@ func FuzzWorstCasePrice(f *testing.F) {
 			}
 			hook := hookstest.NewStub(block.target, hookstest.WithNow(func() time.Time {
 				return time.Unix(
-					int64(block.time), //nolint:gosec // Won't overflow for a few millennia
+					int64(block.time), //#nosec G115 -- Won't overflow for a few millennia
 					int64(block.nanos),
 				)
 			}))

--- a/vms/saevm/gastime/cmpopt.go
+++ b/vms/saevm/gastime/cmpopt.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build !prod && !nocmpopts
@@ -6,10 +6,10 @@
 package gastime
 
 import (
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 

--- a/vms/saevm/gastime/config.go
+++ b/vms/saevm/gastime/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gastime
@@ -8,12 +8,12 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
-
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE
 
+//nolint:revive // struct-tag: canoto allows unexported fields
 type config struct {
 	targetToExcessScaling gas.Gas   `canoto:"uint,1"`
 	minPrice              gas.Price `canoto:"uint,2"`

--- a/vms/saevm/gastime/gastime.go
+++ b/vms/saevm/gastime/gastime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package gastime measures time based on the consumption of gas.
@@ -8,10 +8,10 @@ import (
 	"math"
 	"time"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/holiman/uint256"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
@@ -31,7 +31,7 @@ import (
 // [ACP-176]: https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/176-dynamic-evm-gas-limit-and-price-discovery-updates
 // [ACP-194]: https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-streaming-asynchronous-execution
 //
-//nolint:tagliatelle // Can't handle embedded field
+//nolint:tagliatelle,revive // tagliatelle: can't handle embedded field; struct-tag: canoto allows unexported fields
 type Time struct {
 	*proxytime.Time[gas.Gas] `canoto:"pointer,1"`
 	target                   gas.Gas `canoto:"uint,2"`
@@ -70,7 +70,7 @@ func SubSecond(hooks hook.Points, hdr *types.Header, rate gas.Gas) gas.Gas {
 	// [gas.Gas] is safe while the upper bound guarantees that the mul-div
 	// result can't overflow so we don't have to check the error.
 	g, _, _ := intmath.MulDivCeil(
-		gas.Gas(hooks.SubSecondBlockTime(hdr)), //nolint:gosec // See above
+		gas.Gas(hooks.SubSecondBlockTime(hdr)), //#nosec G115 -- See above
 		rate,
 		gas.Gas(time.Second),
 	)
@@ -190,7 +190,7 @@ func (tm *Time) SetTarget(t gas.Gas) {
 func (tm *Time) Tick(g gas.Gas) {
 	tm.Time.Tick(g)
 
-	R, T := tm.Rate(), tm.Target()
+	R, T := tm.Rate(), tm.Target()         //nolint:revive // unexported-naming: mathematical convention
 	quo, _, _ := intmath.MulDiv(g, R-T, R) // overflow is impossible as (R-T)/R < 1
 	tm.excess = intmath.BoundedAdd(tm.excess, quo, math.MaxUint64)
 }
@@ -203,7 +203,7 @@ func (tm *Time) FastForwardTo(to uint64, toFrac gas.Gas) {
 		return
 	}
 
-	R, T := tm.Rate(), tm.Target()
+	R, T := tm.Rate(), tm.Target() //nolint:revive // unexported-naming: mathematical convention
 
 	// Excess is reduced by the amount of gas skipped (g), multiplied by T/R.
 	// However, to avoid overflow, the implementation needs to be a bit more

--- a/vms/saevm/gastime/gastime_test.go
+++ b/vms/saevm/gastime/gastime_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package gastime
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/arr4n/shed/testerr"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package hook defines points in an SAE block's lifecycle at which common or
@@ -15,9 +15,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
@@ -26,7 +23,11 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
+
 	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )

--- a/vms/saevm/hook/hook_test.go
+++ b/vms/saevm/hook/hook_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package hook

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package hookstest provides a test double for SAE's [hook] package.
@@ -10,10 +10,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
@@ -22,8 +18,13 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
@@ -123,14 +124,16 @@ func (s *Stub) BuildHeader(parent *types.Header) (*types.Header, error) {
 	hdr := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     new(big.Int).Add(parent.Number, common.Big1),
-		Time:       uint64(now.Unix()), //nolint:gosec // Known non-negative
+		Time:       uint64(now.Unix()), //#nosec G115 -- Known non-negative
 		Extra:      e.MarshalCanoto(),
 	}
 	return hdr, nil
 }
 
-// PotentialEndOfBlockOps ignores its arguments and returns a sequence of ops
-// taken from [Stub.Ops] after removing [Stub.InvalidOpIDs].
+// PotentialEndOfBlockOps ignores its arguments and returns [Stub.Ops] as a
+// sequence.
+//
+//nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (s *Stub) PotentialEndOfBlockOps(ctx context.Context, header *types.Header, lastSettledBlock common.Hash, source saetypes.BlockSource) iter.Seq[Op] {
 	return func(yield func(Op) bool) {
 		for _, op := range s.Ops {
@@ -160,7 +163,7 @@ func (*Stub) BuildBlock(
 // with the other arguments.
 func BuildBlock(
 	header *types.Header,
-	blockCtx *block.Context,
+	_ *block.Context,
 	txs []*types.Transaction,
 	receipts []*types.Receipt,
 	ops []Op,
@@ -189,7 +192,7 @@ func (s *Stub) BlockRebuilderFrom(b *types.Block) (hook.BlockBuilder[Op], error)
 
 	return NewStub(s.Target, WithInvalidOpIDs(s.InvalidOpIDs), WithOps(e.ops), WithNow(func() time.Time {
 		return time.Unix(
-			int64(b.Time()), //nolint:gosec // Won't overflow for a few millennia
+			int64(b.Time()), //#nosec G115 -- Won't overflow for a few millennia
 			int64(e.subSec),
 		)
 	})), nil
@@ -203,7 +206,7 @@ func (s *Stub) GasConfigAfter(*types.Header) (gas.Gas, hook.GasPriceConfig) {
 // SubSecondBlockTime returns the sub-second time encoded and stored by
 // [Stub.BuildHeader] in the header's `Extra` field. If said field is empty,
 // SubSecondBlockTime returns 0.
-func (s *Stub) SubSecondBlockTime(hdr *types.Header) time.Duration {
+func (*Stub) SubSecondBlockTime(hdr *types.Header) time.Duration {
 	return getHeaderExtra(hdr, func(e extra) time.Duration { return e.subSec })
 }
 
@@ -214,7 +217,7 @@ func (*Stub) SettledHeight(hdr *types.Header) uint64 {
 }
 
 // EndOfBlockOps return the ops included in the block by [BuildBlock].
-func (s *Stub) EndOfBlockOps(b *types.Block) ([]hook.Op, error) {
+func (*Stub) EndOfBlockOps(b *types.Block) ([]hook.Op, error) {
 	eOps := getHeaderExtra(b.Header(), func(e extra) []Op { return e.ops })
 	hookOps := make([]hook.Op, len(eOps))
 	for i, op := range eOps {
@@ -254,6 +257,7 @@ func (*Stub) AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) e
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE
 
+//nolint:revive // struct-tag: canoto allows unexported fields
 type extra struct {
 	subSec        time.Duration `canoto:"int,1"` //nolint:staticcheck // subSec intentionally communicates that the value is < time.Second
 	ops           []Op          `canoto:"repeated value,2"`

--- a/vms/saevm/intmath/intmath.go
+++ b/vms/saevm/intmath/intmath.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package intmath provides special-case integer arithmetic.

--- a/vms/saevm/intmath/intmath_test.go
+++ b/vms/saevm/intmath/intmath_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package intmath
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const max = math.MaxUint64
+const max64 = math.MaxUint64
 
 func TestBoundedSubtract(t *testing.T) {
 	tests := []struct {
@@ -22,8 +22,8 @@ func TestBoundedSubtract(t *testing.T) {
 		{a: 2, b: 1, floor: 1, want: 1}, // a - b == floor
 		{a: 2, b: 2, floor: 1, want: 1}, // bounded
 		{a: 3, b: 1, floor: 1, want: 2},
-		{a: max, b: 10, floor: max - 9, want: max - 9}, // `a` threshold (`max+1`) would overflow uint64
-		{a: max, b: 10, floor: max - 11, want: max - 10},
+		{a: max64, b: 10, floor: max64 - 9, want: max64 - 9}, // `a` threshold (`max64+1`) would overflow uint64
+		{a: max64, b: 10, floor: max64 - 11, want: max64 - 10},
 	}
 
 	for _, tt := range tests {
@@ -50,9 +50,9 @@ func FuzzBoundedAdd(f *testing.F) {
 		{a: 1, b: 10, ceil: 10, want: 10},
 		{a: 1, b: 10, ceil: 11, want: 11},
 		{a: 1, b: 10, ceil: 12, want: 11},
-		{a: max, b: 0, ceil: 100, want: 100},
-		{a: max, b: 1, ceil: 100, want: 100},
-		{a: max, b: max, ceil: 0, want: 0},
+		{a: max64, b: 0, ceil: 100, want: 100},
+		{a: max64, b: 1, ceil: 100, want: 100},
+		{a: max64, b: max64, ceil: 0, want: 0},
 	}
 
 	for _, tt := range tests {
@@ -79,15 +79,15 @@ func TestBoundedMultiply(t *testing.T) {
 	tests := []struct {
 		a, b, ceil, want uint64
 	}{
-		{a: 2, b: 3, ceil: 10, want: 6},              // not bounded
-		{a: 2, b: 3, ceil: 6, want: 6},               // a*b == ceil
-		{a: 2, b: 3, ceil: 5, want: 5},               // bounded
-		{a: 0, b: 5, ceil: 10, want: 0},              // a == 0
-		{a: 0, b: 0, ceil: 0, want: 0},               // all zero
-		{a: 1, b: 1, ceil: 0, want: 0},               // ceil == 0 bounds everything
-		{a: 2, b: max, ceil: max, want: max},         // a*b would overflow uint64
-		{a: max, b: max, ceil: max, want: max},       // both at max, would overflow
-		{a: max, b: 2, ceil: max - 1, want: max - 1}, // a*b overflows, bounded to max-1
+		{a: 2, b: 3, ceil: 10, want: 6},                    // not bounded
+		{a: 2, b: 3, ceil: 6, want: 6},                     // a*b == ceil
+		{a: 2, b: 3, ceil: 5, want: 5},                     // bounded
+		{a: 0, b: 5, ceil: 10, want: 0},                    // a == 0
+		{a: 0, b: 0, ceil: 0, want: 0},                     // all zero
+		{a: 1, b: 1, ceil: 0, want: 0},                     // ceil == 0 bounds everything
+		{a: 2, b: max64, ceil: max64, want: max64},         // a*b would overflow uint64
+		{a: max64, b: max64, ceil: max64, want: max64},     // both at max, would overflow
+		{a: max64, b: 2, ceil: max64 - 1, want: max64 - 1}, // a*b overflows, bounded to max-1
 	}
 
 	for _, tt := range tests {
@@ -122,9 +122,9 @@ func TestMulDiv(t *testing.T) {
 			wantQuoCeil: 5, wantExtra: 0,
 		},
 		{
-			a: max, b: 4, div: 8, // must avoid overflow
-			wantQuo: max / 2, wantRem: 4,
-			wantQuoCeil: max/2 + 1, wantExtra: 4,
+			a: max64, b: 4, div: 8, // must avoid overflow
+			wantQuo: max64 / 2, wantRem: 4,
+			wantQuoCeil: max64/2 + 1, wantExtra: 4,
 		},
 	}
 
@@ -141,7 +141,7 @@ func TestMulDiv(t *testing.T) {
 		"MulDiv":     MulDiv[uint64],
 		"MulDivCeil": MulDivCeil[uint64],
 	} {
-		if _, _, err := fn(max, 2, 1); !errors.Is(err, ErrOverflow) {
+		if _, _, err := fn(max64, 2, 1); !errors.Is(err, ErrOverflow) {
 			t.Errorf("%s[uint64]([max uint64], 2, 1) got error %v; want %v", name, err, ErrOverflow)
 		}
 	}
@@ -157,10 +157,10 @@ func TestCeilDiv(t *testing.T) {
 		{num: 4, den: 1, want: 4},
 		{num: 4, den: 3, want: 2},
 		{num: 10, den: 3, want: 4},
-		{num: max, den: 2, want: 1 << 63}, // must not overflow
+		{num: max64, den: 2, want: 1 << 63}, // must not overflow
 	}
 
-	rng := rand.New(rand.NewPCG(0, 0)) //nolint:gosec // Reproducibility is valuable for tests
+	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is useful for tests
 	for range 50 {
 		l := uint64(rng.Uint32())
 		r := uint64(rng.Uint32())

--- a/vms/saevm/params/params.go
+++ b/vms/saevm/params/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package params declares [Streaming Asynchronous Execution] (SAE) parameters.

--- a/vms/saevm/proxytime/cmpopt.go
+++ b/vms/saevm/proxytime/cmpopt.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 //go:build !prod && !nocmpopts

--- a/vms/saevm/proxytime/proxytime.go
+++ b/vms/saevm/proxytime/proxytime.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package proxytime measures the passage of time based on a proxy unit and
@@ -24,6 +24,8 @@ type Duration interface {
 
 // Time represents an instant in time, its passage measured by an arbitrary unit
 // of duration. It is not thread safe nor is the zero value valid.
+//
+//nolint:revive // struct-tag: canoto allows unexported fields
 type Time[D Duration] struct {
 	seconds uint64 `canoto:"uint,1"`
 	// invariant: fraction < hertz
@@ -58,7 +60,7 @@ func New[D Duration](unixSeconds uint64, hertz D) *Time[D] {
 // non-negative.
 func Of[D Duration](t time.Time) *Time[D] {
 	const hz = time.Second / time.Nanosecond
-	tm := New(uint64(t.Unix()), D(hz)) //nolint:gosec // Known to be non-negative
+	tm := New(uint64(t.Unix()), D(hz)) //#nosec G115 -- Known to be non-negative
 	tm.Tick(D(t.Nanosecond()))
 	return tm
 }

--- a/vms/saevm/proxytime/proxytime_test.go
+++ b/vms/saevm/proxytime/proxytime_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package proxytime
@@ -10,9 +10,10 @@ import (
 	"testing"
 	"time"
 
-	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	gocmp "github.com/google/go-cmp/cmp"
 )
 
 func frac(num, den uint64) FractionalSecond[uint64] {
@@ -218,7 +219,7 @@ func TestAsTime(t *testing.T) {
 	stdlib := time.Date(1986, time.October, 1, 0, 0, 0, 0, time.UTC)
 
 	const rate uint64 = 500
-	tm := New(uint64(stdlib.Unix()), rate) //nolint:gosec // Known to not overflow
+	tm := New(uint64(stdlib.Unix()), rate) //#nosec G115 -- Known to not overflow
 	if got, want := tm.AsTime(), stdlib; !got.Equal(want) {
 		t.Fatalf("%T.AsTime() at construction got %v; want %v", tm, got, want)
 	}

--- a/vms/saevm/sae/always.go
+++ b/vms/saevm/sae/always.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -8,12 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/avalanchego/snow"
-	snowcommon "github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/triedb"
 
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
@@ -39,6 +39,8 @@ func NewSinceGenesis[T hook.Transaction](hooks hook.PointsG[T], c Config) *Since
 }
 
 // Initialize initializes the VM.
+//
+//nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (vm *SinceGenesis[_]) Initialize(
 	ctx context.Context,
 	snowCtx *snow.Context,
@@ -46,8 +48,8 @@ func (vm *SinceGenesis[_]) Initialize(
 	genesisBytes []byte,
 	upgradeBytes []byte,
 	configBytes []byte,
-	fxs []*snowcommon.Fx,
-	appSender snowcommon.AppSender,
+	fxs []*common.Fx,
+	appSender common.AppSender,
 ) error {
 	db := newEthDB(avaDB)
 	tdb := triedb.NewDatabase(db, vm.config.DBConfig.TrieDBConfig)

--- a/vms/saevm/sae/always_test.go
+++ b/vms/saevm/sae/always_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/version"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 )
 

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/txpool"
@@ -18,13 +16,16 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
 	"github.com/ava-labs/avalanchego/vms/saevm/txgossip"
-	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 	"github.com/ava-labs/avalanchego/vms/saevm/worstcase"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // blockBuilder hides [blockBuilderG]'s generic type behind non-generic methods.
@@ -117,7 +118,7 @@ func (b *blockBuilderG[_]) rebuild(
 		ctx,
 		bCtx,
 		parent,
-		func(f txpool.PendingFilter) []*txgossip.LazyTransaction { return txs },
+		func(txpool.PendingFilter) []*txgossip.LazyTransaction { return txs },
 		rebuilder,
 	)
 }

--- a/vms/saevm/sae/blocks.go
+++ b/vms/saevm/sae/blocks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -9,11 +9,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
@@ -21,7 +16,13 @@ import (
 	"github.com/ava-labs/libevm/rlp"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 

--- a/vms/saevm/sae/consensus.go
+++ b/vms/saevm/sae/consensus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/event"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 )
 
@@ -21,7 +21,7 @@ import (
 // which MAY be nil.
 //
 // [preferred block]: https://github.com/ava-labs/avalanchego/tree/master/vms#set-preference
-func (vm *VM) SetPreference(ctx context.Context, id ids.ID, bCtx *block.Context) error {
+func (vm *VM) SetPreference(ctx context.Context, id ids.ID, _ *block.Context) error {
 	b, err := vm.GetBlock(ctx, id)
 	if err != nil {
 		return err

--- a/vms/saevm/sae/dbconv.go
+++ b/vms/saevm/sae/dbconv.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -7,10 +7,12 @@ package sae
 // every required import has something to do with a database!
 
 import (
-	"github.com/ava-labs/avalanchego/database"
-	evmdb "github.com/ava-labs/avalanchego/vms/evm/database"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/ethdb"
+
+	"github.com/ava-labs/avalanchego/database"
+
+	evmdb "github.com/ava-labs/avalanchego/vms/evm/database"
 )
 
 func newEthDB(db database.Database) ethdb.Database {

--- a/vms/saevm/sae/health.go
+++ b/vms/saevm/sae/health.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -6,6 +6,6 @@ package sae
 import "context"
 
 // HealthCheck returns the current health status of the VM.
-func (vm *VM) HealthCheck(context.Context) (any, error) {
+func (*VM) HealthCheck(context.Context) (any, error) {
 	return nil, nil
 }

--- a/vms/saevm/sae/http.go
+++ b/vms/saevm/sae/http.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae

--- a/vms/saevm/sae/networked_test.go
+++ b/vms/saevm/sae/networked_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -10,14 +10,15 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type networkedSUTs struct {

--- a/vms/saevm/sae/p2p.go
+++ b/vms/saevm/sae/p2p.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -6,10 +6,11 @@ package sae
 import (
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // newNetwork creates the P2P network with a registered validator set.

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -9,20 +9,21 @@ import (
 	"math"
 	"sync/atomic"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/params"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
 	"github.com/ava-labs/avalanchego/vms/saevm/types"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 )
 
 type recovery struct {

--- a/vms/saevm/sae/recovery_test.go
+++ b/vms/saevm/sae/recovery_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -12,9 +12,6 @@ import (
 	"time"
 
 	"github.com/arr4n/shed/testerr"
-	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/avalanchego/database/memdb"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
@@ -25,11 +22,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 )
 
 func TestRecoverFromDatabase(t *testing.T) {
@@ -46,7 +47,7 @@ func TestRecoverFromDatabase(t *testing.T) {
 	}))
 	srcCtx := ctx
 
-	rng := rand.New(rand.NewPCG(0, 0)) //nolint:gosec // Deterministic replay for tests
+	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is useful for tests
 
 	for final := false; !final; {
 		// We need to test rebuilding from trie roots reflecting (a) the last

--- a/vms/saevm/sae/rpc.go
+++ b/vms/saevm/sae/rpc.go
@@ -1,21 +1,22 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
 
 import (
-	"github.com/ava-labs/avalanchego/network/p2p"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/event"
 
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
-	saerpc "github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
 	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
 	"github.com/ava-labs/avalanchego/vms/saevm/txgossip"
+
+	saerpc "github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 

--- a/vms/saevm/sae/rpc/backend.go
+++ b/vms/saevm/sae/rpc/backend.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/blocks.go
+++ b/vms/saevm/sae/rpc/blocks.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/custom.go
+++ b/vms/saevm/sae/rpc/custom.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc
@@ -182,7 +182,7 @@ func (c *customAPI) NewAcceptedTransactions(ctx context.Context, fullTx *bool) (
 				for i, tx := range block.Transactions() {
 					var data any
 					if fullTx != nil && *fullTx {
-						data = ethapi.NewRPCTransaction(tx, hash, num, buildTime, uint64(i), baseFee, chainConfig) //nolint:gosec // i is non-negative
+						data = ethapi.NewRPCTransaction(tx, hash, num, buildTime, uint64(i), baseFee, chainConfig) //#nosec G115 -- i is non-negative
 					} else {
 						data = tx.Hash()
 					}

--- a/vms/saevm/sae/rpc/custom_test.go
+++ b/vms/saevm/sae/rpc/custom_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/debug.go
+++ b/vms/saevm/sae/rpc/debug.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/gasprice.go
+++ b/vms/saevm/sae/rpc/gasprice.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/indexing.go
+++ b/vms/saevm/sae/rpc/indexing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/mempool.go
+++ b/vms/saevm/sae/rpc/mempool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/net.go
+++ b/vms/saevm/sae/rpc/net.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc
@@ -6,8 +6,9 @@ package rpc
 import (
 	"strconv"
 
-	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/libevm/common/hexutil"
+
+	"github.com/ava-labs/avalanchego/network/p2p"
 )
 
 // netAPI offers the `net` RPCs.
@@ -23,7 +24,7 @@ func newNetAPI(peers *p2p.Peers, chainID uint64) *netAPI {
 	}
 }
 
-func (s *netAPI) Listening() bool {
+func (*netAPI) Listening() bool {
 	return true // The node is always listening for p2p connections.
 }
 

--- a/vms/saevm/sae/rpc/readers.go
+++ b/vms/saevm/sae/rpc/readers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/receipts.go
+++ b/vms/saevm/sae/rpc/receipts.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc
@@ -121,6 +121,6 @@ func (ir immediateReceipts) GetTransactionReceipt(ctx context.Context, h common.
 		r.BlockNumber.Uint64(),
 		r.Signer,
 		r.Tx,
-		int(r.TransactionIndex), //nolint:gosec // Known to not overflow
+		int(r.TransactionIndex), //#nosec G115 -- Known to not overflow
 	), nil
 }

--- a/vms/saevm/sae/rpc/rpc.go
+++ b/vms/saevm/sae/rpc/rpc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package rpc converts an SAE VM into forms suitable for backing [ethapi],
@@ -13,8 +13,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/ava-labs/avalanchego/network/p2p"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/accounts"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
@@ -24,6 +22,8 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/rpc"
 
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/gasprice"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"

--- a/vms/saevm/sae/rpc/server.go
+++ b/vms/saevm/sae/rpc/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc
@@ -44,7 +44,7 @@ func (b *backend) RPCGasCap() uint64 {
 	return b.config.GasCap
 }
 
-func (b *backend) Engine() consensus.Engine {
+func (*backend) Engine() consensus.Engine {
 	return (*coinbaseAsAuthor)(nil)
 }
 
@@ -131,6 +131,8 @@ func (b *backend) StateAndHeaderByNumberOrHash(ctx context.Context, numOrHash rp
 // trie data has not been pruned (or requires an archival node for older blocks).
 //
 // Reference: https://geth.ethereum.org/docs/developers/evm-tracing#state-availability
+//
+//nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (b *backend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, tracers.StateReleaseFunc, error) {
 	root, err := b.postExecutionStateRoot(block.Hash(), block.NumberU64())
 	if err != nil {
@@ -152,6 +154,8 @@ func (b *backend) StateAtBlock(ctx context.Context, block *types.Block, reexec u
 // Replay calls [saexec.Execute] - the same pipeline used by
 // [saexec.Executor] - with [noEndOfBlockOps] to suppress end-of-block
 // operations and [saexec.NullReceiptStore] to skip receipt broadcasting.
+//
+//nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	var bCtx vm.BlockContext
 	if ethB.NumberU64() == 0 {

--- a/vms/saevm/sae/rpc/static.go
+++ b/vms/saevm/sae/rpc/static.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc
@@ -7,10 +7,11 @@ import (
 	"context"
 	"math/big"
 
-	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/accounts"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/ethdb"
+
+	ethereum "github.com/ava-labs/libevm"
 )
 
 func (b *backend) ChainDb() ethdb.Database { //nolint:staticcheck // this name required by ethapi.Backend interface
@@ -21,7 +22,7 @@ func (b *backend) RPCTxFeeCap() float64 {
 	return b.config.TxFeeCap
 }
 
-func (b *backend) UnprotectedAllowed() bool {
+func (*backend) UnprotectedAllowed() bool {
 	return false
 }
 
@@ -37,11 +38,11 @@ func (*backend) ExtRPCEnabled() bool {
 // and no longer exposes the total difficulty of the chain at all via the API.
 //
 // TODO(JonathanOppenheimer): Once we update libevm, remove GetTd.
-func (b *backend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
+func (*backend) GetTd(ctx context.Context, _ common.Hash) *big.Int {
 	return new(big.Int)
 }
 
-func (b *backend) SyncProgress() ethereum.SyncProgress {
+func (*backend) SyncProgress() ethereum.SyncProgress {
 	// Avalanchego does not expose APIs until after the node has fully synced.
 	return ethereum.SyncProgress{}
 }

--- a/vms/saevm/sae/rpc/subscriptions.go
+++ b/vms/saevm/sae/rpc/subscriptions.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc
@@ -19,15 +19,15 @@ func (b *backend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscri
 // reorgs makes chain-side and log-removal events impossible. As "pending"
 // refers to accepted but not executed blocks, pending logs are an oxymoron.
 
-func (b *backend) SubscribeChainSideEvent(chan<- core.ChainSideEvent) event.Subscription {
+func (*backend) SubscribeChainSideEvent(chan<- core.ChainSideEvent) event.Subscription {
 	return newNoopSubscription()
 }
 
-func (b *backend) SubscribeRemovedLogsEvent(chan<- core.RemovedLogsEvent) event.Subscription {
+func (*backend) SubscribeRemovedLogsEvent(chan<- core.RemovedLogsEvent) event.Subscription {
 	return newNoopSubscription()
 }
 
-func (b *backend) SubscribePendingLogsEvent(chan<- []*types.Log) event.Subscription {
+func (*backend) SubscribePendingLogsEvent(chan<- []*types.Log) event.Subscription {
 	return newNoopSubscription()
 }
 

--- a/vms/saevm/sae/rpc/transactions.go
+++ b/vms/saevm/sae/rpc/transactions.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/vms/saevm/sae/rpc/web3.go
+++ b/vms/saevm/sae/rpc/web3.go
@@ -1,12 +1,13 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc
 
 import (
-	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/crypto"
+
+	"github.com/ava-labs/avalanchego/version"
 )
 
 // web3API offers the `web3` RPCs.

--- a/vms/saevm/sae/rpc_custom_test.go
+++ b/vms/saevm/sae/rpc_custom_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -23,9 +23,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
-	saerpc "github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
+
+	saerpc "github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
 )
 
 func TestGetChainConfig(t *testing.T) {

--- a/vms/saevm/sae/rpc_gasprice_test.go
+++ b/vms/saevm/sae/rpc_gasprice_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
+
 	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 )
 

--- a/vms/saevm/sae/rpc_receipts_test.go
+++ b/vms/saevm/sae/rpc_receipts_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/arr4n/shed/testerr"
-	"github.com/ava-labs/avalanchego/utils"
-	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/core/types"
@@ -25,9 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	ethereum "github.com/ava-labs/libevm"
 )
 
 // TestStateQueryOnNonCanonicalBlock verifies that state-dependent RPC calls

--- a/vms/saevm/sae/rpc_test.go
+++ b/vms/saevm/sae/rpc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -15,9 +15,6 @@ import (
 	"time"
 
 	"github.com/arr4n/shed/testerr"
-	"github.com/ava-labs/avalanchego/utils"
-	"github.com/ava-labs/avalanchego/version"
-	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -36,11 +33,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	ethereum "github.com/ava-labs/libevm"
 )
 
 var zeroAddr common.Address
@@ -259,7 +260,7 @@ func TestNetNamespace(t *testing.T) {
 			},
 			{
 				method: "net_version",
-				want:   fmt.Sprintf("%d", saetest.ChainConfig().ChainID.Uint64()),
+				want:   saetest.ChainConfig().ChainID.String(),
 			},
 		}...)
 	}
@@ -288,7 +289,7 @@ func TestTxPoolNamespace(t *testing.T) {
 		t.Helper()
 		return sut.wallet.SetNonceAndSign(t, i, &types.DynamicFeeTx{
 			To:        &addresses[i],
-			Gas:       params.TxGas + uint64(i), //nolint:gosec // Won't overflow
+			Gas:       params.TxGas + uint64(i), //#nosec G115 -- Won't overflow
 			GasFeeCap: big.NewInt(int64(i + 1)),
 			Value:     big.NewInt(int64(i + 10)),
 		})
@@ -616,7 +617,7 @@ func TestGetLogs(t *testing.T) {
 	emitter := common.Address{'l', 'o', 'g'}
 	precompile := vm.NewStatefulPrecompile(func(env vm.PrecompileEnvironment, _ []byte) ([]byte, error) {
 		data := make([]byte, 8)
-		rng.Read(data) //nolint:gosec,errcheck // Never returns an error; signature only to implement io.Reader
+		_, _ = rng.Read(data)
 		env.StateDB().AddLog(&types.Log{
 			Address: env.Addresses().EVMSemantic.Self,
 			Data:    data, // Guarantee uniqueness as this is the data under test
@@ -683,10 +684,10 @@ func TestGetLogs(t *testing.T) {
 	ptr := func(h common.Hash) *common.Hash { return &h }
 
 	tests := []struct {
-		name            string
-		query           ethereum.FilterQuery
-		wantLogs        []types.Log
-		wantErrContains string
+		name     string
+		query    ethereum.FilterQuery
+		wantLogs []types.Log
+		wantErr  testerr.Want
 	}{
 		{
 			name: "genesis",
@@ -705,7 +706,7 @@ func TestGetLogs(t *testing.T) {
 			query: ethereum.FilterQuery{
 				BlockHash: &common.Hash{0xde, 0xad},
 			},
-			wantErrContains: "unknown block",
+			wantErr: testerr.Contains("unknown block"),
 		},
 		{
 			name: "on_disk",
@@ -753,11 +754,9 @@ func TestGetLogs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("%T: %[1]v", tt.query)
 			got, err := sut.FilterLogs(ctx, tt.query)
-			if tt.wantErrContains != "" {
-				require.ErrorContains(t, err, tt.wantErrContains, "eth_getLogs(...)")
-				return
+			if diff := testerr.Diff(err, tt.wantErr); diff != "" {
+				t.Fatalf("eth_getLogs(...) %s", diff)
 			}
-			require.NoErrorf(t, err, "eth_getLogs(...)")
 			if diff := cmp.Diff(tt.wantLogs, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("eth_getLogs(...) mismatch (-want +got):\n%s", diff)
 			}
@@ -824,7 +823,7 @@ func TestGetReceipts(t *testing.T) {
 			r.CumulativeGasUsed = totalGas
 			r.BlockHash = b.Hash()
 			r.BlockNumber = b.Number()
-			r.TransactionIndex = uint(i) //nolint:gosec // Known non-negative
+			r.TransactionIndex = uint(i) //#nosec G115 -- Known non-negative
 		}
 		return b, rs
 	}
@@ -1263,7 +1262,7 @@ func (s *SUT) testGetByHash(ctx context.Context, t *testing.T, want *types.Block
 	}...)
 
 	for i, wantTx := range want.Transactions() {
-		txIdx := hexutil.Uint(i) //nolint:gosec // definitely won't overflow
+		txIdx := hexutil.Uint(i) //#nosec G115 -- Won't overflow
 		marshaled, err := wantTx.MarshalBinary()
 		require.NoErrorf(t, err, "%T.MarshalBinary()", wantTx)
 
@@ -1291,7 +1290,7 @@ func (s *SUT) testGetByHash(ctx context.Context, t *testing.T, want *types.Block
 		}...)
 	}
 
-	outOfBoundsIndex := hexutil.Uint(len(want.Transactions()) + 1) //nolint:gosec // Known to not overflow
+	outOfBoundsIndex := hexutil.Uint(len(want.Transactions()) + 1) //#nosec G115 -- Known to not overflow
 	s.testRPC(ctx, t, []rpcTest{
 		{
 			method: "eth_getTransactionByBlockHashAndIndex",
@@ -1379,7 +1378,7 @@ func (s *SUT) testGetByNumber(ctx context.Context, t *testing.T, want *types.Blo
 	}...)
 
 	for i, wantTx := range want.Transactions() {
-		txIdx := hexutil.Uint(i) //nolint:gosec // definitely won't overflow
+		txIdx := hexutil.Uint(i) //#nosec G115 -- Won't overflow
 		marshaled, err := wantTx.MarshalBinary()
 		require.NoErrorf(t, err, "%T.MarshalBinary()", wantTx)
 
@@ -1397,7 +1396,7 @@ func (s *SUT) testGetByNumber(ctx context.Context, t *testing.T, want *types.Blo
 		}...)
 	}
 
-	outOfBoundsIndex := hexutil.Uint(len(want.Transactions()) + 1) //nolint:gosec // Known to not overflow
+	outOfBoundsIndex := hexutil.Uint(len(want.Transactions()) + 1) //#nosec G115 -- Known to not overflow
 	s.testRPC(ctx, t, []rpcTest{
 		{
 			method: "eth_getTransactionByBlockNumberAndIndex",
@@ -1445,9 +1444,9 @@ func (s *SUT) testGetByUnknownNumber(ctx context.Context, t *testing.T) {
 	}...)
 }
 
-func withTxFeeCap(cap float64) sutOption {
+func withTxFeeCap(feeCap float64) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
-		c.vmConfig.RPCConfig.TxFeeCap = cap
+		c.vmConfig.RPCConfig.TxFeeCap = feeCap
 	})
 }
 

--- a/vms/saevm/sae/sae.go
+++ b/vms/saevm/sae/sae.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package sae implements the [Streaming Asynchronous Execution] (SAE) virtual
@@ -18,7 +18,7 @@ import (
 )
 
 func unix(t time.Time) uint64 {
-	return uint64(t.Unix()) //nolint:gosec // Guaranteed to be positive
+	return uint64(t.Unix()) //#nosec G115 -- Guaranteed to be positive
 }
 
 // uint256FromBig is a wrapper around [uint256.FromBig] with extra checks, for

--- a/vms/saevm/sae/tx_test.go
+++ b/vms/saevm/sae/tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae

--- a/vms/saevm/sae/vm.go
+++ b/vms/saevm/sae/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -14,15 +14,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ava-labs/avalanchego/network/p2p"
-	"github.com/ava-labs/avalanchego/network/p2p/gossip"
-	"github.com/ava-labs/avalanchego/snow"
-	snowcommon "github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/utils"
-	"github.com/ava-labs/avalanchego/utils/bloom"
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/version"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -34,12 +25,22 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/bloom"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
 	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
 	"github.com/ava-labs/avalanchego/vms/saevm/txgossip"
+
+	snowcommon "github.com/ava-labs/avalanchego/snow/engine/common"
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
@@ -218,7 +219,7 @@ func NewVM[T hook.Transaction](
 			return nil, err
 		}
 		conf := gossip.BloomSetConfig{Metrics: metrics}
-		pool, err := txgossip.NewSet(snowCtx.Log, txPool, conf)
+		pool, err := txgossip.NewSet(txPool, conf)
 		if err != nil {
 			return nil, err
 		}

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -18,18 +18,6 @@ import (
 	"time"
 
 	"github.com/arr4n/shed/testerr"
-	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/avalanchego/database/memdb"
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
-	snowcommon "github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/snow/snowtest"
-	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -40,7 +28,6 @@ import (
 	"github.com/ava-labs/libevm/ethclient"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/libevm"
-	libevmhookstest "github.com/ava-labs/libevm/libevm/hookstest"
 	"github.com/ava-labs/libevm/libevm/options"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/params"
@@ -52,16 +39,30 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 	"github.com/ava-labs/avalanchego/vms/saevm/txgossip/txgossiptest"
+
+	snowcommon "github.com/ava-labs/avalanchego/snow/engine/common"
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
+	libevmhookstest "github.com/ava-labs/libevm/libevm/hookstest"
 )
 
 func TestMain(m *testing.M) {
@@ -91,7 +92,6 @@ type SUT struct {
 	rawVM   *VM
 	genesis *blocks.Block
 	wallet  *saetest.Wallet
-	avaDB   database.Database
 	db      ethdb.Database
 	hooks   *hookstest.Stub
 	logger  *saetest.TBLogger
@@ -197,7 +197,6 @@ func newSUT(tb testing.TB, numAccounts uint, opts ...sutOption) (context.Context
 			keys,
 			types.LatestSigner(conf.genesis.Config),
 		),
-		avaDB:  conf.db,
 		db:     newEthDB(conf.db),
 		hooks:  conf.hooks,
 		logger: logger,
@@ -291,7 +290,7 @@ func withExecResultsDB(hdb database.HeightIndex) sutOption {
 	})
 }
 
-func withCommitInterval(interval uint64) sutOption {
+func withCommitInterval(interval uint64) sutOption { //nolint:unparam // always 16 for now but caller-controlled by design
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.vmConfig.DBConfig.TrieCommitInterval = interval
 	})
@@ -805,7 +804,7 @@ func TestAcceptBlock(t *testing.T) {
 	unsettled := []*blocks.Block{sut.genesis}
 	sut.genesis = nil // allow it to be GCd when appropriate
 
-	rng := rand.New(rand.NewPCG(0, 0)) //nolint:gosec // Reproducibility is useful for tests
+	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is useful for tests
 	for range 100 {
 		ffMillis := 100 + rng.IntN(1000*(1+saeparams.TauSeconds))
 		vmTime.advance(time.Millisecond * time.Duration(ffMillis))

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sae
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"flag"
-	"fmt"
 	"math"
 	"math/big"
 	"math/rand/v2"
@@ -15,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
@@ -26,9 +24,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/worstcase"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 )
 
 var worstCaseFuzzFlags struct {
@@ -44,13 +44,13 @@ var worstCaseFuzzFlags struct {
 
 func createWorstCaseFuzzFlags(set *flag.FlagSet) {
 	name := func(n string) string {
-		return fmt.Sprintf("worstcase.fuzz.%s", n)
+		return "worstcase.fuzz." + n
 	}
 	fs := &worstCaseFuzzFlags
 
 	set.UintVar(&fs.numAccounts, name("num_eoa"), 10, "Number of EOAs to send funds between")
 	set.TextVar(&fs.balance, name("eoa_balance"), uint256.NewInt(params.Ether), "Starting balance of EOAs")
-	set.UintVar(&fs.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //nolint:gosec // Known to be positive
+	set.UintVar(&fs.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //#nosec G115 -- Known to be positive
 	set.UintVar(&fs.numBlocks, name("blocks"), 50, "Number of blocks to build and execute (fixed)")
 	set.UintVar(&fs.maxNewTxsPerBlock, name("max_new_txs"), 100, "Maximum number of new transactions to send before building each block (uniform distribution)")
 	set.Uint64Var(&fs.maxGasLimit, name("max_gas_limit"), 60e6, "Maximum gas limit per transaction (uniform distribution)")
@@ -92,7 +92,7 @@ func (g *guzzler) PrecompileOverride(a common.Address) (libevm.PrecompiledContra
 // guzzle consumes an amount of gas configurable via its input (call data),
 // which MUST either be an empty slice or a big-endian uint64 indicating the
 // amount of gas to _keep_ (not consume).
-func (g *guzzler) guzzle(env vm.PrecompileEnvironment, input []byte) ([]byte, error) {
+func (*guzzler) guzzle(env vm.PrecompileEnvironment, input []byte) ([]byte, error) {
 	switch len(input) {
 	case 0:
 		env.UseGas(env.Gas())
@@ -202,10 +202,10 @@ func TestWorstCase(t *testing.T) {
 			if flags.rngSeed != 0 {
 				seed = flags.rngSeed
 			} else {
-				seed = rand.Uint64() //nolint:gosec // Not for security
+				seed = rand.Uint64() //#nosec G404 -- Not for security
 			}
 			t.Logf("RNG seed: %d", seed)
-			rng := rand.New(rand.NewPCG(0, seed)) //nolint:gosec // Allow for reproducibility
+			rng := rand.New(rand.NewPCG(0, seed)) //#nosec G404 -- Allow for reproducibility
 
 			for range flags.numBlocks {
 				for range rng.UintN(flags.maxNewTxsPerBlock) {

--- a/vms/saevm/saedb/saedb.go
+++ b/vms/saevm/saedb/saedb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package saedb provides functionality related to storage and access of

--- a/vms/saevm/saedb/saedb_test.go
+++ b/vms/saevm/saedb/saedb_test.go
@@ -1,11 +1,9 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saedb
 
-import (
-	"testing"
-)
+import "testing"
 
 func FuzzTrieDBCommitHeights(f *testing.F) {
 	f.Fuzz(func(t *testing.T, e uint64) {

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saedb
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/state"
@@ -16,6 +15,7 @@ import (
 	"github.com/ava-labs/libevm/triedb"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 

--- a/vms/saevm/saetest/BUILD.bazel
+++ b/vms/saevm/saetest/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "@com_github_ava_labs_libevm//libevm/ethtest",
         "@com_github_ava_labs_libevm//params",
         "@com_github_ava_labs_libevm//trie",
-        "@com_github_google_go_cmp//cmp",
         "@com_github_holiman_uint256//:uint256",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_zap//:zap",

--- a/vms/saevm/saetest/escrow/escrow.go
+++ b/vms/saevm/saetest/escrow/escrow.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // The above copyright and licensing exclude the original Escrow.sol contract

--- a/vms/saevm/saetest/heightdb.go
+++ b/vms/saevm/saetest/heightdb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saetest
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/ava-labs/avalanchego/database"
-
 	"github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 

--- a/vms/saevm/saetest/logging.go
+++ b/vms/saevm/saetest/logging.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saetest
@@ -9,9 +9,10 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
 // logger is the common wrapper around [LogRecorder] and [tbLogger] handlers,

--- a/vms/saevm/saetest/saetest.go
+++ b/vms/saevm/saetest/saetest.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package saetest provides testing helpers for [Streaming Asynchronous
@@ -13,7 +13,6 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/ava-labs/avalanchego/utils/lock"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/state/snapshot"
@@ -21,8 +20,8 @@ import (
 	"github.com/ava-labs/libevm/event"
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/trie"
-	"github.com/google/go-cmp/cmp"
 
+	"github.com/ava-labs/avalanchego/utils/lock"
 	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 )
 
@@ -62,16 +61,6 @@ func ChainConfig() *params.ChainConfig {
 // zero, and post-merge.
 func Rules() params.Rules {
 	return ChainConfig().Rules(new(big.Int), true, 0)
-}
-
-// MerkleRootsEqual returns whether the two arguments have the same Merkle root.
-func MerkleRootsEqual[T types.DerivableList](a, b T) bool {
-	return types.DeriveSha(a, TrieHasher()) == types.DeriveSha(b, TrieHasher())
-}
-
-// CmpByMerkleRoots returns a [cmp.Comparer] using [MerkleRootsEqual].
-func CmpByMerkleRoots[T types.DerivableList]() cmp.Option {
-	return cmp.Comparer(MerkleRootsEqual[T])
 }
 
 // An EventCollector collects all events received from an [event.Subscription].

--- a/vms/saevm/saetest/saetest_test.go
+++ b/vms/saevm/saetest/saetest_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saetest

--- a/vms/saevm/saetest/wallet.go
+++ b/vms/saevm/saetest/wallet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saetest

--- a/vms/saevm/saexec/context.go
+++ b/vms/saevm/saexec/context.go
@@ -1,15 +1,16 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saexec
 
 import (
-	"github.com/ava-labs/avalanchego/cache/lru"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/consensus"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/types"
+
+	"github.com/ava-labs/avalanchego/cache/lru"
+	"github.com/ava-labs/avalanchego/utils/logging"
 
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saexec
@@ -10,8 +10,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
@@ -22,6 +20,8 @@ import (
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"

--- a/vms/saevm/saexec/receipts.go
+++ b/vms/saevm/saexec/receipts.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saexec

--- a/vms/saevm/saexec/saexec.go
+++ b/vms/saevm/saexec/saexec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package saexec provides the execution module of [Streaming Asynchronous
@@ -11,8 +11,6 @@ import (
 	"io"
 	"sync/atomic"
 
-	"github.com/ava-labs/avalanchego/cache/lru"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/types"
@@ -21,9 +19,12 @@ import (
 	"github.com/ava-labs/libevm/libevm/eventual"
 	"github.com/ava-labs/libevm/params"
 
+	"github.com/ava-labs/avalanchego/cache/lru"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saexec
@@ -15,8 +15,6 @@ import (
 	"testing"
 
 	"github.com/arr4n/shed/testerr"
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -26,7 +24,6 @@ import (
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/libevm"
-	libevmhookstest "github.com/ava-labs/libevm/libevm/hookstest"
 	"github.com/ava-labs/libevm/libevm/options"
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/trie"
@@ -38,15 +35,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
-	saehookstest "github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
+
+	saehookstest "github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
+	libevmhookstest "github.com/ava-labs/libevm/libevm/hookstest"
 )
 
 func TestMain(m *testing.M) {
@@ -108,7 +109,7 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 	blockOpts := blockstest.WithBlockOptions(
 		blockstest.WithLogger(logger),
 	)
-	chain := blockstest.NewChainBuilder(config, genesis, blockOpts)
+	chain := blockstest.NewChainBuilder(genesis, blockOpts)
 	src := blocks.Source(chain.GetBlock)
 
 	saedbConfig := saedb.Config{
@@ -229,7 +230,7 @@ func TestSubscriptions(t *testing.T) {
 	precompile := common.Address{'p', 'r', 'e'}
 	stub := &libevmhookstest.Stub{
 		PrecompileOverrides: map[common.Address]libevm.PrecompiledContract{
-			precompile: vm.NewStatefulPrecompile(func(env vm.PrecompileEnvironment, input []byte) (ret []byte, err error) {
+			precompile: vm.NewStatefulPrecompile(func(env vm.PrecompileEnvironment, _ []byte) (ret []byte, err error) {
 				env.StateDB().AddLog(&types.Log{
 					Address: precompile,
 				})
@@ -322,7 +323,7 @@ func TestExecution(t *testing.T) {
 		EffectiveGasPrice: big.NewInt(1),
 	})
 
-	rng := rand.New(rand.NewPCG(0, 0)) //nolint:gosec // Reproducibility is useful for tests
+	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is useful for tests
 	var wantEscrowBalance uint64
 	for range 10 {
 		val := rng.Uint64N(100_000)
@@ -351,7 +352,7 @@ func TestExecution(t *testing.T) {
 
 	var logIndex uint
 	for i, r := range want {
-		ui := uint(i) //nolint:gosec // Known to not overflow
+		ui := uint(i) //#nosec G115 -- Known to not overflow
 
 		r.Status = 1
 		r.TransactionIndex = ui
@@ -602,7 +603,7 @@ func TestGasAccounting(t *testing.T) {
 
 		t.Run("CumulativeGasUsed", func(t *testing.T) {
 			for i, r := range b.Receipts() {
-				ui := uint64(i + 1) //nolint:gosec // Known to not overflow
+				ui := uint64(i + 1) //#nosec G115 -- Known to not overflow
 				assert.Equalf(t, ui*params.TxGas, r.CumulativeGasUsed, "%T.Receipts()[%d]", b, i)
 			}
 		})
@@ -989,7 +990,7 @@ func TestStateRootAvailability(t *testing.T) {
 
 	t.Run("all states", func(t *testing.T) {
 		// We haven't dropped any states.
-		checkStates(t, e, func(height uint64) bool { return true })
+		checkStates(t, e, func(uint64) bool { return true })
 	})
 
 	t.Run("remove in memory state", func(t *testing.T) {

--- a/vms/saevm/saexec/subscription.go
+++ b/vms/saevm/saexec/subscription.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package saexec
@@ -12,7 +12,11 @@ import (
 func (e *Executor) sendPostExecutionEvents(b *types.Block, receipts types.Receipts) {
 	e.headEvents.Send(core.ChainHeadEvent{Block: b})
 
-	var logs []*types.Log
+	var n int
+	for _, r := range receipts {
+		n += len(r.Logs)
+	}
+	logs := make([]*types.Log, 0, n)
 	for _, r := range receipts {
 		logs = append(logs, r.Logs...)
 	}

--- a/vms/saevm/txgossip/BUILD.bazel
+++ b/vms/saevm/txgossip/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//ids",
         "//network/p2p/gossip",
-        "//utils/logging",
         "//vms/saevm/saexec",
         "//vms/saevm/types",
         "@com_github_ava_labs_libevm//common",

--- a/vms/saevm/txgossip/blockchain.go
+++ b/vms/saevm/txgossip/blockchain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txgossip
@@ -11,12 +11,13 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/params"
 
-	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
-	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
-
 	// Imported for [core.ChainHeadEvent] comment resolution. Already a
 	// downstream dependency.
 	_ "github.com/ava-labs/libevm/core"
+
+	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
+
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
 // A BlockChain is the union of [txpool.BlockChain] and [legacypool.BlockChain].

--- a/vms/saevm/txgossip/priority.go
+++ b/vms/saevm/txgossip/priority.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txgossip

--- a/vms/saevm/txgossip/pushpull.go
+++ b/vms/saevm/txgossip/pushpull.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txgossip
@@ -7,9 +7,10 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/libevm/ethapi"
+
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 )
 
 // SendTx implements the respective method of [ethapi.Backend], accepting

--- a/vms/saevm/txgossip/txgossip.go
+++ b/vms/saevm/txgossip/txgossip.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package txgossip provides a mempool for [Streaming Asynchronous Execution],
@@ -10,13 +10,13 @@ package txgossip
 import (
 	"errors"
 
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/network/p2p/gossip"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/txpool"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/rlp"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 )
 
 var _ gossip.Gossipable = Transaction{}
@@ -64,7 +64,7 @@ type Set struct {
 
 // NewSet returns a new Set. Use [gossip.BloomSet.Add] or [Set.SendTx] to add
 // transactions to the pool, which SHOULD NOT be populated directly.
-func NewSet(logger logging.Logger, pool *txpool.TxPool, config gossip.BloomSetConfig) (*Set, error) {
+func NewSet(pool *txpool.TxPool, config gossip.BloomSetConfig) (*Set, error) {
 	s := &txSet{pool}
 	bs, err := gossip.NewBloomSet(s, config)
 	if err != nil {

--- a/vms/saevm/txgossip/txgossip_test.go
+++ b/vms/saevm/txgossip/txgossip_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txgossip
@@ -15,11 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/network/p2p"
-	"github.com/ava-labs/avalanchego/network/p2p/gossip"
-	"github.com/ava-labs/avalanchego/network/p2p/p2ptest"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/txpool"
@@ -35,6 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
+	"github.com/ava-labs/avalanchego/network/p2p/p2ptest"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
@@ -80,7 +80,7 @@ func newSUT(t *testing.T, numAccounts uint) SUT {
 	db := rawdb.NewMemoryDatabase()
 	xdb := saetest.NewExecutionResultsDB()
 	genesis := blockstest.NewGenesis(t, db, xdb, config, saetest.MaxAllocFor(wallet.Addresses()...))
-	chain := blockstest.NewChainBuilder(config, genesis)
+	chain := blockstest.NewChainBuilder(genesis)
 	src := blocks.Source(chain.GetBlock)
 
 	exec, err := saexec.New(genesis, src.AsHeaderSource(), config, db, xdb, saedb.Config{}, hookstest.NewStub(1e6), logger)
@@ -91,7 +91,7 @@ func newSUT(t *testing.T, numAccounts uint) SUT {
 
 	bc := NewBlockChain(exec, src.AsEthBlockSource())
 	pool := newTxPool(t, bc)
-	set, err := NewSet(logger, pool, gossip.BloomSetConfig{})
+	set, err := NewSet(pool, gossip.BloomSetConfig{})
 	require.NoError(t, err, "NewSet()")
 	t.Cleanup(func() {
 		assert.NoErrorf(t, pool.Close(), "%T.Close()", pool)
@@ -123,7 +123,7 @@ func TestExecutorIntegration(t *testing.T) {
 	const numAccounts = 3
 	s := newSUT(t, numAccounts)
 
-	rng := rand.New(rand.NewPCG(0, 0)) //nolint:gosec // Reproducibility is useful in tests
+	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is valuable for tests
 
 	const txPerAccount = 5
 	const numTxs = numAccounts * txPerAccount

--- a/vms/saevm/txgossip/txgossiptest/mempool.go
+++ b/vms/saevm/txgossip/txgossiptest/mempool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package txgossiptest provides test helpers for mempool operations.
@@ -8,11 +8,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/txpool"
 	"github.com/ava-labs/libevm/core/types"
+
+	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 // WaitUntilPending waits until all transactions provided are marked as pending in `pool`.

--- a/vms/saevm/types/types.go
+++ b/vms/saevm/types/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package types defines common types that are used throughout the SAE
@@ -9,9 +9,10 @@
 package types
 
 import (
-	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
+
+	"github.com/ava-labs/avalanchego/database"
 )
 
 type (

--- a/vms/saevm/worstcase/state.go
+++ b/vms/saevm/worstcase/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // Package worstcase provides the worst-case balance and nonce tracking needed
@@ -13,7 +13,6 @@ import (
 	"math/big"
 	"slices"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
@@ -22,11 +21,13 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
-	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 )
 
 // State tracks the worst-case gas price and account state as operations are

--- a/vms/saevm/worstcase/state_benchmark_test.go
+++ b/vms/saevm/worstcase/state_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package worstcase

--- a/vms/saevm/worstcase/state_test.go
+++ b/vms/saevm/worstcase/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package worstcase
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
@@ -27,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"


### PR DESCRIPTION
## Why this should be merged

This PR sets up and applies the `yamllint` linter from strevm, and the tauseconds linter, both of which were not present in AvalancheGo. 

I also dealt with the following golangci lint errors. 

**Fixed** (321 -> 171, 150 resolved)
- `gci` (61): import ordering
- `nolintlint` (46): Stale `//nolint` directives 
- `perfsprint` (6): Unnecessary `fmt.Sprintf`
- `testifylint` (4): testify ""best practices""
- `usetesting` (4): Test context usage — flags context.Background() in tests where t.Context() (Go 1.24+) should be used
- `predeclared` (2): built-in variable shadowing
- `unused` (2): dead code 
- `prealloc` (1): slice preallocation
- `unparam` (1): unused return values
- `revive` partial (85 -> 63, -22):
  - `bool-literal-in-expr` (1): removed redundant `true &&`
    - I feel like this was too obvious to get past review, was there a reason this was included? 
  - `unexported-naming` (4): no-linted `R`, `T` mathematical convention variable names
  - `struct-tag` (18): no-linted canoto structs with unexported fields

As a note I tried to suppress the canoto struct-tag via  the linter config, as revive's struct-tag rule supports a `!tagname` argument to skip checking a tag, but this only suppresses tag value validation. It evidently does not suppress the separate "tag on not-exported field" check (I tried).


<details>
<summary>Old open question</summary>
The following lint errors (171) are not mistakes and need to be discussed 

- `errorlint` (37): intentional use of `%v` instead of `%w` in `fmt.Errorf` -- this avoids exposing wrapped errors.
- `forbidigo` (71): bans `t.Errorf`/`t.Fatalf`/`t.Fatal`/`t.Error`
- `revive` (63): all `unused-receiver` and `unused-parameter`. There are mostly interface implementations that must accept `ctx` or have a receiver but don't use them. AvalancheGo removes these or renames to`_`. 
</details>

We decided as a team that: 

- `errorlint`: drop entirely from the lint config.
- `forbidigo`* unban `t.Fatal`, `t.Fatalf`, `t.Error`, `t.Errorf`.
- `revive` `unused-parameter`/`unused-receiver`: keep both of these but add `allowRegex: "^ctx$"` to `unused-parameter` so unused `ctx context.Context` first arguments are allowed and the `context-as-argument` rule to enforce `ctx` is always the first parameter. 

## How this works
No functional changes 

## How this was tested
CI

## Need to be documented in RELEASES.md?
Yes, maybe in a separate PR. 