### PR TITLE
feat(merkle/sync): label proof duration metrics by result

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@
   - `avalanche_{vmName}_eth_net_tracked_peers` -> `avalanche_{vmName}_sdk_sync_peer_tracker_num_tracked_peers`
   - `avalanche_{vmName}_eth_net_responsive_peers` -> `avalanche_{vmName}_sdk_sync_peer_tracker_num_responsive_peers`
   - `avalanche_{vmName}_eth_net_average_bandwidth` -> `avalanche_{vmName}_sdk_sync_peer_tracker_average_bandwidth`
-- Added Firewood state-sync proof metrics, labeled by `proof_type="range|change"`:
+- Added Firewood state-sync proof metrics, labeled by `proof_type="range|change"`; the duration histograms are additionally labeled by `result="success|failure"`:
   - Server-side histograms: `avalanche_{vmName}_sdk_sync_proof_generation_seconds`, `avalanche_{vmName}_sdk_sync_generated_proof_size_bytes`, and `avalanche_{vmName}_sdk_sync_proof_shrink_new_key_limit`
   - Client-side histograms: `avalanche_{vmName}_sync_firewood_sync_proof_verification_seconds`, `avalanche_{vmName}_sync_firewood_sync_proof_commit_seconds`, and `avalanche_{vmName}_sync_firewood_sync_received_proof_size_bytes`
   - Client-side gauge: `avalanche_{vmName}_sync_firewood_sync_request_key_limit`

--- a/database/merkle/sync/metrics.go
+++ b/database/merkle/sync/metrics.go
@@ -20,7 +20,20 @@ const (
 	proofTypeLabel  = "proof_type"
 	proofTypeRange  = "range"
 	proofTypeChange = "change"
+
+	resultLabel   = "result"
+	resultSuccess = "success"
+	resultFailure = "failure"
 )
+
+// resultLabelFor returns the result label value for an operation that
+// returned err.
+func resultLabelFor(err error) string {
+	if err != nil {
+		return resultFailure
+	}
+	return resultSuccess
+}
 
 var (
 	// durationBuckets span 1ms (fast proof operation) to ~8.2s (slow
@@ -76,15 +89,15 @@ func newSyncerMetrics(namespace string, reg prometheus.Registerer) (*syncerMetri
 		proofVerificationTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "proof_verification_seconds",
-			Help:      "time, in seconds, spent verifying each received proof",
+			Help:      "time, in seconds, spent verifying each received proof, labeled by result",
 			Buckets:   durationBuckets,
-		}, []string{proofTypeLabel}),
+		}, []string{proofTypeLabel, resultLabel}),
 		proofCommitTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "proof_commit_seconds",
-			Help:      "time, in seconds, spent committing each verified proof to the database",
+			Help:      "time, in seconds, spent committing each verified proof to the database, labeled by result",
 			Buckets:   durationBuckets,
-		}, []string{proofTypeLabel}),
+		}, []string{proofTypeLabel, resultLabel}),
 	}
 	m.requestKeyLimit.Set(DefaultRequestKeyLimit)
 	err := errors.Join(
@@ -115,12 +128,12 @@ func (m *syncerMetrics) proofReceived(proofType string, numBytes int) {
 	m.receivedProofSizeBytes.WithLabelValues(proofType).Observe(float64(numBytes))
 }
 
-func (m *syncerMetrics) proofVerified(proofType string, duration time.Duration) {
-	m.proofVerificationTime.WithLabelValues(proofType).Observe(duration.Seconds())
+func (m *syncerMetrics) proofVerified(proofType string, duration time.Duration, err error) {
+	m.proofVerificationTime.WithLabelValues(proofType, resultLabelFor(err)).Observe(duration.Seconds())
 }
 
-func (m *syncerMetrics) proofCommitted(proofType string, duration time.Duration) {
-	m.proofCommitTime.WithLabelValues(proofType).Observe(duration.Seconds())
+func (m *syncerMetrics) proofCommitted(proofType string, duration time.Duration, err error) {
+	m.proofCommitTime.WithLabelValues(proofType, resultLabelFor(err)).Observe(duration.Seconds())
 }
 
 // handlerMetrics observes the server side of proof sync: generating,
@@ -136,9 +149,9 @@ func newHandlerMetrics(namespace string, reg prometheus.Registerer) (*handlerMet
 		proofGenerationTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "proof_generation_seconds",
-			Help:      "time, in seconds, spent generating each proof; the count is the total number of proofs generated",
+			Help:      "time, in seconds, spent generating each proof, labeled by result; the count is the total number of generation attempts",
 			Buckets:   durationBuckets,
-		}, []string{proofTypeLabel}),
+		}, []string{proofTypeLabel, resultLabel}),
 		generatedProofSizeBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "generated_proof_size_bytes",
@@ -160,8 +173,11 @@ func newHandlerMetrics(namespace string, reg prometheus.Registerer) (*handlerMet
 	return &m, err
 }
 
-func (m *handlerMetrics) proofGenerated(proofType string, duration time.Duration) {
-	m.proofGenerationTime.WithLabelValues(proofType).Observe(duration.Seconds())
+// proofGenerated records one proof generation attempt, labeling it a failure
+// if err is non-nil. A failure includes a change proof attempt that falls
+// back to a range proof; the fallback records its own range attempt.
+func (m *handlerMetrics) proofGenerated(proofType string, duration time.Duration, err error) {
+	m.proofGenerationTime.WithLabelValues(proofType, resultLabelFor(err)).Observe(duration.Seconds())
 }
 
 func (m *handlerMetrics) proofServed(proofType string, numBytes int) {

--- a/database/merkle/sync/network_server.go
+++ b/database/merkle/sync/network_server.go
@@ -134,13 +134,13 @@ func (h *ProofHandler[R, C]) handleRangeProofRequest(ctx context.Context, req *p
 			endKey,
 			keyLimit,
 		)
+		h.metrics.proofGenerated(proofTypeRange, time.Since(generationStart), err)
 		if err != nil {
 			if errors.Is(err, ErrInsufficientHistory) {
 				return nil, nil // drop request
 			}
 			return nil, err
 		}
-		h.metrics.proofGenerated(proofTypeRange, time.Since(generationStart))
 
 		innerBytes, err := h.rangeProofMarshaler.Marshal(rangeProof)
 		if err != nil {
@@ -194,6 +194,7 @@ func (h *ProofHandler[R, C]) handleChangeProofRequest(ctx context.Context, req *
 	for keyLimit > 0 {
 		generationStart := time.Now()
 		changeProof, err := h.db.GetChangeProof(ctx, startRoot, endRoot, start, end, int(keyLimit))
+		h.metrics.proofGenerated(proofTypeChange, time.Since(generationStart), err)
 		if err != nil {
 			if !errors.Is(err, ErrInsufficientHistory) {
 				// We should only fail to get a change proof if we have insufficient history.
@@ -222,7 +223,6 @@ func (h *ProofHandler[R, C]) handleChangeProofRequest(ctx context.Context, req *
 		}
 
 		// We generated a change proof. See if it's small enough.
-		h.metrics.proofGenerated(proofTypeChange, time.Since(generationStart))
 		changeProofBytes, err := h.changeProofMarshaler.Marshal(changeProof)
 		if err != nil {
 			return nil, err

--- a/database/merkle/sync/syncer.go
+++ b/database/merkle/sync/syncer.go
@@ -630,26 +630,27 @@ func (s *Syncer[R, C]) handleChangeProofResponse(
 		s.metrics.proofReceived(proofTypeChange, len(responseBytes))
 
 		verificationStart := time.Now()
-		if err := s.db.VerifyChangeProof(
+		err = s.db.VerifyChangeProof(
 			ctx,
 			changeProof,
 			startKey,
 			endKey,
 			endRoot,
 			int(request.KeyLimit),
-		); err != nil {
+		)
+		s.metrics.proofVerified(proofTypeChange, time.Since(verificationStart), err)
+		if err != nil {
 			return fmt.Errorf("%w due to %w", errInvalidChangeProof, err)
 		}
-		s.metrics.proofVerified(proofTypeChange, time.Since(verificationStart))
 
 		// if the proof wasn't empty, apply changes to the sync DB
 		commitStart := time.Now()
 		nextKey, err := s.db.CommitChangeProof(ctx, endKey, changeProof)
+		s.metrics.proofCommitted(proofTypeChange, time.Since(commitStart), err)
 		if err != nil {
 			s.setError(err)
 			return nil
 		}
-		s.metrics.proofCommitted(proofTypeChange, time.Since(commitStart))
 
 		s.completeWorkItem(work, nextKey, targetRootID)
 	case *pb.ProofResponse_RangeProof:
@@ -696,18 +697,19 @@ func (s *Syncer[R, _]) verifyAndCommitRangeProof(
 	keyLimit int,
 ) error {
 	verificationStart := time.Now()
-	if err := s.db.VerifyRangeProof(ctx, rangeProof, start, end, root, keyLimit); err != nil {
+	err := s.db.VerifyRangeProof(ctx, rangeProof, start, end, root, keyLimit)
+	s.metrics.proofVerified(proofTypeRange, time.Since(verificationStart), err)
+	if err != nil {
 		return err
 	}
-	s.metrics.proofVerified(proofTypeRange, time.Since(verificationStart))
 
 	commitStart := time.Now()
 	nextKey, err := s.db.CommitRangeProof(ctx, work.start, work.end, rangeProof)
+	s.metrics.proofCommitted(proofTypeRange, time.Since(commitStart), err)
 	if err != nil {
 		s.setError(err)
 		return nil
 	}
-	s.metrics.proofCommitted(proofTypeRange, time.Since(commitStart))
 
 	s.completeWorkItem(work, nextKey, targetRootID)
 	return nil


### PR DESCRIPTION
## Why this should be merged

Stacked on #5518. The proof duration histograms only observed successful operations, so a server erroring on proof generation, or a client burning CPU verifying a bad proof, was invisible in the timing metrics and the histogram counts.

This labels `proof_generation_seconds`, `proof_verification_seconds`, and `proof_commit_seconds` with `result="success|failure"` and observes failed attempts too. A change proof attempt that falls back to a range proof is recorded as a change failure, so `proof_generation_seconds_count{proof_type="change",result="failure"}` doubles as a fallback-frequency signal.

Label cardinality is bounded: proof_type(2) × result(2) = 4 series per histogram. The `result` label name follows the existing `cache/metercacher` precedent (`result="hit|miss"`).

Note: the histogram `_count` now counts attempts, not successes; dashboards measuring throughput should filter `result="success"`.

## How this works

Adds a `result` label to the three duration histograms and moves each observation above its error check, passing the error to derive the label. Error-handling semantics are unchanged.

## How this was tested

Existing end-to-end sync tests in `x/merkledb` exercise both the handler and syncer paths.

## Need to be documented in RELEASES.md?

Yes, updated the entry added by #5518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)