### PR TITLE
sae: Add Cross-Chain State

### DIFF
--- a/vms/saevm/cchain/state/BUILD.bazel
+++ b/vms/saevm/cchain/state/BUILD.bazel
@@ -1,0 +1,67 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "go_test")
+
+package(default_visibility = [
+    "//vms/saevm/cchain:__subpackages__",
+    "//vms/saevm/cchain:external_consumers",
+])
+
+go_library(
+    name = "state",
+    srcs = [
+        "codec.go",
+        "state.go",
+    ],
+    importpath = "github.com/ava-labs/avalanchego/vms/saevm/cchain/state",
+    deps = [
+        "//chains/atomic",
+        "//codec",
+        "//codec/linearcodec",
+        "//database",
+        "//database/prefixdb",
+        "//graft/coreth/plugin/evm/atomic/state",
+        "//ids",
+        "//snow",
+        "//utils/units",
+        "//utils/wrappers",
+        "//vms/evm/database",
+        "//vms/saevm/cchain/tx",
+        "@com_github_ava_labs_libevm//common",
+        "@com_github_ava_labs_libevm//core/rawdb",
+        "@com_github_ava_labs_libevm//core/types",
+        "@com_github_ava_labs_libevm//trie",
+        "@com_github_ava_labs_libevm//trie/trienode",
+        "@com_github_ava_labs_libevm//triedb",
+        "@com_github_ava_labs_libevm//triedb/hashdb",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "state_test",
+    srcs = ["state_test.go"],
+    embed = [":state"],
+    deps = [
+        "//chains/atomic",
+        "//database",
+        "//database/memdb",
+        "//database/prefixdb",
+        "//database/versiondb",
+        "//graft/coreth/plugin/evm/atomic",
+        "//graft/coreth/plugin/evm/atomic/state",
+        "//ids",
+        "//snow/snowtest",
+        "//utils/logging",
+        "//vms/components/avax",
+        "//vms/saevm/cchain/tx",
+        "//vms/saevm/cchain/tx/txtest",
+        "//vms/saevm/saetest",
+        "//vms/secp256k1fx",
+        "@com_github_ava_labs_libevm//common",
+        "@com_github_ava_labs_libevm//core/types",
+        "@com_github_ava_labs_libevm//libevm/options",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/vms/saevm/cchain/state/codec.go
+++ b/vms/saevm/cchain/state/codec.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"math"
+
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/codec/linearcodec"
+)
+
+const codecVersion uint16 = 0
+
+var c codec.Manager
+
+func init() {
+	c = codec.NewManager(math.MaxInt)
+	lc := linearcodec.NewDefault()
+	if err := c.RegisterCodec(codecVersion, lc); err != nil {
+		panic(err)
+	}
+}

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -74,6 +74,10 @@ func New(snowCtx *snow.Context, db database.Database) (*State, error) {
 	s := &State{
 		snowCtx: snowCtx,
 		db:      db,
+		// Coreth previously wrapped db in a versiondb before using
+		// [prefixdb.New]. To maintain byte compatibility with the existing
+		// trie, we must use [prefixdb.NewNested] rather than [prefixdb.New] and
+		// not compress the prefix.
 		trieDB: triedb.NewDatabase(
 			rawdb.NewDatabase(evmdb.New(prefixdb.NewNested(triePrefix, db))),
 			&triedb.Config{
@@ -212,6 +216,12 @@ const trieKeyLength = state.TrieKeyLength
 // applyTrie writes the per-chain ops into the trie rooted at oldRoot, flushes
 // the resulting trie to disk, and returns the new root.
 func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops map[ids.ID]*oldatomic.Requests) (common.Hash, error) {
+	// Most blocks don't have atomic requests, so we avoid any unnecessary disk
+	// reads in that case.
+	if len(ops) == 0 {
+		return oldRoot, nil
+	}
+
 	tr, err := trie.New(trie.TrieID(oldRoot), trieDB)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("opening trie: %w", err)

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -59,8 +59,8 @@ type State struct {
 
 // New initializes the state with db.
 //
-// TODO(StephenButtolph): Coreth's commitInterval must be reduced to 1 prior to
-// transitioning to SAE. Otherwise the atomic trie may not contain operations
+// TODO(#5375): Coreth's commitInterval must be reduced to 1 prior to
+// transitioning to SAE. Otherwise, the atomic trie may not contain operations
 // for recent blocks.
 func New(snowCtx *snow.Context, db database.Database) (*State, error) {
 	root, height, err := readLast(db)

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -60,7 +60,10 @@ type State struct {
 	db      database.Database
 	trieDB  *triedb.Database
 
-	currentRoot   common.Hash
+	currentRoot common.Hash
+
+	// currentHeight is atomic to allow [State.CurrentHeight] to be called
+	// concurrently with [State.Apply].
 	currentHeight atomic.Uint64
 }
 

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -164,6 +164,11 @@ func (s *State) Apply(height uint64, txs []*tx.Tx) error {
 		return fmt.Errorf("applying shared memory: %w", err)
 	}
 
+	s.snowCtx.Log.Debug("updated atomic trie",
+		zap.Uint64("height", height),
+		zap.Stringer("root", newRoot),
+	)
+
 	s.currentRoot = newRoot
 	s.currentHeight.Store(height)
 	return nil

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -6,6 +6,7 @@
 package state
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"slices"
@@ -212,13 +213,11 @@ func atomicRequests(txs []*tx.Tx) (map[ids.ID]*chainsatomic.Requests, error) {
 	return ops, nil
 }
 
-const trieKeyLength = state.TrieKeyLength
-
 // applyTrie writes the per-chain ops into the trie rooted at oldRoot, flushes
 // the resulting trie to disk, and returns the new root.
 func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops map[ids.ID]*chainsatomic.Requests) (common.Hash, error) {
-	// Most blocks don't have atomic requests, so we avoid any unnecessary disk
-	// reads in that case.
+	// Most blocks don't have atomic requests, so we avoid any unnecessary trie
+	// operations in that case.
 	if len(ops) == 0 {
 		return oldRoot, nil
 	}
@@ -236,15 +235,19 @@ func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops 
 			return common.Hash{}, fmt.Errorf("marshaling atomic requests for chain %s: %w", chainID, err)
 		}
 
-		p := wrappers.Packer{Bytes: make([]byte, trieKeyLength)}
-		p.PackLong(height)
-		p.PackFixedBytes(chainID[:])
-		if err := tr.Update(p.Bytes, v); err != nil {
+		const keyLength = state.TrieKeyLength
+		k := make([]byte, keyLength)
+		binary.BigEndian.PutUint64(k, height)
+		copy(k[wrappers.LongLen:], chainID[:])
+		if err := tr.Update(k, v); err != nil {
 			return common.Hash{}, fmt.Errorf("inserting trie key for chain %s: %w", chainID, err)
 		}
 	}
 
-	newRoot, nodes, err := tr.Commit(false)
+	// [hashdb.Database.Update] would attempt to RLP-decode collected leaves as
+	// [types.StateAccount] to reference storage subtries.
+	const collectLeafs = false
+	newRoot, nodes, err := tr.Commit(collectLeafs)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("committing in-memory trie: %w", err)
 	}
@@ -256,7 +259,9 @@ func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops 
 			return common.Hash{}, fmt.Errorf("updating trieDB with new nodes: %w", err)
 		}
 	}
-	if err := trieDB.Commit(newRoot, false); err != nil {
+
+	const logAsInfo = false
+	if err := trieDB.Commit(newRoot, logAsInfo); err != nil {
 		return common.Hash{}, fmt.Errorf("committing trieDB at root %s: %w", newRoot, err)
 	}
 	return newRoot, nil

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -83,7 +83,7 @@ func New(snowCtx *snow.Context, db database.Database) (*State, error) {
 			&triedb.Config{
 				HashDB: &hashdb.Config{
 					// This trie is append only, so we only need to cache the
-					// leading edge of the trie.
+					// leading edge.
 					CleanCacheSize: units.MiB,
 				},
 			},

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -50,7 +50,7 @@ var (
 //
 // When applying operations, shared memory is updated atomically with the state.
 //
-// [State.Apply] and [State.Close] must not be called concurrently with
+// [State.Apply] and [State.Close] MUST NOT be called concurrently with
 // themselves or each other. All other methods are safe to call concurrently.
 //
 // [State.Close] MUST be called when finished with the state to release

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -1,0 +1,305 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// Package state manages the on-disk state for the C-Chain's cross-chain
+// transactions.
+package state
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sync/atomic"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/trie"
+	"github.com/ava-labs/libevm/trie/trienode"
+	"github.com/ava-labs/libevm/triedb"
+	"github.com/ava-labs/libevm/triedb/hashdb"
+	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/state"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
+
+	oldatomic "github.com/ava-labs/avalanchego/chains/atomic"
+	evmdb "github.com/ava-labs/avalanchego/vms/evm/database"
+)
+
+// These prefixes and keys are byte-compatible with the indices written by
+// [state.AtomicTrie] and [state.AtomicRepository] so that SAE does not require
+// a database migration.
+var (
+	triePrefix = []byte("atomicTrieDB") // See state.atomicTrieStoragePrefix
+
+	commitPrefix  = prefixdb.MakePrefix([]byte("atomicTrieMetaDB"))                          // See state.atomicTrieMetaDBPrefix
+	lastHeightKey = prefixdb.PrefixKey(commitPrefix, []byte("atomicTrieLastCommittedBlock")) // See state.lastCommittedKey
+
+	txIDPrefix = prefixdb.MakePrefix([]byte("atomicTxDB")) // See state.atomicTxIDDBPrefix
+)
+
+// State holds the accepted transactions and the atomic-request trie.
+//
+// When applying operations, shared memory is updated atomically with the state.
+type State struct {
+	snowCtx *snow.Context
+	db      database.Database
+	trieDB  *triedb.Database
+
+	currentRoot   common.Hash
+	currentHeight atomic.Uint64
+}
+
+// New initializes the state with db.
+//
+// TODO(StephenButtolph): Coreth's commitInterval must be reduced to 1 prior to
+// transitioning to SAE. Otherwise the atomic trie may not contain operations
+// for recent blocks.
+func New(snowCtx *snow.Context, db database.Database) (*State, error) {
+	root, height, err := readLast(db)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &State{
+		snowCtx: snowCtx,
+		db:      db,
+		trieDB: triedb.NewDatabase(
+			rawdb.NewDatabase(evmdb.New(prefixdb.NewNested(triePrefix, db))),
+			&triedb.Config{
+				HashDB: &hashdb.Config{
+					CleanCacheSize: 64 * units.MiB,
+				},
+			},
+		),
+		currentRoot: root,
+	}
+	s.currentHeight.Store(height)
+	return s, nil
+}
+
+// readLast returns the last trie root and height. If none have been written, it
+// returns the empty root for the genesis block.
+func readLast(db database.KeyValueReader) (common.Hash, uint64, error) {
+	height, err := database.GetUInt64(db, lastHeightKey)
+	switch {
+	case errors.Is(err, database.ErrNotFound):
+		return types.EmptyRootHash, 0, nil
+	case err != nil:
+		return common.Hash{}, 0, fmt.Errorf("getting last height: %w", err)
+	}
+
+	root, err := readRoot(db, height)
+	if err != nil {
+		return common.Hash{}, 0, fmt.Errorf("getting root for height %d: %w", height, err)
+	}
+	return root, height, nil
+}
+
+func readRoot(db database.KeyValueReader, height uint64) (common.Hash, error) {
+	if height == 0 {
+		return types.EmptyRootHash, nil
+	}
+	root, err := database.GetID(db, rootKey(height))
+	return common.Hash(root), err
+}
+
+func rootKey(height uint64) []byte {
+	return prefixdb.PrefixKey(commitPrefix, database.PackUInt64(height))
+}
+
+// Apply persists the txs accepted at height. It applies their atomic
+// operations to the trie, indexes the txs by ID, and applies the atomic
+// operations to shared memory.
+//
+// Apply is a noop when height is not higher than [State.CurrentHeight].
+//
+// Apply is not thread safe.
+func (s *State) Apply(height uint64, txs []*tx.Tx) error {
+	if currentHeight := s.currentHeight.Load(); height <= currentHeight {
+		// During restarts, it is expected for SAE to reprocess already-applied
+		// heights. Shared memory is not safe to apply multiple times for the
+		// same height, so we MUST skip these duplicate applications.
+		s.snowCtx.Log.Debug("skipping writes for prior height",
+			zap.Uint64("height", height),
+			zap.Uint64("currentHeight", currentHeight),
+		)
+		return nil
+	}
+
+	ops, err := atomicRequests(txs)
+	if err != nil {
+		return fmt.Errorf("merging atomic ops: %w", err)
+	}
+	newRoot, err := applyTrie(s.trieDB, s.currentRoot, height, ops)
+	if err != nil {
+		return fmt.Errorf("applying trie on root %s: %w", s.currentRoot, err)
+	}
+
+	batch := s.db.NewBatch()
+	for _, t := range txs {
+		if err := writeTxByID(batch, height, t); err != nil {
+			return fmt.Errorf("writing tx %s: %w", t.ID(), err)
+		}
+	}
+	if err := database.PutUInt64(batch, lastHeightKey, height); err != nil {
+		return fmt.Errorf("writing last height: %w", err)
+	}
+	if err := database.PutID(batch, rootKey(height), ids.ID(newRoot)); err != nil {
+		return fmt.Errorf("writing root: %w", err)
+	}
+	// Committing the batch atomically with shared memory prevents duplicate
+	// shared memory operations in the event of a crash.
+	//
+	// TODO(StephenButtolph): Skip applying shared memory operations for bonus
+	// blocks.
+	if err := s.snowCtx.SharedMemory.Apply(ops, batch); err != nil {
+		return fmt.Errorf("applying shared memory: %w", err)
+	}
+
+	s.currentRoot = newRoot
+	s.currentHeight.Store(height)
+	return nil
+}
+
+// atomicRequests groups the atomic requests from txs by chainID.
+func atomicRequests(txs []*tx.Tx) (map[ids.ID]*oldatomic.Requests, error) {
+	// To produce a byte-identical trie, txs must be merged in txID order.
+	// This matches the order they were originally read from the tx index when
+	// the trie was first built. Without sorting, the PutRequests and
+	// RemoveRequests within a chain's atomic.Requests could be appended in a
+	// different order, changing the trie value.
+	sorted := slices.Clone(txs)
+	slices.SortFunc(sorted, func(a, b *tx.Tx) int {
+		return a.ID().Compare(b.ID())
+	})
+
+	ops := make(map[ids.ID]*oldatomic.Requests)
+	for _, t := range sorted {
+		chainID, req, err := t.AtomicRequests()
+		if err != nil {
+			return nil, fmt.Errorf("getting atomic requests for tx %s: %w", t.ID(), err)
+		}
+		if existing, ok := ops[chainID]; ok {
+			existing.PutRequests = append(existing.PutRequests, req.PutRequests...)
+			existing.RemoveRequests = append(existing.RemoveRequests, req.RemoveRequests...)
+		} else {
+			ops[chainID] = req
+		}
+	}
+	return ops, nil
+}
+
+const trieKeyLength = state.TrieKeyLength
+
+// applyTrie writes the per-chain ops into the trie rooted at oldRoot, flushes
+// the resulting trie to disk, and returns the new root.
+func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops map[ids.ID]*oldatomic.Requests) (common.Hash, error) {
+	tr, err := trie.New(trie.TrieID(oldRoot), trieDB)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("opening trie: %w", err)
+	}
+
+	// Since each map entry corresponds to a different entry in the trie, the
+	// trie root is order-independent.
+	for chainID, requests := range ops {
+		v, err := c.Marshal(codecVersion, requests)
+		if err != nil {
+			return common.Hash{}, fmt.Errorf("marshaling atomic requests for chain %s: %w", chainID, err)
+		}
+
+		p := wrappers.Packer{Bytes: make([]byte, trieKeyLength)}
+		p.PackLong(height)
+		p.PackFixedBytes(chainID[:])
+		if err := tr.Update(p.Bytes, v); err != nil {
+			return common.Hash{}, fmt.Errorf("inserting trie key for chain %s: %w", chainID, err)
+		}
+	}
+
+	newRoot, nodes, err := tr.Commit(false)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("committing in-memory trie: %w", err)
+	}
+	if nodes != nil {
+		// The parent-root and block-number args have no effect with hashdb;
+		// EmptyRootHash suppresses an otherwise-spurious parent-presence
+		// warning.
+		if err := trieDB.Update(newRoot, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil); err != nil {
+			return common.Hash{}, fmt.Errorf("updating trieDB with new nodes: %w", err)
+		}
+	}
+	if err := trieDB.Commit(newRoot, false); err != nil {
+		return common.Hash{}, fmt.Errorf("committing trieDB at root %s: %w", newRoot, err)
+	}
+	return newRoot, nil
+}
+
+// TODO(StephenButtolph): There isn't a good reason for us to actually write the
+// full tx to the database. We could just write the height, and then expect the
+// caller to fetch the block to get the tx. Paying that extra block fetch on the
+// read side is almost certainly worth avoiding the duplicate write, since this
+// index is only read from the API.
+func writeTxByID(db database.KeyValueWriter, height uint64, t *tx.Tx) error {
+	txBytes, err := t.Bytes()
+	if err != nil {
+		return err
+	}
+
+	p := wrappers.Packer{
+		Bytes: make([]byte, wrappers.LongLen+wrappers.IntLen+len(txBytes)),
+	}
+	p.PackLong(height)
+	p.PackBytes(txBytes)
+
+	txID := t.ID()
+	return db.Put(txKey(txID), p.Bytes)
+}
+
+func txKey(id ids.ID) []byte {
+	return prefixdb.PrefixKey(txIDPrefix, id[:])
+}
+
+// GetTx returns the tx with the given ID along with the block height it was
+// accepted at.
+func (s *State) GetTx(txID ids.ID) (*tx.Tx, uint64, error) {
+	b, err := s.db.Get(txKey(txID))
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading tx: %w", err)
+	}
+
+	p := wrappers.Packer{Bytes: b}
+	height := p.UnpackLong()
+	txBytes := p.UnpackBytes()
+	if p.Errored() {
+		return nil, 0, fmt.Errorf("unpacking tx: %w", p.Err)
+	}
+
+	parsed, err := tx.Parse(txBytes)
+	if err != nil {
+		return nil, 0, fmt.Errorf("parsing tx: %w", err)
+	}
+	return parsed, height, nil
+}
+
+// GetRoot returns the atomic trie root at height.
+func (s *State) GetRoot(height uint64) (common.Hash, error) {
+	return readRoot(s.db, height)
+}
+
+// CurrentHeight returns the highest height successfully applied via
+// [State.Apply].
+func (s *State) CurrentHeight() uint64 {
+	return s.currentHeight.Load()
+}
+
+// Close closes the state, releasing any resources.
+func (s *State) Close() error {
+	return s.trieDB.Close()
+}

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -75,7 +75,9 @@ func New(snowCtx *snow.Context, db database.Database) (*State, error) {
 			rawdb.NewDatabase(evmdb.New(prefixdb.NewNested(triePrefix, db))),
 			&triedb.Config{
 				HashDB: &hashdb.Config{
-					CleanCacheSize: 64 * units.MiB,
+					// This trie is append only, so we only need to cache the
+					// leading edge of the trie.
+					CleanCacheSize: units.MiB,
 				},
 			},
 		),

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -213,6 +213,8 @@ func atomicRequests(txs []*tx.Tx) (map[ids.ID]*chainsatomic.Requests, error) {
 	return ops, nil
 }
 
+var errCleanTrieAfterUpdates = errors.New("clean trie after updates")
+
 // applyTrie writes the per-chain ops into the trie rooted at oldRoot, flushes
 // the resulting trie to disk, and returns the new root.
 func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops map[ids.ID]*chainsatomic.Requests) (common.Hash, error) {
@@ -251,13 +253,11 @@ func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops 
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("committing in-memory trie: %w", err)
 	}
-	if nodes != nil {
-		// The parent-root and block-number args have no effect with hashdb;
-		// EmptyRootHash suppresses an otherwise-spurious parent-presence
-		// warning.
-		if err := trieDB.Update(newRoot, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil); err != nil {
-			return common.Hash{}, fmt.Errorf("updating trieDB with new nodes: %w", err)
-		}
+	if nodes == nil {
+		return common.Hash{}, errCleanTrieAfterUpdates
+	}
+	if err := trieDB.Update(newRoot, oldRoot, height, trienode.NewWithNodeSet(nodes), nil); err != nil {
+		return common.Hash{}, fmt.Errorf("updating trieDB with new nodes: %w", err)
 	}
 
 	const logAsInfo = false

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
 
-	oldatomic "github.com/ava-labs/avalanchego/chains/atomic"
+	chainsatomic "github.com/ava-labs/avalanchego/chains/atomic"
 	evmdb "github.com/ava-labs/avalanchego/vms/evm/database"
 )
 
@@ -184,7 +184,7 @@ func (s *State) Apply(height uint64, txs []*tx.Tx) error {
 }
 
 // atomicRequests groups the atomic requests from txs by chainID.
-func atomicRequests(txs []*tx.Tx) (map[ids.ID]*oldatomic.Requests, error) {
+func atomicRequests(txs []*tx.Tx) (map[ids.ID]*chainsatomic.Requests, error) {
 	// To produce a byte-identical trie, txs must be merged in txID order.
 	// This matches the order they were originally read from the tx index when
 	// the trie was first built. Without sorting, the PutRequests and
@@ -195,7 +195,7 @@ func atomicRequests(txs []*tx.Tx) (map[ids.ID]*oldatomic.Requests, error) {
 		return a.ID().Compare(b.ID())
 	})
 
-	ops := make(map[ids.ID]*oldatomic.Requests)
+	ops := make(map[ids.ID]*chainsatomic.Requests)
 	for _, t := range sorted {
 		chainID, req, err := t.AtomicRequests()
 		if err != nil {
@@ -215,7 +215,7 @@ const trieKeyLength = state.TrieKeyLength
 
 // applyTrie writes the per-chain ops into the trie rooted at oldRoot, flushes
 // the resulting trie to disk, and returns the new root.
-func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops map[ids.ID]*oldatomic.Requests) (common.Hash, error) {
+func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops map[ids.ID]*chainsatomic.Requests) (common.Hash, error) {
 	// Most blocks don't have atomic requests, so we avoid any unnecessary disk
 	// reads in that case.
 	if len(ops) == 0 {

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -49,6 +49,9 @@ var (
 //
 // When applying operations, shared memory is updated atomically with the state.
 //
+// [State.Apply] and [State.Close] must not be called concurrently with
+// themselves or each other. All other methods are safe to call concurrently.
+//
 // [State.Close] MUST be called when finished with the state to release
 // resources.
 type State struct {
@@ -129,8 +132,6 @@ func rootKey(height uint64) []byte {
 // operations to shared memory.
 //
 // Apply is a noop when height is not higher than [State.CurrentHeight].
-//
-// Apply is not thread safe.
 func (s *State) Apply(height uint64, txs []*tx.Tx) error {
 	if currentHeight := s.currentHeight.Load(); height <= currentHeight {
 		// During restarts, it is expected for SAE to reprocess already-applied

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -42,7 +42,7 @@ var (
 	commitPrefix  = prefixdb.MakePrefix([]byte("atomicTrieMetaDB"))                          // See state.atomicTrieMetaDBPrefix
 	lastHeightKey = prefixdb.PrefixKey(commitPrefix, []byte("atomicTrieLastCommittedBlock")) // See state.lastCommittedKey
 
-	txIDPrefix = prefixdb.MakePrefix([]byte("atomicTxDB")) // See state.atomicTxIDDBPrefix
+	txPrefix = prefixdb.MakePrefix([]byte("atomicTxDB")) // See state.atomicTxIDDBPrefix
 )
 
 // State holds the accepted transactions and the atomic-request trie.
@@ -150,7 +150,7 @@ func (s *State) Apply(height uint64, txs []*tx.Tx) error {
 
 	batch := s.db.NewBatch()
 	for _, t := range txs {
-		if err := writeTxByID(batch, height, t); err != nil {
+		if err := writeTx(batch, height, t); err != nil {
 			return fmt.Errorf("writing tx %s: %w", t.ID(), err)
 		}
 	}
@@ -256,7 +256,7 @@ func applyTrie(trieDB *triedb.Database, oldRoot common.Hash, height uint64, ops 
 // caller to fetch the block to get the tx. Paying that extra block fetch on the
 // read side is almost certainly worth avoiding the duplicate write, since this
 // index is only read from the API.
-func writeTxByID(db database.KeyValueWriter, height uint64, t *tx.Tx) error {
+func writeTx(db database.KeyValueWriter, height uint64, t *tx.Tx) error {
 	txBytes, err := t.Bytes()
 	if err != nil {
 		return err
@@ -273,7 +273,7 @@ func writeTxByID(db database.KeyValueWriter, height uint64, t *tx.Tx) error {
 }
 
 func txKey(id ids.ID) []byte {
-	return prefixdb.PrefixKey(txIDPrefix, id[:])
+	return prefixdb.PrefixKey(txPrefix, id[:])
 }
 
 // GetTx returns the tx with the given ID along with the block height it was

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -48,6 +48,9 @@ var (
 // State holds the accepted transactions and the atomic-request trie.
 //
 // When applying operations, shared memory is updated atomically with the state.
+//
+// [State.Close] MUST be called when finished with the state to release
+// resources.
 type State struct {
 	snowCtx *snow.Context
 	db      database.Database

--- a/vms/saevm/cchain/state/state_test.go
+++ b/vms/saevm/cchain/state/state_test.go
@@ -400,6 +400,24 @@ func TestApply(t *testing.T) {
 // TestApply_SortInvariant verifies that the order of txs passed to Apply does
 // not affect the resulting state.
 func TestApply_SortInvariant(t *testing.T) {
+	getRoot := func(txs []*tx.Tx) common.Hash {
+		t.Helper()
+
+		snapshot := slices.Clone(txs)
+		defer func() {
+			require.Equal(t, snapshot, txs, "Apply must not mutate the caller's slice")
+		}()
+
+		s := newSUT(t)
+
+		const height = 1
+		require.NoErrorf(t, s.Apply(height, txs), "%T.Apply(%d)", s.stateImpl, height)
+
+		root, err := s.GetRoot(height)
+		require.NoErrorf(t, err, "%T.GetRoot(%d)", s.stateImpl, height)
+		return root
+	}
+
 	var build builder
 	forward := []*tx.Tx{
 		build.newImport(),
@@ -409,19 +427,9 @@ func TestApply_SortInvariant(t *testing.T) {
 	backward := slices.Clone(forward)
 	slices.Reverse(backward)
 
-	getRoot := func(txs []*tx.Tx) common.Hash {
-		s := newSUT(t)
-
-		const height = 1
-		snapshot := slices.Clone(txs)
-		require.NoErrorf(t, s.Apply(height, txs), "%T.Apply(%d)", s.stateImpl, height)
-		require.Equal(t, snapshot, txs, "Apply must not mutate the caller's slice")
-
-		root, err := s.GetRoot(height)
-		require.NoErrorf(t, err, "%T.GetRoot(%d)", s.stateImpl, height)
-		return root
-	}
-	require.Equal(t, getRoot(forward), getRoot(backward), "Apply must be invariant to the order of txs")
+	forwardRoot := getRoot(forward)
+	backwardRoot := getRoot(backward)
+	require.Equal(t, forwardRoot, backwardRoot, "Apply must be invariant to the order of txs")
 }
 
 // TestCrash verifies that crashes while applying are gracefully handled.

--- a/vms/saevm/cchain/state/state_test.go
+++ b/vms/saevm/cchain/state/state_test.go
@@ -371,6 +371,12 @@ func TestApply(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
+			// There are three different SUTs used in this test:
+			//   - legacy: backed by the prior coreth code and used as the
+			//     reference implementation.
+			// 	 - fresh: backed by the new implementation.
+			//   - migrations[i]: legacy for blocks [0, i), then switched to the
+			//     new implementation for [i, n).
 			legacy := newSUT(t, withLegacyBackend())
 			fresh := newSUT(t)
 			migrations := make([]*SUT, len(test.blocks))
@@ -386,6 +392,8 @@ func TestApply(t *testing.T) {
 					sut.apply(t, b)
 				}
 
+				// Reopening the fresh SUT verifies that the new implementation
+				// correctly flushes to disk and can reload from it.
 				reopenedFresh := newSUT(t, withDB(fresh.db))
 				all = append(all, reopenedFresh)
 				for _, sut := range all {
@@ -449,6 +457,8 @@ func TestCrash(t *testing.T) {
 	want := newSUT(t, withDB(wantDB))
 	want.apply(t, blocks...)
 
+	// Iterating over all of the calls made to the db allows us to crash at
+	// every possible point during Apply.
 	for failAfter := range wantDB.calls {
 		t.Run(fmt.Sprintf("failAfter_%d", failAfter), func(t *testing.T) {
 			t.Parallel()

--- a/vms/saevm/cchain/state/state_test.go
+++ b/vms/saevm/cchain/state/state_test.go
@@ -1,0 +1,526 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/libevm/options"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
+	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx/txtest"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	chainsatomic "github.com/ava-labs/avalanchego/chains/atomic"
+	oldstate "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/state"
+)
+
+// SUT bundles the system under test: a state implementation plus both sides
+// of the shared-memory pair.
+type SUT struct {
+	stateImpl
+
+	// db is used for both the chain state and shared memory
+	db database.Database
+	// sharedMemoryDB contains all the shared memory state.
+	sharedMemoryDB *prefixdb.Database
+}
+
+func newSUT(tb testing.TB, opts ...sutOption) *SUT {
+	tb.Helper()
+
+	props := options.ApplyTo(&sutProperties{
+		db:  memdb.New(),
+		new: newState,
+	}, opts...)
+
+	chainDB := prefixdb.New([]byte("chain"), props.db)
+	smDB := prefixdb.New([]byte("shared memory"), props.db)
+	mem := chainsatomic.NewMemory(smDB)
+	self := mem.NewSharedMemory(snowtest.CChainID)
+
+	state := props.new(tb, chainDB, self)
+	tb.Cleanup(func() {
+		require.NoErrorf(tb, state.Close(), "%T.Close()", state)
+	})
+	return &SUT{
+		stateImpl:      state,
+		db:             props.db,
+		sharedMemoryDB: smDB,
+	}
+}
+
+// stateImpl is the surface common to [State] and [oldState]. It's used by the
+// [SUT] so the same test helpers can drive either backend.
+type stateImpl interface {
+	Apply(height uint64, txs []*tx.Tx) error
+	GetTx(txID ids.ID) (*tx.Tx, uint64, error)
+	GetRoot(height uint64) (common.Hash, error)
+	CurrentHeight() uint64
+	Close() error
+}
+
+// A sutOption configures the default SUT properties used by [newSUT].
+type sutOption = options.Option[sutProperties]
+
+type sutProperties struct {
+	// db is used for both the chain state and shared memory.
+	db  database.Database
+	new func(testing.TB, *prefixdb.Database, chainsatomic.SharedMemory) stateImpl
+}
+
+// withDB configures the SUT to use the given database.
+func withDB(db database.Database) sutOption {
+	return options.Func[sutProperties](func(p *sutProperties) {
+		p.db = db
+	})
+}
+
+// withLegacyBackend configures the SUT to use [oldState] rather than [State].
+func withLegacyBackend() sutOption {
+	return options.Func[sutProperties](func(p *sutProperties) {
+		p.new = newOldState
+	})
+}
+
+func newState(tb testing.TB, db *prefixdb.Database, sm chainsatomic.SharedMemory) stateImpl {
+	ctx := snowtest.Context(tb, snowtest.CChainID)
+	ctx.Log = saetest.NewTBLogger(tb, logging.Debug)
+	ctx.SharedMemory = sm
+
+	s, err := New(ctx, db)
+	require.NoErrorf(tb, err, "New(%T, %T)", ctx, db)
+	return s
+}
+
+// oldState drives the legacy [oldstate] package behind a surface that mirrors
+// [State].
+type oldState struct {
+	tb      testing.TB
+	db      database.Database
+	repo    *oldstate.AtomicRepository
+	backend *oldstate.AtomicBackend
+	parent  common.Hash
+}
+
+func newOldState(tb testing.TB, db *prefixdb.Database, sm chainsatomic.SharedMemory) stateImpl {
+	repo, err := oldstate.NewAtomicTxRepository(versiondb.New(db), atomic.Codec, 0)
+	require.NoErrorf(tb, err, "state.NewAtomicTxRepository(%T, %T, ...)", db, atomic.Codec)
+
+	// Making the legacy backend commit at every height matches the new State's
+	// every-height-is-committed semantics.
+	const commitInterval = 1
+	backend, err := oldstate.NewAtomicBackend(sm, nil, repo, 0, common.Hash{}, commitInterval)
+	require.NoErrorf(tb, err, "state.NewAtomicBackend(%T, %T)", sm, repo)
+	return &oldState{
+		tb:      tb,
+		db:      db,
+		repo:    repo,
+		backend: backend,
+	}
+}
+
+func (o *oldState) Apply(height uint64, txs []*tx.Tx) error {
+	var blockHash common.Hash
+	binary.BigEndian.PutUint64(blockHash[:], height)
+
+	oldTxs := txtest.ToOlds(o.tb, txs)
+	if _, err := o.backend.InsertTxs(blockHash, height, o.parent, oldTxs); err != nil {
+		return err
+	}
+	as, err := o.backend.GetVerifiedAtomicState(blockHash)
+	if err != nil {
+		return err
+	}
+	// The batch is needed to satisfy the API; it carries no extra writes.
+	if err := as.Accept(o.db.NewBatch()); err != nil {
+		return err
+	}
+	o.parent = blockHash
+	return nil
+}
+
+func (o *oldState) GetTx(txID ids.ID) (*tx.Tx, uint64, error) {
+	oldTx, height, err := o.repo.GetByTxID(txID)
+	if err != nil {
+		return nil, 0, err
+	}
+	return txtest.ToNew(o.tb, oldTx), height, nil
+}
+
+func (o *oldState) GetRoot(height uint64) (common.Hash, error) {
+	return o.backend.AtomicTrie().Root(height)
+}
+
+func (o *oldState) CurrentHeight() uint64 {
+	_, h := o.backend.AtomicTrie().LastCommitted()
+	return h
+}
+
+func (*oldState) Close() error { return nil }
+
+// block bundles a height and the txs accepted at it. Tests in this file pass
+// blocks to State.Apply (and to the oldState shim) one at a time.
+type block struct {
+	height uint64
+	txs    []*tx.Tx
+}
+
+// apply calls [SUT.Apply] for each block in order and fails if any call errors.
+func (s *SUT) apply(tb testing.TB, blocks ...block) {
+	tb.Helper()
+
+	for _, b := range blocks {
+		require.NoErrorf(tb, s.Apply(b.height, b.txs), "%T.Apply(%d)", s.stateImpl, b.height)
+	}
+}
+
+func (s *SUT) assertEqual(tb testing.TB, want *SUT) {
+	tb.Helper()
+
+	currentHeight := s.CurrentHeight()
+	require.Equalf(tb, want.CurrentHeight(), currentHeight, "%T.CurrentHeight()", s.stateImpl)
+
+	for h := range currentHeight + 1 {
+		wantRoot, err := want.GetRoot(h)
+		require.NoErrorf(tb, err, "%T.GetRoot(%d)", want.stateImpl, h)
+
+		gotRoot, err := s.GetRoot(h)
+		require.NoErrorf(tb, err, "%T.GetRoot(%d)", s.stateImpl, h)
+		assert.Equalf(tb, wantRoot, gotRoot, "%T.GetRoot(%d)", s.stateImpl, h)
+	}
+
+	type entry struct {
+		Key   []byte
+		Value []byte
+	}
+	dbEntries := func(db database.Database) []entry {
+		tb.Helper()
+
+		it := db.NewIterator()
+		defer it.Release()
+
+		var out []entry
+		for it.Next() {
+			out = append(out, entry{
+				Key:   slices.Clone(it.Key()),
+				Value: slices.Clone(it.Value()),
+			})
+		}
+		require.NoErrorf(tb, it.Error(), "%T.Error()", it)
+		return out
+	}
+
+	wantEntries := dbEntries(want.sharedMemoryDB)
+	gotEntries := dbEntries(s.sharedMemoryDB)
+	assert.Equalf(tb, wantEntries, gotEntries, "shared memory")
+}
+
+func (s *SUT) assertHasTxs(tb testing.TB, blocks []block) {
+	tb.Helper()
+
+	for _, b := range blocks {
+		for _, want := range b.txs {
+			got, height, err := s.GetTx(want.ID())
+			require.NoErrorf(tb, err, "%T.GetTx(%d)", s.stateImpl, b.height)
+			assert.Equalf(tb, b.height, height, "%T.GetTx(%d).Height", s.stateImpl, b.height)
+			if diff := cmp.Diff(want, got, txtest.CmpOpt()); diff != "" {
+				tb.Errorf("%T.GetTx(%d).Tx diff (-want +got):\n%s", s.stateImpl, b.height, diff)
+			}
+		}
+	}
+}
+
+// TestEmpty verifies the state behavior prior to applying any transactions.
+func TestEmpty(t *testing.T) {
+	s := newSUT(t)
+	require.Zerof(t, s.CurrentHeight(), "%T.CurrentHeight()", s.stateImpl)
+
+	_, _, err := s.GetTx(ids.GenerateTestID())
+	require.ErrorIsf(t, err, database.ErrNotFound, "%T.GetTx(...)", s.stateImpl)
+
+	tests := []struct {
+		height  uint64
+		want    common.Hash
+		wantErr error
+	}{
+		{height: 0, want: types.EmptyRootHash},
+		{height: 1, wantErr: database.ErrNotFound},
+	}
+	for _, test := range tests {
+		root, err := s.GetRoot(test.height)
+		require.ErrorIsf(t, err, test.wantErr, "%T.GetRoot(%d)", s.stateImpl, test.height)
+		assert.Equalf(t, test.want, root, "%T.GetRoot(%d)", s.stateImpl, test.height)
+	}
+}
+
+// builder is a helper for constructing transactions.
+type builder struct {
+	count uint32
+}
+
+// newImport returns a minimal [tx.Import] that consumes a unique input from
+// shared memory.
+func (b *builder) newImport() *tx.Tx {
+	b.count++
+	return &tx.Tx{
+		Unsigned: &tx.Import{
+			SourceChain: snowtest.XChainID,
+			ImportedInputs: []*avax.TransferableInput{{
+				UTXOID: avax.UTXOID{
+					OutputIndex: b.count,
+				},
+				In: &secp256k1fx.TransferInput{},
+			}},
+		},
+	}
+}
+
+// newExport returns a minimal [tx.Export] that produces a unique output into
+// shared memory.
+func (b *builder) newExport() *tx.Tx {
+	b.count++
+	return &tx.Tx{
+		Unsigned: &tx.Export{
+			DestinationChain: snowtest.XChainID,
+			ExportedOutputs: []*avax.TransferableOutput{{
+				Out: &secp256k1fx.TransferOutput{
+					Amt: uint64(b.count),
+				},
+			}},
+		},
+	}
+}
+
+// TestApply verifies that applying blocks results in the same state as the
+// prior coreth code regardless of when the state is migrated to the new
+// implementation.
+func TestApply(t *testing.T) {
+	var build builder
+	tests := []struct {
+		name   string
+		blocks []block
+	}{
+		{
+			name: "empty",
+			blocks: []block{
+				{height: 1, txs: nil},
+				{height: 2, txs: []*tx.Tx{}},
+			},
+		},
+		{
+			name: "single_import",
+			blocks: []block{
+				{height: 1, txs: []*tx.Tx{build.newImport()}},
+			},
+		},
+		{
+			name: "single_export",
+			blocks: []block{
+				{height: 1, txs: []*tx.Tx{build.newExport()}},
+			},
+		},
+		{
+			name: "multi_tx_single_height",
+			blocks: []block{
+				{
+					height: 1,
+					txs: []*tx.Tx{
+						build.newImport(),
+						build.newExport(),
+						build.newImport(),
+					},
+				},
+			},
+		},
+		{
+			name: "mixed",
+			blocks: []block{
+				{height: 1, txs: []*tx.Tx{build.newImport()}},
+				{height: 2, txs: nil},
+				{height: 3, txs: []*tx.Tx{build.newExport(), build.newImport()}},
+				{height: 4, txs: nil},
+				{height: 5, txs: []*tx.Tx{build.newImport()}},
+				{height: 6, txs: []*tx.Tx{build.newExport()}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			legacy := newSUT(t, withLegacyBackend())
+			fresh := newSUT(t)
+			migrations := make([]*SUT, len(test.blocks))
+			for i := range migrations {
+				migrations[i] = newSUT(t, withLegacyBackend())
+			}
+
+			for i, b := range test.blocks {
+				migrations[i] = newSUT(t, withDB(migrations[i].db))
+
+				all := append([]*SUT{legacy, fresh}, migrations...)
+				for _, sut := range all {
+					sut.apply(t, b)
+				}
+
+				reopenedFresh := newSUT(t, withDB(fresh.db))
+				all = append(all, reopenedFresh)
+				for _, sut := range all {
+					sut.assertEqual(t, legacy)
+					sut.assertHasTxs(t, test.blocks[:i+1])
+				}
+			}
+		})
+	}
+}
+
+// TestApply_SortInvariant verifies that the order of txs passed to Apply does
+// not affect the resulting state.
+func TestApply_SortInvariant(t *testing.T) {
+	var build builder
+	forward := []*tx.Tx{
+		build.newImport(),
+		build.newImport(),
+		build.newImport(),
+	}
+	backward := slices.Clone(forward)
+	slices.Reverse(backward)
+
+	getRoot := func(txs []*tx.Tx) common.Hash {
+		s := newSUT(t)
+
+		const height = 1
+		snapshot := slices.Clone(txs)
+		require.NoErrorf(t, s.Apply(height, txs), "%T.Apply(%d)", s.stateImpl, height)
+		require.Equal(t, snapshot, txs, "Apply must not mutate the caller's slice")
+
+		root, err := s.GetRoot(height)
+		require.NoErrorf(t, err, "%T.GetRoot(%d)", s.stateImpl, height)
+		return root
+	}
+	require.Equal(t, getRoot(forward), getRoot(backward), "Apply must be invariant to the order of txs")
+}
+
+// TestCrash verifies that crashes while applying are gracefully handled.
+func TestCrash(t *testing.T) {
+	var build builder
+	blocks := []block{
+		{height: 1, txs: nil},
+		{height: 2, txs: []*tx.Tx{build.newImport()}},
+		{height: 3, txs: []*tx.Tx{build.newExport(), build.newImport()}},
+		{height: 4, txs: nil},
+		{height: 5, txs: []*tx.Tx{build.newImport()}},
+		{height: 6, txs: []*tx.Tx{build.newExport()}},
+		{height: 7, txs: []*tx.Tx{build.newImport(), build.newExport()}},
+	}
+
+	wantDB := newFlakyDB(memdb.New(), math.MaxInt)
+	want := newSUT(t, withDB(wantDB))
+	want.apply(t, blocks...)
+
+	for failAfter := range wantDB.calls {
+		t.Run(fmt.Sprintf("failAfter_%d", failAfter), func(t *testing.T) {
+			t.Parallel()
+
+			db := memdb.New()
+			preCrash := newSUT(t, withDB(newFlakyDB(db, failAfter)))
+			remainingBlocks := blocks
+			for i, b := range blocks {
+				if err := preCrash.Apply(b.height, b.txs); err != nil {
+					require.ErrorIsf(t, err, errInjected, "%T.Apply(%d)", preCrash.stateImpl, b.height)
+					break
+				}
+				remainingBlocks = blocks[i+1:]
+			}
+
+			got := newSUT(t, withDB(db))
+			got.apply(t, remainingBlocks...)
+
+			got.assertHasTxs(t, blocks)
+			got.assertEqual(t, want)
+		})
+	}
+}
+
+var errInjected = errors.New("injected fault")
+
+// flakyDB wraps a database and fails after a configured number of mutating
+// operations. Each [flakyDB.Put], [flakyDB.Delete], and [flakyBatch.Write]
+// counts as an op; reads and iteration are not counted and never fail.
+type flakyDB struct {
+	database.Database
+	failAfter int
+	calls     int
+}
+
+func newFlakyDB(db database.Database, failAfter int) *flakyDB {
+	return &flakyDB{
+		Database:  db,
+		failAfter: failAfter,
+	}
+}
+
+func (f *flakyDB) shouldFail() error {
+	if f.calls >= f.failAfter {
+		return errInjected
+	}
+	f.calls++
+	return nil
+}
+
+func (f *flakyDB) Put(key, value []byte) error {
+	if err := f.shouldFail(); err != nil {
+		return err
+	}
+	return f.Database.Put(key, value)
+}
+
+func (f *flakyDB) Delete(key []byte) error {
+	if err := f.shouldFail(); err != nil {
+		return err
+	}
+	return f.Database.Delete(key)
+}
+
+func (f *flakyDB) NewBatch() database.Batch {
+	return &flakyBatch{Batch: f.Database.NewBatch(), db: f}
+}
+
+type flakyBatch struct {
+	database.Batch
+	db *flakyDB
+}
+
+func (b *flakyBatch) Write() error {
+	if err := b.db.shouldFail(); err != nil {
+		return err
+	}
+	return b.Batch.Write()
+}
+
+// Inner returns the wrapper so that [chainsatomic.WriteAll] calls
+// [flakyBatch.Write].
+func (b *flakyBatch) Inner() database.Batch { return b }

--- a/vms/saevm/cchain/tx/codec_test.go
+++ b/vms/saevm/cchain/tx/codec_test.go
@@ -5,7 +5,6 @@ package tx_test
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/ava-labs/libevm/common"
@@ -41,8 +40,8 @@ func TestID(t *testing.T) {
 		t.Run(tx.name, func(t *testing.T) {
 			t.Run("old", func(t *testing.T) {
 				// We must parse the old tx to properly initialize the ID.
-				old, err := parseOldTx(tx.bytes)
-				require.NoError(t, err, "parseOldTx()")
+				old, err := txtest.ParseOld(tx.bytes)
+				require.NoError(t, err, "txtest.ParseOld()")
 				assert.Equalf(t, tx.id, old.ID(), "%T.ID()", old)
 			})
 			t.Run("new", func(t *testing.T) {
@@ -69,24 +68,6 @@ func TestBytes(t *testing.T) {
 	}
 }
 
-var errUnexpectedCredentialType = errors.New("unexpected credential type")
-
-// parseOldTx parses a transaction using coreth's old parsing logic but enforces
-// additional restrictions. Coreth's parsing logic is overly permissive and
-// depends on later verification in [vm.VerifierBackend].
-func parseOldTx(b []byte) (*atomic.Tx, error) {
-	tx, err := atomic.ExtractAtomicTx(b, atomic.Codec)
-	if err != nil {
-		return nil, err
-	}
-	for _, cred := range tx.Creds {
-		if _, ok := cred.(*secp256k1fx.Credential); !ok {
-			return nil, errUnexpectedCredentialType
-		}
-	}
-	return tx, nil
-}
-
 // oldCmpOpt returns a configuration for [cmp.Diff] to compare [atomic.Tx]
 // instances.
 func oldCmpOpt() cmp.Option {
@@ -104,8 +85,8 @@ func TestParse(t *testing.T) {
 	for _, tx := range allTxs {
 		t.Run(tx.name, func(t *testing.T) {
 			t.Run("old", func(t *testing.T) {
-				got, err := parseOldTx(tx.bytes)
-				require.NoError(t, err, "parseOldTx()")
+				got, err := txtest.ParseOld(tx.bytes)
+				require.NoError(t, err, "txtest.ParseOld()")
 				if diff := cmp.Diff(tx.old, got, oldCmpOpt()); diff != "" {
 					t.Errorf("%T.Unmarshal(, %T) diff (-want +got):\n%s", atomic.Codec, got, diff)
 				}
@@ -157,13 +138,13 @@ func FuzzParseCompatibility(f *testing.F) {
 		f.Add(tx.bytes)
 	}
 	f.Fuzz(func(t *testing.T, data []byte) {
-		_, oldErr := parseOldTx(data)
+		_, oldErr := txtest.ParseOld(data)
 		oldOk := oldErr == nil
 
 		_, newErr := Parse(data)
 		newOk := newErr == nil
 
-		assert.Equal(t, oldOk, newOk, "Parse(b) == parseOldTx(b)")
+		assert.Equal(t, oldOk, newOk, "Parse(b) == txtest.ParseOld(b)")
 	})
 }
 
@@ -273,24 +254,6 @@ func FuzzParseSliceRoundTrip(f *testing.F) {
 	})
 }
 
-// parseOldTxs parses a slice of transactions using coreth's old parsing logic
-// but enforces additional restrictions. Coreth's parsing logic is overly
-// permissive and depends on later verification in [vm.VerifierBackend].
-func parseOldTxs(b []byte) ([]*atomic.Tx, error) {
-	txs, err := atomic.ExtractAtomicTxs(b, true, atomic.Codec)
-	if err != nil {
-		return nil, err
-	}
-	for _, tx := range txs {
-		for _, cred := range tx.Creds {
-			if _, ok := cred.(*secp256k1fx.Credential); !ok {
-				return nil, errUnexpectedCredentialType
-			}
-		}
-	}
-	return txs, nil
-}
-
 func FuzzParseSliceCompatibility(f *testing.F) {
 	{
 		newTxs := make([]*Tx, len(allTxs))
@@ -303,13 +266,13 @@ func FuzzParseSliceCompatibility(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		_, oldErr := parseOldTxs(data)
+		_, oldErr := txtest.ParseOlds(data)
 		oldOk := oldErr == nil
 
 		_, newErr := ParseSlice(data)
 		newOk := newErr == nil
 
-		assert.Equal(t, oldOk, newOk, "ParseSlice(b) == parseOldTxs(b)")
+		assert.Equal(t, oldOk, newOk, "ParseSlice(b) == txtest.ParseOlds(b)")
 	})
 }
 
@@ -538,21 +501,9 @@ func TestJSONMarshal(t *testing.T) {
 	}
 }
 
-// toOldTx converts a transaction from the new format into coreth's old format.
-func toOldTx(tb testing.TB, newTx *Tx) *atomic.Tx {
-	tb.Helper()
-
-	bytes, err := newTx.Bytes()
-	require.NoErrorf(tb, err, "%T.Bytes()", newTx)
-
-	oldTx, err := parseOldTx(bytes)
-	require.NoError(tb, err, "parseOldTx()")
-	return oldTx
-}
-
 func FuzzJSONCompatibility(f *testing.F) {
 	fuzz(f, func(t *testing.T, newTx *Tx) {
-		oldTx := toOldTx(t, newTx)
+		oldTx := txtest.ToOld(t, newTx)
 		want, err := json.Marshal(oldTx)
 		require.NoErrorf(t, err, "json.Marshal(%T)", oldTx)
 

--- a/vms/saevm/cchain/tx/tx_test.go
+++ b/vms/saevm/cchain/tx/tx_test.go
@@ -978,7 +978,7 @@ func FuzzAsOpCompatibility(f *testing.F) {
 			t.Skip("invalid tx")
 		}
 
-		oldTx := toOldTx(t, newTx)
+		oldTx := txtest.ToOld(t, newTx)
 		gasUsed, err := oldTx.UnsignedAtomicTx.GasUsed(true)
 		require.NoErrorf(t, err, "%T.GasUsed(true)", oldTx.UnsignedAtomicTx)
 
@@ -1113,7 +1113,7 @@ func TestAtomicRequests(t *testing.T) {
 
 func FuzzAtomicRequestsCompatibility(f *testing.F) {
 	fuzz(f, func(t *testing.T, newTx *Tx) {
-		oldTx := toOldTx(t, newTx)
+		oldTx := txtest.ToOld(t, newTx)
 		wantChainID, wantRequests, err := oldTx.UnsignedAtomicTx.AtomicOps()
 		require.NoErrorf(t, err, "%T.AtomicOps()", oldTx.UnsignedAtomicTx)
 
@@ -1374,7 +1374,7 @@ func FuzzTransferNonAVAXCompatibility(f *testing.F) {
 		}
 
 		var (
-			oldTx = toOldTx(t, newTx)
+			oldTx = txtest.ToOld(t, newTx)
 			ctx   = &snow.Context{AVAXAssetID: avaxAssetID}
 		)
 		require.NoErrorf(t, oldTx.EVMStateTransfer(ctx, oldState), "%T.EVMStateTransfer()", oldTx)
@@ -1745,7 +1745,7 @@ func oldSanityCheck(tx *atomic.Tx, ctx *snow.Context) error {
 func FuzzSanityCheckCompatibility(f *testing.F) {
 	ctx := mainnetContext()
 	fuzz(f, func(t *testing.T, newTx *Tx) {
-		oldTx := toOldTx(t, newTx)
+		oldTx := txtest.ToOld(t, newTx)
 		want := oldSanityCheck(oldTx, ctx) == nil
 		got := newTx.SanityCheck(ctx) == nil
 		assert.Equal(t, want, got, "%T.SanityCheck() == OldSanityCheck(%T)", newTx, oldTx)

--- a/vms/saevm/cchain/tx/txtest/BUILD.bazel
+++ b/vms/saevm/cchain/tx/txtest/BUILD.bazel
@@ -12,11 +12,14 @@ go_library(
     srcs = [
         "cmp.go",
         "fuzzer.go",
+        "legacy.go",
         "wallet.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/vms/saevm/cchain/tx/txtest",
     deps = [
         "//codec",
+        "//graft/coreth/plugin/evm/atomic",
+        "//graft/coreth/plugin/evm/atomic/vm",
         "//ids",
         "//utils/crypto/keychain",
         "//utils/crypto/secp256k1",

--- a/vms/saevm/cchain/tx/txtest/legacy.go
+++ b/vms/saevm/cchain/tx/txtest/legacy.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txtest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	// Imported for [vm.VerifierBackend] comment resolution.
+	_ "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/vm"
+
+	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic"
+	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+var errUnexpectedCredentialType = errors.New("unexpected credential type")
+
+// ParseOld parses a transaction using coreth's old parsing logic while
+// enforcing restrictions imposed by the new parsing logic.
+//
+// Coreth's parsing logic is overly permissive and depends on later verification
+// in [vm.VerifierBackend].
+func ParseOld(b []byte) (*atomic.Tx, error) {
+	tx, err := atomic.ExtractAtomicTx(b, atomic.Codec)
+	if err != nil {
+		return nil, err
+	}
+	for _, cred := range tx.Creds {
+		if _, ok := cred.(*secp256k1fx.Credential); !ok {
+			return nil, errUnexpectedCredentialType
+		}
+	}
+	return tx, nil
+}
+
+// ParseOlds parses a slice of transaction using coreth's old parsing logic
+// while enforcing restrictions imposed by the new parsing logic.
+//
+// Coreth's parsing logic is overly permissive and depends on later verification
+// in [vm.VerifierBackend].
+func ParseOlds(b []byte) ([]*atomic.Tx, error) {
+	txs, err := atomic.ExtractAtomicTxs(b, true, atomic.Codec)
+	if err != nil {
+		return nil, err
+	}
+	for _, tx := range txs {
+		for _, cred := range tx.Creds {
+			if _, ok := cred.(*secp256k1fx.Credential); !ok {
+				return nil, errUnexpectedCredentialType
+			}
+		}
+	}
+	return txs, nil
+}
+
+// ToOld converts a transaction from the new format into coreth's old format.
+func ToOld(tb testing.TB, newTx *tx.Tx) *atomic.Tx {
+	tb.Helper()
+
+	bytes, err := newTx.Bytes()
+	require.NoErrorf(tb, err, "%T.Bytes()", newTx)
+
+	oldTx, err := ParseOld(bytes)
+	require.NoError(tb, err, "ParseOld()")
+	return oldTx
+}
+
+// ToOlds converts a slice of transactions from the new format into coreth's old
+// format.
+func ToOlds(tb testing.TB, newTxs []*tx.Tx) []*atomic.Tx {
+	tb.Helper()
+
+	oldTxs := make([]*atomic.Tx, len(newTxs))
+	for i, newTx := range newTxs {
+		oldTxs[i] = ToOld(tb, newTx)
+	}
+	return oldTxs
+}
+
+// ToNew converts a transaction from coreth's old format into the new format.
+func ToNew(tb testing.TB, oldTx *atomic.Tx) *tx.Tx {
+	tb.Helper()
+
+	// Don't use [atomic.Tx.SignedBytes] in case it wasn't properly initialized.
+	bytes, err := atomic.Codec.Marshal(atomic.CodecVersion, oldTx)
+	require.NoErrorf(tb, err, "%T.Marshal(, %T)", atomic.Codec, oldTx)
+	newTx, err := tx.Parse(bytes)
+	require.NoError(tb, err, "tx.Parse()")
+	return newTx
+}
+
+// ToNews converts a slice of transactions from coreth's old format into the new
+// format.
+func ToNews(tb testing.TB, oldTxs []*atomic.Tx) []*tx.Tx {
+	tb.Helper()
+
+	newTxs := make([]*tx.Tx, len(oldTxs))
+	for i, oldTx := range oldTxs {
+		newTxs[i] = ToNew(tb, oldTx)
+	}
+	return newTxs
+}


### PR DESCRIPTION
## Why this should be merged

This PR factors out the cross-chain state implementation from the SAE PoC #5303.

## How this works

The `AtomicBackend`, `AtomicRepository`, `atomicState`, and `AtomicTrie` is all implemented as a single `State` struct.

The database indices are maintained (unless they are dead code) so no database migration is required.

The trie is written first, followed by the rest of the state.

## How this was tested

- [x] Compatibility tests that read old values from the new state struct
- [x] Database failure tests that verify consistency even under unexpected crashes
- [x] Hash compatibility of the new trie with the old trie.

## Need to be documented in RELEASES.md?

No