### PR TITLE
Remove some unnecessary interfaces in `peer`

### DIFF
--- a/network/metrics.go
+++ b/network/metrics.go
@@ -147,7 +147,7 @@ func newMetrics(
 	return m, err
 }
 
-func (m *metrics) markConnected(peer peer.Peer) {
+func (m *metrics) markConnected(peer *peer.Peer) {
 	m.numPeers.Inc()
 	m.connected.Inc()
 
@@ -166,7 +166,7 @@ func (m *metrics) markConnected(peer peer.Peer) {
 	m.peerConnectedStartTimesSum += now
 }
 
-func (m *metrics) markDisconnected(peer peer.Peer) {
+func (m *metrics) markDisconnected(peer *peer.Peer) {
 	m.numPeers.Dec()
 	m.disconnected.Inc()
 

--- a/network/network.go
+++ b/network/network.go
@@ -150,8 +150,8 @@ type network struct {
 	// to connect to the peer. An entry is deleted from this set once we have
 	// finished the handshake.
 	trackedIPs      map[ids.NodeID]*trackedIP
-	connectingPeers peer.Set
-	connectedPeers  peer.Set
+	connectingPeers *peer.Set
+	connectedPeers  *peer.Set
 	closing         bool
 
 	startupTime time.Time
@@ -339,7 +339,7 @@ func (n *network) Send(
 	// send to peers and update metrics
 	//
 	// Note: It is guaranteed that namedPeers and sampledPeers are disjoint.
-	for _, peers := range [][]peer.Peer{namedPeers, sampledPeers} {
+	for _, peers := range [][]*peer.Peer{namedPeers, sampledPeers} {
 		for _, peer := range peers {
 			if peer.Send(n.onCloseCtx, msg) {
 				sentTo.Add(peer.ID())
@@ -760,8 +760,8 @@ func (n *network) getPeers(
 	nodeIDs set.Set[ids.NodeID],
 	subnetID ids.ID,
 	allower subnets.Allower,
-) []peer.Peer {
-	peers := make([]peer.Peer, 0, nodeIDs.Len())
+) []*peer.Peer {
+	peers := make([]*peer.Peer, 0, nodeIDs.Len())
 
 	n.peersLock.RLock()
 	defer n.peersLock.RUnlock()
@@ -791,7 +791,7 @@ func (n *network) samplePeers(
 	config common.SendConfig,
 	subnetID ids.ID,
 	allower subnets.Allower,
-) []peer.Peer {
+) []*peer.Peer {
 	// As an optimization, if there are fewer validators than
 	// [numValidatorsToSample], only attempt to sample [numValidatorsToSample]
 	// validators to potentially avoid iterating over the entire peer set.
@@ -802,7 +802,7 @@ func (n *network) samplePeers(
 
 	return n.connectedPeers.Sample(
 		numValidatorsToSample+config.NonValidators+config.Peers,
-		func(p peer.Peer) bool {
+		func(p *peer.Peer) bool {
 			// Only return peers that are tracking [subnetID]
 			if trackedSubnets := p.TrackedSubnets(); !trackedSubnets.Contains(subnetID) {
 				return false
@@ -859,7 +859,7 @@ func (n *network) disconnectedFromConnecting(nodeID ids.NodeID) {
 	n.metrics.disconnected.Inc()
 }
 
-func (n *network) disconnectedFromConnected(peer peer.Peer, nodeID ids.NodeID) {
+func (n *network) disconnectedFromConnected(peer *peer.Peer, nodeID ids.NodeID) {
 	n.ipTracker.Disconnected(nodeID)
 	n.router.Disconnected(nodeID)
 

--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -267,7 +267,7 @@ func (p *Peer) ObservedUptime() uint32 {
 	return p.observedUptime.Get()
 }
 
-// Send attempts to send `msg` to the peer. The peer takes ownership of `msg`
+// Send attempts to send msg to the peer. The peer takes ownership of msg
 // for reference counting. This returns false if the message is guaranteed not
 // to be delivered to the peer.
 func (p *Peer) Send(ctx context.Context, msg *message.OutboundMessage) bool {

--- a/network/peer/peer.go
+++ b/network/peer/peer.go
@@ -47,82 +47,11 @@ const (
 	malformedMessageLog      = "malformed message"
 )
 
-var (
-	errClosed = errors.New("closed")
-
-	_ Peer = (*peer)(nil)
-)
+var errClosed = errors.New("closed")
 
 // Peer encapsulates all of the functionality required to send and receive
 // messages with a remote peer.
-type Peer interface {
-	// ID returns the nodeID of the remote peer.
-	ID() ids.NodeID
-
-	// Cert returns the certificate that the remote peer is using to
-	// authenticate their messages.
-	Cert() *staking.Certificate
-
-	// LastSent returns the last time a message was sent to the peer.
-	LastSent() time.Time
-
-	// LastReceived returns the last time a message was received from the peer.
-	LastReceived() time.Time
-
-	// Ready returns true if the peer has finished the p2p handshake and is
-	// ready to send and receive messages.
-	Ready() bool
-
-	// AwaitReady will block until the peer has finished the p2p handshake. If
-	// the context is cancelled or the peer starts closing, then an error will
-	// be returned.
-	AwaitReady(ctx context.Context) error
-
-	// Info returns a description of the state of this peer. It should only be
-	// called after [Ready] returns true.
-	Info() Info
-
-	// IP returns the claimed IP and signature provided by this peer during the
-	// handshake. It should only be called after [Ready] returns true.
-	IP() *SignedIP
-
-	// Version returns the claimed node version this peer is running. It should
-	// only be called after [Ready] returns true.
-	Version() *version.Application
-
-	// TrackedSubnets returns the subnets this peer is running. It should only
-	// be called after [Ready] returns true.
-	TrackedSubnets() set.Set[ids.ID]
-
-	// ObservedUptime returns the local node's primary network uptime according to the
-	// peer. The value ranges from [0, 100]. It should only be called after
-	// [Ready] returns true.
-	ObservedUptime() uint32
-
-	// Send attempts to send [msg] to the peer. The peer takes ownership of
-	// [msg] for reference counting. This returns false if the message is
-	// guaranteed not to be delivered to the peer.
-	Send(ctx context.Context, msg *message.OutboundMessage) bool
-
-	// StartSendGetPeerList attempts to send a GetPeerList message to this peer
-	// on this peer's gossip routine. It is not guaranteed that a GetPeerList
-	// will be sent.
-	StartSendGetPeerList()
-
-	// StartClose will begin shutting down the peer. It will not block.
-	StartClose()
-
-	// Closed returns true once the peer has been fully shutdown. It is
-	// guaranteed that no more messages will be received by this peer once this
-	// returns true.
-	Closed() bool
-
-	// AwaitClosed will block until the peer has been fully shutdown. If the
-	// context is cancelled, then an error will be returned.
-	AwaitClosed(ctx context.Context) error
-}
-
-type peer struct {
+type Peer struct {
 	*Config
 
 	// the connection object that is used to read/write messages from
@@ -217,9 +146,9 @@ func Start(
 	id ids.NodeID,
 	messageQueue MessageQueue,
 	isIngress bool,
-) Peer {
+) *Peer {
 	onClosingCtx, onClosingCtxCancel := context.WithCancel(context.Background())
-	p := &peer{
+	p := &Peer{
 		isIngress:          isIngress,
 		Config:             config,
 		conn:               conn,
@@ -245,33 +174,43 @@ func Start(
 	return p
 }
 
-func (p *peer) ID() ids.NodeID {
+// ID returns the [ids.NodeID] of the remote peer.
+func (p *Peer) ID() ids.NodeID {
 	return p.id
 }
 
-func (p *peer) Cert() *staking.Certificate {
+// Cert returns the certificate that the remote peer is using to
+// authenticate their messages.
+func (p *Peer) Cert() *staking.Certificate {
 	return p.cert
 }
 
-func (p *peer) LastSent() time.Time {
+// LastSent returns the last time a message was sent to the peer.
+func (p *Peer) LastSent() time.Time {
 	return time.Unix(
 		atomic.LoadInt64(&p.lastSent),
 		0,
 	)
 }
 
-func (p *peer) LastReceived() time.Time {
+// LastReceived returns the last time a message was received from the peer.
+func (p *Peer) LastReceived() time.Time {
 	return time.Unix(
 		atomic.LoadInt64(&p.lastReceived),
 		0,
 	)
 }
 
-func (p *peer) Ready() bool {
+// Ready returns true if the peer has finished the p2p handshake and is
+// ready to send and receive messages.
+func (p *Peer) Ready() bool {
 	return p.finishedHandshake.Get()
 }
 
-func (p *peer) AwaitReady(ctx context.Context) error {
+// AwaitReady will block until the peer has finished the p2p handshake. If
+// the context is cancelled or the peer starts closing, then an error will
+// be returned.
+func (p *Peer) AwaitReady(ctx context.Context) error {
 	select {
 	case <-p.onFinishHandshake:
 		return nil
@@ -282,7 +221,9 @@ func (p *peer) AwaitReady(ctx context.Context) error {
 	}
 }
 
-func (p *peer) Info() Info {
+// Info returns a description of the state of this peer. It should only be
+// called after [Peer.Ready] returns true.
+func (p *Peer) Info() Info {
 	primaryUptime := p.ObservedUptime()
 
 	ip, _ := ips.ParseAddrPort(p.conn.RemoteAddr().String())
@@ -301,34 +242,50 @@ func (p *peer) Info() Info {
 	}
 }
 
-func (p *peer) IP() *SignedIP {
+// IP returns the claimed IP and signature provided by this peer during the
+// handshake. It should only be called after [Peer.Ready] returns true.
+func (p *Peer) IP() *SignedIP {
 	return p.ip
 }
 
-func (p *peer) Version() *version.Application {
+// Version returns the claimed node version this peer is running. It should
+// only be called after [Peer.Ready] returns true.
+func (p *Peer) Version() *version.Application {
 	return p.version
 }
 
-func (p *peer) TrackedSubnets() set.Set[ids.ID] {
+// TrackedSubnets returns the subnets this peer is running. It should only
+// be called after [Peer.Ready] returns true.
+func (p *Peer) TrackedSubnets() set.Set[ids.ID] {
 	return p.trackedSubnets
 }
 
-func (p *peer) ObservedUptime() uint32 {
+// ObservedUptime returns the local node's primary network uptime according to
+// the peer. The value ranges from [0, 100]. It should only be called after
+// [Peer.Ready] returns true.
+func (p *Peer) ObservedUptime() uint32 {
 	return p.observedUptime.Get()
 }
 
-func (p *peer) Send(ctx context.Context, msg *message.OutboundMessage) bool {
+// Send attempts to send `msg` to the peer. The peer takes ownership of `msg`
+// for reference counting. This returns false if the message is guaranteed not
+// to be delivered to the peer.
+func (p *Peer) Send(ctx context.Context, msg *message.OutboundMessage) bool {
 	return p.messageQueue.Push(ctx, msg)
 }
 
-func (p *peer) StartSendGetPeerList() {
+// StartSendGetPeerList attempts to send a GetPeerList message to this peer
+// on this peer's gossip routine. It is not guaranteed that a GetPeerList
+// will be sent.
+func (p *Peer) StartSendGetPeerList() {
 	select {
 	case p.getPeerListChan <- struct{}{}:
 	default:
 	}
 }
 
-func (p *peer) StartClose() {
+// StartClose will begin shutting down the peer. It will not block.
+func (p *Peer) StartClose() {
 	p.startClosingOnce.Do(func() {
 		if err := p.conn.Close(); err != nil {
 			p.Log.Debug("failed to close connection",
@@ -342,7 +299,10 @@ func (p *peer) StartClose() {
 	})
 }
 
-func (p *peer) Closed() bool {
+// Closed returns true once the peer has been fully shutdown. It is
+// guaranteed that no more messages will be received by this peer once this
+// returns true.
+func (p *Peer) Closed() bool {
 	select {
 	case _, ok := <-p.onClosed:
 		return !ok
@@ -351,7 +311,9 @@ func (p *peer) Closed() bool {
 	}
 }
 
-func (p *peer) AwaitClosed(ctx context.Context) error {
+// AwaitClosed will block until the peer has been fully shutdown. If the
+// context is cancelled, then an error will be returned.
+func (p *Peer) AwaitClosed(ctx context.Context) error {
 	select {
 	case <-p.onClosed:
 		return nil
@@ -362,7 +324,7 @@ func (p *peer) AwaitClosed(ctx context.Context) error {
 
 // close should be called at the end of each goroutine that has been spun up.
 // When the last goroutine is exiting, the peer will be marked as closed.
-func (p *peer) close() {
+func (p *Peer) close() {
 	if atomic.AddInt64(&p.numExecuting, -1) != 0 {
 		return
 	}
@@ -377,7 +339,7 @@ func (p *peer) close() {
 
 // Read and handle messages from this peer.
 // When this method returns, the connection is closed.
-func (p *peer) readMessages() {
+func (p *Peer) readMessages() {
 	// Track this node with the inbound message throttler.
 	p.InboundMsgThrottler.AddNode(p.id)
 	defer func() {
@@ -507,7 +469,7 @@ func (p *peer) readMessages() {
 	}
 }
 
-func (p *peer) writeMessages() {
+func (p *Peer) writeMessages() {
 	defer func() {
 		p.StartClose()
 		p.close()
@@ -594,7 +556,7 @@ func (p *peer) writeMessages() {
 	}
 }
 
-func (p *peer) writeMessage(writer io.Writer, msg *message.OutboundMessage) {
+func (p *Peer) writeMessage(writer io.Writer, msg *message.OutboundMessage) {
 	msgBytes := msg.Bytes
 	p.Log.Verbo("sending message",
 		zap.Stringer("op", msg.Op),
@@ -640,7 +602,7 @@ func (p *peer) writeMessage(writer io.Writer, msg *message.OutboundMessage) {
 	p.Metrics.Sent(msg)
 }
 
-func (p *peer) sendNetworkMessages() {
+func (p *Peer) sendNetworkMessages() {
 	sendPingsTicker := time.NewTicker(p.PingFrequency)
 	defer func() {
 		sendPingsTicker.Stop()
@@ -713,7 +675,7 @@ func (p *peer) sendNetworkMessages() {
 // It is called when sending a Ping message to account for validator set
 // changes. It's called when sending a Ping rather than in a validator set
 // callback to avoid signature verification on the P-chain accept path.
-func (p *peer) shouldDisconnect() bool {
+func (p *Peer) shouldDisconnect() bool {
 	if !p.VersionCompatibility.Compatible(p.version) {
 		p.Log.Debug(disconnectingLog,
 			zap.String("reason", "version not compatible"),
@@ -750,7 +712,7 @@ func (p *peer) shouldDisconnect() bool {
 	return false
 }
 
-func (p *peer) handle(msg *message.InboundMessage) {
+func (p *Peer) handle(msg *message.InboundMessage) {
 	switch m := msg.Message.(type) { // Network-related message types
 	case *p2p.Ping:
 		p.handlePing(m)
@@ -787,7 +749,7 @@ func (p *peer) handle(msg *message.InboundMessage) {
 	p.Router.HandleInbound(context.Background(), msg)
 }
 
-func (p *peer) handlePing(msg *p2p.Ping) {
+func (p *Peer) handlePing(msg *p2p.Ping) {
 	if msg.Uptime > 100 {
 		p.Log.Debug(malformedMessageLog,
 			zap.Stringer("nodeID", p.id),
@@ -814,7 +776,7 @@ func (p *peer) handlePing(msg *p2p.Ping) {
 	p.Send(p.onClosingCtx, pongMessage)
 }
 
-func (p *peer) getUptime() uint32 {
+func (p *Peer) getUptime() uint32 {
 	primaryUptime, err := p.UptimeCalculator.CalculateUptimePercent(
 		p.id,
 	)
@@ -831,7 +793,7 @@ func (p *peer) getUptime() uint32 {
 	return primaryUptimePercent
 }
 
-func (p *peer) handlePong(*p2p.Pong) {
+func (p *Peer) handlePong(*p2p.Pong) {
 	pingSent := atomic.SwapInt64(&p.lastPingSent, 0)
 	if pingSent == 0 {
 		p.Log.Debug(malformedMessageLog,
@@ -849,7 +811,7 @@ func (p *peer) handlePong(*p2p.Pong) {
 	p.Metrics.RTTSum.Add(float64(elapsed))
 }
 
-func (p *peer) handleHandshake(msg *p2p.Handshake) {
+func (p *Peer) handleHandshake(msg *p2p.Handshake) {
 	if p.gotHandshake.Get() {
 		p.Log.Debug(malformedMessageLog,
 			zap.Stringer("nodeID", p.id),
@@ -1103,7 +1065,7 @@ func (p *peer) handleHandshake(msg *p2p.Handshake) {
 	}
 }
 
-func (p *peer) handleGetPeerList(msg *p2p.GetPeerList) {
+func (p *Peer) handleGetPeerList(msg *p2p.GetPeerList) {
 	if !p.finishedHandshake.Get() {
 		p.Log.Debug(malformedMessageLog,
 			zap.Stringer("nodeID", p.id),
@@ -1161,7 +1123,7 @@ func (p *peer) handleGetPeerList(msg *p2p.GetPeerList) {
 	p.Send(p.onClosingCtx, peerListMsg)
 }
 
-func (p *peer) handlePeerList(msg *p2p.PeerList) {
+func (p *Peer) handlePeerList(msg *p2p.PeerList) {
 	if !p.finishedHandshake.Get() {
 		if !p.gotHandshake.Get() {
 			return
@@ -1232,17 +1194,17 @@ func (p *peer) handlePeerList(msg *p2p.PeerList) {
 	}
 }
 
-func (p *peer) nextTimeout() time.Time {
+func (p *Peer) nextTimeout() time.Time {
 	return p.Clock.Time().Add(p.PongTimeout)
 }
 
-func (p *peer) storeLastSent(time time.Time) {
+func (p *Peer) storeLastSent(time time.Time) {
 	unixTime := time.Unix()
 	atomic.StoreInt64(&p.Config.LastSent, unixTime)
 	atomic.StoreInt64(&p.lastSent, unixTime)
 }
 
-func (p *peer) storeLastReceived(time time.Time) {
+func (p *Peer) storeLastReceived(time time.Time) {
 	unixTime := time.Unix()
 	atomic.StoreInt64(&p.Config.LastReceived, unixTime)
 	atomic.StoreInt64(&p.lastReceived, unixTime)

--- a/network/peer/peer_test.go
+++ b/network/peer/peer_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 type testPeer struct {
-	Peer
+	*Peer
 	inboundMsgChan <-chan *message.InboundMessage
 }
 
@@ -154,7 +154,7 @@ func startTestPeers(rawPeer0 *rawTestPeer, rawPeer1 *rawTestPeer) (*testPeer, *t
 	return peer0, peer1
 }
 
-func awaitReady(t *testing.T, peers ...Peer) {
+func awaitReady(t *testing.T, peers ...*testPeer) {
 	t.Helper()
 	require := require.New(t)
 
@@ -393,13 +393,13 @@ func TestShouldDisconnect(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		initialPeer              *peer
-		expectedPeer             *peer
+		initialPeer              *Peer
+		expectedPeer             *Peer
 		expectedShouldDisconnect bool
 	}{
 		{
 			name: "peer is reporting old version",
-			initialPeer: &peer{
+			initialPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -411,7 +411,7 @@ func TestShouldDisconnect(t *testing.T) {
 					Patch: 0,
 				},
 			},
-			expectedPeer: &peer{
+			expectedPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -427,7 +427,7 @@ func TestShouldDisconnect(t *testing.T) {
 		},
 		{
 			name: "peer is not a validator",
-			initialPeer: &peer{
+			initialPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -435,7 +435,7 @@ func TestShouldDisconnect(t *testing.T) {
 				},
 				version: version.Current,
 			},
-			expectedPeer: &peer{
+			expectedPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -447,7 +447,7 @@ func TestShouldDisconnect(t *testing.T) {
 		},
 		{
 			name: "peer is a validator without a BLS key",
-			initialPeer: &peer{
+			initialPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -466,7 +466,7 @@ func TestShouldDisconnect(t *testing.T) {
 				id:      peerID,
 				version: version.Current,
 			},
-			expectedPeer: &peer{
+			expectedPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -489,7 +489,7 @@ func TestShouldDisconnect(t *testing.T) {
 		},
 		{
 			name: "already verified peer",
-			initialPeer: &peer{
+			initialPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -509,7 +509,7 @@ func TestShouldDisconnect(t *testing.T) {
 				version:              version.Current,
 				txIDOfVerifiedBLSKey: txID,
 			},
-			expectedPeer: &peer{
+			expectedPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -533,7 +533,7 @@ func TestShouldDisconnect(t *testing.T) {
 		},
 		{
 			name: "peer without signature",
-			initialPeer: &peer{
+			initialPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -553,7 +553,7 @@ func TestShouldDisconnect(t *testing.T) {
 				version: version.Current,
 				ip:      &SignedIP{},
 			},
-			expectedPeer: &peer{
+			expectedPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -577,7 +577,7 @@ func TestShouldDisconnect(t *testing.T) {
 		},
 		{
 			name: "peer with invalid signature",
-			initialPeer: &peer{
+			initialPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -599,7 +599,7 @@ func TestShouldDisconnect(t *testing.T) {
 					BLSSignature: must(blsKey.SignProofOfPossession([]byte("wrong message"))),
 				},
 			},
-			expectedPeer: &peer{
+			expectedPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -625,7 +625,7 @@ func TestShouldDisconnect(t *testing.T) {
 		},
 		{
 			name: "peer with valid signature",
-			initialPeer: &peer{
+			initialPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),
@@ -647,7 +647,7 @@ func TestShouldDisconnect(t *testing.T) {
 					BLSSignature: must(blsKey.SignProofOfPossession((&UnsignedIP{}).bytes())),
 				},
 			},
-			expectedPeer: &peer{
+			expectedPeer: &Peer{
 				Config: &Config{
 					Log:                  logging.NoLog{},
 					VersionCompatibility: version.GetCompatibility(upgrade.InitiallyActiveTime),

--- a/network/peer/set.go
+++ b/network/peer/set.go
@@ -47,7 +47,7 @@ func (s *Set) Add(peer *Peer) {
 	}
 }
 
-// GetByID attempts to fetch a [Peer] whose [Peer.ID] is equal to `nodeID`.
+// GetByID attempts to fetch a [Peer] whose [Peer.ID] is equal to nodeID.
 // If no such peer exists in the set, then [false] will be returned.
 func (s *Set) GetByID(nodeID ids.NodeID) (*Peer, bool) {
 	index, ok := s.peersMap[nodeID]
@@ -57,8 +57,8 @@ func (s *Set) GetByID(nodeID ids.NodeID) (*Peer, bool) {
 	return s.peersSlice[index], true
 }
 
-// GetByIndex attempts to fetch a [Peer] who has been allocated `index`.
-// If `index` < 0 or `index` >= [Set.Len], then false will be returned.
+// GetByIndex attempts to fetch a [Peer] who has been allocated index.
+// If index < 0 or index >= [Set.Len], then false will be returned.
 func (s *Set) GetByIndex(index int) (*Peer, bool) {
 	if index < 0 || index >= len(s.peersSlice) {
 		return nil, false
@@ -66,7 +66,7 @@ func (s *Set) GetByIndex(index int) (*Peer, bool) {
 	return s.peersSlice[index], true
 }
 
-// Remove any [Peer] whose [Peer.ID] is equal to `nodeID` from the set.
+// Remove any [Peer] whose [Peer.ID] is equal to nodeID from the set.
 func (s *Set) Remove(nodeID ids.NodeID) {
 	index, ok := s.peersMap[nodeID]
 	if !ok {
@@ -90,9 +90,9 @@ func (s *Set) Len() int {
 	return len(s.peersSlice)
 }
 
-// Sample attempts to return a random slice of peers with length `n`. The
+// Sample attempts to return a random slice of peers with length n. The
 // slice will not include any duplicates. Only peers that cause the
-// `precondition` to return true will be returned in the slice.
+// precondition to return true will be returned in the slice.
 func (s *Set) Sample(n int, precondition func(*Peer) bool) []*Peer {
 	if n <= 0 {
 		return nil

--- a/network/peer/set.go
+++ b/network/peer/set.go
@@ -8,65 +8,35 @@ import (
 	"github.com/ava-labs/avalanchego/utils/sampler"
 )
 
-var _ Set = (*peerSet)(nil)
-
-func NoPrecondition(Peer) bool {
+// NoPrecondition can be supplied to [Set.Sample] to indicate that all peers
+// are eligible to be returned in the sample.
+func NoPrecondition(*Peer) bool {
 	return true
 }
 
 // Set contains a group of peers.
-type Set interface {
-	// Add this peer to the set.
-	//
-	// If a peer with the same [peer.ID] is already in the set, then the new
-	// peer instance will replace the old peer instance.
-	//
-	// Add does not change the [peer.ID] returned from calls to [GetByIndex].
-	Add(peer Peer)
-
-	// GetByID attempts to fetch a [peer] whose [peer.ID] is equal to [nodeID].
-	// If no such peer exists in the set, then [false] will be returned.
-	GetByID(nodeID ids.NodeID) (Peer, bool)
-
-	// GetByIndex attempts to fetch a peer who has been allocated [index]. If
-	// [index] < 0 or [index] >= [Len], then false will be returned.
-	GetByIndex(index int) (Peer, bool)
-
-	// Remove any [peer] whose [peer.ID] is equal to [nodeID] from the set.
-	Remove(nodeID ids.NodeID)
-
-	// Len returns the number of peers currently in this set.
-	Len() int
-
-	// Sample attempts to return a random slice of peers with length [n]. The
-	// slice will not include any duplicates. Only peers that cause the
-	// [precondition] to return true will be returned in the slice.
-	Sample(n int, precondition func(Peer) bool) []Peer
-
-	// Returns information about all the peers.
-	AllInfo() []Info
-
-	// Info returns information about the requested peers if they are in the
-	// set.
-	Info(nodeIDs []ids.NodeID) []Info
-}
-
-type peerSet struct {
+type Set struct {
 	peersMap   map[ids.NodeID]int // nodeID -> peer's index in peersSlice
-	peersSlice []Peer             // invariant: len(peersSlice) == len(peersMap)
+	peersSlice []*Peer            // invariant: len(peersSlice) == len(peersMap)
 }
 
 // NewSet returns a set that does not internally manage synchronization.
 //
-// Only [Add] and [Remove] require exclusion on the data structure. The
+// Only [Set.Add] and [Set.Remove] require exclusion on the data structure. The
 // remaining methods are safe for concurrent use.
-func NewSet() Set {
-	return &peerSet{
+func NewSet() *Set {
+	return &Set{
 		peersMap: make(map[ids.NodeID]int),
 	}
 }
 
-func (s *peerSet) Add(peer Peer) {
+// Add this peer to the set.
+//
+// If a peer with the same [Peer.ID] is already in the set, then the new
+// peer instance will replace the old peer instance.
+//
+// Add does not change the [Peer.ID] returned from calls to [Set.GetByIndex].
+func (s *Set) Add(peer *Peer) {
 	nodeID := peer.ID()
 	index, ok := s.peersMap[nodeID]
 	if !ok {
@@ -77,7 +47,9 @@ func (s *peerSet) Add(peer Peer) {
 	}
 }
 
-func (s *peerSet) GetByID(nodeID ids.NodeID) (Peer, bool) {
+// GetByID attempts to fetch a [Peer] whose [Peer.ID] is equal to `nodeID`.
+// If no such peer exists in the set, then [false] will be returned.
+func (s *Set) GetByID(nodeID ids.NodeID) (*Peer, bool) {
 	index, ok := s.peersMap[nodeID]
 	if !ok {
 		return nil, false
@@ -85,14 +57,17 @@ func (s *peerSet) GetByID(nodeID ids.NodeID) (Peer, bool) {
 	return s.peersSlice[index], true
 }
 
-func (s *peerSet) GetByIndex(index int) (Peer, bool) {
+// GetByIndex attempts to fetch a [Peer] who has been allocated `index`.
+// If `index` < 0 or `index` >= [Set.Len], then false will be returned.
+func (s *Set) GetByIndex(index int) (*Peer, bool) {
 	if index < 0 || index >= len(s.peersSlice) {
 		return nil, false
 	}
 	return s.peersSlice[index], true
 }
 
-func (s *peerSet) Remove(nodeID ids.NodeID) {
+// Remove any [Peer] whose [Peer.ID] is equal to `nodeID` from the set.
+func (s *Set) Remove(nodeID ids.NodeID) {
 	index, ok := s.peersMap[nodeID]
 	if !ok {
 		return
@@ -110,11 +85,15 @@ func (s *peerSet) Remove(nodeID ids.NodeID) {
 	s.peersSlice = s.peersSlice[:lastIndex]
 }
 
-func (s *peerSet) Len() int {
+// Len returns the number of peers currently in this set.
+func (s *Set) Len() int {
 	return len(s.peersSlice)
 }
 
-func (s *peerSet) Sample(n int, precondition func(Peer) bool) []Peer {
+// Sample attempts to return a random slice of peers with length `n`. The
+// slice will not include any duplicates. Only peers that cause the
+// `precondition` to return true will be returned in the slice.
+func (s *Set) Sample(n int, precondition func(*Peer) bool) []*Peer {
 	if n <= 0 {
 		return nil
 	}
@@ -122,7 +101,7 @@ func (s *peerSet) Sample(n int, precondition func(Peer) bool) []Peer {
 	sampler := sampler.NewUniform()
 	sampler.Initialize(uint64(len(s.peersSlice)))
 
-	peers := make([]Peer, 0, n)
+	peers := make([]*Peer, 0, n)
 	for len(peers) < n {
 		index, hasNext := sampler.Next()
 		if !hasNext {
@@ -138,7 +117,8 @@ func (s *peerSet) Sample(n int, precondition func(Peer) bool) []Peer {
 	return peers
 }
 
-func (s *peerSet) AllInfo() []Info {
+// AllInfo returns information about all the peers.
+func (s *Set) AllInfo() []Info {
 	peerInfo := make([]Info, len(s.peersSlice))
 	for i, peer := range s.peersSlice {
 		peerInfo[i] = peer.Info()
@@ -146,7 +126,8 @@ func (s *peerSet) AllInfo() []Info {
 	return peerInfo
 }
 
-func (s *peerSet) Info(nodeIDs []ids.NodeID) []Info {
+// Info returns information about the requested peers if they are in the set.
+func (s *Set) Info(nodeIDs []ids.NodeID) []Info {
 	peerInfo := make([]Info, 0, len(nodeIDs))
 	for _, nodeID := range nodeIDs {
 		if peer, ok := s.GetByID(nodeID); ok {

--- a/network/peer/set_test.go
+++ b/network/peer/set_test.go
@@ -17,24 +17,24 @@ func TestSet(t *testing.T) {
 
 	set := NewSet()
 
-	peer1 := &peer{
+	peer1 := &Peer{
 		id:             ids.BuildTestNodeID([]byte{0x01}),
 		observedUptime: *utils.NewAtomic[uint32](0),
 	}
-	updatedPeer1 := &peer{
+	updatedPeer1 := &Peer{
 		id:             ids.BuildTestNodeID([]byte{0x01}),
 		observedUptime: *utils.NewAtomic[uint32](1),
 	}
-	peer2 := &peer{
+	peer2 := &Peer{
 		id: ids.BuildTestNodeID([]byte{0x02}),
 	}
-	unknownPeer := &peer{
+	unknownPeer := &Peer{
 		id: ids.BuildTestNodeID([]byte{0xff}),
 	}
-	peer3 := &peer{
+	peer3 := &Peer{
 		id: ids.BuildTestNodeID([]byte{0x03}),
 	}
-	peer4 := &peer{
+	peer4 := &Peer{
 		id: ids.BuildTestNodeID([]byte{0x04}),
 	}
 
@@ -104,10 +104,10 @@ func TestSetSample(t *testing.T) {
 
 	set := NewSet()
 
-	peer1 := &peer{
+	peer1 := &Peer{
 		id: ids.BuildTestNodeID([]byte{0x01}),
 	}
-	peer2 := &peer{
+	peer2 := &Peer{
 		id: ids.BuildTestNodeID([]byte{0x02}),
 	}
 
@@ -128,10 +128,10 @@ func TestSetSample(t *testing.T) {
 	require.Empty(peers)
 
 	peers = set.Sample(1, NoPrecondition)
-	require.Equal([]Peer{peer1}, peers)
+	require.Equal([]*Peer{peer1}, peers)
 
 	peers = set.Sample(2, NoPrecondition)
-	require.Equal([]Peer{peer1}, peers)
+	require.Equal([]*Peer{peer1}, peers)
 
 	// Case: 2 peers
 	set.Add(peer2)

--- a/network/peer/test_peer.go
+++ b/network/peer/test_peer.go
@@ -52,7 +52,7 @@ func StartTestPeer(
 	ip netip.AddrPort,
 	networkID uint32,
 	router router.InboundHandler,
-) (Peer, error) {
+) (*Peer, error) {
 	dialer := net.Dialer{}
 	conn, err := dialer.DialContext(ctx, constants.NetworkType, ip.String())
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged

I was debugging som `merkle/sync` code and got annoyed how many interfaces I had to click through. There's only one implementation for both of these interfaces, so I deleted the interface and exported the struct. While I was moving the comments, I went ahead and fixed the godoc links too.

## How this works

Removes indirection layer for straightforward code.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No