### PR TITLE
Add Apple signing, notarization, and GPG signing to macOS releases

### DIFF
--- a/.github/packaging/Dockerfile.macos-zip
+++ b/.github/packaging/Dockerfile.macos-zip
@@ -1,0 +1,68 @@
+# Build container for local validation of the macOS zip packaging pipeline.
+#
+# Mirrors the toolchain of the workflow's sign-publish job (ubuntu-24.04 in
+# CI), so build-zip-pkg.sh runs in the same Linux/GNU userland here as in
+# production. Source tree is bind-mounted at runtime, not COPY'd.
+#
+# Usage (via build-builder-image.sh, which fetches GO_CHECKSUM and
+# APPLE_CODESIGN_CHECKSUM automatically):
+#   .github/packaging/scripts/build-builder-image.sh
+#   docker run --rm -v .:/build -v ./build/macos:/output avalanchego-macos-zip-builder ...
+
+FROM debian:stable-slim
+
+ARG GO_VERSION=INVALID
+ARG GO_CHECKSUM=INVALID
+ARG APPLE_CODESIGN_VERSION=INVALID
+ARG APPLE_CODESIGN_CHECKSUM=INVALID
+ARG TARGETARCH
+
+# Install build dependencies
+# - p7zip-full: 7z, matches the workflow's "Install rcodesign and 7zip" step
+# - gnupg: GPG signing + verification of zip archives
+# - openssl: ECDSA P8 key generation for the encode-app-store-connect-api-key path
+# - curl + ca-certificates: tool downloads
+# - gettext-base: envsubst, harmless to keep parity with the RPM image
+# - git: needed by lib-build-common.sh::init_build_env (safe.directory + status)
+# - file: used by validate to confirm Mach-O format on extracted binaries
+# - jq: parse-check rcodesign encode-app-store-connect-api-key output
+RUN apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        p7zip-full \
+        gnupg \
+        openssl \
+        curl \
+        ca-certificates \
+        gettext-base \
+        git \
+        file \
+        jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go (SHA256-verified, cross-compiles the stub Mach-O binaries)
+RUN curl -fsSL -o /tmp/go.tar.gz \
+        "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+    && echo "${GO_CHECKSUM}  /tmp/go.tar.gz" | sha256sum -c - \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install rcodesign (SHA256-verified, matches the action's vendored binary).
+# The release uses unusual asset arch names: x86_64-unknown-linux-musl /
+# aarch64-unknown-linux-musl. Note that the URL path-encodes the slash in
+# the apple-codesign/<ver> tag as %2F.
+RUN case "${TARGETARCH}" in \
+        amd64) RCODESIGN_ARCH="x86_64-unknown-linux-musl" ;; \
+        arm64) RCODESIGN_ARCH="aarch64-unknown-linux-musl" ;; \
+        *) echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    RCODESIGN_BASE="apple-codesign-${APPLE_CODESIGN_VERSION}-${RCODESIGN_ARCH}" && \
+    curl -fsSL -o /tmp/rcodesign.tar.gz \
+        "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${APPLE_CODESIGN_VERSION}/${RCODESIGN_BASE}.tar.gz" && \
+    echo "${APPLE_CODESIGN_CHECKSUM}  /tmp/rcodesign.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/rcodesign.tar.gz -C /tmp/ && \
+    install "/tmp/${RCODESIGN_BASE}/rcodesign" /usr/local/bin/rcodesign && \
+    rm -rf "/tmp/${RCODESIGN_BASE}" /tmp/rcodesign.tar.gz && \
+    rcodesign --version
+
+WORKDIR /build

--- a/.github/packaging/README.md
+++ b/.github/packaging/README.md
@@ -1,454 +1,86 @@
-# Linux Packaging for AvalancheGo
+# Packaging
 
-## Overview
+This directory contains the packaging implementations for AvalancheGo and
+Subnet-EVM release artifacts. Each supported distribution format has its own
+build and validation pipeline documented separately:
 
-This directory contains the Linux packaging implementation for `avalanchego` and
-`subnet-evm`:
+- [**RPM**](rpm.md) - signed RPMs for RHEL 9.x-compatible Linux systems
+  (`x86_64`, `aarch64`).
+- [**DEB**](deb.md) - signed DEBs for Ubuntu 22.04 (jammy) and 24.04 (noble)
+  (`amd64`, `arm64`).
+- [**macOS zip**](macos-zip.md) - Apple-signed, notarized, and GPG-signed
+  `*.zip` archives for macOS.
 
-- RPM packages for RHEL 9.x-compatible systems
-- DEB packages for Ubuntu 22.04 (jammy) and 24.04 (noble)
+This README is an index. The per-format documents are the source of truth
+for what each pipeline does, how to use it, and why it is implemented the way
+it is.
 
-It exists to ship signed Linux packages without making future maintainers
-reconstruct the packaging model from CI YAML and shell scripts alone.
+## What is shared between formats
 
-This document is for two audiences:
+The pipelines deliberately share infrastructure where it makes sense to keep
+the local-and-CI invariants aligned:
 
-- **users/release engineers** who need to build or publish packages
-- **maintainers** who need to change the packaging implementation safely
+- **Project GPG signing key** - `secrets.RPM_GPG_PRIVATE_KEY` signs RPM, DEB,
+  and macOS zip artifacts. The secret name predates DEB and macOS zip signing
+  but the key identifies the project, not the package format. See the macOS zip
+  doc for the rotation-path notes.
+- **Unified Linux workflow** - `.github/workflows/build-linux-packages.yml`
+  builds both RPM and DEB from a single format × arch matrix that delegates bulk
+  work to the `.github/packaging/actions/build-package` composite action. macOS
+  zips are built by the separate `.github/workflows/build-macos-release.yml`.
+- **Taskfile surface** - `task packaging:<target>` is the entrypoint for both
+  local builds and local validation. The root `Taskfile.yml` includes this
+  directory's `Taskfile.yml`.
+- **Helper library** - `scripts/lib-build-common.sh` provides `setup_gpg`,
+  `assert_files_exist`, `use_ephemeral_gpg_passphrase`, and friends. All three
+  format pipelines source it.
+- **"Single pipeline for local and CI" invariant** - the local validators
+  invoke the same production build scripts the CI workflows run. There is
+  intentionally no separate "local" code path that could diverge.
 
-## Usage
+## Layout
 
-### What gets produced
-
-The packaging pipeline builds two packages per format and architecture:
-
-| Format | Package | Installed path | Dependency floor |
-| --- | --- | --- | --- |
-| RPM | `avalanchego` | `/var/opt/avalanchego/bin/avalanchego` | `glibc >= 2.34` |
-| RPM | `subnet-evm` | `/var/opt/avalanchego/plugins/<VM_ID>` | `glibc >= 2.34` |
-| DEB | `avalanchego` | `/usr/bin/avalanchego` | `libc6 (>= 2.35)` |
-| DEB | `subnet-evm` | `/usr/lib/avalanchego/plugins/<VM_ID>` | `libc6 (>= 2.35)` |
-
-`<VM_ID>` is sourced from `graft/subnet-evm/scripts/constants.sh`.
-
-### Main entrypoints
-
-- Workflow: `.github/workflows/build-linux-packages.yml` (unified RPM + DEB)
-- Build/validate composite action: `.github/packaging/actions/build-package/action.yml`
-- Packaging taskfile: `.github/packaging/Taskfile.yml`
-- Build script: `.github/packaging/scripts/build-package.sh`
-- Validation scripts:
-  - `.github/packaging/scripts/validate-rpm.sh`
-  - `.github/packaging/scripts/validate-deb.sh`
-- `nfpm` package definitions: `.github/packaging/nfpm/*.yml`
-- Builder images:
-  - `.github/packaging/Dockerfile.rpm`
-  - `.github/packaging/Dockerfile.deb`
-
-### Local build and validation
-
-Build and validate the full RPM pipeline locally with:
-
-```bash
-./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml test-build-rpms
+```
+.github/packaging/
+├── README.md              this index
+├── rpm.md                 RPM pipeline documentation
+├── deb.md                 DEB pipeline documentation
+├── macos-zip.md           macOS zip pipeline documentation
+├── Taskfile.yml           shared Taskfile (RPM + DEB + macOS zip tasks)
+├── Dockerfile.rpm         RPM builder image (Rocky Linux 9)
+├── Dockerfile.deb         DEB builder image (Ubuntu 22.04)
+├── Dockerfile.macos-zip   macOS zip validator image (Debian)
+├── actions/
+│   └── build-package/     composite action shared by the Linux workflow
+├── nfpm/                  nfpm package definitions (RPM + DEB)
+└── scripts/
+    ├── lib-build-common.sh
+    ├── build-builder-image.sh
+    ├── build-macos-zip-builder-image.sh
+    ├── build-package.sh
+    ├── build-macos-zip.sh
+    ├── validate-rpm.sh
+    ├── validate-deb.sh
+    ├── validate-macos-zip.sh
+    ├── smoke-test.sh
+    └── workflow-setup-packaging.sh
 ```
 
-Build and validate the full DEB pipeline locally with:
-
-```bash
-./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml test-build-debs
-```
-
-Or, via the root Taskfile include:
-
-```bash
-task packaging:test-build-rpms
-task packaging:test-build-debs
-```
-
-Useful environment variables:
-
-- `PACKAGING_TAG` - tag/version label to embed; defaults to `v0.0.0` for local
-  testing
-- `PACKAGE_ARCH` - package architecture override (`x86_64`/`aarch64` for RPM,
-  `amd64`/`arm64` for DEB); defaults to the host architecture mapped to the
-  package format
-- `GPG_KEY_FILE` - private signing key file; empty means generate/reuse an
-  ephemeral local key
-- `GPG_KEY_PASSPHRASE` - passphrase for `GPG_KEY_FILE`; mirrored internally to
-  the `NFPM_<FORMAT>_PASSPHRASE` variable expected by `nfpm`
-
-Without `GPG_KEY_FILE`, the build generates a short-lived ephemeral RSA key with
-a known throwaway passphrase. This keeps local and PR builds exercising the same
-signing path used by release builds without requiring release credentials.
-
-## CI behavior
-
-`.github/workflows/build-linux-packages.yml` builds both RPM and DEB
-packages from a single workflow (format × arch matrix delegating bulk work
-to `.github/packaging/actions/build-package`) and runs in three modes:
-
-- **tag push** - builds release packages for the pushed tag
-- **workflow_dispatch** - builds packages for an explicitly provided tag
-- **pull_request** - smoke-tests the packaging pipeline for changes under
-  `.github/packaging/` or the workflow itself
-
-PR builds use a synthetic tag (`v0.0.0-pr.<sha>`) and ephemeral signing.
-Non-PR builds import the real signing key from Actions secrets and upload
-packages plus the exported public key as artifacts.
-
-The exported public key is named `GPG-KEY-avalanchego` and lives next to
-each format's packages (`build/rpm/` for RPM, `build/deb/` for DEB).
-
-DEB release runs additionally upload packages to S3 under
-`linux/debs/ubuntu/{jammy,noble}/{arch}/`; the DEB public key is uploaded to
-`linux/debs/ubuntu/{jammy,noble}/` because one signing key serves all
-architectures of a release.
-
-## Conceptual model
-
-The packaging pipeline treats packaging as a layer around the source release
-tree rather than as part of the historical release tree itself.
-
-The model is:
-
-1. Check out the source revision being packaged
-2. Overlay the current `.github/packaging` implementation for manual tag builds
-   when the requested tag may predate packaging support
-3. Build inside a target Linux distribution container so the binary links against the right
-   glibc floor
-4. Package and sign with `nfpm` (single `nfpm package` invocation)
-5. Validate by installing the package in a fresh target Linux distribution container and
-   running smoke tests
-
-This directory is code-adjacent because the Dockerfiles, task entrypoints,
-package manifests, workflow glue, and shell scripts all evolve together.
-
-Four architecture naming schemes are in play and must stay aligned:
-
-| `uname -m` | Docker `TARGETARCH` / Go downloads | RPM arch | DEB arch |
-| --- | --- | --- | --- |
-| `x86_64` | `amd64` | `x86_64` | `amd64` |
-| `arm64` / `aarch64` | `arm64` | `aarch64` | `arm64` |
-
-The Taskfile normalizes host architecture to the names used by a given package
-format; the Dockerfiles use Docker's `TARGETARCH` values for Go and `nfpm`
-downloads.
-
-The packaging path assumes Docker's target platform matches the host's
-`uname -m`. `TARGETARCH` is set by Docker BuildKit from the resolved target
-platform (`--platform`, `DOCKER_DEFAULT_PLATFORM`, or host default in that
-priority), but `build-builder-image.sh` and the Taskfile's `PACKAGE_ARCH`
-default both derive from host `uname -m` independently. If those diverge
-— e.g. `DOCKER_DEFAULT_PLATFORM=linux/amd64` on an arm64 host — the build
-either fails (Go checksum mismatch when the script's host-derived
-`GO_CHECKSUM` doesn't match the tarball Docker downloaded for the resolved
-target) or mislabels packages (the produced `.rpm`/`.deb` carries the
-host's arch in its filename despite being built in a target-arch
-container). Cross-arch local builds are out of scope; use the CI matrix
-or a remote builder.
-
-## Maintenance notes
-
-### Why builds run in target Linux distribution containers
-
-AvalancheGo and Subnet-EVM are dynamically linked against glibc. To produce
-binaries that run on every supported Linux distribution, each build runs inside
-a container based on the *oldest* supported release for that target Linux
-distribution/family — the resulting binary's glibc floor matches that release,
-and newer releases run it via glibc's forward compatibility.
-
-#### RPM — built in `rockylinux:9`
-
-RPMs target RHEL 9.x-compatible systems, so RPM builds run in a `rockylinux:9`
-container and produce binaries linked against glibc 2.34.
-
-#### DEB — built in `ubuntu:22.04`
-
-DEBs target Ubuntu 22.04 (jammy), the oldest LTS we support, so DEB builds run
-in an `ubuntu:22.04` container and produce binaries linked against glibc 2.35.
-Compatibility of the produced packages is then verified by installing and
-smoke-testing in both `ubuntu:22.04` and `ubuntu:24.04` (the newest LTS we
-support).
-
-Building on the default GitHub runner image would link against the runner's
-Ubuntu glibc, which is typically newer than the intended jammy floor.
-
-### Why workflows overlay `.github/packaging` for manual tag builds
-
-`workflow_dispatch` accepts any tag whose source tree the current packaging
-implementation can still build, including tags created before this packaging
-implementation existed in the repository. The practical floor is the commit that
-introduced `graft/` populated with both coreth and subnet-evm: `lib-build-common.sh`
-sources `graft/subnet-evm/scripts/{build,constants}.sh`, so tags predating `graft`
-cannot be rebuilt (see "Implications for maintainers" below).
-
-Those older tags may not contain:
-
-- `.github/packaging/`
-- the current packaging scripts and `nfpm` manifests
-- the current packaging Dockerfiles and helper logic
-
-To keep manual rebuilds of older releases possible, workflows first check out
-the requested tag as the source tree and then overlay `.github/packaging` from
-the workflow branch:
-
-1. `actions/checkout` of the requested tag into the workspace root
-2. second sparse checkout of `.github/packaging` into `.packaging-overlay`
-3. replace the tagged tree's `.github/packaging` with the overlay contents
-4. run the current packaging pipeline against the historical source
-
-This is intentionally narrow: it overlays **only the packaging implementation**,
-not the rest of the branch. That lets maintainers improve packaging logic over
-time while still packaging historical source revisions.
-
-#### Implications for maintainers
-
-When changing `.github/packaging`, keep in mind that `workflow_dispatch` may run
-those scripts against trees that predate the packaging feature.
-
-Changes are safer when they depend only on repository interfaces that already
-exist across the intended release range, such as:
-
-- `scripts/build.sh`
-- `scripts/constants.sh`
-- `graft/subnet-evm/scripts/build.sh`
-- `graft/subnet-evm/scripts/constants.sh`
-
-If packaging changes need newer repository structure or newer build interfaces,
-manual rebuilds of older tags may stop working. If that trade-off is acceptable,
-document the cutoff explicitly in this README and in the workflow change.
-
-### Signing behavior
-
-RPMs and DEBs are always built through the signing path.
-
-- **CI release/manual builds** import the real private key from
-  `secrets.RPM_GPG_PRIVATE_KEY`
-- **local and PR builds** generate an ephemeral RSA key with a known throwaway
-  passphrase
-
-This is deliberate: unsigned fast paths tend to rot, while always exercising the
-signing path keeps packaging validation closer to what is shipped.
-
-Release events (tag push and `workflow_dispatch`) fail fast in
-`workflow-setup-packaging.sh` when no signing key is configured, so a
-misconfigured release cannot silently fall back to the ephemeral key.
-
-The build exports the matching public key next to the packages. On DEB release
-events (tag push / `workflow_dispatch`), `upload-debs-s3` publishes it alongside
-the `.deb`s under `s3://${BUCKET}/linux/debs/ubuntu/<release>/` so DEB consumers
-can fetch and import it before installing. On PR/local builds the key is
-ephemeral and is not published.
-
-### Validation strategy
-
-The main validation entrypoints are `test-build-rpms` and `test-build-debs`.
-They:
-
-1. build both `avalanchego` and `subnet-evm` packages
-2. start a fresh target Linux distribution container
-3. import the exported public key
-4. verify package signatures
-5. install both packages
-6. run smoke tests on the installed binaries
-
-RPM validation runs in `rockylinux:9`. DEB validation runs in both
-`ubuntu:22.04` (the build/target floor) and `ubuntu:24.04` (the newest LTS) to
-catch any compatibility regressions across the supported Ubuntu range.
-
-The smoke tests intentionally check a small set of high-value invariants:
-
-- the package can be installed on the target distro base
-- signature verification works
-- `avalanchego --version` runs and starts with `avalanchego/`
-- `avalanchego --version` contains the git commit hash captured during the build
-- the Subnet-EVM plugin is installed at the expected VM-ID-derived path
-- the plugin binary also reports the expected commit hash
-
-This does **not** replace broader AvalancheGo test coverage. It is specifically
-for validating that the packaging layer produced installable, correctly wired
-artifacts for the target runtime.
-
-### Binary linking rationale
-
-The current approach prefers dynamic glibc linking over static musl linking.
-Future maintainers are likely to revisit alternative linking strategies, and the
-trade-offs are not recoverable from the packaging scripts alone.
-
-#### Problem the packaging layer is solving
-
-We need to ship Linux packages for RHEL-family systems and Ubuntu, while general
-CI runs mostly on Ubuntu. Different distros ship different glibc versions, so a
-dynamically linked binary built against a newer Ubuntu glibc may not run on an
-older target distribution. The packaging pipeline therefore builds inside
-target Linux distribution containers so each package targets the oldest
-supported glibc for its target Linux distribution family.
-
-#### Why dynamic glibc is the current choice
-
-- glibc compatibility is the practical constraint for the supported Linux
-  distributions
-- glibc avoids taking on musl-specific performance and compatibility risk for a
-  performance-sensitive node binary
-- Go race-detector workflows remain compatible with glibc-based builds
-- binaries linked against older glibc generally run on newer glibc releases,
-  which is the compatibility we want to guarantee for each supported distro
-
-#### Why not static musl right now
-
-Static musl would look attractive because it avoids host glibc dependencies, but
-it carries project-specific risks that future maintainers should assume are
-still live unless new evidence says otherwise:
-
-- musl allocator behavior can be materially worse under multithreaded load; for
-  a blockchain node, that is not a casual trade-off
-- musl's smaller default thread stacks have caused surprises in other CGO-heavy
-  projects
-- Go's race detector does not work with musl, which would complicate validation
-- the Firewood/FFI side of the build has historically been more naturally
-  aligned with `*-linux-gnu` targets than with a musl packaging path
-- we do not have a dedicated performance validation loop that would confidently
-  catch musl-induced regressions before release
-
-The important maintenance takeaway is: **do not switch to musl just because it
-seems simpler operationally unless there is fresh performance and compatibility
-validation to justify it.**
-
-#### Why not static glibc
-
-Static glibc avoids some musl concerns, but it does not remove the need to pick
-and validate against a glibc baseline. That means it does not actually solve the
-main portability problem that motivated the current containerized build. It also
-pushes the build into a less common and less well-exercised CGO deployment shape
-than the current dynamic-glibc approach.
-
-#### Container builds are the current stopgap
-
-Building in `rockylinux:9` and `ubuntu:22.04` is the current way to target the
-correct glibc floors. That leaves a residual maintenance concern: broad CI on
-Ubuntu is not the same thing as testing the final release binary on the exact
-same runtime used for packaging. Package smoke tests reduce that gap by
-verifying installation, signatures, and basic execution on target Linux distribution
-containers, but they are not a substitute for full release-path parity.
-
-Future changes should not assume the current packaging smoke tests fully
-eliminate host-vs-release-runtime divergence. They are a pragmatic guardrail,
-not proof that the entire release artifact path has become runtime-agnostic.
-
-#### Longer-term direction: hermetic Bazel toolchain
-
-The longer-term direction is still a hermetic Bazel toolchain that can make
-"test what you ship" easier without relying on containerized release-only build
-plumbing. The key design idea is that build and test should use the same glibc
-baseline regardless of the host runner image.
-
-Earlier design work also identified likely rough edges for anyone revisiting
-that path, including Rust/CGO coordination, toolchain-selection bugs around
-non-default targets, and third-party native dependencies that may need extra
-Bazel integration work. The important point for repository documentation is not
-that each historical detail must remain exhaustive forever, but that "move
-release builds into Bazel" is not a trivial mechanical swap.
-
-Future maintainers revisiting this area should treat the current container build
-as a practical bridge, not necessarily the final architecture.
-
-### Alternative approaches and trade-offs
-
-This section records alternative approaches that help explain the current design
-and may be relevant when future maintainers revisit packaging decisions:
-
-- **Build on the default GitHub runner** - this risks linking against a newer
-  host glibc than the target distributions provide.
-- **Switch to static musl for portability** - this trades away known and
-  still-relevant performance, CGO, and validation properties without current
-  evidence that the trade is safe.
-- **Switch to static glibc** - this does not remove the need to choose and
-  validate a glibc baseline, so it does not solve the central compatibility
-  problem.
-- **Remove the workflow overlay for older tags** - that would drop the ability
-  to rebuild historical releases from before `.github/packaging` existed.
-
-### Invariants to preserve
-
-If you change this area, preserve these unless you are intentionally revisiting
-the design:
-
-- RPMs install under `/var/opt/avalanchego/...`
-- DEBs install under `/usr/bin` and `/usr/lib` (Debian Policy §9.1.2 forbids
-  `/usr/local` for packaged files)
-- Subnet-EVM installs under the VM ID from
-  `graft/subnet-evm/scripts/constants.sh`
-- RPM release builds target glibc 2.34 / Rocky Linux 9 compatibility
-- DEB release builds target glibc 2.35 / Ubuntu 22.04 compatibility
-- the same pipeline path is used for both local smoke testing and CI builds
-- manual tag builds continue to package historical source trees via the overlay
-  mechanism, unless a documented compatibility cutoff is introduced
-
-### Revisit this design if
-
-The current design should be reconsidered if any of these change:
-
-- the supported Linux distribution baselines move away from RHEL 9.x / glibc
-  2.34 or Ubuntu 22.04 / glibc 2.35
-- Bazel becomes the canonical release build path and can unify build and test
-  against the same glibc baseline
-- packaging needs to cover more historical tags than the current repository
-  interfaces can support
-- performance or compatibility data makes static linking newly attractive
-- historical rebuild compatibility is no longer a requirement, or a documented
-  cutoff replaces the current overlay behavior
-- release distribution needs move beyond GitHub Actions artifacts and the
-  current S3 publishing path structure for DEB releases
-
-## References
-
-### Repository entrypoints
-
-- Workflow: `/.github/workflows/build-linux-packages.yml`
-- Build/validate composite action: `/.github/packaging/actions/build-package/action.yml`
-- Taskfile: `/.github/packaging/Taskfile.yml`
-- RPM builder image: `/.github/packaging/Dockerfile.rpm`
-- DEB builder image: `/.github/packaging/Dockerfile.deb`
-- Build script: `/.github/packaging/scripts/build-package.sh`
-- RPM validation script: `/.github/packaging/scripts/validate-rpm.sh`
-- DEB validation script: `/.github/packaging/scripts/validate-deb.sh`
-- Root task include: `/Taskfile.yml`
-
-### Maintainer background for revisiting linking choices
-
-The maintainer-facing conclusions in this README are intended to stand on their
-own, but future revisits of static vs dynamic linking will go better if the
-underlying concern classes are easy to rediscover.
-
-The important background to preserve is:
-
-- **musl is not just a portability shortcut** - it changes allocator/runtime
-  behavior in ways that may matter for a performance-sensitive, multithreaded,
-  CGO-using node process
-- **musl changes the validation surface** - in particular, Go's race detector is
-  not available in the same way it is for the current glibc-based build/test
-  path
-- **static glibc is not a free escape hatch** - it still requires deliberate
-  compatibility validation and introduces its own libc caveats
-- **toolchain changes interact with CGO / Rust / non-default targets** - a
-  future hermetic or static-linking path should assume real integration work,
-  not a mechanical flag flip
-
-If you are actively reconsidering those choices, these references are useful
-starting points rather than normative design inputs:
-
-- musl allocator / performance concerns:
-  - <https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance/>
-  - <https://andygrove.io/2020/05/why-musl-extremely-slow/>
-- musl with Go static linking and race-detector limitations:
-  - <https://honnef.co/articles/statically-compiled-go-programs-always-even-with-cgo-using-musl/>
-- static glibc caveats:
-  - <https://developers.redhat.com/articles/2023/08/31/how-we-ensure-statically-linked-applications-stay-way>
-  - <https://tschottdorf.github.io/golang-static-linking-bug>
-- examples of CGO-heavy projects and trade-off discussion:
-  - <https://github.com/cockroachdb/cockroach/issues/3392>
-  - <https://www.dolthub.com/blog/2024-05-01-cgo-tradeoffs/>
-- toolchain rough edges that earlier exploration surfaced:
-  - <https://github.com/ziglang/zig/issues/12833>
-  - <https://github.com/bazelbuild/rules_rust/issues/2726>
+## Adding a new format
+
+When adding a fourth format (for example a Linux tarball / `apk` / Windows
+archive), the pattern to mirror is:
+
+1. Add a per-format `Dockerfile.<format>` if a build container is needed.
+2. Add a per-format `<format>.md` document following the four-layer
+   structure described in `docs/documentation-guidelines.md`. Use any of
+   `rpm.md`, `deb.md`, or `macos-zip.md` as a model.
+3. Add a per-format build script and validator under `scripts/` (reuse
+   `build-package.sh` if the format fits the shared nfpm path).
+4. Add per-format Taskfile entries (`build-<format>`, `validate-<format>`,
+   `test-build-<format>`).
+5. Link the new doc from the list at the top of this README.
+
+The shared `setup_gpg`, `assert_files_exist`, and Taskfile structure should
+not need to change for a new format that fits the same "build → sign →
+validate-in-fresh-container" shape.

--- a/.github/packaging/Taskfile.yml
+++ b/.github/packaging/Taskfile.yml
@@ -1,8 +1,11 @@
-# Packaging tasks for avalanchego and subnet-evm (RPM and DEB).
+# Packaging tasks for avalanchego and subnet-evm (RPM, DEB, and macOS zips).
 #
 # RPMs are built inside a Rocky Linux 9 container (glibc 2.34).
 # DEBs are built inside an Ubuntu 22.04 container (glibc 2.35).
 # Both formats are signed inline by nfpm.
+# macOS zips are built + signed in a debian:stable-slim container, mirroring
+# the workflow's ubuntu-24.04 sign-publish job. Local test uses a self-signed
+# Apple cert + ephemeral GPG key when real credentials aren't provided.
 # PACKAGING_TAG defaults to v0.0.0 for local testing; set for release builds.
 
 version: '3'
@@ -42,6 +45,12 @@ vars:
   PACKAGING_DEB_DOCKER_IMAGE: avalanchego-deb-builder
   PACKAGING_RPM_OUTPUT_DIR: '{{.REPO_ROOT}}/build/rpm'
   PACKAGING_DEB_OUTPUT_DIR: '{{.REPO_ROOT}}/build/deb'
+  # rcodesign version, sourced from the macOS release workflow so the local
+  # validator and the CI runner pin the same Apple-signing tool.
+  PACKAGING_APPLE_CODESIGN_VERSION:
+    sh: awk -F'"' '/APPLE_CODESIGN_PKG_VERSION:/ {print $2; exit}' "{{.REPO_ROOT}}/.github/workflows/build-macos-release.yml"
+  PACKAGING_MACOS_DOCKER_IMAGE: avalanchego-macos-zip-builder
+  PACKAGING_MACOS_OUTPUT_DIR: '{{.REPO_ROOT}}/build/macos'
 
 tasks:
   default:
@@ -204,3 +213,61 @@ tasks:
       PACKAGE_ARCH: '{{.PACKAGE_ARCH | default .PACKAGING_RPM_HOST_ARCH}}'
     cmds:
       - cmd: '{{.REPO_ROOT}}/.github/packaging/scripts/validate-rpm.sh'
+
+  build-macos-zip-builder-docker-image:
+    desc: Builds the macOS zip validator Docker image
+    internal: true
+    env:
+      GO_VERSION: '{{.PACKAGING_GO_VERSION}}'
+      APPLE_CODESIGN_VERSION: '{{.PACKAGING_APPLE_CODESIGN_VERSION}}'
+      DOCKER_IMAGE: '{{.PACKAGING_MACOS_DOCKER_IMAGE}}'
+      CONTEXT_DIR: '{{.REPO_ROOT}}/.github/packaging'
+      DOCKERFILE: Dockerfile.macos-zip
+    cmds:
+      - cmd: '{{.REPO_ROOT}}/.github/packaging/scripts/build-macos-zip-builder-image.sh'
+
+  build-macos-zip:
+    desc: Builds and signs macOS zip archives (Apple + GPG); ephemeral creds if not provided
+    vars:
+      MACOS_TAG: '{{.PACKAGING_TAG}}'
+    env:
+      GPG_KEY_PASSPHRASE: '{{.GPG_KEY_PASSPHRASE}}'
+      MACOS_SIGNING_PKCS12_BASE64: '{{.MACOS_SIGNING_PKCS12_BASE64}}'
+      MACOS_SIGNING_PASSWORD: '{{.MACOS_SIGNING_PASSWORD}}'
+      MACOS_NOTARIZATION_AUTH_KEY: '{{.MACOS_NOTARIZATION_AUTH_KEY}}'
+      MACOS_NOTARIZATION_KEY_ID: '{{.MACOS_NOTARIZATION_KEY_ID}}'
+      MACOS_NOTARIZATION_ISSUER_ID: '{{.MACOS_NOTARIZATION_ISSUER_ID}}'
+    deps: [build-macos-zip-builder-docker-image]
+    cmds:
+      - cmd: mkdir -p {{.PACKAGING_MACOS_OUTPUT_DIR}}
+      - cmd: >-
+          docker run --rm
+          -v {{.REPO_ROOT}}:/build
+          -v {{.PACKAGING_MACOS_OUTPUT_DIR}}:/output
+          {{if .GPG_KEY_FILE}}-v {{.GPG_KEY_FILE}}:{{.GPG_KEY_FILE}}:ro{{end}}
+          -e TAG={{.MACOS_TAG}}
+          -e OUTPUT_DIR=/output
+          {{if .GPG_KEY_FILE}}-e GPG_KEY_FILE={{.GPG_KEY_FILE}}{{end}}
+          {{if .GPG_KEY_PASSPHRASE}}-e GPG_KEY_PASSPHRASE{{end}}
+          {{if .MACOS_SIGNING_PKCS12_BASE64}}-e MACOS_SIGNING_PKCS12_BASE64{{end}}
+          {{if .MACOS_SIGNING_PASSWORD}}-e MACOS_SIGNING_PASSWORD{{end}}
+          {{if .MACOS_NOTARIZATION_AUTH_KEY}}-e MACOS_NOTARIZATION_AUTH_KEY{{end}}
+          {{if .MACOS_NOTARIZATION_KEY_ID}}-e MACOS_NOTARIZATION_KEY_ID{{end}}
+          {{if .MACOS_NOTARIZATION_ISSUER_ID}}-e MACOS_NOTARIZATION_ISSUER_ID{{end}}
+          {{.PACKAGING_MACOS_DOCKER_IMAGE}}
+          .github/packaging/scripts/build-macos-zip.sh
+
+  validate-macos-zip:
+    desc: Validates built macOS zips by verifying signatures and contents in a fresh container
+    env:
+      TAG: '{{.PACKAGING_TAG}}'
+      PACKAGING_DOCKER_IMAGE: '{{.PACKAGING_MACOS_DOCKER_IMAGE}}'
+    deps: [build-macos-zip-builder-docker-image]
+    cmds:
+      - cmd: '{{.REPO_ROOT}}/.github/packaging/scripts/validate-macos-zip.sh'
+
+  test-build-macos-zip:
+    desc: Builds and validates macOS zips end-to-end
+    cmds:
+      - task: build-macos-zip
+      - task: validate-macos-zip

--- a/.github/packaging/Taskfile.yml
+++ b/.github/packaging/Taskfile.yml
@@ -46,9 +46,13 @@ vars:
   PACKAGING_RPM_OUTPUT_DIR: '{{.REPO_ROOT}}/build/rpm'
   PACKAGING_DEB_OUTPUT_DIR: '{{.REPO_ROOT}}/build/deb'
   # rcodesign version, sourced from the macOS release workflow so the local
-  # validator and the CI runner pin the same Apple-signing tool.
+  # validator and the CI runner pin the same Apple-signing tool. Resolved via
+  # `git rev-parse --show-toplevel` because go-task evaluates included-Taskfile
+  # vars at startup with `{{.TASKFILE_DIR}}` pointing at the root Taskfile dir,
+  # making `{{.REPO_ROOT}}` (computed from TASKFILE_DIR/../..) two levels off
+  # in CI.
   PACKAGING_APPLE_CODESIGN_VERSION:
-    sh: awk -F'"' '/APPLE_CODESIGN_PKG_VERSION:/ {print $2; exit}' "{{.REPO_ROOT}}/.github/workflows/build-macos-release.yml"
+    sh: awk -F'"' '/APPLE_CODESIGN_PKG_VERSION:/ {print $2; exit}' "$(git rev-parse --show-toplevel)/.github/workflows/build-macos-release.yml"
   PACKAGING_MACOS_DOCKER_IMAGE: avalanchego-macos-zip-builder
   PACKAGING_MACOS_OUTPUT_DIR: '{{.REPO_ROOT}}/build/macos'
 

--- a/.github/packaging/deb.md
+++ b/.github/packaging/deb.md
@@ -1,0 +1,276 @@
+# DEB packaging
+
+## Overview
+
+This directory contains the DEB packaging implementation for AvalancheGo and
+Subnet-EVM.
+
+It exists to ship signed DEBs for Ubuntu 22.04 (jammy) and 24.04 (noble)
+without making future maintainers reconstruct the packaging model from CI YAML
+and shell scripts alone.
+
+This document is for two audiences:
+
+- **users/release engineers** who need to build or publish DEBs
+- **maintainers** who need to change the packaging implementation safely
+
+## Usage
+
+### What gets produced
+
+The packaging pipeline builds two DEBs per architecture:
+
+| Package | Installed path |
+| --- | --- |
+| `avalanchego` | `/usr/bin/avalanchego` |
+| `subnet-evm` | `/usr/lib/avalanchego/plugins/<VM_ID>` |
+
+Both packages declare `libc6 (>= 2.35)`. `<VM_ID>` is sourced from
+`graft/subnet-evm/scripts/constants.sh`.
+
+### Main entrypoints
+
+- CI workflow: `.github/workflows/build-linux-packages.yml` (unified RPM + DEB)
+- Build/validate composite action: `.github/packaging/actions/build-package/action.yml`
+- Packaging taskfile: `.github/packaging/Taskfile.yml`
+- Build script: `.github/packaging/scripts/build-package.sh`
+- Validation script: `.github/packaging/scripts/validate-deb.sh`
+- nfpm package definitions: `.github/packaging/nfpm/*.yml`
+
+### Local build and validation
+
+Build and validate the full DEB pipeline locally with:
+
+```bash
+./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml test-build-debs
+```
+
+Or, via the root Taskfile include:
+
+```bash
+task packaging:test-build-debs
+```
+
+Useful environment variables:
+
+- `PACKAGING_TAG` - tag/version label to embed, defaults to `v0.0.0`
+- `PACKAGE_ARCH` - package architecture override (`amd64`/`arm64`); defaults to
+  the host architecture mapped to the DEB naming scheme
+- `GPG_KEY_FILE` - real signing key for non-ephemeral signing
+- `GPG_KEY_PASSPHRASE` - passphrase for the signing key; mirrored internally to
+  the `NFPM_DEB_PASSPHRASE` variable expected by `nfpm`
+
+Without `GPG_KEY_FILE`, the build generates a short-lived ephemeral GPG key so
+that local and PR builds still exercise the signing path.
+
+### CI behavior
+
+`.github/workflows/build-linux-packages.yml` builds both RPM and DEB packages
+from a single workflow (format × arch matrix delegating bulk work to
+`.github/packaging/actions/build-package`) and runs in three modes:
+
+- **tag push** - builds release DEBs for the pushed tag
+- **workflow_dispatch** - builds DEBs for an explicitly provided tag
+- **pull_request** - smoke-tests the packaging pipeline for changes under
+  `.github/packaging/` or the workflow itself
+
+PR builds use a synthetic tag (`v0.0.0-pr.<sha>`) and ephemeral signing.
+Non-PR builds import the real signing key from Actions secrets and upload
+DEBs plus the exported public key as artifacts. See [`rpm.md`](rpm.md) for the
+RPM half of the same workflow.
+
+DEB release runs additionally upload packages to S3 under
+`linux/debs/ubuntu/{jammy,noble}/{arch}/`; the DEB public key is uploaded to
+`linux/debs/ubuntu/{jammy,noble}/` because one signing key serves all
+architectures of a release.
+
+## Conceptual model
+
+The DEB pipeline intentionally treats packaging as a layer *around* the source
+release tree rather than as part of the historical release tree itself.
+
+The model is:
+
+1. Check out the source revision being packaged
+2. Build inside an Ubuntu 22.04 container so the binary links against glibc 2.35
+3. Package with `nfpm`
+4. Sign the DEBs
+5. Validate by installing the built DEBs into fresh `ubuntu:22.04` and
+   `ubuntu:24.04` containers
+
+This directory is code-adjacent because the implementation lives here:
+Dockerfile, task entrypoints, package manifests, and shell scripts all evolve
+together.
+
+Two architecture naming schemes are in play and must stay aligned:
+
+| Context | x86_64 | arm64 |
+| --- | --- | --- |
+| `uname -m` | `x86_64` | `aarch64` |
+| Docker / Go downloads / DEB | `amd64` | `arm64` |
+
+The Taskfile normalizes host architecture to DEB names; the Dockerfile maps
+Docker `TARGETARCH` values to the names expected by upstream downloads.
+
+## Maintenance notes
+
+### Why the build uses Ubuntu 22.04
+
+DEBs target Ubuntu 22.04 (jammy), the oldest LTS we support, so DEB builds run
+in an `ubuntu:22.04` container and produce binaries linked against glibc 2.35.
+Compatibility of the produced packages is then verified by installing and
+smoke-testing in both `ubuntu:22.04` and `ubuntu:24.04` (the newest LTS we
+support).
+
+Building on the default GitHub runner image would link against the runner's
+Ubuntu glibc, which is typically newer than the intended jammy floor.
+
+### Why the workflow overlays `.github/packaging` for manual tag builds
+
+`workflow_dispatch` accepts an arbitrary tag, including tags created before DEB
+packaging existed in this repository.
+
+Those older tags may not contain:
+
+- `.github/packaging/`
+- the current packaging scripts and nfpm manifests
+- the current packaging Dockerfile and helper logic
+
+To keep manual rebuilds of older releases possible, the workflow first checks
+out the requested tag as the source tree and then overlays `.github/packaging`
+from the workflow branch:
+
+1. `actions/checkout` of the requested tag into the workspace root
+2. second sparse checkout of `.github/packaging` into `.packaging-overlay`
+3. copy overlay contents into `.github/packaging` in the tagged tree
+4. run the current packaging pipeline against the historical source
+
+This is intentionally narrow: it overlays **only the packaging implementation**,
+not the rest of the branch. That lets maintainers improve packaging logic over
+time while still packaging historical source revisions.
+
+#### Implications for maintainers
+
+When changing `.github/packaging`, keep in mind that `workflow_dispatch` may run
+those scripts against trees that predate the packaging feature.
+
+Changes are safer when they depend only on repository interfaces that already
+exist across the intended release range, such as:
+
+- `scripts/build.sh`
+- `scripts/constants.sh`
+- `graft/subnet-evm/scripts/build.sh`
+- `graft/subnet-evm/scripts/constants.sh`
+
+If packaging changes need newer repository structure or newer build interfaces,
+manual rebuilds of older tags may stop working. If that trade-off is acceptable,
+document the cutoff explicitly and in the workflow change.
+
+### Signing behavior
+
+DEBs are always built through the signing path.
+
+- **CI release/manual builds** import the real private key from
+  `secrets.RPM_GPG_PRIVATE_KEY`
+- **local and PR builds** generate an ephemeral RSA key with a known throwaway
+  passphrase
+
+This is deliberate: unsigned fast paths tend to rot, while always exercising the
+signing path keeps packaging validation closer to what is shipped.
+
+The build exports the matching public key (`GPG-KEY-avalanchego`) next to the
+DEBs. On DEB release events (tag push / `workflow_dispatch`), `upload-debs-s3`
+publishes it alongside the `.deb`s under
+`s3://${BUCKET}/linux/debs/ubuntu/<release>/` so DEB consumers can fetch and
+import it before installing. On PR/local builds the key is ephemeral and is not
+published.
+
+The GPG key identifies the project, not the package format:
+`secrets.RPM_GPG_PRIVATE_KEY` signs RPM, DEB, and macOS zip artifacts. The
+secret name predates DEB and macOS zip signing; see [`macos-zip.md`](macos-zip.md)
+for the rotation-path notes.
+
+### Validation strategy
+
+The main validation entrypoint is `test-build-debs`, which:
+
+1. builds both DEBs
+2. starts fresh `ubuntu:22.04` and `ubuntu:24.04` containers
+3. imports the public key
+4. verifies DEB signatures
+5. installs both DEBs
+6. runs smoke tests on the installed binaries
+
+DEB validation runs in both `ubuntu:22.04` (the build/target floor) and
+`ubuntu:24.04` (the newest LTS) to catch any compatibility regressions across
+the supported Ubuntu range.
+
+The smoke tests intentionally check a small set of high-value invariants:
+
+- the DEB can be installed on the target distro base
+- signature verification works
+- `avalanchego --version` runs and contains the built commit hash
+- the Subnet-EVM plugin is installed at the expected VM-ID-derived path
+- the plugin binary also reports the expected commit hash
+
+This does **not** replace broader AvalancheGo test coverage. It is specifically
+for validating that the packaging layer produced installable, correctly wired
+artifacts for the target runtime.
+
+### Binary linking rationale
+
+DEB builds share the RPM pipeline's **dynamic glibc linking** rationale: the
+build runs in a target-distribution container (`ubuntu:22.04` for DEB,
+`rockylinux:9` for RPM) so the binary's glibc floor matches the oldest supported
+release for that family. The full trade-off discussion (why not static musl, why
+not static glibc, container builds as the current stopgap, and the longer-term
+hermetic Bazel direction) lives in [`rpm.md`](rpm.md#binary-linking-rationale)
+and applies verbatim, with DEB targeting glibc 2.35 / Ubuntu 22.04 rather than
+glibc 2.34 / Rocky Linux 9.
+
+### Invariants to preserve
+
+If you change this area, preserve these unless you are intentionally revisiting
+the design:
+
+- DEBs install under `/usr/bin` and `/usr/lib` (Debian Policy §9.1.2 forbids
+  `/usr/local` for packaged files)
+- Subnet-EVM installs under the VM ID from
+  `graft/subnet-evm/scripts/constants.sh`
+- release builds target glibc 2.35 / Ubuntu 22.04 compatibility
+- the same pipeline path is used for both local smoke testing and CI builds
+- manual tag builds continue to package historical source trees via the overlay
+  mechanism, unless a documented compatibility cutoff is introduced
+
+### Revisit this design if
+
+The current design should be reconsidered if any of these change:
+
+- the supported Ubuntu baseline moves away from 22.04 / glibc 2.35
+- Bazel becomes the canonical release build path and can unify build and test
+  against the same glibc baseline
+- packaging needs to cover more historical tags than the current repository
+  interfaces can support
+- performance or compatibility data makes static linking newly attractive
+- historical rebuild compatibility is no longer a requirement, or a documented
+  cutoff replaces the current overlay behavior
+- release distribution needs move beyond GitHub Actions artifacts and the
+  current S3 publishing path structure for DEB releases
+
+## References
+
+### Repository entrypoints
+
+- Workflow: `/.github/workflows/build-linux-packages.yml`
+- Build/validate composite action: `/.github/packaging/actions/build-package/action.yml`
+- Taskfile: `/.github/packaging/Taskfile.yml`
+- Builder image: `/.github/packaging/Dockerfile.deb`
+- Build script: `/.github/packaging/scripts/build-package.sh`
+- Validation script: `/.github/packaging/scripts/validate-deb.sh`
+- Shared packaging helpers: `/.github/packaging/scripts/lib-build-common.sh`
+- Root task include: `/Taskfile.yml`
+
+### Related documents
+
+- [`rpm.md`](rpm.md) - RPM pipeline, and the shared binary-linking rationale
+- [`macos-zip.md`](macos-zip.md) - macOS zip pipeline and shared GPG-key notes

--- a/.github/packaging/macos-zip.md
+++ b/.github/packaging/macos-zip.md
@@ -32,8 +32,8 @@ Per architecture, the macOS packaging pipeline produces:
 Each Mach-O binary inside a zip carries an Apple code signature with the
 `runtime` hardened-runtime flag. Each zip is signed with the project's GPG
 key and submitted to Apple's notary service before being published. The
-order is load-bearing; see *Apple-sign / GPG-sign / notarize order* in the
-maintenance notes.
+order of those three operations matters; see *Apple-sign / GPG-sign /
+notarize order* in the maintenance notes.
 
 ### Main entrypoints
 
@@ -54,7 +54,7 @@ task packaging:test-build-macos-zip
 ```
 
 This runs in a `debian:stable-slim`-based Docker container that mirrors the
-toolchain of the CI sign-publish job (`p7zip-full`, `gnupg`, `openssl`, `jq`,
+toolchain of the CI sign job (`p7zip-full`, `gnupg`, `openssl`, `jq`,
 `rcodesign`). It exercises the production `build-zip-pkg.sh` unmodified
 against cross-compiled stub Mach-O binaries, then validates the produced zips
 in a fresh container.
@@ -83,55 +83,75 @@ key-materialization paths, regardless of secret availability.
 
 `.github/workflows/build-macos-release.yml` triggers on:
 
-- **tag push** (`push: tags: ["*"]`) - builds the macOS release for the
-  pushed tag
+- **tag push** (`push: tags: ["v*"]`) - builds the macOS release for the
+  pushed release tag
 - **workflow_dispatch** - builds for an explicitly provided tag
 
-The workflow runs two jobs:
+The workflow runs three jobs:
 
 1. `build-mac` (macos-14): builds the Mach-O binaries natively, uploads them
    as the `macos-binaries` workflow artifact.
-2. `sign-publish` (ubuntu-24.04): downloads `macos-binaries`, materializes
-   Apple credentials, Apple-signs the binaries, runs the production
+2. `sign` (ubuntu-24.04): downloads `macos-binaries`, materializes Apple
+   credentials, Apple-signs the binaries, runs the production
    `build-zip-pkg.sh` to zip and GPG-sign, submits each zip to Apple's notary
-   service, then publishes `*.zip` and `*.zip.sig` to
-   `s3://${secrets.BUCKET}/macos/` and as GitHub workflow artifacts.
+   service, and uploads the signed `*.zip` / `*.zip.sig` as GitHub workflow
+   artifacts. Holds the signing secrets; not granted `id-token: write`.
+3. `publish` (ubuntu-24.04): downloads the signed artifacts and uploads them to
+   `s3://${secrets.BUCKET}/macos/`. This is the only job with `id-token: write`
+   (AWS OIDC), and it holds no signing secrets and runs no packaging scripts.
 
 The workflow imports `secrets.RPM_GPG_PRIVATE_KEY` for GPG signing and the
 sec-team-issued `secrets.MACOS_SIGNING_*` and `secrets.MACOS_NOTARIZATION_*`
 for Apple signing and notarization. An empty `RPM_GPG_PRIVATE_KEY` fails the
-workflow at the `Import GPG key` step (see *Fail-fast on missing GPG secret*
+workflow at the `Build zips and GPG-sign` step (see *Fail-fast on missing GPG secret*
 below).
 
 ## Conceptual model
 
-The macOS pipeline intentionally splits the build and sign-publish stages
-across two GitHub runner images rather than doing everything on a macOS
-runner.
+The macOS pipeline intentionally splits work across three jobs and two GitHub
+runner images rather than doing everything on a macOS runner.
 
-### Two-job split: `build-mac` and `sign-publish`
+### Three-job split: `build-mac`, `sign`, `publish`
 
 | Job | Runner | Purpose |
 | --- | --- | --- |
 | `build-mac` | `macos-14` | native Mach-O build only |
-| `sign-publish` | `ubuntu-24.04` | Apple sign + GPG sign + notarize + upload |
+| `sign` | `ubuntu-24.04` | Apple sign + GPG sign + notarize; holds signing secrets, no `id-token` |
+| `publish` | `ubuntu-24.04` | download signed artifacts + upload to S3; `id-token: write`, no signing secrets |
+
+`sign` and `publish` are separate so that `id-token: write` (AWS OIDC) is never
+granted to the job that holds the signing secrets and runs packaging scripts.
+This mirrors `build-linux-packages.yml`, whose `upload-debs-s3` job is isolated
+for the same reason.
 
 Apple signing, notarization, and publishing all run on Linux because:
 
-- `indygreg/apple-code-sign-action@v1` is a Node JS action and runs on any
-  runner that supports Node 20+
-- the underlying `rcodesign` tool is cross-platform and ships pre-built Linux
-  binaries for both `x86_64` and `aarch64`
-- macOS GitHub-hosted minutes are roughly 10× the price of Linux minutes; the
+- `rcodesign` is cross-platform and ships pre-built Linux binaries for both
+  `x86_64` and `aarch64`, so Apple-signing and notary submission never need a
+  macOS host
+- macOS GitHub-hosted minutes are roughly 10x the price of Linux minutes; the
   parts of the pipeline that do not require a Mach-O build environment should
   not pay that premium
 
 ### Credential lifecycle
 
-All Apple credentials and the GPG key are materialized into `mktemp` files
-and are explicitly removed by the workflow's `Cleanup` step (which runs
-`if: always()`). They are not echoed via `GITHUB_OUTPUT` and never reach
-either the GitHub Releases page or the `s3://${BUCKET}/macos/` prefix.
+Each secret is materialized into a `mktemp` file **inside the single step that
+uses it**, removed by that step's `EXIT` trap (on success or failure), and its
+path is never exported through `$GITHUB_ENV`. So a given secret is on disk only
+for the duration of its own step, never while a different step runs:
+
+| Secret | Materialized + used + deleted in |
+| --- | --- |
+| Signing PKCS#12 | `Apple-sign binaries` |
+| GPG private key | `Build zips and GPG-sign` (raw P8 is decoded, used, and deleted here too) |
+| App Store Connect P8 + encoded API-key JSON | `Notarize zips` |
+
+All of this happens in the `sign` job; the `publish` job that assumes the AWS
+role holds no signing secrets at all. In particular, the notary API key is
+materialized only in `Notarize zips`, so it is not present while the earlier
+`Build zips and GPG-sign` step runs the checked-out packaging script. The
+credentials are not echoed via `GITHUB_OUTPUT` and never reach either the GitHub
+Releases page or the `s3://${BUCKET}/macos/` prefix.
 
 The local validator mirrors this: ephemeral Apple PKCS#12, GPG private key,
 and ECDSA P8 are all written into a `mktemp -d` stage directory cleaned up by
@@ -165,8 +185,8 @@ produces an artifact whose internal entries are `avalanchego` and `subnet-evm`
 ```
 
 Downstream steps reference `build/avalanchego` and `build/subnet-evm`
-explicitly, so the `path: build` is load-bearing - using `path: .` would
-land the files at the workspace root and break the rest of the workflow.
+explicitly, so the `path: build` matters here - using `path: .` would land
+the files at the workspace root and break the rest of the workflow.
 
 The production `build-zip-pkg.sh` then calls `7z a foo.zip build/avalanchego`,
 which preserves the `build/` prefix inside the zip. The validator therefore
@@ -179,54 +199,66 @@ The local validator (`build-macos-zip.sh`) invokes the production
 therefore exercises the same zip + GPG-sign code that runs in CI, not a copy.
 Behavioral divergence between local and CI is structurally avoided.
 
-The Apple-sign and notarize steps are not yet wrapped this way because they
-live inside the `indygreg/apple-code-sign-action@v1` Node JS action rather
-than in a separate script; the local validator invokes `rcodesign` directly
-with the same flag shapes the action uses.
+The Apple-sign, notarize, and API-key-encode steps call `rcodesign` directly
+in both places (CI's `sign` job and the local validator), with the
+same flags. CI installs `rcodesign` from the `indygreg/apple-platform-rs`
+release; the validator bakes it into its Docker image. Neither path depends
+on a third-party GitHub Action to reach the signing tool.
 
 ## Maintenance notes
 
 ### Why `rcodesign` rather than Apple's `codesign`
 
-Apple's `codesign` only runs on macOS. The sign-publish job runs on Linux for
+Apple's `codesign` only runs on macOS. The sign job runs on Linux for
 cost reasons (see *Two-job split* above), so the signing tool must work on
 Linux. `rcodesign` (from `indygreg/apple-platform-rs`) is a pure-Rust
 re-implementation of Apple code-signing and notary submission that works
-without macOS. It is the same tool wrapped by
-`indygreg/apple-code-sign-action`, so using `rcodesign` directly in the local
-validator and via the action in CI keeps the underlying signing
-implementation consistent across both paths.
+without macOS. Both the CI `sign` job and the local validator invoke
+`rcodesign` directly, so the underlying signing implementation is identical
+across both paths.
 
-### Why `indygreg/apple-code-sign-action@v1` is currently pinned by major tag
+### Why the signing tool is `rcodesign` invoked directly, not a GitHub Action
 
-The action is currently pinned to the floating `v1` tag rather than a full
-commit SHA. The pragmatic trade-off:
+Earlier revisions of this workflow wrapped signing and notarization in the
+`indygreg/apple-code-sign-action` GitHub Action, a thin Node wrapper that
+downloads `rcodesign` and shells out to it. It was dropped in favor of
+calling `rcodesign` directly because:
 
-- `v1` follows the same pinning pattern as other GitHub Actions in this
-  repository's release workflows (`actions/checkout@v5`,
-  `aws-actions/configure-aws-credentials@v6`, etc.). Internal consistency.
-- A retag of `v1` to a malicious commit would let an attacker exfiltrate the
-  PKCS#12 password and notarization API key. The action is on a personal
-  GitHub namespace (`indygreg/`), which is meaningfully higher supply-chain
-  risk than first-party `actions/*` and `aws-actions/*` pins.
+- The `sign` job already installs `rcodesign` (it needs it for
+  `encode-app-store-connect-api-key`) and the local validator already calls
+  it directly. Using the action for only the sign/notarize steps meant two
+  different ways of invoking the same tool inside one job.
+- The action lives in a personal GitHub namespace (`indygreg/`) and handled
+  the PKCS#12 password and notarization API key. A retag of its floating `v1`
+  to a malicious commit would have let it exfiltrate those secrets. This
+  repository SHA-pins third-party actions from non-vendor namespaces for
+  exactly this reason (GitHub's own `actions/*` and AWS's `aws-actions/*` stay
+  on version tags); `indygreg/` was the only non-vendor action on a floating
+  tag.
 
-The tarball that `indygreg/apple-platform-rs` ships is already SHA256-pinned
-in the local validator's Dockerfile (`Dockerfile.macos-zip`), via the
-`*.sha256` sidecar from the release. The CI workflow itself does not yet
-SHA-pin either the action or the rcodesign tarball it downloads inline.
+The remaining actions are all vendor ones (`actions/checkout`,
+`actions/*-artifact`, `aws-actions/configure-aws-credentials`). The
+`aws-actions/configure-aws-credentials` action runs only in the separate
+`publish` job, which holds no signing secrets; within the `sign` job, the
+`upload-artifact` that runs after signing does so only after every signing
+secret has already been deleted at its last point of use (see *Credential
+lifecycle*).
 
-When the upstream API stabilizes or supply-chain risk increases enough to
-justify the maintenance overhead, pin to a full commit SHA and enable
-Dependabot to update it.
+Supply-chain integrity of the tool itself is handled by pinning the
+`rcodesign` release tarball's SHA256 in this repository, rather than trusting
+the release's own `*.sha256` sidecar (a compromised release could replace the
+tarball and the sidecar together). The CI workflow verifies against
+`APPLE_CODESIGN_SHA256`; the local builder image passes the per-arch digest as
+a Docker build arg (both live next to the pinned version and must be updated
+together on a version bump).
 
 ### Apple-sign / GPG-sign / notarize order
 
 The CI workflow performs the signing operations in this order, and the
-order is load-bearing:
+order matters:
 
-1. **Apple-sign each Mach-O binary** (`rcodesign sign` via the action). The
-   signature is embedded inside the Mach-O via the `LC_CODE_SIGNATURE` load
-   command.
+1. **Apple-sign each Mach-O binary** (`rcodesign sign`). The signature is
+   embedded inside the Mach-O via the `LC_CODE_SIGNATURE` load command.
 2. **Zip each binary and detached-GPG-sign the resulting zip**
    (`build-zip-pkg.sh`). The GPG signature is over the zip bytes, which
    include the already-Apple-signed Mach-O.
@@ -242,9 +274,9 @@ Mach-O inside the zip would be unsigned.
 
 ### Fail-fast on missing GPG secret
 
-The `Import GPG key` step asserts that `RPM_GPG_PRIVATE_KEY` is non-empty
-and that the materialized key file is non-zero-size before exporting
-`GPG_KEY_FILE` to `$GITHUB_ENV`.
+The `Build zips and GPG-sign` step asserts that `RPM_GPG_PRIVATE_KEY` is
+non-empty and that the materialized key file is non-zero-size before it runs
+`build-zip-pkg.sh`.
 
 This is a deliberate guard against a previously-latent failure mode:
 
@@ -253,28 +285,28 @@ This is a deliberate guard against a previously-latent failure mode:
 - `build-zip-pkg.sh` tests `[[ -s "${GPG_KEY_FILE}" ]]` and silently takes
   the no-op signing branch on a zero-byte file (this branch is intentional;
   it lets the script be reused in contexts that do not have a key).
-- The subsequent `Upload zips to S3` step in the workflow unconditionally
-  copies `*.zip` and then `*.zip.sig`. Without the precondition, `*.zip`
-  is published successfully and then the upload fails on the missing
-  `*.zip.sig`, leaving an unsigned zip in the release bucket.
+- The downstream `publish` job's S3 upload copies `*.zip.sig` and `*.zip`.
+  Without the precondition, an unsigned zip could be produced and later
+  published without a signature.
 
 The precondition replaces "publish unsigned then error" with "fail at the
-import step with a clear message."
+zip-signing step with a clear message."
 
-### Why `secrets.RPM_GPG_PRIVATE_KEY` is shared with RPM signing
+### Why `secrets.RPM_GPG_PRIVATE_KEY` is shared across package formats
 
-The macOS zip workflow reuses the same GPG private key as the RPM packaging
-workflow rather than introducing a `MACOS_GPG_PRIVATE_KEY` secret.
+The macOS zip workflow reuses the same GPG private key as the RPM and DEB
+packaging workflows rather than introducing a `MACOS_GPG_PRIVATE_KEY` secret.
 
 Rationale: the GPG key identifies *the project*, not the package format. End
 users who want to verify "is this artifact really from ava-labs?" use the
-same key whether they downloaded an RPM or a macOS zip (Linux tarballs are
-currently unsigned; if they ever gain GPG signing, the same key would
-naturally be reused). Maintaining two keys for the same provenance claim
-would create rotation and trust-chain complexity without a corresponding
-security benefit. The `RPM_GPG_PRIVATE_KEY` secret name predates macOS zip
-signing; renaming it would require coordinated changes across multiple
-workflows. The name is historical; the key is project-wide.
+same key whether they downloaded an RPM, a DEB, or a macOS zip (plain Linux
+tarballs are currently unsigned; if they ever gain GPG signing, the same key
+would naturally be reused). Maintaining separate keys for the same provenance
+claim would create rotation and trust-chain complexity without a
+corresponding security benefit. The `RPM_GPG_PRIVATE_KEY` secret name
+predates both DEB and macOS zip signing; renaming it would require
+coordinated changes across multiple workflows. The name is historical; the
+key is project-wide.
 
 If the project ever needs per-format signing keys (for example, to support
 different rotation cadences), the migration path is: add new format-specific
@@ -306,8 +338,8 @@ boundary use the sec-team naming convention.
 
 ### Local validator scope
 
-The local validator is intentionally "Tier 1": it exercises the parts of the
-pipeline that are reproducible offline. What it does and does not cover:
+The local validator intentionally covers only the parts of the pipeline that
+are reproducible offline. What it does and does not cover:
 
 | Part | Local validator | Why |
 | --- | --- | --- |
@@ -316,12 +348,12 @@ pipeline that are reproducible offline. What it does and does not cover:
 | `rcodesign encode-app-store-connect-api-key` | yes, with `openssl`-generated ECDSA P8 | encode step is purely local, no network |
 | `rcodesign notary-submit` (notarization) | no | hardcoded `https://appstoreconnect.apple.com/notary/v2/submissions` endpoint in `app-store-connect/src/notary_api.rs`; no `--dry-run`, no env-var endpoint override |
 
-Reaching Tier 2 (running the indygreg action via `act`) or Tier 3 (mocking
-the notary HTTPS endpoint) would require more infrastructure than the
-current Tier-1 setup. Tier 1 covers ~80% of the value at ~5% of the
-complexity: any divergence between local and CI for the signing/zip/GPG
-path will surface; only Apple's notary submission itself is untested
-locally.
+The one part it cannot cover offline is Apple's notary submission itself
+(`rcodesign notary-submit`), which has to reach Apple's servers. Mocking that
+HTTPS endpoint would take more infrastructure than the rest of the validator
+combined, for the single step a real release exercises anyway. Everything
+else, any divergence between local and CI on the sign / zip / GPG path,
+surfaces locally.
 
 ### Stub Mach-O binaries in the local validator
 
@@ -366,8 +398,16 @@ revisiting the design:
 - Apple-sign runs before GPG-sign, which runs before notarize
 - ephemeral credentials never leak from the stage directory to the bind-
   mounted `OUTPUT_DIR` or the published artifacts
-- `Import GPG key` fails fast on an empty `RPM_GPG_PRIVATE_KEY` rather than
-  letting the no-op signing branch produce an unsigned release
+- `Build zips and GPG-sign` fails fast on an empty `RPM_GPG_PRIVATE_KEY`
+  rather than letting the no-op signing branch produce an unsigned release
+- each signing secret is materialized and deleted (EXIT trap) inside the single
+  step that uses it; secret paths are never exported through `$GITHUB_ENV`
+- S3 publishing lives in a separate `publish` job so `id-token: write` is never
+  granted to the job that holds signing secrets and runs packaging scripts
+- each zip's `.sig` is uploaded to S3 before the zip itself, so a partial
+  upload can never leave a consumable zip without its signature
+- the `rcodesign` tarball is verified against a repo-pinned SHA256, not the
+  upstream `*.sha256` sidecar
 - the macOS Mach-O binaries are built natively on `macos-14`; all other
   operations run on `ubuntu-24.04`
 
@@ -376,7 +416,7 @@ revisiting the design:
 The current design should be reconsidered if any of these change:
 
 - rcodesign gains a `--dry-run` flag or env-var endpoint override for
-  notarization (would enable a Tier 3 local mock)
+  notarization (would let the local validator cover notary submission too)
 - Apple migrates away from an rcodesign-compatible API (would force a fall-
   back to Apple's `notarytool` or `codesign`, which only run on macOS)
 - the security team rotates to a per-format GPG signing key (would require
@@ -384,7 +424,7 @@ The current design should be reconsidered if any of these change:
 - GPG signing moves to KMS / cloud-managed keys (would replace
   `setup_gpg`'s key-import branch with a remote-signing branch)
 - macOS GitHub-hosted minutes become cost-competitive with Linux (would
-  collapse the two-job split back into one)
+  collapse the native-build and signing jobs back onto one runner)
 - the project moves zip publishing off S3 / GitHub Releases to another
   distribution channel
 
@@ -404,7 +444,6 @@ The current design should be reconsidered if any of these change:
 
 ### Upstream tooling
 
-- [`indygreg/apple-code-sign-action`](https://github.com/indygreg/apple-code-sign-action) - GitHub Action wrapping rcodesign
 - [`indygreg/apple-platform-rs`](https://github.com/indygreg/apple-platform-rs) - rcodesign source; relevant code paths: `apple-codesign/src/cli/mod.rs` (CLI surface), `app-store-connect/src/notary_api.rs` (hardcoded notary endpoint)
 - [`rcodesign` documentation](https://gregoryszorc.com/docs/apple-codesign/stable/) - including [certificate management](https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_certificate_management.html) and [signing reference](https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_rcodesign_signing.html)
-- [Apple notary service overview](https://developer.apple.com/documentation/security/customizing_the_notarization_workflow)
+- [Apple notary service overview](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)

--- a/.github/packaging/macos-zip.md
+++ b/.github/packaging/macos-zip.md
@@ -1,0 +1,410 @@
+# macOS zip packaging
+
+## Overview
+
+This document describes how AvalancheGo and Subnet-EVM binaries are packaged
+for macOS distribution: Apple code-signed and notarized Mach-O binaries
+delivered as detached-GPG-signed `*.zip` archives.
+
+It exists so future maintainers do not need to reconstruct the macOS signing
+and notarization pipeline from CI YAML, shell scripts, and the
+`indygreg/apple-platform-rs` source tree alone.
+
+This document is for two audiences:
+
+- **users/release engineers** who need to build, validate, or publish macOS
+  zip releases
+- **maintainers** who need to change the macOS packaging implementation safely
+
+## Usage
+
+### What gets produced
+
+Per architecture, the macOS packaging pipeline produces:
+
+| Artifact | Contents |
+| --- | --- |
+| `avalanchego-macos-<TAG>.zip` | Apple-signed `build/avalanchego` Mach-O binary |
+| `avalanchego-macos-<TAG>.zip.sig` | detached GPG signature over the avalanchego zip |
+| `subnet-evm-macos-<TAG>.zip` | Apple-signed `build/subnet-evm` Mach-O binary |
+| `subnet-evm-macos-<TAG>.zip.sig` | detached GPG signature over the subnet-evm zip |
+
+Each Mach-O binary inside a zip carries an Apple code signature with the
+`runtime` hardened-runtime flag. Each zip is signed with the project's GPG
+key and submitted to Apple's notary service before being published. The
+order is load-bearing; see *Apple-sign / GPG-sign / notarize order* in the
+maintenance notes.
+
+### Main entrypoints
+
+- CI workflow: `.github/workflows/build-macos-release.yml`
+- Production zip + GPG-sign script: `.github/workflows/build-zip-pkg.sh`
+- Packaging Taskfile: `.github/packaging/Taskfile.yml`
+- Local validator build script: `.github/packaging/scripts/build-macos-zip.sh`
+- Local validator script: `.github/packaging/scripts/validate-macos-zip.sh`
+- Local builder Docker image: `.github/packaging/Dockerfile.macos-zip`
+- Builder-image bootstrap: `.github/packaging/scripts/build-macos-zip-builder-image.sh`
+
+### Local build and validation
+
+Build and validate the full macOS zip pipeline locally with:
+
+```bash
+task packaging:test-build-macos-zip
+```
+
+This runs in a `debian:stable-slim`-based Docker container that mirrors the
+toolchain of the CI sign-publish job (`p7zip-full`, `gnupg`, `openssl`, `jq`,
+`rcodesign`). It exercises the production `build-zip-pkg.sh` unmodified
+against cross-compiled stub Mach-O binaries, then validates the produced zips
+in a fresh container.
+
+Useful environment variables:
+
+- `PACKAGING_TAG` - tag/version label to embed, defaults to `v0.0.0`
+- `GPG_KEY_FILE` - real GPG signing key for non-ephemeral signing
+- `GPG_KEY_PASSPHRASE` - passphrase for the GPG signing key
+- `MACOS_SIGNING_PKCS12_BASE64` - base64-encoded Apple signing PKCS#12 for
+  non-ephemeral Apple signing
+- `MACOS_SIGNING_PASSWORD` - password for the PKCS#12
+- `MACOS_NOTARIZATION_AUTH_KEY` - base64-encoded App Store Connect API
+  private key (ECDSA P8)
+- `MACOS_NOTARIZATION_KEY_ID`, `MACOS_NOTARIZATION_ISSUER_ID` - identifiers
+  for the API key
+
+Without `GPG_KEY_FILE`, the build generates a short-lived ephemeral GPG key.
+Without `MACOS_SIGNING_PKCS12_BASE64`, it generates a throwaway self-signed
+PKCS#12 via `rcodesign generate-self-signed-certificate`. Without
+`MACOS_NOTARIZATION_AUTH_KEY`, it generates a throwaway ECDSA P8 key via
+`openssl`. Local builds therefore always exercise the signing and
+key-materialization paths, regardless of secret availability.
+
+### CI behavior
+
+`.github/workflows/build-macos-release.yml` triggers on:
+
+- **tag push** (`push: tags: ["*"]`) - builds the macOS release for the
+  pushed tag
+- **workflow_dispatch** - builds for an explicitly provided tag
+
+The workflow runs two jobs:
+
+1. `build-mac` (macos-14): builds the Mach-O binaries natively, uploads them
+   as the `macos-binaries` workflow artifact.
+2. `sign-publish` (ubuntu-24.04): downloads `macos-binaries`, materializes
+   Apple credentials, Apple-signs the binaries, runs the production
+   `build-zip-pkg.sh` to zip and GPG-sign, submits each zip to Apple's notary
+   service, then publishes `*.zip` and `*.zip.sig` to
+   `s3://${secrets.BUCKET}/macos/` and as GitHub workflow artifacts.
+
+The workflow imports `secrets.RPM_GPG_PRIVATE_KEY` for GPG signing and the
+sec-team-issued `secrets.MACOS_SIGNING_*` and `secrets.MACOS_NOTARIZATION_*`
+for Apple signing and notarization. An empty `RPM_GPG_PRIVATE_KEY` fails the
+workflow at the `Import GPG key` step (see *Fail-fast on missing GPG secret*
+below).
+
+## Conceptual model
+
+The macOS pipeline intentionally splits the build and sign-publish stages
+across two GitHub runner images rather than doing everything on a macOS
+runner.
+
+### Two-job split: `build-mac` and `sign-publish`
+
+| Job | Runner | Purpose |
+| --- | --- | --- |
+| `build-mac` | `macos-14` | native Mach-O build only |
+| `sign-publish` | `ubuntu-24.04` | Apple sign + GPG sign + notarize + upload |
+
+Apple signing, notarization, and publishing all run on Linux because:
+
+- `indygreg/apple-code-sign-action@v1` is a Node JS action and runs on any
+  runner that supports Node 20+
+- the underlying `rcodesign` tool is cross-platform and ships pre-built Linux
+  binaries for both `x86_64` and `aarch64`
+- macOS GitHub-hosted minutes are roughly 10× the price of Linux minutes; the
+  parts of the pipeline that do not require a Mach-O build environment should
+  not pay that premium
+
+### Credential lifecycle
+
+All Apple credentials and the GPG key are materialized into `mktemp` files
+and are explicitly removed by the workflow's `Cleanup` step (which runs
+`if: always()`). They are not echoed via `GITHUB_OUTPUT` and never reach
+either the GitHub Releases page or the `s3://${BUCKET}/macos/` prefix.
+
+The local validator mirrors this: ephemeral Apple PKCS#12, GPG private key,
+and ECDSA P8 are all written into a `mktemp -d` stage directory cleaned up by
+an `EXIT` trap. In particular, the encoded App Store Connect API key JSON
+(which contains the private key) is **never** copied to the bind-mounted
+`OUTPUT_DIR`; its shape is parse-checked inline before the stage directory
+is removed.
+
+### Artifact path arithmetic
+
+`actions/upload-artifact@v4+` strips the least-common-ancestor directory
+prefix when given multiple paths. So the upload step:
+
+```yaml
+- uses: actions/upload-artifact@v6
+  with:
+    name: macos-binaries
+    path: |
+      build/avalanchego
+      build/subnet-evm
+```
+
+produces an artifact whose internal entries are `avalanchego` and `subnet-evm`
+(without the `build/` prefix). The download step must restore that prefix:
+
+```yaml
+- uses: actions/download-artifact@v6
+  with:
+    name: macos-binaries
+    path: build
+```
+
+Downstream steps reference `build/avalanchego` and `build/subnet-evm`
+explicitly, so the `path: build` is load-bearing - using `path: .` would
+land the files at the workspace root and break the rest of the workflow.
+
+The production `build-zip-pkg.sh` then calls `7z a foo.zip build/avalanchego`,
+which preserves the `build/` prefix inside the zip. The validator therefore
+expects `build/<pkg>` as the internal entry when listing or extracting.
+
+### Same pipeline for local and CI
+
+The local validator (`build-macos-zip.sh`) invokes the production
+`.github/workflows/build-zip-pkg.sh` script unmodified. Local validation
+therefore exercises the same zip + GPG-sign code that runs in CI, not a copy.
+Behavioral divergence between local and CI is structurally avoided.
+
+The Apple-sign and notarize steps are not yet wrapped this way because they
+live inside the `indygreg/apple-code-sign-action@v1` Node JS action rather
+than in a separate script; the local validator invokes `rcodesign` directly
+with the same flag shapes the action uses.
+
+## Maintenance notes
+
+### Why `rcodesign` rather than Apple's `codesign`
+
+Apple's `codesign` only runs on macOS. The sign-publish job runs on Linux for
+cost reasons (see *Two-job split* above), so the signing tool must work on
+Linux. `rcodesign` (from `indygreg/apple-platform-rs`) is a pure-Rust
+re-implementation of Apple code-signing and notary submission that works
+without macOS. It is the same tool wrapped by
+`indygreg/apple-code-sign-action`, so using `rcodesign` directly in the local
+validator and via the action in CI keeps the underlying signing
+implementation consistent across both paths.
+
+### Why `indygreg/apple-code-sign-action@v1` is currently pinned by major tag
+
+The action is currently pinned to the floating `v1` tag rather than a full
+commit SHA. The pragmatic trade-off:
+
+- `v1` follows the same pinning pattern as other GitHub Actions in this
+  repository's release workflows (`actions/checkout@v5`,
+  `aws-actions/configure-aws-credentials@v6`, etc.). Internal consistency.
+- A retag of `v1` to a malicious commit would let an attacker exfiltrate the
+  PKCS#12 password and notarization API key. The action is on a personal
+  GitHub namespace (`indygreg/`), which is meaningfully higher supply-chain
+  risk than first-party `actions/*` and `aws-actions/*` pins.
+
+The tarball that `indygreg/apple-platform-rs` ships is already SHA256-pinned
+in the local validator's Dockerfile (`Dockerfile.macos-zip`), via the
+`*.sha256` sidecar from the release. The CI workflow itself does not yet
+SHA-pin either the action or the rcodesign tarball it downloads inline.
+
+When the upstream API stabilizes or supply-chain risk increases enough to
+justify the maintenance overhead, pin to a full commit SHA and enable
+Dependabot to update it.
+
+### Apple-sign / GPG-sign / notarize order
+
+The CI workflow performs the signing operations in this order, and the
+order is load-bearing:
+
+1. **Apple-sign each Mach-O binary** (`rcodesign sign` via the action). The
+   signature is embedded inside the Mach-O via the `LC_CODE_SIGNATURE` load
+   command.
+2. **Zip each binary and detached-GPG-sign the resulting zip**
+   (`build-zip-pkg.sh`). The GPG signature is over the zip bytes, which
+   include the already-Apple-signed Mach-O.
+3. **Submit each zip to Apple's notary service** (`rcodesign
+   notary-submit`). Apple's notary inspects the zip and approves it server-
+   side. For zip containers, the notarization ticket is not stapled into the
+   zip itself; the zip bytes are unchanged after notarization.
+
+Re-ordering would break the GPG signature: if notarization were to run
+before GPG-signing, any future Apple-side rewrite of the zip would silently
+invalidate the GPG signature; if zipping ran before Apple-signing, the
+Mach-O inside the zip would be unsigned.
+
+### Fail-fast on missing GPG secret
+
+The `Import GPG key` step asserts that `RPM_GPG_PRIVATE_KEY` is non-empty
+and that the materialized key file is non-zero-size before exporting
+`GPG_KEY_FILE` to `$GITHUB_ENV`.
+
+This is a deliberate guard against a previously-latent failure mode:
+
+- `printf '%s' "${RPM_GPG_PRIVATE_KEY}" > "${GPG_KEY_FILE}"` produces a
+  zero-byte file when the secret is empty.
+- `build-zip-pkg.sh` tests `[[ -s "${GPG_KEY_FILE}" ]]` and silently takes
+  the no-op signing branch on a zero-byte file (this branch is intentional;
+  it lets the script be reused in contexts that do not have a key).
+- The subsequent `Upload zips to S3` step in the workflow unconditionally
+  copies `*.zip` and then `*.zip.sig`. Without the precondition, `*.zip`
+  is published successfully and then the upload fails on the missing
+  `*.zip.sig`, leaving an unsigned zip in the release bucket.
+
+The precondition replaces "publish unsigned then error" with "fail at the
+import step with a clear message."
+
+### Why `secrets.RPM_GPG_PRIVATE_KEY` is shared with RPM signing
+
+The macOS zip workflow reuses the same GPG private key as the RPM packaging
+workflow rather than introducing a `MACOS_GPG_PRIVATE_KEY` secret.
+
+Rationale: the GPG key identifies *the project*, not the package format. End
+users who want to verify "is this artifact really from ava-labs?" use the
+same key whether they downloaded an RPM or a macOS zip (Linux tarballs are
+currently unsigned; if they ever gain GPG signing, the same key would
+naturally be reused). Maintaining two keys for the same provenance claim
+would create rotation and trust-chain complexity without a corresponding
+security benefit. The `RPM_GPG_PRIVATE_KEY` secret name predates macOS zip
+signing; renaming it would require coordinated changes across multiple
+workflows. The name is historical; the key is project-wide.
+
+If the project ever needs per-format signing keys (for example, to support
+different rotation cadences), the migration path is: add new format-specific
+secrets, update the workflows in lockstep, then remove `RPM_GPG_PRIVATE_KEY`.
+
+### `MACOS_SIGNING_*` and `MACOS_NOTARIZATION_*` are separate secret families
+
+Apple credentials are split into two families by the security team:
+
+| Family | Secrets | Purpose |
+| --- | --- | --- |
+| `MACOS_SIGNING_*` | `PKCS12_BASE64`, `PASSWORD` | PKCS#12 holding the Developer ID cert + private key used to sign binaries |
+| `MACOS_NOTARIZATION_*` | `AUTH_KEY`, `KEY_ID`, `ISSUER_ID` | App Store Connect API key used to submit binaries to Apple's notary service |
+
+The split reflects two different credential lifecycles:
+
+- The signing certificate is issued by Apple's Developer Program, lives in an
+  HSM/keyvault, and rotates on Apple's certificate-expiry schedule (typically
+  multi-year). Compromise of this certificate would let an attacker sign
+  software as the project.
+- The App Store Connect API key is project-managed, rotatable on the
+  project's own schedule, and only grants access to submit to Apple's
+  notarization service. Compromise of this key alone does not enable signing.
+
+Workflow-internal env vars (`APPLE_P12_FILE_B64`, `APPLE_API_KEY_B64`, etc.)
+intentionally use shorter, format-agnostic names so the credential-
+materialization logic stays readable. The `secrets.*` references at the
+boundary use the sec-team naming convention.
+
+### Local validator scope
+
+The local validator is intentionally "Tier 1": it exercises the parts of the
+pipeline that are reproducible offline. What it does and does not cover:
+
+| Part | Local validator | Why |
+| --- | --- | --- |
+| Apple-signing a Mach-O | yes, with `rcodesign generate-self-signed-certificate` | rcodesign does not check the trust chain at sign-time, so a self-signed cert exercises the same code path |
+| GPG-signing a zip + verifying | yes, with ephemeral RSA key | full roundtrip in `gpg --import` + `gpg --verify` |
+| `rcodesign encode-app-store-connect-api-key` | yes, with `openssl`-generated ECDSA P8 | encode step is purely local, no network |
+| `rcodesign notary-submit` (notarization) | no | hardcoded `https://appstoreconnect.apple.com/notary/v2/submissions` endpoint in `app-store-connect/src/notary_api.rs`; no `--dry-run`, no env-var endpoint override |
+
+Reaching Tier 2 (running the indygreg action via `act`) or Tier 3 (mocking
+the notary HTTPS endpoint) would require more infrastructure than the
+current Tier-1 setup. Tier 1 covers ~80% of the value at ~5% of the
+complexity: any divergence between local and CI for the signing/zip/GPG
+path will surface; only Apple's notary submission itself is untested
+locally.
+
+### Stub Mach-O binaries in the local validator
+
+The local validator does not depend on the real `avalanchego` or
+`subnet-evm` binaries being present. It cross-compiles a trivial three-line
+Go program (`package main; func main() {}`) twice with `GOOS=darwin
+GOARCH=arm64 CGO_ENABLED=0 go build` to produce real Mach-O binaries.
+
+The validator's purpose is to verify the *packaging* path - sign, zip,
+GPG-sign, encode, validate - not to test the real avalanchego binaries.
+Stub binaries make the test reproducible from any host (Linux or macOS),
+fast, and independent of upstream build state. Real binaries are signed
+and notarized only in the CI workflow on a tag push.
+
+### Architecture naming
+
+Three architecture naming schemes are in play and must stay aligned:
+
+| Context | x86 64-bit | ARM 64-bit |
+| --- | --- | --- |
+| `uname -m` | `x86_64` | `arm64` |
+| Go downloads | `amd64` | `arm64` |
+| rcodesign release assets | `x86_64-unknown-linux-musl` | `aarch64-unknown-linux-musl` |
+
+`scripts/build-macos-zip-builder-image.sh` normalizes between these
+conventions when fetching Go and rcodesign tarballs from upstream. The
+Dockerfile receives the normalized arch via `TARGETARCH` and re-derives the
+upstream-asset names from it. The mappings live in one place per file
+because each upstream uses its own convention.
+
+### Invariants to preserve
+
+If you change this area, preserve these unless you are intentionally
+revisiting the design:
+
+- the local validator invokes the production `build-zip-pkg.sh` script
+  unmodified, not a copy
+- `secrets.RPM_GPG_PRIVATE_KEY` is the GPG signing key for both RPM and
+  macOS zip artifacts
+- `actions/download-artifact@v6` uses `path: build` (not `.`) so downstream
+  references to `build/<pkg>` work
+- Apple-sign runs before GPG-sign, which runs before notarize
+- ephemeral credentials never leak from the stage directory to the bind-
+  mounted `OUTPUT_DIR` or the published artifacts
+- `Import GPG key` fails fast on an empty `RPM_GPG_PRIVATE_KEY` rather than
+  letting the no-op signing branch produce an unsigned release
+- the macOS Mach-O binaries are built natively on `macos-14`; all other
+  operations run on `ubuntu-24.04`
+
+### Revisit this design if
+
+The current design should be reconsidered if any of these change:
+
+- rcodesign gains a `--dry-run` flag or env-var endpoint override for
+  notarization (would enable a Tier 3 local mock)
+- Apple migrates away from an rcodesign-compatible API (would force a fall-
+  back to Apple's `notarytool` or `codesign`, which only run on macOS)
+- the security team rotates to a per-format GPG signing key (would require
+  splitting `RPM_GPG_PRIVATE_KEY` into format-specific secrets)
+- GPG signing moves to KMS / cloud-managed keys (would replace
+  `setup_gpg`'s key-import branch with a remote-signing branch)
+- macOS GitHub-hosted minutes become cost-competitive with Linux (would
+  collapse the two-job split back into one)
+- the project moves zip publishing off S3 / GitHub Releases to another
+  distribution channel
+
+## References
+
+### Repository entrypoints
+
+- Workflow: `/.github/workflows/build-macos-release.yml`
+- Production zip + GPG-sign script: `/.github/workflows/build-zip-pkg.sh`
+- Packaging Taskfile: `/.github/packaging/Taskfile.yml`
+- Builder image: `/.github/packaging/Dockerfile.macos-zip`
+- Builder-image bootstrap: `/.github/packaging/scripts/build-macos-zip-builder-image.sh`
+- Local validator build: `/.github/packaging/scripts/build-macos-zip.sh`
+- Local validator: `/.github/packaging/scripts/validate-macos-zip.sh`
+- Shared packaging helpers: `/.github/packaging/scripts/lib-build-common.sh`
+- Root task include: `/Taskfile.yml`
+
+### Upstream tooling
+
+- [`indygreg/apple-code-sign-action`](https://github.com/indygreg/apple-code-sign-action) - GitHub Action wrapping rcodesign
+- [`indygreg/apple-platform-rs`](https://github.com/indygreg/apple-platform-rs) - rcodesign source; relevant code paths: `apple-codesign/src/cli/mod.rs` (CLI surface), `app-store-connect/src/notary_api.rs` (hardcoded notary endpoint)
+- [`rcodesign` documentation](https://gregoryszorc.com/docs/apple-codesign/stable/) - including [certificate management](https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_certificate_management.html) and [signing reference](https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_rcodesign_signing.html)
+- [Apple notary service overview](https://developer.apple.com/documentation/security/customizing_the_notarization_workflow)

--- a/.github/packaging/rpm.md
+++ b/.github/packaging/rpm.md
@@ -1,0 +1,372 @@
+# RPM packaging
+
+## Overview
+
+This directory contains the RPM packaging implementation for AvalancheGo and
+Subnet-EVM.
+
+It exists to ship signed RPMs for RHEL 9.x-compatible systems without making
+future maintainers reconstruct the packaging model from CI YAML and shell
+scripts alone.
+
+This document is for two audiences:
+
+- **users/release engineers** who need to build or publish RPMs
+- **maintainers** who need to change the packaging implementation safely
+
+## Usage
+
+### What gets produced
+
+The packaging pipeline builds two RPMs per architecture:
+
+| Package | Installed path |
+| --- | --- |
+| `avalanchego` | `/var/opt/avalanchego/bin/avalanchego` |
+| `subnet-evm` | `/var/opt/avalanchego/plugins/<VM_ID>` |
+
+Both packages declare `glibc >= 2.34`.
+
+### Main entrypoints
+
+- CI workflow: `.github/workflows/build-linux-packages.yml` (unified RPM + DEB)
+- Build/validate composite action: `.github/packaging/actions/build-package/action.yml`
+- Packaging taskfile: `.github/packaging/Taskfile.yml`
+- Build script: `.github/packaging/scripts/build-package.sh`
+- Validation script: `.github/packaging/scripts/validate-rpm.sh`
+- nfpm package definitions: `.github/packaging/nfpm/*.yml`
+
+### Local build and validation
+
+Build and validate the full RPM pipeline locally with:
+
+```bash
+./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml test-build-rpms
+```
+
+Or, via the root Taskfile include:
+
+```bash
+task packaging:test-build-rpms
+```
+
+Useful environment variables:
+
+- `PACKAGING_TAG` - tag/version label to embed, defaults to `v0.0.0`
+- `GPG_KEY_FILE` - real signing key for non-ephemeral signing
+- `GPG_KEY_PASSPHRASE` - passphrase for the signing key
+
+Without `GPG_KEY_FILE`, the build generates a short-lived ephemeral GPG key
+so that local and PR builds still exercise the signing path.
+
+### CI behavior
+
+`.github/workflows/build-linux-packages.yml` builds both RPM and DEB packages
+from a single workflow (format × arch matrix delegating bulk work to
+`.github/packaging/actions/build-package`) and runs in three modes:
+
+- **tag push** - builds release RPMs for the pushed tag
+- **workflow_dispatch** - builds RPMs for an explicitly provided tag
+- **pull_request** - smoke-tests the packaging pipeline for changes under
+  `.github/packaging/` or the workflow itself
+
+PR builds use a synthetic tag (`v0.0.0-pr.<sha>`) and ephemeral signing.
+Non-PR builds import the real RPM signing key from Actions secrets and upload
+RPMs plus the exported public key as artifacts. See [`deb.md`](deb.md) for the
+DEB half of the same workflow.
+
+## Conceptual model
+
+The RPM pipeline intentionally treats packaging as a layer *around* the source
+release tree rather than as part of the historical release tree itself.
+
+The model is:
+
+1. Check out the source revision being packaged
+2. Build inside a Rocky Linux 9 container so the binary links against glibc 2.34
+3. Package with `nfpm`
+4. Sign the RPMs
+5. Validate by installing the built RPMs into a fresh Rocky Linux 9 container
+
+This directory is code-adjacent because the implementation lives here:
+Dockerfile, task entrypoints, package manifests, and shell scripts all evolve
+together.
+
+Two architecture naming schemes are in play and must stay aligned:
+
+| Context | x86_64 | arm64 |
+| --- | --- | --- |
+| `uname -m` / RPM | `x86_64` | `aarch64` |
+| Docker / Go downloads | `amd64` | `arm64` |
+
+The Taskfile normalizes host architecture to RPM names; the Dockerfile maps
+Docker `TARGETARCH` values to the names expected by upstream downloads.
+
+## Maintenance notes
+
+### Why the build uses Rocky Linux 9
+
+The packaging target is RHEL 9.x-compatible systems, so builds run in a
+`rockylinux:9` container and produce binaries linked against glibc 2.34.
+Building on the default GitHub runner image would instead link against the host
+Ubuntu glibc, which is too new for the intended target.
+
+Current supported architectures are:
+
+- `x86_64`
+- `aarch64`
+
+### Why the workflow overlays `.github/packaging` for manual tag builds
+
+`workflow_dispatch` accepts an arbitrary tag, including tags created before RPM
+packaging existed in this repository.
+
+Those older tags may not contain:
+
+- `.github/packaging/`
+- the current packaging scripts and nfpm manifests
+- the current packaging Dockerfile and helper logic
+
+To keep manual rebuilds of older releases possible, the workflow first checks
+out the requested tag as the source tree and then overlays `.github/packaging`
+from the workflow branch:
+
+1. `actions/checkout` of the requested tag into the workspace root
+2. second sparse checkout of `.github/packaging` into `.packaging-overlay`
+3. copy overlay contents into `.github/packaging` in the tagged tree
+4. run the current packaging pipeline against the historical source
+
+This is intentionally narrow: it overlays **only the packaging implementation**,
+not the rest of the branch. That lets maintainers improve packaging logic over
+time while still packaging historical source revisions.
+
+#### Implications for maintainers
+
+When changing `.github/packaging`, keep in mind that `workflow_dispatch` may run
+those scripts against trees that predate the packaging feature.
+
+Changes are safer when they depend only on repository interfaces that already
+exist across the intended release range, such as:
+
+- `scripts/build.sh`
+- `scripts/constants.sh`
+- `graft/subnet-evm/scripts/build.sh`
+- `graft/subnet-evm/scripts/constants.sh`
+
+If packaging changes need newer repository structure or newer build interfaces,
+manual rebuilds of older tags may stop working. If that trade-off is acceptable,
+document the cutoff explicitly in this README and in the workflow change.
+
+### Signing behavior
+
+RPMs are always built through the signing path.
+
+- **CI release/manual builds** import the real private key from
+  `secrets.RPM_GPG_PRIVATE_KEY`
+- **local and PR builds** generate an ephemeral RSA key with no passphrase
+
+This is deliberate: unsigned fast paths tend to rot, while always exercising the
+signing path keeps packaging validation closer to what is shipped.
+
+The build exports `GPG-KEY-avalanchego` next to the RPMs so validation and
+consumers can import the matching public key.
+
+### Validation strategy
+
+The main validation entrypoint is `test-build-rpms`, which:
+
+1. builds both RPMs
+2. starts a fresh `rockylinux:9` container
+3. imports the public key
+4. verifies RPM signatures
+5. installs both RPMs
+6. runs smoke tests on the installed binaries
+
+The smoke tests intentionally check a small set of high-value invariants:
+
+- the RPM can be installed on the target distro base
+- signature verification works
+- `avalanchego --version` runs and contains the built commit hash
+- the Subnet-EVM plugin is installed at the expected VM-ID-derived path
+- the plugin binary also reports the expected commit hash
+
+This does **not** replace broader AvalancheGo test coverage. It is specifically
+for validating that the packaging layer produced installable, correctly wired
+artifacts for the target runtime.
+
+### Binary linking rationale
+
+The current approach prefers **dynamic glibc linking** over static musl linking.
+This part of the design is worth documenting in more detail because future
+maintainers are likely to revisit alternative linking strategies, and the
+trade-offs are not recoverable from the packaging scripts alone.
+
+#### Problem the packaging layer is solving
+
+We need to ship RPMs for RHEL-family systems, but CI runners normally build on
+Ubuntu. Different distros ship different glibc versions, so a dynamically linked
+binary built against a newer Ubuntu glibc may not run on an older RHEL-family
+system. The packaging pipeline therefore builds inside `rockylinux:9` so the
+result targets glibc 2.34, which matches the current deployment baseline.
+
+#### Why dynamic glibc is the current choice
+
+- glibc compatibility is the practical constraint for RHEL-family deployment
+- glibc avoids taking on musl-specific performance and compatibility risk for a
+  performance-sensitive node binary
+- Go race-detector workflows remain compatible with glibc-based builds
+- binaries linked against older glibc generally run on newer glibc releases,
+  which is the compatibility direction we want for a RHEL 9 baseline
+
+#### Why not static musl right now
+
+Static musl would look attractive because it avoids host glibc dependencies, but
+it carries project-specific risks that future maintainers should assume are
+still live unless new evidence says otherwise:
+
+- musl allocator behavior can be materially worse under multithreaded load; for
+  a blockchain node, that is not a casual trade-off
+- musl's smaller default thread stacks have caused surprises in other CGO-heavy
+  projects
+- Go's race detector does not work with musl, which would complicate validation
+- the Firewood/FFI side of the build has historically been more naturally aligned
+  with `*-linux-gnu` targets than with a musl packaging path
+- we do not have a dedicated performance validation loop that would confidently
+  catch musl-induced regressions before release
+
+The important maintenance takeaway is: **do not switch to musl just because it
+seems simpler operationally unless there is fresh performance and compatibility
+validation to justify it.**
+
+#### Why not static glibc
+
+Static glibc avoids some musl concerns, but it does not remove the need to pick
+and validate against a glibc baseline. That means it does not actually solve the
+main portability problem that motivated the current containerized build. It also
+pushes the build into a less common and less well-exercised CGO deployment shape
+than the current dynamic-glibc approach.
+
+#### Container builds are the current stopgap
+
+Building in `rockylinux:9` is the current way to target the correct glibc.
+That does leave a residual maintenance concern: broad CI on Ubuntu is not the
+same thing as testing the final release binary on the exact same runtime used
+for packaging. The RPM smoke tests reduce that gap by verifying installation,
+signatures, and basic execution on Rocky Linux 9, but they are not a substitute
+for full release-path parity.
+
+The maintenance implication is that future changes should not assume the
+current packaging smoke tests fully eliminate host-vs-release-runtime
+divergence. They are a pragmatic guardrail, not proof that the entire release
+artifact path has become runtime-agnostic.
+
+#### Longer-term direction: hermetic Bazel toolchain
+
+The longer-term direction is still a hermetic Bazel toolchain that can make
+"test what you ship" easier without relying on containerized release-only build
+plumbing. The key design idea is that build and test should use the same glibc
+baseline regardless of the host runner image.
+
+Earlier design work also identified some likely rough edges for anyone revisiting
+that path, including Rust/CGO coordination, toolchain-selection bugs around
+non-default targets, and third-party native dependencies that may need extra
+Bazel integration work. The important point for repository documentation is not
+that each of those historical details must remain exhaustive forever, but that
+"move release builds into Bazel" is not a trivial mechanical swap.
+
+Future maintainers revisiting this area should treat the current container build
+as a practical bridge, not necessarily the final architecture.
+
+### Alternative approaches and trade-offs
+
+This section records alternative approaches that help explain the current design
+and may be relevant when future maintainers revisit packaging decisions:
+
+- **Build on the default GitHub runner** - this risks linking against a newer
+  host glibc than the target RHEL-family systems provide.
+- **Switch to static musl for portability** - this trades away known and
+  still-relevant performance, CGO, and validation properties without current
+  evidence that the trade is safe.
+- **Switch to static glibc** - this does not remove the need to choose and
+  validate a glibc baseline, so it does not solve the central compatibility
+  problem.
+- **Remove the workflow overlay for older tags** - that would drop the ability
+  to rebuild historical releases from before `.github/packaging` existed.
+
+### Invariants to preserve
+
+If you change this area, preserve these unless you are intentionally revisiting
+the design:
+
+- RPMs install under `/var/opt/avalanchego/...`
+- Subnet-EVM installs under the VM ID from
+  `graft/subnet-evm/scripts/constants.sh`
+- release builds target glibc 2.34 / Rocky Linux 9 compatibility
+- the same pipeline path is used for both local smoke testing and CI builds
+- manual tag builds continue to package historical source trees via the overlay
+  mechanism, unless a documented compatibility cutoff is introduced
+
+### Revisit this design if
+
+The current design should be reconsidered if any of these change:
+
+- the supported Linux distribution baseline moves away from RHEL 9.x / glibc 2.34
+- Bazel becomes the canonical release build path and can unify build and test
+  against the same glibc baseline
+- packaging needs to cover more historical tags than the current repository
+  interfaces can support
+- performance or compatibility data makes static linking newly attractive
+- historical rebuild compatibility is no longer a requirement, or a documented
+  cutoff replaces the current overlay behavior
+- release distribution needs move beyond GitHub Actions artifacts
+
+## References
+
+### Repository entrypoints
+
+- Workflow: `/.github/workflows/build-linux-packages.yml`
+- Build/validate composite action: `/.github/packaging/actions/build-package/action.yml`
+- Taskfile: `/.github/packaging/Taskfile.yml`
+- Builder image: `/.github/packaging/Dockerfile.rpm`
+- Build script: `/.github/packaging/scripts/build-package.sh`
+- Validation script: `/.github/packaging/scripts/validate-rpm.sh`
+- Shared packaging helpers: `/.github/packaging/scripts/lib-build-common.sh`
+- Root task include: `/Taskfile.yml`
+
+### Maintainer background for revisiting linking choices
+
+The maintainer-facing conclusions in this README are intended to stand on their
+own, but future revisits of static vs dynamic linking will go better if the
+underlying concern classes are easy to rediscover.
+
+The important background to preserve is:
+
+- **musl is not just a portability shortcut** - it changes allocator/runtime
+  behavior in ways that may matter for a performance-sensitive, multithreaded,
+  CGO-using node process
+- **musl changes the validation surface** - in particular, Go's race detector
+  is not available in the same way it is for the current glibc-based build/test
+  path
+- **static glibc is not a free escape hatch** - it still requires deliberate
+  compatibility validation and introduces its own libc caveats
+- **toolchain changes interact with CGO / Rust / non-default targets** - a
+  future hermetic or static-linking path should assume real integration work,
+  not a mechanical flag flip
+
+If you are actively reconsidering those choices, these references are useful
+starting points rather than normative design inputs:
+
+- musl allocator / performance concerns:
+  - <https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance/>
+  - <https://andygrove.io/2020/05/why-musl-extremely-slow/>
+- musl with Go static linking and race-detector limitations:
+  - <https://honnef.co/articles/statically-compiled-go-programs-always-even-with-cgo-using-musl/>
+- static glibc caveats:
+  - <https://developers.redhat.com/articles/2023/08/31/how-we-ensure-statically-linked-applications-stay-way>
+  - <https://tschottdorf.github.io/golang-static-linking-bug>
+- examples of CGO-heavy projects and trade-off discussion:
+  - <https://github.com/cockroachdb/cockroach/issues/3392>
+  - <https://www.dolthub.com/blog/2024-05-01-cgo-tradeoffs/>
+- toolchain rough edges that earlier exploration surfaced:
+  - <https://github.com/ziglang/zig/issues/12833>
+  - <https://github.com/bazelbuild/rules_rust/issues/2726>

--- a/.github/packaging/scripts/build-macos-zip-builder-image.sh
+++ b/.github/packaging/scripts/build-macos-zip-builder-image.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Build the macOS-zip validator Docker image with Go and rcodesign checksum
+# verification.
+#
+# Fetches the SHA256 checksum for the Go tarball from go.dev release metadata
+# and for rcodesign from its release sidecar file, then passes both to the
+# Docker build for integrity verification.
+#
+# Required env vars:
+#   GO_VERSION              - Go version to install (e.g., "1.24.12")
+#   APPLE_CODESIGN_VERSION  - rcodesign version (e.g., "0.28.0")
+#   DOCKER_IMAGE            - Name for the built Docker image
+#   CONTEXT_DIR             - Path to the Dockerfile directory
+#   DOCKERFILE              - Dockerfile name (e.g., "Dockerfile.macos-zip")
+
+set -euo pipefail
+
+: "${GO_VERSION:?GO_VERSION must be set}"
+: "${APPLE_CODESIGN_VERSION:?APPLE_CODESIGN_VERSION must be set}"
+: "${DOCKER_IMAGE:?DOCKER_IMAGE must be set}"
+: "${CONTEXT_DIR:?CONTEXT_DIR must be set}"
+: "${DOCKERFILE:?DOCKERFILE must be set (e.g. Dockerfile.macos-zip)}"
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not found on PATH" >&2; exit 1; }
+
+# Map host arch to Go's and rcodesign's naming conventions
+arch=$(uname -m)
+case "${arch}" in
+    x86_64)        goarch="amd64"; rcodesign_arch="x86_64-unknown-linux-musl" ;;
+    aarch64|arm64) goarch="arm64"; rcodesign_arch="aarch64-unknown-linux-musl" ;;
+    *) echo "Unsupported arch: ${arch}" >&2; exit 1 ;;
+esac
+
+# ── Go checksum ──────────────────────────────────────────────────────
+
+go_filename="go${GO_VERSION}.linux-${goarch}.tar.gz"
+echo "Fetching SHA256 checksum for ${go_filename}..."
+go_checksum=$(curl -fsSL "https://go.dev/dl/?mode=json&include=all" \
+    | jq -r --arg fn "${go_filename}" \
+          '[.[] | .files[] | select(.filename == $fn) | .sha256] | first')
+
+if [[ -z "${go_checksum}" || "${go_checksum}" == "null" ]]; then
+    echo "ERROR: Could not find checksum for ${go_filename}" >&2
+    exit 1
+fi
+echo "Go checksum: ${go_checksum}"
+
+# ── rcodesign checksum ───────────────────────────────────────────────
+
+rcodesign_filename="apple-codesign-${APPLE_CODESIGN_VERSION}-${rcodesign_arch}.tar.gz"
+# The tag uses a slash separator (apple-codesign/<ver>) that must be URL-
+# encoded as %2F in the download path.
+rcodesign_sha_url="https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${APPLE_CODESIGN_VERSION}/${rcodesign_filename}.sha256"
+echo "Fetching SHA256 checksum for ${rcodesign_filename}..."
+rcodesign_checksum=$(curl -fsSL "${rcodesign_sha_url}" | awk '{print $1}')
+
+if [[ -z "${rcodesign_checksum}" ]]; then
+    echo "ERROR: Could not fetch checksum for ${rcodesign_filename} from ${rcodesign_sha_url}" >&2
+    exit 1
+fi
+echo "rcodesign checksum: ${rcodesign_checksum}"
+
+# ── Build ───────────────────────────────────────────────────────────
+
+# The docker-container driver leaves the result in BuildKit cache unless we
+# explicitly load it into the local image store for the subsequent docker run.
+build_flags=()
+build_driver=$(
+    docker buildx inspect 2>/dev/null \
+        | awk '/^Driver:/ { print $2; exit }'
+) || true
+if [[ "${build_driver}" == "docker-container" ]]; then
+    build_flags+=(--load)
+fi
+
+docker build "${build_flags[@]}" \
+    --build-arg GO_VERSION="${GO_VERSION}" \
+    --build-arg GO_CHECKSUM="${go_checksum}" \
+    --build-arg APPLE_CODESIGN_VERSION="${APPLE_CODESIGN_VERSION}" \
+    --build-arg APPLE_CODESIGN_CHECKSUM="${rcodesign_checksum}" \
+    -f "${CONTEXT_DIR}/${DOCKERFILE}" \
+    -t "${DOCKER_IMAGE}" \
+    "${CONTEXT_DIR}"

--- a/.github/packaging/scripts/build-macos-zip-builder-image.sh
+++ b/.github/packaging/scripts/build-macos-zip-builder-image.sh
@@ -3,9 +3,9 @@
 # Build the macOS-zip validator Docker image with Go and rcodesign checksum
 # verification.
 #
-# Fetches the SHA256 checksum for the Go tarball from go.dev release metadata
-# and for rcodesign from its release sidecar file, then passes both to the
-# Docker build for integrity verification.
+# Fetches the SHA256 checksum for the Go tarball from go.dev release metadata,
+# uses a repo-pinned digest for rcodesign, then passes both to the Docker build
+# for integrity verification.
 #
 # Required env vars:
 #   GO_VERSION              - Go version to install (e.g., "1.24.12")
@@ -24,13 +24,27 @@ set -euo pipefail
 
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not found on PATH" >&2; exit 1; }
 
-# Map host arch to Go's and rcodesign's naming conventions
+# Map host arch to Go's naming convention, and pin the rcodesign release-tarball
+# SHA256 per arch. The digests are pinned in this repo
+# (rather than fetched from the release's own .sha256 sidecar) so a retagged or
+# replaced upstream release cannot swap the signing binary. Keep in sync with
+# APPLE_CODESIGN_SHA256 / APPLE_CODESIGN_PKG_VERSION in
+# .github/workflows/build-macos-release.yml. Digests are version-specific.
+readonly PINNED_APPLE_CODESIGN_VERSION="0.28.0"
 arch=$(uname -m)
 case "${arch}" in
-    x86_64)        goarch="amd64"; rcodesign_arch="x86_64-unknown-linux-musl" ;;
-    aarch64|arm64) goarch="arm64"; rcodesign_arch="aarch64-unknown-linux-musl" ;;
+    x86_64)        goarch="amd64"; rcodesign_checksum="d0f0e4c7915295a1e79fc8b775b354c76d621a52da4c6b841dc9f0585de06cca" ;;
+    aarch64|arm64) goarch="arm64"; rcodesign_checksum="1d3550680c0444b24b1387753f46efc7dcdb336f9001dbde4508f1c58da90b81" ;;
     *) echo "Unsupported arch: ${arch}" >&2; exit 1 ;;
 esac
+
+# The pinned digests above are only valid for one rcodesign version. Fail loudly
+# if the requested version has drifted, rather than verifying against the wrong
+# digest.
+if [[ "${APPLE_CODESIGN_VERSION}" != "${PINNED_APPLE_CODESIGN_VERSION}" ]]; then
+    echo "ERROR: no pinned rcodesign digest for version ${APPLE_CODESIGN_VERSION} (pinned: ${PINNED_APPLE_CODESIGN_VERSION}); update the digests in $(basename "$0")" >&2
+    exit 1
+fi
 
 # ── Go checksum ──────────────────────────────────────────────────────
 
@@ -45,21 +59,7 @@ if [[ -z "${go_checksum}" || "${go_checksum}" == "null" ]]; then
     exit 1
 fi
 echo "Go checksum: ${go_checksum}"
-
-# ── rcodesign checksum ───────────────────────────────────────────────
-
-rcodesign_filename="apple-codesign-${APPLE_CODESIGN_VERSION}-${rcodesign_arch}.tar.gz"
-# The tag uses a slash separator (apple-codesign/<ver>) that must be URL-
-# encoded as %2F in the download path.
-rcodesign_sha_url="https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${APPLE_CODESIGN_VERSION}/${rcodesign_filename}.sha256"
-echo "Fetching SHA256 checksum for ${rcodesign_filename}..."
-rcodesign_checksum=$(curl -fsSL "${rcodesign_sha_url}" | awk '{print $1}')
-
-if [[ -z "${rcodesign_checksum}" ]]; then
-    echo "ERROR: Could not fetch checksum for ${rcodesign_filename} from ${rcodesign_sha_url}" >&2
-    exit 1
-fi
-echo "rcodesign checksum: ${rcodesign_checksum}"
+echo "rcodesign checksum (pinned): ${rcodesign_checksum}"
 
 # ── Build ───────────────────────────────────────────────────────────
 

--- a/.github/packaging/scripts/build-macos-zip.sh
+++ b/.github/packaging/scripts/build-macos-zip.sh
@@ -108,6 +108,9 @@ done
 # branching (same path RPM/DEB packaging uses). The production script
 # (build-zip-pkg.sh) reads GPG_KEY_FILE and GPG_PASSPHRASE.
 
+# setup_gpg (called below) materializes the signing key at NFPM_SIGNING_KEY:
+# it writes the freshly-generated ephemeral key there, or copies the provided
+# key file to that path. Everything downstream reads the key from this path.
 INPUT_GPG_KEY_FILE="${GPG_KEY_FILE:-}"
 export NFPM_SIGNING_KEY="${STAGE}/gpg-signing-key.asc"
 export GPG_PASSPHRASE="${GPG_KEY_PASSPHRASE:-}"
@@ -139,13 +142,13 @@ done
 
 # ── App Store Connect API key encoding ──────────────────────────────
 #
-# Exercises the workflow's `Materialize Apple credentials` step's
-# encode-app-store-connect-api-key call. Purely local — no network.
+# Exercises the encode-app-store-connect-api-key call the workflow's
+# `Notarize zips` step performs. Purely local, no network.
 #
 # The output JSON contains the private signing key, so we keep it inside
 # the ephemeral STAGE (cleaned up by the EXIT trap) and never write it
 # to the bind-mounted OUTPUT_DIR. That mirrors the production workflow,
-# which mktemps these credentials and rms them in its Cleanup step.
+# which mktemps these credentials and removes them via the step's EXIT trap.
 # The parse-check happens inline here, while the file is still alive.
 
 APPLE_P8="${STAGE}/notarization.p8"

--- a/.github/packaging/scripts/build-macos-zip.sh
+++ b/.github/packaging/scripts/build-macos-zip.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+# Build and sign macOS zip archives inside the macos-zip-builder container.
+#
+# Exercises the same packaging path as the build-macos-release workflow's
+# sign-publish job, but with self-generated credentials where Apple's real
+# ones aren't available locally. Produces:
+#   ${OUTPUT_DIR}/{avalanchego,subnet-evm}-macos-${TAG}.zip{,.sig}
+#   ${OUTPUT_DIR}/GPG-KEY-avalanchego.asc
+
+set -euo pipefail
+
+: "${TAG:?TAG must be set (git tag, e.g. v0.0.0)}"
+: "${OUTPUT_DIR:?OUTPUT_DIR must be set (bind-mounted output dir)}"
+
+REPO_ROOT="/build"
+PACKAGING_DIR="${REPO_ROOT}/.github/packaging"
+
+# shellcheck disable=SC1091
+source "${PACKAGING_DIR}/scripts/lib-build-common.sh"
+
+# Self-signed P12 password used when MACOS_SIGNING_PASSWORD is not provided.
+readonly EPHEMERAL_P12_PASSWORD="avalanchego-ephemeral-p12-password"
+
+# Throwaway issuer/key IDs used when real notarization credentials aren't
+# provided. rcodesign encode-app-store-connect-api-key does not validate
+# the issuer or key id format — it just wraps them into a JSON blob.
+readonly EPHEMERAL_NOTARIZATION_KEY_ID="EPHEMERAL_KEY_ID"
+readonly EPHEMERAL_NOTARIZATION_ISSUER="00000000-0000-0000-0000-000000000000"
+
+# Mark the bind-mounted source tree as git-safe so the script can read
+# the production build-zip-pkg.sh from the repo. We do NOT call the
+# project's full init_build_env (it sources constants.sh + git_commit.sh
+# for the real binary build, which we don't perform here).
+if ! git -C "${REPO_ROOT}" rev-parse HEAD &>/dev/null; then
+    git config --global --add safe.directory "${REPO_ROOT}"
+fi
+
+# Working directory for staging the stub binaries and zip outputs. Kept
+# OUTSIDE the bind-mounted repo so writes don't pierce the host's git tree.
+STAGE="$(mktemp -d /tmp/macos-zip-build.XXXXXXXX)"
+trap 'rm -rf "${STAGE}"' EXIT
+
+echo "=== Building macOS zips (tag: ${TAG}, stage: ${STAGE}) ==="
+
+# ── Stub Mach-O binaries ─────────────────────────────────────────────
+#
+# Cross-compile trivial Mach-O binaries so this test runs reproducibly on
+# both Linux and macOS dev hosts. The point of this validator is to
+# exercise the *packaging* path (sign + zip + GPG-sign), not to package
+# the real avalanchego binary — for that, push a tag and let the
+# build-macos-release workflow do it on a real macos-14 runner.
+
+mkdir -p "${STAGE}/build"
+cat > "${STAGE}/stub.go" <<'EOF'
+package main
+
+func main() {}
+EOF
+
+echo "Cross-compiling Mach-O stubs (darwin/arm64)..."
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 \
+    go build -o "${STAGE}/build/avalanchego" "${STAGE}/stub.go"
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 \
+    go build -o "${STAGE}/build/subnet-evm"  "${STAGE}/stub.go"
+
+# Confirm the cross-compile actually produced Mach-O (`file` ships in the
+# image precisely so this assertion is meaningful).
+file "${STAGE}/build/avalanchego" "${STAGE}/build/subnet-evm"
+
+# ── Apple code-signing ──────────────────────────────────────────────
+#
+# When MACOS_SIGNING_PKCS12_BASE64 is provided, use it (exercises the
+# workflow's real-cert path). Otherwise generate a throwaway self-signed
+# certificate (proves the workflow's signing step is wired correctly;
+# the resulting signature is parseable by rcodesign verify but won't be
+# trusted by Apple's notary or Gatekeeper).
+
+APPLE_P12="${STAGE}/macos-signing.p12"
+APPLE_P12_PASSWORD=""
+
+if [[ -n "${MACOS_SIGNING_PKCS12_BASE64:-}" ]]; then
+    echo "Materializing provided macOS signing P12..."
+    printf '%s' "${MACOS_SIGNING_PKCS12_BASE64}" | base64 -d > "${APPLE_P12}"
+    APPLE_P12_PASSWORD="${MACOS_SIGNING_PASSWORD:-}"
+else
+    echo "Generating throwaway self-signed macOS signing certificate..."
+    APPLE_P12_PASSWORD="${EPHEMERAL_P12_PASSWORD}"
+    rcodesign generate-self-signed-certificate \
+        --p12-file "${APPLE_P12}" \
+        --p12-password "${APPLE_P12_PASSWORD}" \
+        --validity-days 1 \
+        --person-name "AvalancheGo Local Test (ephemeral)"
+fi
+
+for pkg in avalanchego subnet-evm; do
+    echo "Apple-signing ${pkg}..."
+    rcodesign sign \
+        --p12-file "${APPLE_P12}" \
+        --p12-password "${APPLE_P12_PASSWORD}" \
+        --code-signature-flags runtime \
+        "${STAGE}/build/${pkg}"
+done
+
+# ── GPG signing + zip via the production script ─────────────────────
+#
+# Reuse lib-build-common.sh::setup_gpg to handle ephemeral/provided-key
+# branching (same path RPM/DEB packaging uses). The production script
+# (build-zip-pkg.sh) reads GPG_KEY_FILE and GPG_PASSPHRASE.
+
+INPUT_GPG_KEY_FILE="${GPG_KEY_FILE:-}"
+export NFPM_SIGNING_KEY="${STAGE}/gpg-signing-key.asc"
+export GPG_PASSPHRASE="${GPG_KEY_PASSPHRASE:-}"
+
+if [[ -z "${INPUT_GPG_KEY_FILE}" ]]; then
+    use_ephemeral_gpg_passphrase "GPG_PASSPHRASE"
+fi
+
+setup_gpg "${INPUT_GPG_KEY_FILE}" "${OUTPUT_DIR}/GPG-KEY-avalanchego.asc" "MacOS-Zip"
+
+# After setup_gpg, the signing key lives at NFPM_SIGNING_KEY (whether
+# ephemeral or copied from the provided key file).
+export GPG_KEY_FILE="${NFPM_SIGNING_KEY}"
+
+echo "Invoking production build-zip-pkg.sh in stage dir..."
+(
+    cd "${STAGE}"
+    TAG="${TAG}" \
+    GPG_KEY_FILE="${GPG_KEY_FILE}" \
+    GPG_PASSPHRASE="${GPG_PASSPHRASE}" \
+        bash "${REPO_ROOT}/.github/workflows/build-zip-pkg.sh"
+)
+
+# Move zip + sig outputs from stage to the bind-mounted OUTPUT_DIR.
+for pkg in avalanchego subnet-evm; do
+    cp "${STAGE}/${pkg}-macos-${TAG}.zip"     "${OUTPUT_DIR}/"
+    cp "${STAGE}/${pkg}-macos-${TAG}.zip.sig" "${OUTPUT_DIR}/"
+done
+
+# ── App Store Connect API key encoding ──────────────────────────────
+#
+# Exercises the workflow's `Materialize Apple credentials` step's
+# encode-app-store-connect-api-key call. Purely local — no network.
+#
+# The output JSON contains the private signing key, so we keep it inside
+# the ephemeral STAGE (cleaned up by the EXIT trap) and never write it
+# to the bind-mounted OUTPUT_DIR. That mirrors the production workflow,
+# which mktemps these credentials and rms them in its Cleanup step.
+# The parse-check happens inline here, while the file is still alive.
+
+APPLE_P8="${STAGE}/notarization.p8"
+APPLE_API_KEY_JSON="${STAGE}/api-key.json"
+APPLE_KEY_ID=""
+APPLE_ISSUER=""
+
+if [[ -n "${MACOS_NOTARIZATION_AUTH_KEY:-}" ]]; then
+    echo "Materializing provided notarization API key..."
+    printf '%s' "${MACOS_NOTARIZATION_AUTH_KEY}" | base64 -d > "${APPLE_P8}"
+    APPLE_KEY_ID="${MACOS_NOTARIZATION_KEY_ID:?MACOS_NOTARIZATION_KEY_ID required when AUTH_KEY provided}"
+    APPLE_ISSUER="${MACOS_NOTARIZATION_ISSUER_ID:?MACOS_NOTARIZATION_ISSUER_ID required when AUTH_KEY provided}"
+else
+    echo "Generating throwaway ECDSA P8 + key id + issuer id..."
+    openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "${APPLE_P8}"
+    APPLE_KEY_ID="${EPHEMERAL_NOTARIZATION_KEY_ID}"
+    APPLE_ISSUER="${EPHEMERAL_NOTARIZATION_ISSUER}"
+fi
+
+echo "Encoding App Store Connect API key..."
+rcodesign encode-app-store-connect-api-key \
+    --output-path "${APPLE_API_KEY_JSON}" \
+    "${APPLE_ISSUER}" "${APPLE_KEY_ID}" "${APPLE_P8}"
+
+# Parse-check the encoded JSON in-place. Field names vary across rcodesign
+# versions, so we just assert it parses; the encode step itself succeeding
+# is the real signal.
+echo "Parse-checking encoded API key JSON..."
+jq -e . "${APPLE_API_KEY_JSON}" >/dev/null
+
+# ── Post-conditions ─────────────────────────────────────────────────
+
+assert_files_exist "${OUTPUT_DIR}" \
+    "avalanchego-macos-${TAG}.zip" \
+    "avalanchego-macos-${TAG}.zip.sig" \
+    "subnet-evm-macos-${TAG}.zip" \
+    "subnet-evm-macos-${TAG}.zip.sig" \
+    "GPG-KEY-avalanchego.asc"
+
+echo "=== macOS zip build complete ==="
+ls -la "${OUTPUT_DIR}"

--- a/.github/packaging/scripts/validate-macos-zip.sh
+++ b/.github/packaging/scripts/validate-macos-zip.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Post-build validation of macOS zip packages.
+#
+# Verifies the artifacts produced by build-macos-zip.sh by spinning a
+# fresh container, importing the exported GPG public key, verifying each
+# detached signature against its zip, listing the zip contents, and
+# running rcodesign verify on the extracted Mach-O binaries.
+
+set -euo pipefail
+
+: "${TAG:?TAG must be set (Git tag, e.g. v0.0.0)}"
+: "${PACKAGING_DOCKER_IMAGE:?PACKAGING_DOCKER_IMAGE must be set (validator image)}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MACOS_DIR="${REPO_ROOT}/build/macos"
+SCRIPTS_DIR="${REPO_ROOT}/.github/packaging/scripts"
+
+# shellcheck disable=SC1091
+source "${SCRIPTS_DIR}/lib-build-common.sh"
+
+assert_files_exist "${MACOS_DIR}" \
+    "avalanchego-macos-${TAG}.zip" \
+    "avalanchego-macos-${TAG}.zip.sig" \
+    "subnet-evm-macos-${TAG}.zip" \
+    "subnet-evm-macos-${TAG}.zip.sig" \
+    "GPG-KEY-avalanchego.asc"
+
+echo "=== Validating macOS zips in fresh container ==="
+# The validator container reuses the builder image because the
+# verification tools (gpg, 7z, rcodesign, jq) are the same toolchain
+# that the workflow ships in its sign-publish job. Each docker run is
+# fresh, so no builder-side state leaks in.
+docker run --rm \
+    -v "${MACOS_DIR}:/macos:ro" \
+    -e TAG="${TAG}" \
+    "${PACKAGING_DOCKER_IMAGE}" \
+    bash -euxc '
+        WORK=$(mktemp -d)
+        cd "${WORK}"
+
+        # ── GPG signature verification ────────────────────────────
+        # Use an isolated GNUPGHOME so we exercise the same trust path
+        # a downstream consumer would: import the public key, verify.
+        export GNUPGHOME=$(mktemp -d)
+        gpg --batch --import /macos/GPG-KEY-avalanchego.asc
+
+        for pkg in avalanchego subnet-evm; do
+            echo "Verifying GPG signature for ${pkg}..."
+            gpg --batch --verify \
+                "/macos/${pkg}-macos-${TAG}.zip.sig" \
+                "/macos/${pkg}-macos-${TAG}.zip"
+        done
+
+        # ── Zip content sanity ────────────────────────────────────
+        # build-zip-pkg.sh calls "7z a ... build/<pkg>" so the
+        # internal entry preserves the build/ prefix.
+        for pkg in avalanchego subnet-evm; do
+            echo "Listing contents of ${pkg}-macos-${TAG}.zip..."
+            7z l "/macos/${pkg}-macos-${TAG}.zip" | grep -q "build/${pkg}\$"
+        done
+
+        # ── Apple signature parseability (rcodesign verify) ───────
+        # Self-signed signatures verify structurally; trust chain is
+        # not checked by rcodesign verify (it would be by Apple notary).
+        for pkg in avalanchego subnet-evm; do
+            echo "Extracting and rcodesign-verifying ${pkg}..."
+            rm -rf build
+            7z x "/macos/${pkg}-macos-${TAG}.zip" -y >/dev/null
+            file "build/${pkg}" | grep -q "Mach-O"
+            rcodesign verify "build/${pkg}"
+        done
+
+        # API key JSON shape check happens inline in build-macos-zip.sh,
+        # against the ephemeral STAGE copy — the file holds a private
+        # signing key when real notarization creds are provided, so it
+        # never makes it to the bind-mounted OUTPUT_DIR.
+
+        echo "All macOS zip validations passed."
+    '
+
+echo "=== macOS zip validation complete ==="

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -11,23 +11,62 @@ on:
         required: true
   push:
     tags:
-      - "*"
+      # Release tags only. This job signs with the real Apple + GPG keys and
+      # publishes to S3, so it must not fire on arbitrary/non-release tags
+      # (matches build-linux-packages.yml).
+      - "v*"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # The macOS packaging Taskfile greps APPLE_CODESIGN_PKG_VERSION out of this
+  # file (PACKAGING_APPLE_CODESIGN_VERSION in .github/packaging/Taskfile.yml) so
+  # the local validator and CI pin the same rcodesign version. If you rename or
+  # reformat this line, update that awk expression too.
   APPLE_CODESIGN_PKG_VERSION: "0.28.0"
+  # SHA256 of the pinned rcodesign linux x86_64 release tarball, pinned in this
+  # repo so a retagged or replaced upstream release cannot swap the signing
+  # binary. Verifying against the release's own .sha256 sidecar would only catch
+  # transfer corruption, not upstream compromise. Update this together with
+  # APPLE_CODESIGN_PKG_VERSION (and the per-arch digests in the packaging
+  # builder-image script, build-macos-zip-builder-image.sh).
+  APPLE_CODESIGN_SHA256: "d0f0e4c7915295a1e79fc8b775b354c76d621a52da4c6b841dc9f0585de06cca"
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Build the macOS binaries on a native macOS runner. Apple notarization and
-  # GPG signing happen in the downstream sign-publish job on Linux.
+  # GPG signing happen in the downstream sign job on Linux.
   build-mac:
     runs-on: macos-14
     permissions:
       contents: read
 
     steps:
+      # For workflow_dispatch, build the source tree at the requested tag rather
+      # than the default branch (mirrors build-linux-packages.yml). Tag-push
+      # events already check out the pushed tag by default.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      # Defense in depth: workflow_dispatch accepts an arbitrary ref and the
+      # sign-publish job imports the real Apple + GPG signing keys. Refuse to
+      # proceed unless a dispatched input names an actual tag in origin, so the
+      # keys can never sign arbitrary branch content. Tag-push events are already
+      # constrained to refs/tags/* by the `on:` filter.
+      - name: Assert dispatch input is a released tag
+        if: github.event.inputs.tag
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+        shell: bash
+        run: |
+          if [[ ! "${TAG_INPUT}" =~ ^v[0-9] ]]; then
+            echo "ERROR: tag input '${TAG_INPUT}' must start with 'v<digit>' (e.g. v1.14.1)" >&2
+            exit 1
+          fi
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${TAG_INPUT}" >/dev/null; then
+            echo "ERROR: '${TAG_INPUT}' is not a tag in origin; refusing to build/sign a non-tag ref" >&2
+            exit 1
+          fi
+
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 
@@ -48,18 +87,46 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # Apple-sign + notarize + GPG-sign + publish. Runs on Linux because
-  # indygreg/apple-code-sign-action is a JS action (node20) and the
-  # underlying rcodesign tool is cross-platform.
-  sign-publish:
+  # Apple-sign + notarize + GPG-sign. Runs on Linux because rcodesign is
+  # cross-platform (no macOS host needed) and Linux runner minutes are ~10x
+  # cheaper than macOS. This job holds the Apple + GPG signing secrets but is
+  # NOT granted id-token: write; S3 publishing is a separate job so the AWS OIDC
+  # token is never present in a job that runs packaging scripts (mirrors
+  # build-linux-packages.yml's upload-debs-s3 split).
+  sign:
     runs-on: ubuntu-24.04
     needs: build-mac
     permissions:
-      id-token: write
       contents: read
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
 
     steps:
+      # Check out the release tag (not the dispatch-selected ref) so the
+      # packaging script that runs below with the signing secrets comes from the
+      # tag, not an arbitrary branch (mirrors build-linux-packages.yml's
+      # secret-bearing job).
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      # Refuse a non-tag dispatch input before any signing secret is
+      # materialized. Tag-push events are already constrained to refs/tags/v* by
+      # the `on:` filter.
+      - name: Assert dispatch input is a released tag
+        if: github.event.inputs.tag
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+        shell: bash
+        run: |
+          if [[ ! "${TAG_INPUT}" =~ ^v[0-9] ]]; then
+            echo "ERROR: tag input '${TAG_INPUT}' must start with 'v<digit>' (e.g. v1.14.1)" >&2
+            exit 1
+          fi
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${TAG_INPUT}" >/dev/null; then
+            echo "ERROR: '${TAG_INPUT}' is not a tag in origin; refusing to build/sign a non-tag ref" >&2
+            exit 1
+          fi
 
       - name: Download macOS binaries
         uses: actions/download-artifact@v6
@@ -67,21 +134,27 @@ jobs:
           name: macos-binaries
           path: build
 
+      # actions/upload-artifact + download-artifact do not preserve the Unix
+      # executable bit, so the binaries come back non-executable and must be
+      # re-marked before they can be signed and zipped.
       - name: Restore executable bits
         run: chmod +x build/avalanchego build/subnet-evm
 
-      - name: Try to get tag from git
-        if: "${{ github.event.inputs.tag == '' }}"
-        run: |
-          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Try to get tag from workflow dispatch
-        if: "${{ github.event.inputs.tag != '' }}"
+      # Resolve the tag from the dispatch input or the pushed ref, and expose it
+      # as a job output so the downstream publish job can name the S3 objects.
+      - name: Resolve tag
+        id: tag
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          echo "TAG=${INPUT_TAG}" >> "$GITHUB_ENV"
+          set -euo pipefail
+          if [[ -n "${INPUT_TAG}" ]]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "TAG=${TAG}" >> "$GITHUB_ENV"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Install rcodesign and 7zip
@@ -92,133 +165,103 @@ jobs:
           ARCHIVE="apple-codesign-${APPLE_CODESIGN_PKG_VERSION}-x86_64-unknown-linux-musl"
           # Release tag uses a slash separator (apple-codesign/0.28.0) which must
           # be URL-encoded as %2F in the download path.
-          curl -fsSL -o /tmp/rcodesign.tar.gz \
-            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${APPLE_CODESIGN_PKG_VERSION}/${ARCHIVE}.tar.gz"
+          BASE="https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${APPLE_CODESIGN_PKG_VERSION}"
+          curl -fsSL -o /tmp/rcodesign.tar.gz "${BASE}/${ARCHIVE}.tar.gz"
+          # Verify against the digest pinned in this repo (APPLE_CODESIGN_SHA256),
+          # not the upstream .sha256 sidecar: a compromised release could replace
+          # the tarball and its sidecar together, so trusting the sidecar only
+          # guards against transfer corruption.
+          echo "${APPLE_CODESIGN_SHA256}  /tmp/rcodesign.tar.gz" | sha256sum -c -
           tar -xzf /tmp/rcodesign.tar.gz -C /tmp/
           sudo install "/tmp/${ARCHIVE}/rcodesign" /usr/local/bin/rcodesign
           rcodesign --version
         shell: bash
 
-      - name: Materialize Apple credentials
+      # Apple-sign each Mach-O binary with the already-installed rcodesign (same
+      # tool, flags, and P12 the local validator uses in build-macos-zip.sh).
+      # The P12 is materialized inside this step and removed by the EXIT trap, so
+      # it is never on disk while later steps run checked-out packaging code. The
+      # hardened-runtime flag is required for Apple notarization to accept the
+      # binary later.
+      - name: Apple-sign binaries
         env:
           APPLE_P12_FILE_B64: ${{ secrets.MACOS_SIGNING_PKCS12_BASE64 }}
-          APPLE_API_KEY_B64:  ${{ secrets.MACOS_NOTARIZATION_AUTH_KEY }}
-          APPLE_ISSUER:       ${{ secrets.MACOS_NOTARIZATION_ISSUER_ID }}
-          APPLE_KEY_ID:       ${{ secrets.MACOS_NOTARIZATION_KEY_ID }}
+          APPLE_P12_PASSWORD: ${{ secrets.MACOS_SIGNING_PASSWORD }}
         run: |
           set -euo pipefail
           p12="$(mktemp --suffix=.p12)"
           chmod 600 "$p12"
+          trap 'rm -f "$p12"' EXIT
           printf '%s' "$APPLE_P12_FILE_B64" | base64 -d > "$p12"
-
-          p8="$(mktemp --suffix=.p8)"
-          chmod 600 "$p8"
-          printf '%s' "$APPLE_API_KEY_B64" | base64 -d > "$p8"
-
-          json="$(mktemp --suffix=.json)"
-          chmod 600 "$json"
-          rcodesign encode-app-store-connect-api-key \
-            --output-path "$json" \
-            "$APPLE_ISSUER" "$APPLE_KEY_ID" "$p8"
-
-          {
-            echo "APPLE_P12_FILE_PATH=$p12"
-            echo "APPLE_P8_FILE_PATH=$p8"
-            echo "APPLE_API_KEY_JSON_PATH=$json"
-          } >> "$GITHUB_ENV"
+          for bin in avalanchego subnet-evm; do
+            echo "Apple-signing ${bin}..."
+            rcodesign sign \
+              --p12-file "$p12" \
+              --p12-password "$APPLE_P12_PASSWORD" \
+              --code-signature-flags runtime \
+              "build/${bin}"
+          done
         shell: bash
 
-      - name: Import GPG key
+      # Materialize the GPG key inside this step (removed by the EXIT trap) and
+      # run the production zip + GPG-sign script. Fail fast on an empty key
+      # rather than letting build-zip-pkg.sh's no-op branch produce an unsigned
+      # zip that the S3 upload would then publish without a signature.
+      - name: Build zips and GPG-sign
         env:
+          TAG: ${{ env.TAG }}
           RPM_GPG_PRIVATE_KEY: ${{ secrets.RPM_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
         run: |
           set -euo pipefail
-          # Fail fast on an empty/unset secret rather than silently
-          # propagating to build-zip-pkg.sh's no-op signing branch
-          # (which would publish unsigned zips before the Upload step
-          # errors on the missing .sig).
           if [[ -z "${RPM_GPG_PRIVATE_KEY:-}" ]]; then
             echo "ERROR: RPM_GPG_PRIVATE_KEY secret is required but unset/empty" >&2
             exit 1
           fi
           GPG_KEY_FILE="$(mktemp)"
-          chmod 600 "${GPG_KEY_FILE}"
-          printf '%s' "${RPM_GPG_PRIVATE_KEY}" > "${GPG_KEY_FILE}"
-          if [[ ! -s "${GPG_KEY_FILE}" ]]; then
+          chmod 600 "$GPG_KEY_FILE"
+          trap 'rm -f "$GPG_KEY_FILE"' EXIT
+          printf '%s' "$RPM_GPG_PRIVATE_KEY" > "$GPG_KEY_FILE"
+          if [[ ! -s "$GPG_KEY_FILE" ]]; then
             echo "ERROR: GPG key file is empty after writing the secret" >&2
             exit 1
           fi
-          printf 'GPG_KEY_FILE=%s\n' "${GPG_KEY_FILE}" >> "$GITHUB_ENV"
+          export GPG_KEY_FILE
+          ./.github/workflows/build-zip-pkg.sh
         shell: bash
 
-      - name: Apple-sign avalanchego binary
-        uses: indygreg/apple-code-sign-action@v1
-        with:
-          input_path: build/avalanchego
-          sign: true
-          notarize: false
-          p12_file: ${{ env.APPLE_P12_FILE_PATH }}
-          p12_password: ${{ secrets.MACOS_SIGNING_PASSWORD }}
-          sign_args: |
-            --code-signature-flags
-            runtime
-          rcodesign_version: ${{ env.APPLE_CODESIGN_PKG_VERSION }}
-
-      - name: Apple-sign subnet-evm binary
-        uses: indygreg/apple-code-sign-action@v1
-        with:
-          input_path: build/subnet-evm
-          sign: true
-          notarize: false
-          p12_file: ${{ env.APPLE_P12_FILE_PATH }}
-          p12_password: ${{ secrets.MACOS_SIGNING_PASSWORD }}
-          sign_args: |
-            --code-signature-flags
-            runtime
-          rcodesign_version: ${{ env.APPLE_CODESIGN_PKG_VERSION }}
-
-      - name: Build zips and GPG-sign
-        run: ./.github/workflows/build-zip-pkg.sh
+      # Submit each zip to Apple's notary service. The App Store Connect API key
+      # is materialized here (removed by the EXIT trap) rather than up front,
+      # because it is not needed until now; this keeps it off disk while the
+      # packaging script above runs. --wait fails the step if Apple rejects the
+      # asset. Zips are not stapled (the ticket lives server-side for zip
+      # containers), so the zip bytes are unchanged and the GPG signature stays
+      # valid.
+      - name: Notarize zips
         env:
           TAG: ${{ env.TAG }}
-          GPG_KEY_FILE: ${{ env.GPG_KEY_FILE }}
-          GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
-
-      - name: Notarize avalanchego zip
-        uses: indygreg/apple-code-sign-action@v1
-        with:
-          input_path: avalanchego-macos-${{ env.TAG }}.zip
-          sign: false
-          notarize: true
-          app_store_connect_api_key_json_file: ${{ env.APPLE_API_KEY_JSON_PATH }}
-          rcodesign_version: ${{ env.APPLE_CODESIGN_PKG_VERSION }}
-
-      - name: Notarize subnet-evm zip
-        uses: indygreg/apple-code-sign-action@v1
-        with:
-          input_path: subnet-evm-macos-${{ env.TAG }}.zip
-          sign: false
-          notarize: true
-          app_store_connect_api_key_json_file: ${{ env.APPLE_API_KEY_JSON_PATH }}
-          rcodesign_version: ${{ env.APPLE_CODESIGN_PKG_VERSION }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
-          role-session-name: githubrolesession
-          aws-region: us-east-1
-
-      - name: Upload zips to S3
-        env:
-          BUCKET: ${{ secrets.BUCKET }}
-          TAG:    ${{ env.TAG }}
+          APPLE_API_KEY_B64: ${{ secrets.MACOS_NOTARIZATION_AUTH_KEY }}
+          APPLE_ISSUER:      ${{ secrets.MACOS_NOTARIZATION_ISSUER_ID }}
+          APPLE_KEY_ID:      ${{ secrets.MACOS_NOTARIZATION_KEY_ID }}
         run: |
           set -euo pipefail
+          p8="$(mktemp --suffix=.p8)"
+          json="$(mktemp --suffix=.json)"
+          chmod 600 "$p8" "$json"
+          trap 'rm -f "$p8" "$json"' EXIT
+          printf '%s' "$APPLE_API_KEY_B64" | base64 -d > "$p8"
+          rcodesign encode-app-store-connect-api-key \
+            --output-path "$json" \
+            "$APPLE_ISSUER" "$APPLE_KEY_ID" "$p8"
+          rm -f "$p8"
           for name in avalanchego subnet-evm; do
-            aws s3 cp "${name}-macos-${TAG}.zip"     "s3://${BUCKET}/macos/"
-            aws s3 cp "${name}-macos-${TAG}.zip.sig" "s3://${BUCKET}/macos/"
+            echo "Notarizing ${name}-macos-${TAG}.zip..."
+            rcodesign notary-submit \
+              --api-key-file "$json" \
+              --wait \
+              "${name}-macos-${TAG}.zip"
           done
+        shell: bash
 
       - name: Save avalanchego as Github artifact
         uses: actions/upload-artifact@v6
@@ -236,12 +279,54 @@ jobs:
             subnet-evm-macos-${{ env.TAG }}.zip
             subnet-evm-macos-${{ env.TAG }}.zip.sig
 
+      # Each signing secret is materialized inside its own step and removed by
+      # that step's EXIT trap (on success or failure), so only the extracted
+      # binaries need cleaning up here.
       - name: Cleanup
         if: always()
+        run: rm -rf ./build
+
+  # Publish the signed zips to S3. Isolated from the signing job so that
+  # id-token: write (AWS OIDC) is never present in a job that holds signing
+  # secrets or runs packaging scripts (mirrors build-linux-packages.yml's
+  # upload-debs-s3 split). It only consumes the already-signed artifacts.
+  publish:
+    runs-on: ubuntu-24.04
+    needs: sign
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download signed avalanchego zip
+        uses: actions/download-artifact@v6
+        with:
+          name: avalanchego-macos
+          path: .
+
+      - name: Download signed subnet-evm zip
+        uses: actions/download-artifact@v6
+        with:
+          name: subnet-evm-macos
+          path: .
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
+          role-session-name: githubrolesession
+          aws-region: us-east-1
+
+      - name: Upload zips to S3
+        env:
+          BUCKET: ${{ secrets.BUCKET }}
+          TAG:    ${{ needs.sign.outputs.tag }}
         run: |
-          rm -f \
-            "${GPG_KEY_FILE:-}" \
-            "${APPLE_P12_FILE_PATH:-}" \
-            "${APPLE_P8_FILE_PATH:-}" \
-            "${APPLE_API_KEY_JSON_PATH:-}"
-          rm -rf ./build
+          set -euo pipefail
+          # Upload the detached signature before the zip. A .sig with no .zip is
+          # harmless, but a .zip with no .sig would be a consumable unsigned
+          # artifact, so the zip must land last.
+          for name in avalanchego subnet-evm; do
+            aws s3 cp "${name}-macos-${TAG}.zip.sig" "s3://${BUCKET}/macos/"
+            aws s3 cp "${name}-macos-${TAG}.zip"     "s3://${BUCKET}/macos/"
+          done

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -44,6 +44,26 @@ jobs:
         working-directory: ./graft/subnet-evm
         run: ./scripts/run_task.sh build
 
+      - name: Install aws cli
+        run: |
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          sudo installer -pkg AWSCLIV2.pkg -target /
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
+          role-session-name: githubrolesession
+          aws-region: us-east-1
+
+      - name: Import GPG key
+        run: |
+          GPG_KEY_FILE="$(mktemp)"
+          chmod 600 "${GPG_KEY_FILE}"
+          printf '%s' "${{ secrets.RPM_GPG_PRIVATE_KEY }}" > "${GPG_KEY_FILE}"
+          printf 'GPG_KEY_FILE=%s\n' "${GPG_KEY_FILE}" >> "$GITHUB_ENV"
+        shell: bash
+
       - name: Try to get tag from git
         if: "${{ github.event.inputs.tag == '' }}"
         id: get_tag_from_git
@@ -58,50 +78,34 @@ jobs:
           echo "TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Create avalanchego zip file
-        run: 7z a "avalanchego-macos-${TAG}.zip" build/avalanchego
+      - name: Create zip packages and upload to S3
+        run: ./.github/workflows/build-zip-pkg.sh
         env:
           TAG: ${{ env.TAG }}
-
-      - name: Create subnet-evm zip file
-        run: 7z a "subnet-evm-macos-${TAG}.zip" build/subnet-evm
-        env:
-          TAG: ${{ env.TAG }}
-
-      - name: Install aws cli
-        run: |
-          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-          sudo installer -pkg AWSCLIV2.pkg -target /
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
-          role-session-name: githubrolesession
-          aws-region: us-east-1
-
-      - name: Upload avalanchego to S3
-        run: aws s3 cp avalanchego-macos-${{ env.TAG }}.zip "s3://${BUCKET}/macos/"
-        env:
           BUCKET: ${{ secrets.BUCKET }}
-
-      - name: Upload subnet-evm to S3
-        run: aws s3 cp subnet-evm-macos-${{ env.TAG }}.zip "s3://${BUCKET}/macos/"
-        env:
-          BUCKET: ${{ secrets.BUCKET }}
+          GPG_KEY_FILE: ${{ env.GPG_KEY_FILE }}
+          GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
 
       - name: Save avalanchego as Github artifact
         uses: actions/upload-artifact@v6
         with:
           name: avalanchego-macos
-          path: avalanchego-macos-${{ env.TAG }}.zip
+          path: |
+            avalanchego-macos-${{ env.TAG }}.zip
+            avalanchego-macos-${{ env.TAG }}.zip.sig
 
       - name: Save subnet-evm as Github artifact
         uses: actions/upload-artifact@v6
         with:
           name: subnet-evm-macos
-          path: subnet-evm-macos-${{ env.TAG }}.zip
+          path: |
+            subnet-evm-macos-${{ env.TAG }}.zip
+            subnet-evm-macos-${{ env.TAG }}.zip.sig
 
       - name: Cleanup
+        if: always()
         run: |
+          if [[ -n "${GPG_KEY_FILE:-}" ]]; then
+            rm -f "${GPG_KEY_FILE}"
+          fi
           rm -rf ./build

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -15,28 +15,22 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  APPLE_CODESIGN_PKG_VERSION: "0.28.0"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  # Build the macOS binaries on a native macOS runner. Apple notarization and
+  # GPG signing happen in the downstream sign-publish job on Linux.
   build-mac:
-    # Build release artifacts on the oldest macOS version still receiving Apple
-    # security updates to maximize the chance that shipped binaries remain usable
-    # on older supported macOS versions. CI validation can track newer macOS
-    # releases independently.
     runs-on: macos-14
     permissions:
-      id-token: write
       contents: read
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 
-      # Runs a single command using the runners shell
       - name: Build the avalanchego binary
         run: ./scripts/run_task.sh build
 
@@ -44,10 +38,169 @@ jobs:
         working-directory: ./graft/subnet-evm
         run: ./scripts/run_task.sh build
 
-      - name: Install aws cli
+      - name: Upload macOS binaries
+        uses: actions/upload-artifact@v6
+        with:
+          name: macos-binaries
+          path: |
+            build/avalanchego
+            build/subnet-evm
+          retention-days: 1
+          if-no-files-found: error
+
+  # Apple-sign + notarize + GPG-sign + publish. Runs on Linux because
+  # indygreg/apple-code-sign-action is a JS action (node20) and the
+  # underlying rcodesign tool is cross-platform.
+  sign-publish:
+    runs-on: ubuntu-24.04
+    needs: build-mac
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download macOS binaries
+        uses: actions/download-artifact@v6
+        with:
+          name: macos-binaries
+          path: build
+
+      - name: Restore executable bits
+        run: chmod +x build/avalanchego build/subnet-evm
+
+      - name: Try to get tag from git
+        if: "${{ github.event.inputs.tag == '' }}"
         run: |
-          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Try to get tag from workflow dispatch
+        if: "${{ github.event.inputs.tag != '' }}"
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          echo "TAG=${INPUT_TAG}" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Install rcodesign and 7zip
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends p7zip-full
+          ARCHIVE="apple-codesign-${APPLE_CODESIGN_PKG_VERSION}-x86_64-unknown-linux-musl"
+          # Release tag uses a slash separator (apple-codesign/0.28.0) which must
+          # be URL-encoded as %2F in the download path.
+          curl -fsSL -o /tmp/rcodesign.tar.gz \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${APPLE_CODESIGN_PKG_VERSION}/${ARCHIVE}.tar.gz"
+          tar -xzf /tmp/rcodesign.tar.gz -C /tmp/
+          sudo install "/tmp/${ARCHIVE}/rcodesign" /usr/local/bin/rcodesign
+          rcodesign --version
+        shell: bash
+
+      - name: Materialize Apple credentials
+        env:
+          APPLE_P12_FILE_B64: ${{ secrets.MACOS_SIGNING_PKCS12_BASE64 }}
+          APPLE_API_KEY_B64:  ${{ secrets.MACOS_NOTARIZATION_AUTH_KEY }}
+          APPLE_ISSUER:       ${{ secrets.MACOS_NOTARIZATION_ISSUER_ID }}
+          APPLE_KEY_ID:       ${{ secrets.MACOS_NOTARIZATION_KEY_ID }}
+        run: |
+          set -euo pipefail
+          p12="$(mktemp --suffix=.p12)"
+          chmod 600 "$p12"
+          printf '%s' "$APPLE_P12_FILE_B64" | base64 -d > "$p12"
+
+          p8="$(mktemp --suffix=.p8)"
+          chmod 600 "$p8"
+          printf '%s' "$APPLE_API_KEY_B64" | base64 -d > "$p8"
+
+          json="$(mktemp --suffix=.json)"
+          chmod 600 "$json"
+          rcodesign encode-app-store-connect-api-key \
+            --output-path "$json" \
+            "$APPLE_ISSUER" "$APPLE_KEY_ID" "$p8"
+
+          {
+            echo "APPLE_P12_FILE_PATH=$p12"
+            echo "APPLE_P8_FILE_PATH=$p8"
+            echo "APPLE_API_KEY_JSON_PATH=$json"
+          } >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Import GPG key
+        env:
+          RPM_GPG_PRIVATE_KEY: ${{ secrets.RPM_GPG_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          # Fail fast on an empty/unset secret rather than silently
+          # propagating to build-zip-pkg.sh's no-op signing branch
+          # (which would publish unsigned zips before the Upload step
+          # errors on the missing .sig).
+          if [[ -z "${RPM_GPG_PRIVATE_KEY:-}" ]]; then
+            echo "ERROR: RPM_GPG_PRIVATE_KEY secret is required but unset/empty" >&2
+            exit 1
+          fi
+          GPG_KEY_FILE="$(mktemp)"
+          chmod 600 "${GPG_KEY_FILE}"
+          printf '%s' "${RPM_GPG_PRIVATE_KEY}" > "${GPG_KEY_FILE}"
+          if [[ ! -s "${GPG_KEY_FILE}" ]]; then
+            echo "ERROR: GPG key file is empty after writing the secret" >&2
+            exit 1
+          fi
+          printf 'GPG_KEY_FILE=%s\n' "${GPG_KEY_FILE}" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Apple-sign avalanchego binary
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: build/avalanchego
+          sign: true
+          notarize: false
+          p12_file: ${{ env.APPLE_P12_FILE_PATH }}
+          p12_password: ${{ secrets.MACOS_SIGNING_PASSWORD }}
+          sign_args: |
+            --code-signature-flags
+            runtime
+          rcodesign_version: ${{ env.APPLE_CODESIGN_PKG_VERSION }}
+
+      - name: Apple-sign subnet-evm binary
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: build/subnet-evm
+          sign: true
+          notarize: false
+          p12_file: ${{ env.APPLE_P12_FILE_PATH }}
+          p12_password: ${{ secrets.MACOS_SIGNING_PASSWORD }}
+          sign_args: |
+            --code-signature-flags
+            runtime
+          rcodesign_version: ${{ env.APPLE_CODESIGN_PKG_VERSION }}
+
+      - name: Build zips and GPG-sign
+        run: ./.github/workflows/build-zip-pkg.sh
+        env:
+          TAG: ${{ env.TAG }}
+          GPG_KEY_FILE: ${{ env.GPG_KEY_FILE }}
+          GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
+
+      - name: Notarize avalanchego zip
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: avalanchego-macos-${{ env.TAG }}.zip
+          sign: false
+          notarize: true
+          app_store_connect_api_key_json_file: ${{ env.APPLE_API_KEY_JSON_PATH }}
+          rcodesign_version: ${{ env.APPLE_CODESIGN_PKG_VERSION }}
+
+      - name: Notarize subnet-evm zip
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: subnet-evm-macos-${{ env.TAG }}.zip
+          sign: false
+          notarize: true
+          app_store_connect_api_key_json_file: ${{ env.APPLE_API_KEY_JSON_PATH }}
+          rcodesign_version: ${{ env.APPLE_CODESIGN_PKG_VERSION }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -56,35 +209,16 @@ jobs:
           role-session-name: githubrolesession
           aws-region: us-east-1
 
-      - name: Import GPG key
-        run: |
-          GPG_KEY_FILE="$(mktemp)"
-          chmod 600 "${GPG_KEY_FILE}"
-          printf '%s' "${{ secrets.RPM_GPG_PRIVATE_KEY }}" > "${GPG_KEY_FILE}"
-          printf 'GPG_KEY_FILE=%s\n' "${GPG_KEY_FILE}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Try to get tag from git
-        if: "${{ github.event.inputs.tag == '' }}"
-        id: get_tag_from_git
-        run: |
-          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Try to get tag from workflow dispatch
-        if: "${{ github.event.inputs.tag != '' }}"
-        id: get_tag_from_workflow
-        run: |
-          echo "TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Create zip packages and upload to S3
-        run: ./.github/workflows/build-zip-pkg.sh
+      - name: Upload zips to S3
         env:
-          TAG: ${{ env.TAG }}
           BUCKET: ${{ secrets.BUCKET }}
-          GPG_KEY_FILE: ${{ env.GPG_KEY_FILE }}
-          GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
+          TAG:    ${{ env.TAG }}
+        run: |
+          set -euo pipefail
+          for name in avalanchego subnet-evm; do
+            aws s3 cp "${name}-macos-${TAG}.zip"     "s3://${BUCKET}/macos/"
+            aws s3 cp "${name}-macos-${TAG}.zip.sig" "s3://${BUCKET}/macos/"
+          done
 
       - name: Save avalanchego as Github artifact
         uses: actions/upload-artifact@v6
@@ -105,7 +239,9 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          if [[ -n "${GPG_KEY_FILE:-}" ]]; then
-            rm -f "${GPG_KEY_FILE}"
-          fi
+          rm -f \
+            "${GPG_KEY_FILE:-}" \
+            "${APPLE_P12_FILE_PATH:-}" \
+            "${APPLE_P8_FILE_PATH:-}" \
+            "${APPLE_API_KEY_JSON_PATH:-}"
           rm -rf ./build

--- a/.github/workflows/build-zip-pkg.sh
+++ b/.github/workflows/build-zip-pkg.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# ── GPG setup ────────────────────────────────────────────────────
+#
+# When GPG_KEY_FILE is set and non-empty, import the key and define
+# a sign_archive() helper. Otherwise, define a no-op stub.
+
+if [[ -n "${GPG_KEY_FILE:-}" && -s "${GPG_KEY_FILE}" ]]; then
+    GNUPGHOME=$(mktemp -d)
+    export GNUPGHOME
+    trap 'gpgconf --kill gpg-agent 2>/dev/null || true; rm -rf "${GNUPGHOME}"' EXIT
+
+    echo "Importing GPG key for archive signing..."
+    gpg --batch --import "${GPG_KEY_FILE}"
+
+    sign_archive() {
+        local archive="$1"
+        echo "Signing ${archive}..."
+        printf '%s' "${GPG_PASSPHRASE:-}" | gpg --batch --yes --detach-sign \
+            --pinentry-mode loopback \
+            --passphrase-fd 0 \
+            "${archive}"
+        echo "Verifying signature for ${archive}..."
+        gpg --batch --verify "${archive}.sig" "${archive}"
+    }
+
+    GPG_SIGNING_ENABLED=true
+else
+    echo "No GPG key provided, skipping archive signing."
+    sign_archive() { :; }
+    GPG_SIGNING_ENABLED=false
+fi
+
+# ── Build avalanchego zip ────────────────────────────────────────
+
+echo "Build avalanchego zip package..."
+echo "Tag: $TAG"
+7z a "avalanchego-macos-${TAG}.zip" build/avalanchego
+sign_archive "avalanchego-macos-${TAG}.zip"
+aws s3 cp "avalanchego-macos-${TAG}.zip" "s3://${BUCKET}/macos/"
+if [[ "$GPG_SIGNING_ENABLED" == "true" ]]; then
+    aws s3 cp "avalanchego-macos-${TAG}.zip.sig" "s3://${BUCKET}/macos/"
+fi
+
+# ── Build subnet-evm zip ────────────────────────────────────────
+
+echo "Build subnet-evm zip package..."
+7z a "subnet-evm-macos-${TAG}.zip" build/subnet-evm
+sign_archive "subnet-evm-macos-${TAG}.zip"
+aws s3 cp "subnet-evm-macos-${TAG}.zip" "s3://${BUCKET}/macos/"
+if [[ "$GPG_SIGNING_ENABLED" == "true" ]]; then
+    aws s3 cp "subnet-evm-macos-${TAG}.zip.sig" "s3://${BUCKET}/macos/"
+fi

--- a/.github/workflows/build-zip-pkg.sh
+++ b/.github/workflows/build-zip-pkg.sh
@@ -25,12 +25,9 @@ if [[ -n "${GPG_KEY_FILE:-}" && -s "${GPG_KEY_FILE}" ]]; then
         echo "Verifying signature for ${archive}..."
         gpg --batch --verify "${archive}.sig" "${archive}"
     }
-
-    GPG_SIGNING_ENABLED=true
 else
     echo "No GPG key provided, skipping archive signing."
     sign_archive() { :; }
-    GPG_SIGNING_ENABLED=false
 fi
 
 # ── Build avalanchego zip ────────────────────────────────────────
@@ -39,17 +36,9 @@ echo "Build avalanchego zip package..."
 echo "Tag: $TAG"
 7z a "avalanchego-macos-${TAG}.zip" build/avalanchego
 sign_archive "avalanchego-macos-${TAG}.zip"
-aws s3 cp "avalanchego-macos-${TAG}.zip" "s3://${BUCKET}/macos/"
-if [[ "$GPG_SIGNING_ENABLED" == "true" ]]; then
-    aws s3 cp "avalanchego-macos-${TAG}.zip.sig" "s3://${BUCKET}/macos/"
-fi
 
 # ── Build subnet-evm zip ────────────────────────────────────────
 
 echo "Build subnet-evm zip package..."
 7z a "subnet-evm-macos-${TAG}.zip" build/subnet-evm
 sign_archive "subnet-evm-macos-${TAG}.zip"
-aws s3 cp "subnet-evm-macos-${TAG}.zip" "s3://${BUCKET}/macos/"
-if [[ "$GPG_SIGNING_ENABLED" == "true" ]]; then
-    aws s3 cp "subnet-evm-macos-${TAG}.zip.sig" "s3://${BUCKET}/macos/"
-fi


### PR DESCRIPTION
macOS release zips were published to S3 unsigned and un-notarized. This PR:

- Apple code-signs the `avalanchego` and `subnet-evm` Mach-O binaries with the hardened-runtime flag (`rcodesign`).
- Submits each macOS zip to Apple's notary service.
- Adds detached GPG signatures (`.zip.sig`) over each zip, reusing `secrets.RPM_GPG_PRIVATE_KEY` (project-wide).
- Fails fast at the `Import GPG key` step when the secret is empty (closes a latent path that would have published unsigned zips).
- Adds `task packaging:test-build-macos-zip` — runs the production zip + GPG-sign script unmodified in Docker with ephemeral credentials, so the pipeline is locally verifiable on any host.

Closes #5161.

## Design and rationale

[`.github/packaging/macos-zip.md`](https://github.com/ava-labs/avalanchego/blob/PlatCore/5161-add-signing-macos-binaries/.github/packaging/macos-zip.md) — full doc (overview, usage, conceptual model, maintenance notes). The packaging directory README is now an [index](https://github.com/ava-labs/avalanchego/blob/PlatCore/5161-add-signing-macos-binaries/.github/packaging/README.md) pointing at the per-format docs.

## How this was tested

- `task packaging:test-build-macos-zip` end-to-end (cold start ~16s, exit 0).
- Negative path: empty `GPG_KEY_FILE` fails fast at `setup_gpg`; validator surfaces the missing `.sig` from `build-zip-pkg.sh`'s no-op branch.
- `shellcheck -x` and `actionlint -shellcheck=` clean.
- 80/80 PR checks green on the rebased tip.

## RELEASES.md

Yes — a new artifact shape ships (`.zip.sig` sidecars, signed/notarized binaries). Consumers verifying provenance will need to know about the sigs.
