### PR TITLE
feat(sae): add in_memory_blocks gauge

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,7 @@
   - `avalanche_{vmName}_sae_execution_queue_gas_limit` (gauge): sum of the gas limits of accepted blocks that have not yet completed execution.
   - `avalanche_{vmName}_sae_executed_gas_charged_total` (counter): cumulative gas charged by executed blocks (transaction gas used plus end-of-block operation gas).
   - `avalanche_{vmName}_sae_executed_gas_limit_total` (counter): cumulative gas limit (worst-case gas) of executed blocks.
+- Added `avalanche_{vmName}_sae_in_memory_blocks` (gauge): number of SAE blocks still live in memory (created but not yet garbage collected).
 - Renamed Coreth and Subnet-EVM state-sync p2p metrics:
   - `avalanche_{vmName}_eth_net_tracked_peers` -> `avalanche_{vmName}_sdk_sync_peer_tracker_num_tracked_peers`
   - `avalanche_{vmName}_eth_net_responsive_peers` -> `avalanche_{vmName}_sdk_sync_peer_tracker_num_responsive_peers`

--- a/vms/saevm/sae/metrics.go
+++ b/vms/saevm/sae/metrics.go
@@ -22,16 +22,17 @@ func newMetrics(reg prometheus.Registerer) (*metrics, error) {
 			Help: "Height of the latest block that has settled.",
 		}),
 	}
+	// Sampled at scrape time rather than via a setter like lastSettledHeight:
+	// the count changes through GC finalizers, with no event to update on.
+	inMemoryBlocks := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "in_memory_blocks",
+		Help: "Number of SAE blocks still live in memory (created but not yet garbage collected).",
+	}, func() float64 {
+		return float64(blocks.InMemoryBlockCount())
+	})
 	return m, errors.Join(
 		reg.Register(m.lastSettledHeight),
-		// Sampled at scrape time rather than via a setter like lastSettledHeight:
-		// the count changes through GC finalizers, with no event to update on.
-		reg.Register(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Name: "in_memory_blocks",
-			Help: "Number of SAE blocks still live in memory (created but not yet garbage collected).",
-		}, func() float64 {
-			return float64(blocks.InMemoryBlockCount())
-		})),
+		reg.Register(inMemoryBlocks),
 	)
 }
 

--- a/vms/saevm/sae/metrics.go
+++ b/vms/saevm/sae/metrics.go
@@ -3,7 +3,13 @@
 
 package sae
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+)
 
 type metrics struct {
 	lastSettledHeight prometheus.Gauge
@@ -16,10 +22,17 @@ func newMetrics(reg prometheus.Registerer) (*metrics, error) {
 			Help: "Height of the latest block that has settled.",
 		}),
 	}
-	if err := reg.Register(m.lastSettledHeight); err != nil {
-		return nil, err
-	}
-	return m, nil
+	return m, errors.Join(
+		reg.Register(m.lastSettledHeight),
+		// Sampled at scrape time rather than via a setter like lastSettledHeight:
+		// the count changes through GC finalizers, with no event to update on.
+		reg.Register(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "in_memory_blocks",
+			Help: "Number of SAE blocks still live in memory (created but not yet garbage collected).",
+		}, func() float64 {
+			return float64(blocks.InMemoryBlockCount())
+		})),
+	)
 }
 
 func (m *metrics) markSettled(height uint64) {

--- a/vms/saevm/sae/metrics.go
+++ b/vms/saevm/sae/metrics.go
@@ -28,7 +28,7 @@ func newMetrics(reg prometheus.Registerer) (*metrics, error) {
 		prometheus.GaugeOpts{
 			Name: "in_memory_blocks",
 			Help: "Number of SAE blocks still live in memory (created but not yet garbage collected).",
-		}, 
+		},
 		func() float64 {
 			return float64(blocks.InMemoryBlockCount())
 		},

--- a/vms/saevm/sae/metrics.go
+++ b/vms/saevm/sae/metrics.go
@@ -24,12 +24,15 @@ func newMetrics(reg prometheus.Registerer) (*metrics, error) {
 	}
 	// Sampled at scrape time rather than via a setter like lastSettledHeight:
 	// the count changes through GC finalizers, with no event to update on.
-	inMemoryBlocks := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "in_memory_blocks",
-		Help: "Number of SAE blocks still live in memory (created but not yet garbage collected).",
-	}, func() float64 {
-		return float64(blocks.InMemoryBlockCount())
-	})
+	inMemoryBlocks := prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "in_memory_blocks",
+			Help: "Number of SAE blocks still live in memory (created but not yet garbage collected).",
+		}, 
+		func() float64 {
+			return float64(blocks.InMemoryBlockCount())
+		},
+	)
 	return m, errors.Join(
 		reg.Register(m.lastSettledHeight),
 		reg.Register(inMemoryBlocks),


### PR DESCRIPTION
## Why this should be merged

Closes #5512

## How this works

Adds `in_memory_blocks` (gauge) to the `sae` package, exposing `blocks.InMemoryBlockCount()` -- the number of SAE blocks constructed but not yet garbage collected. It answers "how many SAE blocks are still live in
memory?", giving operators a default signal for block retention and leak detection.


## How this was tested

Explicitly decided no tests. 

## Need to be documented in RELEASES.md?

Yes. 