### PR TITLE
[tmpnet] Enable monitoring checks

### DIFF
--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -82,9 +82,8 @@ runs:
         TMPNET_START_METRICS_COLLECTOR: ${{ inputs.prometheus_username != '' }}
         # Skip local log collection when nodes are running in kube since collection will occur in-cluster.
         TMPNET_START_LOGS_COLLECTOR: ${{ inputs.loki_username != '' && inputs.runtime == 'process' }}
-        # TODO(marun) Re-enable when the appropriate secrets are once again available
-        # TMPNET_CHECK_METRICS_COLLECTED: ${{ inputs.prometheus_username != '' }}
-        # TMPNET_CHECK_LOGS_COLLECTED: ${{ inputs.loki_username != '' }}
+        TMPNET_CHECK_METRICS_COLLECTED: ${{ inputs.prometheus_username != '' }}
+        TMPNET_CHECK_LOGS_COLLECTED: ${{ inputs.loki_username != '' }}
         LOKI_URL: ${{ inputs.loki_url }}
         LOKI_PUSH_URL: ${{ inputs.loki_push_url }}
         LOKI_USERNAME: ${{ inputs.loki_username }}


### PR DESCRIPTION
## Why this should be merged

#5545 disabled collection checks pending resolution of the issue. Once this PR is passing CI, merging it will ensure that CI jobs are once again checking that collection of logs and metrics is being performed. 