### PR TITLE
perf(saedb): check cache size HashDB

### DIFF
--- a/vms/saevm/saedb/BUILD.bazel
+++ b/vms/saevm/saedb/BUILD.bazel
@@ -30,11 +30,17 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":saedb"],
     deps = [
+        "//database/leveldb",
+        "//database/pebbledb",
         "//utils/logging",
         "//utils/logging/loggingtest",
+        "//vms/evm/database",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/rawdb",
         "@com_github_ava_labs_libevm//core/types",
+        "@com_github_ava_labs_libevm//ethdb",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -140,7 +140,8 @@ func (t *Tracker) Track(root common.Hash) {
 //
 // 1. If [Config.Archival] is true, then `executionRoot` will be committed.
 // 2. If [ShouldCommitTrieDB] based on `height`, `settledRoot` is committed.
-// 3. Otherwise, nothing is committed.
+// 3. If there is sufficient memory pressure in HashDB, flushes the oldest trie nodes to disk.
+// 4. Otherwise, nothing is committed.
 //
 // This does NOT change in-memory tracking.
 func (t *Tracker) MaybeCommit(settledRoot, executionRoot common.Hash, height uint64) error {
@@ -156,6 +157,9 @@ func (t *Tracker) MaybeCommit(settledRoot, executionRoot common.Hash, height uin
 		commit = settledRoot
 		because = "settled"
 	default:
+		if err := t.maybeCap(height); err != nil {
+			return fmt.Errorf("triedb.Database.Cap() at block %d: %v", height, err)
+		}
 		return nil
 	}
 
@@ -164,6 +168,30 @@ func (t *Tracker) MaybeCommit(settledRoot, executionRoot common.Hash, height uin
 		return fmt.Errorf("%T.Commit(%#x) %s at end of block %d: %v", tdb, commit, because, height, err)
 	}
 	return nil
+}
+
+// maybeCap checks if the in-memory state of a HashDB is too high for an efficient
+// [triedb.Database.Commit] and, if so, moves the oldest state to disk.
+func (t *Tracker) maybeCap(height uint64) error {
+	const (
+		maxCap                = 512 * mibToBytes
+		targetCommitSize      = 20 * mibToBytes                         // for [triedb.Database.Commit]
+		_                uint = targetCommitSize - ethdb.IdealBatchSize // [targetCommitSize] >= [ethdb.IdealBatchSize]
+	)
+
+	// The cap shrinks linearly as we approach the commit interval
+	commitInterval := t.config.CommitInterval
+	distanceFromCommit := commitInterval - height%commitInterval
+	slope := common.StorageSize(maxCap-targetCommitSize) / common.StorageSize(commitInterval)
+	targetCap := common.StorageSize(distanceFromCommit)*slope + targetCommitSize
+
+	tdb := t.cache.TrieDB()
+	_, inMemory, _ := tdb.Size()
+	if inMemory <= targetCap {
+		return nil
+	}
+
+	return tdb.Cap(targetCap - ethdb.IdealBatchSize) // avoid small DB writes
 }
 
 // Untrack informs the [Tracker] that the state corresponding

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -202,8 +202,8 @@ func (t *Tracker) MaybeCommit(settledRoot, executionRoot common.Hash, height uin
 func (t *Tracker) maybeCap(height uint64) error {
 	var (
 		maxCap           = t.config.maxCap()
-		targetCommitSize = t.config.targetCommitSize()
-		commitInterval   = t.config.CommitInterval // for [triedb.Database.Commit]
+		targetCommitSize = t.config.targetCommitSize() // for [triedb.Database.Commit]
+		commitInterval   = t.config.CommitInterval
 	)
 
 	// The cap shrinks linearly as we approach the commit interval

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -45,6 +45,10 @@ type Config struct {
 	SnapshotCacheMiB uint64 // size of the snapshot cache - if 0, snapshots are disabled
 	Archival         bool   // if true, will store every state on disk
 	CommitInterval   uint64 // MUST be set to a non-zero value
+
+	// only configurable for tests
+	maxCapBytes       uint64
+	targetCommitBytes uint64
 }
 
 func (c Config) Verify() error {
@@ -174,10 +178,21 @@ func (t *Tracker) MaybeCommit(settledRoot, executionRoot common.Hash, height uin
 // [triedb.Database.Commit] and, if so, moves the oldest state to disk.
 func (t *Tracker) maybeCap(height uint64) error {
 	const (
-		maxCap                = 512 * mibToBytes
-		targetCommitSize      = 20 * mibToBytes                         // for [triedb.Database.Commit]
-		_                uint = targetCommitSize - ethdb.IdealBatchSize // [targetCommitSize] >= [ethdb.IdealBatchSize]
+		defaultMaxCap           = 512 * mibToBytes
+		defaultTargetCommitSize = 20 * mibToBytes // for [triedb.Database.Commit]
+
+		// defaultTargetCommitSize >= ethdb.IdealBatchSize
+		_ uint = defaultTargetCommitSize - ethdb.IdealBatchSize
 	)
+
+	maxCap := common.StorageSize(defaultMaxCap)
+	if t.config.maxCapBytes > 0 {
+		maxCap = common.StorageSize(t.config.maxCapBytes)
+	}
+	targetCommitSize := common.StorageSize(defaultTargetCommitSize)
+	if t.config.targetCommitBytes > 0 {
+		targetCommitSize = common.StorageSize(t.config.targetCommitBytes)
+	}
 
 	// The cap shrinks linearly as we approach the commit interval
 	commitInterval := t.config.CommitInterval

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -39,6 +39,15 @@ const (
 	maxCacheMiB = math.MaxInt / mibToBytes
 )
 
+// Used in [Tracker.maybeCap] to determine memory pressure.
+const (
+	defaultMaxCap           = 512 * mibToBytes
+	defaultTargetCommitSize = 20 * mibToBytes
+
+	// defaultTargetCommitSize >= ethdb.IdealBatchSize
+	_ uint = defaultTargetCommitSize - ethdb.IdealBatchSize
+)
+
 // Config allows parameterization of the TrieDB and when state is committed.
 type Config struct {
 	TrieCacheMiB     uint64 // size of the TrieDB cache
@@ -80,6 +89,20 @@ func (c Config) snapConfig() *snapshot.Config {
 		CacheSize:  int(c.SnapshotCacheMiB), //#nosec G115 // checked in [Config.Verify]
 		AsyncBuild: true,
 	}
+}
+
+func (c Config) maxCap() common.StorageSize {
+	if c.maxCapBytes > 0 {
+		return common.StorageSize(c.maxCapBytes)
+	}
+	return common.StorageSize(defaultMaxCap)
+}
+
+func (c Config) targetCommitSize() common.StorageSize {
+	if c.targetCommitBytes > 0 {
+		return common.StorageSize(c.targetCommitBytes)
+	}
+	return common.StorageSize(defaultTargetCommitSize)
 }
 
 var _ StateDBOpener = (*Tracker)(nil)
@@ -177,25 +200,13 @@ func (t *Tracker) MaybeCommit(settledRoot, executionRoot common.Hash, height uin
 // maybeCap checks if the in-memory state of a HashDB is too high for an efficient
 // [triedb.Database.Commit] and, if so, moves the oldest state to disk.
 func (t *Tracker) maybeCap(height uint64) error {
-	const (
-		defaultMaxCap           = 512 * mibToBytes
-		defaultTargetCommitSize = 20 * mibToBytes // for [triedb.Database.Commit]
-
-		// defaultTargetCommitSize >= ethdb.IdealBatchSize
-		_ uint = defaultTargetCommitSize - ethdb.IdealBatchSize
+	var (
+		maxCap           = t.config.maxCap()
+		targetCommitSize = t.config.targetCommitSize()
+		commitInterval   = t.config.CommitInterval // for [triedb.Database.Commit]
 	)
 
-	maxCap := common.StorageSize(defaultMaxCap)
-	if t.config.maxCapBytes > 0 {
-		maxCap = common.StorageSize(t.config.maxCapBytes)
-	}
-	targetCommitSize := common.StorageSize(defaultTargetCommitSize)
-	if t.config.targetCommitBytes > 0 {
-		targetCommitSize = common.StorageSize(t.config.targetCommitBytes)
-	}
-
 	// The cap shrinks linearly as we approach the commit interval
-	commitInterval := t.config.CommitInterval
 	distanceFromCommit := commitInterval - height%commitInterval
 	slope := common.StorageSize(maxCap-targetCommitSize) / common.StorageSize(commitInterval)
 	targetCap := common.StorageSize(distanceFromCommit)*slope + targetCommitSize

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -56,8 +56,8 @@ type Config struct {
 	CommitInterval   uint64 // MUST be set to a non-zero value
 
 	// only configurable for tests
-	maxCapBytes       uint64
-	targetCommitBytes uint64
+	maxCapBytes       common.StorageSize
+	targetCommitBytes common.StorageSize
 }
 
 func (c Config) Verify() error {
@@ -93,16 +93,16 @@ func (c Config) snapConfig() *snapshot.Config {
 
 func (c Config) maxCap() common.StorageSize {
 	if c.maxCapBytes > 0 {
-		return common.StorageSize(c.maxCapBytes)
+		return c.maxCapBytes
 	}
-	return common.StorageSize(defaultMaxCap)
+	return defaultMaxCap
 }
 
 func (c Config) targetCommitSize() common.StorageSize {
 	if c.targetCommitBytes > 0 {
-		return common.StorageSize(c.targetCommitBytes)
+		return c.targetCommitBytes
 	}
-	return common.StorageSize(defaultTargetCommitSize)
+	return defaultTargetCommitSize
 }
 
 var _ StateDBOpener = (*Tracker)(nil)
@@ -208,7 +208,7 @@ func (t *Tracker) maybeCap(height uint64) error {
 
 	// The cap shrinks linearly as we approach the commit interval
 	distanceFromCommit := commitInterval - height%commitInterval
-	slope := common.StorageSize(maxCap-targetCommitSize) / common.StorageSize(commitInterval)
+	slope := (maxCap - targetCommitSize) / common.StorageSize(commitInterval)
 	targetCap := common.StorageSize(distanceFromCommit)*slope + targetCommitSize
 
 	tdb := t.cache.TrieDB()

--- a/vms/saevm/saedb/tracker_test.go
+++ b/vms/saevm/saedb/tracker_test.go
@@ -4,16 +4,25 @@
 package saedb
 
 import (
+	"encoding/binary"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/database/leveldb"
+	"github.com/ava-labs/avalanchego/database/pebbledb"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
+
+	evmdb "github.com/ava-labs/avalanchego/vms/evm/database"
 )
 
 func TestNewTracker(t *testing.T) {
@@ -74,5 +83,201 @@ func TestNewTracker(t *testing.T) {
 			gotRoot := rawdb.ReadSnapshotRoot(db)
 			require.Equal(t, wantRoot, gotRoot, "rawdb.ReadSnapshotRoot()")
 		})
+	}
+}
+
+// writeBlock simulates the execution of a block by opening a [state.StateDB]
+// at `prevRoot`, writing new accounts and storage unique to `height`, and
+// committing the result, returning the post-"execution" root.
+//
+// Each call adds roughly 100 KiB of dirty trie nodes to the [Tracker]'s
+// in-memory cache.
+func writeBlock(tb testing.TB, tr *Tracker, prevRoot common.Hash, height uint64) common.Hash {
+	tb.Helper()
+
+	sdb, err := tr.StateDB(prevRoot)
+	require.NoErrorf(tb, err, "%T.StateDB(%#x)", tr, prevRoot)
+
+	const (
+		accountsPerBlock = 64
+		slotsPerAccount  = 16
+	)
+	for i := uint64(0); i < accountsPerBlock; i++ {
+		var addr common.Address
+		binary.BigEndian.PutUint64(addr[:8], height)
+		binary.BigEndian.PutUint64(addr[8:16], i)
+		sdb.SetNonce(addr, height) // MUST be have a non-empty account
+		for s := range uint64(slotsPerAccount) {
+			var key, val common.Hash
+			binary.BigEndian.PutUint64(key[:8], s)
+			binary.BigEndian.PutUint64(val[:8], height)
+			val[31] = 1 // guarantee a non-zero value so the slot is stored
+			sdb.SetState(addr, key, val)
+		}
+	}
+
+	root, err := sdb.Commit(height, true /*EIP-158*/)
+	require.NoErrorf(tb, err, "%T.Commit(%d)", sdb, height)
+	return root
+}
+
+// TestTrackerMaybeCap checks that [Tracker.MaybeCommit] decreases memory
+// pressure to prevent a [triedb.Database.Commit] from being too expensive.
+func TestTrackerMaybeCap(t *testing.T) {
+	const (
+		commitInterval    = 64
+		maxCapBytes       = 2 * mibToBytes
+		targetCommitBytes = 128 * 1024
+
+		// MUST be > [ethdb.IdealBatchSize] so that [Tracker.maybeCap] never
+		// calls Cap with a negative limit.
+		_ uint = targetCommitBytes - ethdb.IdealBatchSize
+	)
+
+	cfg := Config{
+		CommitInterval:    commitInterval,
+		maxCapBytes:       maxCapBytes,
+		targetCommitBytes: targetCommitBytes,
+	}
+	log := loggingtest.New(t, logging.Debug)
+
+	tr, err := NewTracker(rawdb.NewMemoryDatabase(), cfg, types.EmptyRootHash, log)
+	require.NoError(t, err, "NewTracker()")
+
+	prevRoot := types.EmptyRootHash
+	t.Cleanup(func() { assert.NoErrorf(t, tr.Close(prevRoot), "%T.Close()", tr) })
+
+	inMemorySize := func() common.StorageSize {
+		_, dirties, _ := tr.cache.TrieDB().Size()
+		return dirties
+	}
+
+	var capsFired int
+	for height := uint64(1); height < cfg.CommitInterval; height++ {
+		root := writeBlock(t, tr, prevRoot, height)
+		before := inMemorySize()
+		require.NoErrorf(t, tr.MaybeCommit(common.Hash{}, root, height), "%T.MaybeCommit() at height %d", tr, height)
+		after := inMemorySize()
+
+		// Invariant: whatever schedule maybeCap uses to shrink its target, the
+		// in-memory size never exceeds the configured maximum after MaybeCommit.
+		require.LessOrEqualf(t, after, common.StorageSize(maxCapBytes), "in-memory size exceeds the maximum cap after %T.MaybeCommit() at height %d", tr, height)
+
+		// MaybeCommit can ONLY decrease memory pressure
+		if after < before {
+			capsFired++
+		}
+		prevRoot = root
+	}
+
+	// Each run will generate the same state, so this is deterministic
+	require.Greater(t, capsFired, 5, "test did not generate enough state to exercise capping")
+
+	//
+	root := writeBlock(t, tr, prevRoot, commitInterval)
+	before := inMemorySize()
+	require.NoErrorf(t, tr.MaybeCommit(root, root, commitInterval), "%T.MaybeCommit() at height %d", tr, commitInterval)
+	require.Less(t, inMemorySize(), before, "in-memory size did not drop after commit at the interval")
+}
+
+// BenchmarkTrackerCommitInterval measures the cost of block processing under
+// a [Tracker] over a full commit interval.
+//
+// Each database runs in two modes to isolate the effect of capping:
+//   - capped: [Tracker.maybeCap] flushes state throughout the interval.
+//   - uncapped: the cap never fires, so all dirty state accumulates until
+//     the single trie commit at the interval boundary.
+func BenchmarkTrackerCommitInterval(b *testing.B) {
+	const (
+		maxCapBytes       = 8 * mibToBytes
+		targetCommitBytes = 512 * 1024
+
+		// MUST be > [ethdb.IdealBatchSize] so that [Tracker.maybeCap] never
+		// calls Cap with a negative limit.
+		_ uint = targetCommitBytes - ethdb.IdealBatchSize
+	)
+
+	modes := []struct {
+		name        string
+		maxCapBytes uint64
+	}{
+		{name: "capped", maxCapBytes: maxCapBytes},
+		// Large enough that the target cap always exceeds the dirty size.
+		{name: "uncapped", maxCapBytes: 1 << 40},
+	}
+
+	// Each call to open MUST return a fresh, empty database.
+	tests := []struct {
+		name string
+		open func(b *testing.B) ethdb.Database
+	}{
+		{
+			name: "memdb",
+			open: func(*testing.B) ethdb.Database {
+				return rawdb.NewMemoryDatabase()
+			},
+		},
+		{
+			name: "avalanchego_pebble",
+			open: func(b *testing.B) ethdb.Database {
+				db, err := pebbledb.New(b.TempDir(), nil, loggingtest.New(b, logging.Debug), prometheus.NewRegistry())
+				require.NoError(b, err, "pebbledb.New()")
+				return rawdb.NewDatabase(evmdb.New(db))
+			},
+		},
+		{
+			name: "avalanchego_leveldb",
+			open: func(b *testing.B) ethdb.Database {
+				db, err := leveldb.New(b.TempDir(), nil, loggingtest.New(b, logging.Debug), prometheus.NewRegistry())
+				require.NoError(b, err, "leveldb.New()")
+				return rawdb.NewDatabase(evmdb.New(db))
+			},
+		},
+	}
+	for _, tt := range tests {
+		for _, mode := range modes {
+			b.Run(tt.name+"/"+mode.name, func(b *testing.B) {
+				cfg := Config{
+					CommitInterval:    64,
+					TrieCacheMiB:      1,
+					maxCapBytes:       mode.maxCapBytes,
+					targetCommitBytes: targetCommitBytes,
+				}
+
+				var (
+					maxPause  time.Duration
+					peakDirty common.StorageSize
+				)
+				for b.Loop() {
+					b.StopTimer()
+					db := tt.open(b)
+					tr, err := NewTracker(db, cfg, types.EmptyRootHash, logging.NoLog{})
+					require.NoError(b, err, "NewTracker()")
+					b.StartTimer()
+
+					prevRoot := types.EmptyRootHash
+					for height := uint64(1); height <= cfg.CommitInterval; height++ {
+						root := writeBlock(b, tr, prevRoot, height)
+
+						_, dirty, _ := tr.cache.TrieDB().Size()
+						peakDirty = max(peakDirty, dirty)
+
+						start := time.Now()
+						require.NoErrorf(b, tr.MaybeCommit(root, root, height), "%T.MaybeCommit() at height %d", tr, height)
+						maxPause = max(maxPause, time.Since(start))
+
+						prevRoot = root
+					}
+
+					b.StopTimer()
+					require.NoErrorf(b, tr.Close(prevRoot), "%T.Close()", tr)
+					require.NoErrorf(b, db.Close(), "%T.Close()", db)
+					b.StartTimer()
+				}
+				b.ReportMetric(float64(cfg.CommitInterval), "blocks/op")
+				b.ReportMetric(float64(maxPause.Milliseconds()), "max-pause-ms")
+				b.ReportMetric(float64(peakDirty)/mibToBytes, "peak-dirty-MiB")
+			})
+		}
 	}
 }

--- a/vms/saevm/saedb/tracker_test.go
+++ b/vms/saevm/saedb/tracker_test.go
@@ -99,15 +99,15 @@ func writeBlock(tb testing.TB, tr *Tracker, prevRoot common.Hash, height uint64)
 	require.NoErrorf(tb, err, "%T.StateDB(%#x)", tr, prevRoot)
 
 	const (
-		accountsPerBlock = 64
-		slotsPerAccount  = 16
+		accountsPerBlock uint64 = 64
+		slotsPerAccount  uint64 = 16
 	)
-	for i := uint64(0); i < accountsPerBlock; i++ {
+	for i := range accountsPerBlock {
 		var addr common.Address
 		binary.BigEndian.PutUint64(addr[:8], height)
 		binary.BigEndian.PutUint64(addr[8:16], i)
 		sdb.SetNonce(addr, height) // MUST have a non-empty account
-		for s := range uint64(slotsPerAccount) {
+		for s := range slotsPerAccount {
 			var key, val common.Hash
 			binary.BigEndian.PutUint64(key[:8], s)
 			binary.BigEndian.PutUint64(val[:8], height)
@@ -187,6 +187,9 @@ func TestTrackerMaybeCap(t *testing.T) {
 //   - capped: [Tracker.maybeCap] flushes state throughout the interval.
 //   - uncapped: the cap never fires, so all dirty state accumulates until
 //     the single trie commit at the interval boundary.
+//
+// The goal is to minimize the `max-pause-ms` metric, which is the maximum time
+// spent in a single block.
 func BenchmarkTrackerCommitInterval(b *testing.B) {
 	const (
 		maxCapBytes       = 8 * mibToBytes
@@ -199,7 +202,7 @@ func BenchmarkTrackerCommitInterval(b *testing.B) {
 
 	modes := []struct {
 		name        string
-		maxCapBytes uint64
+		maxCapBytes common.StorageSize
 	}{
 		{name: "capped", maxCapBytes: maxCapBytes},
 		// Large enough that the target cap always exceeds the dirty size.

--- a/vms/saevm/saedb/tracker_test.go
+++ b/vms/saevm/saedb/tracker_test.go
@@ -173,8 +173,8 @@ func TestTrackerMaybeCap(t *testing.T) {
 	// Each run will generate the same state, so this is deterministic
 	require.Greater(t, capsFired, 5, "test did not generate enough state to exercise capping")
 
-	//
 	root := writeBlock(t, tr, prevRoot, commitInterval)
+	prevRoot = root // for cleanup
 	before := inMemorySize()
 	require.NoErrorf(t, tr.MaybeCommit(root, root, commitInterval), "%T.MaybeCommit() at height %d", tr, commitInterval)
 	require.Less(t, inMemorySize(), before, "in-memory size did not drop after commit at the interval")
@@ -192,7 +192,7 @@ func BenchmarkTrackerCommitInterval(b *testing.B) {
 		maxCapBytes       = 8 * mibToBytes
 		targetCommitBytes = 512 * 1024
 
-		// MUST be > [ethdb.IdealBatchSize] so that [Tracker.maybeCap] never
+		// MUST be >= [ethdb.IdealBatchSize] so that [Tracker.maybeCap] never
 		// calls Cap with a negative limit.
 		_ uint = targetCommitBytes - ethdb.IdealBatchSize
 	)

--- a/vms/saevm/saedb/tracker_test.go
+++ b/vms/saevm/saedb/tracker_test.go
@@ -106,7 +106,7 @@ func writeBlock(tb testing.TB, tr *Tracker, prevRoot common.Hash, height uint64)
 		var addr common.Address
 		binary.BigEndian.PutUint64(addr[:8], height)
 		binary.BigEndian.PutUint64(addr[8:16], i)
-		sdb.SetNonce(addr, height) // MUST be have a non-empty account
+		sdb.SetNonce(addr, height) // MUST have a non-empty account
 		for s := range uint64(slotsPerAccount) {
 			var key, val common.Hash
 			binary.BigEndian.PutUint64(key[:8], s)


### PR DESCRIPTION
## Why this should be merged

If there's a lot of state differences in the 4096 blocks since we last committed, we could potentially block for a long time. We shouldn't block the execution thread on this, since it can be amortized across several blocks

## How this works

Commits a small historical set of nodes if the memory pressure is high.

## How this was tested

I'm not sure we can...

## Need to be documented in RELEASES.md?

No
