### PR TITLE
feat: Prevent Helicon blocks in coreth

### DIFF
--- a/graft/coreth/miner/worker.go
+++ b/graft/coreth/miner/worker.go
@@ -151,6 +151,12 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateConte
 		timestampMS = uint64(tstart.UnixMilli())
 	)
 
+	// No Helicon blocks allowed
+	if chainExtra.IsHelicon(timestamp) && timestamp > 0 {
+		timestamp = *chainExtra.HeliconTimestamp - 1
+		timestampMS = (timestamp+1)*1000 - 1
+	}
+
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     new(big.Int).Add(parent.Number, common.Big1),

--- a/graft/coreth/params/extras/config.go
+++ b/graft/coreth/params/extras/config.go
@@ -79,7 +79,7 @@ var (
 		c.NetworkUpgrades.HeliconTimestamp = utils.PointerTo[uint64](0)
 	})
 
-	TestChainConfig = copyConfig(TestHeliconChainConfig)
+	TestChainConfig = copyConfig(TestGraniteChainConfig)
 )
 
 func copyConfig(c *ChainConfig) *ChainConfig {

--- a/graft/coreth/plugin/evm/atomic/vm/vm_test.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm_test.go
@@ -1640,11 +1640,8 @@ func TestWaitForEvent(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			fork := upgradetest.Latest
 			vm := newAtomicTestVM()
-			tvm := vmtest.SetupTestVM(t, vm, vmtest.TestVMConfig{
-				Fork: &fork,
-			})
+			tvm := vmtest.SetupTestVM(t, vm, vmtest.TestVMConfig{})
 			key := vmtest.TestKeys[0].ToECDSA()
 			address := vmtest.TestEthAddrs[0]
 

--- a/graft/coreth/plugin/evm/vm_test.go
+++ b/graft/coreth/plugin/evm/vm_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ava-labs/avalanchego/graft/coreth/miner"
 	"github.com/ava-labs/avalanchego/graft/coreth/node"
 	"github.com/ava-labs/avalanchego/graft/coreth/params"
+	"github.com/ava-labs/avalanchego/graft/coreth/params/extras"
 	"github.com/ava-labs/avalanchego/graft/coreth/params/paramstest"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/customheader"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/customtypes"
@@ -48,6 +49,7 @@ import (
 	"github.com/ava-labs/avalanchego/graft/evm/rpc"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
@@ -110,10 +112,8 @@ func TestVMContinuousProfiler(t *testing.T) {
 	profilerDir := t.TempDir()
 	profilerFrequency := 500 * time.Millisecond
 	configJSON := fmt.Sprintf(`{"continuous-profiler-dir": %q,"continuous-profiler-frequency": "500ms"}`, profilerDir)
-	fork := upgradetest.Latest
 	vm := newDefaultTestVM()
 	vmtest.SetupTestVM(t, vm, vmtest.TestVMConfig{
-		Fork:       &fork,
 		ConfigJSON: configJSON,
 	})
 	require.Equal(t, vm.config.ContinuousProfilerDir, profilerDir, "profiler dir should be set")
@@ -1547,7 +1547,6 @@ func TestWaitForEvent(t *testing.T) {
 
 	for _, testCase := range []struct {
 		name     string
-		Fork     *upgradetest.Fork
 		testCase func(*testing.T, *VM)
 	}{
 		{
@@ -1713,14 +1712,8 @@ func TestWaitForEvent(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			fork := upgradetest.Latest
-			if testCase.Fork != nil {
-				fork = *testCase.Fork
-			}
 			vm := newDefaultTestVM()
-			vmtest.SetupTestVM(t, vm, vmtest.TestVMConfig{
-				Fork: &fork,
-			})
+			vmtest.SetupTestVM(t, vm, vmtest.TestVMConfig{})
 			testCase.testCase(t, vm)
 			require.NoError(t, vm.Shutdown(t.Context()))
 		})
@@ -1746,13 +1739,10 @@ func (*testService) Echo(str string, i int, args *echoArgs) echoResult {
 // emulates server test
 func TestCreateHandlers(t *testing.T) {
 	var (
-		ctx  = t.Context()
-		fork = upgradetest.Latest
-		vm   = newDefaultTestVM()
+		ctx = t.Context()
+		vm  = newDefaultTestVM()
 	)
-	vmtest.SetupTestVM(t, vm, vmtest.TestVMConfig{
-		Fork: &fork,
-	})
+	vmtest.SetupTestVM(t, vm, vmtest.TestVMConfig{})
 	defer func() {
 		require.NoError(t, vm.Shutdown(ctx))
 	}()
@@ -2159,6 +2149,77 @@ func TestMinDelayExcessInHeader(t *testing.T) {
 	}
 }
 
+// TestHeliconBlockValidation tests that blocks with Helicon timestamps cannot
+// be verified, cannot be built, but can be parsed.
+func TestHeliconBlockValidation(t *testing.T) {
+	ctx := t.Context()
+
+	heliconTime := upgrade.InitiallyActiveTime.Add(5 * time.Second)
+	heliconTimestamp := uint64(heliconTime.Unix())
+
+	extConfig := defaultExtensions()
+	extConfig.Clock.Set(heliconTime)
+	vm := &VM{}
+	require.NoError(t, vm.SetExtensionConfig(extConfig))
+
+	// Snow context must match chain config
+	snowCtx, prefixedDB, _, _ := vmtest.SetupGenesis(t, upgradetest.Granite)
+	snowCtx.NetworkUpgrades.HeliconTime = heliconTime
+
+	// Build a chain config that mirrors TestGraniteChainConfig but with
+	// HeliconTimestamp set to match the upgrade config above.
+	customExtras := *extras.TestGraniteChainConfig
+	customExtras.NetworkUpgrades.HeliconTimestamp = utils.PointerTo(heliconTimestamp)
+	customChainConfig := params.WithExtra(
+		params.TestChainConfig,
+		&customExtras,
+	)
+
+	appSender := &enginetest.Sender{
+		T:                 t,
+		CantSendAppGossip: true,
+		SendAppGossipF:    func(context.Context, commonEng.SendConfig, []byte) error { return nil },
+	}
+
+	err := vm.Initialize(ctx, snowCtx, prefixedDB, []byte(vmtest.GenesisJSON(customChainConfig)), nil, nil, nil, appSender)
+	require.NoErrorf(t, err, "%T.Initialize()", vm)
+
+	require.NoError(t, vm.SetState(ctx, snow.Bootstrapping))
+	require.NoError(t, vm.SetState(ctx, snow.NormalOp))
+	defer func() {
+		require.NoErrorf(t, vm.Shutdown(ctx), "%T.Shutdown()", vm)
+	}()
+
+	signedTx := newSignedLegacyTx(t, vm.chainConfig, vmtest.TestKeys[0].ToECDSA(), 0, &vmtest.TestEthAddrs[1], big.NewInt(1), 21000, vmtest.InitialBaseFee, nil)
+	blk, err := vmtest.IssueTxsAndBuild([]*types.Transaction{signedTx}, vm)
+	require.NoError(t, err)
+
+	ethBlock := blk.(*chain.BlockWrapper).Block.(*wrappedBlock).ethBlock
+	header := ethBlock.Header()
+	require.Less(t, header.Time, heliconTimestamp, "block builder created a Helicon block")
+
+	// Make malicious helicon block
+	header.Time = heliconTimestamp
+	modifiedBlock := customtypes.NewBlockWithExtData(
+		header,
+		[]*types.Transaction{signedTx},
+		nil,
+		nil,
+		trie.NewStackTrie(nil),
+		nil,
+		true,
+	)
+
+	snowBlock, err := wrapBlock(modifiedBlock, vm)
+	require.NoError(t, err, "wrapBlock()")
+
+	err = snowBlock.Verify(ctx)
+	require.ErrorIsf(t, err, errIsHeliconBlock, "%T.Verify()", snowBlock)
+
+	_, err = vm.ParseBlock(ctx, snowBlock.Bytes())
+	require.NoError(t, err, "Helicon blocks must be parsable")
+}
+
 func TestInspectDatabases(t *testing.T) {
 	var (
 		vm = newDefaultTestVM()
@@ -2208,7 +2269,7 @@ func TestFirewoodArchivalQueries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
-			fork := upgradetest.Latest
+			fork := upgradetest.Granite
 
 			vm := newDefaultTestVM()
 			tvm := vmtest.SetupTestVM(t, vm, vmtest.TestVMConfig{

--- a/graft/coreth/plugin/evm/vmtest/test_syncervm.go
+++ b/graft/coreth/plugin/evm/vmtest/test_syncervm.go
@@ -288,9 +288,7 @@ func initSyncServerAndClientVMs(t *testing.T, test SyncTestParams, numBlocks int
 	// This is necessary to support fetching a state summary.
 	config := fmt.Sprintf(`{"commit-interval": %d, "state-history": %d, "state-sync-commit-interval": %d}`, test.SyncableInterval, test.SyncableInterval, test.SyncableInterval)
 	serverVM, cb := testSetup.NewVM()
-	fork := upgradetest.Latest
 	serverTest := SetupTestVM(t, serverVM, TestVMConfig{
-		Fork:       &fork,
 		ConfigJSON: config,
 		Scheme:     test.StateScheme,
 	})
@@ -352,7 +350,6 @@ func initSyncServerAndClientVMs(t *testing.T, test SyncTestParams, numBlocks int
 
 	syncerVM, syncerCB := testSetup.NewVM()
 	syncerTest := SetupTestVM(t, syncerVM, TestVMConfig{
-		Fork:       &fork,
 		ConfigJSON: stateSyncEnabledJSON,
 		Scheme:     test.StateScheme,
 		IsSyncing:  true,

--- a/graft/coreth/plugin/evm/vmtest/test_vm.go
+++ b/graft/coreth/plugin/evm/vmtest/test_vm.go
@@ -51,7 +51,7 @@ type TestVMSuite struct {
 // issuer channel, database, atomic memory, app sender, and context.
 // Expects the passed VM to be a uninitialized VM.
 func SetupTestVM(t *testing.T, vm commoneng.VM, config TestVMConfig) *TestVMSuite {
-	fork := upgradetest.Latest
+	fork := upgradetest.Granite
 	if config.Fork != nil {
 		fork = *config.Fork
 	}

--- a/graft/coreth/plugin/evm/wrapped_block.go
+++ b/graft/coreth/plugin/evm/wrapped_block.go
@@ -57,6 +57,7 @@ var (
 	errParentBeaconRootNonEmpty            = errors.New("invalid non-empty parentBeaconRoot")
 	errBlobGasUsedNilInCancun              = errors.New("blob gas used must not be nil in Cancun")
 	errBlobsNotEnabled                     = errors.New("blobs not enabled on avalanche networks")
+	errIsHeliconBlock                      = errors.New("helicon blocks are not valid on pre-SAE C-Chain")
 )
 
 var (
@@ -339,6 +340,12 @@ func (b *wrappedBlock) semanticVerify(predicateContext *precompileconfig.Predica
 	}
 
 	header := b.ethBlock.Header()
+
+	// Coreth cannot verify Helicon blocks, but they still must be parsable.
+	if extraConfig.IsHelicon(header.Time) {
+		return fmt.Errorf("%w: %s at height %d", errIsHeliconBlock, header.Hash(), header.Number.Uint64())
+	}
+
 	// Ensure MinDelayExcess is consistent with rules and minimum block delay is enforced.
 	if err := customheader.VerifyMinDelayExcess(extraConfig, parent, header); err != nil {
 		return err

--- a/graft/coreth/precompile/contracts/warp/contract_test.go
+++ b/graft/coreth/precompile/contracts/warp/contract_test.go
@@ -29,7 +29,7 @@ import (
 
 var forks = []upgradetest.Fork{
 	upgradetest.Fortuna,
-	upgradetest.Latest,
+	upgradetest.Granite,
 }
 
 func runTests(


### PR DESCRIPTION
## Why this should be merged

Coreth cannot execute an asynchronous block, so it can't build one or verify one either.

## How this works

Prevents building or verifying blocks. They must be parsable. Most of the diff is fixing other tests to use Granite instead.

## How this was tested

New UT

## Need to be documented in RELEASES.md?

No
