### PR TITLE
refactor: simplify atomic rexec

### DIFF
--- a/graft/coreth/consensus/dummy/consensus.go
+++ b/graft/coreth/consensus/dummy/consensus.go
@@ -61,9 +61,8 @@ type (
 	)
 
 	ConsensusCallbacks struct {
-		OnFinalizeAndAssemble              OnFinalizeAndAssembleCallbackType
-		OnExtraStateChange                 OnExtraStateChangeType
-		OnHistoricalReplayExtraStateChange OnExtraStateChangeType
+		OnFinalizeAndAssemble OnFinalizeAndAssembleCallbackType
+		OnExtraStateChange    OnExtraStateChangeType
 	}
 
 	DummyEngine struct {
@@ -237,38 +236,14 @@ func (*DummyEngine) Prepare(_ consensus.ChainHeaderReader, header *types.Header)
 }
 
 func (eng *DummyEngine) Finalize(chain consensus.ChainHeaderReader, block *types.Block, parent *types.Header, state *state.StateDB, receipts []*types.Receipt) error {
-	return eng.finalize(chain, block, parent, state, receipts, false)
-}
-
-func (eng *DummyEngine) FinalizeForHistoricalReplay(
-	chain consensus.ChainHeaderReader,
-	block *types.Block,
-	parent *types.Header,
-	state *state.StateDB,
-	receipts []*types.Receipt,
-) error {
-	return eng.finalize(chain, block, parent, state, receipts, true)
-}
-
-func (eng *DummyEngine) finalize(
-	chain consensus.ChainHeaderReader,
-	block *types.Block,
-	parent *types.Header,
-	state *state.StateDB,
-	receipts []*types.Receipt,
-	historicalReplay bool,
-) error {
 	// Perform extra state change while finalizing the block
 	var (
 		contribution, extDataGasUsed *big.Int
 		err                          error
 	)
-	callback := eng.cb.OnExtraStateChange
-	if historicalReplay && eng.cb.OnHistoricalReplayExtraStateChange != nil {
-		callback = eng.cb.OnHistoricalReplayExtraStateChange
-	}
-	if callback != nil {
-		contribution, extDataGasUsed, err = callback(block, parent, state)
+
+	if eng.cb.OnExtraStateChange != nil {
+		contribution, extDataGasUsed, err = eng.cb.OnExtraStateChange(block, parent, state)
 		if err != nil {
 			return err
 		}

--- a/graft/coreth/core/state_processor.go
+++ b/graft/coreth/core/state_processor.go
@@ -28,7 +28,6 @@
 package core
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -53,11 +52,6 @@ type StateProcessor struct {
 	engine consensus.Engine    // Consensus engine used for block rewards
 }
 
-// FinalizeFunc finalizes a block after its transactions have been applied.
-// It matches the signature of consensus.Engine.Finalize and lets callers
-// substitute an alternative finalizer (e.g. for historical replay).
-type FinalizeFunc func(chain consensus.ChainHeaderReader, block *types.Block, parent *types.Header, state *state.StateDB, receipts []*types.Receipt) error
-
 // NewStateProcessor initialises a new StateProcessor.
 func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consensus.Engine) *StateProcessor {
 	return &StateProcessor{
@@ -75,24 +69,6 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consen
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
 func (p *StateProcessor) Process(block *types.Block, parent *types.Header, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
-	return p.ProcessWithFinalize(block, parent, statedb, cfg, p.engine.Finalize)
-}
-
-// ProcessWithFinalize is like Process, but invokes the supplied finalize
-// callback in place of the engine's default Finalize. Historical replay uses
-// this to skip live-validation dependencies while still applying the block's
-// deterministic state transitions.
-func (p *StateProcessor) ProcessWithFinalize(
-	block *types.Block,
-	parent *types.Header,
-	statedb *state.StateDB,
-	cfg vm.Config,
-	finalize FinalizeFunc,
-) (types.Receipts, []*types.Log, uint64, error) {
-	if finalize == nil {
-		return nil, nil, 0, errors.New("missing finalize function")
-	}
-
 	var (
 		receipts    types.Receipts
 		usedGas     = new(uint64)
@@ -135,7 +111,7 @@ func (p *StateProcessor) ProcessWithFinalize(
 		allLogs = append(allLogs, receipt.Logs...)
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
-	if err := finalize(p.bc, block, parent, statedb, receipts); err != nil {
+	if err := p.engine.Finalize(p.bc, block, parent, statedb, receipts); err != nil {
 		return nil, nil, 0, fmt.Errorf("engine finalization check failed: %w", err)
 	}
 

--- a/graft/coreth/eth/BUILD.bazel
+++ b/graft/coreth/eth/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/eth",
     deps = [
         "//graft/coreth/consensus",
-        "//graft/coreth/consensus/dummy",
         "//graft/coreth/core",
         "//graft/coreth/core/extstate",
         "//graft/coreth/core/txpool",

--- a/graft/coreth/eth/state_accessor.go
+++ b/graft/coreth/eth/state_accessor.go
@@ -33,7 +33,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ava-labs/avalanchego/graft/coreth/consensus/dummy"
 	"github.com/ava-labs/avalanchego/graft/coreth/core"
 	"github.com/ava-labs/avalanchego/graft/coreth/core/extstate"
 	"github.com/ava-labs/avalanchego/graft/coreth/eth/tracers"
@@ -329,14 +328,6 @@ func (eth *Ethereum) firewoodState(ctx context.Context, header *types.Header, re
 	// Re-execute blocks forward from current+1 to the target block. Historical
 	// replay must skip live-validation dependencies (e.g. shared memory for
 	// atomic imports), so substitute the engine's historical-replay finalizer.
-	processor, ok := eth.blockchain.Processor().(*core.StateProcessor)
-	if !ok {
-		return nil, nil, fmt.Errorf("expected *core.StateProcessor for Firewood historical replay, got %T", eth.blockchain.Processor())
-	}
-	engine, ok := eth.engine.(*dummy.DummyEngine)
-	if !ok {
-		return nil, nil, fmt.Errorf("expected *dummy.DummyEngine for Firewood historical replay, got %T", eth.engine)
-	}
 	for current.Number.Uint64() < header.Number.Uint64() {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
@@ -348,7 +339,7 @@ func (eth *Ethereum) firewoodState(ctx context.Context, header *types.Header, re
 			return nil, nil, fmt.Errorf("block %d not found", next)
 		}
 
-		_, _, _, err := processor.ProcessWithFinalize(nextBlock, current, cache, vm.Config{}, engine.FinalizeForHistoricalReplay)
+		_, _, _, err := eth.blockchain.Processor().Process(nextBlock, current, cache, vm.Config{})
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process block %d: %w", next, err)
 		}

--- a/graft/coreth/plugin/evm/atomic/vm/vm.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm.go
@@ -449,9 +449,8 @@ func (vm *VM) Logger() logging.Logger { return vm.Ctx.Log }
 
 func (vm *VM) createConsensusCallbacks() dummy.ConsensusCallbacks {
 	return dummy.ConsensusCallbacks{
-		OnFinalizeAndAssemble:              vm.onFinalizeAndAssemble,
-		OnExtraStateChange:                 vm.onExtraStateChange,
-		OnHistoricalReplayExtraStateChange: vm.onHistoricalReplayExtraStateChange,
+		OnFinalizeAndAssemble: vm.onFinalizeAndAssemble,
+		OnExtraStateChange:    vm.onExtraStateChange,
 	}
 }
 
@@ -625,23 +624,6 @@ func (vm *VM) onFinalizeAndAssemble(
 }
 
 func (vm *VM) onExtraStateChange(block *types.Block, parent *types.Header, statedb *state.StateDB) (*big.Int, *big.Int, error) {
-	return vm.onExtraStateChangeWithMode(block, parent, statedb, false)
-}
-
-func (vm *VM) onHistoricalReplayExtraStateChange(
-	block *types.Block,
-	parent *types.Header,
-	statedb *state.StateDB,
-) (*big.Int, *big.Int, error) {
-	return vm.onExtraStateChangeWithMode(block, parent, statedb, true)
-}
-
-func (vm *VM) onExtraStateChangeWithMode(
-	block *types.Block,
-	parent *types.Header,
-	statedb *state.StateDB,
-	historicalReplay bool,
-) (*big.Int, *big.Int, error) {
 	var (
 		batchContribution = big.NewInt(0)
 		batchGasUsed      = big.NewInt(0)
@@ -658,7 +640,7 @@ func (vm *VM) onExtraStateChangeWithMode(
 	}
 
 	// If [atomicBackend] is nil, the VM is still initializing and is reprocessing accepted blocks.
-	if vm.AtomicBackend != nil && !historicalReplay {
+	if lastAccepted := vm.LastAcceptedExtendedBlock(); lastAccepted != nil && vm.AtomicBackend != nil && lastAccepted.Height() <= block.NumberU64() {
 		if vm.AtomicBackend.IsBonus(block.NumberU64(), block.Hash()) {
 			log.Info("skipping atomic tx verification on bonus block", "block", block.Hash())
 		} else {

--- a/graft/coreth/plugin/evm/atomic/vm/vm.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm.go
@@ -640,22 +640,25 @@ func (vm *VM) onExtraStateChange(block *types.Block, parent *types.Header, state
 	}
 
 	// If [atomicBackend] is nil, the VM is still initializing and is reprocessing accepted blocks.
-	if lastAccepted := vm.LastAcceptedExtendedBlock(); lastAccepted != nil && vm.AtomicBackend != nil && lastAccepted.Height() <= block.NumberU64() {
-		if vm.AtomicBackend.IsBonus(block.NumberU64(), block.Hash()) {
-			log.Info("skipping atomic tx verification on bonus block", "block", block.Hash())
-		} else {
-			// Verify [txs] do not conflict with themselves or ancestor blocks.
-			if err := vm.verifyTxs(txs, block.ParentHash(), block.BaseFee(), block.NumberU64(), rulesExtra); err != nil {
+	if vm.AtomicBackend != nil {
+		// If we are reprocessing state to serve a request, we don't need to verfiy either.
+		if lastAccepted := vm.LastAcceptedExtendedBlock(); lastAccepted != nil && lastAccepted.Height() <= block.NumberU64() {
+			if vm.AtomicBackend.IsBonus(block.NumberU64(), block.Hash()) {
+				log.Info("skipping atomic tx verification on bonus block", "block", block.Hash())
+			} else {
+				// Verify [txs] do not conflict with themselves or ancestor blocks.
+				if err := vm.verifyTxs(txs, block.ParentHash(), block.BaseFee(), block.NumberU64(), rulesExtra); err != nil {
+					return nil, nil, err
+				}
+			}
+			// Update the atomic backend with [txs] from this block.
+			//
+			// Note: The atomic trie canonically contains the duplicate operations
+			// from any bonus blocks.
+			_, err := vm.AtomicBackend.InsertTxs(block.Hash(), block.NumberU64(), block.ParentHash(), txs)
+			if err != nil {
 				return nil, nil, err
 			}
-		}
-		// Update the atomic backend with [txs] from this block.
-		//
-		// Note: The atomic trie canonically contains the duplicate operations
-		// from any bonus blocks.
-		_, err := vm.AtomicBackend.InsertTxs(block.Hash(), block.NumberU64(), block.ParentHash(), txs)
-		if err != nil {
-			return nil, nil, err
 		}
 	}
 


### PR DESCRIPTION
## Why this should be merged

There's a lot of extra stuff that we can avoid with an unrelated change (arguably, a fix)

## How this works

By nature of re-execution, that means we've accepted something else. If we've already accepted it, then we don't need to verify it.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
