### PR TITLE
app, subprocess: use signal.NotifyContext and thread context through NewCmd

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -87,45 +88,36 @@ func New(config nodeconfig.Config) (App, error) {
 }
 
 func Run(app App) int {
-	// start running the application
-	app.Start()
+	// cancel the context on SIGINT or SIGTERM to initiate shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
-	// register terminationSignals to kill the application
-	terminationSignals := make(chan os.Signal, 1)
-	signal.Notify(terminationSignals, syscall.SIGINT, syscall.SIGTERM)
-
+	// SIGABRT is not a shutdown signal; handle it separately to print a stack
+	// trace to stderr without stopping the application.
 	stackTraceSignal := make(chan os.Signal, 1)
 	signal.Notify(stackTraceSignal, syscall.SIGABRT)
-
-	// start up a new go routine to handle attempts to kill the application
-	go func() {
-		for range terminationSignals {
-			app.Stop()
-			return
-		}
+	defer func() {
+		signal.Stop(stackTraceSignal)
+		close(stackTraceSignal)
 	}()
 
-	// start a goroutine to listen on SIGABRT signals,
-	// to print the stack trace to standard error.
 	go func() {
 		for range stackTraceSignal {
 			fmt.Fprint(os.Stderr, utils.GetStacktrace(true))
 		}
 	}()
 
-	// wait for the app to exit and get the exit code response
-	exitCode := app.ExitCode()
+	// start running the application
+	app.Start()
 
-	// shut down the termination signal go routine
-	signal.Stop(terminationSignals)
-	close(terminationSignals)
+	// stop the application when the shutdown context is cancelled.
+	go func() {
+		<-ctx.Done()
+		stop()
+		app.Stop()
+	}()
 
-	// shut down the stack trace go routine
-	signal.Stop(stackTraceSignal)
-	close(stackTraceSignal)
-
-	// return the exit code that the application reported
-	return exitCode
+	return app.ExitCode()
 }
 
 // app is a wrapper around a node that runs in this process

--- a/network/network.go
+++ b/network/network.go
@@ -59,6 +59,10 @@ var (
 )
 
 // Network defines the functionality of the networking library.
+//
+// Contexts passed to methods on this interface bound individual operations
+// and do not control the lifetime of the network. To stop the network, call
+// StartClose and wait for Dispatch to return.
 type Network interface {
 	// All consensus messages can be sent through this interface. Thread safety
 	// must be managed internally in the network.

--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -210,6 +210,11 @@ type peer struct {
 //
 // Invariant: There must only be one peer running at a time with a reference to
 // the same [config.InboundMsgThrottler].
+//
+// The peer manages its own internal context for the lifetime of its goroutines.
+// Callers cannot cancel the peer through an external context. To stop the peer,
+// call StartClose and wait with AwaitClosed. Contexts passed to AwaitReady and
+// AwaitClosed control how long the caller waits, not the peer lifetime.
 func Start(
 	config *Config,
 	conn net.Conn,

--- a/vms/rpcchainvm/factory.go
+++ b/vms/rpcchainvm/factory.go
@@ -57,7 +57,7 @@ func (f *factory) New(log logging.Logger) (interface{}, error) {
 	status, stopper, err := subprocess.Bootstrap(
 		context.TODO(),
 		listener,
-		subprocess.NewCmd(f.path),
+		subprocess.NewCmd(context.Background(), f.path),
 		config,
 	)
 	if err != nil {

--- a/vms/rpcchainvm/runtime/subprocess/linux_stopper.go
+++ b/vms/rpcchainvm/runtime/subprocess/linux_stopper.go
@@ -20,8 +20,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime"
 )
 
-func NewCmd(path string, args ...string) *exec.Cmd {
-	cmd := exec.Command(path, args...)
+func NewCmd(ctx context.Context, path string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, path, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGTERM}
 	return cmd
 }

--- a/vms/rpcchainvm/runtime/subprocess/non_linux_stopper.go
+++ b/vms/rpcchainvm/runtime/subprocess/non_linux_stopper.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
-func NewCmd(path string, args ...string) *exec.Cmd {
-	return exec.Command(path, args...)
+func NewCmd(ctx context.Context, path string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, path, args...)
 }
 
 func stop(_ context.Context, log logging.Logger, cmd *exec.Cmd) {


### PR DESCRIPTION
## Why this should be merged

Issue #4976 tracks three follow-up improvements from the #4163 review. This PR addresses all three. Items 1 and 2 touch different files from #4975 (app startup and subprocess vs. network layers) and can land independently.

Replacing `signal.Notify` with `signal.NotifyContext` in `app/app.go` makes shutdown context-driven rather than channel-driven, which is the idiomatic approach since Go 1.16.

Adding a context parameter to `subprocess.NewCmd` brings it in line with how the rest of the codebase handles long-lived processes. The call site in `factory.go` passes `context.Background()` so the subprocess lifetime is not tied to any cancellable context.

## How this works

`app/app.go`: `Run()` creates a notify context for SIGINT and SIGTERM. SIGABRT keeps its own `signal.Notify` channel since it triggers a stack trace dump and does not cause shutdown.

`subprocess.NewCmd`: both platform implementations now accept `ctx` as the first parameter and pass it to `exec.CommandContext`. The existing `SysProcAttr` setup on Linux is unchanged.

`network/network.go` and `network/peer/peer.go`: godoc clarifying that contexts passed to methods control individual operation lifetimes, not the network or peer lifetime.

## How this was tested

```
GOOS=linux go build ./vms/rpcchainvm/runtime/subprocess/...
GOOS=linux go vet ./vms/rpcchainvm/runtime/subprocess/...
```

Full CI will cover the remaining packages.

## Need to be documented in RELEASES.md?

No