### PR TITLE
Clarify Claude PR review prompt and fix head checkout

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,6 +35,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v5
         with:
+          # Needed to fetch the PR head commit since we are using pull_request_target
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1
         with:
@@ -44,8 +46,23 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
+            The PR head commit is checked out in the current working directory.
+
+            Review the PR using:
+            - `gh pr view ${{ github.event.pull_request.number }}` for the PR title, description, and file list.
+            - `gh pr diff ${{ github.event.pull_request.number }}` as the source of truth for changed lines.
+            - `Read`, `Grep`, `Glob`, and `LS` for local code context.
+
+            Requirements:
+            - Use `mcp__github_inline_comment__create_inline_comment` for every finding.
+            - Anchor every inline comment to a changed line from `gh pr diff`; the issue may reference related surrounding code.
+            - Do not post top-level PR comments.
+            - Do not run tests, install dependencies, execute scripts, or modify files.
+            - If there are no high-confidence issues, do not comment.
+
+            Review policy:
             ${{ steps.prompt.outputs.content }}
           claude_args: |
             --model claude-opus-4-6
-            --max-turns 10
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 50
+            --allowedTools "Read,Grep,Glob,LS,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -63,6 +63,6 @@ jobs:
             Review policy:
             ${{ steps.prompt.outputs.content }}
           claude_args: |
-            --model claude-opus-4-6
-            --max-turns 50
+            --model claude-opus-4-8
+            --max-turns 100
             --allowedTools "Read,Grep,Glob,LS,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/agents/pr-review.md
+++ b/agents/pr-review.md
@@ -1,5 +1,3 @@
-Review this pull request. The PR branch is checked out in the current working directory.
-
 Skim the PR description for intent. Comment on a gap between what it claims and what the diff does only when that gap is **obvious** (not slight wording drift) and it affects correctness, safety, or maintainability.
 
 ## Areas to look at
@@ -14,7 +12,6 @@ Skim the PR description for intent. Comment on a gap between what it claims and 
 
 ## How to leave feedback
 
-- Prefer **inline comments** on the relevant lines when supported; each note should suggest an outcome or next step.
 - For cross-cutting concerns, one comment that ties threads together can be clearer than repeating the same idea on every file.
 - Avoid repeating what formatters, linters, or CI already cover unless something is objectively wrong.
 - **Fewer, higher-signal** comments are better than commenting on every file—silence is acceptable when the change looks sound.


### PR DESCRIPTION
## Why this should be merged

- Moved workflow related prompt instructions to the workflow file instead of the agent prompt file.
- Added some instruction in the workflow that should help the LLM to review the PR and make inline comments correctly.
- Increase max turns to 100 because the previous value of 10 is not enough even on smaller PRs ([example](https://github.com/ava-labs/avalanchego/actions/runs/25577217171/job/75087224978?pr=5331#step:5:345)). 
- Ensure `actions/checkout@v5` is checking out the PR head commit instead of master, which is the case when using `pull_request_target`.
- Update model to claude opus 4.8

## How this works

- `actions/checkout` now uses `github.event.pull_request.head.sha` so the job sees the PR head, not the base branch.
- The inline prompt tells the agent to use `gh pr view` / `gh pr diff`, local `Read`/`Grep`/`Glob`/`LS`, and `create_inline_comment`; `max-turns` is raised from 10 to 100.
- `agents/pr-review.md` drops duplicated checkout/inline wording now covered by the workflow prompt. Workflow now includes only the workflow related agent prompts.

## How this was tested

Cannot be tested until this is merged.

## Need to be documented in RELEASES.md?

No.