### PR TITLE
fix: Commit on reprocess for archival

### DIFF
--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -1908,7 +1908,10 @@ func (bc *BlockChain) reprocessState(current *types.Block, reexec uint64) error 
 	if t, ok := bc.triedb.Backend().(*firewood.TrieDB); ok {
 		t.SetHashAndHeight(current.Hash(), current.NumberU64())
 	}
-	var roots []common.Hash
+
+	// Firewood requires every root to be committed, and archival nodes
+	// expect every state to always be available.
+	commitEvery := bc.CacheConfig().StateScheme == customrawdb.FirewoodScheme || !bc.CacheConfig().Pruning
 	for current.NumberU64() < origin {
 		// TODO: handle canceled context
 
@@ -1944,7 +1947,6 @@ func (bc *BlockChain) reprocessState(current *types.Block, reexec uint64) error 
 		if err != nil {
 			return err
 		}
-		roots = append(roots, root)
 
 		// Write any unsaved indices to disk
 		if writeIndices {
@@ -1964,22 +1966,18 @@ func (bc *BlockChain) reprocessState(current *types.Block, reexec uint64) error 
 		}, current.Hash()); err != nil {
 			return err
 		}
+
+		if commitEvery {
+			if err := triedb.Commit(root, true); err != nil {
+				return err
+			}
+		}
 	}
 
 	_, nodes, imgs := triedb.Size()
 	log.Info("Historical state regenerated", "block", current.NumberU64(), "elapsed", time.Since(start), "nodes", nodes, "preimages", imgs)
 
-	// Firewood requires processing each root individually.
-	if bc.CacheConfig().StateScheme == customrawdb.FirewoodScheme {
-		for _, root := range roots {
-			if err := triedb.Commit(root, true); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	if previousRoot != (common.Hash{}) {
+	if !commitEvery && previousRoot != (common.Hash{}) {
 		return triedb.Commit(previousRoot, true)
 	}
 	return nil

--- a/graft/coreth/core/blockchain_test.go
+++ b/graft/coreth/core/blockchain_test.go
@@ -451,7 +451,7 @@ func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
 	}
 
 	chainDataDir := t.TempDir()
-	pruningConfig := &CacheConfig{
+	config := &CacheConfig{
 		TrieCleanLimit:            256,
 		TrieDirtyLimit:            256,
 		TrieDirtyCommitTarget:     20,
@@ -464,7 +464,7 @@ func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
 		ChainDataDir:              chainDataDir,
 	}
 
-	blockchain, err := createBlockChain(chainDB, pruningConfig, gspec, common.Hash{})
+	blockchain, err := createBlockChain(chainDB, config, gspec, common.Hash{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/graft/coreth/core/blockchain_test.go
+++ b/graft/coreth/core/blockchain_test.go
@@ -424,6 +424,93 @@ func TestBlockChainOfflinePruningUngracefulShutdown(t *testing.T) {
 	}
 }
 
+// TestArchiveUngracefulShutdown ensures that if the blockchain
+// crashes without emptying the acceptor queue, all states will be persisted
+// after startup.
+func TestArchiveUngracefulShutdown(t *testing.T) {
+	for _, s := range schemes {
+		t.Run(s, func(t *testing.T) {
+			testArchiveUngracefulShutdown(t, s)
+		})
+	}
+}
+
+func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
+	var (
+		key1, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _   = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		addr1     = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2     = crypto.PubkeyToAddress(key2.PublicKey)
+		chainDB   = rawdb.NewMemoryDatabase()
+		numStates = uint64(5)
+	)
+
+	gspec := &Genesis{
+		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
+	}
+
+	chainDataDir := t.TempDir()
+	pruningConfig := &CacheConfig{
+		TrieCleanLimit:            256,
+		TrieDirtyLimit:            256,
+		TrieDirtyCommitTarget:     20,
+		TriePrefetcherParallelism: 4,
+		Pruning:                   false, // archival
+		CommitInterval:            1,
+		StateHistory:              2, // avoid caching all states
+		AcceptorQueueLimit:        64,
+		StateScheme:               scheme,
+		ChainDataDir:              chainDataDir,
+	}
+
+	blockchain, err := createBlockChain(chainDB, pruningConfig, gspec, common.Hash{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate (2 * numStates) blocks.
+	signer := types.HomesteadSigner{}
+	_, blocks, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, 2*int(numStates), 10, func(i int, gen *BlockGen) {
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), ethparams.TxGas, nil, nil), signer, key1)
+		gen.AddTx(tx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := blockchain.InsertChain(blocks); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range blocks[:numStates] {
+		if err := blockchain.Accept(b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// close the acceptor queue before accepting to simulate crashing with a full queue
+	blockchain.stopAcceptor()
+	for _, b := range blocks[numStates:] {
+		if err := blockchain.Accept(b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Completely close chain, startup again, ensure all states are available.
+	blockchain.Stop()
+
+	blockchain, err = createBlockChain(chainDB, blockchain.cacheConfig, gspec, blocks[len(blocks)-1].Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range blocks {
+		if !blockchain.HasState(b.Root()) {
+			t.Fatalf("missing state for block %d", b.NumberU64())
+		}
+	}
+	blockchain.Stop()
+}
+
 // TestPruningToNonPruning tests that opening a previously pruned database as a
 // non-pruned database is successful.
 //

--- a/graft/coreth/core/blockchain_test.go
+++ b/graft/coreth/core/blockchain_test.go
@@ -458,7 +458,7 @@ func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
 		TriePrefetcherParallelism: 4,
 		Pruning:                   false, // archival
 		CommitInterval:            1,
-		StateHistory:              2, // avoid caching all states
+		StateHistory:              2, // Minimum allowable by Firewood
 		AcceptorQueueLimit:        64,
 		StateScheme:               scheme,
 		ChainDataDir:              chainDataDir,
@@ -488,7 +488,9 @@ func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
 		}
 	}
 
-	// close the acceptor queue before accepting to simulate crashing with a full queue
+	// Close the acceptor queue prior to committing the rest of the blocks.
+	// This simulates a crash when the acceptor queue is non-empty, since those
+	// operations will not be completed.
 	blockchain.stopAcceptor()
 	for _, b := range blocks[numStates:] {
 		if err := blockchain.Accept(b); err != nil {

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -1947,7 +1947,10 @@ func (bc *BlockChain) reprocessState(current *types.Block, reexec uint64) error 
 	if t, ok := bc.triedb.Backend().(*firewood.TrieDB); ok {
 		t.SetHashAndHeight(current.Hash(), current.NumberU64())
 	}
-	var roots []common.Hash
+
+	// Firewood requires every root to be committed, and archival nodes
+	// expect every state to always be available.
+	commitEvery := bc.CacheConfig().StateScheme == customrawdb.FirewoodScheme || !bc.CacheConfig().Pruning
 	for current.NumberU64() < origin {
 		// TODO: handle canceled context
 
@@ -1983,7 +1986,6 @@ func (bc *BlockChain) reprocessState(current *types.Block, reexec uint64) error 
 		if err != nil {
 			return err
 		}
-		roots = append(roots, root)
 
 		// Write any unsaved indices to disk
 		if writeIndices {
@@ -2003,22 +2005,18 @@ func (bc *BlockChain) reprocessState(current *types.Block, reexec uint64) error 
 		}, current.Hash()); err != nil {
 			return err
 		}
+
+		if commitEvery {
+			if err := triedb.Commit(root, true); err != nil {
+				return err
+			}
+		}
 	}
 
 	_, nodes, imgs := triedb.Size()
 	log.Info("Historical state regenerated", "block", current.NumberU64(), "elapsed", time.Since(start), "nodes", nodes, "preimages", imgs)
 
-	// Firewood requires processing each root individually.
-	if bc.CacheConfig().StateScheme == customrawdb.FirewoodScheme {
-		for _, root := range roots {
-			if err := triedb.Commit(root, true); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	if previousRoot != (common.Hash{}) {
+	if !commitEvery && previousRoot != (common.Hash{}) {
 		return triedb.Commit(previousRoot, true)
 	}
 	return nil

--- a/graft/subnet-evm/core/blockchain_test.go
+++ b/graft/subnet-evm/core/blockchain_test.go
@@ -399,7 +399,7 @@ func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
 	}
 
 	chainDataDir := t.TempDir()
-	pruningConfig := &CacheConfig{
+	config := &CacheConfig{
 		TrieCleanLimit:            256,
 		TrieDirtyLimit:            256,
 		TrieDirtyCommitTarget:     20,
@@ -412,7 +412,7 @@ func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
 		ChainDataDir:              chainDataDir,
 	}
 
-	blockchain, err := createBlockChain(chainDB, pruningConfig, gspec, common.Hash{})
+	blockchain, err := createBlockChain(chainDB, config, gspec, common.Hash{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/graft/subnet-evm/core/blockchain_test.go
+++ b/graft/subnet-evm/core/blockchain_test.go
@@ -372,6 +372,93 @@ func TestBlockChainOfflinePruningUngracefulShutdown(t *testing.T) {
 	}
 }
 
+// TestArchiveUngracefulShutdown ensures that if the blockchain
+// crashes without emptying the acceptor queue, all states will be persisted
+// after startup.
+func TestArchiveUngracefulShutdown(t *testing.T) {
+	for _, s := range schemes {
+		t.Run(s, func(t *testing.T) {
+			testArchiveUngracefulShutdown(t, s)
+		})
+	}
+}
+
+func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
+	var (
+		key1, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _   = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		addr1     = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2     = crypto.PubkeyToAddress(key2.PublicKey)
+		chainDB   = rawdb.NewMemoryDatabase()
+		numStates = uint64(5)
+	)
+
+	gspec := &Genesis{
+		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
+	}
+
+	chainDataDir := t.TempDir()
+	pruningConfig := &CacheConfig{
+		TrieCleanLimit:            256,
+		TrieDirtyLimit:            256,
+		TrieDirtyCommitTarget:     20,
+		TriePrefetcherParallelism: 4,
+		Pruning:                   false, // archival
+		CommitInterval:            1,
+		StateHistory:              2, // avoid caching all states
+		AcceptorQueueLimit:        64,
+		StateScheme:               scheme,
+		ChainDataDir:              chainDataDir,
+	}
+
+	blockchain, err := createBlockChain(chainDB, pruningConfig, gspec, common.Hash{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate (2 * numStates) blocks.
+	signer := types.HomesteadSigner{}
+	_, blocks, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, 2*int(numStates), 10, func(i int, gen *BlockGen) {
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), ethparams.TxGas, nil, nil), signer, key1)
+		gen.AddTx(tx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := blockchain.InsertChain(blocks); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range blocks[:numStates] {
+		if err := blockchain.Accept(b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// close the acceptor queue before accepting to simulate crashing with a full queue
+	blockchain.stopAcceptor()
+	for _, b := range blocks[numStates:] {
+		if err := blockchain.Accept(b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Completely close chain, startup again, ensure all states are available.
+	blockchain.Stop()
+
+	blockchain, err = createBlockChain(chainDB, blockchain.cacheConfig, gspec, blocks[len(blocks)-1].Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range blocks {
+		if !blockchain.HasState(b.Root()) {
+			t.Fatalf("missing state for block %d", b.NumberU64())
+		}
+	}
+	blockchain.Stop()
+}
+
 // TestPruningToNonPruning tests that opening a previously pruned database as a
 // non-pruned database is successful.
 //

--- a/graft/subnet-evm/core/blockchain_test.go
+++ b/graft/subnet-evm/core/blockchain_test.go
@@ -406,7 +406,7 @@ func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
 		TriePrefetcherParallelism: 4,
 		Pruning:                   false, // archival
 		CommitInterval:            1,
-		StateHistory:              2, // avoid caching all states
+		StateHistory:              2, // Minimum allowable by Firewood
 		AcceptorQueueLimit:        64,
 		StateScheme:               scheme,
 		ChainDataDir:              chainDataDir,
@@ -436,7 +436,9 @@ func testArchiveUngracefulShutdown(t *testing.T, scheme string) {
 		}
 	}
 
-	// close the acceptor queue before accepting to simulate crashing with a full queue
+	// Close the acceptor queue prior to committing the rest of the blocks.
+	// This simulates a crash when the acceptor queue is non-empty, since those
+	// operations will not be completed.
 	blockchain.stopAcceptor()
 	for _, b := range blocks[numStates:] {
 		if err := blockchain.Accept(b); err != nil {


### PR DESCRIPTION
## Why this should be merged

If the node crashes with a full acceptor queue, the blocks will be re-executed on startup. However, if the node is archival, the states will not be committed. This can result in missing state.

## How this works

commit every state if archival

## How this was tested

Added a test

## Need to be documented in RELEASES.md?

No
