### PR TITLE
refactor(saevm): rationalize header cloning

### DIFF
--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -91,9 +91,10 @@ func (b *Block) MarkSynchronous(hooks hook.Points, db ethdb.Database, xdb types.
 	// itself. As the only reason to pass receipts here is for later settlement
 	// in another block, there is no need to pass anything meaningful as it
 	// would also require them to be received as an argument to MarkSynchronous.
-	target, cfg := hooks.GasConfigAfter(b.Header())
+	header := b.Header()
+	target, cfg := hooks.GasConfigAfter(header)
 	execTime, err := gastime.New(
-		hooks.BlockTime(b.Header()),
+		hooks.BlockTime(header),
 		// Target, excess, and config _after_ are a requirement of
 		// [Block.MarkExecuted].
 		target,

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -292,21 +292,23 @@ var errMissingBlock = errors.New("missing block")
 // in the block range (h, settled), both exclusive.
 func ancestorInputIDs(h *types.Header, settled common.Hash, source saetypes.BlockSource) (set.Set[ids.ID], error) {
 	var s set.Set[ids.ID]
-	for h.ParentHash != settled {
-		parentNumber := h.Number.Uint64() - 1
-		p, ok := source(h.ParentHash, parentNumber)
+	parentHash := h.ParentHash
+	parentNumber := h.Number.Uint64() - 1
+	for parentHash != settled {
+		p, ok := source(parentHash, parentNumber)
 		if !ok {
-			return nil, fmt.Errorf("%w: %s (%d)", errMissingBlock, h.ParentHash, parentNumber)
+			return nil, fmt.Errorf("%w: %s (%d)", errMissingBlock, parentHash, parentNumber)
 		}
 
 		txs, err := tx.ParseSlice(customtypes.BlockExtData(p))
 		if err != nil {
-			return nil, fmt.Errorf("parsing txs: %s (%d): %w", h.ParentHash, parentNumber, err)
+			return nil, fmt.Errorf("parsing txs: %s (%d): %w", parentHash, parentNumber, err)
 		}
 		for _, t := range txs {
 			s.Union(t.InputIDs())
 		}
-		h = p.Header()
+		parentHash = p.ParentHash()
+		parentNumber--
 	}
 	return s, nil
 }

--- a/vms/saevm/saexec/context.go
+++ b/vms/saevm/saexec/context.go
@@ -25,6 +25,8 @@ type chainContext struct {
 
 func (c *chainContext) GetHeader(h common.Hash, n uint64) *types.Header {
 	if hdr, ok := c.recent.Get(n); ok && hdr.Hash() == h {
+		// The cache retains [hdr] and may serve it again, so we MUST return an
+		// independent copy to prevent a caller from mutating the cached header.
 		return types.CopyHeader(hdr)
 	}
 	// eth_call on historical state will miss the cache but we still need to

--- a/vms/saevm/saexec/context.go
+++ b/vms/saevm/saexec/context.go
@@ -25,7 +25,7 @@ type chainContext struct {
 
 func (c *chainContext) GetHeader(h common.Hash, n uint64) *types.Header {
 	if hdr, ok := c.recent.Get(n); ok && hdr.Hash() == h {
-		// The cache retains [hdr] and may serve it again, so we MUST return an
+		// The cache retains hdr and may serve it again, so we MUST return an
 		// independent copy to prevent a caller from mutating the cached header.
 		return types.CopyHeader(hdr)
 	}

--- a/vms/saevm/worstcase/state.go
+++ b/vms/saevm/worstcase/state.go
@@ -132,9 +132,9 @@ func (s *State) StartBlock(h *types.Header) error {
 	// expectedParentHash is updated prior to modifying the GasLimit and BaseFee
 	// to ensure that historical block hashes are not modified.
 	s.expectedParentHash = h.Hash()
-	// We MUST copy [h] before mutating GasLimit and BaseFee below: callers such
-	// as the historical block-building path retain and continue to mutate the
-	// header after StartBlock returns.
+	// We MUST copy h before mutating GasLimit and BaseFee below: StartBlock
+	// does not own h, and the block builder retains and continues to mutate
+	// the header it passes for the block under construction.
 	s.curr = types.CopyHeader(h)
 	s.curr.GasLimit = uint64(s.maxBlockSize)
 	s.curr.BaseFee = s.baseFee.ToBig()

--- a/vms/saevm/worstcase/state.go
+++ b/vms/saevm/worstcase/state.go
@@ -132,6 +132,9 @@ func (s *State) StartBlock(h *types.Header) error {
 	// expectedParentHash is updated prior to modifying the GasLimit and BaseFee
 	// to ensure that historical block hashes are not modified.
 	s.expectedParentHash = h.Hash()
+	// We MUST copy [h] before mutating GasLimit and BaseFee below: callers such
+	// as the historical block-building path retain and continue to mutate the
+	// header after StartBlock returns.
 	s.curr = types.CopyHeader(h)
 	s.curr.GasLimit = uint64(s.maxBlockSize)
 	s.curr.BaseFee = s.baseFee.ToBig()


### PR DESCRIPTION
## Why this should be merged

Closes #5275.

This PR applies the heuristic from that issue where the the `return`er is responsible for deciding whether a copy is necessary. Do note that this PR does not we address the 'libevm-mandated' cloning. libevm's `types.Block.Header()` always returns a copy, so every remaining `Header()` call still clones, even when the caller only reads a field or two (e.g. `hooks.BlockTime(parent.Header())` clones a whole header just to read the timestamp).

Would a more comprehensive fix (e.g. adding aa non-cloning accessor), make sense here, In a follow up issue? Not at all?

## How this works

Avoids unnecessary clones (libevm's `types.Block.Header()` returns a fresh `CopyHeader` on every call), and documents two important clones from Cey's old PR (https://github.com/ava-labs/strevm/pull/254). 

## How this was tested
CI. 