### PR TITLE
feat(saevm): set a minimum atomic tx gas based on serialized size

### DIFF
--- a/vms/saevm/cchain/dynamic/target.go
+++ b/vms/saevm/cchain/dynamic/target.go
@@ -11,20 +11,20 @@ import "github.com/ava-labs/avalanchego/vms/components/gas"
 // https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/176-dynamic-evm-gas-limit-and-price-discovery-updates/README.md
 type TargetExponent uint64
 
-// InitialTargetExponent is the initial target exponent. Its target is the
-// 1,000,000 gas-per-second minimum.
+// InitialTargetExponent is the initial target exponent. Its target is
+// [MinTarget].
 const InitialTargetExponent TargetExponent = 0
+
+// MinTarget is the minimum target gas per second.
+const MinTarget = gas.Gas(1_000_000)
 
 // Target returns the target gas per second.
 //
-// Target = minimum * e^(t / conversionRate)
+// Target = [MinTarget] * e^(t / conversionRate)
 func (t TargetExponent) Target() gas.Gas {
-	const (
-		minimum        = 1_000_000 // gas
-		conversionRate = 1 << 25
-	)
+	const conversionRate = 1 << 25
 	return gas.Gas(gas.CalculatePrice(
-		minimum,
+		gas.Price(MinTarget),
 		gas.Gas(t),
 		conversionRate,
 	))

--- a/vms/saevm/cchain/dynamic/target.go
+++ b/vms/saevm/cchain/dynamic/target.go
@@ -16,7 +16,7 @@ type TargetExponent uint64
 const InitialTargetExponent TargetExponent = 0
 
 // MinTarget is the minimum target gas per second.
-const MinTarget = gas.Gas(1_000_000)
+const MinTarget = 1_000_000
 
 // Target returns the target gas per second.
 //
@@ -24,7 +24,7 @@ const MinTarget = gas.Gas(1_000_000)
 func (t TargetExponent) Target() gas.Gas {
 	const conversionRate = 1 << 25
 	return gas.Gas(gas.CalculatePrice(
-		gas.Price(MinTarget),
+		MinTarget,
 		gas.Gas(t),
 		conversionRate,
 	))

--- a/vms/saevm/cchain/dynamic/target.go
+++ b/vms/saevm/cchain/dynamic/target.go
@@ -11,12 +11,14 @@ import "github.com/ava-labs/avalanchego/vms/components/gas"
 // https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/176-dynamic-evm-gas-limit-and-price-discovery-updates/README.md
 type TargetExponent uint64
 
-// InitialTargetExponent is the initial target exponent. Its target is
-// [MinTarget].
-const InitialTargetExponent TargetExponent = 0
+const (
+	// InitialTargetExponent is the initial target exponent. Its target is
+	// [MinTarget].
+	InitialTargetExponent TargetExponent = 0
 
-// MinTarget is the minimum target gas per second.
-const MinTarget = 1_000_000
+	// MinTarget is the minimum target gas per second.
+	MinTarget = 1_000_000
+)
 
 // Target returns the target gas per second.
 //

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -518,7 +518,7 @@ type hookTx struct {
 	id     ids.ID
 	tx     *tx.Tx
 	inputs set.Set[ids.ID]
-	size   int
+	size   uint64
 	op     hook.Op
 }
 
@@ -535,7 +535,7 @@ func newHookTx(t *tx.Tx, avaxAssetID ids.ID) (*hookTx, error) {
 		id:     op.ID,
 		tx:     t,
 		inputs: t.InputIDs(),
-		size:   len(bytes),
+		size:   uint64(len(bytes)),
 		op:     op,
 	}, nil
 }
@@ -544,4 +544,4 @@ func (t *hookTx) AsOp() hook.Op { return t.op }
 
 // Size returns the transaction's serialized size, which is what it
 // contributes to the block's ExtData.
-func (t *hookTx) Size() int { return t.size }
+func (t *hookTx) Size() uint64 { return t.size }

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -542,4 +542,6 @@ func newHookTx(t *tx.Tx, avaxAssetID ids.ID) (*hookTx, error) {
 
 func (t *hookTx) AsOp() hook.Op { return t.op }
 
+// Size returns the transaction's serialized size, which is what it
+// contributes to the block's ExtData.
 func (t *hookTx) Size() int { return t.size }

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -518,6 +518,7 @@ type hookTx struct {
 	id     ids.ID
 	tx     *tx.Tx
 	inputs set.Set[ids.ID]
+	size   int
 	op     hook.Op
 }
 
@@ -526,12 +527,19 @@ func newHookTx(t *tx.Tx, avaxAssetID ids.ID) (*hookTx, error) {
 	if err != nil {
 		return nil, err
 	}
+	bytes, err := t.Bytes()
+	if err != nil {
+		return nil, err
+	}
 	return &hookTx{
 		id:     op.ID,
 		tx:     t,
 		inputs: t.InputIDs(),
+		size:   len(bytes),
 		op:     op,
 	}, nil
 }
 
 func (t *hookTx) AsOp() hook.Op { return t.op }
+
+func (t *hookTx) Size() int { return t.size }

--- a/vms/saevm/cchain/tx/BUILD.bazel
+++ b/vms/saevm/cchain/tx/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
     embed = [":tx"],
     deps = [
         "//chains/atomic",
+        "//codec",
         "//database/memdb",
         "//graft/coreth/core/extstate",
         "//graft/coreth/params/extras/extrastest",

--- a/vms/saevm/cchain/tx/codec.go
+++ b/vms/saevm/cchain/tx/codec.go
@@ -5,6 +5,7 @@ package tx
 
 import (
 	"errors"
+	"math"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
@@ -18,7 +19,10 @@ const codecVersion uint16 = 0
 var c codec.Manager
 
 func init() {
-	c = codec.NewDefaultManager()
+	// No codec size limit: it would bound the whole slice in
+	// [MarshalSlice] and [ParseSlice], not individual transactions.
+	// Block size limits bound the total instead.
+	c = codec.NewManager(math.MaxInt)
 
 	// Registration order impacts the typeID included in the canonical format.
 	// We skip registrations in specific locations so that UTXOs in shared

--- a/vms/saevm/cchain/tx/codec.go
+++ b/vms/saevm/cchain/tx/codec.go
@@ -19,9 +19,9 @@ const codecVersion uint16 = 0
 var c codec.Manager
 
 func init() {
-	// No codec size limit: it would bound the whole slice in
-	// [MarshalSlice] and [ParseSlice], not individual transactions.
-	// Block size limits bound the total instead.
+	// The codec marshals both individual transactions and transaction slices,
+	// so size is enforced by the p2p layer, mempool, and block builder rather
+	// than by the codec itself.
 	c = codec.NewManager(math.MaxInt)
 
 	// Registration order impacts the typeID included in the canonical format.

--- a/vms/saevm/cchain/tx/codec_test.go
+++ b/vms/saevm/cchain/tx/codec_test.go
@@ -273,6 +273,10 @@ func FuzzParseSliceCompatibility(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		_, oldErr := txtest.ParseOlds(data)
+		// The new codec intentionally has no size limit.
+		if errors.Is(oldErr, codec.ErrUnmarshalTooBig) {
+			t.Skip("input exceeds legacy codec size limit")
+		}
 		oldOk := oldErr == nil
 
 		_, newErr := ParseSlice(data)

--- a/vms/saevm/cchain/tx/codec_test.go
+++ b/vms/saevm/cchain/tx/codec_test.go
@@ -5,6 +5,7 @@ package tx_test
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/ava-labs/libevm/common"
@@ -16,6 +17,7 @@ import (
 	// Imported for [vm.VerifierBackend] comment resolution.
 	_ "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/vm"
 
+	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -139,6 +141,10 @@ func FuzzParseCompatibility(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, data []byte) {
 		_, oldErr := txtest.ParseOld(data)
+		// The new codec intentionally has no size limit.
+		if errors.Is(oldErr, codec.ErrUnmarshalTooBig) {
+			t.Skip("input exceeds legacy codec size limit")
+		}
 		oldOk := oldErr == nil
 
 		_, newErr := Parse(data)

--- a/vms/saevm/cchain/tx/tx.go
+++ b/vms/saevm/cchain/tx/tx.go
@@ -165,9 +165,9 @@ func (t *Tx) AsOp(avaxAssetID ids.ID) (hook.Op, error) {
 const (
 	// intrinsicGas is an initial static amount of gas that every [Tx] must pay.
 	intrinsicGas = ap5.AtomicTxIntrinsicGas
-	// gasPerByte is an additional amount of gas that is charged per-byte of an
+	// GasPerByte is an additional amount of gas that is charged per-byte of an
 	// [Unsigned] transaction.
-	gasPerByte = 1 // [atomic.TxBytesGas]
+	GasPerByte = 1 // [atomic.TxBytesGas]
 	// gasPerSig is an additional amount of gas that is charged per-signature
 	// included in a [Tx].
 	gasPerSig = gas.Gas(secp256k1fx.CostPerSignature)
@@ -180,7 +180,7 @@ func gasUsed(t Unsigned) (gas.Gas, error) {
 	if err != nil {
 		return 0, err
 	}
-	bytesGas, err := math.Mul(gas.Gas(numBytes), gasPerByte) //#nosec G115 -- Known non-negative
+	bytesGas, err := math.Mul(gas.Gas(numBytes), GasPerByte) //#nosec G115 -- Known non-negative
 	if err != nil {
 		return 0, err
 	}

--- a/vms/saevm/cchain/tx/txtest/legacy.go
+++ b/vms/saevm/cchain/tx/txtest/legacy.go
@@ -12,6 +12,7 @@ import (
 	// Imported for [vm.VerifierBackend] comment resolution.
 	_ "github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic/vm"
 
+	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/atomic"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
@@ -65,6 +66,10 @@ func ToOld(tb testing.TB, newTx *tx.Tx) *atomic.Tx {
 	require.NoErrorf(tb, err, "%T.Bytes()", newTx)
 
 	oldTx, err := ParseOld(bytes)
+	// The new C-chain codec no longer enforces a size limit.
+	if errors.Is(err, codec.ErrUnmarshalTooBig) {
+		tb.Skipf("tx exceeds legacy codec size limit: %s", err)
+	}
 	require.NoError(tb, err, "ParseOld()")
 	return oldTx
 }

--- a/vms/saevm/cchain/txpool/BUILD.bazel
+++ b/vms/saevm/cchain/txpool/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//utils/set",
         "//utils/setmap",
         "//vms/saevm/blocks",
+        "//vms/saevm/cchain/dynamic",
         "//vms/saevm/cchain/tx",
         "//vms/saevm/hook",
         "@com_github_ava_labs_libevm//core",

--- a/vms/saevm/cchain/txpool/txpool.go
+++ b/vms/saevm/cchain/txpool/txpool.go
@@ -174,6 +174,9 @@ var (
 	errInsufficientFee   = errors.New("insufficient fee")
 )
 
+// Each tx byte must cost at least one gas.
+const _ uint = tx.GasPerByte - 1
+
 // Add validates tx and inserts it into the pool.
 //
 // If tx conflicts with a transaction already in the pool, the lower-fee
@@ -195,6 +198,9 @@ func (p *Txpool) Add(tx *tx.Tx) error {
 	// every admitted tx stays includable. An unincludable tx never pays its
 	// fee, so an attacker could pin it with a free, arbitrarily high GasFeeCap
 	// and fill the pool.
+	//
+	// Since each tx byte costs at least one gas, this also caps tx size at
+	// MinTarget bytes, bounding the pool's memory.
 	if t.op.Gas > dynamic.MinTarget {
 		return fmt.Errorf("%w: %d > %d", errExcessGas, t.op.Gas, dynamic.MinTarget)
 	}

--- a/vms/saevm/cchain/txpool/txpool.go
+++ b/vms/saevm/cchain/txpool/txpool.go
@@ -191,16 +191,16 @@ func (p *Txpool) Add(tx *tx.Tx) error {
 		return err
 	}
 
-	// Cap gas at the minimum gas target so that an admitted tx remains
-	// includable no matter where the dynamic target sits; anything larger
-	// risks squatting in the pool until evicted by fee competition.
+	// Cap admitted-tx gas at MinTarget, the floor of the dynamic target, so
+	// every admitted tx stays includable. An unincludable tx never pays its
+	// fee, so an attacker could pin it with a free, arbitrarily high GasFeeCap
+	// and fill the pool.
 	if t.op.Gas > dynamic.MinTarget {
 		return fmt.Errorf("%w: %d > %d", errExcessGas, t.op.Gas, dynamic.MinTarget)
 	}
 
-	// TODO(JonathanOppenheimer): We should consider raising an atomic tx's
-	// gas to some minimum based on its serialized size, so that byte-heavy
-	// txs pay their "fair" share.
+	// TODO(JonathanOppenheimer): Consider raising the gas per byte of
+	// cross-chain txs so that byte-heavy txs pay their fair share.
 
 	// We must verify the tx against a state that is at least as high as the
 	// last block processed by the pool subscription.

--- a/vms/saevm/cchain/txpool/txpool.go
+++ b/vms/saevm/cchain/txpool/txpool.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/setmap"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/cchain/dynamic"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
@@ -167,6 +168,7 @@ var (
 	ErrAlreadyKnown = errors.New("transaction already in pool")
 
 	errSanityCheck       = errors.New("sanity check")
+	errExcessGas         = errors.New("gas exceeds minimum gas target")
 	errVerifyCredentials = errors.New("credential verification")
 	errVerifyState       = errors.New("state verification")
 	errInsufficientFee   = errors.New("insufficient fee")
@@ -189,7 +191,16 @@ func (p *Txpool) Add(tx *tx.Tx) error {
 		return err
 	}
 
-	// TODO:(StephenButtolph): Should we enforce a maximum gas amount here?
+	// Cap gas at the minimum gas target so that an admitted tx remains
+	// includable no matter where the dynamic target sits; anything larger
+	// risks squatting in the pool until evicted by fee competition.
+	if t.op.Gas > dynamic.MinTarget {
+		return fmt.Errorf("%w: %d > %d", errExcessGas, t.op.Gas, dynamic.MinTarget)
+	}
+
+	// TODO(JonathanOppenheimer): We should consider raising an atomic tx's
+	// gas to some minimum based on its serialized size, so that byte-heavy
+	// txs pay their "fair" share.
 
 	// We must verify the tx against a state that is at least as high as the
 	// last block processed by the pool subscription.

--- a/vms/saevm/cchain/txpool/txpool_test.go
+++ b/vms/saevm/cchain/txpool/txpool_test.go
@@ -326,6 +326,14 @@ func TestAdd(t *testing.T) {
 		missingCreds = newExport(t, []*secp256k1.PrivateKey{alice}, withCredentials(nil))
 	)
 
+	// Each single-sig input costs 1000 gas of signature verification alone, so
+	// 1000 of them exceed the 1M minimum gas target.
+	manySigKeys := make([]*secp256k1.PrivateKey, 1_000)
+	for i := range manySigKeys {
+		manySigKeys[i] = newKey(t)
+	}
+	manySigs := newExport(t, manySigKeys)
+
 	allKeys := []*secp256k1.PrivateKey{alice, bob, charles}
 	maxSizeTxs := make([]*tx.Tx, maxSize)
 	for i := range maxSizeTxs {
@@ -353,6 +361,11 @@ func TestAdd(t *testing.T) {
 			name:    "as_op_failure",
 			toAdd:   unmarshalable,
 			wantErr: errAsOp,
+		},
+		{
+			name:    "gas_over_minimum_target",
+			toAdd:   manySigs,
+			wantErr: errExcessGas,
 		},
 		{
 			name:    "verify_credentials_failure",

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -133,6 +133,7 @@ type BlockBuilder[T Transaction] interface {
 // [Op].
 type Transaction interface {
 	AsOp() Op
+	Size() int
 }
 
 // AccountDebit includes an amount that an account should have debited,

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -133,6 +133,8 @@ type BlockBuilder[T Transaction] interface {
 // [Op].
 type Transaction interface {
 	AsOp() Op
+	// Size returns the transaction's serialized size. It MUST be
+	// non-negative.
 	Size() int
 }
 

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -133,9 +133,8 @@ type BlockBuilder[T Transaction] interface {
 // [Op].
 type Transaction interface {
 	AsOp() Op
-	// Size returns the transaction's serialized size. It MUST be
-	// non-negative.
-	Size() int
+	// Size returns the transaction's serialized size.
+	Size() uint64
 }
 
 // AccountDebit includes an amount that an account should have debited,

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -306,6 +306,7 @@ func (o Op) Size() int {
 	o.CalculateCanotoCache()
 	return int(o.CachedCanotoSize())
 }
+
 // AsOp converts the op into a representation that SAE can use directly.
 func (o Op) AsOp() hook.Op {
 	hookOp := hook.Op{

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -301,6 +301,9 @@ type Op struct {
 	canotoData canotoData_Op
 }
 
+// Size returns the op's serialized size
+func (o Op) Size() int { return len(o.MarshalCanoto()) }
+
 // AsOp converts the op into a representation that SAE can use directly.
 func (o Op) AsOp() hook.Op {
 	hookOp := hook.Op{

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -302,9 +302,9 @@ type Op struct {
 }
 
 // Size returns the op's serialized size
-func (o Op) Size() int {
+func (o Op) Size() uint64 {
 	o.CalculateCanotoCache()
-	return int(o.CachedCanotoSize()) //#nosec G115 -- in-memory size fits in int
+	return o.CachedCanotoSize()
 }
 
 // AsOp converts the op into a representation that SAE can use directly.

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -302,8 +302,10 @@ type Op struct {
 }
 
 // Size returns the op's serialized size
-func (o Op) Size() int { return len(o.MarshalCanoto()) }
-
+func (o Op) Size() int {
+	o.CalculateCanotoCache()
+	return int(o.CachedCanotoSize())
+}
 // AsOp converts the op into a representation that SAE can use directly.
 func (o Op) AsOp() hook.Op {
 	hookOp := hook.Op{

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -304,7 +304,7 @@ type Op struct {
 // Size returns the op's serialized size
 func (o Op) Size() int {
 	o.CalculateCanotoCache()
-	return int(o.CachedCanotoSize())
+	return int(o.CachedCanotoSize()) //#nosec G115 -- in-memory size fits in int
 }
 
 // AsOp converts the op into a representation that SAE can use directly.

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -136,7 +136,7 @@ var (
 // and [blockBuilder.rebuild]. The block context MAY be nil.
 //
 // blockByteBudget caps the cumulative serialized size of included
-// transactions.
+// transactions and end-of-block ops.
 func (b *blockBuilderG[T]) buildWithTxs(
 	ctx context.Context,
 	bCtx *block.Context,
@@ -272,15 +272,15 @@ func (b *blockBuilderG[T]) buildWithTxs(
 			continue
 		}
 
-		// Skip transactions that would push the block body past its
-		// serialized-byte budget, even if mempool admission accepted more
-		// bytes than the gas-per-byte rule intends. The budget is shared with
-		// the end-of-block ops appended below.
+		// Skip transactions that would push the block past its serialized-byte
+		// budget, even if mempool admission accepted more bytes than the
+		// gas-per-byte rule intends. The budget is shared with the
+		// end-of-block ops appended below.
 		txBytes := tx.Size()
 		if includedBytes+txBytes > blockByteBudget {
 			txLog.Debug("Skipping transaction: block byte budget reached",
 				zap.Uint64("tx_bytes", txBytes),
-				zap.Uint64("included_body_bytes", includedBytes),
+				zap.Uint64("included_bytes", includedBytes),
 			)
 			continue
 		}
@@ -308,13 +308,13 @@ func (b *blockBuilderG[T]) buildWithTxs(
 			zap.Int("op_index", len(includedOps)),
 		)
 
-		// Ops are carried in the built block, so they consume the same body
-		// byte budget as the transactions included above.
+		// Ops are carried in the built block, so they consume the same byte
+		// budget as the transactions included above.
 		opBytes := uint64(tx.Size()) //#nosec G115 -- [hook.Transaction.Size] MUST be non-negative
 		if includedBytes+opBytes > blockByteBudget {
 			opLog.Debug("Skipping op: block byte budget reached",
 				zap.Uint64("op_bytes", opBytes),
-				zap.Uint64("included_body_bytes", includedBytes),
+				zap.Uint64("included_bytes", includedBytes),
 			)
 			continue
 		}

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -310,7 +310,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 
 		// Ops are carried in the built block, so they consume the same byte
 		// budget as the transactions included above.
-		opBytes := uint64(tx.Size()) //#nosec G115 -- [hook.Transaction.Size] MUST be non-negative
+		opBytes := tx.Size()
 		if includedBytes+opBytes > blockByteBudget {
 			opLog.Debug("Skipping op: block byte budget reached",
 				zap.Uint64("op_bytes", opBytes),

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -251,7 +251,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		candidates = pendingTxs(txpool.PendingFilter{
 			BaseFee: state.BaseFee(),
 		})
-		included          []*types.Transaction
+		included      []*types.Transaction
 		includedBytes uint64
 	)
 	for _, ltx := range candidates {
@@ -277,10 +277,10 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		// bytes than the gas-per-byte rule intends. The budget is shared with
 		// the end-of-block ops appended below.
 		txBytes := tx.Size()
-		if includedBodyBytes+txBytes > blockByteBudget {
+		if includedBytes+txBytes > blockByteBudget {
 			txLog.Debug("Skipping transaction: block byte budget reached",
 				zap.Uint64("tx_bytes", txBytes),
-				zap.Uint64("included_body_bytes", includedBodyBytes),
+				zap.Uint64("included_body_bytes", includedBytes),
 			)
 			continue
 		}
@@ -294,7 +294,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		}
 		txLog.Trace("Including transaction")
 		included = append(included, tx)
-		includedBodyBytes += txBytes
+		includedBytes += txBytes
 	}
 	var includedOps []T
 	for tx := range builder.PotentialEndOfBlockOps(ctx, hdr, lastSettled.Hash(), b.source) {
@@ -311,10 +311,10 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		// Ops are serialized into the block's ExtData, so they consume the
 		// same body byte budget as the EVM transactions included above.
 		opBytes := uint64(tx.Size()) //#nosec G115 -- size is a non-negative byte length
-		if includedBodyBytes+opBytes > blockByteBudget {
+		if includedBytes+opBytes > blockByteBudget {
 			opLog.Debug("Skipping op: block byte budget reached",
 				zap.Uint64("op_bytes", opBytes),
-				zap.Uint64("included_body_bytes", includedBodyBytes),
+				zap.Uint64("included_body_bytes", includedBytes),
 			)
 			continue
 		}
@@ -325,7 +325,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		}
 		opLog.Trace("Including op")
 		includedOps = append(includedOps, tx)
-		includedBodyBytes += opBytes
+		includedBytes += opBytes
 	}
 	hdr.GasUsed = state.GasUsed()
 

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -252,7 +252,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 			BaseFee: state.BaseFee(),
 		})
 		included          []*types.Transaction
-		includedBodyBytes uint64
+		includedBytes uint64
 	)
 	for _, ltx := range candidates {
 		// If we don't have enough gas remaining in the block for the minimum

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -308,9 +308,9 @@ func (b *blockBuilderG[T]) buildWithTxs(
 			zap.Int("op_index", len(includedOps)),
 		)
 
-		// Ops are serialized into the block's ExtData, so they consume the
-		// same body byte budget as the EVM transactions included above.
-		opBytes := uint64(tx.Size()) //#nosec G115 -- size is a non-negative byte length
+		// Ops are carried in the built block, so they consume the same body
+		// byte budget as the transactions included above.
+		opBytes := uint64(tx.Size()) //#nosec G115 -- [hook.Transaction.Size] MUST be non-negative
 		if includedBytes+opBytes > blockByteBudget {
 			opLog.Debug("Skipping op: block byte budget reached",
 				zap.Uint64("op_bytes", opBytes),

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -251,8 +251,8 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		candidates = pendingTxs(txpool.PendingFilter{
 			BaseFee: state.BaseFee(),
 		})
-		included        []*types.Transaction
-		includedTxBytes uint64
+		included          []*types.Transaction
+		includedBodyBytes uint64
 	)
 	for _, ltx := range candidates {
 		// If we don't have enough gas remaining in the block for the minimum
@@ -272,14 +272,15 @@ func (b *blockBuilderG[T]) buildWithTxs(
 			continue
 		}
 
-		// Skip transactions that would push the block's transactions past
-		// their serialized-byte budget, even if mempool admission accepted
-		// more bytes than the gas-per-byte rule intends.
+		// Skip transactions that would push the block body past its
+		// serialized-byte budget, even if mempool admission accepted more
+		// bytes than the gas-per-byte rule intends. The budget is shared with
+		// the end-of-block ops appended below.
 		txBytes := tx.Size()
-		if includedTxBytes+txBytes > blockByteBudget {
+		if includedBodyBytes+txBytes > blockByteBudget {
 			txLog.Debug("Skipping transaction: block byte budget reached",
 				zap.Uint64("tx_bytes", txBytes),
-				zap.Uint64("included_tx_bytes", includedTxBytes),
+				zap.Uint64("included_body_bytes", includedBodyBytes),
 			)
 			continue
 		}
@@ -293,7 +294,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		}
 		txLog.Trace("Including transaction")
 		included = append(included, tx)
-		includedTxBytes += txBytes
+		includedBodyBytes += txBytes
 	}
 	var includedOps []T
 	for tx := range builder.PotentialEndOfBlockOps(ctx, hdr, lastSettled.Hash(), b.source) {
@@ -307,12 +308,24 @@ func (b *blockBuilderG[T]) buildWithTxs(
 			zap.Int("op_index", len(includedOps)),
 		)
 
+		// Ops are serialized into the block's ExtData, so they consume the
+		// same body byte budget as the EVM transactions included above.
+		opBytes := uint64(tx.Size()) //#nosec G115 -- size is a non-negative byte length
+		if includedBodyBytes+opBytes > blockByteBudget {
+			opLog.Debug("Skipping op: block byte budget reached",
+				zap.Uint64("op_bytes", opBytes),
+				zap.Uint64("included_body_bytes", includedBodyBytes),
+			)
+			continue
+		}
+
 		if err := state.Apply(op); err != nil {
 			opLog.Debug("Could not apply op", zap.Error(err))
 			continue
 		}
 		opLog.Trace("Including op")
 		includedOps = append(includedOps, tx)
+		includedBodyBytes += opBytes
 	}
 	hdr.GasUsed = state.GasUsed()
 

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -458,8 +458,8 @@ func TestBuildBlockOpByteBackstop(t *testing.T) {
 	ops := []hookstest.Op{newOp(19_200), newOp(19_200), newOp(19_200), newOp(1)}
 
 	var (
-		big   = uint64(ops[0].Size())
-		small = uint64(ops[3].Size())
+		big   = uint64(ops[0].Size()) //#nosec G115 -- Known non-negative
+		small = uint64(ops[3].Size()) //#nosec G115 -- Known non-negative
 	)
 	require.LessOrEqual(t, 2*big+small, uint64(saeparams.TargetBlockBytes), "fixture: two big ops plus the small op must fit the byte budget")
 	require.Greater(t, 3*big, uint64(saeparams.TargetBlockBytes), "fixture: three big ops must exceed the byte budget")

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -461,8 +461,8 @@ func TestBuildBlockOpByteBackstop(t *testing.T) {
 		big   = ops[0].Size()
 		small = ops[3].Size()
 	)
-	require.LessOrEqual(t, 2*big+small, saeparams.TargetBlockBytes, "two big ops plus the small op must fit the byte budget")
-	require.Greater(t, 3*big, saeparams.TargetBlockBytes, "three big ops must exceed the byte budget")
+	require.LessOrEqual(t, 2*big+small, uint64(saeparams.TargetBlockBytes), "two big ops plus the small op must fit the byte budget")
+	require.Greater(t, 3*big, uint64(saeparams.TargetBlockBytes), "three big ops must exceed the byte budget")
 
 	ctx, sut := newSUT(t, 0, options.Func[sutConfig](func(c *sutConfig) {
 		c.hooks.Ops = ops

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -458,11 +458,11 @@ func TestBuildBlockOpByteBackstop(t *testing.T) {
 	ops := []hookstest.Op{newOp(19_200), newOp(19_200), newOp(19_200), newOp(1)}
 
 	var (
-		big   = uint64(ops[0].Size()) //#nosec G115 -- Known non-negative
-		small = uint64(ops[3].Size()) //#nosec G115 -- Known non-negative
+		big   = ops[0].Size()
+		small = ops[3].Size()
 	)
-	require.LessOrEqual(t, 2*big+small, uint64(saeparams.TargetBlockBytes), "fixture: two big ops plus the small op must fit the byte budget")
-	require.Greater(t, 3*big, uint64(saeparams.TargetBlockBytes), "fixture: three big ops must exceed the byte budget")
+	require.LessOrEqual(t, 2*big+small, saeparams.TargetBlockBytes, "fixture: two big ops plus the small op must fit the byte budget")
+	require.Greater(t, 3*big, saeparams.TargetBlockBytes, "fixture: three big ops must exceed the byte budget")
 
 	ctx, sut := newSUT(t, 0, options.Func[sutConfig](func(c *sutConfig) {
 		c.hooks.Ops = ops

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -11,6 +11,7 @@ import (
 	"math/rand/v2"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -438,6 +439,44 @@ func TestBuildBlockByteBackstop(t *testing.T) {
 	for i, tx := range builtTxs {
 		require.Equalf(t, heavyTxs[i].Hash(), tx.Hash(), "built.Transactions()[%d].Hash()", i)
 	}
+}
+
+func TestBuildBlockOpByteBackstop(t *testing.T) {
+	newOp := func(mints int) hookstest.Op {
+		return hookstest.Op{
+			ID:        ids.GenerateTestID(),
+			Gas:       1_000,
+			GasFeeCap: *uint256.NewInt(params.Wei),
+			Mint: slices.Repeat([]hookstest.AccountCredit{{
+				Address: common.Address{1},
+				Amount:  *uint256.NewInt(1),
+			}}, mints),
+		}
+	}
+	// Three big ops of which only two fit the byte budget, followed by a
+	// small op that fits in the space left after the third is skipped.
+	ops := []hookstest.Op{newOp(19_200), newOp(19_200), newOp(19_200), newOp(1)}
+
+	var (
+		big   = uint64(ops[0].Size())
+		small = uint64(ops[3].Size())
+	)
+	require.LessOrEqual(t, 2*big+small, uint64(saeparams.TargetBlockBytes), "fixture: two big ops plus the small op must fit the byte budget")
+	require.Greater(t, 3*big, uint64(saeparams.TargetBlockBytes), "fixture: three big ops must exceed the byte budget")
+
+	ctx, sut := newSUT(t, 0, options.Func[sutConfig](func(c *sutConfig) {
+		c.hooks.Ops = ops
+	}))
+
+	built, err := sut.rawVM.blockBuilder.build(ctx, nil, sut.genesis)
+	require.NoError(t, err, "blockBuilder.build()")
+
+	// The third op is too big and gets skipped, but one skip shouldn't stop
+	// inclusion. The smaller op after it still fits, so it's included.
+	want := []hook.Op{ops[0].AsOp(), ops[1].AsOp(), ops[3].AsOp()}
+	got, err := sut.hooks.EndOfBlockOps(built.EthBlock())
+	require.NoErrorf(t, err, "%T.EndOfBlockOps()", sut.hooks)
+	require.Equal(t, want, got, "ops included in block")
 }
 
 func TestVerifyBlockSizeLimit(t *testing.T) {

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -461,8 +461,8 @@ func TestBuildBlockOpByteBackstop(t *testing.T) {
 		big   = ops[0].Size()
 		small = ops[3].Size()
 	)
-	require.LessOrEqual(t, 2*big+small, saeparams.TargetBlockBytes, "fixture: two big ops plus the small op must fit the byte budget")
-	require.Greater(t, 3*big, saeparams.TargetBlockBytes, "fixture: three big ops must exceed the byte budget")
+	require.LessOrEqual(t, 2*big+small, saeparams.TargetBlockBytes, "two big ops plus the small op must fit the byte budget")
+	require.Greater(t, 3*big, saeparams.TargetBlockBytes, "three big ops must exceed the byte budget")
 
 	ctx, sut := newSUT(t, 0, options.Func[sutConfig](func(c *sutConfig) {
 		c.hooks.Ops = ops


### PR DESCRIPTION
## Why this should be merged

Closes #5468

Atomic txs live in a block's `ExtData`, which the block builder's byte budget didn't count, so a block full of byte-heavy atomic txs could exceed the max P2P message size and become ungossipable.

## How this works

For admission into the atomic mempool:

- Gas must be <= the minimum gas target (1M gas), so an admitted tx stays includable no matter where the dynamic target sits.
- Byte size needs no check: the atomic tx codec already rejects anything over 256 KiB, which a compile-time assertion pins under the target block size.

During block building:

- Account for atomic tx size by adding a Size function to the SAE  Transaction interface, and count ops against the same byte budget as the EVM transactions.

I added a TODO to consider pricing atomic tx gas by serialized size.

## How this was tested

- `TestBuildBlockOpByteBackstop`: ops that exceed the byte budget are skipped without ending op inclusion.
- `TestAdd/gas_over_minimum_target`: a tx over the minimum gas target is rejected at admission.

## Need to be documented in RELEASES.md?

No