### PR TITLE
refactor(gastime): Accept baseFee in `New()`

### DIFF
--- a/main/BUILD.bazel
+++ b/main/BUILD.bazel
@@ -23,6 +23,7 @@ go_binary(
         # tests only by constraining the files with: //go:build !nocmpopts
         # If any identifiers leak then the binary won't build.
         "nocmpopts",
+        "prod",
     ],
     visibility = ["//visibility:public"],
     x_defs = {

--- a/vms/saevm/blocks/block_test.go
+++ b/vms/saevm/blocks/block_test.go
@@ -23,7 +23,7 @@ import (
 func newEthBlock(num, time uint64, parent *types.Block) *types.Block {
 	hdr := &types.Header{
 		Number:  new(big.Int).SetUint64(num),
-		BaseFee: new(big.Int).SetUint64(1),
+		BaseFee: big.NewInt(1),
 		Time:    time,
 	}
 	if parent != nil {

--- a/vms/saevm/blocks/block_test.go
+++ b/vms/saevm/blocks/block_test.go
@@ -22,8 +22,9 @@ import (
 
 func newEthBlock(num, time uint64, parent *types.Block) *types.Block {
 	hdr := &types.Header{
-		Number: new(big.Int).SetUint64(num),
-		Time:   time,
+		Number:  new(big.Int).SetUint64(num),
+		BaseFee: new(big.Int).SetUint64(1),
+		Time:    time,
 	}
 	if parent != nil {
 		hdr.ParentHash = parent.Hash()
@@ -73,7 +74,7 @@ func newChain(tb testing.TB, db ethdb.Database, xdb saetypes.ExecutionResults, s
 			// [newChain], and non-zero sub-second time for genesis is
 			// unnecessary.
 			h := hookstest.NewStub(1)
-			require.NoError(tb, b.MarkSynchronous(h, db, xdb, 0), "MarkSynchronous()")
+			require.NoError(tb, b.MarkSynchronous(h, db, xdb), "MarkSynchronous()")
 		}
 
 		parent = byNum[n]

--- a/vms/saevm/blocks/blockstest/blocks.go
+++ b/vms/saevm/blocks/blockstest/blocks.go
@@ -123,6 +123,7 @@ func NewGenesis(tb testing.TB, db ethdb.Database, xdb saetypes.ExecutionResults,
 	tb.Helper()
 	conf := &genesisConfig{
 		gasTarget: math.MaxUint64,
+		baseFee:   params.GWei,
 	}
 	options.ApplyTo(conf, opts...)
 
@@ -130,6 +131,7 @@ func NewGenesis(tb testing.TB, db ethdb.Database, xdb saetypes.ExecutionResults,
 		Config:    config,
 		Timestamp: conf.timestamp,
 		Alloc:     alloc,
+		BaseFee:   new(big.Int).SetUint64(conf.baseFee),
 	}
 
 	tdb := state.NewDatabaseWithConfig(db, conf.tdbConfig).TrieDB()
@@ -139,7 +141,7 @@ func NewGenesis(tb testing.TB, db ethdb.Database, xdb saetypes.ExecutionResults,
 
 	b := NewBlock(tb, gen.ToBlock(), nil, nil)
 	h := hookstest.NewStub(conf.gasTarget)
-	require.NoErrorf(tb, b.MarkSynchronous(h, db, xdb, conf.gasExcess), "%T.MarkSynchronous()", b)
+	require.NoErrorf(tb, b.MarkSynchronous(h, db, xdb), "%T.MarkSynchronous()", b)
 	return b
 }
 
@@ -147,7 +149,7 @@ type genesisConfig struct {
 	tdbConfig *triedb.Config
 	timestamp uint64
 	gasTarget gas.Gas
-	gasExcess gas.Gas
+	baseFee   uint64
 }
 
 // A GenesisOption configures [NewGenesis].
@@ -174,9 +176,9 @@ func WithGasTarget(target gas.Gas) GenesisOption {
 	})
 }
 
-// WithGasExcess overrides the gas excess used by [NewGenesis].
-func WithGasExcess(excess gas.Gas) GenesisOption {
+// WithBaseFee overrides the base fee used by [NewGenesis].
+func WithBaseFee(baseFee uint64) GenesisOption {
 	return options.Func[genesisConfig](func(gc *genesisConfig) {
-		gc.gasExcess = excess
+		gc.baseFee = baseFee
 	})
 }

--- a/vms/saevm/blocks/execution_test.go
+++ b/vms/saevm/blocks/execution_test.go
@@ -174,9 +174,9 @@ type selfAsHasher common.Hash
 
 func (h selfAsHasher) Hash() common.Hash { return common.Hash(h) }
 
-func mustNewGasTime(tb testing.TB, at time.Time, target, excess gas.Gas, gasPriceConfig gastime.GasPriceConfig) *gastime.Time {
+func mustNewGasTime(tb testing.TB, at time.Time, target gas.Gas, price gas.Price, gasPriceConfig gastime.GasPriceConfig) *gastime.Time {
 	tb.Helper()
-	tm, err := gastime.New(at, target, excess, gasPriceConfig)
+	tm, err := gastime.New(at, target, price, gasPriceConfig)
 	require.NoError(tb, err, "gastime.New()")
 	return tm
 }

--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 	"slices"
 	"sync/atomic"
 	"time"
@@ -97,8 +96,7 @@ func (b *Block) MarkSynchronous(hooks hook.Points, db ethdb.Database, xdb types.
 
 	// The base fee must be capped at [math.MaxUint64] to avoid overflow in the gastime.
 	baseFee := uint64(math.MaxUint64)
-	maxFee := new(big.Int).SetUint64(math.MaxUint64)
-	if bf := ethB.BaseFee(); maxFee.Cmp(bf) > 0 {
+	if bf := ethB.BaseFee(); bf.IsUint64() {
 		baseFee = bf.Uint64()
 	}
 

--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -95,17 +95,19 @@ func (b *Block) MarkSynchronous(hooks hook.Points, db ethdb.Database, xdb types.
 	// would also require them to be received as an argument to MarkSynchronous.
 	target, cfg := hooks.GasConfigAfter(b.Header())
 
-	baseFee := ethB.BaseFee()
+	// The base fee must be capped at [math.MaxUint64] to avoid overflow in the gastime.
+	baseFee := uint64(math.MaxUint64)
 	maxFee := new(big.Int).SetUint64(math.MaxUint64)
-	if maxFee.Cmp(baseFee) < 0 {
-		baseFee = maxFee
+	if bf := ethB.BaseFee(); maxFee.Cmp(bf) > 0 {
+		baseFee = bf.Uint64()
 	}
+
 	execTime, err := gastime.New(
 		hooks.BlockTime(b.Header()),
 		// Target, excess, and config _after_ are a requirement of
 		// [Block.MarkExecuted].
 		target,
-		gas.Price(baseFee.Uint64()),
+		gas.Price(baseFee),
 		cfg,
 	)
 	if err != nil {
@@ -116,9 +118,8 @@ func (b *Block) MarkSynchronous(hooks hook.Points, db ethdb.Database, xdb types.
 		receiptRoot:   ethB.ReceiptHash(),
 		stateRootPost: ethB.Root(),
 	}
-	if err := e.setBaseFee(baseFee); err != nil {
-		return err
-	}
+	e.baseFee.SetUint64(baseFee)
+
 	if err := b.markExecuted(db.NewBatch(), xdb, e, false, nil); err != nil {
 		return err
 	}

--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
 	"slices"
 	"sync/atomic"
 	"time"
@@ -85,19 +87,25 @@ func (b *Block) markSettled(lastSettled *atomic.Pointer[Block]) error {
 // has not yet commenced asynchronous execution.
 //
 // TODO(arr4n) refactor to avoid requiring DB writes.
-func (b *Block) MarkSynchronous(hooks hook.Points, db ethdb.Database, xdb types.ExecutionResults, excessAfter gas.Gas) error {
+func (b *Block) MarkSynchronous(hooks hook.Points, db ethdb.Database, xdb types.ExecutionResults) error {
 	ethB := b.EthBlock()
 	// Receipts of a synchronous block have already been "settled" by the block
 	// itself. As the only reason to pass receipts here is for later settlement
 	// in another block, there is no need to pass anything meaningful as it
 	// would also require them to be received as an argument to MarkSynchronous.
 	target, cfg := hooks.GasConfigAfter(b.Header())
+
+	baseFee := ethB.BaseFee()
+	maxFee := new(big.Int).SetUint64(math.MaxUint64)
+	if maxFee.Cmp(baseFee) < 0 {
+		baseFee = maxFee
+	}
 	execTime, err := gastime.New(
 		hooks.BlockTime(b.Header()),
 		// Target, excess, and config _after_ are a requirement of
 		// [Block.MarkExecuted].
 		target,
-		excessAfter,
+		gas.Price(baseFee.Uint64()),
 		cfg,
 	)
 	if err != nil {
@@ -108,7 +116,7 @@ func (b *Block) MarkSynchronous(hooks hook.Points, db ethdb.Database, xdb types.
 		receiptRoot:   ethB.ReceiptHash(),
 		stateRootPost: ethB.Root(),
 	}
-	if err := e.setBaseFee(ethB.BaseFee()); err != nil {
+	if err := e.setBaseFee(baseFee); err != nil {
 		return err
 	}
 	if err := b.markExecuted(db.NewBatch(), xdb, e, false, nil); err != nil {

--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -95,9 +95,14 @@ func (b *Block) MarkSynchronous(hooks hook.Points, db ethdb.Database, xdb types.
 	target, cfg := hooks.GasConfigAfter(b.Header())
 
 	// The base fee must be capped at [math.MaxUint64] to avoid overflow in the gastime.
-	baseFee := uint64(math.MaxUint64)
-	if bf := ethB.BaseFee(); bf.IsUint64() {
+	var baseFee uint64
+	switch bf := ethB.BaseFee(); {
+	case bf == nil:
+		baseFee = 0
+	case bf.IsUint64():
 		baseFee = bf.Uint64()
+	default:
+		baseFee = math.MaxUint64
 	}
 
 	execTime, err := gastime.New(

--- a/vms/saevm/gastime/BUILD.bazel
+++ b/vms/saevm/gastime/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//vms/components/gas",
         "//vms/saevm/intmath",
         "//vms/saevm/proxytime",
+        "@com_github_ava_labs_libevm//libevm/testonly",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
         "@com_github_holiman_uint256//:uint256",

--- a/vms/saevm/gastime/BUILD.bazel
+++ b/vms/saevm/gastime/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "config.go",
         "gastime.canoto.go",
         "gastime.go",
+        "testonly.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/vms/saevm/gastime",
     visibility = ["//visibility:public"],

--- a/vms/saevm/gastime/acp176_test.go
+++ b/vms/saevm/gastime/acp176_test.go
@@ -41,7 +41,7 @@ func TestInvalidConfigRejected(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tm := mustNewFromExcess(t, time.Unix(42, 0), target, 0, DefaultGasPriceConfig())
+			tm := mustNew(t, time.Unix(42, 0), target, DefaultMinPrice, DefaultGasPriceConfig())
 
 			initialScaling := tm.config.TargetToExcessScaling
 			initialMinPrice := tm.config.MinPrice
@@ -59,11 +59,11 @@ func TestInvalidConfigRejected(t *testing.T) {
 // rather than BeforeBlock.
 func TestTargetUpdateTiming(t *testing.T) {
 	const (
-		initialTime           = 42
-		initialTarget gas.Gas = 1_600_000
-		initialExcess         = 1_234_567_890
+		initialTime             = 42
+		initialTarget gas.Gas   = 1_600_000
+		initialPrice  gas.Price = 20_000
 	)
-	tm := mustNewFromExcess(t, time.Unix(initialTime, 0), initialTarget, initialExcess, DefaultGasPriceConfig())
+	tm := mustNew(t, time.Unix(initialTime, 0), initialTarget, initialPrice, DefaultGasPriceConfig())
 	initialRate := tm.Rate()
 
 	const (
@@ -71,7 +71,6 @@ func TestTargetUpdateTiming(t *testing.T) {
 		newTarget = initialTarget + 100_000
 	)
 
-	initialPrice := tm.Price()
 	tm.BeforeBlock(time.Unix(newTime, 0))
 	assert.Equal(t, uint64(newTime), tm.Unix(), "Unix time advanced by BeforeBlock()")
 	assert.Equal(t, initialTarget, tm.Target(), "Target not changed by BeforeBlock()")

--- a/vms/saevm/gastime/acp176_test.go
+++ b/vms/saevm/gastime/acp176_test.go
@@ -41,7 +41,7 @@ func TestInvalidConfigRejected(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tm := mustNew(t, time.Unix(42, 0), target, 0, DefaultGasPriceConfig())
+			tm := mustNewFromExcess(t, time.Unix(42, 0), target, 0, DefaultGasPriceConfig())
 
 			initialScaling := tm.config.TargetToExcessScaling
 			initialMinPrice := tm.config.MinPrice
@@ -63,7 +63,7 @@ func TestTargetUpdateTiming(t *testing.T) {
 		initialTarget gas.Gas = 1_600_000
 		initialExcess         = 1_234_567_890
 	)
-	tm := mustNew(t, time.Unix(initialTime, 0), initialTarget, initialExcess, DefaultGasPriceConfig())
+	tm := mustNewFromExcess(t, time.Unix(initialTime, 0), initialTarget, initialExcess, DefaultGasPriceConfig())
 	initialRate := tm.Rate()
 
 	const (
@@ -109,8 +109,8 @@ func FuzzWorstCasePrice(f *testing.F) {
 		gasCfg := DefaultGasPriceConfig()
 
 		initUnix := int64(min(initTimestamp, math.MaxInt64)) //#nosec G115 -- Clamped to MaxInt64
-		worstcase := mustNew(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
-		actual := mustNew(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
+		worstcase := mustNewFromExcess(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
+		actual := mustNewFromExcess(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
 
 		blocks := []struct {
 			time   uint64
@@ -766,7 +766,7 @@ func TestAfterBlock(t *testing.T) {
 	ignore := cmpopts.IgnoreFields(state{}, "UnixTime", "ConsumedThisSecond", "Target", "Config")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tm := mustNew(t, time.Unix(0, 0), tt.init.Target, tt.init.Excess, tt.init.Config)
+			tm := mustNewFromExcess(t, time.Unix(0, 0), tt.init.Target, tt.init.Excess, tt.init.Config)
 
 			tt.init.Rate = tm.Target() * TargetToRate
 			tm.requireState(
@@ -809,8 +809,8 @@ func TestOscillatingMinPrice(t *testing.T) {
 	lowPriceConfig := highPriceConfig
 	lowPriceConfig.MinPrice = lowMinPrice
 
-	control := mustNew(t, time.Unix(0, 0), target, 0, highPriceConfig)
-	modified := mustNew(t, time.Unix(0, 0), target, 0, highPriceConfig)
+	control := mustNewFromExcess(t, time.Unix(0, 0), target, 0, highPriceConfig)
+	modified := mustNewFromExcess(t, time.Unix(0, 0), target, 0, highPriceConfig)
 
 	require.Equalf(t, highMinPrice, control.Price(), "%T.Price()", control)
 	require.Equalf(t, highMinPrice, modified.Price(), "%T.Price()", modified)

--- a/vms/saevm/gastime/gastime.go
+++ b/vms/saevm/gastime/gastime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
+	"github.com/ava-labs/libevm/libevm/testonly"
 )
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE
@@ -124,6 +125,14 @@ func (tm *Time) Target() gas.Gas {
 // Excess returns the `x` variable of ACP-176.
 func (tm *Time) Excess() gas.Gas {
 	return tm.excess
+}
+
+// TestOnlySetExcess permanently overrides the [Time.Excess] but panics if
+// called outside of a testing environment. See [testonly.OrPanic].
+func (tm *Time) TestOnlySetExcess(x gas.Gas) {
+	testonly.OrPanic(func() {
+		tm.excess = x
+	})
 }
 
 // Price returns the price of a unit of gas, i.e. the "base fee", determined by

--- a/vms/saevm/gastime/gastime.go
+++ b/vms/saevm/gastime/gastime.go
@@ -9,12 +9,12 @@ import (
 	"math"
 	"time"
 
+	"github.com/ava-labs/libevm/libevm/testonly"
 	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/intmath"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
-	"github.com/ava-labs/libevm/libevm/testonly"
 )
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE

--- a/vms/saevm/gastime/gastime.go
+++ b/vms/saevm/gastime/gastime.go
@@ -45,7 +45,7 @@ type Time struct {
 // second.
 func New(at time.Time, target gas.Gas, startingPrice gas.Price, c GasPriceConfig) (*Time, error) {
 	target = clampTarget(target)
-	excess := excessForPrice(startingPrice, excessScalingFactor(target, c))
+	excess := excessForPrice(startingPrice, excessScalingFactor(target, c.TargetToExcessScaling))
 	return newFromExcess(at, target, excess, c)
 }
 
@@ -137,14 +137,14 @@ func (tm *Time) Price() gas.Price {
 // excessScalingFactor returns the K variable of ACP-103/176, i.e.
 // [GasPriceConfig.TargetToExcessScaling] * T, capped at [math.MaxUint64].
 func (tm *Time) excessScalingFactor() gas.Gas {
-	return excessScalingFactor(tm.target, tm.config)
+	return excessScalingFactor(tm.target, tm.config.TargetToExcessScaling)
 }
 
 // TODO(StephenButtolph): Rather than capping this at MaxUint64, we should move
 // the evaluation of T * K into the exponential calculation. This would allow us
 // to never round any values during calculation of extreme inputs.
-func excessScalingFactor(target gas.Gas, c GasPriceConfig) gas.Gas {
-	return intmath.BoundedMultiply(c.TargetToExcessScaling, target, math.MaxUint64)
+func excessScalingFactor(target gas.Gas, scalingFactor gas.Gas) gas.Gas {
+	return intmath.BoundedMultiply(target, scalingFactor, math.MaxUint64)
 }
 
 // BaseFee is equivalent to [Time.Price], returning the result as a uint256 for

--- a/vms/saevm/gastime/gastime.go
+++ b/vms/saevm/gastime/gastime.go
@@ -43,15 +43,13 @@ type Time struct {
 // New returns a new [Time], derived from a [time.Time]. The consumption of
 // `target` * [TargetToRate] units of [gas.Gas] is equivalent to a tick of 1
 // second.
-//
-// TODO(StephenButtolph): startingExcess is pretty difficult for a caller to
-// meaningfully provide. We should instead take in startingPrice.
-func New(at time.Time, target, startingExcess gas.Gas, c GasPriceConfig) (*Time, error) {
-	tm := proxytime.Of[gas.Gas](at)
+func New(at time.Time, target gas.Gas, startingPrice gas.Price, c GasPriceConfig) (*Time, error) {
+	pt := proxytime.Of[gas.Gas](at)
 	target = clampTarget(target)
-	tm.SetRate(rateOf(target))
+	pt.SetRate(rateOf(target))
 
-	return FromProxyTime(tm, startingExcess, c)
+	excess := excessForPrice(startingPrice, excessScalingFactor(target, c))
+	return FromProxyTime(pt, excess, c)
 }
 
 var errZeroTarget = errors.New("zero target not allowed")
@@ -139,7 +137,11 @@ func (tm *Time) Price() gas.Price {
 // the evaluation of T * K into the exponential calculation. This would allow us
 // to never round any values during calculation of extreme inputs.
 func (tm *Time) excessScalingFactor() gas.Gas {
-	return intmath.BoundedMultiply(tm.config.TargetToExcessScaling, tm.target, math.MaxUint64)
+	return excessScalingFactor(tm.target, tm.config)
+}
+
+func excessScalingFactor(target gas.Gas, c GasPriceConfig) gas.Gas {
+	return intmath.BoundedMultiply(c.TargetToExcessScaling, target, math.MaxUint64)
 }
 
 // BaseFee is equivalent to [Time.Price], returning the result as a uint256 for

--- a/vms/saevm/gastime/gastime.go
+++ b/vms/saevm/gastime/gastime.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/ava-labs/libevm/libevm/testonly"
 	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
@@ -125,14 +124,6 @@ func (tm *Time) Target() gas.Gas {
 // Excess returns the `x` variable of ACP-176.
 func (tm *Time) Excess() gas.Gas {
 	return tm.excess
-}
-
-// TestOnlySetExcess permanently overrides the [Time.Excess] but panics if
-// called outside of a testing environment. See [testonly.OrPanic].
-func (tm *Time) TestOnlySetExcess(x gas.Gas) {
-	testonly.OrPanic(func() {
-		tm.excess = x
-	})
 }
 
 // Price returns the price of a unit of gas, i.e. the "base fee", determined by

--- a/vms/saevm/gastime/gastime.go
+++ b/vms/saevm/gastime/gastime.go
@@ -44,11 +44,15 @@ type Time struct {
 // `target` * [TargetToRate] units of [gas.Gas] is equivalent to a tick of 1
 // second.
 func New(at time.Time, target gas.Gas, startingPrice gas.Price, c GasPriceConfig) (*Time, error) {
+	target = clampTarget(target)
+	excess := excessForPrice(startingPrice, excessScalingFactor(target, c))
+	return newFromExcess(at, target, excess, c)
+}
+
+func newFromExcess(at time.Time, target gas.Gas, excess gas.Gas, c GasPriceConfig) (*Time, error) {
 	pt := proxytime.Of[gas.Gas](at)
 	target = clampTarget(target)
 	pt.SetRate(rateOf(target))
-
-	excess := excessForPrice(startingPrice, excessScalingFactor(target, c))
 	return FromProxyTime(pt, excess, c)
 }
 
@@ -132,14 +136,13 @@ func (tm *Time) Price() gas.Price {
 
 // excessScalingFactor returns the K variable of ACP-103/176, i.e.
 // [GasPriceConfig.TargetToExcessScaling] * T, capped at [math.MaxUint64].
-//
-// TODO(StephenButtolph): Rather than capping this at MaxUint64, we should move
-// the evaluation of T * K into the exponential calculation. This would allow us
-// to never round any values during calculation of extreme inputs.
 func (tm *Time) excessScalingFactor() gas.Gas {
 	return excessScalingFactor(tm.target, tm.config)
 }
 
+// TODO(StephenButtolph): Rather than capping this at MaxUint64, we should move
+// the evaluation of T * K into the exponential calculation. This would allow us
+// to never round any values during calculation of extreme inputs.
 func excessScalingFactor(target gas.Gas, c GasPriceConfig) gas.Gas {
 	return intmath.BoundedMultiply(c.TargetToExcessScaling, target, math.MaxUint64)
 }

--- a/vms/saevm/gastime/gastime_test.go
+++ b/vms/saevm/gastime/gastime_test.go
@@ -18,11 +18,18 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
-func mustNew(tb testing.TB, at time.Time, target, startingExcess gas.Gas, gasPriceConfig GasPriceConfig) *Time {
+func mustNewFromExcess(tb testing.TB, at time.Time, target, startingExcess gas.Gas, gasPriceConfig GasPriceConfig) *Time {
 	tb.Helper()
-	tm, err := New(at, target, startingExcess, gasPriceConfig)
+	tm, err := newFromExcess(at, target, startingExcess, gasPriceConfig)
 	require.NoError(tb, err, "New(%v, %d, %d, %v)", at, target, startingExcess, gasPriceConfig)
 	return tm
+}
+
+func newFromExcess(at time.Time, target, startingExcess gas.Gas, gasPriceConfig GasPriceConfig) (*Time, error) {
+	pt := proxytime.Of[gas.Gas](at)
+	target = clampTarget(target)
+	pt.SetRate(rateOf(target))
+	return FromProxyTime(pt, startingExcess, gasPriceConfig)
 }
 
 func (tm *Time) cloneViaCanotoRoundTrip(tb testing.TB) *Time {
@@ -33,7 +40,7 @@ func (tm *Time) cloneViaCanotoRoundTrip(tb testing.TB) *Time {
 }
 
 func TestClone(t *testing.T) {
-	tm := mustNew(t, time.Unix(42, 1), 1e6, 1e5, GasPriceConfig{TargetToExcessScaling: 100, MinPrice: 200})
+	tm := mustNewFromExcess(t, time.Unix(42, 1), 1e6, 1e5, GasPriceConfig{TargetToExcessScaling: 100, MinPrice: 200})
 
 	if diff := cmp.Diff(tm, tm.Clone(), CmpOpt()); diff != "" {
 		t.Errorf("%T.Clone() diff (-want +got):\n%s", tm, diff)
@@ -75,20 +82,21 @@ func (tm *Time) requireState(tb testing.TB, desc string, want state, opts ...cmp
 	}
 }
 
-func TestNew(t *testing.T) {
+func TestNewInitialState(t *testing.T) {
 	frac := func(num, den gas.Gas) (f proxytime.FractionalSecond[gas.Gas]) {
 		f.Numerator = num
 		f.Denominator = den
 		return
 	}
 
-	ignore := cmpopts.IgnoreFields(state{}, "Rate", "Config", "Price")
+	ignore := cmpopts.IgnoreFields(state{}, "Rate", "Config", "Excess")
 
 	tests := []struct {
-		name           string
-		unix, nanos    int64
-		target, excess gas.Gas
-		want           state
+		name        string
+		unix, nanos int64
+		target      gas.Gas
+		price       gas.Price
+		want        state
 	}{
 		{
 			name:   "rate at nanosecond resolution",
@@ -99,6 +107,7 @@ func TestNew(t *testing.T) {
 				UnixTime:           42,
 				ConsumedThisSecond: frac(123_456, 1e9),
 				Target:             1e9 / TargetToRate,
+				Price:              DefaultMinPrice,
 			},
 		},
 		{
@@ -106,12 +115,12 @@ func TestNew(t *testing.T) {
 			unix:   100,
 			nanos:  TargetToRate,
 			target: 50 / TargetToRate,
-			excess: 987_654,
+			price:  math.MaxUint64,
 			want: state{
 				UnixTime:           100,
 				ConsumedThisSecond: frac(1, 50),
 				Target:             50 / TargetToRate,
-				Excess:             987_654,
+				Price:              math.MaxUint64,
 			},
 		},
 	}
@@ -119,8 +128,9 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tm := time.Unix(tt.unix, tt.nanos)
-			got := mustNew(t, tm, tt.target, tt.excess, DefaultGasPriceConfig())
-			got.requireState(t, fmt.Sprintf("New(%v, %d, %d)", tm, tt.target, tt.excess), tt.want, ignore)
+			got, err := New(tm, tt.target, tt.price, DefaultGasPriceConfig())
+			require.NoError(t, err)
+			got.requireState(t, fmt.Sprintf("New(%v, %d, %d)", tm, tt.target, tt.price), tt.want, ignore)
 		})
 	}
 }
@@ -134,7 +144,7 @@ func TestNewZeroTarget(t *testing.T) {
 
 func TestExcess(t *testing.T) {
 	const rate = gas.Gas(3.2e6)
-	tm := mustNew(t, time.Unix(42, 0), rate/2, 0, DefaultGasPriceConfig())
+	tm := mustNewFromExcess(t, time.Unix(42, 0), rate/2, 0, DefaultGasPriceConfig())
 
 	frac := func(num gas.Gas) (f proxytime.FractionalSecond[gas.Gas]) {
 		f.Numerator = num
@@ -322,7 +332,7 @@ func TestMinAndStaticPrice(t *testing.T) {
 			cfg.MinPrice = tt.minPrice
 			cfg.StaticPricing = tt.static
 
-			tm, err := New(time.Unix(0, 0), target, tt.startingExcess, cfg)
+			tm, err := newFromExcess(time.Unix(0, 0), target, tt.startingExcess, cfg)
 			if diff := testerr.Diff(err, tt.wantErr); diff != "" {
 				t.Fatalf("New(..., %+v) %s", cfg, diff)
 			}
@@ -342,7 +352,7 @@ func TestTickExcessOverflow(t *testing.T) {
 		startExcess = math.MaxUint64 - shortFall
 		tick        = TargetToRate * (1 + shortFall) // increases excess by 1+shortFall -> overflow risk
 	)
-	tm := mustNew(t, time.Unix(0, 0), 1, startExcess, DefaultGasPriceConfig())
+	tm := mustNewFromExcess(t, time.Unix(0, 0), 1, startExcess, DefaultGasPriceConfig())
 	tm.Tick(tick)
 	require.Greater(t, tm.Excess(), gas.Gas(startExcess), "Excess() must increase after Tick(>1)")
 }

--- a/vms/saevm/gastime/gastime_test.go
+++ b/vms/saevm/gastime/gastime_test.go
@@ -18,18 +18,18 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
-func mustNewFromExcess(tb testing.TB, at time.Time, target, startingExcess gas.Gas, gasPriceConfig GasPriceConfig) *Time {
+func mustNew(tb testing.TB, at time.Time, target gas.Gas, startingPrice gas.Price, c GasPriceConfig) *Time {
 	tb.Helper()
-	tm, err := newFromExcess(at, target, startingExcess, gasPriceConfig)
-	require.NoError(tb, err, "New(%v, %d, %d, %v)", at, target, startingExcess, gasPriceConfig)
+	tm, err := New(at, target, startingPrice, c)
+	require.NoError(tb, err, "New(%v, %d, %d, %v)", at, target, startingPrice, c)
 	return tm
 }
 
-func newFromExcess(at time.Time, target, startingExcess gas.Gas, gasPriceConfig GasPriceConfig) (*Time, error) {
-	pt := proxytime.Of[gas.Gas](at)
-	target = clampTarget(target)
-	pt.SetRate(rateOf(target))
-	return FromProxyTime(pt, startingExcess, gasPriceConfig)
+func mustNewFromExcess(tb testing.TB, at time.Time, target, startingExcess gas.Gas, gasPriceConfig GasPriceConfig) *Time {
+	tb.Helper()
+	tm, err := newFromExcess(at, target, startingExcess, gasPriceConfig)
+	require.NoError(tb, err, "newFromExcess(%v, %d, %d, %v)", at, target, startingExcess, gasPriceConfig)
+	return tm
 }
 
 func (tm *Time) cloneViaCanotoRoundTrip(tb testing.TB) *Time {
@@ -40,7 +40,7 @@ func (tm *Time) cloneViaCanotoRoundTrip(tb testing.TB) *Time {
 }
 
 func TestClone(t *testing.T) {
-	tm := mustNewFromExcess(t, time.Unix(42, 1), 1e6, 1e5, GasPriceConfig{TargetToExcessScaling: 100, MinPrice: 200})
+	tm := mustNew(t, time.Unix(42, 1), 1e6, 1e5, GasPriceConfig{TargetToExcessScaling: 100, MinPrice: 200})
 
 	if diff := cmp.Diff(tm, tm.Clone(), CmpOpt()); diff != "" {
 		t.Errorf("%T.Clone() diff (-want +got):\n%s", tm, diff)
@@ -111,7 +111,7 @@ func TestNewInitialState(t *testing.T) {
 			},
 		},
 		{
-			name:   "scaling in constructor not applied to starting excess",
+			name:   "scaling in constructor not applied to starting price",
 			unix:   100,
 			nanos:  TargetToRate,
 			target: 50 / TargetToRate,
@@ -123,14 +123,23 @@ func TestNewInitialState(t *testing.T) {
 				Price:              math.MaxUint64,
 			},
 		},
+		{
+			name:   "price is maintained",
+			price:  123_456,
+			target: 1e6 / TargetToRate,
+			want: state{
+				ConsumedThisSecond: frac(0, 1e6),
+				Target:             1e6 / TargetToRate,
+				Price:              123_456,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tm := time.Unix(tt.unix, tt.nanos)
-			got, err := New(tm, tt.target, tt.price, DefaultGasPriceConfig())
-			require.NoError(t, err)
-			got.requireState(t, fmt.Sprintf("New(%v, %d, %d)", tm, tt.target, tt.price), tt.want, ignore)
+			got := mustNew(t, tm, tt.target, tt.price, DefaultGasPriceConfig())
+			got.requireState(t, fmt.Sprintf("New(%v, %d, %d, %v)", tm, tt.target, tt.price, DefaultGasPriceConfig()), tt.want, ignore)
 		})
 	}
 }

--- a/vms/saevm/gastime/testonly.go
+++ b/vms/saevm/gastime/testonly.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+//go:build !prod
+
+package gastime
+
+import (
+	"github.com/ava-labs/libevm/libevm/testonly"
+
+	"github.com/ava-labs/avalanchego/vms/components/gas"
+)
+
+// TestOnlySetExcess permanently overrides the [Time.Excess] but panics if
+// called outside of a testing environment. See [testonly.OrPanic].
+func (tm *Time) TestOnlySetExcess(x gas.Gas) {
+	testonly.OrPanic(func() {
+		tm.excess = x
+	})
+}

--- a/vms/saevm/sae/blocks.go
+++ b/vms/saevm/sae/blocks.go
@@ -226,10 +226,7 @@ func (vm *VM) settledBlockFromDB(db ethdb.Reader, hash common.Hash, num uint64) 
 	if err != nil {
 		return nil, err
 	}
-	// Excess is only used for executing the next block, which can never
-	// be the case if `b` isn't actually the last synchronous block, so
-	// passing the same value for all is OK.
-	if err := b.MarkSynchronous(vm.hooks, vm.db, vm.xdb, vm.config.ExcessAfterLastSynchronous); err != nil {
+	if err := b.MarkSynchronous(vm.hooks, vm.db, vm.xdb); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/vms/saevm/sae/rpc_custom_test.go
+++ b/vms/saevm/sae/rpc_custom_test.go
@@ -37,10 +37,14 @@ func TestGetChainConfig(t *testing.T) {
 	})
 }
 
+func withGenesisBaseFee(fee uint64) sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		c.genesis.BaseFee = new(big.Int).SetUint64(fee)
+	})
+}
+
 func TestBaseFee(t *testing.T) {
-	ctx, sut := newSUT(t, 0, options.Func[sutConfig](func(c *sutConfig) {
-		c.genesis.BaseFee = big.NewInt(params.InitialBaseFee)
-	}))
+	ctx, sut := newSUT(t, 0, withGenesisBaseFee(params.InitialBaseFee))
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_baseFee",
 		want:   hexBig(params.InitialBaseFee),
@@ -54,9 +58,7 @@ func TestBaseFee(t *testing.T) {
 }
 
 func TestSuggestPriceOptions(t *testing.T) {
-	ctx, sut := newSUT(t, 0, options.Func[sutConfig](func(c *sutConfig) {
-		c.genesis.BaseFee = big.NewInt(params.InitialBaseFee)
-	}))
+	ctx, sut := newSUT(t, 0, withGenesisBaseFee(params.InitialBaseFee))
 	// Before any blocks with worst-case bounds, the base fee falls back to the
 	// genesis base fee and the tip defaults to the minimum (no txs yet).
 	sut.testRPC(ctx, t, rpcTest{

--- a/vms/saevm/sae/rpc_custom_test.go
+++ b/vms/saevm/sae/rpc_custom_test.go
@@ -38,7 +38,9 @@ func TestGetChainConfig(t *testing.T) {
 }
 
 func TestBaseFee(t *testing.T) {
-	ctx, sut := newSUT(t, 0)
+	ctx, sut := newSUT(t, 0, options.Func[sutConfig](func(c *sutConfig) {
+		c.genesis.BaseFee = big.NewInt(params.InitialBaseFee)
+	}))
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_baseFee",
 		want:   hexBig(params.InitialBaseFee),
@@ -52,7 +54,9 @@ func TestBaseFee(t *testing.T) {
 }
 
 func TestSuggestPriceOptions(t *testing.T) {
-	ctx, sut := newSUT(t, 0)
+	ctx, sut := newSUT(t, 0, options.Func[sutConfig](func(c *sutConfig) {
+		c.genesis.BaseFee = big.NewInt(params.InitialBaseFee)
+	}))
 	// Before any blocks with worst-case bounds, the base fee falls back to the
 	// genesis base fee and the tip defaults to the minimum (no txs yet).
 	sut.testRPC(ctx, t, rpcTest{

--- a/vms/saevm/sae/vm.go
+++ b/vms/saevm/sae/vm.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/bloom"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/version"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/sae/rpc"
@@ -99,8 +98,6 @@ type Config struct {
 	DBConfig      saedb.Config
 	RPCConfig     rpc.Config
 
-	ExcessAfterLastSynchronous gas.Gas
-
 	Now func() time.Time // defaults to [time.Now] if nil
 }
 
@@ -156,7 +153,7 @@ func NewVM[T hook.Transaction](
 	vm.last.synchronous = lastSync.Height()
 
 	{ // ==========  Sync -> Async  ==========
-		if err := lastSync.MarkSynchronous(hooks, db, xdb, cfg.ExcessAfterLastSynchronous); err != nil {
+		if err := lastSync.MarkSynchronous(hooks, db, xdb); err != nil {
 			return nil, fmt.Errorf("%T{genesis}.MarkSynchronous(): %v", lastSync, err)
 		}
 		if err := canonicaliseLastSynchronous(db, lastSync); err != nil {

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -127,6 +127,7 @@ func newSUT(tb testing.TB, numAccounts uint, opts ...sutOption) (context.Context
 			Config:     saetest.ChainConfig(),
 			Alloc:      saetest.MaxAllocFor(keys.Addresses()...),
 			Timestamp:  saeparams.TauSeconds,
+			BaseFee:    big.NewInt(1),
 			Difficulty: big.NewInt(0), // irrelevant but required
 		},
 		db: memdb.New(),

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -105,7 +105,13 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 
 	wallet := saetest.NewUNSAFEWallet(tb, 1, types.LatestSigner(config))
 	alloc := saetest.MaxAllocFor(wallet.Addresses()...)
-	genesis := blockstest.NewGenesis(tb, db, xdb, config, alloc, blockstest.WithTrieDBConfig(tdbConfig), blockstest.WithGasTarget(sutCfg.hooks.Target), blockstest.WithBaseFee(1))
+
+	genOpts := []blockstest.GenesisOption{
+		blockstest.WithTrieDBConfig(tdbConfig),
+		blockstest.WithGasTarget(sutCfg.hooks.Target),
+		blockstest.WithBaseFee(1),
+	}
+	genesis := blockstest.NewGenesis(tb, db, xdb, config, alloc, genOpts...)
 
 	blockOpts := blockstest.WithBlockOptions(
 		blockstest.WithLogger(logger),

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -105,7 +105,7 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 
 	wallet := saetest.NewUNSAFEWallet(tb, 1, types.LatestSigner(config))
 	alloc := saetest.MaxAllocFor(wallet.Addresses()...)
-	genesis := blockstest.NewGenesis(tb, db, xdb, config, alloc, blockstest.WithTrieDBConfig(tdbConfig), blockstest.WithGasTarget(sutCfg.hooks.Target))
+	genesis := blockstest.NewGenesis(tb, db, xdb, config, alloc, blockstest.WithTrieDBConfig(tdbConfig), blockstest.WithGasTarget(sutCfg.hooks.Target), blockstest.WithBaseFee(1))
 
 	blockOpts := blockstest.WithBlockOptions(
 		blockstest.WithLogger(logger),

--- a/vms/saevm/worstcase/state_test.go
+++ b/vms/saevm/worstcase/state_test.go
@@ -46,7 +46,7 @@ type SUT struct {
 
 const (
 	initialGasTarget = 1_000_000
-	initialExcess    = 60_303_807 // Maximum excess that results in gas price of 1
+	initialBaseFee   = 10
 )
 
 func newSUT(tb testing.TB, alloc types.GenesisAlloc) SUT {
@@ -62,7 +62,7 @@ func newSUT(tb testing.TB, alloc types.GenesisAlloc) SUT {
 		config,
 		alloc,
 		blockstest.WithGasTarget(initialGasTarget),
-		blockstest.WithGasExcess(initialExcess),
+		blockstest.WithBaseFee(initialBaseFee),
 	)
 	hooks := hookstest.NewStub(initialGasTarget)
 	s, err := NewState(hooks, config, genesis, saetest.NewStateDBOpener(cache, nil))
@@ -109,7 +109,10 @@ func TestMultipleBlocks(t *testing.T) {
 	lastHash := sut.genesis.Hash()
 	wantLatestEndTime := sut.genesis.ExecutedByGasTime().Clone()
 
-	const importedAmount = 10
+	const (
+		importedAmount = 10
+		gasFeeCap      = 2 * initialBaseFee
+	)
 	type op struct {
 		name    string
 		op      Op
@@ -127,13 +130,13 @@ func TestMultipleBlocks(t *testing.T) {
 		{
 			hooks:        hookstest.NewStub(2 * initialGasTarget), // Will double the target _after_ this block.
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(1),
+			wantBaseFee:  uint256.NewInt(10),
 			ops: []op{
 				{
 					name: "include_small_operation",
 					op: Op{
 						Gas:       gas.Gas(params.TxGas),
-						GasFeeCap: *uint256.NewInt(1),
+						GasFeeCap: *uint256.NewInt(gasFeeCap),
 						Burn: map[common.Address]hook.AccountDebit{
 							eoa: {},
 						},
@@ -144,7 +147,7 @@ func TestMultipleBlocks(t *testing.T) {
 					name: "would_exceed_limit",
 					op: Op{
 						Gas:       gas.Gas(initialMaxBlockSize - params.TxGas + 1),
-						GasFeeCap: *uint256.NewInt(1),
+						GasFeeCap: *uint256.NewInt(gasFeeCap),
 					},
 					wantErr: core.ErrGasLimitReached,
 				},
@@ -152,7 +155,7 @@ func TestMultipleBlocks(t *testing.T) {
 					name: "fill_block",
 					op: Op{
 						Gas:       gas.Gas(initialMaxBlockSize - params.TxGas),
-						GasFeeCap: *uint256.NewInt(1),
+						GasFeeCap: *uint256.NewInt(gasFeeCap),
 					},
 					wantErr: nil,
 				},
@@ -166,13 +169,13 @@ func TestMultipleBlocks(t *testing.T) {
 		{
 			hooks:        hookstest.NewStub(initialGasTarget), // Restore the target _after_ this block.
 			wantGasLimit: 2 * initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(2),
+			wantBaseFee:  uint256.NewInt(11),
 			ops: []op{
 				{
 					name: "import",
 					op: Op{
 						Gas:       1,
-						GasFeeCap: *uint256.NewInt(2),
+						GasFeeCap: *uint256.NewInt(gasFeeCap),
 						Mint: map[common.Address]uint256.Int{
 							eoaNoBalance: *uint256.NewInt(importedAmount),
 						},
@@ -183,7 +186,7 @@ func TestMultipleBlocks(t *testing.T) {
 					name: "imported_funds_insufficient",
 					op: Op{
 						Gas:       1,
-						GasFeeCap: *uint256.NewInt(2),
+						GasFeeCap: *uint256.NewInt(gasFeeCap),
 						Burn: map[common.Address]AccountDebit{
 							eoaNoBalance: {
 								Amount:     *uint256.NewInt(importedAmount + 1),
@@ -197,7 +200,7 @@ func TestMultipleBlocks(t *testing.T) {
 					name: "spend_imported_funds",
 					op: Op{
 						Gas:       1,
-						GasFeeCap: *uint256.NewInt(2),
+						GasFeeCap: *uint256.NewInt(gasFeeCap),
 						Burn: map[common.Address]AccountDebit{
 							eoaNoBalance: {
 								Amount:     *uint256.NewInt(importedAmount),
@@ -216,29 +219,29 @@ func TestMultipleBlocks(t *testing.T) {
 		},
 		{
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(2),
+			wantBaseFee:  uint256.NewInt(11),
 			txsAfterOps: []*types.Transaction{
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					To:       &common.Address{},
 					Gas:      100_000,
-					GasPrice: big.NewInt(2),
+					GasPrice: big.NewInt(11),
 				}),
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					To:       &common.Address{},
 					Gas:      200_000,
-					GasPrice: big.NewInt(2),
+					GasPrice: big.NewInt(11),
 					Value:    big.NewInt(123_456),
 				}),
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					To:       nil,
 					Gas:      100_000,
-					GasPrice: big.NewInt(10), // charged in full
+					GasPrice: big.NewInt(500), // charged in full
 				}),
 				wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
 					To:        &common.Address{},
 					Gas:       100_000,
 					GasTipCap: big.NewInt(1),
-					GasFeeCap: big.NewInt(100),
+					GasFeeCap: big.NewInt(11),
 				}),
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					// Irrelevant parameters that only need to be valid. Needed
@@ -246,16 +249,16 @@ func TestMultipleBlocks(t *testing.T) {
 					// the penultimate tx.
 					To:       &common.Address{},
 					Gas:      params.TxGas,
-					GasPrice: big.NewInt(2),
+					GasPrice: big.NewInt(11),
 				}),
 			},
 			wantMinSenderBalances: []map[common.Address]uint64{
 				// Before each tx:
 				{eoaViaTx: startingBalance},
-				{eoaViaTx: startingBalance - 2*100_000},
-				{eoaViaTx: startingBalance - 2*100_000 - (2*200_000 + 123_456)},
-				{eoaViaTx: startingBalance - 2*100_000 - (2*200_000 + 123_456) - 10*100_000},             // non-dynamic fee
-				{eoaViaTx: startingBalance - 2*100_000 - (2*200_000 + 123_456) - 10*100_000 - 3*100_000}, // dynamic fee: effective gas price = baseFee + gasTipCap
+				{eoaViaTx: startingBalance - 11*100_000},
+				{eoaViaTx: startingBalance - 11*100_000 - (11*200_000 + 123_456)},
+				{eoaViaTx: startingBalance - 11*100_000 - (11*200_000 + 123_456) - 500*100_000},              // non-dynamic fee
+				{eoaViaTx: startingBalance - 11*100_000 - (11*200_000 + 123_456) - 500*100_000 - 11*100_000}, // dynamic fee: effective gas price = baseFee + gasTipCap
 			},
 		},
 		{
@@ -264,7 +267,7 @@ func TestMultipleBlocks(t *testing.T) {
 			// fee.
 			time:         21,
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(1),
+			wantBaseFee:  uint256.NewInt(9),
 		},
 	}
 	for i, block := range tests {
@@ -282,12 +285,12 @@ func TestMultipleBlocks(t *testing.T) {
 		require.Equalf(t, block.wantBaseFee, state.BaseFee(), "base fee after StartBlock(%d)", i)
 		require.Equalf(t, block.wantGasLimit, state.GasLimit(), "gas limit after StartBlock(%d)", i)
 
-		for _, op := range block.ops {
+		for j, op := range block.ops {
 			gotErr := state.Apply(op.op)
-			require.ErrorIsf(t, gotErr, op.wantErr, "Apply(%s) error", op.name)
+			require.ErrorIsf(t, gotErr, op.wantErr, "Apply(%s) error %d:%d", op.name, i, j)
 		}
-		for _, tx := range block.txsAfterOps {
-			require.NoErrorf(t, state.ApplyTx(tx), "ApplyTx()")
+		for j, tx := range block.txsAfterOps {
+			require.NoErrorf(t, state.ApplyTx(tx), "ApplyTx() %d:%d", i, j)
 		}
 
 		got, err := state.FinishBlock()
@@ -344,7 +347,7 @@ func TestTransactionValidation(t *testing.T) {
 			name: "nonce_too_high",
 			tx: &types.LegacyTx{
 				Nonce:    1,
-				GasPrice: big.NewInt(1),
+				GasPrice: big.NewInt(initialBaseFee),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 			},
@@ -354,7 +357,7 @@ func TestTransactionValidation(t *testing.T) {
 			name:  "nonce_too_low",
 			nonce: 1,
 			tx: &types.LegacyTx{
-				GasPrice: big.NewInt(1),
+				GasPrice: big.NewInt(initialBaseFee),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 			},
@@ -365,7 +368,7 @@ func TestTransactionValidation(t *testing.T) {
 			nonce: math.MaxUint64,
 			tx: &types.LegacyTx{
 				Nonce:    math.MaxUint64,
-				GasPrice: big.NewInt(1),
+				GasPrice: big.NewInt(initialBaseFee),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 			},
@@ -386,7 +389,7 @@ func TestTransactionValidation(t *testing.T) {
 		{
 			name: "negative_value",
 			tx: &types.LegacyTx{
-				GasPrice: big.NewInt(1),
+				GasPrice: big.NewInt(initialBaseFee),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 				Value:    big.NewInt(-1),
@@ -406,7 +409,7 @@ func TestTransactionValidation(t *testing.T) {
 			name: "insufficient_funds",
 			tx: &types.LegacyTx{
 				Gas:      params.TxGas,
-				GasPrice: big.NewInt(1),
+				GasPrice: big.NewInt(initialBaseFee),
 				To:       &common.Address{},
 				Value:    big.NewInt(0),
 			},
@@ -418,7 +421,7 @@ func TestTransactionValidation(t *testing.T) {
 			name:    "gas_limit_exceeded",
 			balance: initialMaxBlockSize,
 			tx: &types.LegacyTx{
-				GasPrice: big.NewInt(1),
+				GasPrice: big.NewInt(initialBaseFee),
 				Gas:      initialMaxBlockSize + 1,
 				To:       &common.Address{},
 			},
@@ -454,7 +457,7 @@ func TestTransactionValidation(t *testing.T) {
 			name: "gas_tip_cap_very_high",
 			tx: &types.DynamicFeeTx{
 				GasTipCap: new(big.Int).Lsh(big.NewInt(1), 256),
-				GasFeeCap: big.NewInt(1),
+				GasFeeCap: big.NewInt(initialBaseFee),
 				Gas:       params.TxGas,
 				To:        &common.Address{},
 			},
@@ -463,8 +466,8 @@ func TestTransactionValidation(t *testing.T) {
 		{
 			name: "gas_tip_above_fee_cap",
 			tx: &types.DynamicFeeTx{
-				GasTipCap: big.NewInt(2),
-				GasFeeCap: big.NewInt(1),
+				GasTipCap: big.NewInt(1 + initialBaseFee),
+				GasFeeCap: big.NewInt(initialBaseFee),
 				Gas:       params.TxGas,
 				To:        &common.Address{},
 			},
@@ -482,7 +485,7 @@ func TestTransactionValidation(t *testing.T) {
 		},
 		{
 			name:    "dynamic_fee_insufficient_for_fee_cap",
-			balance: 100_000, // enough for effectiveGasPrice (1) * gas (21000) but not gasFeeCap (100) * gas (21000) = 2_100_000
+			balance: 300_000, // enough for effectiveGasPrice (10) * gas (21000) but not gasFeeCap (100) * gas (21000) = 2_100_000
 			tx: &types.DynamicFeeTx{
 				GasTipCap: big.NewInt(0),
 				GasFeeCap: big.NewInt(100),
@@ -496,7 +499,7 @@ func TestTransactionValidation(t *testing.T) {
 		{
 			name: "sender_not_eoa",
 			tx: &types.LegacyTx{
-				GasPrice: big.NewInt(1),
+				GasPrice: big.NewInt(initialBaseFee),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 			},
@@ -586,7 +589,7 @@ func TestStartBlockQueueFull(t *testing.T) {
 
 		err := state.Apply(Op{
 			Gas:       gas,
-			GasFeeCap: *uint256.NewInt(2),
+			GasFeeCap: *uint256.NewInt(2 * initialBaseFee),
 		})
 		require.NoError(t, err, "Apply()")
 
@@ -617,7 +620,7 @@ func TestStartBlockQueueFullDueToTargetChanges(t *testing.T) {
 
 	err := state.Apply(Op{
 		Gas:       initialMaxBlockSize,
-		GasFeeCap: *uint256.NewInt(1),
+		GasFeeCap: *uint256.NewInt(initialBaseFee),
 	})
 	require.NoError(t, err, "Apply()")
 
@@ -679,7 +682,7 @@ func TestCanExecuteTransactionHook(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tx := wallet.SetNonceAndSign(t, tt.account, &types.DynamicFeeTx{
-				GasFeeCap: big.NewInt(1),
+				GasFeeCap: big.NewInt(initialBaseFee),
 				Gas:       params.TxGas,
 				To:        &common.Address{},
 			})

--- a/vms/saevm/worstcase/state_test.go
+++ b/vms/saevm/worstcase/state_test.go
@@ -46,7 +46,6 @@ type SUT struct {
 
 const (
 	initialGasTarget = 1_000_000
-	initialBaseFee   = 10
 )
 
 func newSUT(tb testing.TB, alloc types.GenesisAlloc) SUT {
@@ -62,7 +61,7 @@ func newSUT(tb testing.TB, alloc types.GenesisAlloc) SUT {
 		config,
 		alloc,
 		blockstest.WithGasTarget(initialGasTarget),
-		blockstest.WithBaseFee(initialBaseFee),
+		blockstest.WithBaseFee(params.Wei),
 	)
 	hooks := hookstest.NewStub(initialGasTarget)
 	s, err := NewState(hooks, config, genesis, saetest.NewStateDBOpener(cache, nil))
@@ -107,12 +106,17 @@ func TestMultipleBlocks(t *testing.T) {
 
 	state := sut.State
 	lastHash := sut.genesis.Hash()
-	wantLatestEndTime := sut.genesis.ExecutedByGasTime().Clone()
 
-	const (
-		importedAmount = 10
-		gasFeeCap      = 2 * initialBaseFee
-	)
+	const maxExcessForPrice1 = 60_303_807
+	tm := state.clock
+	tm.TestOnlySetExcess(maxExcessForPrice1 + 1)
+	require.Equal(t, gas.Price(2), tm.Price())
+	tm.TestOnlySetExcess(maxExcessForPrice1)
+	require.Equal(t, gas.Price(1), tm.Price())
+
+	wantLatestEndTime := tm.Clone()
+
+	const importedAmount = 10
 	type op struct {
 		name    string
 		op      Op
@@ -130,13 +134,13 @@ func TestMultipleBlocks(t *testing.T) {
 		{
 			hooks:        hookstest.NewStub(2 * initialGasTarget), // Will double the target _after_ this block.
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(10),
+			wantBaseFee:  uint256.NewInt(1),
 			ops: []op{
 				{
 					name: "include_small_operation",
 					op: Op{
 						Gas:       gas.Gas(params.TxGas),
-						GasFeeCap: *uint256.NewInt(gasFeeCap),
+						GasFeeCap: *uint256.NewInt(1),
 						Burn: map[common.Address]hook.AccountDebit{
 							eoa: {},
 						},
@@ -147,7 +151,7 @@ func TestMultipleBlocks(t *testing.T) {
 					name: "would_exceed_limit",
 					op: Op{
 						Gas:       gas.Gas(initialMaxBlockSize - params.TxGas + 1),
-						GasFeeCap: *uint256.NewInt(gasFeeCap),
+						GasFeeCap: *uint256.NewInt(1),
 					},
 					wantErr: core.ErrGasLimitReached,
 				},
@@ -155,7 +159,7 @@ func TestMultipleBlocks(t *testing.T) {
 					name: "fill_block",
 					op: Op{
 						Gas:       gas.Gas(initialMaxBlockSize - params.TxGas),
-						GasFeeCap: *uint256.NewInt(gasFeeCap),
+						GasFeeCap: *uint256.NewInt(1),
 					},
 					wantErr: nil,
 				},
@@ -169,13 +173,13 @@ func TestMultipleBlocks(t *testing.T) {
 		{
 			hooks:        hookstest.NewStub(initialGasTarget), // Restore the target _after_ this block.
 			wantGasLimit: 2 * initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(11),
+			wantBaseFee:  uint256.NewInt(2),
 			ops: []op{
 				{
 					name: "import",
 					op: Op{
 						Gas:       1,
-						GasFeeCap: *uint256.NewInt(gasFeeCap),
+						GasFeeCap: *uint256.NewInt(2),
 						Mint: map[common.Address]uint256.Int{
 							eoaNoBalance: *uint256.NewInt(importedAmount),
 						},
@@ -186,7 +190,7 @@ func TestMultipleBlocks(t *testing.T) {
 					name: "imported_funds_insufficient",
 					op: Op{
 						Gas:       1,
-						GasFeeCap: *uint256.NewInt(gasFeeCap),
+						GasFeeCap: *uint256.NewInt(2),
 						Burn: map[common.Address]AccountDebit{
 							eoaNoBalance: {
 								Amount:     *uint256.NewInt(importedAmount + 1),
@@ -200,7 +204,7 @@ func TestMultipleBlocks(t *testing.T) {
 					name: "spend_imported_funds",
 					op: Op{
 						Gas:       1,
-						GasFeeCap: *uint256.NewInt(gasFeeCap),
+						GasFeeCap: *uint256.NewInt(2),
 						Burn: map[common.Address]AccountDebit{
 							eoaNoBalance: {
 								Amount:     *uint256.NewInt(importedAmount),
@@ -219,29 +223,29 @@ func TestMultipleBlocks(t *testing.T) {
 		},
 		{
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(11),
+			wantBaseFee:  uint256.NewInt(2),
 			txsAfterOps: []*types.Transaction{
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					To:       &common.Address{},
 					Gas:      100_000,
-					GasPrice: big.NewInt(11),
+					GasPrice: big.NewInt(2),
 				}),
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					To:       &common.Address{},
 					Gas:      200_000,
-					GasPrice: big.NewInt(11),
+					GasPrice: big.NewInt(2),
 					Value:    big.NewInt(123_456),
 				}),
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					To:       nil,
 					Gas:      100_000,
-					GasPrice: big.NewInt(500), // charged in full
+					GasPrice: big.NewInt(10), // charged in full
 				}),
 				wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
 					To:        &common.Address{},
 					Gas:       100_000,
 					GasTipCap: big.NewInt(1),
-					GasFeeCap: big.NewInt(11),
+					GasFeeCap: big.NewInt(100),
 				}),
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					// Irrelevant parameters that only need to be valid. Needed
@@ -249,16 +253,16 @@ func TestMultipleBlocks(t *testing.T) {
 					// the penultimate tx.
 					To:       &common.Address{},
 					Gas:      params.TxGas,
-					GasPrice: big.NewInt(11),
+					GasPrice: big.NewInt(2),
 				}),
 			},
 			wantMinSenderBalances: []map[common.Address]uint64{
 				// Before each tx:
 				{eoaViaTx: startingBalance},
-				{eoaViaTx: startingBalance - 11*100_000},
-				{eoaViaTx: startingBalance - 11*100_000 - (11*200_000 + 123_456)},
-				{eoaViaTx: startingBalance - 11*100_000 - (11*200_000 + 123_456) - 500*100_000},              // non-dynamic fee
-				{eoaViaTx: startingBalance - 11*100_000 - (11*200_000 + 123_456) - 500*100_000 - 11*100_000}, // dynamic fee: effective gas price = baseFee + gasTipCap
+				{eoaViaTx: startingBalance - 2*100_000},
+				{eoaViaTx: startingBalance - 2*100_000 - (2*200_000 + 123_456)},
+				{eoaViaTx: startingBalance - 2*100_000 - (2*200_000 + 123_456) - 10*100_000},             // non-dynamic fee
+				{eoaViaTx: startingBalance - 2*100_000 - (2*200_000 + 123_456) - 10*100_000 - 3*100_000}, // dynamic fee: effective gas price = baseFee + gasTipCap
 			},
 		},
 		{
@@ -267,7 +271,7 @@ func TestMultipleBlocks(t *testing.T) {
 			// fee.
 			time:         21,
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(9),
+			wantBaseFee:  uint256.NewInt(1),
 		},
 	}
 	for i, block := range tests {
@@ -285,12 +289,12 @@ func TestMultipleBlocks(t *testing.T) {
 		require.Equalf(t, block.wantBaseFee, state.BaseFee(), "base fee after StartBlock(%d)", i)
 		require.Equalf(t, block.wantGasLimit, state.GasLimit(), "gas limit after StartBlock(%d)", i)
 
-		for j, op := range block.ops {
+		for _, op := range block.ops {
 			gotErr := state.Apply(op.op)
-			require.ErrorIsf(t, gotErr, op.wantErr, "Apply(%s) error %d:%d", op.name, i, j)
+			require.ErrorIsf(t, gotErr, op.wantErr, "Apply(%s) error", op.name)
 		}
-		for j, tx := range block.txsAfterOps {
-			require.NoErrorf(t, state.ApplyTx(tx), "ApplyTx() %d:%d", i, j)
+		for _, tx := range block.txsAfterOps {
+			require.NoErrorf(t, state.ApplyTx(tx), "ApplyTx()")
 		}
 
 		got, err := state.FinishBlock()
@@ -347,7 +351,7 @@ func TestTransactionValidation(t *testing.T) {
 			name: "nonce_too_high",
 			tx: &types.LegacyTx{
 				Nonce:    1,
-				GasPrice: big.NewInt(initialBaseFee),
+				GasPrice: big.NewInt(1),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 			},
@@ -357,7 +361,7 @@ func TestTransactionValidation(t *testing.T) {
 			name:  "nonce_too_low",
 			nonce: 1,
 			tx: &types.LegacyTx{
-				GasPrice: big.NewInt(initialBaseFee),
+				GasPrice: big.NewInt(1),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 			},
@@ -368,7 +372,7 @@ func TestTransactionValidation(t *testing.T) {
 			nonce: math.MaxUint64,
 			tx: &types.LegacyTx{
 				Nonce:    math.MaxUint64,
-				GasPrice: big.NewInt(initialBaseFee),
+				GasPrice: big.NewInt(1),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 			},
@@ -389,7 +393,7 @@ func TestTransactionValidation(t *testing.T) {
 		{
 			name: "negative_value",
 			tx: &types.LegacyTx{
-				GasPrice: big.NewInt(initialBaseFee),
+				GasPrice: big.NewInt(1),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 				Value:    big.NewInt(-1),
@@ -409,7 +413,7 @@ func TestTransactionValidation(t *testing.T) {
 			name: "insufficient_funds",
 			tx: &types.LegacyTx{
 				Gas:      params.TxGas,
-				GasPrice: big.NewInt(initialBaseFee),
+				GasPrice: big.NewInt(1),
 				To:       &common.Address{},
 				Value:    big.NewInt(0),
 			},
@@ -421,7 +425,7 @@ func TestTransactionValidation(t *testing.T) {
 			name:    "gas_limit_exceeded",
 			balance: initialMaxBlockSize,
 			tx: &types.LegacyTx{
-				GasPrice: big.NewInt(initialBaseFee),
+				GasPrice: big.NewInt(1),
 				Gas:      initialMaxBlockSize + 1,
 				To:       &common.Address{},
 			},
@@ -457,7 +461,7 @@ func TestTransactionValidation(t *testing.T) {
 			name: "gas_tip_cap_very_high",
 			tx: &types.DynamicFeeTx{
 				GasTipCap: new(big.Int).Lsh(big.NewInt(1), 256),
-				GasFeeCap: big.NewInt(initialBaseFee),
+				GasFeeCap: big.NewInt(1),
 				Gas:       params.TxGas,
 				To:        &common.Address{},
 			},
@@ -466,8 +470,8 @@ func TestTransactionValidation(t *testing.T) {
 		{
 			name: "gas_tip_above_fee_cap",
 			tx: &types.DynamicFeeTx{
-				GasTipCap: big.NewInt(1 + initialBaseFee),
-				GasFeeCap: big.NewInt(initialBaseFee),
+				GasTipCap: big.NewInt(2),
+				GasFeeCap: big.NewInt(1),
 				Gas:       params.TxGas,
 				To:        &common.Address{},
 			},
@@ -485,7 +489,7 @@ func TestTransactionValidation(t *testing.T) {
 		},
 		{
 			name:    "dynamic_fee_insufficient_for_fee_cap",
-			balance: 300_000, // enough for effectiveGasPrice (10) * gas (21000) but not gasFeeCap (100) * gas (21000) = 2_100_000
+			balance: 100_000, // enough for effectiveGasPrice (1) * gas (21000) but not gasFeeCap (100) * gas (21000) = 2_100_000
 			tx: &types.DynamicFeeTx{
 				GasTipCap: big.NewInt(0),
 				GasFeeCap: big.NewInt(100),
@@ -499,7 +503,7 @@ func TestTransactionValidation(t *testing.T) {
 		{
 			name: "sender_not_eoa",
 			tx: &types.LegacyTx{
-				GasPrice: big.NewInt(initialBaseFee),
+				GasPrice: big.NewInt(1),
 				Gas:      params.TxGas,
 				To:       &common.Address{},
 			},
@@ -589,7 +593,7 @@ func TestStartBlockQueueFull(t *testing.T) {
 
 		err := state.Apply(Op{
 			Gas:       gas,
-			GasFeeCap: *uint256.NewInt(2 * initialBaseFee),
+			GasFeeCap: *uint256.NewInt(2),
 		})
 		require.NoError(t, err, "Apply()")
 
@@ -620,7 +624,7 @@ func TestStartBlockQueueFullDueToTargetChanges(t *testing.T) {
 
 	err := state.Apply(Op{
 		Gas:       initialMaxBlockSize,
-		GasFeeCap: *uint256.NewInt(initialBaseFee),
+		GasFeeCap: *uint256.NewInt(1),
 	})
 	require.NoError(t, err, "Apply()")
 
@@ -682,7 +686,7 @@ func TestCanExecuteTransactionHook(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tx := wallet.SetNonceAndSign(t, tt.account, &types.DynamicFeeTx{
-				GasFeeCap: big.NewInt(initialBaseFee),
+				GasFeeCap: big.NewInt(1),
 				Gas:       params.TxGas,
 				To:        &common.Address{},
 			})


### PR DESCRIPTION
## Why this should be merged

It's impractical to provide an excess for the last synchronous block, since this can just be any deterministic excess from the provided base fee.

## How this works

Computes the lowest excess for the base fee, and uses this. Just requires a lot of test adjustments

## How this was tested

Refactored some tests to use this code path.

## Need to be documented in RELEASES.md?

No
