### PR TITLE
chore: skip flaky TestTransactionSkipIndexing

### DIFF
--- a/graft/coreth/core/txindexer_test.go
+++ b/graft/coreth/core/txindexer_test.go
@@ -167,6 +167,8 @@ func getTail(limit uint64, lastAccepted uint64) *uint64 {
 }
 
 func TestTransactionSkipIndexing(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/ava-labs/avalanchego/issues/5170")
+
 	// Configure and generate a sample block chain
 	require := require.New(t)
 	var (

--- a/graft/subnet-evm/core/txindexer_test.go
+++ b/graft/subnet-evm/core/txindexer_test.go
@@ -167,6 +167,8 @@ func getTail(limit uint64, lastAccepted uint64) *uint64 {
 }
 
 func TestTransactionSkipIndexing(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/ava-labs/avalanchego/issues/5170")
+
 	// Configure and generate a sample block chain
 	require := require.New(t)
 	var (


### PR DESCRIPTION
## Why this should be merged

`TestTransactionSkipIndexing` has been flaking for sometime now - this test should be skipped until the EVM team resolves it.

Ref: #5170 

## How this works

Skips `TestTransactionSkipIndexing` during testing.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
