### PR TITLE
Revert state.Database registration

### DIFF
--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -432,7 +432,7 @@ func NewBlockChain(
 		quit:              make(chan struct{}),
 		acceptedLogsCache: NewFIFOCache[common.Hash, [][]*types.Log](cacheConfig.AcceptedCacheSize),
 	}
-	bc.stateCache = state.NewDatabaseWithNodeDB(bc.db, bc.triedb)
+	bc.stateCache = extstate.NewDatabaseWithNodeDB(bc.db, bc.triedb)
 	bc.validator = NewBlockValidator(chainConfig, bc, engine)
 	bc.processor = NewStateProcessor(chainConfig, bc, engine)
 
@@ -2213,7 +2213,7 @@ func (bc *BlockChain) ResetToStateSyncedBlock(block *types.Block) error {
 	bc.hc.SetCurrentHeader(block.Header())
 
 	lastAcceptedHash := block.Hash()
-	bc.stateCache = state.NewDatabaseWithNodeDB(bc.db, bc.triedb)
+	bc.stateCache = extstate.NewDatabaseWithNodeDB(bc.db, bc.triedb)
 
 	if err := bc.loadLastState(lastAcceptedHash); err != nil {
 		return err

--- a/graft/coreth/core/extstate/BUILD.bazel
+++ b/graft/coreth/core/extstate/BUILD.bazel
@@ -9,6 +9,7 @@ package(default_visibility = [
 go_library(
     name = "extstate",
     srcs = [
+        "database.go",
         "options.go",
         "statedb.go",
     ],
@@ -16,13 +17,16 @@ go_library(
     deps = [
         "//graft/coreth/params",
         "//graft/coreth/plugin/evm/customtypes",
+        "//graft/evm/firewood",
         "//graft/evm/utils",
         "//vms/evm/predicate",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/state",
         "@com_github_ava_labs_libevm//core/types",
+        "@com_github_ava_labs_libevm//ethdb",
         "@com_github_ava_labs_libevm//libevm",
         "@com_github_ava_labs_libevm//libevm/stateconf",
+        "@com_github_ava_labs_libevm//triedb",
         "@com_github_holiman_uint256//:uint256",
     ],
 )

--- a/graft/coreth/core/extstate/database.go
+++ b/graft/coreth/core/extstate/database.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package extstate
+
+import (
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/triedb"
+
+	"github.com/ava-labs/avalanchego/graft/evm/firewood"
+)
+
+func NewDatabaseWithConfig(db ethdb.Database, config *triedb.Config) state.Database {
+	coredb := state.NewDatabaseWithConfig(db, config)
+	return wrapIfFirewood(coredb)
+}
+
+func NewDatabaseWithNodeDB(db ethdb.Database, triedb *triedb.Database) state.Database {
+	coredb := state.NewDatabaseWithNodeDB(db, triedb)
+	return wrapIfFirewood(coredb)
+}
+
+func wrapIfFirewood(db state.Database) state.Database {
+	fw, ok := db.TrieDB().Backend().(*firewood.TrieDB)
+	if !ok {
+		return db
+	}
+	return firewood.NewStateAccessor(db, fw)
+}

--- a/graft/coreth/core/genesis.go
+++ b/graft/coreth/core/genesis.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ava-labs/avalanchego/graft/coreth/core/extstate"
 	"github.com/ava-labs/avalanchego/graft/coreth/params"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/customtypes"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/upgrade/ap3"
@@ -248,7 +249,7 @@ func (g *Genesis) trieConfig() *triedb.Config {
 
 // TODO: migrate this function to "flush" for more similarity with upstream.
 func (g *Genesis) toBlock(db ethdb.Database, triedb *triedb.Database) (*types.Block, error) {
-	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseWithNodeDB(db, triedb), nil)
+	statedb, err := state.New(types.EmptyRootHash, extstate.NewDatabaseWithNodeDB(db, triedb), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/graft/coreth/eth/BUILD.bazel
+++ b/graft/coreth/eth/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//graft/coreth/consensus",
         "//graft/coreth/core",
+        "//graft/coreth/core/extstate",
         "//graft/coreth/core/txpool",
         "//graft/coreth/core/txpool/legacypool",
         "//graft/coreth/eth/ethconfig",
@@ -68,6 +69,7 @@ graft_go_test(
     ],
     embed = [":eth"],
     deps = [
+        "//graft/coreth/core/extstate",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/rawdb",
         "@com_github_ava_labs_libevm//core/state",

--- a/graft/coreth/eth/api_debug_test.go
+++ b/graft/coreth/eth/api_debug_test.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/graft/coreth/core/extstate"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/state"
@@ -74,7 +75,7 @@ func TestAccountRange(t *testing.T) {
 	t.Parallel()
 
 	var (
-		statedb = state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{Preimages: true})
+		statedb = extstate.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{Preimages: true})
 		sdb, _  = state.New(types.EmptyRootHash, statedb, nil)
 		addrs   = [AccountRangeMaxResults * 2]common.Address{}
 		m       = map[common.Address]bool{}
@@ -171,7 +172,7 @@ func TestStorageRangeAt(t *testing.T) {
 
 	// Create a state where account 0x010000... has a few storage entries.
 	var (
-		db          = state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{Preimages: true})
+		db          = extstate.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{Preimages: true})
 		sdb, _      = state.New(types.EmptyRootHash, db, nil)
 		addr        = common.Address{0x01}
 		keys        = []common.Hash{}

--- a/graft/coreth/eth/state_accessor.go
+++ b/graft/coreth/eth/state_accessor.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/graft/coreth/core"
+	"github.com/ava-labs/avalanchego/graft/coreth/core/extstate"
 	"github.com/ava-labs/avalanchego/graft/coreth/eth/tracers"
 	"github.com/ava-labs/avalanchego/graft/evm/firewood"
 	"github.com/ava-labs/avalanchego/vms/evm/sync/customrawdb"
@@ -83,7 +84,7 @@ func (eth *Ethereum) hashState(ctx context.Context, block *types.Block, reexec u
 			// the internal junks created by tracing will be persisted into the disk.
 			// TODO(rjl493456442), clean cache is disabled to prevent memory leak,
 			// please re-enable it for better performance.
-			database = state.NewDatabaseWithConfig(eth.chainDb, triedb.HashDefaults)
+			database = extstate.NewDatabaseWithConfig(eth.chainDb, triedb.HashDefaults)
 			if statedb, err = state.New(block.Root(), database, nil); err == nil {
 				log.Info("Found disk backend for state trie", "root", block.Root(), "number", block.Number())
 				return statedb, noopReleaser, nil
@@ -101,7 +102,7 @@ func (eth *Ethereum) hashState(ctx context.Context, block *types.Block, reexec u
 		// TODO(rjl493456442), clean cache is disabled to prevent memory leak,
 		// please re-enable it for better performance.
 		tdb = triedb.NewDatabase(eth.chainDb, triedb.HashDefaults)
-		database = state.NewDatabaseWithNodeDB(eth.chainDb, tdb)
+		database = extstate.NewDatabaseWithNodeDB(eth.chainDb, tdb)
 
 		// If we didn't check the live database, do check state over ephemeral database,
 		// otherwise we would rewind past a persisted block (specific corner case is
@@ -395,7 +396,7 @@ func (eth *Ethereum) inMemoryGenesisDB() (state.Database, error) {
 	if _, err := eth.config.Genesis.Commit(db, tdb); err != nil {
 		return nil, err
 	}
-	return state.NewDatabaseWithNodeDB(db, tdb), nil
+	return extstate.NewDatabaseWithNodeDB(db, tdb), nil
 }
 
 // stateAtBlock retrieves the state database associated with a certain block.

--- a/graft/coreth/tests/BUILD.bazel
+++ b/graft/coreth/tests/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     srcs = ["state_test_util.go"],
     importpath = "github.com/ava-labs/avalanchego/graft/coreth/tests",
     deps = [
+        "//graft/coreth/core/extstate",
         "//graft/evm/core/state/snapshot",
         "//graft/evm/firewood",
         "//graft/evm/triedb/hashdb",

--- a/graft/coreth/tests/state_test_util.go
+++ b/graft/coreth/tests/state_test_util.go
@@ -30,6 +30,7 @@ package tests
 import (
 	"os"
 
+	"github.com/ava-labs/avalanchego/graft/coreth/core/extstate"
 	"github.com/ava-labs/avalanchego/graft/evm/core/state/snapshot"
 	"github.com/ava-labs/avalanchego/graft/evm/firewood"
 	"github.com/ava-labs/avalanchego/graft/evm/triedb/hashdb"
@@ -74,7 +75,7 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bo
 	}
 
 	triedb := triedb.NewDatabase(db, tconf)
-	sdb := state.NewDatabaseWithNodeDB(db, triedb)
+	sdb := extstate.NewDatabaseWithNodeDB(db, triedb)
 	statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)

--- a/graft/evm/firewood/BUILD.bazel
+++ b/graft/evm/firewood/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "account_trie.go",
         "base_trie.go",
+        "metrics.go",
         "reconstructed_state.go",
         "reconstructed_trie.go",
         "state.go",

--- a/graft/evm/firewood/hash_test.go
+++ b/graft/evm/firewood/hash_test.go
@@ -84,6 +84,8 @@ func newFuzzState(t *testing.T) *fuzzState {
 			DBOverride: fwCfg.BackendConstructor,
 		},
 	)
+	fwTDB := firewoodState.TrieDB().Backend().(*TrieDB)
+	firewoodState = NewStateAccessor(firewoodState, fwTDB)
 	fwTr, err := firewoodState.OpenTrie(ethRoot)
 	r.NoError(err)
 	t.Cleanup(func() {

--- a/graft/evm/firewood/metrics.go
+++ b/graft/evm/firewood/metrics.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/log"
+)
+
+func init() {
+	if err := ffi.StartMetrics(); err != nil {
+		log.Crit("starting firewood metrics", "error", err)
+	}
+}

--- a/graft/evm/firewood/state.go
+++ b/graft/evm/firewood/state.go
@@ -6,18 +6,9 @@ package firewood
 import (
 	"fmt"
 
-	"github.com/ava-labs/firewood-go-ethhash/ffi"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
-	"github.com/ava-labs/libevm/log"
 )
-
-func init() {
-	state.RegisterDatabaseInterceptor(wrapIfFirewood)
-	if err := ffi.StartMetrics(); err != nil {
-		log.Crit("starting firewood metrics", "error", err)
-	}
-}
 
 var _ state.Database = (*stateAccessor)(nil)
 
@@ -26,11 +17,7 @@ type stateAccessor struct {
 	triedb *TrieDB
 }
 
-func wrapIfFirewood(db state.Database) state.Database {
-	fw, ok := db.TrieDB().Backend().(*TrieDB)
-	if !ok {
-		return db
-	}
+func NewStateAccessor(db state.Database, fw *TrieDB) state.Database {
 	return &stateAccessor{
 		Database: db,
 		triedb:   fw,

--- a/graft/evm/firewood/triedb_test.go
+++ b/graft/evm/firewood/triedb_test.go
@@ -25,16 +25,19 @@ func newTestDatabase(t *testing.T) state.Database {
 
 func newTestDatabaseWithConfig(t *testing.T, cfg TrieDBConfig) state.Database {
 	t.Helper()
-
-	memdb := rawdb.NewMemoryDatabase()
-	tdb := triedb.NewDatabase(memdb, &triedb.Config{
+	triedbConfig := &triedb.Config{
 		DBOverride: cfg.BackendConstructor,
-	})
+	}
+	internalState := state.NewDatabaseWithConfig(
+		rawdb.NewMemoryDatabase(),
+		triedbConfig,
+	)
+	tdb := internalState.TrieDB().Backend().(*TrieDB)
 	t.Cleanup(func() {
 		require.NoError(t, tdb.Close())
 	})
 
-	return state.NewDatabaseWithNodeDB(memdb, tdb)
+	return NewStateAccessor(internalState, tdb)
 }
 
 func TestCommitEmptyGenesis(t *testing.T) {

--- a/graft/evm/sync/evmstate/firewood_syncer_test.go
+++ b/graft/evm/sync/evmstate/firewood_syncer_test.go
@@ -186,12 +186,14 @@ func createDB(t *testing.T) state.Database {
 	triedbConfig := &triedb.Config{
 		DBOverride: config.BackendConstructor,
 	}
-
-	cache := state.NewDatabaseWithConfig(diskdb, triedbConfig)
+	// Create the state database using libevm's state package, then wrap it with
+	// firewood.NewStateAccessor to avoid an import cycle between firewood and state packages.
+	internalState := state.NewDatabaseWithConfig(diskdb, triedbConfig)
+	tdb := internalState.TrieDB().Backend().(*firewood.TrieDB)
 	t.Cleanup(func() {
-		require.NoError(t, cache.TrieDB().Close())
+		require.NoError(t, tdb.Close())
 	})
-	return cache
+	return firewood.NewStateAccessor(internalState, tdb)
 }
 
 func assertFirewoodConsistency(t *testing.T, root common.Hash, clientState state.Database, accounts map[*utilstest.Key]*types.StateAccount) {

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -449,7 +449,7 @@ func NewBlockChain(
 		quit:                make(chan struct{}),
 		acceptedLogsCache:   NewFIFOCache[common.Hash, [][]*types.Log](cacheConfig.AcceptedCacheSize),
 	}
-	bc.stateCache = state.NewDatabaseWithNodeDB(bc.db, bc.triedb)
+	bc.stateCache = extstate.NewDatabaseWithNodeDB(bc.db, bc.triedb)
 	bc.validator = NewBlockValidator(chainConfig, bc, engine)
 	bc.processor = NewStateProcessor(chainConfig, bc, engine)
 
@@ -2252,7 +2252,7 @@ func (bc *BlockChain) ResetToStateSyncedBlock(block *types.Block) error {
 	bc.hc.SetCurrentHeader(block.Header())
 
 	lastAcceptedHash := block.Hash()
-	bc.stateCache = state.NewDatabaseWithNodeDB(bc.db, bc.triedb)
+	bc.stateCache = extstate.NewDatabaseWithNodeDB(bc.db, bc.triedb)
 
 	if err := bc.loadLastState(lastAcceptedHash); err != nil {
 		return err

--- a/graft/subnet-evm/core/extstate/BUILD.bazel
+++ b/graft/subnet-evm/core/extstate/BUILD.bazel
@@ -8,16 +8,20 @@ package(default_visibility = [
 go_library(
     name = "extstate",
     srcs = [
+        "database.go",
         "options.go",
         "statedb.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/core/extstate",
     deps = [
+        "//graft/evm/firewood",
         "//graft/evm/utils",
         "//graft/subnet-evm/params",
         "//vms/evm/predicate",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/state",
         "@com_github_ava_labs_libevm//core/types",
+        "@com_github_ava_labs_libevm//ethdb",
+        "@com_github_ava_labs_libevm//triedb",
     ],
 )

--- a/graft/subnet-evm/core/extstate/database.go
+++ b/graft/subnet-evm/core/extstate/database.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package extstate
+
+import (
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/triedb"
+
+	"github.com/ava-labs/avalanchego/graft/evm/firewood"
+)
+
+func NewDatabaseWithConfig(db ethdb.Database, config *triedb.Config) state.Database {
+	coredb := state.NewDatabaseWithConfig(db, config)
+	return wrapIfFirewood(coredb)
+}
+
+func NewDatabaseWithNodeDB(db ethdb.Database, triedb *triedb.Database) state.Database {
+	coredb := state.NewDatabaseWithNodeDB(db, triedb)
+	return wrapIfFirewood(coredb)
+}
+
+func wrapIfFirewood(db state.Database) state.Database {
+	fw, ok := db.TrieDB().Backend().(*firewood.TrieDB)
+	if !ok {
+		return db
+	}
+	return firewood.NewStateAccessor(db, fw)
+}

--- a/graft/subnet-evm/core/genesis.go
+++ b/graft/subnet-evm/core/genesis.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/graft/evm/firewood"
 	"github.com/ava-labs/avalanchego/graft/evm/triedb/pathdb"
+	"github.com/ava-labs/avalanchego/graft/subnet-evm/core/extstate"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/params"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/params/extras"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/customtypes"
@@ -273,7 +274,7 @@ func (g *Genesis) trieConfig() *triedb.Config {
 
 // TODO: migrate this function to "flush" for more similarity with upstream.
 func (g *Genesis) toBlock(db ethdb.Database, triedb *triedb.Database) (*types.Block, error) {
-	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseWithNodeDB(db, triedb), nil)
+	statedb, err := state.New(types.EmptyRootHash, extstate.NewDatabaseWithNodeDB(db, triedb), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/graft/subnet-evm/eth/BUILD.bazel
+++ b/graft/subnet-evm/eth/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//graft/subnet-evm/commontype",
         "//graft/subnet-evm/consensus",
         "//graft/subnet-evm/core",
+        "//graft/subnet-evm/core/extstate",
         "//graft/subnet-evm/core/txpool",
         "//graft/subnet-evm/core/txpool/legacypool",
         "//graft/subnet-evm/eth/ethconfig",
@@ -69,6 +70,7 @@ graft_go_test(
     ],
     embed = [":eth"],
     deps = [
+        "//graft/subnet-evm/core/extstate",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/rawdb",
         "@com_github_ava_labs_libevm//core/state",

--- a/graft/subnet-evm/eth/api_debug_test.go
+++ b/graft/subnet-evm/eth/api_debug_test.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/graft/subnet-evm/core/extstate"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/state"
@@ -75,7 +76,7 @@ func TestAccountRange(t *testing.T) {
 	t.Parallel()
 
 	var (
-		statedb = state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{Preimages: true})
+		statedb = extstate.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{Preimages: true})
 		sdb, _  = state.New(types.EmptyRootHash, statedb, nil)
 		addrs   = [AccountRangeMaxResults * 2]common.Address{}
 		m       = map[common.Address]bool{}
@@ -172,7 +173,7 @@ func TestStorageRangeAt(t *testing.T) {
 
 	// Create a state where account 0x010000... has a few storage entries.
 	var (
-		db     = state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{Preimages: true})
+		db     = extstate.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{Preimages: true})
 		sdb, _ = state.New(types.EmptyRootHash, db, nil)
 		addr   = common.Address{0x01}
 		keys   = []common.Hash{ // hashes of Keys of storage

--- a/graft/subnet-evm/eth/state_accessor.go
+++ b/graft/subnet-evm/eth/state_accessor.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/graft/evm/firewood"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/core"
+	"github.com/ava-labs/avalanchego/graft/subnet-evm/core/extstate"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/eth/tracers"
 	"github.com/ava-labs/avalanchego/vms/evm/sync/customrawdb"
 	"github.com/ava-labs/firewood-go-ethhash/ffi"
@@ -83,7 +84,7 @@ func (eth *Ethereum) hashState(ctx context.Context, block *types.Block, reexec u
 			// the internal junks created by tracing will be persisted into the disk.
 			// TODO(rjl493456442), clean cache is disabled to prevent memory leak,
 			// please re-enable it for better performance.
-			database = state.NewDatabaseWithConfig(eth.chainDb, triedb.HashDefaults)
+			database = extstate.NewDatabaseWithConfig(eth.chainDb, triedb.HashDefaults)
 			if statedb, err = state.New(block.Root(), database, nil); err == nil {
 				log.Info("Found disk backend for state trie", "root", block.Root(), "number", block.Number())
 				return statedb, noopReleaser, nil
@@ -101,7 +102,7 @@ func (eth *Ethereum) hashState(ctx context.Context, block *types.Block, reexec u
 		// TODO(rjl493456442), clean cache is disabled to prevent memory leak,
 		// please re-enable it for better performance.
 		tdb = triedb.NewDatabase(eth.chainDb, triedb.HashDefaults)
-		database = state.NewDatabaseWithNodeDB(eth.chainDb, tdb)
+		database = extstate.NewDatabaseWithNodeDB(eth.chainDb, tdb)
 
 		// If we didn't check the live database, do check state over ephemeral database,
 		// otherwise we would rewind past a persisted block (specific corner case is
@@ -395,7 +396,7 @@ func (eth *Ethereum) inMemoryGenesisDB() (state.Database, error) {
 	if _, err := eth.config.Genesis.Commit(db, tdb); err != nil {
 		return nil, err
 	}
-	return state.NewDatabaseWithNodeDB(db, tdb), nil
+	return extstate.NewDatabaseWithNodeDB(db, tdb), nil
 }
 
 // stateAtBlock retrieves the state database associated with a certain block.

--- a/graft/subnet-evm/tests/BUILD.bazel
+++ b/graft/subnet-evm/tests/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//graft/evm/firewood",
         "//graft/evm/triedb/hashdb",
         "//graft/evm/triedb/pathdb",
+        "//graft/subnet-evm/core/extstate",
         "//vms/evm/sync/customrawdb",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/rawdb",

--- a/graft/subnet-evm/tests/state_test_util.go
+++ b/graft/subnet-evm/tests/state_test_util.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ava-labs/avalanchego/graft/evm/firewood"
 	"github.com/ava-labs/avalanchego/graft/evm/triedb/hashdb"
 	"github.com/ava-labs/avalanchego/graft/evm/triedb/pathdb"
+	"github.com/ava-labs/avalanchego/graft/subnet-evm/core/extstate"
 	"github.com/ava-labs/avalanchego/vms/evm/sync/customrawdb"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -74,7 +75,7 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bo
 	}
 
 	triedb := triedb.NewDatabase(db, tconf)
-	sdb := state.NewDatabaseWithNodeDB(db, triedb)
+	sdb := extstate.NewDatabaseWithNodeDB(db, triedb)
 	statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)


### PR DESCRIPTION
## Why this should be merged

#5314 was made pre-emptively - the original plan was to share firewood implementations between coreth and SAE, but this didn't work as well as expected.

## How this works

This is not a clean revert - There was a conflict in the genesis files as well as not updating the go.mod.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
