### PR TITLE
Remove unexpected subnet-evm NewHTTPHandler implementation

### DIFF
--- a/graft/subnet-evm/plugin/evm/vm.go
+++ b/graft/subnet-evm/plugin/evm/vm.go
@@ -1204,25 +1204,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	return apis, nil
 }
 
-// NewHTTPHandler implements the block.ChainVM interface
-func (vm *VM) NewHTTPHandler(ctx context.Context) (http.Handler, error) {
-	handlers, err := vm.CreateHandlers(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return the main RPC handler as the primary HTTP handler
-	if handler, exists := handlers[ethRPCEndpoint]; exists {
-		return handler, nil
-	}
-
-	// Fallback to a default handler if no RPC handler exists
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "No HTTP handler available", http.StatusNotFound)
-	}), nil
-}
-
-func (*VM) CreateHTTP2Handler(context.Context) (http.Handler, error) {
+func (*VM) NewHTTPHandler(context.Context) (http.Handler, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Why this should be merged

This implementation was added randomly in a version bump PR. It shouldn't exist.

## How this works

Removes spurious implementation.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A