### PR TITLE
Fix delegator state inconsistency on put/delete pairs

### DIFF
--- a/vms/platformvm/state/BUILD.bazel
+++ b/vms/platformvm/state/BUILD.bazel
@@ -91,6 +91,7 @@ go_test(
         "//cache/lru",
         "//codec",
         "//database",
+        "//database/linkeddb",
         "//database/memdb",
         "//genesis",
         "//ids",

--- a/vms/platformvm/state/BUILD.bazel
+++ b/vms/platformvm/state/BUILD.bazel
@@ -91,7 +91,6 @@ go_test(
         "//cache/lru",
         "//codec",
         "//database",
-        "//database/linkeddb",
         "//database/memdb",
         "//genesis",
         "//ids",

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -464,6 +464,7 @@ func TestDiffCurrentDelegator(t *testing.T) {
 	// The iterator should have the 1 delegator we put in [d]
 	require.True(gotCurrentDelegatorIter.Next())
 	require.Equal(gotCurrentDelegatorIter.Value(), currentDelegator)
+	gotCurrentDelegatorIter.Release()
 
 	// Delete the current delegator
 	require.NoError(d.DeleteCurrentDelegator(currentDelegator))
@@ -472,6 +473,7 @@ func TestDiffCurrentDelegator(t *testing.T) {
 	// The iterator should have no elements.
 	gotCurrentDelegatorIter, err = d.GetCurrentDelegatorIterator(currentDelegator.SubnetID, currentDelegator.NodeID)
 	require.NoError(err)
+	defer gotCurrentDelegatorIter.Release()
 	require.False(gotCurrentDelegatorIter.Next())
 }
 
@@ -498,6 +500,7 @@ func TestDiffPendingDelegator(t *testing.T) {
 	// The iterator should have the 1 delegator we put in [d]
 	require.True(gotPendingDelegatorIter.Next())
 	require.Equal(gotPendingDelegatorIter.Value(), pendingDelegator)
+	gotPendingDelegatorIter.Release()
 
 	// Delete the pending delegator
 	d.DeletePendingDelegator(pendingDelegator)
@@ -506,6 +509,7 @@ func TestDiffPendingDelegator(t *testing.T) {
 	// The iterator should have no elements.
 	gotPendingDelegatorIter, err = d.GetPendingDelegatorIterator(pendingDelegator.SubnetID, pendingDelegator.NodeID)
 	require.NoError(err)
+	defer gotPendingDelegatorIter.Release()
 	require.False(gotPendingDelegatorIter.Next())
 }
 

--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -203,9 +203,9 @@ func (v *baseStakers) PutDelegator(staker *Staker) {
 	validator.delegators.ReplaceOrInsert(staker)
 
 	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	// Cancel a prior delete only when the re-added staker is identical.
-	// A mismatch (e.g. different weight) is recorded as a replacement.
-	if existing, ok := validatorDiff.deletedDelegators[staker.TxID]; ok && existing.Equals(staker) {
+	// A delete followed by a re-add of the same staker is a no-op.
+	// Undo the deletion instead of recording an add.
+	if _, ok := validatorDiff.deletedDelegators[staker.TxID]; ok {
 		delete(validatorDiff.deletedDelegators, staker.TxID)
 	} else {
 		if validatorDiff.addedDelegators == nil {

--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -203,10 +203,16 @@ func (v *baseStakers) PutDelegator(staker *Staker) {
 	validator.delegators.ReplaceOrInsert(staker)
 
 	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	if validatorDiff.addedDelegators == nil {
-		validatorDiff.addedDelegators = btree.NewG(defaultTreeDegree, (*Staker).Less)
+	// A delete followed by a re-add of the same staker is a no-op.
+	// Undo the deletion instead of recording an add.
+	if _, ok := validatorDiff.deletedDelegators[staker.TxID]; ok {
+		delete(validatorDiff.deletedDelegators, staker.TxID)
+	} else {
+		if validatorDiff.addedDelegators == nil {
+			validatorDiff.addedDelegators = btree.NewG(defaultTreeDegree, (*Staker).Less)
+		}
+		validatorDiff.addedDelegators.ReplaceOrInsert(staker)
 	}
-	validatorDiff.addedDelegators.ReplaceOrInsert(staker)
 
 	v.stakers.ReplaceOrInsert(staker)
 }
@@ -219,6 +225,14 @@ func (v *baseStakers) DeleteDelegator(staker *Staker) {
 	v.pruneValidator(staker.SubnetID, staker.NodeID)
 
 	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
+	// An add followed by a delete of the same staker is a no-op.
+	// Undo the addition instead of recording a delete.
+	if validatorDiff.addedDelegators != nil {
+		if _, ok := validatorDiff.addedDelegators.Delete(staker); ok {
+			v.stakers.Delete(staker)
+			return
+		}
+	}
 	if validatorDiff.deletedDelegators == nil {
 		validatorDiff.deletedDelegators = make(map[ids.ID]*Staker)
 	}
@@ -449,6 +463,14 @@ func (s *diffStakers) GetDelegatorIterator(
 
 func (s *diffStakers) PutDelegator(staker *Staker) {
 	validatorDiff := s.getOrCreateDiff(staker.SubnetID, staker.NodeID)
+	// A delete followed by a re-add of the same staker is a no-op on the diff.
+	// Undo the deletion instead of recording an add.
+	if _, ok := validatorDiff.deletedDelegators[staker.TxID]; ok {
+		delete(validatorDiff.deletedDelegators, staker.TxID)
+		delete(s.deletedStakers, staker.TxID)
+		return
+	}
+
 	if validatorDiff.addedDelegators == nil {
 		validatorDiff.addedDelegators = btree.NewG(defaultTreeDegree, (*Staker).Less)
 	}
@@ -462,6 +484,15 @@ func (s *diffStakers) PutDelegator(staker *Staker) {
 
 func (s *diffStakers) DeleteDelegator(staker *Staker) {
 	validatorDiff := s.getOrCreateDiff(staker.SubnetID, staker.NodeID)
+	// An add followed by a delete of the same staker is a no-op on the diff.
+	// Undo the addition instead of recording a delete.
+	if validatorDiff.addedDelegators != nil {
+		if _, ok := validatorDiff.addedDelegators.Delete(staker); ok {
+			s.addedStakers.Delete(staker)
+			return
+		}
+	}
+
 	if validatorDiff.deletedDelegators == nil {
 		validatorDiff.deletedDelegators = make(map[ids.ID]*Staker)
 	}

--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -203,9 +203,10 @@ func (v *baseStakers) PutDelegator(staker *Staker) {
 	validator.delegators.ReplaceOrInsert(staker)
 
 	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	// A delete followed by a re-add of the same staker is a no-op.
-	// Undo the deletion instead of recording an add.
-	if _, ok := validatorDiff.deletedDelegators[staker.TxID]; ok {
+	// Cancel a prior delete only when the re-added staker is identical.
+	// A mismatch (e.g. different weight) must be recorded as a replacement
+	// so the diff captures the field change for the next DB write.
+	if existing, ok := validatorDiff.deletedDelegators[staker.TxID]; ok && existing.Equals(staker) {
 		delete(validatorDiff.deletedDelegators, staker.TxID)
 	} else {
 		if validatorDiff.addedDelegators == nil {

--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -203,9 +203,9 @@ func (v *baseStakers) PutDelegator(staker *Staker) {
 	validator.delegators.ReplaceOrInsert(staker)
 
 	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	// A delete followed by a re-add of the same staker is a no-op.
-	// Undo the deletion instead of recording an add.
-	if _, ok := validatorDiff.deletedDelegators[staker.TxID]; ok {
+	// Cancel a prior delete only when the re-added staker is identical.
+	// A mismatch (e.g. different weight) is recorded as a replacement.
+	if existing, ok := validatorDiff.deletedDelegators[staker.TxID]; ok && existing.Equals(staker) {
 		delete(validatorDiff.deletedDelegators, staker.TxID)
 	} else {
 		if validatorDiff.addedDelegators == nil {
@@ -463,9 +463,10 @@ func (s *diffStakers) GetDelegatorIterator(
 
 func (s *diffStakers) PutDelegator(staker *Staker) {
 	validatorDiff := s.getOrCreateDiff(staker.SubnetID, staker.NodeID)
-	// A delete followed by a re-add of the same staker is a no-op on the diff.
-	// Undo the deletion instead of recording an add.
-	if _, ok := validatorDiff.deletedDelegators[staker.TxID]; ok {
+	// Cancel a prior delete only when the re-added staker is identical.
+	// A mismatch (e.g. different weight) is recorded as a replacement
+	// rather than silently dropping the updated fields.
+	if existing, ok := validatorDiff.deletedDelegators[staker.TxID]; ok && existing.Equals(staker) {
 		delete(validatorDiff.deletedDelegators, staker.TxID)
 		delete(s.deletedStakers, staker.TxID)
 		return

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -425,7 +425,6 @@ func TestDiffStakersDelegatorCancelOut(t *testing.T) {
 		t.Helper()
 
 		iter := diff.GetDelegatorIterator(parent, delegator.SubnetID, delegator.NodeID)
-		defer iter.Release()
 		require.Equal(t, want, iterator.ToSlice(iter))
 	}
 
@@ -437,7 +436,6 @@ func TestDiffStakersDelegatorCancelOut(t *testing.T) {
 		verify(t, diff, iterator.FromSlice(delegator), []*Staker{delegator})
 
 		iter := diff.GetStakerIterator(iterator.FromSlice(delegator))
-		defer iter.Release()
 		require.Equal(t, []*Staker{delegator}, iterator.ToSlice(iter))
 	})
 
@@ -449,7 +447,6 @@ func TestDiffStakersDelegatorCancelOut(t *testing.T) {
 		verify(t, diff, iterator.Empty[*Staker]{}, nil)
 
 		iter := diff.GetStakerIterator(iterator.Empty[*Staker]{})
-		defer iter.Release()
 		require.Empty(t, iterator.ToSlice(iter))
 	})
 }
@@ -501,7 +498,6 @@ func TestBaseStakersDelegatorCancelOutPersistence(t *testing.T) {
 		require.False(t, has)
 
 		iter := v.GetDelegatorIterator(delegator.SubnetID, delegator.NodeID)
-		defer iter.Release()
 		require.Empty(t, iterator.ToSlice(iter))
 	})
 }

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -418,31 +418,96 @@ func TestDiffStakersDelegator(t *testing.T) {
 	)
 }
 
-func TestDiffStakersDelegatorCancelOut(t *testing.T) {
-	delegator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
+func TestDiffDelegatorCancelOut(t *testing.T) {
+	setupState := func(t *testing.T) (*State, *Staker) {
+		t.Helper()
+		state := newTestState(t, memdb.New())
+		subnetID := ids.GenerateTestID()
+		nodeID := ids.GenerateTestNodeID()
+		require.NoError(t, state.PutCurrentValidator(newTestStaker(subnetID, nodeID)))
+		return state, newTestStaker(subnetID, nodeID)
+	}
 
-	t.Run("delete then put same persisted delegator", func(t *testing.T) {
-		diff := &diffStakers{}
-		diff.DeleteDelegator(delegator)
-		diff.PutDelegator(delegator)
+	currentDelegators := func(t *testing.T, state *State, d *Staker) []*Staker {
+		t.Helper()
+		iter, err := state.GetCurrentDelegatorIterator(d.SubnetID, d.NodeID)
+		require.NoError(t, err)
+		defer iter.Release()
+		return iterator.ToSlice(iter)
+	}
 
-		delegatorIter := diff.GetDelegatorIterator(iterator.FromSlice(delegator), delegator.SubnetID, delegator.NodeID)
-		require.Equal(t, []*Staker{delegator}, iterator.ToSlice(delegatorIter))
+	t.Run("delete then put identical delegator leaves state unchanged", func(t *testing.T) {
+		state, delegator := setupState(t)
+		require.NoError(t, state.PutCurrentDelegator(delegator))
 
-		iter := diff.GetStakerIterator(iterator.FromSlice(delegator))
-		require.Equal(t, []*Staker{delegator}, iterator.ToSlice(iter))
+		diff, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+		require.NoError(t, err)
+		require.NoError(t, diff.DeleteCurrentDelegator(delegator))
+		require.NoError(t, diff.PutCurrentDelegator(delegator))
+		require.NoError(t, diff.Apply(state))
+
+		require.Equal(t, []*Staker{delegator}, currentDelegators(t, state, delegator))
 	})
 
-	t.Run("put then delete same delegator", func(t *testing.T) {
-		diff := &diffStakers{}
-		diff.PutDelegator(delegator)
-		diff.DeleteDelegator(delegator)
+	t.Run("delete then put with updated weight applies the replacement", func(t *testing.T) {
+		state, delegator := setupState(t)
+		delegator.Weight = 2
+		require.NoError(t, state.PutCurrentDelegator(delegator))
 
-		delegatorIter := diff.GetDelegatorIterator(iterator.Empty[*Staker]{}, delegator.SubnetID, delegator.NodeID)
-		require.Empty(t, iterator.ToSlice(delegatorIter))
+		updated := *delegator
+		updated.Weight = delegator.Weight - 1
 
-		iter := diff.GetStakerIterator(iterator.Empty[*Staker]{})
-		require.Empty(t, iterator.ToSlice(iter))
+		diff, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+		require.NoError(t, err)
+		require.NoError(t, diff.DeleteCurrentDelegator(delegator))
+		require.NoError(t, diff.PutCurrentDelegator(&updated))
+		require.NoError(t, diff.Apply(state))
+
+		require.Equal(t, []*Staker{&updated}, currentDelegators(t, state, delegator))
+	})
+
+	t.Run("put then delete identical delegator leaves state empty", func(t *testing.T) {
+		state, delegator := setupState(t)
+
+		diff, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+		require.NoError(t, err)
+		require.NoError(t, diff.PutCurrentDelegator(delegator))
+		require.NoError(t, diff.DeleteCurrentDelegator(delegator))
+		require.NoError(t, diff.Apply(state))
+
+		require.Empty(t, currentDelegators(t, state, delegator))
+	})
+
+	t.Run("put then delete with mismatched weight leaves state empty", func(t *testing.T) {
+		state, delegator := setupState(t)
+		delegator.Weight = 2
+
+		mismatched := *delegator
+		mismatched.Weight = delegator.Weight - 1
+
+		diff, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+		require.NoError(t, err)
+		require.NoError(t, diff.PutCurrentDelegator(delegator))
+		require.NoError(t, diff.DeleteCurrentDelegator(&mismatched))
+		require.NoError(t, diff.Apply(state))
+
+		require.Empty(t, currentDelegators(t, state, delegator))
+	})
+
+	t.Run("pending: delete then put identical delegator leaves state unchanged", func(t *testing.T) {
+		state, delegator := setupState(t)
+		state.PutPendingDelegator(delegator)
+
+		diff, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+		require.NoError(t, err)
+		diff.DeletePendingDelegator(delegator)
+		diff.PutPendingDelegator(delegator)
+		require.NoError(t, diff.Apply(state))
+
+		iter, err := state.GetPendingDelegatorIterator(delegator.SubnetID, delegator.NodeID)
+		require.NoError(t, err)
+		defer iter.Release()
+		require.Equal(t, []*Staker{delegator}, iterator.ToSlice(iter))
 	})
 }
 
@@ -454,13 +519,13 @@ func TestBaseStakersDelegatorCancelOutPersistence(t *testing.T) {
 		diff := v.validatorDiffs[delegator.SubnetID][delegator.NodeID]
 		require.NotNil(t, diff)
 		require.NoError(t, writeCurrentDelegatorDiff(list, diff, CodecVersion1))
+		delete(v.validatorDiffs[delegator.SubnetID], delegator.NodeID)
 	}
 
-	t.Run("delete then put same persisted delegator", func(t *testing.T) {
+	t.Run("delete then put identical persisted delegator", func(t *testing.T) {
 		list := linkeddb.NewDefault(memdb.New())
 		v := newBaseStakers()
 
-		// Persist the delegator.
 		v.PutDelegator(delegator)
 		writeDiff(t, v, list)
 
@@ -478,7 +543,7 @@ func TestBaseStakersDelegatorCancelOutPersistence(t *testing.T) {
 		require.True(t, has)
 	})
 
-	t.Run("put then delete same delegator", func(t *testing.T) {
+	t.Run("put then delete identical delegator never persists", func(t *testing.T) {
 		list := linkeddb.NewDefault(memdb.New())
 		v := newBaseStakers()
 

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -421,19 +421,13 @@ func TestDiffStakersDelegator(t *testing.T) {
 func TestDiffStakersDelegatorCancelOut(t *testing.T) {
 	delegator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
 
-	verify := func(t *testing.T, diff *diffStakers, parent iterator.Iterator[*Staker], want []*Staker) {
-		t.Helper()
-
-		iter := diff.GetDelegatorIterator(parent, delegator.SubnetID, delegator.NodeID)
-		require.Equal(t, want, iterator.ToSlice(iter))
-	}
-
 	t.Run("delete then put same persisted delegator", func(t *testing.T) {
 		diff := &diffStakers{}
 		diff.DeleteDelegator(delegator)
 		diff.PutDelegator(delegator)
 
-		verify(t, diff, iterator.FromSlice(delegator), []*Staker{delegator})
+		delegatorIter := diff.GetDelegatorIterator(iterator.FromSlice(delegator), delegator.SubnetID, delegator.NodeID)
+		require.Equal(t, []*Staker{delegator}, iterator.ToSlice(delegatorIter))
 
 		iter := diff.GetStakerIterator(iterator.FromSlice(delegator))
 		require.Equal(t, []*Staker{delegator}, iterator.ToSlice(iter))
@@ -444,7 +438,8 @@ func TestDiffStakersDelegatorCancelOut(t *testing.T) {
 		diff.PutDelegator(delegator)
 		diff.DeleteDelegator(delegator)
 
-		verify(t, diff, iterator.Empty[*Staker]{}, nil)
+		delegatorIter := diff.GetDelegatorIterator(iterator.Empty[*Staker]{}, delegator.SubnetID, delegator.NodeID)
+		require.Empty(t, iterator.ToSlice(delegatorIter))
 
 		iter := diff.GetStakerIterator(iterator.Empty[*Staker]{})
 		require.Empty(t, iterator.ToSlice(iter))

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -560,6 +560,55 @@ func TestBaseStakersDelegatorCancelOutPersistence(t *testing.T) {
 		iter := v.GetDelegatorIterator(delegator.SubnetID, delegator.NodeID)
 		require.Empty(t, iterator.ToSlice(iter))
 	})
+
+	t.Run("delete then put with updated metadata persists the replacement", func(t *testing.T) {
+		list := linkeddb.NewDefault(memdb.New())
+		v := newBaseStakers()
+
+		v.PutDelegator(delegator)
+		writeDiff(t, v, list)
+
+		updated := *delegator
+		updated.PotentialReward = delegator.PotentialReward + 1
+
+		v.DeleteDelegator(delegator)
+		v.PutDelegator(&updated)
+		writeDiff(t, v, list)
+
+		metadataBytes, err := list.Get(delegator.TxID[:])
+		require.NoError(t, err)
+		var metadata delegatorMetadata
+		require.NoError(t, parseDelegatorMetadata(metadataBytes, &metadata))
+		require.Equal(t, updated.PotentialReward, metadata.PotentialReward)
+	})
+
+	t.Run("pending: delete then put with updated metadata persists the entry", func(t *testing.T) {
+		validatorList := linkeddb.NewDefault(memdb.New())
+		delegatorList := linkeddb.NewDefault(memdb.New())
+		v := newBaseStakers()
+
+		writePending := func(t *testing.T) {
+			t.Helper()
+			diff := v.validatorDiffs[delegator.SubnetID][delegator.NodeID]
+			require.NotNil(t, diff)
+			require.NoError(t, writePendingDiff(validatorList, delegatorList, diff))
+			delete(v.validatorDiffs[delegator.SubnetID], delegator.NodeID)
+		}
+
+		v.PutDelegator(delegator)
+		writePending(t)
+
+		updated := *delegator
+		updated.PotentialReward = delegator.PotentialReward + 1
+
+		v.DeleteDelegator(delegator)
+		v.PutDelegator(&updated)
+		writePending(t)
+
+		has, err := delegatorList.Has(delegator.TxID[:])
+		require.NoError(t, err)
+		require.True(t, has)
+	})
 }
 
 func newTestStaker(subnetID ids.ID, nodeID ids.NodeID) *Staker {

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/avalanchego/database/linkeddb"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/utils/iterator"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis/genesistest"
+	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
@@ -428,15 +428,7 @@ func TestDiffDelegatorCancelOut(t *testing.T) {
 		return state, newTestStaker(subnetID, nodeID)
 	}
 
-	currentDelegators := func(t *testing.T, state *State, d *Staker) []*Staker {
-		t.Helper()
-		iter, err := state.GetCurrentDelegatorIterator(d.SubnetID, d.NodeID)
-		require.NoError(t, err)
-		defer iter.Release()
-		return iterator.ToSlice(iter)
-	}
-
-	t.Run("delete then put identical delegator leaves state unchanged", func(t *testing.T) {
+	t.Run("delete_then_put_identical_delegator", func(t *testing.T) {
 		state, delegator := setupState(t)
 		require.NoError(t, state.PutCurrentDelegator(delegator))
 
@@ -449,7 +441,7 @@ func TestDiffDelegatorCancelOut(t *testing.T) {
 		require.Equal(t, []*Staker{delegator}, currentDelegators(t, state, delegator))
 	})
 
-	t.Run("delete then put with updated weight applies the replacement", func(t *testing.T) {
+	t.Run("delete_then_put_updated_weight", func(t *testing.T) {
 		state, delegator := setupState(t)
 		delegator.Weight = 2
 		require.NoError(t, state.PutCurrentDelegator(delegator))
@@ -466,7 +458,7 @@ func TestDiffDelegatorCancelOut(t *testing.T) {
 		require.Equal(t, []*Staker{&updated}, currentDelegators(t, state, delegator))
 	})
 
-	t.Run("put then delete identical delegator leaves state empty", func(t *testing.T) {
+	t.Run("put_then_delete_identical", func(t *testing.T) {
 		state, delegator := setupState(t)
 
 		diff, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
@@ -478,7 +470,7 @@ func TestDiffDelegatorCancelOut(t *testing.T) {
 		require.Empty(t, currentDelegators(t, state, delegator))
 	})
 
-	t.Run("put then delete with mismatched weight leaves state empty", func(t *testing.T) {
+	t.Run("put_then_delete_mismatched_weight", func(t *testing.T) {
 		state, delegator := setupState(t)
 		delegator.Weight = 2
 
@@ -494,7 +486,7 @@ func TestDiffDelegatorCancelOut(t *testing.T) {
 		require.Empty(t, currentDelegators(t, state, delegator))
 	})
 
-	t.Run("pending: delete then put identical delegator leaves state unchanged", func(t *testing.T) {
+	t.Run("pending_delete_then_put_identical", func(t *testing.T) {
 		state, delegator := setupState(t)
 		state.PutPendingDelegator(delegator)
 
@@ -504,111 +496,141 @@ func TestDiffDelegatorCancelOut(t *testing.T) {
 		diff.PutPendingDelegator(delegator)
 		require.NoError(t, diff.Apply(state))
 
-		iter, err := state.GetPendingDelegatorIterator(delegator.SubnetID, delegator.NodeID)
-		require.NoError(t, err)
-		defer iter.Release()
-		require.Equal(t, []*Staker{delegator}, iterator.ToSlice(iter))
+		require.Equal(t, []*Staker{delegator}, pendingDelegators(t, state, delegator))
 	})
 }
 
-func TestBaseStakersDelegatorCancelOutPersistence(t *testing.T) {
-	delegator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
-
-	writeDiff := func(t *testing.T, v *baseStakers, list linkeddb.LinkedDB) {
+// TestStateDelegatorCancelOutCommitAndLoad verifies that deleting and re-adding
+// a delegator within a single commit cycle persists correctly across a reload from disk.
+func TestStateDelegatorCancelOutCommitAndLoad(t *testing.T) {
+	newStateAndDelegator := func(t *testing.T, pending bool) (state *State, db database.Database, delegator *Staker) {
 		t.Helper()
-		diff := v.validatorDiffs[delegator.SubnetID][delegator.NodeID]
-		require.NotNil(t, diff)
-		require.NoError(t, writeCurrentDelegatorDiff(list, diff, CodecVersion1))
-		delete(v.validatorDiffs[delegator.SubnetID], delegator.NodeID)
+		db = memdb.New()
+		state = newTestState(t, db)
+
+		startTime := time.Now().Truncate(time.Second)
+		endTime := startTime.Add(genesistest.DefaultValidatorDuration)
+
+		unsignedDelegator := createPermissionlessDelegatorTx(constants.PrimaryNetworkID, txs.Validator{
+			NodeID: defaultValidatorNodeID,
+			End:    uint64(endTime.Unix()),
+			Wght:   6789,
+		})
+		delegatorTx := &txs.Tx{Unsigned: unsignedDelegator}
+		require.NoError(t, delegatorTx.Initialize(txs.Codec))
+		state.AddTx(delegatorTx, status.Committed)
+
+		var err error
+		if pending {
+			delegator, err = NewPendingStaker(delegatorTx.ID(), unsignedDelegator)
+		} else {
+			// non-zero reward so the reload assertions validate reward persistence
+			delegator, err = NewCurrentStaker(delegatorTx.ID(), unsignedDelegator, startTime, 100)
+		}
+		require.NoError(t, err)
+		return state, db, delegator
 	}
 
-	t.Run("delete then put identical persisted delegator", func(t *testing.T) {
-		list := linkeddb.NewDefault(memdb.New())
-		v := newBaseStakers()
+	t.Run("delete_then_put_identical", func(t *testing.T) {
+		state, db, delegator := newStateAndDelegator(t, false)
+		require.NoError(t, state.PutCurrentDelegator(delegator))
+		state.SetHeight(1)
+		require.NoError(t, state.Commit())
 
-		v.PutDelegator(delegator)
-		writeDiff(t, v, list)
+		// Delete then re-add the identical delegator in one commit cycle.
+		require.NoError(t, state.DeleteCurrentDelegator(delegator))
+		require.NoError(t, state.PutCurrentDelegator(delegator))
+		state.SetHeight(2)
+		require.NoError(t, state.Commit())
 
-		has, err := list.Has(delegator.TxID[:])
-		require.NoError(t, err)
-		require.True(t, has)
-
-		// Delete then re-add. The cancel-out must keep the DB entry.
-		v.DeleteDelegator(delegator)
-		v.PutDelegator(delegator)
-		writeDiff(t, v, list)
-
-		has, err = list.Has(delegator.TxID[:])
-		require.NoError(t, err)
-		require.True(t, has)
+		state = newTestState(t, db)
+		require.Equal(t, []*Staker{delegator}, currentDelegators(t, state, delegator))
 	})
 
-	t.Run("put then delete identical delegator never persists", func(t *testing.T) {
-		list := linkeddb.NewDefault(memdb.New())
-		v := newBaseStakers()
+	t.Run("put_then_delete_identical", func(t *testing.T) {
+		state, db, delegator := newStateAndDelegator(t, false)
 
-		// Put then delete in the same diff cycle. The cancel-out must not
-		// write the delegator to the DB.
-		v.PutDelegator(delegator)
-		v.DeleteDelegator(delegator)
-		writeDiff(t, v, list)
+		// Put then delete the identical delegator in one commit cycle.
+		require.NoError(t, state.PutCurrentDelegator(delegator))
+		require.NoError(t, state.DeleteCurrentDelegator(delegator))
+		state.SetHeight(1)
+		require.NoError(t, state.Commit())
 
-		has, err := list.Has(delegator.TxID[:])
-		require.NoError(t, err)
-		require.False(t, has)
-
-		iter := v.GetDelegatorIterator(delegator.SubnetID, delegator.NodeID)
-		require.Empty(t, iterator.ToSlice(iter))
+		state = newTestState(t, db)
+		require.Empty(t, currentDelegators(t, state, delegator))
 	})
 
-	t.Run("delete then put with updated metadata persists the replacement", func(t *testing.T) {
-		list := linkeddb.NewDefault(memdb.New())
-		v := newBaseStakers()
-
-		v.PutDelegator(delegator)
-		writeDiff(t, v, list)
+	t.Run("delete_then_put_updated_reward", func(t *testing.T) {
+		state, db, delegator := newStateAndDelegator(t, false)
+		require.NoError(t, state.PutCurrentDelegator(delegator))
+		state.SetHeight(1)
+		require.NoError(t, state.Commit())
 
 		updated := *delegator
 		updated.PotentialReward = delegator.PotentialReward + 1
 
-		v.DeleteDelegator(delegator)
-		v.PutDelegator(&updated)
-		writeDiff(t, v, list)
+		require.NoError(t, state.DeleteCurrentDelegator(delegator))
+		require.NoError(t, state.PutCurrentDelegator(&updated))
+		state.SetHeight(2)
+		require.NoError(t, state.Commit())
 
-		metadataBytes, err := list.Get(delegator.TxID[:])
-		require.NoError(t, err)
-		var metadata delegatorMetadata
-		require.NoError(t, parseDelegatorMetadata(metadataBytes, &metadata))
-		require.Equal(t, updated.PotentialReward, metadata.PotentialReward)
+		state = newTestState(t, db)
+		require.Equal(t, []*Staker{&updated}, currentDelegators(t, state, delegator))
 	})
 
-	t.Run("pending: delete then put with updated metadata persists the entry", func(t *testing.T) {
-		validatorList := linkeddb.NewDefault(memdb.New())
-		delegatorList := linkeddb.NewDefault(memdb.New())
-		v := newBaseStakers()
+	t.Run("pending_delete_then_put_identical", func(t *testing.T) {
+		state, db, delegator := newStateAndDelegator(t, true)
+		state.PutPendingDelegator(delegator)
+		state.SetHeight(1)
+		require.NoError(t, state.Commit())
 
-		writePending := func(t *testing.T) {
-			t.Helper()
-			diff := v.validatorDiffs[delegator.SubnetID][delegator.NodeID]
-			require.NotNil(t, diff)
-			require.NoError(t, writePendingDiff(validatorList, delegatorList, diff))
-			delete(v.validatorDiffs[delegator.SubnetID], delegator.NodeID)
-		}
+		// Delete then re-add the identical delegator in one commit cycle.
+		state.DeletePendingDelegator(delegator)
+		state.PutPendingDelegator(delegator)
+		state.SetHeight(2)
+		require.NoError(t, state.Commit())
 
-		v.PutDelegator(delegator)
-		writePending(t)
-
-		updated := *delegator
-		updated.PotentialReward = delegator.PotentialReward + 1
-
-		v.DeleteDelegator(delegator)
-		v.PutDelegator(&updated)
-		writePending(t)
-
-		has, err := delegatorList.Has(delegator.TxID[:])
-		require.NoError(t, err)
-		require.True(t, has)
+		state = newTestState(t, db)
+		require.Equal(t, []*Staker{delegator}, pendingDelegators(t, state, delegator))
 	})
+
+	t.Run("pending_delete_then_put_mismatched", func(t *testing.T) {
+		state, db, delegator := newStateAndDelegator(t, true)
+		state.PutPendingDelegator(delegator)
+		state.SetHeight(1)
+		require.NoError(t, state.Commit())
+
+		// Differing weight prevents the cancel-out, so the diff holds both a
+		// delete and an add for the same txID.
+		mismatched := *delegator
+		mismatched.Weight++
+		state.DeletePendingDelegator(delegator)
+		state.PutPendingDelegator(&mismatched)
+		state.SetHeight(2)
+		require.NoError(t, state.Commit())
+
+		// We expect the original delegator, not mismatched: pending delegators
+		// persist only the txID, so on reload the staker
+		// is rebuilt entirely from the unchanged tx.
+		state = newTestState(t, db)
+		require.Equal(t, []*Staker{delegator}, pendingDelegators(t, state, delegator))
+	})
+}
+
+func currentDelegators(t *testing.T, state *State, staker *Staker) []*Staker {
+	t.Helper()
+	it, err := state.GetCurrentDelegatorIterator(staker.SubnetID, staker.NodeID)
+	require.NoError(t, err)
+	defer it.Release()
+	return iterator.ToSlice(it)
+}
+
+func pendingDelegators(t *testing.T, state *State, staker *Staker) []*Staker {
+	t.Helper()
+	it, err := state.GetPendingDelegatorIterator(staker.SubnetID, staker.NodeID)
+	require.NoError(t, err)
+	defer it.Release()
+	return iterator.ToSlice(it)
 }
 
 func newTestStaker(subnetID ids.ID, nodeID ids.NodeID) *Staker {

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/linkeddb"
+	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
@@ -414,6 +416,94 @@ func TestDiffStakersDelegator(t *testing.T) {
 	require.Empty(
 		iterator.ToSlice(delegatorIterator),
 	)
+}
+
+func TestDiffStakersDelegatorCancelOut(t *testing.T) {
+	delegator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
+
+	verify := func(t *testing.T, diff *diffStakers, parent iterator.Iterator[*Staker], want []*Staker) {
+		t.Helper()
+
+		iter := diff.GetDelegatorIterator(parent, delegator.SubnetID, delegator.NodeID)
+		defer iter.Release()
+		require.Equal(t, want, iterator.ToSlice(iter))
+	}
+
+	t.Run("delete then put same persisted delegator", func(t *testing.T) {
+		diff := &diffStakers{}
+		diff.DeleteDelegator(delegator)
+		diff.PutDelegator(delegator)
+
+		verify(t, diff, iterator.FromSlice(delegator), []*Staker{delegator})
+
+		iter := diff.GetStakerIterator(iterator.FromSlice(delegator))
+		defer iter.Release()
+		require.Equal(t, []*Staker{delegator}, iterator.ToSlice(iter))
+	})
+
+	t.Run("put then delete same delegator", func(t *testing.T) {
+		diff := &diffStakers{}
+		diff.PutDelegator(delegator)
+		diff.DeleteDelegator(delegator)
+
+		verify(t, diff, iterator.Empty[*Staker]{}, nil)
+
+		iter := diff.GetStakerIterator(iterator.Empty[*Staker]{})
+		defer iter.Release()
+		require.Empty(t, iterator.ToSlice(iter))
+	})
+}
+
+func TestBaseStakersDelegatorCancelOutPersistence(t *testing.T) {
+	delegator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
+
+	writeDiff := func(t *testing.T, v *baseStakers, list linkeddb.LinkedDB) {
+		t.Helper()
+		diff := v.validatorDiffs[delegator.SubnetID][delegator.NodeID]
+		require.NotNil(t, diff)
+		require.NoError(t, writeCurrentDelegatorDiff(list, diff, CodecVersion1))
+	}
+
+	t.Run("delete then put same persisted delegator", func(t *testing.T) {
+		list := linkeddb.NewDefault(memdb.New())
+		v := newBaseStakers()
+
+		// Persist the delegator.
+		v.PutDelegator(delegator)
+		writeDiff(t, v, list)
+
+		has, err := list.Has(delegator.TxID[:])
+		require.NoError(t, err)
+		require.True(t, has)
+
+		// Delete then re-add. The cancel-out must keep the DB entry.
+		v.DeleteDelegator(delegator)
+		v.PutDelegator(delegator)
+		writeDiff(t, v, list)
+
+		has, err = list.Has(delegator.TxID[:])
+		require.NoError(t, err)
+		require.True(t, has)
+	})
+
+	t.Run("put then delete same delegator", func(t *testing.T) {
+		list := linkeddb.NewDefault(memdb.New())
+		v := newBaseStakers()
+
+		// Put then delete in the same diff cycle. The cancel-out must not
+		// write the delegator to the DB.
+		v.PutDelegator(delegator)
+		v.DeleteDelegator(delegator)
+		writeDiff(t, v, list)
+
+		has, err := list.Has(delegator.TxID[:])
+		require.NoError(t, err)
+		require.False(t, has)
+
+		iter := v.GetDelegatorIterator(delegator.SubnetID, delegator.NodeID)
+		defer iter.Release()
+		require.Empty(t, iterator.ToSlice(iter))
+	})
 }
 
 func newTestStaker(subnetID ids.ID, nodeID ids.NodeID) *Staker {

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -2878,6 +2878,13 @@ func writeCurrentDelegatorDiff(
 	validatorDiff *diffValidator,
 	codecVersion uint16,
 ) error {
+	// Delete before adding so a same-TxID replacement ends with the new entry.
+	for _, staker := range validatorDiff.deletedDelegators {
+		if err := currentDelegatorList.Delete(staker.TxID[:]); err != nil {
+			return fmt.Errorf("failed to delete current staker: %w", err)
+		}
+	}
+
 	addedDelegatorIterator := iterator.FromTree(validatorDiff.addedDelegators)
 	defer addedDelegatorIterator.Release()
 
@@ -2891,12 +2898,6 @@ func writeCurrentDelegatorDiff(
 		}
 		if err := writeDelegatorMetadata(currentDelegatorList, metadata, codecVersion); err != nil {
 			return fmt.Errorf("failed to write current delegator to list: %w", err)
-		}
-	}
-
-	for _, staker := range validatorDiff.deletedDelegators {
-		if err := currentDelegatorList.Delete(staker.TxID[:]); err != nil {
-			return fmt.Errorf("failed to delete current staker: %w", err)
 		}
 	}
 	return nil
@@ -2947,6 +2948,13 @@ func writePendingDiff(
 		}
 	}
 
+	// Delete before adding so a same-TxID replacement ends with the new entry.
+	for _, staker := range validatorDiff.deletedDelegators {
+		if err := pendingDelegatorList.Delete(staker.TxID[:]); err != nil {
+			return fmt.Errorf("failed to delete pending delegator: %w", err)
+		}
+	}
+
 	addedDelegatorIterator := iterator.FromTree(validatorDiff.addedDelegators)
 	defer addedDelegatorIterator.Release()
 	for addedDelegatorIterator.Next() {
@@ -2954,12 +2962,6 @@ func writePendingDiff(
 
 		if err := pendingDelegatorList.Put(staker.TxID[:], nil); err != nil {
 			return fmt.Errorf("failed to write pending delegator to list: %w", err)
-		}
-	}
-
-	for _, staker := range validatorDiff.deletedDelegators {
-		if err := pendingDelegatorList.Delete(staker.TxID[:]); err != nil {
-			return fmt.Errorf("failed to delete pending delegator: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Why this should be merged

Defensive fix for an internal consistency issue in `baseStakers` and `diffStakers`. The pending writes don't cancel out matching `PutDelegator` / `DeleteDelegator` pairs, so both `addedDelegators` and `deletedDelegators` can end up populated for the same `TxID`, inconsistent with the in-memory btree.

There's no way to trigger this normally. The bug requires the same delegator (same `staker.TxID`) to be both added and removed within a single diff, which no current code path does.

## How this works

Cancel out matching put/delete pairs in two places:

- `baseStakers.PutDelegator` / `DeleteDelegator`: when a call is the inverse of an earlier call in the pending writes, undo the prior call instead of recording the new one.
- `diffStakers.PutDelegator` / `DeleteDelegator`: same shape applied to the in-flight diff. Without this, `GetDelegatorIterator` on a delete-then-readd diff would filter the re-added delegator out.

## How this was tested

- **`TestDiffStakersDelegatorCancelOut`** — diff-level read correctness via `GetDelegatorIterator` / `GetStakerIterator` for both `delete-then-put` and `put-then-delete`. The `delete-then-put` subtest fails without the fix: `deletedDelegators` still contains the staker, so the iterator filters out the parent-supplied entry and returns `nil`.

- **`TestBaseStakersDelegatorCancelOutPersistence`** — writes the diff through `writeCurrentDelegatorDiff` into a memdb-backed `linkeddb` and checks the persisted row for both orderings. The `delete-then-put` subtest fails without the fix: `writeCurrentDelegatorDiff` sees the staker in `deletedDelegators` and removes the DB row.

## Need to be documented in RELEASES.md?

No