### PR TITLE
[ci] Cache nix flake to minimize infra flakes

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -84,9 +84,24 @@ runs:
   using: composite
   steps:
     # Nix installation is idempotent skipped if already installed by the calling workflow.
+    #
+    # TODO(marun) Switch to ./.github/actions/install-nix once this action is no
+    # longer used from outside this repo.
+    # Reference: https://github.com/ava-labs/avalanchego/issues/5599
     - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
       with:
         github_access_token: ${{ inputs.github-token }}
+    # Mirror the repo install-nix cache here so jobs do not need to fetch the
+    # same flake inputs on every run.
+    - name: Restore and save Nix store cache
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock') }}
+        restore-prefixes-first-match: |
+          nix-${{ runner.os }}-${{ runner.arch }}-
+        gc-max-store-size-linux: 5G
+        gc-max-store-size-macos: 5G
     - run: echo "dependencies installed"
       shell: nix develop --command bash {0}
     # Cache Go modules (architecture-independent)

--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -1,5 +1,5 @@
 name: 'Install nix'
-description: 'Install nix and populate the store for the repo flake'
+description: 'Install nix and load the repo flake dependencies into the store'
 
 inputs:
   github_token:
@@ -13,7 +13,21 @@ runs:
     - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
       with:
         github_access_token: ${{ inputs.github_token }}
-    - run: nix develop --command echo "dependencies installed"
+    # Cache the Nix store on Linux and macOS so jobs do not need to fetch the
+    # same flake inputs on every run. Key by OS, arch, and flake.lock so the
+    # cache is reused across matching runners and replaced when inputs change.
+    # Cap the saved store size to keep cache growth bounded.
+    - name: Restore and save Nix store cache
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock') }}
+        restore-prefixes-first-match: |
+          nix-${{ runner.os }}-${{ runner.arch }}-
+        gc-max-store-size-linux: 5G
+        gc-max-store-size-macos: 5G
+    - name: Load flake dependencies
+      run: nix develop --command echo "dependencies installed"
       shell: bash
     # Cache Go modules (architecture-independent)
     - uses: actions/cache@v5

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -107,9 +107,7 @@ jobs:
       # c-chain-reexecution-benchmark's Nix install will be skipped; installation is idempotent.
       - name: Install Nix
         if: matrix.libevm-ref != '' || matrix.firewood-ref != ''
-        uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-nix
       - name: Configure dependency versions
         if: matrix.libevm-ref != '' || matrix.firewood-ref != ''
         shell: nix develop --command bash {0}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -100,9 +100,7 @@ jobs:
       # c-chain-reexecution-benchmark's Nix install will be skipped; installation is idempotent.
       - name: Install Nix
         if: matrix.libevm-ref != '' || matrix.firewood-ref != ''
-        uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-nix
       - name: Configure dependency versions
         if: matrix.libevm-ref != '' || matrix.firewood-ref != ''
         shell: nix develop --command bash {0}

--- a/.github/workflows/firewood-chaos-test.yml
+++ b/.github/workflows/firewood-chaos-test.yml
@@ -87,9 +87,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/install-nix
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
## Why this should be merged

Previously our nix flake had to be downloaded by every job. Caching the downloads minimizes those downloads and with it the potential for infra flakes.

As part of this change, all workflows have been switched to use `.github/actions/install-nix` instead of `cachix/install-nix-action` to ensure the new caching configuration is applied. The exception is the `c-chain-reexecution-benchmark` custom action which is intended for consumption by external repos and so can't reference the repo-local install action.

## How this was tested

A job picked at random on this PR [demonstrates a cache restore](https://github.com/ava-labs/avalanchego/actions/runs/28210094784/job/83572683499?pr=5588#step:3:429):

```
Restoring a cache with the key "nix-Linux-X64-12be27ca6bf3b08e6b05e59940f9df118b0096ba7f4482850476c04b5808898d".
```