### PR TITLE
Make lint-all safe to execute

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -336,10 +336,14 @@ tasks:
   lint-all:
     desc: Runs all lint checks
     cmds:
-      # Phase 1: Read-only checks (safe to parallelize)
-      - task: _lint-readonly
-      # Phase 2: Tree-mutating checks (must be sequential to avoid
-      # git index and bazel server contention)
+      # Phase 1: Read-only checks that are safe to parallelize.
+      - task: _lint-readonly-parallel
+      # Phase 2: Read-only checks that must be serialized because
+      # some tools (e.g. golangci-lint) are not safe to run
+      # concurrently.
+      - task: _lint-readonly-serial
+      # Phase 3: Tree-mutating checks must be sequential to avoid git
+      # index and bazel server contention.
       - task: check-yaml-fmt
       - task: check-go-mod-tidy
       - task: check-require-directives-round-trip
@@ -349,15 +353,21 @@ tasks:
     desc: Runs gosec with G115 enabled on vms/saevm
     cmd: '{{.NIX_RUN}} ./scripts/run_tool.sh golangci-lint run --config .gosec-golangci.yml ./vms/saevm/...'
 
-  _lint-readonly:
+  _lint-readonly-parallel:
     internal: true
     deps:
-      - lint
-      - lint-saevm
       - lint-action
       - lint-shell
       - check-go-version
       - check-require-directives
+
+  _lint-readonly-serial:
+    internal: true
+    cmds:
+      # lint and lint-saevm both invoke golangci-lint which aborts on
+      # concurrent runs.
+      - task: lint
+      - task: lint-saevm
 
   lint-all-ci:
     desc: Runs all lint checks one-by-one

--- a/graft/coreth/Taskfile.yml
+++ b/graft/coreth/Taskfile.yml
@@ -91,14 +91,27 @@ tasks:
     cmd: '{{.NIX_RUN}} ../evm/scripts/lint.sh'
 
   lint-all:
-    desc: Runs all lint checks in parallel
+    desc: Runs all lint checks
+    cmds:
+      # Phase 1: Read-only checks that are safe to parallelize.
+      - task: _lint-readonly-parallel
+      # Phase 2: Tree-mutating checks must be sequential to avoid git
+      # index and bazel server contention.
+      - task: _lint-tree-mutating-serial
+
+  _lint-readonly-parallel:
+    internal: true
     deps:
       - lint
       - shellcheck
-      - check-generate-codec
-      - check-generate-mocks
-      - check-generate-rlp
-      - check-generate-bindings
+
+  _lint-tree-mutating-serial:
+    internal: true
+    cmds:
+      - task: check-generate-codec
+      - task: check-generate-mocks
+      - task: check-generate-rlp
+      - task: check-generate-bindings
 
   lint-all-ci:
     desc: Runs all lint checks one-by-one

--- a/graft/coreth/Taskfile.yml
+++ b/graft/coreth/Taskfile.yml
@@ -95,8 +95,8 @@ tasks:
     cmds:
       # Phase 1: Read-only checks that are safe to parallelize.
       - task: _lint-readonly-parallel
-      # Phase 2: Tree-mutating checks must be sequential to avoid git
-      # index and bazel server contention.
+      # Phase 2: Tree-mutating checks must be sequential to avoid races
+      # while rewriting generated files and verifying a clean git state.
       - task: _lint-tree-mutating-serial
 
   _lint-readonly-parallel:

--- a/graft/subnet-evm/Taskfile.yml
+++ b/graft/subnet-evm/Taskfile.yml
@@ -108,8 +108,8 @@ tasks:
     cmds:
       # Phase 1: Read-only checks that are safe to parallelize.
       - task: _lint-readonly-parallel
-      # Phase 2: Tree-mutating checks must be sequential to avoid git
-      # index and bazel server contention.
+      # Phase 2: Tree-mutating checks must be sequential to avoid races
+      # while rewriting generated files and verifying a clean git state.
       - task: _lint-tree-mutating-serial
 
   _lint-readonly-parallel:

--- a/graft/subnet-evm/Taskfile.yml
+++ b/graft/subnet-evm/Taskfile.yml
@@ -104,14 +104,27 @@ tasks:
     cmd: '{{.NIX_RUN}} ../evm/scripts/lint.sh'
 
   lint-all:
-    desc: Runs all lint checks in parallel
+    desc: Runs all lint checks
+    cmds:
+      # Phase 1: Read-only checks that are safe to parallelize.
+      - task: _lint-readonly-parallel
+      # Phase 2: Tree-mutating checks must be sequential to avoid git
+      # index and bazel server contention.
+      - task: _lint-tree-mutating-serial
+
+  _lint-readonly-parallel:
+    internal: true
     deps:
       - lint
       - shellcheck
-      - check-generate-codec
-      - check-generate-mocks
-      - check-generate-rlp
-      - check-generate-bindings
+
+  _lint-tree-mutating-serial:
+    internal: true
+    cmds:
+      - task: check-generate-codec
+      - task: check-generate-mocks
+      - task: check-generate-rlp
+      - task: check-generate-bindings
 
   lint-all-ci:
     desc: Runs all lint checks one-by-one


### PR DESCRIPTION
## Why this should be merged

Split lint-all into parallel and serial phases so unsafe combinations no longer run together. This avoids concurrent golangci-lint invocations and keeps tree-mutating checks serialized to prevent git index and bazel server contention.

## How this was tested

Manually verified local success. The `lint-all-ci` jobs run in CI but are intentionally serial to avoid overloading the runners. The `lint-all` jobs try to maximize parallelism for local development usage.
