### PR TITLE
[tmpnet] Temporarily disable collection checks

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -82,8 +82,9 @@ runs:
         TMPNET_START_METRICS_COLLECTOR: ${{ inputs.prometheus_username != '' }}
         # Skip local log collection when nodes are running in kube since collection will occur in-cluster.
         TMPNET_START_LOGS_COLLECTOR: ${{ inputs.loki_username != '' && inputs.runtime == 'process' }}
-        TMPNET_CHECK_METRICS_COLLECTED: ${{ inputs.prometheus_username != '' }}
-        TMPNET_CHECK_LOGS_COLLECTED: ${{ inputs.loki_username != '' }}
+        # TODO(marun) Re-enable when the appropriate secrets are once again available
+        # TMPNET_CHECK_METRICS_COLLECTED: ${{ inputs.prometheus_username != '' }}
+        # TMPNET_CHECK_LOGS_COLLECTED: ${{ inputs.loki_username != '' }}
         LOKI_URL: ${{ inputs.loki_url }}
         LOKI_PUSH_URL: ${{ inputs.loki_push_url }}
         LOKI_USERNAME: ${{ inputs.loki_username }}


### PR DESCRIPTION
## Why this should be merged

The run-monitored-tmpnet-cmd checks by default whether logs and metrics have been collected to insure against misconfiguration preventing collection. These checks have started failing, indicating a configuration issue. Rather than blocking merge until a fix, this change disables the checks and a subsequent change can re-enable once healthy.

#5546 will re-enable the checks.
