### PR TITLE
Remove **/testdata from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,6 @@ tests/upgrade/upgrade.test
 
 vendor
 
-**/testdata
-
 .direnv
 # Personal extension to .envrc
 .envrc.local


### PR DESCRIPTION

## Why this should be merged

We want to checkout `testdata/Fuzz` folders for corpus data for the fuzz tests.

## How this works

Removes `**/testdata` regex from `.gitignore`

## How this was tested

CI + local run with `./scripts/run_task.sh test-fuzz`

## Need to be documented in RELEASES.md?

no
