### PR TITLE
[ci] Ensure useful output when a required job fails

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -37,10 +37,19 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "$NEEDS_JSON" | jq -e '
-            to_entries
-            | all(.value.result == "success")
-          ' >/dev/null
+          failed_jobs="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success")
+              | .key
+            ' <<<"$NEEDS_JSON"
+          )"
+
+          if [[ -n "$failed_jobs" ]]; then
+            echo "Required jobs failed:"
+            printf '%s\n' "$failed_jobs"
+            exit 1
+          fi
 
   # Check Bazel metadata first so stale generated files fail with one
   # actionable error instead of cascading into multiple Bazel build/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,19 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "$NEEDS_JSON" | jq -e '
-            to_entries
-            | all(.value.result == "success")
-          ' >/dev/null
+          failed_jobs="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success")
+              | .key
+            ' <<<"$NEEDS_JSON"
+          )"
+
+          if [[ -n "$failed_jobs" ]]; then
+            echo "Required jobs failed:"
+            printf '%s\n' "$failed_jobs"
+            exit 1
+          fi
 
   Unit:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/coreth-ci.yml
+++ b/.github/workflows/coreth-ci.yml
@@ -24,10 +24,19 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "$NEEDS_JSON" | jq -e '
-            to_entries
-            | all(.value.result == "success")
-          ' >/dev/null
+          failed_jobs="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success")
+              | .key
+            ' <<<"$NEEDS_JSON"
+          )"
+
+          if [[ -n "$failed_jobs" ]]; then
+            echo "Required jobs failed:"
+            printf '%s\n' "$failed_jobs"
+            exit 1
+          fi
 
   lint_test:
     name: Lint

--- a/.github/workflows/evm-ci.yml
+++ b/.github/workflows/evm-ci.yml
@@ -23,10 +23,19 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "$NEEDS_JSON" | jq -e '
-            to_entries
-            | all(.value.result == "success")
-          ' >/dev/null
+          failed_jobs="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success")
+              | .key
+            ' <<<"$NEEDS_JSON"
+          )"
+
+          if [[ -n "$failed_jobs" ]]; then
+            echo "Required jobs failed:"
+            printf '%s\n' "$failed_jobs"
+            exit 1
+          fi
 
   lint_test:
     name: Lint

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -28,10 +28,19 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "$NEEDS_JSON" | jq -e '
-            to_entries
-            | all(.value.result == "success")
-          ' >/dev/null
+          failed_jobs="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success")
+              | .key
+            ' <<<"$NEEDS_JSON"
+          )"
+
+          if [[ -n "$failed_jobs" ]]; then
+            echo "Required jobs failed:"
+            printf '%s\n' "$failed_jobs"
+            exit 1
+          fi
 
   lint_test:
     name: Lint


### PR DESCRIPTION
## Why this should be merged

Previously the failure of a required job would produce no useful output to indicate the nature of the failure. While the github UI does provide a useful visual indication of which jobs failed, the logs of a required job should also provide useful output.

## How this works
 
Adds a new shared script defining more useful required job behavior. 

## How this was tested

- [Test PR](https://github.com/ava-labs/avalanchego/pull/5397) shows an [indication of failure](https://github.com/ava-labs/avalanchego/actions/runs/26119844195/job/76821454054?pr=5397):
```
Required jobs failed:
Unit
```
