### PR TITLE
chore: bump Firewood to v0.4.0

### DIFF
--- a/.bazel/patches/build_files/com_github_ava_labs_firewood_go_ethhash_ffi/BUILD.bazel
+++ b/.bazel/patches/build_files/com_github_ava_labs_firewood_go_ethhash_ffi/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/.bazel/patches/com_github_ava_labs_firewood_go_ethhash_ffi.patch
+++ b/.bazel/patches/com_github_ava_labs_firewood_go_ethhash_ffi.patch
@@ -2,7 +2,7 @@ diff --git a/BUILD.bazel b/BUILD.bazel
 new file mode 100644
 --- /dev/null
 +++ b/BUILD.bazel
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,60 @@
 +# gazelle:ignore
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
@@ -44,6 +44,7 @@ new file mode 100644
 +        "@com_github_prometheus_client_golang//prometheus",
 +        "@com_github_prometheus_client_model//go",
 +        "@com_github_prometheus_common//expfmt",
++        "@org_golang_google_protobuf//proto",
 +    ],
 +)
 +

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2 // indirect
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0
 	github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82l+9LfV2NSl4Klk+9pjaxd3M=
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1 h1:2LXaw0vQ/nSjSKyNil2NoNXXuH+nFSSrlUUBl1x6Jcg=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1/go.mod h1:0Z60sYkUFvvOlOc0XHGbP+271EjP5KjaaOA0EQxCCSA=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0 h1:7OzfDVz9/lKyr9EfHZnNEvXevlW6utComzePoT4vaMQ=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a h1:rPtNc8GdAxiCxSdL+kaM42Lfuoxi034X4Fe20lR2auI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1 h1:Y9UdRQj28/t+GNzVSlP6nvoNLtzNRo3fNXLUc/NscVM=

--- a/go.work.sum
+++ b/go.work.sum
@@ -335,6 +335,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.3.0/go.mod h1:71C76bo47zlDX9gWnn3p/0QZQXkTQ/GNqUNI6fchvjs=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0 h1:7OzfDVz9/lKyr9EfHZnNEvXevlW6utComzePoT4vaMQ=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
 github.com/aws/aws-sdk-go-v2 v1.21.2 h1:+LXZ0sgo8quN9UOKXXzAWRT3FWd4NxeXWOZom9pE7GA=
 github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVATHrjKtxIpM=
 github.com/aws/aws-sdk-go-v2/config v1.18.45 h1:Aka9bI7n8ysuwPeFdm77nfbyHCAKQ3z9ghB3S/38zes=

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -10,7 +10,7 @@ go 1.25.8
 require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0
 	github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3

--- a/graft/coreth/go.sum
+++ b/graft/coreth/go.sum
@@ -26,8 +26,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1 h1:2LXaw0vQ/nSjSKyNil2NoNXXuH+nFSSrlUUBl1x6Jcg=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1/go.mod h1:0Z60sYkUFvvOlOc0XHGbP+271EjP5KjaaOA0EQxCCSA=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0 h1:7OzfDVz9/lKyr9EfHZnNEvXevlW6utComzePoT4vaMQ=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a h1:rPtNc8GdAxiCxSdL+kaM42Lfuoxi034X4Fe20lR2auI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -6,7 +6,7 @@ go 1.25.8
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.14.2
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0
 	github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/graft/evm/go.sum
+++ b/graft/evm/go.sum
@@ -19,8 +19,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1 h1:2LXaw0vQ/nSjSKyNil2NoNXXuH+nFSSrlUUBl1x6Jcg=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1/go.mod h1:0Z60sYkUFvvOlOc0XHGbP+271EjP5KjaaOA0EQxCCSA=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0 h1:7OzfDVz9/lKyr9EfHZnNEvXevlW6utComzePoT4vaMQ=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a h1:rPtNc8GdAxiCxSdL+kaM42Lfuoxi034X4Fe20lR2auI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0
 	github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3

--- a/graft/subnet-evm/go.sum
+++ b/graft/subnet-evm/go.sum
@@ -28,8 +28,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1 h1:2LXaw0vQ/nSjSKyNil2NoNXXuH+nFSSrlUUBl1x6Jcg=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.3.1/go.mod h1:0Z60sYkUFvvOlOc0XHGbP+271EjP5KjaaOA0EQxCCSA=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0 h1:7OzfDVz9/lKyr9EfHZnNEvXevlW6utComzePoT4vaMQ=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.4.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a h1:rPtNc8GdAxiCxSdL+kaM42Lfuoxi034X4Fe20lR2auI=
 github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=


### PR DESCRIPTION
## Why this should be merged

Bumps `firewood-go-ethhash/ffi` from `v0.3.1` to `v0.4.0`.

## How this works

Version bump.

**Notes**: 
- This PR also updates the custom Bazel BUILD patch for `firewood-go-ethhash/ffi`. Firewood `v0.4.0` imports `google.golang.org/protobuf/proto` in [metrics.go](https://github.com/ava-labs/firewood/blob/82131879f969b2ba9682db580304979b8c8e8688/ffi/metrics.go#L24); this dependency was missing in the patch file, resulting in checks such as `bazel-test-coreth` failing.
- Bumping to `v0.4.0` means that consumers of Firewood metrics (e.g. Grafana dashboards) will need to account for metrics changes introduced in https://github.com/ava-labs/firewood/pull/1912. 

## How this was tested

CI

## Need to be documented in RELEASES.md?

No