### PR TITLE
sae: Prevent logging after Txpool.Close

### DIFF
--- a/vms/saevm/cchain/txpool/txpool.go
+++ b/vms/saevm/cchain/txpool/txpool.go
@@ -52,6 +52,7 @@ type Txpool struct {
 	snowCtx *snow.Context
 	sub     event.Subscription
 	maxSize int
+	wg      sync.WaitGroup
 
 	// stateLock is ordered before [Pending.lock]. Acquiring stateLock with
 	// [Pending.lock] held will deadlock.
@@ -98,7 +99,9 @@ func New(
 		maxSize: maxSize,
 		state:   state,
 	}
-	go p.updateState(chainConfig, chain, executed)
+	p.wg.Go(func() {
+		p.updateState(chainConfig, chain, executed)
+	})
 	return p, nil
 }
 
@@ -234,6 +237,7 @@ func (p *Txpool) Add(tx *tx.Tx) error {
 // Close releases all allocated resources.
 func (p *Txpool) Close() {
 	p.sub.Unsubscribe()
+	p.wg.Wait()
 }
 
 // inputUTXOs returns the union of all UTXO IDs consumed by transactions in b,


### PR DESCRIPTION
## Why this should be merged

Addresses flake seen in: https://github.com/ava-labs/avalanchego/actions/runs/25691843426/job/75430043624?pr=5365

```
==================
WARNING: DATA RACE
Read at 0x00c0000d7c4b by goroutine 1348:
  testing.(*common).destination()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1055 +0x1cc
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1027 +0xbe
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1191 +0x8e
  testing.TB.Logf-fm()
      <autogenerated>:1 +0x82
  github.com/ava-labs/avalanchego/vms/saevm/saetest.(*TBLogger).log()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/saetest/logging.go:166 +0x747
  github.com/ava-labs/avalanchego/vms/saevm/saetest.(*logger).log()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/saetest/logging.go:46 +0x427
  github.com/ava-labs/avalanchego/vms/saevm/saetest.(*logger).Debug()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/saetest/logging.go:49 +0x5d
  github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.(*Txpool).updateState()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:148 +0x9cd
  github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.(*Txpool).updateState()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:117 +0x539
  github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.(*Txpool).updateState()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:117 +0x539
  github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.New.gowrap1()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:101 +0x6b

Previous write at 0x00c0000d7c4b by goroutine 1122:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1921 +0x904
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.25.10/x64/src/runtime/panic.go:589 +0x5d
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1997 +0x44

Goroutine 1348 (running) created at:
  github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.New()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:101 +0x4a8
  github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.newSUT()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool_test.go:139 +0x357
  github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.TestUpdateEvictsConflicts.func1()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool_test.go:525 +0xb8
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1997 +0x44

Goroutine 1122 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1997 +0x9d2
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:2477 +0x84
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1934 +0x21c
  testing.runTests()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:2475 +0x96c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:2337 +0xed4
  go.uber.org/goleak.VerifyTestMain()
      /home/runner/go/pkg/mod/go.uber.org/goleak@v1.3.0/testmain.go:53 +0x64
  github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.TestMain()
      /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool_test.go:46 +0x76
  main.main()
      _testmain.go:67 +0x171
==================
panic: Log in goroutine after TestUpdateEvictsConflicts/avax_tx_conflict_evicts_tx has completed: [Log@DEBUG] updated to new state map[blockHash:0x8140c3492a37613332a0dfd874c13ece64ba045178278899b245c6ce56fb9b0d blockNumber:1] - /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:148
	

goroutine 784 [running]:
testing.(*common).log(0xc00018bdc0, {0xc0001fc620, 0xd2})
	/opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1030 +0x1df
testing.(*common).Logf(0xc00018bdc0, {0x234c7db, 0x16}, {0xc00049a8c0, 0x5, 0x5})
	/opt/hostedtoolcache/go/1.25.10/x64/src/testing/testing.go:1191 +0x8f
github.com/ava-labs/avalanchego/vms/saevm/saetest.(*TBLogger).log(0xc000534c00, 0xf8, {0x234929c, 0x14}, {0xc0002f8d00, 0x2, 0xc00056dc20?})
	/home/runner/work/avalanchego/avalanchego/vms/saevm/saetest/logging.go:166 +0x748
github.com/ava-labs/avalanchego/vms/saevm/saetest.(*logger).log(0xc0006c2a80, 0xf8, {0x234929c, 0x14}, {0x0, 0x0, 0x0})
	/home/runner/work/avalanchego/avalanchego/vms/saevm/saetest/logging.go:46 +0x428
github.com/ava-labs/avalanchego/vms/saevm/saetest.(*logger).Debug(0xc0006c2a80, {0x234929c, 0x14}, {0x0, 0x0, 0x0})
	/home/runner/work/avalanchego/avalanchego/vms/saevm/saetest/logging.go:49 +0x5e
github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.(*Txpool).updateState(0xc00037c370, 0x341d920, {0x27328a0, 0xc0006ea280}, 0xc0007661c0)
	/home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:148 +0x9ce
created by github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool.New in goroutine 783
	/home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:101 +0x4a9
FAIL	github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool	1.398s
```

## How this works

Apparently, calling `t.Info` after the test returns is explicitly reported as a panic (but not in a threadsafe way).

We do not currently wait for the txpool's goroutine to exit prior to returning from `Close`. This resulted in a `DEBUG` log being made after `Close` returned. `Close` is called in the `t.Cleanup`, so the log was also written after the `t.Run` had returned, which triggered both a panic and a DATA RACE.

## How this was tested

I was able to reproduce the issue locally by introducing a `time.Sleep` before the log call. After this modification, the issue disapeared. (`time.Sleep` obviously not included in this diff haha)

## Need to be documented in RELEASES.md?

No