### PR TITLE
feat(saevm): add accepted worst-case gas throughput metric

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,7 @@
   - `avalanche_{vmName}_sae_execution_queue_gas_limit` (gauge): sum of the gas limits of accepted blocks that have not yet completed execution.
   - `avalanche_{vmName}_sae_executed_gas_charged_total` (counter): cumulative gas charged by executed blocks (transaction gas used plus end-of-block operation gas).
   - `avalanche_{vmName}_sae_executed_gas_limit_total` (counter): cumulative gas limit (worst-case gas) of executed blocks.
+- Added `avalanche_{vmName}_sae_accepted_worst_case_gas_total` (counter): cumulative gas limit (worst-case gas) of blocks accepted into the execution queue; the acceptance-side counterpart of `executed_gas_limit_total`.
 - Renamed Coreth and Subnet-EVM state-sync p2p metrics:
   - `avalanche_{vmName}_eth_net_tracked_peers` -> `avalanche_{vmName}_sdk_sync_peer_tracker_num_tracked_peers`
   - `avalanche_{vmName}_eth_net_responsive_peers` -> `avalanche_{vmName}_sdk_sync_peer_tracker_num_responsive_peers`

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,7 +12,7 @@
   - `avalanche_{vmName}_sae_execution_queue_gas_limit` (gauge): sum of the gas limits of accepted blocks that have not yet completed execution.
   - `avalanche_{vmName}_sae_executed_gas_charged_total` (counter): cumulative gas charged by executed blocks (transaction gas used plus end-of-block operation gas).
   - `avalanche_{vmName}_sae_executed_gas_limit_total` (counter): cumulative gas limit (worst-case gas) of executed blocks.
-- Added `avalanche_{vmName}_sae_accepted_worst_case_gas_total` (counter): cumulative gas limit (worst-case gas) of blocks accepted into the execution queue; the acceptance-side counterpart of `executed_gas_limit_total`.
+- Added `avalanche_{vmName}_sae_accepted_gas_limit_total` (counter): cumulative gas limit (worst-case gas) of blocks accepted into the execution queue; the acceptance-side counterpart of `executed_gas_limit_total`.
 - Renamed Coreth and Subnet-EVM state-sync p2p metrics:
   - `avalanche_{vmName}_eth_net_tracked_peers` -> `avalanche_{vmName}_sdk_sync_peer_tracker_num_tracked_peers`
   - `avalanche_{vmName}_eth_net_responsive_peers` -> `avalanche_{vmName}_sdk_sync_peer_tracker_num_responsive_peers`

--- a/vms/saevm/saexec/metrics.go
+++ b/vms/saevm/saexec/metrics.go
@@ -37,9 +37,9 @@ type metrics struct {
 	executedGasCharged prometheus.Counter
 	executedGasLimit   prometheus.Counter
 
-	// acceptedWorstCaseGas is the gas limit (worst-case gas) of blocks entering
+	// acceptedGasLimit is the gas limit (worst-case gas) of blocks entering
 	// the execution queue, the acceptance-side counterpart of executedGasLimit.
-	acceptedWorstCaseGas prometheus.Counter
+	acceptedGasLimit prometheus.Counter
 }
 
 func newMetrics(reg prometheus.Registerer, lastExecutedHeight uint64) (*metrics, error) {
@@ -74,8 +74,8 @@ func newMetrics(reg prometheus.Registerer, lastExecutedHeight uint64) (*metrics,
 			Name: "executed_gas_limit_total",
 			Help: "Cumulative gas limit (worst-case gas) of executed blocks.",
 		}),
-		acceptedWorstCaseGas: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "accepted_worst_case_gas_total",
+		acceptedGasLimit: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "accepted_gas_limit_total",
 			Help: "Cumulative gas limit (worst-case gas) of blocks accepted into the execution queue.",
 		}),
 	}
@@ -88,7 +88,7 @@ func newMetrics(reg prometheus.Registerer, lastExecutedHeight uint64) (*metrics,
 		reg.Register(m.executionQueueGasLimit),
 		reg.Register(m.executedGasCharged),
 		reg.Register(m.executedGasLimit),
-		reg.Register(m.acceptedWorstCaseGas),
+		reg.Register(m.acceptedGasLimit),
 	)
 }
 
@@ -105,7 +105,7 @@ func (m *metrics) observeExecuteDuration(d time.Duration) {
 func (m *metrics) markEnqueued(gasLimit uint64) {
 	m.executionQueueBlocks.Inc()
 	m.executionQueueGasLimit.Add(float64(gasLimit))
-	m.acceptedWorstCaseGas.Add(float64(gasLimit))
+	m.acceptedGasLimit.Add(float64(gasLimit))
 }
 
 // markExecuted records that the block at the given height, with the given gas

--- a/vms/saevm/saexec/metrics.go
+++ b/vms/saevm/saexec/metrics.go
@@ -36,6 +36,10 @@ type metrics struct {
 	// executedGasLimit is the gas limit (worst-case gas) of those same blocks.
 	executedGasCharged prometheus.Counter
 	executedGasLimit   prometheus.Counter
+
+	// acceptedWorstCaseGas is the gas limit (worst-case gas) of blocks counted
+	// at acceptance, the acceptance-side counterpart of executedGasLimit.
+	acceptedWorstCaseGas prometheus.Counter
 }
 
 func newMetrics(reg prometheus.Registerer, lastExecutedHeight uint64) (*metrics, error) {
@@ -70,6 +74,10 @@ func newMetrics(reg prometheus.Registerer, lastExecutedHeight uint64) (*metrics,
 			Name: "executed_gas_limit_total",
 			Help: "Cumulative gas limit (worst-case gas) of executed blocks.",
 		}),
+		acceptedWorstCaseGas: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "accepted_worst_case_gas_total",
+			Help: "Cumulative gas limit (worst-case gas) of blocks accepted into the execution queue.",
+		}),
 	}
 	m.lastExecutedHeight.Set(float64(lastExecutedHeight))
 	return m, errors.Join(
@@ -80,6 +88,7 @@ func newMetrics(reg prometheus.Registerer, lastExecutedHeight uint64) (*metrics,
 		reg.Register(m.executionQueueGasLimit),
 		reg.Register(m.executedGasCharged),
 		reg.Register(m.executedGasLimit),
+		reg.Register(m.acceptedWorstCaseGas),
 	)
 }
 
@@ -96,6 +105,7 @@ func (m *metrics) observeExecuteDuration(d time.Duration) {
 func (m *metrics) markEnqueued(gasLimit uint64) {
 	m.executionQueueBlocks.Inc()
 	m.executionQueueGasLimit.Add(float64(gasLimit))
+	m.acceptedWorstCaseGas.Add(float64(gasLimit))
 }
 
 // markExecuted records that the block at the given height, with the given gas

--- a/vms/saevm/saexec/metrics.go
+++ b/vms/saevm/saexec/metrics.go
@@ -37,8 +37,8 @@ type metrics struct {
 	executedGasCharged prometheus.Counter
 	executedGasLimit   prometheus.Counter
 
-	// acceptedWorstCaseGas is the gas limit (worst-case gas) of blocks counted
-	// at acceptance, the acceptance-side counterpart of executedGasLimit.
+	// acceptedWorstCaseGas is the gas limit (worst-case gas) of blocks entering
+	// the execution queue, the acceptance-side counterpart of executedGasLimit.
 	acceptedWorstCaseGas prometheus.Counter
 }
 


### PR DESCRIPTION
## Why this should be merged

Closes #5510 

## How this works

Adds `accepted_worst_case_gas_total` (counter) to `saexec`, incremented in `markEnqueued` with the block's header gas limit (worst-case gas) as it's accepted into the execution queue. It's the acceptance-side counterpart of `executed_gas_limit_total`.

While this metric seem useless at first brush, it's intended use is `rate(..._accepted_worst_case_gas_total[5m])` is which is the worst-case gas admission throughput; compared against `rate(..._executed_gas_limit_total[5m])` it shows whether execution keeps pace with acceptance. Unlike the `execution_queue_gas_limit` gauge, the counter captures throughput without aliasing between scrapes.

## How this was tested
  
Explicitly decided no tests. 

## Need to be documented in RELEASES.md?

Yes
