### PR TITLE
[bazel] Check for duplicate go_library defs in BUILD.bazel files

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -198,6 +198,10 @@ tasks:
       - task: bazel-sync-module-metadata
       - task: check-clean-branch
 
+  check-bazel-multiple-go-libraries:
+    desc: Check that each BUILD.bazel defines at most one go_library
+    cmd: '{{.NIX_RUN}} ./scripts/check_bazel_multiple_go_libraries.sh'
+
   check-clean-branch:
     desc: Checks that the git working tree is clean
     cmd: '{{.NIX_RUN}} .github/workflows/check-clean-branch.sh'

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -486,6 +486,18 @@ task bazel-clean-all              # or: bazel clean --expunge
 task bazel-check-metadata
 ```
 
+As part of `bazel-check-metadata`, package-local `BUILD.bazel` files are
+expected to define at most one `go_library` rule. Multiple
+`go_library` rules in one directory are usually stale metadata left
+behind by a package rename or move, where Gazelle added the new rule
+without removing the old checked-in one.
+
+This repo prefers linting for that stale-rule pattern rather than
+deleting and regenerating all non-curated `BUILD.bazel` files. The lint
+is narrower and safer: it fails on the specific suspicious state we want
+to prevent, without relying on a maintained list of which BUILD files
+are safe to destroy and recreate from scratch.
+
 In CI, the Bazel workflow runs `bazel-check-metadata` before Bazel build
 and test jobs. This makes stale metadata fail with a single actionable
 error instead of surfacing later as multiple downstream Bazel failures.

--- a/scripts/check_bazel_metadata.sh
+++ b/scripts/check_bazel_metadata.sh
@@ -27,6 +27,10 @@ if ! ./scripts/run_task.sh check-bazel-gazelle-generate; then
   exit 1
 fi
 
+if ! ./scripts/run_task.sh check-bazel-multiple-go-libraries; then
+  exit 1
+fi
+
 # Must run after fmt and gazelle since either could modify source BUILD
 # files in .bazel/patches/build_files/. In practice gazelle skips them
 # (they have `# gazelle:ignore`) but buildifier will reformat them.

--- a/scripts/check_bazel_multiple_go_libraries.sh
+++ b/scripts/check_bazel_multiple_go_libraries.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Gazelle can add a replacement go_library when a package/importpath is renamed
+# without removing the old rule from the checked-in BUILD.bazel.  Bazel then attempts
+# to build both targets, and the stale one often references files that no longer
+# exist. This check keeps the policy simple: package-local BUILD.bazel files should
+# define at most one go_library rule, so stale rename content fails early under
+# bazel-check-metadata instead of surfacing later as a compile error.
+
+set -euo pipefail
+
+if ! [[ "$0" =~ scripts/check_bazel_multiple_go_libraries.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+failed=0
+
+while IFS= read -r -d '' build_file; do
+  count=$(
+    awk '
+      /^[[:space:]]*go_library\($/ {
+        count++
+      }
+      END {
+        print count + 0
+      }
+    ' "${build_file}"
+  )
+
+  if (( count > 1 )); then
+    echo "${build_file}: contains ${count} go_library rules"
+    failed=1
+  fi
+done < <(
+  find . \
+    -path './.git' -prune -o \
+    -path './.direnv' -prune -o \
+    -path './bazel-*' -prune -o \
+    -path './.bazel/patches/build_files' -prune -o \
+    -name 'BUILD.bazel' -type f -print0
+)
+
+if (( failed )); then
+  cat >&2 <<'EOF'
+Each BUILD.bazel file must define at most one go_library rule.
+Multiple go_library rules in one directory are usually stale metadata from a package rename or move.
+Remove the duplicate rule and rerun:
+  task bazel-check-metadata
+EOF
+  exit 1
+fi


### PR DESCRIPTION
## Why this should be merged

A package rename in #5209 resulted in the unit test job failure due to gazelle adding a `go_library` definition for the new package name but not removing the now-stale `go_library` definition for the previous package name. This is a deficiency of gazelle - it doesn't clean up when packages are renamed. The simplest solution is to to lint on duplicate `go_library` definitions.

## How this was tested

 - Created a [test PR](https://github.com/ava-labs/avalanchego/pull/5410) adding a duplicate go_library definition failed its metadata checks
   - https://github.com/ava-labs/avalanchego/actions/runs/26185983641/job/77041517280?pr=5410
