### PR TITLE
Remove last synchronous from `NewVM`

### DIFF
--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -530,6 +530,7 @@ func (bc *BlockChain) batchBlockAcceptedIndices(batch ethdb.Batch, b *types.Bloc
 	if err := customrawdb.WriteAcceptorTip(batch, b.Hash()); err != nil {
 		return fmt.Errorf("%w: failed to write acceptor tip key", err)
 	}
+	rawdb.WriteFinalizedBlockHash(batch, b.Hash())
 	return nil
 }
 
@@ -842,7 +843,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := bc.db.NewBatch()
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
+
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 
@@ -2189,7 +2190,6 @@ func (bc *BlockChain) ResetToStateSyncedBlock(block *types.Block) error {
 	if err := bc.batchBlockAcceptedIndices(batch, block); err != nil {
 		return err
 	}
-	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 	customrawdb.WriteSnapshotBlockHash(batch, block.Hash())

--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -842,7 +842,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := bc.db.NewBatch()
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-
+	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 
@@ -2189,6 +2189,7 @@ func (bc *BlockChain) ResetToStateSyncedBlock(block *types.Block) error {
 	if err := bc.batchBlockAcceptedIndices(batch, block); err != nil {
 		return err
 	}
+	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 	customrawdb.WriteSnapshotBlockHash(batch, block.Hash())

--- a/graft/coreth/core/genesis.go
+++ b/graft/coreth/core/genesis.go
@@ -393,12 +393,17 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	if err := config.CheckConfigForkOrder(); err != nil {
 		return nil, err
 	}
-	rawdb.WriteBlock(db, block)
-	rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), nil)
-	rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadBlockHash(db, block.Hash())
-	rawdb.WriteHeadHeaderHash(db, block.Hash())
-	rawdb.WriteChainConfig(db, block.Hash(), config)
+	batch := db.NewBatch()
+	rawdb.WriteBlock(batch, block)
+	rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), nil)
+	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
+	rawdb.WriteHeadBlockHash(batch, block.Hash())
+	rawdb.WriteHeadHeaderHash(batch, block.Hash())
+	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
+	rawdb.WriteChainConfig(batch, block.Hash(), config)
+	if err := batch.Write(); err != nil {
+		return nil, fmt.Errorf("failed to write genesis block: %w", err)
+	}
 	return block, nil
 }
 

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -547,6 +547,7 @@ func (bc *BlockChain) batchBlockAcceptedIndices(batch ethdb.Batch, b *types.Bloc
 	if err := customrawdb.WriteAcceptorTip(batch, b.Hash()); err != nil {
 		return fmt.Errorf("%w: failed to write acceptor tip key", err)
 	}
+	rawdb.WriteFinalizedBlockHash(batch, b.Hash())
 	return nil
 }
 
@@ -859,7 +860,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := bc.db.NewBatch()
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
+
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 
@@ -2228,7 +2229,6 @@ func (bc *BlockChain) ResetToStateSyncedBlock(block *types.Block) error {
 	if err := bc.batchBlockAcceptedIndices(batch, block); err != nil {
 		return err
 	}
-	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 	customrawdb.WriteSnapshotBlockHash(batch, block.Hash())

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -859,7 +859,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := bc.db.NewBatch()
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-
+	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 
@@ -2228,6 +2228,7 @@ func (bc *BlockChain) ResetToStateSyncedBlock(block *types.Block) error {
 	if err := bc.batchBlockAcceptedIndices(batch, block); err != nil {
 		return err
 	}
+	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 	customrawdb.WriteSnapshotBlockHash(batch, block.Hash())

--- a/graft/subnet-evm/core/genesis.go
+++ b/graft/subnet-evm/core/genesis.go
@@ -428,6 +428,7 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
+	rawdb.WriteFinalizedBlockHash(batch, block.Hash())
 	customrawdb.WriteChainConfig(batch, block.Hash(), config, params.GetExtra(config).UpgradeConfig)
 	if err := batch.Write(); err != nil {
 		return nil, fmt.Errorf("failed to write genesis block: %w", err)

--- a/vms/saevm/blocks/blockstest/BUILD.bazel
+++ b/vms/saevm/blocks/blockstest/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//vms/saevm/saetest",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core",
-        "@com_github_ava_labs_libevm//core/state",
         "@com_github_ava_labs_libevm//core/types",
         "@com_github_ava_labs_libevm//ethdb",
         "@com_github_ava_labs_libevm//event",

--- a/vms/saevm/blocks/blockstest/blocks.go
+++ b/vms/saevm/blocks/blockstest/blocks.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
-	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/libevm/options"
@@ -133,10 +132,9 @@ func NewGenesis(tb testing.TB, db ethdb.Database, config *params.ChainConfig, al
 		BaseFee:   new(big.Int).SetUint64(conf.baseFee),
 	}
 
-	tdb := state.NewDatabaseWithConfig(db, conf.tdbConfig).TrieDB()
-	_, hash, err := core.SetupGenesisBlock(db, tdb, gen)
+	tdb := triedb.NewDatabase(db, conf.tdbConfig)
+	_, _, err := core.SetupGenesisBlock(db, tdb, gen)
 	require.NoError(tb, err, "core.SetupGenesisBlock()")
-	require.NoErrorf(tb, tdb.Commit(hash, true), "%T.Commit(core.SetupGenesisBlock(...))", tdb)
 
 	h := hookstest.NewStub(conf.gasTarget)
 	xdb := saetest.NewExecutionResultsDB()

--- a/vms/saevm/cchain/genesis.go
+++ b/vms/saevm/cchain/genesis.go
@@ -172,10 +172,10 @@ var (
 // It verifies that the genesis is compatible with any previously setup genesis
 // state by checking the genesis block hash along with the rules used to execute
 // the head block.
-func (g *genesis) setup(db ethdb.Database, trieConfig *triedb.Config) (_ *types.Block, retErr error) {
+func (g *genesis) setup(db ethdb.Database, trieConfig *triedb.Config) (retErr error) {
 	block, err := g.block()
 	if err != nil {
-		return nil, fmt.Errorf("constructing genesis block: %w", err)
+		return fmt.Errorf("constructing genesis block: %w", err)
 	}
 
 	// We can't exit early here. Even if the genesis block is on disk, the
@@ -183,10 +183,10 @@ func (g *genesis) setup(db ethdb.Database, trieConfig *triedb.Config) (_ *types.
 	hash := block.Hash()
 	if prev := rawdb.ReadCanonicalHash(db, genesisNumber); prev == (common.Hash{}) {
 		if err := writeGenesisBlock(db, block, g.Config); err != nil {
-			return nil, fmt.Errorf("writing block: %w", err)
+			return fmt.Errorf("writing block: %w", err)
 		}
 	} else if prev != hash {
-		return nil, &core.GenesisMismatchError{
+		return &core.GenesisMismatchError{
 			Stored: prev,
 			New:    hash,
 		}
@@ -197,18 +197,18 @@ func (g *genesis) setup(db ethdb.Database, trieConfig *triedb.Config) (_ *types.
 	{
 		prev := rawdb.ReadChainConfig(db, hash)
 		if prev == nil {
-			return nil, errNoStoredChainConfig
+			return errNoStoredChainConfig
 		}
 		head := rawdb.ReadHeadHeader(db)
 		if head == nil {
-			return nil, errNoHeadHeader
+			return errNoHeadHeader
 		}
 		height, timestamp := head.Number.Uint64(), head.Time
 		// TODO(JonathanOppenheimer): coreth exposes a `skip-upgrade-check` config
 		// that bypasses this compatibility check; we need to make such a check
 		// unnecessary for the c-chain.
 		if err := prev.CheckCompatible(g.Config, height, timestamp); err != nil {
-			return nil, fmt.Errorf("incompatible chain config: %w", err)
+			return fmt.Errorf("incompatible chain config: %w", err)
 		}
 		// We will be executing new blocks based on the new chain config, so we
 		// need to keep it up-to-date in the database for the next restart.
@@ -224,10 +224,10 @@ func (g *genesis) setup(db ethdb.Database, trieConfig *triedb.Config) (_ *types.
 	// the trie to determine if the genesis was previously initialized.
 	if !tdb.Initialized(block.Root()) {
 		if _, err := g.writeState(db, tdb); err != nil {
-			return nil, fmt.Errorf("writing genesis state: %w", err)
+			return fmt.Errorf("writing genesis state: %w", err)
 		}
 	}
-	return block, nil
+	return nil
 }
 
 func writeGenesisBlock(db ethdb.Database, block *types.Block, config *ethparams.ChainConfig) error {

--- a/vms/saevm/cchain/genesis_test.go
+++ b/vms/saevm/cchain/genesis_test.go
@@ -619,8 +619,8 @@ func TestSetupGenesis(t *testing.T) {
 			require.NoErrorf(t, g.setup(db, trieConfig), "%T.setup(initial)", g)
 
 			block, err := g.block()
-			genesisHash := block.Hash()
 			require.NoErrorf(t, err, "%T.block()", g)
+			genesisHash := block.Hash()
 			gotConfig := rawdb.ReadChainConfig(db, genesisHash)
 			cmpBaseConfig := cmp.Options{
 				cmpopts.IgnoreUnexported(corethparams.ChainConfig{}),

--- a/vms/saevm/cchain/genesis_test.go
+++ b/vms/saevm/cchain/genesis_test.go
@@ -616,12 +616,11 @@ func TestSetupGenesis(t *testing.T) {
 			)
 			require.NoError(t, err, "parseGenesis(initial)")
 
-			block, err := g.setup(db, trieConfig)
-			require.NoErrorf(t, err, "%T.setup(initial)", g)
+			require.NoErrorf(t, g.setup(db, trieConfig), "%T.setup(initial)", g)
 
+			block, err := g.block()
 			genesisHash := block.Hash()
-			require.Equal(t, genesisHash, rawdb.ReadCanonicalHash(db, 0), "rawdb.ReadCanonicalHash(initial)")
-
+			require.NoErrorf(t, err, "%T.block()", g)
 			gotConfig := rawdb.ReadChainConfig(db, genesisHash)
 			cmpBaseConfig := cmp.Options{
 				cmpopts.IgnoreUnexported(corethparams.ChainConfig{}),
@@ -646,7 +645,7 @@ func TestSetupGenesis(t *testing.T) {
 			)
 			require.NoError(t, err, "parseGenesis(restart)")
 
-			block, err = g.setup(db, trieConfig)
+			err = g.setup(db, trieConfig)
 			if diff := testerr.Diff(err, tt.wantErr); diff != "" {
 				t.Fatalf("%T.setup(restart) error (-want +got)\n%s", g, diff)
 			}
@@ -655,7 +654,6 @@ func TestSetupGenesis(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, genesisHash, block.Hash(), "%T.setup(restart).Hash()", g)
 			gotConfig = rawdb.ReadChainConfig(db, genesisHash)
 			if diff := cmp.Diff(g.Config, gotConfig, cmpBaseConfig); diff != "" {
 				t.Errorf("stored base config after restart (-want +got)\n%s", diff)

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -109,8 +109,7 @@ func (vm *VM) Initialize(
 	vm.chainConfig = genesis.Config
 
 	saeConfig := userConfig.saeConfig(vm.now)
-	genesisBlock, err := genesis.setup(ethDB, saeConfig.DBConfig.TrieDBConfig)
-	if err != nil {
+	if err := genesis.setup(ethDB, saeConfig.DBConfig.TrieDBConfig); err != nil {
 		return fmt.Errorf("setting up genesis: %w", err)
 	}
 
@@ -133,7 +132,7 @@ func (vm *VM) Initialize(
 		vm.now,
 		userConfig.desired(),
 	)
-	vm.VM, err = sae.NewVM(ctx, hooks, saeConfig, snowCtx, vm.chainConfig, ethDB, genesisBlock, appSender)
+	vm.VM, err = sae.NewVM(ctx, hooks, saeConfig, snowCtx, vm.chainConfig, ethDB, appSender)
 	if err != nil {
 		return fmt.Errorf("creating SAE VM: %w", err)
 	}

--- a/vms/saevm/sae/BUILD.bazel
+++ b/vms/saevm/sae/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core",
         "@com_github_ava_labs_libevm//core/rawdb",
+        "@com_github_ava_labs_libevm//core/state",
         "@com_github_ava_labs_libevm//core/txpool",
         "@com_github_ava_labs_libevm//core/txpool/legacypool",
         "@com_github_ava_labs_libevm//core/types",

--- a/vms/saevm/sae/always.go
+++ b/vms/saevm/sae/always.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/rawdb"
-	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/triedb"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -66,7 +65,12 @@ func (vm *SinceGenesis[_]) Initialize(
 	if err != nil {
 		return fmt.Errorf("core.SetupGenesisBlock(...): %v", err)
 	}
-	finalizeLastSynchronous(db, hash)
+
+	// [NewVM] assumes that the genesis block is "finalized", which does not
+	// happen in [core.SetupGenesisBlock]. This MUST only happen once.
+	if rawdb.ReadFinalizedBlockHash(db) == (ethcommon.Hash{}) {
+		rawdb.WriteFinalizedBlockHash(db, hash)
+	}
 
 	inner, err := NewVM(ctx, vm.hooks, vm.config, snowCtx, config, db, appSender)
 	if err != nil {
@@ -74,14 +78,6 @@ func (vm *SinceGenesis[_]) Initialize(
 	}
 	vm.VM = inner
 	return nil
-}
-
-// finalizeLastSynchronous writes the genesis block's hash
-// as finalized in the case there wasn't anything already written.
-func finalizeLastSynchronous(db ethdb.Database, hash ethcommon.Hash) {
-	if rawdb.ReadFinalizedBlockHash(db) == (ethcommon.Hash{}) {
-		rawdb.WriteFinalizedBlockHash(db, hash)
-	}
 }
 
 // Shutdown gracefully closes the VM.

--- a/vms/saevm/sae/always.go
+++ b/vms/saevm/sae/always.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/triedb"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -17,6 +19,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 var _ adaptor.ChainVM[*blocks.Block] = (*SinceGenesis[hook.Transaction])(nil)
@@ -58,17 +62,28 @@ func (vm *SinceGenesis[_]) Initialize(
 	if err := json.Unmarshal(genesisBytes, genesis); err != nil {
 		return fmt.Errorf("json.Unmarshal(%T): %v", genesis, err)
 	}
-	config, _, err := core.SetupGenesisBlock(db, tdb, genesis)
+	config, hash, err := core.SetupGenesisBlock(db, tdb, genesis)
 	if err != nil {
 		return fmt.Errorf("core.SetupGenesisBlock(...): %v", err)
 	}
+	canonicaliseLastSynchronous(db, hash)
 
-	inner, err := NewVM(ctx, vm.hooks, vm.config, snowCtx, config, db, genesis.ToBlock(), appSender)
+	inner, err := NewVM(ctx, vm.hooks, vm.config, snowCtx, config, db, appSender)
 	if err != nil {
 		return err
 	}
 	vm.VM = inner
 	return nil
+}
+
+// canonicaliseLastSynchronous writes the genesis block's hash
+// as finalized in the case there wasn't anything already written.
+func canonicaliseLastSynchronous(db ethdb.Database, hash ethcommon.Hash) {
+	// If any other block has been accepted then the last synchronous block
+	// must have been canonicalised in a previous initialisation.
+	if rawdb.ReadFinalizedBlockHash(db) == (ethcommon.Hash{}) {
+		rawdb.WriteFinalizedBlockHash(db, hash)
+	}
 }
 
 // Shutdown gracefully closes the VM.

--- a/vms/saevm/sae/always.go
+++ b/vms/saevm/sae/always.go
@@ -66,7 +66,7 @@ func (vm *SinceGenesis[_]) Initialize(
 	if err != nil {
 		return fmt.Errorf("core.SetupGenesisBlock(...): %v", err)
 	}
-	canonicaliseLastSynchronous(db, hash)
+	finalizeLastSynchronous(db, hash)
 
 	inner, err := NewVM(ctx, vm.hooks, vm.config, snowCtx, config, db, appSender)
 	if err != nil {
@@ -76,11 +76,9 @@ func (vm *SinceGenesis[_]) Initialize(
 	return nil
 }
 
-// canonicaliseLastSynchronous writes the genesis block's hash
+// finalizeLastSynchronous writes the genesis block's hash
 // as finalized in the case there wasn't anything already written.
-func canonicaliseLastSynchronous(db ethdb.Database, hash ethcommon.Hash) {
-	// If any other block has been accepted then the last synchronous block
-	// must have been canonicalised in a previous initialisation.
+func finalizeLastSynchronous(db ethdb.Database, hash ethcommon.Hash) {
 	if rawdb.ReadFinalizedBlockHash(db) == (ethcommon.Hash{}) {
 		rawdb.WriteFinalizedBlockHash(db, hash)
 	}

--- a/vms/saevm/sae/always.go
+++ b/vms/saevm/sae/always.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 
+	snowcommon "github.com/ava-labs/avalanchego/snow/engine/common"
 	ethcommon "github.com/ava-labs/libevm/common"
 )
 
@@ -52,8 +52,8 @@ func (vm *SinceGenesis[_]) Initialize(
 	genesisBytes []byte,
 	upgradeBytes []byte,
 	configBytes []byte,
-	fxs []*common.Fx,
-	appSender common.AppSender,
+	fxs []*snowcommon.Fx,
+	appSender snowcommon.AppSender,
 ) error {
 	db := newEthDB(avaDB)
 	tdb := triedb.NewDatabase(db, vm.config.DBConfig.TrieDBConfig)

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -65,7 +65,7 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 		return nil, fmt.Errorf("%w: no height for finalized block", errIncompleteRecoveryState)
 	}
 
-	// Search for first settled post-execution state
+	// Search for highest settled post-execution state
 	for height := *lastSettledHeight; ; height-- {
 		ethB, err := canonicalBlock(rec.db, height)
 		if err != nil {

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -5,12 +5,15 @@ package sae
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"iter"
 	"math"
 	"sync/atomic"
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/params"
 
@@ -19,7 +22,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
-	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
 	"github.com/ava-labs/avalanchego/vms/saevm/types"
 
@@ -27,13 +29,12 @@ import (
 )
 
 type recovery struct {
-	db              ethdb.Database
-	xdb             types.ExecutionResults
-	chainConfig     *params.ChainConfig
-	log             logging.Logger
-	hooks           hook.Points
-	config          Config
-	lastSynchronous *blocks.Block
+	db          ethdb.Database
+	xdb         types.ExecutionResults
+	chainConfig *params.ChainConfig
+	log         logging.Logger
+	hooks       hook.Points
+	config      Config
 }
 
 func (rec *recovery) newCanonicalBlock(num uint64, parent *blocks.Block) (*blocks.Block, error) {
@@ -44,23 +45,47 @@ func (rec *recovery) newCanonicalBlock(num uint64, parent *blocks.Block) (*block
 	return blocks.New(ethB, parent, nil, rec.log)
 }
 
-func (rec *recovery) lastCommittedBlock() (*blocks.Block, error) {
-	num := saedb.LastHeightWithExecutionRootCommitted(
-		rec.db,
-		rec.config.DBConfig,
-		rec.hooks,
-		rec.lastSynchronous.Height(),
-	)
-	if ls := rec.lastSynchronous; num == ls.Height() {
-		return ls, nil
+var errIncompleteRecoveryState = errors.New("incomplete recovery state")
+
+// lastCommittedBlock returns the highest settled block whose post-execution
+// state is available on disk. This is required because its post-execution state
+// is the basis for the worst-case checks needed for block verifications.
+func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
+	cache := state.NewDatabaseWithConfig(rec.db, rec.config.DBConfig.TrieDBConfig)
+	defer func() {
+		retErr = errors.Join(retErr, cache.TrieDB().Close())
+	}()
+
+	lastSettledHash := rawdb.ReadFinalizedBlockHash(rec.db)
+	if lastSettledHash == (common.Hash{}) {
+		return nil, fmt.Errorf("%w: no finalized block recorded", errIncompleteRecoveryState)
+	}
+	lastSettledHeight := rawdb.ReadHeaderNumber(rec.db, lastSettledHash)
+	if lastSettledHeight == nil {
+		return nil, fmt.Errorf("%w: no height for finalized block", errIncompleteRecoveryState)
 	}
 
-	ethB, err := canonicalBlock(rec.db, num)
-	if err != nil {
-		return nil, err
+	// Search for first settled post-execution state
+	for height := *lastSettledHeight; ; height-- {
+		ethB, err := canonicalBlock(rec.db, height)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err := blocks.RestoreSettledBlock(ethB, rec.hooks, rec.log, rec.db, rec.xdb, rec.chainConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := state.New(b.PostExecutionStateRoot(), cache, nil); err == nil {
+			return b, nil
+		}
+
+		if b.Synchronous() {
+			// invariant expected at initialization.
+			return nil, fmt.Errorf("%w: last synchronous block %d has no available post-execution state", errIncompleteRecoveryState, height)
+		}
 	}
-	// We only commit settled execution results, so this block is guaranteed to be settled.
-	return blocks.RestoreSettledBlock(ethB, rec.hooks, rec.log, rec.db, rec.xdb, rec.chainConfig)
 }
 
 func (rec *recovery) canonicalAfter(parent *blocks.Block) iter.Seq2[*blocks.Block, error] {
@@ -132,9 +157,6 @@ func (rec *recovery) consensusCriticalBlocks(exec *saexec.Executor) (_ *syncMap[
 					return nil
 				}
 				return b.MarkSettled(blackhole)
-
-			case b.Height() == rec.lastSynchronous.Height()+1:
-				chain = append(chain, rec.lastSynchronous)
 
 			default:
 				parent, err := rec.newCanonicalBlock(b.Height()-1, nil)

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -77,7 +77,7 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 			return nil, err
 		}
 
-		if _, err := state.New(b.PostExecutionStateRoot(), cache, nil); err == nil {
+		if _, err := state.New(b.PostExecutionStateRoot(), cache, nil); err == nil { // if NO error
 			return b, nil
 		}
 
@@ -168,7 +168,7 @@ func (rec *recovery) consensusCriticalBlocks(exec *saexec.Executor) (_ *syncMap[
 				}
 				chain = append(chain, parent)
 
-				if !b.Settled() {
+				if !b.Settled() && !parent.Synchronous() {
 					continue
 				}
 				if err := parent.MarkSettled(blackhole); err != nil {

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -45,8 +45,6 @@ func (rec *recovery) newCanonicalBlock(num uint64, parent *blocks.Block) (*block
 	return blocks.New(ethB, parent, nil, rec.log)
 }
 
-var errIncompleteRecoveryState = errors.New("incomplete recovery state")
-
 // lastCommittedBlock returns the highest settled block whose post-execution
 // state is available on disk. This is required because its post-execution state
 // is the basis for the worst-case checks needed for block verifications.
@@ -58,14 +56,24 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 
 	lastSettledHash := rawdb.ReadFinalizedBlockHash(rec.db)
 	if lastSettledHash == (common.Hash{}) {
-		return nil, fmt.Errorf("%w: no finalized block recorded", errIncompleteRecoveryState)
+		return nil, errors.New("no finalized block recorded")
 	}
 	lastSettledHeight := rawdb.ReadHeaderNumber(rec.db, lastSettledHash)
 	if lastSettledHeight == nil {
-		return nil, fmt.Errorf("%w: no height for finalized block", errIncompleteRecoveryState)
+		return nil, fmt.Errorf("no height for finalized block %s", lastSettledHash)
 	}
 
 	// Search for highest settled post-execution state
+	// Invariant: The state is written to disk AFTER the block is written to
+	// disk. Therefore, the state can only lag behind the block read.
+	// Additionally, we assume any block has been written atomically, so
+	// if the last settled height was found, the underlying block is present.
+	// At minimum, [NewVM] requires a genesis block to be written (which is
+	// synchronous by definition).
+	//
+	// There's no reasonable cap on how far back to search, since the distance
+	// between the settler and settled block is unbounded, and node crashes
+	// must be accounted for.
 	for height := *lastSettledHeight; ; height-- {
 		ethB, err := canonicalBlock(rec.db, height)
 		if err != nil {
@@ -82,8 +90,7 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 		}
 
 		if b.Synchronous() {
-			// invariant expected at initialization.
-			return nil, fmt.Errorf("%w: last synchronous block %d has no available post-execution state", errIncompleteRecoveryState, height)
+			return nil, fmt.Errorf("last synchronous block %d has no available post-execution state", height)
 		}
 	}
 }

--- a/vms/saevm/sae/vm.go
+++ b/vms/saevm/sae/vm.go
@@ -16,10 +16,8 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
-	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/txpool"
 	"github.com/ava-labs/libevm/core/txpool/legacypool"
-	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/event"
 	"github.com/ava-labs/libevm/params"
@@ -45,7 +43,9 @@ import (
 
 // VM implements all of [adaptor.ChainVM] except for the `Initialize` method,
 // which needs to be provided by a harness. In all cases, the harness MUST
-// provide a last-synchronous block, which MAY be the genesis.
+// ensure that the last-synchronous block (which MAY be the genesis) is
+// canonical on disk with its post-execution state committed before [NewVM] is
+// called.
 type VM struct {
 	*p2p.Network
 	Peers          *p2p.Peers
@@ -113,7 +113,6 @@ func NewVM[T hook.Transaction](
 	snowCtx *snow.Context,
 	chainConfig *params.ChainConfig,
 	db ethdb.Database,
-	lastSynchronous *types.Block,
 	sender snowcommon.AppSender,
 ) (_ *VM, retErr error) {
 	if cfg.Now == nil {
@@ -150,17 +149,8 @@ func NewVM[T hook.Transaction](
 	vm.xdb = xdb
 	vm.toClose = append(vm.toClose, &xdb)
 
-	// ==========  Sync -> Async  ==========
-	lastSync, err := blocks.RestoreSettledBlock(lastSynchronous, hooks, snowCtx.Log, db, xdb, chainConfig)
-	if err != nil {
-		return nil, fmt.Errorf("blocks.RestoreSettledBlock([last synchronous]): %v", err)
-	}
-	if err := canonicaliseLastSynchronous(db, lastSync); err != nil {
-		return nil, err
-	}
-
-	rec := &recovery{db, xdb, chainConfig, snowCtx.Log, hooks, cfg, lastSync}
 	{ // ==========  Block State  ==========
+		rec := &recovery{db, xdb, chainConfig, snowCtx.Log, hooks, cfg}
 		lastCommitted, err := rec.lastCommittedBlock()
 		if err != nil {
 			return nil, err
@@ -298,30 +288,6 @@ func NewVM[T hook.Transaction](
 	}
 
 	return vm, nil
-}
-
-// canonicaliseLastSynchronous writes all necessary information to the database
-// to have the block be considered accepted/canonical by SAE. If there are any
-// canonical blocks at a height greater than the provided block then this
-// function is a no-op, which makes it effectively idempotent with respect to
-// the rest of SAE processing.
-func canonicaliseLastSynchronous(db ethdb.Database, block *blocks.Block) error {
-	if !block.Synchronous() {
-		return fmt.Errorf("only synchronous block can be canonicalised: %d / %#x is async", block.NumberU64(), block.Hash())
-	}
-	num := block.NumberU64()
-	if rawdb.ReadCanonicalHash(db, num+1) != (common.Hash{}) {
-		// If any other block has been accepted then the last synchronous block
-		// must have been canonicalised in a previous initialisation.
-		return nil
-	}
-
-	h := block.Hash()
-	b := db.NewBatch()
-	rawdb.WriteCanonicalHash(b, h, num)
-	block.SetAsHeadBlock(b)
-	rawdb.WriteFinalizedBlockHash(b, h)
-	return b.Write()
 }
 
 // signalNewTxsToEngine subscribes to the [txpool.TxPool] to unblock

--- a/vms/saevm/saedb/BUILD.bazel
+++ b/vms/saevm/saedb/BUILD.bazel
@@ -11,9 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//utils/logging",
-        "//vms/saevm/hook",
         "@com_github_ava_labs_libevm//common",
-        "@com_github_ava_labs_libevm//core/rawdb",
         "@com_github_ava_labs_libevm//core/state",
         "@com_github_ava_labs_libevm//core/state/snapshot",
         "@com_github_ava_labs_libevm//ethdb",

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/state/snapshot"
 	"github.com/ava-labs/libevm/ethdb"
@@ -16,7 +15,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
 
 // Config allows parameterization of the TrieDB and when state is committed.
@@ -125,30 +123,6 @@ func (t *Tracker) MaybeCommit(settledRoot, executionRoot common.Hash, height uin
 		return fmt.Errorf("%T.Commit(%#x) %s at end of block %d: %v", tdb, settledRoot, because, height, err)
 	}
 	return nil
-}
-
-// LastHeightWithExecutionRootCommitted returns the greatest block height for
-// which [Tracker.MaybeCommit] called [triedb.Database.Commit] with the
-// post-execution state root of the block, no matter whether the node was
-// archival or not.
-func LastHeightWithExecutionRootCommitted(db ethdb.Database, c Config, hooks hook.Points, lastSynchronous uint64) uint64 {
-	switch head := rawdb.ReadHeadHeader(db).Number.Uint64(); {
-	case head <= lastSynchronous:
-		return lastSynchronous
-
-	default:
-		num := LastCommittedTrieDBHeight(head, c.CommitInterval())
-		if num <= lastSynchronous {
-			return lastSynchronous
-		}
-		return hooks.SettledBy(
-			rawdb.ReadHeader(
-				db,
-				rawdb.ReadCanonicalHash(db, num),
-				num,
-			),
-		).Height
-	}
 }
 
 // Untrack informs the [Tracker] that the state corresponding


### PR DESCRIPTION
## Why this should be merged

Now, the only reason that `NewVM` needs the last synchronous block is to ensure you don't roll back too far in recovery. What if we had a way to detect that?

## How this works

Rather than directly computing the most recent state root that's deterministically available for HashDB, we check several recent states for the most recently committed, settled block.

Resolves #5257 

## How this was tested

Existing UT, but is that sufficient?

## Need to be documented in RELEASES.md?

No
