### PR TITLE
ci: pass GITHUB_TOKEN to claude-code-action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # Required for Claude to post PR comments and inline review feedback
-      id-token: write # Required for OIDC authentication with Anthropic's API
     steps:
       - name: Checkout trusted prompt from master
         uses: actions/checkout@v5

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Provides the workflow's GITHUB_TOKEN to anthropics/claude-code-action directly instead of relying on the action's GitHub App OIDC token exchange for GitHub API access.

## Why this should be merged
Enables claude reviews on PRs

## How this works
Provides the workflow's GITHUB_TOKEN to anthropics/claude-code-action directly instead of relying on the action's GitHub App OIDC token exchange for GitHub API access.

## How this was tested
Wasn't.  Only runs on master.  

## Need to be documented in RELEASES.md?
No