### PR TITLE
[ci] Shift unit testing from PR runs to pre-merge and scheduled jobs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,8 @@
+# GitHub Actions workflows
+
+This directory contains repository CI/CD workflows.
+
+## Guides
+
+- [Test workflows](./test-workflows.md) - how PR, pre-merge, and scheduled test coverage are
+  split; what the CI labels do; and how to change the policy safely

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,9 @@
+# GitHub Actions workflows
+
+This directory contains GitHub Actions workflows for continuous integration
+and deployment.
+
+## Guides
+
+- [Test workflows](./test-workflows.md) - test coverage for PR, pre-merge,
+  and scheduled runs; labels that select test coverage; and maintainer guidance

--- a/.github/workflows/bazel-ci-matrix.yml
+++ b/.github/workflows/bazel-ci-matrix.yml
@@ -2,6 +2,10 @@ name: Bazel
 
 # Top-level Bazel CI entrypoint. This workflow defines the platform matrix
 # once and invokes bazel-ci.yml once per platform.
+#
+# PRs default to the cheapest useful Bazel coverage. Applying the ci/pre-merge
+# label upgrades a PR to the same Bazel unit-test coverage as pre-merge runs so
+# contributors can reproduce merge-queue coverage before landing.
 on:
   push:
     tags:
@@ -10,6 +14,7 @@ on:
       - master
       - dev
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 
@@ -34,16 +39,26 @@ jobs:
         id: set-platforms
         shell: bash
         run: |
-          echo 'platforms=["linux-amd64","linux-arm64","darwin-arm64"]' >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if jq -e '.pull_request.labels[]? | select(.name == "ci/pre-merge")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo 'platforms=[{"platform_name":"linux-amd64-24.04","runner":"ubuntu-24.04","unit_test_mode":"race","run_e2e":true},{"platform_name":"darwin-arm64","runner":"macos-26","unit_test_mode":"race","run_e2e":true}]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'platforms=[{"platform_name":"linux-amd64-24.04","runner":"ubuntu-24.04","unit_test_mode":"fast","run_e2e":true}]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'platforms=[{"platform_name":"linux-amd64-24.04","runner":"ubuntu-24.04","unit_test_mode":"race","run_e2e":true},{"platform_name":"darwin-arm64","runner":"macos-26","unit_test_mode":"race","run_e2e":true}]' >> "$GITHUB_OUTPUT"
+          fi
   matrix:
     needs: bz-define-matrix
-    name: ${{ matrix.platform }}
+    name: ${{ matrix.platform_name }}
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(needs.bz-define-matrix.outputs.platforms) }}
+        include: ${{ fromJSON(needs.bz-define-matrix.outputs.platforms) }}
     uses: ./.github/workflows/bazel-ci.yml
     with:
-      platform_name: ${{ matrix.platform }}
-      runner: ${{ matrix.platform == 'linux-amd64' && 'ubuntu-24.04' || matrix.platform == 'linux-arm64' && 'ubuntu-24.04-arm' || 'macos-26' }}
+      platform_name: ${{ matrix.platform_name }}
+      runner: ${{ matrix.runner }}
+      unit_test_mode: ${{ matrix.unit_test_mode }}
+      run_e2e: ${{ matrix.run_e2e }}
     secrets: inherit

--- a/.github/workflows/bazel-ci-matrix.yml
+++ b/.github/workflows/bazel-ci-matrix.yml
@@ -2,6 +2,10 @@ name: Bazel
 
 # Top-level Bazel CI entrypoint. This workflow defines the platform matrix
 # once and invokes bazel-ci.yml once per platform.
+#
+# Bazel unit tests are authoritative on default PRs. The ci/pre-merge label
+# adds Darwin/arm64 coverage before merge. This checks that master still works
+# for Darwin developers.
 on:
   push:
     tags:
@@ -10,6 +14,7 @@ on:
       - master
       - dev
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 
@@ -34,16 +39,26 @@ jobs:
         id: set-platforms
         shell: bash
         run: |
-          echo 'platforms=["linux-amd64","linux-arm64","darwin-arm64"]' >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if jq -e '.pull_request.labels[]? | select(.name == "ci/pre-merge")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo 'platforms=[{"platform_name":"linux-amd64-24.04","runner":"ubuntu-24.04","unit_test_mode":"default","run_e2e":true},{"platform_name":"darwin-arm64","runner":"macos-26","unit_test_mode":"default","run_e2e":true}]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'platforms=[{"platform_name":"linux-amd64-24.04","runner":"ubuntu-24.04","unit_test_mode":"default","run_e2e":true}]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'platforms=[{"platform_name":"linux-amd64-24.04","runner":"ubuntu-24.04","unit_test_mode":"default","run_e2e":true},{"platform_name":"darwin-arm64","runner":"macos-26","unit_test_mode":"default","run_e2e":true}]' >> "$GITHUB_OUTPUT"
+          fi
   matrix:
     needs: bz-define-matrix
-    name: ${{ matrix.platform }}
+    name: ${{ matrix.platform_name }}
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(needs.bz-define-matrix.outputs.platforms) }}
+        include: ${{ fromJSON(needs.bz-define-matrix.outputs.platforms) }}
     uses: ./.github/workflows/bazel-ci.yml
     with:
-      platform_name: ${{ matrix.platform }}
-      runner: ${{ matrix.platform == 'linux-amd64' && 'ubuntu-24.04' || matrix.platform == 'linux-arm64' && 'ubuntu-24.04-arm' || 'macos-26' }}
+      platform_name: ${{ matrix.platform_name }}
+      runner: ${{ matrix.runner }}
+      unit_test_mode: ${{ matrix.unit_test_mode }}
+      run_e2e: ${{ matrix.run_e2e }}
     secrets: inherit

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -11,6 +11,14 @@ on:
       runner:
         required: true
         type: string
+      unit_test_mode:
+        required: false
+        type: string
+        default: race-shuffle
+      run_e2e:
+        required: false
+        type: boolean
+        default: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -37,14 +45,21 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["e2e"]'
         run: |
-          failed_jobs="$(
-            jq -r '
+          failed_jobs="$({
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
-          )"
+          })"
 
           if [[ -n "$failed_jobs" ]]; then
             echo "Required jobs failed:"
@@ -73,7 +88,17 @@ jobs:
       - uses: ./.github/actions/setup-bazel
       - name: Run unit tests with Bazel
         shell: bash
-        run: ./scripts/run_task.sh bazel-test-main
+        run: |
+          case '${{ inputs.unit_test_mode }}' in
+            fast) task_name='bazel-test-main-fast' ;;
+            race) task_name='bazel-test-main-race' ;;
+            race-shuffle) task_name='bazel-test-main-race-shuffle' ;;
+            *)
+              echo "unknown unit test mode: ${{ inputs.unit_test_mode }}" >&2
+              exit 1
+              ;;
+          esac
+          ./scripts/run_task.sh "$task_name"
 
   unit-coreth:
     needs: setup
@@ -83,7 +108,17 @@ jobs:
       - uses: ./.github/actions/setup-bazel
       - name: Run coreth unit tests with Bazel
         shell: bash
-        run: ./scripts/run_task.sh bazel-test-coreth
+        run: |
+          case '${{ inputs.unit_test_mode }}' in
+            fast) task_name='bazel-test-coreth-fast' ;;
+            race) task_name='bazel-test-coreth-race' ;;
+            race-shuffle) task_name='bazel-test-coreth-race-shuffle' ;;
+            *)
+              echo "unknown unit test mode: ${{ inputs.unit_test_mode }}" >&2
+              exit 1
+              ;;
+          esac
+          ./scripts/run_task.sh "$task_name"
 
   unit-subnet-evm:
     needs: setup
@@ -93,9 +128,20 @@ jobs:
       - uses: ./.github/actions/setup-bazel
       - name: Run subnet-evm unit tests with Bazel
         shell: bash
-        run: ./scripts/run_task.sh bazel-test-subnet-evm
+        run: |
+          case '${{ inputs.unit_test_mode }}' in
+            fast) task_name='bazel-test-subnet-evm-fast' ;;
+            race) task_name='bazel-test-subnet-evm-race' ;;
+            race-shuffle) task_name='bazel-test-subnet-evm-race-shuffle' ;;
+            *)
+              echo "unknown unit test mode: ${{ inputs.unit_test_mode }}" >&2
+              exit 1
+              ;;
+          esac
+          ./scripts/run_task.sh "$task_name"
 
   e2e:
+    if: ${{ inputs.run_e2e }}
     needs: setup
     runs-on: ${{ inputs.runner }}
     steps:

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -11,6 +11,14 @@ on:
       runner:
         required: true
         type: string
+      unit_test_mode:
+        required: false
+        type: string
+        default: race-shuffle
+      run_e2e:
+        required: false
+        type: boolean
+        default: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -37,11 +45,18 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["e2e"]'
         run: |
           failed_jobs="$({
-            jq -r '
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
           })"
@@ -77,7 +92,18 @@ jobs:
       - name: Run AvalancheGo unit tests with Bazel
         uses: ./.github/actions/run-bazel-with-disk-space
         with:
-          run: ./scripts/run_task.sh bazel-test-unit-avalanchego-race-shuffle
+          run: |
+            case '${{ inputs.unit_test_mode }}' in
+              default) task_name='bazel-test-unit-avalanchego' ;;
+              race) task_name='bazel-test-unit-avalanchego-race' ;;
+              shuffle) task_name='bazel-test-unit-avalanchego-shuffle' ;;
+              race-shuffle) task_name='bazel-test-unit-avalanchego-race-shuffle' ;;
+              *)
+                echo "unknown unit test mode: ${{ inputs.unit_test_mode }}" >&2
+                exit 1
+                ;;
+            esac
+            ./scripts/run_task.sh "$task_name"
 
   unit-coreth:
     needs: setup
@@ -87,7 +113,18 @@ jobs:
       - name: Run coreth unit tests with Bazel
         uses: ./.github/actions/run-bazel-with-disk-space
         with:
-          run: ./scripts/run_task.sh bazel-test-unit-coreth-race-shuffle
+          run: |
+            case '${{ inputs.unit_test_mode }}' in
+              default) task_name='bazel-test-unit-coreth' ;;
+              race) task_name='bazel-test-unit-coreth-race' ;;
+              shuffle) task_name='bazel-test-unit-coreth-shuffle' ;;
+              race-shuffle) task_name='bazel-test-unit-coreth-race-shuffle' ;;
+              *)
+                echo "unknown unit test mode: ${{ inputs.unit_test_mode }}" >&2
+                exit 1
+                ;;
+            esac
+            ./scripts/run_task.sh "$task_name"
 
   unit-subnet-evm:
     needs: setup
@@ -97,9 +134,21 @@ jobs:
       - name: Run subnet-evm unit tests with Bazel
         uses: ./.github/actions/run-bazel-with-disk-space
         with:
-          run: ./scripts/run_task.sh bazel-test-unit-subnet-evm-race-shuffle
+          run: |
+            case '${{ inputs.unit_test_mode }}' in
+              default) task_name='bazel-test-unit-subnet-evm' ;;
+              race) task_name='bazel-test-unit-subnet-evm-race' ;;
+              shuffle) task_name='bazel-test-unit-subnet-evm-shuffle' ;;
+              race-shuffle) task_name='bazel-test-unit-subnet-evm-race-shuffle' ;;
+              *)
+                echo "unknown unit test mode: ${{ inputs.unit_test_mode }}" >&2
+                exit 1
+                ;;
+            esac
+            ./scripts/run_task.sh "$task_name"
 
   e2e:
+    if: ${{ inputs.run_e2e }}
     needs: setup
     runs-on: ${{ inputs.runner }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Tests
 
+# PR validation keeps the overlapping Go unit-test coverage off by default because
+# Bazel covers unit tests on PRs. Applying the ci/pre-merge label opts a PR into
+# the Go unit-test shard as well so contributors can reproduce pre-merge unit
+# coverage before merge.
 on:
   push:
     tags:
@@ -8,6 +12,7 @@ on:
       - master
       - dev
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 
@@ -55,11 +60,18 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["Unit"]'
         run: |
           failed_jobs="$(
-            jq -r '
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
           )"
@@ -71,17 +83,18 @@ jobs:
           fi
 
   Unit:
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
+        os: [macos-26, ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
       - name: test-unit
         shell: bash
-        run: ./scripts/run_task.sh test-unit
+        run: ./scripts/run_task.sh test-unit-race
         env:
           TIMEOUT: ${{ env.TIMEOUT }}
   Fuzz:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+# Bazel unit tests are authoritative on default PRs. The ci/pre-merge label
+# adds native Go unit tests before merge. This checks that master still works
+# for developers who run Go tests without Bazel.
 on:
   push:
     tags:
@@ -8,6 +11,7 @@ on:
       - master
       - dev
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 
@@ -55,11 +59,18 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["Unit", "e2e"]'
         run: |
           failed_jobs="$(
-            jq -r '
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
           )"
@@ -71,11 +82,12 @@ jobs:
           fi
 
   Unit:
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
+        os: [macos-26, ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
@@ -93,13 +105,14 @@ jobs:
         shell: bash
         run: ./scripts/run_task.sh test-fuzz
   e2e:
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # The default free runners lack the resources for parallel execution, so
-        # beefier runners are required.
-        os: [blacksmith-4vcpu-ubuntu-2404, ubuntu-24.04-arm-4-core]
+        # a beefier Linux runner is required.
+        os: [blacksmith-4vcpu-ubuntu-2404, macos-26]
     steps:
       - uses: actions/checkout@v5
       - name: Run e2e tests

--- a/.github/workflows/coreth-ci.yml
+++ b/.github/workflows/coreth-ci.yml
@@ -1,11 +1,20 @@
 name: Coreth
+
+# PR validation skips Coreth unit tests by default. Applying the ci/pre-merge
+# label upgrades a PR to the same unit-test coverage as pre-merge runs so
+# contributors can reproduce stronger validation before landing. Scheduled and
+# manually dispatched runs restore the broader multi-platform unit-test matrix.
 on:
   push:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  schedule:
+    - cron: '35 2 * * *'
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -15,6 +24,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - lint_test
+      - define-unit-test-matrix
       - unit_test
       - e2e_warp
     runs-on: ubuntu-24.04
@@ -23,14 +33,21 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["unit_test"]'
         run: |
-          failed_jobs="$(
-            jq -r '
+          failed_jobs="$({
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
-          )"
+          })"
 
           if [[ -n "$failed_jobs" ]]; then
             echo "Required jobs failed:"
@@ -52,8 +69,30 @@ jobs:
       - name: Check go.mod and go.sum are up-to-date
         run: ./scripts/run_task.sh check-go-mod-tidy
 
+  define-unit-test-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      platforms: ${{ steps.set-platforms.outputs.platforms }}
+    steps:
+      - name: Define unit-test matrix
+        id: set-platforms
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test-race-shuffle"},{"os":"ubuntu-22.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04","task_name":"build-test-race-shuffle"}]' >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if jq -e '.pull_request.labels[]? | select(.name == "ci/pre-merge")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo 'platforms=[{"os":"macos-26","task_name":"build-test-race"},{"os":"ubuntu-24.04","task_name":"build-test-race"}]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'platforms=[]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test-race"},{"os":"ubuntu-24.04","task_name":"build-test-race"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   unit_test:
-    name: Unit Tests (${{ matrix.os }})
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
+    needs: define-unit-test-matrix
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -61,11 +100,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.platforms) }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
-      - run: ./scripts/run_task.sh build-test
+      - run: ./scripts/run_task.sh ${{ matrix.task_name }}
       - run: ./scripts/run_task.sh coverage
 
   e2e_warp:

--- a/.github/workflows/coreth-ci.yml
+++ b/.github/workflows/coreth-ci.yml
@@ -1,11 +1,20 @@
 name: Coreth
+
+# Default PRs run Coreth Warp E2E tests on Ubuntu 24.04 amd64. The
+# ci/pre-merge label runs unit and E2E tests on Ubuntu 24.04 amd64 and macOS 26
+# arm64. Scheduled and manual runs test all five CI platforms with
+# race-shuffle and run Warp E2E tests.
 on:
   push:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  schedule:
+    - cron: '35 2 * * *'
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -15,6 +24,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - lint_test
+      - define-unit-test-matrix
       - unit_test
       - e2e_warp
     runs-on: ubuntu-24.04
@@ -23,14 +33,21 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["lint_test", "unit_test", "e2e_warp"]'
         run: |
-          failed_jobs="$(
-            jq -r '
+          failed_jobs="$({
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
-          )"
+          })"
 
           if [[ -n "$failed_jobs" ]]; then
             echo "Required jobs failed:"
@@ -39,6 +56,7 @@ jobs:
           fi
 
   lint_test:
+    if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
     name: Lint
     runs-on: ubuntu-24.04
     defaults:
@@ -53,8 +71,35 @@ jobs:
       - name: Check go.mod and go.sum are up-to-date
         run: ./scripts/run_task.sh check-go-mod-tidy
 
+  define-unit-test-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      platforms: ${{ steps.set-platforms.outputs.platforms }}
+      e2e_platforms: ${{ steps.set-platforms.outputs.e2e_platforms }}
+    steps:
+      - name: Define unit-test matrix
+        id: set-platforms
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo 'platforms=[{"os":"ubuntu-22.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-22.04-arm","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04-arm","task_name":"build-test-race-shuffle"},{"os":"macos-26","task_name":"build-test-race-shuffle"}]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_platforms=[{"os":"ubuntu-22.04"},{"os":"ubuntu-24.04"},{"os":"ubuntu-22.04-arm"},{"os":"ubuntu-24.04-arm"},{"os":"macos-26"}]' >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if jq -e '.pull_request.labels[]? | select(.name == "ci/pre-merge")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo 'platforms=[{"os":"macos-26","task_name":"build-test"},{"os":"ubuntu-24.04","task_name":"build-test"}]' >> "$GITHUB_OUTPUT"
+              echo 'e2e_platforms=[{"os":"macos-26"},{"os":"ubuntu-24.04"}]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'platforms=[]' >> "$GITHUB_OUTPUT"
+              echo 'e2e_platforms=[{"os":"ubuntu-24.04"}]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test"},{"os":"ubuntu-24.04","task_name":"build-test"}]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_platforms=[{"os":"macos-26"},{"os":"ubuntu-24.04"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   unit_test:
-    name: Unit Tests (${{ matrix.os }})
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
+    needs: define-unit-test-matrix
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -62,16 +107,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.platforms) }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
-      - run: ./scripts/run_task.sh build-test
+      - run: ./scripts/run_task.sh ${{ matrix.task_name }}
       - run: ./scripts/run_task.sh coverage
 
   e2e_warp:
-    name: E2E Warp Tests
-    runs-on: ubuntu-24.04
+    needs: define-unit-test-matrix
+    name: E2E Warp Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.e2e_platforms) }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v5
@@ -82,7 +132,7 @@ jobs:
         with:
           run: ./scripts/run_task.sh test-e2e-warp-ci
           working_directory: ./graft/coreth
-          artifact_prefix: warp
+          artifact_prefix: warp-${{ matrix.os }}
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
           prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
           prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}

--- a/.github/workflows/evm-ci.yml
+++ b/.github/workflows/evm-ci.yml
@@ -1,11 +1,21 @@
 name: EVM Shared
+
+# PR validation skips EVM shared unit tests by default. Applying the
+# ci/pre-merge label upgrades a PR to the same unit-test coverage as pre-merge
+# runs so contributors can reproduce stronger validation before landing.
+# Scheduled and manually dispatched runs restore the broader multi-platform
+# unit-test matrix.
 on:
   push:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  schedule:
+    - cron: '45 2 * * *'
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -15,6 +25,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - lint_test
+      - define-unit-test-matrix
       - unit_test
     runs-on: ubuntu-24.04
     steps:
@@ -22,14 +33,21 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["unit_test"]'
         run: |
-          failed_jobs="$(
-            jq -r '
+          failed_jobs="$({
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
-          )"
+          })"
 
           if [[ -n "$failed_jobs" ]]; then
             echo "Required jobs failed:"
@@ -51,8 +69,30 @@ jobs:
       - name: Check go.mod and go.sum are up-to-date
         run: ../../scripts/run_task.sh check-go-mod-tidy
 
+  define-unit-test-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      platforms: ${{ steps.set-platforms.outputs.platforms }}
+    steps:
+      - name: Define unit-test matrix
+        id: set-platforms
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test-race-shuffle"},{"os":"ubuntu-22.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04","task_name":"build-test-race-shuffle"}]' >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if jq -e '.pull_request.labels[]? | select(.name == "ci/pre-merge")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo 'platforms=[{"os":"macos-26","task_name":"build-test-race"},{"os":"ubuntu-24.04","task_name":"build-test-race"}]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'platforms=[]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test-race"},{"os":"ubuntu-24.04","task_name":"build-test-race"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   unit_test:
-    name: Unit Tests (${{ matrix.os }})
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
+    needs: define-unit-test-matrix
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -60,9 +100,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.platforms) }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
-      - run: ../../scripts/run_task.sh build-test
+      - run: ../../scripts/run_task.sh ${{ matrix.task_name }}
       - run: ../../scripts/run_task.sh coverage

--- a/.github/workflows/evm-ci.yml
+++ b/.github/workflows/evm-ci.yml
@@ -1,11 +1,19 @@
 name: EVM Shared
+
+# Default PRs do not run EVM unit tests. The ci/pre-merge label runs unit tests
+# on Ubuntu 24.04 amd64 and macOS 26 arm64. Scheduled and manual runs test all
+# five CI platforms with race-shuffle.
 on:
   push:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  schedule:
+    - cron: '45 2 * * *'
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -15,6 +23,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - lint_test
+      - define-unit-test-matrix
       - unit_test
     runs-on: ubuntu-24.04
     steps:
@@ -22,14 +31,21 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["lint_test", "unit_test"]'
         run: |
-          failed_jobs="$(
-            jq -r '
+          failed_jobs="$({
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
-          )"
+          })"
 
           if [[ -n "$failed_jobs" ]]; then
             echo "Required jobs failed:"
@@ -38,6 +54,7 @@ jobs:
           fi
 
   lint_test:
+    if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
     name: Lint
     runs-on: ubuntu-24.04
     defaults:
@@ -51,8 +68,30 @@ jobs:
       - name: Check go.mod and go.sum are up-to-date
         run: ../../scripts/run_task.sh check-go-mod-tidy
 
+  define-unit-test-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      platforms: ${{ steps.set-platforms.outputs.platforms }}
+    steps:
+      - name: Define unit-test matrix
+        id: set-platforms
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo 'platforms=[{"os":"ubuntu-22.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-22.04-arm","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04-arm","task_name":"build-test-race-shuffle"},{"os":"macos-26","task_name":"build-test-race-shuffle"}]' >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if jq -e '.pull_request.labels[]? | select(.name == "ci/pre-merge")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo 'platforms=[{"os":"macos-26","task_name":"build-test"},{"os":"ubuntu-24.04","task_name":"build-test"}]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'platforms=[]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test"},{"os":"ubuntu-24.04","task_name":"build-test"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   unit_test:
-    name: Unit Tests (${{ matrix.os }})
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
+    needs: define-unit-test-matrix
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -60,9 +99,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.platforms) }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
-      - run: ../../scripts/run_task.sh build-test
+      - run: ../../scripts/run_task.sh ${{ matrix.task_name }}
       - run: ../../scripts/run_task.sh coverage

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -1,12 +1,21 @@
 name: Subnet-EVM
 
+# PR validation skips Subnet-EVM unit tests by default. Applying the
+# ci/pre-merge label upgrades a PR to the same unit-test coverage as pre-merge
+# runs so contributors can reproduce stronger validation before landing.
+# Scheduled and manually dispatched runs restore the broader multi-platform
+# unit-test matrix.
 on:
   push:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  schedule:
+    - cron: '40 2 * * *'
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -16,6 +25,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - lint_test
+      - define-unit-test-matrix
       - unit_test
       - e2e_warp
       - e2e_load
@@ -27,14 +37,21 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["unit_test"]'
         run: |
-          failed_jobs="$(
-            jq -r '
+          failed_jobs="$({
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
-          )"
+          })"
 
           if [[ -n "$failed_jobs" ]]; then
             echo "Required jobs failed:"
@@ -56,8 +73,30 @@ jobs:
       - name: Check go.mod and go.sum are up-to-date
         run: ./scripts/run_task.sh check-go-mod-tidy
 
+  define-unit-test-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      platforms: ${{ steps.set-platforms.outputs.platforms }}
+    steps:
+      - name: Define unit-test matrix
+        id: set-platforms
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test-race-shuffle"},{"os":"ubuntu-22.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04","task_name":"build-test-race-shuffle"}]' >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if jq -e '.pull_request.labels[]? | select(.name == "ci/pre-merge")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo 'platforms=[{"os":"macos-26","task_name":"build-test-race"},{"os":"ubuntu-24.04","task_name":"build-test-race"}]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'platforms=[]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test-race"},{"os":"ubuntu-24.04","task_name":"build-test-race"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   unit_test:
-    name: Unit Tests (${{ matrix.os }})
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
+    needs: define-unit-test-matrix
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -65,11 +104,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.platforms) }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
-      - run: ./scripts/run_task.sh build-test
+      - run: ./scripts/run_task.sh ${{ matrix.task_name }}
       - run: ./scripts/run_task.sh coverage
 
   e2e_warp:

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -1,12 +1,20 @@
 name: Subnet-EVM
 
+# Default PRs run Subnet-EVM Warp and load E2E tests on Ubuntu 24.04 amd64.
+# The ci/pre-merge label runs unit and E2E tests on Ubuntu 24.04 amd64 and
+# macOS 26 arm64. Scheduled and manual runs test all five CI platforms with
+# race-shuffle and run Warp and load E2E tests.
 on:
   push:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  schedule:
+    - cron: '40 2 * * *'
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -16,6 +24,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - lint_test
+      - define-unit-test-matrix
       - unit_test
       - e2e_warp
       - e2e_load
@@ -27,14 +36,21 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          SKIPPABLE_JOBS_JSON: '["lint_test", "unit_test", "e2e_warp", "e2e_load", "test_build_image", "test_build_antithesis_images"]'
         run: |
-          failed_jobs="$(
-            jq -r '
+          failed_jobs="$({
+            jq -r --argjson skippable_jobs "$SKIPPABLE_JOBS_JSON" '
               to_entries[]
-              | select(.value.result != "success")
+              | select(
+                  .value.result != "success"
+                  and (
+                    .value.result != "skipped"
+                    or (.key as $job | ($skippable_jobs | index($job)) == null)
+                  )
+                )
               | .key
             ' <<<"$NEEDS_JSON"
-          )"
+          })"
 
           if [[ -n "$failed_jobs" ]]; then
             echo "Required jobs failed:"
@@ -43,6 +59,7 @@ jobs:
           fi
 
   lint_test:
+    if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
     name: Lint
     runs-on: ubuntu-24.04
     defaults:
@@ -57,8 +74,35 @@ jobs:
       - name: Check go.mod and go.sum are up-to-date
         run: ./scripts/run_task.sh check-go-mod-tidy
 
+  define-unit-test-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      platforms: ${{ steps.set-platforms.outputs.platforms }}
+      e2e_platforms: ${{ steps.set-platforms.outputs.e2e_platforms }}
+    steps:
+      - name: Define unit-test matrix
+        id: set-platforms
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo 'platforms=[{"os":"ubuntu-22.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04","task_name":"build-test-race-shuffle"},{"os":"ubuntu-22.04-arm","task_name":"build-test-race-shuffle"},{"os":"ubuntu-24.04-arm","task_name":"build-test-race-shuffle"},{"os":"macos-26","task_name":"build-test-race-shuffle"}]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_platforms=[{"os":"ubuntu-22.04"},{"os":"ubuntu-24.04"},{"os":"ubuntu-22.04-arm"},{"os":"ubuntu-24.04-arm"},{"os":"macos-26"}]' >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if jq -e '.pull_request.labels[]? | select(.name == "ci/pre-merge")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo 'platforms=[{"os":"macos-26","task_name":"build-test"},{"os":"ubuntu-24.04","task_name":"build-test"}]' >> "$GITHUB_OUTPUT"
+              echo 'e2e_platforms=[{"os":"macos-26"},{"os":"ubuntu-24.04"}]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'platforms=[]' >> "$GITHUB_OUTPUT"
+              echo 'e2e_platforms=[{"os":"ubuntu-24.04"}]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'platforms=[{"os":"macos-26","task_name":"build-test"},{"os":"ubuntu-24.04","task_name":"build-test"}]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_platforms=[{"os":"macos-26"},{"os":"ubuntu-24.04"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   unit_test:
-    name: Unit Tests (${{ matrix.os }})
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci/pre-merge') }}
+    needs: define-unit-test-matrix
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -66,16 +110,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, ubuntu-22.04, ubuntu-24.04]
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.platforms) }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project
-      - run: ./scripts/run_task.sh build-test
+      - run: ./scripts/run_task.sh ${{ matrix.task_name }}
       - run: ./scripts/run_task.sh coverage
 
   e2e_warp:
-    name: e2e warp tests
-    runs-on: ubuntu-24.04
+    needs: define-unit-test-matrix
+    name: e2e warp tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.e2e_platforms) }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v5
@@ -86,7 +135,7 @@ jobs:
         with:
           run: ./scripts/run_task.sh test-e2e-warp-ci
           working_directory: ./graft/subnet-evm
-          artifact_prefix: warp
+          artifact_prefix: warp-${{ matrix.os }}
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
           prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
           prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
@@ -97,8 +146,13 @@ jobs:
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
 
   e2e_load:
-    name: e2e load tests
-    runs-on: ubuntu-24.04
+    needs: define-unit-test-matrix
+    name: e2e load tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.define-unit-test-matrix.outputs.e2e_platforms) }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v5
@@ -109,7 +163,7 @@ jobs:
         with:
           run: ./scripts/run_task.sh test-e2e-load-ci
           working_directory: ./graft/subnet-evm
-          artifact_prefix: load
+          artifact_prefix: load-${{ matrix.os }}
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
           prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
           prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
@@ -120,6 +174,7 @@ jobs:
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
 
   test_build_image:
+    if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
     name: Image build
     runs-on: ubuntu-24.04
     steps:
@@ -132,6 +187,7 @@ jobs:
           working_directory: ./graft/subnet-evm
 
   test_build_antithesis_images:
+    if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
     name: Build Antithesis images
     # Use a faster runner pending migration to bazel. The default free runners result
     # in 20+ minute runtime, slowing down every PR and merge queue CI run.

--- a/.github/workflows/test-workflows.md
+++ b/.github/workflows/test-workflows.md
@@ -1,0 +1,217 @@
+# Test workflows
+
+## Overview
+
+This document explains how unit tests are split across PR, pre-merge, and
+scheduled workflows:
+
+- **PR runs** provide the fastest useful feedback.
+- **Pre-merge runs** add stronger validation before merge.
+- **Scheduled runs** provide broader platform coverage and stronger test
+  coverage.
+
+The main goals are:
+
+- keep default PR feedback fast
+- avoid duplicate coverage between Bazel and native Go workflows on PRs
+- preserve broader validation before merge and on a schedule
+- make the expanded coverage reproducible on demand when needed
+
+## Usage
+
+### Default PR coverage
+
+Default PR coverage uses the Bazel workflow for unit tests:
+
+- Bazel unit tests run on `linux-amd64/24.04`
+- Bazel unit tests use the `fast` mode
+  - no race detection
+  - no shuffle
+
+The native Go `Unit` job in `ci.yml` is skipped on PR runs to avoid duplicate
+unit-test coverage.
+
+The graft-module Go test jobs are also skipped on default PRs:
+
+- `coreth-ci.yml`
+- `subnet-evm-ci.yml`
+- `evm-ci.yml`
+
+### `ci/pre-merge`
+
+Applying the `ci/pre-merge` label upgrades a PR to the same test coverage
+used before merge:
+
+- enables the native Go `Unit` job in `ci.yml`
+- enables the Go test jobs in:
+  - `coreth-ci.yml`
+  - `subnet-evm-ci.yml`
+  - `evm-ci.yml`
+- expands Bazel unit coverage to:
+  - `linux-amd64/24.04`
+  - `darwin-arm64`
+- runs all enabled Go unit-test jobs on:
+  - `linux-amd64/24.04`
+  - `darwin-arm64`
+- switches Bazel unit tests from `fast` to `race`
+  - enables race detection
+  - keeps shuffle off
+- runs the enabled Go test jobs with race detection on and shuffle off
+
+This label lets contributors reproduce pre-merge coverage on a PR.
+
+### `ci/all-platforms`
+
+Applying the `ci/all-platforms` label runs the scheduled workflow on a PR.
+This helps validate workflow changes before merge and reproduce failures that
+otherwise appear only in scheduled runs.
+
+That workflow runs:
+
+- Bazel unit tests on:
+  - `linux-amd64/24.04`
+  - `linux-amd64/22.04`
+  - `linux-arm64/24.04`
+  - `linux-arm64/22.04`
+  - `darwin-arm64`
+- native Go unit tests on the same platform set
+- Bazel e2e on `linux-arm64/24.04`
+- the `race-shuffle` test mode for unit tests
+
+### Scheduled runs
+
+The scheduled workflow restores broader coverage without making every PR
+expensive.
+
+Scheduled runs:
+
+- run both Bazel and native Go unit tests
+- cover all supported CI platforms listed above
+- run Bazel e2e on `linux-arm64/24.04`
+- keep race detection and shuffle enabled
+
+The graft-module workflows also have scheduled and manually dispatched test
+coverage:
+
+- `coreth-ci.yml`
+- `subnet-evm-ci.yml`
+- `evm-ci.yml`
+
+For those workflows, scheduled/manual unit tests run on:
+
+- `linux-amd64/22.04`
+- `linux-amd64/24.04`
+- `darwin-arm64`
+
+and use race detection with shuffle enabled.
+
+### Manual validation
+
+The scheduled unit-test workflow also supports `workflow_dispatch`, so it can
+be run manually against a branch when broader validation is needed. The same is
+true for the graft-module workflows listed above.
+
+## Conceptual model
+
+### Why Bazel owns default PR unit coverage
+
+PR unit testing defaults to Bazel so PRs use one fast test workflow instead
+of running duplicate Bazel and Go unit tests.
+
+### Why the native Go unit path still exists
+
+The Go test workflow outside Bazel is still useful. It checks a different
+path and helps ensure Go tests still work for developers who do not use Bazel.
+Keeping it in pre-merge and scheduled runs helps catch issues that one test
+workflow alone might miss.
+
+### Why the Bazel workflows stay together
+
+The Bazel CI jobs share a setup phase that prepares dependencies and cache
+state for later Bazel jobs. Because GitHub Actions `needs` only works within a
+single workflow, those jobs stay together.
+
+That is why the Bazel workflow has a single required summary job.
+
+## Maintenance notes
+
+### Test caching affects the test modes
+
+Part of this split comes from how the Go test cache behaves:
+
+- `-shuffle=on` uses a time-based seed, so it prevents cache hits
+- `-race` results are not reused by the Go test cache
+
+That leads to three useful modes:
+
+- **fast**
+  - no race
+  - no shuffle
+  - used for default PR Bazel unit tests
+- **race**
+  - race on
+  - shuffle off
+  - used for pre-merge coverage
+- **race-shuffle**
+  - race on
+  - shuffle on
+  - used for scheduled coverage
+
+### Required-job behavior
+
+The required summary jobs allow `skipped` only for jobs that are optional
+in that workflow mode.
+
+The workflow files define which jobs are optional. When changing
+conditional execution in [`bazel-ci.yml`](./bazel-ci.yml), [`ci.yml`](./ci.yml),
+[`coreth-ci.yml`](./coreth-ci.yml), [`subnet-evm-ci.yml`](./subnet-evm-ci.yml),
+or [`evm-ci.yml`](./evm-ci.yml), update the matching required-summary logic in
+the same change.
+
+[`unit-tests-scheduled.yml`](./unit-tests-scheduled.yml) is informational
+rather than a required PR gate. The `ci/all-platforms` label lets contributors
+opt into that broader coverage on a PR when they want results that normally
+appear only in scheduled runs, but its results are not part of the required
+checks.
+
+Do not expand that behavior casually. If another job can be skipped, update
+the allowlist in the same change.
+
+### Local reproduction uses stable task names
+
+Workflow test execution should go through stable `task` names that also work
+locally.
+
+For Bazel unit jobs, workflows should use the public no-argument task names,
+such as `bazel-test-fast`, `bazel-test-race`, and `bazel-test-race-shuffle`.
+
+The same applies to the Go test jobs, which use stable public task targets
+such as `test-unit-race`, `build-test-race`, and `build-test-race-shuffle`.
+
+### When to revisit this design
+
+Revisit the split if any of these assumptions change:
+
+- default PR runtime is no longer a significant concern
+- scheduled coverage no longer benefits enough from race detection and shuffle
+  to justify the extra runtime and lower cache hit rate
+- scheduled-only failures become common enough that `workflow_dispatch` and
+  `ci/all-platforms` are insufficient
+- the Bazel and non-Bazel Go test paths stop providing meaningfully distinct
+  validation
+- non-unit Bazel coverage also needs to be included in scheduled runs
+
+## References
+
+- [`bazel-ci-matrix.yml`](./bazel-ci-matrix.yml)
+- [`bazel-ci.yml`](./bazel-ci.yml)
+- [`ci.yml`](./ci.yml)
+- [`unit-tests-scheduled.yml`](./unit-tests-scheduled.yml)
+- [`coreth-ci.yml`](./coreth-ci.yml)
+- [`subnet-evm-ci.yml`](./subnet-evm-ci.yml)
+- [`evm-ci.yml`](./evm-ci.yml)
+- [`../../Taskfile.yml`](../../Taskfile.yml)
+- [`../../graft/coreth/Taskfile.yml`](../../graft/coreth/Taskfile.yml)
+- [`../../graft/subnet-evm/Taskfile.yml`](../../graft/subnet-evm/Taskfile.yml)
+- [`../../graft/evm/Taskfile.yml`](../../graft/evm/Taskfile.yml)
+- [`../../docs/bazel.md`](../../docs/bazel.md)

--- a/.github/workflows/test-workflows.md
+++ b/.github/workflows/test-workflows.md
@@ -1,0 +1,168 @@
+# Test workflows
+
+## Table of contents
+
+- [Overview](#overview)
+- [Usage](#usage)
+  - [Default PR coverage](#default-pr-coverage)
+  - [`ci/pre-merge`](#cipre-merge)
+  - [`ci/all-platforms`](#ciall-platforms)
+  - [Scheduled and manual runs](#scheduled-and-manual-runs)
+- [Design](#design)
+  - [Bazel is the PR authority](#bazel-is-the-pr-authority)
+  - [Pre-merge tests protect developers](#pre-merge-tests-protect-developers)
+  - [Scheduled tests protect releases](#scheduled-tests-protect-releases)
+  - [Why Bazel jobs use one workflow](#why-bazel-jobs-use-one-workflow)
+- [Maintainer guidance](#maintainer-guidance)
+  - [Test modes and caching](#test-modes-and-caching)
+  - [Required-job behavior](#required-job-behavior)
+  - [Run the same tasks locally](#run-the-same-tasks-locally)
+  - [When to change this policy](#when-to-change-this-policy)
+
+## Overview
+
+This document describes unit-test and E2E-test coverage for pull requests,
+merge-group runs, scheduled runs, and manual runs.
+
+- Default PRs use Ubuntu 24.04 amd64.
+- Pre-merge runs use Ubuntu 24.04 amd64 and macOS 26 arm64.
+- Scheduled runs use Ubuntu 22.04 amd64 and arm64, Ubuntu 24.04 amd64 and
+  arm64, and macOS 26 arm64.
+
+Bazel is the unit-test authority for default PRs. Default PRs use native Go
+only for tests that Bazel does not run. This avoids duplicate test paths.
+Pre-merge runs add native Go and macOS coverage. Scheduled runs add the other
+platforms and the `race-shuffle` mode. Contributors can request either larger
+set with a PR label.
+
+## Usage
+
+### Default PR coverage
+
+A default PR runs Bazel unit tests and Bazel E2E tests on Ubuntu 24.04 amd64.
+Bazel unit tests use the default mode. Race detection and shuffle are off.
+
+The native `Unit` and E2E jobs in [`ci.yml`](./ci.yml) do not run. The
+Coreth, Subnet-EVM, and EVM Go unit-test jobs also do not run. Coreth Warp and
+Subnet-EVM Warp and load E2E jobs run on Ubuntu 24.04 amd64. Bazel does not run
+these tests.
+
+### `ci/pre-merge`
+
+Add the `ci/pre-merge` label to a PR. The label runs the same test coverage as
+a merge-group run.
+
+The label runs Bazel and native Go unit and E2E tests on Ubuntu 24.04 amd64 and
+macOS 26 arm64. It enables the native `Unit` job and the Coreth, Subnet-EVM,
+and EVM Go unit-test jobs. It also runs Coreth Warp and Subnet-EVM Warp and
+load E2E tests. Unit tests use the default mode.
+
+The Bazel E2E task builds AvalancheGo with race detection. The E2E test suite
+does not use race detection.
+
+### `ci/all-platforms`
+
+Add the `ci/all-platforms` label to a PR. The label starts
+[`unit-tests-scheduled.yml`](./unit-tests-scheduled.yml). Use it to check a
+change to scheduled coverage or to reproduce a scheduled failure.
+
+The workflow runs Bazel and native Go unit tests on all five scheduled
+platforms. It uses the `race-shuffle` mode. It runs Bazel E2E tests once on each
+platform. The Bazel E2E task builds AvalancheGo with race detection. The test
+suite does not use race detection.
+
+### Scheduled and manual runs
+
+Scheduled runs execute the same root coverage as the `ci/all-platforms` label.
+They run Bazel and native Go unit tests with `race-shuffle`. They run Bazel E2E
+tests once on each scheduled platform.
+
+The Coreth, Subnet-EVM, and EVM workflows also run every day. Their unit tests
+run on all five scheduled platforms with `race-shuffle`. Coreth Warp and
+Subnet-EVM Warp and load E2E tests run on the same platforms.
+
+You can start these workflows with `workflow_dispatch`. Manual root runs use
+the scheduled root coverage. Manual Coreth and Subnet-EVM runs include the
+scheduled E2E coverage. Manual graft workflows skip lint jobs.
+
+## Design
+
+### Bazel is the PR authority
+
+Default PRs do not require native Go unit tests. Bazel covers the same unit
+tests. This reduces PR runtime without removing the Bazel test path.
+
+### Pre-merge tests protect developers
+
+Pre-merge runs add native Go coverage and macOS coverage. They test the paths
+that developers use without Bazel. They run before merge because a failure can
+disrupt developers who use `master`.
+
+### Scheduled tests protect releases
+
+Scheduled runs add Ubuntu 22.04 and Linux arm64 coverage. They also use
+`race-shuffle`. These tests can find platform-specific and timing-dependent
+failures before a release. They do not delay ordinary PR iteration.
+
+### Why Bazel jobs use one workflow
+
+Bazel jobs share a setup job. The setup job prepares dependencies and cache
+state. GitHub Actions only permits `needs` dependencies in one workflow. The
+Bazel jobs therefore remain in one workflow. The workflow has one required
+summary job.
+
+## Maintainer guidance
+
+### Test modes and caching
+
+The workflows use four unit-test modes:
+
+- **default**: race detection off and shuffle off; used for default PRs and
+  pre-merge runs
+- **race**: race detection on and shuffle off; available for local validation
+- **shuffle**: race detection off and shuffle on; available for local validation
+- **race-shuffle**: race detection on and shuffle on; used for scheduled runs
+
+Bazel can reuse default-mode test results. The `race`, `shuffle`, and
+`race-shuffle` Bazel configurations disable test-result caching. Native Go
+unit-test jobs write coverage profiles. Go does not cache a test command that
+writes a coverage profile. Race detection and shuffle also prevent Go from
+caching test results.
+
+### Required-job behavior
+
+Required summary jobs accept `skipped` only for jobs that the workflow can skip.
+
+When you change a job condition in [`bazel-ci.yml`](./bazel-ci.yml),
+[`ci.yml`](./ci.yml), [`coreth-ci.yml`](./coreth-ci.yml),
+[`subnet-evm-ci.yml`](./subnet-evm-ci.yml), or [`evm-ci.yml`](./evm-ci.yml),
+update its required-summary logic in the same change.
+
+[`unit-tests-scheduled.yml`](./unit-tests-scheduled.yml) is not a required PR
+check. The `ci/all-platforms` label starts it, but its result is not required,
+so the workflow has no required summary job.
+
+### Run the same tasks locally
+
+Workflows call public `task` names that also work locally.
+
+Bazel unit-test workflows use scoped task names. Examples include
+`bazel-test-unit-avalanchego`, `bazel-test-unit-avalanchego-race`, and
+`bazel-test-unit-avalanchego-race-shuffle`.
+
+Native Go unit-test workflows use `test-unit`, `test-unit-race`,
+`test-unit-shuffle`, and `test-unit-race-shuffle`. Graft workflows use
+`build-test`, `build-test-race`, `build-test-shuffle`, and
+`build-test-race-shuffle`.
+
+### When to change this policy
+
+Change this policy when one or more conditions apply:
+
+- PR duration no longer requires reduced unit-test coverage.
+- Scheduled `race-shuffle` runs do not find enough failures to justify their
+  runtime.
+- Scheduled-only failures occur often enough that the `ci/all-platforms` label
+  does not provide enough feedback.
+- Bazel and native Go test paths no longer cover different behavior.
+- Scheduled runs need Bazel coverage beyond unit tests and E2E tests.

--- a/.github/workflows/unit-tests-scheduled.yml
+++ b/.github/workflows/unit-tests-scheduled.yml
@@ -1,0 +1,90 @@
+name: Scheduled Unit Tests
+
+# Scheduled unit-test coverage complements the faster PR and pre-merge workflows.
+#
+# PRs run only the Bazel workflow on the primary deployment platform with a
+# cache-friendly unit-test configuration, while pre-merge runs cover the primary
+# deployment and development platforms without shuffle. This workflow restores
+# the broader unit-test signal on a schedule by:
+#   - running both Go and Bazel unit tests
+#   - covering all currently supported CI platforms
+#   - keeping the race-shuffle behavior to better surface races and
+#     inter-test dependencies
+#   - restoring Bazel e2e coverage on linux-arm64/24.04
+#
+# To validate changes to this workflow before merge, PRs can opt in by applying
+# the ci/all-platforms label.
+on:
+  schedule:
+    - cron: '30 2 * * *' # Once a day at 02:30 UTC
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event_name == 'pull_request'
+      && format('pr-{0}', github.event.pull_request.number)
+      || format('{0}-{1}', github.event_name, github.ref)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  define-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      bazel_platforms: ${{ steps.set-matrix.outputs.bazel_platforms }}
+      go_platforms: ${{ steps.set-matrix.outputs.go_platforms }}
+    steps:
+      - name: Define scheduled unit-test matrix
+        id: set-matrix
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] \
+            && ! jq -e '.pull_request.labels[]? | select(.name == "ci/all-platforms")' "$GITHUB_EVENT_PATH" >/dev/null; then
+            echo 'bazel_platforms=[]' >> "$GITHUB_OUTPUT"
+            echo 'go_platforms=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo 'bazel_platforms=[{"platform_name":"linux-amd64-24.04","runner":"ubuntu-24.04","run_e2e":false},{"platform_name":"linux-amd64-22.04","runner":"ubuntu-22.04","run_e2e":false},{"platform_name":"linux-arm64-24.04","runner":"ubuntu-24.04-arm","run_e2e":true},{"platform_name":"linux-arm64-22.04","runner":"ubuntu-22.04-arm","run_e2e":false},{"platform_name":"darwin-arm64","runner":"macos-26","run_e2e":false}]' >> "$GITHUB_OUTPUT"
+          echo 'go_platforms=[{"os":"macos-26"},{"os":"ubuntu-22.04"},{"os":"ubuntu-24.04"},{"os":"ubuntu-22.04-arm"},{"os":"ubuntu-24.04-arm"}]' >> "$GITHUB_OUTPUT"
+
+  # Reuse the shared Bazel workflow so the scheduled runs exercise the same
+  # setup and Bazel unit-test job structure as PR and pre-merge runs, but on a
+  # wider platform matrix.
+  bazel-matrix:
+    needs: define-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.define-matrix.outputs.bazel_platforms) }}
+    uses: ./.github/workflows/bazel-ci.yml
+    with:
+      platform_name: ${{ matrix.platform_name }}
+      runner: ${{ matrix.runner }}
+      run_e2e: ${{ matrix.run_e2e }}
+    secrets: inherit
+
+  # Run the native Go unit-test path across the same platform set so scheduled
+  # runs continue validating both the Bazel and non-Bazel test entrypoints.
+  go-unit:
+    needs: define-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.define-matrix.outputs.go_platforms) }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-go-for-project
+      - name: test-unit
+        shell: bash
+        run: ./scripts/run_task.sh test-unit-race-shuffle

--- a/.github/workflows/unit-tests-scheduled.yml
+++ b/.github/workflows/unit-tests-scheduled.yml
@@ -1,0 +1,86 @@
+name: Scheduled Unit Tests
+
+# This workflow runs the tests omitted from default PRs and pre-merge runs.
+#
+# It runs Bazel and native Go unit tests on Ubuntu 22.04 amd64 and arm64,
+# Ubuntu 24.04 amd64 and arm64, and macOS 26 arm64. It uses race-shuffle.
+# It also runs Bazel E2E tests once on each platform. The task builds
+# AvalancheGo with race detection. The E2E test suite does not use race
+# detection.
+#
+# Add the ci/all-platforms label to a PR to start this workflow.
+on:
+  schedule:
+    - cron: '30 2 * * *' # Once a day at 02:30 UTC
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event_name == 'pull_request'
+      && format('pr-{0}', github.event.pull_request.number)
+      || format('{0}-{1}', github.event_name, github.ref)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  define-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      bazel_platforms: ${{ steps.set-matrix.outputs.bazel_platforms }}
+      go_platforms: ${{ steps.set-matrix.outputs.go_platforms }}
+    steps:
+      - name: Define scheduled unit-test matrix
+        id: set-matrix
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] \
+            && ! jq -e '.pull_request.labels[]? | select(.name == "ci/all-platforms")' "$GITHUB_EVENT_PATH" >/dev/null; then
+            echo 'bazel_platforms=[]' >> "$GITHUB_OUTPUT"
+            echo 'go_platforms=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo 'bazel_platforms=[{"platform_name":"linux-amd64-22.04","runner":"ubuntu-22.04","unit_test_mode":"race-shuffle","run_e2e":true},{"platform_name":"linux-amd64-24.04","runner":"ubuntu-24.04","unit_test_mode":"race-shuffle","run_e2e":true},{"platform_name":"linux-arm64-22.04","runner":"ubuntu-22.04-arm","unit_test_mode":"race-shuffle","run_e2e":true},{"platform_name":"linux-arm64-24.04","runner":"ubuntu-24.04-arm","unit_test_mode":"race-shuffle","run_e2e":true},{"platform_name":"darwin-arm64","runner":"macos-26","unit_test_mode":"race-shuffle","run_e2e":true}]' >> "$GITHUB_OUTPUT"
+          echo 'go_platforms=[{"os":"ubuntu-22.04","task_name":"test-unit-race-shuffle"},{"os":"ubuntu-24.04","task_name":"test-unit-race-shuffle"},{"os":"ubuntu-22.04-arm","task_name":"test-unit-race-shuffle"},{"os":"ubuntu-24.04-arm","task_name":"test-unit-race-shuffle"},{"os":"macos-26","task_name":"test-unit-race-shuffle"}]' >> "$GITHUB_OUTPUT"
+
+  # Reuse the shared Bazel workflow so the scheduled runs exercise the same
+  # setup and Bazel unit-test job structure as PR and pre-merge runs, but on a
+  # wider platform matrix.
+  bazel-matrix:
+    needs: define-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.define-matrix.outputs.bazel_platforms) }}
+    uses: ./.github/workflows/bazel-ci.yml
+    with:
+      platform_name: ${{ matrix.platform_name }}
+      runner: ${{ matrix.runner }}
+      unit_test_mode: ${{ matrix.unit_test_mode }}
+      run_e2e: ${{ matrix.run_e2e }}
+    secrets: inherit
+
+  # Run the native Go unit-test path across the same platform set so scheduled
+  # runs continue validating both the Bazel and non-Bazel test entrypoints.
+  go-unit:
+    needs: define-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.define-matrix.outputs.go_platforms) }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-go-for-project
+      - name: test-unit
+        shell: bash
+        run: ./scripts/run_task.sh ${{ matrix.task_name }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -87,9 +87,39 @@ tasks:
     desc: Run unit tests with Bazel (shuffle on, race on)
     cmd: '{{.NIX_RUN}} bazelisk test //...'
 
+  bazel-test-race-shuffle:
+    desc: Run unit tests with Bazel (shuffle on, race on)
+    cmd: '{{.NIX_RUN}} bazelisk test //...'
+
+  _bazel-test-coreth:
+    internal: true
+    vars:
+      BAZEL_CONFIG: ""
+    cmd: '{{.NIX_RUN}} ./scripts/run_bazel_ci_command.sh test{{if .BAZEL_CONFIG}} --config={{.BAZEL_CONFIG}}{{end}} //graft/coreth/... //graft/evm/...'
+
   bazel-test-coreth:
     desc: Run coreth/evm unit tests with Bazel
-    cmd: '{{.NIX_RUN}} ./scripts/run_bazel_ci_command.sh test //graft/coreth/... //graft/evm/...'
+    cmds:
+      - task: _bazel-test-coreth
+
+  bazel-test-coreth-race-shuffle:
+    desc: Run coreth/evm unit tests with Bazel (shuffle on, race on)
+    cmds:
+      - task: _bazel-test-coreth
+
+  bazel-test-coreth-fast:
+    desc: Run coreth/evm unit tests with Bazel (no race, no shuffle)
+    cmds:
+      - task: _bazel-test-coreth
+        vars:
+          BAZEL_CONFIG: fast
+
+  bazel-test-coreth-race:
+    desc: Run coreth/evm unit tests with Bazel (race on, no shuffle)
+    cmds:
+      - task: _bazel-test-coreth
+        vars:
+          BAZEL_CONFIG: noshuffle
 
   bazel-test-e2e:
     desc: Run E2E tests with bazel-built binary
@@ -113,13 +143,69 @@ tasks:
     desc: Run unit tests with Bazel (no race, no shuffle - faster local iteration)
     cmd: '{{.NIX_RUN}} bazelisk test --config=fast //...'
 
+  bazel-test-race:
+    desc: Run unit tests with Bazel (race on, no shuffle)
+    cmd: '{{.NIX_RUN}} bazelisk test --config=noshuffle //...'
+
+  _bazel-test-main:
+    internal: true
+    vars:
+      BAZEL_CONFIG: ""
+    cmd: '{{.NIX_RUN}} ./scripts/run_bazel_ci_command.sh test{{if .BAZEL_CONFIG}} --config={{.BAZEL_CONFIG}}{{end}} //... -- -//graft/...'
+
   bazel-test-main:
     desc: Run main module unit tests with Bazel (excludes graft modules)
-    cmd: '{{.NIX_RUN}} ./scripts/run_bazel_ci_command.sh test //... -- -//graft/...'
+    cmds:
+      - task: _bazel-test-main
+
+  bazel-test-main-race-shuffle:
+    desc: Run main module unit tests with Bazel (excludes graft modules; shuffle on, race on)
+    cmds:
+      - task: _bazel-test-main
+
+  bazel-test-main-fast:
+    desc: Run main module unit tests with Bazel (excludes graft modules; no race, no shuffle)
+    cmds:
+      - task: _bazel-test-main
+        vars:
+          BAZEL_CONFIG: fast
+
+  bazel-test-main-race:
+    desc: Run main module unit tests with Bazel (excludes graft modules; race on, no shuffle)
+    cmds:
+      - task: _bazel-test-main
+        vars:
+          BAZEL_CONFIG: noshuffle
+
+  _bazel-test-subnet-evm:
+    internal: true
+    vars:
+      BAZEL_CONFIG: ""
+    cmd: '{{.NIX_RUN}} ./scripts/run_bazel_ci_command.sh test{{if .BAZEL_CONFIG}} --config={{.BAZEL_CONFIG}}{{end}} //graft/subnet-evm/...'
 
   bazel-test-subnet-evm:
     desc: Run subnet-evm unit tests with Bazel
-    cmd: '{{.NIX_RUN}} ./scripts/run_bazel_ci_command.sh test //graft/subnet-evm/...'
+    cmds:
+      - task: _bazel-test-subnet-evm
+
+  bazel-test-subnet-evm-race-shuffle:
+    desc: Run subnet-evm unit tests with Bazel (shuffle on, race on)
+    cmds:
+      - task: _bazel-test-subnet-evm
+
+  bazel-test-subnet-evm-fast:
+    desc: Run subnet-evm unit tests with Bazel (no race, no shuffle)
+    cmds:
+      - task: _bazel-test-subnet-evm
+        vars:
+          BAZEL_CONFIG: fast
+
+  bazel-test-subnet-evm-race:
+    desc: Run subnet-evm unit tests with Bazel (race on, no shuffle)
+    cmds:
+      - task: _bazel-test-subnet-evm
+        vars:
+          BAZEL_CONFIG: noshuffle
 
   build:
     desc: Builds avalanchego
@@ -547,6 +633,18 @@ tasks:
 
   test-unit:
     desc: Runs unit tests
+    # Invoking with bash ensures compatibility with CI execution on Windows
+    cmd: '{{.NIX_RUN}} bash ./scripts/build_test.sh'
+
+  test-unit-race-shuffle:
+    desc: Runs unit tests with race detection and shuffle enabled
+    # Invoking with bash ensures compatibility with CI execution on Windows
+    cmd: '{{.NIX_RUN}} bash ./scripts/build_test.sh'
+
+  test-unit-race:
+    desc: Runs unit tests with race detection and shuffle disabled
+    env:
+      NO_SHUFFLE: TRUE
     # Invoking with bash ensures compatibility with CI execution on Windows
     cmd: '{{.NIX_RUN}} bash ./scripts/build_test.sh'
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -99,7 +99,7 @@ tasks:
           {{.NIX_RUN}} bash -c 'AVALANCHEGO_PATH=$(bazelisk cquery --output=files //main:avalanchego 2>/dev/null) bash -x ./scripts/tests.e2e.existing.sh'
 
   bazel-test-e2e-ci:
-    desc: Run E2E tests with bazel-built binary [serially with race detection]
+    desc: Run E2E tests serially with an AvalancheGo binary built with race detection
     env:
       E2E_SERIAL: 1
     cmds:
@@ -727,15 +727,29 @@ tasks:
     cmd: '{{.NIX_RUN}} ./scripts/test_run_task_launcher.sh'
 
   test-unit:
-    desc: Runs unit tests
-    # Invoking with bash ensures compatibility with CI execution on Windows
-    cmd: '{{.NIX_RUN}} bash ./scripts/build_test.sh'
-
-  test-unit-fast:
-    desc: Runs unit tests
+    desc: Runs unit tests with the default PR/local mode (no race, no shuffle)
     env:
       NO_SHUFFLE: TRUE # Allows caching
       NO_RACE: TRUE    # Tests are much faster without race detection
+    cmd: '{{.NIX_RUN}} bash ./scripts/build_test.sh'
+
+  test-unit-race:
+    desc: Runs unit tests with race detection and shuffle disabled
+    env:
+      NO_SHUFFLE: TRUE
+    # Invoking with bash ensures compatibility with CI execution on Windows
+    cmd: '{{.NIX_RUN}} bash ./scripts/build_test.sh'
+
+  test-unit-shuffle:
+    desc: Runs unit tests with race detection disabled and shuffle enabled
+    env:
+      NO_RACE: TRUE
+    # Invoking with bash ensures compatibility with CI execution on Windows
+    cmd: '{{.NIX_RUN}} bash ./scripts/build_test.sh'
+
+  test-unit-race-shuffle:
+    desc: Runs unit tests with race detection and shuffle enabled
+    # Invoking with bash ensures compatibility with CI execution on Windows
     cmd: '{{.NIX_RUN}} bash ./scripts/build_test.sh'
 
   test-upgrade:

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -25,8 +25,11 @@ task bazel-build
 # Build with optimizations
 task bazel-build-opt
 
-# Run unit tests
-task bazel-test
+# Run unit tests (default/full mode: race on, shuffle on)
+task bazel-test-race-shuffle
+
+# Fast local iteration (no race, no shuffle)
+task bazel-test-fast
 
 # Update Bazel metadata after changing Go imports or Bazel module deps
 task bazel-generate-metadata
@@ -407,7 +410,7 @@ with a few exceptions:
 
 ```bash
 # Run all unit tests (shuffle enabled, race on)
-task bazel-test                    # or: bazel test //...
+task bazel-test-race-shuffle      # or: bazel test //...
 
 # Run tests for a specific package
 bazel test //utils/...
@@ -418,6 +421,9 @@ bazel test //utils:set_test --test_filter=TestSet_Add
 # Fast local iteration (no race, no shuffle)
 task bazel-test-fast               # or: bazel test --config=fast //...
 
+# Race detection without shuffle
+task bazel-test-race              # or: bazel test --config=noshuffle //...
+
 # Collect coverage
 bazel coverage //...
 
@@ -427,22 +433,22 @@ task bazel-test-e2e
 
 #### Test Options
 
-| Option | Default | Toggle with |
-|--------|---------|-------------|
-| Race detection | ON | `--config=norace` (disable) |
-| Shuffle | ON | `--config=noshuffle` (disable) |
-| Fast mode | - | `--config=fast` (no shuffle, no race) |
+| Public mode | Behavior | Bazel config |
+|-------------|----------|--------------|
+| `race-shuffle` | race on, shuffle on | default |
+| `race` | race on, shuffle off | `--config=noshuffle` |
+| `fast` | race off, shuffle off | `--config=fast` |
 
 Examples:
 ```bash
-# Disable race detection
-bazel test --config=norace //...
+# Race detection with shuffle enabled
+task bazel-test-race-shuffle      # or: bazel test //...
 
-# Disable shuffle only
-bazel test --config=noshuffle //...
+# Race detection without shuffle
+task bazel-test-race              # or: bazel test --config=noshuffle //...
 
 # Fast mode (no shuffle, no race)
-bazel test --config=fast //...
+task bazel-test-fast              # or: bazel test --config=fast //...
 ```
 
 #### Test Timeouts

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -469,8 +469,8 @@ Use `bazel test //...` for broader Bazel validation. It runs
 # Run all generated unit tests (no race, no shuffle)
 task bazel-test-unit-all           # or: bazel test //:unit_tests
 
-# CI uses race detection and shuffle.
-# Run all generated unit tests with this mode.
+# Scheduled CI runs this mode. PR and pre-merge CI use the default mode.
+# See the test-workflow guide.
 task bazel-test-unit-all-race-shuffle  # or: bazel test --config=race-shuffle //:unit_tests
 
 # Run tests for a specific package
@@ -494,6 +494,8 @@ task bazel-test-e2e
 
 Bazel unit-test task names use `bazel-test-unit-<area>`. Use `all` to run every
 unit-test shard.
+
+For the CI modes and platform coverage, see [Test workflows](../.github/workflows/test-workflows.md).
 
 #### Generated Unit-Test Suites
 

--- a/graft/coreth/Taskfile.yml
+++ b/graft/coreth/Taskfile.yml
@@ -20,6 +20,23 @@ tasks:
     desc: Run all Go tests with retry logic for flaky tests, race detection, and coverage reporting
     cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
 
+  build-test-race-shuffle:
+    desc: Run all Go tests with race detection and shuffle enabled
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-fast:
+    desc: Run all Go tests without race detection or shuffle for faster CI and local iteration
+    env:
+      NO_RACE: TRUE
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race:
+    desc: Run all Go tests with race detection and shuffle disabled
+    env:
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
   check-clean-branch:
     desc: Checks that the git working tree is clean
     cmds:

--- a/graft/coreth/Taskfile.yml
+++ b/graft/coreth/Taskfile.yml
@@ -17,7 +17,26 @@ tasks:
   default: '{{.NIX_RUN}} ./scripts/run_task.sh --list'
 
   build-test:
-    desc: Run all Go tests with retry logic for flaky tests, race detection, and coverage reporting
+    desc: Run all Go tests with the default PR/local mode (no race, no shuffle)
+    env:
+      NO_RACE: TRUE
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race-shuffle:
+    desc: Run all Go tests with race detection and shuffle enabled
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race:
+    desc: Run all Go tests with race detection and shuffle disabled
+    env:
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-shuffle:
+    desc: Run all Go tests with race detection disabled and shuffle enabled
+    env:
+      NO_RACE: TRUE
     cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
 
   check-clean-branch:

--- a/graft/coreth/scripts/build_test.sh
+++ b/graft/coreth/scripts/build_test.sh
@@ -7,13 +7,18 @@ REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd ../../../ && pwd )
 source "$REPO_ROOT"/scripts/constants.sh
 
 # We pass in the arguments to this script directly to enable easily passing parameters such as enabling race detection,
-# parallelism, and test coverage.
+# shuffling, parallelism, and test coverage.
 # DO NOT RUN tests from the top level "tests" directory since they are run by ginkgo
 race="-race"
 if [[ -n "${NO_RACE:-}" ]]; then
     race=""
 fi
 
+shuffle="on"
+if [[ -n "${NO_SHUFFLE:-}" ]]; then
+    shuffle="off"
+fi
+
 cd "$REPO_ROOT/graft/coreth"
 # shellcheck disable=SC2046
-go test -shuffle=on ${race:-} -timeout="${TIMEOUT:-900s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list .//... | grep -v github.com/ava-labs/avalanchego/graft/coreth/tests)
+go test -shuffle="$shuffle" ${race:-} -timeout="${TIMEOUT:-900s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list .//... | grep -v github.com/ava-labs/avalanchego/graft/coreth/tests)

--- a/graft/evm/Taskfile.yml
+++ b/graft/evm/Taskfile.yml
@@ -21,6 +21,23 @@ tasks:
     desc: Run all Go tests with retry logic for flaky tests, race detection, and coverage reporting
     cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
 
+  build-test-race-shuffle:
+    desc: Run all Go tests with race detection and shuffle enabled
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-fast:
+    desc: Run all Go tests without race detection or shuffle for faster CI and local iteration
+    env:
+      NO_RACE: TRUE
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race:
+    desc: Run all Go tests with race detection and shuffle disabled
+    env:
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
   check-clean-branch:
     desc: Checks that the git working tree is clean
     cmds:

--- a/graft/evm/Taskfile.yml
+++ b/graft/evm/Taskfile.yml
@@ -18,7 +18,26 @@ tasks:
   default: '{{.NIX_RUN}} ./scripts/run_task.sh --list'
 
   build-test:
-    desc: Run all Go tests with retry logic for flaky tests, race detection, and coverage reporting
+    desc: Run all Go tests with the default PR/local mode (no race, no shuffle)
+    env:
+      NO_RACE: TRUE
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race-shuffle:
+    desc: Run all Go tests with race detection and shuffle enabled
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race:
+    desc: Run all Go tests with race detection and shuffle disabled
+    env:
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-shuffle:
+    desc: Run all Go tests with race detection disabled and shuffle enabled
+    env:
+      NO_RACE: TRUE
     cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
 
   check-clean-branch:

--- a/graft/evm/scripts/build_test.sh
+++ b/graft/evm/scripts/build_test.sh
@@ -7,13 +7,18 @@ REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd ../../../ && pwd )
 source "$REPO_ROOT"/scripts/constants.sh
 
 # We pass in the arguments to this script directly to enable easily passing parameters such as enabling race detection,
-# parallelism, and test coverage.
+# shuffling, parallelism, and test coverage.
 # DO NOT RUN tests from the top level "tests" directory since they are run by ginkgo
 race="-race"
 if [[ -n "${NO_RACE:-}" ]]; then
     race=""
 fi
 
+shuffle="on"
+if [[ -n "${NO_SHUFFLE:-}" ]]; then
+    shuffle="off"
+fi
+
 cd "$REPO_ROOT/graft/evm"
 # shellcheck disable=SC2046
-go test -shuffle=on ${race:-} -timeout="${TIMEOUT:-600s}" -coverprofile=coverage.out -covermode=atomic "$@" ./...
+go test -shuffle="$shuffle" ${race:-} -timeout="${TIMEOUT:-600s}" -coverprofile=coverage.out -covermode=atomic "$@" ./...

--- a/graft/subnet-evm/Taskfile.yml
+++ b/graft/subnet-evm/Taskfile.yml
@@ -32,6 +32,23 @@ tasks:
     desc: Run all Go tests with retry logic for flaky tests, race detection, and coverage reporting
     cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
 
+  build-test-race-shuffle:
+    desc: Run all Go tests with race detection and shuffle enabled
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-fast:
+    desc: Run all Go tests without race detection or shuffle for faster CI and local iteration
+    env:
+      NO_RACE: TRUE
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race:
+    desc: Run all Go tests with race detection and shuffle disabled
+    env:
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
   check-clean-branch:
     desc: Checks that the git working tree is clean
     cmds:

--- a/graft/subnet-evm/Taskfile.yml
+++ b/graft/subnet-evm/Taskfile.yml
@@ -29,7 +29,26 @@ tasks:
     cmd: '{{.NIX_RUN}} ./scripts/build_docker_image.sh' # publish_docker.yml
 
   build-test:
-    desc: Run all Go tests with retry logic for flaky tests, race detection, and coverage reporting
+    desc: Run all Go tests with the default PR/local mode (no race, no shuffle)
+    env:
+      NO_RACE: TRUE
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race-shuffle:
+    desc: Run all Go tests with race detection and shuffle enabled
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-race:
+    desc: Run all Go tests with race detection and shuffle disabled
+    env:
+      NO_SHUFFLE: TRUE
+    cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
+
+  build-test-shuffle:
+    desc: Run all Go tests with race detection disabled and shuffle enabled
+    env:
+      NO_RACE: TRUE
     cmd: '{{.NIX_RUN}} ./scripts/build_test.sh'
 
   check-clean-branch:

--- a/graft/subnet-evm/scripts/build_test.sh
+++ b/graft/subnet-evm/scripts/build_test.sh
@@ -7,13 +7,18 @@ REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd ../../../ && pwd )
 source "$REPO_ROOT"/scripts/constants.sh
 
 # We pass in the arguments to this script directly to enable easily passing parameters such as enabling race detection,
-# parallelism, and test coverage.
+# shuffling, parallelism, and test coverage.
 # DO NOT RUN tests from the top level "tests" directory since they are run by ginkgo
 race="-race"
 if [[ -n "${NO_RACE:-}" ]]; then
     race=""
 fi
 
+shuffle="on"
+if [[ -n "${NO_SHUFFLE:-}" ]]; then
+    shuffle="off"
+fi
+
 cd "$REPO_ROOT/graft/subnet-evm"
 # shellcheck disable=SC2046
-go test -shuffle=on ${race:-} -timeout="${TIMEOUT:-900s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list .//... | grep -v github.com/ava-labs/avalanchego/graft/subnet-evm/tests)
+go test -shuffle="$shuffle" ${race:-} -timeout="${TIMEOUT:-900s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list .//... | grep -v github.com/ava-labs/avalanchego/graft/subnet-evm/tests)


### PR DESCRIPTION
## Why this should be merged

Previously, unit test coverage was duplicated across Bazel and Go jobs. The test configuration included `-shuffle=on` and `-race`, neither of which is cacheable. To minimize work on PR runs, unit test coverage will execute with Bazel against our primary supported platform (linux-amd64/24.04) and with a cache-friendly test configuration.

Pre-merge jobs continue Bazel coverage, add Go unit test coverage, enable `-race`, disable shuffle, and cover both the primary supported platform and the primary development platform (darwin-arm64). Adding the `ci/pre-merge` label to a PR opts it into that pre-merge coverage.

Unit test coverage for the remaining supported platforms moves to a daily scheduled unit-test workflow which runs with both `-race` and `-shuffle=on` to detect races and test dependencies. Adding the `ci/full-platforms` label to a PR opts it into that otherwise scheduled-only coverage.

## How this was tested

## TODO

 - [ ] Link PR runs
 - [ ] Link PR run with pre-merge label
 - [ ] Link PR run with scheduled label
