### PR TITLE
test: enable fuzz testing for graft directories

### DIFF
--- a/scripts/build_fuzz.sh
+++ b/scripts/build_fuzz.sh
@@ -26,9 +26,7 @@ else
     timeout=$((fuzzTime + 1200))
 fi
 
-EXCLUDE_DIR="graft"
-
-files=$(grep -r --exclude-dir="$EXCLUDE_DIR" --include='**_test.go' --files-with-matches 'func Fuzz' "$fuzzDir")
+files=$(grep -r --include='**_test.go' --files-with-matches 'func Fuzz' "$fuzzDir")
 failed=false
 for file in ${files}
 do


### PR DESCRIPTION
## Why this should be merged

We want to enable fuzz testing for targets in `graft/` -- specifically fuzzing for ACP-224, which prompted this separate PR. 

## How this works
Removes the exclusion. 

## How this was tested
N/A

## Need to be documented in RELEASES.md?
No 