### PR TITLE
fix(firewood): clear stale storage on same-block account resurrection

### DIFF
--- a/graft/evm/firewood/triedb.go
+++ b/graft/evm/firewood/triedb.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ava-labs/libevm/triedb/database"
 )
 
-const firewoodDir = "firewood"
+const FirewoodDir = "firewood"
 
 var (
 	_ triedb.DBConstructor = TrieDBConfig{}.BackendConstructor
@@ -145,7 +145,7 @@ func New(config TrieDBConfig) (*TrieDB, error) {
 	if err := validateDir(config.DatabaseDir); err != nil {
 		return nil, err
 	}
-	path := filepath.Join(config.DatabaseDir, firewoodDir)
+	path := filepath.Join(config.DatabaseDir, FirewoodDir)
 
 	// The Firewood constructor will check that commitCount is nonzero.
 	minDeferredPersistenceCommitCount := uint64(config.RevisionsInMemory - 1)

--- a/vms/saevm/firewood/BUILD.bazel
+++ b/vms/saevm/firewood/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     deps = [
         "//utils/logging",
         "//utils/logging/loggingtest",
+        "//utils/set",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core",
         "@com_github_ava_labs_libevm//core/rawdb",

--- a/vms/saevm/firewood/BUILD.bazel
+++ b/vms/saevm/firewood/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "go_test")
+
+go_library(
+    name = "firewood",
+    srcs = [
+        "account_trie.go",
+        "base_trie.go",
+        "state.go",
+        "storage_trie.go",
+        "triedb.go",
+    ],
+    importpath = "github.com/ava-labs/avalanchego/vms/saevm/firewood",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//graft/evm/firewood",
+        "//utils/logging",
+        "@com_github_ava_labs_firewood_go_ethhash_ffi//:ffi",
+        "@com_github_ava_labs_libevm//common",
+        "@com_github_ava_labs_libevm//core/rawdb",
+        "@com_github_ava_labs_libevm//core/state",
+        "@com_github_ava_labs_libevm//core/types",
+        "@com_github_ava_labs_libevm//crypto",
+        "@com_github_ava_labs_libevm//ethdb",
+        "@com_github_ava_labs_libevm//libevm/stateconf",
+        "@com_github_ava_labs_libevm//metrics",
+        "@com_github_ava_labs_libevm//rlp",
+        "@com_github_ava_labs_libevm//trie",
+        "@com_github_ava_labs_libevm//trie/trienode",
+        "@com_github_ava_labs_libevm//trie/triestate",
+        "@com_github_ava_labs_libevm//triedb",
+        "@com_github_ava_labs_libevm//triedb/database",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "firewood_test",
+    srcs = ["triedb_test.go"],
+    embed = [":firewood"],
+    deps = [
+        "//utils/logging",
+        "//utils/logging/loggingtest",
+        "@com_github_ava_labs_libevm//common",
+        "@com_github_ava_labs_libevm//core",
+        "@com_github_ava_labs_libevm//core/rawdb",
+        "@com_github_ava_labs_libevm//core/state",
+        "@com_github_ava_labs_libevm//core/types",
+        "@com_github_ava_labs_libevm//crypto",
+        "@com_github_ava_labs_libevm//params",
+        "@com_github_ava_labs_libevm//triedb",
+        "@com_github_holiman_uint256//:uint256",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/vms/saevm/firewood/BUILD.bazel
+++ b/vms/saevm/firewood/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//graft/evm/firewood",
         "//utils/logging",
+        "//utils/set",
         "@com_github_ava_labs_firewood_go_ethhash_ffi//:ffi",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/rawdb",
@@ -41,7 +42,6 @@ go_test(
     deps = [
         "//utils/logging",
         "//utils/logging/loggingtest",
-        "//utils/set",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core",
         "@com_github_ava_labs_libevm//core/rawdb",

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -24,9 +24,9 @@ All proposals are either explicitly freed (via `Drop`) or committed. Proposals a
 - `TrieDB.Close`: all pending and committable proposals are dropped before the database is closed.
 - `TrieDB.Commit`: proposals are committed in ancestor-first order; if any commit fails, the remaining proposals are dropped rather than leaked.
 - `TrieDB.trieHash`: immediately dropped when a proposal produces no state change (root is unchanged).
-- `accountTrie.hash`: the previous reader is dropped when a new proposal replaces it.
+- `accountTrie.hash`: the previous reader is dropped when a new proposal replaces it. Or, similarly, when all changes from a proposal are reverted.
 
-However, the `state.Trie` implementation does not have a `Close` method or anything similar, so any proposal or revision remaining within a trie can only be garbage collected. Because the account trie is only ever created by the `state.StateDB`, one must only allow these objects to be garbage collected prior to calling `TrieDB.Close()`.
+Revisions are freed when possible (e.g. in `accountTrie.hash` when unused), but in general, they will be freeed via `runtime.AddCleanup`, because the `state.Trie` implementation does not have a `Close` method or anything similar. Any proposal or revision remaining within a trie can only be garbage collected. The account trie is only ever created by the `state.StateDB`, so one must allow these objects to be garbage collected prior to calling `TrieDB.Close()`.
 
 ## Operation Model
 

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -17,16 +17,16 @@ db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{
 
 ## Rust Memory Management
 
-Firewood's CGo FFI exposes two types of Rust-owned heap objects: `ffi.Revision` and `ffi.Proposal`. Both must be explicitly freed to avoid leaking Rust memory — Go's garbage collector does not manage Rust allocations.
+Firewood's CGo FFI exposes two types of Rust-owned heap objects: `ffi.Revision` and `ffi.Proposal`. Both should be explicitly freed to avoid leaking Rust memory - otherwise we must rely on Go's garbage collector to eventually call `runtime.AddCleanup`.
 
-All proposals are either explicitly freed (via `Drop`) or committed. Proposals are dropped in the following functions:
+All proposals tracked by the `TrieDB` are either explicitly freed (via `Drop`) or committed. Proposals are dropped in the following functions:
 
 - `TrieDB.Close`: all pending and committable proposals are dropped before the database is closed.
 - `TrieDB.Commit`: proposals are committed in ancestor-first order; if any commit fails, the remaining proposals are dropped rather than leaked.
 - `TrieDB.trieHash`: immediately dropped when a proposal produces no state change (root is unchanged).
 - `accountTrie.hash`: the previous reader is dropped when a new proposal replaces it. Or, similarly, when all changes from a proposal are reverted.
 
-Revisions are freed when possible (e.g. in `accountTrie.hash` when unused), but in general, they will be freeed via `runtime.AddCleanup`, because the `state.Trie` implementation does not have a `Close` method or anything similar. Any proposal or revision remaining within a trie can only be garbage collected. The account trie is only ever created by the `state.StateDB`, so one must allow these objects to be garbage collected prior to calling `TrieDB.Close()`.
+Revisions are freed when possible (e.g. in `accountTrie.hash` when unused), but in general, they will be freed via `runtime.AddCleanup`, because the `state.Trie` implementation does not have a `Close` method or anything similar. Any proposal or revision remaining within a trie can only be garbage collected. The account trie is only ever created by the `state.StateDB`, so one must allow these objects to be garbage collected prior to calling `TrieDB.Close()`.
 
 ## Operation Model
 
@@ -53,8 +53,10 @@ Reads never reflect pending writes (see [Why reads aren't safe](#why-reads-arent
 ### Why `Commit` commits multiple proposals at once
 
 `TrieDB.Commit(root)` does not commit only the proposal for `root`. It walks back the entire chain of uncommitted ancestor proposals and commits them all in ancestor-first order before committing `root`.
-
-This is required because Firewood enforces strict ancestor ordering: a child proposal cannot be committed before its parent. The `DeferredCommitInterval` configuration deliberately delays disk commits to batch I/O, allowing multiple blocks' worth of proposals to accumulate as an in-memory linked list. When `Commit` is eventually called for a later root, all uncommitted ancestors are flushed in a single pass.
+This is required because Firewood enforces strict ancestor ordering: a child proposal cannot be committed before its parent.
+The `DeferredCommitInterval` configuration deliberately delays disk commits to batch I/O, allowing multiple blocks' worth of proposals to accumulate before persisting to disk.
+This differs from `HashDB`, which synchronously writes all nodes on `Commit()` for the provided state root.
+This allows Firewood a performance improvement, but it is recommended that users frequently call `Commit`, as it will not result in faster state growth.
 
 The `TrieDB` will never return an empty proposal, so there will never be ambiguity about which proposal represents `root`, unlike in the historical Firewood TrieDB. There will never be two proposals with the same root, since at minimum, a nonce is incremented.
 
@@ -83,3 +85,7 @@ What is the expected value of `val`? Should it be `nil`, since the account was d
 The important detail here is that the `state.StateDB` will never do read after writing. Maintaining a map of pending writes would cover most cases, but storage reads would also need to check whether the parent account has been prefix-deleted — which is difficult to track without the full trie context. Additionally, if an account is recreated after deletion, a naive pending-writes map could not determine whether storage should be considered deleted when read later. Even worse, if an account is deleted by the `state.StateDB`, the corresponding storages will never be explicitly deleted from the storage trie, so we have to rely on prefix deletions.
 
 For all these caveats, the only logical conclusion for compatibility is that the implementation of `state.Trie` must only guarantee that the `state.StateDB` functions correctly. Since it will not read after writing until `state.StateDB.IntermediateRoot` is called, we can rely on reading from an actual proposal/revision.
+
+### Relation to the snapshot
+
+The go-ethereum `snapshot.Tree` allows fast reads for HashDB by avoiding loading all intermediate merkle nodes into the trie by storing a flattened K/V layer. The `state.StateDB` allows configuring parallel prefetchers to load the data in asynchronously for faster hashing later. In Firewood, there is little benefit to this optimization due to the path-based storage scheme, and avoids the need to have a concurrent-safe trie, an iterator, and divorcing the storage trie from the account trie. Because these all complicate the implementation with no performance benefit, the snapshot is NOT supported with Firewood.

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -19,14 +19,14 @@ db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{
 
 Firewood's CGo FFI exposes two types of Rust-owned heap objects: `ffi.Revision` and `ffi.Proposal`. Both must be explicitly freed to avoid leaking Rust memory — Go's garbage collector does not manage Rust allocations.
 
-Proposals must be either freed (via `Drop`) or committed. This happens in the following places:
+All proposals are either explicitly freed (via `Drop`) or committed. Proposals are dropped in the following functions:
 
-- `trieHash`: immediately dropped when a proposal produces no state change (root is unchanged).
-- `accountTrie.hash`: the previous reader is dropped when a new proposal replaces it.
 - `TrieDB.Close`: all pending and committable proposals are dropped before the database is closed.
 - `TrieDB.Commit`: proposals are committed in ancestor-first order; if any commit fails, the remaining proposals are dropped rather than leaked.
+- `TrieDB.trieHash`: immediately dropped when a proposal produces no state change (root is unchanged).
+- `accountTrie.hash`: the previous reader is dropped when a new proposal replaces it.
 
-However, the `state.Trie` implementation does not have a `Close` method or anything similar, so any proposal or revision remaining within a trie can only be garbage collected. Because this is only ever used by the `state.StateDB`, one must only allow these objects to be garbage collected prior to calling `TrieDB.Close()`, which will wait a short time until all objects have been freed.
+However, the `state.Trie` implementation does not have a `Close` method or anything similar, so any proposal or revision remaining within a trie can only be garbage collected. Because the account trie is only ever created by the `state.StateDB`, one must only allow these objects to be garbage collected prior to calling `TrieDB.Close()`.
 
 ## Operation Model
 
@@ -56,17 +56,15 @@ Reads never reflect pending writes (see [Why reads aren't safe](#why-reads-arent
 
 This is required because Firewood enforces strict ancestor ordering: a child proposal cannot be committed before its parent. The `DeferredCommitInterval` configuration deliberately delays disk commits to batch I/O, allowing multiple blocks' worth of proposals to accumulate as an in-memory linked list. When `Commit` is eventually called for a later root, all uncommitted ancestors are flushed in a single pass.
 
-The `TrieDB` will never create an empty proposal, so there will never be ambiguity about which proposal represents `root`, unlike in the historical Firewood TrieDB. There will never be two proposals with the same root, since at minimum, a nonce is incremented.
+The `TrieDB` will never return an empty proposal, so there will never be ambiguity about which proposal represents `root`, unlike in the historical Firewood TrieDB. There will never be two proposals with the same root, since at minimum, a nonce is incremented.
 
-As a consequence, `Commit` for a single root may write many proposals to disk. Any error from `Commit` should be treated as fatal.
+As a consequence, `Commit` for a single root may queue many proposals to be committed, and thus could be written to disk at any time. Any error from `Commit` should be treated as fatal. `Commit` is not expected to be an expensive operation, since all disk commits are handled asynchronously.
 
 ### Why `Reader` is unimplemented (custom trie reader)
 
 `TrieDB.Reader(root)` always returns an error. The `triedb.Backend` interface expects `Reader` to supply node bytes to a generic `trie.Trie`, which then reassembles the Merkle Trie from encoded node data. Firewood does not store state in that format, and the resulting `trie.Trie` created would be nonsensical.
 
 Instead, this package provides custom `accountTrie` and `storageTrie` implementations that read directly from `ffi.Revision` and `ffi.Proposal` objects via flat key-value `Get` calls. This avoids another implementation of a reader-like object, and allows re-using the Firewood API.
-
-Returning an error from `Reader` ensures no code path accidentally falls back to the standard MPT reader, which would fail or silently read stale data.
 
 ### Why reads aren't safe
 
@@ -81,7 +79,7 @@ accountTrie.DeleteAccount(addr)
 val := storageTrie.GetStorage(addr, key)
 ```
 
-What is the expected value of `val`? Should it be `nil`, since the account was deleted? Should it be `putVal`, since the storage trie in go-ethereum is a separate struct? Or should it return an error, since this is nonsensical?
-The important detail here is that the `state.StateDB` will never do this. Maintaining a map of pending writes would cover most cases, but storage reads would also need to check whether the parent account has been prefix-deleted — which is difficult to track without the full trie context. Additionally, if an account is recreated after deletion, a naive pending-writes map could not determine whether storage should be considered deleted when read later. Even worse, if an account is deleted by the `state.StateDB`, the corresponding storages will never be explicitly deleted from the storage trie, so we have to rely on prefix deletions.
+What is the expected value of `val`? Should it be `nil`, since the account was deleted? Should it be `putVal`, since the storage trie in go-ethereum is a separate struct? Or should it return an error, because an invariant was violated?
+The important detail here is that the `state.StateDB` will never do read after writing. Maintaining a map of pending writes would cover most cases, but storage reads would also need to check whether the parent account has been prefix-deleted — which is difficult to track without the full trie context. Additionally, if an account is recreated after deletion, a naive pending-writes map could not determine whether storage should be considered deleted when read later. Even worse, if an account is deleted by the `state.StateDB`, the corresponding storages will never be explicitly deleted from the storage trie, so we have to rely on prefix deletions.
 
 For all these caveats, the only logical conclusion for compatibility is that the implementation of `state.Trie` must only guarantee that the `state.StateDB` functions correctly. Since it will not read after writing until `state.StateDB.IntermediateRoot` is called, we can rely on reading from an actual proposal/revision.

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -47,6 +47,16 @@ Reads never reflect pending writes (see [Why reads aren't safe](#why-reads-arent
 - After a `SELFDESTRUCT`, storage reads return nothing correctly, because the prefix-deleted state is reflected in the proposal produced by the next `Hash()`.
 - If storage for a self-destructed account is read *before* the next `Hash()`, the old reader would still show the account's storage — but `state.StateDB` never reads storage for a self-destructed account before committing, so this edge case does not arise.
 
+### Same-block resurrection
+
+If an account is self-destructed and recreated within the same block, `state.StateDB` never calls `DeleteAccount` — the account is alive at commit time, so only `UpdateAccount` runs. Under `rawdb.HashScheme`, go-ethereum orphans the old storage through storage-root indirection; Firewood's flat keyspace has none, so the prior incarnation's slots would silently leak into the new state root.
+
+This stems from pre-Cancun `SELFDESTRUCT` semantics, under which any account could be fully deleted — storage included — and a new contract redeployed to the same address within the same block. EIP-6780 (active on the C-Chain) restricts full deletion to a contract created and self-destructed in the same transaction, so post-Cancun the only resurrection path is a single transaction that creates, self-destructs, and recreates the account. The detection below is hardfork-agnostic and covers both.
+
+The tries detect this from the account root: a value of exactly `types.EmptyRootHash` means `state.StateDB` believes the account has no storage. If storage for it still exists — in the backing reader, or already pending in the trie's update operations — it belongs to a destructed prior incarnation, and a `PrefixDelete` is emitted before the new incarnation writes any account or storage data. `OpenStorageTrie` only records the account root; the clear fires in `UpdateAccount` for recreations with no new storage, or before the storage trie's first mutation otherwise.
+
+Reverts and reads need no special handling. Because the tries observe state only at `Hash()`/`Commit()` boundaries — after the `state.StateDB` journal has settled — a reverted self-destruct or recreation never produces trie operations, and `state.StateDB` short-circuits storage reads of a destructed account before they reach the trie. At block scope, the `PrefixDelete` is an ordinary batch operation inside a proposal, so dropping the proposal discards it.
+
 ## Design Decisions
 
 ### Why `Commit` commits multiple proposals at once

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -1,0 +1,87 @@
+# Firewood for SAE
+
+## Overview
+
+This package integrates [Firewood](https://github.com/ava-labs/firewood), a Rust-based key-value store optimized for Ethereum state, with the SAE EVM. It provides a `state.Database` backed by Firewood via CGo FFI, replacing the standard Merkle Patricia Trie with Firewood's internal path-based storage.
+
+## Use
+
+`TrieDB` implements `triedb.DBOverride` (acting as `triedb.HashDB` for compatibility) and is passed to `state.NewDatabaseWithConfig` via `TrieDBConfig.BackendConstructor`. The `state.RegisterDatabaseInterceptor` registered in `init()` ensures that any `state.Database` backed by this `TrieDB` uses Firewood's custom trie implementations instead of the standard ones.
+
+```go
+cfg := firewood.DefaultConfig(dataDir, log)
+db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{
+    DBOverride: cfg.BackendConstructor,
+})
+```
+
+## Rust Memory Management
+
+Firewood's CGo FFI exposes two types of Rust-owned heap objects: `ffi.Revision` and `ffi.Proposal`. Both must be explicitly freed to avoid leaking Rust memory — Go's garbage collector does not manage Rust allocations.
+
+Proposals must be either freed (via `Drop`) or committed. This happens in the following places:
+
+- `trieHash`: immediately dropped when a proposal produces no state change (root is unchanged).
+- `accountTrie.hash`: the previous reader is dropped when a new proposal replaces it.
+- `TrieDB.Close`: all pending and committable proposals are dropped before the database is closed.
+- `TrieDB.Commit`: proposals are committed in ancestor-first order; if any commit fails, the remaining proposals are dropped rather than leaked.
+
+However, the `state.Trie` implementation does not have a `Close` method or anything similar, so any proposal or revision remaining within a trie can only be garbage collected. Because this is only ever used by the `state.StateDB`, one must only allow these objects to be garbage collected prior to calling `TrieDB.Close()`, which will wait a short time until all objects have been freed.
+
+## Operation Model
+
+### Linear proposal chain only
+
+Unlike `graft/evm/firewood`, which supports an arbitrary DAG of proposals (multiple concurrent children per parent), this implementation **requires a strictly linear chain**: each proposal has at most one child, and that child must eventually be committed. This maps onto the SAE EVM's single-chain, sequential block execution model.
+
+The linear invariant means:
+
+- Any proposal created via `accountTrie.Hash()` will be tracked in `accountTrie.Commit()`, and **must** then be moved to the committable map in `TrieDB.Update`.
+- The parent of each new proposal must be either the current committed tip of the Firewood database or the most recent uncommitted proposal in the chain.
+- Branching — creating two proposals from the same parent — is not supported.
+
+## SELFDESTRUCT Handling
+
+Reads never reflect pending writes (see [Why reads aren't safe](#why-reads-arent-safe)); this has particular implications for `SELFDESTRUCT`. The `SELFDESTRUCT` opcode must delete an account's entire storage trie, but `state.StateDB` does not iterate over and individually delete each storage slot — it relies on the trie to handle bulk deletion. Firewood handles this via prefix deletion: `DeleteAccount` issues an `ffi.PrefixDelete(accountKey)`, which atomically removes the account leaf and all storage slots that share the same key prefix. This means:
+
+- No explicit storage-trie iteration is required for self-destructed accounts.
+- After a `SELFDESTRUCT`, storage reads return nothing correctly, because the prefix-deleted state is reflected in the proposal produced by the next `Hash()`.
+- If storage for a self-destructed account is read *before* the next `Hash()`, the old reader would still show the account's storage — but `state.StateDB` never reads storage for a self-destructed account before committing, so this edge case does not arise.
+
+## Design Decisions
+
+### Why `Commit` commits multiple proposals at once
+
+`TrieDB.Commit(root)` does not commit only the proposal for `root`. It walks back the entire chain of uncommitted ancestor proposals and commits them all in ancestor-first order before committing `root`.
+
+This is required because Firewood enforces strict ancestor ordering: a child proposal cannot be committed before its parent. The `DeferredCommitInterval` configuration deliberately delays disk commits to batch I/O, allowing multiple blocks' worth of proposals to accumulate as an in-memory linked list. When `Commit` is eventually called for a later root, all uncommitted ancestors are flushed in a single pass.
+
+The `TrieDB` will never create an empty proposal, so there will never be ambiguity about which proposal represents `root`, unlike in the historical Firewood TrieDB. There will never be two proposals with the same root, since at minimum, a nonce is incremented.
+
+As a consequence, `Commit` for a single root may write many proposals to disk. Any error from `Commit` should be treated as fatal.
+
+### Why `Reader` is unimplemented (custom trie reader)
+
+`TrieDB.Reader(root)` always returns an error. The `triedb.Backend` interface expects `Reader` to supply node bytes to a generic `trie.Trie`, which then reassembles the Merkle Trie from encoded node data. Firewood does not store state in that format, and the resulting `trie.Trie` created would be nonsensical.
+
+Instead, this package provides custom `accountTrie` and `storageTrie` implementations that read directly from `ffi.Revision` and `ffi.Proposal` objects via flat key-value `Get` calls. This avoids another implementation of a reader-like object, and allows re-using the Firewood API.
+
+Returning an error from `Reader` ensures no code path accidentally falls back to the standard MPT reader, which would fail or silently read stale data.
+
+### Why reads aren't safe
+
+Unexpectedly perhaps, calling `UpdateAccount` immediately followed by `GetAccount` on the account trie will return the old version of the account. This is because we cannot safely determine where a storage node should be deleted or not quickly. Imagine the following case:
+
+```go
+accountTrie := db.OpenTrie(root)
+storageTrie := db.OpenStorageTrie(root, addr, accountRoot, accountTrie)
+storageTrie.UpdateStorage(addr, key, putVal)
+accountTrie.DeleteAccount(addr)
+
+val := storageTrie.GetStorage(addr, key)
+```
+
+What is the expected value of `val`? Should it be `nil`, since the account was deleted? Should it be `putVal`, since the storage trie in go-ethereum is a separate struct? Or should it return an error, since this is nonsensical?
+The important detail here is that the `state.StateDB` will never do this. Maintaining a map of pending writes would cover most cases, but storage reads would also need to check whether the parent account has been prefix-deleted — which is difficult to track without the full trie context. Additionally, if an account is recreated after deletion, a naive pending-writes map could not determine whether storage should be considered deleted when read later. Even worse, if an account is deleted by the `state.StateDB`, the corresponding storages will never be explicitly deleted from the storage trie, so we have to rely on prefix deletions.
+
+For all these caveats, the only logical conclusion for compatibility is that the implementation of `state.Trie` must only guarantee that the `state.StateDB` functions correctly. Since it will not read after writing until `state.StateDB.IntermediateRoot` is called, we can rely on reading from an actual proposal/revision.

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -23,8 +23,7 @@ All proposals tracked by the `TrieDB` are either explicitly freed (via `Drop`) o
 
 - `TrieDB.Close`: all pending and committable proposals are dropped before the database is closed.
 - `TrieDB.Commit`: proposals are committed in ancestor-first order; if any commit fails, the remaining proposals are dropped rather than leaked.
-- `TrieDB.trieHash`: immediately dropped when a proposal produces no state change (root is unchanged).
-- `accountTrie.hash`: the previous reader is dropped when a new proposal replaces it. Or, similarly, when all changes from a proposal are reverted.
+- `accountTrie.hash`: the previous reader is dropped when a new proposal replaces it.
 
 Revisions are freed when possible (e.g. in `accountTrie.hash` when unused), but in general, they will be freed via `runtime.AddCleanup`, because the `state.Trie` implementation does not have a `Close` method or anything similar. Any proposal or revision remaining within a trie can only be garbage collected. The account trie is only ever created by the `state.StateDB`, so one must allow these objects to be garbage collected prior to calling `TrieDB.Close()`.
 

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -70,11 +70,11 @@ func (a *accountTrie) hash() (common.Hash, error) {
 		return a.root, nil
 	}
 
-	proposal, available, err := a.fw.trieHash(a.parentRoot, a.updateOps)
+	proposal, err := a.fw.trieHash(a.parentRoot, a.updateOps)
 	switch {
 	case err != nil:
 		return common.Hash{}, err
-	case !available:
+	case proposal == nil:
 		// TODO(#5506): Create [ffi.Reconstructed] to allow stateful RPCs.
 		return common.Hash{}, fmt.Errorf("base revision %#x is not proposable", a.parentRoot)
 	}

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -90,6 +90,14 @@ func (a *accountTrie) hash() (common.Hash, error) {
 		a.reader = proposal.p
 		a.root = proposal.root
 	case a.pending != nil:
+		// Close all previous relics of revisions.
+		if err := a.reader.Drop(); err != nil {
+			a.fw.log.Warn("dropping previous trie reader", zap.Error(err))
+		}
+		if err := a.pending.p.Drop(); err != nil {
+			a.fw.log.Warn("dropping previous trie proposal", zap.Error(err))
+		}
+		a.pending = nil
 		// All changes in a previous proposal were reverted, so we can create a new reader from the parent root.
 		reader, err := a.fw.Firewood.Revision(ffi.Hash(a.parentRoot))
 		if err != nil {

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -56,9 +56,6 @@ func newAccountTrie(root common.Hash, db *TrieDB) (*accountTrie, error) {
 //
 // Any proposals created by this method will be freed once the accountTrie
 // is garbage collected.
-//
-// If there are no changes since the last call, the cached root is returned.
-// On error, the zero hash is returned.
 func (a *accountTrie) Hash() common.Hash {
 	hash, err := a.hash()
 	if err != nil {
@@ -78,35 +75,19 @@ func (a *accountTrie) hash() (common.Hash, error) {
 	case err != nil:
 		return common.Hash{}, err
 	case !available:
-		// TODO(rodrigovillar): Create reconstruction for APIs
+		// TODO(#5506): Create [ffi.Reconstructed] to allow stateful RPCs.
 		return common.Hash{}, fmt.Errorf("base revision %#x is not proposable", a.parentRoot)
-	case proposal != nil:
-		// Best effort drop of previous reader.
-		// Use new proposal for all future reads.
-		if err := a.reader.Drop(); err != nil {
-			a.fw.log.Warn("dropping previous trie reader", zap.Error(err))
-		}
-		a.pending = proposal
-		a.reader = proposal.p
-		a.root = proposal.root
-	case a.pending != nil:
-		// Close all previous relics of revisions.
-		if err := a.reader.Drop(); err != nil {
-			a.fw.log.Warn("dropping previous trie reader", zap.Error(err))
-		}
-		if err := a.pending.p.Drop(); err != nil {
-			a.fw.log.Warn("dropping previous trie proposal", zap.Error(err))
-		}
-		a.pending = nil
-		// All changes in a previous proposal were reverted, so we can create a new reader from the parent root.
-		reader, err := a.fw.Firewood.Revision(ffi.Hash(a.parentRoot))
-		if err != nil {
-			return common.Hash{}, fmt.Errorf("reverting to previous trie reader: %w", err)
-		}
-		a.reader = reader
-		a.root = a.parentRoot
 	}
 
+	// Best effort drop of previous reader (and thus any associated proposal).
+	// Use new proposal for all future reads.
+	if err := a.reader.Drop(); err != nil {
+		a.fw.log.Warn("dropping previous trie reader", zap.Error(err))
+	}
+
+	a.pending = proposal
+	a.reader = proposal.p
+	a.root = proposal.root
 	a.hasChanges = false // Avoid re-hashing until next update
 	return a.root, nil
 }
@@ -120,10 +101,14 @@ func (a *accountTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
 	if err != nil {
 		return common.Hash{}, nil, err
 	}
-	a.fw.trieCommit(a.pending)
 
-	set := trienode.NewNodeSet(common.Hash{})
-	return hash, set, nil
+	// The [state.StateDB] will only call [triedb.Database.Update] if the returned root differs from the parent.
+	if hash == a.parentRoot {
+		return a.parentRoot, nil, nil
+	}
+
+	a.fw.trieCommit(a.pending)
+	return hash, trienode.NewNodeSet(common.Hash{}), nil
 }
 
 // Copy creates a copy of the [accountTrie].

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -43,6 +43,8 @@ func newAccountTrie(root common.Hash, db *TrieDB) (*accountTrie, error) {
 		return nil, err
 	}
 	return &accountTrie{
+		// cleared and storageOpsAfterClear are left nil; set.Set treats a nil
+		// set as empty and self-initializes on first Add.
 		baseTrie:   &baseTrie{reader: reader, root: root},
 		parentRoot: root,
 		fw:         db,

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -1,0 +1,133 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/trie/trienode"
+	"go.uber.org/zap"
+)
+
+var _ state.Trie = (*accountTrie)(nil)
+
+// accountTrie implements [state.Trie] for managing account states.
+// Although it fulfills the [state.Trie] interface, it has some important differences:
+//  1. [accountTrie.Commit] is not used as expected in the state package. The [storageTrie] doesn't return
+//     values, and we thus rely on the shared [baseTrie]. Additionally, no [trienode.NodeSet] is
+//     actually constructed, since Firewood manages nodes internally and the list of changes
+//     is not needed externally.
+//  2. The [accountTrie.Hash] method actually creates the [ffi.Proposal], since Firewood cannot calculate
+//     the hash of the trie without committing it.
+//  3. the [accountTrie.GetAccount] and [accountTrie.GetStorage] methods cannot read from changes since
+//     the most recent call to [accountTrie.Hash], and this is a very difficult problem to solve due
+//     to account deletions on the `SELFDESTRUCT` opcode not manually calling [state.Trie.DeleteStorage].
+//     Because of this, we have to rely on prefix deletions of the account to delete its associated storage.
+//     Since the [state.StateDB] will never call a Get method on updated values, this is safe.
+//
+// Note this is not concurrent safe.
+type accountTrie struct {
+	*baseTrie
+	parentRoot common.Hash
+	pending    *proposalRef
+	fw         *TrieDB
+}
+
+func newAccountTrie(root common.Hash, db *TrieDB) (*accountTrie, error) {
+	reader, err := db.Firewood.Revision(ffi.Hash(root))
+	if err != nil {
+		return nil, err
+	}
+	return &accountTrie{
+		baseTrie:   &baseTrie{reader: reader, root: root},
+		parentRoot: root,
+		fw:         db,
+	}, nil
+}
+
+// Hash returns the current hash of the state trie.
+// This will create the necessary proposals to guarantee that the changes can
+// later be committed. Any new proposal will be tracked by the accountTrie
+// until a call to [accountTrie.Commit].
+//
+// Any proposals created by this method will be freed once the accountTrie
+// is garbage collected.
+//
+// If there are no changes since the last call, the cached root is returned.
+// On error, the zero hash is returned.
+func (a *accountTrie) Hash() common.Hash {
+	hash, err := a.hash()
+	if err != nil {
+		a.fw.log.Error("hashing account trie", zap.Error(err))
+		return common.Hash{}
+	}
+	return hash
+}
+
+func (a *accountTrie) hash() (common.Hash, error) {
+	if !a.hasChanges {
+		return a.root, nil
+	}
+
+	proposal, available, err := a.fw.trieHash(a.parentRoot, a.updateOps)
+	switch {
+	case err != nil:
+		return common.Hash{}, err
+	case !available:
+		// TODO(rodrigovillar): Create reconstruction for APIs
+		return common.Hash{}, fmt.Errorf("base revision %#x is not proposable", a.parentRoot)
+	case proposal != nil:
+		// Best effort drop of previous reader.
+		// Use new proposal for all future reads.
+		if err := a.reader.Drop(); err != nil {
+			a.fw.log.Warn("dropping previous trie reader", zap.Error(err))
+		}
+		a.pending = proposal
+		a.reader = proposal.p
+		a.root = proposal.root
+	case a.pending != nil:
+		// All changes in a previous proposal were reverted, so we can create a new reader from the parent root.
+		reader, err := a.fw.Firewood.Revision(ffi.Hash(a.parentRoot))
+		if err != nil {
+			return common.Hash{}, fmt.Errorf("reverting to previous trie reader: %w", err)
+		}
+		a.reader = reader
+		a.root = a.parentRoot
+	}
+
+	a.hasChanges = false // Avoid re-hashing until next update
+	return a.root, nil
+}
+
+// Commit returns the new root hash of the trie and an empty [trienode.NodeSet].
+// The boolean input is ignored, as it is a relic of the StateTrie implementation.
+// If the changes are not yet already tracked by the [TrieDB], they are created.
+func (a *accountTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
+	// Creates proposal as side effect.
+	hash, err := a.hash()
+	if err != nil {
+		return common.Hash{}, nil, err
+	}
+	a.fw.trieCommit(a.pending)
+
+	set := trienode.NewNodeSet(common.Hash{})
+	return hash, set, nil
+}
+
+// Copy creates a copy of the [accountTrie].
+func (a *accountTrie) Copy() *accountTrie {
+	reader, err := a.fw.Firewood.Revision(ffi.Hash(a.parentRoot))
+	if err != nil {
+		a.fw.log.Error("creating trie copy", zap.Error(err))
+		return nil
+	}
+	return &accountTrie{
+		baseTrie:   a.baseTrie.copy(reader),
+		parentRoot: a.parentRoot,
+		fw:         a.fw,
+	}
+}

--- a/vms/saevm/firewood/base_trie.go
+++ b/vms/saevm/firewood/base_trie.go
@@ -150,7 +150,7 @@ func (a *baseTrie) copy(reader trieReader) *baseTrie {
 	return &baseTrie{
 		reader:     reader,
 		root:       a.root,
-		hasChanges: a.hasChanges,
+		hasChanges: true,
 		updateOps:  slices.Clone(a.updateOps), // each ffi.BatchOp is read-only, safe to shallow copy
 	}
 }

--- a/vms/saevm/firewood/base_trie.go
+++ b/vms/saevm/firewood/base_trie.go
@@ -16,6 +16,17 @@ import (
 	"github.com/ava-labs/libevm/trie"
 )
 
+func accountKey(addr common.Address) []byte {
+	return crypto.Keccak256Hash(addr.Bytes()).Bytes()
+}
+
+func storageKey(addr common.Address, key []byte) []byte {
+	var combinedKey [2 * common.HashLength]byte
+	copy(combinedKey[:common.HashLength], accountKey(addr))
+	copy(combinedKey[common.HashLength:], crypto.Keccak256Hash(key).Bytes())
+	return combinedKey[:]
+}
+
 type trieReader interface {
 	Get([]byte) ([]byte, error)
 	Drop() error
@@ -44,9 +55,7 @@ type baseTrie struct {
 // GetAccount returns the state account associated with an address.
 // Returns (nil, nil) if the account does not exist.
 func (a *baseTrie) GetAccount(addr common.Address) (*types.StateAccount, error) {
-	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-
-	accountBytes, err := a.reader.Get(key)
+	accountBytes, err := a.reader.Get(accountKey(addr))
 	if err != nil {
 		return nil, err
 	}
@@ -63,20 +72,18 @@ func (a *baseTrie) GetAccount(addr common.Address) (*types.StateAccount, error) 
 
 // UpdateAccount replaces or creates the state account associated with an address.
 func (a *baseTrie) UpdateAccount(addr common.Address, account *types.StateAccount) error {
-	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
 	data, err := rlp.EncodeToBytes(account)
 	if err != nil {
 		return err
 	}
-	a.updateOps = append(a.updateOps, ffi.Put(key, data))
+	a.updateOps = append(a.updateOps, ffi.Put(accountKey(addr), data))
 	a.hasChanges = true
 	return nil
 }
 
 // DeleteAccount removes the state account associated with an address AND its storage trie.
 func (a *baseTrie) DeleteAccount(addr common.Address) error {
-	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	a.updateOps = append(a.updateOps, ffi.PrefixDelete(key))
+	a.updateOps = append(a.updateOps, ffi.PrefixDelete(accountKey(addr)))
 	a.hasChanges = true
 	return nil
 }
@@ -84,13 +91,7 @@ func (a *baseTrie) DeleteAccount(addr common.Address) error {
 // GetStorage returns the value associated with a storage key for a given account address.
 // Returns (nil, nil) if the slot does not exist.
 func (a *baseTrie) GetStorage(addr common.Address, key []byte) ([]byte, error) {
-	var combinedKey [2 * common.HashLength]byte
-	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	storageKey := crypto.Keccak256Hash(key).Bytes()
-	copy(combinedKey[:common.HashLength], accountKey)
-	copy(combinedKey[common.HashLength:], storageKey)
-
-	storageBytes, err := a.reader.Get(combinedKey[:])
+	storageBytes, err := a.reader.Get(storageKey(addr, key))
 	if err != nil || storageBytes == nil {
 		return nil, err
 	}
@@ -102,31 +103,19 @@ func (a *baseTrie) GetStorage(addr common.Address, key []byte) ([]byte, error) {
 
 // UpdateStorage replaces or creates the value associated with a storage key for a given account address.
 func (a *baseTrie) UpdateStorage(addr common.Address, key []byte, value []byte) error {
-	var combinedKey [2 * common.HashLength]byte
-	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	storageKey := crypto.Keccak256Hash(key).Bytes()
-	copy(combinedKey[:common.HashLength], accountKey)
-	copy(combinedKey[common.HashLength:], storageKey)
-
 	data, err := rlp.EncodeToBytes(value)
 	if err != nil {
 		return err
 	}
 
-	a.updateOps = append(a.updateOps, ffi.Put(combinedKey[:], data))
+	a.updateOps = append(a.updateOps, ffi.Put(storageKey(addr, key), data))
 	a.hasChanges = true
 	return nil
 }
 
 // DeleteStorage removes the value associated with a storage key for a given account address.
 func (a *baseTrie) DeleteStorage(addr common.Address, key []byte) error {
-	var combinedKey [2 * common.HashLength]byte
-	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
-	storageKey := crypto.Keccak256Hash(key).Bytes()
-	copy(combinedKey[:common.HashLength], accountKey)
-	copy(combinedKey[common.HashLength:], storageKey)
-
-	a.updateOps = append(a.updateOps, ffi.Delete(combinedKey[:]))
+	a.updateOps = append(a.updateOps, ffi.Delete(storageKey(addr, key)))
 	a.hasChanges = true
 	return nil
 }

--- a/vms/saevm/firewood/base_trie.go
+++ b/vms/saevm/firewood/base_trie.go
@@ -5,6 +5,7 @@ package firewood
 
 import (
 	"errors"
+	"maps"
 	"slices"
 
 	"github.com/ava-labs/firewood-go-ethhash/ffi"
@@ -14,18 +15,9 @@ import (
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/rlp"
 	"github.com/ava-labs/libevm/trie"
+
+	"github.com/ava-labs/avalanchego/utils/set"
 )
-
-func accountKey(addr common.Address) []byte {
-	return crypto.Keccak256Hash(addr.Bytes()).Bytes()
-}
-
-func storageKey(addr common.Address, key []byte) []byte {
-	var combinedKey [2 * common.HashLength]byte
-	copy(combinedKey[:common.HashLength], accountKey(addr))
-	copy(combinedKey[common.HashLength:], crypto.Keccak256Hash(key).Bytes())
-	return combinedKey[:]
-}
 
 type trieReader interface {
 	Get([]byte) ([]byte, error)
@@ -50,6 +42,63 @@ type baseTrie struct {
 
 	updateOps  []ffi.BatchOp
 	hasChanges bool
+
+	// cleared holds addresses whose current incarnation already had its stale
+	// storage prefix-deleted by [baseTrie.clearStaleStorage]. An entry is
+	// dropped once the incarnation's storage is flushed (an account Put with a
+	// non-empty root), letting the next incarnation fire again.
+	cleared set.Set[common.Address]
+	// storageOpsAfterClear holds addresses with storage writes in updateOps
+	// since the last PrefixDelete. The reader alone can't tell whether an
+	// account has storage: a copied trie reads the pre-block revision while its
+	// cloned updateOps may already carry storage writes.
+	storageOpsAfterClear set.Set[common.Address]
+}
+
+// accountKey returns the Firewood key of an account: keccak(addr).
+func accountKey(addr common.Address) []byte {
+	return crypto.Keccak256(addr.Bytes())
+}
+
+// storageKey returns the Firewood key of a storage slot:
+// keccak(addr) || keccak(key). An account's key prefixes its slots' keys, so
+// [baseTrie.DeleteAccount] removes all of its storage with one PrefixDelete.
+func storageKey(addr common.Address, key []byte) []byte {
+	return append(crypto.Keccak256(addr.Bytes()), crypto.Keccak256(key)...)
+}
+
+// clearStaleStorage removes a prior incarnation's storage when an account is
+// recreated after a same-block self-destruct. [state.StateDB] never calls
+// [state.Trie.DeleteAccount] for a destructed-then-recreated account: under
+// [rawdb.HashScheme] it orphans the old storage via storage-root indirection,
+// which Firewood's flat keyspace lacks. So infer it — if the StateDB believes
+// the account has no storage, any storage in the reader or pending updateOps
+// belongs to a prior incarnation and is prefix-deleted.
+//
+// MUST run before the address's new slots are appended to updateOps, and fires
+// at most once per incarnation: [accountTrie.Hash] replays all updateOps each
+// call, so a PrefixDelete after a live incarnation's slot writes would wipe them.
+func (a *baseTrie) clearStaleStorage(addr common.Address) error {
+	if a.cleared.Contains(addr) {
+		return nil
+	}
+
+	if !a.storageOpsAfterClear.Contains(addr) {
+		prev, err := a.GetAccount(addr)
+		if err != nil || prev == nil || prev.Root == types.EmptyRootHash {
+			return err // no prior incarnation, or no storage to clear
+		}
+	}
+
+	// DeleteAccount emits the PrefixDelete and updates the incarnation
+	// bookkeeping; the caller re-puts the account after this.
+	return a.DeleteAccount(addr)
+}
+
+// markStorageOp records that updateOps now contain a storage operation for the
+// address. See [baseTrie.storageOpsAfterClear].
+func (a *baseTrie) markStorageOp(addr common.Address) {
+	a.storageOpsAfterClear.Add(addr)
 }
 
 // GetAccount returns the state account associated with an address.
@@ -71,7 +120,20 @@ func (a *baseTrie) GetAccount(addr common.Address) (*types.StateAccount, error) 
 }
 
 // UpdateAccount replaces or creates the state account associated with an address.
+//
+// A same-block recreation with no new storage reaches the trie only here, so
+// [baseTrie.clearStaleStorage] runs before the account is written.
 func (a *baseTrie) UpdateAccount(addr common.Address, account *types.StateAccount) error {
+	if account.Root == types.EmptyRootHash {
+		if err := a.clearStaleStorage(addr); err != nil {
+			return err
+		}
+	} else {
+		// A non-empty root means this incarnation's storage was hashed, so a
+		// later [types.EmptyRootHash] signals a new incarnation that may fire again.
+		a.cleared.Remove(addr)
+	}
+
 	data, err := rlp.EncodeToBytes(account)
 	if err != nil {
 		return err
@@ -84,6 +146,8 @@ func (a *baseTrie) UpdateAccount(addr common.Address, account *types.StateAccoun
 // DeleteAccount removes the state account associated with an address AND its storage trie.
 func (a *baseTrie) DeleteAccount(addr common.Address) error {
 	a.updateOps = append(a.updateOps, ffi.PrefixDelete(accountKey(addr)))
+	a.cleared.Add(addr)
+	a.storageOpsAfterClear.Remove(addr)
 	a.hasChanges = true
 	return nil
 }
@@ -109,6 +173,7 @@ func (a *baseTrie) UpdateStorage(addr common.Address, key []byte, value []byte) 
 	}
 
 	a.updateOps = append(a.updateOps, ffi.Put(storageKey(addr, key), data))
+	a.markStorageOp(addr)
 	a.hasChanges = true
 	return nil
 }
@@ -116,6 +181,7 @@ func (a *baseTrie) UpdateStorage(addr common.Address, key []byte, value []byte) 
 // DeleteStorage removes the value associated with a storage key for a given account address.
 func (a *baseTrie) DeleteStorage(addr common.Address, key []byte) error {
 	a.updateOps = append(a.updateOps, ffi.Delete(storageKey(addr, key)))
+	a.markStorageOp(addr)
 	a.hasChanges = true
 	return nil
 }
@@ -137,10 +203,12 @@ func (*baseTrie) GetKey([]byte) []byte {
 // copy creates a copy of the baseTrie fields with the given reader.
 func (a *baseTrie) copy(reader trieReader) *baseTrie {
 	return &baseTrie{
-		reader:     reader,
-		root:       a.root,
-		hasChanges: true,
-		updateOps:  slices.Clone(a.updateOps), // each ffi.BatchOp is read-only, safe to shallow copy
+		reader:               reader,
+		root:                 a.root,
+		hasChanges:           true,
+		updateOps:            slices.Clone(a.updateOps), // each ffi.BatchOp is read-only, safe to shallow copy
+		cleared:              maps.Clone(a.cleared),
+		storageOpsAfterClear: maps.Clone(a.storageOpsAfterClear),
 	}
 }
 

--- a/vms/saevm/firewood/base_trie.go
+++ b/vms/saevm/firewood/base_trie.go
@@ -1,0 +1,175 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"errors"
+	"slices"
+
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/rlp"
+	"github.com/ava-labs/libevm/trie"
+)
+
+type trieReader interface {
+	Get([]byte) ([]byte, error)
+	Drop() error
+}
+
+var (
+	_ trieReader = (*ffi.Revision)(nil)
+	_ trieReader = (*ffi.Proposal)(nil)
+)
+
+// baseTrie contains the shared state and methods for all Firewood
+// trie implementations. It provides the read/write operations that are
+// identical between [accountTrie] and [storageTrie].
+// All reads are performed based on the base [trieReader], so updates
+// tracked here do not affect the values returned.
+//
+// Not concurrent-safe.
+type baseTrie struct {
+	reader trieReader
+	root   common.Hash
+
+	updateOps  []ffi.BatchOp
+	hasChanges bool
+}
+
+// GetAccount returns the state account associated with an address.
+// Returns (nil, nil) if the account does not exist.
+func (a *baseTrie) GetAccount(addr common.Address) (*types.StateAccount, error) {
+	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+
+	accountBytes, err := a.reader.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if accountBytes == nil {
+		return nil, nil
+	}
+
+	// Decode the account node
+	account := new(types.StateAccount)
+	err = rlp.DecodeBytes(accountBytes, account)
+	return account, err
+}
+
+// UpdateAccount replaces or creates the state account associated with an address.
+func (a *baseTrie) UpdateAccount(addr common.Address, account *types.StateAccount) error {
+	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	data, err := rlp.EncodeToBytes(account)
+	if err != nil {
+		return err
+	}
+	a.updateOps = append(a.updateOps, ffi.Put(key, data))
+	a.hasChanges = true
+	return nil
+}
+
+// DeleteAccount removes the state account associated with an address AND its storage trie.
+func (a *baseTrie) DeleteAccount(addr common.Address) error {
+	key := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	a.updateOps = append(a.updateOps, ffi.PrefixDelete(key))
+	a.hasChanges = true
+	return nil
+}
+
+// GetStorage returns the value associated with a storage key for a given account address.
+// Returns (nil, nil) if the slot does not exist.
+func (a *baseTrie) GetStorage(addr common.Address, key []byte) ([]byte, error) {
+	var combinedKey [2 * common.HashLength]byte
+	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	storageKey := crypto.Keccak256Hash(key).Bytes()
+	copy(combinedKey[:common.HashLength], accountKey)
+	copy(combinedKey[common.HashLength:], storageKey)
+
+	storageBytes, err := a.reader.Get(combinedKey[:])
+	if err != nil || storageBytes == nil {
+		return nil, err
+	}
+
+	// Decode the storage value
+	_, decoded, _, err := rlp.Split(storageBytes)
+	return decoded, err
+}
+
+// UpdateStorage replaces or creates the value associated with a storage key for a given account address.
+func (a *baseTrie) UpdateStorage(addr common.Address, key []byte, value []byte) error {
+	var combinedKey [2 * common.HashLength]byte
+	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	storageKey := crypto.Keccak256Hash(key).Bytes()
+	copy(combinedKey[:common.HashLength], accountKey)
+	copy(combinedKey[common.HashLength:], storageKey)
+
+	data, err := rlp.EncodeToBytes(value)
+	if err != nil {
+		return err
+	}
+
+	a.updateOps = append(a.updateOps, ffi.Put(combinedKey[:], data))
+	a.hasChanges = true
+	return nil
+}
+
+// DeleteStorage removes the value associated with a storage key for a given account address.
+func (a *baseTrie) DeleteStorage(addr common.Address, key []byte) error {
+	var combinedKey [2 * common.HashLength]byte
+	accountKey := crypto.Keccak256Hash(addr.Bytes()).Bytes()
+	storageKey := crypto.Keccak256Hash(key).Bytes()
+	copy(combinedKey[:common.HashLength], accountKey)
+	copy(combinedKey[common.HashLength:], storageKey)
+
+	a.updateOps = append(a.updateOps, ffi.Delete(combinedKey[:]))
+	a.hasChanges = true
+	return nil
+}
+
+// UpdateContractCode implements state.Trie.
+// Contract code is controlled by rawdb, so we don't need to do anything here.
+// This always returns nil.
+func (*baseTrie) UpdateContractCode(common.Address, common.Hash, []byte) error {
+	return nil
+}
+
+// GetKey implements state.Trie.
+// Preimages are not supported in Firewood.
+// It always returns nil.
+func (*baseTrie) GetKey([]byte) []byte {
+	return nil
+}
+
+// copy creates a copy of the baseTrie fields with the given reader.
+func (a *baseTrie) copy(reader trieReader) *baseTrie {
+	return &baseTrie{
+		reader:     reader,
+		root:       a.root,
+		hasChanges: a.hasChanges,
+		updateOps:  slices.Clone(a.updateOps), // each ffi.BatchOp is read-only, safe to shallow copy
+	}
+}
+
+var (
+	errNodeIteratorNotImplemented = errors.New("NodeIterator not implemented for Firewood")
+	errProveNotImplemented        = errors.New("Prove not implemented for Firewood")
+)
+
+// NodeIterator implements state.Trie.
+// Firewood does not support iterating over internal nodes.
+// This always returns an error.
+func (*baseTrie) NodeIterator([]byte) (trie.NodeIterator, error) {
+	return nil, errNodeIteratorNotImplemented
+}
+
+// Prove implements state.Trie.
+// Firewood does not support providing key proofs.
+// This always returns an error.
+func (*baseTrie) Prove([]byte, ethdb.KeyValueWriter) error {
+	return errProveNotImplemented
+}

--- a/vms/saevm/firewood/state.go
+++ b/vms/saevm/firewood/state.go
@@ -50,7 +50,7 @@ func (*stateAccessor) OpenStorageTrie(stateRoot common.Hash, addr common.Address
 	if !ok {
 		return nil, fmt.Errorf("invalid account trie type: %T", self)
 	}
-	return newStorageTrie(accountTrie.baseTrie), nil
+	return newStorageTrie(accountTrie.baseTrie, addr, accountRoot), nil
 }
 
 // CopyTrie returns a deep copy of the given trie.

--- a/vms/saevm/firewood/state.go
+++ b/vms/saevm/firewood/state.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/state"
+	"go.uber.org/zap"
+
+	// Need metrics registration from init function.
+	// TODO(alarso16): Move metrics initialization after deletion of graft.
+	graftfw "github.com/ava-labs/avalanchego/graft/evm/firewood"
+)
+
+var _ state.Database = (*stateAccessor)(nil)
+
+func init() {
+	var _ *graftfw.TrieDB // protect import for metrics registration
+	state.RegisterDatabaseInterceptor(interceptor)
+}
+
+func interceptor(db state.Database) state.Database {
+	if tdb, ok := db.TrieDB().Backend().(*TrieDB); ok {
+		return &stateAccessor{
+			Database: db,
+			triedb:   tdb,
+		}
+	}
+	return db
+}
+
+type stateAccessor struct {
+	state.Database
+	triedb *TrieDB
+}
+
+// OpenTrie opens the main account trie.
+func (s *stateAccessor) OpenTrie(root common.Hash) (state.Trie, error) {
+	return newAccountTrie(root, s.triedb)
+}
+
+// OpenStorageTrie opens a wrapped version of the account trie.
+//
+//nolint:revive // removing names loses context.
+func (*stateAccessor) OpenStorageTrie(stateRoot common.Hash, addr common.Address, accountRoot common.Hash, self state.Trie) (state.Trie, error) {
+	accountTrie, ok := self.(*accountTrie)
+	if !ok {
+		return nil, fmt.Errorf("invalid account trie type: %T", self)
+	}
+	return newStorageTrie(accountTrie.baseTrie), nil
+}
+
+// CopyTrie returns a deep copy of the given trie.
+// It can be altered by the caller.
+func (s *stateAccessor) CopyTrie(t state.Trie) state.Trie {
+	switch t := t.(type) {
+	case *accountTrie:
+		return t.Copy()
+	case *storageTrie:
+		// The storage trie just wraps the account trie, and the [state.StateDB] will reopen as necessary
+		return nil
+	default:
+		// Returning nil may cause a panic downstream, but this should never happen.
+		s.triedb.log.Fatal("unknown trie type", zap.String("type", fmt.Sprintf("%T", t)))
+		return nil
+	}
+}

--- a/vms/saevm/firewood/state.go
+++ b/vms/saevm/firewood/state.go
@@ -12,13 +12,13 @@ import (
 
 	// Need metrics registration from init function.
 	// TODO(alarso16): Move metrics initialization after deletion of graft.
-	graftfw "github.com/ava-labs/avalanchego/graft/evm/firewood"
+	graft "github.com/ava-labs/avalanchego/graft/evm/firewood"
 )
 
 var _ state.Database = (*stateAccessor)(nil)
 
 func init() {
-	var _ *graftfw.TrieDB // protect import for metrics registration
+	var _ *graft.TrieDB // protect import for metrics registration
 	state.RegisterDatabaseInterceptor(interceptor)
 }
 

--- a/vms/saevm/firewood/storage_trie.go
+++ b/vms/saevm/firewood/storage_trie.go
@@ -6,6 +6,7 @@ package firewood
 import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/trie/trienode"
 )
 
@@ -13,25 +14,73 @@ var _ state.Trie = (*storageTrie)(nil)
 
 type storageTrie struct {
 	*baseTrie
+	addr           common.Address
+	accountRoot    common.Hash
+	storageChanged bool
 }
 
 // newStorageTrie returns a wrapper around a [baseTrie] since Firewood
 // does not require a separate storage trie. All changes are tracked by the base
 // trie.
-func newStorageTrie(base *baseTrie) *storageTrie {
+func newStorageTrie(base *baseTrie, addr common.Address, accountRoot common.Hash) *storageTrie {
 	return &storageTrie{
-		baseTrie: base,
+		baseTrie:    base,
+		addr:        addr,
+		accountRoot: accountRoot,
 	}
 }
 
-// Commit is a no-op for storage tries, as all changes are tracked by the base trie.
-// It always returns a nil NodeSet and zero hash.
-func (*storageTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
-	return common.Hash{}, nil, nil
+// clearStaleStorageBeforeWrite clears prior-incarnation storage before the
+// first storage mutation for an account that StateDB considers storage-empty.
+func (s *storageTrie) clearStaleStorageBeforeWrite() error {
+	if s.storageChanged || s.accountRoot != types.EmptyRootHash {
+		return nil
+	}
+	return s.clearStaleStorage(s.addr)
 }
 
-// Hash returns an empty hash, as the storage roots are managed internally to Firewood.
-func (*storageTrie) Hash() common.Hash {
+// UpdateStorage replaces or creates the value associated with a storage key for
+// this account.
+func (s *storageTrie) UpdateStorage(_ common.Address, key []byte, value []byte) error {
+	if err := s.clearStaleStorageBeforeWrite(); err != nil {
+		return err
+	}
+	if err := s.baseTrie.UpdateStorage(s.addr, key, value); err != nil {
+		return err
+	}
+	s.storageChanged = true
+	return nil
+}
+
+// DeleteStorage removes the value associated with a storage key for this account.
+func (s *storageTrie) DeleteStorage(_ common.Address, key []byte) error {
+	if err := s.clearStaleStorageBeforeWrite(); err != nil {
+		return err
+	}
+	if err := s.baseTrie.DeleteStorage(s.addr, key); err != nil {
+		return err
+	}
+	s.storageChanged = true
+	return nil
+}
+
+// Commit is a no-op for storage tries, as all changes are tracked by the base trie.
+// It always returns a nil NodeSet.
+func (s *storageTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
+	return s.Hash(), nil, nil
+}
+
+// Hash returns the storage root that should be written to the account.
+//
+// If storage was not mutated, the original account root is preserved. If
+// storage was mutated, Firewood stores the slots in its flat keyspace and uses
+// the zero hash as the account's storage-root sentinel. This MUST NOT be
+// [types.EmptyRootHash], because [baseTrie.clearStaleStorage] relies on that
+// root to mean "StateDB believes this account has no storage".
+func (s *storageTrie) Hash() common.Hash {
+	if !s.storageChanged {
+		return s.accountRoot
+	}
 	return common.Hash{}
 }
 

--- a/vms/saevm/firewood/storage_trie.go
+++ b/vms/saevm/firewood/storage_trie.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/trie/trienode"
+)
+
+var _ state.Trie = (*storageTrie)(nil)
+
+type storageTrie struct {
+	*baseTrie
+}
+
+// newStorageTrie returns a wrapper around a [baseTrie] since Firewood
+// does not require a separate storage trie. All changes are tracked by the base
+// trie.
+func newStorageTrie(base *baseTrie) *storageTrie {
+	return &storageTrie{
+		baseTrie: base,
+	}
+}
+
+// Commit is a no-op for storage tries, as all changes are tracked by the base trie.
+// It always returns a nil NodeSet and zero hash.
+func (*storageTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
+	return common.Hash{}, nil, nil
+}
+
+// Hash returns an empty hash, as the storage roots are managed internally to Firewood.
+func (*storageTrie) Hash() common.Hash {
+	return common.Hash{}
+}
+
+// Copy returns nil, as storage tries do not need to be copied separately.
+// All usage of a copied storage trie should first ensure it is non-nil.
+func (*storageTrie) Copy() *storageTrie {
+	return nil
+}

--- a/vms/saevm/firewood/triedb.go
+++ b/vms/saevm/firewood/triedb.go
@@ -29,9 +29,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
+
+	graft "github.com/ava-labs/avalanchego/graft/evm/firewood"
 )
 
-const firewoodDir = "firewood" // MUST match graft/evm/firewood/triedb.go
+const firewoodDir = graft.FirewoodDir
 
 var (
 	_ triedb.DBConstructor = TrieDBConfig{}.BackendConstructor
@@ -118,12 +120,12 @@ func validateDir(dir string) error {
 }
 
 // TrieDB is a triedb.DBOverride implementation backed by Firewood.
-// It acts as HashDB for backwards compatibility with most our code.
+// It acts as HashDB for backwards compatibility with most of our code.
 //
 // It MUST NOT be used for a synchronous EVM, because this implementation
 // relies on any proposal being created eventually being committed, as opposed
 // to the arbitrary DAG supported by `graft/evm/firewood`. Even in this
-// narrower use case, the behavior of the two implementations are NOT the same.
+// narrower use case, the behavior of the two implementations is NOT the same.
 //
 // TrieDB implements [triedb.HashDB], despite being a path-based storage
 // system, for easier compatibility with the rest of our codebase. Since
@@ -166,7 +168,6 @@ func New(config TrieDBConfig) (*TrieDB, error) {
 		options = append(options, ffi.WithRootStore())
 	}
 	if metrics.EnabledExpensive {
-		// TODO(alarso16): Does Firewood use this?
 		options = append(options, ffi.WithExpensiveMetrics())
 	}
 
@@ -174,6 +175,12 @@ func New(config TrieDBConfig) (*TrieDB, error) {
 	fw, err := ffi.New(path, ffi.EthereumNodeHashing, options...)
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
+	}
+
+	if root := common.Hash(fw.Root()); root == types.EmptyRootHash {
+		config.Log.Debug("empty firewood database opened", zap.String("path", path))
+	} else {
+		config.Log.Debug("firewood database opened", zap.Stringer("root", root), zap.String("path", path))
 	}
 
 	return &TrieDB{
@@ -200,18 +207,25 @@ func (t *TrieDB) Close() error {
 		t.pending = nil
 	}
 
+	// Allow some time for garbage collection and disk persistence of the
+	// last committed revision.
 	go runtime.GC()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second) // allow some time for garbage collection.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	return errors.Join(err, t.Firewood.Close(ctx))
 }
 
-// Initialized indicates where any state has been committed, typically used to
+// Initialized indicates whether any state has been committed, typically used to
 // check if the genesis block has been committed.
 func (t *TrieDB) Initialized(genesisRoot common.Hash) bool {
+	// If the genesis root is empty, no state changes are necessary to Firewood,
+	// and thus the genesis state can be considered committed.
 	if genesisRoot == types.EmptyRootHash {
 		return true
 	}
+
+	// If the disk root is not empty, then we must have committed something,
+	// so we must have committed the genesis root, regardless of its value.
 	return common.Hash(t.Firewood.Root()) != types.EmptyRootHash
 }
 
@@ -241,7 +255,7 @@ func (t *TrieDB) Update(root common.Hash, parent common.Hash, block uint64, node
 	return nil
 }
 
-// Commit allows this proposal to be persisted to disk. The given root must have
+// Commit ensures the given root is persisted to disk. The given root MUST have
 // been previously provided to [TrieDB.Update]. any error returned from this
 // function should be treated as fatal.
 func (t *TrieDB) Commit(root common.Hash, report bool) error {
@@ -249,8 +263,10 @@ func (t *TrieDB) Commit(root common.Hash, report bool) error {
 	if !ok {
 		// If this state root is available only on disk, we must have already committed it.
 		rev, err := t.Firewood.Revision(ffi.Hash(root))
-		if err != nil {
+		if errors.Is(err, ffi.ErrRevisionNotFound) {
 			return fmt.Errorf("no committable proposal found for root %s", root)
+		} else if err != nil {
+			return fmt.Errorf("retrieving revision for root %s: %w", root, err)
 		}
 		return rev.Drop()
 	}
@@ -314,12 +330,6 @@ func (t *TrieDB) trieHash(parentRoot common.Hash, batchOps []ffi.BatchOp) (*prop
 		return nil, false, fmt.Errorf("creating proposal: %w", err)
 	}
 
-	// If there are no state changes, we don't need to track this proposal.
-	// [TrieDB.Update] will never be called.
-	if proposal.Root() == ffi.Hash(parentRoot) {
-		return nil, true, proposal.Drop()
-	}
-
 	return &proposalRef{
 		p:      proposal,
 		root:   common.Hash(proposal.Root()),
@@ -329,11 +339,9 @@ func (t *TrieDB) trieHash(parentRoot common.Hash, batchOps []ffi.BatchOp) (*prop
 
 // trieCommit considers the provided proposal as canonical.
 // Should be called on [state.Trie.Commit].
+//
+// p MUST not be nil.
 func (t *TrieDB) trieCommit(p *proposalRef) {
-	if p == nil {
-		return
-	}
-
 	// add to linked list, since proposal is final.
 	if parent := p.parent; parent != nil {
 		if parent.p != nil {
@@ -343,6 +351,7 @@ func (t *TrieDB) trieCommit(p *proposalRef) {
 			p.parent = nil
 		}
 	}
+
 	t.pending = p
 }
 
@@ -351,7 +360,7 @@ func (t *TrieDB) trieCommit(p *proposalRef) {
 // During a [state.StateDB.Commit] operation, providing [rawdb.HashScheme] from
 // this function will prevent the statedb from trying to iterate over a self-
 // destructed account's storage trie, since Firewood will prefix-delete the
-// the storage trie and does not implement an iterator.
+// storage trie and does not implement an iterator.
 func (*TrieDB) Scheme() string {
 	var _ state.StateDB // protect import
 	return rawdb.HashScheme

--- a/vms/saevm/firewood/triedb.go
+++ b/vms/saevm/firewood/triedb.go
@@ -73,12 +73,48 @@ func DefaultConfig(dir string, log logging.Logger) TrieDBConfig {
 func (c TrieDBConfig) BackendConstructor(ethdb.Database) triedb.DBOverride {
 	db, err := New(c)
 	if err != nil {
-		if c.Log == nil {
-			panic(fmt.Sprintf("creating firewood database: %v", err))
-		}
 		c.Log.Fatal("creating firewood database", zap.Error(err))
 	}
 	return db
+}
+
+var (
+	errDatabaseDirNotProvided = errors.New("DatabaseDir must be provided")
+	errTooFewRevisions        = errors.New("RevisionsInMemory must be >= 2")
+	errCommitIntervalTooBig   = errors.New("DeferredCommitInterval must be < RevisionsInMemory")
+	errNotDirectory           = errors.New("database directory path is not a directory")
+)
+
+func (c TrieDBConfig) Validate() error {
+	if c.Log == nil {
+		panic("TrieDBConfig.Log must be set")
+	}
+	if err := validateDir(c.DatabaseDir); err != nil {
+		return err
+	}
+	if c.RevisionsInMemory < 2 {
+		return fmt.Errorf("%w: got %d", errTooFewRevisions, c.RevisionsInMemory)
+	}
+	if c.DeferredCommitInterval >= uint64(c.RevisionsInMemory) {
+		return fmt.Errorf("%w: %d >= %d", errCommitIntervalTooBig, c.DeferredCommitInterval, c.RevisionsInMemory)
+	}
+	return nil
+}
+
+// validateDir ensures that the given directory exists and is a directory.
+func validateDir(dir string) error {
+	if dir == "" {
+		return errDatabaseDirNotProvided
+	}
+
+	switch info, err := os.Stat(dir); {
+	case err != nil:
+		return fmt.Errorf("os.Stat() on database directory: %w", err)
+	case !info.IsDir():
+		return fmt.Errorf("%w: %q", errNotDirectory, dir)
+	}
+
+	return nil
 }
 
 // TrieDB is a triedb.DBOverride implementation backed by Firewood.
@@ -116,20 +152,15 @@ type proposalRef struct {
 }
 
 func New(config TrieDBConfig) (*TrieDB, error) {
-	if err := validateDir(config.DatabaseDir); err != nil {
+	if err := config.Validate(); err != nil {
 		return nil, err
 	}
-	path := filepath.Join(config.DatabaseDir, firewoodDir)
-
-	// The Firewood constructor will check that commitCount is nonzero.
-	minDeferredPersistenceCommitCount := uint64(config.RevisionsInMemory - 1)
-	commitCount := min(config.DeferredCommitInterval, minDeferredPersistenceCommitCount)
 
 	options := []ffi.Option{
 		ffi.WithReadCacheStrategy(ffi.CacheAllReads), // Based on benchmarking, highest cache hit rate
 		ffi.WithNodeCacheSizeInBytes(config.CacheSizeBytes),
 		ffi.WithRevisions(config.RevisionsInMemory),
-		ffi.WithDeferredPersistenceCommitCount(commitCount),
+		ffi.WithDeferredPersistenceCommitCount(config.DeferredCommitInterval),
 	}
 	if config.Archive {
 		options = append(options, ffi.WithRootStore())
@@ -139,6 +170,7 @@ func New(config TrieDBConfig) (*TrieDB, error) {
 		options = append(options, ffi.WithExpensiveMetrics())
 	}
 
+	path := filepath.Join(config.DatabaseDir, firewoodDir)
 	fw, err := ffi.New(path, ffi.EthereumNodeHashing, options...)
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
@@ -149,22 +181,6 @@ func New(config TrieDBConfig) (*TrieDB, error) {
 		committable: make(map[common.Hash]*proposalRef),
 		log:         config.Log,
 	}, nil
-}
-
-// validateDir ensures that the given directory exists and is a directory.
-func validateDir(dir string) error {
-	if dir == "" {
-		return errors.New("chain data directory must be set")
-	}
-
-	switch info, err := os.Stat(dir); {
-	case err != nil:
-		return fmt.Errorf("os.Stat() on database directory: %w", err)
-	case !info.IsDir():
-		return fmt.Errorf("database directory path is not a directory: %q", dir)
-	}
-
-	return nil
 }
 
 // Close drops all proposals that have not yet been committed and closes the

--- a/vms/saevm/firewood/triedb.go
+++ b/vms/saevm/firewood/triedb.go
@@ -304,11 +304,10 @@ func (t *TrieDB) Commit(root common.Hash, report bool) error {
 }
 
 // trieHash creates a new proposal from either a committable proposal or the tip of the database.
-// Returns (non-nil, true, nil) if a proposal was successfully created.
-// Returns (nil, true, nil) when the ops produce no state change (nothing to track).
-// Returns (nil, false, nil) when the parent root exists but is not proposable.
-// Returns (nil, _, err) for any error.
-func (t *TrieDB) trieHash(parentRoot common.Hash, batchOps []ffi.BatchOp) (*proposalRef, bool, error) {
+// Returns (non-nil, nil) if a proposal was successfully created.
+// Returns (nil, nil) if the parent revision cannot be used as the base for a proposal.
+// Returns (nil, err) for any error.
+func (t *TrieDB) trieHash(parentRoot common.Hash, batchOps []ffi.BatchOp) (*proposalRef, error) {
 	parent, foundProposal := t.committable[parentRoot]
 	var propose func([]ffi.BatchOp) (*ffi.Proposal, error)
 	switch {
@@ -320,21 +319,21 @@ func (t *TrieDB) trieHash(parentRoot common.Hash, batchOps []ffi.BatchOp) (*prop
 	default:
 		// check if a reconstruction could be made
 		if rev, err := t.Firewood.Revision(ffi.Hash(parentRoot)); err == nil {
-			return nil, false, rev.Drop()
+			return nil, rev.Drop()
 		}
-		return nil, false, fmt.Errorf("parent root %+x not found in database", parentRoot)
+		return nil, fmt.Errorf("parent root %+x not found in database", parentRoot)
 	}
 
 	proposal, err := propose(batchOps)
 	if err != nil {
-		return nil, false, fmt.Errorf("creating proposal: %w", err)
+		return nil, fmt.Errorf("creating proposal: %w", err)
 	}
 
 	return &proposalRef{
 		p:      proposal,
 		root:   common.Hash(proposal.Root()),
 		parent: parent,
-	}, true, nil
+	}, nil
 }
 
 // trieCommit considers the provided proposal as canonical.

--- a/vms/saevm/firewood/triedb.go
+++ b/vms/saevm/firewood/triedb.go
@@ -1,0 +1,367 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"time"
+
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/stateconf"
+	"github.com/ava-labs/libevm/metrics"
+	"github.com/ava-labs/libevm/trie"
+	"github.com/ava-labs/libevm/trie/trienode"
+	"github.com/ava-labs/libevm/trie/triestate"
+	"github.com/ava-labs/libevm/triedb"
+	"github.com/ava-labs/libevm/triedb/database"
+	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+const firewoodDir = "firewood" // MUST match graft/evm/firewood/triedb.go
+
+var (
+	_ triedb.DBConstructor = TrieDBConfig{}.BackendConstructor
+	_ triedb.HashDB        = (*TrieDB)(nil)
+)
+
+// TrieDBConfig holds the configuration for creating a [TrieDB].
+type TrieDBConfig struct {
+	DatabaseDir       string
+	CacheSizeBytes    uint
+	RevisionsInMemory uint // must be >= 2
+	Archive           bool
+	// DeferredCommitInterval must be < RevisionsInMemory as otherwise, it's
+	// possible to reap the latest persisted revision.
+	DeferredCommitInterval uint64
+	Log                    logging.Logger
+	// TODO(alarso16): Something for metrics?
+}
+
+// DefaultConfig returns a sensible TrieDBConfig with the given directory.
+// The default config is:
+//   - CacheSizeBytes: 1MB
+//   - RevisionsInMemory: 128
+//   - CacheStrategy: [ffi.CacheAllReads]
+//   - DeferredCommitInterval: 64
+func DefaultConfig(dir string, log logging.Logger) TrieDBConfig {
+	return TrieDBConfig{
+		DatabaseDir:            dir,
+		CacheSizeBytes:         1024 * 1024, // 1MB
+		RevisionsInMemory:      128,
+		DeferredCommitInterval: 64,
+		Log:                    log,
+	}
+}
+
+// BackendConstructor implements the [triedb.DBConstructor] interface.
+// It creates a new Firewood database with the given configuration.
+// Any error during creation will cause the program to exit.
+func (c TrieDBConfig) BackendConstructor(ethdb.Database) triedb.DBOverride {
+	db, err := New(c)
+	if err != nil {
+		if c.Log == nil {
+			panic(fmt.Sprintf("creating firewood database: %v", err))
+		}
+		c.Log.Fatal("creating firewood database", zap.Error(err))
+	}
+	return db
+}
+
+// TrieDB is a triedb.DBOverride implementation backed by Firewood.
+// It acts as HashDB for backwards compatibility with most our code.
+//
+// It MUST NOT be used for a synchronous EVM, because this implementation
+// relies on any proposal being created eventually being committed, as opposed
+// to the arbitrary DAG supported by `graft/evm/firewood`. Even in this
+// narrower use case, the behavior of the two implementations are NOT the same.
+//
+// TrieDB implements [triedb.HashDB], despite being a path-based storage
+// system, for easier compatibility with the rest of our codebase. Since
+// Firewood internally tracks revision deletion and we have no need to journal,
+// much of the complexity of [triedb.PathDB] is avoided.
+type TrieDB struct {
+	// The underlying Firewood database, used for storing proposals and revisions.
+	// This is exported as read-only, with knowledge that the consumer will not close it
+	// and the latest state can be modified at any time during execution.
+	Firewood *ffi.Database
+
+	pending     *proposalRef
+	committable map[common.Hash]*proposalRef
+
+	log logging.Logger
+}
+
+// A proposalRef is an element in a doubly-linked list of proposals.
+// Available in the [TrieDB.committable] map by state root, and linked together
+// by parent-child relationships.
+type proposalRef struct {
+	p      *ffi.Proposal
+	root   common.Hash
+	parent *proposalRef
+	child  *proposalRef
+}
+
+func New(config TrieDBConfig) (*TrieDB, error) {
+	if err := validateDir(config.DatabaseDir); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(config.DatabaseDir, firewoodDir)
+
+	// The Firewood constructor will check that commitCount is nonzero.
+	minDeferredPersistenceCommitCount := uint64(config.RevisionsInMemory - 1)
+	commitCount := min(config.DeferredCommitInterval, minDeferredPersistenceCommitCount)
+
+	options := []ffi.Option{
+		ffi.WithReadCacheStrategy(ffi.CacheAllReads), // Based on benchmarking, highest cache hit rate
+		ffi.WithNodeCacheSizeInBytes(config.CacheSizeBytes),
+		ffi.WithRevisions(config.RevisionsInMemory),
+		ffi.WithDeferredPersistenceCommitCount(commitCount),
+	}
+	if config.Archive {
+		options = append(options, ffi.WithRootStore())
+	}
+	if metrics.EnabledExpensive {
+		// TODO(alarso16): Does Firewood use this?
+		options = append(options, ffi.WithExpensiveMetrics())
+	}
+
+	fw, err := ffi.New(path, ffi.EthereumNodeHashing, options...)
+	if err != nil {
+		return nil, fmt.Errorf("opening database: %w", err)
+	}
+
+	return &TrieDB{
+		Firewood:    fw,
+		committable: make(map[common.Hash]*proposalRef),
+		log:         config.Log,
+	}, nil
+}
+
+// validateDir ensures that the given directory exists and is a directory.
+func validateDir(dir string) error {
+	if dir == "" {
+		return errors.New("chain data directory must be set")
+	}
+
+	switch info, err := os.Stat(dir); {
+	case err != nil:
+		return fmt.Errorf("os.Stat() on database directory: %w", err)
+	case !info.IsDir():
+		return fmt.Errorf("database directory path is not a directory: %q", dir)
+	}
+
+	return nil
+}
+
+// Close drops all proposals that have not yet been committed and closes the
+// underlying Firewood database.  If a reference to a [state.Trie] obtained
+// from this parent [state.Database] is still accessible during this call, an
+// error will be returned.
+//
+// TODO(alarso16): Force drop all pending revisions on close once supported.
+func (t *TrieDB) Close() error {
+	var err error
+	for _, proposal := range t.committable {
+		err = errors.Join(err, proposal.p.Drop())
+	}
+	t.committable = nil
+	if t.pending != nil {
+		err = errors.Join(err, t.pending.p.Drop())
+		t.pending = nil
+	}
+
+	go runtime.GC()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second) // allow some time for garbage collection.
+	defer cancel()
+	return errors.Join(err, t.Firewood.Close(ctx))
+}
+
+// Initialized indicates where any state has been committed, typically used to
+// check if the genesis block has been committed.
+func (t *TrieDB) Initialized(genesisRoot common.Hash) bool {
+	if genesisRoot == types.EmptyRootHash {
+		return true
+	}
+	return common.Hash(t.Firewood.Root()) != types.EmptyRootHash
+}
+
+// Update considers the given root as the new head of tracked roots.  This root,
+// if different than parent, must have been created via [state.Trie.Commit] with
+// a Firewood-backed [state.StateDB]. After Update returns, the user can call
+// [TrieDB.Commit] to queue the proposal to be moved to disk.
+//
+//nolint:revive // removing names loses context.
+func (t *TrieDB) Update(root common.Hash, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set, _ ...stateconf.TrieDBUpdateOption) error {
+	possible := t.pending
+	if possible == nil {
+		// Update will never be called if no state change is proposed.
+		return fmt.Errorf("no pending proposal to update for root %s", root)
+	}
+
+	if possible.root != root {
+		return fmt.Errorf("proposal root %s does not match update root %s", possible.root, root)
+	}
+
+	if possible.parent != nil && possible.parent.root != parent {
+		return fmt.Errorf("proposal parent root %s does not match update parent %s", possible.parent.root, parent)
+	}
+
+	t.pending = nil
+	t.committable[root] = possible
+	return nil
+}
+
+// Commit allows this proposal to be persisted to disk. The given root must have
+// been previously provided to [TrieDB.Update]. any error returned from this
+// function should be treated as fatal.
+func (t *TrieDB) Commit(root common.Hash, report bool) error {
+	p, ok := t.committable[root]
+	if !ok {
+		// If this state root is available only on disk, we must have already committed it.
+		rev, err := t.Firewood.Revision(ffi.Hash(root))
+		if err != nil {
+			return fmt.Errorf("no committable proposal found for root %s", root)
+		}
+		return rev.Drop()
+	}
+	if child := p.child; child != nil {
+		child.parent = nil // detach from doubly-linked list
+	}
+
+	// Walk back the proposal chain and collect all proposals to apply in order.
+	var proposals []*ffi.Proposal
+	for cur := p; cur != nil; cur = cur.parent {
+		proposals = append(proposals, cur.p)
+		cur.p = nil
+		delete(t.committable, cur.root)
+	}
+
+	var err error
+	for _, proposal := range slices.Backward(proposals) {
+		if err != nil {
+			// If a previous proposal failed to commit, we need to drop this proposal to avoid a leak.
+			err = errors.Join(err, proposal.Drop())
+			continue
+		}
+		err = proposal.Commit()
+	}
+
+	var log logging.Func
+	if report {
+		log = t.log.Info
+	} else {
+		log = t.log.Debug
+	}
+	log("committing proposal", zap.Stringer("root", root), zap.Int("numProposals", len(proposals)), zap.Error(err))
+
+	return err
+}
+
+// trieHash creates a new proposal from either a committable proposal or the tip of the database.
+// Returns (non-nil, true, nil) if a proposal was successfully created.
+// Returns (nil, true, nil) when the ops produce no state change (nothing to track).
+// Returns (nil, false, nil) when the parent root exists but is not proposable.
+// Returns (nil, _, err) for any error.
+func (t *TrieDB) trieHash(parentRoot common.Hash, batchOps []ffi.BatchOp) (*proposalRef, bool, error) {
+	parent, foundProposal := t.committable[parentRoot]
+	var propose func([]ffi.BatchOp) (*ffi.Proposal, error)
+	switch {
+	case foundProposal:
+		propose = parent.p.Propose
+	case parentRoot == common.Hash(t.Firewood.Root()):
+		propose = t.Firewood.Propose
+		parent = nil // nothing else would be required to be committed first
+	default:
+		// check if a reconstruction could be made
+		if rev, err := t.Firewood.Revision(ffi.Hash(parentRoot)); err == nil {
+			return nil, false, rev.Drop()
+		}
+		return nil, false, fmt.Errorf("parent root %+x not found in database", parentRoot)
+	}
+
+	proposal, err := propose(batchOps)
+	if err != nil {
+		return nil, false, fmt.Errorf("creating proposal: %w", err)
+	}
+
+	// If there are no state changes, we don't need to track this proposal.
+	// [TrieDB.Update] will never be called.
+	if proposal.Root() == ffi.Hash(parentRoot) {
+		return nil, true, proposal.Drop()
+	}
+
+	return &proposalRef{
+		p:      proposal,
+		root:   common.Hash(proposal.Root()),
+		parent: parent,
+	}, true, nil
+}
+
+// trieCommit considers the provided proposal as canonical.
+// Should be called on [state.Trie.Commit].
+func (t *TrieDB) trieCommit(p *proposalRef) {
+	if p == nil {
+		return
+	}
+
+	// add to linked list, since proposal is final.
+	if parent := p.parent; parent != nil {
+		if parent.p != nil {
+			parent.child = p
+		} else {
+			// parent proposal is already committed, detach from list
+			p.parent = nil
+		}
+	}
+	t.pending = p
+}
+
+// Scheme returns [rawdb.HashScheme] to identify the database.
+//
+// During a [state.StateDB.Commit] operation, providing [rawdb.HashScheme] from
+// this function will prevent the statedb from trying to iterate over a self-
+// destructed account's storage trie, since Firewood will prefix-delete the
+// the storage trie and does not implement an iterator.
+func (*TrieDB) Scheme() string {
+	var _ state.StateDB // protect import
+	return rawdb.HashScheme
+}
+
+var errReaderNotSupported = errors.New("TrieDB does not support creating a trie reader")
+
+// Reader implements [triedb.Backend]. This is expected to be used by a [trie.Trie],
+// so Firewood does not need to support this.
+func (*TrieDB) Reader(common.Hash) (database.Reader, error) {
+	var _ trie.Trie // protect import
+	return nil, errReaderNotSupported
+}
+
+// Size is managed by Firewood, so this returns 0 for both values to avoid confusion.
+func (*TrieDB) Size() (common.StorageSize, common.StorageSize) {
+	return 0, 0
+}
+
+// Cap is not supported.
+func (*TrieDB) Cap(common.StorageSize) error {
+	return nil
+}
+
+// Reference is a no-op since Firewood doesn't require explicit reference counting.
+func (*TrieDB) Reference(common.Hash, common.Hash) {}
+
+// Dereference is a no-op since Firewood doesn't require explicit reference counting.
+func (*TrieDB) Dereference(common.Hash) {}

--- a/vms/saevm/firewood/triedb.go
+++ b/vms/saevm/firewood/triedb.go
@@ -356,7 +356,6 @@ func (t *TrieDB) trieHash(parentRoot common.Hash, batchOps []ffi.BatchOp) (*prop
 // p MUST not be nil.
 func (t *TrieDB) trieCommit(p *proposalRef) {
 	t.pending = p
-
 }
 
 // Scheme returns [rawdb.HashScheme] to identify the database.

--- a/vms/saevm/firewood/triedb.go
+++ b/vms/saevm/firewood/triedb.go
@@ -43,29 +43,28 @@ var (
 // TrieDBConfig holds the configuration for creating a [TrieDB].
 type TrieDBConfig struct {
 	DatabaseDir       string
+	Log               logging.Logger
 	CacheSizeBytes    uint
 	RevisionsInMemory uint // must be >= 2
 	Archive           bool
 	// DeferredCommitInterval must be < RevisionsInMemory as otherwise, it's
 	// possible to reap the latest persisted revision.
 	DeferredCommitInterval uint64
-	Log                    logging.Logger
 	// TODO(alarso16): Something for metrics?
 }
 
 // DefaultConfig returns a sensible TrieDBConfig with the given directory.
 // The default config is:
-//   - CacheSizeBytes: 1MB
+//   - CacheSizeBytes: 1MiB
 //   - RevisionsInMemory: 128
-//   - CacheStrategy: [ffi.CacheAllReads]
 //   - DeferredCommitInterval: 64
 func DefaultConfig(dir string, log logging.Logger) TrieDBConfig {
 	return TrieDBConfig{
 		DatabaseDir:            dir,
-		CacheSizeBytes:         1024 * 1024, // 1MB
+		Log:                    log,
+		CacheSizeBytes:         1024 * 1024,
 		RevisionsInMemory:      128,
 		DeferredCommitInterval: 64,
-		Log:                    log,
 	}
 }
 
@@ -237,6 +236,7 @@ func (t *TrieDB) Initialized(genesisRoot common.Hash) bool {
 //nolint:revive // removing names loses context.
 func (t *TrieDB) Update(root common.Hash, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set, _ ...stateconf.TrieDBUpdateOption) error {
 	possible := t.pending
+	t.pending = nil
 	if possible == nil {
 		// Update will never be called if no state change is proposed.
 		return fmt.Errorf("no pending proposal to update for root %s", root)
@@ -250,8 +250,22 @@ func (t *TrieDB) Update(root common.Hash, parent common.Hash, block uint64, node
 		return fmt.Errorf("proposal parent root %s does not match update parent %s", possible.parent.root, parent)
 	}
 
-	t.pending = nil
 	t.committable[root] = possible
+
+	if possible.parent == nil {
+		// parent is disk, base of linked list
+		return nil
+	}
+
+	parentRef := possible.parent
+	if parentRef.p != nil {
+		// parent hasn't been committed yet, link together in list
+		parentRef.child = possible
+	} else {
+		// parent proposal is already committed, detach from list
+		possible.parent = nil
+	}
+
 	return nil
 }
 
@@ -341,17 +355,8 @@ func (t *TrieDB) trieHash(parentRoot common.Hash, batchOps []ffi.BatchOp) (*prop
 //
 // p MUST not be nil.
 func (t *TrieDB) trieCommit(p *proposalRef) {
-	// add to linked list, since proposal is final.
-	if parent := p.parent; parent != nil {
-		if parent.p != nil {
-			parent.child = p
-		} else {
-			// parent proposal is already committed, detach from list
-			p.parent = nil
-		}
-	}
-
 	t.pending = p
+
 }
 
 // Scheme returns [rawdb.HashScheme] to identify the database.

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -25,8 +25,11 @@ import (
 )
 
 func mustNewStateDB(t *testing.T, db state.Database, root common.Hash) *state.StateDB {
+	t.Helper()
+
 	st, err := state.New(root, db, nil)
-	require.NoError(t, err)
+	require.NoErrorf(t, err, "state.New(%s, %T)", root, db)
+
 	return st
 }
 
@@ -62,7 +65,7 @@ func newSUT(t *testing.T) *SUT {
 		DBOverride: cfg.BackendConstructor,
 	})
 	t.Cleanup(func() {
-		require.NoError(t, fwDB.TrieDB().Close())
+		require.NoError(t, fwDB.TrieDB().Close(), "firewood triedb.Close()")
 	})
 	hashDB := state.NewDatabase(rawdb.NewMemoryDatabase())
 
@@ -181,8 +184,13 @@ func (s *SUT) stateDBCommit(t *testing.T) {
 }
 
 func (s *SUT) diskCommit(t *testing.T) {
-	require.NoError(t, s.fwDB.TrieDB().Commit(s.lastRoot, false))
-	require.NoError(t, s.hashDB.TrieDB().Commit(s.lastRoot, false))
+	require.NoErrorf(t, s.fwDB.TrieDB().Commit(s.lastRoot, false), "triedb.Commit(%s)", s.lastRoot)
+	require.NoErrorf(t, s.hashDB.TrieDB().Commit(s.lastRoot, false), "triedb.Commit(%s)", s.lastRoot)
+}
+
+func (s *SUT) copyStateDB() {
+	s.fwState = s.fwState.Copy()
+	s.hashState = s.hashState.Copy()
 }
 
 const (
@@ -194,12 +202,39 @@ const (
 	opSetStorage                   // write a new storage slot on an existing account
 	opDeleteStorage                // zero out an existing storage slot on an existing account
 	opIntermediateRoot             // verify all account and storage hashes match the model
+	opCopyStateDB                  // copies statedb for future ops
 	maxOp
 )
 
 // FuzzStateDB compares the state root of an arbitrary sequence of operations on
 // a Firewood-backed [state.StateDB] against a reference HashDB.
 func FuzzStateDB(f *testing.F) {
+	f.Add([]byte{
+		opCreateAccount,
+		opStateDBCommit,
+	})
+	f.Add([]byte{
+		opCreateAccount,
+		opUpdateAccount,
+		opSetStorage,
+		opStateDBCommit,
+		opDiskCommit,
+	})
+	f.Add([]byte{
+		opCreateAccount,
+		opSetStorage,
+		opIntermediateRoot,
+		opDeleteStorage,
+		opStateDBCommit,
+	})
+	f.Add([]byte{
+		opCreateAccount,
+		opStateDBCommit,
+		opDeleteAccount,
+		opStateDBCommit,
+	})
+	f.Add([]byte{opStateDBCommit, opDiskCommit})
+
 	f.Fuzz(func(t *testing.T, steps []byte) {
 		sut := newSUT(t)
 		for _, step := range steps {
@@ -216,34 +251,36 @@ func FuzzStateDB(f *testing.F) {
 				t.Log("create account")
 				sut.createAccount()
 			case opUpdateAccount:
-				t.Log("update account")
 				if len(sut.model.addrs) > 0 {
+					t.Log("update account")
 					sut.updateAccount(param)
 				}
 			case opDeleteAccount:
-				t.Log("delete account")
 				if len(sut.model.addrs) > 0 {
+					t.Log("delete account")
 					sut.deleteAccount(param)
 				}
 			case opSetStorage:
-				t.Log("set storage")
 				if len(sut.model.addrs) > 0 {
+					t.Log("set storage")
 					sut.setStorage(param)
 				}
 			case opDeleteStorage:
-				t.Log("delete storage")
 				if len(sut.model.addrs) > 0 {
+					t.Log("delete storage")
 					sut.deleteStorage(param)
 				}
 			case opIntermediateRoot:
-				t.Log("check hashes")
+				t.Log("intermediate root")
 				sut.intermediateRoot(t)
+			case opCopyStateDB:
+				t.Log("copy StateDB")
+				sut.copyStateDB()
 			default:
 				t.Skip("invalid operation")
 			}
 		}
 		sut.intermediateRoot(t) // final flush to tries and verify all pending state
-		sut = nil               // allow garbage collection
 	})
 }
 
@@ -270,7 +307,7 @@ func TestGenesis(t *testing.T) {
 	_, _, err := core.SetupGenesisBlock(memDB, tdb, &g)
 	require.NoError(t, err)
 	require.True(t, tdb.Initialized(genesisRoot), "Genesis root should be initialized in the database after setup")
-	require.NoError(t, tdb.Close())
+	require.NoError(t, tdb.Close(), "triedb.Close()")
 
 	t.Run("recovery", func(t *testing.T) {
 		cfg.Log = loggingtest.New(t, logging.Debug)
@@ -278,7 +315,7 @@ func TestGenesis(t *testing.T) {
 			DBOverride: cfg.BackendConstructor,
 		})
 		require.True(t, tdb.Initialized(genesisRoot), "Genesis root should still be initialized in the database")
-		require.NoError(t, tdb.Close())
+		require.NoError(t, tdb.Close(), "triedb.Close()")
 	})
 }
 
@@ -288,11 +325,6 @@ func TestInvalidConfig(t *testing.T) {
 		cfg     func(TrieDBConfig) TrieDBConfig
 		wantErr error
 	}{
-		{
-			name:    "valid config",
-			cfg:     func(cfg TrieDBConfig) TrieDBConfig { return cfg },
-			wantErr: nil,
-		},
 		{
 			name: "empty directory",
 			cfg: func(cfg TrieDBConfig) TrieDBConfig {
@@ -334,14 +366,14 @@ func TestInvalidConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.cfg(DefaultConfig(t.TempDir(), loggingtest.New(t, logging.Debug)))
 			_, err := New(cfg)
-			require.ErrorIs(t, err, tt.wantErr)
+			require.ErrorIs(t, err, tt.wantErr, "New()")
 		})
 	}
 }
 
-func TestNoLogger(t *testing.T) {
+func TestNoLoggerPanics(t *testing.T) {
 	cfg := DefaultConfig(t.TempDir(), nil)
 	require.Panics(t, func() {
 		_, _ = New(cfg)
-	})
+	}, "New()")
 }

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -140,11 +140,11 @@ func (s *SUT) nextHash() common.Hash {
 // [state.Trie.DeleteAccount].
 func (s *SUT) createAccount(param byte) {
 	var addr common.Address
-	if len(s.model.destructedThisTx) > 0 && param&1 == 0 {
+	if len(s.model.destructed) > 0 && param&1 == 0 {
 		// choose a previously destructed account to resurrect.
-		i := int(param>>1) % len(s.model.destructedThisTx)
-		addr = s.model.destructedThisTx[i]
-		s.model.destructedThisTx = removeUnordered(s.model.destructedThisTx, i)
+		i := int(param>>1) % len(s.model.destructed)
+		addr = s.model.destructed[i]
+		s.model.destructed = removeUnordered(s.model.destructed, i)
 	} else {
 		addr = common.BytesToAddress(s.nextHash().Bytes())
 	}

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -120,8 +120,8 @@ func (s *SUT) createAccount(param byte) {
 	if len(s.model.destructedThisTx) > 0 && param&1 == 0 {
 		// choose a previously destructed account to resurrect.
 		i := int(param>>1) % len(s.model.destructedThisTx)
-		s.model.destructedThisTx = removeUnordered(s.model.destructedThisTx, i)
 		addr = s.model.destructedThisTx[i]
+		s.model.destructedThisTx = removeUnordered(s.model.destructedThisTx, i)
 	} else {
 		addr = common.BytesToAddress(s.nextHash().Bytes())
 	}

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"math/big"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/ava-labs/libevm/common"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
-	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 func mustNewDB(t *testing.T) state.Database {
@@ -55,13 +55,9 @@ type accountModel struct {
 }
 
 type fuzzModel struct {
-	accounts map[common.Address]*accountModel
-	addrs    []common.Address // live addresses ordered by creation time
-
-	// Per-transaction tracking, reset at every transaction boundary
-	// see [SUT.finaliseTx])
-	createdThisTx    set.Set[common.Address]
-	destructedThisTx []common.Address // addresses destructed this tx, eligible for resurrection
+	accounts   map[common.Address]*accountModel
+	addrs      []common.Address // live addresses ordered by creation time
+	destructed []common.Address // self-destructed addresses available for recreation
 }
 
 func (m *fuzzModel) selectAddr(param byte) common.Address {
@@ -76,14 +72,39 @@ func removeUnordered[T any](s []T, i int) []T {
 	return s[:last]
 }
 
+// clone returns a deep copy of the model, used to restore it on revert.
+func (m *fuzzModel) clone() *fuzzModel {
+	accounts := make(map[common.Address]*accountModel, len(m.accounts))
+	for addr, acc := range m.accounts {
+		accounts[addr] = &accountModel{
+			nonce:   acc.nonce,
+			balance: acc.balance.Clone(),
+			storage: slices.Clone(acc.storage),
+		}
+	}
+	return &fuzzModel{
+		accounts:   accounts,
+		addrs:      slices.Clone(m.addrs),
+		destructed: slices.Clone(m.destructed),
+	}
+}
+
+// snapshotRef pairs the snapshot IDs of both databases with the model state
+// at the time the snapshot was taken.
+type snapshotRef struct {
+	fwID, hashID int
+	model        *fuzzModel
+}
+
 type SUT struct {
 	fwDB, hashDB       state.Database
 	fwState, hashState *state.StateDB
 
-	lastRoot common.Hash
-	blockNum uint64
-	counter  uint64 // drives deterministic address/key generation
-	model    *fuzzModel
+	lastRoot  common.Hash
+	blockNum  uint64
+	counter   uint64 // drives deterministic address/key generation
+	model     *fuzzModel
+	snapshots []snapshotRef
 }
 
 func newSUT(t *testing.T) *SUT {
@@ -100,8 +121,7 @@ func newSUT(t *testing.T) *SUT {
 		hashState: hashState,
 		lastRoot:  root,
 		model: &fuzzModel{
-			accounts:      make(map[common.Address]*accountModel),
-			createdThisTx: set.NewSet[common.Address](0),
+			accounts: make(map[common.Address]*accountModel),
 		},
 	}
 }
@@ -112,16 +132,19 @@ func (s *SUT) nextHash() common.Hash {
 	return crypto.Keccak256Hash(binary.BigEndian.AppendUint64(nil, s.counter))
 }
 
-// createAccount creates an account, modelling an EVM contract deployment. When
-// an account has been destructed earlier in the current transaction, that
-// accound could be resurrected.
+// createAccount models an EVM contract deployment. When a previously
+// self-destructed account is available, an even param resurrects it at the
+// same address instead of allocating a new one. Same-block resurrection
+// exercises the path where [state.StateDB] clears the prior incarnation's
+// storage via [state.StateDB.Commit] rather than calling
+// [state.Trie.DeleteAccount].
 func (s *SUT) createAccount(param byte) {
 	var addr common.Address
-	if len(s.model.destructedThisTx) > 0 && param&1 == 0 {
-		// choose a previously destructed account to resurrect.
-		i := int(param>>1) % len(s.model.destructedThisTx)
-		s.model.destructedThisTx = removeUnordered(s.model.destructedThisTx, i)
-		addr = s.model.destructedThisTx[i]
+	if len(s.model.destructed) > 0 && param&1 == 0 {
+		// Resurrect a previously self-destructed account.
+		i := int(param>>1) % len(s.model.destructed)
+		addr = s.model.destructed[i]
+		s.model.destructed = removeUnordered(s.model.destructed, i)
 	} else {
 		addr = common.BytesToAddress(s.nextHash().Bytes())
 	}
@@ -132,7 +155,6 @@ func (s *SUT) createAccount(param byte) {
 		balance: bal.Clone(),
 	}
 	s.model.addrs = append(s.model.addrs, addr)
-	s.model.createdThisTx.Add(addr)
 
 	s.fwState.CreateAccount(addr)
 	s.fwState.SetNonce(addr, 1)
@@ -154,26 +176,15 @@ func (s *SUT) updateAccount(param byte) {
 	s.hashState.SetBalance(addr, acc.balance)
 }
 
-// selfDestruct6780 models the SELFDESTRUCT opcode under EIP-6780. The call is
-// always issued to the StateDB (it is a legal operation on any account), but it
-// only actually destructs the account — and so only updates the model — when the
-// account was created in the current transaction. On a pre-existing account it
-// is a no-op and the account remains live.
-func (s *SUT) selfDestruct6780(param byte) {
+func (s *SUT) deleteAccount(param byte) {
 	i := int(param) % len(s.model.addrs)
 	addr := s.model.addrs[i]
-
-	s.fwState.Selfdestruct6780(addr)
-	s.hashState.Selfdestruct6780(addr)
-
-	if !s.model.createdThisTx.Contains(addr) {
-		return // not created this tx: Selfdestruct6780 is a no-op
-	}
-
 	delete(s.model.accounts, addr)
-	s.model.createdThisTx.Remove(addr)
-	s.model.destructedThisTx = append(s.model.destructedThisTx, addr)
 	s.model.addrs = removeUnordered(s.model.addrs, i)
+	s.model.destructed = append(s.model.destructed, addr)
+
+	s.fwState.SelfDestruct(addr)
+	s.hashState.SelfDestruct(addr)
 }
 
 func (s *SUT) setStorage(param byte) {
@@ -200,29 +211,60 @@ func (s *SUT) deleteStorage(param byte) {
 	s.hashState.SetState(addr, key, common.Hash{})
 }
 
-// finaliseTx resets the model's per-transaction tracking to mirror
-// [state.StateDB.Finalise].
-// Any accounts created this transaction can no longer be selfdestructed,
-// and any accounts destructed this transaction can no longer be resurrected.
-func (s *SUT) finaliseTx() {
-	s.model.createdThisTx.Clear()
-	s.model.destructedThisTx = s.model.destructedThisTx[:0]
+// getStorage reads a committed storage slot — either one that was previously
+// written, or a never-written one. The returned values are deliberately NOT
+// compared: trie-level read semantics are limited (see "Why reads aren't
+// safe" in the README). The read itself MUST NOT mutate state; the root
+// comparisons in later operations verify this.
+func (s *SUT) getStorage(param byte) {
+	addr := s.model.selectAddr(param)
+	key := s.nextHash() // a slot that was never written
+	if storage := s.model.accounts[addr].storage; len(storage) > 0 && param%2 == 0 {
+		key = storage[int(param)%len(storage)]
+	}
+
+	s.fwState.GetCommittedState(addr, key)
+	s.hashState.GetCommittedState(addr, key)
 }
 
-func (s *SUT) finalise() {
-	s.fwState.Finalise(true /* EIP-158 */)
-	s.hashState.Finalise(true /* EIP-158 */)
-	s.finaliseTx()
+// snapshot records a [state.StateDB.Snapshot] on both databases together with
+// a copy of the model, so a later revert restores all three in lockstep.
+func (s *SUT) snapshot() {
+	s.snapshots = append(s.snapshots, snapshotRef{
+		fwID:   s.fwState.Snapshot(),
+		hashID: s.hashState.Snapshot(),
+		model:  s.model.clone(),
+	})
+}
+
+// revertToSnapshot reverts both databases and the model to a previously
+// recorded snapshot. The chosen snapshot and all later ones are discarded,
+// matching [state.StateDB.RevertToSnapshot], which invalidates them.
+func (s *SUT) revertToSnapshot(param byte) {
+	i := int(param) % len(s.snapshots)
+	ref := s.snapshots[i]
+	s.fwState.RevertToSnapshot(ref.fwID)
+	s.hashState.RevertToSnapshot(ref.hashID)
+	s.model = ref.model
+	s.snapshots = s.snapshots[:i]
+}
+
+// dropSnapshots discards all recorded snapshots. Snapshots MUST NOT be
+// reverted across a Finalise or a Copy, mirroring the EVM, which only reverts
+// within a single transaction.
+func (s *SUT) dropSnapshots() {
+	s.snapshots = nil
 }
 
 func (s *SUT) intermediateRoot(t *testing.T) {
+	s.dropSnapshots()
 	fwRoot := s.fwState.IntermediateRoot(true /* EIP-158 */)
 	hashRoot := s.hashState.IntermediateRoot(true /* EIP-158 */)
 	require.Equal(t, hashRoot, fwRoot, "root mismatch")
-	s.finaliseTx() // IntermediateRoot calls Finalise
 }
 
 func (s *SUT) stateDBCommit(t *testing.T) {
+	s.dropSnapshots()
 	hashRoot, err := s.hashState.Commit(s.blockNum, true /* EIP-158 */)
 	require.NoError(t, err)
 	fwRoot, err := s.fwState.Commit(s.blockNum, true /* EIP-158 */)
@@ -234,7 +276,6 @@ func (s *SUT) stateDBCommit(t *testing.T) {
 
 	s.fwState = mustNewStateDB(t, s.fwDB, s.lastRoot)
 	s.hashState = mustNewStateDB(t, s.hashDB, s.lastRoot)
-	s.finaliseTx() // Commit calls Finalise
 }
 
 func (s *SUT) diskCommit(t *testing.T) {
@@ -243,61 +284,123 @@ func (s *SUT) diskCommit(t *testing.T) {
 }
 
 func (s *SUT) copyStateDB() {
+	s.dropSnapshots()
 	s.fwState = s.fwState.Copy()
 	s.hashState = s.hashState.Copy()
 }
 
-// TODO(#5539): support [*state.StateDB.SelfDestruct]
 const (
-	opStateDBCommit    byte = iota // commit pending changes; root changes iff state changed
-	opDiskCommit                   // flush pending, then commit a clean StateDB; root must be unchanged
-	opCreateAccount                // deploy an account; resurrects a same-tx destructed account when one exists
-	opUpdateAccount                // increment nonce and balance of an existing account
-	opSelfDestruct6780             // SELFDESTRUCT (EIP-6780) an account; no-op unless created this tx
-	opFinalise                     // end the current transaction without computing a root
-	opSetStorage                   // write a new storage slot on an existing account
-	opDeleteStorage                // zero out an existing storage slot on an existing account
-	opIntermediateRoot             // verify all account and storage hashes match the model
-	opCopyStateDB                  // copies statedb for future ops
+	// Account ops.
+	opCreateAccount byte = iota // add a new account, or resurrect a self-destructed one
+	opUpdateAccount             // increment nonce and balance of an existing account
+	opDeleteAccount             // delete an existing account via [state.StateDB.SelfDestruct]
+	// Storage ops.
+	opSetStorage    // write a new storage slot on an existing account
+	opDeleteStorage // zero out an existing storage slot on an existing account
+	opGetStorage    // read a committed storage slot; must not mutate state
+	// Snapshot ops.
+	opSnapshot         // record a snapshot of both databases and the model
+	opRevertToSnapshot // revert both databases and the model to a recorded snapshot
+	// Lifecycle ops.
+	opIntermediateRoot // verify all account and storage hashes match the model
+	opStateDBCommit    // commit pending changes; root changes iff state changed
+	opDiskCommit       // flush pending, then commit a clean StateDB; root must be unchanged
+	opCopyStateDB      // copies statedb for future ops
 	maxOp
 )
 
 // FuzzStateDB compares the state root of an arbitrary sequence of operations on
 // a Firewood-backed [state.StateDB] against a reference HashDB.
 func FuzzStateDB(f *testing.F) {
-	f.Add([]byte{
-		opCreateAccount,
-		opStateDBCommit,
-	})
-	f.Add([]byte{
-		opCreateAccount,
-		opUpdateAccount,
-		opSetStorage,
-		opStateDBCommit,
-		opDiskCommit,
-	})
-	f.Add([]byte{
-		opCreateAccount,
-		opSetStorage,
-		opIntermediateRoot,
-		opDeleteStorage,
-		opStateDBCommit,
-	})
-	f.Add([]byte{opStateDBCommit, opDiskCommit})
-	f.Add([]byte{
-		opCreateAccount,
-		opFinalise,
-		opSelfDestruct6780,
-		opStateDBCommit,
-	})
-	f.Add([]byte{
-		opCreateAccount,
-		opSetStorage,
-		opSelfDestruct6780,
-		opCreateAccount, // resurrects the just-destructed account
-		opSetStorage,
-		opStateDBCommit,
-	})
+	seeds := []struct {
+		name string
+		ops  []byte
+	}{
+		{name: "create then commit", ops: []byte{opCreateAccount, opStateDBCommit}},
+		{
+			name: "update, store, then flush to disk",
+			ops:  []byte{opCreateAccount, opUpdateAccount, opSetStorage, opStateDBCommit, opDiskCommit},
+		},
+		{
+			name: "store, hash, delete storage, commit",
+			ops:  []byte{opCreateAccount, opSetStorage, opIntermediateRoot, opDeleteStorage, opStateDBCommit},
+		},
+		{
+			name: "create, commit, self-destruct, commit",
+			ops:  []byte{opCreateAccount, opStateDBCommit, opDeleteAccount, opStateDBCommit},
+		},
+		{name: "empty commits", ops: []byte{opStateDBCommit, opDiskCommit}},
+		{
+			// The destructed account is prefix-deleted at the intervening
+			// commit, so the recreated account starts with empty storage.
+			name: "recreate in a later block than the self-destruct",
+			ops: []byte{
+				opCreateAccount, opSetStorage, opStateDBCommit,
+				opDeleteAccount, opStateDBCommit,
+				opCreateAccount, opSetStorage, opStateDBCommit,
+			},
+		},
+		{
+			// The account's prior storage must not leak into the recreated
+			// account's state.
+			name: "recreate in the same block as the self-destruct",
+			ops: []byte{
+				opCreateAccount, opSetStorage, opStateDBCommit,
+				opDeleteAccount, opCreateAccount, opStateDBCommit,
+			},
+		},
+		{
+			// The prior incarnation's storage was never committed: it exists
+			// only in the trie's pending update operations, and the copy resets
+			// the trie's reader to the pre-block state.
+			name: "same-block recreate with uncommitted prior storage, after a copy",
+			ops: []byte{
+				opCreateAccount, opSetStorage, opIntermediateRoot,
+				opCopyStateDB,
+				opDeleteAccount, opCreateAccount,
+			},
+		},
+		{
+			// Reading a never-written slot opens a storage trie with no
+			// subsequent account write; the read must not affect the root.
+			name: "read a never-written slot",
+			ops: []byte{
+				opCreateAccount, opStateDBCommit,
+				opGetStorage, opStateDBCommit,
+			},
+		},
+		{
+			// The committed root must equal the pre-block root.
+			name: "fully reverted self-destruct and recreation",
+			ops: []byte{
+				opCreateAccount, opSetStorage, opStateDBCommit,
+				opSnapshot,
+				opDeleteAccount, opCreateAccount,
+				opRevertToSnapshot, opStateDBCommit,
+			},
+		},
+		{
+			name: "reverted self-destruct keeps the account and storage",
+			ops: []byte{
+				opCreateAccount, opSetStorage,
+				opSnapshot,
+				opDeleteAccount,
+				opRevertToSnapshot, opStateDBCommit,
+			},
+		},
+		{
+			name: "reverted self-destruct, recreation, and new storage",
+			ops: []byte{
+				opCreateAccount, opSetStorage, opStateDBCommit,
+				opSnapshot,
+				opDeleteAccount, opCreateAccount, opSetStorage,
+				opRevertToSnapshot, opStateDBCommit,
+			},
+		},
+	}
+	for _, seed := range seeds {
+		f.Add(seed.ops)
+	}
 
 	f.Fuzz(func(t *testing.T, steps []byte) {
 		sut := newSUT(t)
@@ -313,10 +416,10 @@ func FuzzStateDB(f *testing.F) {
 					t.Log("update account")
 					sut.updateAccount(param)
 				}
-			case opSelfDestruct6780:
+			case opDeleteAccount:
 				if len(sut.model.addrs) > 0 {
 					t.Log("delete account")
-					sut.selfDestruct6780(param)
+					sut.deleteAccount(param)
 				}
 			case opSetStorage:
 				if len(sut.model.addrs) > 0 {
@@ -328,9 +431,19 @@ func FuzzStateDB(f *testing.F) {
 					t.Log("delete storage")
 					sut.deleteStorage(param)
 				}
-			case opFinalise:
-				t.Log("finalise (end transaction)")
-				sut.finalise()
+			case opGetStorage:
+				if len(sut.model.addrs) > 0 {
+					t.Log("get storage")
+					sut.getStorage(param)
+				}
+			case opSnapshot:
+				t.Log("snapshot")
+				sut.snapshot()
+			case opRevertToSnapshot:
+				if len(sut.snapshots) > 0 {
+					t.Log("revert to snapshot")
+					sut.revertToSnapshot(param)
+				}
 			case opIntermediateRoot:
 				t.Log("intermediate root (end transaction)")
 				sut.intermediateRoot(t)

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
+	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 func mustNewStateDB(t *testing.T, db state.Database, root common.Hash) *state.StateDB {
@@ -43,6 +44,11 @@ type accountModel struct {
 type fuzzModel struct {
 	accounts map[common.Address]*accountModel
 	addrs    []common.Address // live addresses ordered by creation time
+
+	// Per-transaction tracking, reset at every transaction boundary
+	// see [SUT.finaliseTx])
+	createdThisTx    set.Set[common.Address]
+	destructedThisTx []common.Address // addresses destructed this tx, eligible for resurrection
 }
 
 func (m *fuzzModel) selectAddr(param byte) common.Address {
@@ -79,7 +85,8 @@ func newSUT(t *testing.T) *SUT {
 		hashState: hashState,
 		lastRoot:  root,
 		model: &fuzzModel{
-			accounts: make(map[common.Address]*accountModel),
+			accounts:      make(map[common.Address]*accountModel),
+			createdThisTx: set.NewSet[common.Address](0),
 		},
 	}
 }
@@ -90,17 +97,47 @@ func (s *SUT) nextHash() common.Hash {
 	return crypto.Keccak256Hash(binary.BigEndian.AppendUint64(nil, s.counter))
 }
 
-func (s *SUT) createAccount() {
-	addr := common.BytesToAddress(s.nextHash().Bytes())
-	if _, exists := s.model.accounts[addr]; exists {
-		return // address collision — skip rather than reset an existing account
+// createAccount creates an account, modelling an EVM contract deployment. When
+// an account has been destructed earlier in the current transaction, that
+// accound could be resurrected.
+func (s *SUT) createAccount(param byte) {
+	if len(s.model.destructedThisTx) > 0 && param&1 == 0 {
+		s.recreateAccount(param >> 1)
+		return
 	}
+
+	addr := common.BytesToAddress(s.nextHash().Bytes())
 	bal := uint256.NewInt(100)
 	s.model.accounts[addr] = &accountModel{
 		nonce:   1,
 		balance: bal.Clone(),
 	}
 	s.model.addrs = append(s.model.addrs, addr)
+	s.model.createdThisTx.Add(addr)
+
+	s.fwState.CreateAccount(addr)
+	s.fwState.SetNonce(addr, 1)
+	s.fwState.SetBalance(addr, bal)
+	s.hashState.CreateAccount(addr)
+	s.hashState.SetNonce(addr, 1)
+	s.hashState.SetBalance(addr, bal)
+}
+
+func (s *SUT) recreateAccount(param byte) {
+	i := int(param) % len(s.model.destructedThisTx)
+	addr := s.model.destructedThisTx[i]
+	// Swap with last element and truncate (order doesn't matter for correctness).
+	last := len(s.model.destructedThisTx) - 1
+	s.model.destructedThisTx[i] = s.model.destructedThisTx[last]
+	s.model.destructedThisTx = s.model.destructedThisTx[:last]
+
+	bal := uint256.NewInt(100)
+	s.model.accounts[addr] = &accountModel{
+		nonce:   1,
+		balance: bal.Clone(),
+	}
+	s.model.addrs = append(s.model.addrs, addr)
+	s.model.createdThisTx.Add(addr)
 
 	s.fwState.CreateAccount(addr)
 	s.fwState.SetNonce(addr, 1)
@@ -122,18 +159,30 @@ func (s *SUT) updateAccount(param byte) {
 	s.hashState.SetBalance(addr, acc.balance)
 }
 
-func (s *SUT) deleteAccount(param byte) {
+// selfDestruct6780 models the SELFDESTRUCT opcode under EIP-6780. The call is
+// always issued to the StateDB (it is a legal operation on any account), but it
+// only actually destructs the account — and so only updates the model — when the
+// account was created in the current transaction. On a pre-existing account it
+// is a no-op and the account remains live.
+func (s *SUT) selfDestruct6780(param byte) {
 	i := int(param) % len(s.model.addrs)
 	addr := s.model.addrs[i]
+
+	s.fwState.Selfdestruct6780(addr)
+	s.hashState.Selfdestruct6780(addr)
+
+	if !s.model.createdThisTx.Contains(addr) {
+		return // not created this tx: Selfdestruct6780 is a no-op
+	}
+
 	delete(s.model.accounts, addr)
+	s.model.createdThisTx.Remove(addr)
+	s.model.destructedThisTx = append(s.model.destructedThisTx, addr)
 
 	// Swap with last element and truncate (order doesn't matter for correctness).
 	last := len(s.model.addrs) - 1
 	s.model.addrs[i] = s.model.addrs[last]
 	s.model.addrs = s.model.addrs[:last]
-
-	s.fwState.SelfDestruct(addr)
-	s.hashState.SelfDestruct(addr)
 }
 
 func (s *SUT) setStorage(param byte) {
@@ -163,10 +212,26 @@ func (s *SUT) deleteStorage(param byte) {
 	s.hashState.SetState(addr, key, common.Hash{})
 }
 
+// finaliseTx resets the model's per-transaction tracking to mirror
+// [state.StateDB.Finalise].
+// Any accounts created this transaction can no longer be selfdestructed,
+// and any accounts destructed this transaction can no longer be resurrected.
+func (s *SUT) finaliseTx() {
+	s.model.createdThisTx.Clear()
+	s.model.destructedThisTx = s.model.destructedThisTx[:0]
+}
+
+func (s *SUT) finalise() {
+	s.fwState.Finalise(true /* EIP-158 */)
+	s.hashState.Finalise(true /* EIP-158 */)
+	s.finaliseTx()
+}
+
 func (s *SUT) intermediateRoot(t *testing.T) {
 	fwRoot := s.fwState.IntermediateRoot(true /* EIP-158 */)
 	hashRoot := s.hashState.IntermediateRoot(true /* EIP-158 */)
 	require.Equal(t, hashRoot, fwRoot, "root mismatch")
+	s.finaliseTx() // IntermediateRoot calls Finalise
 }
 
 func (s *SUT) stateDBCommit(t *testing.T) {
@@ -181,6 +246,7 @@ func (s *SUT) stateDBCommit(t *testing.T) {
 
 	s.fwState = mustNewStateDB(t, s.fwDB, s.lastRoot)
 	s.hashState = mustNewStateDB(t, s.hashDB, s.lastRoot)
+	s.finaliseTx() // Commit calls Finalise
 }
 
 func (s *SUT) diskCommit(t *testing.T) {
@@ -196,9 +262,10 @@ func (s *SUT) copyStateDB() {
 const (
 	opStateDBCommit    byte = iota // commit pending changes; root changes iff state changed
 	opDiskCommit                   // flush pending, then commit a clean StateDB; root must be unchanged
-	opCreateAccount                // add a new account with a deterministic address
+	opCreateAccount                // deploy an account; resurrects a same-tx destructed account when one exists
 	opUpdateAccount                // increment nonce and balance of an existing account
-	opDeleteAccount                // delete an existing account via [state.StateDB.SelfDestruct]
+	opSelfDestruct6780             // SELFDESTRUCT (EIP-6780) an account; no-op unless created this tx
+	opFinalise                     // end the current transaction without computing a root
 	opSetStorage                   // write a new storage slot on an existing account
 	opDeleteStorage                // zero out an existing storage slot on an existing account
 	opIntermediateRoot             // verify all account and storage hashes match the model
@@ -227,13 +294,21 @@ func FuzzStateDB(f *testing.F) {
 		opDeleteStorage,
 		opStateDBCommit,
 	})
+	f.Add([]byte{opStateDBCommit, opDiskCommit})
 	f.Add([]byte{
 		opCreateAccount,
-		opStateDBCommit,
-		opDeleteAccount,
+		opFinalise,
+		opSelfDestruct6780,
 		opStateDBCommit,
 	})
-	f.Add([]byte{opStateDBCommit, opDiskCommit})
+	f.Add([]byte{
+		opCreateAccount,
+		opSetStorage,
+		opSelfDestruct6780,
+		opCreateAccount, // resurrects the just-destructed account
+		opSetStorage,
+		opStateDBCommit,
+	})
 
 	f.Fuzz(func(t *testing.T, steps []byte) {
 		sut := newSUT(t)
@@ -241,24 +316,18 @@ func FuzzStateDB(f *testing.F) {
 			op := step % maxOp
 			param := step / maxOp
 			switch op {
-			case opStateDBCommit:
-				t.Log("state.StateDB.Commit()")
-				sut.stateDBCommit(t)
-			case opDiskCommit:
-				t.Log("triedb.Commit()")
-				sut.diskCommit(t)
 			case opCreateAccount:
 				t.Log("create account")
-				sut.createAccount()
+				sut.createAccount(param)
 			case opUpdateAccount:
 				if len(sut.model.addrs) > 0 {
 					t.Log("update account")
 					sut.updateAccount(param)
 				}
-			case opDeleteAccount:
+			case opSelfDestruct6780:
 				if len(sut.model.addrs) > 0 {
 					t.Log("delete account")
-					sut.deleteAccount(param)
+					sut.selfDestruct6780(param)
 				}
 			case opSetStorage:
 				if len(sut.model.addrs) > 0 {
@@ -270,9 +339,18 @@ func FuzzStateDB(f *testing.F) {
 					t.Log("delete storage")
 					sut.deleteStorage(param)
 				}
+			case opFinalise:
+				t.Log("finalise (end transaction)")
+				sut.finalise()
 			case opIntermediateRoot:
-				t.Log("intermediate root")
+				t.Log("intermediate root (end transaction)")
 				sut.intermediateRoot(t)
+			case opStateDBCommit:
+				t.Log("commit (end block)")
+				sut.stateDBCommit(t)
+			case opDiskCommit:
+				t.Log("disk commit (previous block)")
+				sut.diskCommit(t)
 			case opCopyStateDB:
 				t.Log("copy StateDB")
 				sut.copyStateDB()

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -25,6 +25,19 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 )
 
+func mustNewDB(t *testing.T) state.Database {
+	t.Helper()
+
+	cfg := DefaultConfig(t.TempDir(), loggingtest.New(t, logging.Debug))
+	db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{
+		DBOverride: cfg.BackendConstructor,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, db.TrieDB().Close(), "triedb.Close()")
+	})
+	return db
+}
+
 func mustNewStateDB(t *testing.T, db state.Database, root common.Hash) *state.StateDB {
 	t.Helper()
 
@@ -55,6 +68,14 @@ func (m *fuzzModel) selectAddr(param byte) common.Address {
 	return m.addrs[int(param)%len(m.addrs)]
 }
 
+// removeUnordered removes the element at index i by swapping in the last
+// element and truncating. Order is not preserved.
+func removeUnordered[T any](s []T, i int) []T {
+	last := len(s) - 1
+	s[i] = s[last]
+	return s[:last]
+}
+
 type SUT struct {
 	fwDB, hashDB       state.Database
 	fwState, hashState *state.StateDB
@@ -66,13 +87,7 @@ type SUT struct {
 }
 
 func newSUT(t *testing.T) *SUT {
-	cfg := DefaultConfig(t.TempDir(), loggingtest.New(t, logging.Debug))
-	fwDB := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{
-		DBOverride: cfg.BackendConstructor,
-	})
-	t.Cleanup(func() {
-		require.NoError(t, fwDB.TrieDB().Close(), "firewood triedb.Close()")
-	})
+	fwDB := mustNewDB(t)
 	hashDB := state.NewDatabase(rawdb.NewMemoryDatabase())
 
 	root := types.EmptyRootHash
@@ -101,35 +116,15 @@ func (s *SUT) nextHash() common.Hash {
 // an account has been destructed earlier in the current transaction, that
 // accound could be resurrected.
 func (s *SUT) createAccount(param byte) {
+	var addr common.Address
 	if len(s.model.destructedThisTx) > 0 && param&1 == 0 {
-		s.recreateAccount(param >> 1)
-		return
+		// choose a previously destructed account to resurrect.
+		i := int(param>>1) % len(s.model.destructedThisTx)
+		s.model.destructedThisTx = removeUnordered(s.model.destructedThisTx, i)
+		addr = s.model.destructedThisTx[i]
+	} else {
+		addr = common.BytesToAddress(s.nextHash().Bytes())
 	}
-
-	addr := common.BytesToAddress(s.nextHash().Bytes())
-	bal := uint256.NewInt(100)
-	s.model.accounts[addr] = &accountModel{
-		nonce:   1,
-		balance: bal.Clone(),
-	}
-	s.model.addrs = append(s.model.addrs, addr)
-	s.model.createdThisTx.Add(addr)
-
-	s.fwState.CreateAccount(addr)
-	s.fwState.SetNonce(addr, 1)
-	s.fwState.SetBalance(addr, bal)
-	s.hashState.CreateAccount(addr)
-	s.hashState.SetNonce(addr, 1)
-	s.hashState.SetBalance(addr, bal)
-}
-
-func (s *SUT) recreateAccount(param byte) {
-	i := int(param) % len(s.model.destructedThisTx)
-	addr := s.model.destructedThisTx[i]
-	// Swap with last element and truncate (order doesn't matter for correctness).
-	last := len(s.model.destructedThisTx) - 1
-	s.model.destructedThisTx[i] = s.model.destructedThisTx[last]
-	s.model.destructedThisTx = s.model.destructedThisTx[:last]
 
 	bal := uint256.NewInt(100)
 	s.model.accounts[addr] = &accountModel{
@@ -178,11 +173,7 @@ func (s *SUT) selfDestruct6780(param byte) {
 	delete(s.model.accounts, addr)
 	s.model.createdThisTx.Remove(addr)
 	s.model.destructedThisTx = append(s.model.destructedThisTx, addr)
-
-	// Swap with last element and truncate (order doesn't matter for correctness).
-	last := len(s.model.addrs) - 1
-	s.model.addrs[i] = s.model.addrs[last]
-	s.model.addrs = s.model.addrs[:last]
+	s.model.addrs = removeUnordered(s.model.addrs, i)
 }
 
 func (s *SUT) setStorage(param byte) {
@@ -203,10 +194,7 @@ func (s *SUT) deleteStorage(param byte) {
 	}
 	i := int(param) % len(storage)
 	key := storage[i]
-	// Swap with last element and truncate (order doesn't matter)
-	last := len(storage) - 1
-	storage[i] = storage[last]
-	s.model.accounts[addr].storage = storage[:last]
+	s.model.accounts[addr].storage = removeUnordered(storage, i)
 
 	s.fwState.SetState(addr, key, common.Hash{})
 	s.hashState.SetState(addr, key, common.Hash{})
@@ -259,6 +247,7 @@ func (s *SUT) copyStateDB() {
 	s.hashState = s.hashState.Copy()
 }
 
+// TODO(#5539): support [*state.StateDB.SelfDestruct]
 const (
 	opStateDBCommit    byte = iota // commit pending changes; root changes iff state changed
 	opDiskCommit                   // flush pending, then commit a clean StateDB; root must be unchanged
@@ -395,6 +384,49 @@ func TestGenesis(t *testing.T) {
 		require.True(t, tdb.Initialized(genesisRoot), "Genesis root should still be initialized in the database")
 		require.NoError(t, tdb.Close(), "triedb.Close()")
 	})
+}
+
+// TestMultipleTries verifies that the TrieDB is not informed any changes
+// unless [state.StateDB.Commit] is called.
+// TODO(#5506): This should be safe concurrently as well.
+func TestMultipleTries(t *testing.T) {
+	db := mustNewDB(t)
+
+	sdb1 := mustNewStateDB(t, db, types.EmptyRootHash)
+	sdb2 := mustNewStateDB(t, db, types.EmptyRootHash)
+	addr := common.BytesToAddress([]byte{1})
+	for i, sdb := range []*state.StateDB{sdb1, sdb2} {
+		sdb.CreateAccount(addr)
+		sdb.SetNonce(addr, 1)
+		sdb.SetBalance(addr, uint256.NewInt(uint64(i))) // different balance to force different root
+		_ = sdb.IntermediateRoot(true)                  // force proposal creation
+	}
+
+	// Only one can be committed, choose first
+	root1, err := sdb1.Commit(0, true)
+	require.NoError(t, err, "sdb1.Commit()")
+	require.NoErrorf(t, db.TrieDB().Commit(root1, false), "triedb.Commit(%s)", root1)
+}
+
+// TestMultipleProposals verifies that a single [triedb.Commit] call
+// chains the commit of dependent proposals.
+func TestMultipleProposals(t *testing.T) {
+	db := mustNewDB(t)
+
+	const numBlocks = 5
+	lastRoot := types.EmptyRootHash
+	for i := range numBlocks {
+		addr := common.BytesToAddress([]byte{byte(i)})
+		sdb := mustNewStateDB(t, db, lastRoot)
+		sdb.CreateAccount(addr)
+		sdb.SetNonce(addr, 1)
+		sdb.SetBalance(addr, uint256.NewInt(0))
+		root, err := sdb.Commit(uint64(i), true)
+		require.NoError(t, err, "sdb.Commit()")
+		lastRoot = root
+	}
+
+	require.NoErrorf(t, db.TrieDB().Commit(lastRoot, false), "triedb.Commit(%s)", lastRoot)
 }
 
 func TestInvalidConfig(t *testing.T) {

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -6,6 +6,7 @@ package firewood
 import (
 	"encoding/binary"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/ava-labs/libevm/common"
@@ -278,5 +279,69 @@ func TestGenesis(t *testing.T) {
 		})
 		require.True(t, tdb.Initialized(genesisRoot), "Genesis root should still be initialized in the database")
 		require.NoError(t, tdb.Close())
+	})
+}
+
+func TestInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     func(TrieDBConfig) TrieDBConfig
+		wantErr error
+	}{
+		{
+			name:    "valid config",
+			cfg:     func(cfg TrieDBConfig) TrieDBConfig { return cfg },
+			wantErr: nil,
+		},
+		{
+			name: "empty directory",
+			cfg: func(cfg TrieDBConfig) TrieDBConfig {
+				cfg.DatabaseDir = ""
+				return cfg
+			},
+			wantErr: errDatabaseDirNotProvided,
+		},
+		{
+			name: "file instead of directory",
+			cfg: func(cfg TrieDBConfig) TrieDBConfig {
+				file := t.TempDir() + "/file"
+				require.NoError(t, os.WriteFile(file, []byte("not a directory"), 0o600))
+				cfg.DatabaseDir = file
+				return cfg
+			},
+			wantErr: errNotDirectory,
+		},
+		{
+			name: "too few revisions",
+			cfg: func(cfg TrieDBConfig) TrieDBConfig {
+				cfg.RevisionsInMemory = 1
+				return cfg
+			},
+			wantErr: errTooFewRevisions,
+		},
+		{
+			name: "commit interval too big",
+			cfg: func(cfg TrieDBConfig) TrieDBConfig {
+				cfg.DeferredCommitInterval = 5
+				cfg.RevisionsInMemory = 5
+				return cfg
+			},
+			wantErr: errCommitIntervalTooBig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg(DefaultConfig(t.TempDir(), loggingtest.New(t, logging.Debug)))
+			_, err := New(cfg)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestNoLogger(t *testing.T) {
+	cfg := DefaultConfig(t.TempDir(), nil)
+	require.Panics(t, func() {
+		_, _ = New(cfg)
 	})
 }

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -1,0 +1,282 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"encoding/binary"
+	"math/big"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/params"
+	"github.com/ava-labs/libevm/triedb"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
+)
+
+func mustNewStateDB(t *testing.T, db state.Database, root common.Hash) *state.StateDB {
+	st, err := state.New(root, db, nil)
+	require.NoError(t, err)
+	return st
+}
+
+// accountModel is the in-memory reference for a single account.
+type accountModel struct {
+	nonce   uint64
+	balance *uint256.Int
+	storage []common.Hash // list of active keys
+}
+
+type fuzzModel struct {
+	accounts map[common.Address]*accountModel
+	addrs    []common.Address // live addresses ordered by creation time
+}
+
+func (m *fuzzModel) selectAddr(param byte) common.Address {
+	return m.addrs[int(param)%len(m.addrs)]
+}
+
+type SUT struct {
+	fwDB, hashDB       state.Database
+	fwState, hashState *state.StateDB
+
+	lastRoot common.Hash
+	blockNum uint64
+	counter  uint64 // drives deterministic address/key generation
+	model    *fuzzModel
+}
+
+func newSUT(t *testing.T) *SUT {
+	cfg := DefaultConfig(t.TempDir(), loggingtest.New(t, logging.Debug))
+	fwDB := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{
+		DBOverride: cfg.BackendConstructor,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, fwDB.TrieDB().Close())
+	})
+	hashDB := state.NewDatabase(rawdb.NewMemoryDatabase())
+
+	root := types.EmptyRootHash
+	fwState := mustNewStateDB(t, fwDB, root)
+	hashState := mustNewStateDB(t, hashDB, root)
+	return &SUT{
+		fwDB:      fwDB,
+		fwState:   fwState,
+		hashDB:    hashDB,
+		hashState: hashState,
+		lastRoot:  root,
+		model: &fuzzModel{
+			accounts: make(map[common.Address]*accountModel),
+		},
+	}
+}
+
+// nextHash generates a new deterministic hash by hashing the internal counter.
+func (s *SUT) nextHash() common.Hash {
+	s.counter++
+	return crypto.Keccak256Hash(binary.BigEndian.AppendUint64(nil, s.counter))
+}
+
+func (s *SUT) createAccount() {
+	addr := common.BytesToAddress(s.nextHash().Bytes())
+	if _, exists := s.model.accounts[addr]; exists {
+		return // address collision — skip rather than reset an existing account
+	}
+	bal := uint256.NewInt(100)
+	s.model.accounts[addr] = &accountModel{
+		nonce:   1,
+		balance: bal.Clone(),
+	}
+	s.model.addrs = append(s.model.addrs, addr)
+
+	s.fwState.CreateAccount(addr)
+	s.fwState.SetNonce(addr, 1)
+	s.fwState.SetBalance(addr, bal)
+	s.hashState.CreateAccount(addr)
+	s.hashState.SetNonce(addr, 1)
+	s.hashState.SetBalance(addr, bal)
+}
+
+func (s *SUT) updateAccount(param byte) {
+	addr := s.model.selectAddr(param)
+	acc := s.model.accounts[addr]
+	acc.nonce++
+	acc.balance = new(uint256.Int).Add(acc.balance, uint256.NewInt(1))
+
+	s.fwState.SetNonce(addr, acc.nonce)
+	s.fwState.SetBalance(addr, acc.balance)
+	s.hashState.SetNonce(addr, acc.nonce)
+	s.hashState.SetBalance(addr, acc.balance)
+}
+
+func (s *SUT) deleteAccount(param byte) {
+	i := int(param) % len(s.model.addrs)
+	addr := s.model.addrs[i]
+	delete(s.model.accounts, addr)
+
+	// Swap with last element and truncate (order doesn't matter for correctness).
+	last := len(s.model.addrs) - 1
+	s.model.addrs[i] = s.model.addrs[last]
+	s.model.addrs = s.model.addrs[:last]
+
+	s.fwState.SelfDestruct(addr)
+	s.hashState.SelfDestruct(addr)
+}
+
+func (s *SUT) setStorage(param byte) {
+	addr := s.model.selectAddr(param)
+	key := s.nextHash()
+	val := s.nextHash()
+	s.model.accounts[addr].storage = append(s.model.accounts[addr].storage, key)
+
+	s.fwState.SetState(addr, key, val)
+	s.hashState.SetState(addr, key, val)
+}
+
+func (s *SUT) deleteStorage(param byte) {
+	addr := s.model.selectAddr(param)
+	storage := s.model.accounts[addr].storage
+	if len(storage) == 0 {
+		return
+	}
+	i := int(param) % len(storage)
+	key := storage[i]
+	// Swap with last element and truncate (order doesn't matter)
+	last := len(storage) - 1
+	storage[i] = storage[last]
+	s.model.accounts[addr].storage = storage[:last]
+
+	s.fwState.SetState(addr, key, common.Hash{})
+	s.hashState.SetState(addr, key, common.Hash{})
+}
+
+func (s *SUT) intermediateRoot(t *testing.T) {
+	fwRoot := s.fwState.IntermediateRoot(true /* EIP-158 */)
+	hashRoot := s.hashState.IntermediateRoot(true /* EIP-158 */)
+	require.Equal(t, hashRoot, fwRoot, "root mismatch")
+}
+
+func (s *SUT) stateDBCommit(t *testing.T) {
+	hashRoot, err := s.hashState.Commit(s.blockNum, true /* EIP-158 */)
+	require.NoError(t, err)
+	fwRoot, err := s.fwState.Commit(s.blockNum, true /* EIP-158 */)
+	require.NoError(t, err)
+	require.Equal(t, hashRoot, fwRoot, "root mismatch after commit")
+
+	s.lastRoot = fwRoot
+	s.blockNum++
+
+	s.fwState = mustNewStateDB(t, s.fwDB, s.lastRoot)
+	s.hashState = mustNewStateDB(t, s.hashDB, s.lastRoot)
+}
+
+func (s *SUT) diskCommit(t *testing.T) {
+	require.NoError(t, s.fwDB.TrieDB().Commit(s.lastRoot, false))
+	require.NoError(t, s.hashDB.TrieDB().Commit(s.lastRoot, false))
+}
+
+const (
+	opStateDBCommit    byte = iota // commit pending changes; root changes iff state changed
+	opDiskCommit                   // flush pending, then commit a clean StateDB; root must be unchanged
+	opCreateAccount                // add a new account with a deterministic address
+	opUpdateAccount                // increment nonce and balance of an existing account
+	opDeleteAccount                // delete an existing account via [state.StateDB.SelfDestruct]
+	opSetStorage                   // write a new storage slot on an existing account
+	opDeleteStorage                // zero out an existing storage slot on an existing account
+	opIntermediateRoot             // verify all account and storage hashes match the model
+	maxOp
+)
+
+// FuzzStateDB compares the state root of an arbitrary sequence of operations on
+// a Firewood-backed [state.StateDB] against a reference HashDB.
+func FuzzStateDB(f *testing.F) {
+	f.Fuzz(func(t *testing.T, steps []byte) {
+		sut := newSUT(t)
+		for _, step := range steps {
+			op := step % maxOp
+			param := step / maxOp
+			switch op {
+			case opStateDBCommit:
+				t.Log("state.StateDB.Commit()")
+				sut.stateDBCommit(t)
+			case opDiskCommit:
+				t.Log("triedb.Commit()")
+				sut.diskCommit(t)
+			case opCreateAccount:
+				t.Log("create account")
+				sut.createAccount()
+			case opUpdateAccount:
+				t.Log("update account")
+				if len(sut.model.addrs) > 0 {
+					sut.updateAccount(param)
+				}
+			case opDeleteAccount:
+				t.Log("delete account")
+				if len(sut.model.addrs) > 0 {
+					sut.deleteAccount(param)
+				}
+			case opSetStorage:
+				t.Log("set storage")
+				if len(sut.model.addrs) > 0 {
+					sut.setStorage(param)
+				}
+			case opDeleteStorage:
+				t.Log("delete storage")
+				if len(sut.model.addrs) > 0 {
+					sut.deleteStorage(param)
+				}
+			case opIntermediateRoot:
+				t.Log("check hashes")
+				sut.intermediateRoot(t)
+			default:
+				t.Skip("invalid operation")
+			}
+		}
+		sut.intermediateRoot(t) // final flush to tries and verify all pending state
+		sut = nil               // allow garbage collection
+	})
+}
+
+func TestGenesis(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig(dir, loggingtest.New(t, logging.Debug))
+	memDB := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memDB, &triedb.Config{
+		DBOverride: cfg.BackendConstructor,
+	})
+
+	g := core.Genesis{
+		Config: params.MergedTestChainConfig,
+		Alloc: types.GenesisAlloc{
+			common.BytesToAddress([]byte{1}): {Balance: big.NewInt(100)},
+		},
+		Timestamp:  0,
+		Difficulty: big.NewInt(0), // irrelevant but required
+	}
+
+	genesisRoot := g.ToBlock().Root()
+	require.False(t, tdb.Initialized(genesisRoot), "Genesis root should not be initialized in the database")
+
+	_, _, err := core.SetupGenesisBlock(memDB, tdb, &g)
+	require.NoError(t, err)
+	require.True(t, tdb.Initialized(genesisRoot), "Genesis root should be initialized in the database after setup")
+	require.NoError(t, tdb.Close())
+
+	t.Run("recovery", func(t *testing.T) {
+		cfg.Log = loggingtest.New(t, logging.Debug)
+		tdb = triedb.NewDatabase(memDB, &triedb.Config{
+			DBOverride: cfg.BackendConstructor,
+		})
+		require.True(t, tdb.Initialized(genesisRoot), "Genesis root should still be initialized in the database")
+		require.NoError(t, tdb.Close())
+	})
+}

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -120,8 +120,8 @@ func (s *SUT) createAccount(param byte) {
 	if len(s.model.destructedThisTx) > 0 && param&1 == 0 {
 		// choose a previously destructed account to resurrect.
 		i := int(param>>1) % len(s.model.destructedThisTx)
-		s.model.destructedThisTx = removeUnordered(s.model.destructedThisTx, i)
 		addr = s.model.destructedThisTx[i]
+		s.model.destructedThisTx = removeUnordered(s.model.destructedThisTx, i)
 	} else {
 		addr = common.BytesToAddress(s.nextHash().Bytes())
 	}
@@ -398,7 +398,7 @@ func TestMultipleTries(t *testing.T) {
 	for i, sdb := range []*state.StateDB{sdb1, sdb2} {
 		sdb.CreateAccount(addr)
 		sdb.SetNonce(addr, 1)
-		sdb.SetBalance(addr, uint256.NewInt(uint64(i))) // different balance to force different root
+		sdb.SetBalance(addr, uint256.NewInt(uint64(i))) //#nosec G115 // different balance to force different root
 		_ = sdb.IntermediateRoot(true)                  // force proposal creation
 	}
 
@@ -421,7 +421,7 @@ func TestMultipleProposals(t *testing.T) {
 		sdb.CreateAccount(addr)
 		sdb.SetNonce(addr, 1)
 		sdb.SetBalance(addr, uint256.NewInt(0))
-		root, err := sdb.Commit(uint64(i), true)
+		root, err := sdb.Commit(uint64(i), true) //#nosec G115 // guaranteed to be positive
 		require.NoError(t, err, "sdb.Commit()")
 		lastRoot = root
 	}


### PR DESCRIPTION
 ## Why this should be merged

Firewood stores account and storage data in a flat keyspace. Under pre-EIP-6780 `SELFDESTRUCT` semantics, an account with existing storage can be self-destructed and recreated before commit. In that case, `StateDB` sees the account as live at commit time and does not call `DeleteAccount`. HashDB handles this through storage-root indirection, but Firewood must explicitly clear the old storage prefix to avoid stale slots leaking into the recreated account’s state root.

Post-EIP-6780, full deletion is limited to contracts created in the same transaction, so this is not an issue for Cancun and later execution -- we also know it's not an issue at least on the c-chain since genesis as we successfully bootstrapped with this bug present. This is required for L1s though... 

## How this works

The Firewood trie now detects recreated storage-empty accounts and emits a `PrefixDelete` before writing the new incarnation’s account or storage data. Stale storage is cleared either before the storage trie’s first mutation or in `UpdateAccount` when the recreated account has no storage writes.

The change also tracks pending storage operations across trie copies so uncommitted prior-incarnation storage is handled correctly.

## How this was tested

Expanded the Firewood fuzz harness with self-destruct/recreate, read-only storage access, copy, snapshot, and revert cases, including explicit same-block resurrection seeds.

## Need to be documented in RELEASES.md?

No.


_Claude helped me build this PR_