### PR TITLE
test(sae): Ignore filters subscription from goleak

### DIFF
--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -75,8 +75,10 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/ava-labs/libevm/core/state/snapshot.(*diskLayer).generate"),
 		// TxPool.Close() doesn't wait for its loop() method to signal termination.
 		goleak.IgnoreTopFunction("github.com/ava-labs/libevm/core/txpool.(*TxPool).loop.func2"),
-		// All filters subscriptions can't be closed after the TxPool is closed.
-		goleak.IgnoreAnyFunction("github.com/ava-labs/libevm/eth/filters.(*Subscription).Unsubscribe"),
+		// Not all filters subscriptions can be closed after the TxPool is closed.
+		goleak.IgnoreTopFunction("github.com/ava-labs/libevm/eth/filters.(*FilterAPI).Logs.func1.deferwrap1.(*Subscription).Unsubscribe.1"),
+		goleak.IgnoreTopFunction("github.com/ava-labs/libevm/eth/filters.(*FilterAPI).NewHeads.func1.deferwrap1.(*Subscription).Unsubscribe.1"),
+		goleak.IgnoreTopFunction("github.com/ava-labs/libevm/eth/filters.(*FilterAPI).NewPendingTransactions.func1.deferwrap1.(*Subscription).Unsubscribe.1"),
 	)
 }
 

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -75,6 +75,8 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/ava-labs/libevm/core/state/snapshot.(*diskLayer).generate"),
 		// TxPool.Close() doesn't wait for its loop() method to signal termination.
 		goleak.IgnoreTopFunction("github.com/ava-labs/libevm/core/txpool.(*TxPool).loop.func2"),
+		// All filters subscriptions can't be closed after the TxPool is closed.
+		goleak.IgnoreAnyFunction("github.com/ava-labs/libevm/eth/filters.(*Subscription).Unsubscribe"),
 	)
 }
 


### PR DESCRIPTION
## Why this should be merged

Unsubscribing from filters subscriptions is inherently flaky. If the TxPool is closed soon after the subscription is closed (e.g. by the rpc handler), then there is no one to read from a channel it waits on. 

## How this works

We could fix this upstream, but it's not worth the effort. We're reasonably confident there's no bug in our code, so we can just ignore it.

## How this was tested

Running a bunch of parallel tests in CI (see #5280 for examples of the flake and more recent test runs for it not happening)

## Need to be documented in RELEASES.md?

No