### PR TITLE
[ci] Extend start-kind-cluster timeout and improve failure legibility

### DIFF
--- a/.github/actions/collect-kind-diagnostics/action.yml
+++ b/.github/actions/collect-kind-diagnostics/action.yml
@@ -1,0 +1,23 @@
+name: 'Collect kind diagnostics'
+description: 'Collect runner, Docker, kind, and Kubernetes diagnostics for kind-backed jobs'
+
+inputs:
+  artifact_name:
+    description: 'Name of the uploaded diagnostics artifact'
+    required: true
+  diagnostics_dir:
+    description: 'Directory to write diagnostics into'
+    default: /tmp/kind-diagnostics
+
+runs:
+  using: composite
+  steps:
+    - name: Collect diagnostics
+      shell: bash
+      run: ./scripts/collect_kind_diagnostics.sh "${{ inputs.diagnostics_dir }}"
+    - name: Upload diagnostics
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.diagnostics_dir }}
+        if-no-files-found: warn

--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -103,14 +103,8 @@ runs:
       uses: ./.github/actions/upload-tmpnet-artifact
       with:
         name: ${{ inputs.artifact_prefix }}-tmpnet-data
-    - name: Export kind logs
+    - name: Collect kind diagnostics
       if: always() && (inputs.runtime == 'kube')
-      shell: bash
-      run: kind export logs /tmp/kind-logs
-    - name: Upload kind logs
-      if: always() && (inputs.runtime == 'kube')
-      uses: actions/upload-artifact@v6
+      uses: ./.github/actions/collect-kind-diagnostics
       with:
-        name: ${{ inputs.artifact_prefix }}-kind-logs
-        path: /tmp/kind-logs
-        if-no-files-found: error
+        artifact_name: ${{ inputs.artifact_prefix }}-kind-diagnostics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,11 @@ jobs:
       - name: Run e2e tests
         shell: bash
         run: ./scripts/run_task.sh test-bootstrap-monitor-e2e
+      - name: Collect kind diagnostics
+        if: failure()
+        uses: ./.github/actions/collect-kind-diagnostics
+        with:
+          artifact_name: bootstrap-monitor-kind-diagnostics
   load:
     name: Run process-based load test
     runs-on: ubuntu-24.04
@@ -323,3 +328,8 @@ jobs:
       - name: Deploy kind with chaos mesh
         shell: bash
         run: ./scripts/run_task.sh test-robustness
+      - name: Collect kind diagnostics
+        if: failure()
+        uses: ./.github/actions/collect-kind-diagnostics
+        with:
+          artifact_name: robustness-kind-diagnostics

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,6 +233,10 @@ tasks:
       - cmd: '{{.NIX_RUN}} ./scripts/check_require_directives_round_trip.sh'
       - task: check-clean-branch
 
+  collect-kind-diagnostics:
+    desc: Collects runner, Docker, kind, and Kubernetes diagnostics. Optional arg is output dir.
+    cmd: '{{.NIX_RUN}} ./scripts/collect_kind_diagnostics.sh {{.CLI_ARGS}}'
+
   create-kind-cluster:
     desc: Creates the default kind cluster
     cmd: '{{.NIX_RUN}} bash -x ./scripts/start_kind_cluster.sh {{.CLI_ARGS}}'

--- a/scripts/collect_kind_diagnostics.sh
+++ b/scripts/collect_kind_diagnostics.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIAGNOSTICS_DIR="${1:-${KIND_DIAGNOSTICS_DIR:-$(mktemp -d)}}"
+mkdir -p "${DIAGNOSTICS_DIR}"
+
+run_capture() {
+  local output_file="$1"
+  shift
+
+  {
+    echo "$ $*"
+    "$@"
+  } > "${output_file}" 2>&1 || true
+}
+
+{
+  date -u
+  uname -a
+  free -h
+  df -h
+  docker system df
+  docker ps -a
+  docker images
+} > "${DIAGNOSTICS_DIR}/runner.txt" 2>&1 || true
+
+run_capture "${DIAGNOSTICS_DIR}/docker-inspect.json" docker inspect kind-control-plane kind-registry
+run_capture "${DIAGNOSTICS_DIR}/kind-control-plane.log" docker logs kind-control-plane
+run_capture "${DIAGNOSTICS_DIR}/kind-registry.log" docker logs kind-registry
+
+if kind get clusters 2>/dev/null | grep -q "^kind$"; then
+  run_capture "${DIAGNOSTICS_DIR}/kind-export.log" kind export logs "${DIAGNOSTICS_DIR}/kind-logs"
+else
+  echo "kind cluster not found" > "${DIAGNOSTICS_DIR}/kind-export.log"
+fi
+
+{
+  kind get clusters
+  kubectl cluster-info
+  kubectl get nodes -o wide
+  kubectl get pods -A -o wide
+  kubectl get events -A --sort-by=.lastTimestamp
+  kubectl describe nodes
+  kubectl describe pods -A
+} > "${DIAGNOSTICS_DIR}/kubernetes.txt" 2>&1 || true
+
+find "${DIAGNOSTICS_DIR}" -type f -print

--- a/tests/fixture/tmpnet/start_kind_cluster.go
+++ b/tests/fixture/tmpnet/start_kind_cluster.go
@@ -72,6 +72,10 @@ func StartKindCluster(
 	startLogsCollector bool,
 	installChaosMesh bool,
 ) error {
+	if _, ok := ctx.Deadline(); !ok {
+		return stacktrace.New("unable to start kind cluster with a context without a deadline")
+	}
+
 	configContext := KindKubeconfigContext
 
 	clusterRunning, err := isKindClusterRunning(log, configPath, configContext)
@@ -89,12 +93,13 @@ func StartKindCluster(
 			zap.String("kubeconfigContext", configContext),
 		)
 
-		startCtx, cancel := context.WithTimeout(ctx, DefaultNetworkTimeout)
-		defer cancel()
-		cmd := exec.CommandContext(startCtx, "bash", "-x", "kind-with-registry.sh")
+		cmd := exec.CommandContext(ctx, "bash", "-x", "kind-with-registry.sh")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				err = errors.Join(err, fmt.Errorf("start-kind-cluster context ended: %w", ctxErr))
+			}
 			return stacktrace.Errorf("failed to run kind-with-registry.sh: %w", err)
 		}
 	}


### PR DESCRIPTION
## Why this should be merged

Previously, kind cluster startup used DefaultNetworkTimeout (2m) inside StartKindCluster even though tmpnetctl already supplies a 5m timeout for kind setup. That caused CI jobs to kill kind setup after two minutes with only a vague `signal: killed` failure.

The timeout issue is addressed by using the context provided to StartKindCluster so that the 5m timeout set by tmpnetctl is used. A new check that the provided context has a deadline minimizes the possibility of accidental misuse.

The lack of legibility on failure is addressed by adding a reusable scripts/ collector for runner, Docker, kind, and Kubernetes diagnostics. A Taskfile entry makes the same collector available locally, and the CI jobs using kind use this script to collect diagnostics that are uploaded as an artifact.

## How this was tested

Checked that a job using kind collected [diagnostics](https://productionresultssa13.blob.core.windows.net/actions-results/513c84d9-d99e-4fea-946d-df739150ac15/workflow-job-run-f0f28c89-9ad0-5f72-bfeb-903871de731f/artifacts/336720d624a8a5761a04c509e2ed5cdab388d0f02e1adf389d0010010bcd3517.zip?rscd=attachment%3B+filename%3D%22e2e-kube-kind-diagnostics.zip%22&rsct=application%2Fzip&se=2026-05-06T22%3A13%3A52Z&sig=Tu46ZMxRV%2BP2RC7FmQvDft6O%2FWqrdTxpogGFlTuxT%2Bc%3D&ske=2026-05-06T23%3A34%3A59Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-05-06T19%3A34%3A59Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-05-06T22%3A03%3A47Z&sv=2025-11-05).

## Need to be documented in RELEASES.md?

N/A