### PR TITLE
ci: free runner disk before publishing Antithesis images

### DIFF
--- a/.github/workflows/publish_antithesis_images.yml
+++ b/.github/workflows/publish_antithesis_images.yml
@@ -18,7 +18,18 @@ env:
 
 jobs:
   antithesis:
+    name: Build and push ${{ matrix.test_setup }} images
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test_setup: avalanchego
+            task: build-antithesis-images-avalanchego
+          - test_setup: xsvm
+            task: build-antithesis-images-xsvm
+          - test_setup: subnet-evm
+            task: build-antithesis-images-subnet-evm
 
     steps:
       - name: Checkout Repository
@@ -31,20 +42,8 @@ jobs:
           username: _json_key
           password: ${{ secrets.ANTITHESIS_GAR_JSON_KEY }}
 
-      - name: Build and push images for avalanchego test setup
-        run: ./scripts/run_task.sh build-antithesis-images-avalanchego
-        env:
-          IMAGE_PREFIX: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
-          IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
-
-      - name: Build and push images for xsvm test setup
-        run: ./scripts/run_task.sh build-antithesis-images-xsvm
-        env:
-          IMAGE_PREFIX: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
-          IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
-
-      - name: Build and push images for subnet-evm test setup
-        run: ./scripts/run_task.sh build-antithesis-images-subnet-evm
+      - name: Build and push images for ${{ matrix.test_setup }} test setup
+        run: ./scripts/run_task.sh ${{ matrix.task }}
         env:
           IMAGE_PREFIX: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
           IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}

--- a/.github/workflows/publish_antithesis_images.yml
+++ b/.github/workflows/publish_antithesis_images.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           docker-images: true
 
       - name: Checkout Repository

--- a/.github/workflows/publish_antithesis_images.yml
+++ b/.github/workflows/publish_antithesis_images.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: true
+          tool-cache: false
           docker-images: true
 
       - name: Checkout Repository

--- a/.github/workflows/publish_antithesis_images.yml
+++ b/.github/workflows/publish_antithesis_images.yml
@@ -18,20 +18,14 @@ env:
 
 jobs:
   antithesis:
-    name: Build and push ${{ matrix.test_setup }} images
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - test_setup: avalanchego
-            task: build-antithesis-images-avalanchego
-          - test_setup: xsvm
-            task: build-antithesis-images-xsvm
-          - test_setup: subnet-evm
-            task: build-antithesis-images-subnet-evm
 
     steps:
+      - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          docker-images: true
+
       - name: Checkout Repository
         uses: actions/checkout@v4
 
@@ -42,8 +36,20 @@ jobs:
           username: _json_key
           password: ${{ secrets.ANTITHESIS_GAR_JSON_KEY }}
 
-      - name: Build and push images for ${{ matrix.test_setup }} test setup
-        run: ./scripts/run_task.sh ${{ matrix.task }}
+      - name: Build and push images for avalanchego test setup
+        run: ./scripts/run_task.sh build-antithesis-images-avalanchego
+        env:
+          IMAGE_PREFIX: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
+          IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
+
+      - name: Build and push images for xsvm test setup
+        run: ./scripts/run_task.sh build-antithesis-images-xsvm
+        env:
+          IMAGE_PREFIX: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
+          IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
+
+      - name: Build and push images for subnet-evm test setup
+        run: ./scripts/run_task.sh build-antithesis-images-subnet-evm
         env:
           IMAGE_PREFIX: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
           IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}


### PR DESCRIPTION
## Why this should be merged

GitHub CI runs will fail while exporting the subnet-evm Docker image (see https://github.com/ava-labs/avalanchego/actions/runs/24575107195 as an example) due to a lack of disk space. (The log showed the runner had only 10 MB free and Docker failed with `no space left on device`). 

We can fix this by cleaning up state in-between steps. 

## How this works

Add `jlumbroso/free-disk-space@v1.3.1` before checkout/login/build steps, configured to remove unused hosted-runner tool cache and Docker images:

```
with:
  tool-cache: true
  docker-images: true
```
  
The rest of the workflow is unchanged.


## How this was tested
CI -- see https://github.com/ava-labs/avalanchego/actions/runs/24998210575. 

## Need to be documented in RELEASES.md?
No 