### PR TITLE
test: poll for new image while waiting for node health

### DIFF
--- a/tests/fixture/bootstrapmonitor/README.md
+++ b/tests/fixture/bootstrapmonitor/README.md
@@ -125,7 +125,7 @@ The intention of `bootstrap-monitor` is to enable a Kubernetes [StatefulSet](htt
          serialized to a file on the data volume
      - If the images are the same, the data volume is used as-is to
        enable resuming an in-progress test.
- - `bootstrap-monitor wait-for-completion` is intended to run as a sidecar of the avalanchego container. It polls the health of the node container to detect when a bootstrap test has completed successfully, and it also polls for a new image while waiting. When a new image is found, the managing `StatefulSet` is updated with    the details of the image to trigger a new test. The process to detect a new image is the same as was described for the `init` command.
+ - `bootstrap-monitor wait-for-completion` is intended to run as a sidecar of the avalanchego container. It polls the health of the node container to detect when a bootstrap test has completed successfully, and it also polls for a new image while waiting. When a new image is found, the managing `StatefulSet` is updated with the details of the image to trigger a new test. The process to detect a new image is the same as was described for the `init` command.
 
 ## Package details
 

--- a/tests/fixture/bootstrapmonitor/README.md
+++ b/tests/fixture/bootstrapmonitor/README.md
@@ -39,7 +39,7 @@ processed. This is configured by including
 
 ## Overview
 
-The intention of `bootstrap-monitor` is to enable a Kubernetes [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) to perform continuous bootstrap testing for a given avalanchego configuration. It ensures that a testing pod either starts or resume a test, polls for a new image while the test is running, and initiates a new test when one is found.
+The intention of `bootstrap-monitor` is to enable a Kubernetes [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) to perform continuous bootstrap testing for a given avalanchego configuration. It ensures that a testing pod either starts or resumes a test, polls for a new image while the test is running, and initiates a new test when one is found.
 
  - Both the `init` and `wait-for-completion` commands of the
    `bootstrap-monitor` binary are intended to run as containers of a

--- a/tests/fixture/bootstrapmonitor/README.md
+++ b/tests/fixture/bootstrapmonitor/README.md
@@ -39,12 +39,7 @@ processed. This is configured by including
 
 ## Overview
 
-The intention of `bootstrap-monitor` is to enable a Kubernetes
-[StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
-to perform continuous bootstrap testing for a given avalanchego
-configuration. It ensures that a testing pod either starts or resumes
-a test, and upon completion of a test, polls for a new image to test
-and initiates a new test when one is found.
+The intention of `bootstrap-monitor` is to enable a Kubernetes [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) to perform continuous bootstrap testing for a given avalanchego configuration. It ensures that a testing pod either starts or resume a test, polls for a new image while the test is running, and initiates a new test when one is found.
 
  - Both the `init` and `wait-for-completion` commands of the
    `bootstrap-monitor` binary are intended to run as containers of a
@@ -130,13 +125,7 @@ and initiates a new test when one is found.
          serialized to a file on the data volume
      - If the images are the same, the data volume is used as-is to
        enable resuming an in-progress test.
- - `bootstrap-monitor wait-for-completion` is intended to run as a
-   sidecar of the avalanchego container. It polls the health of the
-   node container to detect when a bootstrap test has completed
-   successfully and then polls for a new image to test. When a new
-   image is found, the managing `StatefulSet` is updated with the
-   details of the image to trigger a new test. The process to detect a
-   new image is the same as was described for the `init` command.
+ - `bootstrap-monitor wait-for-completion` is intended to run as a sidecar of the avalanchego container. It polls the health of the node container to detect when a bootstrap test has completed successfully, and it also polls for a new image while waiting. When a new image is found, the managing `StatefulSet` is updated with    the details of the image to trigger a new test. The process to detect a new image is the same as was described for the `init` command.
 
 ## Package details
 

--- a/tests/fixture/bootstrapmonitor/wait.go
+++ b/tests/fixture/bootstrapmonitor/wait.go
@@ -26,6 +26,10 @@ import (
 const (
 	contextDuration = 30 * time.Second
 
+	// Block until the StatefulSet recreates the pod, as exiting sooner
+	// would let the kubelet restart the container with the old image.
+	postUpdateGracePeriod = 5 * time.Minute
+
 	ImageUnchanged = "Image unchanged"
 )
 
@@ -77,42 +81,38 @@ func WaitForCompletion(
 	}
 
 	log.Info("Waiting for node to report healthy")
-	if err := wait.PollImmediateInfinite(healthCheckInterval, func() (bool, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), contextDuration)
+	var (
+		bootstrapped       bool
+		nextImageCheckTime = time.Now().Add(imageCheckInterval)
+	)
+	if err := wait.PollUntilContextCancel(context.Background(), healthCheckInterval, true, func(pollCtx context.Context) (bool, error) {
+		ctx, cancel := context.WithTimeout(pollCtx, contextDuration)
 		defer cancel()
 
-		// Define common fields for logging
-		diskUsage := getDiskUsage(log, dataDir)
-		commonFields := []zap.Field{
-			zap.String("diskUsage", diskUsage),
-			zap.Duration("duration", time.Since(testDetails.StartTime)),
-		}
-
-		// Check whether the node is reporting healthy which indicates that bootstrap is complete
-		if healthy, err := tmpnet.CheckNodeHealth(ctx, nodeURL); err != nil {
-			log.Error("failed to check node health", zap.Error(err))
-			return false, nil
-		} else {
-			if !healthy.Healthy {
-				log.Info("Node reported unhealthy", commonFields...)
-				return false, nil
+		if !bootstrapped {
+			commonFields := []zap.Field{
+				zap.String("diskUsage", getDiskUsage(log, dataDir)),
+				zap.Duration("duration", time.Since(testDetails.StartTime)),
 			}
-
-			log.Info("Node reported healthy")
+			healthy, err := tmpnet.CheckNodeHealth(ctx, nodeURL)
+			switch {
+			case err != nil:
+				log.Error("failed to check node health", zap.Error(err))
+			case healthy.Healthy:
+				bootstrapped = true
+				log.Info("Bootstrap completed successfully",
+					append(commonFields, zap.Reflect("testConfig", testConfig))...,
+				)
+				log.Info("Waiting for new image to test")
+			default:
+				log.Info("Node reported unhealthy", commonFields...)
+			}
 		}
 
-		commonFields = append(commonFields, zap.Reflect("testConfig", testConfig))
-		log.Info("Bootstrap completed successfully", commonFields...)
-
-		return true, nil
-	}); err != nil {
-		return fmt.Errorf("failed to wait for node to report healthy: %w", err)
-	}
-
-	log.Info("Waiting for new image to test")
-	if err := wait.PollImmediateInfinite(imageCheckInterval, func() (bool, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), contextDuration)
-		defer cancel()
+		if time.Now().Before(nextImageCheckTime) {
+			return false, nil
+		}
+		nextImageCheckTime = time.Now().Add(imageCheckInterval)
 
 		log.Info("Starting pod to get the image id for the `master` tag")
 		masterImageDetails, err := getMasterImageDetails(ctx, log, clientset, namespace, testConfig.Image, nodeContainerName)
@@ -136,15 +136,12 @@ func WaitForCompletion(
 			log.Error("failed to set container image", zap.Error(err))
 			return false, nil
 		}
-
-		// Statefulset will restart the pod with the new image
 		return true, nil
 	}); err != nil {
-		return fmt.Errorf("failed to wait for new image to test: %w", err)
+		return fmt.Errorf("failed to wait for completion: %w", err)
 	}
 
-	// Avoid exiting immediately to avoid container restart before the pod is recreated with the new image
-	time.Sleep(5 * time.Minute)
+	time.Sleep(postUpdateGracePeriod)
 	return nil
 }
 

--- a/tests/fixture/bootstrapmonitor/wait.go
+++ b/tests/fixture/bootstrapmonitor/wait.go
@@ -82,7 +82,8 @@ func WaitForCompletion(
 
 	log.Info("Waiting for node to report healthy")
 	var (
-		bootstrapped       bool
+		bootstrapped bool
+		// Defer the first check as the node hasn't begun bootstrapping yet.
 		nextImageCheckTime = time.Now().Add(imageCheckInterval)
 	)
 	if err := wait.PollUntilContextCancel(context.Background(), healthCheckInterval, true, func(pollCtx context.Context) (bool, error) {
@@ -104,11 +105,15 @@ func WaitForCompletion(
 					append(commonFields, zap.Reflect("testConfig", testConfig))...,
 				)
 				log.Info("Waiting for new image to test")
+				// Check immediately in case `master` is already updated.
+				nextImageCheckTime = time.Now()
 			default:
 				log.Info("Node reported unhealthy", commonFields...)
 			}
 		}
 
+		// Assumes imageCheckInterval >= healthCheckInterval (the outer poll
+		// cadence). The defaults of 5m / 1m satisfy this.
 		if time.Now().Before(nextImageCheckTime) {
 			return false, nil
 		}


### PR DESCRIPTION
 ## Why this should be merged

If a node breaks while testing, and fails to ever report healthy, current gets stuck in the bootstrapmonitor's `wait-for-completion` stage indefinitely. The image-update poll only runs *after* the health-poll loop returns, so a node stuck on a buggy build never gets refreshed with a fix from `master` -- we have to manually ping the infra team to fix it, as we don't have access to these machines. 

## How this works
For each iteration: 

1.  While not yet bootstrapped, checks node health. On healthy, sets the `bootstrapped` flag and logs success.
2.  Always checks for an updated `master`  image. If found, patches the `StatefulSet` and returns.

## How this was tested

You can see the [run](https://github.com/ava-labs/avalanchego/actions/runs/26138856665), here including the`Run bootstrap monitor e2e tests` job that ran the refactored loop. So we know the bootstrap flow still works. 

I did not admittedly test the "stuck-unhealthy" -> "image still updates". I'm not really sure how to test this, as this is itself a test. Maybe I could extend the e2e with a deliberately-broken-config case if desired? 

## Need to be documented in RELEASES.md?
No
