### PR TITLE
[ci] Simplify required job maintenance with workflow-level aggregators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  tests-required:
+    if: ${{ always() }}
+    needs:
+      - Unit
+      - Fuzz
+      - e2e
+      - e2e_post_latest
+      - e2e_kube
+      - e2e_existing_network
+      - Upgrade
+      - Lint
+      - tausecondslint
+      - links-lint
+      - check_generated_protobuf
+      - check_mockgen
+      - check_canotogen
+      - check_contract_bindings
+      - check_go_mod_tidy
+      - test_build_image
+      - test_build_antithesis_avalanchego_images
+      - test_build_antithesis_xsvm_images
+      - e2e_bootstrap_monitor
+      - load
+      - load_kube_kind
+      - robustness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless all needed jobs succeeded
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | jq -e '
+            to_entries
+            | all(.value.result == "success")
+          ' >/dev/null
+
   Unit:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/coreth-ci.yml
+++ b/.github/workflows/coreth-ci.yml
@@ -8,6 +8,24 @@ on:
     types: [checks_requested]
 
 jobs:
+  coreth-required:
+    if: ${{ always() }}
+    needs:
+      - lint_test
+      - unit_test
+      - e2e_warp
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless all needed jobs succeeded
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | jq -e '
+            to_entries
+            | all(.value.result == "success")
+          ' >/dev/null
+
   lint_test:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/evm-ci.yml
+++ b/.github/workflows/evm-ci.yml
@@ -8,6 +8,23 @@ on:
     types: [checks_requested]
 
 jobs:
+  evm-shared-required:
+    if: ${{ always() }}
+    needs:
+      - lint_test
+      - unit_test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless all needed jobs succeeded
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | jq -e '
+            to_entries
+            | all(.value.result == "success")
+          ' >/dev/null
+
   lint_test:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -9,6 +9,27 @@ on:
     types: [checks_requested]
 
 jobs:
+  subnet-evm-required:
+    if: ${{ always() }}
+    needs:
+      - lint_test
+      - unit_test
+      - e2e_warp
+      - e2e_load
+      - test_build_image
+      - test_build_antithesis_images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless all needed jobs succeeded
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | jq -e '
+            to_entries
+            | all(.value.result == "success")
+          ' >/dev/null
+
   lint_test:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why this should be merged

Previously, required jobs were maintained on a per-job basis. As per the example of SAE, this change switches to defining a single required job per workflow that will only pass if all of the jobs it depends on pass. This means that future maintenance of required jobs can be done via PRs rather than requiring repo permissions.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A