### PR TITLE
Allow disabling handler gossip ticker via gossipFrequency=0

### DIFF
--- a/snow/networking/handler/BUILD.bazel
+++ b/snow/networking/handler/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "handler",
     srcs = [
         "engine.go",
+        "gossip_ticker.go",
         "handler.go",
         "health.go",
         "message_queue.go",
@@ -44,6 +45,7 @@ go_test(
     name = "handler_test",
     srcs = [
         "engine_test.go",
+        "gossip_ticker_test.go",
         "handler_test.go",
         "health_test.go",
         "message_queue_test.go",

--- a/snow/networking/handler/gossip_ticker.go
+++ b/snow/networking/handler/gossip_ticker.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handler
+
+import "time"
+
+// gossipTicker mirrors the shape of *time.Ticker, but a [frequency] of 0
+// produces a disabled ticker whose channel never fires.
+type gossipTicker struct {
+	C    <-chan time.Time
+	stop func()
+}
+
+// Stop releases the underlying ticker, if any.
+func (g *gossipTicker) Stop() {
+	g.stop()
+}
+
+// newGossipTicker returns a ticker that fires every [frequency]. If
+// [frequency] is 0, the returned ticker is disabled.
+func newGossipTicker(frequency time.Duration) *gossipTicker {
+	if frequency <= 0 {
+		return &gossipTicker{stop: func() {}}
+	}
+	t := time.NewTicker(frequency)
+	return &gossipTicker{
+		C:    t.C,
+		stop: t.Stop,
+	}
+}

--- a/snow/networking/handler/gossip_ticker_test.go
+++ b/snow/networking/handler/gossip_ticker_test.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A nil channel is never ready in a select, so the gossip arm of the
+// dispatcher is effectively disabled if g.C == nil.
+func TestGossipTicker(t *testing.T) {
+	tests := []struct {
+		name    string
+		freq    time.Duration
+		wantNil bool
+	}{
+		{
+			name:    "disabled",
+			freq:    0,
+			wantNil: true,
+		},
+		{
+			name:    "enabled",
+			freq:    time.Millisecond,
+			wantNil: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newGossipTicker(tt.freq)
+			defer g.Stop()
+
+			if tt.wantNil {
+				require.Nil(t, g.C)
+			} else {
+				require.NotNil(t, g.C)
+			}
+		})
+	}
+}

--- a/snow/networking/handler/handler.go
+++ b/snow/networking/handler/handler.go
@@ -94,7 +94,9 @@ type handler struct {
 	// since peerTracker is already tracking validators
 	validators validators.Manager
 	// Receives messages from the VM
-	msgFromVMChan   chan common.Message
+	msgFromVMChan chan common.Message
+	// How often to fire an internal gossip request to the engine. A value of 0
+	// disables the gossip ticker so [engine.Gossip] is never called.
 	gossipFrequency time.Duration
 
 	engineManager *EngineManager
@@ -401,7 +403,7 @@ func (h *handler) dispatchAsync(ctx context.Context) {
 }
 
 func (h *handler) dispatchChans(ctx context.Context) {
-	gossiper := time.NewTicker(h.gossipFrequency)
+	gossiper := newGossipTicker(h.gossipFrequency)
 	defer func() {
 		gossiper.Stop()
 		h.closeDispatcher(ctx)


### PR DESCRIPTION
## Why this should be merged

Simplex does not need to send gossip requests. When creating a new handler for `Simplex` we want to be able to pass in a `gossipFrequency` of 0 so that we don't need to dispatch gossip requests periodically. Previously passing in a 0 value would panic the handler, but now it will simply disable the gossiper. This also has an added benefit of significantly reducing the `debug` and `verbo` logs seen on simplex chains as `chan` messages are logged [here](https://github.com/ava-labs/avalanchego/blob/82afaf5314d6236e08b55bce056d24bda37596c3/snow/networking/handler/handler.go#L879-L889)

## How this works

We ensure to only create the gossip ticker if `gossipFrequency` > 0. 

## How this was tested

Added a unit test

## Need to be documented in RELEASES.md?
