### PR TITLE
feat: add pathdb 33-33.5m scheduled benchmark

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.json
@@ -39,6 +39,11 @@
                 "runner": "avago-runner-i4i-16xlarge-local-ssd",
                 "test": "hashdb-archive-69m-69m100k",
                 "timeout-minutes": 1440
+            },
+            {
+                "runner": "avago-runner-i4i-4xlarge-local-ssd",
+                "test": "pathdb-33m-33m500k",
+                "timeout-minutes": 1440
             }
         ]
     }

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -151,6 +151,12 @@ if [[ -n "$TEST_NAME" ]]; then
             END_BLOCK="${END_BLOCK:-69100000}"
             CONFIG="${CONFIG:-archive}"
             ;;
+        pathdb-33m-33m500k)
+            BLOCK_DIR_SRC="${BLOCK_DIR_SRC:-cchain-mainnet-blocks-30m-40m-ldb}"
+            CURRENT_STATE_DIR_SRC="${CURRENT_STATE_DIR_SRC:-cchain-current-state-pathdb-full-33m}"
+            START_BLOCK="${START_BLOCK:-33000001}"
+            END_BLOCK="${END_BLOCK:-33500000}"
+            ;;
         firewood-101-250k)
             BLOCK_DIR_SRC="${BLOCK_DIR_SRC:-cchain-mainnet-blocks-1m-ldb}"
             CURRENT_STATE_DIR_SRC="${CURRENT_STATE_DIR_SRC:-cchain-current-state-firewood-100}"

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -156,6 +156,7 @@ if [[ -n "$TEST_NAME" ]]; then
             CURRENT_STATE_DIR_SRC="${CURRENT_STATE_DIR_SRC:-cchain-current-state-pathdb-full-33m}"
             START_BLOCK="${START_BLOCK:-33000001}"
             END_BLOCK="${END_BLOCK:-33500000}"
+            CONFIG="${CONFIG:-pathdb}"
             ;;
         firewood-101-250k)
             BLOCK_DIR_SRC="${BLOCK_DIR_SRC:-cchain-mainnet-blocks-1m-ldb}"

--- a/scripts/benchmark_cchain_range.sh
+++ b/scripts/benchmark_cchain_range.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 #     END_BLOCK: The ending block height (inclusive).
 #
 #   Optional (reexecution tests):
-#     CONFIG: VM config preset (default, archive, firewood, firewood-archive).
+#     CONFIG: VM config preset (default, archive, pathdb, firewood, firewood-archive).
 #     LABELS: Comma-separated key=value pairs for metric labels.
 #     BENCHMARK_OUTPUT_FILE: If set, benchmark output is also written to this file.
 #     METRICS_SERVER_ENABLED: If set, enables the metrics server.
@@ -72,6 +72,7 @@ Available tests:
   hashdb-69m-69m100k                - Blocks 69m-69.1m with hashdb
   hashdb-archive-69m-69m100k        - Blocks 69m-69.1m with hashdb archive
   hashdb-archive-ssc-69m-69m100k    - Blocks 69m-69.1m with hashdb archive from a statesynced checkpoint
+  pathdb-33m-33m500k                - Blocks 33m-33.5m with pathdb
   firewood-101-250k                 - Blocks 101-250k with firewood
   firewood-archive-101-250k         - Blocks 101-250k with firewood archive
   firewood-33m-33m500k              - Blocks 33m-33.5m with firewood

--- a/tests/reexecute/c/README.md
+++ b/tests/reexecute/c/README.md
@@ -245,7 +245,7 @@ BLOCK_DIR_SRC=cchain-mainnet-blocks-10k-ldb CURRENT_STATE_DIR_SRC=cchain-current
 
 To support testing the VM in multiple configurations, the benchmark supports a set of pre-defined configs passed via the `CONFIG` environment variable.
 
-The currently supported options are: "default", "archive", and "firewood".
+The currently supported options are: "default", "archive", "pathdb", "firewood", and "firewood-archive".
 
 To execute a benchmark with any of these options, you must use a compatible `CURRENT_STATE_DIR` or `CURRENT_STATE_DIR_SRC` or the VM will refuse to start with an incompatible existing database and newly provided config.
 


### PR DESCRIPTION
## Why this should be merged

As part of benchmarking Firewood's performance, we've been benchmarking against HashDB. However, go-ethereum recommends using PathDB, which is superior to HashDB in terms of performance and disk usage. This PR adds PathDB to our benchmarking suite, keeping in line with gauging Firewood's performance against alternative EVM databases.

## How this works

- Adds `pathdb-33m-33m500k` test default
- Adds `pathdb-33m-33m500k` to the list of daily scheduled reexecution tests

## How this was tested

CI + ran reexecution test using PathDB config here: https://github.com/ava-labs/avalanchego/actions/runs/25469843779/job/74731204252

## Need to be documented in RELEASES.md?

No
