### PR TITLE
fix: change atomic trie commit interval to be 1

### DIFF
--- a/graft/coreth/plugin/evm/atomic/state/atomic_backend.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_backend.go
@@ -44,11 +44,11 @@ type AtomicBackend struct {
 func NewAtomicBackend(
 	sharedMemory avalancheatomic.SharedMemory,
 	bonusBlocks map[uint64]ids.ID, repo *AtomicRepository,
-	lastAcceptedHeight uint64, lastAcceptedHash common.Hash, commitInterval uint64,
+	lastAcceptedHeight uint64, lastAcceptedHash common.Hash,
 ) (*AtomicBackend, error) {
 	codec := repo.codec
 
-	atomicTrie, err := newAtomicTrie(repo.atomicTrieStorage, repo.metadataDB, codec, lastAcceptedHeight, commitInterval)
+	atomicTrie, err := newAtomicTrie(repo.atomicTrieStorage, repo.metadataDB, codec, lastAcceptedHeight)
 	if err != nil {
 		return nil, err
 	}
@@ -127,14 +127,11 @@ func (a *AtomicBackend) initialize(lastAcceptedHeight uint64) error {
 		if err := a.atomicTrie.InsertTrie(nodes, root); err != nil {
 			return err
 		}
-		isCommit, err := a.atomicTrie.AcceptTrie(height, root)
-		if err != nil {
+		if err := a.atomicTrie.AcceptTrie(height, root); err != nil {
 			return err
 		}
-		if isCommit {
-			if err := a.repo.db.Commit(); err != nil {
-				return err
-			}
+		if err := a.repo.db.Commit(); err != nil {
+			return err
 		}
 		// Trie must be re-opened after committing (not safe for re-use after commit)
 		tr, err = a.atomicTrie.OpenTrie(root)
@@ -158,7 +155,7 @@ func (a *AtomicBackend) initialize(lastAcceptedHeight uint64) error {
 		if err := a.atomicTrie.InsertTrie(nil, lastAcceptedRoot); err != nil {
 			return err
 		}
-		if _, err := a.atomicTrie.AcceptTrie(lastAcceptedHeight, lastAcceptedRoot); err != nil {
+		if err := a.atomicTrie.AcceptTrie(lastAcceptedHeight, lastAcceptedRoot); err != nil {
 			return err
 		}
 	}

--- a/graft/coreth/plugin/evm/atomic/state/atomic_state.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_state.go
@@ -48,8 +48,8 @@ func (a *atomicState) Accept(commitBatch database.Batch) error {
 		}
 	}
 
-	// Accept the root of this atomic trie (will be persisted if at a commit interval)
-	if _, err := a.backend.atomicTrie.AcceptTrie(a.blockHeight, a.atomicRoot); err != nil {
+	// Accept the root of this atomic trie (persisted at every block).
+	if err := a.backend.atomicTrie.AcceptTrie(a.blockHeight, a.atomicRoot); err != nil {
 		return err
 	}
 	// Update the last accepted block to this block and remove it from

--- a/graft/coreth/plugin/evm/atomic/state/atomic_trie.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_trie.go
@@ -37,7 +37,6 @@ var lastCommittedKey = []byte("atomicTrieLastCommittedBlock")
 
 // AtomicTrie is a trie that is used to store atomic operations.
 type AtomicTrie struct {
-	commitInterval      uint64                     // commit interval, same as commitHeightInterval by default
 	metadataDB          avalanchedatabase.Database // Underlying database containing the atomic trie metadata
 	trieDB              *triedb.Database           // Trie database
 	lastCommittedRoot   common.Hash                // trie root of the most recent commit
@@ -47,11 +46,11 @@ type AtomicTrie struct {
 	memoryCap           common.StorageSize
 }
 
-// newAtomicTrie returns a new instance of a atomicTrie with a configurable commitHeightInterval, used in testing.
-// Initializes the trie before returning it.
+// newAtomicTrie returns a new instance of an AtomicTrie, initialized before
+// returning it.
 func newAtomicTrie(
 	atomicTrieStorage avalanchedatabase.Database, metadataDB avalanchedatabase.Database,
-	codec codec.Manager, lastAcceptedHeight uint64, commitHeightInterval uint64,
+	codec codec.Manager, lastAcceptedHeight uint64,
 ) (*AtomicTrie, error) {
 	root, height, err := lastCommittedRootIfExists(metadataDB)
 	if err != nil {
@@ -61,10 +60,10 @@ func newAtomicTrie(
 	if root == (common.Hash{}) {
 		root = types.EmptyRootHash
 	}
-	// If the last committed height is above the last accepted height, then we fall back to
-	// the last commit below the last accepted height.
+	// If the last committed height is above the last accepted height, then we fall
+	// back to the root committed at the last accepted height.
 	if height > lastAcceptedHeight {
-		height = nearestCommitHeight(lastAcceptedHeight, commitHeightInterval)
+		height = lastAcceptedHeight
 		root, err = getRoot(metadataDB, height)
 		if err != nil {
 			return nil, err
@@ -81,7 +80,6 @@ func newAtomicTrie(
 	)
 
 	return &AtomicTrie{
-		commitInterval:      commitHeightInterval,
 		metadataDB:          metadataDB,
 		trieDB:              trieDB,
 		codec:               codec,
@@ -89,7 +87,7 @@ func newAtomicTrie(
 		lastCommittedHeight: height,
 		memoryCap:           atomicTrieMemoryCap,
 		// Initialize lastAcceptedRoot to the last committed root.
-		// If there were further blocks processed (ahead of the commit interval),
+		// If there were further blocks processed (not yet committed),
 		// AtomicBackend will call InsertTrie/AcceptTrie on atomic ops
 		// for those blocks.
 		lastAcceptedRoot: root,
@@ -122,11 +120,6 @@ func lastCommittedRootIfExists(db avalanchedatabase.Database) (common.Hash, uint
 	return common.BytesToHash(hash), height, nil
 }
 
-// nearestCommitheight returns the nearest multiple of commitInterval less than or equal to blockNumber
-func nearestCommitHeight(blockNumber uint64, commitInterval uint64) uint64 {
-	return blockNumber - (blockNumber % commitInterval)
-}
-
 func (a *AtomicTrie) OpenTrie(root common.Hash) (*trie.Trie, error) {
 	return trie.New(trie.TrieID(root), a.trieDB)
 }
@@ -136,7 +129,7 @@ func (a *AtomicTrie) Commit(height uint64, root common.Hash) error {
 	if err := a.trieDB.Commit(root, false); err != nil {
 		return err
 	}
-	log.Info("committed atomic trie", "root", root.String(), "height", height)
+	log.Debug("committed atomic trie", "root", root.String(), "height", height)
 	return a.updateLastCommitted(root, height)
 }
 
@@ -260,25 +253,17 @@ func (a *AtomicTrie) InsertTrie(nodes *trienode.NodeSet, root common.Hash) error
 	return nil
 }
 
-// AcceptTrie commits the triedb at [root] if needed and returns true if a commit
-// was performed.
-func (a *AtomicTrie) AcceptTrie(height uint64, root common.Hash) (bool, error) {
-	hasCommitted := false
-	// Because we do not accept the trie at every height, we may need to
-	// populate roots at prior commit heights that were skipped.
-	for nextCommitHeight := a.lastCommittedHeight + a.commitInterval; nextCommitHeight < height; nextCommitHeight += a.commitInterval {
-		if err := a.Commit(nextCommitHeight, a.lastAcceptedRoot); err != nil {
-			return false, err
+// AcceptTrie commits the triedb at root for height.
+func (a *AtomicTrie) AcceptTrie(height uint64, root common.Hash) error {
+	// Populate roots at any heights that were skipped since the last commit.
+	for skippedHeight := a.lastCommittedHeight + 1; skippedHeight < height; skippedHeight++ {
+		if err := a.Commit(skippedHeight, a.lastAcceptedRoot); err != nil {
+			return err
 		}
-		hasCommitted = true
 	}
 
-	// Commit this root if we have reached the [commitInterval].
-	if height%a.commitInterval == 0 {
-		if err := a.Commit(height, root); err != nil {
-			return false, err
-		}
-		hasCommitted = true
+	if err := a.Commit(height, root); err != nil {
+		return err
 	}
 
 	// The following dereferences, if any, the previously inserted root.
@@ -288,10 +273,10 @@ func (a *AtomicTrie) AcceptTrie(height uint64, root common.Hash) (bool, error) {
 	//   references to all the relevant data from the previous root, so the previous
 	//   root can be dereferenced.
 	if err := a.trieDB.Dereference(a.lastAcceptedRoot); err != nil {
-		return false, err
+		return err
 	}
 	a.lastAcceptedRoot = root
-	return hasCommitted, nil
+	return nil
 }
 
 func (a *AtomicTrie) RejectTrie(root common.Hash) error {

--- a/graft/coreth/plugin/evm/atomic/state/atomic_trie_iterator_test.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_trie_iterator_test.go
@@ -32,7 +32,7 @@ func TestIteratorCanIterate(t *testing.T) {
 
 	// create an atomic trie
 	// on create it will initialize all the transactions from the above atomic repository
-	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{}, 100)
+	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{})
 	require.NoError(t, err)
 	atomicTrie1 := atomicBackend.AtomicTrie()
 
@@ -45,7 +45,7 @@ func TestIteratorCanIterate(t *testing.T) {
 
 	// iterate on a new atomic trie to make sure there is no resident state affecting the data and the
 	// iterator
-	atomicBackend2, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{}, 100)
+	atomicBackend2, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{})
 	require.NoError(t, err)
 	atomicTrie2 := atomicBackend2.AtomicTrie()
 	lastCommittedHash2, lastCommittedHeight2 := atomicTrie2.LastCommitted()
@@ -71,8 +71,7 @@ func TestIteratorHandlesInvalidData(t *testing.T) {
 
 	// create an atomic trie
 	// on create it will initialize all the transactions from the above atomic repository
-	commitInterval := uint64(100)
-	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{}, commitInterval)
+	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{})
 	require.NoError(err)
 	atomicTrie := atomicBackend.AtomicTrie()
 
@@ -91,9 +90,9 @@ func TestIteratorHandlesInvalidData(t *testing.T) {
 	nextRoot, nodes, err := atomicTrieSnapshot.Commit(false)
 	require.NoError(err)
 	require.NoError(atomicTrie.InsertTrie(nodes, nextRoot))
-	isCommit, err := atomicTrie.AcceptTrie(lastCommittedHeight+commitInterval, nextRoot)
-	require.NoError(err)
-	require.True(isCommit)
+	// The atomic trie commits at every height, so accepting the next height
+	// commits the (corrupted) root.
+	require.NoError(atomicTrie.AcceptTrie(lastCommittedHeight+1, nextRoot))
 
 	corruptedHash, _ := atomicTrie.LastCommitted()
 	iter, err := atomicTrie.Iterator(corruptedHash, nil)

--- a/graft/coreth/plugin/evm/atomic/state/atomic_trie_test.go
+++ b/graft/coreth/plugin/evm/atomic/state/atomic_trie_test.go
@@ -31,7 +31,9 @@ import (
 	avalancheatomic "github.com/ava-labs/avalanchego/chains/atomic"
 )
 
-const testCommitInterval = 100
+// numTestHeights is the number of heights indexed by tests that simply need to
+// process a range of blocks.
+const numTestHeights = 100
 
 // indexAtomicTxs updates [tr] with entries in [atomicOps] at height by creating
 // a new snapshot, calculating a new root, and calling InsertTrie followed
@@ -51,85 +53,29 @@ func indexAtomicTxs(tr *AtomicTrie, height uint64, atomicOps map[ids.ID]*avalanc
 	if err := tr.InsertTrie(nodes, root); err != nil {
 		return err
 	}
-	_, err = tr.AcceptTrie(height, root)
-	return err
-}
-
-func TestNearestCommitHeight(t *testing.T) {
-	type test struct {
-		height, commitInterval, expectedCommitHeight uint64
-	}
-
-	for _, test := range []test{
-		{
-			height:               4500,
-			commitInterval:       4096,
-			expectedCommitHeight: 4096,
-		},
-		{
-			height:               8500,
-			commitInterval:       4096,
-			expectedCommitHeight: 8192,
-		},
-		{
-			height:               950,
-			commitInterval:       100,
-			expectedCommitHeight: 900,
-		},
-	} {
-		commitHeight := nearestCommitHeight(test.height, test.commitInterval)
-		require.Equal(t, test.expectedCommitHeight, commitHeight)
-	}
+	return tr.AcceptTrie(height, root)
 }
 
 func TestAtomicTrieInitialize(t *testing.T) {
 	type test struct {
-		commitInterval, lastAcceptedHeight, expectedCommitHeight uint64
-		numTxsPerBlock                                           func(uint64) int
+		lastAcceptedHeight uint64
+		numTxsPerBlock     func(uint64) int
 	}
 	for name, test := range map[string]test{
 		"genesis": {
-			commitInterval:       10,
-			lastAcceptedHeight:   0,
-			expectedCommitHeight: 0,
-			numTxsPerBlock:       constTxsPerHeight(0),
+			lastAcceptedHeight: 0,
+			numTxsPerBlock:     constTxsPerHeight(0),
 		},
-		"before first commit": {
-			commitInterval:       10,
-			lastAcceptedHeight:   5,
-			expectedCommitHeight: 0,
-			numTxsPerBlock:       constTxsPerHeight(3),
+		"atomic txs at every height": {
+			lastAcceptedHeight: 100,
+			numTxsPerBlock:     constTxsPerHeight(3),
 		},
-		"first commit": {
-			commitInterval:       10,
-			lastAcceptedHeight:   10,
-			expectedCommitHeight: 10,
-			numTxsPerBlock:       constTxsPerHeight(3),
-		},
-		"past first commit": {
-			commitInterval:       10,
-			lastAcceptedHeight:   15,
-			expectedCommitHeight: 10,
-			numTxsPerBlock:       constTxsPerHeight(3),
-		},
-		"many existing commits": {
-			commitInterval:       10,
-			lastAcceptedHeight:   1000,
-			expectedCommitHeight: 1000,
-			numTxsPerBlock:       constTxsPerHeight(3),
-		},
-		"many existing commits plus 1": {
-			commitInterval:       10,
-			lastAcceptedHeight:   1001,
-			expectedCommitHeight: 1000,
-			numTxsPerBlock:       constTxsPerHeight(3),
-		},
-		"some blocks without atomic tx": {
-			commitInterval:       10,
-			lastAcceptedHeight:   101,
-			expectedCommitHeight: 100,
+		"gaps between atomic txs with trailing empty blocks": {
+			lastAcceptedHeight: 101,
+			// Atomic txs only appear at sparse heights <= 50, so heights 51..101
+			// have none and must be back-filled with a committed root.
 			numTxsPerBlock: func(height uint64) int {
-				if height <= 50 || height == 101 {
+				if height <= 50 {
 					return 1
 				}
 				return 0
@@ -144,27 +90,35 @@ func TestAtomicTrieInitialize(t *testing.T) {
 			writeTxs(t, repo, 1, test.lastAcceptedHeight+1, test.numTxsPerBlock, nil, operationsMap)
 
 			// Construct the atomic trie for the first time
-			atomicBackend1, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, test.lastAcceptedHeight, common.Hash{}, test.commitInterval)
+			atomicBackend1, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, test.lastAcceptedHeight, common.Hash{})
 			require.NoError(t, err)
 			atomicTrie1 := atomicBackend1.AtomicTrie()
 
 			rootHash1, commitHeight1 := atomicTrie1.LastCommitted()
-			require.Equal(t, test.expectedCommitHeight, commitHeight1)
-			if test.expectedCommitHeight != 0 {
+			require.Equal(t, test.lastAcceptedHeight, commitHeight1)
+			if test.lastAcceptedHeight != 0 {
 				require.NotZero(t, rootHash1)
 			}
 
-			// Verify the operations up to the expected commit height
-			verifyOperations(t, atomicTrie1, atomictest.TestTxCodec, rootHash1, 1, test.expectedCommitHeight, operationsMap)
+			// A committed root must exist at every height up to the last committed
+			// height, including heights with no atomic txs (back-filled during
+			// initialization). SAE relies on this property.
+			for h := uint64(1); h <= commitHeight1; h++ {
+				root, err := atomicTrie1.Root(h)
+				require.NoError(t, err)
+				require.NotZerof(t, root, "expected committed root at height %d", h)
+			}
+
+			verifyOperations(t, atomicTrie1, atomictest.TestTxCodec, rootHash1, 1, test.lastAcceptedHeight, operationsMap)
 
 			// Construct the atomic trie again (on the same database) and ensure the last accepted root is correct.
-			atomicBackend2, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, test.lastAcceptedHeight, common.Hash{}, test.commitInterval)
+			atomicBackend2, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, test.lastAcceptedHeight, common.Hash{})
 			require.NoError(t, err)
 			atomicTrie2 := atomicBackend2.AtomicTrie()
 			require.Equal(t, atomicTrie1.LastAcceptedRoot(), atomicTrie2.LastAcceptedRoot())
 
 			// Construct the atomic trie again (on an empty database) and ensure that it produces the same hash.
-			atomicBackend3, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, test.lastAcceptedHeight, common.Hash{}, test.commitInterval)
+			atomicBackend3, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, test.lastAcceptedHeight, common.Hash{})
 			require.NoError(t, err)
 			atomicTrie3 := atomicBackend3.AtomicTrie()
 
@@ -172,10 +126,11 @@ func TestAtomicTrieInitialize(t *testing.T) {
 			require.Equal(t, commitHeight1, commitHeight3)
 			require.Equal(t, rootHash1, rootHash3)
 
-			// We now index additional operations up the next commit interval in order to confirm that nothing
-			// during the initialization phase will cause an invalid root when indexing continues.
-			nextCommitHeight := nearestCommitHeight(test.lastAcceptedHeight+test.commitInterval, test.commitInterval)
-			for i := test.lastAcceptedHeight + 1; i <= nextCommitHeight; i++ {
+			// Index some additional blocks to confirm that nothing during the
+			// initialization phase causes an invalid root when indexing continues.
+			const additionalBlocks = 10
+			nextHeight := test.lastAcceptedHeight + additionalBlocks
+			for i := test.lastAcceptedHeight + 1; i <= nextHeight; i++ {
 				txs := atomictest.NewTestTxs(test.numTxsPerBlock(i))
 				require.NoError(t, repo.Write(i, txs))
 
@@ -184,21 +139,21 @@ func TestAtomicTrieInitialize(t *testing.T) {
 				require.NoError(t, indexAtomicTxs(atomicTrie1, i, atomicOps))
 				operationsMap[i] = atomicOps
 			}
-			updatedRoot, updatedLastCommitHeight := atomicTrie1.LastCommitted()
-			require.Equal(t, nextCommitHeight, updatedLastCommitHeight)
+			updatedRoot, updatedHeight := atomicTrie1.LastCommitted()
+			require.Equal(t, nextHeight, updatedHeight)
 			require.NotZero(t, updatedRoot)
 
-			// Verify the operations up to the new expected commit height
-			verifyOperations(t, atomicTrie1, atomictest.TestTxCodec, updatedRoot, 1, updatedLastCommitHeight, operationsMap)
+			// Verify the operations up to the new last committed height.
+			verifyOperations(t, atomicTrie1, atomictest.TestTxCodec, updatedRoot, 1, updatedHeight, operationsMap)
 
 			// Generate a new atomic trie to compare the root against.
-			atomicBackend4, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, nextCommitHeight, common.Hash{}, test.commitInterval)
+			atomicBackend4, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, nextHeight, common.Hash{})
 			require.NoError(t, err)
 			atomicTrie4 := atomicBackend4.AtomicTrie()
 
 			rootHash4, commitHeight4 := atomicTrie4.LastCommitted()
 			require.Equal(t, updatedRoot, rootHash4)
-			require.Equal(t, updatedLastCommitHeight, commitHeight4)
+			require.Equal(t, updatedHeight, commitHeight4)
 		})
 	}
 }
@@ -212,13 +167,13 @@ func TestIndexerInitializesOnlyOnce(t *testing.T) {
 	writeTxs(t, repo, 1, lastAcceptedHeight+1, constTxsPerHeight(2), nil, operationsMap)
 
 	// Initialize atomic repository
-	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{}, 10 /* commitInterval*/)
+	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{})
 	require.NoError(t, err)
 	atomicTrie := atomicBackend.AtomicTrie()
 
 	hash, height := atomicTrie.LastCommitted()
 	require.NotZero(t, hash)
-	require.Equal(t, uint64(20), height)
+	require.Equal(t, lastAcceptedHeight, height)
 
 	// We write another tx at a height below the last committed height in the repo and then
 	// re-initialize the atomic trie since initialize is not supposed to run again the height
@@ -227,7 +182,7 @@ func TestIndexerInitializesOnlyOnce(t *testing.T) {
 	require.NoError(t, repo.Write(15, []*atomic.Tx{atomictest.GenerateTestExportTx()}))
 
 	// Re-initialize the atomic trie
-	atomicBackend, err = NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{}, 10 /* commitInterval */)
+	atomicBackend, err = NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{})
 	require.NoError(t, err)
 	atomicTrie = atomicBackend.AtomicTrie()
 
@@ -240,50 +195,16 @@ func newTestAtomicTrie(t *testing.T) *AtomicTrie {
 	db := versiondb.New(memdb.New())
 	repo, err := NewAtomicTxRepository(db, atomictest.TestTxCodec, 0)
 	require.NoError(t, err)
-	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, 0, common.Hash{}, testCommitInterval)
+	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, 0, common.Hash{})
 	require.NoError(t, err)
 	return atomicBackend.AtomicTrie()
-}
-
-func TestIndexerWriteAndRead(t *testing.T) {
-	atomicTrie := newTestAtomicTrie(t)
-
-	blockRootMap := make(map[uint64]common.Hash)
-	lastCommittedBlockHeight := uint64(0)
-	var lastCommittedBlockHash common.Hash
-
-	// process 305 blocks so that we get three commits (100, 200, 300)
-	for height := uint64(1); height <= testCommitInterval*3+5; /*=305*/ height++ {
-		atomicRequests, err := atomictest.ConvertToAtomicOps(atomictest.GenerateTestImportTx())
-		require.NoError(t, err)
-		require.NoError(t, indexAtomicTxs(atomicTrie, height, atomicRequests))
-		if height%testCommitInterval == 0 {
-			lastCommittedBlockHash, lastCommittedBlockHeight = atomicTrie.LastCommitted()
-			require.NotZero(t, lastCommittedBlockHash)
-			blockRootMap[lastCommittedBlockHeight] = lastCommittedBlockHash
-		}
-	}
-
-	// ensure we have 3 roots
-	require.Len(t, blockRootMap, 3)
-
-	hash, height := atomicTrie.LastCommitted()
-	require.Equal(t, lastCommittedBlockHeight, height)
-	require.Equal(t, lastCommittedBlockHash, hash)
-
-	// Verify that [atomicTrie] can access each of the expected roots
-	for height, hash := range blockRootMap {
-		root, err := atomicTrie.Root(height)
-		require.NoError(t, err)
-		require.Equal(t, hash, root)
-	}
 }
 
 func TestAtomicOpsAreNotTxOrderDependent(t *testing.T) {
 	atomicTrie1 := newTestAtomicTrie(t)
 	atomicTrie2 := newTestAtomicTrie(t)
 
-	for height := uint64(0); height <= testCommitInterval; /*=205*/ height++ {
+	for height := uint64(0); height <= numTestHeights; height++ {
 		tx1 := atomictest.GenerateTestImportTx()
 		tx2 := atomictest.GenerateTestImportTx()
 		atomicRequests1, err := mergeAtomicOps([]*atomic.Tx{tx1, tx2})
@@ -297,16 +218,14 @@ func TestAtomicOpsAreNotTxOrderDependent(t *testing.T) {
 	root1, height1 := atomicTrie1.LastCommitted()
 	root2, height2 := atomicTrie2.LastCommitted()
 	require.NotZero(t, root1)
-	require.Equal(t, uint64(testCommitInterval), height1)
-	require.Equal(t, uint64(testCommitInterval), height2)
+	require.Equal(t, uint64(numTestHeights), height1)
+	require.Equal(t, uint64(numTestHeights), height2)
 	require.Equal(t, root1, root2)
 }
 
 func TestAtomicTrieDoesNotSkipBonusBlocks(t *testing.T) {
 	lastAcceptedHeight := uint64(100)
 	numTxsPerBlock := 3
-	commitInterval := uint64(10)
-	expectedCommitHeight := uint64(100)
 	db := versiondb.New(memdb.New())
 	repo, err := NewAtomicTxRepository(db, atomictest.TestTxCodec, lastAcceptedHeight)
 	require.NoError(t, err)
@@ -319,22 +238,22 @@ func TestAtomicTrieDoesNotSkipBonusBlocks(t *testing.T) {
 		14: {},
 	}
 	// Construct the atomic trie for the first time
-	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), bonusBlocks, repo, lastAcceptedHeight, common.Hash{}, commitInterval)
+	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), bonusBlocks, repo, lastAcceptedHeight, common.Hash{})
 	require.NoError(t, err)
 	atomicTrie := atomicBackend.AtomicTrie()
 
 	rootHash, commitHeight := atomicTrie.LastCommitted()
-	require.Equal(t, expectedCommitHeight, commitHeight)
+	require.Equal(t, lastAcceptedHeight, commitHeight)
 	require.NotZero(t, rootHash)
 
 	// Verify the operations are as expected
-	verifyOperations(t, atomicTrie, atomictest.TestTxCodec, rootHash, 1, expectedCommitHeight, operationsMap)
+	verifyOperations(t, atomicTrie, atomictest.TestTxCodec, rootHash, 1, lastAcceptedHeight, operationsMap)
 }
 
 func TestIndexingNilShouldNotImpactTrie(t *testing.T) {
 	// operations to index
 	ops := make([]map[ids.ID]*avalancheatomic.Requests, 0)
-	for i := 0; i <= testCommitInterval; i++ {
+	for i := 0; i <= numTestHeights; i++ {
 		atomicOps, err := atomictest.ConvertToAtomicOps(atomictest.GenerateTestImportTx())
 		require.NoError(t, err)
 		ops = append(ops, atomicOps)
@@ -342,7 +261,7 @@ func TestIndexingNilShouldNotImpactTrie(t *testing.T) {
 
 	// without nils
 	a1 := newTestAtomicTrie(t)
-	for i := uint64(0); i <= testCommitInterval; i++ {
+	for i := uint64(0); i <= numTestHeights; i++ {
 		if i%2 == 0 {
 			require.NoError(t, indexAtomicTxs(a1, i, ops[i]))
 		}
@@ -350,11 +269,11 @@ func TestIndexingNilShouldNotImpactTrie(t *testing.T) {
 
 	root1, height1 := a1.LastCommitted()
 	require.NotZero(t, root1)
-	require.Equal(t, uint64(testCommitInterval), height1)
+	require.Equal(t, uint64(numTestHeights), height1)
 
 	// with nils
 	a2 := newTestAtomicTrie(t)
-	for i := uint64(0); i <= testCommitInterval; i++ {
+	for i := uint64(0); i <= numTestHeights; i++ {
 		if i%2 == 0 {
 			require.NoError(t, indexAtomicTxs(a2, i, ops[i]))
 		} else {
@@ -363,7 +282,7 @@ func TestIndexingNilShouldNotImpactTrie(t *testing.T) {
 	}
 	root2, height2 := a2.LastCommitted()
 	require.NotZero(t, root2)
-	require.Equal(t, uint64(testCommitInterval), height2)
+	require.Equal(t, uint64(numTestHeights), height2)
 
 	// key requirement of the test
 	require.Equal(t, root1, root2)
@@ -371,21 +290,19 @@ func TestIndexingNilShouldNotImpactTrie(t *testing.T) {
 
 func TestApplyToSharedMemory(t *testing.T) {
 	type test struct {
-		commitInterval, lastAcceptedHeight uint64
-		setMarker                          func(*AtomicBackend) error
-		expectOpsApplied                   func(height uint64) bool
-		bonusBlockHeights                  map[uint64]ids.ID
+		lastAcceptedHeight uint64
+		setMarker          func(*AtomicBackend) error
+		expectOpsApplied   func(height uint64) bool
+		bonusBlockHeights  map[uint64]ids.ID
 	}
 
 	for name, test := range map[string]test{
 		"marker is set to height": {
-			commitInterval:     10,
 			lastAcceptedHeight: 25,
 			setMarker:          func(a *AtomicBackend) error { return a.MarkApplyToSharedMemoryCursor(10) },
-			expectOpsApplied:   func(height uint64) bool { return height > 10 && height <= 20 },
+			expectOpsApplied:   func(height uint64) bool { return height > 10 && height <= 25 },
 		},
 		"marker is set to height, should skip bonus blocks": {
-			commitInterval:     10,
 			lastAcceptedHeight: 25,
 			setMarker:          func(a *AtomicBackend) error { return a.MarkApplyToSharedMemoryCursor(10) },
 			bonusBlockHeights:  map[uint64]ids.ID{15: {}},
@@ -393,11 +310,10 @@ func TestApplyToSharedMemory(t *testing.T) {
 				if height == 15 {
 					return false
 				}
-				return height > 10 && height <= 20
+				return height > 10 && height <= 25
 			},
 		},
 		"marker is set to height + blockchain ID": {
-			commitInterval:     10,
 			lastAcceptedHeight: 25,
 			setMarker: func(a *AtomicBackend) error {
 				cursor := make([]byte, wrappers.LongLen+len(atomictest.TestBlockchainID[:]))
@@ -405,10 +321,9 @@ func TestApplyToSharedMemory(t *testing.T) {
 				copy(cursor[wrappers.LongLen:], atomictest.TestBlockchainID[:])
 				return a.repo.metadataDB.Put(appliedSharedMemoryCursorKey, cursor)
 			},
-			expectOpsApplied: func(height uint64) bool { return height > 10 && height <= 20 },
+			expectOpsApplied: func(height uint64) bool { return height > 10 && height <= 25 },
 		},
 		"marker not set": {
-			commitInterval:     10,
 			lastAcceptedHeight: 25,
 			setMarker:          func(*AtomicBackend) error { return nil },
 			expectOpsApplied:   func(uint64) bool { return false },
@@ -424,13 +339,13 @@ func TestApplyToSharedMemory(t *testing.T) {
 			// Initialize atomic repository
 			m := avalancheatomic.NewMemory(db)
 			sharedMemories := atomictest.NewSharedMemories(m, snowtest.CChainID, atomictest.TestBlockchainID)
-			backend, err := NewAtomicBackend(sharedMemories.ThisChain, test.bonusBlockHeights, repo, test.lastAcceptedHeight, common.Hash{}, test.commitInterval)
+			backend, err := NewAtomicBackend(sharedMemories.ThisChain, test.bonusBlockHeights, repo, test.lastAcceptedHeight, common.Hash{})
 			require.NoError(t, err)
 			atomicTrie := backend.AtomicTrie()
 
 			hash, height := atomicTrie.LastCommitted()
 			require.NotZero(t, hash)
-			require.Equal(t, uint64(20), height)
+			require.Equal(t, test.lastAcceptedHeight, height)
 
 			// prepare peer chain's shared memory by applying items we expect to remove as puts
 			for _, ops := range operationsMap {
@@ -459,7 +374,7 @@ func TestApplyToSharedMemory(t *testing.T) {
 			// marker should be removed after ApplyToSharedMemory is complete
 			testOps()
 			// reinitialize the atomic trie
-			_, err = NewAtomicBackend(sharedMemories.ThisChain, nil, repo, test.lastAcceptedHeight, common.Hash{}, test.commitInterval)
+			_, err = NewAtomicBackend(sharedMemories.ThisChain, nil, repo, test.lastAcceptedHeight, common.Hash{})
 			require.NoError(t, err)
 			// require that ops were applied as expected
 			testOps()
@@ -470,107 +385,71 @@ func TestApplyToSharedMemory(t *testing.T) {
 func TestAtomicTrie_AcceptTrie(t *testing.T) {
 	t.Parallel()
 
+	// When AcceptTrie is called with a height beyond lastCommittedHeight+1,
+	// the gap lastCommittedHeight+1, height-1 is back-filled with the
+	// current lastAcceptedRoot, and the supplied root is committed at height.
 	testCases := map[string]struct {
 		lastAcceptedRoot        common.Hash
 		lastCommittedRoot       common.Hash
 		lastCommittedHeight     uint64
-		commitInterval          uint64
 		height                  uint64
 		root                    common.Hash
-		wantHasCommitted        bool
 		wantLastCommittedHeight uint64
 		wantLastCommittedRoot   common.Hash
 		wantLastAcceptedRoot    common.Hash
-		wantTipBufferRoot       common.Hash
 		wantMetadataDBKVs       map[string]string // hex to hex
 	}{
-		"no_committing": {
+		"backfill_gap": {
 			lastAcceptedRoot:        types.EmptyRootHash,
 			lastCommittedRoot:       common.Hash{2},
 			lastCommittedHeight:     100,
-			commitInterval:          10,
 			height:                  105,
 			root:                    common.Hash{3},
-			wantLastCommittedHeight: 100,
-			wantLastCommittedRoot:   common.Hash{2},
+			wantLastCommittedHeight: 105,
+			wantLastCommittedRoot:   common.Hash{3},
 			wantLastAcceptedRoot:    common.Hash{3},
-			wantTipBufferRoot:       common.Hash{3},
 			wantMetadataDBKVs: map[string]string{
-				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100
-				hex.EncodeToString(lastCommittedKey): "0000000000000064",                         // height 100
+				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100 (pre-existing)
+				"0000000000000065":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 101 (back-filled)
+				"0000000000000066":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 102 (back-filled)
+				"0000000000000067":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 103 (back-filled)
+				"0000000000000068":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 104 (back-filled)
+				"0000000000000069":                   hex.EncodeToString(common.Hash{3}.Bytes()), // height 105 (committed)
+				hex.EncodeToString(lastCommittedKey): "0000000000000069",                         // height 105
 			},
 		},
-		"no_committing_with_previous_root": {
+		"backfill_gap_with_previous_root": {
 			lastAcceptedRoot:        common.Hash{1},
 			lastCommittedRoot:       common.Hash{2},
 			lastCommittedHeight:     100,
-			commitInterval:          10,
 			height:                  105,
 			root:                    common.Hash{3},
-			wantLastCommittedHeight: 100,
-			wantLastCommittedRoot:   common.Hash{2},
-			wantLastAcceptedRoot:    common.Hash{3},
-			wantTipBufferRoot:       common.Hash{3},
-			wantMetadataDBKVs: map[string]string{
-				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100
-				hex.EncodeToString(lastCommittedKey): "0000000000000064",                         // height 100
-			},
-		},
-		"commit_all_up_to_height_without_height": {
-			lastAcceptedRoot:        types.EmptyRootHash,
-			lastCommittedRoot:       common.Hash{2},
-			lastCommittedHeight:     60,
-			commitInterval:          10,
-			height:                  105,
-			root:                    common.Hash{3},
-			wantHasCommitted:        true,
-			wantLastCommittedHeight: 100,
-			wantLastCommittedRoot:   types.EmptyRootHash,
-			wantLastAcceptedRoot:    common.Hash{3},
-			wantTipBufferRoot:       common.Hash{3},
-			wantMetadataDBKVs: map[string]string{
-				"000000000000003c":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 60
-				"0000000000000046":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 70
-				"0000000000000050":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 80
-				"000000000000005a":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 90
-				"0000000000000064":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 100
-				hex.EncodeToString(lastCommittedKey): "0000000000000064",                         // height 100
-			},
-		},
-		"commit_root": {
-			lastAcceptedRoot:        types.EmptyRootHash,
-			lastCommittedRoot:       common.Hash{2},
-			lastCommittedHeight:     100,
-			commitInterval:          10,
-			height:                  110,
-			root:                    common.Hash{3},
-			wantHasCommitted:        true,
-			wantLastCommittedHeight: 110,
+			wantLastCommittedHeight: 105,
 			wantLastCommittedRoot:   common.Hash{3},
 			wantLastAcceptedRoot:    common.Hash{3},
-			wantTipBufferRoot:       common.Hash{3},
 			wantMetadataDBKVs: map[string]string{
-				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100
-				"000000000000006e":                   hex.EncodeToString(common.Hash{3}.Bytes()), // height 110
-				hex.EncodeToString(lastCommittedKey): "000000000000006e",                         // height 110
+				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100 (pre-existing)
+				"0000000000000065":                   hex.EncodeToString(common.Hash{1}.Bytes()), // height 101 (back-filled w/ lastAcceptedRoot)
+				"0000000000000066":                   hex.EncodeToString(common.Hash{1}.Bytes()), // height 102 (back-filled w/ lastAcceptedRoot)
+				"0000000000000067":                   hex.EncodeToString(common.Hash{1}.Bytes()), // height 103 (back-filled w/ lastAcceptedRoot)
+				"0000000000000068":                   hex.EncodeToString(common.Hash{1}.Bytes()), // height 104 (back-filled w/ lastAcceptedRoot)
+				"0000000000000069":                   hex.EncodeToString(common.Hash{3}.Bytes()), // height 105 (committed)
+				hex.EncodeToString(lastCommittedKey): "0000000000000069",                         // height 105
 			},
 		},
-		"commit_root_with_previous_root": {
+		"no_gap": {
 			lastAcceptedRoot:        common.Hash{1},
 			lastCommittedRoot:       common.Hash{2},
-			lastCommittedHeight:     100,
-			commitInterval:          10,
-			height:                  110,
+			lastCommittedHeight:     104,
+			height:                  105,
 			root:                    common.Hash{3},
-			wantHasCommitted:        true,
-			wantLastCommittedHeight: 110,
+			wantLastCommittedHeight: 105,
 			wantLastCommittedRoot:   common.Hash{3},
 			wantLastAcceptedRoot:    common.Hash{3},
-			wantTipBufferRoot:       common.Hash{3},
 			wantMetadataDBKVs: map[string]string{
-				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100
-				"000000000000006e":                   hex.EncodeToString(common.Hash{3}.Bytes()), // height 110
-				hex.EncodeToString(lastCommittedKey): "000000000000006e",                         // height 110
+				"0000000000000068":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 104 (pre-existing)
+				"0000000000000069":                   hex.EncodeToString(common.Hash{3}.Bytes()), // height 105 (committed)
+				hex.EncodeToString(lastCommittedKey): "0000000000000069",                         // height 105
 			},
 		},
 	}
@@ -584,7 +463,7 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			metadataDB := prefixdb.New(atomicTrieMetaDBPrefix, versionDB)
 			const lastAcceptedHeight = 0 // no effect
 			atomicTrie, err := newAtomicTrie(atomicTrieStorage, metadataDB, atomictest.TestTxCodec,
-				lastAcceptedHeight, testCase.commitInterval)
+				lastAcceptedHeight)
 			require.NoError(t, err)
 			atomicTrie.lastAcceptedRoot = testCase.lastAcceptedRoot
 			if testCase.lastAcceptedRoot != types.EmptyRootHash {
@@ -606,17 +485,16 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			}
 			require.NoError(t, atomicTrie.updateLastCommitted(testCase.lastCommittedRoot, testCase.lastCommittedHeight))
 
-			hasCommitted, err := atomicTrie.AcceptTrie(testCase.height, testCase.root)
-			require.NoError(t, err)
+			require.NoError(t, atomicTrie.AcceptTrie(testCase.height, testCase.root))
 
-			require.Equal(t, testCase.wantHasCommitted, hasCommitted)
 			require.Equal(t, testCase.wantLastCommittedHeight, atomicTrie.lastCommittedHeight)
 			require.Equal(t, testCase.wantLastCommittedRoot, atomicTrie.lastCommittedRoot)
 			require.Equal(t, testCase.wantLastAcceptedRoot, atomicTrie.lastAcceptedRoot)
 
-			// Check dereferencing previous dirty root inserted occurred
+			// Acceptance leaves no dirty storage: the inserted root was either
+			// committed during back-fill or dereferenced.
 			_, storageSize, _ := atomicTrie.trieDB.Size()
-			require.Zerof(t, storageSize, "storage size should be zero after accepting the trie due to the dirty nodes derefencing but is %s", storageSize)
+			require.Zerof(t, storageSize, "dirty storage size should be zero after accepting the trie but is %s", storageSize)
 
 			for wantKeyHex, wantValueHex := range testCase.wantMetadataDBKVs {
 				wantKey, err := hex.DecodeString(wantKeyHex)
@@ -649,7 +527,7 @@ func BenchmarkAtomicTrieInit(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		sharedMemory := atomictest.TestSharedMemory()
-		atomicBackend, err := NewAtomicBackend(sharedMemory, nil, repo, lastAcceptedHeight, common.Hash{}, 5000)
+		atomicBackend, err := NewAtomicBackend(sharedMemory, nil, repo, lastAcceptedHeight, common.Hash{})
 		require.NoError(b, err)
 		atomicTrie = atomicBackend.AtomicTrie()
 
@@ -674,7 +552,7 @@ func BenchmarkAtomicTrieIterate(b *testing.B) {
 	require.NoError(b, err)
 	writeTxs(b, repo, 1, lastAcceptedHeight, constTxsPerHeight(3), nil, operationsMap)
 
-	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{}, 5000)
+	atomicBackend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, lastAcceptedHeight, common.Hash{})
 	require.NoError(b, err)
 	atomicTrie := atomicBackend.AtomicTrie()
 
@@ -745,7 +623,7 @@ func benchmarkApplyToSharedMemory(b *testing.B, disk database.Database, blocks u
 	repo, err := NewAtomicTxRepository(db, atomictest.TestTxCodec, lastAcceptedHeight)
 	require.NoError(b, err)
 
-	backend, err := NewAtomicBackend(sharedMemory, nil, repo, 0, common.Hash{}, 5000)
+	backend, err := NewAtomicBackend(sharedMemory, nil, repo, 0, common.Hash{})
 	require.NoError(b, err)
 	trie := backend.AtomicTrie()
 	for height := uint64(1); height <= lastAcceptedHeight; height++ {

--- a/graft/coreth/plugin/evm/atomic/sync/syncer.go
+++ b/graft/coreth/plugin/evm/atomic/sync/syncer.go
@@ -185,18 +185,14 @@ func (s *Syncer) onLeafs(ctx context.Context, keys [][]byte, values [][]byte) er
 			if err := s.atomicTrie.InsertTrie(nodes, root); err != nil {
 				return err
 			}
-			// AcceptTrie commits the trieDB and returns [isCommit] as true
-			// if we have reached or crossed a commit interval.
-			isCommit, err := s.atomicTrie.AcceptTrie(s.lastHeight, root)
-			if err != nil {
+			// AcceptTrie commits the trieDB at every height.
+			if err := s.atomicTrie.AcceptTrie(s.lastHeight, root); err != nil {
 				return err
 			}
-			if isCommit {
-				// Flush pending changes to disk to preserve progress and
-				// free up memory if the trieDB was committed.
-				if err := s.db.Commit(); err != nil {
-					return err
-				}
+			// Flush pending changes to disk to preserve progress and free up
+			// memory.
+			if err := s.db.Commit(); err != nil {
+				return err
 			}
 			// Trie must be re-opened after committing (not safe for re-use after commit)
 			trie, err := s.atomicTrie.OpenTrie(root)
@@ -225,7 +221,7 @@ func (s *Syncer) onFinish() error {
 	if err := s.atomicTrie.InsertTrie(nodes, root); err != nil {
 		return err
 	}
-	if _, err := s.atomicTrie.AcceptTrie(s.targetHeight, root); err != nil {
+	if err := s.atomicTrie.AcceptTrie(s.targetHeight, root); err != nil {
 		return err
 	}
 	if err := s.db.Commit(); err != nil {

--- a/graft/coreth/plugin/evm/atomic/sync/syncer_test.go
+++ b/graft/coreth/plugin/evm/atomic/sync/syncer_test.go
@@ -31,9 +31,11 @@ import (
 )
 
 const (
-	testCommitInterval = 1024
-	testTargetHeight   = 100
-	testNumWorkers     = 4
+	// testRequestSize is the maximum number of leaves fetched per network
+	// request (the syncer's default).
+	testRequestSize  = defaultRequestSize
+	testTargetHeight = 100
+	testNumWorkers   = 4
 )
 
 type atomicSyncTestCheckpoint struct {
@@ -70,7 +72,7 @@ func TestSyncerScenarios(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := rand.New(rand.NewSource(1))
-			targetHeight := 10 * uint64(testCommitInterval)
+			targetHeight := 10 * uint64(testRequestSize)
 			serverTrieDB := triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)
 			root, _, _ := synctest.GenerateIndependentTrie(t, r, serverTrieDB, int(targetHeight), state.TrieKeyLength)
 
@@ -106,19 +108,21 @@ func TestSyncerResumeScenarios(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := rand.New(rand.NewSource(1))
-			targetHeight := 10 * uint64(testCommitInterval)
+			targetHeight := 10 * uint64(testRequestSize)
 			serverTrieDB := triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)
 			numTrieKeys := int(targetHeight) - 1 // no atomic ops for genesis
 			root, _, _ := synctest.GenerateIndependentTrie(t, r, serverTrieDB, numTrieKeys, state.TrieKeyLength)
 
+			// The atomic trie commits at every height, so an interrupted sync
+			// loses no committed progress.
 			testSyncer(t, serverTrieDB, targetHeight, root, []atomicSyncTestCheckpoint{
 				{
 					targetRoot:              root,
 					targetHeight:            targetHeight,
-					leafCutoff:              testCommitInterval*5 - 1,
-					expectedNumLeavesSynced: testCommitInterval * 4,
+					leafCutoff:              testRequestSize*5 - 1,
+					expectedNumLeavesSynced: testRequestSize * 4,
 				},
-			}, int64(targetHeight)+testCommitInterval-1, tt.numWorkers) // we will resync the last commitInterval - 1 leafs
+			}, int64(targetHeight), tt.numWorkers)
 		})
 	}
 }
@@ -150,25 +154,27 @@ func TestSyncerResumeNewRootCheckpointScenarios(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := rand.New(rand.NewSource(1))
-			targetHeight1 := 10 * uint64(testCommitInterval)
+			targetHeight1 := 10 * uint64(testRequestSize)
 			serverTrieDB := triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)
 			numTrieKeys1 := int(targetHeight1) - 1 // no atomic ops for genesis
 			root1, _, _ := synctest.GenerateIndependentTrie(t, r, serverTrieDB, numTrieKeys1, state.TrieKeyLength)
 
-			targetHeight2 := 20 * uint64(testCommitInterval)
+			targetHeight2 := 20 * uint64(testRequestSize)
 			numTrieKeys2 := int(targetHeight2) - 1 // no atomic ops for genesis
 			root2, _, _ := synctest.FillIndependentTrie(
 				t, r, numTrieKeys1, numTrieKeys2, state.TrieKeyLength, serverTrieDB, root1,
 			)
 
+			// The atomic trie commits at every height, so an interrupted sync
+			// loses no committed progress.
 			testSyncer(t, serverTrieDB, targetHeight1, root1, []atomicSyncTestCheckpoint{
 				{
 					targetRoot:              root2,
 					targetHeight:            targetHeight2,
-					leafCutoff:              testCommitInterval*5 - 1,
-					expectedNumLeavesSynced: testCommitInterval * 4,
+					leafCutoff:              testRequestSize*5 - 1,
+					expectedNumLeavesSynced: testRequestSize * 4,
 				},
-			}, int64(targetHeight2)+testCommitInterval-1, tt.numWorkers) // we will resync the last commitInterval - 1 leafs
+			}, int64(targetHeight2), tt.numWorkers)
 		})
 	}
 }
@@ -184,13 +190,13 @@ func TestSyncerParallelizationScenarios(t *testing.T) {
 	}{
 		{
 			name:         "parallelization with 4 workers",
-			targetHeight: 2 * uint64(testCommitInterval), // 2,048 leaves for meaningful parallelization
+			targetHeight: 2 * uint64(testRequestSize), // 2,048 leaves for meaningful parallelization
 			numWorkers:   4,
 			description:  "should work correctly with 4 worker goroutines",
 		},
 		{
 			name:         "default parallelization",
-			targetHeight: uint64(testCommitInterval), // 1,024 leaves to test commit boundary
+			targetHeight: uint64(testRequestSize), // 1,024 leaves (one request batch)
 			numWorkers:   0,
 			description:  "should default to parallelization with default workers",
 		},
@@ -307,7 +313,7 @@ func testSyncer(t *testing.T, serverTrieDB *triedb.Database, targetHeight uint64
 	clientTrieDB := atomicTrie.TrieDB()
 	synctest.AssertTrieConsistency(t, targetRoot, serverTrieDB, clientTrieDB, nil)
 
-	// check all commit heights are created correctly
+	// Verify the committed root matches the root derived from the server trie's keys
 	hasher := trie.NewEmpty(triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil))
 
 	serverTrie, err := trie.New(trie.TrieID(targetRoot), serverTrieDB)
@@ -333,7 +339,7 @@ func testSyncer(t *testing.T, serverTrieDB *triedb.Database, targetHeight uint64
 	for height := uint64(0); height <= targetHeight; height++ {
 		require.NoErrorf(t, addAllKeysWithPrefix(database.PackUInt64(height)), "failed to add keys for height %d", height)
 
-		if height%testCommitInterval == 0 {
+		if height%testRequestSize == 0 {
 			expected := hasher.Hash()
 			root, err := atomicTrie.Root(height)
 			require.NoError(t, err)
@@ -359,7 +365,7 @@ func setupTestInfrastructure(t *testing.T, serverTrieDB *triedb.Database) (conte
 	repo, err := state.NewAtomicTxRepository(clientDB, message.CorethCodec, 0)
 	require.NoError(t, err, "NewAtomicTxRepository()")
 
-	atomicBackend, err := state.NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, 0, common.Hash{}, testCommitInterval)
+	atomicBackend, err := state.NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, 0, common.Hash{})
 	require.NoError(t, err, "NewAtomicBackend()")
 
 	return ctx, mockClient, atomicBackend, clientDB

--- a/graft/coreth/plugin/evm/atomic/vm/syncervm_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/syncervm_test.go
@@ -94,9 +94,7 @@ func TestAtomicSyncerVM(t *testing.T) {
 				if isServer {
 					serverAtomicTrie := atomicVM.AtomicBackend.AtomicTrie()
 					// Calling AcceptTrie with SyncableInterval creates a commit for the atomic trie
-					committed, err := serverAtomicTrie.AcceptTrie(params.SyncableInterval, serverAtomicTrie.LastAcceptedRoot())
-					require.NoError(t, err)
-					require.True(t, committed)
+					require.NoError(t, serverAtomicTrie.AcceptTrie(params.SyncableInterval, serverAtomicTrie.LastAcceptedRoot()))
 					require.NoError(t, atomicVM.VersionDB().Commit())
 				}
 			}

--- a/graft/coreth/plugin/evm/atomic/vm/vm.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm.go
@@ -234,7 +234,6 @@ func (vm *VM) Initialize(
 	vm.AtomicBackend, err = atomicstate.NewAtomicBackend(
 		vm.Ctx.SharedMemory, bonusBlockHeights,
 		vm.AtomicTxRepository, lastAcceptedHeight, lastAcceptedHash,
-		vm.InnerVM.Config().CommitInterval,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create atomic backend: %w", err)

--- a/vms/saevm/cchain/state/state.go
+++ b/vms/saevm/cchain/state/state.go
@@ -68,10 +68,6 @@ type State struct {
 }
 
 // New initializes the state with db.
-//
-// TODO(#5375): Coreth's commitInterval must be reduced to 1 prior to
-// transitioning to SAE. Otherwise, the atomic trie may not contain operations
-// for recent blocks.
 func New(snowCtx *snow.Context, db database.Database) (*State, error) {
 	root, height, err := readLast(db)
 	if err != nil {

--- a/vms/saevm/cchain/state/state_test.go
+++ b/vms/saevm/cchain/state/state_test.go
@@ -128,10 +128,9 @@ func newOldState(tb testing.TB, db *prefixdb.Database, sm chainsatomic.SharedMem
 	repo, err := oldstate.NewAtomicTxRepository(versiondb.New(db), atomic.Codec, 0)
 	require.NoErrorf(tb, err, "state.NewAtomicTxRepository(%T, %T, ...)", db, atomic.Codec)
 
-	// Making the legacy backend commit at every height matches the new State's
-	// every-height-is-committed semantics.
-	const commitInterval = 1
-	backend, err := oldstate.NewAtomicBackend(sm, nil, repo, 0, common.Hash{}, commitInterval)
+	// The legacy backend commits the atomic trie at every height, matching the
+	// new State's every-height-is-committed semantics.
+	backend, err := oldstate.NewAtomicBackend(sm, nil, repo, 0, common.Hash{})
 	require.NoErrorf(tb, err, "state.NewAtomicBackend(%T, %T)", sm, repo)
 	return &oldState{
 		tb:      tb,


### PR DESCRIPTION
## Why this should be merged

Resolves #5375.

SAE picks up coreth's atomic trie right where it left off to avoid a database migration on the transition. On startup it seeds its state from the last committed atomic root/height (`lastCommittedKey`) and trusts that this root is the complete atomic state as of the last accepted block. 

With coreth's previous commit interval (`4096`), the last committed root can lag the chain tip by up to `4096` blocks, so the trie SAE inherits would be missing the atomic operations of recent blocks, with no way to recover them.

This will increase the storage required, but because the atomic trie is append-only and small, committing it at every block is fairly cheap. I ran a benchmark between a commit interval of 1 and 4096 on master to see the storage differential effectuated by this change: 

```
                      │    4096     │                  1                  │
                      │   sec/op    │   sec/op     vs base                │
  AtomicTrieAccept-14   16.58µ ± 2%   31.92µ ± 4%  +92.50% (p=0.000 n=10)

                      │     4096     │                  1                   │
                      │     B/op     │     B/op      vs base                │
  AtomicTrieAccept-14   26.58Ki ± 1%   32.51Ki ± 1%  +22.31% (p=0.000 n=10)

                      │    4096    │                 1                 │
                      │ allocs/op  │ allocs/op   vs base               │
  AtomicTrieAccept-14   396.0 ± 1%   428.0 ± 0%  +8.08% (p=0.000 n=10)
```

The percentages may look big but it's just tiny in context IMO. 


<details>

<summary>the benchmark</summary>

```go
func BenchmarkAtomicTrieAccept(b *testing.B) {
	// 4096 is the legacy default commit interval (config.defaultCommitInterval).
	for _, commitInterval := range []uint64{1, 4096} {
		b.Run(fmt.Sprintf("commit-interval=%d", commitInterval), func(b *testing.B) {
			disk := levelDB(b)
			defer disk.Close()
			db := versiondb.New(disk)
			repo, err := NewAtomicTxRepository(db, atomictest.TestTxCodec, 0)
			require.NoError(b, err)
			backend, err := NewAtomicBackend(atomictest.TestSharedMemory(), nil, repo, 0, common.Hash{}, commitInterval)
			require.NoError(b, err)
			tr := backend.AtomicTrie()

			ops := make([]map[ids.ID]*avalancheatomic.Requests, 1024)
			for i := range ops {
				o, err := atomictest.ConvertToAtomicOps(atomictest.GenerateTestImportTx())
				require.NoError(b, err)
				ops[i] = o
			}

			b.ReportAllocs()
			b.ResetTimer()
			for i := 0; i < b.N; i++ {
				height := uint64(i + 1)
				snapshot, err := tr.OpenTrie(tr.LastAcceptedRoot())
				require.NoError(b, err)
				require.NoError(b, tr.UpdateTrie(snapshot, height, ops[i%len(ops)]))
				root, nodes, err := snapshot.Commit(false)
				require.NoError(b, err)
				require.NoError(b, tr.InsertTrie(nodes, root))
				// Flush to disk on the same cadence as production: when the trie
				// actually committed (every block at interval 1, every 4096 at 4096).
				isCommit, err := tr.AcceptTrie(height, root)
				require.NoError(b, err)
				if isCommit {
					require.NoError(b, db.Commit())
				}
			}
		})
	}
}
```

</details>

## How this works

This PR just removes the `commitInterval` parameter/field from `NewAtomicBackend`, `newAtomicTrie`, and the `AtomicTrie` struct. The atomic trie now always commits at every accepted block. Tests were adjusted accordingly. 


## How this was tested

I updated atomic-trie unit tests to assert a committed root at every height (including no-tx heights via back-fill) and to cover AcceptTrie's gap back-fill directly. I also updated the atomic sync tests for testing resume and adjusted the SAE state test to construct the legacy backend without the interval.

## Need to be documented in RELEASES.md?
No, this is not a user facing API, and the EVM `commit-interval` flag is left untouched. 
