### PR TITLE
feat(orchestrator): Add `SummaryHandler` interface

### DIFF
--- a/vms/saevm/orchestrator/BUILD.bazel
+++ b/vms/saevm/orchestrator/BUILD.bazel
@@ -13,9 +13,11 @@ go_library(
         "//snow",
         "//snow/engine/common",
         "//snow/engine/snowman/block",
+        "//utils",
         "//vms/saevm/adaptor",
         "//vms/saevm/blocks",
         "//vms/saevm/network",
+        "@com_github_ava_labs_libevm//core/types",
     ],
 )
 
@@ -23,5 +25,18 @@ go_test(
     name = "orchestrator_test",
     srcs = ["orchestrator_test.go"],
     embed = [":orchestrator"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//database",
+        "//ids",
+        "//snow",
+        "//snow/engine/common",
+        "//snow/engine/enginetest",
+        "//snow/engine/snowman/block",
+        "//snow/snowtest",
+        "//vms/saevm/adaptor",
+        "//vms/saevm/blocks",
+        "//vms/saevm/network",
+        "@com_github_ava_labs_libevm//core/types",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/vms/saevm/orchestrator/orchestrator.go
+++ b/vms/saevm/orchestrator/orchestrator.go
@@ -5,7 +5,10 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"net/http"
+
+	"github.com/ava-labs/libevm/core/types"
 
 	"github.com/ava-labs/avalanchego/api/health"
 	"github.com/ava-labs/avalanchego/database"
@@ -13,17 +16,43 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/network"
 )
 
-var _ adaptor.ChainVM[*blocks.Block] = (*orchestrator)(nil)
+var _ adaptor.ChainVM[*blocks.Block] = (*orchestrator[adaptor.SummaryProperties])(nil)
 
-// ChainVM is the subset of [adaptor.ChainVM] that must be provided by the VM to
-// work with the orchestrator.
+// Parser turns the raw config and genesis bytes into the typed values the
+// orchestrator and its collaborators need.
+type Parser interface {
+	ParseConfig([]byte) (VMConfig, error)
+	ParseGenesis([]byte) (*types.Block, error)
+}
+
+// VMConfig is the parsed VM configuration.
+type VMConfig interface {
+	StateSyncConfig() StateSyncConfig // TODO
+}
+
+// StateDependent contains all methods that route to the summary handler until
+// the chain is built, then route to the chain. This allows the engine to
+// startup without fully initializing the VM.
+type StateDependent interface {
+	GetBlock(context.Context, ids.ID) (*blocks.Block, error)
+	LastAccepted(context.Context) (ids.ID, error)
+	GetBlockIDAtHeight(context.Context, uint64) (ids.ID, error)
+	WaitForEvent(context.Context) (common.Message, error)
+	Shutdown(context.Context) error
+}
+
+// ChainVM is the executing chain the orchestrator builds and routes to.
 type ChainVM interface {
+	StateDependent
+
 	// Initialize is similar to [common.VM.Initialize], but abstracts network creation.
+	// All other methods MUST be callable after Initialize.
 	Initialize(
 		ctx context.Context,
 		snowCtx *snow.Context,
@@ -33,30 +62,72 @@ type ChainVM interface {
 		network *network.Network,
 	) error
 
+	// TODO(alarso16): this needs to be callable immediately after Initialize.
+	CreateHandlers(context.Context) (map[string]http.Handler, error)
+
+	// All other methods are exactly like [adaptor.ChainVM].
 	health.Checker
 	SetState(ctx context.Context, state snow.State) error
-	Shutdown(context.Context) error
-	Version(context.Context) (string, error)
-	CreateHandlers(context.Context) (map[string]http.Handler, error)
 	NewHTTPHandler(ctx context.Context) (http.Handler, error)
-	WaitForEvent(ctx context.Context) (common.Message, error)
 
-	GetBlock(context.Context, ids.ID) (*blocks.Block, error)
 	ParseBlock(context.Context, []byte) (*blocks.Block, error)
 	BuildBlock(context.Context, *block.Context) (*blocks.Block, error) // block.Context MAY be nil
+	SetPreference(context.Context, ids.ID, *block.Context) error       // block.Context MAY be nil
 	VerifyBlock(context.Context, *block.Context, *blocks.Block) error  // block.Context MAY be nil
-	AcceptBlock(context.Context, *blocks.Block) error
 	RejectBlock(context.Context, *blocks.Block) error
-	SetPreference(context.Context, ids.ID, *block.Context) error // block.Context MAY be nil
-	LastAccepted(context.Context) (ids.ID, error)
-	GetBlockIDAtHeight(context.Context, uint64) (ids.ID, error)
+	AcceptBlock(context.Context, *blocks.Block) error
+
+	Version(context.Context) (string, error)
 }
 
-type orchestrator struct {
+// StateSyncConfig configures state sync.
+type StateSyncConfig struct {
+	Enabled        *bool
+	NodeIDs        []ids.NodeID
+	StateScheme    string
+	CommitInterval uint64
+}
+
+// SummaryHandler is the state syncable component. It serves summaries and the
+// disk-backed block methods during sync and signals completion via WaitForEvent.
+type SummaryHandler[SP adaptor.SummaryProperties] interface {
+	StateDependent
+
+	Initialize(
+		ctx context.Context,
+		snowCtx *snow.Context,
+		cfg StateSyncConfig,
+		db database.Database,
+		genesis *types.Block,
+	) error
+	StateSyncEnabled(context.Context) (bool, error)
+	GetLastStateSummary(context.Context) (SP, error)
+	GetOngoingSyncStateSummary(context.Context) (SP, error)
+	GetStateSummary(context.Context, uint64) (SP, error)
+	ParseStateSummary(context.Context, []byte) (SP, error)
+	AcceptSummary(context.Context, SP) (block.StateSyncMode, error)
+}
+
+// deferredBuild holds the inputs captured at Initialize for the late chain build.
+type deferredBuild struct {
+	snowCtx      *snow.Context
+	db           database.Database
+	genesisBytes []byte
+	configBytes  []byte
+}
+
+// orchestrator is the single VM the engine sees. It routes each call to the state
+// syncable component while syncing and to the executing chain once built.
+type orchestrator[SP adaptor.SummaryProperties] struct {
 	*network.Network
 	ChainVM
+	SummaryHandler[SP]
 
-	initialized bool
+	parser Parser
+
+	state           utils.Atomic[snow.State] // zero value is [snow.Initializing]
+	deferred        deferredBuild
+	syncInitialized bool
 }
 
 // New constructs a new [adaptor.ChainVMWithContext] with the provided [ChainVM].
@@ -64,12 +135,36 @@ type orchestrator struct {
 // is not expected to be initialized, but it MUST be fully initialized after
 // [ChainVM.Initialize].
 func New(zeroVM ChainVM) adaptor.ChainVMWithContext {
-	return adaptor.Convert(&orchestrator{
+	return adaptor.Convert(&orchestrator[adaptor.SummaryProperties]{
 		ChainVM: zeroVM,
 	})
 }
 
-func (o *orchestrator) Initialize(
+type shim struct {
+	adaptor.ChainVMWithContext
+	block.StateSyncableVM
+}
+
+// NewStateSyncable constructs a new [adaptor.ChainVMWithContext] with the provided [ChainVM].
+// The returned orchestrator is not initialized. The provided [ChainVM]
+// is not expected to be initialized, but it MUST be fully initialized after
+// [ChainVM.Initialize].
+// The returned struct additionally implements [block.StateSyncableVM].
+func NewStateSyncable[SP adaptor.SummaryProperties](zeroVM ChainVM, summaryHandler SummaryHandler[SP], parser Parser) adaptor.ChainVMWithContext {
+	o := &orchestrator[SP]{
+		SummaryHandler: summaryHandler,
+		ChainVM:        zeroVM,
+		parser:         parser,
+	}
+	return shim{
+		ChainVMWithContext: adaptor.Convert(o),
+		StateSyncableVM:    adaptor.ConvertStateSync(o),
+	}
+}
+
+// Initialize creates the shared network, initializes the summary handler, and
+// captures the inputs for the chain build deferred to bootstrapping.
+func (o *orchestrator[_]) Initialize(
 	ctx context.Context,
 	snowCtx *snow.Context,
 	db database.Database,
@@ -84,16 +179,92 @@ func (o *orchestrator) Initialize(
 		return err
 	}
 	o.Network = network
-	if err := o.ChainVM.Initialize(ctx, snowCtx, db, genesisBytes, configBytes, network); err != nil {
+
+	// Capture for eventual chain initialize
+	o.deferred = deferredBuild{
+		snowCtx:      snowCtx,
+		db:           db,
+		genesisBytes: genesisBytes,
+		configBytes:  configBytes,
+	}
+
+	// Allow no summary handler for testing.
+	if o.SummaryHandler == nil {
+		return nil
+	}
+
+	config, err := o.parser.ParseConfig(configBytes)
+	if err != nil {
 		return err
 	}
-	o.initialized = true
+
+	g, err := o.parser.ParseGenesis(genesisBytes)
+	if err != nil {
+		return err
+	}
+	if err := o.SummaryHandler.Initialize(ctx, snowCtx, config.StateSyncConfig(), db, g); err != nil {
+		return err
+	}
+	o.syncInitialized = true
+
 	return nil
 }
 
-func (o *orchestrator) Shutdown(ctx context.Context) error {
-	if !o.initialized {
+func (o *orchestrator[_]) StateSyncEnabled(ctx context.Context) (bool, error) {
+	if o.SummaryHandler == nil {
+		return false, nil
+	}
+	return o.SummaryHandler.StateSyncEnabled(ctx)
+}
+
+// Shutdown releases the summary handler always and the chain if it was built.
+func (o *orchestrator[_]) Shutdown(ctx context.Context) error {
+	var err error
+	if o.state.Get() >= snow.Bootstrapping {
+		err = o.ChainVM.Shutdown(ctx)
+	}
+	if o.syncInitialized {
+		err = errors.Join(err, o.SummaryHandler.Shutdown(ctx))
+	}
+	return err
+}
+
+func (o *orchestrator[_]) SetState(ctx context.Context, state snow.State) error {
+	prev := o.state.Get()
+	defer o.state.Set(state) // In defer to guarantee ChainVM is initialized first
+
+	if state < snow.Bootstrapping {
 		return nil
 	}
-	return o.ChainVM.Shutdown(ctx)
+
+	if prev < snow.Bootstrapping {
+		b := o.deferred
+		if err := o.ChainVM.Initialize(ctx, b.snowCtx, b.db, b.genesisBytes, b.configBytes, o.Network); err != nil {
+			return err
+		}
+	}
+	return o.ChainVM.SetState(ctx, state)
+}
+
+func (o *orchestrator[_]) activeHandler() StateDependent {
+	if o.state.Get() >= snow.Bootstrapping || o.SummaryHandler == nil {
+		return o.ChainVM
+	}
+	return o.SummaryHandler
+}
+
+func (o *orchestrator[_]) GetBlock(ctx context.Context, id ids.ID) (*blocks.Block, error) {
+	return o.activeHandler().GetBlock(ctx, id)
+}
+
+func (o *orchestrator[_]) GetBlockIDAtHeight(ctx context.Context, height uint64) (ids.ID, error) {
+	return o.activeHandler().GetBlockIDAtHeight(ctx, height)
+}
+
+func (o *orchestrator[_]) LastAccepted(ctx context.Context) (ids.ID, error) {
+	return o.activeHandler().LastAccepted(ctx)
+}
+
+func (o *orchestrator[_]) WaitForEvent(ctx context.Context) (common.Message, error) {
+	return o.activeHandler().WaitForEvent(ctx)
 }

--- a/vms/saevm/orchestrator/orchestrator_test.go
+++ b/vms/saevm/orchestrator/orchestrator_test.go
@@ -4,12 +4,278 @@
 package orchestrator
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
+	"github.com/ava-labs/libevm/core/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/network"
 )
 
-func TestShutdownBeforeInitialize(t *testing.T) {
-	o := New(nil)
-	require.NoError(t, o.Shutdown(t.Context()))
+func TestInterfaces(t *testing.T) {
+	t.Run("New()", func(t *testing.T) {
+		o := New(nil)
+		_, ok := o.(block.StateSyncableVM)
+		require.Falsef(t, ok, "New() should not return a block.StateSynableVM")
+	})
+
+	t.Run("NewStateSyncable()", func(t *testing.T) {
+		o := NewStateSyncable[adaptor.SummaryProperties](nil, nil, nil)
+		_, ok := o.(block.StateSyncableVM)
+		require.Truef(t, ok, "NewStateSyncable() should return a block.StateSyncableVM")
+	})
 }
+
+func mustInitialize(t *testing.T, o adaptor.ChainVMWithContext) {
+	t.Helper()
+
+	err := o.Initialize(t.Context(), snowtest.Context(t, ids.ID{}), nil, nil, nil, nil, nil, &enginetest.SenderStub{})
+	require.NoErrorf(t, err, "%T.Initialize()", o)
+}
+
+func TestShutdownAnyState(t *testing.T) {
+	for _, state := range []snow.State{snow.Initializing, snow.StateSyncing, snow.Bootstrapping, snow.NormalOp} {
+		t.Run(state.String(), func(t *testing.T) {
+			chain := &spyChainVM{}
+			summary := &spySummaryHandler{}
+			o := NewStateSyncable[adaptor.SummaryProperties](chain, summary, parser{})
+			if state != snow.Initializing {
+				mustInitialize(t, o)
+				require.NoErrorf(t, o.SetState(t.Context(), state), "SetState(%s)", state)
+			}
+			require.NoErrorf(t, o.Shutdown(t.Context()), "Shutdown() at %s", state)
+		})
+	}
+}
+
+func TestSkipBootstrapping(t *testing.T) {
+	chain := &spyChainVM{}
+	summary := &spySummaryHandler{}
+	o := NewStateSyncable[adaptor.SummaryProperties](chain, summary, parser{})
+	mustInitialize(t, o)
+	ctx := t.Context()
+
+	require.NoErrorf(t, o.SetState(ctx, snow.NormalOp), "SetState(NormalOp)")
+
+	// The orchestrator should have routed the bootstrapping state to the chain
+	// and not the summary handler.
+	require.Equal(t, initializeMethod, chain.routed.take(), "should route to ChainVM")
+	require.Equal(t, noMethod, summary.routed.take(), "should not reach SummaryHandler")
+}
+
+func TestStateRouting(t *testing.T) {
+	chain := &spyChainVM{}
+	summary := &spySummaryHandler{}
+	o := NewStateSyncable[adaptor.SummaryProperties](chain, summary, parser{})
+	mustInitialize(t, o)
+	ctx := t.Context()
+
+	routedMethods := []struct {
+		method routedMethod
+		call   func()
+	}{
+		{
+			method: getBlockMethod,
+			call:   func() { _, _ = o.GetBlock(ctx, ids.Empty) },
+		},
+		{
+			method: getBlockIDAtHeightMethod,
+			call:   func() { _, _ = o.GetBlockIDAtHeight(ctx, 0) },
+		},
+		{
+			method: lastAcceptedMethod,
+			call:   func() { _, _ = o.LastAccepted(ctx) },
+		},
+		{
+			method: waitForEventMethod,
+			call:   func() { _, _ = o.WaitForEvent(ctx) },
+		},
+	}
+	states := []struct {
+		state   snow.State
+		toChain bool
+	}{
+		{snow.Initializing, false},
+		{snow.StateSyncing, false},
+		{snow.Bootstrapping, true},
+		{snow.NormalOp, true},
+	}
+
+	for _, st := range states {
+		t.Run(st.state.String(), func(t *testing.T) {
+			require.NoErrorf(t, o.SetState(ctx, st.state), "SetState(%s)", st.state)
+			for _, m := range routedMethods {
+				t.Run(m.method.String(), func(t *testing.T) {
+					m.call()
+
+					gotChain, gotSummary := chain.routed.take(), summary.routed.take()
+					if st.toChain {
+						require.Equal(t, m.method, gotChain, "should route to ChainVM")
+						require.Equal(t, noMethod, gotSummary, "should not reach SummaryHandler")
+					} else {
+						require.Equal(t, m.method, gotSummary, "should route to SummaryHandler")
+						require.Equal(t, noMethod, gotChain, "should not reach ChainVM")
+					}
+				})
+			}
+		})
+	}
+}
+
+type routedMethod int
+
+const (
+	noMethod routedMethod = iota // zero value
+	getBlockMethod
+	getBlockIDAtHeightMethod
+	lastAcceptedMethod
+	waitForEventMethod
+	initializeMethod
+)
+
+func (m routedMethod) String() string {
+	switch m {
+	case getBlockMethod:
+		return "GetBlock"
+	case getBlockIDAtHeightMethod:
+		return "GetBlockIDAtHeight"
+	case lastAcceptedMethod:
+		return "LastAccepted"
+	case waitForEventMethod:
+		return "WaitForEvent"
+	default:
+		return "none"
+	}
+}
+
+// routeRecorder captures the routed method a stub most recently received, so a
+// test can observe which handler the orchestrator selected.
+type routeRecorder struct {
+	method routedMethod
+}
+
+func (r *routeRecorder) record(m routedMethod) { r.method = m }
+
+// take returns the recorded method and resets the recorder to [noMethod].
+func (r *routeRecorder) take() routedMethod {
+	m := r.method
+	r.method = noMethod
+	return m
+}
+
+// spyChainVM tracks the most recent routed method it received
+type spyChainVM struct {
+	routed routeRecorder
+}
+
+func (c *spyChainVM) Initialize(context.Context, *snow.Context, database.Database, []byte, []byte, *network.Network) error {
+	c.routed.record(initializeMethod)
+	return nil
+}
+
+func (c *spyChainVM) WaitForEvent(context.Context) (common.Message, error) {
+	c.routed.record(waitForEventMethod)
+	return common.PendingTxs, nil
+}
+
+func (c *spyChainVM) GetBlock(context.Context, ids.ID) (*blocks.Block, error) {
+	c.routed.record(getBlockMethod)
+	return nil, nil
+}
+
+func (c *spyChainVM) LastAccepted(context.Context) (ids.ID, error) {
+	c.routed.record(lastAcceptedMethod)
+	return ids.Empty, nil
+}
+
+func (c *spyChainVM) GetBlockIDAtHeight(context.Context, uint64) (ids.ID, error) {
+	c.routed.record(getBlockIDAtHeightMethod)
+	return ids.Empty, nil
+}
+
+func (*spyChainVM) HealthCheck(context.Context) (interface{}, error)          { return nil, nil }
+func (*spyChainVM) SetState(context.Context, snow.State) error                { return nil }
+func (*spyChainVM) Shutdown(context.Context) error                            { return nil }
+func (*spyChainVM) NewHTTPHandler(context.Context) (http.Handler, error)      { return nil, nil }
+func (*spyChainVM) ParseBlock(context.Context, []byte) (*blocks.Block, error) { return nil, nil }
+func (*spyChainVM) BuildBlock(context.Context, *block.Context) (*blocks.Block, error) {
+	return nil, nil
+}
+func (*spyChainVM) VerifyBlock(context.Context, *block.Context, *blocks.Block) error { return nil }
+func (*spyChainVM) AcceptBlock(context.Context, *blocks.Block) error                 { return nil }
+func (*spyChainVM) RejectBlock(context.Context, *blocks.Block) error                 { return nil }
+func (*spyChainVM) SetPreference(context.Context, ids.ID, *block.Context) error      { return nil }
+
+func (*spyChainVM) Version(context.Context) (string, error)                         { return "", nil }
+func (*spyChainVM) CreateHandlers(context.Context) (map[string]http.Handler, error) { return nil, nil }
+
+// spySummaryHandler tracks the most recent routed method it received
+type spySummaryHandler struct {
+	routed routeRecorder
+}
+
+func (h *spySummaryHandler) WaitForEvent(context.Context) (common.Message, error) {
+	h.routed.record(waitForEventMethod)
+	return common.StateSyncDone, nil
+}
+
+func (*spySummaryHandler) Initialize(context.Context, *snow.Context, StateSyncConfig, database.Database, *types.Block) error {
+	return nil
+}
+
+func (h *spySummaryHandler) GetBlock(context.Context, ids.ID) (*blocks.Block, error) {
+	h.routed.record(getBlockMethod)
+	return nil, nil
+}
+
+func (h *spySummaryHandler) LastAccepted(context.Context) (ids.ID, error) {
+	h.routed.record(lastAcceptedMethod)
+	return ids.Empty, nil
+}
+
+func (h *spySummaryHandler) GetBlockIDAtHeight(context.Context, uint64) (ids.ID, error) {
+	h.routed.record(getBlockIDAtHeightMethod)
+	return ids.Empty, nil
+}
+
+func (*spySummaryHandler) Shutdown(context.Context) error                 { return nil }
+func (*spySummaryHandler) StateSyncEnabled(context.Context) (bool, error) { return false, nil }
+func (*spySummaryHandler) GetLastStateSummary(context.Context) (adaptor.SummaryProperties, error) {
+	return nil, nil
+}
+
+func (*spySummaryHandler) GetOngoingSyncStateSummary(context.Context) (adaptor.SummaryProperties, error) {
+	return nil, nil
+}
+
+func (*spySummaryHandler) GetStateSummary(context.Context, uint64) (adaptor.SummaryProperties, error) {
+	return nil, nil
+}
+
+func (*spySummaryHandler) ParseStateSummary(context.Context, []byte) (adaptor.SummaryProperties, error) {
+	return nil, nil
+}
+
+func (*spySummaryHandler) AcceptSummary(context.Context, adaptor.SummaryProperties) (block.StateSyncMode, error) {
+	return block.StateSyncSkipped, nil
+}
+
+type parser struct{}
+
+func (parser) ParseGenesis([]byte) (*types.Block, error) { return nil, nil }
+func (parser) ParseConfig([]byte) (VMConfig, error)      { return config{}, nil }
+
+type config struct{}
+
+func (config) StateSyncConfig() StateSyncConfig { return StateSyncConfig{} }

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -157,10 +157,10 @@ func newSUT(tb testing.TB, numAccounts uint, opts ...sutOption) (context.Context
 	}, opts...)
 
 	vm := NewSinceGenesis(conf.hooks, conf.vmConfig)
-	snow := orchestrator.New(vm)
+	snowVM := orchestrator.New(vm)
 	tb.Cleanup(func() {
 		ctx := context.WithoutCancel(tb.Context())
-		require.NoError(tb, snow.Shutdown(ctx), "Shutdown()")
+		require.NoError(tb, snowVM.Shutdown(ctx), "Shutdown()")
 	})
 
 	logger := loggingtest.New(tb, conf.logLevel)
@@ -172,7 +172,7 @@ func newSUT(tb testing.TB, numAccounts uint, opts ...sutOption) (context.Context
 
 	sender := saetest.NewSender(tb, conf.validators)
 
-	require.NoError(tb, snow.Initialize(
+	require.NoError(tb, snowVM.Initialize(
 		ctx,
 		snowCtx,
 		conf.db,
@@ -182,6 +182,7 @@ func newSUT(tb testing.TB, numAccounts uint, opts ...sutOption) (context.Context
 		nil, // Fxs
 		sender,
 	), "Initialize()")
+	require.NoError(tb, snowVM.SetState(ctx, snow.NormalOp), "SetState(NormalOp)")
 
 	if len(conf.precompiles) > 0 {
 		// All precompile registrations must occur after the VM is initialized,
@@ -198,11 +199,11 @@ func newSUT(tb testing.TB, numAccounts uint, opts ...sutOption) (context.Context
 
 	// Avalanchego marks the local node as connected so that p2p protocols
 	// don't need to treat our node as a special case.
-	require.NoErrorf(tb, snow.Connected(ctx, snowCtx.NodeID, version.Current), "Connected(%s)", snowCtx.NodeID)
+	require.NoErrorf(tb, snowVM.Connected(ctx, snowCtx.NodeID, version.Current), "Connected(%s)", snowCtx.NodeID)
 
-	rpcClient, ethClient := dialRPC(ctx, tb, snow)
+	rpcClient, ethClient := dialRPC(ctx, tb, snowVM)
 	sut := &SUT{
-		ChainVM:   snow,
+		ChainVM:   snowVM,
 		Client:    ethClient,
 		rpcClient: rpcClient,
 		rawVM:     vm.VM,


### PR DESCRIPTION
## Why this should be merged

There's some operations that need to happen before we fully initialize the VM, so there's routing in the orchestrator to determine when to send methods to the VM.

Really, the important thing to review here is the interface definitions

## How this works

Knowledge of the inner workings of consensus, and some careful synchronous guarantees.

## How this was tested

New UT

## Need to be documented in RELEASES.md?

No
