### PR TITLE
refactor: use predefined hashdb test

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.json
@@ -8,11 +8,7 @@
             },
             {
                 "runner": "avalanche-avalanchego-runner-2ti",
-                "config": "default",
-                "start-block": 101,
-                "end-block": 250000,
-                "block-dir-src": "cchain-mainnet-blocks-1m-ldb",
-                "current-state-dir-src": "cchain-current-state-hashdb-full-100",
+                "test": "hashdb-101-250k",
                 "timeout-minutes": 30
             }
         ]


### PR DESCRIPTION
## Why this should be merged

Closes #5146.

## How this works

Uses `hashdb-101-250k` predefined test instead of writing out entire test spec.

## How this was tested

CI: https://github.com/ava-labs/avalanchego/actions/runs/23901295323/job/69698377209?pr=5164

## Need to be documented in RELEASES.md?

No