### PR TITLE
chore: Remove gosec from test files

### DIFF
--- a/.gosec-golangci.yml
+++ b/.gosec-golangci.yml
@@ -3,3 +3,13 @@ linters:
   default: none
   enable:
     - gosec
+  exclusions:
+    rules:
+      # Exclude some linters from running on test files.
+      # 1. Exclude the top level tests/ directory.
+      # 2. Exclude any file prefixed with test_ in any directory.
+      # 3. Exclude any directory suffixed with test.
+      # 4. Exclude any file suffixed with _test.go.
+      - path: "(^tests/)|(^(.*/)*test_[^/]*\\.go$)|(.*test/.*)|(.*_test\\.go$)"
+        linters:
+          - gosec

--- a/chains/atomic/atomictest/shared_memory.go
+++ b/chains/atomic/atomictest/shared_memory.go
@@ -46,14 +46,14 @@ func TestSharedMemoryPutAndGet(t *testing.T, chainID0, chainID1 ids.ID, sm0, sm1
 // can support large values.
 func TestSharedMemoryLargePutGetAndRemove(t *testing.T, chainID0, chainID1 ids.ID, sm0, sm1 atomic.SharedMemory, _ database.Database) {
 	require := require.New(t)
-	rand := rand.New(rand.NewSource(0)) //#nosec G404
+	rand := rand.New(rand.NewSource(0))
 
 	totalSize := 16 * units.MiB  // 16 MiB
 	elementSize := 4 * units.KiB // 4 KiB
 	pairSize := 2 * elementSize  // 8 KiB
 
 	b := make([]byte, totalSize)
-	_, err := rand.Read(b) // #nosec G404
+	_, err := rand.Read(b)
 	require.NoError(err)
 
 	elems := []*atomic.Element{}
@@ -152,7 +152,7 @@ func TestSharedMemoryLargeIndexed(t *testing.T, chainID0, chainID1 ids.ID, sm0, 
 	pairSize := 3 * elementSize  // 3 KiB
 
 	b := make([]byte, totalSize)
-	_, err := rand.Read(b) // #nosec G404
+	_, err := rand.Read(b)
 	require.NoError(err)
 
 	elems := []*atomic.Element{}
@@ -307,14 +307,14 @@ func TestPutAndRemoveBatch(t *testing.T, chainID0, _ ids.ID, _, sm1 atomic.Share
 // support large batches.
 func TestSharedMemoryLargeBatchSize(t *testing.T, _, chainID1 ids.ID, sm0, _ atomic.SharedMemory, db database.Database) {
 	require := require.New(t)
-	rand := rand.New(rand.NewSource(0)) //#nosec G404
+	rand := rand.New(rand.NewSource(0))
 
 	totalSize := 8 * units.MiB   // 8 MiB
 	elementSize := 4 * units.KiB // 4 KiB
 	pairSize := 2 * elementSize  // 8 KiB
 
 	bytes := make([]byte, totalSize)
-	_, err := rand.Read(bytes) // #nosec G404
+	_, err := rand.Read(bytes)
 	require.NoError(err)
 
 	batch := db.NewBatch()

--- a/database/dbtest/benchmark.go
+++ b/database/dbtest/benchmark.go
@@ -46,9 +46,9 @@ func SetupBenchmark(b *testing.B, count int, keySize, valueSize int) ([][]byte, 
 	for i := 0; i < count; i++ {
 		keyBytes := make([]byte, keySize)
 		valueBytes := make([]byte, valueSize)
-		_, err := rand.Read(keyBytes) // #nosec G404
+		_, err := rand.Read(keyBytes)
 		require.NoError(err)
-		_, err = rand.Read(valueBytes) // #nosec G404
+		_, err = rand.Read(valueBytes)
 		require.NoError(err)
 		keys[i], values[i] = keyBytes, valueBytes
 	}

--- a/database/dbtest/dbtest.go
+++ b/database/dbtest/dbtest.go
@@ -1241,16 +1241,16 @@ func FuzzNewIteratorWithPrefix(f *testing.F, db database.Database) {
 		numKeyValues uint,
 	) {
 		require := require.New(t)
-		r := rand.New(rand.NewSource(randSeed)) // #nosec G404
+		r := rand.New(rand.NewSource(randSeed))
 
 		// Put a bunch of key-values
 		expected := map[string][]byte{}
 		for i := 0; i < int(numKeyValues); i++ {
 			key := make([]byte, r.Intn(maxKeyLen))
-			_, _ = r.Read(key) // #nosec G404
+			_, _ = r.Read(key)
 
 			value := make([]byte, r.Intn(maxValueLen))
-			_, _ = r.Read(value) // #nosec G404
+			_, _ = r.Read(value)
 
 			if len(value) == 0 {
 				// Consistently treat zero length values as nil
@@ -1305,17 +1305,17 @@ func FuzzNewIteratorWithStartAndPrefix(f *testing.F, db database.Database) {
 		numKeyValues uint,
 	) {
 		require := require.New(t)
-		r := rand.New(rand.NewSource(randSeed)) // #nosec G404
+		r := rand.New(rand.NewSource(randSeed))
 
 		expected := map[string][]byte{}
 
 		// Put a bunch of key-values
 		for i := 0; i < int(numKeyValues); i++ {
 			key := make([]byte, r.Intn(maxKeyLen))
-			_, _ = r.Read(key) // #nosec G404
+			_, _ = r.Read(key)
 
 			value := make([]byte, r.Intn(maxValueLen))
-			_, _ = r.Read(value) // #nosec G404
+			_, _ = r.Read(value)
 
 			if len(value) == 0 {
 				// Consistently treat zero length values as nil

--- a/ids/bits_test.go
+++ b/ids/bits_test.go
@@ -70,7 +70,7 @@ func TestEqualSubsetBadMiddle(t *testing.T) {
 }
 
 func TestEqualSubsetAll3Bytes(t *testing.T) {
-	seed := rand.Uint64() //#nosec G404
+	seed := rand.Uint64()
 	t.Logf("seed: %d", seed)
 	id1 := ID{}.Prefix(seed)
 

--- a/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
+++ b/tests/fixture/bootstrapmonitor/e2e/e2e_test.go
@@ -254,7 +254,7 @@ func buildImage(tc tests.TestContext, imageName string, forceNewHash bool, scrip
 		tc.ContextWithTimeout(e2e.DefaultTimeout*2), // Double the timeout to account for CI being really slow
 		"bash",
 		args...,
-	) // #nosec G204
+	)
 	cmd.Env = append(os.Environ(),
 		"DOCKER_IMAGE="+imageName,
 		"FORCE_TAG_MASTER=1",

--- a/tests/fixture/e2e/env.go
+++ b/tests/fixture/e2e/env.go
@@ -235,7 +235,7 @@ func NewTestEnvironment(tc tests.TestContext, flagVars *FlagVars, desiredNetwork
 func (te *TestEnvironment) GetRandomNodeURI() tmpnet.NodeURI {
 	var (
 		tc             = te.testContext
-		r              = rand.New(rand.NewSource(time.Now().Unix())) //#nosec G404
+		r              = rand.New(rand.NewSource(time.Now().Unix()))
 		network        = te.GetNetwork()
 		availableNodes = []*tmpnet.Node{}
 	)

--- a/tests/load/tests.go
+++ b/tests/load/tests.go
@@ -74,8 +74,8 @@ func NewRandomTest(
 		// twice is practically zero. Using random values simplifies gas calculations
 		// as it removes the need to use an SLOAD operation to verify a different
 		// value is being written.
-		writeRand  = rand.New(rand.NewSource(0)) //#nosec G404
-		modifyRand = rand.New(rand.NewSource(1)) //#nosec G404
+		writeRand  = rand.New(rand.NewSource(0))
+		modifyRand = rand.New(rand.NewSource(1))
 	)
 
 	weightedTests := []WeightedTest{
@@ -190,7 +190,7 @@ func NewRandomWeightedTest(
 		)
 	}
 
-	rand := rand.New(source) //#nosec G404
+	rand := rand.New(source)
 
 	return &RandomWeightedTest{
 		tests:       tests,

--- a/utils/bag/bag_benchmark_test.go
+++ b/utils/bag/bag_benchmark_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func BenchmarkBagListSmall(b *testing.B) {
-	rand := rand.New(rand.NewSource(1337)) //#nosec G404
+	rand := rand.New(rand.NewSource(1337))
 	smallLen := 5
 	bag := Bag[int]{}
 	for i := 0; i < smallLen; i++ {
@@ -22,7 +22,7 @@ func BenchmarkBagListSmall(b *testing.B) {
 }
 
 func BenchmarkBagListMedium(b *testing.B) {
-	rand := rand.New(rand.NewSource(1337)) //#nosec G404
+	rand := rand.New(rand.NewSource(1337))
 	mediumLen := 25
 	bag := Bag[int]{}
 	for i := 0; i < mediumLen; i++ {
@@ -36,7 +36,7 @@ func BenchmarkBagListMedium(b *testing.B) {
 }
 
 func BenchmarkBagListLarge(b *testing.B) {
-	rand := rand.New(rand.NewSource(1337)) //#nosec G404
+	rand := rand.New(rand.NewSource(1337))
 	largeLen := 100000
 	bag := Bag[int]{}
 	for i := 0; i < largeLen; i++ {

--- a/utils/bloom/filter_test.go
+++ b/utils/bloom/filter_test.go
@@ -60,7 +60,7 @@ func TestNormalUsage(t *testing.T) {
 
 	toAdd := make([]uint64, 1024)
 	for i := range toAdd {
-		toAdd[i] = rand.Uint64() //#nosec G404
+		toAdd[i] = rand.Uint64()
 	}
 
 	initialNumHashes, initialNumBytes := OptimalParameters(1024, 0.01)

--- a/utils/bytes_test.go
+++ b/utils/bytes_test.go
@@ -79,7 +79,7 @@ func BenchmarkBytesPool_Random(b *testing.B) {
 	p := NewBytesPool()
 	sizes := make([]int, 1_000)
 	for i := range sizes {
-		sizes[i] = rand.Intn(100_000) //#nosec G404
+		sizes[i] = rand.Intn(100_000)
 	}
 
 	b.ResetTimer()

--- a/utils/sampler/rand_test.go
+++ b/utils/sampler/rand_test.go
@@ -169,7 +169,7 @@ func TestRNG(t *testing.T) {
 				onInvalid: t.FailNow,
 				nums:      test.nums,
 			}
-			mathRNG := rand.New(stdSource) //#nosec G404
+			mathRNG := rand.New(stdSource)
 			stdVal := mathRNG.Int63n(int64(test.maximum + 1))
 			require.Equal(test.expected, uint64(stdVal))
 			require.Empty(source.nums)
@@ -202,7 +202,7 @@ func FuzzRNG(f *testing.F) {
 			onInvalid: t.SkipNow,
 			nums:      sourceNums,
 		}
-		mathRNG := rand.New(stdSource) //#nosec G404
+		mathRNG := rand.New(stdSource)
 		stdVal := mathRNG.Int63n(int64(maximum + 1))
 		require.Equal(val, uint64(stdVal))
 		require.Len(stdSource.nums, len(source.nums))

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -364,8 +364,8 @@ func TestDiffL1ValidatorsErrors(t *testing.T) {
 			// Initialize subnetID, weight, and endAccumulatedFee as they are
 			// constant among all tests.
 			test.l1Validator.SubnetID = l1Validator.SubnetID
-			test.l1Validator.Weight = 1                        // Not removed
-			test.l1Validator.EndAccumulatedFee = rand.Uint64() //#nosec G404
+			test.l1Validator.Weight = 1 // Not removed
+			test.l1Validator.EndAccumulatedFee = rand.Uint64()
 			err = d.PutL1Validator(test.l1Validator)
 			require.ErrorIs(err, test.expectedErr)
 

--- a/vms/platformvm/validators/manager_benchmark_test.go
+++ b/vms/platformvm/validators/manager_benchmark_test.go
@@ -178,7 +178,7 @@ func addSubnetDelegator(
 	nodeIDs []ids.NodeID,
 	height uint64,
 ) error {
-	i := rand.Intn(len(nodeIDs)) //#nosec G404
+	i := rand.Intn(len(nodeIDs))
 	nodeID := nodeIDs[i]
 	s.PutCurrentDelegator(&state.Staker{
 		TxID:            ids.GenerateTestID(),

--- a/vms/platformvm/warp/message/l1_validator_weight_test.go
+++ b/vms/platformvm/warp/message/l1_validator_weight_test.go
@@ -18,8 +18,8 @@ func TestL1ValidatorWeight(t *testing.T) {
 
 	msg, err := NewL1ValidatorWeight(
 		ids.GenerateTestID(),
-		rand.Uint64(), //#nosec G404
-		rand.Uint64(), //#nosec G404
+		rand.Uint64(),
+		rand.Uint64(),
 	)
 	require.NoError(err)
 

--- a/vms/platformvm/warp/message/register_l1_validator_test.go
+++ b/vms/platformvm/warp/message/register_l1_validator_test.go
@@ -32,20 +32,20 @@ func TestRegisterL1Validator(t *testing.T) {
 		ids.GenerateTestID(),
 		ids.GenerateTestNodeID(),
 		newBLSPublicKey(t),
-		rand.Uint64(), //#nosec G404
+		rand.Uint64(),
 		PChainOwner{
-			Threshold: rand.Uint32(), //#nosec G404
+			Threshold: rand.Uint32(),
 			Addresses: []ids.ShortID{
 				ids.GenerateTestShortID(),
 			},
 		},
 		PChainOwner{
-			Threshold: rand.Uint32(), //#nosec G404
+			Threshold: rand.Uint32(),
 			Addresses: []ids.ShortID{
 				ids.GenerateTestShortID(),
 			},
 		},
-		rand.Uint64(), //#nosec G404
+		rand.Uint64(),
 	)
 	require.NoError(err)
 
@@ -74,7 +74,7 @@ func TestRegisterL1Validator_Verify(t *testing.T) {
 				constants.PrimaryNetworkID,
 				ids.GenerateTestNodeID(),
 				newBLSPublicKey(t),
-				rand.Uint64(), //#nosec G404
+				rand.Uint64(),
 				PChainOwner{
 					Threshold: 1,
 					Addresses: []ids.ShortID{
@@ -94,7 +94,7 @@ func TestRegisterL1Validator_Verify(t *testing.T) {
 				ids.GenerateTestID(),
 				ids.GenerateTestNodeID(),
 				newBLSPublicKey(t),
-				rand.Uint64(), //#nosec G404
+				rand.Uint64(),
 				PChainOwner{
 					Threshold: 1,
 					Addresses: []ids.ShortID{
@@ -114,7 +114,7 @@ func TestRegisterL1Validator_Verify(t *testing.T) {
 				SubnetID:     ids.GenerateTestID(),
 				NodeID:       nil,
 				BLSPublicKey: newBLSPublicKey(t),
-				Expiry:       rand.Uint64(), //#nosec G404
+				Expiry:       rand.Uint64(),
 				RemainingBalanceOwner: PChainOwner{
 					Threshold: 1,
 					Addresses: []ids.ShortID{
@@ -134,7 +134,7 @@ func TestRegisterL1Validator_Verify(t *testing.T) {
 				ids.GenerateTestID(),
 				ids.EmptyNodeID,
 				newBLSPublicKey(t),
-				rand.Uint64(), //#nosec G404
+				rand.Uint64(),
 				PChainOwner{
 					Threshold: 1,
 					Addresses: []ids.ShortID{
@@ -154,7 +154,7 @@ func TestRegisterL1Validator_Verify(t *testing.T) {
 				ids.GenerateTestID(),
 				ids.GenerateTestNodeID(),
 				newBLSPublicKey(t),
-				rand.Uint64(), //#nosec G404
+				rand.Uint64(),
 				PChainOwner{
 					Threshold: 0,
 					Addresses: []ids.ShortID{
@@ -174,7 +174,7 @@ func TestRegisterL1Validator_Verify(t *testing.T) {
 				ids.GenerateTestID(),
 				ids.GenerateTestNodeID(),
 				newBLSPublicKey(t),
-				rand.Uint64(), //#nosec G404
+				rand.Uint64(),
 				PChainOwner{
 					Threshold: 1,
 					Addresses: []ids.ShortID{

--- a/vms/saevm/blocks/blockstest/chain.go
+++ b/vms/saevm/blocks/blockstest/chain.go
@@ -148,7 +148,7 @@ func (cb *ChainBuilder) ResolveBlockNumber(bn rpc.BlockNumber) (uint64, error) {
 		if bn < 0 {
 			return 0, fmt.Errorf("%s block unsupported", bn)
 		}
-		n := uint64(bn) //#nosec G115 -- Non-negative checked above
+		n := uint64(bn)
 		if n > head {
 			return 0, fmt.Errorf("%w: %d", ErrBlockNotFound, n)
 		}

--- a/vms/saevm/gastime/acp176_test.go
+++ b/vms/saevm/gastime/acp176_test.go
@@ -110,7 +110,7 @@ func FuzzWorstCasePrice(f *testing.F) {
 		initTarget = max(initTarget, 1)
 		gasCfg := DefaultGasPriceConfig()
 
-		initUnix := int64(min(initTimestamp, math.MaxInt64)) //#nosec G115 -- Clamped to MaxInt64
+		initUnix := int64(min(initTimestamp, math.MaxInt64))
 		worstcase := mustNew(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
 		actual := mustNew(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
 
@@ -123,28 +123,28 @@ func FuzzWorstCasePrice(f *testing.F) {
 		}{
 			{
 				time:   time0,
-				nanos:  time.Duration(nanos0 % 1e9), //#nosec G115
+				nanos:  time.Duration(nanos0 % 1e9),
 				used:   gas.Gas(used0),
 				limit:  gas.Gas(limit0),
 				target: gas.Gas(target0),
 			},
 			{
 				time:   time1,
-				nanos:  time.Duration(nanos1 % 1e9), //#nosec G115
+				nanos:  time.Duration(nanos1 % 1e9),
 				used:   gas.Gas(used1),
 				limit:  gas.Gas(limit1),
 				target: gas.Gas(target1),
 			},
 			{
 				time:   time2,
-				nanos:  time.Duration(nanos2 % 1e9), //#nosec G115
+				nanos:  time.Duration(nanos2 % 1e9),
 				used:   gas.Gas(used2),
 				limit:  gas.Gas(limit2),
 				target: gas.Gas(target2),
 			},
 			{
 				time:   time3,
-				nanos:  time.Duration(nanos3 % 1e9), //#nosec G115
+				nanos:  time.Duration(nanos3 % 1e9),
 				used:   gas.Gas(used3),
 				limit:  gas.Gas(limit3),
 				target: gas.Gas(target3),
@@ -153,7 +153,7 @@ func FuzzWorstCasePrice(f *testing.F) {
 		for _, block := range blocks {
 			block.limit = max(block.used, block.limit)
 			block.target = clampTarget(max(block.target, 1))
-			blockSeconds := int64(min(block.time, math.MaxInt64)) //#nosec G115 -- Clamped to MaxInt64
+			blockSeconds := int64(min(block.time, math.MaxInt64))
 
 			tm := time.Unix(blockSeconds, int64(block.nanos))
 			worstcase.BeforeBlock(tm)

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -118,7 +118,7 @@ func (s *Stub) BuildHeader(parent *types.Header) (*types.Header, error) {
 	hdr := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     new(big.Int).Add(parent.Number, common.Big1),
-		Time:       uint64(now.Unix()), //#nosec G115 -- Known non-negative
+		Time:       uint64(now.Unix()),
 		Extra:      e.MarshalCanoto(),
 	}
 	return hdr, nil
@@ -186,7 +186,7 @@ func (s *Stub) BlockRebuilderFrom(b *types.Block) (hook.BlockBuilder[Op], error)
 
 	return NewStub(s.Target, WithInvalidOpIDs(s.InvalidOpIDs), WithOps(e.ops), WithNow(func() time.Time {
 		return time.Unix(
-			int64(b.Time()), //#nosec G115 -- Won't overflow for a few millennia
+			int64(b.Time()),
 			int64(e.subSec),
 		)
 	})), nil
@@ -201,8 +201,8 @@ func (s *Stub) GasConfigAfter(*types.Header) (gas.Gas, gastime.GasPriceConfig) {
 // stored seconds in [types.Header.Time] and the sub-second component from
 // [types.Header.Extra].
 func (*Stub) BlockTime(hdr *types.Header) time.Time {
-	subSec := getHeaderExtra(hdr).subSec             //nolint:staticcheck // subSec intentionally communicates that the value is < time.Second
-	return time.Unix(int64(hdr.Time), int64(subSec)) //#nosec G115 -- Won't overflow for a few millennia
+	subSec := getHeaderExtra(hdr).subSec //nolint:staticcheck // subSec intentionally communicates that the value is < time.Second
+	return time.Unix(int64(hdr.Time), int64(subSec))
 }
 
 // SettledHeight returns the height encoded in the Header by [Stub.BuildBlock]

--- a/vms/saevm/intmath/intmath_test.go
+++ b/vms/saevm/intmath/intmath_test.go
@@ -160,7 +160,7 @@ func TestCeilDiv(t *testing.T) {
 		{num: max64, den: 2, want: 1 << 63}, // must not overflow
 	}
 
-	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is useful for tests
+	rng := rand.New(rand.NewPCG(0, 0))
 	for range 50 {
 		l := uint64(rng.Uint32())
 		r := uint64(rng.Uint32())

--- a/vms/saevm/proxytime/proxytime_test.go
+++ b/vms/saevm/proxytime/proxytime_test.go
@@ -219,7 +219,7 @@ func TestAsTime(t *testing.T) {
 	stdlib := time.Date(1986, time.October, 1, 0, 0, 0, 0, time.UTC)
 
 	const rate uint64 = 500
-	tm := New(uint64(stdlib.Unix()), rate) //#nosec G115 -- Known to not overflow
+	tm := New(uint64(stdlib.Unix()), rate)
 	if got, want := tm.AsTime(), stdlib; !got.Equal(want) {
 		t.Fatalf("%T.AsTime() at construction got %v; want %v", tm, got, want)
 	}

--- a/vms/saevm/sae/accept_block_test.go
+++ b/vms/saevm/sae/accept_block_test.go
@@ -44,7 +44,7 @@ func TestAcceptBlock(t *testing.T) {
 	unsettled := []*blocks.Block{sut.genesis}
 	sut.genesis = nil // allow it to be GCd when appropriate
 
-	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is useful for tests
+	rng := rand.New(rand.NewPCG(0, 0))
 	for range 100 {
 		ffMillis := 100 + rng.IntN(1000*(1+saeparams.TauSeconds))
 		vmTime.advance(time.Millisecond * time.Duration(ffMillis))

--- a/vms/saevm/sae/recovery_test.go
+++ b/vms/saevm/sae/recovery_test.go
@@ -47,7 +47,7 @@ func TestRecoverFromDatabase(t *testing.T) {
 	}))
 	srcCtx := ctx
 
-	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is useful for tests
+	rng := rand.New(rand.NewPCG(0, 0))
 
 	for final := false; !final; {
 		// We need to test rebuilding from trie roots reflecting (a) the last

--- a/vms/saevm/sae/rpc_test.go
+++ b/vms/saevm/sae/rpc_test.go
@@ -289,7 +289,7 @@ func TestTxPoolNamespace(t *testing.T) {
 		t.Helper()
 		return sut.wallet.SetNonceAndSign(t, i, &types.DynamicFeeTx{
 			To:        &addresses[i],
-			Gas:       params.TxGas + uint64(i), //#nosec G115 -- Won't overflow
+			Gas:       params.TxGas + uint64(i),
 			GasFeeCap: big.NewInt(int64(i + 1)),
 			Value:     big.NewInt(int64(i + 10)),
 		})
@@ -823,7 +823,7 @@ func TestGetReceipts(t *testing.T) {
 			r.CumulativeGasUsed = totalGas
 			r.BlockHash = b.Hash()
 			r.BlockNumber = b.Number()
-			r.TransactionIndex = uint(i) //#nosec G115 -- Known non-negative
+			r.TransactionIndex = uint(i)
 		}
 		return b, rs
 	}
@@ -1262,7 +1262,7 @@ func (s *SUT) testGetByHash(ctx context.Context, t *testing.T, want *types.Block
 	}...)
 
 	for i, wantTx := range want.Transactions() {
-		txIdx := hexutil.Uint(i) //#nosec G115 -- Won't overflow
+		txIdx := hexutil.Uint(i)
 		marshaled, err := wantTx.MarshalBinary()
 		require.NoErrorf(t, err, "%T.MarshalBinary()", wantTx)
 
@@ -1290,7 +1290,7 @@ func (s *SUT) testGetByHash(ctx context.Context, t *testing.T, want *types.Block
 		}...)
 	}
 
-	outOfBoundsIndex := hexutil.Uint(len(want.Transactions()) + 1) //#nosec G115 -- Known to not overflow
+	outOfBoundsIndex := hexutil.Uint(len(want.Transactions()) + 1)
 	s.testRPC(ctx, t, []rpcTest{
 		{
 			method: "eth_getTransactionByBlockHashAndIndex",
@@ -1378,7 +1378,7 @@ func (s *SUT) testGetByNumber(ctx context.Context, t *testing.T, want *types.Blo
 	}...)
 
 	for i, wantTx := range want.Transactions() {
-		txIdx := hexutil.Uint(i) //#nosec G115 -- Won't overflow
+		txIdx := hexutil.Uint(i)
 		marshaled, err := wantTx.MarshalBinary()
 		require.NoErrorf(t, err, "%T.MarshalBinary()", wantTx)
 
@@ -1396,7 +1396,7 @@ func (s *SUT) testGetByNumber(ctx context.Context, t *testing.T, want *types.Blo
 		}...)
 	}
 
-	outOfBoundsIndex := hexutil.Uint(len(want.Transactions()) + 1) //#nosec G115 -- Known to not overflow
+	outOfBoundsIndex := hexutil.Uint(len(want.Transactions()) + 1)
 	s.testRPC(ctx, t, []rpcTest{
 		{
 			method: "eth_getTransactionByBlockNumberAndIndex",

--- a/vms/saevm/sae/worstcase_test.go
+++ b/vms/saevm/sae/worstcase_test.go
@@ -50,7 +50,7 @@ func createWorstCaseFuzzFlags(set *flag.FlagSet) {
 
 	set.UintVar(&fs.numAccounts, name("num_eoa"), 10, "Number of EOAs to send funds between")
 	set.TextVar(&fs.balance, name("eoa_balance"), uint256.NewInt(params.Ether), "Starting balance of EOAs")
-	set.UintVar(&fs.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS") //#nosec G115 -- Known to be positive
+	set.UintVar(&fs.parallel, name("parallel"), uint(runtime.GOMAXPROCS(0)), "Number of parallel tests to run; defaults to GOMAXPROCS")
 	set.UintVar(&fs.numBlocks, name("blocks"), 50, "Number of blocks to build and execute (fixed)")
 	set.UintVar(&fs.maxNewTxsPerBlock, name("max_new_txs"), 100, "Maximum number of new transactions to send before building each block (uniform distribution)")
 	set.Uint64Var(&fs.maxGasLimit, name("max_gas_limit"), 60e6, "Maximum gas limit per transaction (uniform distribution)")
@@ -202,10 +202,10 @@ func TestWorstCase(t *testing.T) {
 			if flags.rngSeed != 0 {
 				seed = flags.rngSeed
 			} else {
-				seed = rand.Uint64() //#nosec G404 -- Not for security
+				seed = rand.Uint64()
 			}
 			t.Logf("RNG seed: %d", seed)
-			rng := rand.New(rand.NewPCG(0, seed)) //#nosec G404 -- Allow for reproducibility
+			rng := rand.New(rand.NewPCG(0, seed))
 
 			for range flags.numBlocks {
 				for range rng.UintN(flags.maxNewTxsPerBlock) {

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -323,7 +323,7 @@ func TestExecution(t *testing.T) {
 		EffectiveGasPrice: big.NewInt(1),
 	})
 
-	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is useful for tests
+	rng := rand.New(rand.NewPCG(0, 0))
 	var wantEscrowBalance uint64
 	for range 10 {
 		val := rng.Uint64N(100_000)
@@ -352,7 +352,7 @@ func TestExecution(t *testing.T) {
 
 	var logIndex uint
 	for i, r := range want {
-		ui := uint(i) //#nosec G115 -- Known to not overflow
+		ui := uint(i)
 
 		r.Status = 1
 		r.TransactionIndex = ui
@@ -603,7 +603,7 @@ func TestGasAccounting(t *testing.T) {
 
 		t.Run("CumulativeGasUsed", func(t *testing.T) {
 			for i, r := range b.Receipts() {
-				ui := uint64(i + 1) //#nosec G115 -- Known to not overflow
+				ui := uint64(i + 1)
 				assert.Equalf(t, ui*params.TxGas, r.CumulativeGasUsed, "%T.Receipts()[%d]", b, i)
 			}
 		})

--- a/vms/saevm/txgossip/txgossip_test.go
+++ b/vms/saevm/txgossip/txgossip_test.go
@@ -123,7 +123,7 @@ func TestExecutorIntegration(t *testing.T) {
 	const numAccounts = 3
 	s := newSUT(t, numAccounts)
 
-	rng := rand.New(rand.NewPCG(0, 0)) //#nosec G404 -- Reproducibility is valuable for tests
+	rng := rand.New(rand.NewPCG(0, 0))
 
 	const txPerAccount = 5
 	const numTxs = numAccounts * txPerAccount

--- a/wallet/chain/p/builder_test.go
+++ b/wallet/chain/p/builder_test.go
@@ -587,7 +587,7 @@ func TestConvertSubnetToL1Tx(t *testing.T) {
 		validators = []*txs.ConvertSubnetToL1Validator{
 			{
 				NodeID:  utils.RandomBytes(ids.NodeIDLen),
-				Weight:  rand.Uint64(), //#nosec G404
+				Weight:  rand.Uint64(),
 				Balance: units.Avax,
 				Signer:  *pop0,
 				RemainingBalanceOwner: message.PChainOwner{
@@ -605,7 +605,7 @@ func TestConvertSubnetToL1Tx(t *testing.T) {
 			},
 			{
 				NodeID:                utils.RandomBytes(ids.NodeIDLen),
-				Weight:                rand.Uint64(), //#nosec G404
+				Weight:                rand.Uint64(),
 				Balance:               2 * units.Avax,
 				Signer:                *pop1,
 				RemainingBalanceOwner: message.PChainOwner{},


### PR DESCRIPTION
## Why this should be merged

Specifying each nosec clause in a test file is unnecessary. If something's wrong, the test will probably fail! Most of the time, it's false positives anyway

## How this works

Remove gosec checks from tests and all corresponding nolints. I found some other stale nosec's, so I removed them too. Unfortunately, there doesn't seem to be a linter for unnecessary nosec's.

## How this was tested

CI passes

## Need to be documented in RELEASES.md?

No