### PR TITLE
Fix bootstrapping bug when promoting pending delegators

### DIFF
--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -151,6 +151,8 @@ func advanceTimeTo(
 		if stakerToRemove.StartTime.After(newChainTime) {
 			break
 		}
+
+		// Iterate over validators first to preserve expected modification ordering for state
 		if !stakerToRemove.Priority.IsPendingValidator() {
 			continue
 		}
@@ -183,6 +185,8 @@ func advanceTimeTo(
 		if stakerToRemove.StartTime.After(newChainTime) {
 			break
 		}
+
+		// Iterate over delegators last to preserve expected modification ordering for state
 		if !stakerToRemove.Priority.IsPendingDelegator() {
 			continue
 		}

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -191,11 +191,13 @@ func advanceTimeTo(
 
 		// Buffer state changes so that we can perform validator updates before delegator updates to respect state's
 		// expected order of operations.
+		promotion := promotion{pending: stakerToRemove, current: &stakerToAdd}
+
 		switch {
 		case stakerToRemove.Priority.IsPendingValidator():
-			validatorPromotions = append(validatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
+			validatorPromotions = append(validatorPromotions, promotion)
 		case stakerToRemove.Priority.IsPendingDelegator():
-			delegatorPromotions = append(delegatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
+			delegatorPromotions = append(delegatorPromotions, promotion)
 		default:
 			return nil, false, fmt.Errorf("expected staker priority got %d", stakerToRemove.Priority)
 		}

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -192,7 +192,7 @@ func advanceTimeTo(
 		// Buffer state changes so that we can perform validator updates before delegator updates to respect state's
 		// expected order of operations.
 		switch stakerToRemove.Priority {
-		case txs.PrimaryNetworkValidatorPendingPriority, txs.SubnetPermissionlessValidatorPendingPriority:
+		case txs.PrimaryNetworkValidatorPendingPriority, txs.SubnetPermissionlessValidatorPendingPriority, txs.SubnetPermissionedValidatorPendingPriority:
 			validatorPromotions = append(validatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
 		case txs.PrimaryNetworkDelegatorApricotPendingPriority, txs.PrimaryNetworkDelegatorBanffPendingPriority, txs.SubnetPermissionlessDelegatorPendingPriority:
 			delegatorPromotions = append(delegatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -159,6 +159,7 @@ func advanceTimeTo(
 
 		stakerToAdd := newCurrentStakerFromPendingStaker(stakerToRemove)
 
+		// Only permissionless networks (including the primary network) are eligible for minting rewards
 		if stakerToRemove.Priority != txs.SubnetPermissionedValidatorPendingPriority {
 			potentialReward, err := mintReward(backend, parentState, changes, stakerToRemove)
 			if err != nil {

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -127,73 +127,79 @@ func advanceTimeTo(
 
 	// Promote any pending stakers to current if [StartTime] <= [newChainTime].
 	//
+	// Pending validators are promoted before pending delegators so that when we attempt to promote a current delegator,
+	// the current validator exists to satisfy a defensive check that a current delegator being added must have an
+	// existing current validator.
+	//
+	// Pending stakers are ordered such that ties in Staker.NextTime are broken by Staker.Priority. It is possible for a
+	// tie to result in an Apricot pending delegator being ordered before a pending validator, so we must do two passes
+	// to promote pending validators before pending delegators to respect the expected ordering.
+	//
 	// Invariant: It is not safe to modify the state while iterating over it,
 	// so we use the parentState's iterator rather than the changes iterator.
-	// ParentState must not be modified before this iterator is released.
-	pendingStakerIterator, err := parentState.GetPendingStakerIterator()
+	// ParentState must not be modified before each iterator is released.
+	var changed bool
+
+	pendingValidatorIterator, err := parentState.GetPendingStakerIterator()
 	if err != nil {
 		return nil, false, err
 	}
-	defer pendingStakerIterator.Release()
 
-	var changed bool
-	for pendingStakerIterator.Next() {
-		stakerToRemove := pendingStakerIterator.Value()
+	defer pendingValidatorIterator.Release()
+	for pendingValidatorIterator.Next() {
+		stakerToRemove := pendingValidatorIterator.Value()
 		if stakerToRemove.StartTime.After(newChainTime) {
 			break
 		}
-
-		stakerToAdd := *stakerToRemove
-		stakerToAdd.NextTime = stakerToRemove.EndTime
-		stakerToAdd.Priority = txs.PendingToCurrentPriorities[stakerToRemove.Priority]
-
-		if stakerToRemove.Priority == txs.SubnetPermissionedValidatorPendingPriority {
-			if err := changes.PutCurrentValidator(&stakerToAdd); err != nil {
-				return nil, false, err
-			}
-			changes.DeletePendingValidator(stakerToRemove)
-			changed = true
+		if !stakerToRemove.Priority.IsPendingValidator() {
 			continue
 		}
 
-		supply, err := changes.GetCurrentSupply(stakerToRemove.SubnetID)
-		if err != nil {
-			return nil, false, err
-		}
+		stakerToAdd := newCurrentStakerFromPendingStaker(stakerToRemove)
 
-		rewards, err := GetRewardsCalculator(backend, parentState, stakerToRemove.SubnetID)
-		if err != nil {
-			return nil, false, err
-		}
-
-		potentialReward := rewards.Calculate(
-			stakerToRemove.EndTime.Sub(stakerToRemove.StartTime),
-			stakerToRemove.Weight,
-			supply,
-		)
-		stakerToAdd.PotentialReward = potentialReward
-
-		// Invariant: [rewards.Calculate] can never return a [potentialReward]
-		//            such that [supply + potentialReward > maximumSupply].
-		changes.SetCurrentSupply(stakerToRemove.SubnetID, supply+potentialReward)
-
-		switch stakerToRemove.Priority {
-		case txs.PrimaryNetworkValidatorPendingPriority, txs.SubnetPermissionlessValidatorPendingPriority:
-			if err := changes.PutCurrentValidator(&stakerToAdd); err != nil {
+		if stakerToRemove.Priority != txs.SubnetPermissionedValidatorPendingPriority {
+			potentialReward, err := mintReward(backend, parentState, changes, stakerToRemove)
+			if err != nil {
 				return nil, false, err
 			}
-			changes.DeletePendingValidator(stakerToRemove)
-
-		case txs.PrimaryNetworkDelegatorApricotPendingPriority, txs.PrimaryNetworkDelegatorBanffPendingPriority, txs.SubnetPermissionlessDelegatorPendingPriority:
-			if err := changes.PutCurrentDelegator(&stakerToAdd); err != nil {
-				return nil, false, fmt.Errorf("putting current delegator: %w", err)
-			}
-			changes.DeletePendingDelegator(stakerToRemove)
-
-		default:
-			return nil, false, fmt.Errorf("expected staker priority got %d", stakerToRemove.Priority)
+			stakerToAdd.PotentialReward = potentialReward
 		}
 
+		if err := changes.PutCurrentValidator(stakerToAdd); err != nil {
+			return nil, false, err
+		}
+		changes.DeletePendingValidator(stakerToRemove)
+		changed = true
+	}
+
+	pendingDelegatorIterator, err := parentState.GetPendingStakerIterator()
+	if err != nil {
+		return nil, false, err
+	}
+
+	defer pendingDelegatorIterator.Release()
+	for pendingDelegatorIterator.Next() {
+		stakerToRemove := pendingDelegatorIterator.Value()
+		if stakerToRemove.StartTime.After(newChainTime) {
+			break
+		}
+		if !stakerToRemove.Priority.IsPendingDelegator() {
+			continue
+		}
+
+		stakerToAdd := newCurrentStakerFromPendingStaker(stakerToRemove)
+
+		potentialReward, err := mintReward(backend, parentState, changes, stakerToRemove)
+		if err != nil {
+			return nil, false, err
+		}
+		stakerToAdd.PotentialReward = potentialReward
+
+		if err := changes.PutCurrentDelegator(stakerToAdd); err != nil {
+			return nil, false, fmt.Errorf("putting current delegator: %w", err)
+		}
+
+		changes.DeletePendingDelegator(stakerToRemove)
 		changed = true
 	}
 
@@ -256,6 +262,45 @@ func advanceTimeTo(
 
 	changes.SetTimestamp(newChainTime)
 	return changes, changed, nil
+}
+
+// newCurrentStakerFromPendingStaker returns a copy of pending as a current staker.
+func newCurrentStakerFromPendingStaker(pending *state.Staker) *state.Staker {
+	current := *pending
+	current.NextTime = pending.EndTime
+	current.Priority = txs.PendingToCurrentPriorities[pending.Priority]
+
+	return &current
+}
+
+// mintReward calculates the potential reward for a pending staker being promoted to current and applies the resulting
+// supply update to changes.
+func mintReward(
+	backend *Backend,
+	parentState state.Chain,
+	changes *state.Diff,
+	staker *state.Staker,
+) (uint64, error) {
+	supply, err := changes.GetCurrentSupply(staker.SubnetID)
+	if err != nil {
+		return 0, err
+	}
+
+	rewards, err := GetRewardsCalculator(backend, parentState, staker.SubnetID)
+	if err != nil {
+		return 0, err
+	}
+
+	potentialReward := rewards.Calculate(
+		staker.EndTime.Sub(staker.StartTime),
+		staker.Weight,
+		supply,
+	)
+
+	// Invariant: rewards.Calculate can never return a potentialReward such that
+	// supply + potentialReward > maximumSupply.
+	changes.SetCurrentSupply(staker.SubnetID, supply+potentialReward)
+	return potentialReward, nil
 }
 
 // Remove all expiries whose timestamp now implies they can never be re-issued.

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -191,10 +191,10 @@ func advanceTimeTo(
 
 		// Buffer state changes so that we can perform validator updates before delegator updates to respect state's
 		// expected order of operations.
-		switch stakerToRemove.Priority {
-		case txs.PrimaryNetworkValidatorPendingPriority, txs.SubnetPermissionlessValidatorPendingPriority, txs.SubnetPermissionedValidatorPendingPriority:
+		switch {
+		case stakerToRemove.Priority.IsPendingValidator():
 			validatorPromotions = append(validatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
-		case txs.PrimaryNetworkDelegatorApricotPendingPriority, txs.PrimaryNetworkDelegatorBanffPendingPriority, txs.SubnetPermissionlessDelegatorPendingPriority:
+		case stakerToRemove.Priority.IsPendingDelegator():
 			delegatorPromotions = append(delegatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
 		default:
 			return nil, false, fmt.Errorf("expected staker priority got %d", stakerToRemove.Priority)

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -191,10 +191,13 @@ func advanceTimeTo(
 
 		// Buffer state changes so that we can perform validator updates before delegator updates to respect state's
 		// expected order of operations.
-		if stakerToRemove.Priority.IsPendingValidator() {
+		switch stakerToRemove.Priority {
+		case txs.PrimaryNetworkValidatorPendingPriority, txs.SubnetPermissionlessValidatorPendingPriority:
 			validatorPromotions = append(validatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
-		} else {
+		case txs.PrimaryNetworkDelegatorApricotPendingPriority, txs.PrimaryNetworkDelegatorBanffPendingPriority, txs.SubnetPermissionlessDelegatorPendingPriority:
 			delegatorPromotions = append(delegatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
+		default:
+			return nil, false, fmt.Errorf("expected staker priority got %d", stakerToRemove.Priority)
 		}
 	}
 

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -184,8 +184,8 @@ func advanceTimeTo(
 			)
 			stakerToAdd.PotentialReward = potentialReward
 
-			// Invariant: [rewards.Calculate] can never return a [potentialReward]
-			//            such that [supply + potentialReward > maximumSupply].
+			// Invariant: reward.Calculator.Calculate can never return a potentialReward
+			//            such that supply + potentialReward > maximumSupply.
 			changes.SetCurrentSupply(stakerToRemove.SubnetID, supply+potentialReward)
 		}
 

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -133,80 +133,86 @@ func advanceTimeTo(
 	//
 	// Pending stakers are ordered such that ties in Staker.NextTime are broken by Staker.Priority. It is possible for a
 	// tie to result in an Apricot pending delegator being ordered before a pending validator, so we must do two passes
-	// to promote pending validators before pending delegators to respect the expected ordering.
+	// to promote pending validators before pending delegators to respect the expected ordering. Rewards however must be
+	// performed in the original staker iterator ordering to respect the historical ordering.
 	//
 	// Invariant: It is not safe to modify the state while iterating over it,
 	// so we use the parentState's iterator rather than the changes iterator.
-	// ParentState must not be modified before each iterator is released.
-	var changed bool
+	// ParentState must not be modified before this iterator is released.
+	type promotion struct {
+		pending *state.Staker
+		current *state.Staker
+	}
 
-	pendingValidatorIterator, err := parentState.GetPendingStakerIterator()
+	var (
+		validatorPromotions []promotion
+		delegatorPromotions []promotion
+	)
+
+	pendingStakerIterator, err := parentState.GetPendingStakerIterator()
 	if err != nil {
 		return nil, false, err
 	}
+	defer pendingStakerIterator.Release()
 
-	defer pendingValidatorIterator.Release()
-	for pendingValidatorIterator.Next() {
-		stakerToRemove := pendingValidatorIterator.Value()
+	for pendingStakerIterator.Next() {
+		stakerToRemove := pendingStakerIterator.Value()
 		if stakerToRemove.StartTime.After(newChainTime) {
 			break
 		}
 
-		// Iterate over validators first to preserve expected modification ordering for state
-		if !stakerToRemove.Priority.IsPendingValidator() {
-			continue
-		}
+		stakerToAdd := *stakerToRemove
+		stakerToAdd.NextTime = stakerToRemove.EndTime
+		stakerToAdd.Priority = txs.PendingToCurrentPriorities[stakerToRemove.Priority]
 
-		stakerToAdd := newCurrentStakerFromPendingStaker(stakerToRemove)
-
-		// Only permissionless networks (including the primary network) are eligible for minting rewards
+		// Only permissionless networks (including the primary network) are eligible for rewards
 		if stakerToRemove.Priority != txs.SubnetPermissionedValidatorPendingPriority {
-			potentialReward, err := mintReward(backend, parentState, changes, stakerToRemove)
+			supply, err := changes.GetCurrentSupply(stakerToRemove.SubnetID)
 			if err != nil {
 				return nil, false, err
 			}
+
+			rewards, err := GetRewardsCalculator(backend, parentState, stakerToRemove.SubnetID)
+			if err != nil {
+				return nil, false, err
+			}
+
+			potentialReward := rewards.Calculate(
+				stakerToRemove.EndTime.Sub(stakerToRemove.StartTime),
+				stakerToRemove.Weight,
+				supply,
+			)
 			stakerToAdd.PotentialReward = potentialReward
+
+			// Invariant: [rewards.Calculate] can never return a [potentialReward]
+			//            such that [supply + potentialReward > maximumSupply].
+			changes.SetCurrentSupply(stakerToRemove.SubnetID, supply+potentialReward)
 		}
 
-		if err := changes.PutCurrentValidator(stakerToAdd); err != nil {
-			return nil, false, err
+		// Buffer state changes so that we can perform validator updates before delegator updates to respect state's
+		// expected order of operations.
+		if stakerToRemove.Priority.IsPendingValidator() {
+			validatorPromotions = append(validatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
+		} else {
+			delegatorPromotions = append(delegatorPromotions, promotion{pending: stakerToRemove, current: &stakerToAdd})
 		}
-		changes.DeletePendingValidator(stakerToRemove)
-		changed = true
 	}
 
-	pendingDelegatorIterator, err := parentState.GetPendingStakerIterator()
-	if err != nil {
-		return nil, false, err
+	for _, p := range validatorPromotions {
+		if err := changes.PutCurrentValidator(p.current); err != nil {
+			return nil, false, fmt.Errorf("putting current validator: %w", err)
+		}
+		changes.DeletePendingValidator(p.pending)
 	}
 
-	defer pendingDelegatorIterator.Release()
-	for pendingDelegatorIterator.Next() {
-		stakerToRemove := pendingDelegatorIterator.Value()
-		if stakerToRemove.StartTime.After(newChainTime) {
-			break
-		}
-
-		// Iterate over delegators last to preserve expected modification ordering for state
-		if !stakerToRemove.Priority.IsPendingDelegator() {
-			continue
-		}
-
-		stakerToAdd := newCurrentStakerFromPendingStaker(stakerToRemove)
-
-		potentialReward, err := mintReward(backend, parentState, changes, stakerToRemove)
-		if err != nil {
-			return nil, false, err
-		}
-		stakerToAdd.PotentialReward = potentialReward
-
-		if err := changes.PutCurrentDelegator(stakerToAdd); err != nil {
+	for _, p := range delegatorPromotions {
+		if err := changes.PutCurrentDelegator(p.current); err != nil {
 			return nil, false, fmt.Errorf("putting current delegator: %w", err)
 		}
-
-		changes.DeletePendingDelegator(stakerToRemove)
-		changed = true
+		changes.DeletePendingDelegator(p.pending)
 	}
+
+	changed := len(validatorPromotions) > 0 || len(delegatorPromotions) > 0
 
 	// Remove any current stakers whose [EndTime] <= [newChainTime].
 	//
@@ -267,45 +273,6 @@ func advanceTimeTo(
 
 	changes.SetTimestamp(newChainTime)
 	return changes, changed, nil
-}
-
-// newCurrentStakerFromPendingStaker returns a copy of pending as a current staker.
-func newCurrentStakerFromPendingStaker(pending *state.Staker) *state.Staker {
-	current := *pending
-	current.NextTime = pending.EndTime
-	current.Priority = txs.PendingToCurrentPriorities[pending.Priority]
-
-	return &current
-}
-
-// mintReward calculates the potential reward for a pending staker being promoted to current and applies the resulting
-// supply update to changes.
-func mintReward(
-	backend *Backend,
-	parentState state.Chain,
-	changes *state.Diff,
-	staker *state.Staker,
-) (uint64, error) {
-	supply, err := changes.GetCurrentSupply(staker.SubnetID)
-	if err != nil {
-		return 0, err
-	}
-
-	rewards, err := GetRewardsCalculator(backend, parentState, staker.SubnetID)
-	if err != nil {
-		return 0, err
-	}
-
-	potentialReward := rewards.Calculate(
-		staker.EndTime.Sub(staker.StartTime),
-		staker.Weight,
-		supply,
-	)
-
-	// Invariant: rewards.Calculate can never return a potentialReward such that
-	// supply + potentialReward > maximumSupply.
-	changes.SetCurrentSupply(staker.SubnetID, supply+potentialReward)
-	return potentialReward, nil
 }
 
 // Remove all expiries whose timestamp now implies they can never be re-issued.

--- a/vms/platformvm/txs/executor/state_changes_test.go
+++ b/vms/platformvm/txs/executor/state_changes_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
@@ -26,7 +27,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/state/statetest"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validators/fee"
-	"github.com/ava-labs/avalanchego/database"
 )
 
 func TestAdvanceTimeTo_UpdatesFeeState(t *testing.T) {
@@ -384,10 +384,10 @@ func TestAdvanceTimeTo_PromotePendingDelegatorAndValidator(t *testing.T) {
 	)
 
 	require.NoError(t, s.PutPendingValidator(&state.Staker{
-		TxID:      ids.GenerateTestID(),
-		NodeID:    nodeID,
-		SubnetID:  constants.PrimaryNetworkID,
-		Weight:    units.MilliAvax,
+		TxID:     ids.GenerateTestID(),
+		NodeID:   nodeID,
+		SubnetID: constants.PrimaryNetworkID,
+		Weight:   units.MilliAvax,
 		// Both the validator and delegator share a start time to have their iteration order broken by their priority
 		StartTime: startTime,
 		EndTime:   endTime,
@@ -396,10 +396,10 @@ func TestAdvanceTimeTo_PromotePendingDelegatorAndValidator(t *testing.T) {
 	}))
 
 	s.PutPendingDelegator(&state.Staker{
-		TxID:      ids.GenerateTestID(),
-		NodeID:    nodeID,
-		SubnetID:  constants.PrimaryNetworkID,
-		Weight:    units.MilliAvax,
+		TxID:     ids.GenerateTestID(),
+		NodeID:   nodeID,
+		SubnetID: constants.PrimaryNetworkID,
+		Weight:   units.MilliAvax,
 		// Both the validator and delegator share a start time to have their iteration order broken by their priority
 		StartTime: startTime,
 		EndTime:   endTime,

--- a/vms/platformvm/txs/executor/state_changes_test.go
+++ b/vms/platformvm/txs/executor/state_changes_test.go
@@ -449,3 +449,81 @@ func TestAdvanceTimeTo_PromotePendingDelegatorAndValidator(t *testing.T) {
 
 	require.False(t, pendingDelegatorItr.Next())
 }
+
+// TestAdvanceTimeTo_PromotePendingDelegatorAndValidator_PreservesRewardOrder tests that promoting pending stakers mints
+// rewards in the historical pending staking iterator order.
+func TestAdvanceTimeTo_PromotePendingDelegatorAndValidator_PreservesRewardOrder(t *testing.T) {
+	s := statetest.New(t, statetest.Config{})
+
+	var (
+		startTime       = s.GetTimestamp().Add(time.Second)
+		endTime         = startTime.Add(14 * 24 * time.Hour)
+		nodeID          = ids.GenerateTestNodeID()
+		validatorWeight = 2 * units.MegaAvax
+		delegatorWeight = units.KiloAvax
+	)
+
+	require.NoError(t, s.PutPendingValidator(&state.Staker{
+		TxID:      ids.GenerateTestID(),
+		NodeID:    nodeID,
+		SubnetID:  constants.PrimaryNetworkID,
+		Weight:    validatorWeight,
+		StartTime: startTime,
+		EndTime:   endTime,
+		NextTime:  startTime,
+		Priority:  txs.PrimaryNetworkValidatorPendingPriority,
+	}))
+
+	s.PutPendingDelegator(&state.Staker{
+		TxID:      ids.GenerateTestID(),
+		NodeID:    nodeID,
+		SubnetID:  constants.PrimaryNetworkID,
+		Weight:    delegatorWeight,
+		StartTime: startTime,
+		EndTime:   endTime,
+		NextTime:  startTime,
+		Priority:  txs.PrimaryNetworkDelegatorApricotPendingPriority,
+	})
+
+	rewards := reward.NewCalculator(reward.Config{
+		MaxConsumptionRate: .12 * reward.PercentDenominator,
+		MinConsumptionRate: .1 * reward.PercentDenominator,
+		MintingPeriod:      365 * 24 * time.Hour,
+		SupplyCap:          720 * units.MegaAvax,
+	})
+
+	initialSupply, err := s.GetCurrentSupply(constants.PrimaryNetworkID)
+	require.NoError(t, err)
+
+	duration := endTime.Sub(startTime)
+	wantDelegatorReward := rewards.Calculate(duration, delegatorWeight, initialSupply)
+	wantValidatorReward := rewards.Calculate(duration, validatorWeight, initialSupply+wantDelegatorReward)
+
+	_, err = AdvanceTimeTo(
+		&Backend{
+			Config: &config.Internal{
+				DynamicFeeConfig:   genesis.LocalParams.DynamicFeeConfig,
+				ValidatorFeeConfig: genesis.LocalParams.ValidatorFeeConfig,
+				UpgradeConfig:      upgradetest.GetConfig(upgradetest.Latest),
+			},
+			Rewards: rewards,
+		},
+		s,
+		startTime,
+	)
+	require.NoError(t, err)
+
+	gotValidator, err := s.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, wantValidatorReward, gotValidator.PotentialReward)
+
+	delegatorItr, err := s.GetCurrentDelegatorIterator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	defer delegatorItr.Release()
+	require.True(t, delegatorItr.Next())
+	require.Equal(t, wantDelegatorReward, delegatorItr.Value().PotentialReward)
+
+	gotSupply, err := s.GetCurrentSupply(constants.PrimaryNetworkID)
+	require.NoError(t, err)
+	require.Equal(t, initialSupply+wantDelegatorReward+wantValidatorReward, gotSupply)
+}

--- a/vms/platformvm/txs/executor/state_changes_test.go
+++ b/vms/platformvm/txs/executor/state_changes_test.go
@@ -388,6 +388,7 @@ func TestAdvanceTimeTo_PromotePendingDelegatorAndValidator(t *testing.T) {
 		NodeID:    nodeID,
 		SubnetID:  constants.PrimaryNetworkID,
 		Weight:    units.MilliAvax,
+		// Both the validator and delegator share a start time to have their iteration order broken by their priority
 		StartTime: startTime,
 		EndTime:   endTime,
 		NextTime:  startTime,
@@ -399,21 +400,14 @@ func TestAdvanceTimeTo_PromotePendingDelegatorAndValidator(t *testing.T) {
 		NodeID:    nodeID,
 		SubnetID:  constants.PrimaryNetworkID,
 		Weight:    units.MilliAvax,
+		// Both the validator and delegator share a start time to have their iteration order broken by their priority
 		StartTime: startTime,
 		EndTime:   endTime,
 		NextTime:  startTime,
 		Priority:  txs.PrimaryNetworkDelegatorApricotPendingPriority,
 	})
 
-	nextStakerChangeTime, err := state.GetNextStakerChangeTime(
-		genesis.LocalParams.ValidatorFeeConfig,
-		s,
-		mockable.MaxTime,
-	)
-	require.NoError(t, err)
-	require.False(t, startTime.After(nextStakerChangeTime))
-
-	ok, err := AdvanceTimeTo(
+	updated, err := AdvanceTimeTo(
 		&Backend{
 			Config: &config.Internal{
 				DynamicFeeConfig:   genesis.LocalParams.DynamicFeeConfig,
@@ -431,7 +425,7 @@ func TestAdvanceTimeTo_PromotePendingDelegatorAndValidator(t *testing.T) {
 		startTime,
 	)
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.True(t, updated)
 
 	// Check that the stakers got promoted to current
 	gotValidator, err := s.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)

--- a/vms/platformvm/txs/executor/state_changes_test.go
+++ b/vms/platformvm/txs/executor/state_changes_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/utils/iterator"
@@ -20,9 +21,12 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis/genesistest"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state/statetest"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validators/fee"
+	"github.com/ava-labs/avalanchego/database"
 )
 
 func TestAdvanceTimeTo_UpdatesFeeState(t *testing.T) {
@@ -365,4 +369,89 @@ func TestAdvanceTimeTo_UpdateL1Validators(t *testing.T) {
 			require.Equal(uint64(secondsToAdvance), s.GetAccruedFees())
 		})
 	}
+}
+
+// Regression test for a case where a pending delegator and validator are promoted to current stakers. Only Apricot can
+// trip this regression, because after Apricot pending validators always sort before pending delegators according to
+// txs.Priority.
+func TestAdvanceTimeTo_PromotePendingDelegatorAndValidator(t *testing.T) {
+	s := statetest.New(t, statetest.Config{})
+
+	var (
+		startTime = s.GetTimestamp().Add(time.Second)
+		endTime   = startTime.Add(14 * 24 * time.Hour)
+		nodeID    = ids.GenerateTestNodeID()
+	)
+
+	require.NoError(t, s.PutPendingValidator(&state.Staker{
+		TxID:      ids.GenerateTestID(),
+		NodeID:    nodeID,
+		SubnetID:  constants.PrimaryNetworkID,
+		Weight:    units.MilliAvax,
+		StartTime: startTime,
+		EndTime:   endTime,
+		NextTime:  startTime,
+		Priority:  txs.PrimaryNetworkValidatorPendingPriority,
+	}))
+
+	s.PutPendingDelegator(&state.Staker{
+		TxID:      ids.GenerateTestID(),
+		NodeID:    nodeID,
+		SubnetID:  constants.PrimaryNetworkID,
+		Weight:    units.MilliAvax,
+		StartTime: startTime,
+		EndTime:   endTime,
+		NextTime:  startTime,
+		Priority:  txs.PrimaryNetworkDelegatorApricotPendingPriority,
+	})
+
+	nextStakerChangeTime, err := state.GetNextStakerChangeTime(
+		genesis.LocalParams.ValidatorFeeConfig,
+		s,
+		mockable.MaxTime,
+	)
+	require.NoError(t, err)
+	require.False(t, startTime.After(nextStakerChangeTime))
+
+	ok, err := AdvanceTimeTo(
+		&Backend{
+			Config: &config.Internal{
+				DynamicFeeConfig:   genesis.LocalParams.DynamicFeeConfig,
+				ValidatorFeeConfig: genesis.LocalParams.ValidatorFeeConfig,
+				UpgradeConfig:      upgradetest.GetConfig(upgradetest.Latest),
+			},
+			Rewards: reward.NewCalculator(reward.Config{
+				MaxConsumptionRate: .12 * reward.PercentDenominator,
+				MinConsumptionRate: .1 * reward.PercentDenominator,
+				MintingPeriod:      365 * 24 * time.Hour,
+				SupplyCap:          720 * units.MegaAvax,
+			}),
+		},
+		s,
+		startTime,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Check that the stakers got promoted to current
+	gotValidator, err := s.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, txs.PrimaryNetworkValidatorCurrentPriority, gotValidator.Priority)
+
+	currentDelegatorItr, err := s.GetCurrentDelegatorIterator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	defer currentDelegatorItr.Release()
+
+	require.True(t, currentDelegatorItr.Next())
+	require.Equal(t, txs.PrimaryNetworkDelegatorCurrentPriority, currentDelegatorItr.Value().Priority)
+
+	// Check that they are no longer pending
+	_, err = s.GetPendingValidator(constants.PrimaryNetworkID, nodeID)
+	require.Equal(t, database.ErrNotFound, err)
+
+	pendingDelegatorItr, err := s.GetPendingDelegatorIterator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	defer pendingDelegatorItr.Release()
+
+	require.False(t, pendingDelegatorItr.Next())
 }


### PR DESCRIPTION
## Why this should be merged

Historical blocks where a pending validator + delegator have the same timestamp break ties by priority, and apricot pending delegators are higher than pending validators in priority. This means that when promoting delgators, we try adding them to the current staker set before their validators have been added which is an invalid intermediary state, tripping the defensive check added by https://github.com/ava-labs/avalanchego/pull/5040.

This tripped a failure when verifying a historical block
```
failed to verify block 2MvZ8Xy4boxG12S8oKJM9XdM2LvoGhXbiLKAxdZDMng8oJBjqx (height=99272, parentID=2ACC7GaHrQhbKfs3xs5Vtm3LMPUyrqTmHrREhjWpe7H7mhAc6x) in bootstrapping: putting current delegator: getting current validator: not found with last accepted 2ACC7GaHrQhbKfs3xs5Vtm3LMPUyrqTmHrREhjWpe7H7mhAc6x (height=99271) while processing sync message: ancestors from NodeID-NpagUxt6KQiwPch9Sd4osv8kD1TZnkjdk
```

## How this works

Iterates over pending validators before pending delegators to avoid tripping the defensive check

## How this was tested

Regression test fails on master:
```
=== RUN   TestAdvanceTimeTo_PromotePendingDelegatorAndValidator
    state_changes_test.go:433: 
        	Error Trace:	/Users/joshua.kim/workspace/avalanchego/vms/platformvm/txs/executor/state_changes_test.go:433
        	Error:      	Received unexpected error:
        	            	putting current delegator: getting current validator: not found
        	Test:       	TestAdvanceTimeTo_PromotePendingDelegatorAndValidator
```

Also was able to sync past the previously failing block at `height=99272`:
```
[05-19|13:03:33.947] INFO <P Chain> bootstrap/storage.go:195 executing blocks {"numToExecute": 278442}
[05-19|13:04:19.317] INFO <P Chain> bootstrap/storage.go:252 executing blocks {"numExecuted": 44418, "numToExecute": 278442, "eta": "4m39s", "pctComplete": 15.95}
[05-19|13:04:24.374] INFO <P Chain> bootstrap/storage.go:252 executing blocks {"numExecuted": 44465, "numToExecute": 278442, "eta": "4h56m51s", "pctComplete": 15.97}
[05-19|13:04:29.374] INFO <P Chain> bootstrap/storage.go:252 executing blocks {"numExecuted": 47743, "numToExecute": 278442, "eta": "53m52s", "pctComplete": 17.15}
[05-19|13:04:34.383] INFO <P Chain> bootstrap/storage.go:252 executing blocks {"numExecuted": 65886, "numToExecute": 278442, "eta": "8m30s", "pctComplete": 23.66}
[05-19|13:04:39.383] INFO <P Chain> bootstrap/storage.go:252 executing blocks {"numExecuted": 81448, "numToExecute": 278442, "eta": "4m33s", "pctComplete": 29.25}
[05-19|13:04:44.383] INFO <P Chain> bootstrap/storage.go:252 executing blocks {"numExecuted": 92452, "numToExecute": 278442, "eta": "3m18s", "pctComplete": 33.2}
[05-19|13:04:49.384] INFO <P Chain> bootstrap/storage.go:252 executing blocks {"numExecuted": 103786, "numToExecute": 278442, "eta": "2m29s", "pctComplete": 37.27}
[05-19|13:04:54.384] INFO <P Chain> bootstrap/storage.go:252 executing blocks {"numExecuted": 109476, "numToExecute": 278442, "eta": "2m11s", "pctComplete": 39.32}
```
## Need to be documented in RELEASES.md?

No
