### PR TITLE
chore: increase fuzz timeout to 5m

### DIFF
--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -30,4 +30,4 @@ fi
 TEST_TARGETS="$(eval "go list ./... ${EXCLUDED_TARGETS}")"
 
 # shellcheck disable=SC2086
-go test -tags test ${shuffle:-} ${race:-} -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}
+go test -tags test ${shuffle:-} ${race:-} -timeout="${TIMEOUT:-5m}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}


### PR DESCRIPTION
## Why this should be merged

We want to run fuzz tests in CI, and the current 2m is not enough time for fuzz to run without [flaking](https://github.com/ava-labs/avalanchego/actions/runs/24987143389/job/73163292188?pr=4872). 5m seems like ample time, and would not bottleneck CI.

## How this works
Changes `120s` to `5m`


## How this was tested
CI

## Need to be documented in RELEASES.md?
No