### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/database/pebbledb/db.go
+++ b/database/pebbledb/db.go
@@ -290,8 +290,8 @@ func keyRange(start, prefix []byte) *pebble.IterOptions {
 // Assumes the Database uses bytes.Compare for key comparison and not a custom
 // comparer.
 func prefixToUpperBound(prefix []byte) []byte {
-	for i := len(prefix) - 1; i >= 0; i-- {
-		if prefix[i] != 0xFF {
+	for i, v := range slices.Backward(prefix) {
+		if v != 0xFF {
 			upperBound := make([]byte, i+1)
 			copy(upperBound, prefix)
 			upperBound[i]++

--- a/database/rpcdb/db_client.go
+++ b/database/rpcdb/db_client.go
@@ -6,6 +6,7 @@ package rpcdb
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sync"
 
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -151,8 +152,7 @@ type batch struct {
 func (b *batch) Write() error {
 	request := &rpcdbpb.WriteBatchRequest{}
 	keySet := set.NewSet[string](len(b.Ops))
-	for i := len(b.Ops) - 1; i >= 0; i-- {
-		op := b.Ops[i]
+	for _, op := range slices.Backward(b.Ops) {
 		key := string(op.Key)
 		if keySet.Contains(key) {
 			continue

--- a/x/merkledb/proof.go
+++ b/x/merkledb/proof.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 
 	"google.golang.org/protobuf/proto"
 
@@ -678,8 +679,7 @@ func addPathInfo(
 		shouldInsertRightChildren = insertChildrenGreaterThan.HasValue()
 	)
 
-	for i := len(proofPath) - 1; i >= 0; i-- {
-		proofNode := proofPath[i]
+	for _, proofNode := range slices.Backward(proofPath) {
 		key := proofNode.Key
 
 		if key.hasPartialByte() && !proofNode.ValueOrHash.IsNothing() {


### PR DESCRIPTION
## Why this should be merged

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899
## How this works

## How this was tested

## Need to be documented in RELEASES.md?
