### PR TITLE
chore: skip flaky TestFirewoodSync

### DIFF
--- a/graft/evm/sync/evmstate/firewood_syncer_test.go
+++ b/graft/evm/sync/evmstate/firewood_syncer_test.go
@@ -35,6 +35,8 @@ import (
 )
 
 func TestFirewoodSync(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/ava-labs/avalanchego/issues/5353")
+
 	tests := []struct {
 		name       string
 		clientSize int


### PR DESCRIPTION
## Why this should be merged

I recently had a PR get kicked out of the merge queue due to this test flake: https://github.com/ava-labs/avalanchego/actions/runs/25498891460/job/74827217498. 

Linked is the corresponding issue I created for this flaky test: https://github.com/ava-labs/avalanchego/issues/5353

## How this works

Skips `TestFirewoodSync` while the EVM team develops a fix for it.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No