### PR TITLE
ci: remove failing m6i scheduled re-execution benchmark

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.json
@@ -16,11 +16,6 @@
     "schedule": {
         "include": [
             {
-                "runner": "avago-runner-m6i-4xlarge-ebs-fast",
-                "test": "hashdb-33m-33m500k",
-                "timeout-minutes": 1440
-            },
-            {
                 "runner": "avago-runner-i4i-4xlarge-local-ssd",
                 "test": "hashdb-33m-33m500k",
                 "timeout-minutes": 1440


### PR DESCRIPTION
## Why this should be merged

The scheduled `C-Chain Re-Execution Benchmark w/ Container` workflow includes an `avago-runner-m6i-4xlarge-ebs-fast` / `hashdb-33m-33m500k` matrix entry that fails every single time and thus is not useful. 

The m6i entry last succeeded on January 27th -- since than of the 90 scheduled runs, there have been 0 successes but there have been 34 failures and 56 cancellations.

This runner can be added be back when it's fixed, but in the meantime it shouldn't pollute the benchmarks. 

## How this works

I just removed the entry. As an aside, the same `hashdb-33m-33m500k` benchmark remains covered by the scheduled `avago-runner-i4i-4xlarge-local-ssd` matrix entry, but not 100% confident. Regardless it's not useful. 

## How this was tested
Will see in runs 

## Need to be documented in RELEASES.md?
No