### PR TITLE
test(firewood): Fix fuzz test

### DIFF
--- a/graft/evm/firewood/hash_test.go
+++ b/graft/evm/firewood/hash_test.go
@@ -84,6 +84,8 @@ func newFuzzState(t *testing.T) *fuzzState {
 			DBOverride: fwCfg.BackendConstructor,
 		},
 	)
+	fwTDB := firewoodState.TrieDB().Backend().(*TrieDB)
+	firewoodState = NewStateAccessor(firewoodState, fwTDB)
 	fwTr, err := firewoodState.OpenTrie(ethRoot)
 	r.NoError(err)
 	t.Cleanup(func() {
@@ -144,7 +146,7 @@ func (fs *fuzzState) commit() {
 
 		// HashDB/PathDB only allows updating the triedb if there have been changes.
 		if _, ok := tr.ethDatabase.TrieDB().Backend().(*TrieDB); ok {
-			triedbopt := stateconf.WithTrieDBUpdatePayload(common.Hash{byte(int64(fs.blockNumber - 1))}, common.Hash{byte(int64(fs.blockNumber))})
+			triedbopt := blockNumToUpdatePayload(fs.blockNumber)
 			fs.require.NoError(tr.ethDatabase.TrieDB().Update(updatedRoot, tr.lastRoot, fs.blockNumber, mergedNodeSet, nil, triedbopt), "failed to update triedb in %s", tr.name)
 			tr.lastRoot = updatedRoot
 		} else if updatedRoot != tr.lastRoot {
@@ -167,6 +169,12 @@ func (fs *fuzzState) commit() {
 			tr.name, expectedRoot.Hex(), tr.lastRoot.Hex(), i,
 		)
 	}
+}
+
+func blockNumToUpdatePayload(blockNum uint64) stateconf.TrieDBUpdateOption {
+	parentHash := common.BytesToHash(binary.BigEndian.AppendUint64(nil, blockNum))
+	childHash := common.BytesToHash(binary.BigEndian.AppendUint64(nil, blockNum+1)) // add to avoid underflow
+	return stateconf.WithTrieDBUpdatePayload(parentHash, childHash)
 }
 
 // createAccount generates a new, unique account and adds it to both tries and the tracked


### PR DESCRIPTION
## Why this should be merged

#5319 noticed that this fuzz test failed. Really, it was never being run, so there's been problems with this for a while.

## How this works

Two fixes:
1. The `state.Database` needed wrapped with the firewood specific one.
2. There was a byte overflow due to poor input management

## How this was tested

Fuzzed locally for a while

## Need to be documented in RELEASES.md?

No