### PR TITLE
chore: bump Firewood to v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0
 	github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82l+9LfV2NSl4Klk+9pjaxd3M=
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0 h1:LXdgVYLV01sn2g4hqZUU8kP3/v3Uf4/1/069rFcc1u8=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0 h1:ci1MTLOPeHyhlNmKo4iZWoeyuLCYt3AQHne35x8uHTg=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
 github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981 h1:rbQ7kUImcDc33u1zj1+cyU7P8BboQq2wmBWNa5OR5Us=
 github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad h1:P5IRndHUinfIZ73jdxl3M6jdcnKkQOLYvhGvE3VDiSU=

--- a/go.work.sum
+++ b/go.work.sum
@@ -338,6 +338,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.3.0/go.mod h1:71C76bo47zlDX9gWnn3p/0QZQXkTQ/GNqUNI6fchvjs=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0 h1:ci1MTLOPeHyhlNmKo4iZWoeyuLCYt3AQHne35x8uHTg=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1 h1:Y9UdRQj28/t+GNzVSlP6nvoNLtzNRo3fNXLUc/NscVM=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1/go.mod h1:GVzumIo3zR23/qGRN2AdnVkIPHcKMq/D89EGWZfMGQ0=
 github.com/aws/aws-sdk-go-v2 v1.21.2 h1:+LXZ0sgo8quN9UOKXXzAWRT3FWd4NxeXWOZom9pE7GA=

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -10,7 +10,7 @@ go 1.25.10
 require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0
 	github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3

--- a/graft/coreth/go.sum
+++ b/graft/coreth/go.sum
@@ -26,8 +26,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0 h1:LXdgVYLV01sn2g4hqZUU8kP3/v3Uf4/1/069rFcc1u8=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0 h1:ci1MTLOPeHyhlNmKo4iZWoeyuLCYt3AQHne35x8uHTg=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
 github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981 h1:rbQ7kUImcDc33u1zj1+cyU7P8BboQq2wmBWNa5OR5Us=
 github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -6,7 +6,7 @@ go 1.25.10
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.14.2
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0
 	github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/graft/evm/go.sum
+++ b/graft/evm/go.sum
@@ -19,8 +19,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0 h1:LXdgVYLV01sn2g4hqZUU8kP3/v3Uf4/1/069rFcc1u8=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0 h1:ci1MTLOPeHyhlNmKo4iZWoeyuLCYt3AQHne35x8uHTg=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
 github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981 h1:rbQ7kUImcDc33u1zj1+cyU7P8BboQq2wmBWNa5OR5Us=
 github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0
 	github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3

--- a/graft/subnet-evm/go.sum
+++ b/graft/subnet-evm/go.sum
@@ -28,8 +28,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0 h1:LXdgVYLV01sn2g4hqZUU8kP3/v3Uf4/1/069rFcc1u8=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.5.0/go.mod h1:MoUHYlFrwaflfLpHt8nmQUHoLy2CCHaFNH/n7vazUuI=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0 h1:ci1MTLOPeHyhlNmKo4iZWoeyuLCYt3AQHne35x8uHTg=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.6.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
 github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981 h1:rbQ7kUImcDc33u1zj1+cyU7P8BboQq2wmBWNa5OR5Us=
 github.com/ava-labs/libevm v1.13.15-0.20260430210457-c891ff86e981/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=


### PR DESCRIPTION
## Why this should be merged

New version of Firewood.

## How this works

Bumps `firewood-go-ethhash/ffi` from `v0.5.0` to `v0.6.0`.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No
