### PR TITLE
External Chain Verifier implementation

### DIFF
--- a/graft/subnet-evm/plugin/evm/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "//graft/subnet-evm/precompile/precompileconfig",
         "//graft/subnet-evm/precompile/registry",
         "//graft/subnet-evm/warp",
+        "//graft/subnet-evm/warp/external",
         "//ids",
         "//network/p2p",
         "//network/p2p/acp118",

--- a/graft/subnet-evm/plugin/evm/extension/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/extension/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//graft/subnet-evm/plugin/evm/config",
         "//ids",
         "//network/p2p",
+        "//network/p2p/acp118",
         "//snow/consensus/snowman",
         "//snow/engine/common",
         "//snow/engine/snowman/block",

--- a/graft/subnet-evm/plugin/evm/extension/config.go
+++ b/graft/subnet-evm/plugin/evm/extension/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/config"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/p2p/acp118"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
@@ -148,6 +149,12 @@ type Config struct {
 	// Clock is the clock to use for time related operations.
 	// It's optional and can be nil
 	Clock *mockable.Clock
+	// ExternalChainVerifier, if non-nil, is composed with the existing warp
+	// backend to handle ACP-118 signature requests for events on external
+	// chains. It is routed messages whose payloads parse as ExternalMessage;
+	// all other messages continue to the existing warp backend unchanged.
+	// It's optional and can be nil.
+	ExternalChainVerifier acp118.Verifier
 }
 
 func (c *Config) Validate() error {

--- a/graft/subnet-evm/plugin/evm/vm.go
+++ b/graft/subnet-evm/plugin/evm/vm.go
@@ -66,6 +66,7 @@ import (
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/extension"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/precompileconfig"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/warp"
+	"github.com/ava-labs/avalanchego/graft/subnet-evm/warp/external"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/acp118"
@@ -491,10 +492,21 @@ func (vm *VM) Initialize(
 
 	go vm.ctx.Log.RecoverAndPanic(vm.startContinuousProfiler)
 
-	// Add p2p warp message warpHandler
+	// Native warp signature requests (ACP-118, handler ID 2).
 	warpHandler := acp118.NewCachedHandler(meteredCache, vm.warpBackend, vm.ctx.WarpSigner)
 	if err = vm.P2PNetwork().AddHandler(p2p.SignatureRequestHandlerID, warpHandler); err != nil {
 		return err
+	}
+
+	// External chain attestation signature requests (handler ID 4). Only
+	// registered when an ExternalChainVerifier is configured. Uses a separate
+	// handler ID so routing is structural rather than content-based, keeping
+	// the two protocols independent and each independently testable.
+	if vm.extensionConfig.ExternalChainVerifier != nil {
+		externalHandler := acp118.NewCachedHandler(meteredCache, vm.extensionConfig.ExternalChainVerifier, vm.ctx.WarpSigner)
+		if err = vm.P2PNetwork().AddHandler(external.SignatureRequestHandlerID, externalHandler); err != nil {
+			return err
+		}
 	}
 
 	vm.stateSyncDone = make(chan struct{})

--- a/graft/subnet-evm/warp/external/BUILD.bazel
+++ b/graft/subnet-evm/warp/external/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "graft_go_test")
+
+package(default_visibility = [
+    "//graft/subnet-evm:__subpackages__",
+    "//graft/subnet-evm:external_consumers",
+])
+
+go_library(
+    name = "external",
+    srcs = [
+        "codec.go",
+        "message.go",
+        "sidecar.go",
+        "verifier.go",
+    ],
+    importpath = "github.com/ava-labs/avalanchego/graft/subnet-evm/warp/external",
+    deps = [
+        "//codec",
+        "//codec/linearcodec",
+        "//ids",
+        "//network/p2p/acp118",
+        "//snow/engine/common",
+        "//utils/hashing",
+        "//utils/units",
+        "//vms/platformvm/warp",
+        "//vms/platformvm/warp/payload",
+    ],
+)
+
+graft_go_test(
+    name = "external_test",
+    srcs = ["verifier_test.go"],
+    deps = [
+        ":external",
+        "//ids",
+        "//vms/platformvm/warp",
+        "//vms/platformvm/warp/payload",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/graft/subnet-evm/warp/external/codec.go
+++ b/graft/subnet-evm/warp/external/codec.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package external
+
+import (
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/codec/linearcodec"
+	"github.com/ava-labs/avalanchego/utils/units"
+)
+
+const (
+	CodecVersion   = 0
+	MaxMessageSize = 24 * units.KiB
+)
+
+var Codec codec.Manager
+
+func init() {
+	Codec = codec.NewManager(MaxMessageSize)
+	lc := linearcodec.NewDefault()
+	if err := Codec.RegisterCodec(CodecVersion, lc); err != nil {
+		panic(err)
+	}
+}

--- a/graft/subnet-evm/warp/external/message.go
+++ b/graft/subnet-evm/warp/external/message.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package external
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/hashing"
+)
+
+// ExternalMessage is encoded as the inner payload of a warp AddressedCall for
+// external chain attestation messages. It represents the event being attested
+// to and is included in the signed output.
+//
+// Lookup hints needed to verify the event (e.g. a Solana transaction signature)
+// travel in the ACP-118 justification field and are never part of the signed
+// output.
+type ExternalMessage struct {
+	// identifies the external chain (e.g. "solana", "bitcoin").
+	SourceChainType string `serialize:"true" json:"sourceChainType"`
+
+	// SourceAddress is the program or contract address on the source chain that
+	// emitted the event. Must be present in the per-chain allowlist configured
+	// on each validator's ExternalChainVerifier.
+	SourceAddress string `serialize:"true" json:"sourceAddress"`
+
+	// DestContract is the 20-byte destination contract address on the L1.
+	DestContract []byte `serialize:"true" json:"destContract"`
+
+	// SourceBlockHeight is the block or slot number on the source chain at
+	// which the attested event occurred.
+	SourceBlockHeight uint64 `serialize:"true" json:"sourceBlockHeight"`
+
+	// Payload is the application-level data being transferred.
+	Payload []byte `serialize:"true" json:"payload"`
+
+	bytes []byte
+}
+
+// Bytes returns the canonical binary encoding of this message.
+func (m *ExternalMessage) Bytes() []byte {
+	return m.bytes
+}
+
+// MessageID returns a hash of the message bytes. It serves as the
+// replay-protection key in the on-chain ExternalChainAdapter.
+func (m *ExternalMessage) MessageID() ids.ID {
+	return hashing.ComputeHash256Array(m.bytes)
+}
+
+func (m *ExternalMessage) initialize(b []byte) {
+	m.bytes = b
+}
+
+// Q: Do I need netowrkID for message protection?
+// NewExternalMessage creates and initializes an ExternalMessage.
+func NewExternalMessage(
+	sourceChainType string,
+	sourceAddress string,
+	destContract []byte,
+	sourceBlockHeight uint64,
+	payload []byte,
+) (*ExternalMessage, error) {
+	msg := &ExternalMessage{
+		SourceChainType:   sourceChainType,
+		SourceAddress:     sourceAddress,
+		DestContract:      destContract,
+		SourceBlockHeight: sourceBlockHeight,
+		Payload:           payload,
+	}
+	b, err := Codec.Marshal(CodecVersion, msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ExternalMessage: %w", err)
+	}
+	msg.initialize(b)
+	return msg, nil
+}
+
+// ParseExternalMessage deserializes an ExternalMessage from its binary encoding.
+func ParseExternalMessage(b []byte) (*ExternalMessage, error) {
+	var msg ExternalMessage
+	if _, err := Codec.Unmarshal(b, &msg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ExternalMessage: %w", err)
+	}
+	msg.initialize(b)
+	return &msg, nil
+}

--- a/graft/subnet-evm/warp/external/sidecar.go
+++ b/graft/subnet-evm/warp/external/sidecar.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package external
+
+import "context"
+
+// ExternalEvent combines the signed message content with the relayer-supplied
+// justification. It is passed to the sidecar for verification.
+//
+// Message contains what is being attested to and will be signed.
+// Justification carries lookup hints (e.g. a Solana transaction signature or
+// slot number) that help the sidecar verify but are not part of the signed
+// output and are never seen by the on-chain adapter.
+type ExternalEvent struct {
+	Message       *ExternalMessage
+	Justification []byte
+}
+
+// SidecarClient is the interface the ExternalChainVerifier uses to delegate
+// verification decisions to the local sidecar process. The sidecar is
+// responsible for all chain-specific logic: connecting to external RPCs,
+// parsing chain-specific data formats, and applying the configured validation
+// rules.
+//
+// Verify returns nil if the event passes all configured validation rules, or a
+// non-nil error describing the first failure.
+type SidecarClient interface {
+	Verify(ctx context.Context, event *ExternalEvent) error
+}

--- a/graft/subnet-evm/warp/external/verifier.go
+++ b/graft/subnet-evm/warp/external/verifier.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package external
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/network/p2p/acp118"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
+)
+
+const (
+	ParseErrCode  int32 = 1
+	VerifyErrCode int32 = 2
+
+	// SignatureRequestHandlerID is the p2p handler ID for external chain
+	// attestation signature requests. It is distinct from
+	// p2p.SignatureRequestHandlerID (ACP-118, ID=2), which is reserved for
+	// native warp signature requests backed by local chain state. External chain
+	// requests require sidecar involvement and are a different protocol.
+	SignatureRequestHandlerID = 4
+)
+
+var _ acp118.Verifier = (*ExternalChainVerifier)(nil)
+
+// AllowedSources maps source chain type to the set of allowed source program
+// or contract addresses on that chain. An empty inner map means all source
+// addresses are permitted for that chain type. A missing key means the chain
+// type is not permitted at all.
+//
+// This allowlist is the Go-side equivalent of the address trust decision that
+// Nick's method provides automatically on EVM chains. Since non-EVM chains have
+// no canonical deployment address mechanism, operators must configure it
+// explicitly.
+// Q: I think we're gonna need this passed in as a config for the external
+// interop
+type AllowedSources map[string]map[string]struct{}
+
+// ExternalChainVerifier implements acp118.Verifier for external chain
+// attestation messages. It parses the ExternalMessage from the warp payload,
+// validates the source against the configured allowlist, then delegates the
+// actual chain verification to the local sidecar process.
+type ExternalChainVerifier struct {
+	sidecar        SidecarClient
+	allowedSources AllowedSources
+}
+
+// NewExternalChainVerifier constructs an ExternalChainVerifier.
+func NewExternalChainVerifier(sidecar SidecarClient, allowedSources AllowedSources) *ExternalChainVerifier {
+	return &ExternalChainVerifier{
+		sidecar:        sidecar,
+		allowedSources: allowedSources,
+	}
+}
+
+func (v *ExternalChainVerifier) Verify(
+	ctx context.Context,
+	unsignedMessage *avalancheWarp.UnsignedMessage,
+	justification []byte,
+) *common.AppError {
+	// Parse outer payload as AddressedCall. External messages use an empty
+	// SourceAddress since they are not emitted by an on-chain contract.
+	parsed, err := payload.Parse(unsignedMessage.Payload)
+	if err != nil {
+		return &common.AppError{
+			Code:    ParseErrCode,
+			Message: "failed to parse warp payload: " + err.Error(),
+		}
+	}
+	addressedCall, ok := parsed.(*payload.AddressedCall)
+	if !ok {
+		return &common.AppError{
+			Code:    ParseErrCode,
+			Message: fmt.Sprintf("expected AddressedCall payload, got %T", parsed),
+		}
+	}
+
+	msg, err := ParseExternalMessage(addressedCall.Payload)
+	if err != nil {
+		return &common.AppError{
+			Code:    ParseErrCode,
+			Message: "failed to parse ExternalMessage: " + err.Error(),
+		}
+	}
+
+	if appErr := v.checkAllowlist(msg); appErr != nil {
+		return appErr
+	}
+
+	if err := v.sidecar.Verify(ctx, &ExternalEvent{
+		Message:       msg,
+		Justification: justification,
+	}); err != nil {
+		return &common.AppError{
+			Code:    VerifyErrCode,
+			Message: "sidecar verification failed: " + err.Error(),
+		}
+	}
+
+	return nil
+}
+
+func (v *ExternalChainVerifier) checkAllowlist(msg *ExternalMessage) *common.AppError {
+	allowed, ok := v.allowedSources[msg.SourceChainType]
+	if !ok {
+		return &common.AppError{
+			Code:    VerifyErrCode,
+			Message: fmt.Sprintf("source chain type %q is not in the allowlist", msg.SourceChainType),
+		}
+	}
+	// Empty inner map means all source addresses are allowed for this chain type.
+	if len(allowed) == 0 {
+		return nil
+	}
+	if _, ok := allowed[msg.SourceAddress]; !ok {
+		return &common.AppError{
+			Code:    VerifyErrCode,
+			Message: fmt.Sprintf("source address %q on chain type %q is not in the allowlist", msg.SourceAddress, msg.SourceChainType),
+		}
+	}
+	return nil
+}

--- a/graft/subnet-evm/warp/external/verifier.go
+++ b/graft/subnet-evm/warp/external/verifier.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/ava-labs/avalanchego/network/p2p/acp118"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
-	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
+
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 )
 
 const (

--- a/graft/subnet-evm/warp/external/verifier_test.go
+++ b/graft/subnet-evm/warp/external/verifier_test.go
@@ -12,8 +12,9 @@ import (
 
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/warp/external"
 	"github.com/ava-labs/avalanchego/ids"
-	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
+
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 )
 
 // mockSidecarClient is a hand-rolled SidecarClient for testing.
@@ -44,18 +45,17 @@ func buildExternalWarpMessage(t *testing.T, msg *external.ExternalMessage) *aval
 	return warpMsg
 }
 
-func buildValidMessage(t *testing.T) (*external.ExternalMessage, *avalancheWarp.UnsignedMessage) {
+func buildValidMessage(t *testing.T) *avalancheWarp.UnsignedMessage {
 	t.Helper()
 	msg, err := external.NewExternalMessage(
 		testChainType,
 		testAddress,
-		[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
-			0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14},
+		make([]byte, 20),
 		42_000,
 		[]byte("hello from solana"),
 	)
 	require.NoError(t, err)
-	return msg, buildExternalWarpMessage(t, msg)
+	return buildExternalWarpMessage(t, msg)
 }
 
 // ExternalChainVerifier tests
@@ -68,7 +68,7 @@ func TestVerifier_InvalidOuterPayload(t *testing.T) {
 	warpMsg, err := avalancheWarp.NewUnsignedMessage(testNetworkID, testChainID, []byte("not a valid payload"))
 	require.NoError(t, err)
 
-	appErr := v.Verify(context.Background(), warpMsg, nil)
+	appErr := v.Verify(t.Context(), warpMsg, nil)
 	require.NotNil(t, appErr)
 	require.Equal(t, external.ParseErrCode, appErr.Code)
 }
@@ -83,7 +83,7 @@ func TestVerifier_NonAddressedCallPayload(t *testing.T) {
 	warpMsg, err := avalancheWarp.NewUnsignedMessage(testNetworkID, testChainID, hashPayload.Bytes())
 	require.NoError(t, err)
 
-	appErr := v.Verify(context.Background(), warpMsg, nil)
+	appErr := v.Verify(t.Context(), warpMsg, nil)
 	require.NotNil(t, appErr)
 	require.Equal(t, external.ParseErrCode, appErr.Code)
 }
@@ -98,7 +98,7 @@ func TestVerifier_NonExternalMessagePayload(t *testing.T) {
 	warpMsg, err := avalancheWarp.NewUnsignedMessage(testNetworkID, testChainID, ac.Bytes())
 	require.NoError(t, err)
 
-	appErr := v.Verify(context.Background(), warpMsg, nil)
+	appErr := v.Verify(t.Context(), warpMsg, nil)
 	require.NotNil(t, appErr)
 	require.Equal(t, external.ParseErrCode, appErr.Code)
 }
@@ -107,9 +107,9 @@ func TestVerifier_ChainTypeNotAllowed(t *testing.T) {
 	v := external.NewExternalChainVerifier(&mockSidecarClient{}, external.AllowedSources{
 		// "solana" is not registered.
 	})
-	_, warpMsg := buildValidMessage(t)
+	warpMsg := buildValidMessage(t)
 
-	appErr := v.Verify(context.Background(), warpMsg, nil)
+	appErr := v.Verify(t.Context(), warpMsg, nil)
 	require.NotNil(t, appErr)
 	require.Equal(t, external.VerifyErrCode, appErr.Code)
 }
@@ -120,9 +120,9 @@ func TestVerifier_SourceAddressNotAllowed(t *testing.T) {
 			"OtherProgram": {},
 		},
 	})
-	_, warpMsg := buildValidMessage(t)
+	warpMsg := buildValidMessage(t)
 
-	appErr := v.Verify(context.Background(), warpMsg, nil)
+	appErr := v.Verify(t.Context(), warpMsg, nil)
 	require.NotNil(t, appErr)
 	require.Equal(t, external.VerifyErrCode, appErr.Code)
 }
@@ -133,9 +133,9 @@ func TestVerifier_AllSourceAddressesAllowed(t *testing.T) {
 	v := external.NewExternalChainVerifier(sidecar, external.AllowedSources{
 		testChainType: {},
 	})
-	_, warpMsg := buildValidMessage(t)
+	warpMsg := buildValidMessage(t)
 
-	appErr := v.Verify(context.Background(), warpMsg, nil)
+	appErr := v.Verify(t.Context(), warpMsg, nil)
 	require.Nil(t, appErr)
 }
 
@@ -144,9 +144,9 @@ func TestVerifier_SidecarFails(t *testing.T) {
 	v := external.NewExternalChainVerifier(sidecar, external.AllowedSources{
 		testChainType: {testAddress: {}},
 	})
-	_, warpMsg := buildValidMessage(t)
+	warpMsg := buildValidMessage(t)
 
-	appErr := v.Verify(context.Background(), warpMsg, nil)
+	appErr := v.Verify(t.Context(), warpMsg, nil)
 	require.NotNil(t, appErr)
 	require.Equal(t, external.VerifyErrCode, appErr.Code)
 }
@@ -156,9 +156,9 @@ func TestVerifier_SidecarPasses(t *testing.T) {
 	v := external.NewExternalChainVerifier(sidecar, external.AllowedSources{
 		testChainType: {testAddress: {}},
 	})
-	_, warpMsg := buildValidMessage(t)
+	warpMsg := buildValidMessage(t)
 
-	appErr := v.Verify(context.Background(), warpMsg, nil)
+	appErr := v.Verify(t.Context(), warpMsg, nil)
 	require.Nil(t, appErr)
 }
 
@@ -168,10 +168,10 @@ func TestVerifier_JustificationPassedToSidecar(t *testing.T) {
 	v := external.NewExternalChainVerifier(sidecar, external.AllowedSources{
 		testChainType: {testAddress: {}},
 	})
-	_, warpMsg := buildValidMessage(t)
+	warpMsg := buildValidMessage(t)
 	justification := []byte("solana-tx-sig-abc123")
 
-	appErr := v.Verify(context.Background(), warpMsg, justification)
+	appErr := v.Verify(t.Context(), warpMsg, justification)
 	require.Nil(t, appErr)
 	require.NotNil(t, capturedEvent)
 	require.Equal(t, justification, capturedEvent.Justification)

--- a/graft/subnet-evm/warp/external/verifier_test.go
+++ b/graft/subnet-evm/warp/external/verifier_test.go
@@ -1,0 +1,188 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package external_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/graft/subnet-evm/warp/external"
+	"github.com/ava-labs/avalanchego/ids"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
+)
+
+// mockSidecarClient is a hand-rolled SidecarClient for testing.
+type mockSidecarClient struct {
+	err error
+}
+
+func (m *mockSidecarClient) Verify(_ context.Context, _ *external.ExternalEvent) error {
+	return m.err
+}
+
+// helpers
+
+const (
+	testNetworkID uint32 = 1
+	testChainType        = "solana"
+	testAddress          = "SomeProgram1111111111111111111111111111111111"
+)
+
+var testChainID = ids.GenerateTestID()
+
+func buildExternalWarpMessage(t *testing.T, msg *external.ExternalMessage) *avalancheWarp.UnsignedMessage {
+	t.Helper()
+	ac, err := payload.NewAddressedCall(nil, msg.Bytes())
+	require.NoError(t, err)
+	warpMsg, err := avalancheWarp.NewUnsignedMessage(testNetworkID, testChainID, ac.Bytes())
+	require.NoError(t, err)
+	return warpMsg
+}
+
+func buildValidMessage(t *testing.T) (*external.ExternalMessage, *avalancheWarp.UnsignedMessage) {
+	t.Helper()
+	msg, err := external.NewExternalMessage(
+		testChainType,
+		testAddress,
+		[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+			0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14},
+		42_000,
+		[]byte("hello from solana"),
+	)
+	require.NoError(t, err)
+	return msg, buildExternalWarpMessage(t, msg)
+}
+
+// ExternalChainVerifier tests
+
+func TestVerifier_InvalidOuterPayload(t *testing.T) {
+	v := external.NewExternalChainVerifier(&mockSidecarClient{}, external.AllowedSources{
+		testChainType: {},
+	})
+	// Payload bytes that cannot be parsed as any warp payload.
+	warpMsg, err := avalancheWarp.NewUnsignedMessage(testNetworkID, testChainID, []byte("not a valid payload"))
+	require.NoError(t, err)
+
+	appErr := v.Verify(context.Background(), warpMsg, nil)
+	require.NotNil(t, appErr)
+	require.Equal(t, external.ParseErrCode, appErr.Code)
+}
+
+func TestVerifier_NonAddressedCallPayload(t *testing.T) {
+	v := external.NewExternalChainVerifier(&mockSidecarClient{}, external.AllowedSources{
+		testChainType: {},
+	})
+	// Hash payload, not AddressedCall.
+	hashPayload, err := payload.NewHash(ids.GenerateTestID())
+	require.NoError(t, err)
+	warpMsg, err := avalancheWarp.NewUnsignedMessage(testNetworkID, testChainID, hashPayload.Bytes())
+	require.NoError(t, err)
+
+	appErr := v.Verify(context.Background(), warpMsg, nil)
+	require.NotNil(t, appErr)
+	require.Equal(t, external.ParseErrCode, appErr.Code)
+}
+
+func TestVerifier_NonExternalMessagePayload(t *testing.T) {
+	v := external.NewExternalChainVerifier(&mockSidecarClient{}, external.AllowedSources{
+		testChainType: {},
+	})
+	// AddressedCall with inner bytes that are not an ExternalMessage.
+	ac, err := payload.NewAddressedCall(nil, []byte("not an external message"))
+	require.NoError(t, err)
+	warpMsg, err := avalancheWarp.NewUnsignedMessage(testNetworkID, testChainID, ac.Bytes())
+	require.NoError(t, err)
+
+	appErr := v.Verify(context.Background(), warpMsg, nil)
+	require.NotNil(t, appErr)
+	require.Equal(t, external.ParseErrCode, appErr.Code)
+}
+
+func TestVerifier_ChainTypeNotAllowed(t *testing.T) {
+	v := external.NewExternalChainVerifier(&mockSidecarClient{}, external.AllowedSources{
+		// "solana" is not registered.
+	})
+	_, warpMsg := buildValidMessage(t)
+
+	appErr := v.Verify(context.Background(), warpMsg, nil)
+	require.NotNil(t, appErr)
+	require.Equal(t, external.VerifyErrCode, appErr.Code)
+}
+
+func TestVerifier_SourceAddressNotAllowed(t *testing.T) {
+	v := external.NewExternalChainVerifier(&mockSidecarClient{}, external.AllowedSources{
+		testChainType: {
+			"OtherProgram": {},
+		},
+	})
+	_, warpMsg := buildValidMessage(t)
+
+	appErr := v.Verify(context.Background(), warpMsg, nil)
+	require.NotNil(t, appErr)
+	require.Equal(t, external.VerifyErrCode, appErr.Code)
+}
+
+func TestVerifier_AllSourceAddressesAllowed(t *testing.T) {
+	// Empty inner map means all source addresses are permitted.
+	sidecar := &mockSidecarClient{}
+	v := external.NewExternalChainVerifier(sidecar, external.AllowedSources{
+		testChainType: {},
+	})
+	_, warpMsg := buildValidMessage(t)
+
+	appErr := v.Verify(context.Background(), warpMsg, nil)
+	require.Nil(t, appErr)
+}
+
+func TestVerifier_SidecarFails(t *testing.T) {
+	sidecar := &mockSidecarClient{err: errors.New("transaction not found")}
+	v := external.NewExternalChainVerifier(sidecar, external.AllowedSources{
+		testChainType: {testAddress: {}},
+	})
+	_, warpMsg := buildValidMessage(t)
+
+	appErr := v.Verify(context.Background(), warpMsg, nil)
+	require.NotNil(t, appErr)
+	require.Equal(t, external.VerifyErrCode, appErr.Code)
+}
+
+func TestVerifier_SidecarPasses(t *testing.T) {
+	sidecar := &mockSidecarClient{}
+	v := external.NewExternalChainVerifier(sidecar, external.AllowedSources{
+		testChainType: {testAddress: {}},
+	})
+	_, warpMsg := buildValidMessage(t)
+
+	appErr := v.Verify(context.Background(), warpMsg, nil)
+	require.Nil(t, appErr)
+}
+
+func TestVerifier_JustificationPassedToSidecar(t *testing.T) {
+	var capturedEvent *external.ExternalEvent
+	sidecar := &captureSidecarClient{capture: &capturedEvent}
+	v := external.NewExternalChainVerifier(sidecar, external.AllowedSources{
+		testChainType: {testAddress: {}},
+	})
+	_, warpMsg := buildValidMessage(t)
+	justification := []byte("solana-tx-sig-abc123")
+
+	appErr := v.Verify(context.Background(), warpMsg, justification)
+	require.Nil(t, appErr)
+	require.NotNil(t, capturedEvent)
+	require.Equal(t, justification, capturedEvent.Justification)
+}
+
+type captureSidecarClient struct {
+	capture **external.ExternalEvent
+}
+
+func (c *captureSidecarClient) Verify(_ context.Context, event *external.ExternalEvent) error {
+	*c.capture = event
+	return nil
+}
+

--- a/graft/subnet-evm/warp/external/verifier_test.go
+++ b/graft/subnet-evm/warp/external/verifier_test.go
@@ -185,4 +185,3 @@ func (c *captureSidecarClient) Verify(_ context.Context, event *external.Externa
 	*c.capture = event
 	return nil
 }
-


### PR DESCRIPTION
## Why this should be merged
This PR implements the `ExternalChainVerifier` extending `acp118.Verifier` and necessary types for the external interop sidecar project. It's the first of several PRs that together enable Avalanche L1 validators to attest to events on non-Avalanche chains (e.g. Solana) using their existing BLS keys and the ACP-118 signature protocol.

## How this works
**graft/subnet-evm/warp/external** package with four files:
- message.go: `ExternalMessage`, the struct that gets serialized into the warp payload and ultimately signed. Contains the source chain type, source address, destination contract, block height, and application payload. MessageID() is derived from its bytes and used by the on-chain adapter for replay protection.
- codec.go : `linearcodec` setup for `ExternalMessage` serialization, consistent with the existing warp codec pattern.
- sidecar.go: `ExternalEvent`(message + justification together) and the `SidecarClient` interface. The justification carries lookup hints like a Solana transaction signature that help the sidecar verify but are never part of the signed output.
- verifier.go: `ExternalChainVerifier `implementing `acp118.Verifier`. Parses the warp payload as an `AddressedCall` containing an `ExternalMessage`, validates the source chain type and address against a configured `AllowedSources` allowlist, then delegates to the `SidecarClient. Returns` typed AppError codes (ParseErrCode = 1, VerifyErrCode = 2) so callers can distinguish parse failures from verification failures.

**Modified files**:
- extension/config.go: adds optional `ExternalChainVerifieracp118.Verifier`field to `extension.Config`, the existing injection point for VM customization.
- vm.go: registers the `ExternalChainVerifier` as an `acp118.NewCachedHandler`at handler ID 4 (separate from the native warp handler at ID 2), so external chain signature requests don't touch the native warp path at all. Handler is only registered when the field is non-nil, so L1s that don't use external interop are unaffected.

## How this was tested
This PR includes a suite of unit tests that are currently all green, and the code compiles. Since this PR doesn't introduce a lot of business logic, or anything that depends on live data, the testing is constrained to the correctness of the functions and interfaces.

## Need to be documented in RELEASES.md?
Nope.