### PR TITLE
test(sae): Race in block source test

### DIFF
--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1025,6 +1025,7 @@ func TestBlockSources(t *testing.T) {
 	settled := sut.runConsensusLoop(t)
 	vmTime.advanceToSettle(ctx, t, settled)
 	unsettled := sut.runConsensusLoop(t)
+	require.NoErrorf(t, unsettled.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", unsettled)
 
 	verified := sut.createAndVerifyBlock(t, unsettled)
 	unverified := sut.buildAndParseBlock(t, unwrap(t, verified))


### PR DESCRIPTION
## Why this should be merged

A race was seen in [CI](https://github.com/ava-labs/avalanchego/actions/runs/26301919160/job/77428970783).

## How this works

the race is from execution writing to atomic pointers, and the test reading from them. Although no data would be corrupted, and whether the block executed or not is more-or-less unrelated to the test, we can just wait until the block is executed to guarantee behavior.

## How this was tested

Inspection, and CI still passes

## Need to be documented in RELEASES.md?

No