### PR TITLE
fix(saevm): Remove flaky bloom inclusion check

### DIFF
--- a/vms/saevm/cchain/gossip_test.go
+++ b/vms/saevm/cchain/gossip_test.go
@@ -121,9 +121,7 @@ func TestPushGossipAfterPullGossip(t *testing.T) {
 	// Because vdrB doesn't consider vdrA a validator and isn't connected to
 	// api, vdrB can only learn about the transaction if vdrA pushes it.
 	vdrB.assertTxBloomEmpty(t)
-
 	require.NoErrorf(t, vdrA.IssueTx(vdrACtx, stx), "%T.IssueTx()", vdrA.VM)
-	vdrA.assertTxBloomContains(t, stx.ID())
 
 	blk := vdrB.runConsensusLoop(vdrBCtx, t)
 	if diff := cmp.Diff([]*tx.Tx{stx}, blockTxs(t, blk), txtest.CmpOpt()); diff != "" {


### PR DESCRIPTION
## Why this should be merged

This fixes a test flake encountered by: https://github.com/ava-labs/avalanchego/actions/runs/27835272451/job/82381680091

```
-test.shuffle 1781884174049400437
--- FAIL: TestPushGossipAfterPullGossip (0.22s)
    logging.go:170: [Log@INFO] Initializing BlockDB map[blockCacheSize:256 dataDir:/tmp/TestPushGossipAfterPullGossip3444675297/001/sae_execution_results indexDir:/tmp/TestPushGossipAfterPullGossip3444675297/001/sae_execution_results maxDataFileSize:536870912000 maxDataFiles:10] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:229
    logging.go:170: [Log@INFO] Index file is empty, writing initial index file header map[] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:946
    logging.go:170: [Log@DEBUG] non-data file found in data directory map[error:input does not match format fileName:blockdb.idx] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:896
    logging.go:170: [Log@INFO] BlockDB initialized successfully map[maxBlockHeight:18446744073709551615 nextWriteOffset:0] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:255
    logging.go:170: [Log@DEBUG] Opened data file map[fileIndex:0 filePath:/tmp/TestPushGossipAfterPullGossip3444675297/001/sae_execution_results/blockdb_0.dat] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:1048
    logging.go:170: [Log@DEBUG] Block written successfully map[blockSize:97 dataOffset:0 height:0] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:377
    logging.go:170: [Log@INFO] Initializing BlockDB map[blockCacheSize:256 dataDir:/tmp/TestPushGossipAfterPullGossip3444675297/002/sae_execution_results indexDir:/tmp/TestPushGossipAfterPullGossip3444675297/002/sae_execution_results maxDataFileSize:536870912000 maxDataFiles:10] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:229
    logging.go:170: [Log@INFO] Index file is empty, writing initial index file header map[] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:946
    logging.go:170: [Log@DEBUG] non-data file found in data directory map[error:input does not match format fileName:blockdb.idx] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:896
    logging.go:170: [Log@INFO] BlockDB initialized successfully map[maxBlockHeight:18446744073709551615 nextWriteOffset:0] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:255
    logging.go:170: [Log@DEBUG] Opened data file map[fileIndex:0 filePath:/tmp/TestPushGossipAfterPullGossip3444675297/002/sae_execution_results/blockdb_0.dat] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:1048
    logging.go:170: [Log@DEBUG] Block written successfully map[blockSize:97 dataOffset:0 height:0] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:377
    logging.go:170: [Log@INFO] Initializing BlockDB map[blockCacheSize:256 dataDir:/tmp/TestPushGossipAfterPullGossip3444675297/003/sae_execution_results indexDir:/tmp/TestPushGossipAfterPullGossip3444675297/003/sae_execution_results maxDataFileSize:536870912000 maxDataFiles:10] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:229
    logging.go:170: [Log@INFO] Index file is empty, writing initial index file header map[] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:946
    logging.go:170: [Log@DEBUG] non-data file found in data directory map[error:input does not match format fileName:blockdb.idx] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:896
    logging.go:170: [Log@INFO] BlockDB initialized successfully map[maxBlockHeight:18446744073709551615 nextWriteOffset:0] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:255
    logging.go:170: [Log@DEBUG] Opened data file map[fileIndex:0 filePath:/tmp/TestPushGossipAfterPullGossip3444675297/003/sae_execution_results/blockdb_0.dat] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:1048
    logging.go:170: [Log@DEBUG] Block written successfully map[blockSize:97 dataOffset:0 height:0] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:377
    logging.go:170: [Log@DEBUG] API called map[encoding:hexnc method:issueTx service:avax tx:0x0000000000010000000ae902a9a86640bfdb1cd0e36c0cc982b83e5765fad5f6bbe6abdcce7b5ae7d7c73d0ad12b8ee8928edf248ca91ca55600fb383f07c32bff1d6dec472b25cf59a7000000013dfef0913cf5ee8c6781d79ff35e9a8644fc22e500000000000000024a177205df5c29929d06db9d941f83d5ea985de302015e99252d16469a6610db0000000000000000000000014a177205df5c29929d06db9d941f83d5ea985de302015e99252d16469a6610db0000000700000000000000010000000000000000000000010000000162ef21ff66cfc9ec65449b0ea122bce9f872bc0800000001000000090000000181b5b331048490d0cf3fff21ca5cbe710848cdb3fed15780509c340444d67b7e663314ff78b361800c564d96f11c7038c6cb2c1f162423dd83452be3345ef34201] - /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/api.go:213
    logging.go:170: [Log@DEBUG] API called map[encoding:hexnc method:issueTx service:avax tx:0x0000000000010000000ae902a9a86640bfdb1cd0e36c0cc982b83e5765fad5f6bbe6abdcce7b5ae7d7c73d0ad12b8ee8928edf248ca91ca55600fb383f07c32bff1d6dec472b25cf59a7000000013dfef0913cf5ee8c6781d79ff35e9a8644fc22e500000000000000024a177205df5c29929d06db9d941f83d5ea985de302015e99252d16469a6610db0000000000000000000000014a177205df5c29929d06db9d941f83d5ea985de302015e99252d16469a6610db0000000700000000000000010000000000000000000000010000000162ef21ff66cfc9ec65449b0ea122bce9f872bc0800000001000000090000000181b5b331048490d0cf3fff21ca5cbe710848cdb3fed15780509c340444d67b7e663314ff78b361800c564d96f11c7038c6cb2c1f162423dd83452be3345ef34201] - /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/api.go:213
    gossip_test.go:126: 
        	Error Trace:	/home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/gossip_test.go:28
        	            				/home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/gossip_test.go:126
        	Error:      	Should be true
        	Test:       	TestPushGossipAfterPullGossip
        	Messages:   	bloom filter should contain 2RTMMtFNWqYYnFDvemVzkPnTnKzFdVJU9VkV8kPFHoG68tmjZb (0)
    logging.go:170: [Log@DEBUG] failed to add gossip to the known set map[error:transaction already in pool id:2RTMMtFNWqYYnFDvemVzkPnTnKzFdVJU9VkV8kPFHoG68tmjZb nodeID:NodeID-EDWeePaynALUXDXtY33Pa9dSRnhW3MawA] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/handler.go:135
    logging.go:170: [Log@TRACE] Including op map[block_time:1781884175 last_settled_gas_time:5+(0/2000000) last_settled_hash:0x8aeeed1ca1c63fbd500e2080d304d71881d2c25a9b6af9de4cfbbd72e0218183 last_settled_height:0 op_id:2RTMMtFNWqYYnFDvemVzkPnTnKzFdVJU9VkV8kPFHoG68tmjZb op_index:0 parent_hash:0x8aeeed1ca1c63fbd500e2080d304d71881d2c25a9b6af9de4cfbbd72e0218183 parent_height:0] - /home/runner/work/avalanchego/avalanchego/vms/saevm/sae/block_builder.go:294
    logging.go:170: [Log@TRACE] Including op map[block_time:1781884175 last_settled_gas_time:5+(0/2000000) last_settled_hash:0x8aeeed1ca1c63fbd500e2080d304d71881d2c25a9b6af9de4cfbbd72e0218183 last_settled_height:0 op_id:2RTMMtFNWqYYnFDvemVzkPnTnKzFdVJU9VkV8kPFHoG68tmjZb op_index:0 parent_hash:0x8aeeed1ca1c63fbd500e2080d304d71881d2c25a9b6af9de4cfbbd72e0218183 parent_height:0] - /home/runner/work/avalanchego/avalanchego/vms/saevm/sae/block_builder.go:294
    logging.go:170: [Log@DEBUG] Accepted block map[hash:0xff931208ca4c2e90faab6cc7b3e17cdbb826c02ad0d60f14af68b4acdf7cf904 height:1] - /home/runner/work/avalanchego/avalanchego/vms/saevm/sae/consensus.go:101
    logging.go:170: [Log@DEBUG] Executing block map[block_hash:0xff931208ca4c2e90faab6cc7b3e17cdbb826c02ad0d60f14af68b4acdf7cf904 block_height:1 block_time:1781884175 tx_count:0] - /home/runner/work/avalanchego/avalanchego/vms/saevm/saexec/execution.go:175
    logging.go:170: [Log@DEBUG] updated atomic trie map[height:1 root:0xd6fb912cf7a1ca744178dfaeeb650583ac153ff84c8e279ede466d2e15aa4a41] - /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/state/state.go:181
    logging.go:170: [Log@DEBUG] Block execution complete map[block_hash:0xff931208ca4c2e90faab6cc7b3e17cdbb826c02ad0d60f14af68b4acdf7cf904 block_height:1 block_time:1781884175 gas_consumed:11230 gas_time:2026-06-19 15:49:35.133615 +0000 UTC tx_count:0 wall_time:2026-06-19 15:49:35.131792127 +0000 UTC] - /home/runner/work/avalanchego/avalanchego/vms/saevm/saexec/execution.go:277
    logging.go:170: [Log@DEBUG] Block written successfully map[blockSize:114 dataOffset:119 height:1] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:377
    logging.go:170: [Log@DEBUG] updated to new state map[blockHash:0xff931208ca4c2e90faab6cc7b3e17cdbb826c02ad0d60f14af68b4acdf7cf904 blockNumber:1] - /home/runner/work/avalanchego/avalanchego/vms/saevm/cchain/txpool/txpool.go:151
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@INFO] Block database closed successfully map[] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:283
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@INFO] Block database closed successfully map[] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:283
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@DEBUG] shutting down gossip map[] - /home/runner/work/avalanchego/avalanchego/network/p2p/gossip/gossip.go:630
    logging.go:170: [Log@INFO] Block database closed successfully map[] - /home/runner/work/avalanchego/avalanchego/x/blockdb/database.go:283
FAIL
coverage: 82.2% of statements
FAIL	github.com/ava-labs/avalanchego/vms/saevm/cchain	3.232s
```

## How this works

When writing this test, I had expected `IssueTx(tx) == nil` to imply that `bloom.Contains(tx) == true`.

This is true in the other tests. However, with `TestPushGossipAfterPullGossip` does not guarantee this.

Specifically, in the other tests, there is only one goroutine adding `tx` to the txpool, and that is the API issuer. Because there is only one goroutine, we are guaranteed for the full issuance flow to happen synchronously, which includes the bloom filter modification.

In `TestPushGossipAfterPullGossip`, however, there are two goroutines that are potentially adding `tx` to the txpool.
1. The test's goroutine routing through the API client
2. The API node's push gossip goroutine

This still doesn't obviously explain why the check is flaky, but it introduces the following edge case that I hadn't anticipated.
1. The push gossip goroutine is executing this code: https://github.com/ava-labs/avalanchego/blob/b8da248b245842aba233b9693e08372c094c6982/network/p2p/gossip/set.go#L101-L104. The `s.set.Add(v)` finishes, but the goroutine is interrupted before calling `s.addToBloom(v.GossipID())`.
2. The API client calls this same function, but `s.set.Add(v)` now returns `ErrAlreadyKnown`. This error is caught by the API service and dropped.
3. The test then asserts that the bloom filter includes the tx because the API client returned from its call to issue the tx without error.

The push gossip goroutine will eventually add the tx to the bloom filter, but the test has already failed.

## How this was tested

It wasn't.

## Need to be documented in RELEASES.md?

No