### PR TITLE
ci(release): add a dispatch-driven workflow that drafts a GitHub release page

### DIFF
--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -124,10 +124,23 @@ live release's assets afterwards.
   signing ([#5161](https://github.com/ava-labs/avalanchego/issues/5161)) must
   be merged before a tag can publish — the manifest lists 6 `.sig` companions
   and the pipeline fails closed without them.
-- **Pre-merge testability:** `push: tags` reads workflow files from the tagged
-  commit, so the pipeline can be exercised before merging by tagging a
-  throwaway `v0.0.0-rc*` commit on a scratch branch (with a temporary
-  `RELEASES.md` entry) and deleting the draft + tag afterwards.
+- **Pre-merge testability:** the release is `workflow_dispatch`-driven, so the
+  pipeline can be exercised before merging by pushing a throwaway `v0.0.0-rc*`
+  tag (with a temporary `RELEASES.md` entry) and dispatching this workflow from
+  the feature branch (`gh workflow run release.yml --ref <branch> -f tag=v0.0.0-rc*`),
+  then deleting the draft + tag afterwards.
+- **Deferred hardening (release-time supply chain):** the `publish` job checks
+  out the release tag's commit and runs the `release-*.sh` helpers — including
+  the guards — with `contents: write` and a job-wide `GH_TOKEN`. A tag pointing
+  at a malicious commit could therefore ship modified helper/guard scripts that
+  run with the write token. This needs push access to create a `v*` tag at an
+  arbitrary commit AND dispatch permission (both write-level), so it is an
+  insider / credential-compromise vector, not an external one. A future
+  hardening pass should run the orchestration helpers from a trusted
+  default-branch checkout, check out the tag in a separate data-only path
+  (`persist-credentials: false`) for `RELEASES.md`, scope `GH_TOKEN` to only the
+  `gh`/release-creation steps, and verify tag trust (protected/signed tag or
+  ancestry) before any write-scoped token is exposed.
 
 ## References
 

--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -2,11 +2,19 @@
 
 ## Overview
 
-Pushing a `v*.*.*` tag creates a **draft** GitHub release page with release notes
-parsed from [`RELEASES.md`](../../RELEASES.md), a `Previous Tag:` pointer, and all
-build artifacts attached ([#5162](https://github.com/ava-labs/avalanchego/issues/5162)).
+Dispatching the release workflow for a `vX.Y.Z` tag (after the tags are pushed)
+creates a **draft** GitHub release page with release notes parsed from
+[`RELEASES.md`](../../RELEASES.md), a `Previous Tag:` pointer, and all build
+artifacts attached ([#5162](https://github.com/ava-labs/avalanchego/issues/5162)).
 A human reviews the draft and publishes it via the GitHub UI; nothing becomes
 publicly visible without that step.
+
+The release is triggered by `workflow_dispatch`, not a `push: tags` filter. The
+release procedure pushes four tags at once (root + three graft modules), and
+GitHub creates no tag push events when more than three tags are pushed together,
+so a tag-push trigger would silently never fire. Dispatching explicitly also
+keeps a release from waking the repo's wildcard `tags: "*"` workflows (CI, Bazel,
+buf, Docker publish), which the four-tag push otherwise leaves suppressed.
 
 Audience: maintainers cutting releases; CI maintainers changing the release
 pipeline or its artifact set.
@@ -19,9 +27,11 @@ Cutting a release:
    `## Pending (vX.Y.Z)` or `## [vX.Y.Z](url)` — with a non-empty body. The
    section must exist **in the tagged commit**; the workflow fails fast (before
    any build) if it doesn't.
-2. Push the tag. The [`release` workflow](../workflows/release.yml) validates,
-   fans out the five artifact builds, and creates the draft release.
-3. Review the draft on GitHub (title, body, asset set, pre-release flag) and
+2. Push the tags: `task tags-push -- vX.Y.Z`.
+3. Dispatch the release: `task release:trigger -- vX.Y.Z`. The
+   [`release` workflow](../workflows/release.yml) validates, fans out the
+   artifact builds, and creates the draft release.
+4. Review the draft on GitHub (title, body, asset set, pre-release flag) and
    publish it. Decide "set as latest" in the UI — the workflow never sets it.
 
 Tags with a semver suffix (e.g. `v1.15.0-rc1`) are marked `prerelease`.
@@ -44,26 +54,27 @@ Failure recovery:
   everything the manifest requires; the draft is not created.
 
 Ad-hoc rebuilds of a single producer still work via each producer workflow's
-`workflow_dispatch`. A commented-out direct-publish opt-in (skip the draft
-step) lives in [`release.yml`](../workflows/release.yml).
+`workflow_dispatch`.
 
 ## Conceptual model
 
 ```
-push v*.*.* ── validate-tag ──┬─ build-linux-packages ─┐  (rpm + deb, jammy/noble S3)
-  classify stable/prerelease  ├─ build-linux           ┤  publish
-  duplicate-release guard     ├─ build-macos           ┼► body + publish-set gates
-  RELEASES.md notes gate      └────────────────────────┘  draft release + post-assert
+release:trigger(tag) ── validate-tag ──┬─ build-linux-packages ─┐  (rpm + deb, jammy/noble S3)
+  (workflow_dispatch)                   ├─ build-linux           ┤  publish
+  classify stable/prerelease            ├─ build-macos           ┼► body + publish-set gates
+  duplicate-release guard               └────────────────────────┘  draft release + post-assert
+  RELEASES.md notes gate
 ```
 
-One umbrella workflow ([`release.yml`](../workflows/release.yml)) owns the
-`push: tags` trigger and calls its producer workflows via `workflow_call`;
-`needs:` makes `publish` wait for all of them, and artifacts are collected
-in-run with `actions/download-artifact`. Linux packages (RPM + DEB) come from
-the unified [`build-linux-packages.yml`](../workflows/build-linux-packages.yml),
-made reusable for this umbrella; it builds one codename-agnostic `.deb` per arch
-and, on the tag push, fans each into the jammy + noble S3 prefixes. All release
-logic lives in single-purpose `release-*.sh` helpers under
+One umbrella workflow ([`release.yml`](../workflows/release.yml)) is dispatched
+explicitly (`task release:trigger`) and calls its producer workflows via
+`workflow_call`; `needs:` makes `publish` wait for all of them, and artifacts
+are collected in-run with `actions/download-artifact`. Linux packages (RPM +
+DEB) come from the unified
+[`build-linux-packages.yml`](../workflows/build-linux-packages.yml), made
+reusable for this umbrella; it builds one codename-agnostic `.deb` per arch and,
+on a release, fans each into the jammy + noble S3 prefixes. All release logic
+lives in single-purpose `release-*.sh` helpers under
 [`.github/workflows/`](../workflows/); the YAML only wires them together.
 
 [`release-expected-manifest.sh`](../workflows/release-expected-manifest.sh) is

--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -1,0 +1,124 @@
+# GitHub release page automation
+
+## Overview
+
+Pushing a `v*.*.*` tag creates a **draft** GitHub release page with release notes
+parsed from [`RELEASES.md`](../../RELEASES.md), a `Previous Tag:` pointer, and all
+build artifacts attached ([#5162](https://github.com/ava-labs/avalanchego/issues/5162)).
+A human reviews the draft and publishes it via the GitHub UI; nothing becomes
+publicly visible without that step.
+
+Audience: maintainers cutting releases; CI maintainers changing the release
+pipeline or its artifact set.
+
+## Usage
+
+Cutting a release:
+
+1. Ensure [`RELEASES.md`](../../RELEASES.md) has a section for the tag — either
+   `## Pending (vX.Y.Z)` or `## [vX.Y.Z](url)` — with a non-empty body. The
+   section must exist **in the tagged commit**; the workflow fails fast (before
+   any build) if it doesn't.
+2. Push the tag. The [`release` workflow](../workflows/release.yml) validates,
+   fans out the five artifact builds, and creates the draft release.
+3. Review the draft on GitHub (title, body, asset set, pre-release flag) and
+   publish it. Decide "set as latest" in the UI — the workflow never sets it.
+
+Tags with a semver suffix (e.g. `v1.15.0-rc1`) are marked `prerelease`.
+
+Local validation (no GitHub mutation, no builds):
+
+```sh
+GH_REPO=ava-labs/avalanchego task release:dry-run -- v1.15.0
+```
+
+Every pipeline step is also exposed 1:1 — see `task --list-all | grep release:`
+or [`Taskfile.yml`](./Taskfile.yml). The same scripts run in CI and locally.
+
+Failure recovery:
+
+- **"release already exists"** — the guard refuses to overwrite any existing
+  release, draft included, and prints copy-paste commands to inspect and delete
+  it by release ID. Delete, then re-push the tag.
+- **"expected artifacts missing"** — a producer finished without uploading
+  everything the manifest requires; the draft is not created.
+
+Ad-hoc rebuilds of a single producer still work via each producer workflow's
+`workflow_dispatch`. A commented-out direct-publish opt-in (skip the draft
+step) lives in [`release.yml`](../workflows/release.yml).
+
+## Conceptual model
+
+```
+push v*.*.* ── validate-tag ──┬─ build-rpms      ─┐
+  classify stable/prerelease  ├─ build-linux     ─┤   publish
+  duplicate-release guard     ├─ build-macos     ─┼─► body + publish-set gates
+  RELEASES.md notes gate      ├─ build-deb-amd64 ─┤   draft release + post-assert
+                              └─ build-deb-arm64 ─┘
+```
+
+One umbrella workflow ([`release.yml`](../workflows/release.yml)) owns the
+`push: tags` trigger and calls the five producer workflows via `workflow_call`;
+`needs:` makes `publish` wait for all of them, and artifacts are collected
+in-run with `actions/download-artifact`. All logic lives in single-purpose
+`release-*.sh` helpers under [`.github/workflows/`](../workflows/); the YAML
+only wires them together.
+
+[`release-expected-manifest.sh`](../workflows/release-expected-manifest.sh) is
+the single source of truth for the asset set (20 basenames: 4 debs, 4 RPMs,
+4 Linux tarballs + 4 `.sig`, 2 macOS zips + 2 `.sig`). The publish job copies
+exactly the manifest entries into the publish set (failing on any missing one),
+asserts set-equality before creating the release, and re-asserts against the
+live release's assets afterwards.
+
+## Maintenance notes
+
+- **Adding/removing a release asset** requires two changes: the producer's
+  `upload-artifact` step and the manifest. Both completeness gates enforce the
+  manifest, so a drifted producer fails the run rather than shipping a partial
+  release.
+- **Drafts are invisible to tag-keyed APIs.** `GET /releases/tags/{tag}` (and
+  `gh release view/delete <tag>`) excludes drafts, so every read/delete in this
+  pipeline uses the listing endpoint filtered by `tag_name`. The same GitHub
+  rule means draft listings require a push-capable token: `validate-tag` runs
+  with `contents: write` solely so its duplicate-release guard can see drafts.
+- **The existence guard fails closed.** It first proves the repo is reachable
+  (`gh api repos/<repo>` must return 2xx) before trusting "no release found",
+  and runs twice: in `validate-tag` and again immediately before release
+  creation (the build matrix is a 30+ minute race window).
+- **`$GITHUB_OUTPUT`/`$GITHUB_ENV` writes are assignment-first** (`v="$(helper)"`
+  then `echo`): under `bash -e`, a failing command substitution inside `echo`'s
+  arguments is silently swallowed, which would convert helper failures into
+  empty outputs.
+- **Deb basenames embed the codename** (`avalanchego-vX.Y.Z-{jammy,noble}-{arch}.deb`)
+  because the deb producers emit identically-named files; the rename happens at
+  publish-set assembly (by artifact-path substring), so S3 layout is unchanged.
+- **The GPG public key is not a release asset.** It is distributed exclusively
+  via S3; it rides inside the `rpms-*` artifacts for validation and the
+  manifest-driven assembler ignores it.
+- **`workflow-setup-packaging.sh` keeps its own tag resolution** instead of the
+  shared `release-resolve-tag.sh`: it needs the `pull_request` fallback
+  (`v0.0.0-pr.<sha>`), and on old-tag `workflow_dispatch` rebuilds the
+  [packaging overlay](../packaging/README.md) restores only
+  `.github/packaging/**`, so the shared resolver wouldn't exist on disk.
+- **Prerequisites:** linux detached signatures
+  ([#5160](https://github.com/ava-labs/avalanchego/issues/5160)) and macOS
+  signing ([#5161](https://github.com/ava-labs/avalanchego/issues/5161)) must
+  be merged before a tag can publish — the manifest lists 6 `.sig` companions
+  and the pipeline fails closed without them.
+- **Pre-merge testability:** `push: tags` reads workflow files from the tagged
+  commit, so the pipeline can be exercised before merging by tagging a
+  throwaway `v0.0.0-rc*` commit on a scratch branch (with a temporary
+  `RELEASES.md` entry) and deleting the draft + tag afterwards.
+
+## References
+
+- [`release.yml`](../workflows/release.yml) — umbrella workflow
+- [`release-*.sh` helpers](../workflows/) — one script per pipeline step; each
+  has a usage header and is runnable from a developer shell
+- [`Taskfile.yml`](./Taskfile.yml) — `task release:*` wrappers
+- [`.github/packaging/README.md`](../packaging/README.md) — RPM/deb production
+- [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release) —
+  release-creation action
+- [`scripts/lib_version.sh`](../../scripts/lib_version.sh) — canonical
+  `SEMVER_REGEX` shared with the tag-management scripts

--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -50,23 +50,28 @@ step) lives in [`release.yml`](../workflows/release.yml).
 ## Conceptual model
 
 ```
-push v*.*.* ── validate-tag ──┬─ build-rpms      ─┐
-  classify stable/prerelease  ├─ build-linux     ─┤   publish
-  duplicate-release guard     ├─ build-macos     ─┼─► body + publish-set gates
-  RELEASES.md notes gate      ├─ build-deb-amd64 ─┤   draft release + post-assert
-                              └─ build-deb-arm64 ─┘
+push v*.*.* ── validate-tag ──┬─ build-linux-packages ─┐  (rpm + deb, jammy/noble S3)
+  classify stable/prerelease  ├─ build-linux           ┤  publish
+  duplicate-release guard     ├─ build-macos           ┼► body + publish-set gates
+  RELEASES.md notes gate      └────────────────────────┘  draft release + post-assert
 ```
 
 One umbrella workflow ([`release.yml`](../workflows/release.yml)) owns the
-`push: tags` trigger and calls the five producer workflows via `workflow_call`;
+`push: tags` trigger and calls its producer workflows via `workflow_call`;
 `needs:` makes `publish` wait for all of them, and artifacts are collected
-in-run with `actions/download-artifact`. All logic lives in single-purpose
-`release-*.sh` helpers under [`.github/workflows/`](../workflows/); the YAML
-only wires them together.
+in-run with `actions/download-artifact`. Linux packages (RPM + DEB) come from
+the unified [`build-linux-packages.yml`](../workflows/build-linux-packages.yml),
+made reusable for this umbrella; it builds one codename-agnostic `.deb` per arch
+and, on the tag push, fans each into the jammy + noble S3 prefixes. All release
+logic lives in single-purpose `release-*.sh` helpers under
+[`.github/workflows/`](../workflows/); the YAML only wires them together.
 
 [`release-expected-manifest.sh`](../workflows/release-expected-manifest.sh) is
-the single source of truth for the asset set (20 basenames: 4 debs, 4 RPMs,
-4 Linux tarballs + 4 `.sig`, 2 macOS zips + 2 `.sig`). The publish job copies
+the single source of truth for the asset set (24 basenames: 8 debs
+[avalanchego + subnet-evm x jammy/noble x amd64/arm64], 4 RPMs, 4 Linux
+tarballs + 4 `.sig`, 2 macOS zips + 2 `.sig`). Each per-arch `.deb` is published
+under both its jammy and noble names, preserving the codename split on the
+release page. The publish job copies
 exactly the manifest entries into the publish set (failing on any missing one),
 asserts set-equality before creating the release, and re-asserts against the
 live release's assets afterwards.
@@ -90,9 +95,11 @@ live release's assets afterwards.
   then `echo`): under `bash -e`, a failing command substitution inside `echo`'s
   arguments is silently swallowed, which would convert helper failures into
   empty outputs.
-- **Deb basenames embed the codename** (`avalanchego-vX.Y.Z-{jammy,noble}-{arch}.deb`)
-  because the deb producers emit identically-named files; the rename happens at
-  publish-set assembly (by artifact-path substring), so S3 layout is unchanged.
+- **Deb basenames embed the codename** (`{avalanchego,subnet-evm}-vX.Y.Z-{jammy,noble}-{arch}.deb`)
+  even though the unified producer builds one codename-agnostic `.deb` per arch
+  (Ubuntu 22.04, `libc6 >= 2.35`, validated on both jammy and noble). The
+  assembler duplicates each per-arch binary into its jammy and noble names, so
+  the codename split is preserved on the release page and mirrors the S3 layout.
 - **The GPG public key is not a release asset.** It is distributed exclusively
   via S3; it rides inside the `rpms-*` artifacts for validation and the
   manifest-driven assembler ignores it.

--- a/.github/release/Taskfile.yml
+++ b/.github/release/Taskfile.yml
@@ -74,6 +74,14 @@ tasks:
       Usage: GH_REPO=ava-labs/avalanchego task release:assert-published-assets -- v1.14.3
     cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-assert-published-assets.sh {{.CLI_ARGS}}'
 
+  trigger:
+    desc: |
+      Dispatch the release workflow for TAG. The release is dispatch-driven,
+      not tag-push-driven (see README). Run after `task tags-push -- <TAG>`.
+      Requires an authenticated `gh`.
+      Usage: task release:trigger -- v1.15.0
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-trigger.sh {{.CLI_ARGS}}'
+
   # ----- Composites (script-backed; Taskfile stays thin) -----
 
   validate-tag:

--- a/.github/release/Taskfile.yml
+++ b/.github/release/Taskfile.yml
@@ -5,11 +5,15 @@ version: '3'
 # once from this file's directory so the namespace can be invoked from any
 # working dir.
 
+# Vars are RELEASE_-prefixed (matching the packaging namespace's PACKAGING_
+# prefix): vars defined in an included Taskfile leak into the root namespace,
+# so an unprefixed NIX_RUN here would override the root Taskfile's NIX_RUN
+# and break every root task.
 vars:
   REPO_ROOT:
     sh: cd "{{.TASKFILE_DIR}}/../.." && pwd
-  NIX_RUN: '{{.REPO_ROOT}}/scripts/nix_run.sh'
-  WORKFLOWS_DIR: '{{.REPO_ROOT}}/.github/workflows'
+  RELEASE_NIX_RUN: '{{.REPO_ROOT}}/scripts/nix_run.sh'
+  RELEASE_WORKFLOWS_DIR: '{{.REPO_ROOT}}/.github/workflows'
 
 tasks:
   default:
@@ -22,53 +26,53 @@ tasks:
 
   classify-tag:
     desc: 'Classify TAG as stable or prerelease. Usage: task release:classify-tag -- v1.14.3'
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-classify-tag.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-classify-tag.sh {{.CLI_ARGS}}'
 
   check-exists:
     desc: 'Fail if a GitHub release already exists for TAG (draft-aware). Usage: task release:check-exists -- v1.14.3'
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-check-exists.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-check-exists.sh {{.CLI_ARGS}}'
 
   assert-notes-exist:
     desc: 'Assert RELEASES.md has a section for TAG. Usage: task release:assert-notes-exist -- v1.14.3'
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-assert-notes-exist.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-assert-notes-exist.sh {{.CLI_ARGS}}'
 
   extract-notes:
     desc: 'Print the RELEASES.md section body for TAG. Usage: task release:extract-notes -- v1.14.3'
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-extract-notes.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-extract-notes.sh {{.CLI_ARGS}}'
 
   previous-tag:
     desc: 'Print the prior tag from RELEASES.md (tri-state exit). Usage: task release:previous-tag -- v1.14.3'
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-previous-tag.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-previous-tag.sh {{.CLI_ARGS}}'
 
   resolve-previous-tag:
     desc: 'Wrapper that collapses the tri-state exit into (0 or 2). Usage: task release:resolve-previous-tag -- v1.14.3'
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-resolve-previous-tag.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-resolve-previous-tag.sh {{.CLI_ARGS}}'
 
   expected-manifest:
     desc: 'Print canonical expected-asset basenames for TAG. Usage: task release:expected-manifest -- v1.14.3'
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-expected-manifest.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-expected-manifest.sh {{.CLI_ARGS}}'
 
   build-body:
     desc: 'Build release body for TAG. Usage: task release:build-body -- v1.14.3 v1.14.2'
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-build-body.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-build-body.sh {{.CLI_ARGS}}'
 
   build-publish-set:
     desc: |
       Assemble publish-set from producer outputs.
       Usage: task release:build-publish-set -- v1.14.3 ./release-assets ./publish-assets
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-build-publish-set.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-build-publish-set.sh {{.CLI_ARGS}}'
 
   assert-publish-set:
     desc: |
       Assert publish-set directory equals the canonical manifest.
       Usage: task release:assert-publish-set -- v1.14.3 ./publish-assets
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-assert-publish-set.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-assert-publish-set.sh {{.CLI_ARGS}}'
 
   assert-published-assets:
     desc: |
       Re-query the live release and assert its assets equal the manifest.
       Usage: GH_REPO=ava-labs/avalanchego task release:assert-published-assets -- v1.14.3
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-assert-published-assets.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-assert-published-assets.sh {{.CLI_ARGS}}'
 
   # ----- Composites (script-backed; Taskfile stays thin) -----
 
@@ -78,13 +82,13 @@ tasks:
       (classify + check-exists + assert-notes-exist).
       Usage: GH_REPO=ava-labs/avalanchego task release:validate-tag -- v1.14.3
     cmds:
-      - '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-classify-tag.sh {{.CLI_ARGS}}'
-      - '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-check-exists.sh {{.CLI_ARGS}}'
-      - '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-assert-notes-exist.sh {{.CLI_ARGS}}'
+      - '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-classify-tag.sh {{.CLI_ARGS}}'
+      - '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-check-exists.sh {{.CLI_ARGS}}'
+      - '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-assert-notes-exist.sh {{.CLI_ARGS}}'
 
   dry-run:
     desc: |
       End-to-end local dry-run: validate-tag + previous-tag + body preview +
       manifest preview. Does NOT build artifacts; does NOT mutate GitHub.
       Usage: GH_REPO=ava-labs/avalanchego task release:dry-run -- v1.14.3
-    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-dry-run.sh {{.CLI_ARGS}}'
+    cmd: '{{.RELEASE_NIX_RUN}} {{.RELEASE_WORKFLOWS_DIR}}/release-dry-run.sh {{.CLI_ARGS}}'

--- a/.github/release/Taskfile.yml
+++ b/.github/release/Taskfile.yml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: '3'
+
+# Path conventions match .github/packaging/Taskfile.yml. REPO_ROOT is computed
+# once from this file's directory so the namespace can be invoked from any
+# working dir.
+
+vars:
+  REPO_ROOT:
+    sh: cd "{{.TASKFILE_DIR}}/../.." && pwd
+  NIX_RUN: '{{.REPO_ROOT}}/scripts/nix_run.sh'
+  WORKFLOWS_DIR: '{{.REPO_ROOT}}/.github/workflows'
+
+tasks:
+  default:
+    desc: List release tasks
+    # `task --list-all <arg>` ignores the trailing arg and lists everything;
+    # filter with grep instead (same approach as the packaging namespace).
+    cmd: task --list-all | grep 'release:'
+
+  # ----- Single-script wrappers (1:1 with .github/workflows/release-*.sh) -----
+
+  classify-tag:
+    desc: 'Classify TAG as stable or prerelease. Usage: task release:classify-tag -- v1.14.3'
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-classify-tag.sh {{.CLI_ARGS}}'
+
+  check-exists:
+    desc: 'Fail if a GitHub release already exists for TAG (draft-aware). Usage: task release:check-exists -- v1.14.3'
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-check-exists.sh {{.CLI_ARGS}}'
+
+  assert-notes-exist:
+    desc: 'Assert RELEASES.md has a section for TAG. Usage: task release:assert-notes-exist -- v1.14.3'
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-assert-notes-exist.sh {{.CLI_ARGS}}'
+
+  extract-notes:
+    desc: 'Print the RELEASES.md section body for TAG. Usage: task release:extract-notes -- v1.14.3'
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-extract-notes.sh {{.CLI_ARGS}}'
+
+  previous-tag:
+    desc: 'Print the prior tag from RELEASES.md (tri-state exit). Usage: task release:previous-tag -- v1.14.3'
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-previous-tag.sh {{.CLI_ARGS}}'
+
+  resolve-previous-tag:
+    desc: 'Wrapper that collapses the tri-state exit into (0 or 2). Usage: task release:resolve-previous-tag -- v1.14.3'
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-resolve-previous-tag.sh {{.CLI_ARGS}}'
+
+  expected-manifest:
+    desc: 'Print canonical expected-asset basenames for TAG. Usage: task release:expected-manifest -- v1.14.3'
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-expected-manifest.sh {{.CLI_ARGS}}'
+
+  build-body:
+    desc: 'Build release body for TAG. Usage: task release:build-body -- v1.14.3 v1.14.2'
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-build-body.sh {{.CLI_ARGS}}'
+
+  build-publish-set:
+    desc: |
+      Assemble publish-set from producer outputs.
+      Usage: task release:build-publish-set -- v1.14.3 ./release-assets ./publish-assets
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-build-publish-set.sh {{.CLI_ARGS}}'
+
+  assert-publish-set:
+    desc: |
+      Assert publish-set directory equals the canonical manifest.
+      Usage: task release:assert-publish-set -- v1.14.3 ./publish-assets
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-assert-publish-set.sh {{.CLI_ARGS}}'
+
+  assert-published-assets:
+    desc: |
+      Re-query the live release and assert its assets equal the manifest.
+      Usage: GH_REPO=ava-labs/avalanchego task release:assert-published-assets -- v1.14.3
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-assert-published-assets.sh {{.CLI_ARGS}}'
+
+  # ----- Composites (script-backed; Taskfile stays thin) -----
+
+  validate-tag:
+    desc: |
+      Run the same gates as release.yml's validate-tag job locally
+      (classify + check-exists + assert-notes-exist).
+      Usage: GH_REPO=ava-labs/avalanchego task release:validate-tag -- v1.14.3
+    cmds:
+      - '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-classify-tag.sh {{.CLI_ARGS}}'
+      - '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-check-exists.sh {{.CLI_ARGS}}'
+      - '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-assert-notes-exist.sh {{.CLI_ARGS}}'
+
+  dry-run:
+    desc: |
+      End-to-end local dry-run: validate-tag + previous-tag + body preview +
+      manifest preview. Does NOT build artifacts; does NOT mutate GitHub.
+      Usage: GH_REPO=ava-labs/avalanchego task release:dry-run -- v1.14.3
+    cmd: '{{.NIX_RUN}} {{.WORKFLOWS_DIR}}/release-dry-run.sh {{.CLI_ARGS}}'

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -25,6 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Build the release tag's source, not the dispatch/caller ref.
+          # inputs.tag is the tag passed by the release umbrella (workflow_call);
+          # github.event.inputs.tag covers direct dispatch; github.ref covers push.
+          ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
 
       - uses: ./.github/actions/setup-go-for-project
 
@@ -92,6 +97,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Build the release tag's source, not the dispatch/caller ref.
+          # inputs.tag is the tag passed by the release umbrella (workflow_call);
+          # github.event.inputs.tag covers direct dispatch; github.ref covers push.
+          ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
 
       - uses: ./.github/actions/setup-go-for-project
 

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -1,14 +1,17 @@
 name: build-linux-release
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to include in artifact name'
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to include in artifact name'
         required: true
-  push:
-    tags:
-      - "*"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -44,18 +47,15 @@ jobs:
           role-session-name: githubrolesession
           aws-region: us-east-1
 
-      - name: Try to get tag from git
-        if: "${{ github.event.inputs.tag == '' }}"
-        id: get_tag_from_git
+      - name: Resolve tag
+        # Assignment-first, NOT `echo "TAG=$(script)" >> …`: under bash -e a
+        # failing command substitution inside echo's arguments is swallowed,
+        # whereas a failing substitution in a plain assignment fails the step.
         run: |
-          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Try to get tag from workflow dispatch
-        if: "${{ github.event.inputs.tag != '' }}"
-        id: get_tag_from_workflow
-        run: |
-          echo "TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+          tag="$(./.github/workflows/release-resolve-tag.sh)"
+          echo "TAG=${tag}" >> "$GITHUB_ENV"
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
         shell: bash
 
       - name: Create tgz package structure and upload to S3
@@ -114,18 +114,15 @@ jobs:
           role-session-name: githubrolesession
           aws-region: us-east-1
 
-      - name: Try to get tag from git
-        if: "${{ github.event.inputs.tag == '' }}"
-        id: get_tag_from_git
+      - name: Resolve tag
+        # Assignment-first, NOT `echo "TAG=$(script)" >> …`: under bash -e a
+        # failing command substitution inside echo's arguments is swallowed,
+        # whereas a failing substitution in a plain assignment fails the step.
         run: |
-          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Try to get tag from workflow dispatch
-        if: "${{ github.event.inputs.tag != '' }}"
-        id: get_tag_from_workflow
-        run: |
-          echo "TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+          tag="$(./.github/workflows/release-resolve-tag.sh)"
+          echo "TAG=${tag}" >> "$GITHUB_ENV"
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
         shell: bash
 
       - name: Create tgz package structure and upload to S3

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -26,10 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Build the release tag's source, not the dispatch/caller ref.
-          # inputs.tag is the tag passed by the release umbrella (workflow_call);
-          # github.event.inputs.tag covers direct dispatch; github.ref covers push.
-          ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
+          # Build the release tag's source, not the dispatch/caller ref. A tag
+          # input is fully qualified to refs/tags/ so a branch named like the tag
+          # cannot shadow it (actions/checkout resolves a bare name to a branch
+          # before a tag). github.ref (push) is already fully qualified.
+          ref: ${{ (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
 
       # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
       # and upload release-named artifacts unless the dispatched input is a real
@@ -117,10 +118,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Build the release tag's source, not the dispatch/caller ref.
-          # inputs.tag is the tag passed by the release umbrella (workflow_call);
-          # github.event.inputs.tag covers direct dispatch; github.ref covers push.
-          ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
+          # Build the release tag's source, not the dispatch/caller ref. A tag
+          # input is fully qualified to refs/tags/ so a branch named like the tag
+          # cannot shadow it (actions/checkout resolves a bare name to a branch
+          # before a tag). github.ref (push) is already fully qualified.
+          ref: ${{ (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
 
       # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
       # and upload release-named artifacts unless the dispatched input is a real

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -31,6 +31,25 @@ jobs:
           # github.event.inputs.tag covers direct dispatch; github.ref covers push.
           ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
 
+      # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
+      # and upload release-named artifacts unless the dispatched input is a real
+      # tag in origin. Skipped on workflow_call (the umbrella already validated
+      # the tag) and on push (the on: filter constrains it to refs/tags).
+      - name: Assert dispatch input is a released tag
+        if: github.event.inputs.tag
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+        shell: bash
+        run: |
+          if [[ ! "${TAG_INPUT}" =~ ^v[0-9] ]]; then
+            echo "ERROR: tag input '${TAG_INPUT}' must start with 'v<digit>' (e.g. v1.15.0)" >&2
+            exit 1
+          fi
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${TAG_INPUT}" >/dev/null; then
+            echo "ERROR: '${TAG_INPUT}' is not a tag in origin; refusing to build/upload a non-tag ref" >&2
+            exit 1
+          fi
+
       - uses: ./.github/actions/setup-go-for-project
 
       - run: go version
@@ -102,6 +121,25 @@ jobs:
           # inputs.tag is the tag passed by the release umbrella (workflow_call);
           # github.event.inputs.tag covers direct dispatch; github.ref covers push.
           ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
+
+      # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
+      # and upload release-named artifacts unless the dispatched input is a real
+      # tag in origin. Skipped on workflow_call (the umbrella already validated
+      # the tag) and on push (the on: filter constrains it to refs/tags).
+      - name: Assert dispatch input is a released tag
+        if: github.event.inputs.tag
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+        shell: bash
+        run: |
+          if [[ ! "${TAG_INPUT}" =~ ^v[0-9] ]]; then
+            echo "ERROR: tag input '${TAG_INPUT}' must start with 'v<digit>' (e.g. v1.15.0)" >&2
+            exit 1
+          fi
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${TAG_INPUT}" >/dev/null; then
+            echo "ERROR: '${TAG_INPUT}' is not a tag in origin; refusing to build/upload a non-tag ref" >&2
+            exit 1
+          fi
 
       - uses: ./.github/actions/setup-go-for-project
 

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -7,6 +7,11 @@ on:
         description: 'Tag to include in artifact name'
         type: string
         required: true
+      sha:
+        description: 'Exact commit to build (release umbrella pins this to the validated tag commit). Empty for standalone dispatch/push, which resolve the tag ref.'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       tag:
@@ -26,11 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Build the release tag's source, not the dispatch/caller ref. A tag
-          # input is fully qualified to refs/tags/ so a branch named like the tag
-          # cannot shadow it (actions/checkout resolves a bare name to a branch
-          # before a tag). github.ref (push) is already fully qualified.
-          ref: ${{ (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
+          # Build the exact validated commit when the umbrella pins it via
+          # inputs.sha, so a mid-run tag move cannot change what is built. Absent
+          # a SHA (standalone dispatch/push) fall back to the tag, fully qualified
+          # to refs/tags/ so a like-named branch cannot shadow it (checkout
+          # resolves a bare name to a branch before a tag); github.ref (push) is
+          # already qualified. The tag name is still used only for artifact names.
+          ref: ${{ inputs.sha || (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
 
       # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
       # and upload release-named artifacts unless the dispatched input is a real
@@ -118,11 +125,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Build the release tag's source, not the dispatch/caller ref. A tag
-          # input is fully qualified to refs/tags/ so a branch named like the tag
-          # cannot shadow it (actions/checkout resolves a bare name to a branch
-          # before a tag). github.ref (push) is already fully qualified.
-          ref: ${{ (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
+          # Build the exact validated commit when the umbrella pins it via
+          # inputs.sha, so a mid-run tag move cannot change what is built. Absent
+          # a SHA (standalone dispatch/push) fall back to the tag, fully qualified
+          # to refs/tags/ so a like-named branch cannot shadow it (checkout
+          # resolves a bare name to a branch before a tag); github.ref (push) is
+          # already qualified. The tag name is still used only for artifact names.
+          ref: ${{ inputs.sha || (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
 
       # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
       # and upload release-named artifacts unless the dispatched input is a real

--- a/.github/workflows/build-linux-packages.yml
+++ b/.github/workflows/build-linux-packages.yml
@@ -6,14 +6,21 @@ name: build-linux-packages
 # differences are captured by the matrix below.
 
 on:
+  # Called by the release umbrella (.github/workflows/release.yml), which owns
+  # the tag-push trigger and passes the validated tag in. This workflow no
+  # longer listens on `push: tags` directly, so a tag push produces exactly one
+  # orchestrated run instead of racing a standalone packaging run.
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to build packages for (passed by the release umbrella)'
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to build packages for'
         required: true
-  push:
-    tags:
-      - "v*"
   pull_request:
     paths:
       - ".github/packaging/**"
@@ -57,7 +64,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # inputs.tag (workflow_call, from the umbrella) is a semver tag already
+          # validated by the umbrella's validate-tag job; github.event.inputs.tag
+          # covers direct workflow_dispatch; github.ref covers any remaining path.
+          ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
 
       # Defense in depth: workflow_dispatch accepts an arbitrary ref, and non-PR
       # events import the real signing key. The overlay below replaces only
@@ -65,7 +75,9 @@ jobs:
       # run from the checked-out ref. Refuse to proceed unless the dispatched input
       # names an actual tag in origin (not a branch), so the key can never sign
       # arbitrary branch content.
-      # tag-push events are already constrained to refs/tags/v* by the `on:` filter.
+      # Tag builds now arrive via workflow_call from the release umbrella, which
+      # validates the tag (release-classify-tag.sh) before fan-out; this assert
+      # only guards the direct workflow_dispatch path.
       - name: Assert dispatch input is a released tag
         if: github.event.inputs.tag
         env:
@@ -109,7 +121,7 @@ jobs:
         with:
           format: ${{ matrix.format }}
           package-arch: ${{ matrix.package_arch }}
-          tag-input: ${{ github.event.inputs.tag }}
+          tag-input: ${{ inputs.tag || github.event.inputs.tag }}
           gpg-private-key: ${{ github.event_name != 'pull_request' && secrets.RPM_GPG_PRIVATE_KEY || '' }}
           gpg-passphrase: ${{ github.event_name != 'pull_request' && secrets.RPM_GPG_PASSPHRASE || '' }}
           release: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}

--- a/.github/workflows/build-linux-packages.yml
+++ b/.github/workflows/build-linux-packages.yml
@@ -65,9 +65,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           # inputs.tag (workflow_call, from the umbrella) is a semver tag already
-          # validated by the umbrella's validate-tag job; github.event.inputs.tag
-          # covers direct workflow_dispatch; github.ref covers any remaining path.
-          ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
+          # validated by the umbrella; github.event.inputs.tag covers direct
+          # dispatch; github.ref (PR/other) is already qualified. A tag input is
+          # fully qualified to refs/tags/ so a like-named branch cannot shadow it
+          # (actions/checkout resolves a bare name to a branch before a tag).
+          ref: ${{ (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
 
       # Defense in depth: workflow_dispatch accepts an arbitrary ref, and non-PR
       # events import the real signing key. The overlay below replaces only

--- a/.github/workflows/build-linux-packages.yml
+++ b/.github/workflows/build-linux-packages.yml
@@ -16,6 +16,11 @@ on:
         description: 'Tag to build packages for (passed by the release umbrella)'
         type: string
         required: true
+      sha:
+        description: 'Exact commit to build (release umbrella pins this to the validated tag commit). Empty for standalone dispatch/PR, which resolve the tag/PR ref.'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       tag:
@@ -64,12 +69,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # inputs.tag (workflow_call, from the umbrella) is a semver tag already
-          # validated by the umbrella; github.event.inputs.tag covers direct
-          # dispatch; github.ref (PR/other) is already qualified. A tag input is
-          # fully qualified to refs/tags/ so a like-named branch cannot shadow it
-          # (actions/checkout resolves a bare name to a branch before a tag).
-          ref: ${{ (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
+          # Build the exact validated commit when the umbrella pins it via
+          # inputs.sha, so a mid-run tag move cannot change the packaged source.
+          # Absent a SHA (standalone dispatch/PR) fall back to the tag, fully
+          # qualified to refs/tags/ so a like-named branch cannot shadow it
+          # (checkout resolves a bare name to a branch before a tag); github.ref
+          # (PR/other) is already qualified. The tag is still used for naming only.
+          ref: ${{ inputs.sha || (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
 
       # Defense in depth: workflow_dispatch accepts an arbitrary ref, and non-PR
       # events import the real signing key. The overlay below replaces only

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -37,8 +37,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
         with:
-          # Build the release tag's source, not the dispatch/caller ref.
-          ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
+          # Build the release tag's source, not the dispatch/caller ref; a tag
+          # input is fully qualified to refs/tags/ so a like-named branch cannot
+          # shadow it (checkout resolves a bare name to a branch before a tag).
+          ref: ${{ (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
 
       # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
       # and upload release-named artifacts unless the dispatched input is a real

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
+        with:
+          # Build the release tag's source, not the dispatch/caller ref.
+          ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -39,6 +39,26 @@ jobs:
         with:
           # Build the release tag's source, not the dispatch/caller ref.
           ref: ${{ inputs.tag || github.event.inputs.tag || github.ref }}
+
+      # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
+      # and upload release-named artifacts unless the dispatched input is a real
+      # tag in origin. Skipped on workflow_call (the umbrella already validated
+      # the tag) and on push (the on: filter constrains it to refs/tags).
+      - name: Assert dispatch input is a released tag
+        if: github.event.inputs.tag
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+        shell: bash
+        run: |
+          if [[ ! "${TAG_INPUT}" =~ ^v[0-9] ]]; then
+            echo "ERROR: tag input '${TAG_INPUT}' must start with 'v<digit>' (e.g. v1.15.0)" >&2
+            exit 1
+          fi
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${TAG_INPUT}" >/dev/null; then
+            echo "ERROR: '${TAG_INPUT}' is not a tag in origin; refusing to build/upload a non-tag ref" >&2
+            exit 1
+          fi
+
       - uses: ./.github/actions/setup-go-for-project
       - run: go version
 

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -10,6 +10,11 @@ on:
         description: 'Tag to include in artifact name'
         type: string
         required: true
+      sha:
+        description: 'Exact commit to build (release umbrella pins this to the validated tag commit). Empty for standalone dispatch/push, which resolve the tag ref.'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       tag:
@@ -37,10 +42,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
         with:
-          # Build the release tag's source, not the dispatch/caller ref; a tag
-          # input is fully qualified to refs/tags/ so a like-named branch cannot
-          # shadow it (checkout resolves a bare name to a branch before a tag).
-          ref: ${{ (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
+          # Build the exact validated commit when the umbrella pins it via
+          # inputs.sha, so a mid-run tag move cannot change what is built. Absent
+          # a SHA (standalone dispatch/push) fall back to the tag, fully qualified
+          # to refs/tags/ so a like-named branch cannot shadow it. The tag name is
+          # still used only for artifact names.
+          ref: ${{ inputs.sha || (inputs.tag || github.event.inputs.tag) && format('refs/tags/{0}', inputs.tag || github.event.inputs.tag) || github.ref }}
 
       # A standalone workflow_dispatch can name an arbitrary ref; refuse to build
       # and upload release-named artifacts unless the dispatched input is a real

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -4,14 +4,17 @@ name: build-macos-release
 
 # Controls when the action will run.
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to include in artifact name'
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to include in artifact name'
         required: true
-  push:
-    tags:
-      - "*"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -44,18 +47,15 @@ jobs:
         working-directory: ./graft/subnet-evm
         run: ./scripts/run_task.sh build
 
-      - name: Try to get tag from git
-        if: "${{ github.event.inputs.tag == '' }}"
-        id: get_tag_from_git
+      - name: Resolve tag
+        # Assignment-first, NOT `echo "TAG=$(script)" >> …`: under bash -e a
+        # failing command substitution inside echo's arguments is swallowed,
+        # whereas a failing substitution in a plain assignment fails the step.
         run: |
-          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Try to get tag from workflow dispatch
-        if: "${{ github.event.inputs.tag != '' }}"
-        id: get_tag_from_workflow
-        run: |
-          echo "TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+          tag="$(./.github/workflows/release-resolve-tag.sh)"
+          echo "TAG=${tag}" >> "$GITHUB_ENV"
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
         shell: bash
 
       - name: Create avalanchego zip file

--- a/.github/workflows/release-assert-notes-exist.sh
+++ b/.github/workflows/release-assert-notes-exist.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# release-assert-notes-exist.sh — fail loudly if RELEASES.md has no section
+# for the pushed tag.
+#
+# Usage: release-assert-notes-exist.sh <TAG> [RELEASES_MD_PATH]
+#
+# Runs release-extract-notes.sh on <TAG> and checks the exit code. If the
+# helper exits non-zero (no matching `## Pending ($TAG)` or `## [$TAG](url)`
+# section), prints a multi-line diagnostic explaining what's expected, then
+# exits 1.
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-assert-notes-exist.sh <TAG> [RELEASES_MD_PATH]}"
+RELEASES_MD="${2:-RELEASES.md}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! "${HERE}/release-extract-notes.sh" "$TAG" "$RELEASES_MD" >/dev/null 2>&1; then
+  echo "Error: ${RELEASES_MD} does not contain a section for tag '${TAG}'." >&2
+  echo "Expected one of these level-2 headers (with a non-empty body):" >&2
+  echo "  ## Pending (${TAG})" >&2
+  echo "  ## [${TAG}](https://github.com/ava-labs/avalanchego/releases/tag/${TAG})" >&2
+  echo "Add the section (header + body) to ${RELEASES_MD} and re-tag." >&2
+  exit 1
+fi
+echo "Found a ${RELEASES_MD} section for ${TAG}."

--- a/.github/workflows/release-assert-publish-set.sh
+++ b/.github/workflows/release-assert-publish-set.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# release-assert-publish-set.sh — assert the local publish-set exactly
+# matches the canonical manifest.
+#
+# Usage: release-assert-publish-set.sh <TAG> <DIR>
+#
+# Compares the basenames of files under DIR (max-depth 1) against the
+# manifest emitted by release-expected-manifest.sh. Fails (exit 1) with a
+# unified diff on any mismatch.
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-assert-publish-set.sh <TAG> <DIR>}"
+DIR="${2:?Usage: release-assert-publish-set.sh <TAG> <DIR>}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/release-lib.sh
+source "${HERE}/release-lib.sh"
+
+expected_file="$(mktemp)"
+actual_file="$(mktemp)"
+trap 'rm -f "$expected_file" "$actual_file"' EXIT
+
+"${HERE}/release-expected-manifest.sh" "$TAG" | sort -u > "$expected_file"
+find "$DIR" -maxdepth 1 -type f -exec basename {} \; | sort -u > "$actual_file"
+
+assert_set_equals_manifest "$expected_file" "$actual_file" "publish-set"
+echo "Publish-set matches manifest exactly."

--- a/.github/workflows/release-assert-published-assets.sh
+++ b/.github/workflows/release-assert-published-assets.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# release-assert-published-assets.sh — assert the GitHub release's asset
+# set exactly matches the canonical manifest.
+#
+# Usage: release-assert-published-assets.sh <TAG>
+#
+# Reads:
+#   GH_REPO or GITHUB_REPOSITORY
+#   GH_TOKEN  (for `gh api`)
+#
+# Uses the LISTING endpoint, not the tag-keyed endpoint, so drafts created
+# by the publish job are visible (the tag-keyed endpoint excludes drafts).
+# Fails (exit 1) with a unified diff on any drift; fails (exit 1) with a
+# distinct message if no release exists for the tag — softprops may have
+# silently no-op'd.
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-assert-published-assets.sh <TAG>}"
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+if [[ -z "$REPO" ]]; then
+  echo "Error: GH_REPO or GITHUB_REPOSITORY must be set" >&2
+  exit 1
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/release-lib.sh
+source "${HERE}/release-lib.sh"
+
+expected_file="$(mktemp)"
+published_file="$(mktemp)"
+trap 'rm -f "$expected_file" "$published_file"' EXIT
+
+"${HERE}/release-expected-manifest.sh" "$TAG" | sort -u > "$expected_file"
+
+gh api --paginate "repos/${REPO}/releases?per_page=100" \
+    --jq ".[] | select(.tag_name == \"${TAG}\") | .assets[].name" \
+  | sort -u > "$published_file"
+
+if [[ ! -s "$published_file" ]]; then
+  echo "Error: no release (draft or published) found for tag '${TAG}'." >&2
+  echo "softprops/action-gh-release may have silently failed; investigate." >&2
+  exit 1
+fi
+
+assert_set_equals_manifest "$expected_file" "$published_file" "published release assets"
+echo "Published release for ${TAG} has exactly the expected asset set."

--- a/.github/workflows/release-build-body.sh
+++ b/.github/workflows/release-build-body.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# release-build-body.sh — emit the full release body for <TAG>.
+#
+# Usage: release-build-body.sh <TAG> <PREV_TAG_OR_EMPTY> [RELEASES_MD_PATH]
+#
+# Writes to stdout:
+#   - Optional "Previous Tag: ..." line (omitted when PREV_TAG is empty)
+#   - Blank line
+#   - The RELEASES.md section body for <TAG> (via release-extract-notes.sh)
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-build-body.sh <TAG> <PREV_TAG_OR_EMPTY> [RELEASES_MD_PATH]}"
+PREV_TAG="${2-}"
+RELEASES_MD="${3:-RELEASES.md}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -n "$PREV_TAG" ]]; then
+  printf 'Previous Tag: [%s](https://github.com/ava-labs/avalanchego/releases/tag/%s)\n\n' \
+    "$PREV_TAG" "$PREV_TAG"
+fi
+
+"${HERE}/release-extract-notes.sh" "$TAG" "$RELEASES_MD"

--- a/.github/workflows/release-build-publish-set.sh
+++ b/.github/workflows/release-build-publish-set.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# release-build-publish-set.sh — assemble publish-set from producer outputs.
+#
+# Usage: release-build-publish-set.sh <TAG> <SOURCE_DIR> <DEST_DIR>
+#
+# For each entry in release-expected-manifest.sh's output, find the matching
+# source file under SOURCE_DIR (with deb-codename disambiguation by path
+# substring) and copy it to DEST_DIR under the manifest's target basename.
+# Fails (exit 1) on any missing entry, listing the missing manifest targets
+# and the downloaded inventory.
+#
+# Deb files require codename disambiguation: after the deb producer's
+# artifact-bundle rename (`debs-jammy-amd64`, `debs-noble-amd64`, etc.),
+# the producer outputs arrive under SOURCE_DIR/debs-{codename}-{arch}/
+# carrying identically-named files (`avalanchego-${TAG}-${arch}.deb`).
+# resolve_source() maps each codename-suffixed target name to the source
+# file by path substring, so each deb arrives in DEST_DIR with a unique
+# basename matching the manifest.
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-build-publish-set.sh <TAG> <SOURCE_DIR> <DEST_DIR>}"
+SOURCE_DIR="${2:?Usage: release-build-publish-set.sh <TAG> <SOURCE_DIR> <DEST_DIR>}"
+DEST_DIR="${3:?Usage: release-build-publish-set.sh <TAG> <SOURCE_DIR> <DEST_DIR>}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$DEST_DIR"
+
+resolve_source() {
+  local target="$1"
+  case "$target" in
+    avalanchego-*-jammy-amd64.deb)
+      find "$SOURCE_DIR" -type f -path '*jammy*' -name "avalanchego-${TAG}-amd64.deb" | sort | head -n1
+      ;;
+    avalanchego-*-noble-amd64.deb)
+      find "$SOURCE_DIR" -type f -path '*noble*' -name "avalanchego-${TAG}-amd64.deb" | sort | head -n1
+      ;;
+    avalanchego-*-jammy-arm64.deb)
+      find "$SOURCE_DIR" -type f -path '*jammy*' -name "avalanchego-${TAG}-arm64.deb" | sort | head -n1
+      ;;
+    avalanchego-*-noble-arm64.deb)
+      find "$SOURCE_DIR" -type f -path '*noble*' -name "avalanchego-${TAG}-arm64.deb" | sort | head -n1
+      ;;
+    *)
+      find "$SOURCE_DIR" -type f -name "$target" | sort | head -n1
+      ;;
+  esac
+}
+
+missing=()
+while IFS= read -r expected; do
+  [[ -z "$expected" ]] && continue
+  match="$(resolve_source "$expected")"
+  if [[ -z "$match" ]]; then
+    missing+=("$expected")
+    continue
+  fi
+  cp "$match" "${DEST_DIR}/${expected}"
+done <<<"$("${HERE}/release-expected-manifest.sh" "$TAG")"
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Error: expected artifacts missing from producer outputs:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "Downloaded inventory (${SOURCE_DIR}):" >&2
+  find "$SOURCE_DIR" -type f | sort >&2
+  exit 1
+fi
+echo "Publish-set assembled:"
+ls -la "$DEST_DIR/"

--- a/.github/workflows/release-build-publish-set.sh
+++ b/.github/workflows/release-build-publish-set.sh
@@ -9,13 +9,12 @@
 # Fails (exit 1) on any missing entry, listing the missing manifest targets
 # and the downloaded inventory.
 #
-# Deb files require codename disambiguation: after the deb producer's
-# artifact-bundle rename (`debs-jammy-amd64`, `debs-noble-amd64`, etc.),
-# the producer outputs arrive under SOURCE_DIR/debs-{codename}-{arch}/
-# carrying identically-named files (`avalanchego-${TAG}-${arch}.deb`).
-# resolve_source() maps each codename-suffixed target name to the source
-# file by path substring, so each deb arrives in DEST_DIR with a unique
-# basename matching the manifest.
+# Deb files need codename handling: the unified producer builds one
+# codename-agnostic .deb per arch and uploads per-arch bundles
+# (SOURCE_DIR/debs-amd64/, SOURCE_DIR/debs-arm64/), each carrying avalanchego
+# and subnet-evm plus the GPG key. resolve_source() maps every codename-embedded
+# manifest target (jammy/noble) back to its single per-arch file; the cp below
+# then renames it, so each per-arch binary is published under both codenames.
 
 set -euo pipefail
 
@@ -29,23 +28,16 @@ mkdir -p "$DEST_DIR"
 
 resolve_source() {
   local target="$1"
-  case "$target" in
-    avalanchego-*-jammy-amd64.deb)
-      find "$SOURCE_DIR" -type f -path '*jammy*' -name "avalanchego-${TAG}-amd64.deb" | sort | head -n1
-      ;;
-    avalanchego-*-noble-amd64.deb)
-      find "$SOURCE_DIR" -type f -path '*noble*' -name "avalanchego-${TAG}-amd64.deb" | sort | head -n1
-      ;;
-    avalanchego-*-jammy-arm64.deb)
-      find "$SOURCE_DIR" -type f -path '*jammy*' -name "avalanchego-${TAG}-arm64.deb" | sort | head -n1
-      ;;
-    avalanchego-*-noble-arm64.deb)
-      find "$SOURCE_DIR" -type f -path '*noble*' -name "avalanchego-${TAG}-arm64.deb" | sort | head -n1
-      ;;
-    *)
-      find "$SOURCE_DIR" -type f -name "$target" | sort | head -n1
-      ;;
-  esac
+  # A codename-embedded deb target (<pkg>-<tag>-<jammy|noble>-<arch>.deb) has no
+  # codename in the built file: strip it and match the single per-arch binary
+  # <pkg>-<tag>-<arch>.deb in its debs-<arch> bundle. Everything else (rpms,
+  # tarballs, macOS zips, .sig) matches the manifest basename verbatim.
+  if [[ "$target" =~ ^(avalanchego|subnet-evm)-.*-(jammy|noble)-(amd64|arm64)\.deb$ ]]; then
+    find "$SOURCE_DIR" -type f \
+      -name "${BASH_REMATCH[1]}-${TAG}-${BASH_REMATCH[3]}.deb" | sort | head -n1
+  else
+    find "$SOURCE_DIR" -type f -name "$target" | sort | head -n1
+  fi
 }
 
 missing=()

--- a/.github/workflows/release-check-exists.sh
+++ b/.github/workflows/release-check-exists.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# release-check-exists.sh — fail loudly if a GitHub release already exists for <TAG>.
+#
+# Usage: release-check-exists.sh <TAG>
+#
+# Exit codes:
+#   0  — release does NOT exist (proceed)
+#   1  — release exists (refuse to overwrite)
+#   2  — could not determine (auth, rate limit, network, outage, etc.) — fail closed
+#
+# Requires the `gh` CLI authenticated. Either GH_REPO or GITHUB_REPOSITORY
+# must be set (the GitHub Actions runner sets GITHUB_REPOSITORY automatically).
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-check-exists.sh <TAG>}"
+
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+if [[ -z "$REPO" ]]; then
+  echo "Error: GH_REPO or GITHUB_REPOSITORY must be set" >&2
+  exit 2
+fi
+
+tmp_out="$(mktemp)"
+tmp_err="$(mktemp)"
+trap 'rm -f "$tmp_out" "$tmp_err"' EXIT
+
+# Prove the repo is actually reachable before trusting any "release missing"
+# result. GitHub returns 404 for several distinct cases — release missing
+# (good), repo missing/wrong (bad), repo private + token lacks access (bad) —
+# and we can't distinguish them from the release output alone. Querying
+# repos/${REPO} first removes the ambiguity: success here means "repo exists
+# and is visible to this token".
+repo_rc=0
+gh api --include "repos/${REPO}" >"$tmp_out" 2>"$tmp_err" || repo_rc=$?
+if [[ "$repo_rc" != "0" ]]; then
+  repo_status="$(awk 'NR==1 && /^HTTP\// {print $2; exit}' "$tmp_out" || true)"
+  echo "Error: cannot access repo '${REPO}' (HTTP ${repo_status:-unknown})." >&2
+  echo "Refusing to proceed — release existence cannot be determined without repo access." >&2
+  echo "--- stdout ---" >&2
+  cat "$tmp_out" >&2
+  echo "--- stderr ---" >&2
+  cat "$tmp_err" >&2
+  exit 2
+fi
+
+# The workflow creates releases AS DRAFTS by default. GitHub's
+# `GET /repos/.../releases/tags/{tag}` endpoint deliberately excludes
+# drafts — it returns 404 for any tag that has only a draft release.
+# Using that endpoint would let us silently create a SECOND draft for the
+# same tag on a re-trigger, breaking idempotence. The listing endpoint
+# (`GET /repos/.../releases`) DOES include drafts (for users with
+# collaborator access), so we use it with a tag-name filter to catch
+# both draft and published releases.
+list_rc=0
+gh api --paginate "repos/${REPO}/releases?per_page=100" \
+    --jq ".[] | select(.tag_name == \"${TAG}\") | {id: .id, draft: .draft, name: .name}" \
+    >"$tmp_out" 2>"$tmp_err" || list_rc=$?
+
+if [[ "$list_rc" != "0" ]]; then
+  echo "Error: failed to list releases on '${REPO}'." >&2
+  echo "Refusing to proceed (fail-closed):" >&2
+  echo "--- stdout ---" >&2
+  cat "$tmp_out" >&2
+  echo "--- stderr ---" >&2
+  cat "$tmp_err" >&2
+  exit 2
+fi
+
+# gh api --jq prints one JSON object per matching release. Empty file = none.
+if [[ -s "$tmp_out" ]]; then
+  is_draft="$(jq -r '.draft' "$tmp_out" 2>/dev/null | head -n1 || echo unknown)"
+  existing_id="$(jq -r '.id' "$tmp_out" 2>/dev/null | head -n1)"
+  echo "Error: release for tag '${TAG}' already exists on GitHub (draft=${is_draft}, id=${existing_id})." >&2
+  echo "Refusing to overwrite. To re-create, inspect and delete via the listing endpoint" >&2
+  echo "(tag-keyed 'gh release view'/'gh release delete' may not see drafts depending on gh CLI version):" >&2
+  echo "" >&2
+  echo "  # Inspect:" >&2
+  echo "  gh api --paginate \"repos/${REPO}/releases?per_page=100\" \\" >&2
+  echo "    --jq \".[] | select(.tag_name == \\\"${TAG}\\\") | {id, draft, prerelease, name, assets: [.assets[].name]}\"" >&2
+  echo "" >&2
+  echo "  # Delete (by release id — works for drafts and published alike):" >&2
+  echo "  gh api -X DELETE \"repos/${REPO}/releases/${existing_id}\"" >&2
+  echo "" >&2
+  echo "  # Then delete the tag separately (the release DELETE doesn't remove the underlying tag):" >&2
+  echo "  git push origin --delete \"${TAG}\"" >&2
+  exit 1
+fi
+
+echo "No existing release (draft or published) for ${TAG} — proceeding."
+exit 0

--- a/.github/workflows/release-classify-tag.sh
+++ b/.github/workflows/release-classify-tag.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# release-classify-tag.sh — classify a release tag as stable or pre-release.
+#
+# Usage: release-classify-tag.sh <TAG>
+#
+# Validates that <TAG> matches the canonical SEMVER_REGEX (vX.Y.Z[-suffix])
+# and prints "prerelease" if the tag has a suffix, "stable" otherwise.
+# Exits non-zero on invalid input.
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-classify-tag.sh <TAG>}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/release-lib.sh
+source "${HERE}/release-lib.sh"
+
+if [[ ! "$TAG" =~ $SEMVER_REGEX ]]; then
+  echo "Error: tag '${TAG}' does not match vX.Y.Z(-suffix)?" >&2
+  exit 1
+fi
+
+if [[ -n "${BASH_REMATCH[1]:-}" ]]; then
+  echo "prerelease"
+else
+  echo "stable"
+fi

--- a/.github/workflows/release-dry-run.sh
+++ b/.github/workflows/release-dry-run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# release-dry-run.sh — local end-to-end dry-run of the release validation chain.
+#
+# Usage: release-dry-run.sh <TAG>
+#
+# Runs the same gates as release.yml's validate-tag job (classify, check-exists,
+# assert-notes-exist), then resolves the previous tag, prints the release body
+# preview, and prints the expected manifest. Does NOT build any artifacts.
+# Does NOT mutate GitHub state.
+#
+# Requires:
+#   - GH_REPO or GITHUB_REPOSITORY set (for the existence check)
+#   - `gh` authenticated for the existence check
+#   - `awk` + `jq` available on PATH (via nix or host)
+#
+# Exit codes match the underlying helpers (the first failing helper short-
+# circuits the chain via `set -e`).
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-dry-run.sh <TAG>}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> [1/5] classify-tag"
+"${HERE}/release-classify-tag.sh" "$TAG"
+
+echo "==> [2/5] check-exists (read-only API call against ${GH_REPO:-${GITHUB_REPOSITORY:-<unset>}})"
+"${HERE}/release-check-exists.sh" "$TAG"
+
+echo "==> [3/5] assert-notes-exist"
+"${HERE}/release-assert-notes-exist.sh" "$TAG"
+
+echo "==> [4/5] resolve previous tag + build release body (preview)"
+prev="$("${HERE}/release-resolve-previous-tag.sh" "$TAG")"
+echo "previous_tag=${prev:-<none>}"
+"${HERE}/release-build-body.sh" "$TAG" "$prev"
+
+echo
+echo "==> [5/5] expected manifest"
+"${HERE}/release-expected-manifest.sh" "$TAG"
+
+echo
+echo "Dry-run for ${TAG} passed all gates. No artifacts built; no GitHub state mutated."

--- a/.github/workflows/release-expected-manifest.sh
+++ b/.github/workflows/release-expected-manifest.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# release-expected-manifest.sh — emit the canonical list of artifact basenames
+# expected on the GitHub release for <TAG>.
+#
+# Usage: release-expected-manifest.sh <TAG>
+#
+# Each line is one expected basename.
+#
+# The GPG public key (GPG-KEY-avalanchego) is deliberately NOT listed: the
+# key is distributed exclusively via S3. It rides inside the rpms-*
+# workflow artifacts for RPM validation, but the manifest-driven publish-set
+# assembler ignores any downloaded file that isn't in this manifest, so it
+# never reaches the release page.
+#
+# Deb basenames embed the codename to disambiguate jammy from noble (the deb
+# producers emit identically-named files under codename-distinct artifact
+# bundles). The release workflow's publish-set assembler resolves each
+# codename-suffixed target name by path substring (`*jammy*` or `*noble*`)
+# when copying into publish-assets/, preserving the S3 path convention for
+# downstream consumers.
+#
+# Detached signatures (.sig companions) are first-class release deliverables
+# and ARE listed in this manifest. PRECONDITION: the linux-binary
+# detached-signature PR (PlatCore/5160) and the macOS signing PR
+# (PlatCore/5161) MUST be merged on master before this release workflow
+# ships. Without them, producers won't upload .sig files and the publish-set
+# assembler will fail loudly with "expected artifacts missing" — which is
+# exactly the intended fail-closed behavior. Embedded GPG signatures inside
+# RPMs and debs do NOT produce separate .sig files and stay off this list.
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-expected-manifest.sh <TAG>}"
+
+cat <<EOF
+avalanchego-${TAG}-jammy-amd64.deb
+avalanchego-${TAG}-noble-amd64.deb
+avalanchego-${TAG}-jammy-arm64.deb
+avalanchego-${TAG}-noble-arm64.deb
+avalanchego-${TAG}-x86_64.rpm
+avalanchego-${TAG}-aarch64.rpm
+subnet-evm-${TAG}-x86_64.rpm
+subnet-evm-${TAG}-aarch64.rpm
+avalanchego-linux-amd64-${TAG}.tar.gz
+avalanchego-linux-amd64-${TAG}.tar.gz.sig
+avalanchego-linux-arm64-${TAG}.tar.gz
+avalanchego-linux-arm64-${TAG}.tar.gz.sig
+subnet-evm-linux-amd64-${TAG}.tar.gz
+subnet-evm-linux-amd64-${TAG}.tar.gz.sig
+subnet-evm-linux-arm64-${TAG}.tar.gz
+subnet-evm-linux-arm64-${TAG}.tar.gz.sig
+avalanchego-macos-${TAG}.zip
+avalanchego-macos-${TAG}.zip.sig
+subnet-evm-macos-${TAG}.zip
+subnet-evm-macos-${TAG}.zip.sig
+EOF

--- a/.github/workflows/release-expected-manifest.sh
+++ b/.github/workflows/release-expected-manifest.sh
@@ -12,12 +12,15 @@
 # assembler ignores any downloaded file that isn't in this manifest, so it
 # never reaches the release page.
 #
-# Deb basenames embed the codename to disambiguate jammy from noble (the deb
-# producers emit identically-named files under codename-distinct artifact
-# bundles). The release workflow's publish-set assembler resolves each
-# codename-suffixed target name by path substring (`*jammy*` or `*noble*`)
-# when copying into publish-assets/, preserving the S3 path convention for
-# downstream consumers.
+# Deb basenames embed the codename (jammy/noble) even though the unified
+# packaging workflow (build-linux-packages.yml) builds ONE codename-agnostic
+# .deb per arch: it is built on Ubuntu 22.04 with a libc6 >= 2.35 floor and
+# that single binary is install-tested on, and serves, both jammy and noble.
+# The producer uploads per-arch bundles (debs-amd64, debs-arm64), each carrying
+# both avalanchego and subnet-evm. The publish-set assembler duplicates each
+# per-arch binary into its jammy and noble release names, preserving the
+# codename split on the release page and mirroring the S3 layout
+# (linux/debs/ubuntu/{jammy,noble}/{arch}/).
 #
 # Detached signatures (.sig companions) are first-class release deliverables
 # and ARE listed in this manifest. PRECONDITION: the linux-binary
@@ -37,6 +40,10 @@ avalanchego-${TAG}-jammy-amd64.deb
 avalanchego-${TAG}-noble-amd64.deb
 avalanchego-${TAG}-jammy-arm64.deb
 avalanchego-${TAG}-noble-arm64.deb
+subnet-evm-${TAG}-jammy-amd64.deb
+subnet-evm-${TAG}-noble-amd64.deb
+subnet-evm-${TAG}-jammy-arm64.deb
+subnet-evm-${TAG}-noble-arm64.deb
 avalanchego-${TAG}-x86_64.rpm
 avalanchego-${TAG}-aarch64.rpm
 subnet-evm-${TAG}-x86_64.rpm

--- a/.github/workflows/release-extract-notes.sh
+++ b/.github/workflows/release-extract-notes.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# release-extract-notes.sh — extract a release section from RELEASES.md.
+#
+# Usage: release-extract-notes.sh <TAG> [RELEASES_MD_PATH]
+#
+# Prints the body of the markdown section whose header contains the tag
+# (matches "## Pending (vX.Y.Z)" or "## [vX.Y.Z](...)" forms). Trims
+# leading/trailing blank lines. Exits 1 if no section matches OR if the
+# matched section has only a header (no body) — a header-only section is
+# treated as "no notes" so the release-notes preflight gate fails fast
+# rather than letting a draft ship with only the "Previous Tag:" prefix.
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-extract-notes.sh <TAG> [RELEASES_MD_PATH]}"
+RELEASES_MD="${2:-RELEASES.md}"
+
+if [[ ! -f "$RELEASES_MD" ]]; then
+  echo "Error: ${RELEASES_MD} not found" >&2
+  exit 1
+fi
+
+awk -v tag="$TAG" '
+  /^## / {
+    if (in_section) exit       # next section header — stop collecting
+    if (index($0, "(" tag ")") || index($0, "[" tag "]")) {
+      in_section = 1
+      next
+    }
+    next                       # other ## headers (different versions) — skip
+  }
+  in_section { lines[++n] = $0 }
+  END {
+    if (!in_section) exit 1
+    start = 1
+    while (start <= n && lines[start] == "") start++
+    end = n
+    while (end >= start && lines[end] == "") end--
+    # A section with only a header (or only blank lines below it) leaves
+    # start > end after trimming. Without this guard the script would exit
+    # 0 with no output, which downstream callers treat as success — the
+    # release-notes preflight gate would pass and the draft release would
+    # ship with just the "Previous Tag:" prefix and no actual notes.
+    if (start > end) exit 1
+    for (i = start; i <= end; i++) print lines[i]
+  }
+' "$RELEASES_MD"

--- a/.github/workflows/release-lib.sh
+++ b/.github/workflows/release-lib.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# release-lib.sh — shared functions for release-*.sh helpers.
+#
+# Sourced by other release-*.sh scripts; not invoked directly.
+# Re-exports SEMVER_REGEX from scripts/lib_version.sh so the release pipeline
+# uses the same canonical regex as the tag-management scripts.
+
+# Resolve repo root by going up two levels from this file's directory
+# (.github/workflows/ → .github/ → repo root).
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${LIB_DIR}/../.." && pwd)"
+# shellcheck source=scripts/lib_version.sh
+source "${REPO_ROOT}/scripts/lib_version.sh"
+
+# assert_set_equals_manifest <expected_file> <actual_file> <description>
+#   Compares two newline-delimited sorted-and-deduped sets. Prints a unified
+#   diff and returns 1 on mismatch. Used by the "set equality" gates in the
+#   publish job (publish-set vs manifest, published assets vs manifest).
+#   <description> is a human-readable noun phrase for the error line
+#   (e.g. "publish-set").
+assert_set_equals_manifest() {
+  local expected_file="$1"
+  local actual_file="$2"
+  local description="$3"
+  if ! diff -u "$expected_file" "$actual_file" >/dev/null; then
+    echo "Error: ${description} does not match manifest." >&2
+    diff -u "$expected_file" "$actual_file" >&2 || true
+    return 1
+  fi
+}

--- a/.github/workflows/release-previous-tag.sh
+++ b/.github/workflows/release-previous-tag.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# release-previous-tag.sh — find the previous tag in RELEASES.md.
+#
+# Usage: release-previous-tag.sh <TAG> [RELEASES_MD_PATH]
+#
+# Scans the file (top-to-bottom = newest-to-oldest) for the section header
+# matching <TAG>, then prints the version tag from the very next ## header.
+# Exit codes:
+#   0  — previous tag printed
+#   1  — <TAG> found but no preceding entry (it's the oldest in the file)
+#   2  — <TAG> not found in the file at all
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-previous-tag.sh <TAG> [RELEASES_MD_PATH]}"
+RELEASES_MD="${2:-RELEASES.md}"
+
+awk -v tag="$TAG" '
+  /^## / {
+    if (after) {
+      if (match($0, /[([]v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?[)\]]/)) {
+        prev = substr($0, RSTART+1, RLENGTH-2)
+        print prev
+        found = 1
+        exit
+      }
+      next
+    }
+    if (index($0, "(" tag ")") || index($0, "[" tag "]")) {
+      after = 1
+    }
+  }
+  END {
+    if (found) exit 0   # success path — previous tag was printed
+    if (!after) exit 2  # target tag not found at all
+    exit 1              # target tag found but no preceding entry
+  }
+' "$RELEASES_MD"

--- a/.github/workflows/release-resolve-previous-tag.sh
+++ b/.github/workflows/release-resolve-previous-tag.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# release-resolve-previous-tag.sh — call release-previous-tag.sh and translate
+# its tri-state exit code into a single value suitable for the workflow.
+#
+# Usage: release-resolve-previous-tag.sh <TAG> [RELEASES_MD_PATH]
+#
+# Output:
+#   - Exit 0, stdout = previous tag, when the upstream helper succeeds.
+#   - Exit 0, stdout = empty,        when <TAG> is the oldest entry (upstream exit 1).
+#   - Exit 2, no output,             when <TAG> is not in RELEASES.md (upstream exit 2).
+#
+# This collapses the "previous_tag may be empty" case into normal success so
+# the publish job's step stays a trivial assign-and-emit block, while the
+# fatal not-found case (exit 2) still fails the step.
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-resolve-previous-tag.sh <TAG> [RELEASES_MD_PATH]}"
+RELEASES_MD="${2:-RELEASES.md}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+rc=0
+prev="$("${HERE}/release-previous-tag.sh" "$TAG" "$RELEASES_MD")" || rc=$?
+
+case "$rc" in
+  0) printf '%s\n' "$prev" ;;
+  1) printf '\n' ;; # <TAG> is the oldest entry — no previous tag, but not an error.
+  *) exit "$rc" ;;  # 2 (not found) or any other failure — propagate.
+esac

--- a/.github/workflows/release-resolve-tag.sh
+++ b/.github/workflows/release-resolve-tag.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# release-resolve-tag.sh — resolve the release tag from the producer/umbrella
+# input or fall back to GITHUB_REF.
+#
+# Usage: TAG_INPUT=<maybe-empty> release-resolve-tag.sh
+#
+# Reads:
+#   TAG_INPUT   — set by workflow_call/workflow_dispatch (preferred when non-empty)
+#   GITHUB_REF  — set by Actions runner; e.g. "refs/tags/v1.14.3" on push:tags
+#
+# Prints the resolved tag on stdout. Exits 1 when TAG_INPUT is empty AND
+# GITHUB_REF is unset (e.g. invoked outside Actions with no input).
+
+set -euo pipefail
+
+if [[ -n "${TAG_INPUT:-}" ]]; then
+  printf '%s\n' "$TAG_INPUT"
+  exit 0
+fi
+if [[ -z "${GITHUB_REF:-}" ]]; then
+  echo "Error: TAG_INPUT empty and GITHUB_REF not set" >&2
+  exit 1
+fi
+printf '%s\n' "${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/release-trigger.sh
+++ b/.github/workflows/release-trigger.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# release-trigger.sh — dispatch the release workflow for TAG.
+#
+# Usage: release-trigger.sh <TAG>
+#
+# The release is dispatch-driven rather than tag-push-driven. The release
+# procedure pushes four tags at once (root + three graft modules), and GitHub
+# creates no tag push events when more than three tags are pushed together
+# (https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#push),
+# so a `push: tags` trigger on release.yml would silently never fire.
+# Dispatching explicitly also keeps a release from waking the repo's wildcard
+# `tags: "*"` workflows (CI, Bazel, buf, Docker publish), which the four-tag
+# push otherwise leaves suppressed.
+#
+# Run this AFTER the tags exist on the remote (`task tags-push -- <TAG>`).
+#
+# Requires:
+#   - `gh` authenticated with permission to dispatch workflows
+#   - GH_REPO set, or a checkout whose origin remote is the target repo
+#   - release.yml present on the repo's default branch (it defines the
+#     workflow_dispatch input this dispatches against)
+
+set -euo pipefail
+
+TAG="${1:?Usage: release-trigger.sh <TAG>}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/release-lib.sh
+source "${HERE}/release-lib.sh"
+
+if [[ ! "$TAG" =~ $SEMVER_REGEX ]]; then
+    echo "Error: '$TAG' is not a valid release tag (expected vX.Y.Z or vX.Y.Z-suffix)." >&2
+    exit 1
+fi
+
+echo "Dispatching release workflow for ${TAG}..."
+gh workflow run release.yml --field tag="${TAG}"
+
+echo ""
+echo "Dispatched. Watch the run with:"
+echo "  gh run list --workflow=release.yml --limit 5"
+echo "  gh run watch \"\$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')\""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,16 +223,6 @@ jobs:
       - name: Assert publish-set equals manifest exactly
         run: ./.github/workflows/release-assert-publish-set.sh "$TAG" publish-assets
 
-      # validate-tag ran release-check-exists.sh at the top of the workflow,
-      # but the window between that initial guard and this publish step is
-      # the full duration of the build matrix (often 30+ min). A manual
-      # `gh release create`, a retry from another workflow, or a sibling
-      # pipeline can create the release inside that window. Re-check
-      # immediately before softprops to fail closed if that has happened
-      # rather than overwrite or conflict with an existing release.
-      - name: Final pre-publish existence re-check
-        run: ./.github/workflows/release-check-exists.sh "$TAG"
-
       # Fail closed if the tag was force-moved during the build window: the
       # artifacts and body were built/rendered from the commit validate-tag
       # resolved, so refuse to publish if origin's tag no longer points there.
@@ -269,6 +259,14 @@ jobs:
       - name: Re-verify the full release tag set is intact
         run: ./scripts/verify_tags_remote.sh "$TAG"
         shell: bash
+
+      # Existence re-check LAST, immediately before softprops. validate-tag
+      # checked at the top of the workflow, but a manual `gh release create`, a
+      # retry, or a sibling pipeline can create the release during the 30+ min
+      # build/guard window. Running it after the tag guards makes it the final
+      # gate, so we fail closed rather than conflict with an existing release.
+      - name: Final pre-publish existence re-check
+        run: ./.github/workflows/release-check-exists.sh "$TAG"
 
       - name: Create GitHub release (as draft)
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,25 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
-  # Hidden direct-publish opt-in. The active default is draft creation —
-  # direct publishing requires uncommenting the block below AND swapping
-  # the `draft:`/`make_latest:` lines in the publish job.
-  # workflow_dispatch:
-  #   inputs:
-  #     tag:
-  #       description: 'Tag to publish (non-draft) a release for'
-  #       required: true
+  # Dispatch-driven, NOT tag-push-driven. The release procedure pushes four
+  # tags at once (root + three graft modules), and GitHub creates no tag push
+  # events when more than three tags are pushed together
+  # (https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#push),
+  # so a `push: tags` trigger would silently never fire. Dispatching explicitly
+  # (see `task release:trigger -- vX.Y.Z`) also keeps a release from waking the
+  # repo's wildcard `tags: "*"` workflows (CI, Bazel, buf, Docker publish),
+  # which the four-tag push otherwise leaves suppressed. The release still lands
+  # as a DRAFT (see the publish job); a human publishes it from the GitHub UI.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build and draft a release for (e.g. v1.15.0)'
+        required: true
 
-# Defense against force-pushed tag re-runs: serialize publishers for the
-# same tag ref. Tags are immutable absent --force, but if someone
-# force-pushes the same tag twice in quick succession, the concurrency
-# group ensures the second run waits and then hits the fail-closed
-# existence check.
+# Serialize publishers for the same tag: re-dispatching a tag while a run is in
+# flight makes the second run wait, then hit the fail-closed existence check.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event.inputs.tag }}
   cancel-in-progress: false
 
 # Principle of least privilege. Default workflow scope to read-only. Each
@@ -50,6 +50,10 @@ jobs:
       kind: ${{ steps.classify.outputs.kind }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Validate the tag's own RELEASES.md and run the tag's release scripts,
+          # not whatever is on the dispatch ref (the default branch).
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Derive tag
         id: derive
@@ -136,6 +140,10 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Render the release body from the tag's RELEASES.md, per the README
+          # contract that the notes section must exist in the tagged commit.
+          ref: ${{ needs.validate-tag.outputs.tag }}
 
       - name: Find previous tag in RELEASES.md
         id: prev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,231 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  # Hidden direct-publish opt-in. The active default is draft creation —
+  # direct publishing requires uncommenting the block below AND swapping
+  # the `draft:`/`make_latest:` lines in the publish job.
+  # workflow_dispatch:
+  #   inputs:
+  #     tag:
+  #       description: 'Tag to publish (non-draft) a release for'
+  #       required: true
+
+# Defense against force-pushed tag re-runs: serialize publishers for the
+# same tag ref. Tags are immutable absent --force, but if someone
+# force-pushes the same tag twice in quick succession, the concurrency
+# group ensures the second run waits and then hits the fail-closed
+# existence check.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+# Principle of least privilege. Default workflow scope to read-only. Each
+# fan-out job declares its own permissions to match the producer's actual
+# needs (id-token: write only for the AWS-OIDC producers). Two jobs override
+# to `contents: write`: `publish` (creates the release) and `validate-tag`
+# (see its permissions block for why a read-only check is not enough).
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-22.04
+    permissions:
+      # contents:write so the releases LISTING includes drafts — GitHub only
+      # returns draft releases to push-capable tokens, and drafts are this
+      # workflow's default output, so the most common duplicate (a re-run
+      # after a prior run already created the draft) is invisible to a
+      # read-only token and the fail-fast guard would fail open. No new
+      # exposure: `publish` already runs tag-controlled scripts with the
+      # same scope, so a malicious tag-pusher gains no capability here.
+      contents: write
+    outputs:
+      tag: ${{ steps.derive.outputs.tag }}
+      kind: ${{ steps.classify.outputs.kind }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Derive tag
+        id: derive
+        # Assignment-first so a resolver failure fails this step with its own
+        # diagnostic (`echo "tag=$(script)"` would swallow the exit code).
+        run: |
+          tag="$(./.github/workflows/release-resolve-tag.sh)"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+        shell: bash
+
+      - name: Classify tag (stable vs prerelease)
+        id: classify
+        # Assignment-first: a swallowed classifier failure would leave `kind`
+        # empty, which downstream evaluates as "not prerelease" — i.e. an
+        # invalid tag would silently ship as a stable release.
+        run: |
+          kind="$(./.github/workflows/release-classify-tag.sh "$TAG")"
+          echo "kind=${kind}" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ steps.derive.outputs.tag }}
+
+      - name: Fail if release already exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.derive.outputs.tag }}
+        run: ./.github/workflows/release-check-exists.sh "$TAG"
+
+      # Fail-fast if RELEASES.md has no section for the pushed tag. Critical
+      # placement in the fan-out variant — this check sits inside validate-tag,
+      # BEFORE the 30+ min build fan-out, so a missing release-notes entry
+      # costs ~100ms of runner time instead of blowing the full build matrix.
+      - name: Verify RELEASES.md has release notes for the tag
+        env:
+          TAG: ${{ steps.derive.outputs.tag }}
+        run: ./.github/workflows/release-assert-notes-exist.sh "$TAG"
+
+  build-rpms:
+    needs: validate-tag
+    uses: ./.github/workflows/build-rpm-release.yml
+    with:
+      tag: ${{ needs.validate-tag.outputs.tag }}
+    secrets: inherit
+    permissions:
+      contents: read
+
+  build-linux:
+    needs: validate-tag
+    uses: ./.github/workflows/build-linux-binaries.yml
+    with:
+      tag: ${{ needs.validate-tag.outputs.tag }}
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+
+  build-macos:
+    needs: validate-tag
+    uses: ./.github/workflows/build-macos-release.yml
+    with:
+      tag: ${{ needs.validate-tag.outputs.tag }}
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+
+  build-deb-amd64:
+    needs: validate-tag
+    uses: ./.github/workflows/build-ubuntu-amd64-release.yml
+    with:
+      tag: ${{ needs.validate-tag.outputs.tag }}
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+
+  build-deb-arm64:
+    needs: validate-tag
+    uses: ./.github/workflows/build-ubuntu-arm64-release.yml
+    with:
+      tag: ${{ needs.validate-tag.outputs.tag }}
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+
+  publish:
+    needs:
+      - validate-tag
+      - build-rpms
+      - build-linux
+      - build-macos
+      - build-deb-amd64
+      - build-deb-arm64
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ needs.validate-tag.outputs.tag }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Find previous tag in RELEASES.md
+        id: prev
+        # Assignment-first so the wrapper's fatal exit 2 ("tag not in
+        # RELEASES.md") fails this step instead of silently degrading into
+        # the benign empty-previous_tag case (`echo "k=$(script)"` swallows
+        # the substitution's exit code under bash -e).
+        run: |
+          prev="$(./.github/workflows/release-resolve-previous-tag.sh "$TAG")"
+          echo "previous_tag=${prev}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release body
+        run: ./.github/workflows/release-build-body.sh "$TAG" "$PREV_TAG" RELEASES.md > release-body.md
+        env:
+          PREV_TAG: ${{ steps.prev.outputs.previous_tag }}
+
+      - name: Download in-run artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: release-assets
+
+      - name: List artifacts before assembly
+        run: find release-assets -type f | sort
+
+      - name: Build publish-set from canonical manifest
+        run: ./.github/workflows/release-build-publish-set.sh "$TAG" release-assets publish-assets
+
+      - name: Assert publish-set equals manifest exactly
+        run: ./.github/workflows/release-assert-publish-set.sh "$TAG" publish-assets
+
+      # validate-tag ran release-check-exists.sh at the top of the workflow,
+      # but the window between that initial guard and this publish step is
+      # the full duration of the build matrix (often 30+ min). A manual
+      # `gh release create`, a retry from another workflow, or a sibling
+      # pipeline can create the release inside that window. Re-check
+      # immediately before softprops to fail closed if that has happened
+      # rather than overwrite or conflict with an existing release.
+      - name: Final pre-publish existence re-check
+        run: ./.github/workflows/release-check-exists.sh "$TAG"
+
+      - name: Create GitHub release (as draft)
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          name: ${{ env.TAG }}
+          body_path: release-body.md
+          prerelease: ${{ needs.validate-tag.outputs.kind == 'prerelease' }}
+          fail_on_unmatched_files: true
+          files: |
+            publish-assets/*
+          # The workflow always lands the release as a DRAFT. A human
+          # publishes it via the GitHub UI after reviewing title, body,
+          # assets, and pre-release/latest flags. Drafts aren't visible
+          # to non-collaborators, so a mid-upload failure leaves an
+          # invisible partial-state that's safe to delete and retry.
+          draft: true
+          #
+          # `make_latest` is a publish-time global pointer — it asks
+          # GitHub to designate THIS release as the repository's /latest,
+          # which a draft can't satisfy because drafts aren't publicly
+          # addressable. We leave it OFF the active draft path so the
+          # human publisher can decide "set as latest" in the GitHub UI.
+          #
+          # HIDDEN DIRECT-PUBLISH OPT-IN (not the default):
+          # To skip the manual review step and publish immediately, set
+          # `draft: false` (or remove the line above — softprops defaults
+          # to published when `draft` is unset) AND uncomment make_latest.
+          # draft: false
+          # make_latest: ${{ needs.validate-tag.outputs.kind == 'stable' }}
+
+      # softprops/action-gh-release silently no-ops on duplicate
+      # filenames, so trust-but-verify the GitHub state matches what we
+      # expected to upload. Fails loudly so the release can be deleted
+      # +republished rather than left half-baked.
+      - name: Verify published release assets equal the manifest
+        run: ./.github/workflows/release-assert-published-assets.sh "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
     outputs:
       tag: ${{ steps.derive.outputs.tag }}
       kind: ${{ steps.classify.outputs.kind }}
+      # Peeled commit the tag pointed to at validation time. publish re-checks
+      # the remote tag against this and fails closed if it was moved mid-build.
+      sha: ${{ steps.sha.outputs.sha }}
     steps:
       # Fail fast, before checkout, if the dispatched input is not an actual tag
       # in origin. Runs before checkout (git ls-remote needs no local clone) so
@@ -74,6 +77,16 @@ jobs:
           # never shadow the tag. Runs the tag's own RELEASES.md + release
           # scripts, not whatever is on the dispatch ref (the default branch).
           ref: refs/tags/${{ github.event.inputs.tag }}
+
+      - name: Resolve tag commit SHA
+        id: sha
+        # HEAD is the commit the tag points to (the checkout above resolved the
+        # fully-qualified tag). Assignment-first so a rev-parse failure fails
+        # this step rather than emitting an empty output.
+        run: |
+          sha="$(git rev-parse HEAD)"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+        shell: bash
 
       - name: Derive tag
         id: derive
@@ -214,6 +227,33 @@ jobs:
       # rather than overwrite or conflict with an existing release.
       - name: Final pre-publish existence re-check
         run: ./.github/workflows/release-check-exists.sh "$TAG"
+
+      # Fail closed if the tag was force-moved during the build window: the
+      # artifacts and body were built/rendered from the commit validate-tag
+      # resolved, so refuse to publish if origin's tag no longer points there.
+      # Release tags are annotated (git tag -s); peel with ^{} to the commit.
+      - name: Assert the release tag still points to the validated commit
+        env:
+          TAG: ${{ env.TAG }}
+          EXPECTED_SHA: ${{ needs.validate-tag.outputs.sha }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          url="https://github.com/${REPO}.git"
+          peeled="$(git ls-remote "$url" "refs/tags/${TAG}^{}" | awk '{print $1}')"
+          if [[ -z "$peeled" ]]; then
+            # Lightweight tag: the ref itself is the commit.
+            peeled="$(git ls-remote "$url" "refs/tags/${TAG}" | awk '{print $1}')"
+          fi
+          if [[ -z "$peeled" ]]; then
+            echo "ERROR: tag '${TAG}' no longer exists in ${REPO}; refusing to publish." >&2
+            exit 1
+          fi
+          if [[ "$peeled" != "${EXPECTED_SHA}" ]]; then
+            echo "ERROR: tag '${TAG}' moved since validation (validated ${EXPECTED_SHA}, now ${peeled}); refusing to publish." >&2
+            exit 1
+          fi
+          echo "Tag '${TAG}' still points to the validated commit ${EXPECTED_SHA}."
 
       - name: Create GitHub release (as draft)
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
       tag: ${{ steps.derive.outputs.tag }}
       kind: ${{ steps.classify.outputs.kind }}
     steps:
-      # Fail fast, before the 30+ min build fan-out, if the dispatched input is
-      # not an actual tag in origin. Runs before checkout (git ls-remote needs
-      # no local clone) and covers every producer, since they all build this
-      # same tag. Guards against a typo, an un-pushed tag, or a like-named branch.
+      # Fail fast, before checkout, if the dispatched input is not an actual tag
+      # in origin. Runs before checkout (git ls-remote needs no local clone) so
+      # the tag checkout below gets a friendly message instead of a cryptic
+      # failure. The full multi-module tag set is verified after checkout.
       - name: Assert the release tag exists in origin
         env:
           TAG_INPUT: ${{ github.event.inputs.tag }}
@@ -84,6 +84,16 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
         env:
           TAG_INPUT: ${{ github.event.inputs.tag }}
+        shell: bash
+
+      - name: Verify all release tags exist in origin
+        # The root-tag preflight above only lets the checkout succeed; this
+        # asserts the full multi-module tag set (root + graft/coreth, graft/evm,
+        # graft/subnet-evm, from lib_go_modules.sh) was pushed, so a partial
+        # tags-push cannot yield a release with missing module tags.
+        run: ./scripts/verify_tags_remote.sh "$TAG"
+        env:
+          TAG: ${{ steps.derive.outputs.tag }}
         shell: bash
 
       - name: Classify tag (stable vs prerelease)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,10 +184,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Fully-qualified tag ref: render the release body from the tag's
-          # RELEASES.md, per the README contract that the notes section must
-          # exist in the tagged commit.
-          ref: refs/tags/${{ needs.validate-tag.outputs.tag }}
+          # Pin to the exact commit validate-tag resolved, not the mutable tag
+          # name, so the release body and publish-set are rendered from the
+          # validated tree even if the tag is moved mid-run. The tag-move guard
+          # below still confirms origin's tag (which the release points at via
+          # tag_name) has not moved off this commit before publishing.
+          ref: ${{ needs.validate-tag.outputs.sha }}
 
       - name: Find previous tag in RELEASES.md
         id: prev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,16 @@ jobs:
           fi
           echo "Tag '${TAG}' still points to the validated commit ${EXPECTED_SHA}."
 
+      # Re-verify the full coordinated tag set immediately before release
+      # creation. validate-tag ran this before the ~30 min build window, so a
+      # module tag (graft/coreth, graft/evm, graft/subnet-evm) could have been
+      # moved or deleted since. verify_tags_remote.sh asserts all release tags
+      # still exist and peel to one commit; the guard above already pinned the
+      # root tag to the validated SHA, so the whole set is at that commit.
+      - name: Re-verify the full release tag set is intact
+        run: ./scripts/verify_tags_remote.sh "$TAG"
+        shell: bash
+
       - name: Create GitHub release (as draft)
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         # asserts the full multi-module tag set (root + graft/coreth, graft/evm,
         # graft/subnet-evm, from lib_go_modules.sh) was pushed, so a partial
         # tags-push cannot yield a release with missing module tags.
-        run: ./scripts/verify_tags_remote.sh "$TAG"
+        run: ./scripts/workflow-verify-tag-set.sh "$TAG"
         env:
           TAG: ${{ steps.derive.outputs.tag }}
         shell: bash
@@ -257,7 +257,7 @@ jobs:
       # still exist and peel to one commit; the guard above already pinned the
       # root tag to the validated SHA, so the whole set is at that commit.
       - name: Re-verify the full release tag set is intact
-        run: ./scripts/verify_tags_remote.sh "$TAG"
+        run: ./scripts/workflow-verify-tag-set.sh "$TAG"
         shell: bash
 
       # Existence re-check LAST, immediately before softprops. validate-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,19 @@ jobs:
           TAG: ${{ steps.derive.outputs.tag }}
         run: ./.github/workflows/release-assert-notes-exist.sh "$TAG"
 
-  build-rpms:
+  build-linux-packages:
     needs: validate-tag
-    uses: ./.github/workflows/build-rpm-release.yml
+    # Unified RPM + DEB producer (master's build-linux-packages.yml, made
+    # reusable). Builds all four format x arch packages; on this tag-push its
+    # upload-debs-s3 job fans each deb into the jammy + noble S3 prefixes,
+    # preserving the codename split at the distribution layer.
+    uses: ./.github/workflows/build-linux-packages.yml
     with:
       tag: ${{ needs.validate-tag.outputs.tag }}
     secrets: inherit
     permissions:
       contents: read
+      id-token: write   # upload-debs-s3 (jammy/noble) assumes an AWS role via OIDC
 
   build-linux:
     needs: validate-tag
@@ -117,34 +122,12 @@ jobs:
       contents: read
       id-token: write
 
-  build-deb-amd64:
-    needs: validate-tag
-    uses: ./.github/workflows/build-ubuntu-amd64-release.yml
-    with:
-      tag: ${{ needs.validate-tag.outputs.tag }}
-    secrets: inherit
-    permissions:
-      contents: read
-      id-token: write
-
-  build-deb-arm64:
-    needs: validate-tag
-    uses: ./.github/workflows/build-ubuntu-arm64-release.yml
-    with:
-      tag: ${{ needs.validate-tag.outputs.tag }}
-    secrets: inherit
-    permissions:
-      contents: read
-      id-token: write
-
   publish:
     needs:
       - validate-tag
-      - build-rpms
+      - build-linux-packages
       - build-linux
       - build-macos
-      - build-deb-amd64
-      - build-deb-arm64
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,31 @@ jobs:
       tag: ${{ steps.derive.outputs.tag }}
       kind: ${{ steps.classify.outputs.kind }}
     steps:
+      # Fail fast, before the 30+ min build fan-out, if the dispatched input is
+      # not an actual tag in origin. Runs before checkout (git ls-remote needs
+      # no local clone) and covers every producer, since they all build this
+      # same tag. Guards against a typo, an un-pushed tag, or a like-named branch.
+      - name: Assert the release tag exists in origin
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          if [[ ! "${TAG_INPUT}" =~ ^v[0-9] ]]; then
+            echo "ERROR: tag '${TAG_INPUT}' must start with 'v<digit>' (e.g. v1.15.0)" >&2
+            exit 1
+          fi
+          if ! git ls-remote --exit-code "https://github.com/${REPO}.git" "refs/tags/${TAG_INPUT}" >/dev/null; then
+            echo "ERROR: '${TAG_INPUT}' is not a tag in ${REPO}; push the release tags first (task tags-push -- ${TAG_INPUT})." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v5
         with:
-          # Validate the tag's own RELEASES.md and run the tag's release scripts,
-          # not whatever is on the dispatch ref (the default branch).
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # Fully-qualified tag ref (not a bare name) so a like-named branch can
+          # never shadow the tag. Runs the tag's own RELEASES.md + release
+          # scripts, not whatever is on the dispatch ref (the default branch).
+          ref: refs/tags/${{ github.event.inputs.tag }}
 
       - name: Derive tag
         id: derive
@@ -141,9 +161,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Render the release body from the tag's RELEASES.md, per the README
-          # contract that the notes section must exist in the tagged commit.
-          ref: ${{ needs.validate-tag.outputs.tag }}
+          # Fully-qualified tag ref: render the release body from the tag's
+          # RELEASES.md, per the README contract that the notes section must
+          # exist in the tagged commit.
+          ref: refs/tags/${{ needs.validate-tag.outputs.tag }}
 
       - name: Find previous tag in RELEASES.md
         id: prev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,7 @@ jobs:
     uses: ./.github/workflows/build-linux-packages.yml
     with:
       tag: ${{ needs.validate-tag.outputs.tag }}
+      sha: ${{ needs.validate-tag.outputs.sha }}
     secrets: inherit
     permissions:
       contents: read
@@ -154,6 +155,7 @@ jobs:
     uses: ./.github/workflows/build-linux-binaries.yml
     with:
       tag: ${{ needs.validate-tag.outputs.tag }}
+      sha: ${{ needs.validate-tag.outputs.sha }}
     secrets: inherit
     permissions:
       contents: read
@@ -164,6 +166,7 @@ jobs:
     uses: ./.github/workflows/build-macos-release.yml
     with:
       tag: ${{ needs.validate-tag.outputs.tag }}
+      sha: ${{ needs.validate-tag.outputs.sha }}
     secrets: inherit
     permissions:
       contents: read

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,6 +12,8 @@ version: '3'
 includes:
   packaging:
     taskfile: .github/packaging/Taskfile.yml
+  release:
+    taskfile: .github/release/Taskfile.yml
 
 vars:
   # Task entrypoints run through the repo's nix wrapper so they use the pinned

--- a/scripts/create_tags.sh
+++ b/scripts/create_tags.sh
@@ -28,12 +28,15 @@ fi
 
 VERSION="${1:?Usage: create_tags.sh [--no-sign] <version>}"
 
-if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib_version.sh
+source "$REPO_ROOT/scripts/lib_version.sh"
+
+if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
     echo "Error: Version must match vX.Y.Z or vX.Y.Z-suffix" >&2
     exit 1
 fi
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$REPO_ROOT/scripts/lib_go_modules.sh"
 
 TAGS=()

--- a/scripts/lib_version.sh
+++ b/scripts/lib_version.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# lib_version.sh — shared version-validation constants.
+#
+# Source from another script after resolving the repo root, e.g.:
+#   REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+#   # shellcheck source=scripts/lib_version.sh
+#   source "${REPO_ROOT}/scripts/lib_version.sh"
+
+# Canonical semver regex for avalanchego release tags.
+# Matches vX.Y.Z or vX.Y.Z-suffix.
+# shellcheck disable=SC2034  # consumed by sourcing scripts, not in this file
+readonly SEMVER_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$'

--- a/scripts/push_tags.sh
+++ b/scripts/push_tags.sh
@@ -21,12 +21,15 @@ fi
 VERSION="${1:?Usage: push_tags.sh <version>}"
 REMOTE="${GIT_REMOTE:-origin}"
 
-if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib_version.sh
+source "$REPO_ROOT/scripts/lib_version.sh"
+
+if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
     echo "Error: Version must match vX.Y.Z or vX.Y.Z-suffix" >&2
     exit 1
 fi
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$REPO_ROOT/scripts/lib_go_modules.sh"
 
 TAGS=()

--- a/scripts/push_tags.sh
+++ b/scripts/push_tags.sh
@@ -47,9 +47,6 @@ for tag in "${TAGS[@]}"; do
 done
 
 echo "Pushing tags for $VERSION to $REMOTE:"
-# GitHub does not create tag push/create events when more than three tags are
-# pushed at once, which prevents release workflows from running. Push the tags
-# individually so each push stays under that limit.
-for tag in "${TAGS[@]}"; do
-    git push "$REMOTE" "$tag"
-done
+# --atomic: all tags land or none do, so a partial push can't leave the remote
+# with an inconsistent subset of the release's coordinated tags.
+git push --atomic "$REMOTE" "${TAGS[@]}"

--- a/scripts/verify_tags_remote.sh
+++ b/scripts/verify_tags_remote.sh
@@ -22,12 +22,15 @@ fi
 VERSION="${1:?Usage: verify_tags_remote.sh <version>}"
 REMOTE="${GIT_REMOTE:-origin}"
 
-if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib_version.sh
+source "$REPO_ROOT/scripts/lib_version.sh"
+
+if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
     echo "Error: Version must match vX.Y.Z or vX.Y.Z-suffix" >&2
     exit 1
 fi
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$REPO_ROOT/scripts/lib_go_modules.sh"
 
 TAGS=()

--- a/scripts/verify_tags_remote.sh
+++ b/scripts/verify_tags_remote.sh
@@ -39,16 +39,29 @@ for prefix in "${TAG_PREFIXES[@]}"; do
 done
 
 echo "Verifying tags for $VERSION on $REMOTE:"
-remote_refs=$(git ls-remote --tags "$REMOTE" | awk '{print $2}')
+remote_ls="$(git ls-remote --tags "$REMOTE")"
+
+# Resolve a tag to the commit it points at: prefer the peeled (^{}) line that
+# annotated tags emit; fall back to the ref line for lightweight tags.
+tag_commit() {
+    local tag="$1"
+    awk -v peeled="refs/tags/${tag}^{}" -v plain="refs/tags/${tag}" '
+        $2==peeled {p=$1} $2==plain {r=$1}
+        END { if (p!="") print p; else print r }
+    ' <<<"$remote_ls"
+}
 
 missing=()
-for tag in "${TAGS[@]}"; do
-    ref="refs/tags/$tag"
-    if echo "$remote_refs" | grep -qxF "$ref"; then
-        echo "  $tag ✓"
-    else
+commits=()
+for i in "${!TAGS[@]}"; do
+    tag="${TAGS[$i]}"
+    commit="$(tag_commit "$tag")"
+    commits[i]="$commit"
+    if [[ -z "$commit" ]]; then
         echo "  $tag ✗ (missing)" >&2
         missing+=("$tag")
+    else
+        echo "  $tag ✓ ${commit}"
     fi
 done
 
@@ -59,5 +72,23 @@ if [[ ${#missing[@]} -gt 0 ]]; then
     exit 1
 fi
 
+# All release tags must point at the same commit. create_tags.sh tags a single
+# commit, so a stale or non-atomically pushed module tag resolving elsewhere
+# would hand Go-module consumers a version that disagrees with the root release.
+root_commit="${commits[0]}"
+divergent=()
+for i in "${!TAGS[@]}"; do
+    if [[ "${commits[$i]}" != "$root_commit" ]]; then
+        divergent+=("${TAGS[$i]} -> ${commits[$i]}")
+    fi
+done
+
+if [[ ${#divergent[@]} -gt 0 ]]; then
+    echo "" >&2
+    echo "Error: release tags for $VERSION point at different commits on $REMOTE (expected all at ${root_commit}):" >&2
+    printf '  %s\n' "${divergent[@]}" >&2
+    exit 1
+fi
+
 echo ""
-echo "All tags for $VERSION verified on $REMOTE."
+echo "All tags for $VERSION verified on $REMOTE (commit ${root_commit})."

--- a/scripts/workflow-verify-tag-set.sh
+++ b/scripts/workflow-verify-tag-set.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# workflow-verify-tag-set.sh — CI-only glue for the release workflow.
+#
+# Usage: workflow-verify-tag-set.sh <TAG>
+#
+# Thin wrapper over verify_tags_remote.sh so the release workflow can invoke the
+# shared multi-module tag verifier directly, without the run_task.sh toolchain
+# (the release jobs run plain bash and have no task/nix/go setup). Named
+# workflow-*.sh per scripts/actionlint.sh, which exempts that convention from
+# the "workflow run: steps must call scripts/* via run_task.sh" check.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${HERE}/verify_tags_remote.sh" "$@"


### PR DESCRIPTION
## Why this should be merged

Closes [#5162](https://github.com/ava-labs/avalanchego/issues/5162): release pages are assembled by hand today. 

This automates it, one dispatch produces 

- a **draft** GitHub release with notes parsed from `RELEASES.md`, 
- a `Previous Tag:` pointer, 
- the full 25-asset set, and 
- `prerelease` derived from the tag suffix. 

A human still reviews and publishes; the pipeline fails closed on duplicate releases, missing release notes, and missing artifacts.

## How this works

A new umbrella [`release.yml`](https://github.com/ava-labs/avalanchego/blob/PlatCore/5162-create-github-release-page/.github/workflows/release.yml) is **dispatch-driven**, not tag-push-driven: a release pushes four tags at once (root + three graft modules) and GitHub emits no push event past three, so `task release:trigger -- vX.Y.Z` dispatches it explicitly. It validates the tag (duplicate-release guard + `RELEASES.md` gate, before any build), fans out to three producer workflows via `workflow_call`, and a final `publish` job assembles a manifest-enforced asset set and creates the draft release.

Full design, usage (`task release:*`, local dry-run), and maintenance invariants are documented in [`.github/release/README.md`](https://github.com/ava-labs/avalanchego/blob/PlatCore/5162-create-github-release-page/.github/release/README.md).

Notable mechanics:

- Producers gain `workflow_call`; their `workflow_dispatch`/`pull_request` triggers are unchanged.
- All reads/deletes of releases use the listing endpoint (tag-keyed APIs don't  see drafts); the existence guard verifies repo reachability before trusting  "not found".
- `scripts/lib_version.sh` single-sources `SEMVER_REGEX`; helper logic lives in single-purpose `release-*.sh` scripts, mirrored 1:1 by a `task release:*` namespace (14 tasks).

**Merge prerequisites:** [#5160](https://github.com/ava-labs/avalanchego/issues/5160) and [#5161](https://github.com/ava-labs/avalanchego/issues/5161) — the manifest expects 6 `.sig` companions and the pipeline fails closed until producers upload them.

## How this was tested

- 47-check local battery over every helper: resolver paths, stable/prerelease  classification, notes extraction (incl. header-only-section regression),  previous-tag tri-state (incl. oldest entry `v1.6.3`), body assembly, manifest  invariants, publish-set assembly with extraneous-/missing-asset failure modes  — all PASS.
- Live read-only checks against this repo: existence guard exits 1 on existing  `v1.14.2`, 0 on missing `v9.99.99`, 2 (fail-closed) on an inaccessible repo;  `release:dry-run` stops at the correct gate for both failure paths.
- `./scripts/shellcheck.sh` and `./scripts/actionlint.sh` clean (nix dev shell).
- Live end-to-end via `task release:trigger` with a throwaway  `v0.0.0-rc999-test` tag, verifying draft creation, `prerelease: true`, the  25-asset set, and clean deletion by release ID.

## Need to be documented in RELEASES.md?

No — CI/release tooling only; no node behavior changes. (The pipeline *reads* `RELEASES.md`: a tag must have a section with a non-empty body there before it can be released.)
