### PR TITLE
bazel: enforce graft visibility with gazelle defaults

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_test")
+load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary", "gazelle_test")
 
 exports_files(["BUILD.bazel"])
 
@@ -9,12 +9,21 @@ exports_files(["BUILD.bazel"])
 # gazelle:proto disable_global
 # gazelle:map_kind go_test go_test //.bazel:defs.bzl
 
+gazelle_binary(
+    name = "gazelle_bin",
+    languages = DEFAULT_LANGUAGES + [
+        "@bazel_gazelle//language/bazel/visibility",
+    ],
+)
+
 gazelle(
     name = "gazelle",
     command = "fix",
+    gazelle = ":gazelle_bin",
 )
 
 gazelle_test(
     name = "gazelle_test",
+    gazelle = ":gazelle_bin",
     workspace = "//:BUILD.bazel",
 )

--- a/graft/coreth/BUILD.bazel
+++ b/graft/coreth/BUILD.bazel
@@ -7,7 +7,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 package_group(
     name = "external_consumers",
     packages = [

--- a/graft/coreth/BUILD.bazel
+++ b/graft/coreth/BUILD.bazel
@@ -1,2 +1,26 @@
 # gazelle:prefix github.com/ava-labs/avalanchego/graft/coreth
 # gazelle:map_kind go_test graft_go_test //.bazel:defs.bzl
+# gazelle:default_visibility //graft/coreth:__subpackages__,//graft/coreth:external_consumers
+
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
+package_group(
+    name = "external_consumers",
+    packages = [
+        "//main",
+        "//node",
+        "//tests/e2e",
+        "//tests/e2e/c",
+        "//tests/fixture/e2e",
+        "//tests/reexecute",
+        "//tests/reexecute/c",
+        "//tests/reexecute/chaos",
+        "//vms/evm/emulate",
+        "//wallet/chain/c",
+        "//wallet/subnet/primary",
+    ],
+)

--- a/graft/coreth/accounts/abi/bind/BUILD.bazel
+++ b/graft/coreth/accounts/abi/bind/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "bind",
     srcs = [

--- a/graft/coreth/accounts/abi/bind/BUILD.bazel
+++ b/graft/coreth/accounts/abi/bind/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "bind",
     srcs = [
@@ -12,7 +18,6 @@ go_library(
         "util.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/accounts/abi/bind",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/nativeasset",
         "//graft/evm/rpc",

--- a/graft/coreth/accounts/abi/bind/backends/BUILD.bazel
+++ b/graft/coreth/accounts/abi/bind/backends/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "backends",
     srcs = ["simulated.go"],

--- a/graft/coreth/accounts/abi/bind/backends/BUILD.bazel
+++ b/graft/coreth/accounts/abi/bind/backends/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "backends",
     srcs = ["simulated.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/accounts/abi/bind/backends",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/accounts/abi/bind",
         "//graft/coreth/ethclient/simulated",

--- a/graft/coreth/cmd/simulator/config/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/config/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "config",
     srcs = ["flags.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/cmd/simulator/config",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",

--- a/graft/coreth/cmd/simulator/config/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/config/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "config",
     srcs = ["flags.go"],

--- a/graft/coreth/cmd/simulator/key/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/key/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "key",
     srcs = ["key.go"],

--- a/graft/coreth/cmd/simulator/key/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/key/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "key",
     srcs = ["key.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/cmd/simulator/key",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//crypto",

--- a/graft/coreth/cmd/simulator/load/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/load/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "load",
     srcs = [

--- a/graft/coreth/cmd/simulator/load/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/load/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "load",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "worker.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/cmd/simulator/load",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/cmd/simulator/config",
         "//graft/coreth/cmd/simulator/key",

--- a/graft/coreth/cmd/simulator/main/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/main/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "main_lib",
     srcs = ["main.go"],

--- a/graft/coreth/cmd/simulator/main/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/main/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "main_lib",
     srcs = ["main.go"],
@@ -17,5 +23,4 @@ go_library(
 go_binary(
     name = "main",
     embed = [":main_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/graft/coreth/cmd/simulator/metrics/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/metrics/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "metrics",
     srcs = ["metrics.go"],

--- a/graft/coreth/cmd/simulator/metrics/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/metrics/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "metrics",
     srcs = ["metrics.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/cmd/simulator/metrics",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/rpc",
         "@com_github_ava_labs_libevm//log",

--- a/graft/coreth/cmd/simulator/txs/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/txs/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "txs",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "tx_generator.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/cmd/simulator/txs",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/cmd/simulator/metrics",
         "//graft/coreth/ethclient",

--- a/graft/coreth/cmd/simulator/txs/BUILD.bazel
+++ b/graft/coreth/cmd/simulator/txs/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "txs",
     srcs = [

--- a/graft/coreth/consensus/BUILD.bazel
+++ b/graft/coreth/consensus/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "consensus",
     srcs = [

--- a/graft/coreth/consensus/BUILD.bazel
+++ b/graft/coreth/consensus/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "consensus",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "errors.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/consensus",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/params",
         "@com_github_ava_labs_libevm//common",

--- a/graft/coreth/consensus/dummy/BUILD.bazel
+++ b/graft/coreth/consensus/dummy/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "dummy",
     srcs = ["consensus.go"],

--- a/graft/coreth/consensus/dummy/BUILD.bazel
+++ b/graft/coreth/consensus/dummy/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "dummy",
     srcs = ["consensus.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/consensus/dummy",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/consensus",
         "//graft/coreth/params",

--- a/graft/coreth/core/BUILD.bazel
+++ b/graft/coreth/core/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "core",
     srcs = [

--- a/graft/coreth/core/BUILD.bazel
+++ b/graft/coreth/core/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "core",
     srcs = [
@@ -31,7 +37,6 @@ go_library(
         "types.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/core",
-    visibility = ["//visibility:public"],
     deps = [
         "//database",
         "//graft/coreth/consensus",

--- a/graft/coreth/core/coretest/BUILD.bazel
+++ b/graft/coreth/core/coretest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "coretest",
     srcs = ["test_indices.go"],

--- a/graft/coreth/core/coretest/BUILD.bazel
+++ b/graft/coreth/core/coretest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "coretest",
     srcs = ["test_indices.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/core/coretest",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_ava_labs_libevm//core/rawdb",
         "@com_github_ava_labs_libevm//ethdb",

--- a/graft/coreth/core/extstate/BUILD.bazel
+++ b/graft/coreth/core/extstate/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "extstate",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "statedb.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/core/extstate",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/params",
         "//graft/coreth/plugin/evm/customtypes",

--- a/graft/coreth/core/extstate/BUILD.bazel
+++ b/graft/coreth/core/extstate/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "extstate",
     srcs = [

--- a/graft/coreth/core/txpool/BUILD.bazel
+++ b/graft/coreth/core/txpool/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "txpool",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "validation.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/core/txpool",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core",
         "//graft/coreth/params",

--- a/graft/coreth/core/txpool/BUILD.bazel
+++ b/graft/coreth/core/txpool/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "txpool",
     srcs = [

--- a/graft/coreth/core/txpool/blobpool/BUILD.bazel
+++ b/graft/coreth/core/txpool/blobpool/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "blobpool",
     srcs = [
@@ -14,7 +20,6 @@ go_library(
         "slotter.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/core/txpool/blobpool",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core",
         "//graft/coreth/core/txpool",

--- a/graft/coreth/core/txpool/blobpool/BUILD.bazel
+++ b/graft/coreth/core/txpool/blobpool/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "blobpool",
     srcs = [

--- a/graft/coreth/core/txpool/legacypool/BUILD.bazel
+++ b/graft/coreth/core/txpool/legacypool/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "legacypool",
     srcs = [
@@ -10,7 +16,6 @@ go_library(
         "noncer.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/core/txpool/legacypool",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core",
         "//graft/coreth/core/txpool",

--- a/graft/coreth/core/txpool/legacypool/BUILD.bazel
+++ b/graft/coreth/core/txpool/legacypool/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "legacypool",
     srcs = [

--- a/graft/coreth/core/vm/runtime/BUILD.bazel
+++ b/graft/coreth/core/vm/runtime/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "runtime",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "runtime.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/core/vm/runtime",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core",
         "//graft/coreth/params",

--- a/graft/coreth/core/vm/runtime/BUILD.bazel
+++ b/graft/coreth/core/vm/runtime/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "runtime",
     srcs = [

--- a/graft/coreth/eth/BUILD.bazel
+++ b/graft/coreth/eth/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "eth",
     srcs = [
@@ -14,7 +20,6 @@ go_library(
         "state_accessor.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/eth",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/consensus",
         "//graft/coreth/core",

--- a/graft/coreth/eth/BUILD.bazel
+++ b/graft/coreth/eth/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "eth",
     srcs = [

--- a/graft/coreth/eth/ethconfig/BUILD.bazel
+++ b/graft/coreth/eth/ethconfig/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "ethconfig",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "gen_config.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/eth/ethconfig",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core",
         "//graft/coreth/core/txpool/blobpool",

--- a/graft/coreth/eth/ethconfig/BUILD.bazel
+++ b/graft/coreth/eth/ethconfig/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "ethconfig",
     srcs = [

--- a/graft/coreth/eth/filters/BUILD.bazel
+++ b/graft/coreth/eth/filters/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "filters",
     srcs = [

--- a/graft/coreth/eth/filters/BUILD.bazel
+++ b/graft/coreth/eth/filters/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "filters",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "filter_system.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/eth/filters",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core",
         "//graft/coreth/internal/ethapi",

--- a/graft/coreth/eth/gasestimator/BUILD.bazel
+++ b/graft/coreth/eth/gasestimator/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "gasestimator",
     srcs = ["gasestimator.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/eth/gasestimator",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core",
         "//graft/coreth/params",

--- a/graft/coreth/eth/gasestimator/BUILD.bazel
+++ b/graft/coreth/eth/gasestimator/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "gasestimator",
     srcs = ["gasestimator.go"],

--- a/graft/coreth/eth/gasprice/BUILD.bazel
+++ b/graft/coreth/eth/gasprice/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "gasprice",
     srcs = [

--- a/graft/coreth/eth/gasprice/BUILD.bazel
+++ b/graft/coreth/eth/gasprice/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "gasprice",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "gasprice.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/eth/gasprice",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core",
         "//graft/coreth/params",

--- a/graft/coreth/eth/tracers/BUILD.bazel
+++ b/graft/coreth/eth/tracers/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "tracers",
     srcs = [

--- a/graft/coreth/eth/tracers/BUILD.bazel
+++ b/graft/coreth/eth/tracers/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "tracers",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "tracker.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/eth/tracers",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/consensus",
         "//graft/coreth/core",

--- a/graft/coreth/ethclient/BUILD.bazel
+++ b/graft/coreth/ethclient/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "ethclient",
     srcs = [

--- a/graft/coreth/ethclient/BUILD.bazel
+++ b/graft/coreth/ethclient/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "ethclient",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "signer.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/ethclient",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/accounts/abi/bind",
         "//graft/coreth/interfaces",

--- a/graft/coreth/ethclient/corethclient/BUILD.bazel
+++ b/graft/coreth/ethclient/corethclient/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "corethclient",
     srcs = ["corethclient.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/ethclient/corethclient",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/ethclient",
         "//graft/evm/rpc",

--- a/graft/coreth/ethclient/corethclient/BUILD.bazel
+++ b/graft/coreth/ethclient/corethclient/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "corethclient",
     srcs = ["corethclient.go"],

--- a/graft/coreth/ethclient/simulated/BUILD.bazel
+++ b/graft/coreth/ethclient/simulated/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "simulated",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "options.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/ethclient/simulated",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/consensus/dummy",
         "//graft/coreth/core",

--- a/graft/coreth/ethclient/simulated/BUILD.bazel
+++ b/graft/coreth/ethclient/simulated/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "simulated",
     srcs = [

--- a/graft/coreth/interfaces/BUILD.bazel
+++ b/graft/coreth/interfaces/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "interfaces",
     srcs = ["interfaces.go"],

--- a/graft/coreth/interfaces/BUILD.bazel
+++ b/graft/coreth/interfaces/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "interfaces",
     srcs = ["interfaces.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/interfaces",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_ava_labs_libevm//:libevm",
         "@com_github_ava_labs_libevm//common",

--- a/graft/coreth/internal/blocktest/BUILD.bazel
+++ b/graft/coreth/internal/blocktest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "blocktest",
     srcs = ["test_hash.go"],

--- a/graft/coreth/internal/blocktest/BUILD.bazel
+++ b/graft/coreth/internal/blocktest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "blocktest",
     srcs = ["test_hash.go"],

--- a/graft/coreth/internal/debug/BUILD.bazel
+++ b/graft/coreth/internal/debug/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "debug",
     srcs = [

--- a/graft/coreth/internal/debug/BUILD.bazel
+++ b/graft/coreth/internal/debug/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "debug",
     srcs = [

--- a/graft/coreth/internal/ethapi/BUILD.bazel
+++ b/graft/coreth/internal/ethapi/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "ethapi",
     srcs = [

--- a/graft/coreth/internal/ethapi/BUILD.bazel
+++ b/graft/coreth/internal/ethapi/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "ethapi",
     srcs = [

--- a/graft/coreth/internal/flags/BUILD.bazel
+++ b/graft/coreth/internal/flags/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "flags",
     srcs = [

--- a/graft/coreth/internal/flags/BUILD.bazel
+++ b/graft/coreth/internal/flags/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "flags",
     srcs = [

--- a/graft/coreth/internal/shutdowncheck/BUILD.bazel
+++ b/graft/coreth/internal/shutdowncheck/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "shutdowncheck",
     srcs = ["shutdown_tracker.go"],

--- a/graft/coreth/internal/shutdowncheck/BUILD.bazel
+++ b/graft/coreth/internal/shutdowncheck/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "shutdowncheck",
     srcs = ["shutdown_tracker.go"],

--- a/graft/coreth/internal/version/BUILD.bazel
+++ b/graft/coreth/internal/version/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "version",
     srcs = [

--- a/graft/coreth/internal/version/BUILD.bazel
+++ b/graft/coreth/internal/version/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "version",
     srcs = [

--- a/graft/coreth/miner/BUILD.bazel
+++ b/graft/coreth/miner/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "miner",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "worker.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/miner",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/consensus",
         "//graft/coreth/core",

--- a/graft/coreth/miner/BUILD.bazel
+++ b/graft/coreth/miner/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "miner",
     srcs = [

--- a/graft/coreth/nativeasset/BUILD.bazel
+++ b/graft/coreth/nativeasset/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "nativeasset",
     srcs = ["contract.go"],

--- a/graft/coreth/nativeasset/BUILD.bazel
+++ b/graft/coreth/nativeasset/BUILD.bazel
@@ -1,11 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "nativeasset",
     srcs = ["contract.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/nativeasset",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/precompile/contract",
         "@com_github_ava_labs_libevm//common",

--- a/graft/coreth/network/BUILD.bazel
+++ b/graft/coreth/network/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "network",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "waiting_handler.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/network",
-    visibility = ["//visibility:public"],
     deps = [
         "//codec",
         "//graft/evm/message",

--- a/graft/coreth/network/BUILD.bazel
+++ b/graft/coreth/network/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "network",
     srcs = [

--- a/graft/coreth/node/BUILD.bazel
+++ b/graft/coreth/node/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "node",
     srcs = [

--- a/graft/coreth/node/BUILD.bazel
+++ b/graft/coreth/node/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "node",
     srcs = [
@@ -10,7 +16,6 @@ go_library(
         "node.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/node",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/internal/debug",
         "//graft/evm/rpc",

--- a/graft/coreth/params/BUILD.bazel
+++ b/graft/coreth/params/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "params",
     srcs = [

--- a/graft/coreth/params/BUILD.bazel
+++ b/graft/coreth/params/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "params",
     srcs = [
@@ -12,7 +18,6 @@ go_library(
         "protocol_params_ext.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/params",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/nativeasset",
         "//graft/coreth/params/extras",

--- a/graft/coreth/params/extras/BUILD.bazel
+++ b/graft/coreth/params/extras/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "extras",
     srcs = [

--- a/graft/coreth/params/extras/BUILD.bazel
+++ b/graft/coreth/params/extras/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "extras",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "rules.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/params/extras",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/precompile/modules",
         "//graft/coreth/precompile/precompileconfig",

--- a/graft/coreth/params/extras/extrastest/BUILD.bazel
+++ b/graft/coreth/params/extras/extrastest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "extrastest",
     srcs = ["test_rules.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/params/extras/extrastest",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/params",
         "//graft/coreth/params/extras",

--- a/graft/coreth/params/extras/extrastest/BUILD.bazel
+++ b/graft/coreth/params/extras/extrastest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "extrastest",
     srcs = ["test_rules.go"],

--- a/graft/coreth/params/paramstest/BUILD.bazel
+++ b/graft/coreth/params/paramstest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "paramstest",
     srcs = ["forks.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/params/paramstest",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/params",
         "//upgrade/upgradetest",

--- a/graft/coreth/params/paramstest/BUILD.bazel
+++ b/graft/coreth/params/paramstest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "paramstest",
     srcs = ["forks.go"],

--- a/graft/coreth/plugin/BUILD.bazel
+++ b/graft/coreth/plugin/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "plugin_lib",
     srcs = [

--- a/graft/coreth/plugin/BUILD.bazel
+++ b/graft/coreth/plugin/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "plugin_lib",
     srcs = [
@@ -24,5 +30,4 @@ go_library(
 go_binary(
     name = "plugin",
     embed = [":plugin_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/graft/coreth/plugin/evm/BUILD.bazel
+++ b/graft/coreth/plugin/evm/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "evm",
     srcs = [
@@ -18,7 +24,6 @@ go_library(
         "wrapped_block.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm",
-    visibility = ["//visibility:public"],
     deps = [
         "//api",
         "//cache/lru",

--- a/graft/coreth/plugin/evm/BUILD.bazel
+++ b/graft/coreth/plugin/evm/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "evm",
     srcs = [

--- a/graft/coreth/plugin/evm/atomic/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "atomic",
     srcs = [
@@ -14,7 +20,6 @@ go_library(
         "tx.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic",
-    visibility = ["//visibility:public"],
     deps = [
         "//chains/atomic",
         "//codec",

--- a/graft/coreth/plugin/evm/atomic/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "atomic",
     srcs = [

--- a/graft/coreth/plugin/evm/atomic/atomictest/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/atomictest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "atomictest",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "tx.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/atomictest",
-    visibility = ["//visibility:public"],
     deps = [
         "//chains/atomic",
         "//codec",

--- a/graft/coreth/plugin/evm/atomic/atomictest/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/atomictest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "atomictest",
     srcs = [

--- a/graft/coreth/plugin/evm/atomic/state/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/state/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "state",
     srcs = [

--- a/graft/coreth/plugin/evm/atomic/state/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/state/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "state",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "atomic_trie_iterator.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/state",
-    visibility = ["//visibility:public"],
     deps = [
         "//chains/atomic",
         "//codec",

--- a/graft/coreth/plugin/evm/atomic/sync/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/sync/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "sync",
     srcs = [

--- a/graft/coreth/plugin/evm/atomic/sync/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/sync/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "sync",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "syncer.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/sync",
-    visibility = ["//visibility:public"],
     deps = [
         "//codec",
         "//database/versiondb",

--- a/graft/coreth/plugin/evm/atomic/txpool/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/txpool/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "txpool",
     srcs = [

--- a/graft/coreth/plugin/evm/atomic/txpool/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/txpool/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "txpool",
     srcs = [
@@ -10,7 +16,6 @@ go_library(
         "txs.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/txpool",
-    visibility = ["//visibility:public"],
     deps = [
         "//cache/lru",
         "//graft/coreth/plugin/evm/atomic",

--- a/graft/coreth/plugin/evm/atomic/vm/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/vm/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "vm",
     srcs = [
@@ -17,7 +23,6 @@ go_library(
         "mainnet_ext_data_hashes.json",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/vm",
-    visibility = ["//visibility:public"],
     deps = [
         "//api",
         "//codec",

--- a/graft/coreth/plugin/evm/atomic/vm/BUILD.bazel
+++ b/graft/coreth/plugin/evm/atomic/vm/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "vm",
     srcs = [

--- a/graft/coreth/plugin/evm/client/BUILD.bazel
+++ b/graft/coreth/plugin/evm/client/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "client",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "utils.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/client",
-    visibility = ["//visibility:public"],
     deps = [
         "//api",
         "//graft/coreth/plugin/evm/atomic",

--- a/graft/coreth/plugin/evm/client/BUILD.bazel
+++ b/graft/coreth/plugin/evm/client/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "client",
     srcs = [

--- a/graft/coreth/plugin/evm/config/BUILD.bazel
+++ b/graft/coreth/plugin/evm/config/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "config",
     srcs = [

--- a/graft/coreth/plugin/evm/config/BUILD.bazel
+++ b/graft/coreth/plugin/evm/config/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "config",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "default_config.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/config",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//utils/constants",

--- a/graft/coreth/plugin/evm/customheader/BUILD.bazel
+++ b/graft/coreth/plugin/evm/customheader/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "customheader",
     srcs = [
@@ -14,7 +20,6 @@ go_library(
         "time.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/customheader",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/params/extras",
         "//graft/coreth/plugin/evm/customtypes",

--- a/graft/coreth/plugin/evm/customheader/BUILD.bazel
+++ b/graft/coreth/plugin/evm/customheader/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "customheader",
     srcs = [

--- a/graft/coreth/plugin/evm/customtypes/BUILD.bazel
+++ b/graft/coreth/plugin/evm/customtypes/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "customtypes",
     srcs = [
@@ -13,7 +19,6 @@ go_library(
         "state_account_ext.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/customtypes",
-    visibility = ["//visibility:public"],
     deps = [
         "//vms/evm/acp226",
         "@com_github_ava_labs_libevm//common",

--- a/graft/coreth/plugin/evm/customtypes/BUILD.bazel
+++ b/graft/coreth/plugin/evm/customtypes/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "customtypes",
     srcs = [

--- a/graft/coreth/plugin/evm/extension/BUILD.bazel
+++ b/graft/coreth/plugin/evm/extension/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "extension",
     srcs = ["config.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/extension",
-    visibility = ["//visibility:public"],
     deps = [
         "//database",
         "//database/versiondb",

--- a/graft/coreth/plugin/evm/extension/BUILD.bazel
+++ b/graft/coreth/plugin/evm/extension/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "extension",
     srcs = ["config.go"],

--- a/graft/coreth/plugin/evm/log/BUILD.bazel
+++ b/graft/coreth/plugin/evm/log/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "log",
     srcs = ["log.go"],

--- a/graft/coreth/plugin/evm/log/BUILD.bazel
+++ b/graft/coreth/plugin/evm/log/BUILD.bazel
@@ -1,11 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "log",
     srcs = ["log.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/log",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/log",
         "@com_github_ava_labs_libevm//log",

--- a/graft/coreth/plugin/evm/tempextrastest/BUILD.bazel
+++ b/graft/coreth/plugin/evm/tempextrastest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 graft_go_test(
     name = "tempextrastest_test",
     srcs = ["tempextras_test.go"],

--- a/graft/coreth/plugin/evm/tempextrastest/BUILD.bazel
+++ b/graft/coreth/plugin/evm/tempextrastest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 graft_go_test(
     name = "tempextrastest_test",
     srcs = ["tempextras_test.go"],

--- a/graft/coreth/plugin/evm/upgrade/ap0/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap0/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "ap0",
     srcs = ["params.go"],

--- a/graft/coreth/plugin/evm/upgrade/ap0/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap0/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "ap0",
     srcs = ["params.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/ap0",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//utils/units",

--- a/graft/coreth/plugin/evm/upgrade/ap1/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap1/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "ap1",
     srcs = ["params.go"],

--- a/graft/coreth/plugin/evm/upgrade/ap1/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap1/BUILD.bazel
@@ -1,9 +1,14 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "ap1",
     srcs = ["params.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/ap1",
-    visibility = ["//visibility:public"],
     deps = ["//graft/evm/utils"],
 )

--- a/graft/coreth/plugin/evm/upgrade/ap3/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap3/BUILD.bazel
@@ -1,11 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "ap3",
     srcs = ["window.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/ap3",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//utils/wrappers",

--- a/graft/coreth/plugin/evm/upgrade/ap3/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap3/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "ap3",
     srcs = ["window.go"],

--- a/graft/coreth/plugin/evm/upgrade/ap4/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap4/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "ap4",
     srcs = ["cost.go"],

--- a/graft/coreth/plugin/evm/upgrade/ap4/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap4/BUILD.bazel
@@ -1,11 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "ap4",
     srcs = ["cost.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/ap4",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//utils/math",

--- a/graft/coreth/plugin/evm/upgrade/ap5/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap5/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "ap5",
     srcs = ["params.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/ap5",
-    visibility = ["//visibility:public"],
 )

--- a/graft/coreth/plugin/evm/upgrade/ap5/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/ap5/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "ap5",
     srcs = ["params.go"],

--- a/graft/coreth/plugin/evm/upgrade/cortina/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/cortina/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "cortina",
     srcs = ["params.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/cortina",
-    visibility = ["//visibility:public"],
 )

--- a/graft/coreth/plugin/evm/upgrade/cortina/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/cortina/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "cortina",
     srcs = ["params.go"],

--- a/graft/coreth/plugin/evm/upgrade/etna/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/etna/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "etna",
     srcs = ["params.go"],

--- a/graft/coreth/plugin/evm/upgrade/etna/BUILD.bazel
+++ b/graft/coreth/plugin/evm/upgrade/etna/BUILD.bazel
@@ -1,9 +1,14 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "etna",
     srcs = ["params.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/etna",
-    visibility = ["//visibility:public"],
     deps = ["//graft/evm/utils"],
 )

--- a/graft/coreth/plugin/evm/vmerrors/BUILD.bazel
+++ b/graft/coreth/plugin/evm/vmerrors/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "vmerrors",
     srcs = ["errors.go"],

--- a/graft/coreth/plugin/evm/vmerrors/BUILD.bazel
+++ b/graft/coreth/plugin/evm/vmerrors/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "vmerrors",
     srcs = ["errors.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/vmerrors",
-    visibility = ["//visibility:public"],
 )

--- a/graft/coreth/plugin/evm/vmtest/BUILD.bazel
+++ b/graft/coreth/plugin/evm/vmtest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "vmtest",
     srcs = [

--- a/graft/coreth/plugin/evm/vmtest/BUILD.bazel
+++ b/graft/coreth/plugin/evm/vmtest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "vmtest",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "test_vm.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/vmtest",
-    visibility = ["//visibility:public"],
     deps = [
         "//api/metrics",
         "//chains/atomic",

--- a/graft/coreth/plugin/factory/BUILD.bazel
+++ b/graft/coreth/plugin/factory/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "factory",
     srcs = ["factory.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/plugin/factory",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/plugin/evm",
         "//graft/coreth/plugin/evm/atomic/vm",

--- a/graft/coreth/plugin/factory/BUILD.bazel
+++ b/graft/coreth/plugin/factory/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "factory",
     srcs = ["factory.go"],

--- a/graft/coreth/precompile/contract/BUILD.bazel
+++ b/graft/coreth/precompile/contract/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "contract",
     srcs = [

--- a/graft/coreth/precompile/contract/BUILD.bazel
+++ b/graft/coreth/precompile/contract/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "contract",
     srcs = [
@@ -10,7 +16,6 @@ go_library(
         "utils.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/precompile/contract",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/precompile/precompileconfig",
         "//snow",

--- a/graft/coreth/precompile/contracts/warp/BUILD.bazel
+++ b/graft/coreth/precompile/contracts/warp/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "warp",
     srcs = [

--- a/graft/coreth/precompile/contracts/warp/BUILD.bazel
+++ b/graft/coreth/precompile/contracts/warp/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "warp",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
     ],
     embedsrcs = ["IWarpMessenger.abi"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/precompile/contracts/warp",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/precompile/contract",
         "//graft/coreth/precompile/modules",

--- a/graft/coreth/precompile/contracts/warp/warpbindings/BUILD.bazel
+++ b/graft/coreth/precompile/contracts/warp/warpbindings/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "warpbindings",
     srcs = ["compile.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/precompile/contracts/warp/warpbindings",
-    visibility = ["//visibility:public"],
 )

--- a/graft/coreth/precompile/contracts/warp/warpbindings/BUILD.bazel
+++ b/graft/coreth/precompile/contracts/warp/warpbindings/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "warpbindings",
     srcs = ["compile.go"],

--- a/graft/coreth/precompile/modules/BUILD.bazel
+++ b/graft/coreth/precompile/modules/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "modules",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "registerer.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/precompile/modules",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/precompile/contract",
         "//graft/evm/constants",

--- a/graft/coreth/precompile/modules/BUILD.bazel
+++ b/graft/coreth/precompile/modules/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "modules",
     srcs = [

--- a/graft/coreth/precompile/precompileconfig/BUILD.bazel
+++ b/graft/coreth/precompile/precompileconfig/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "precompileconfig",
     srcs = [

--- a/graft/coreth/precompile/precompileconfig/BUILD.bazel
+++ b/graft/coreth/precompile/precompileconfig/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "precompileconfig",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "upgradeable.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/precompile/precompileconfig",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//snow",

--- a/graft/coreth/precompile/precompiletest/BUILD.bazel
+++ b/graft/coreth/precompile/precompiletest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "precompiletest",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "test_predicate.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/precompile/precompiletest",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core/extstate",
         "//graft/coreth/params/extras",

--- a/graft/coreth/precompile/precompiletest/BUILD.bazel
+++ b/graft/coreth/precompile/precompiletest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "precompiletest",
     srcs = [

--- a/graft/coreth/precompile/registry/BUILD.bazel
+++ b/graft/coreth/precompile/registry/BUILD.bazel
@@ -1,9 +1,14 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "registry",
     srcs = ["registry.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/precompile/registry",
-    visibility = ["//visibility:public"],
     deps = ["//graft/coreth/precompile/contracts/warp"],
 )

--- a/graft/coreth/precompile/registry/BUILD.bazel
+++ b/graft/coreth/precompile/registry/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "registry",
     srcs = ["registry.go"],

--- a/graft/coreth/tests/BUILD.bazel
+++ b/graft/coreth/tests/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "tests",
     srcs = ["state_test_util.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/tests",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/coreth/core/extstate",
         "//graft/evm/core/state/snapshot",

--- a/graft/coreth/tests/BUILD.bazel
+++ b/graft/coreth/tests/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "tests",
     srcs = ["state_test_util.go"],

--- a/graft/coreth/tests/utils/BUILD.bazel
+++ b/graft/coreth/tests/utils/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "utils",
     srcs = [
@@ -10,7 +16,6 @@ go_library(
         "tmpnet.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/tests/utils",
-    visibility = ["//visibility:public"],
     deps = [
         "//api/health",
         "//config",

--- a/graft/coreth/tests/utils/BUILD.bazel
+++ b/graft/coreth/tests/utils/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "utils",
     srcs = [

--- a/graft/coreth/tests/warp/BUILD.bazel
+++ b/graft/coreth/tests/warp/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 graft_go_test(
     name = "warp_test",
     srcs = ["warp_test.go"],

--- a/graft/coreth/tests/warp/BUILD.bazel
+++ b/graft/coreth/tests/warp/BUILD.bazel
@@ -1,5 +1,11 @@
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 graft_go_test(
     name = "warp_test",
     srcs = ["warp_test.go"],

--- a/graft/coreth/warp/BUILD.bazel
+++ b/graft/coreth/warp/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "warp",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "verifier_stats.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/warp",
-    visibility = ["//visibility:public"],
     deps = [
         "//cache",
         "//cache/lru",

--- a/graft/coreth/warp/BUILD.bazel
+++ b/graft/coreth/warp/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "warp",
     srcs = [

--- a/graft/coreth/warp/warptest/BUILD.bazel
+++ b/graft/coreth/warp/warptest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/coreth:__subpackages__",
+    "//graft/coreth:external_consumers",
+])
+
+
 go_library(
     name = "warptest",
     srcs = ["block_client.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/warp/warptest",
-    visibility = ["//visibility:public"],
     deps = [
         "//database",
         "//ids",

--- a/graft/coreth/warp/warptest/BUILD.bazel
+++ b/graft/coreth/warp/warptest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/coreth:external_consumers",
 ])
 
-
 go_library(
     name = "warptest",
     srcs = ["block_client.go"],

--- a/graft/subnet-evm/BUILD.bazel
+++ b/graft/subnet-evm/BUILD.bazel
@@ -1,2 +1,16 @@
 # gazelle:prefix github.com/ava-labs/avalanchego/graft/subnet-evm
 # gazelle:map_kind go_test graft_go_test //.bazel:defs.bzl
+# gazelle:default_visibility //graft/subnet-evm:__subpackages__,//graft/subnet-evm:external_consumers
+
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
+package_group(
+    name = "external_consumers",
+    packages = [
+        "//vms/evm/emulate",
+    ],
+)

--- a/graft/subnet-evm/BUILD.bazel
+++ b/graft/subnet-evm/BUILD.bazel
@@ -7,7 +7,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 package_group(
     name = "external_consumers",
     packages = [

--- a/graft/subnet-evm/accounts/abi/bind/BUILD.bazel
+++ b/graft/subnet-evm/accounts/abi/bind/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "bind",
     srcs = [
@@ -13,7 +19,6 @@ go_library(
         "util.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/accounts/abi/bind",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/rpc",
         "@com_github_ava_labs_libevm//:libevm",

--- a/graft/subnet-evm/accounts/abi/bind/BUILD.bazel
+++ b/graft/subnet-evm/accounts/abi/bind/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "bind",
     srcs = [

--- a/graft/subnet-evm/accounts/abi/bind/backends/BUILD.bazel
+++ b/graft/subnet-evm/accounts/abi/bind/backends/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "backends",
     srcs = ["simulated.go"],

--- a/graft/subnet-evm/accounts/abi/bind/backends/BUILD.bazel
+++ b/graft/subnet-evm/accounts/abi/bind/backends/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "backends",
     srcs = ["simulated.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/accounts/abi/bind/backends",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "//graft/subnet-evm/ethclient/simulated",

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/BUILD.bazel
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "precompilebind",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "precompile_module_template.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/accounts/abi/bind/precompilebind",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "//graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest",

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/BUILD.bazel
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "precompilebind",
     srcs = [

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest/BUILD.bazel
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "templatetest",
     srcs = [
@@ -7,5 +13,4 @@ go_library(
         "precompile_contract_test_template.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest",
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest/BUILD.bazel
+++ b/graft/subnet-evm/accounts/abi/bind/precompilebind/templatetest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "templatetest",
     srcs = [

--- a/graft/subnet-evm/cmd/precompilegen/BUILD.bazel
+++ b/graft/subnet-evm/cmd/precompilegen/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "precompilegen_lib",
     srcs = ["main.go"],
@@ -19,5 +25,4 @@ go_library(
 go_binary(
     name = "precompilegen",
     embed = [":precompilegen_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/cmd/precompilegen/BUILD.bazel
+++ b/graft/subnet-evm/cmd/precompilegen/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "precompilegen_lib",
     srcs = ["main.go"],

--- a/graft/subnet-evm/cmd/simulator/config/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/config/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "config",
     srcs = ["flags.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/cmd/simulator/config",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",

--- a/graft/subnet-evm/cmd/simulator/config/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/config/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "config",
     srcs = ["flags.go"],

--- a/graft/subnet-evm/cmd/simulator/key/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/key/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "key",
     srcs = ["key.go"],

--- a/graft/subnet-evm/cmd/simulator/key/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/key/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "key",
     srcs = ["key.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/cmd/simulator/key",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//crypto",

--- a/graft/subnet-evm/cmd/simulator/load/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/load/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "load",
     srcs = [

--- a/graft/subnet-evm/cmd/simulator/load/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/load/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "load",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "worker.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/cmd/simulator/load",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/cmd/simulator/config",
         "//graft/subnet-evm/cmd/simulator/key",

--- a/graft/subnet-evm/cmd/simulator/main/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/main/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "main_lib",
     srcs = ["main.go"],

--- a/graft/subnet-evm/cmd/simulator/main/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/main/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "main_lib",
     srcs = ["main.go"],
@@ -17,5 +23,4 @@ go_library(
 go_binary(
     name = "main",
     embed = [":main_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/cmd/simulator/metrics/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/metrics/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "metrics",
     srcs = ["metrics.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/cmd/simulator/metrics",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/rpc",
         "@com_github_ava_labs_libevm//log",

--- a/graft/subnet-evm/cmd/simulator/metrics/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/metrics/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "metrics",
     srcs = ["metrics.go"],

--- a/graft/subnet-evm/cmd/simulator/txs/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/txs/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "txs",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "tx_generator.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/cmd/simulator/txs",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/cmd/simulator/metrics",
         "//graft/subnet-evm/ethclient",

--- a/graft/subnet-evm/cmd/simulator/txs/BUILD.bazel
+++ b/graft/subnet-evm/cmd/simulator/txs/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "txs",
     srcs = [

--- a/graft/subnet-evm/commontype/BUILD.bazel
+++ b/graft/subnet-evm/commontype/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "commontype",
     srcs = [

--- a/graft/subnet-evm/commontype/BUILD.bazel
+++ b/graft/subnet-evm/commontype/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "commontype",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "test_fee_config.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/commontype",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "@com_github_ava_labs_libevm//common",

--- a/graft/subnet-evm/consensus/BUILD.bazel
+++ b/graft/subnet-evm/consensus/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "consensus",
     srcs = [

--- a/graft/subnet-evm/consensus/BUILD.bazel
+++ b/graft/subnet-evm/consensus/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "consensus",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "errors.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/consensus",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/commontype",
         "//graft/subnet-evm/params",

--- a/graft/subnet-evm/consensus/dummy/BUILD.bazel
+++ b/graft/subnet-evm/consensus/dummy/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "dummy",
     srcs = ["consensus.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/consensus/dummy",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//graft/subnet-evm/consensus",

--- a/graft/subnet-evm/consensus/dummy/BUILD.bazel
+++ b/graft/subnet-evm/consensus/dummy/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "dummy",
     srcs = ["consensus.go"],

--- a/graft/subnet-evm/core/BUILD.bazel
+++ b/graft/subnet-evm/core/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "core",
     srcs = [
@@ -32,7 +38,6 @@ go_library(
         "types.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/core",
-    visibility = ["//visibility:public"],
     deps = [
         "//database",
         "//graft/evm/constants",

--- a/graft/subnet-evm/core/BUILD.bazel
+++ b/graft/subnet-evm/core/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "core",
     srcs = [

--- a/graft/subnet-evm/core/coretest/BUILD.bazel
+++ b/graft/subnet-evm/core/coretest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "coretest",
     srcs = ["test_indices.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/core/coretest",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_ava_labs_libevm//core/rawdb",
         "@com_github_ava_labs_libevm//ethdb",

--- a/graft/subnet-evm/core/coretest/BUILD.bazel
+++ b/graft/subnet-evm/core/coretest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "coretest",
     srcs = ["test_indices.go"],

--- a/graft/subnet-evm/core/extstate/BUILD.bazel
+++ b/graft/subnet-evm/core/extstate/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "extstate",
     srcs = [

--- a/graft/subnet-evm/core/extstate/BUILD.bazel
+++ b/graft/subnet-evm/core/extstate/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "extstate",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "statedb.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/core/extstate",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/firewood",
         "//graft/evm/utils",

--- a/graft/subnet-evm/core/txpool/BUILD.bazel
+++ b/graft/subnet-evm/core/txpool/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "txpool",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "validation.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/core/txpool",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/core",
         "//graft/subnet-evm/params",

--- a/graft/subnet-evm/core/txpool/BUILD.bazel
+++ b/graft/subnet-evm/core/txpool/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "txpool",
     srcs = [

--- a/graft/subnet-evm/core/txpool/blobpool/BUILD.bazel
+++ b/graft/subnet-evm/core/txpool/blobpool/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "blobpool",
     srcs = [

--- a/graft/subnet-evm/core/txpool/blobpool/BUILD.bazel
+++ b/graft/subnet-evm/core/txpool/blobpool/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "blobpool",
     srcs = [
@@ -14,7 +20,6 @@ go_library(
         "slotter.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/core/txpool/blobpool",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/commontype",
         "//graft/subnet-evm/core",

--- a/graft/subnet-evm/core/txpool/legacypool/BUILD.bazel
+++ b/graft/subnet-evm/core/txpool/legacypool/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "legacypool",
     srcs = [
@@ -10,7 +16,6 @@ go_library(
         "noncer.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/core/txpool/legacypool",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//graft/subnet-evm/commontype",

--- a/graft/subnet-evm/core/txpool/legacypool/BUILD.bazel
+++ b/graft/subnet-evm/core/txpool/legacypool/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "legacypool",
     srcs = [

--- a/graft/subnet-evm/core/vm/runtime/BUILD.bazel
+++ b/graft/subnet-evm/core/vm/runtime/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "runtime",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "runtime.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/core/vm/runtime",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/core",
         "//graft/subnet-evm/params",

--- a/graft/subnet-evm/core/vm/runtime/BUILD.bazel
+++ b/graft/subnet-evm/core/vm/runtime/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "runtime",
     srcs = [

--- a/graft/subnet-evm/eth/BUILD.bazel
+++ b/graft/subnet-evm/eth/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "eth",
     srcs = [
@@ -14,7 +20,6 @@ go_library(
         "state_accessor.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/eth",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/core/state/pruner",
         "//graft/evm/firewood",

--- a/graft/subnet-evm/eth/BUILD.bazel
+++ b/graft/subnet-evm/eth/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "eth",
     srcs = [

--- a/graft/subnet-evm/eth/ethconfig/BUILD.bazel
+++ b/graft/subnet-evm/eth/ethconfig/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "ethconfig",
     srcs = [

--- a/graft/subnet-evm/eth/ethconfig/BUILD.bazel
+++ b/graft/subnet-evm/eth/ethconfig/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "ethconfig",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "gen_config.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/eth/ethconfig",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/core",
         "//graft/subnet-evm/core/txpool/blobpool",

--- a/graft/subnet-evm/eth/filters/BUILD.bazel
+++ b/graft/subnet-evm/eth/filters/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "filters",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "filter_system.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/eth/filters",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/rpc",
         "//graft/subnet-evm/core",

--- a/graft/subnet-evm/eth/filters/BUILD.bazel
+++ b/graft/subnet-evm/eth/filters/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "filters",
     srcs = [

--- a/graft/subnet-evm/eth/gasestimator/BUILD.bazel
+++ b/graft/subnet-evm/eth/gasestimator/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "gasestimator",
     srcs = ["gasestimator.go"],

--- a/graft/subnet-evm/eth/gasestimator/BUILD.bazel
+++ b/graft/subnet-evm/eth/gasestimator/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "gasestimator",
     srcs = ["gasestimator.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/eth/gasestimator",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/core",
         "//graft/subnet-evm/params",

--- a/graft/subnet-evm/eth/gasprice/BUILD.bazel
+++ b/graft/subnet-evm/eth/gasprice/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "gasprice",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "gasprice.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/eth/gasprice",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/rpc",
         "//graft/subnet-evm/commontype",

--- a/graft/subnet-evm/eth/gasprice/BUILD.bazel
+++ b/graft/subnet-evm/eth/gasprice/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "gasprice",
     srcs = [

--- a/graft/subnet-evm/eth/tracers/BUILD.bazel
+++ b/graft/subnet-evm/eth/tracers/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "tracers",
     srcs = [

--- a/graft/subnet-evm/eth/tracers/BUILD.bazel
+++ b/graft/subnet-evm/eth/tracers/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "tracers",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "tracker.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/eth/tracers",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/firewood",
         "//graft/evm/rpc",

--- a/graft/subnet-evm/ethclient/BUILD.bazel
+++ b/graft/subnet-evm/ethclient/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "ethclient",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "signer.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/ethclient",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/rpc",
         "//graft/subnet-evm/accounts/abi/bind",

--- a/graft/subnet-evm/ethclient/BUILD.bazel
+++ b/graft/subnet-evm/ethclient/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "ethclient",
     srcs = [

--- a/graft/subnet-evm/ethclient/simulated/BUILD.bazel
+++ b/graft/subnet-evm/ethclient/simulated/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "simulated",
     srcs = [

--- a/graft/subnet-evm/ethclient/simulated/BUILD.bazel
+++ b/graft/subnet-evm/ethclient/simulated/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "simulated",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "options.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/ethclient/simulated",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/constants",
         "//graft/evm/rpc",

--- a/graft/subnet-evm/ethclient/subnetevmclient/BUILD.bazel
+++ b/graft/subnet-evm/ethclient/subnetevmclient/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "subnetevmclient",
     srcs = ["subnet_evm_client.go"],

--- a/graft/subnet-evm/ethclient/subnetevmclient/BUILD.bazel
+++ b/graft/subnet-evm/ethclient/subnetevmclient/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "subnetevmclient",
     srcs = ["subnet_evm_client.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/ethclient/subnetevmclient",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/rpc",
         "//graft/subnet-evm/ethclient",

--- a/graft/subnet-evm/examples/sign-uptime-message/BUILD.bazel
+++ b/graft/subnet-evm/examples/sign-uptime-message/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "sign-uptime-message_lib",
     srcs = ["main.go"],

--- a/graft/subnet-evm/examples/sign-uptime-message/BUILD.bazel
+++ b/graft/subnet-evm/examples/sign-uptime-message/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "sign-uptime-message_lib",
     srcs = ["main.go"],
@@ -26,5 +32,4 @@ go_library(
 go_binary(
     name = "sign-uptime-message",
     embed = [":sign-uptime-message_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/interfaces/BUILD.bazel
+++ b/graft/subnet-evm/interfaces/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "interfaces",
     srcs = ["interfaces.go"],

--- a/graft/subnet-evm/interfaces/BUILD.bazel
+++ b/graft/subnet-evm/interfaces/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "interfaces",
     srcs = ["interfaces.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/interfaces",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_ava_labs_libevm//:libevm",
         "@com_github_ava_labs_libevm//common",

--- a/graft/subnet-evm/internal/blocktest/BUILD.bazel
+++ b/graft/subnet-evm/internal/blocktest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "blocktest",
     srcs = ["test_hash.go"],

--- a/graft/subnet-evm/internal/blocktest/BUILD.bazel
+++ b/graft/subnet-evm/internal/blocktest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "blocktest",
     srcs = ["test_hash.go"],

--- a/graft/subnet-evm/internal/debug/BUILD.bazel
+++ b/graft/subnet-evm/internal/debug/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "debug",
     srcs = [

--- a/graft/subnet-evm/internal/debug/BUILD.bazel
+++ b/graft/subnet-evm/internal/debug/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "debug",
     srcs = [

--- a/graft/subnet-evm/internal/ethapi/BUILD.bazel
+++ b/graft/subnet-evm/internal/ethapi/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "ethapi",
     srcs = [

--- a/graft/subnet-evm/internal/ethapi/BUILD.bazel
+++ b/graft/subnet-evm/internal/ethapi/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "ethapi",
     srcs = [

--- a/graft/subnet-evm/internal/flags/BUILD.bazel
+++ b/graft/subnet-evm/internal/flags/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "flags",
     srcs = [

--- a/graft/subnet-evm/internal/flags/BUILD.bazel
+++ b/graft/subnet-evm/internal/flags/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "flags",
     srcs = [

--- a/graft/subnet-evm/internal/shutdowncheck/BUILD.bazel
+++ b/graft/subnet-evm/internal/shutdowncheck/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "shutdowncheck",
     srcs = ["shutdown_tracker.go"],

--- a/graft/subnet-evm/internal/shutdowncheck/BUILD.bazel
+++ b/graft/subnet-evm/internal/shutdowncheck/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "shutdowncheck",
     srcs = ["shutdown_tracker.go"],

--- a/graft/subnet-evm/internal/version/BUILD.bazel
+++ b/graft/subnet-evm/internal/version/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "version",
     srcs = [

--- a/graft/subnet-evm/internal/version/BUILD.bazel
+++ b/graft/subnet-evm/internal/version/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "version",
     srcs = [

--- a/graft/subnet-evm/miner/BUILD.bazel
+++ b/graft/subnet-evm/miner/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "miner",
     srcs = [

--- a/graft/subnet-evm/miner/BUILD.bazel
+++ b/graft/subnet-evm/miner/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "miner",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "worker.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/miner",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/commontype",
         "//graft/subnet-evm/consensus",

--- a/graft/subnet-evm/network/BUILD.bazel
+++ b/graft/subnet-evm/network/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "network",
     srcs = [

--- a/graft/subnet-evm/network/BUILD.bazel
+++ b/graft/subnet-evm/network/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "network",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "waiting_handler.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/network",
-    visibility = ["//visibility:public"],
     deps = [
         "//codec",
         "//graft/evm/message",

--- a/graft/subnet-evm/network/peertest/BUILD.bazel
+++ b/graft/subnet-evm/network/peertest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "peertest",
     srcs = ["request_id.go"],

--- a/graft/subnet-evm/network/peertest/BUILD.bazel
+++ b/graft/subnet-evm/network/peertest/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "peertest",
     srcs = ["request_id.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/network/peertest",
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/node/BUILD.bazel
+++ b/graft/subnet-evm/node/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "node",
     srcs = [

--- a/graft/subnet-evm/node/BUILD.bazel
+++ b/graft/subnet-evm/node/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "node",
     srcs = [
@@ -10,7 +16,6 @@ go_library(
         "node.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/node",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/rpc",
         "//graft/subnet-evm/internal/debug",

--- a/graft/subnet-evm/params/BUILD.bazel
+++ b/graft/subnet-evm/params/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "params",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "hooks_libevm.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/params",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/params/extras",
         "//graft/subnet-evm/plugin/evm/customheader",

--- a/graft/subnet-evm/params/BUILD.bazel
+++ b/graft/subnet-evm/params/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "params",
     srcs = [

--- a/graft/subnet-evm/params/extras/BUILD.bazel
+++ b/graft/subnet-evm/params/extras/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "extras",
     srcs = [

--- a/graft/subnet-evm/params/extras/BUILD.bazel
+++ b/graft/subnet-evm/params/extras/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "extras",
     srcs = [
@@ -12,7 +18,6 @@ go_library(
         "state_upgrade.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/params/extras",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//graft/subnet-evm/commontype",

--- a/graft/subnet-evm/params/extras/extrastest/BUILD.bazel
+++ b/graft/subnet-evm/params/extras/extrastest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "extrastest",
     srcs = ["rules.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/params/extras/extrastest",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/params/extras",
         "//upgrade",

--- a/graft/subnet-evm/params/extras/extrastest/BUILD.bazel
+++ b/graft/subnet-evm/params/extras/extrastest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "extrastest",
     srcs = ["rules.go"],

--- a/graft/subnet-evm/params/paramstest/BUILD.bazel
+++ b/graft/subnet-evm/params/paramstest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "paramstest",
     srcs = ["forks.go"],

--- a/graft/subnet-evm/params/paramstest/BUILD.bazel
+++ b/graft/subnet-evm/params/paramstest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "paramstest",
     srcs = ["forks.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/params/paramstest",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/params",
         "//upgrade/upgradetest",

--- a/graft/subnet-evm/plugin/BUILD.bazel
+++ b/graft/subnet-evm/plugin/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "plugin_lib",
     srcs = ["main.go"],
@@ -15,5 +21,4 @@ go_library(
 go_binary(
     name = "plugin",
     embed = [":plugin_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/plugin/BUILD.bazel
+++ b/graft/subnet-evm/plugin/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "plugin_lib",
     srcs = ["main.go"],

--- a/graft/subnet-evm/plugin/evm/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "evm",
     srcs = [

--- a/graft/subnet-evm/plugin/evm/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "evm",
     srcs = [
@@ -21,7 +27,6 @@ go_library(
         "wrapped_block.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm",
-    visibility = ["//visibility:public"],
     deps = [
         "//api",
         "//api/metrics",

--- a/graft/subnet-evm/plugin/evm/blockgascost/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/blockgascost/BUILD.bazel
@@ -1,11 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "blockgascost",
     srcs = ["cost.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/blockgascost",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/commontype",
         "//utils/math",

--- a/graft/subnet-evm/plugin/evm/blockgascost/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/blockgascost/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "blockgascost",
     srcs = ["cost.go"],

--- a/graft/subnet-evm/plugin/evm/client/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/client/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "client",
     srcs = ["client.go"],

--- a/graft/subnet-evm/plugin/evm/client/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/client/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "client",
     srcs = ["client.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/client",
-    visibility = ["//visibility:public"],
     deps = [
         "//api",
         "//graft/subnet-evm/plugin/evm/config",

--- a/graft/subnet-evm/plugin/evm/config/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/config/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "config",
     srcs = [

--- a/graft/subnet-evm/plugin/evm/config/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/config/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "config",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "default_config.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/config",
-    visibility = ["//visibility:public"],
     deps = [
         "//database/pebbledb",
         "@com_github_ava_labs_libevm//common",

--- a/graft/subnet-evm/plugin/evm/customheader/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/customheader/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "customheader",
     srcs = [
@@ -13,7 +19,6 @@ go_library(
         "time.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/customheader",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/commontype",
         "//graft/subnet-evm/params/extras",

--- a/graft/subnet-evm/plugin/evm/customheader/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/customheader/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "customheader",
     srcs = [

--- a/graft/subnet-evm/plugin/evm/customtypes/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/customtypes/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "customtypes",
     srcs = [

--- a/graft/subnet-evm/plugin/evm/customtypes/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/customtypes/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "customtypes",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "libevm.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/customtypes",
-    visibility = ["//visibility:public"],
     deps = [
         "//vms/evm/acp226",
         "@com_github_ava_labs_libevm//common",

--- a/graft/subnet-evm/plugin/evm/extension/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/extension/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "extension",
     srcs = ["config.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/extension",
-    visibility = ["//visibility:public"],
     deps = [
         "//database",
         "//database/versiondb",

--- a/graft/subnet-evm/plugin/evm/extension/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/extension/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "extension",
     srcs = ["config.go"],

--- a/graft/subnet-evm/plugin/evm/log/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/log/BUILD.bazel
@@ -1,11 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "log",
     srcs = ["log.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/log",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/log",
         "@com_github_ava_labs_libevm//log",

--- a/graft/subnet-evm/plugin/evm/log/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/log/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "log",
     srcs = ["log.go"],

--- a/graft/subnet-evm/plugin/evm/tempextrastest/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/tempextrastest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 graft_go_test(
     name = "tempextrastest_test",
     srcs = ["tempextras_test.go"],

--- a/graft/subnet-evm/plugin/evm/tempextrastest/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/tempextrastest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 graft_go_test(
     name = "tempextrastest_test",
     srcs = ["tempextras_test.go"],

--- a/graft/subnet-evm/plugin/evm/upgrade/legacy/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/upgrade/legacy/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "legacy",
     srcs = ["params.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/upgrade/legacy",
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/plugin/evm/upgrade/legacy/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/upgrade/legacy/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "legacy",
     srcs = ["params.go"],

--- a/graft/subnet-evm/plugin/evm/upgrade/subnetevm/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/upgrade/subnetevm/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "subnetevm",
     srcs = ["window.go"],

--- a/graft/subnet-evm/plugin/evm/upgrade/subnetevm/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/upgrade/subnetevm/BUILD.bazel
@@ -1,11 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "subnetevm",
     srcs = ["window.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/upgrade/subnetevm",
-    visibility = ["//visibility:public"],
     deps = [
         "//utils/wrappers",
         "@com_github_ava_labs_libevm//common/math",

--- a/graft/subnet-evm/plugin/evm/vmerrors/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/vmerrors/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "vmerrors",
     srcs = ["errors.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/vmerrors",
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/plugin/evm/vmerrors/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/vmerrors/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "vmerrors",
     srcs = ["errors.go"],

--- a/graft/subnet-evm/plugin/runner/BUILD.bazel
+++ b/graft/subnet-evm/plugin/runner/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "runner",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "runner.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/runner",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/plugin/evm",
         "//utils/logging",

--- a/graft/subnet-evm/plugin/runner/BUILD.bazel
+++ b/graft/subnet-evm/plugin/runner/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "runner",
     srcs = [

--- a/graft/subnet-evm/precompile/allowlist/BUILD.bazel
+++ b/graft/subnet-evm/precompile/allowlist/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "allowlist",
     srcs = [

--- a/graft/subnet-evm/precompile/allowlist/BUILD.bazel
+++ b/graft/subnet-evm/precompile/allowlist/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "allowlist",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
     ],
     embedsrcs = ["IAllowList.abi"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/allowlist",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/precompile/contract",
         "//graft/subnet-evm/precompile/precompileconfig",

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/BUILD.bazel
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "allowlisttest",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "test_allowlist_helpers.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/allowlist/allowlisttest",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "//graft/subnet-evm/core/extstate",

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/BUILD.bazel
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "allowlisttest",
     srcs = [

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/bindings/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "bindings",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "gen_allowlisttest_binding.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/allowlist/allowlisttest/bindings",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "@com_github_ava_labs_libevm//:libevm",

--- a/graft/subnet-evm/precompile/allowlist/allowlisttest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/allowlist/allowlisttest/bindings/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "bindings",
     srcs = [

--- a/graft/subnet-evm/precompile/contract/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contract/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "contract",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "utils.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contract",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/precompile/precompileconfig",
         "//snow",

--- a/graft/subnet-evm/precompile/contract/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contract/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "contract",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/acp224feemanager/acp224feemanagertest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/acp224feemanager/acp224feemanagertest/bindings/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "bindings",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "gen_iacp224feemanager_binding.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/acp224feemanager/acp224feemanagertest/bindings",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "@com_github_ava_labs_libevm//:libevm",

--- a/graft/subnet-evm/precompile/contracts/acp224feemanager/acp224feemanagertest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/acp224feemanager/acp224feemanagertest/bindings/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "bindings",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/deployerallowlist/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/deployerallowlist/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "deployerallowlist",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/deployerallowlist/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/deployerallowlist/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "deployerallowlist",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "module.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/deployerallowlist",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/precompile/allowlist",
         "//graft/subnet-evm/precompile/contract",

--- a/graft/subnet-evm/precompile/contracts/feemanager/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/feemanager/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "feemanager",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/feemanager/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/feemanager/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "feemanager",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
     ],
     embedsrcs = ["IFeeManager.abi"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/feemanager",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/commontype",
         "//graft/subnet-evm/precompile/allowlist",

--- a/graft/subnet-evm/precompile/contracts/feemanager/feemanagertest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/feemanager/feemanagertest/bindings/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "bindings",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/feemanager/feemanagertest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/feemanager/feemanagertest/bindings/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "bindings",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "gen_ifeemanager_binding.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/feemanager/feemanagertest/bindings",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "@com_github_ava_labs_libevm//:libevm",

--- a/graft/subnet-evm/precompile/contracts/nativeminter/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "nativeminter",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/nativeminter/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "nativeminter",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
     ],
     embedsrcs = ["INativeMinter.abi"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/nativeminter",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//graft/subnet-evm/precompile/allowlist",

--- a/graft/subnet-evm/precompile/contracts/nativeminter/nativemintertest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/nativemintertest/bindings/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "bindings",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/nativeminter/nativemintertest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/nativeminter/nativemintertest/bindings/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "bindings",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "gen_nativemintertest_binding.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/nativeminter/nativemintertest/bindings",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "@com_github_ava_labs_libevm//:libevm",

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "rewardmanager",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
     ],
     embedsrcs = ["IRewardManager.abi"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/rewardmanager",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/constants",
         "//graft/subnet-evm/precompile/allowlist",

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "rewardmanager",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/rewardmanagertest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/rewardmanagertest/bindings/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "bindings",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/rewardmanager/rewardmanagertest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/rewardmanager/rewardmanagertest/bindings/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "bindings",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "gen_rewardmanagertest_binding.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/rewardmanager/rewardmanagertest/bindings",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "@com_github_ava_labs_libevm//:libevm",

--- a/graft/subnet-evm/precompile/contracts/txallowlist/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/txallowlist/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "txallowlist",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "module.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/txallowlist",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/precompile/allowlist",
         "//graft/subnet-evm/precompile/contract",

--- a/graft/subnet-evm/precompile/contracts/txallowlist/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/txallowlist/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "txallowlist",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/utilstest/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/utilstest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "utilstest",
     srcs = ["simulated_helpers.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/utilstest",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "//graft/subnet-evm/eth/ethconfig",

--- a/graft/subnet-evm/precompile/contracts/utilstest/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/utilstest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "utilstest",
     srcs = ["simulated_helpers.go"],

--- a/graft/subnet-evm/precompile/contracts/warp/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/warp/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "warp",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/warp/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/warp/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "warp",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
     ],
     embedsrcs = ["IWarpMessenger.abi"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/warp",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/precompile/contract",
         "//graft/subnet-evm/precompile/modules",

--- a/graft/subnet-evm/precompile/contracts/warp/warpbindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/warp/warpbindings/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "warpbindings",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "gen_iwarpmessenger_binding.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/warp/warpbindings",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "@com_github_ava_labs_libevm//:libevm",

--- a/graft/subnet-evm/precompile/contracts/warp/warpbindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/warp/warpbindings/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "warpbindings",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/warp/warptest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/warp/warptest/bindings/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "bindings",
     srcs = [

--- a/graft/subnet-evm/precompile/contracts/warp/warptest/bindings/BUILD.bazel
+++ b/graft/subnet-evm/precompile/contracts/warp/warptest/bindings/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "bindings",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "gen_warptest_binding.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/warp/warptest/bindings",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/accounts/abi/bind",
         "@com_github_ava_labs_libevm//:libevm",

--- a/graft/subnet-evm/precompile/modules/BUILD.bazel
+++ b/graft/subnet-evm/precompile/modules/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "modules",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "registerer.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/modules",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/constants",
         "//graft/evm/utils",

--- a/graft/subnet-evm/precompile/modules/BUILD.bazel
+++ b/graft/subnet-evm/precompile/modules/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "modules",
     srcs = [

--- a/graft/subnet-evm/precompile/precompileconfig/BUILD.bazel
+++ b/graft/subnet-evm/precompile/precompileconfig/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "precompileconfig",
     srcs = [
@@ -9,7 +15,6 @@ go_library(
         "upgradeable.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/precompileconfig",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils",
         "//graft/subnet-evm/commontype",

--- a/graft/subnet-evm/precompile/precompileconfig/BUILD.bazel
+++ b/graft/subnet-evm/precompile/precompileconfig/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "precompileconfig",
     srcs = [

--- a/graft/subnet-evm/precompile/precompiletest/BUILD.bazel
+++ b/graft/subnet-evm/precompile/precompiletest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "precompiletest",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "test_predicate.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/precompiletest",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/utils/utilstest",
         "//graft/subnet-evm/commontype",

--- a/graft/subnet-evm/precompile/precompiletest/BUILD.bazel
+++ b/graft/subnet-evm/precompile/precompiletest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "precompiletest",
     srcs = [

--- a/graft/subnet-evm/precompile/registry/BUILD.bazel
+++ b/graft/subnet-evm/precompile/registry/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "registry",
     srcs = ["registry.go"],

--- a/graft/subnet-evm/precompile/registry/BUILD.bazel
+++ b/graft/subnet-evm/precompile/registry/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "registry",
     srcs = ["registry.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/registry",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/precompile/contracts/deployerallowlist",
         "//graft/subnet-evm/precompile/contracts/feemanager",

--- a/graft/subnet-evm/stateupgrade/BUILD.bazel
+++ b/graft/subnet-evm/stateupgrade/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "stateupgrade",
     srcs = [
@@ -7,7 +13,6 @@ go_library(
         "state_upgrade.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/stateupgrade",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/subnet-evm/params/extras",
         "@com_github_ava_labs_libevm//common",

--- a/graft/subnet-evm/stateupgrade/BUILD.bazel
+++ b/graft/subnet-evm/stateupgrade/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "stateupgrade",
     srcs = [

--- a/graft/subnet-evm/tests/BUILD.bazel
+++ b/graft/subnet-evm/tests/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "tests",
     srcs = [

--- a/graft/subnet-evm/tests/BUILD.bazel
+++ b/graft/subnet-evm/tests/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "tests",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
     ],
     embedsrcs = ["genesis.json"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/tests",
-    visibility = ["//visibility:public"],
     deps = [
         "//graft/evm/core/state/snapshot",
         "//graft/evm/firewood",

--- a/graft/subnet-evm/tests/antithesis/BUILD.bazel
+++ b/graft/subnet-evm/tests/antithesis/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "antithesis_lib",
     srcs = ["main.go"],
@@ -30,5 +36,4 @@ go_library(
 go_binary(
     name = "antithesis",
     embed = [":antithesis_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/tests/antithesis/BUILD.bazel
+++ b/graft/subnet-evm/tests/antithesis/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "antithesis_lib",
     srcs = ["main.go"],

--- a/graft/subnet-evm/tests/antithesis/gencomposeconfig/BUILD.bazel
+++ b/graft/subnet-evm/tests/antithesis/gencomposeconfig/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "gencomposeconfig_lib",
     srcs = ["main.go"],

--- a/graft/subnet-evm/tests/antithesis/gencomposeconfig/BUILD.bazel
+++ b/graft/subnet-evm/tests/antithesis/gencomposeconfig/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "gencomposeconfig_lib",
     srcs = ["main.go"],
@@ -16,5 +22,4 @@ go_library(
 go_binary(
     name = "gencomposeconfig",
     embed = [":gencomposeconfig_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/graft/subnet-evm/tests/load/BUILD.bazel
+++ b/graft/subnet-evm/tests/load/BUILD.bazel
@@ -1,5 +1,11 @@
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 graft_go_test(
     name = "load_test",
     srcs = ["load_test.go"],

--- a/graft/subnet-evm/tests/load/BUILD.bazel
+++ b/graft/subnet-evm/tests/load/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 graft_go_test(
     name = "load_test",
     srcs = ["load_test.go"],

--- a/graft/subnet-evm/tests/utils/BUILD.bazel
+++ b/graft/subnet-evm/tests/utils/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "utils",
     srcs = [
@@ -10,7 +16,6 @@ go_library(
         "tmpnet.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/tests/utils",
-    visibility = ["//visibility:public"],
     deps = [
         "//api/health",
         "//api/info",

--- a/graft/subnet-evm/tests/utils/BUILD.bazel
+++ b/graft/subnet-evm/tests/utils/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "utils",
     srcs = [

--- a/graft/subnet-evm/tests/warp/BUILD.bazel
+++ b/graft/subnet-evm/tests/warp/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 graft_go_test(
     name = "warp_test",
     srcs = ["warp_test.go"],

--- a/graft/subnet-evm/tests/warp/BUILD.bazel
+++ b/graft/subnet-evm/tests/warp/BUILD.bazel
@@ -1,5 +1,11 @@
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 graft_go_test(
     name = "warp_test",
     srcs = ["warp_test.go"],

--- a/graft/subnet-evm/warp/BUILD.bazel
+++ b/graft/subnet-evm/warp/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//.bazel:defs.bzl", "graft_go_test")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "warp",
     srcs = [
@@ -11,7 +17,6 @@ go_library(
         "verifier_stats.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/warp",
-    visibility = ["//visibility:public"],
     deps = [
         "//cache",
         "//cache/lru",

--- a/graft/subnet-evm/warp/BUILD.bazel
+++ b/graft/subnet-evm/warp/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "warp",
     srcs = [

--- a/graft/subnet-evm/warp/messages/BUILD.bazel
+++ b/graft/subnet-evm/warp/messages/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "messages",
     srcs = [

--- a/graft/subnet-evm/warp/messages/BUILD.bazel
+++ b/graft/subnet-evm/warp/messages/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "messages",
     srcs = [
@@ -8,7 +14,6 @@ go_library(
         "validator_uptime.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/warp/messages",
-    visibility = ["//visibility:public"],
     deps = [
         "//codec",
         "//codec/linearcodec",

--- a/graft/subnet-evm/warp/warptest/BUILD.bazel
+++ b/graft/subnet-evm/warp/warptest/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//graft/subnet-evm:external_consumers",
 ])
 
-
 go_library(
     name = "warptest",
     srcs = ["block_client.go"],

--- a/graft/subnet-evm/warp/warptest/BUILD.bazel
+++ b/graft/subnet-evm/warp/warptest/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+
 go_library(
     name = "warptest",
     srcs = ["block_client.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/warp/warptest",
-    visibility = ["//visibility:public"],
     deps = [
         "//database",
         "//ids",


### PR DESCRIPTION
## Why this should be merged

Enforces sub-directory visibility through the build system instead of relying on the CI linter.

## How this works

`graft/{coreth,subnet-evm}/BUILD.bazel` define `external_consumers` targets and include Gazelle directives to set `default_visibility` to said target as well as the respective `__subpackages__` (i.e. sub-directories). The root `BUILD.bazel` file is updated to use a `gazelle` binary that understands the directives.

## How this was tested

CI still builds despite the removal of the `//visibility:public` attributes across all other files, meaning that dependent targets are still allowed. No negative test performed as inspection is sufficient and this is a non-critical change.

## Need to be documented in RELEASES.md?

No