### PR TITLE
chore: share `releases.md` ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 # merging.
 
 * @ava-labs/platform-avalanchego
+/RELEASES.md @ava-labs/platform-avalanchego @ava-labs/platform-evm
 /graft/coreth @ava-labs/platform-evm
 /graft/evm @ava-labs/platform-evm
 /graft/subnet-evm @ava-labs/platform-evm


### PR DESCRIPTION
## Why this should be merged

If pure EVM code touches `RELEASES.md`, the AvalancheGo should not have to approve.

## How this works
Self-explanatory. 

## How this was tested
N/A

## Need to be documented in RELEASES.md?
N/A
