### PR TITLE
[ci] Use versioned GitHub Actions runners instead of `-latest`

### DIFF
--- a/.github/workflows/bazel-ci-matrix.yml
+++ b/.github/workflows/bazel-ci-matrix.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   bz-define-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       platforms: ${{ steps.set-platforms.outputs.platforms }}
     steps:

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -20,7 +20,10 @@ env:
 jobs:
   # This workflow contains a single job called "build"
   build-mac:
-    # The type of runner that the job will run on
+    # Build release artifacts on the oldest macOS version still receiving Apple
+    # security updates to maximize the chance that shipped binaries remain usable
+    # on older supported macOS versions. CI validation can track newer macOS
+    # releases independently.
     runs-on: macos-14
     permissions:
       id-token: write

--- a/.github/workflows/c-chain-reexecution-benchmark-container.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.json
@@ -2,7 +2,7 @@
     "pull_request": {
         "include": [
             {
-                "runner": "ubuntu-latest",
+                "runner": "ubuntu-24.04",
                 "test": "hashdb-101-250k",
                 "timeout-minutes": 30
             },

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   define-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
@@ -2,7 +2,7 @@
     "pull_request": {
         "include": [
             {
-              "runner": "ubuntu-latest",
+              "runner": "ubuntu-24.04",
               "test": "hashdb-101-250k",
               "timeout-minutes": 30
             },

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   define-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - load
       - load_kube_kind
       - robustness
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Fail unless all needed jobs succeeded
         shell: bash
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
+        os: [macos-26, ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -75,7 +75,7 @@ jobs:
         env:
           TIMEOUT: ${{ env.TIMEOUT }}
   Fuzz:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v5
       - name: Run e2e tests
@@ -105,7 +105,7 @@ jobs:
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   e2e_post_latest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Run e2e tests
@@ -123,7 +123,7 @@ jobs:
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   e2e_kube:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
@@ -141,7 +141,7 @@ jobs:
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   e2e_existing_network:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Run e2e tests with existing network
@@ -158,7 +158,7 @@ jobs:
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   Upgrade:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Run e2e tests
@@ -175,7 +175,7 @@ jobs:
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
@@ -183,7 +183,7 @@ jobs:
         shell: nix develop --command bash -x {0}
         run: ./scripts/run_task.sh lint-all-ci
   tausecondslint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Check for TauSeconds misuse with time.Add()
@@ -195,7 +195,7 @@ jobs:
           fi
   links-lint:
     name: Markdown Links Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: umbrelladocs/action-linkspector@de84085e0f51452a470558693d7d308fbb2fa261 # v1.2.5
@@ -203,7 +203,7 @@ jobs:
           fail_level: any
   check_generated_protobuf:
     name: Up-to-date protobuf
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       # Use the dev shell instead of bufbuild/buf-action to ensure the dev shell provides the expected versions
@@ -212,7 +212,7 @@ jobs:
         run: ./scripts/run_task.sh check-generate-protobuf
   check_mockgen:
     name: Up-to-date mocks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -220,7 +220,7 @@ jobs:
         run: ./scripts/run_task.sh check-generate-mocks
   check_canotogen:
     name: Up-to-date canoto
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -228,7 +228,7 @@ jobs:
         run: ./scripts/run_task.sh check-generate-canoto
   check_contract_bindings:
     name: Up-to-date contract bindings
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
@@ -236,7 +236,7 @@ jobs:
         run: task check-generate-load-contract-bindings
   check_go_mod_tidy:
     name: Up-to-date go.mod and go.sum
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -244,7 +244,7 @@ jobs:
         run: ./scripts/run_task.sh check-go-mod-tidy
   test_build_image:
     name: Image build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up QEMU (required for cross-platform builds)
@@ -254,7 +254,7 @@ jobs:
         run: ./scripts/run_task.sh test-build-image
   test_build_antithesis_avalanchego_images:
     name: Build Antithesis avalanchego images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -263,7 +263,7 @@ jobs:
         run: ./scripts/run_task.sh test-build-antithesis-images-avalanchego
   test_build_antithesis_xsvm_images:
     name: Build Antithesis xsvm images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -272,7 +272,7 @@ jobs:
         run: ./scripts/run_task.sh test-build-antithesis-images-xsvm
   e2e_bootstrap_monitor:
     name: Run bootstrap monitor e2e tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
@@ -281,7 +281,7 @@ jobs:
         run: ./scripts/run_task.sh test-bootstrap-monitor-e2e
   load:
     name: Run process-based load test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
@@ -298,7 +298,7 @@ jobs:
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   load_kube_kind:
     name: Run load test on kind cluster
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
@@ -315,7 +315,7 @@ jobs:
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   robustness:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,7 +12,7 @@ jobs:
       github.event.label.name == 'ai-review' &&
       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER", "CONTRIBUTOR"]'), github.event.pull_request.author_association) &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write # Required for Claude to post PR comments and inline review feedback

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/coreth-ci.yml
+++ b/.github/workflows/coreth-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - lint_test
       - unit_test
       - e2e_warp
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Fail unless all needed jobs succeeded
         shell: bash
@@ -31,7 +31,7 @@ jobs:
 
   lint_test:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./graft/coreth
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-22.04, ubuntu-latest]
+        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -61,7 +61,7 @@ jobs:
 
   e2e_warp:
     name: E2E Warp Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v5

--- a/.github/workflows/evm-ci.yml
+++ b/.github/workflows/evm-ci.yml
@@ -16,7 +16,7 @@ jobs:
     needs:
       - lint_test
       - unit_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Fail unless all needed jobs succeeded
         shell: bash
@@ -30,7 +30,7 @@ jobs:
 
   lint_test:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./graft/evm
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-22.04, ubuntu-latest]
+        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project

--- a/.github/workflows/firewood-chaos-test.yml
+++ b/.github/workflows/firewood-chaos-test.yml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   define-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     timeout-minutes: ${{ matrix.timeout-minutes || 60 }}
-    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   fuzz:
     name: fuzz (${{ matrix.shard }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish_antithesis_images.yml
+++ b/.github/workflows/publish_antithesis_images.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   antithesis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   publish_docker_image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up QEMU (required for cross-platform builds)

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - e2e_load
       - test_build_image
       - test_build_antithesis_images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Fail unless all needed jobs succeeded
         shell: bash
@@ -35,7 +35,7 @@ jobs:
 
   lint_test:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./graft/subnet-evm
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-22.04, ubuntu-latest]
+        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -65,7 +65,7 @@ jobs:
 
   e2e_warp:
     name: e2e warp tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v5
@@ -88,7 +88,7 @@ jobs:
 
   e2e_load:
     name: e2e load tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v5
@@ -111,7 +111,7 @@ jobs:
 
   test_build_image:
     name: Image build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./graft/subnet-evm
@@ -124,7 +124,7 @@ jobs:
 
   test_build_antithesis_images:
     name: Build Antithesis images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:

--- a/.github/workflows/trigger-antithesis-avalanchego.yml
+++ b/.github/workflows/trigger-antithesis-avalanchego.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   antithesis_avalanchego:
     name: Run Antithesis Avalanchego Test Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: antithesishq/antithesis-trigger-action@b7d0c9d1d9316bd4de73a44144c56636ea3a64ba # v0.8
         with:

--- a/.github/workflows/trigger-antithesis-subnet-evm.yml
+++ b/.github/workflows/trigger-antithesis-subnet-evm.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   antithesis_subnet_evm:
     name: Run Antithesis Subnet-EVM Test Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: antithesishq/antithesis-trigger-action@6c0a27302c0a3cd97d87d40bd6704e673abed4bb # v0.9
         with:

--- a/.github/workflows/trigger-antithesis-xsvm.yml
+++ b/.github/workflows/trigger-antithesis-xsvm.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   antithesis_xsvm:
     name: Run Antithesis XSVM Test Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: antithesishq/antithesis-trigger-action@b7d0c9d1d9316bd4de73a44144c56636ea3a64ba # v0.8
         with:

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -23,3 +23,26 @@ if [[ -n "${SCRIPT_USAGE}" ]]; then
   echo "Error: the lines listed above must be converted to use scripts/run_task.sh to ensure local reproducibility."
   exit 1
 fi
+
+echo "Checking for floating GitHub runner labels..."
+# Floating runner labels (e.g. ubuntu-latest, macos-latest) can change out
+# from under the default branch and break CI without any corresponding change
+# in the repository. Require explicit runner versions so image upgrades happen
+# only through intentional repo changes that can be reviewed.
+FLOATING_RUNNERS=
+for file in "${AVALANCHE_PATH}"/.github/workflows/*.{yml,yaml,json}; do
+  # Skip if no matches found (in case one of the extensions doesn't exist)
+  [[ -f "$file" ]] || continue
+
+  MATCHES=$(grep -H -n -P '\b(?:ubuntu|macos)-latest\b' "$file" || true)
+  if [[ -n "${MATCHES}" ]]; then
+    echo "${MATCHES}"
+    FLOATING_RUNNERS=1
+  fi
+done
+
+if [[ -n "${FLOATING_RUNNERS}" ]]; then
+  echo "Error: floating GitHub runner labels are forbidden."
+  echo "Pin explicit runner versions instead so runner image upgrades happen through reviewed repo changes rather than when GitHub updates a floating label on the default branch."
+  exit 1
+fi


### PR DESCRIPTION
## Why this should be merged

Previously, `macos-latest` and `ubuntu-latest` runners were used for convenience to avoid having to update runner names (e.g. macos-15 -> macos-26) when a new version was released. It also avoided having to update the set of required jobs if the job name embedded the runner name (common for matrix jobs).

Now, though, we're using the default arm runners (which lack `-latest` versions) and have switched to a required-job-per-workflow strategy. That removes the value of using `-latest` since we have to maintain runner versions and required jobs no longer embed runner names. Using explicit version names has the added benefit of ensuring that we upgrade our runner versions via PRs and avoid the potential for a `-latest` runner version upgrade breaking master.

## How this was tested

CI

## Need to be documented in RELEASES.md?

N/A