### PR TITLE
test: stop fuzzing merkledb

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,7 +23,6 @@ jobs:
           - codec
           - utils
           - x/archivedb
-          - x/merkledb
           - vms/platformvm
           - vms/evm
           - vms/saevm


### PR DESCRIPTION
## Why this should be merged

MerkleDB is not used in production and is not expected to become production code. Its fuzz shard still runs in scheduled CI despite only covering the deprecated MerkleDB implementation. It flakes a lot and isn't under development, so the only real thing it does is fail our daily fuzz runs. 

## How this works
Removes x/merkledb from the scheduled fuzz workflow matrix.

## How this was tested
N/A

## Need to be documented in RELEASES.md?
N/A