### PR TITLE
network: reject non-positive timer frequencies

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -522,10 +522,10 @@ func getNetworkConfig(
 		return network.Config{}, fmt.Errorf("%s must be in [0,1]", NetworkHealthMaxPortionSendQueueFillKey)
 	case config.DialerConfig.ConnectionTimeout < 0:
 		return network.Config{}, fmt.Errorf("%q must be >= 0", NetworkOutboundConnectionTimeoutKey)
-	case config.PeerListPullGossipFreq < 0:
-		return network.Config{}, fmt.Errorf("%s must be >= 0", NetworkPeerListPullGossipFreqKey)
-	case config.PeerListBloomResetFreq < 0:
-		return network.Config{}, fmt.Errorf("%s must be >= 0", NetworkPeerListBloomResetFreqKey)
+	case config.PeerListPullGossipFreq <= 0:
+		return network.Config{}, fmt.Errorf("%s must be > 0", NetworkPeerListPullGossipFreqKey)
+	case config.PeerListBloomResetFreq <= 0:
+		return network.Config{}, fmt.Errorf("%s must be > 0", NetworkPeerListBloomResetFreqKey)
 	case config.ThrottlerConfig.InboundMsgThrottlerConfig.CPUThrottlerConfig.MaxRecheckDelay < constants.MinInboundThrottlerMaxRecheckDelay:
 		return network.Config{}, fmt.Errorf("%s must be >= %d", InboundThrottlerCPUMaxRecheckDelayKey, constants.MinInboundThrottlerMaxRecheckDelay)
 	case config.ThrottlerConfig.InboundMsgThrottlerConfig.DiskThrottlerConfig.MaxRecheckDelay < constants.MinInboundThrottlerMaxRecheckDelay:
@@ -546,6 +546,8 @@ func getNetworkConfig(
 		return network.Config{}, fmt.Errorf("%s must be >= 0", NetworkReadHandshakeTimeoutKey)
 	case config.MaxClockDifference < 0:
 		return network.Config{}, fmt.Errorf("%s must be >= 0", NetworkMaxClockDifferenceKey)
+	case config.UptimeMetricFreq <= 0:
+		return network.Config{}, fmt.Errorf("%s must be > 0", UptimeMetricFreqKey)
 	}
 	return config, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -970,6 +970,54 @@ func TestGetDiskSpaceConfig(t *testing.T) {
 	}
 }
 
+func TestGetNetworkConfigRejectsNonPositiveTickerFrequencies(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value time.Duration
+	}{
+		{
+			name: "zero peer list pull gossip frequency",
+			key:  NetworkPeerListPullGossipFreqKey,
+		},
+		{
+			name:  "negative peer list pull gossip frequency",
+			key:   NetworkPeerListPullGossipFreqKey,
+			value: -time.Second,
+		},
+		{
+			name: "zero peer list bloom reset frequency",
+			key:  NetworkPeerListBloomResetFreqKey,
+		},
+		{
+			name:  "negative peer list bloom reset frequency",
+			key:   NetworkPeerListBloomResetFreqKey,
+			value: -time.Second,
+		},
+		{
+			name: "zero uptime metric frequency",
+			key:  UptimeMetricFreqKey,
+		},
+		{
+			name:  "negative uptime metric frequency",
+			key:   UptimeMetricFreqKey,
+			value: -time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			v := setupViperFlags()
+			v.Set(tt.key, tt.value)
+
+			_, err := getNetworkConfig(v, constants.UnitTestID, false, time.Second)
+
+			require.ErrorContains(err, fmt.Sprintf("%s must be > 0", tt.key))
+		})
+	}
+}
+
 // setups config json file and writes content
 func setupConfigJSON(t *testing.T, rootPath string, value string) string {
 	configFilePath := filepath.Join(rootPath, "config.json")


### PR DESCRIPTION
## Summary

- reject non-positive durations for network timer-backed config values
- cover peer-list pull gossip, peer-list bloom reset, and uptime metric frequencies
- add regression coverage for zero and negative values

## Root cause

`network.runTimers` creates tickers directly from configured durations. `time.NewTicker` panics for non-positive durations, but config parsing allowed `0` for the peer-list frequencies and did not guard the uptime metric frequency.

Closes #5416

## Testing

- `go test ./config -run TestGetNetworkConfigRejectsNonPositiveTickerFrequencies -count=1`
- `go test ./config ./network -count=1`