### PR TITLE
feat(rpc-metrics): 0/7 plumb prometheus.Registerer into rpc.NewServer

### DIFF
--- a/graft/coreth/ethclient/simulated/backend.go
+++ b/graft/coreth/ethclient/simulated/backend.go
@@ -141,7 +141,7 @@ func newWithNode(stack *node.Node, conf *eth.Config, blockPeriod uint64) (*Backe
 	if err != nil {
 		return nil, err
 	}
-	server := rpc.NewServer(0)
+	server := rpc.NewServer(0, nil)
 	for _, api := range backend.APIs() {
 		if err := server.RegisterName(api.Namespace, api.Service); err != nil {
 			return nil, err

--- a/graft/coreth/plugin/evm/vm.go
+++ b/graft/coreth/plugin/evm/vm.go
@@ -1027,7 +1027,7 @@ func (*VM) Version(context.Context) (string, error) {
 
 // CreateHandlers makes new http handlers that can handle API calls
 func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
-	handler := rpc.NewServer(vm.config.APIMaxDuration.Duration)
+	handler := rpc.NewServer(vm.config.APIMaxDuration.Duration, vm.sdkMetrics)
 	if vm.config.BatchRequestLimit > 0 && vm.config.BatchResponseMaxSize > 0 {
 		handler.SetBatchLimits(int(vm.config.BatchRequestLimit), int(vm.config.BatchResponseMaxSize))
 	}

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/holiman/bloomfilter/v2 v2.0.3
 	github.com/holiman/uint256 v1.2.4
+	github.com/prometheus/client_golang v1.23.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.49.0
@@ -65,7 +66,6 @@ require (
 	github.com/onsi/gomega v1.36.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/graft/evm/rpc/BUILD.bazel
+++ b/graft/evm/rpc/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "testing.go",
         "types.go",
         "websocket.go",
+        "ws_metrics.go",
     ],
     importpath = "github.com/ava-labs/avalanchego/graft/evm/rpc",
     visibility = ["//visibility:public"],
@@ -31,6 +32,7 @@ go_library(
         "@com_github_ava_labs_libevm//rpc",
         "@com_github_deckarep_golang_set_v2//:golang-set",
         "@com_github_gorilla_websocket//:websocket",
+        "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_x_time//rate",
     ],
 )

--- a/graft/evm/rpc/client_test.go
+++ b/graft/evm/rpc/client_test.go
@@ -559,7 +559,7 @@ func TestClientSubscriptionUnsubscribeServer(t *testing.T) {
 	t.Parallel()
 
 	// Create the server.
-	srv := NewServer(0)
+	srv := NewServer(0, nil)
 	srv.RegisterName("nftest", new(notificationTestService))
 	p1, p2 := net.Pipe()
 	recorder := &unsubscribeRecorder{ServerCodec: NewCodec(p1)}
@@ -596,7 +596,7 @@ func TestClientSubscriptionChannelClose(t *testing.T) {
 	t.Parallel()
 
 	var (
-		srv     = NewServer(0)
+		srv     = NewServer(0, nil)
 		httpsrv = httptest.NewServer(srv.WebsocketHandler(nil))
 		wsURL   = "ws:" + strings.TrimPrefix(httpsrv.URL, "http:")
 	)

--- a/graft/evm/rpc/http_test.go
+++ b/graft/evm/rpc/http_test.go
@@ -52,7 +52,7 @@ func confirmStatusCode(t *testing.T, got, want int) {
 func confirmRequestValidationCode(t *testing.T, method, contentType, body string, expectedStatusCode int) {
 	t.Helper()
 
-	s := NewServer(0)
+	s := NewServer(0, nil)
 	request := httptest.NewRequest(method, "http://url.com", strings.NewReader(body))
 	if len(contentType) > 0 {
 		request.Header.Set("Content-Type", contentType)
@@ -119,7 +119,7 @@ func TestHTTPResponseWithEmptyGet(t *testing.T) {
 func TestHTTPRespBodyUnlimited(t *testing.T) {
 	const respLength = defaultBodyLimit * 3
 
-	s := NewServer(0)
+	s := NewServer(0, nil)
 	defer s.Stop()
 	s.RegisterName("test", largeRespService{respLength})
 	ts := httptest.NewServer(s)

--- a/graft/evm/rpc/server.go
+++ b/graft/evm/rpc/server.go
@@ -76,6 +76,10 @@ type Server struct {
 // If [maximumDuration] > 0, the deadline of incoming requests is
 // [maximumDuration] in the future. Otherwise, no deadline is assigned to
 // incoming requests.
+//
+// [metricsRegistry] is where the server's native-Prometheus metric vectors are
+// registered. A nil registry disables metric registration: the server then
+// holds a nil *rpcMetrics whose methods are no-ops (see ws_metrics.go).
 func NewServer(maximumDuration time.Duration, metricsRegistry prometheus.Registerer) *Server {
 	server := &Server{
 		idgen:           randomIDGenerator(),

--- a/graft/evm/rpc/server.go
+++ b/graft/evm/rpc/server.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/libevm/log"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const MetadataApi = "rpc"
@@ -64,6 +65,10 @@ type Server struct {
 	batchItemLimit     int
 	batchResponseLimit int
 	httpBodyLimit      int
+
+	// metrics holds the server's native-Prometheus metrics. Always non-nil; see
+	// ws_metrics.go.
+	metrics *rpcMetrics
 }
 
 // NewServer creates a new server instance with no registered handlers.
@@ -71,12 +76,13 @@ type Server struct {
 // If [maximumDuration] > 0, the deadline of incoming requests is
 // [maximumDuration] in the future. Otherwise, no deadline is assigned to
 // incoming requests.
-func NewServer(maximumDuration time.Duration) *Server {
+func NewServer(maximumDuration time.Duration, metricsRegistry prometheus.Registerer) *Server {
 	server := &Server{
 		idgen:           randomIDGenerator(),
 		codecs:          make(map[ServerCodec]struct{}),
 		maximumDuration: maximumDuration,
 		httpBodyLimit:   defaultBodyLimit,
+		metrics:         newRPCMetrics(metricsRegistry),
 	}
 	server.run.Store(true)
 	// Register the default service providing meta information about the RPC service such

--- a/graft/evm/rpc/server.go
+++ b/graft/evm/rpc/server.go
@@ -78,8 +78,8 @@ type Server struct {
 // incoming requests.
 //
 // [metricsRegistry] is where the server's native-Prometheus metric vectors are
-// registered. A nil registry disables metric registration: the server then
-// holds a nil *rpcMetrics whose methods are no-ops (see ws_metrics.go).
+// registered. A nil registry disables metric registration: newRPCMetrics still
+// returns a non-nil *rpcMetrics, but it registers nothing (see ws_metrics.go).
 func NewServer(maximumDuration time.Duration, metricsRegistry prometheus.Registerer) *Server {
 	server := &Server{
 		idgen:           randomIDGenerator(),

--- a/graft/evm/rpc/server_test.go
+++ b/graft/evm/rpc/server_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 func TestServerRegisterName(t *testing.T) {
-	server := NewServer(0)
+	server := NewServer(0, nil)
 	service := new(testService)
 
 	svcName := "test"

--- a/graft/evm/rpc/subscription_test.go
+++ b/graft/evm/rpc/subscription_test.go
@@ -71,7 +71,7 @@ func TestSubscriptions(t *testing.T) {
 		subCount          = len(namespaces)
 		notificationCount = 3
 
-		server                 = NewServer(0)
+		server                 = NewServer(0, nil)
 		clientConn, serverConn = net.Pipe()
 		out                    = json.NewEncoder(clientConn)
 		in                     = json.NewDecoder(clientConn)

--- a/graft/evm/rpc/testservice_test.go
+++ b/graft/evm/rpc/testservice_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func newTestServer() *Server {
-	server := NewServer(0)
+	server := NewServer(0, nil)
 	server.idgen = sequentialIDGenerator()
 	if err := server.RegisterName("test", new(testService)); err != nil {
 		panic(err)

--- a/graft/evm/rpc/websocket_test.go
+++ b/graft/evm/rpc/websocket_test.go
@@ -272,7 +272,7 @@ func TestClientWebsocketLargeMessage(t *testing.T) {
 	t.Skip("Flaky test from go-ethereum")
 
 	var (
-		srv     = NewServer(0)
+		srv     = NewServer(0, nil)
 		httpsrv = httptest.NewServer(srv.WebsocketHandler(nil))
 		wsURL   = "ws:" + strings.TrimPrefix(httpsrv.URL, "http:")
 	)

--- a/graft/evm/rpc/ws_metrics.go
+++ b/graft/evm/rpc/ws_metrics.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// This file is NOT derived from go-ethereum. It is first-party Ava Labs code
+// holding the native-Prometheus metrics for the RPC server. Keeping all metrics
+// code here (rather than in the upstream-derived rpc sources) keeps the merge
+// surface against libevm/go-ethereum small: the derived files carry only tiny
+// mechanical hooks that call into this file, so a future re-sync conflicts on a
+// few call sites instead of rewritten bodies.
+//
+// See docs/design/websocket-rpc-visibility.md.
+
+package rpc
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// rpcMetrics holds the native-Prometheus metric vectors for the RPC server.
+//
+// Vectors are added per phase of the websocket-rpc-visibility design; Phase 0
+// establishes only the struct and the plumbing that carries it from NewServer
+// into the server (and, in later phases, the handler). No metrics are emitted
+// yet.
+type rpcMetrics struct {
+	// reg is the registerer the metric vectors are registered against. It may be
+	// nil (tests, or transports constructed without a metrics registry), in
+	// which case registration is skipped.
+	reg prometheus.Registerer //nolint:unused // plumbed in Phase 0; first read in Phase 1, which registers the metric vectors
+}
+
+// newRPCMetrics builds the RPC metrics set and registers its vectors against
+// reg. A nil reg is allowed and yields a metrics set that registers nothing, so
+// callers and the request hot path never need a nil check.
+func newRPCMetrics(reg prometheus.Registerer) *rpcMetrics {
+	return &rpcMetrics{reg: reg}
+}

--- a/graft/evm/scripts/upstream_files.txt
+++ b/graft/evm/scripts/upstream_files.txt
@@ -3,5 +3,6 @@ core/*
 log/*
 triedb/*
 
+!rpc/ws_metrics.go
 !core/state/snapshot/snapshot_ext.go
 !core/state/snapshot/main_test.go

--- a/graft/subnet-evm/ethclient/simulated/backend.go
+++ b/graft/subnet-evm/ethclient/simulated/backend.go
@@ -142,7 +142,7 @@ func newWithNode(stack *node.Node, conf *eth.Config, blockPeriod uint64) (*Backe
 	if err != nil {
 		return nil, err
 	}
-	server := rpc.NewServer(0)
+	server := rpc.NewServer(0, nil)
 	for _, api := range backend.APIs() {
 		if err := server.RegisterName(api.Namespace, api.Service); err != nil {
 			return nil, err

--- a/graft/subnet-evm/plugin/evm/vm.go
+++ b/graft/subnet-evm/plugin/evm/vm.go
@@ -1144,7 +1144,7 @@ func newHandler(name string, service interface{}) (http.Handler, error) {
 
 // CreateHandlers makes new http handlers that can handle API calls
 func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
-	handler := rpc.NewServer(vm.config.APIMaxDuration.Duration)
+	handler := rpc.NewServer(vm.config.APIMaxDuration.Duration, vm.sdkMetrics)
 	if vm.config.BatchRequestLimit > 0 && vm.config.BatchResponseMaxSize > 0 {
 		handler.SetBatchLimits(int(vm.config.BatchRequestLimit), int(vm.config.BatchResponseMaxSize))
 	}


### PR DESCRIPTION
## Why this should be merged

We have no visibility into WebSocket RPC usage. This is Phase 0 of the
websocket RPC connection visibility design
(docs/design/websocket-rpc-visibility.md): it lands only the plumbing so
the dependency-adding diff is small and reviewable on its own, with no
metrics emitted yet.

## How this works

- Adds a prometheus.Registerer parameter to rpc.NewServer and builds an
  *rpcMetrics struct held on the Server.
- Defines rpcMetrics and newRPCMetrics in a new first-party file
  (ws_metrics.go), not in the upstream-derived rpc sources, so future
  re-syncs against libevm/go-ethereum conflict on a few call sites
  rather than rewritten bodies.
- Because rpc/* is globbed as go-ethereum-derived for license checks,
  the new first-party file is excluded in scripts/upstream_files.txt (a
  `!` entry, mirroring the existing core/state/snapshot exclusions) so it
  is validated against the Ava Labs BSD header rather than the upstream
  LGPL one. The accompanying BUILD.bazel src/dep additions are
  gazelle-generated.
- Passes vm.sdkMetrics from coreth and subnet-evm CreateHandlers; passes
  nil from tests and the simulated backends (newRPCMetrics handles nil).
- Promotes prometheus/client_golang to a direct dependency in graft/evm.

Handler-level threading (initClient/newHandler) and metric vectors are
deferred to later phases, which are the first to emit anything.

## How this was tested

Existing rpc package tests, updated for the new NewServer signature.

## Need to be documented in RELEASES.md?

No.
