### PR TITLE
chore: log if the Firewood database is empty

### DIFF
--- a/graft/evm/firewood/triedb.go
+++ b/graft/evm/firewood/triedb.go
@@ -170,6 +170,10 @@ func New(config TrieDBConfig) (*TrieDB, error) {
 	}
 
 	initialRoot := fw.Root()
+	if initialRoot == ffi.EmptyRoot {
+		log.Debug("firewood opened with no committed revisions", "path", path)
+	}
+
 	blockHashes := make(map[common.Hash]struct{})
 	blockHashes[common.Hash{}] = struct{}{}
 	return &TrieDB{

--- a/graft/evm/firewood/triedb.go
+++ b/graft/evm/firewood/triedb.go
@@ -171,7 +171,9 @@ func New(config TrieDBConfig) (*TrieDB, error) {
 
 	initialRoot := fw.Root()
 	if initialRoot == ffi.EmptyRoot {
-		log.Debug("firewood opened with no committed revisions", "path", path)
+		log.Debug("empty firewood database opened", "path", path)
+	} else {
+		log.Debug("firewood database opened", "root", initialRoot, "path", path)
 	}
 
 	blockHashes := make(map[common.Hash]struct{})


### PR DESCRIPTION
## Why this should be merged

Recently, we had a node migration where all data was copied except the Firewood database file. As a result, the node failed to start up post-migration, printing the following error message:

```
{"level":"fatal","timestamp":"2026-05-16T02:34:17.327Z","caller":"chains/manager.go:396","msg":"error creating required chain","subnetID":"11111111111111111111111111111111LpoYY","chainID":"2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse
55x1Q5","vmID":"mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6","error":"error while creating new snowman vm failed to initialize inner VM: required historical state unavailable (reexec=8192)"}
```

SSHing into the node revealed that the Firewood database file was missing. Just looking at the logs that were printed, it was not clear that the Firewood database file was missing.

## How this works

When opening the Firewood database, if the latest revision state root is the empty root, we print the following debug statement:

```
firewood opened with no committed revisions, path ...
```

This information is incredibly useful in the node that the node fails to start up - it provides a stronger signal that the Firewood database is empty rather than the current logs (if it is).

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
