### PR TITLE
Remove qemu mirror from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install qemu (required for cross-platform builds)
-        run: |
-          sudo apt update
-          sudo apt -y install qemu-user-static
+      - name: Set up QEMU (required for cross-platform builds)
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Check image build
         shell: bash
         run: ./scripts/run_task.sh test-build-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Install qemu (required for cross-platform builds)
         run: |
           sudo apt update
-          sudo apt -y install qemu-system qemu-user-static
+          sudo apt -y install qemu-user-static
       - name: Check image build
         shell: bash
         run: ./scripts/run_task.sh test-build-image

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install qemu (required for cross-platform builds)
         run: |
           sudo apt update
-          sudo apt -y install qemu-system qemu-user-static
+          sudo apt -y install qemu-user-static
           sudo systemctl restart docker
       - name: Create multiplatform docker builder
         run: docker buildx create --use

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -14,11 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install qemu (required for cross-platform builds)
-        run: |
-          sudo apt update
-          sudo apt -y install qemu-user-static
-          sudo systemctl restart docker
+      - name: Set up QEMU (required for cross-platform builds)
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Create multiplatform docker builder
         run: docker buildx create --use
       - name: Build and publish images to DockerHub

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install qemu (required for cross-platform builds)
         run: |
           sudo apt update
-          sudo apt -y install qemu-system qemu-user-static
+          sudo apt -y install qemu-user-static
       - name: Check image build
         run: ./scripts/run_task.sh test-build-image
 

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -93,10 +93,8 @@ jobs:
         working-directory: ./graft/subnet-evm
     steps:
       - uses: actions/checkout@v4
-      - name: Install qemu (required for cross-platform builds)
-        run: |
-          sudo apt update
-          sudo apt -y install qemu-user-static
+      - name: Set up QEMU (required for cross-platform builds)
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Check image build
         run: ./scripts/run_task.sh test-build-image
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -409,7 +409,7 @@ tasks:
 
   test-build-image:
     # On mac, docker/podman/lima should work out-of-the-box.
-    # On linux, requires qemu (e.g. apt -y install qemu-system qemu-user-static).
+    # On linux, requires qemu (e.g. apt -y install qemu-user-static).
     desc: Runs test of cross-platform docker image build
     cmd: '{{.NIX_RUN}} bash -x scripts/tests.build_image.sh'
 


### PR DESCRIPTION
## Why this should be merged

We've run into docker builds taking extremely long sometimes, installing `qemu` can take over an hour sometimes. This removes the usage of the slow mirrors and significantly reduces the amount downloaded into the runner.

## How this works

Uses an upstream docker github action rather than manual `apt install`.

## How this was tested

I'm trusting CI here to actually assert that this change is ok.

- [X] CI passes without `qemu-system`
- [X] CI passes with the github action

## Need to be documented in RELEASES.md?

No