### PR TITLE
build(sae): add `testonly` attributes

### DIFF
--- a/vms/saevm/blocks/blockstest/BUILD.bazel
+++ b/vms/saevm/blocks/blockstest/BUILD.bazel
@@ -3,6 +3,7 @@ load("//.bazel:defs.bzl", "go_test")
 
 go_library(
     name = "blockstest",
+    testonly = True,
     srcs = [
         "blocks.go",
         "chain.go",

--- a/vms/saevm/hook/hookstest/BUILD.bazel
+++ b/vms/saevm/hook/hookstest/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "hookstest",
+    testonly = True,
     srcs = [
         "stub.canoto.go",
         "stub.go",

--- a/vms/saevm/saetest/BUILD.bazel
+++ b/vms/saevm/saetest/BUILD.bazel
@@ -3,6 +3,7 @@ load("//.bazel:defs.bzl", "go_test")
 
 go_library(
     name = "saetest",
+    testonly = True,
     srcs = [
         "heightdb.go",
         "logging.go",

--- a/vms/saevm/saetest/escrow/BUILD.bazel
+++ b/vms/saevm/saetest/escrow/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "escrow",
+    testonly = True,
     srcs = ["escrow.go"],
     importpath = "github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow",
     visibility = ["//visibility:public"],

--- a/vms/saevm/txgossip/txgossiptest/BUILD.bazel
+++ b/vms/saevm/txgossip/txgossiptest/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "txgossiptest",
+    testonly = True,
     srcs = ["mempool.go"],
     importpath = "github.com/ava-labs/avalanchego/vms/saevm/txgossip/txgossiptest",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## Why this should be merged

Stops accidental importing of test-helper packages into production.

## How this works

Sets Bazel `testonly = True` on appropriate targest.

## How this was tested

If CI passes then these targets are only being imported by `go_test()` targets, as expected.

## Need to be documented in RELEASES.md?

No