### PR TITLE
style: enforce `context-as-argument` ordering, remove `errorlint`, un-interface coreth client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,6 @@ linters:
     - durationcheck
     # - embeddedstructfieldcheck
     - errcheck
-    - errorlint
     - forbidigo
     - goconst
     - gocheckcompilerdirectives
@@ -105,11 +104,6 @@ linters:
             # in lint.sh to produce warnings instead of errors.
             - pkg: io/ioutil
               desc: io/ioutil is deprecated. Use package io or os instead.
-    errorlint:
-      # Check for plain type assertions and type switches.
-      asserts: false
-      # Check for plain error comparisons.
-      comparison: false
     forbidigo:
       # Forbid the following identifiers (list of regexp).
       forbid:
@@ -145,6 +139,11 @@ linters:
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
         - name: bool-literal-in-expr
           disabled: false
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+        - name: context-as-argument
+          disabled: false
+          arguments:
+            - allowTypesBefore: "*testing.T,*testing.B,*testing.F,testing.TB"
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
         - name: early-return
           disabled: false
@@ -197,6 +196,8 @@ linters:
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
         - name: unused-parameter
           disabled: false
+          arguments:
+            - allowRegex: "^ctx$"
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
         - name: unused-receiver
           disabled: false

--- a/graft/coreth/plugin/evm/client/client.go
+++ b/graft/coreth/plugin/evm/client/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"golang.org/x/exp/slog"
 
@@ -154,4 +155,28 @@ func (c *Client) GetVMConfig(ctx context.Context, options ...rpc.Option) (*confi
 	res := &ConfigReply{}
 	err := c.adminRequester.SendRequest(ctx, "admin.getVMConfig", struct{}{}, res, options...)
 	return res.Config, err
+}
+
+// AwaitTxAccepted polls GetAtomicTxStatus every freq until txID is accepted
+// or ctx is cancelled.
+func (c *Client) AwaitTxAccepted(ctx context.Context, txID ids.ID, freq time.Duration, options ...rpc.Option) error {
+	ticker := time.NewTicker(freq)
+	defer ticker.Stop()
+
+	for {
+		status, err := c.GetAtomicTxStatus(ctx, txID, options...)
+		if err != nil {
+			return err
+		}
+
+		if status == atomic.Accepted {
+			return nil
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }

--- a/graft/coreth/plugin/evm/client/client.go
+++ b/graft/coreth/plugin/evm/client/client.go
@@ -20,46 +20,29 @@ import (
 	"github.com/ava-labs/avalanchego/utils/rpc"
 )
 
-// Interface compliance
-var _ Client = (*client)(nil)
-
 var errInvalidAddr = errors.New("invalid hex address")
 
-// Client interface for interacting with EVM [chain]
-type Client interface {
-	IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error)
-	GetAtomicTxStatus(ctx context.Context, txID ids.ID, options ...rpc.Option) (atomic.Status, error)
-	GetAtomicTx(ctx context.Context, txID ids.ID, options ...rpc.Option) ([]byte, error)
-	GetAtomicUTXOs(ctx context.Context, addrs []ids.ShortID, sourceChain string, limit uint32, startAddress ids.ShortID, startUTXOID ids.ID, options ...rpc.Option) ([][]byte, ids.ShortID, ids.ID, error)
-	StartCPUProfiler(ctx context.Context, options ...rpc.Option) error
-	StopCPUProfiler(ctx context.Context, options ...rpc.Option) error
-	MemoryProfile(ctx context.Context, options ...rpc.Option) error
-	LockProfile(ctx context.Context, options ...rpc.Option) error
-	SetLogLevel(ctx context.Context, level slog.Level, options ...rpc.Option) error
-	GetVMConfig(ctx context.Context, options ...rpc.Option) (*config.Config, error)
-}
-
-// Client implementation for interacting with EVM [chain]
-type client struct {
+// Client for interacting with EVM [chain]
+type Client struct {
 	requester      rpc.EndpointRequester
 	adminRequester rpc.EndpointRequester
 }
 
 // NewClient returns a Client for interacting with EVM [chain]
-func NewClient(uri, chain string) Client {
-	return &client{
+func NewClient(uri, chain string) *Client {
+	return &Client{
 		requester:      rpc.NewEndpointRequester(fmt.Sprintf("%s/ext/bc/%s/avax", uri, chain)),
 		adminRequester: rpc.NewEndpointRequester(fmt.Sprintf("%s/ext/bc/%s/admin", uri, chain)),
 	}
 }
 
 // NewCChainClient returns a Client for interacting with the C Chain
-func NewCChainClient(uri string) Client {
+func NewCChainClient(uri string) *Client {
 	return NewClient(uri, "C")
 }
 
 // IssueTx issues a transaction to a node and returns the TxID
-func (c *client) IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error) {
+func (c *Client) IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error) {
 	res := &api.JSONTxID{}
 	txStr, err := formatting.Encode(formatting.Hex, txBytes)
 	if err != nil {
@@ -79,7 +62,7 @@ type GetAtomicTxStatusReply struct {
 }
 
 // GetAtomicTxStatus returns the status of [txID]
-func (c *client) GetAtomicTxStatus(ctx context.Context, txID ids.ID, options ...rpc.Option) (atomic.Status, error) {
+func (c *Client) GetAtomicTxStatus(ctx context.Context, txID ids.ID, options ...rpc.Option) (atomic.Status, error) {
 	res := &GetAtomicTxStatusReply{}
 	err := c.requester.SendRequest(ctx, "avax.getAtomicTxStatus", &api.JSONTxID{
 		TxID: txID,
@@ -88,7 +71,7 @@ func (c *client) GetAtomicTxStatus(ctx context.Context, txID ids.ID, options ...
 }
 
 // GetAtomicTx returns the byte representation of [txID]
-func (c *client) GetAtomicTx(ctx context.Context, txID ids.ID, options ...rpc.Option) ([]byte, error) {
+func (c *Client) GetAtomicTx(ctx context.Context, txID ids.ID, options ...rpc.Option) ([]byte, error) {
 	res := &api.FormattedTx{}
 	err := c.requester.SendRequest(ctx, "avax.getAtomicTx", &api.GetTxArgs{
 		TxID:     txID,
@@ -103,7 +86,7 @@ func (c *client) GetAtomicTx(ctx context.Context, txID ids.ID, options ...rpc.Op
 
 // GetAtomicUTXOs returns the byte representation of the atomic UTXOs controlled by [addresses]
 // from [sourceChain]
-func (c *client) GetAtomicUTXOs(ctx context.Context, addrs []ids.ShortID, sourceChain string, limit uint32, startAddress ids.ShortID, startUTXOID ids.ID, options ...rpc.Option) ([][]byte, ids.ShortID, ids.ID, error) {
+func (c *Client) GetAtomicUTXOs(ctx context.Context, addrs []ids.ShortID, sourceChain string, limit uint32, startAddress ids.ShortID, startUTXOID ids.ID, options ...rpc.Option) ([][]byte, ids.ShortID, ids.ID, error) {
 	res := &api.GetUTXOsReply{}
 	err := c.requester.SendRequest(ctx, "avax.getUTXOs", &api.GetUTXOsArgs{
 		Addresses:   ids.ShortIDsToStrings(addrs),
@@ -135,19 +118,19 @@ func (c *client) GetAtomicUTXOs(ctx context.Context, addrs []ids.ShortID, source
 	return utxos, endAddr, endUTXOID, err
 }
 
-func (c *client) StartCPUProfiler(ctx context.Context, options ...rpc.Option) error {
+func (c *Client) StartCPUProfiler(ctx context.Context, options ...rpc.Option) error {
 	return c.adminRequester.SendRequest(ctx, "admin.startCPUProfiler", struct{}{}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) StopCPUProfiler(ctx context.Context, options ...rpc.Option) error {
+func (c *Client) StopCPUProfiler(ctx context.Context, options ...rpc.Option) error {
 	return c.adminRequester.SendRequest(ctx, "admin.stopCPUProfiler", struct{}{}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) MemoryProfile(ctx context.Context, options ...rpc.Option) error {
+func (c *Client) MemoryProfile(ctx context.Context, options ...rpc.Option) error {
 	return c.adminRequester.SendRequest(ctx, "admin.memoryProfile", struct{}{}, &api.EmptyReply{}, options...)
 }
 
-func (c *client) LockProfile(ctx context.Context, options ...rpc.Option) error {
+func (c *Client) LockProfile(ctx context.Context, options ...rpc.Option) error {
 	return c.adminRequester.SendRequest(ctx, "admin.lockProfile", struct{}{}, &api.EmptyReply{}, options...)
 }
 
@@ -156,7 +139,7 @@ type SetLogLevelArgs struct {
 }
 
 // SetLogLevel dynamically sets the log level for the C Chain
-func (c *client) SetLogLevel(ctx context.Context, level slog.Level, options ...rpc.Option) error {
+func (c *Client) SetLogLevel(ctx context.Context, level slog.Level, options ...rpc.Option) error {
 	return c.adminRequester.SendRequest(ctx, "admin.setLogLevel", &SetLogLevelArgs{
 		Level: level.String(),
 	}, &api.EmptyReply{}, options...)
@@ -167,7 +150,7 @@ type ConfigReply struct {
 }
 
 // GetVMConfig returns the current config of the VM
-func (c *client) GetVMConfig(ctx context.Context, options ...rpc.Option) (*config.Config, error) {
+func (c *Client) GetVMConfig(ctx context.Context, options ...rpc.Option) (*config.Config, error) {
 	res := &ConfigReply{}
 	err := c.adminRequester.SendRequest(ctx, "admin.getVMConfig", struct{}{}, res, options...)
 	return res.Config, err

--- a/graft/evm/scripts/lint.sh
+++ b/graft/evm/scripts/lint.sh
@@ -105,13 +105,6 @@ function test_single_import {
   fi
 }
 
-function test_require_error_is_no_funcs_as_params {
-  if grep -R -zo -P 'require.ErrorIs\(.+?\)[^\n]*\)\n' "${AVALANCHE_FILES[@]}"; then
-    echo ""
-    return 1
-  fi
-}
-
 function test_require_no_error_inline_func {
   # Flag only when a single variable whose name contains "err" or "Err"
   # (e.g., err, myErr, parseError) is assigned from a call (:= or =), and later

--- a/graft/evm/scripts/lint.sh
+++ b/graft/evm/scripts/lint.sh
@@ -51,7 +51,7 @@ source "$SCRIPT_DIR/lint_setup.sh"
 # by default, "./scripts/lint.sh" runs all lint tests
 # to run only "license_header" test
 # TESTS='license_header' ./scripts/lint.sh
-TESTS=${TESTS:-"golangci_lint avalanche_golangci_lint warn_testify_assert license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func import_testing_only_in_tests"}
+TESTS=${TESTS:-"golangci_lint avalanche_golangci_lint warn_testify_assert license_header single_import interface_compliance_nil require_no_error_inline_func import_testing_only_in_tests"}
 
 function test_golangci_lint {
   "$RUN_TOOL" golangci-lint run --config ../.golangci.yml

--- a/graft/evm/sync/engine/registry_test.go
+++ b/graft/evm/sync/engine/registry_test.go
@@ -202,7 +202,7 @@ func TestSyncerRegistry_ConcurrentStart(t *testing.T) {
 			require.NoError(t, registry.Register(NewBarrierSyncer(name, &allStartedWG, releaseCh)))
 		}
 
-		doneCh := startSyncersAsync(registry, ctx, newTestClientSummary(t, c))
+		doneCh := startSyncersAsync(ctx, registry, newTestClientSummary(t, c))
 
 		utilstest.WaitGroupWithTimeout(t, &allStartedWG, 2*time.Second, "timed out waiting for barrier syncers to start")
 		close(releaseCh)
@@ -232,7 +232,7 @@ func TestSyncerRegistry_ErrorPropagatesAndCancelsOthers(t *testing.T) {
 		const numCancelSyncers = 2
 		startedWG := registerCancelAwareSyncers(t, registry, numCancelSyncers, 4*time.Second)
 
-		doneCh := startSyncersAsync(registry, ctx, newTestClientSummary(t, c))
+		doneCh := startSyncersAsync(ctx, registry, newTestClientSummary(t, c))
 
 		// Ensure all syncers (error syncer and cancel-aware syncers) are running before triggering the error.
 		utilstest.WaitGroupWithTimeout(t, &errorSyncerStartedWG, 2*time.Second, "timed out waiting for error syncer to start")
@@ -274,7 +274,7 @@ func TestSyncerRegistry_FirstErrorWinsAcrossMany(t *testing.T) {
 			require.NoError(t, registry.Register(NewErrorSyncer(name, &allErrorSyncersStartedWG, trigger, errInstance)))
 		}
 
-		doneCh := startSyncersAsync(registry, ctx, newTestClientSummary(t, c))
+		doneCh := startSyncersAsync(ctx, registry, newTestClientSummary(t, c))
 
 		// Wait for all error syncers to start before triggering the error.
 		utilstest.WaitGroupWithTimeout(t, &allErrorSyncersStartedWG, 2*time.Second, "timed out waiting for error syncers to start")
@@ -336,7 +336,7 @@ func TestSyncerRegistry_ContextCancellationErrors(t *testing.T) {
 				ctx, cancel := newTestContext(t, tt.wantErr, tt.timeout)
 				t.Cleanup(cancel)
 
-				doneCh := startSyncersAsync(registry, ctx, newTestClientSummary(t, c))
+				doneCh := startSyncersAsync(ctx, registry, newTestClientSummary(t, c))
 
 				// Wait for syncers to start.
 				waitTimeout := 2 * time.Second
@@ -412,7 +412,7 @@ func TestSyncerRegistry_MixedCancellationAndSuccess(t *testing.T) {
 		const numCancelSyncers = 2
 		startedWG := registerCancelAwareSyncers(t, registry, numCancelSyncers, 5*time.Second)
 
-		doneCh := startSyncersAsync(registry, ctx, newTestClientSummary(t, c))
+		doneCh := startSyncersAsync(ctx, registry, newTestClientSummary(t, c))
 
 		utilstest.WaitGroupWithTimeout(t, &successWG, 2*time.Second, "success syncer did not start")
 		utilstest.WaitGroupWithTimeout(t, startedWG, 2*time.Second, "timed out waiting for syncers to start")
@@ -428,7 +428,7 @@ func TestSyncerRegistry_MixedCancellationAndSuccess(t *testing.T) {
 }
 
 // startSyncersAsync starts the syncers asynchronously using StartAsync and returns a channel to receive the error.
-func startSyncersAsync(registry *SyncerRegistry, ctx context.Context, summary message.Syncable) <-chan error {
+func startSyncersAsync(ctx context.Context, registry *SyncerRegistry, summary message.Syncable) <-chan error {
 	doneCh := make(chan error, 1)
 	g := registry.StartAsync(ctx, summary)
 	go func() {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -86,7 +86,10 @@ function test_single_import {
 }
 
 function test_require_error_is_no_funcs_as_params {
-  if find . -type f -name '*.go' "${FIND_EXCLUDES[@]}" -print0 | xargs -0 grep -zo -P 'require.ErrorIs\(.+?\)[^\n]*\)\n'; then
+  # Detects require.ErrorIs calls with nested function calls as arguments,
+  # e.g. require.ErrorIs(t, someFunc(), err). The regex skips double-quoted
+  # strings ("...") so that "()" inside message literals doesn't false-positive.
+  if find . -type f -name '*.go' "${FIND_EXCLUDES[@]}" -print0 | xargs -0 grep -zo -P 'require.ErrorIs\(("(?:[^"\\]|\\.)*"|[^)"])+\)[^\n]*\)\n'; then
     echo ""
     return 1
   fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -43,7 +43,7 @@ fi
 # by default, "./scripts/lint.sh" runs all lint tests
 # to run only "license_header" test
 # TESTS='license_header' ./scripts/lint.sh
-TESTS=${TESTS:-"golangci_lint warn_testify_assert license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func import_testing_only_in_tests"}
+TESTS=${TESTS:-"golangci_lint warn_testify_assert license_header single_import interface_compliance_nil require_no_error_inline_func import_testing_only_in_tests"}
 
 function test_golangci_lint {
   ./scripts/run_tool.sh golangci-lint run --config .golangci.yml

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -85,16 +85,6 @@ function test_single_import {
   fi
 }
 
-function test_require_error_is_no_funcs_as_params {
-  # Detects require.ErrorIs calls with nested function calls as arguments,
-  # e.g. require.ErrorIs(t, someFunc(), err). The regex skips double-quoted
-  # strings ("...") so that "()" inside message literals doesn't false-positive.
-  if find . -type f -name '*.go' "${FIND_EXCLUDES[@]}" -print0 | xargs -0 grep -zo -P 'require.ErrorIs\(("(?:[^"\\]|\\.)*"|[^)"])+\)[^\n]*\)\n'; then
-    echo ""
-    return 1
-  fi
-}
-
 function test_require_no_error_inline_func {
   if find . -type f -name '*.go' "${FIND_EXCLUDES[@]}" -print0 | xargs -0 grep -zo -P '\t+err :?= ((?!require|if).|\n)*require\.NoError\((t, )?err\)'; then
     echo ""

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -695,7 +695,7 @@ func (w *workload) confirmXChainTx(ctx context.Context, tx *xtxs.Tx) error {
 	txID := tx.ID()
 	for _, uri := range w.uris {
 		client := avm.NewClient(uri, "X")
-		if err := avm.AwaitTxAccepted(client, ctx, txID, 100*time.Millisecond); err != nil {
+		if err := client.AwaitTxAccepted(ctx, txID, 100*time.Millisecond); err != nil {
 			return fmt.Errorf("failed to confirm X-chain transaction %s on %s: %w", txID, uri, err)
 		}
 		w.log.Info("confirmed X-chain transaction",
@@ -713,7 +713,7 @@ func (w *workload) confirmPChainTx(ctx context.Context, tx *ptxs.Tx) error {
 	txID := tx.ID()
 	for _, uri := range w.uris {
 		client := platformvm.NewClient(uri)
-		if err := platformvm.AwaitTxAccepted(client, ctx, txID, 100*time.Millisecond); err != nil {
+		if err := client.AwaitTxAccepted(ctx, txID, 100*time.Millisecond); err != nil {
 			return fmt.Errorf("failed to confirm P-chain transaction %s on %s: %w", txID, uri, err)
 		}
 		w.log.Info("confirmed P-chain transaction",

--- a/tests/e2e/p/owner_retrieval.go
+++ b/tests/e2e/p/owner_retrieval.go
@@ -45,8 +45,7 @@ var _ = e2e.DescribePChain("[P-Chain Wallet]", func() {
 		require.NotEqual(subnetID, constants.PrimaryNetworkID)
 
 		tc.By("verifying owner", func() {
-			subnetOwners, err := platformvm.GetSubnetOwners(
-				pChainClient,
+			subnetOwners, err := pChainClient.GetSubnetOwners(
 				tc.DefaultContext(),
 				subnetID,
 			)
@@ -77,8 +76,7 @@ var _ = e2e.DescribePChain("[P-Chain Wallet]", func() {
 		require.NoError(err)
 
 		tc.By("verifying new owner", func() {
-			subnetOwners, err := platformvm.GetSubnetOwners(
-				pChainClient,
+			subnetOwners, err := pChainClient.GetSubnetOwners(
 				tc.DefaultContext(),
 				subnetID,
 			)

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -273,12 +273,12 @@ var _ = e2e.DescribeXChainSerial("[Virtuous Transfer Tx AVAX]", func() {
 				txID := tx.ID()
 				for _, u := range rpcEps {
 					xc := avm.NewClient(u, "X")
-					require.NoError(avm.AwaitTxAccepted(xc, tc.DefaultContext(), txID, 2*time.Second))
+					require.NoError(xc.AwaitTxAccepted(tc.DefaultContext(), txID, 2*time.Second))
 				}
 
 				for _, u := range rpcEps {
 					xc := avm.NewClient(u, "X")
-					require.NoError(avm.AwaitTxAccepted(xc, tc.DefaultContext(), txID, 2*time.Second))
+					require.NoError(xc.AwaitTxAccepted(tc.DefaultContext(), txID, 2*time.Second))
 
 					mm, err := tests.GetNodeMetrics(tc.DefaultContext(), u)
 					require.NoError(err)

--- a/vms/avm/client.go
+++ b/vms/avm/client.go
@@ -218,13 +218,7 @@ func (c *Client) GetTxFee(ctx context.Context, options ...rpc.Option) (uint64, u
 	return uint64(res.TxFee), uint64(res.CreateAssetTxFee), err
 }
 
-func AwaitTxAccepted(
-	c *Client,
-	ctx context.Context,
-	txID ids.ID,
-	freq time.Duration,
-	options ...rpc.Option,
-) error {
+func (c *Client) AwaitTxAccepted(ctx context.Context, txID ids.ID, freq time.Duration, options ...rpc.Option) error {
 	ticker := time.NewTicker(freq)
 	defer ticker.Stop()
 

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -586,13 +586,7 @@ func (c *Client) GetValidatorFeeState(ctx context.Context, options ...rpc.Option
 	return res.Excess, res.Price, res.Time, err
 }
 
-func AwaitTxAccepted(
-	c *Client,
-	ctx context.Context,
-	txID ids.ID,
-	freq time.Duration,
-	options ...rpc.Option,
-) error {
+func (c *Client) AwaitTxAccepted(ctx context.Context, txID ids.ID, freq time.Duration, options ...rpc.Option) error {
 	ticker := time.NewTicker(freq)
 	defer ticker.Stop()
 
@@ -616,11 +610,7 @@ func AwaitTxAccepted(
 }
 
 // GetSubnetOwners returns a map of subnet ID to current subnet's owner
-func GetSubnetOwners(
-	c *Client,
-	ctx context.Context,
-	subnetIDs ...ids.ID,
-) (map[ids.ID]fx.Owner, error) {
+func (c *Client) GetSubnetOwners(ctx context.Context, subnetIDs ...ids.ID) (map[ids.ID]fx.Owner, error) {
 	subnetOwners := make(map[ids.ID]fx.Owner, len(subnetIDs))
 	for _, subnetID := range subnetIDs {
 		subnetInfo, err := c.GetSubnet(ctx, subnetID)
@@ -637,11 +627,7 @@ func GetSubnetOwners(
 }
 
 // GetDeactivationOwners returns a map of validation ID to deactivation owners
-func GetDeactivationOwners(
-	c *Client,
-	ctx context.Context,
-	validationIDs ...ids.ID,
-) (map[ids.ID]fx.Owner, error) {
+func (c *Client) GetDeactivationOwners(ctx context.Context, validationIDs ...ids.ID) (map[ids.ID]fx.Owner, error) {
 	deactivationOwners := make(map[ids.ID]fx.Owner, len(validationIDs))
 	for _, validationID := range validationIDs {
 		l1Validator, _, err := c.GetL1Validator(ctx, validationID)
@@ -654,17 +640,12 @@ func GetDeactivationOwners(
 }
 
 // GetOwners returns the union of GetSubnetOwners and GetDeactivationOwners.
-func GetOwners(
-	c *Client,
-	ctx context.Context,
-	subnetIDs []ids.ID,
-	validationIDs []ids.ID,
-) (map[ids.ID]fx.Owner, error) {
-	subnetOwners, err := GetSubnetOwners(c, ctx, subnetIDs...)
+func (c *Client) GetOwners(ctx context.Context, subnetIDs []ids.ID, validationIDs []ids.ID) (map[ids.ID]fx.Owner, error) {
+	subnetOwners, err := c.GetSubnetOwners(ctx, subnetIDs...)
 	if err != nil {
 		return nil, err
 	}
-	deactivationOwners, err := GetDeactivationOwners(c, ctx, validationIDs...)
+	deactivationOwners, err := c.GetDeactivationOwners(ctx, validationIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/chain/c/BUILD.bazel
+++ b/wallet/chain/c/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//utils/crypto/secp256k1",
         "//utils/logging",
         "//utils/math",
-        "//utils/rpc",
         "//utils/set",
         "//vms/avm",
         "//vms/components/avax",

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -4,7 +4,6 @@
 package c
 
 import (
-	"context"
 	"math/big"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/client"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/rpc"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 
@@ -168,7 +166,7 @@ func (w *wallet) IssueAtomicTx(
 		return w.Backend.AcceptAtomicTx(ctx, tx)
 	}
 
-	if err := awaitTxAccepted(ctx, w.avaxClient, txID, ops.PollFrequency()); err != nil {
+	if err := w.avaxClient.AwaitTxAccepted(ctx, txID, ops.PollFrequency()); err != nil {
 		return err
 	}
 
@@ -196,33 +194,4 @@ func (w *wallet) baseFee(options []common.Option) (*big.Int, error) {
 
 	ctx := ops.Context()
 	return w.ethClient.EstimateBaseFee(ctx)
-}
-
-// TODO: Upstream this function into coreth.
-func awaitTxAccepted(
-	ctx context.Context,
-	c *client.Client,
-	txID ids.ID,
-	freq time.Duration,
-	options ...rpc.Option,
-) error {
-	ticker := time.NewTicker(freq)
-	defer ticker.Stop()
-
-	for {
-		status, err := c.GetAtomicTxStatus(ctx, txID, options...)
-		if err != nil {
-			return err
-		}
-
-		if status == atomic.Accepted {
-			return nil
-		}
-
-		select {
-		case <-ticker.C:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
 }

--- a/wallet/chain/c/wallet.go
+++ b/wallet/chain/c/wallet.go
@@ -66,7 +66,7 @@ type Wallet interface {
 func NewWallet(
 	builder Builder,
 	signer Signer,
-	avaxClient client.Client,
+	avaxClient *client.Client,
 	ethClient *ethclient.Client,
 	backend Backend,
 ) Wallet {
@@ -83,7 +83,7 @@ type wallet struct {
 	Backend
 	builder    Builder
 	signer     Signer
-	avaxClient client.Client
+	avaxClient *client.Client
 	ethClient  *ethclient.Client
 }
 
@@ -168,7 +168,7 @@ func (w *wallet) IssueAtomicTx(
 		return w.Backend.AcceptAtomicTx(ctx, tx)
 	}
 
-	if err := awaitTxAccepted(w.avaxClient, ctx, txID, ops.PollFrequency()); err != nil {
+	if err := awaitTxAccepted(ctx, w.avaxClient, txID, ops.PollFrequency()); err != nil {
 		return err
 	}
 
@@ -200,8 +200,8 @@ func (w *wallet) baseFee(options []common.Option) (*big.Int, error) {
 
 // TODO: Upstream this function into coreth.
 func awaitTxAccepted(
-	c client.Client,
 	ctx context.Context,
+	c *client.Client,
 	txID ids.ID,
 	freq time.Duration,
 	options ...rpc.Option,

--- a/wallet/chain/p/client.go
+++ b/wallet/chain/p/client.go
@@ -55,7 +55,7 @@ func (c *Client) IssueTx(
 		return c.backend.AcceptTx(ctx, tx)
 	}
 
-	if err := platformvm.AwaitTxAccepted(c.client, ctx, txID, ops.PollFrequency()); err != nil {
+	if err := c.client.AwaitTxAccepted(ctx, txID, ops.PollFrequency()); err != nil {
 		return err
 	}
 

--- a/wallet/chain/x/wallet.go
+++ b/wallet/chain/x/wallet.go
@@ -314,7 +314,7 @@ func (w *wallet) IssueTx(
 		return w.backend.AcceptTx(ctx, tx)
 	}
 
-	if err := avm.AwaitTxAccepted(w.client, ctx, txID, ops.PollFrequency()); err != nil {
+	if err := w.client.AwaitTxAccepted(ctx, txID, ops.PollFrequency()); err != nil {
 		return err
 	}
 

--- a/wallet/subnet/primary/api.go
+++ b/wallet/subnet/primary/api.go
@@ -41,6 +41,7 @@ const (
 var (
 	_ UTXOClient = (*platformvm.Client)(nil)
 	_ UTXOClient = (*avm.Client)(nil)
+	_ UTXOClient = (*client.Client)(nil)
 )
 
 type UTXOClient interface {
@@ -60,7 +61,7 @@ type AVAXState struct {
 	PCTX    *pbuilder.Context
 	XClient *avm.Client
 	XCTX    *xbuilder.Context
-	CClient client.Client
+	CClient *client.Client
 	CCTX    *c.Context
 	UTXOs   walletcommon.UTXOs
 }

--- a/wallet/subnet/primary/wallet.go
+++ b/wallet/subnet/primary/wallet.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/keychain"
-	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/ava-labs/avalanchego/wallet/chain/c"
 	"github.com/ava-labs/avalanchego/wallet/chain/p"
 	"github.com/ava-labs/avalanchego/wallet/chain/x"
@@ -97,7 +96,7 @@ func MakeWallet(
 		return nil, err
 	}
 
-	owners, err := platformvm.GetOwners(avaxState.PClient, ctx, config.SubnetIDs, config.ValidationIDs)
+	owners, err := avaxState.PClient.GetOwners(ctx, config.SubnetIDs, config.ValidationIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +147,7 @@ func MakePWallet(
 		return nil, err
 	}
 
-	owners, err := platformvm.GetOwners(client, ctx, config.SubnetIDs, config.ValidationIDs)
+	owners, err := client.GetOwners(ctx, config.SubnetIDs, config.ValidationIDs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why this should be merged

This is also a requisite for the strevm merger. 

A few different things are done here: 

- Remove `errorlint` linter (saevm code has wrapping violations that would block CI)
- Add revive context-as-argument rule enforcing `context.Context `as first parameter (with `*testing.T` allowed before `ctx`)
   - Add unused-parameter `allowRegex` for `^ctx$`
- Fix `require_error_is_no_funcs_as_params` regex in scripts/lint.sh to skip "()" inside double-quoted message strings
- Convert `AwaitTxAccepted`, `GetSubnetOwners`, `GetDeactivationOwners`, `GetOwners` to methods on *Client in `vms/avm` and `vms/platformvm` to satisfy `context-as-argument` lint
- Remove unnecessary `Client` interface from `graft/coreth/plugin/evm/client`     

## How this was tested
CI

## Need to be documented in RELEASES.md?
No