### PR TITLE
Add better debug info to error logs in state

### DIFF
--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -288,7 +288,7 @@ func (d *Diff) GetCurrentValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker,
 
 func (d *Diff) SetStakingInfo(subnetID ids.ID, nodeID ids.NodeID, stakingInfo StakingInfo) error {
 	if _, err := d.GetCurrentValidator(subnetID, nodeID); err != nil {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with subnet id %s and node id %s: %w", subnetID, nodeID, err)
 	}
 
 	if d.modifiedStakingInfo == nil {
@@ -305,7 +305,7 @@ func (d *Diff) SetStakingInfo(subnetID ids.ID, nodeID ids.NodeID, stakingInfo St
 
 func (d *Diff) GetStakingInfo(subnetID ids.ID, nodeID ids.NodeID) (StakingInfo, error) {
 	if _, err := d.GetCurrentValidator(subnetID, nodeID); err != nil {
-		return StakingInfo{}, err
+		return StakingInfo{}, fmt.Errorf("getting current validator with subnet id %s and node id %s: %w", subnetID, nodeID, err)
 	}
 
 	if stakingInfo, ok := d.modifiedStakingInfo[subnetID][nodeID]; ok {
@@ -320,13 +320,13 @@ func (d *Diff) GetStakingInfo(subnetID ids.ID, nodeID ids.NodeID) (StakingInfo, 
 
 func (d *Diff) PutCurrentValidator(staker *Staker) error {
 	if _, err := d.GetCurrentValidator(staker.SubnetID, staker.NodeID); err != nil && !errors.Is(err, database.ErrNotFound) {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with tx id %s: %w", staker.TxID, err)
 	} else if err == nil {
 		return fmt.Errorf("%w: %s", errUnexpectedStaker, staker.NodeID)
 	}
 
 	if err := d.currentStakerDiffs.PutValidator(staker); err != nil {
-		return fmt.Errorf("putting validator: %w", err)
+		return fmt.Errorf("putting validator with tx id %s: %w", staker.TxID, err)
 	}
 
 	return nil
@@ -334,10 +334,10 @@ func (d *Diff) PutCurrentValidator(staker *Staker) error {
 
 func (d *Diff) DeleteCurrentValidator(staker *Staker) error {
 	if _, err := d.GetCurrentValidator(staker.SubnetID, staker.NodeID); err != nil {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with tx id %s: %w", staker.TxID, err)
 	}
 
-	if err := verifyNoDelegators(d, staker.SubnetID, staker.NodeID); err != nil {
+	if err := verifyNoDelegators(d, staker); err != nil {
 		return err
 	}
 
@@ -361,7 +361,7 @@ func (d *Diff) GetCurrentDelegatorIterator(subnetID ids.ID, nodeID ids.NodeID) (
 
 func (d *Diff) PutCurrentDelegator(staker *Staker) error {
 	if _, err := d.GetCurrentValidator(staker.SubnetID, staker.NodeID); err != nil {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with tx id %s: %w", staker.TxID, err)
 	}
 
 	d.currentStakerDiffs.PutDelegator(staker)
@@ -370,7 +370,7 @@ func (d *Diff) PutCurrentDelegator(staker *Staker) error {
 
 func (d *Diff) DeleteCurrentDelegator(staker *Staker) error {
 	if _, err := d.GetCurrentValidator(staker.SubnetID, staker.NodeID); err != nil {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with tx id %s: %w", staker.TxID, err)
 	}
 
 	d.currentStakerDiffs.DeleteDelegator(staker)
@@ -638,7 +638,7 @@ func (d *Diff) Apply(baseState Chain) error {
 			// Delegators must be removed before their respective validators
 			for _, delegator := range validatorDiff.deletedDelegators {
 				if err := baseState.DeleteCurrentDelegator(delegator); err != nil {
-					return fmt.Errorf("deleting current delegator: %w", err)
+					return fmt.Errorf("deleting current delegator with tx id %s: %w", delegator.TxID, err)
 				}
 			}
 
@@ -646,12 +646,12 @@ func (d *Diff) Apply(baseState Chain) error {
 			// We therefore first delete and then only after add it.
 			if validatorDiff.removed != nil {
 				if err := baseState.DeleteCurrentValidator(validatorDiff.removed); err != nil {
-					return fmt.Errorf("deleting current validator: %w", err)
+					return fmt.Errorf("deleting current validator with tx id %s: %w", validatorDiff.removed.TxID, err)
 				}
 			}
 			if validatorDiff.added != nil {
 				if err := baseState.PutCurrentValidator(validatorDiff.added); err != nil {
-					return err
+					return fmt.Errorf("putting current validator with tx id %s: %w", validatorDiff.added.TxID, err)
 				}
 			}
 
@@ -734,7 +734,7 @@ func addCurrentDelegators(state Chain, validator *diffValidator) error {
 
 	for addedDelegatorIterator.Next() {
 		if err := state.PutCurrentDelegator(addedDelegatorIterator.Value()); err != nil {
-			return fmt.Errorf("putting current delegator: %w", err)
+			return fmt.Errorf("putting current delegator with tx id %s: %w", addedDelegatorIterator.Value().TxID, err)
 		}
 	}
 

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -739,7 +739,7 @@ func New(
 
 func (s *State) GetStakingInfo(subnetID ids.ID, vdrID ids.NodeID) (StakingInfo, error) {
 	if _, err := s.GetCurrentValidator(subnetID, vdrID); err != nil {
-		return StakingInfo{}, fmt.Errorf("getting current validator: %w", err)
+		return StakingInfo{}, fmt.Errorf("getting current validator with subnet id %s and node id %s: %w", subnetID, vdrID, err)
 	}
 
 	return s.validatorState.GetStakingInfo(subnetID, vdrID)
@@ -747,7 +747,7 @@ func (s *State) GetStakingInfo(subnetID ids.ID, vdrID ids.NodeID) (StakingInfo, 
 
 func (s *State) SetStakingInfo(subnetID ids.ID, vdrID ids.NodeID, stakingInfo StakingInfo) error {
 	if _, err := s.GetCurrentValidator(subnetID, vdrID); err != nil {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with subnet id %s and node id %s: %w", subnetID, vdrID, err)
 	}
 
 	return s.validatorState.SetStakingInfo(subnetID, vdrID, stakingInfo)
@@ -900,9 +900,9 @@ func (s *State) GetCurrentValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker
 
 func (s *State) PutCurrentValidator(staker *Staker) error {
 	if _, err := s.GetCurrentValidator(staker.SubnetID, staker.NodeID); err != nil && !errors.Is(err, database.ErrNotFound) {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with tx id %s: %w", staker.TxID, err)
 	} else if err == nil {
-		return fmt.Errorf("%w: %s", errUnexpectedStaker, staker.NodeID)
+		return fmt.Errorf("%w: %s", errUnexpectedStaker, staker.TxID)
 	}
 
 	s.currentStakers.PutValidator(staker)
@@ -912,10 +912,10 @@ func (s *State) PutCurrentValidator(staker *Staker) error {
 
 func (s *State) DeleteCurrentValidator(staker *Staker) error {
 	if _, err := s.GetCurrentValidator(staker.SubnetID, staker.NodeID); err != nil {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with tx id %s: %w", staker.TxID, err)
 	}
 
-	if err := verifyNoDelegators(s, staker.SubnetID, staker.NodeID); err != nil {
+	if err := verifyNoDelegators(s, staker); err != nil {
 		return err
 	}
 
@@ -925,16 +925,16 @@ func (s *State) DeleteCurrentValidator(staker *Staker) error {
 
 // verifyNoDelegators checks that the validator for the subnetID and nodeID pair does not have
 // delegators associated with it.
-func verifyNoDelegators(cs CurrentStakers, subnetID ids.ID, nodeID ids.NodeID) error {
-	itr, err := cs.GetCurrentDelegatorIterator(subnetID, nodeID)
+func verifyNoDelegators(cs CurrentStakers, staker *Staker) error {
+	itr, err := cs.GetCurrentDelegatorIterator(staker.SubnetID, staker.NodeID)
 	if err != nil {
-		return fmt.Errorf("getting current delegator iterator: %w", err)
+		return fmt.Errorf("getting current delegator iterator for validator with tx id %s: %w", staker.TxID, err)
 	}
 
 	defer itr.Release()
 
 	if itr.Next() {
-		return fmt.Errorf("%w: delegators must be deleted before their validator", errDeleteOrder)
+		return fmt.Errorf("%w: validator with tx id %s has delegator with tx id %s", errDeleteOrder, staker.TxID, itr.Value().TxID)
 	}
 
 	return nil
@@ -946,7 +946,7 @@ func (s *State) GetCurrentDelegatorIterator(subnetID ids.ID, nodeID ids.NodeID) 
 
 func (s *State) PutCurrentDelegator(staker *Staker) error {
 	if _, err := s.GetCurrentValidator(staker.SubnetID, staker.NodeID); err != nil {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with tx id %s: %w", staker.TxID, err)
 	}
 
 	s.currentStakers.PutDelegator(staker)
@@ -955,7 +955,7 @@ func (s *State) PutCurrentDelegator(staker *Staker) error {
 
 func (s *State) DeleteCurrentDelegator(staker *Staker) error {
 	if _, err := s.GetCurrentValidator(staker.SubnetID, staker.NodeID); err != nil {
-		return fmt.Errorf("getting current validator: %w", err)
+		return fmt.Errorf("getting current validator with tx id %s: %w", staker.TxID, err)
 	}
 
 	s.currentStakers.DeleteDelegator(staker)


### PR DESCRIPTION
## Why this should be merged

Adds tx id/other metadata to error context for state types

## How this works

Adds error info. Uses tx id where possible but falls back to subnet + node ids where tx id is not available.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
