### PR TITLE
fix: use growable buffer in GetStacktrace

### DIFF
--- a/utils/stacktrace.go
+++ b/utils/stacktrace.go
@@ -6,7 +6,12 @@ package utils
 import "runtime"
 
 func GetStacktrace(all bool) string {
-	buf := make([]byte, 1<<24)
-	n := runtime.Stack(buf, all)
-	return string(buf[:n])
+	buf := make([]byte, 1<<16)
+	for {
+		n := runtime.Stack(buf, all)
+		if n < len(buf) {
+			return string(buf[:n])
+		}
+		buf = make([]byte, len(buf)*2)
+	}
 }


### PR DESCRIPTION
Replace fixed 16MB buffer with a growable one starting at 64KB. Doubles the buffer size until the full stacktrace fits, preventing silent truncation when all=true with many goroutines