### PR TITLE
test(sae): Address legacypool race

### DIFF
--- a/vms/saevm/sae/BUILD.bazel
+++ b/vms/saevm/sae/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "go_test")
 
 # gazelle:exclude accept_block_test.go
+# gazelle:exclude worstcase_test.go
 
 go_library(
     name = "sae",
@@ -77,7 +78,6 @@ go_test(
         "rpc_test.go",
         "tx_test.go",
         "vm_test.go",
-        "worstcase_test.go",
     ],
     embed = [":sae"],
     deps = [
@@ -104,7 +104,6 @@ go_test(
         "//vms/saevm/gastime",
         "//vms/saevm/hook",
         "//vms/saevm/hook/hookstest",
-        "//vms/saevm/intmath",
         "//vms/saevm/params",
         "//vms/saevm/sae/rpc",
         "//vms/saevm/saedb",
@@ -112,7 +111,6 @@ go_test(
         "//vms/saevm/saetest/escrow",
         "//vms/saevm/txgossip/txgossiptest",
         "//vms/saevm/types",
-        "//vms/saevm/worstcase",
         "@com_github_arr4n_shed//testerr",
         "@com_github_ava_labs_libevm//:libevm",
         "@com_github_ava_labs_libevm//common",
@@ -145,7 +143,7 @@ go_test(
 )
 
 go_test(
-    name = "accept_block_test",
+    name = "flaky_test",
     srcs = [
         "accept_block_test.go",
         "always_test.go",
@@ -160,9 +158,9 @@ go_test(
         "vm_test.go",
         "worstcase_test.go",
     ],
-    args = ["-test.run=TestAcceptBlock"],
+    args = ["-test.run=TestAcceptBlock|TestWorstCase"],
     embed = [":sae"],
-    env = {"SAEVM_TEST_ACCEPT_BLOCK": "1"},
+    env = {"SAEVM_TEST_FLAKY": "1"},
     flaky = True,
     deps = [
         "//database",

--- a/vms/saevm/sae/BUILD.bazel
+++ b/vms/saevm/sae/BUILD.bazel
@@ -143,7 +143,7 @@ go_test(
 )
 
 go_test(
-    name = "flaky_test",
+    name = "flaky_tests",
     srcs = [
         "accept_block_test.go",
         "always_test.go",

--- a/vms/saevm/sae/accept_block_test.go
+++ b/vms/saevm/sae/accept_block_test.go
@@ -24,8 +24,8 @@ func TestAcceptBlock(t *testing.T) {
 	// TODO(JonathanOppenheimer): determine whether this test is actually flaky
 	// or whether there's a bug in the test. This test is enabled in Bazel and
 	// disabled in go test.
-	if os.Getenv("SAEVM_TEST_ACCEPT_BLOCK") == "" {
-		t.Skip("FLAKY: set SAEVM_TEST_ACCEPT_BLOCK to run")
+	if os.Getenv("SAEVM_TEST_FLAKY") == "" {
+		t.Skip("FLAKY: set SAEVM_TEST_FLAKY to run")
 	}
 
 	// We use a generous timeout because GC finalizers from previous tests take

--- a/vms/saevm/sae/rpc_test.go
+++ b/vms/saevm/sae/rpc_test.go
@@ -812,19 +812,22 @@ func TestGetReceipts(t *testing.T) {
 			GasPrice: big.NewInt(1),
 		})
 		txs = append(txs, tx1, tx2)
-		want = append(want, &types.Receipt{
-			TxHash:            tx1.Hash(),
-			Status:            types.ReceiptStatusSuccessful,
-			GasUsed:           params.TxGas,
-			EffectiveGasPrice: big.NewInt(2),
-			Logs:              []*types.Log{},
-		}, &types.Receipt{
-			TxHash:            tx2.Hash(),
-			Status:            types.ReceiptStatusSuccessful,
-			GasUsed:           params.TxGas,
-			EffectiveGasPrice: big.NewInt(1),
-			Logs:              []*types.Log{},
-		})
+		want = append(want, []*types.Receipt{
+			{
+				TxHash:            tx1.Hash(),
+				Status:            types.ReceiptStatusSuccessful,
+				GasUsed:           params.TxGas,
+				EffectiveGasPrice: big.NewInt(2),
+				Logs:              []*types.Log{},
+			},
+			{
+				TxHash:            tx2.Hash(),
+				Status:            types.ReceiptStatusSuccessful,
+				GasUsed:           params.TxGas,
+				EffectiveGasPrice: big.NewInt(1),
+				Logs:              []*types.Log{},
+			},
+		}...)
 	}
 
 	slice := func(t *testing.T, from, to int) (*blocks.Block, []*types.Receipt) {

--- a/vms/saevm/sae/rpc_test.go
+++ b/vms/saevm/sae/rpc_test.go
@@ -789,22 +789,37 @@ func TestGetReceipts(t *testing.T) {
 
 	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 	precompileOpt, unblock := withBlockingPrecompile(blockingPrecompile)
-	ctx, sut := newSUT(t, 1, timeOpt, precompileOpt)
+	ctx, sut := newSUT(t, 2, timeOpt, precompileOpt)
 	t.Cleanup(unblock)
 
 	var (
 		txs  []*types.Transaction
 		want []*types.Receipt
 	)
-	for range 6 {
-		tx := sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+	// The mempool cannot be relied on to mark a transaction as pending
+	// if there is already a pending transaction with the same account.
+	// To avoid this, we use two different accounts and price the
+	// transactions such that the builder will maintain ordering.
+	for range 3 {
+		tx1 := sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+			To:       &zeroAddr,
+			Gas:      params.TxGas,
+			GasPrice: big.NewInt(2), // ensure this tx is first in block
+		})
+		tx2 := sut.wallet.SetNonceAndSign(t, 1, &types.LegacyTx{
 			To:       &zeroAddr,
 			Gas:      params.TxGas,
 			GasPrice: big.NewInt(1),
 		})
-		txs = append(txs, tx)
+		txs = append(txs, tx1, tx2)
 		want = append(want, &types.Receipt{
-			TxHash:            tx.Hash(),
+			TxHash:            tx1.Hash(),
+			Status:            types.ReceiptStatusSuccessful,
+			GasUsed:           params.TxGas,
+			EffectiveGasPrice: big.NewInt(2),
+			Logs:              []*types.Log{},
+		}, &types.Receipt{
+			TxHash:            tx2.Hash(),
 			Status:            types.ReceiptStatusSuccessful,
 			GasUsed:           params.TxGas,
 			EffectiveGasPrice: big.NewInt(1),
@@ -825,7 +840,6 @@ func TestGetReceipts(t *testing.T) {
 			r.BlockNumber = b.Number()
 			r.TransactionIndex = uint(i) //#nosec G115 -- Known non-negative
 		}
-		require.NoError(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
 		return b, rs
 	}
 
@@ -835,6 +849,7 @@ func TestGetReceipts(t *testing.T) {
 	settled, wantSettled := slice(t, 2, 4)
 	vmTime.advanceToSettle(ctx, t, settled)
 	unsettled, wantUnsettled := slice(t, 4, 6)
+	require.NoErrorf(t, unsettled.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", unsettled)
 
 	pending := sut.runConsensusLoop(t, sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 		To:       &blockingPrecompile,

--- a/vms/saevm/sae/rpc_test.go
+++ b/vms/saevm/sae/rpc_test.go
@@ -825,6 +825,7 @@ func TestGetReceipts(t *testing.T) {
 			r.BlockNumber = b.Number()
 			r.TransactionIndex = uint(i) //#nosec G115 -- Known non-negative
 		}
+		require.NoError(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
 		return b, rs
 	}
 
@@ -834,7 +835,6 @@ func TestGetReceipts(t *testing.T) {
 	settled, wantSettled := slice(t, 2, 4)
 	vmTime.advanceToSettle(ctx, t, settled)
 	unsettled, wantUnsettled := slice(t, 4, 6)
-	require.NoError(t, unsettled.WaitUntilExecuted(ctx), "WaitUntilExecuted()")
 
 	pending := sut.runConsensusLoop(t, sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 		To:       &blockingPrecompile,

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -362,6 +362,10 @@ func (s *SUT) mustSendTx(tb testing.TB, txs ...*types.Transaction) {
 
 // sendTxsAndWaitUntilPending sends all `txs` to the mempool, and waits for
 // each to be marked as pending.
+//
+// WARNING: if there is a block executing concurrently with this method,
+// the pending state of the transactions may not be accurately reflected,
+// resulting in a timeout.
 func (s *SUT) sendTxsAndWaitUntilPending(tb testing.TB, txs ...*types.Transaction) {
 	tb.Helper()
 
@@ -369,6 +373,11 @@ func (s *SUT) sendTxsAndWaitUntilPending(tb testing.TB, txs ...*types.Transactio
 	s.waitUntilTxsPending(tb, txs...)
 }
 
+// waitUntilTxsPending waits until all `txs` are marked as pending in the mempool.
+//
+// WARNING: if there is a block executing concurrently with this method,
+// the pending state of the transactions may not be accurately reflected,
+// resulting in a timeout.
 func (s *SUT) waitUntilTxsPending(tb testing.TB, txs ...*types.Transaction) {
 	tb.Helper()
 

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"math/big"
 	"net/http/httptest"
 	"os"
@@ -64,9 +63,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	createWorstCaseFuzzFlags(flag.CommandLine)
-	flag.Parse()
-
 	log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelError, true)))
 
 	goleak.VerifyTestMain(

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -59,9 +59,9 @@ func parseWorstCaseFlags() *worstCaseFlags {
 	set.Uint64Var(&fs.maxTxValue, name("max_tx_value"), params.Ether/1000, "Maximum tx value to send per transaction (uniform distribution)")
 	set.Uint64Var(&fs.rngSeed, name("rng_seed"), 0, "Seed for random-number generator; ignored if zero")
 
-	// Parse returns an error in practice, because the testing harness provides
-	// additional unregistered flags. [flag.ContinueOnError] allows the expected
-	// flags to be parsed anyways.
+	// Parse returns an error because the testing harness provides additional
+	// unregistered flags. [flag.ContinueOnError] allows the expected flags to
+	// be parsed anyways.
 	_ = set.Parse(os.Args[1:])
 	return fs
 }

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -44,26 +44,26 @@ type worstCaseFlags struct {
 }
 
 func parseWorstCaseFlags() *worstCaseFlags {
-	fs := flag.NewFlagSet("worstcase", flag.ContinueOnError)
-	f := &worstCaseFlags{}
+	set := flag.NewFlagSet("worstcase", flag.ContinueOnError)
+	fs := &worstCaseFlags{}
 
 	name := func(n string) string {
 		return "worstcase.fuzz." + n
 	}
-	fs.UintVar(&f.numAccounts, name("num_eoa"), 10, "Number of EOAs to send funds between")
-	fs.TextVar(&f.balance, name("eoa_balance"), uint256.NewInt(params.Ether), "Starting balance of EOAs")
-	fs.UintVar(&f.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //#nosec G115 -- Known to be positive
-	fs.UintVar(&f.numBlocks, name("blocks"), 50, "Number of blocks to build and execute (fixed)")
-	fs.UintVar(&f.maxNewTxsPerBlock, name("max_new_txs"), 100, "Maximum number of new transactions to send before building each block (uniform distribution)")
-	fs.Uint64Var(&f.maxGasLimit, name("max_gas_limit"), 60e6, "Maximum gas limit per transaction (uniform distribution)")
-	fs.Uint64Var(&f.maxTxValue, name("max_tx_value"), params.Ether/1000, "Maximum tx value to send per transaction (uniform distribution)")
-	fs.Uint64Var(&f.rngSeed, name("rng_seed"), 0, "Seed for random-number generator; ignored if zero")
+	set.UintVar(&fs.numAccounts, name("num_eoa"), 10, "Number of EOAs to send funds between")
+	set.TextVar(&fs.balance, name("eoa_balance"), uint256.NewInt(params.Ether), "Starting balance of EOAs")
+	set.UintVar(&fs.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //#nosec G115 -- Known to be positive
+	set.UintVar(&fs.numBlocks, name("blocks"), 50, "Number of blocks to build and execute (fixed)")
+	set.UintVar(&fs.maxNewTxsPerBlock, name("max_new_txs"), 100, "Maximum number of new transactions to send before building each block (uniform distribution)")
+	set.Uint64Var(&fs.maxGasLimit, name("max_gas_limit"), 60e6, "Maximum gas limit per transaction (uniform distribution)")
+	set.Uint64Var(&fs.maxTxValue, name("max_tx_value"), params.Ether/1000, "Maximum tx value to send per transaction (uniform distribution)")
+	set.Uint64Var(&fs.rngSeed, name("rng_seed"), 0, "Seed for random-number generator; ignored if zero")
 
 	// Parse returns an error in practice, because the testing harness provides
 	// additional unregistered flags. [flag.ContinueOnError] allows the expected
 	// flags to be parsed anyways.
-	_ = fs.Parse(os.Args[1:])
-	return f
+	_ = set.Parse(os.Args[1:])
+	return fs
 }
 
 // A guzzler is both a [params.ChainConfigHooks] and [params.RulesHooks]. When

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -6,6 +6,7 @@ package sae
 import (
 	"encoding/binary"
 	"errors"
+	"flag"
 	"math"
 	"math/big"
 	"math/rand/v2"
@@ -82,6 +83,40 @@ func (*guzzler) guzzle(env vm.PrecompileEnvironment, input []byte) ([]byte, erro
 	return nil, nil
 }
 
+type worstCaseFlags struct {
+	numAccounts       uint
+	balance           uint256.Int
+	parallel          uint
+	numBlocks         uint
+	maxNewTxsPerBlock uint
+	maxGasLimit       uint64
+	maxTxValue        uint64
+	rngSeed           uint64
+}
+
+func parseWorstCaseFlags() *worstCaseFlags {
+	fs := flag.NewFlagSet("worstcase", flag.ContinueOnError)
+	f := &worstCaseFlags{}
+
+	name := func(n string) string {
+		return "worstcase.fuzz." + n
+	}
+	fs.UintVar(&f.numAccounts, name("num_eoa"), 10, "Number of EOAs to send funds between")
+	fs.TextVar(&f.balance, name("eoa_balance"), uint256.NewInt(params.Ether), "Starting balance of EOAs")
+	fs.UintVar(&f.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //#nosec G115 -- Known to be positive
+	fs.UintVar(&f.numBlocks, name("blocks"), 50, "Number of blocks to build and execute (fixed)")
+	fs.UintVar(&f.maxNewTxsPerBlock, name("max_new_txs"), 100, "Maximum number of new transactions to send before building each block (uniform distribution)")
+	fs.Uint64Var(&f.maxGasLimit, name("max_gas_limit"), 60e6, "Maximum gas limit per transaction (uniform distribution)")
+	fs.Uint64Var(&f.maxTxValue, name("max_tx_value"), params.Ether/1000, "Maximum tx value to send per transaction (uniform distribution)")
+	fs.Uint64Var(&f.rngSeed, name("rng_seed"), 0, "Seed for random-number generator; ignored if zero")
+
+	// Parse returns an error in practice, because the testing harness provides
+	// additional unregistered flags. [flag.ContinueOnError] allows the expected
+	// flags to be parsed anyways.
+	_ = fs.Parse(os.Args[1:])
+	return f
+}
+
 func TestWorstCase(t *testing.T) {
 	// TODO(alarso16): This test flakes due to a race in the legacypool. When
 	// a block executes, it sends an event to the pool, which causes an
@@ -91,17 +126,8 @@ func TestWorstCase(t *testing.T) {
 		t.Skip("FLAKY: set SAEVM_TEST_FLAKY to run")
 	}
 
-	const (
-		numAccounts       = 10
-		numBlocks         = 50
-		maxNewTxsPerBlock = 100
-		maxGasLimit       = 60e6
-		maxTxValue        = params.Ether / 1000
-	)
-	var (
-		balance  = uint256.NewInt(params.Ether)
-		parallel = runtime.GOMAXPROCS(0)
-	)
+	flags := parseWorstCaseFlags()
+	t.Logf("Flags: %+v", flags)
 
 	guzzle := common.Address{'g', 'u', 'z', 'z', 'l', 'e'}
 	g := &guzzler{Addr: guzzle}
@@ -117,7 +143,7 @@ func TestWorstCase(t *testing.T) {
 
 		for _, acc := range c.genesis.Alloc {
 			// Note that `acc` isn't a pointer, but `Balance` is.
-			acc.Balance.Set(balance.ToBig())
+			acc.Balance.Set(flags.balance.ToBig())
 		}
 	})
 
@@ -175,26 +201,33 @@ func TestWorstCase(t *testing.T) {
 		t.FailNow()
 	}
 
-	for range parallel {
+	for range flags.parallel {
 		t.Run("fuzz", func(t *testing.T) {
 			t.Parallel()
 
 			timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 
-			ctx, sut := newSUT(t, numAccounts, sutOpt, timeOpt)
+			ctx, sut := newSUT(t, flags.numAccounts, sutOpt, timeOpt)
 
 			addrs := sut.wallet.Addresses()
 			numEOAs := len(addrs)
 			addrs = append(addrs, guzzle)
 			guzzlerIdx := numEOAs
 
-			rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Allow for reproducibility
+			var seed uint64
+			if flags.rngSeed != 0 {
+				seed = flags.rngSeed
+			} else {
+				seed = rand.Uint64() //#nosec G404 -- Not for security
+			}
+			t.Logf("RNG seed: %d", seed)
+			rng := rand.New(rand.NewPCG(0, seed)) //#nosec G404 -- Allow for reproducibility
 
-			for range numBlocks {
-				for range rng.UintN(maxNewTxsPerBlock) {
+			for range flags.numBlocks {
+				for range rng.UintN(flags.maxNewTxsPerBlock) {
 					from := rng.IntN(numEOAs)
 					to := rng.IntN(numEOAs + 1)
-					gasLim := params.TxGas + rng.Uint64N(maxGasLimit)
+					gasLim := params.TxGas + rng.Uint64N(flags.maxGasLimit)
 					var data []byte
 					if to == guzzlerIdx {
 						data = binary.BigEndian.AppendUint64(nil, rng.Uint64N(gasLim))
@@ -205,7 +238,7 @@ func TestWorstCase(t *testing.T) {
 						GasFeeCap: big.NewInt(1 + rng.Int64N(100)),
 						Gas:       gasLim,
 						Data:      data,
-						Value:     uint256.NewInt(rng.Uint64N(maxTxValue)).ToBig(),
+						Value:     uint256.NewInt(rng.Uint64N(flags.maxTxValue)).ToBig(),
 					})
 
 					if err := sut.SendTransaction(ctx, tx); err != nil {

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"math/big"
 	"math/rand/v2"
+	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -110,6 +111,13 @@ func (*guzzler) guzzle(env vm.PrecompileEnvironment, input []byte) ([]byte, erro
 }
 
 func TestWorstCase(t *testing.T) {
+	// TODO(alarso16): This test flakes due to a race in the legacypool. When
+	// a block executes, it sends an event to the pool, which causes an
+	// incorrect nonce update if the pool already had a pending transaction from
+	// the same account.
+	if os.Getenv("SAEVM_TEST_FLAKY") == "" {
+		t.Skip("FLAKY: set SAEVM_TEST_FLAKY to run")
+	}
 	flags := worstCaseFuzzFlags
 	t.Logf("Flags: %+v", flags)
 

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -32,6 +32,40 @@ import (
 	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 )
 
+type worstCaseFlags struct {
+	numAccounts       uint
+	balance           uint256.Int
+	parallel          uint
+	numBlocks         uint
+	maxNewTxsPerBlock uint
+	maxGasLimit       uint64
+	maxTxValue        uint64
+	rngSeed           uint64
+}
+
+func parseWorstCaseFlags() *worstCaseFlags {
+	fs := flag.NewFlagSet("worstcase", flag.ContinueOnError)
+	f := &worstCaseFlags{}
+
+	name := func(n string) string {
+		return "worstcase.fuzz." + n
+	}
+	fs.UintVar(&f.numAccounts, name("num_eoa"), 10, "Number of EOAs to send funds between")
+	fs.TextVar(&f.balance, name("eoa_balance"), uint256.NewInt(params.Ether), "Starting balance of EOAs")
+	fs.UintVar(&f.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //#nosec G115 -- Known to be positive
+	fs.UintVar(&f.numBlocks, name("blocks"), 50, "Number of blocks to build and execute (fixed)")
+	fs.UintVar(&f.maxNewTxsPerBlock, name("max_new_txs"), 100, "Maximum number of new transactions to send before building each block (uniform distribution)")
+	fs.Uint64Var(&f.maxGasLimit, name("max_gas_limit"), 60e6, "Maximum gas limit per transaction (uniform distribution)")
+	fs.Uint64Var(&f.maxTxValue, name("max_tx_value"), params.Ether/1000, "Maximum tx value to send per transaction (uniform distribution)")
+	fs.Uint64Var(&f.rngSeed, name("rng_seed"), 0, "Seed for random-number generator; ignored if zero")
+
+	// Parse returns an error in practice, because the testing harness provides
+	// additional unregistered flags. [flag.ContinueOnError] allows the expected
+	// flags to be parsed anyways.
+	_ = fs.Parse(os.Args[1:])
+	return f
+}
+
 // A guzzler is both a [params.ChainConfigHooks] and [params.RulesHooks]. When
 // registered as libevm extras they result in the [guzzler.guzzle] method being
 // a [vm.PrecompiledStatefulContract] instantiated at the address specified in
@@ -81,40 +115,6 @@ func (*guzzler) guzzle(env vm.PrecompileEnvironment, input []byte) ([]byte, erro
 		panic("bad test setup; calldata MUST be empty or an 8-byte slice")
 	}
 	return nil, nil
-}
-
-type worstCaseFlags struct {
-	numAccounts       uint
-	balance           uint256.Int
-	parallel          uint
-	numBlocks         uint
-	maxNewTxsPerBlock uint
-	maxGasLimit       uint64
-	maxTxValue        uint64
-	rngSeed           uint64
-}
-
-func parseWorstCaseFlags() *worstCaseFlags {
-	fs := flag.NewFlagSet("worstcase", flag.ContinueOnError)
-	f := &worstCaseFlags{}
-
-	name := func(n string) string {
-		return "worstcase.fuzz." + n
-	}
-	fs.UintVar(&f.numAccounts, name("num_eoa"), 10, "Number of EOAs to send funds between")
-	fs.TextVar(&f.balance, name("eoa_balance"), uint256.NewInt(params.Ether), "Starting balance of EOAs")
-	fs.UintVar(&f.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //#nosec G115 -- Known to be positive
-	fs.UintVar(&f.numBlocks, name("blocks"), 50, "Number of blocks to build and execute (fixed)")
-	fs.UintVar(&f.maxNewTxsPerBlock, name("max_new_txs"), 100, "Maximum number of new transactions to send before building each block (uniform distribution)")
-	fs.Uint64Var(&f.maxGasLimit, name("max_gas_limit"), 60e6, "Maximum gas limit per transaction (uniform distribution)")
-	fs.Uint64Var(&f.maxTxValue, name("max_tx_value"), params.Ether/1000, "Maximum tx value to send per transaction (uniform distribution)")
-	fs.Uint64Var(&f.rngSeed, name("rng_seed"), 0, "Seed for random-number generator; ignored if zero")
-
-	// Parse returns an error in practice, because the testing harness provides
-	// additional unregistered flags. [flag.ContinueOnError] allows the expected
-	// flags to be parsed anyways.
-	_ = fs.Parse(os.Args[1:])
-	return f
 }
 
 func TestWorstCase(t *testing.T) {

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -6,7 +6,6 @@ package sae
 import (
 	"encoding/binary"
 	"errors"
-	"flag"
 	"math"
 	"math/big"
 	"math/rand/v2"
@@ -31,33 +30,6 @@ import (
 
 	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
 )
-
-var worstCaseFuzzFlags struct {
-	numAccounts       uint
-	balance           uint256.Int
-	parallel          uint
-	numBlocks         uint
-	maxNewTxsPerBlock uint
-	maxGasLimit       uint64
-	maxTxValue        uint64
-	rngSeed           uint64
-}
-
-func createWorstCaseFuzzFlags(set *flag.FlagSet) {
-	name := func(n string) string {
-		return "worstcase.fuzz." + n
-	}
-	fs := &worstCaseFuzzFlags
-
-	set.UintVar(&fs.numAccounts, name("num_eoa"), 10, "Number of EOAs to send funds between")
-	set.TextVar(&fs.balance, name("eoa_balance"), uint256.NewInt(params.Ether), "Starting balance of EOAs")
-	set.UintVar(&fs.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //#nosec G115 -- Known to be positive
-	set.UintVar(&fs.numBlocks, name("blocks"), 50, "Number of blocks to build and execute (fixed)")
-	set.UintVar(&fs.maxNewTxsPerBlock, name("max_new_txs"), 100, "Maximum number of new transactions to send before building each block (uniform distribution)")
-	set.Uint64Var(&fs.maxGasLimit, name("max_gas_limit"), 60e6, "Maximum gas limit per transaction (uniform distribution)")
-	set.Uint64Var(&fs.maxTxValue, name("max_tx_value"), params.Ether/1000, "Maximum tx value to send per transaction (uniform distribution)")
-	set.Uint64Var(&fs.rngSeed, name("rng_seed"), 0, "Seed for random-number generator; ignored if zero")
-}
 
 // A guzzler is both a [params.ChainConfigHooks] and [params.RulesHooks]. When
 // registered as libevm extras they result in the [guzzler.guzzle] method being
@@ -118,8 +90,18 @@ func TestWorstCase(t *testing.T) {
 	if os.Getenv("SAEVM_TEST_FLAKY") == "" {
 		t.Skip("FLAKY: set SAEVM_TEST_FLAKY to run")
 	}
-	flags := worstCaseFuzzFlags
-	t.Logf("Flags: %+v", flags)
+
+	const (
+		numAccounts       = 10
+		numBlocks         = 50
+		maxNewTxsPerBlock = 100
+		maxGasLimit       = 60e6
+		maxTxValue        = params.Ether / 1000
+	)
+	var (
+		balance  = uint256.NewInt(params.Ether)
+		parallel = runtime.GOMAXPROCS(0)
+	)
 
 	guzzle := common.Address{'g', 'u', 'z', 'z', 'l', 'e'}
 	g := &guzzler{Addr: guzzle}
@@ -135,7 +117,7 @@ func TestWorstCase(t *testing.T) {
 
 		for _, acc := range c.genesis.Alloc {
 			// Note that `acc` isn't a pointer, but `Balance` is.
-			acc.Balance.Set(flags.balance.ToBig())
+			acc.Balance.Set(balance.ToBig())
 		}
 	})
 
@@ -193,33 +175,26 @@ func TestWorstCase(t *testing.T) {
 		t.FailNow()
 	}
 
-	for range flags.parallel {
+	for range parallel {
 		t.Run("fuzz", func(t *testing.T) {
 			t.Parallel()
 
 			timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 
-			ctx, sut := newSUT(t, flags.numAccounts, sutOpt, timeOpt)
+			ctx, sut := newSUT(t, numAccounts, sutOpt, timeOpt)
 
 			addrs := sut.wallet.Addresses()
 			numEOAs := len(addrs)
 			addrs = append(addrs, guzzle)
 			guzzlerIdx := numEOAs
 
-			var seed uint64
-			if flags.rngSeed != 0 {
-				seed = flags.rngSeed
-			} else {
-				seed = rand.Uint64() //#nosec G404 -- Not for security
-			}
-			t.Logf("RNG seed: %d", seed)
-			rng := rand.New(rand.NewPCG(0, seed)) //#nosec G404 -- Allow for reproducibility
+			rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Allow for reproducibility
 
-			for range flags.numBlocks {
-				for range rng.UintN(flags.maxNewTxsPerBlock) {
+			for range numBlocks {
+				for range rng.UintN(maxNewTxsPerBlock) {
 					from := rng.IntN(numEOAs)
 					to := rng.IntN(numEOAs + 1)
-					gasLim := params.TxGas + rng.Uint64N(flags.maxGasLimit)
+					gasLim := params.TxGas + rng.Uint64N(maxGasLimit)
 					var data []byte
 					if to == guzzlerIdx {
 						data = binary.BigEndian.AppendUint64(nil, rng.Uint64N(gasLim))
@@ -230,7 +205,7 @@ func TestWorstCase(t *testing.T) {
 						GasFeeCap: big.NewInt(1 + rng.Int64N(100)),
 						Gas:       gasLim,
 						Data:      data,
-						Value:     uint256.NewInt(rng.Uint64N(flags.maxTxValue)).ToBig(),
+						Value:     uint256.NewInt(rng.Uint64N(maxTxValue)).ToBig(),
 					})
 
 					if err := sut.SendTransaction(ctx, tx); err != nil {


### PR DESCRIPTION
## Why this should be merged

There is a bug in the legacypool that's not worth fixing. Specifically, at the end of block execution, an event is sent to the TxPool to indicate a reorg. This is expected to update nonces so that transactions already in the mempool are either evicted or promoted using this new data. However, the internal nonce tracking happens after the promotions, so if there is already a pending tx for some account in the pool that is still executable, a dependent queued transaction will be incorrectly gapped. If the pending tx is ever repriced or executed (and maybe some other cases), the queued transaction can later be moved to pending.

This is a rather complicated problem, and still exists upstream in go-ethereum. There is no simple way to inject a couple lines in libevm to address this, so we should probably just deal with it here. Most importantly, this doesn't significantly affect any production processes, since the transaction will just be included in a later block. It only affects testing, because we want to rely on adding transactions to a block.

## How this works

This race requires a few conditions:
1. A block is currently executing (i.e. the NewHead event could come anytime)
2. A transaction for an address is marked as pending
3. A transaction for the same address is marked as queued, but a reorg is scheduled

This is pretty specific, so there's several ways that we can in general fix this. I only know of two flakes of this manner, fixed in this PR. The first flake, `TestWorstCase`, relies on execution in the background, so we must just mark it as flaky. The second flake is easily avoided by not issuing transactions while a block is executing.

I manually reviewed all tests in `sae/saevm`, and if there were any blocks that expected multiple transactions from a single account, I ensured that they are either listed above, or are the first block created (aka race avoided)

## How this was tested

Lots and lots of debugging... if the flakes come back, I'm happy to further investigate

## Need to be documented in RELEASES.md?

No
