### PR TITLE
Add Firewood state dump tooling for targeted block-height debugging

### DIFF
--- a/graft/coreth/core/block_validator.go
+++ b/graft/coreth/core/block_validator.go
@@ -30,15 +30,22 @@ package core
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/ava-labs/avalanchego/graft/coreth/consensus"
 	"github.com/ava-labs/avalanchego/graft/coreth/params"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/ap0"
+	"github.com/ava-labs/avalanchego/graft/evm/firewood"
+	"github.com/ava-labs/avalanchego/utils/maybe"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/log"
 	ethparams "github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/trie"
 )
+
+const dumpOnBlockHeightEnvVar = "DUMP_ON_BLOCK_HEIGHT"
 
 // BlockValidator is responsible for validating block headers, uncles and
 // processed state.
@@ -48,16 +55,34 @@ type BlockValidator struct {
 	config *params.ChainConfig // Chain configuration options
 	bc     *BlockChain         // Canonical block chain
 	engine consensus.Engine    // Consensus engine used for validating
+
+	dumpOnBlockHeight maybe.Maybe[uint64]
 }
 
 // NewBlockValidator returns a new block validator which is safe for re-use
 func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain, engine consensus.Engine) *BlockValidator {
 	validator := &BlockValidator{
-		config: config,
-		engine: engine,
-		bc:     blockchain,
+		config:            config,
+		engine:            engine,
+		bc:                blockchain,
+		dumpOnBlockHeight: parseDumpOnBlockHeight(),
 	}
 	return validator
+}
+
+func parseDumpOnBlockHeight() maybe.Maybe[uint64] {
+	dumpHeightStr, ok := os.LookupEnv(dumpOnBlockHeightEnvVar)
+	if !ok {
+		return maybe.Nothing[uint64]()
+	}
+
+	dumpHeight, err := strconv.ParseUint(dumpHeightStr, 10, 64)
+	if err != nil {
+		log.Warn("invalid "+dumpOnBlockHeightEnvVar, "value", dumpHeightStr, "err", err)
+		return maybe.Nothing[uint64]()
+	}
+
+	return maybe.Some(dumpHeight)
 }
 
 // ValidateBody validates the given block's uncles and verifies the block
@@ -136,9 +161,30 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	if receiptSha != header.ReceiptHash {
 		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash, receiptSha)
 	}
+
+	root := statedb.IntermediateRoot(v.config.IsEIP158(header.Number))
+	if v.dumpOnBlockHeight.HasValue() && block.NumberU64() == v.dumpOnBlockHeight.Value() {
+		dumpHeight := v.dumpOnBlockHeight.Value()
+		backend := statedb.Database().TrieDB().Backend()
+		if tdb, ok := backend.(*firewood.TrieDB); ok {
+			proposalDump, err := tdb.DumpProposal(root)
+			if err != nil {
+				log.Warn("failed to dump firewood proposal",
+					"env", dumpOnBlockHeightEnvVar, "height", dumpHeight,
+					"block", block.NumberU64(), "hash", block.Hash(),
+					"root", root.Hex(), "err", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "BEGIN %s=%d block=%d hash=%s remote_root=%s local_root=%s\n%s\nEND %s\n", dumpOnBlockHeightEnvVar, dumpHeight, block.NumberU64(), block.Hash(), header.Root.Hex(), root.Hex(), proposalDump, dumpOnBlockHeightEnvVar)
+			}
+		} else {
+			log.Warn(dumpOnBlockHeightEnvVar+" set but trie backend is not firewood",
+				"height", dumpHeight, "backend", fmt.Sprintf("%T", backend))
+		}
+	}
+
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.
-	if root := statedb.IntermediateRoot(v.config.IsEIP158(header.Number)); header.Root != root {
+	if header.Root != root {
 		return fmt.Errorf("invalid merkle root (remote: %x local: %x) dberr: %w", header.Root, root, statedb.Error())
 	}
 	return nil

--- a/graft/evm/firewood/triedb.go
+++ b/graft/evm/firewood/triedb.go
@@ -415,6 +415,73 @@ func (t *TrieDB) Commit(root common.Hash, report bool) error {
 	return nil
 }
 
+// DumpProposal returns a textual dump of the tracked Firewood proposal for root.
+// This is intended for debugging and forensic analysis.
+func (t *TrieDB) DumpProposal(root common.Hash) (string, error) {
+	t.proposals.Lock()
+
+	proposals, ok := t.proposals.byStateRoot[root]
+	if ok && len(proposals) > 0 {
+		for _, p := range proposals {
+			if p.handle != nil {
+				dump, err := p.handle.Dump()
+				t.proposals.Unlock()
+				if err != nil {
+					return "", err
+				}
+				return fmt.Sprintf("# source=byStateRoot root=%s\n%s", root.Hex(), dump), nil
+			}
+		}
+	}
+
+	for key, p := range t.possible {
+		if key.root != root || p == nil || p.handle == nil {
+			continue
+		}
+		dump, err := p.handle.Dump()
+		t.proposals.Unlock()
+		if err != nil {
+			return "", fmt.Errorf("dumping possible proposal for root %s (parent block %s): %w", root.Hex(), key.parentBlockHash.Hex(), err)
+		}
+		return fmt.Sprintf("# source=possible parent_block=%s\n%s", key.parentBlockHash.Hex(), dump), nil
+	}
+
+	if t.proposals.tree != nil && t.proposals.tree.handle != nil {
+		treeRoot := t.proposals.tree.root
+		dump, err := t.proposals.tree.handle.Dump()
+		t.proposals.Unlock()
+		if err != nil {
+			return "", fmt.Errorf("dumping current tree proposal while root %s was missing: %w", root.Hex(), err)
+		}
+		return fmt.Sprintf("# source=tree requested_root=%s current_tree_root=%s\n%s", root.Hex(), treeRoot.Hex(), dump), nil
+	}
+
+	t.proposals.Unlock()
+
+	// The remaining lookups use only Firewood FFI (no proposals state),
+	// so we don't need to hold the proposals lock.
+	revision, err := t.Firewood.Revision(ffi.Hash(root))
+	if err == nil {
+		defer func() {
+			if err := revision.Drop(); err != nil {
+				log.Debug("failed to drop revision after dump", "root", root.Hex(), "err", err)
+			}
+		}()
+		dump, err := revision.Dump()
+		if err != nil {
+			return "", fmt.Errorf("dumping persisted revision for root %s: %w", root.Hex(), err)
+		}
+		return fmt.Sprintf("# source=revision root=%s\n%s", root.Hex(), dump), nil
+	}
+
+	dump, dumpErr := t.Firewood.Dump()
+	if dumpErr == nil {
+		return fmt.Sprintf("# source=database requested_root=%s current_root=%s\n%s", root.Hex(), common.Hash(t.Firewood.Root()).Hex(), dump), nil
+	}
+
+	return "", fmt.Errorf("%w for root %s (no active handle in byStateRoot/possible/tree; revision_err=%v; database_dump_err=%v)", errNoProposalFound, root.Hex(), err, dumpErr)
+}
+
 func (ps *proposals) findProposalToCommitWhenLocked(root common.Hash) (*proposal, error) {
 	var candidate *proposal
 

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -285,7 +285,7 @@ if [[ -n "${CHAOS_MODE:-}" ]]; then
         --max-wait-time="${MAX_WAIT_TIME}" \
         --config="${CONFIG}"
 else
-    go run github.com/ava-labs/avalanchego/tests/reexecute/c \
+    go run ./tests/reexecute/c \
         --block-dir="${BLOCK_DIR}" \
         --current-state-dir="${CURRENT_STATE_DIR}" \
         ${RUNNER_TYPE:+--runner="${RUNNER_TYPE}"} \


### PR DESCRIPTION
## Why this should be merged

- add DUMP_ON_BLOCK_HEIGHT env var in coreth block validation to dump firewood state at a chosen height
- add firewood TrieDB.DumpProposal with fallback chain (byStateRoot -> possible -> tree -> revision -> database)
- make merkle-root dberr formatting nil-safe in coreth and subnet-evm validators
- run reexecute benchmark via local package path (go run ./tests/...)

## How this works

- DumpProposal releases the proposals lock before Firewood FFI calls (Revision/Dump) to avoid blocking proposal operations during dump
- Error/warning paths use structured log.Warn instead of fmt.Fprintf to stderr; the successful dump output stays on stderr as a delimited forensic blob
- Each DumpProposal lookup path is annotated with a # source= prefix for traceability

## How this was tested

Targeted debugging sessions with firewood hashing changes

## Need to be documented in RELEASES.md?

No