### PR TITLE
feat(saevm): Remove API ordering assumptions from e2e tests

### DIFF
--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -115,11 +115,16 @@ var _ = e2e.DescribeCChain("[Dynamic Fees]", func() {
 			zap.Uint64("gasLimit", gasLimit),
 		)
 
+		// Nonces are tracked locally avoid making implicit assumptions of API
+		// ordering behavior. Transactions MAY be marked as executed before the
+		// block that includes them is fully executed. It is not safe to assume
+		// that the "latest" block's nonce has updated to reflect a transaction
+		// whose receipt has been returned.
+		nonce, err := ethClient.AcceptedNonceAt(tc.DefaultContext(), ethAddress)
+		require.NoError(err)
+
 		var contractAddress common.Address
 		tc.By("deploying an expensive contract", func() {
-			// Create transaction
-			nonce, err := ethClient.AcceptedNonceAt(tc.DefaultContext(), ethAddress)
-			require.NoError(err)
 			compiledContract := common.Hex2Bytes(consumeGasCompiledContract)
 			tx := types.NewTx(&types.DynamicFeeTx{
 				ChainID:   cChainID,
@@ -137,6 +142,7 @@ var _ = e2e.DescribeCChain("[Dynamic Fees]", func() {
 			require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 
 			contractAddress = receipt.ContractAddress
+			nonce++
 		})
 
 		initialGasPrice, err := ethClient.EstimateBaseFee(tc.DefaultContext())
@@ -180,9 +186,6 @@ var _ = e2e.DescribeCChain("[Dynamic Fees]", func() {
 					zap.Stringer("targetPrice", targetGasPrice),
 				)
 
-				// Create the transaction
-				nonce, err := ethClient.AcceptedNonceAt(tc.DefaultContext(), ethAddress)
-				require.NoError(err)
 				tx := types.NewTx(&types.DynamicFeeTx{
 					ChainID:   cChainID,
 					Nonce:     nonce,
@@ -198,6 +201,8 @@ var _ = e2e.DescribeCChain("[Dynamic Fees]", func() {
 				receipt := e2e.SendEthTransaction(tc, ethClient, signedTx)
 				// The transaction should have run out of gas
 				require.Equal(types.ReceiptStatusFailed, receipt.Status)
+
+				nonce++
 
 				// The gas price will be checked at the start of the next iteration
 				return false
@@ -229,9 +234,6 @@ var _ = e2e.DescribeCChain("[Dynamic Fees]", func() {
 					zap.Stringer("newPrice", gasPrice),
 				)
 
-				// Create the transaction
-				nonce, err := ethClient.AcceptedNonceAt(tc.DefaultContext(), ethAddress)
-				require.NoError(err)
 				tx := types.NewTx(&types.DynamicFeeTx{
 					ChainID:   cChainID,
 					Nonce:     nonce,
@@ -245,6 +247,8 @@ var _ = e2e.DescribeCChain("[Dynamic Fees]", func() {
 				signedTx := sign(tx)
 				receipt := e2e.SendEthTransaction(tc, ethClient, signedTx)
 				require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+
+				nonce++
 
 				// The gas price will be checked at the start of the next iteration
 				return false

--- a/tests/e2e/c/dynamic_fees.go
+++ b/tests/e2e/c/dynamic_fees.go
@@ -115,11 +115,11 @@ var _ = e2e.DescribeCChain("[Dynamic Fees]", func() {
 			zap.Uint64("gasLimit", gasLimit),
 		)
 
-		// Nonces are tracked locally avoid making implicit assumptions of API
-		// ordering behavior. Transactions MAY be marked as executed before the
-		// block that includes them is fully executed. It is not safe to assume
-		// that the "latest" block's nonce has updated to reflect a transaction
-		// whose receipt has been returned.
+		// Nonces are tracked locally to avoid making implicit assumptions about
+		// API ordering behavior. Transactions MAY be marked as executed before
+		// the block that includes them is fully executed. It is not safe to
+		// assume that the "latest" block's nonce has been updated to reflect a
+		// transaction whose receipt has been returned.
 		nonce, err := ethClient.AcceptedNonceAt(tc.DefaultContext(), ethAddress)
 		require.NoError(err)
 

--- a/tests/e2e/p/BUILD.bazel
+++ b/tests/e2e/p/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//vms/platformvm/warp/message",
         "//vms/platformvm/warp/payload",
         "//vms/proposervm",
+        "//vms/saevm/cchain",
         "//vms/secp256k1fx",
         "//wallet/subnet/primary/common",
         "@com_github_mitchellh_mapstructure//:mapstructure",

--- a/tests/e2e/p/interchain_workflow.go
+++ b/tests/e2e/p/interchain_workflow.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/saevm/cchain"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
@@ -222,19 +223,30 @@ var _ = e2e.DescribePChain("[Interchain Workflow]", ginkgo.Label(e2e.UsesCChainL
 		tc.By("initializing a new eth client")
 		ethClient := e2e.NewEthClient(tc, nodeURI)
 
-		tc.By("importing AVAX from the P-Chain to the C-Chain", func() {
-			_, err := cWallet.IssueImportTx(
-				constants.PlatformChainID,
-				recipientEthAddress,
-				tc.WithDefaultContext(),
-				e2e.WithSuggestedGasPrice(tc, ethClient),
-				changeOwner,
-			)
-			require.NoError(err)
-		})
+		tc.By("importing AVAX from the P-Chain to the C-Chain")
+		importTx, err := cWallet.IssueImportTx(
+			constants.PlatformChainID,
+			recipientEthAddress,
+			tc.WithDefaultContext(),
+			e2e.WithSuggestedGasPrice(tc, ethClient),
+			changeOwner,
+		)
+		require.NoError(err)
+
+		// Transactions MAY be marked as executed before the block that includes
+		// them is fully executed. It is not safe to assume that the "latest"
+		// block's balance has been updated.
+		tc.By("getting inclusion height of the import transaction")
+		cchainClient := cchain.NewClient(nodeURI.URI)
+		_, height, err := cchainClient.GetTx(tc.DefaultContext(), importTx.ID())
+		require.NoError(err)
 
 		tc.By("checking that the recipient address has received imported funds on the C-Chain")
-		balance, err := ethClient.BalanceAt(tc.DefaultContext(), recipientEthAddress, nil)
+		balance, err := ethClient.BalanceAt(
+			tc.DefaultContext(),
+			recipientEthAddress,
+			new(big.Int).SetUint64(height),
+		)
 		require.NoError(err)
 		require.Positive(balance.Cmp(big.NewInt(0)))
 

--- a/vms/saevm/cchain/BUILD.bazel
+++ b/vms/saevm/cchain/BUILD.bazel
@@ -10,7 +10,9 @@ package(default_visibility = [
 
 package_group(
     name = "external_consumers",
-    packages = [],
+    packages = [
+        "//tests/e2e/p",
+    ],
 )
 
 go_library(


### PR DESCRIPTION
## Why this should be merged

These tests aren't broken, but they make a key assumption:

> If an API marks a transaction as having been executed, by either fetching receipts or by polling the tx status endpoint, then the **Latest** block should reference a chain where that transaction has been included.

With SAE, this assumption intentionally does not hold any longer. SAE attempts to minimize the transaction inclusion latency by returning the status of the transaction as quickly as possible. Which includes not waiting for the full block to finish execution.

## How this works

By looking up the state at a specific height, or just removing the query using **Latest** entirely, we avoid making this assumption on the interaction between different RPC calls and the **Latest** block definition.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No. This is a testing only change which will allow for SAE to be tested in E2E