### PR TITLE
fix(saevm): reject C-Chain blocks with a non-zero version

### DIFF
--- a/graft/coreth/plugin/evm/customtypes/block_ext.go
+++ b/graft/coreth/plugin/evm/customtypes/block_ext.go
@@ -164,6 +164,11 @@ func BlockTime(eth *ethtypes.Header) time.Time {
 	return time.Unix(int64(eth.Time), 0)
 }
 
+// TODO(JonathanOppenheimer): take options instead of the positional
+// arguments, most of which are frequently nil/zero at call sites.
+//
+// Note: this code will get deleted but we may bring a simiar helper into
+// SAE.
 func NewBlockWithExtData(
 	header *ethtypes.Header, txs []*ethtypes.Transaction, uncles []*ethtypes.Header, receipts []*ethtypes.Receipt,
 	hasher ethtypes.TrieHasher, extdata []byte, recalc bool,

--- a/vms/saevm/cchain/cchaintest/blocks.go
+++ b/vms/saevm/cchain/cchaintest/blocks.go
@@ -30,6 +30,7 @@ type blockProperties struct {
 	ethTxs        []*types.Transaction
 	crossChainTxs []*tx.Tx
 	extDataHash   *common.Hash
+	version       uint32
 }
 
 // WithNumber sets the block's header number.
@@ -70,6 +71,15 @@ func WithMismatchedExtDataHash() BlockOption {
 	})
 }
 
+// WithBlockVersion sets the block's BlockBodyExtra Version. The default of 0 is
+// the only version accepted by the C-Chain ParseBlock; a non-zero value
+// simulates a block declaring an unsupported version.
+func WithBlockVersion(v uint32) BlockOption {
+	return options.Func[blockProperties](func(p *blockProperties) {
+		p.version = v
+	})
+}
+
 // NewTestBlock builds a [*types.Block] from the provided options. By default the
 // block has number 1, a zero parent hash, no Ethereum or cross-chain transactions,
 // and an ExtDataHash computed from its (empty) ExtData.
@@ -81,28 +91,27 @@ func NewTestBlock(tb testing.TB, opts ...BlockOption) *types.Block {
 	extData, err := tx.MarshalSlice(props.crossChainTxs)
 	require.NoErrorf(tb, err, "tx.MarshalSlice(%d txs)", len(props.crossChainTxs))
 
-	header := &types.Header{
-		ParentHash: props.parent,
-		Number:     new(big.Int).SetUint64(props.number),
-	}
-	setExtDataHash := true
+	// By default the header commits the ExtDataHash computed from the block's
+	// own ExtData; a caller-supplied hash overrides this to simulate tampering.
+	extDataHash := customtypes.CalcExtDataHash(extData)
 	if props.extDataHash != nil {
-		header = customtypes.WithHeaderExtra(
-			header,
-			&customtypes.HeaderExtra{ExtDataHash: *props.extDataHash},
-		)
-		setExtDataHash = false
+		extDataHash = *props.extDataHash
 	}
-
-	return customtypes.NewBlockWithExtData(
-		header,
-		props.ethTxs,
-		nil, // uncles
-		nil, // receipts
-		saetest.TrieHasher(),
-		extData,
-		setExtDataHash,
+	header := customtypes.WithHeaderExtra(
+		&types.Header{
+			ParentHash: props.parent,
+			Number:     new(big.Int).SetUint64(props.number),
+		},
+		&customtypes.HeaderExtra{ExtDataHash: extDataHash},
 	)
+
+	block := types.NewBlock(header, props.ethTxs, nil /* uncles */, nil /* receipts */, saetest.TrieHasher())
+	extDataCopy := slices.Clone(extData)
+	customtypes.SetBlockExtra(block, &customtypes.BlockBodyExtra{
+		Version: props.version,
+		ExtData: &extDataCopy,
+	})
+	return block
 }
 
 // NewBlock returns a block whose ExtData encodes txs and whose header is

--- a/vms/saevm/cchain/cchaintest/blocks.go
+++ b/vms/saevm/cchain/cchaintest/blocks.go
@@ -106,10 +106,9 @@ func NewTestBlock(tb testing.TB, opts ...BlockOption) *types.Block {
 	)
 
 	block := types.NewBlock(header, props.ethTxs, nil /* uncles */, nil /* receipts */, saetest.TrieHasher())
-	extDataCopy := slices.Clone(extData)
 	customtypes.SetBlockExtra(block, &customtypes.BlockBodyExtra{
 		Version: props.version,
-		ExtData: &extDataCopy,
+		ExtData: &extData,
 	})
 	return block
 }

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -198,17 +198,24 @@ func (vm *VM) Initialize(
 	return nil
 }
 
-// errExtDataHashMismatch is returned by [VM.ParseBlock] when a block's extData
-// does not hash to the ExtDataHash committed in its header.
-var errExtDataHashMismatch = errors.New("extData hash does not match header")
+var (
+	// errInvalidBlockVersion is returned by [VM.ParseBlock] when a block's
+	// BlockBodyExtra carries a Version other than 0, the only supported version.
+	errInvalidBlockVersion = errors.New("invalid block version")
+	// errExtDataHashMismatch is returned by [VM.ParseBlock] when a block's extData
+	// does not hash to the ExtDataHash committed in its header.
+	errExtDataHashMismatch = errors.New("extData hash does not match header")
+)
 
-// ParseBlock parses buf via the embedded SAE VM and additionally verifies that
-// the block's extData matches the ExtDataHash committed in the header.
+// ParseBlock parses buf via the embedded SAE VM and additionally performs the
+// C-Chain syntactic checks that the SAE VM is unaware of: that the block's
+// BlockBodyExtra Version is 0 (the only supported version) and that its extData
+// matches the ExtDataHash committed in the header.
 //
-// The block ID is the header hash, which commits ExtDataHash, so a block whose
-// extData body was tampered keeps the same ID. This override is the boundary
-// that rejects such blocks before they are accepted, persisted, or executed;
-// the SAE VM's own ParseBlock is unaware of the C-Chain extData concept.
+// The block ID is the header hash. The header neither hashes the body's Version
+// nor its extData bytes (it commits only ExtDataHash), so a block with a
+// tampered Version or extData keeps the same ID. This override is the boundary
+// that rejects such blocks before they are accepted, persisted, or executed.
 func (vm *VM) ParseBlock(ctx context.Context, buf []byte) (*blocks.Block, error) {
 	b, err := vm.VM.ParseBlock(ctx, buf)
 	if err != nil {
@@ -216,6 +223,10 @@ func (vm *VM) ParseBlock(ctx context.Context, buf []byte) (*blocks.Block, error)
 	}
 
 	eth := b.EthBlock()
+	if version := customtypes.BlockVersion(eth); version != 0 {
+		return nil, fmt.Errorf("%w: %d", errInvalidBlockVersion, version)
+	}
+
 	extData := customtypes.BlockExtData(eth)
 	// TODO: Handle pre-AP1 blocks, which incorrectly did not set ExtDataHash.
 	// This isn't needed prior to Helicon, but will be required to fully remove

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -789,8 +789,8 @@ func TestMinGasConsumptionFloor(t *testing.T) {
 }
 
 // TestParseBlock verifies that the cchain ParseBlock override accepts
-// well-formed blocks and rejects blocks whose extData does not match the
-// ExtDataHash committed in the header.
+// well-formed blocks and rejects blocks with an unsupported (non-zero) version
+// or whose extData does not match the ExtDataHash committed in the header.
 func TestParseBlock(t *testing.T) {
 	ctx, sut := newSUT(t)
 

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -815,6 +815,11 @@ func TestParseBlock(t *testing.T) {
 			block:   cchaintest.NewTamperedBlock(t, 1, common.Hash{}, tx1),
 			wantErr: errExtDataHashMismatch,
 		},
+		{
+			name:    "invalid_version",
+			block:   cchaintest.NewTestBlock(t, cchaintest.WithBlockVersion(1)),
+			wantErr: errInvalidBlockVersion,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

graft/coreth rejects blocks whose `BlockBodyExtra.Version` isn't `0` (the only supported version); SAE's C-Chain VM was missing this check. `Version` lives in the block body, not the header, so it isn't committed by the block ID. this means a peer can ship a bogus version under a valid, agreed-upon ID and consensus won't catch it. This PR carries that check over.

## How this works

Adds the version check to the C-Chain `ParseBlock` override in `vms/saevm/cchain/vm.go`. 

## How this was tested

Added an `invalid_version` case to `TestParseBlock`. 

## Need to be documented in RELEASES.md?

No