### PR TITLE
feat(sae): Store last accepted hash

### DIFF
--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -843,7 +843,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := bc.db.NewBatch()
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-
+	rawdb.WriteHeadFastBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 

--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -2192,6 +2192,7 @@ func (bc *BlockChain) ResetToStateSyncedBlock(block *types.Block) error {
 	}
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
+	rawdb.WriteHeadFastBlockHash(batch, block.Hash())
 	customrawdb.WriteSnapshotBlockHash(batch, block.Hash())
 	rawdb.WriteSnapshotRoot(batch, block.Root())
 	if err := customrawdb.WriteSyncPerformed(batch, block.NumberU64()); err != nil {

--- a/graft/coreth/core/genesis.go
+++ b/graft/coreth/core/genesis.go
@@ -399,6 +399,7 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
+	rawdb.WriteHeadFastBlockHash(batch, block.Hash())
 	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	rawdb.WriteChainConfig(batch, block.Hash(), config)
 	if err := batch.Write(); err != nil {

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -2231,6 +2231,7 @@ func (bc *BlockChain) ResetToStateSyncedBlock(block *types.Block) error {
 	}
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
+	rawdb.WriteHeadFastBlockHash(batch, block.Hash())
 	customrawdb.WriteSnapshotBlockHash(batch, block.Hash())
 	rawdb.WriteSnapshotRoot(batch, block.Root())
 	if err := customrawdb.WriteSyncPerformed(batch, block.NumberU64()); err != nil {

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -860,7 +860,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := bc.db.NewBatch()
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-
+	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 

--- a/graft/subnet-evm/core/genesis.go
+++ b/graft/subnet-evm/core/genesis.go
@@ -428,6 +428,7 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
+	rawdb.WriteHeadFastBlockHash(batch, block.Hash())
 	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	customrawdb.WriteChainConfig(batch, block.Hash(), config, params.GetExtra(config).UpgradeConfig)
 	if err := batch.Write(); err != nil {

--- a/vms/saevm/cchain/genesis.go
+++ b/vms/saevm/cchain/genesis.go
@@ -240,6 +240,7 @@ func writeGenesisBlock(db ethdb.Database, block *types.Block, config *ethparams.
 	rawdb.WriteFinalizedBlockHash(b, hash)
 	rawdb.WriteHeadBlockHash(b, hash)
 	rawdb.WriteHeadHeaderHash(b, hash)
+	rawdb.WriteHeadFastBlockHash(b, hash)
 	rawdb.WriteChainConfig(b, hash, config)
 	return b.Write()
 }

--- a/vms/saevm/docs/invariants.md
+++ b/vms/saevm/docs/invariants.md
@@ -31,15 +31,15 @@ While it also has a notion of a "safe" block (with reduced probability of re-org
 
 #### Mapping
 
-| SAE      | `rawdb`   |
-| -------- | --------- |
-| Accepted | Canonical |
-| Executed | Head      |
-| Settled  | Finalized |
+| SAE      | `rawdb`             |
+| -------- | ------------------- |
+| Accepted | Canonical, HeadFast |
+| Executed | Head                |
+| Settled  | Finalized           |
 
 #### Rationale
 
-* Accepted and canonical are effectively identical concepts, save for nuanced differences between the consensus mechanisms.
+* Accepted and canonical are effectively identical concepts, save for nuanced differences between the consensus mechanisms. `libevm`'s `HeadFast` denotes a recorded block whose state has not yet been executed; this aligns with SAE's definition of Accepted and is convenient for indexing the last-accepted block.
 
 * From an API perspective, we treat "latest" (i.e. the chain head) as the last-executed block.
 Mirroring this on disk allows for simple integration with the upstream API implementations.

--- a/vms/saevm/sae/consensus.go
+++ b/vms/saevm/sae/consensus.go
@@ -59,6 +59,7 @@ func (vm *VM) AcceptBlock(ctx context.Context, b *blocks.Block) error {
 		rawdb.WriteTxLookupEntriesByBlock(batch, b.EthBlock())
 		// D(b ∈ A)
 		rawdb.WriteCanonicalHash(batch, b.Hash(), b.NumberU64())
+		rawdb.WriteHeadFastBlockHash(batch, b.Hash())
 
 		if err := batch.Write(); err != nil {
 			return err

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -97,6 +97,12 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 func (rec *recovery) canonicalAfter(parent *blocks.Block) iter.Seq2[*blocks.Block, error] {
 	return func(yield func(*blocks.Block, error) bool) {
 		lastAcceptedHash := rawdb.ReadHeadFastBlockHash(rec.db)
+		if lastAcceptedHash == (common.Hash{}) {
+			// SAE writes this hash on [VM.AcceptBlock], so the set of accepted,
+			// asynchronous blocks MUST be empty.
+			return
+		}
+
 		for curr := parent; curr.Hash() != lastAcceptedHash; {
 			b, err := rec.newCanonicalBlock(curr.Height()+1, curr)
 			if !yield(b, err) || err != nil {

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"iter"
-	"math"
 	"sync/atomic"
 
 	"github.com/ava-labs/libevm/common"
@@ -96,15 +95,14 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 }
 
 func (rec *recovery) canonicalAfter(parent *blocks.Block) iter.Seq2[*blocks.Block, error] {
-	nums, _ := rawdb.ReadAllCanonicalHashes(rec.db, parent.NumberU64()+1, math.MaxUint64, math.MaxInt)
-
 	return func(yield func(*blocks.Block, error) bool) {
-		for _, num := range nums {
-			b, err := rec.newCanonicalBlock(num, parent)
+		lastAcceptedHash := rawdb.ReadHeadFastBlockHash(rec.db)
+		for curr := parent; curr.Hash() != lastAcceptedHash; {
+			b, err := rec.newCanonicalBlock(curr.Height()+1, curr)
 			if !yield(b, err) || err != nil {
 				return
 			}
-			parent = b
+			curr = b
 		}
 	}
 }

--- a/vms/saevm/sae/recovery_test.go
+++ b/vms/saevm/sae/recovery_test.go
@@ -138,6 +138,10 @@ func TestRecoverSimple(t *testing.T) {
 		archival  bool
 	}{
 		{
+			name:      "genesis",
+			numBlocks: 0,
+		},
+		{
 			name:      "archival",
 			numBlocks: 10,
 			archival:  true,


### PR DESCRIPTION
## Why this should be merged

It's very convenient to have the last accepted hash available! Specifically, it's simpler to support the `block.ChainVM.LastAccepted` call in the case where the entire network crashes and is starting back up, since the current implementation will not be able to properly initialize, as the last accepted block is only stored in memory on the VM. This won't be accessible if the node is state-syncing.

## How this works

`rawdb.WriteHeadFastBlockHash` is used for fastsync to know up to which block needs executed after the node finishes syncing. This is actually rather similar to the use case here, where we want to know the most recent block hash we know about, whether or not it's executed.

## How this was tested

The production diff is technically unnecessary, but does test it through the recovery logic!

## Need to be documented in RELEASES.md?

No
