### PR TITLE
fix(sae): Can't parse invalid block body

### DIFF
--- a/vms/saevm/sae/BUILD.bazel
+++ b/vms/saevm/sae/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "@com_github_ava_labs_libevm//event",
         "@com_github_ava_labs_libevm//params",
         "@com_github_ava_labs_libevm//rlp",
+        "@com_github_ava_labs_libevm//trie",
         "@com_github_ava_labs_libevm//triedb",
         "@com_github_holiman_uint256//:uint256",
         "@com_github_prometheus_client_golang//prometheus",

--- a/vms/saevm/sae/blocks.go
+++ b/vms/saevm/sae/blocks.go
@@ -64,22 +64,42 @@ func (vm *VM) ParseBlock(ctx context.Context, buf []byte) (*blocks.Block, error)
 
 	// Block body must match what is declared by the header.
 	hasher := trie.NewStackTrie(nil)
-	if types.DeriveSha(types.Transactions(b.Transactions()), hasher) != b.Header().TxHash {
+	hdr := b.Header()
+	if types.DeriveSha(b.Transactions(), hasher) != hdr.TxHash {
 		return nil, errTxHashMismatch
 	}
-	if types.CalcUncleHash(b.Uncles()) != b.Header().UncleHash {
+	if types.CalcUncleHash(b.Uncles()) != hdr.UncleHash {
 		return nil, errUncleHashMismatch
 	}
-	// If blob gas is set, withdrawals hash isn't nil.
-	if b.Header().WithdrawalsHash == nil {
-		if len(b.Withdrawals()) > 0 {
+	{
+		// The withdrawals hash being set depends on the Ethereum hard fork.
+		var want *common.Hash
+		switch w := b.Withdrawals(); {
+		case w == nil:
+			want = nil
+		case len(w) == 0:
+			want = &types.EmptyWithdrawalsHash
+		default:
+			h := types.DeriveSha(w, hasher)
+			want = &h
+		}
+		got := hdr.WithdrawalsHash
+		if !comparePtrs(want, got) {
 			return nil, errWithdrawalHashMismatch
 		}
-	} else if types.DeriveSha(types.Withdrawals(b.Withdrawals()), hasher) != *b.Header().WithdrawalsHash {
-		return nil, errWithdrawalHashMismatch
 	}
 
 	return vm.blockBuilder.new(b, nil, nil)
+}
+
+func comparePtrs[T comparable](a, b *T) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 // BuildBlock builds a new block, using the last block passed to

--- a/vms/saevm/sae/blocks.go
+++ b/vms/saevm/sae/blocks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/rlp"
+	"github.com/ava-labs/libevm/trie"
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -37,6 +38,10 @@ const (
 var (
 	errBlockHeightNotUint64 = errors.New("block height not uint64")
 	errBlockTooFarInFuture  = errors.New("block too far in the future")
+
+	errTxHashMismatch         = errors.New("transaction hash mismatch")
+	errUncleHashMismatch      = errors.New("uncle hash mismatch")
+	errWithdrawalHashMismatch = errors.New("withdrawals hash mismatch")
 )
 
 // ParseBlock parses the buffer as [rlp] encoding of a [types.Block]. It does
@@ -55,6 +60,23 @@ func (vm *VM) ParseBlock(ctx context.Context, buf []byte) (*blocks.Block, error)
 	// make this some future engineer's problem in a few millennia.
 	if b.Time() > unix(vm.config.Now())+maxFutureBlockSeconds {
 		return nil, fmt.Errorf("%w: >%s", errBlockTooFarInFuture, maxFutureBlockDuration)
+	}
+
+	// Block body must match what is declared by the header.
+	hasher := trie.NewStackTrie(nil)
+	if types.DeriveSha(types.Transactions(b.Transactions()), hasher) != b.Header().TxHash {
+		return nil, errTxHashMismatch
+	}
+	if types.CalcUncleHash(b.Uncles()) != b.Header().UncleHash {
+		return nil, errUncleHashMismatch
+	}
+	// If blob gas is set, withdrawals hash isn't nil.
+	if b.Header().WithdrawalsHash == nil {
+		if len(b.Withdrawals()) > 0 {
+			return nil, errWithdrawalHashMismatch
+		}
+	} else if types.DeriveSha(types.Withdrawals(b.Withdrawals()), hasher) != *b.Header().WithdrawalsHash {
+		return nil, errWithdrawalHashMismatch
 	}
 
 	return vm.blockBuilder.new(b, nil, nil)
@@ -98,8 +120,8 @@ func (vm *VM) VerifyBlock(ctx context.Context, bCtx *block.Context, b *blocks.Bl
 	// also provides a clearer failure message.
 	if reH, verH := rebuilt.Hash(), b.Hash(); reH != verH {
 		vm.log().Debug("block verification failed",
-			zap.Reflect("block", b.Header()),
-			zap.Reflect("rebuilt", rebuilt.Header()),
+			zap.String("block", fmt.Sprintf("%+v", b.Header())),
+			zap.String("rebuilt", fmt.Sprintf("%+v", rebuilt.Header())),
 		)
 		return fmt.Errorf("%w; rebuilt as %#x when verifying %#x", errHashMismatch, reH, verH)
 	}

--- a/vms/saevm/sae/blocks.go
+++ b/vms/saevm/sae/blocks.go
@@ -83,8 +83,7 @@ func (vm *VM) ParseBlock(ctx context.Context, buf []byte) (*blocks.Block, error)
 			h := types.DeriveSha(w, hasher)
 			want = &h
 		}
-		got := hdr.WithdrawalsHash
-		if !comparePtrs(want, got) {
+		if !compareHashPtrs(want, hdr.WithdrawalsHash) {
 			return nil, errWithdrawalHashMismatch
 		}
 	}
@@ -92,14 +91,15 @@ func (vm *VM) ParseBlock(ctx context.Context, buf []byte) (*blocks.Block, error)
 	return vm.blockBuilder.new(b, nil, nil)
 }
 
-func comparePtrs[T comparable](a, b *T) bool {
-	if a == nil {
-		return b == nil
-	}
-	if b == nil {
+func compareHashPtrs(a, b *common.Hash) bool {
+	switch an, bn := a == nil, b == nil; {
+	case an && bn:
+		return true
+	case an || bn:
 		return false
+	default:
+		return *a == *b
 	}
-	return *a == *b
 }
 
 // BuildBlock builds a new block, using the last block passed to

--- a/vms/saevm/sae/blocks.go
+++ b/vms/saevm/sae/blocks.go
@@ -140,8 +140,8 @@ func (vm *VM) VerifyBlock(ctx context.Context, bCtx *block.Context, b *blocks.Bl
 	// also provides a clearer failure message.
 	if reH, verH := rebuilt.Hash(), b.Hash(); reH != verH {
 		vm.log().Debug("block verification failed",
-			zap.String("block", fmt.Sprintf("%+v", b.Header())),
-			zap.String("rebuilt", fmt.Sprintf("%+v", rebuilt.Header())),
+			zap.Reflect("block", b.Header()),
+			zap.Reflect("rebuilt", rebuilt.Header()),
 		)
 		return fmt.Errorf("%w; rebuilt as %#x when verifying %#x", errHashMismatch, reH, verH)
 	}

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -767,24 +767,56 @@ func TestSyntacticBlockChecks(t *testing.T) {
 		{
 			name: "block_height_overflow_protection",
 			header: &types.Header{
-				Number: new(big.Int).Lsh(big.NewInt(1), 64),
+				Number:    new(big.Int).Lsh(big.NewInt(1), 64),
+				UncleHash: types.EmptyUncleHash,
+				TxHash:    types.EmptyTxsHash,
 			},
 			wantErr: errBlockHeightNotUint64,
 		},
 		{
 			name: "block_time_at_maximum",
 			header: &types.Header{
-				Number: big.NewInt(1),
-				Time:   now + maxFutureBlockSeconds,
+				Number:    big.NewInt(1),
+				UncleHash: types.EmptyUncleHash,
+				Time:      now + maxFutureBlockSeconds,
+				TxHash:    types.EmptyTxsHash,
 			},
 		},
 		{
 			name: "block_time_after_maximum",
 			header: &types.Header{
-				Number: big.NewInt(1),
-				Time:   now + maxFutureBlockSeconds + 1,
+				Number:    big.NewInt(1),
+				UncleHash: types.EmptyUncleHash,
+				Time:      now + maxFutureBlockSeconds + 1,
+				TxHash:    types.EmptyTxsHash,
 			},
 			wantErr: errBlockTooFarInFuture,
+		},
+		{
+			name: "invalid_tx_hash",
+			header: &types.Header{
+				Number:    big.NewInt(1),
+				UncleHash: types.EmptyUncleHash,
+			},
+			wantErr: errTxHashMismatch,
+		},
+		{
+			name: "invalid_uncle_hash",
+			header: &types.Header{
+				Number: big.NewInt(1),
+				TxHash: types.EmptyTxsHash,
+			},
+			wantErr: errUncleHashMismatch,
+		},
+		{
+			name: "invalid_withdrawals_hash",
+			header: &types.Header{
+				Number:          big.NewInt(1),
+				TxHash:          types.EmptyTxsHash,
+				UncleHash:       types.EmptyUncleHash,
+				WithdrawalsHash: &common.Hash{},
+			},
+			wantErr: errWithdrawalHashMismatch,
 		},
 	}
 

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -752,27 +752,16 @@ func TestEmptyChainConfig(t *testing.T) {
 }
 
 func TestSyntacticBlockChecks(t *testing.T) {
-	ctx, sut := newSUT(t, 1)
+	ctx, sut := newSUT(t, 0)
 
 	const now = 1e6
 	sut.rawVM.config.Now = func() time.Time {
 		return time.Unix(now, 0)
 	}
 
-	validHeader := &types.Header{
-		Number:    big.NewInt(1),
-		UncleHash: types.EmptyUncleHash,
-		TxHash:    types.EmptyTxsHash,
-	}
-	mutate := func(fn func(*types.Header)) *types.Header {
-		h := types.CopyHeader(validHeader)
-		fn(h)
-		return h
-	}
-
-	txBody := types.Body{
+	bodyWithTx := types.Body{
 		Transactions: []*types.Transaction{
-			sut.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
+			types.NewTx(&types.DynamicFeeTx{
 				To:        &zeroAddr,
 				Gas:       params.TxGas,
 				GasFeeCap: big.NewInt(1),
@@ -782,111 +771,127 @@ func TestSyntacticBlockChecks(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		header      *types.Header
+		name string
+		// mutate will receive a valid header for an empty body and should return a mutated version of it.
+		mutate      func(*types.Header) *types.Header
 		body        types.Body
 		withdrawals []*types.Withdrawal
 		wantErr     error
 	}{
 		{
 			name:   "valid_header", // base case for test setup
-			header: types.CopyHeader(validHeader),
+			mutate: func(h *types.Header) *types.Header { return h },
 		},
 		{
 			name: "block_height_overflow_protection",
-			header: mutate(func(h *types.Header) {
+			mutate: func(h *types.Header) *types.Header {
 				h.Number = new(big.Int).Lsh(big.NewInt(1), 64)
-			}),
+				return h
+			},
 			wantErr: errBlockHeightNotUint64,
 		},
 		{
 			name: "block_time_at_maximum",
-			header: mutate(func(h *types.Header) {
+			mutate: func(h *types.Header) *types.Header {
 				h.Time = now + maxFutureBlockSeconds
-			}),
+				return h
+			},
 		},
 		{
 			name: "block_time_after_maximum",
-			header: mutate(func(h *types.Header) {
+			mutate: func(h *types.Header) *types.Header {
 				h.Time = now + maxFutureBlockSeconds + 1
-			}),
+				return h
+			},
 			wantErr: errBlockTooFarInFuture,
 		},
 		{
 			name: "invalid_tx_hash_empty",
-			header: mutate(func(h *types.Header) {
+			mutate: func(h *types.Header) *types.Header {
 				h.TxHash = common.Hash{}
-			}),
+				return h
+			},
 			wantErr: errTxHashMismatch,
 		},
 		{
 			name:    "invalid_tx_hash_nonempty",
-			header:  types.CopyHeader(validHeader), // uses [types.EmptyTxsHash]
-			body:    txBody,                        // contains a tx
+			mutate:  func(h *types.Header) *types.Header { return h }, // uses [types.EmptyTxsHash]
+			body:    bodyWithTx,                                       // contains a tx
 			wantErr: errTxHashMismatch,
 		},
 		{
 			name: "valid_tx_hash_nonempty",
-			header: mutate(func(h *types.Header) {
-				h.TxHash = types.DeriveSha(types.Transactions(txBody.Transactions), saetest.TrieHasher())
-			}),
-			body: txBody,
+			mutate: func(h *types.Header) *types.Header {
+				h.TxHash = types.DeriveSha(types.Transactions(bodyWithTx.Transactions), saetest.TrieHasher())
+				return h
+			},
+			body: bodyWithTx,
 		},
 		{
 			name: "invalid_uncle_hash_empty",
-			header: mutate(func(h *types.Header) {
+			mutate: func(h *types.Header) *types.Header {
 				h.UncleHash = common.Hash{}
-			}),
+				return h
+			},
 			wantErr: errUncleHashMismatch,
 		},
 		{
 			name:   "invalid_uncle_hash_nonempty",
-			header: types.CopyHeader(validHeader),
+			mutate: func(h *types.Header) *types.Header { return h }, // uses [types.EmptyUncleHash]
 			body: types.Body{
-				Uncles: []*types.Header{validHeader},
+				Uncles: []*types.Header{{}},
 			},
 			wantErr: errUncleHashMismatch,
 		},
 		{
 			name: "valid_uncle_hash_nonempty",
-			header: mutate(func(h *types.Header) {
-				h.UncleHash = types.CalcUncleHash([]*types.Header{validHeader})
-			}),
+			mutate: func(h *types.Header) *types.Header {
+				h.UncleHash = types.CalcUncleHash([]*types.Header{{}})
+				return h
+			},
 			body: types.Body{
-				Uncles: []*types.Header{validHeader},
+				Uncles: []*types.Header{{}},
 			},
 			wantErr: nil,
 		},
 		{
 			name: "nil_withdrawals_nonnil_hash",
-			header: mutate(func(h *types.Header) {
+			mutate: func(h *types.Header) *types.Header {
 				h.WithdrawalsHash = &types.EmptyWithdrawalsHash
-			}),
+				return h
+			},
 			wantErr: errWithdrawalHashMismatch,
 		},
 		{
 			name: "nonnil_withdrawals_nil_hash",
-			header: mutate(func(h *types.Header) {
+			mutate: func(h *types.Header) *types.Header {
 				h.WithdrawalsHash = nil
-			}),
+				return h
+			},
 			withdrawals: []*types.Withdrawal{},
 			wantErr:     errWithdrawalHashMismatch,
 		},
 		{
 			name: "nonnil_withdrawals_nonempty_hash",
-			header: mutate(func(h *types.Header) {
+			mutate: func(h *types.Header) *types.Header {
 				h.WithdrawalsHash = &types.EmptyWithdrawalsHash
-			}),
+				return h
+			},
 			withdrawals: []*types.Withdrawal{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ethB := types.NewBlockWithHeader(tt.header).WithBody(tt.body).WithWithdrawals(tt.withdrawals)
+			hdr := tt.mutate(&types.Header{
+				Number:    big.NewInt(1),
+				UncleHash: types.EmptyUncleHash,
+				TxHash:    types.EmptyTxsHash,
+			})
+			ethB := types.NewBlockWithHeader(hdr).WithBody(tt.body).WithWithdrawals(tt.withdrawals)
 			b := blockstest.NewBlock(t, ethB, nil, nil)
 			_, err := sut.ParseBlock(ctx, b.Bytes())
-			assert.ErrorIs(t, err, tt.wantErr, "ParseBlock(#%v @ time %v) when stubbed time is %d", tt.header.Number, tt.header.Time, uint64(now))
+			assert.ErrorIs(t, err, tt.wantErr, "ParseBlock(#%v @ time %v) when stubbed time is %d", hdr.Number, hdr.Time, uint64(now))
 		})
 	}
 }

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -752,77 +752,139 @@ func TestEmptyChainConfig(t *testing.T) {
 }
 
 func TestSyntacticBlockChecks(t *testing.T) {
-	ctx, sut := newSUT(t, 0)
+	ctx, sut := newSUT(t, 1)
 
 	const now = 1e6
 	sut.rawVM.config.Now = func() time.Time {
 		return time.Unix(now, 0)
 	}
 
+	validHeader := &types.Header{
+		Number:    big.NewInt(1),
+		UncleHash: types.EmptyUncleHash,
+		TxHash:    types.EmptyTxsHash,
+	}
+	mutate := func(fn func(*types.Header)) *types.Header {
+		h := types.CopyHeader(validHeader)
+		fn(h)
+		return h
+	}
+
+	txBody := types.Body{
+		Transactions: []*types.Transaction{
+			sut.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
+				To:        &zeroAddr,
+				Gas:       params.TxGas,
+				GasFeeCap: big.NewInt(1),
+				Value:     big.NewInt(1),
+			}),
+		},
+	}
+
 	tests := []struct {
-		name    string
-		header  *types.Header
-		wantErr error
+		name        string
+		header      *types.Header
+		body        types.Body
+		withdrawals []*types.Withdrawal
+		wantErr     error
 	}{
 		{
+			name:   "valid_header", // base case for test setup
+			header: types.CopyHeader(validHeader),
+		},
+		{
 			name: "block_height_overflow_protection",
-			header: &types.Header{
-				Number:    new(big.Int).Lsh(big.NewInt(1), 64),
-				UncleHash: types.EmptyUncleHash,
-				TxHash:    types.EmptyTxsHash,
-			},
+			header: mutate(func(h *types.Header) {
+				h.Number = new(big.Int).Lsh(big.NewInt(1), 64)
+			}),
 			wantErr: errBlockHeightNotUint64,
 		},
 		{
 			name: "block_time_at_maximum",
-			header: &types.Header{
-				Number:    big.NewInt(1),
-				UncleHash: types.EmptyUncleHash,
-				Time:      now + maxFutureBlockSeconds,
-				TxHash:    types.EmptyTxsHash,
-			},
+			header: mutate(func(h *types.Header) {
+				h.Time = now + maxFutureBlockSeconds
+			}),
 		},
 		{
 			name: "block_time_after_maximum",
-			header: &types.Header{
-				Number:    big.NewInt(1),
-				UncleHash: types.EmptyUncleHash,
-				Time:      now + maxFutureBlockSeconds + 1,
-				TxHash:    types.EmptyTxsHash,
-			},
+			header: mutate(func(h *types.Header) {
+				h.Time = now + maxFutureBlockSeconds + 1
+			}),
 			wantErr: errBlockTooFarInFuture,
 		},
 		{
-			name: "invalid_tx_hash",
-			header: &types.Header{
-				Number:    big.NewInt(1),
-				UncleHash: types.EmptyUncleHash,
-			},
+			name: "invalid_tx_hash_empty",
+			header: mutate(func(h *types.Header) {
+				h.TxHash = common.Hash{}
+			}),
 			wantErr: errTxHashMismatch,
 		},
 		{
-			name: "invalid_uncle_hash",
-			header: &types.Header{
-				Number: big.NewInt(1),
-				TxHash: types.EmptyTxsHash,
+			name:    "invalid_tx_hash_nonempty",
+			header:  types.CopyHeader(validHeader), // uses [types.EmptyTxsHash]
+			body:    txBody,                        // contains a tx
+			wantErr: errTxHashMismatch,
+		},
+		{
+			name: "valid_tx_hash_nonempty",
+			header: mutate(func(h *types.Header) {
+				h.TxHash = types.DeriveSha(types.Transactions(txBody.Transactions), saetest.TrieHasher())
+			}),
+			body: txBody,
+		},
+		{
+			name: "invalid_uncle_hash_empty",
+			header: mutate(func(h *types.Header) {
+				h.UncleHash = common.Hash{}
+			}),
+			wantErr: errUncleHashMismatch,
+		},
+		{
+			name:   "invalid_uncle_hash_nonempty",
+			header: types.CopyHeader(validHeader),
+			body: types.Body{
+				Uncles: []*types.Header{validHeader},
 			},
 			wantErr: errUncleHashMismatch,
 		},
 		{
-			name: "invalid_withdrawals_hash",
-			header: &types.Header{
-				Number:          big.NewInt(1),
-				TxHash:          types.EmptyTxsHash,
-				UncleHash:       types.EmptyUncleHash,
-				WithdrawalsHash: &common.Hash{},
+			name: "valid_uncle_hash_nonempty",
+			header: mutate(func(h *types.Header) {
+				h.UncleHash = types.CalcUncleHash([]*types.Header{validHeader})
+			}),
+			body: types.Body{
+				Uncles: []*types.Header{validHeader},
 			},
+			wantErr: nil,
+		},
+		{
+			name: "nil_withdrawals_nonnil_hash",
+			header: mutate(func(h *types.Header) {
+				h.WithdrawalsHash = &types.EmptyWithdrawalsHash
+			}),
 			wantErr: errWithdrawalHashMismatch,
+		},
+		{
+			name: "nonnil_withdrawals_nil_hash",
+			header: mutate(func(h *types.Header) {
+				h.WithdrawalsHash = nil
+			}),
+			withdrawals: []*types.Withdrawal{},
+			wantErr:     errWithdrawalHashMismatch,
+		},
+		{
+			name: "nonnil_withdrawals_nonempty_hash",
+			header: mutate(func(h *types.Header) {
+				h.WithdrawalsHash = &types.EmptyWithdrawalsHash
+			}),
+			withdrawals: []*types.Withdrawal{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := blockstest.NewBlock(t, types.NewBlockWithHeader(tt.header), nil, nil)
+			ethB := types.NewBlockWithHeader(tt.header).WithBody(tt.body).WithWithdrawals(tt.withdrawals)
+			b := blockstest.NewBlock(t, ethB, nil, nil)
 			_, err := sut.ParseBlock(ctx, b.Bytes())
 			assert.ErrorIs(t, err, tt.wantErr, "ParseBlock(#%v @ time %v) when stubbed time is %d", tt.header.Number, tt.header.Time, uint64(now))
 		})


### PR DESCRIPTION
## Why this should be merged

We shouldn't be able to parse blocks with bodies that don't match the header. 

## How this works

Since the withdrawals hash (always `nil`) and the uncle hash (always `types.EmptyUnclesHash`) contribute to the header's hash, we don't have to verify them at parse time - they will be caught during rebuild. 

## How this was tested

New UT

## Need to be documented in RELEASES.md?

No
