### PR TITLE
[ci]: Upgrade all workflows to use NodeJS 24

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -90,14 +90,14 @@ runs:
     - run: echo "dependencies installed"
       shell: nix develop --command bash {0}
     # Cache Go modules (architecture-independent)
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: go-mod-cache
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mod-${{ hashFiles('go.work.sum') }}
         restore-keys: ${{ runner.os }}-go-mod-
     # Cache Go build cache (architecture-specific)
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
         key: ${{ runner.os }}-${{ runner.arch }}-go-build-${{ hashFiles('go.work.sum') }}
@@ -121,7 +121,7 @@ runs:
       shell: bash
       run: echo "::warning::Monitoring credentials not found. Skipping collector start. Is the PR from a fork branch?"
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}
@@ -160,7 +160,7 @@ runs:
         TMPDIR: /tmp
         NIX_BUILD_TOP: /tmp
     - name: Upload Benchmark Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: benchmark-output-${{ inputs.test }}-${{ inputs.runner_type }}
         path: ${{ env.BENCHMARK_OUTPUT_FILE }}

--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -16,14 +16,14 @@ runs:
     - run: nix develop --command echo "dependencies installed"
       shell: bash
     # Cache Go modules (architecture-independent)
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: go-mod-cache
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mod-${{ hashFiles('go.work.sum', 'tools/external/go.sum') }}
         restore-keys: ${{ runner.os }}-go-mod-
     # Cache Go build cache (architecture-specific)
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
         key: ${{ runner.os }}-${{ runner.arch }}-go-build-${{ hashFiles('go.work.sum', 'tools/external/go.sum') }}

--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -109,7 +109,7 @@ runs:
       run: kind export logs /tmp/kind-logs
     - name: Upload kind logs
       if: always() && (inputs.runtime == 'kube')
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.artifact_prefix }}-kind-logs
         path: /tmp/kind-logs

--- a/.github/actions/setup-go-for-project/action.yml
+++ b/.github/actions/setup-go-for-project/action.yml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
         cache-dependency-path: |

--- a/.github/actions/upload-tmpnet-artifact/action.yml
+++ b/.github/actions/upload-tmpnet-artifact/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Upload tmpnet data
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.name }}
         path: |

--- a/.github/workflows/bazel-ci-matrix.yml
+++ b/.github/workflows/bazel-ci-matrix.yml
@@ -13,6 +13,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 
@@ -47,7 +50,7 @@ jobs:
   check-metadata:
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check Bazel metadata
         uses: ./.github/actions/run-bazel-task
         with:
@@ -58,7 +61,7 @@ jobs:
     needs: check-metadata
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run unit tests with Bazel
         uses: ./.github/actions/run-bazel-task
         with:
@@ -69,7 +72,7 @@ jobs:
     needs: check-metadata
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run coreth unit tests with Bazel
         uses: ./.github/actions/run-bazel-task
         with:
@@ -80,7 +83,7 @@ jobs:
     needs: check-metadata
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run subnet-evm unit tests with Bazel
         uses: ./.github/actions/run-bazel-task
         with:
@@ -91,7 +94,7 @@ jobs:
     needs: check-metadata
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run e2e tests with Bazel-built binary
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -10,12 +10,15 @@ on:
     paths:
       - "proto/**"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@dfda68eacb65895184c76b9ae522b977636a2c47 # v1.1.4
+      - uses: actions/checkout@v5
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           input: "proto"
           # Breaking changes are managed by the rpcchainvm protocol version.

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - "*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-x86_64-binaries-tarball:
     runs-on: ubuntu-22.04
@@ -18,7 +21,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-go-for-project
 
@@ -35,7 +38,7 @@ jobs:
         run: sudo snap install aws-cli --classic
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
           role-session-name: githubrolesession
@@ -65,13 +68,13 @@ jobs:
           RELEASE: "jammy"
 
       - name: Save avalanchego as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: avalanchego-amd64
           path: /tmp/avalanchego/avalanchego-linux-amd64-${{ env.TAG }}.tar.gz
 
       - name: Save subnet-evm as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: subnet-evm-amd64
           path: /tmp/avalanchego/subnet-evm-linux-amd64-${{ env.TAG }}.tar.gz
@@ -88,7 +91,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-go-for-project
 
@@ -105,7 +108,7 @@ jobs:
         run: sudo snap install aws-cli --classic
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
           role-session-name: githubrolesession
@@ -135,13 +138,13 @@ jobs:
           RELEASE: "jammy"
 
       - name: Save avalanchego as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: avalanchego-arm64
           path: /tmp/avalanchego/avalanchego-linux-arm64-${{ env.TAG }}.tar.gz
 
       - name: Save subnet-evm as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: subnet-evm-arm64
           path: /tmp/avalanchego/subnet-evm-linux-arm64-${{ env.TAG }}.tar.gz

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -13,6 +13,9 @@ on:
     tags:
       - "*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -26,7 +29,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 
@@ -68,7 +71,7 @@ jobs:
           sudo installer -pkg AWSCLIV2.pkg -target /
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
           role-session-name: githubrolesession
@@ -85,13 +88,13 @@ jobs:
           BUCKET: ${{ secrets.BUCKET }}
 
       - name: Save avalanchego as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: avalanchego-macos
           path: avalanchego-macos-${{ env.TAG }}.zip
 
       - name: Save subnet-evm as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: subnet-evm-macos
           path: subnet-evm-macos-${{ env.TAG }}.zip

--- a/.github/workflows/build-rpm-release.yml
+++ b/.github/workflows/build-rpm-release.yml
@@ -14,6 +14,9 @@ on:
       - ".github/packaging/**"
       - ".github/workflows/build-rpm-release.yml"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-rpm:
     strategy:
@@ -30,7 +33,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -39,7 +42,7 @@ jobs:
       # workflow branch so that packaging:test-build-rpms is available.
       - name: Overlay packaging scripts from workflow branch
         if: github.event.inputs.tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: .packaging-overlay
           sparse-checkout: .github/packaging
@@ -82,7 +85,7 @@ jobs:
 
       - name: Upload RPMs as artifacts
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rpms-${{ matrix.rpm_arch }}
           path: |

--- a/.github/workflows/build-ubuntu-amd64-release.yml
+++ b/.github/workflows/build-ubuntu-amd64-release.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - "*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-jammy-amd64-package:
     runs-on: ubuntu-22.04
@@ -18,7 +21,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 
@@ -29,7 +32,7 @@ jobs:
         run: sudo snap install aws-cli --classic
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
           role-session-name: githubrolesession
@@ -59,7 +62,7 @@ jobs:
           RELEASE: "jammy"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: jammy
           path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb
@@ -76,7 +79,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 
@@ -101,7 +104,7 @@ jobs:
         shell: bash
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
           role-session-name: githubrolesession
@@ -117,7 +120,7 @@ jobs:
           RELEASE: "noble"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: noble
           path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-amd64.deb

--- a/.github/workflows/build-ubuntu-arm64-release.yml
+++ b/.github/workflows/build-ubuntu-arm64-release.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - "*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-jammy-arm64-package:
     runs-on: custom-arm64-jammy
@@ -18,7 +21,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 
@@ -29,7 +32,7 @@ jobs:
         run: sudo snap install aws-cli --classic
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
           role-session-name: githubrolesession
@@ -59,7 +62,7 @@ jobs:
           RELEASE: "jammy"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: jammy
           path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb
@@ -76,7 +79,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 
@@ -87,7 +90,7 @@ jobs:
         run: sudo snap install aws-cli --classic
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_SA_ROLE_ARN }}
           role-session-name: githubrolesession
@@ -117,7 +120,7 @@ jobs:
           RELEASE: "noble"
 
       - name: Save as Github artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: noble
           path: /tmp/avalanchego/avalanchego-${{ env.TAG }}-arm64.deb

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -40,13 +40,16 @@ on:
   schedule:
     - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   define-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}
@@ -91,7 +94,7 @@ jobs:
       contents: write
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install ARC Dependencies
         shell: bash
         run: |

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -40,13 +40,16 @@ on:
   # schedule:
   #   - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   define-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}
@@ -92,7 +95,7 @@ jobs:
       contents: write
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Nix is required before calling polyrepo.
       # c-chain-reexecution-benchmark's Nix install will be skipped; installation is idempotent.
       - name: Install Nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 
@@ -64,7 +67,7 @@ jobs:
       matrix:
         os: [macos-14, ubuntu-22.04, ubuntu-24.04, custom-arm64-jammy, custom-arm64-noble]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - name: test-unit
         shell: bash
@@ -74,7 +77,7 @@ jobs:
   Fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - name: test-fuzz
         shell: bash
@@ -86,7 +89,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, custom-arm64-noble]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run e2e tests
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
@@ -104,7 +107,7 @@ jobs:
   e2e_post_latest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run e2e tests
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
@@ -122,7 +125,7 @@ jobs:
   e2e_kube:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
           run: ./scripts/run_task.sh test-e2e-kube-ci
@@ -140,7 +143,7 @@ jobs:
   e2e_existing_network:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run e2e tests with existing network
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
@@ -157,7 +160,7 @@ jobs:
   Upgrade:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run e2e tests
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
@@ -174,7 +177,7 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
       - name: Runs all lint checks
         shell: nix develop --command bash -x {0}
@@ -182,7 +185,7 @@ jobs:
   tausecondslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for TauSeconds misuse with time.Add()
         run: |
           if grep -rn '\.Add([^)]*TauSeconds' --include='*.go' .; then
@@ -194,7 +197,7 @@ jobs:
     name: Markdown Links Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: umbrelladocs/action-linkspector@de84085e0f51452a470558693d7d308fbb2fa261 # v1.2.5
         with:
           fail_level: any
@@ -202,7 +205,7 @@ jobs:
     name: Up-to-date protobuf
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Use the dev shell instead of bufbuild/buf-action to ensure the dev shell provides the expected versions
       - uses: ./.github/actions/install-nix
       - shell: nix develop --command bash -x {0}
@@ -211,7 +214,7 @@ jobs:
     name: Up-to-date mocks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - shell: bash
         run: ./scripts/run_task.sh check-generate-mocks
@@ -219,7 +222,7 @@ jobs:
     name: Up-to-date canoto
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - shell: bash
         run: ./scripts/run_task.sh check-generate-canoto
@@ -227,7 +230,7 @@ jobs:
     name: Up-to-date contract bindings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
       - shell: nix develop --command bash -x {0}
         run: task check-generate-load-contract-bindings
@@ -235,7 +238,7 @@ jobs:
     name: Up-to-date go.mod and go.sum
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - shell: bash
         run: ./scripts/run_task.sh check-go-mod-tidy
@@ -243,9 +246,9 @@ jobs:
     name: Image build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up QEMU (required for cross-platform builds)
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
       - name: Check image build
         shell: bash
         run: ./scripts/run_task.sh test-build-image
@@ -253,7 +256,7 @@ jobs:
     name: Build Antithesis avalanchego images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - name: Check image build for avalanchego test setup
         shell: bash
@@ -262,7 +265,7 @@ jobs:
     name: Build Antithesis xsvm images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - name: Check image build for xsvm test setup
         shell: bash
@@ -271,7 +274,7 @@ jobs:
     name: Run bootstrap monitor e2e tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
       - name: Run e2e tests
         shell: bash
@@ -280,7 +283,7 @@ jobs:
     name: Run process-based load test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
           run: ./scripts/run_task.sh test-load -- --load-timeout=30s
@@ -297,7 +300,7 @@ jobs:
     name: Run load test on kind cluster
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
           run: ./scripts/run_task.sh test-load-kube-kind -- --load-timeout=30s
@@ -314,7 +317,7 @@ jobs:
   robustness:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
       # TODO(marun) Extend testing of robustness beyond deploying a suitable test environment
       - name: Deploy kind with chaos mesh

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   review:
     if: >-
@@ -16,7 +19,7 @@ jobs:
       id-token: write # Required for OIDC authentication with Anthropic's API
     steps:
       - name: Checkout trusted prompt from master
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: master
           sparse-checkout: agents/pr-review.md
@@ -31,7 +34,7 @@ jobs:
             cat trusted-prompt/agents/pr-review.md
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: Analyze
@@ -40,14 +43,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Golang
         uses: ./.github/actions/setup-go-for-project
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,4 +59,4 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4

--- a/.github/workflows/coreth-ci.yml
+++ b/.github/workflows/coreth-ci.yml
@@ -7,6 +7,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   coreth-required:
     if: ${{ always() }}
@@ -33,7 +36,7 @@ jobs:
       run:
         working-directory: ./graft/coreth
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
       - name: Run all lint checks
         run: ./scripts/run_task.sh lint-all-ci
@@ -51,7 +54,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: ./scripts/run_task.sh build-test
       - run: ./scripts/run_task.sh coverage
@@ -61,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Run Warp E2E Tests

--- a/.github/workflows/evm-ci.yml
+++ b/.github/workflows/evm-ci.yml
@@ -7,6 +7,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   evm-shared-required:
     if: ${{ always() }}
@@ -32,7 +35,7 @@ jobs:
       run:
         working-directory: ./graft/evm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - name: Run all lint checks
         run: ../../scripts/run_task.sh lint-all-ci
@@ -50,7 +53,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: ../../scripts/run_task.sh build-test
       - run: ../../scripts/run_task.sh coverage

--- a/.github/workflows/firewood-chaos-test.yml
+++ b/.github/workflows/firewood-chaos-test.yml
@@ -38,13 +38,16 @@ on:
   schedule:
     - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   define-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}
@@ -88,12 +91,12 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'
           role-duration-seconds: '43200'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run chaos test with Firewood
         shell: nix develop --impure --command bash -x {0}
         run: ./scripts/run_task.sh test-cchain-reexecution -- "${{ matrix.test || '' }}"

--- a/.github/workflows/firewood-load-test.yml
+++ b/.github/workflows/firewood-load-test.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 9 * * *' # Runs every day at 09:00 UTC (04:00 EST)
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   firewood-load-test:
     runs-on: avalanche-avalanchego-runner
@@ -19,7 +22,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y xz-utils
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
           run: ./scripts/run_task.sh test-load -- --load-timeout=30m --firewood

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * *" # Once a day at midnight UTC
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 
@@ -28,7 +31,7 @@ jobs:
           - graft
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: ./.github/actions/setup-go-for-project
       - name: Run fuzz tests

--- a/.github/workflows/fuzz_merkledb.yml
+++ b/.github/workflows/fuzz_merkledb.yml
@@ -6,6 +6,9 @@ on:
     # Run every 6 hours
     - cron: "0 0,6,12,18 * * *"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 
@@ -14,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: ./.github/actions/setup-go-for-project
       - name: Run merkledb fuzz tests

--- a/.github/workflows/publish_antithesis_images.yml
+++ b/.github/workflows/publish_antithesis_images.yml
@@ -13,6 +13,7 @@ on:
       - master
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: us-central1-docker.pkg.dev
   REPOSITORY: molten-verve-216720/avalanche-repository
 
@@ -27,10 +28,10 @@ jobs:
           docker-images: true
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to GAR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: _json_key

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -9,13 +9,16 @@ on:
       - master
       - dev
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish_docker_image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up QEMU (required for cross-platform builds)
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
       - name: Create multiplatform docker builder
         run: docker buildx create --use
       - name: Build and publish images to DockerHub

--- a/.github/workflows/self-hosted-load-tests.yaml
+++ b/.github/workflows/self-hosted-load-tests.yaml
@@ -18,6 +18,9 @@ on:
         description: "Load test duration: e.g. 5m, 10m, 1h..."
         required: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   load_test:
     name: Run load test on self-hosted runners
@@ -33,7 +36,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y xz-utils
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run load test
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,11 +2,14 @@ name: Mark stale issues and pull requests
 on:
   schedule:
     - cron: '0 0 * * 0' # Run every day at midnight UTC on Sunday
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # Overall configuration
           operations-per-run: 100

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   subnet-evm-required:
     if: ${{ always() }}
@@ -37,7 +40,7 @@ jobs:
       run:
         working-directory: ./graft/subnet-evm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
       - name: Run all lint checks
         run: ./scripts/run_task.sh lint-all-ci
@@ -55,7 +58,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - run: ./scripts/run_task.sh build-test
       - run: ./scripts/run_task.sh coverage
@@ -65,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Run Warp E2E Tests
@@ -88,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Run E2E Load Tests
@@ -113,9 +116,9 @@ jobs:
       run:
         working-directory: ./graft/subnet-evm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up QEMU (required for cross-platform builds)
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
       - name: Check image build
         run: ./scripts/run_task.sh test-build-image
 
@@ -127,7 +130,7 @@ jobs:
         with:
           tool-cache: true
           docker-images: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - name: Check image build for subnet-evm test setup
         shell: bash

--- a/.github/workflows/trigger-antithesis-avalanchego.yml
+++ b/.github/workflows/trigger-antithesis-avalanchego.yml
@@ -24,6 +24,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   antithesis_avalanchego:
     name: Run Antithesis Avalanchego Test Setup

--- a/.github/workflows/trigger-antithesis-subnet-evm.yml
+++ b/.github/workflows/trigger-antithesis-subnet-evm.yml
@@ -24,6 +24,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   antithesis_subnet_evm:
     name: Run Antithesis Subnet-EVM Test Setup

--- a/.github/workflows/trigger-antithesis-xsvm.yml
+++ b/.github/workflows/trigger-antithesis-xsvm.yml
@@ -24,6 +24,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   antithesis_xsvm:
     name: Run Antithesis XSVM Test Setup


### PR DESCRIPTION
## Why this should be merged

All our workflows are being annotated with warnings that we're still using NodeJS 20 and that our runners are going to start using NodeJS 24 by default as of June 2026 and 20 will be removed as of September 2026. Better to upgrade to 24 early to avoid the annotation clutter and ensure we don't forget to switch.

Setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` for all workflows ensures we're using NodeJS 24 in advance of the switch, and all actions have been upgraded to NodeJS 24 versions except the `antithesishq/antithesis-trigger-action` since it currently only supports version 20.

## How this was tested

Checked CI for the annotation warnings

## Need to be documented in RELEASES.md?

N/A