### PR TITLE
Cache BLS operations in Simplex fuzz tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2 // indirect
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0
-	github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1
+	github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0 h1:7OzfDVz9/lKyr9EfHZnNEvXevl
 github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a h1:rPtNc8GdAxiCxSdL+kaM42Lfuoxi034X4Fe20lR2auI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
-github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1 h1:Y9UdRQj28/t+GNzVSlP6nvoNLtzNRo3fNXLUc/NscVM=
-github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1/go.mod h1:GVzumIo3zR23/qGRN2AdnVkIPHcKMq/D89EGWZfMGQ0=
+github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad h1:P5IRndHUinfIZ73jdxl3M6jdcnKkQOLYvhGvE3VDiSU=
+github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad/go.mod h1:DADqV3zJ+ij8GqliStJ+aj9l/cPtb5ZUhNy5KxlDEsQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.work.sum
+++ b/go.work.sum
@@ -335,8 +335,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.3.0/go.mod h1:71C76bo47zlDX9gWnn3p/0QZQXkTQ/GNqUNI6fchvjs=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0 h1:7OzfDVz9/lKyr9EfHZnNEvXevlW6utComzePoT4vaMQ=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
+github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1 h1:Y9UdRQj28/t+GNzVSlP6nvoNLtzNRo3fNXLUc/NscVM=
+github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1/go.mod h1:GVzumIo3zR23/qGRN2AdnVkIPHcKMq/D89EGWZfMGQ0=
 github.com/aws/aws-sdk-go-v2 v1.21.2 h1:+LXZ0sgo8quN9UOKXXzAWRT3FWd4NxeXWOZom9pE7GA=
 github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVATHrjKtxIpM=
 github.com/aws/aws-sdk-go-v2/config v1.18.45 h1:Aka9bI7n8ysuwPeFdm77nfbyHCAKQ3z9ghB3S/38zes=

--- a/simplex/BUILD.bazel
+++ b/simplex/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "//snow/engine/snowman/block/blocktest",
         "//snow/networking/sender/sendermock",
         "//snow/snowtest",
+        "//utils",
         "//utils/constants",
         "//utils/crypto/bls",
         "//utils/crypto/bls/signer/localsigner",

--- a/simplex/engine.go
+++ b/simplex/engine.go
@@ -57,7 +57,8 @@ type Engine struct {
 	shutdownOnce sync.Once
 }
 
-// The VM must be initialized before creating the engine
+// NewEngine creates a new simplex engine. The VM must be initialized before
+// calling this function.
 func NewEngine(ctx context.Context, config *Config) (*Engine, error) {
 	if config.Params == nil {
 		return nil, errNilSimplexParameters
@@ -66,6 +67,14 @@ func NewEngine(ctx context.Context, config *Config) (*Engine, error) {
 	signer, verifier, err := NewBLSAuth(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BLS auth: %w", err)
+	}
+
+	return newEngineWithSignerVerifier(ctx, config, signer, verifier)
+}
+
+func newEngineWithSignerVerifier(ctx context.Context, config *Config, signer BLSSigner, verifier BLSVerifier) (*Engine, error) {
+	if config.Params == nil {
+		return nil, errNilSimplexParameters
 	}
 
 	qcDeserializer := &QCDeserializer{

--- a/simplex/engine_test.go
+++ b/simplex/engine_test.go
@@ -870,11 +870,12 @@ func setupEngineForFuzz(t *testing.T) (*Engine, []*Config) {
 
 	verifier := createVerifierForFuzz(configs[0])
 
-	engine, err := newEngineWithSignerVerifier(t.Context(), configs[0], signer, verifier)
+	ctx := t.Context()
+	engine, err := newEngineWithSignerVerifier(ctx, configs[0], signer, verifier)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, engine.Shutdown(t.Context()))
+		require.NoError(t, engine.Shutdown(ctx))
 	})
 
 	// We start the epoch directly instead of calling engine.Start because we want to avoid starting the engine's internal ticker.
@@ -902,11 +903,6 @@ func setupEngine(t *testing.T) (*Engine, []*Config) {
 }
 
 func createSimplexEngineConfig(t *testing.T, reuseKeys keyReuseOption) []*Config {
-	if reuseKeys {
-		// We can only reuse the key if it was successfully cached.
-		require.NotNil(t, cachedBLSKey)
-	}
-
 	configs := newNetworkConfigsWithKeyReuse(t, 4, reuseKeys)
 
 	config := configs[0]

--- a/simplex/engine_test.go
+++ b/simplex/engine_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/networking/sender/sendermock"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
 
@@ -625,7 +628,7 @@ func NewReplicationResponseMessage(qcBytes []byte) *p2p.Simplex {
 func FuzzSimplexVotes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, blockDigest []byte, signer []byte, epoch, round, seq uint64, version uint32) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
+		engine, configs := setupEngineForFuzz(t)
 
 		msg := &p2p.Simplex{
 			Message: &p2p.Simplex_Vote{
@@ -652,7 +655,7 @@ func FuzzSimplexVotes(f *testing.F) {
 func FuzzSimplexEmptyVotes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, signer []byte, epoch, round uint64, signerValue []byte) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
+		engine, configs := setupEngineForFuzz(t)
 
 		msg := &p2p.Simplex{
 			Message: &p2p.Simplex_EmptyVote{
@@ -670,7 +673,7 @@ func FuzzSimplexEmptyVotes(f *testing.F) {
 func FuzzSimplexFinalizeVotes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, signer []byte, signerValue []byte, blockDigest []byte, epoch, round, seq uint64, version uint32) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
+		engine, configs := setupEngineForFuzz(t)
 
 		msg := &p2p.Simplex{
 			Message: &p2p.Simplex_FinalizeVote{
@@ -695,10 +698,11 @@ func FuzzSimplexFinalizeVotes(f *testing.F) {
 }
 
 func FuzzSimplexNotarizations(f *testing.F) {
-	f.Fuzz(func(t *testing.T, qcData, blockDigest []byte, epoch, round, seq uint64, version uint32) {
+	qc := buildQCWithBytes(f, newConfigsForQC(f), []byte("fuzz qc message"))
+
+	f.Fuzz(func(t *testing.T, blockDigest []byte, epoch, round, seq uint64, version uint32) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
-		qc := buildQCWithBytes(t, configs, qcData)
+		engine, configs := setupEngineForFuzz(t)
 
 		msg := &p2p.Simplex{
 			Message: &p2p.Simplex_Notarization{
@@ -723,10 +727,11 @@ func FuzzSimplexNotarizations(f *testing.F) {
 }
 
 func FuzzSimplexFinalizations(f *testing.F) {
-	f.Fuzz(func(t *testing.T, qcData, blockDigest []byte, epoch, round, seq uint64, version uint32) {
+	qc := buildQCWithBytes(f, newConfigsForQC(f), []byte("fuzz qc message"))
+
+	f.Fuzz(func(t *testing.T, blockDigest []byte, epoch, round, seq uint64, version uint32) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
-		qc := buildQCWithBytes(t, configs, qcData)
+		engine, configs := setupEngineForFuzz(t)
 
 		msg := &p2p.Simplex{
 			Message: &p2p.Simplex_Finalization{
@@ -753,7 +758,7 @@ func FuzzSimplexFinalizations(f *testing.F) {
 func FuzzSimplexReplicationRequests(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seq1, seq2, seq3, latestRound uint64) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
+		engine, configs := setupEngineForFuzz(t)
 
 		msg := &p2p.Simplex{
 			Message: &p2p.Simplex_ReplicationRequest{
@@ -769,10 +774,11 @@ func FuzzSimplexReplicationRequests(f *testing.F) {
 }
 
 func FuzzSimplexReplicationResponses(f *testing.F) {
-	f.Fuzz(func(t *testing.T, qcData, blockDigest []byte, epoch, round, seq uint64, version uint32) {
+	qc := buildQCWithBytes(f, newConfigsForQC(f), []byte("fuzz qc message"))
+
+	f.Fuzz(func(t *testing.T, blockDigest []byte, epoch, round, seq uint64, version uint32) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
-		qc := buildQCWithBytes(t, configs, qcData)
+		engine, configs := setupEngineForFuzz(t)
 
 		msg := &p2p.Simplex{
 			Message: &p2p.Simplex_ReplicationResponse{
@@ -807,7 +813,7 @@ func FuzzSimplexReplicationResponses(f *testing.F) {
 func FuzzSimplexBlockProposals(f *testing.F) {
 	f.Fuzz(func(t *testing.T, blockBytes []byte, blockDigest []byte, round, epoch, seq uint64, version uint32) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
+		engine, configs := setupEngineForFuzz(t)
 		msg := &p2p.Simplex{
 			ChainId: []byte("chain-1"),
 			Message: &p2p.Simplex_BlockProposal{
@@ -835,10 +841,11 @@ func FuzzSimplexBlockProposals(f *testing.F) {
 }
 
 func FuzzSimplexEmptyNotarizations(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte, round uint64, epoch uint64) {
+	qc := buildQCWithBytes(f, newConfigsForQC(f), []byte("fuzz qc message"))
+
+	f.Fuzz(func(t *testing.T, round uint64, epoch uint64) {
 		ctx := t.Context()
-		engine, configs := setupEngine(t)
-		qc := buildQCWithBytes(t, configs, data)
+		engine, configs := setupEngineForFuzz(t)
 		msg := &p2p.Simplex{
 			Message: &p2p.Simplex_EmptyNotarization{
 				EmptyNotarization: &p2p.EmptyNotarization{
@@ -852,27 +859,83 @@ func FuzzSimplexEmptyNotarizations(f *testing.F) {
 	})
 }
 
-func setupEngine(t *testing.T) (*Engine, []*Config) {
-	configs := newNetworkConfigs(t, 4)
-	ctx := t.Context()
+func setupEngineForFuzz(t *testing.T) (*Engine, []*Config) {
+	configs := createSimplexEngineConfig(t, reuseKeys)
 
-	config := configs[0]
-	config.Sender.(*sendermock.ExternalSender).EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	engine, err := NewEngine(ctx, config)
-	require.NoError(t, err)
-
-	// ensure any go-routines started by the engine are cleaned up after the test finishes
-	t.Cleanup(func() {
-		require.NoError(t, engine.Shutdown(ctx))
-	})
-
-	config.VM.(*wrappedVM).ParseBlockF = func(_ context.Context, _ []byte) (snowman.Block, error) {
-		return newTestBlock(t, newBlockConfig{round: 1}).vmBlock, nil
+	signer := BLSSigner{
+		chainID:   configs[0].Ctx.ChainID,
+		networkID: constants.UnitTestID,
+		signBLS:   cachedBLSKey.Sign,
 	}
 
-	require.NoError(t, engine.Start(ctx, 1))
+	verifier := createVerifierForFuzz(configs[0])
+
+	engine, err := newEngineWithSignerVerifier(t.Context(), configs[0], signer, verifier)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, engine.Shutdown(t.Context()))
+	})
+
+	// We start the epoch directly instead of calling engine.Start because we want to avoid starting the engine's internal ticker.
+	// We don't need the ticker because it won't have enough time to tick during the fuzz iteration.
+	require.NoError(t, engine.epoch.Start())
+
+	return engine, configs
+}
+
+func setupEngine(t *testing.T) (*Engine, []*Config) {
+	configs := createSimplexEngineConfig(t, noKeyReuse)
+
+	engine, err := NewEngine(t.Context(), configs[0])
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, engine.Shutdown(t.Context()))
+	})
+
+	require.NoError(t, engine.Start(t.Context(), 1))
 	md := engine.epoch.Metadata()
 	require.Equal(t, uint64(1), md.Seq)
 	require.Equal(t, uint64(1), md.Round)
 	return engine, configs
+}
+
+func createSimplexEngineConfig(t *testing.T, reuseKeys keyReuseOption) []*Config {
+	if reuseKeys {
+		// We can only reuse the key if it was successfully cached.
+		require.NotNil(t, cachedBLSKey)
+	}
+
+	configs := newNetworkConfigsWithKeyReuse(t, 4, reuseKeys)
+
+	config := configs[0]
+	config.Sender.(*sendermock.ExternalSender).EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	config.VM.(*wrappedVM).ParseBlockF = func(_ context.Context, _ []byte) (snowman.Block, error) {
+		return newTestBlock(t, newBlockConfig{round: 1}).vmBlock, nil
+	}
+	return configs
+}
+
+func createVerifierForFuzz(config *Config) BLSVerifier {
+	verifier := BLSVerifier{
+		nodeID2PK: make(map[ids.NodeID]*bls.PublicKey),
+		networkID: config.Ctx.NetworkID,
+		chainID:   config.Ctx.ChainID,
+	}
+
+	nodeIDs := make([]ids.NodeID, 0, len(config.Params.InitialValidators))
+	for _, node := range config.Params.InitialValidators {
+		verifier.nodeID2PK[node.NodeID] = cachedBLSKey.PublicKey()
+		nodeIDs = append(nodeIDs, node.NodeID)
+	}
+	utils.Sort(nodeIDs)
+	verifier.canonicalNodeIDs = nodeIDs
+	verifier.canonicalNodeIDIndices = make(map[ids.NodeID]int, len(nodeIDs))
+	for i, nodeID := range nodeIDs {
+		verifier.canonicalNodeIDIndices[nodeID] = i
+	}
+
+	return verifier
 }

--- a/simplex/util_test.go
+++ b/simplex/util_test.go
@@ -47,9 +47,7 @@ func init() {
 	if err != nil {
 		panic("failed to generate cached BLS key: " + err.Error())
 	}
-	if err == nil {
-		cachedCompressedPK = cachedBLSKey.PublicKey().Compress()
-	}
+	cachedCompressedPK = cachedBLSKey.PublicKey().Compress()
 }
 
 type testNodeConfig struct {

--- a/simplex/util_test.go
+++ b/simplex/util_test.go
@@ -29,6 +29,39 @@ import (
 	simplexparams "github.com/ava-labs/avalanchego/snow/consensus/simplex"
 )
 
+var (
+	cachedBLSKey       *localsigner.LocalSigner
+	cachedCompressedPK []byte
+)
+
+type keyReuseOption bool
+
+const (
+	noKeyReuse keyReuseOption = false
+	reuseKeys  keyReuseOption = true
+)
+
+func init() {
+	var err error
+	cachedBLSKey, err = localsigner.New()
+	if err != nil {
+		panic("failed to generate cached BLS key: " + err.Error())
+	}
+	if err == nil {
+		cachedCompressedPK = cachedBLSKey.PublicKey().Compress()
+	}
+}
+
+type testNodeConfig struct {
+	reuseKeys keyReuseOption
+}
+
+type testNodeConfigOption func(*testNodeConfig)
+
+func testNodeConfigWithKeyReuse(cfg *testNodeConfig) {
+	cfg.reuseKeys = reuseKeys
+}
+
 type newBlockConfig struct {
 	// If prev is nil, newBlock will create the genesis block
 	prev *Block
@@ -94,14 +127,50 @@ type testNode struct {
 	signFunc SignFunc
 }
 
-// newNetworkConfigs creates a slice of Configs for testing purposes.
-// they are initialized with a common chainID and a set of validators.
+// newConfigsForQC builds a minimal set of configs sufficient for building a QC
+// (signers + validator membership). It avoids the heavier per-config setup
+// (mocks, WAL, message creator) so it can be called from f.Fuzz outer scope.
+func newConfigsForQC(t testing.TB) []*Config {
+	numNodes := 4
+	require.Positive(t, numNodes)
+
+	chainID := ids.GenerateTestID()
+	testNodes := generateTestNodes(t, uint64(numNodes), testNodeConfigWithKeyReuse)
+	chainParameters := newSimplexChainParams(testNodes)
+
+	configs := make([]*Config, 0, numNodes)
+	for _, node := range testNodes {
+		configs = append(configs, &Config{
+			Ctx: SimplexChainContext{
+				NodeID:    node.NodeID,
+				ChainID:   chainID,
+				NetworkID: constants.UnitTestID,
+			},
+			SignBLS: node.signFunc,
+			Params:  chainParameters,
+		})
+	}
+	return configs
+}
+
+// newNetworkConfigs creates a slice of Configs for testing purposes,
+// initialized with a common chainID and a set of validators each having
+// a freshly generated BLS key.
 func newNetworkConfigs(t *testing.T, numNodes uint64) []*Config {
+	return newNetworkConfigsWithKeyReuse(t, numNodes, noKeyReuse)
+}
+
+// newNetworkConfigsWithKeyReuse is like newNetworkConfigs but allows the
+// caller to opt into reusing a single cached BLS key across all validators
+// (intended for fuzz tests where BLS key generation dominates setup cost).
+func newNetworkConfigsWithKeyReuse(t *testing.T, numNodes uint64, reuseKeys keyReuseOption) []*Config {
 	require.Positive(t, numNodes)
 
 	chainID := ids.GenerateTestID()
 
-	testNodes := generateTestNodes(t, numNodes)
+	testNodes := generateTestNodes(t, numNodes, func(cfg *testNodeConfig) {
+		cfg.reuseKeys = reuseKeys
+	})
 	chainParameters := newSimplexChainParams(testNodes)
 	configs := make([]*Config, 0, numNodes)
 
@@ -148,17 +217,33 @@ func newSimplexChainParams(nodes []*testNode) *simplexparams.Parameters {
 	return params
 }
 
-func generateTestNodes(t *testing.T, num uint64) []*testNode {
+func generateTestNodes(t testing.TB, num uint64, opts ...testNodeConfigOption) []*testNode {
+	var cfg testNodeConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	nodes := make([]*testNode, num)
 	for i := uint64(0); i < num; i++ {
-		ls, err := localsigner.New()
-		require.NoError(t, err)
+		var ls *localsigner.LocalSigner
+		var err error
+		var pk []byte
+
+		if cfg.reuseKeys {
+			ls = cachedBLSKey
+			require.NotNil(t, ls, "cached BLS key is not available")
+			pk = cachedCompressedPK
+		} else {
+			ls, err = localsigner.New()
+			require.NoError(t, err)
+			pk = ls.PublicKey().Compress()
+		}
 
 		nodeID := ids.GenerateTestNodeID()
 		nodes[i] = &testNode{
 			ValidatorInfo: simplexparams.ValidatorInfo{
 				NodeID:    nodeID,
-				PublicKey: ls.PublicKey().Compress(),
+				PublicKey: pk,
 			},
 			signFunc: ls.Sign,
 		}


### PR DESCRIPTION
## Why this should be merged

The simplex fuzz tests fail in CI because they're too computationally heavy.

In order to reduce the computational load of running fuzz tests, we cache BLS keygen and re-use QC construction.

## How this works

This commit creates a global cache of BLS keys for tests and re-uses it in fuzz tests, as well as moves QC construction to outside of the fuzz iteration.

The engine setup was creating a validator configuration for Simplex, which included using BLST (for BLS key generation), as well as spinning up a ticker goroutine to progress the time. This made the tests much heavier and slower. 

By caching the key construction and creating the QC once and not in each iteration, we alleviate the computational load.

This PR also imports a new version of simplex which includes a [bug fix](https://github.com/ava-labs/Simplex/pull/374/changes/104444104f3760249c5003ea3dd5deb16dfe5466) that fixes a goroutine leak.

With the goroutine leak but without the BLS caching, performance is x2 slower.

## How this was tested

I ran on a weak AWS VM some of the fuzz tests before the change and after and it failed before and succeeded after. 
The rate of fuzz iterations per second was much higher after the change:

before:
    
```
Fuzzing FuzzSimplexVotes in ./simplex/engine_test.go
 warning: both GOPATH and GOROOT are the same directory (/home/ubuntu/go); see https://go.dev/wiki/InstallTroubleshooting
fuzz: elapsed: 0s, gathering baseline coverage: 0/49 completed
fuzz: elapsed: 1s, gathering baseline coverage: 49/49 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 804 (268/sec), new interesting: 2 (total: 51)
fuzz: elapsed: 6s, execs: 2231 (476/sec), new interesting: 2 (total: 51)
fuzz: elapsed: 9s, execs: 3245 (338/sec), new interesting: 2 (total: 51)
 fuzz: elapsed: 12s, execs: 4126 (294/sec), new interesting: 2 (total: 51)
fuzz: elapsed: 15s, execs: 5048 (307/sec), new interesting: 2 (total: 51)
fuzz: elapsed: 18s, execs: 6032 (328/sec), new interesting: 2 (total: 51)
fuzz: elapsed: 21s, execs: 7128 (365/sec), new interesting: 2 (total: 51)
fuzz: elapsed: 24s, execs: 8966 (613/sec), new interesting: 3 (total: 52)
fuzz: elapsed: 27s, execs: 10980 (671/sec), new interesting: 3 (total: 52)
fuzz: elapsed: 30s, execs: 12964 (662/sec), new interesting: 3 (total: 52)
```

after: 

```
Fuzzing FuzzSimplexVotes in ./simplex/engine_test.go
warning: both GOPATH and GOROOT are the same directory (/home/ubuntu/go); see https://go.dev/wiki/InstallTroubleshooting
fuzz: elapsed: 0s, gathering baseline coverage: 0/47 completed
fuzz: elapsed: 1s, gathering baseline coverage: 47/47 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 4508 (1502/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 6s, execs: 11820 (2438/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 9s, execs: 19075 (2418/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 12s, execs: 26201 (2375/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 15s, execs: 33801 (2533/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 18s, execs: 40932 (2377/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 21s, execs: 48531 (2533/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 24s, execs: 55768 (2410/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 27s, execs: 62882 (2372/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 30s, execs: 70216 (2446/sec), new interesting: 1 (total: 48)
fuzz: elapsed: 33s, execs: 77040 (2274/sec), new interesting: 1 (total: 48)
```

## Need to be documented in RELEASES.md?
