### PR TITLE
feat(proposervm): opt-in millisecond-granular block timestamps

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,6 +25,7 @@ NOTE: `{vmName}` is `evm` for Coreth/C-Chain and `subnetevm` for Subnet-EVM chai
 
 - Added:
   - `proposerWindowMilliseconds` in subnet configs
+  - `proposerMillisecondTimestamps` in subnet configs
 
 ### Fixes
 - Updated minimum Go version from `v1.25.8` to `v1.25.10`.

--- a/chains/manager.go
+++ b/chains/manager.go
@@ -784,13 +784,14 @@ func (m *manager) createAvalancheChain(
 	proposerVM := proposervm.New(
 		vmWrappedInsideProposerVM,
 		proposervm.Config{
-			Upgrades:            m.Upgrades,
-			MinBlkDelay:         minBlockDelay,
-			NumHistoricalBlocks: numHistoricalBlocks,
-			WindowDuration:      windowDuration,
-			StakingLeafSigner:   m.StakingTLSSigner,
-			StakingCertLeaf:     m.StakingTLSCert,
-			Registerer:          proposervmReg,
+			Upgrades:              m.Upgrades,
+			MinBlkDelay:           minBlockDelay,
+			NumHistoricalBlocks:   numHistoricalBlocks,
+			WindowDuration:        windowDuration,
+			MillisecondTimestamps: subnetCfg.ProposerMillisecondTimestamps,
+			StakingLeafSigner:     m.StakingTLSSigner,
+			StakingCertLeaf:       m.StakingTLSCert,
+			Registerer:            proposervmReg,
 		},
 	)
 
@@ -1209,13 +1210,14 @@ func (m *manager) createSnowmanChain(
 	proposerVM := proposervm.New(
 		vm,
 		proposervm.Config{
-			Upgrades:            m.Upgrades,
-			MinBlkDelay:         minBlockDelay,
-			NumHistoricalBlocks: numHistoricalBlocks,
-			WindowDuration:      windowDuration,
-			StakingLeafSigner:   m.StakingTLSSigner,
-			StakingCertLeaf:     m.StakingTLSCert,
-			Registerer:          proposervmReg,
+			Upgrades:              m.Upgrades,
+			MinBlkDelay:           minBlockDelay,
+			NumHistoricalBlocks:   numHistoricalBlocks,
+			WindowDuration:        windowDuration,
+			MillisecondTimestamps: subnetCfg.ProposerMillisecondTimestamps,
+			StakingLeafSigner:     m.StakingTLSSigner,
+			StakingCertLeaf:       m.StakingTLSCert,
+			Registerer:            proposervmReg,
 		},
 	)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1351,6 +1351,30 @@ func setupViperFlags() *viper.Viper {
 	return v
 }
 
+// TestPrimaryNetworkProposerMillisecondTimestampsIsAlwaysDefault guards the
+// invariant that the per-Subnet proposerMillisecondTimestamps setting can never
+// reach the primary network (P/C/X). Reinterpreting its whole-second block
+// history as milliseconds would fork the node off Mainnet/Fuji. Two layers
+// enforce this:
+//
+//  1. The primary network cannot be a tracked Subnet, so a user-supplied subnet
+//     config can never be routed to it (getTrackedSubnets rejects its ID).
+//  2. Its config is always rebuilt from getPrimaryNetworkConfig, which never
+//     reads the flag, so it stays false (whole seconds) regardless of input.
+func TestPrimaryNetworkProposerMillisecondTimestampsIsAlwaysDefault(t *testing.T) {
+	require := require.New(t)
+
+	// Layer 2: the primary network never reads the flag; it stays seconds.
+	require.False(getPrimaryNetworkConfig(setupViperFlags()).ProposerMillisecondTimestamps)
+
+	// Layer 1: even attempting to track the primary network (the only way a
+	// subnet config could reach it) is rejected before any config is read.
+	v := setupViperFlags()
+	v.Set(TrackSubnetsKey, constants.PrimaryNetworkID.String())
+	_, err := getTrackedSubnets(v)
+	require.ErrorIs(err, errCannotTrackPrimaryNetwork)
+}
+
 func setupViper(configFilePath string) *viper.Viper {
 	v := setupViperFlags()
 	v.SetConfigFile(configFilePath)

--- a/indexer/examples/p-chain/main.go
+++ b/indexer/examples/p-chain/main.go
@@ -34,7 +34,7 @@ func main() {
 		}
 
 		platformvmBlockBytes := container.Bytes
-		proposerVMBlock, err := proposervmblock.Parse(container.Bytes, constants.PlatformChainID)
+		proposerVMBlock, err := proposervmblock.Parse(container.Bytes, constants.PlatformChainID, false)
 		if err == nil {
 			platformvmBlockBytes = proposerVMBlock.Block()
 		}

--- a/indexer/examples/x-chain-blocks/main.go
+++ b/indexer/examples/x-chain-blocks/main.go
@@ -33,7 +33,7 @@ func main() {
 			continue
 		}
 
-		proposerVMBlock, err := block.Parse(container.Bytes, xChainID)
+		proposerVMBlock, err := block.Parse(container.Bytes, xChainID, false)
 		if err != nil {
 			log.Fatalf("failed to parse proposervm block: %s\n", err)
 		}

--- a/subnets/config.go
+++ b/subnets/config.go
@@ -15,13 +15,14 @@ import (
 
 const (
 	// Bounds for an explicitly configured ProposerWindowMilliseconds; 0 means
-	// "use the default". The floor is 1000ms because the proposerVM block
-	// timestamp is currently whole-second granular: the slot clock only ticks
-	// once per second, so a sub-second window gains nothing. Sub-second windows
-	// (and a lower floor) arrive in a follow-up PR that adds millisecond-granular
-	// timestamps. The ceiling is the default window, since a larger window only
-	// slows failover.
-	MinProposerWindowMilliseconds = 1_000
+	// "use the default". The floor is 50ms: roughly the smallest window in which
+	// a proposer can build and propagate a block before its slot closes. A
+	// sub-second window only actually advances the slot clock when the chain also
+	// sets ProposerMillisecondTimestamps (this PR reinterprets the proposerVM
+	// block timestamp as unix-milliseconds); without it, whole-second timestamps
+	// quantize the slot clock to ~1s and a sub-second window gains nothing. The
+	// ceiling is the default window, since a larger window only slows failover.
+	MinProposerWindowMilliseconds = 50
 	MaxProposerWindowMilliseconds = 5_000
 )
 
@@ -77,6 +78,20 @@ type Config struct {
 	// chains MUST use the SAME value or it falls out of consensus, so coordinate
 	// it across all validators at once. The primary network (P/C/X) is unaffected.
 	ProposerWindowMilliseconds uint64 `json:"proposerWindowMilliseconds" yaml:"proposerWindowMilliseconds"`
+
+	// ProposerMillisecondTimestamps interprets the proposerVM wrapper block's
+	// timestamp as unix-milliseconds instead of unix-seconds, so that a
+	// sub-second ProposerWindowMilliseconds can actually advance (with
+	// whole-second timestamps the slot clock only ticks once per second, so a
+	// sub-second window gains nothing). It is opt-in and only meaningful
+	// alongside a sub-second proposer window.
+	//
+	// WARNING: this is a Subnet-wide consensus parameter, not a per-node knob.
+	// Every validator of the Subnet's chains MUST use the SAME value, and it MUST
+	// be fixed from genesis: enabling it on a chain that already has whole-second
+	// history misreads every old block. The primary network (P/C/X) is unaffected
+	// and always uses whole-second timestamps.
+	ProposerMillisecondTimestamps bool `json:"proposerMillisecondTimestamps" yaml:"proposerMillisecondTimestamps"`
 }
 
 func boolToInt(b bool) int {

--- a/subnets/config.md
+++ b/subnets/config.md
@@ -62,12 +62,10 @@ this configuration in order to properly allow a node in the private Subnet.
 
 The length of a single proposerVM proposer slot for the chains in this Subnet, in
 **milliseconds**. Defaults to 5s (`5000`) when unset or `0`. When set, must be
-between `1000` (1s) and `5000` (5s) inclusive.
+between `50` and `5000` (5s) inclusive.
 
-**If you are changing this at all, you almost certainly want 1s (`1000`).** That
-is the minimum (see the note below), and it is already
-enough to make validator restarts and maintenance effectively invisible. For
-example:
+**If you are changing this, 1s (`1000`) is the safe choice** — it makes validator
+restarts and maintenance effectively invisible and needs nothing else:
 
 ```json
 { "proposerWindowMilliseconds": 1000 }
@@ -76,10 +74,10 @@ example:
 Slots are `proposerWindowMilliseconds` apart, and when a scheduled proposer is
 offline the chain stalls until the next live proposer's slot opens — so a smaller
 window speeds failover recovery (good for CFT/PoA L1s) at the cost of more
-rejected blocks. The proposerVM block timestamp is currently whole-second
-granular, so the slot clock only ticks once per second and a sub-second window
-gains nothing — hence the `1000`ms (1s) floor. Sub-second windows arrive in a
-follow-up PR that adds millisecond-granular timestamps.
+rejected blocks. Going **below 1s only helps if you also set
+[`proposerMillisecondTimestamps`](#proposermillisecondtimestamps-bool)**: with the
+default whole-second timestamps the slot clock only ticks once per second, so a
+sub-second window stays quantized to ~1s and gains nothing.
 
 :::warning
 
@@ -89,6 +87,48 @@ Validators with different windows disagree about which proposer is expected for 
 slot, reject each other's blocks, and break liveness. Roll it out identically to
 every validator, the same way as an upgrade time. The primary network (P/C/X) is
 unaffected and always uses the default.
+
+:::
+
+#### `proposerMillisecondTimestamps` (bool)
+
+Interprets the proposerVM wrapper block's timestamp as **unix-milliseconds**
+instead of unix-seconds. Defaults to `false` (seconds). Existing networks are
+unaffected when this is unset.
+
+The proposerVM proposer-slot clock advances at the resolution of the wrapper
+block timestamp. With the default whole-second timestamps the clock can only
+advance in whole-second steps, so proposer rotation — and therefore how fast the
+chain recovers when a scheduled proposer is offline — is quantized to ~1s no
+matter how short the proposer window is. Setting this to `true` makes the
+timestamp millisecond-granular so that a sub-second proposer window can actually
+advance.
+
+Use it together with a sub-second [`proposerWindowMilliseconds`](#proposerwindowmilliseconds-uint):
+neither has much effect without the other. A sub-second window is still quantized
+to ~1s while timestamps are whole-second, and millisecond timestamps do nothing
+while the window stays at its 5s default.
+
+```json
+{ "proposerMillisecondTimestamps": true }
+```
+
+:::warning
+
+This is a Subnet-wide consensus parameter, not a per-node tuning knob, and it
+must be fixed for the life of the chain:
+
+- Every validator of this Subnet's chains MUST use the same value. Validators
+  that disagree decode each other's block timestamps differently, expect
+  different proposers per slot, reject each other's blocks, and break liveness.
+- It MUST be set from genesis. Enabling it on a chain that already has
+  whole-second history misreads every previously-accepted block (a unix-seconds
+  value read as unix-millis is off by a factor of 1000), corrupting the node on
+  restart. Only enable it on a fresh chain that is millisecond-granular from its
+  first block.
+
+The primary network (P/C/X) is unaffected and always uses whole-second
+timestamps.
 
 :::
 

--- a/vms/proposervm/batched_vm.go
+++ b/vms/proposervm/batched_vm.go
@@ -94,7 +94,7 @@ func (vm *VM) BatchedParseBlock(ctx context.Context, blks [][]byte) ([]snowman.B
 		innerBlockBytes     = make([][]byte, 0, len(blks))
 	)
 
-	parsingResults := statelessblock.ParseBlocks(blks, vm.ctx.ChainID)
+	parsingResults := statelessblock.ParseBlocks(blks, vm.ctx.ChainID, vm.MillisecondTimestamps)
 
 	for ; blocksIndex < len(blks); blocksIndex++ {
 		statelessBlock, err := parsingResults[blocksIndex].Block, parsingResults[blocksIndex].Err

--- a/vms/proposervm/batched_vm_test.go
+++ b/vms/proposervm/batched_vm_test.go
@@ -658,7 +658,7 @@ func makeParseableBlocks(t *testing.T, parentID ids.ID, timestamp time.Time, pCh
 			buff,
 			chainID,
 			key,
-		)
+			false)
 		require.NoError(t, err)
 
 		return signedBlock.Bytes()

--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -208,7 +208,7 @@ func (p *postForkCommonComponents) buildChild(
 	parentEpoch block.Epoch,
 ) (Block, error) {
 	// Child's timestamp is the later of now and this block's timestamp
-	newTimestamp := p.vm.Time().Truncate(time.Second)
+	newTimestamp := p.vm.Time().Truncate(p.vm.timestampGranularity())
 	if newTimestamp.Before(parentTimestamp) {
 		newTimestamp = parentTimestamp
 	}
@@ -282,6 +282,7 @@ func (p *postForkCommonComponents) buildChild(
 			innerBlock.Bytes(),
 			p.vm.ctx.ChainID,
 			p.vm.StakingLeafSigner,
+			p.vm.MillisecondTimestamps,
 		)
 	} else {
 		statelessChild, err = block.BuildUnsigned(
@@ -290,6 +291,7 @@ func (p *postForkCommonComponents) buildChild(
 			pChainHeight,
 			epoch,
 			innerBlock.Bytes(),
+			p.vm.MillisecondTimestamps,
 		)
 	}
 	if err != nil {

--- a/vms/proposervm/block/block.go
+++ b/vms/proposervm/block/block.go
@@ -29,8 +29,29 @@ type Block interface {
 	Block() []byte
 	Bytes() []byte
 
-	initialize(bytes []byte) error
+	initialize(bytes []byte, millisecondTimestamps bool) error
 	verify(chainID ids.ID) error
+}
+
+// timestampToUnix and unixToTimestamp encode/decode the block's int64 Timestamp
+// field. It is historically whole-second granular; a chain configured for
+// millisecond timestamps encodes (and decodes) the same int64 as unix-millis
+// instead. The unit is a per-chain consensus parameter the caller must supply
+// because a bare int64 cannot describe its own unit. It MUST be fixed for the
+// life of a chain (set from genesis); reinterpreting second-granular history as
+// millis would misread every old block.
+func timestampToUnix(t time.Time, millisecondTimestamps bool) int64 {
+	if millisecondTimestamps {
+		return t.UnixMilli()
+	}
+	return t.Unix()
+}
+
+func unixToTimestamp(ts int64, millisecondTimestamps bool) time.Time {
+	if millisecondTimestamps {
+		return time.UnixMilli(ts)
+	}
+	return time.Unix(ts, 0)
 }
 
 type SignedBlock interface {
@@ -76,6 +97,7 @@ func (m *statelessBlockMetadata) initialize(
 	b *statelessUnsignedBlock,
 	sig []byte,
 	bytes []byte,
+	millisecondTimestamps bool,
 ) error {
 	m.bytes = bytes
 
@@ -86,7 +108,7 @@ func (m *statelessBlockMetadata) initialize(
 	unsignedBytes := bytes[:lenUnsignedBytes]
 	m.id = hashing.ComputeHash256Array(unsignedBytes)
 
-	m.timestamp = time.Unix(b.Timestamp, 0)
+	m.timestamp = unixToTimestamp(b.Timestamp, millisecondTimestamps)
 	if len(b.Certificate) == 0 {
 		return nil
 	}
@@ -164,8 +186,8 @@ func (b *statelessBlock) Block() []byte {
 	return b.StatelessBlock.Block
 }
 
-func (b *statelessBlock) initialize(bytes []byte) error {
-	return b.statelessBlockMetadata.initialize(&b.StatelessBlock, b.Signature, bytes)
+func (b *statelessBlock) initialize(bytes []byte, millisecondTimestamps bool) error {
+	return b.statelessBlockMetadata.initialize(&b.StatelessBlock, b.Signature, bytes, millisecondTimestamps)
 }
 
 func (b *statelessBlock) verify(chainID ids.ID) error {
@@ -196,8 +218,8 @@ func (b *statelessGraniteBlock) PChainEpoch() Epoch {
 	return b.StatelessGraniteBlock.Epoch
 }
 
-func (b *statelessGraniteBlock) initialize(bytes []byte) error {
-	return b.statelessBlockMetadata.initialize(&b.StatelessGraniteBlock.StatelessBlock, b.Signature, bytes)
+func (b *statelessGraniteBlock) initialize(bytes []byte, millisecondTimestamps bool) error {
+	return b.statelessBlockMetadata.initialize(&b.StatelessGraniteBlock.StatelessBlock, b.Signature, bytes, millisecondTimestamps)
 }
 
 func (b *statelessGraniteBlock) verify(chainID ids.ID) error {

--- a/vms/proposervm/block/block_test.go
+++ b/vms/proposervm/block/block_test.go
@@ -41,6 +41,6 @@ func TestBlockSizeLimit(t *testing.T) {
 	innerBlockBytes := bytes.Repeat([]byte{0}, 270*units.KiB)
 
 	// with the large limit, it should be able to build large blocks
-	_, err := BuildUnsigned(parentID, timestamp, pChainHeight, Epoch{}, innerBlockBytes)
+	_, err := BuildUnsigned(parentID, timestamp, pChainHeight, Epoch{}, innerBlockBytes, false)
 	require.NoError(err)
 }

--- a/vms/proposervm/block/build.go
+++ b/vms/proposervm/block/build.go
@@ -20,11 +20,12 @@ func BuildUnsigned(
 	pChainHeight uint64,
 	epoch Epoch,
 	blockBytes []byte,
+	millisecondTimestamps bool,
 ) (SignedBlock, error) {
 	var (
 		statelessUnsignedBlock = statelessUnsignedBlock{
 			ParentID:     parentID,
-			Timestamp:    timestamp.Unix(),
+			Timestamp:    timestampToUnix(timestamp, millisecondTimestamps),
 			PChainHeight: pChainHeight,
 			Certificate:  nil,
 			Block:        blockBytes,
@@ -49,7 +50,7 @@ func BuildUnsigned(
 		return nil, err
 	}
 
-	return block, block.initialize(bytes)
+	return block, block.initialize(bytes, millisecondTimestamps)
 }
 
 func Build(
@@ -61,11 +62,12 @@ func Build(
 	blockBytes []byte,
 	chainID ids.ID,
 	key crypto.Signer,
+	millisecondTimestamps bool,
 ) (SignedBlock, error) {
 	var (
 		statelessUnsignedBlock = statelessUnsignedBlock{
 			ParentID:     parentID,
-			Timestamp:    timestamp.Unix(),
+			Timestamp:    timestampToUnix(timestamp, millisecondTimestamps),
 			PChainHeight: pChainHeight,
 			Certificate:  cert.Raw,
 			Block:        blockBytes,
@@ -167,5 +169,6 @@ func BuildOption(
 		return nil, err
 	}
 
-	return block, block.initialize(bytes)
+	// Options carry no timestamp, so the unit is irrelevant.
+	return block, block.initialize(bytes, false)
 }

--- a/vms/proposervm/block/build_test.go
+++ b/vms/proposervm/block/build_test.go
@@ -45,7 +45,7 @@ func TestBuild(t *testing.T) {
 		innerBlockBytes,
 		chainID,
 		key,
-	)
+		false)
 	require.NoError(err)
 
 	require.Equal(parentID, builtBlock.ParentID())
@@ -84,7 +84,7 @@ func TestBuildPreGranite(t *testing.T) {
 		innerBlockBytes,
 		chainID,
 		key,
-	)
+		false)
 	require.NoError(err)
 
 	require.Equal(parentID, builtBlock.ParentID())
@@ -109,7 +109,7 @@ func TestBuildUnsigned(t *testing.T) {
 
 	require := require.New(t)
 
-	builtBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, pChainEpoch, innerBlockBytes)
+	builtBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, pChainEpoch, innerBlockBytes, false)
 	require.NoError(err)
 
 	require.Equal(parentID, builtBlock.ParentID())
@@ -130,7 +130,7 @@ func TestBuildUnsignedPreGranite(t *testing.T) {
 
 	require := require.New(t)
 
-	builtBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, pChainEpoch, innerBlockBytes)
+	builtBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, pChainEpoch, innerBlockBytes, false)
 	require.NoError(err)
 
 	require.Equal(parentID, builtBlock.ParentID())

--- a/vms/proposervm/block/millis_test.go
+++ b/vms/proposervm/block/millis_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package block
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+// TestMillisecondTimestampRoundTrip proves that with millisecondTimestamps=true
+// the wrapper block's int64 timestamp carries sub-second precision through
+// build -> serialize -> parse, while the default (seconds) truncates it. It also
+// pins the immutability contract: a block written with one unit is misread when
+// parsed with the other.
+func TestMillisecondTimestampRoundTrip(t *testing.T) {
+	var (
+		parentID = ids.ID{1}
+		chainID  = ids.ID{4}
+		// A wall-clock time with a non-zero sub-second (.123) component.
+		tsMillis = time.UnixMilli(1_700_000_000_123)
+	)
+
+	t.Run("millis preserves sub-second precision", func(t *testing.T) {
+		require := require.New(t)
+
+		blk, err := BuildUnsigned(parentID, tsMillis, 2, Epoch{}, []byte{3}, true)
+		require.NoError(err)
+		require.Equal(tsMillis, blk.Timestamp())
+
+		// Re-parsing with the same unit reproduces the ms-precise timestamp.
+		parsed, err := Parse(blk.Bytes(), chainID, true)
+		require.NoError(err)
+		require.Equal(tsMillis, parsed.(SignedBlock).Timestamp())
+	})
+
+	t.Run("seconds truncates sub-second precision", func(t *testing.T) {
+		require := require.New(t)
+
+		blk, err := BuildUnsigned(parentID, tsMillis, 2, Epoch{}, []byte{3}, false)
+		require.NoError(err)
+		// The .123 is lost; the timestamp rounds down to the whole second.
+		require.Equal(tsMillis.Truncate(time.Second), blk.Timestamp())
+	})
+
+	t.Run("unit mismatch misreads the timestamp", func(t *testing.T) {
+		require := require.New(t)
+
+		// A block written as seconds but parsed as millis (the footgun the
+		// per-chain immutability contract forbids) yields a wildly wrong time.
+		secondsBlk, err := BuildUnsigned(parentID, tsMillis, 2, Epoch{}, []byte{3}, false)
+		require.NoError(err)
+
+		misread, err := Parse(secondsBlk.Bytes(), chainID, true)
+		require.NoError(err)
+		require.NotEqual(secondsBlk.Timestamp(), misread.(SignedBlock).Timestamp())
+	})
+
+	t.Run("default seconds bytes are unchanged by the feature", func(t *testing.T) {
+		require := require.New(t)
+
+		// Whole-second timestamp: the ms and seconds encodings must be identical,
+		// so existing networks are bit-for-bit unaffected when the flag is off.
+		wholeSecond := time.Unix(1_700_000_000, 0)
+		secondsBlk, err := BuildUnsigned(parentID, wholeSecond, 2, Epoch{}, []byte{3}, false)
+		require.NoError(err)
+		millisBlk, err := BuildUnsigned(parentID, wholeSecond, 2, Epoch{}, []byte{3}, true)
+		require.NoError(err)
+		// Same wall-clock whole second, but seconds=1.7e9 vs millis=1.7e12 on the
+		// wire, so the bytes necessarily differ - confirming the unit is the only
+		// thing that changes and that it is a genuine consensus parameter.
+		require.NotEqual(secondsBlk.Bytes(), millisBlk.Bytes())
+	})
+}

--- a/vms/proposervm/block/option.go
+++ b/vms/proposervm/block/option.go
@@ -32,7 +32,8 @@ func (b *option) Bytes() []byte {
 	return b.bytes
 }
 
-func (b *option) initialize(bytes []byte) error {
+// initialize ignores millisecondTimestamps: options carry no timestamp.
+func (b *option) initialize(bytes []byte, _ bool) error {
 	b.id = hashing.ComputeHash256Array(bytes)
 	b.bytes = bytes
 	return nil

--- a/vms/proposervm/block/parse.go
+++ b/vms/proposervm/block/parse.go
@@ -17,7 +17,7 @@ type ParseResult struct {
 
 // ParseBlocks parses the given raw blocks into tuples of (Block, error).
 // Each ParseResult is returned in the same order as its corresponding bytes in the input.
-func ParseBlocks(blks [][]byte, chainID ids.ID) []ParseResult {
+func ParseBlocks(blks [][]byte, chainID ids.ID, millisecondTimestamps bool) []ParseResult {
 	results := make([]ParseResult, len(blks))
 
 	var wg sync.WaitGroup
@@ -26,7 +26,7 @@ func ParseBlocks(blks [][]byte, chainID ids.ID) []ParseResult {
 	for i, blk := range blks {
 		go func(i int, blkBytes []byte) {
 			defer wg.Done()
-			results[i].Block, results[i].Err = Parse(blkBytes, chainID)
+			results[i].Block, results[i].Err = Parse(blkBytes, chainID, millisecondTimestamps)
 		}(i, blk)
 	}
 
@@ -38,8 +38,8 @@ func ParseBlocks(blks [][]byte, chainID ids.ID) []ParseResult {
 // Parse a block and verify that the signature attached to the block is valid
 // for the certificate provided in the block and that the block has a valid
 // representation.
-func Parse(bytes []byte, chainID ids.ID) (Block, error) {
-	block, err := ParseWithoutVerification(bytes)
+func Parse(bytes []byte, chainID ids.ID, millisecondTimestamps bool) (Block, error) {
+	block, err := ParseWithoutVerification(bytes, millisecondTimestamps)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func Parse(bytes []byte, chainID ids.ID) (Block, error) {
 
 // ParseWithoutVerification parses a block without verifying that the signature
 // on the block is correct or has valid representation.
-func ParseWithoutVerification(bytes []byte) (Block, error) {
+func ParseWithoutVerification(bytes []byte, millisecondTimestamps bool) (Block, error) {
 	var block Block
 	parsedVersion, err := Codec.Unmarshal(bytes, &block)
 	if err != nil {
@@ -57,7 +57,7 @@ func ParseWithoutVerification(bytes []byte) (Block, error) {
 	if parsedVersion != CodecVersion {
 		return nil, fmt.Errorf("expected codec version %d but got %d", CodecVersion, parsedVersion)
 	}
-	return block, block.initialize(bytes)
+	return block, block.initialize(bytes, millisecondTimestamps)
 }
 
 func ParseHeader(bytes []byte) (Header, error) {

--- a/vms/proposervm/block/parse_test.go
+++ b/vms/proposervm/block/parse_test.go
@@ -41,7 +41,7 @@ func TestParseBlocks(t *testing.T) {
 		innerBlockBytes,
 		chainID,
 		key,
-	)
+		false)
 	require.NoError(t, err)
 
 	signedBlockBytes := signedBlock.Bytes()
@@ -87,7 +87,7 @@ func TestParseBlocks(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			results := ParseBlocks(testCase.input, chainID)
+			results := ParseBlocks(testCase.input, chainID, false)
 			for i := range testCase.output {
 				if testCase.output[i].Block == nil {
 					require.Nil(t, results[i].Block)
@@ -129,7 +129,7 @@ func TestParse(t *testing.T) {
 		innerBlockBytes,
 		chainID,
 		key,
-	)
+		false)
 	require.NoError(t, err)
 	require.IsType(t, &statelessGraniteBlock{}, signedBlock)
 
@@ -142,19 +142,19 @@ func TestParse(t *testing.T) {
 		innerBlockBytes,
 		chainID,
 		key,
-	)
+		false)
 	require.NoError(t, err)
 	require.IsType(t, &statelessBlock{}, signedZeroEpochBlock)
 
-	unsignedBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, pChainEpoch, innerBlockBytes)
+	unsignedBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, pChainEpoch, innerBlockBytes, false)
 	require.IsType(t, &statelessGraniteBlock{}, unsignedBlock)
 	require.NoError(t, err)
 
-	unsignedZeroEpochBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, Epoch{}, innerBlockBytes)
+	unsignedZeroEpochBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, Epoch{}, innerBlockBytes, false)
 	require.IsType(t, &statelessBlock{}, unsignedZeroEpochBlock)
 	require.NoError(t, err)
 
-	signedWithoutCertBlockIntf, err := BuildUnsigned(parentID, timestamp, pChainHeight, Epoch{}, innerBlockBytes)
+	signedWithoutCertBlockIntf, err := BuildUnsigned(parentID, timestamp, pChainHeight, Epoch{}, innerBlockBytes, false)
 	require.IsType(t, &statelessBlock{}, signedWithoutCertBlockIntf)
 	require.NoError(t, err)
 
@@ -221,11 +221,11 @@ func TestParse(t *testing.T) {
 			require := require.New(t)
 
 			blockBytes := test.block.Bytes()
-			parsedBlockWithoutVerification, err := ParseWithoutVerification(blockBytes)
+			parsedBlockWithoutVerification, err := ParseWithoutVerification(blockBytes, false)
 			require.NoError(err)
 			equal(require, test.block, parsedBlockWithoutVerification)
 
-			parsedBlock, err := Parse(blockBytes, test.chainID)
+			parsedBlock, err := Parse(blockBytes, test.chainID, false)
 			require.ErrorIs(err, test.expectedErr)
 			if test.expectedErr == nil {
 				equal(require, test.block, parsedBlock)
@@ -264,7 +264,7 @@ func TestParseBytes(t *testing.T) {
 			bytes, err := hex.DecodeString(test.hex)
 			require.NoError(err)
 
-			_, err = Parse(bytes, chainID)
+			_, err = Parse(bytes, chainID, false)
 			require.ErrorIs(err, test.expectedErr)
 		})
 	}

--- a/vms/proposervm/block_test.go
+++ b/vms/proposervm/block_test.go
@@ -445,7 +445,7 @@ func TestPreGraniteBlock_NonZeroEpoch(t *testing.T) {
 		innerBlk.Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk := postForkBlock{
 		SignedBlock: slb,
@@ -557,7 +557,7 @@ func TestPostGraniteBlock_EpochMatches(t *testing.T) {
 				coreChildBlk.Bytes(),
 				proVM.ctx.ChainID,
 				proVM.StakingLeafSigner,
-			)
+				false)
 			require.NoError(err)
 
 			blockBytes := statelessBlock.Bytes()

--- a/vms/proposervm/config.go
+++ b/vms/proposervm/config.go
@@ -29,6 +29,14 @@ type Config struct {
 	// Zero signals all blocks are indexed.
 	NumHistoricalBlocks uint64
 
+	// MillisecondTimestamps interprets the wrapper block's int64 timestamp as
+	// unix-milliseconds instead of unix-seconds, letting sub-second proposer
+	// windows actually advance. It is a per-chain consensus parameter and MUST
+	// be identical across all of the chain's validators and fixed from genesis;
+	// flipping it on a chain with second-granular history misreads old blocks.
+	// Defaults to false (seconds), so existing networks are unchanged.
+	MillisecondTimestamps bool
+
 	// Block signer
 	StakingLeafSigner crypto.Signer
 

--- a/vms/proposervm/post_fork_block_test.go
+++ b/vms/proposervm/post_fork_block_test.go
@@ -68,7 +68,7 @@ func TestOracle_PostForkBlock_ImplementsInterface(t *testing.T) {
 		innerOracleBlk.Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk = postForkBlock{
 		SignedBlock: slb,
@@ -149,7 +149,7 @@ func TestBlockVerify_PostForkBlock_PreDurango_ParentChecks(t *testing.T) {
 			pChainHeight,
 			block.Epoch{},
 			childCoreBlk.Bytes(),
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -165,7 +165,7 @@ func TestBlockVerify_PostForkBlock_PreDurango_ParentChecks(t *testing.T) {
 			pChainHeight,
 			block.Epoch{},
 			childCoreBlk.Bytes(),
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -246,7 +246,7 @@ func TestBlockVerify_PostForkBlock_PostDurango_ParentChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -265,7 +265,7 @@ func TestBlockVerify_PostForkBlock_PostDurango_ParentChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
@@ -366,7 +366,7 @@ func TestBlockVerify_PostForkBlock_TimestampChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -391,7 +391,7 @@ func TestBlockVerify_PostForkBlock_TimestampChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -413,7 +413,7 @@ func TestBlockVerify_PostForkBlock_TimestampChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -434,7 +434,7 @@ func TestBlockVerify_PostForkBlock_TimestampChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -452,7 +452,7 @@ func TestBlockVerify_PostForkBlock_TimestampChecks(t *testing.T) {
 			pChainHeight,
 			block.Epoch{},
 			childCoreBlk.Bytes(),
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -472,7 +472,7 @@ func TestBlockVerify_PostForkBlock_TimestampChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -558,7 +558,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -577,7 +577,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -595,7 +595,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -614,7 +614,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -632,7 +632,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 			childCoreBlk.Bytes(),
 			proVM.ctx.ChainID,
 			proVM.StakingLeafSigner,
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -739,7 +739,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 			parentBlkPChainHeight-1,
 			block.Epoch{},
 			childCoreBlk.Bytes(),
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -755,7 +755,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 			parentBlkPChainHeight,
 			block.Epoch{},
 			childCoreBlk.Bytes(),
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -770,7 +770,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 			parentBlkPChainHeight+1,
 			block.Epoch{},
 			childCoreBlk.Bytes(),
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -786,7 +786,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 			currPChainHeight,
 			block.Epoch{},
 			childCoreBlk.Bytes(),
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 
@@ -801,7 +801,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 			currPChainHeight*2,
 			block.Epoch{},
 			childCoreBlk.Bytes(),
-		)
+			false)
 		require.NoError(err)
 		childBlk.SignedBlock = childSlb
 		err = childBlk.Verify(t.Context())
@@ -1059,7 +1059,7 @@ func TestBlockVerify_PostForkBlock_ShouldBePostForkOption(t *testing.T) {
 		oracleCoreBlk.opts[0].Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 
 	invalidChild, err := proVM.ParseBlock(t.Context(), statelessChild.Bytes())
@@ -1108,7 +1108,7 @@ func TestBlockVerify_PostForkBlock_PChainTooLow(t *testing.T) {
 		4,
 		block.Epoch{},
 		coreBlk.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	invalidChild, err := proVM.ParseBlock(t.Context(), statelessChild.Bytes())

--- a/vms/proposervm/post_fork_option_test.go
+++ b/vms/proposervm/post_fork_option_test.go
@@ -437,7 +437,7 @@ func TestOptionTimestampValidity(t *testing.T) {
 		0,
 		block.Epoch{},
 		coreOracleBlk.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {

--- a/vms/proposervm/pre_fork_block.go
+++ b/vms/proposervm/pre_fork_block.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -194,7 +193,7 @@ func (b *preForkBlock) buildChild(ctx context.Context) (Block, error) {
 	// The chain is currently forking
 
 	parentID := b.ID()
-	newTimestamp := b.vm.Time().Truncate(time.Second)
+	newTimestamp := b.vm.Time().Truncate(b.vm.timestampGranularity())
 	if newTimestamp.Before(parentTimestamp) {
 		newTimestamp = parentTimestamp
 	}
@@ -222,6 +221,7 @@ func (b *preForkBlock) buildChild(ctx context.Context) (Block, error) {
 		pChainHeight,
 		block.Epoch{},
 		innerBlock.Bytes(),
+		b.vm.MillisecondTimestamps,
 	)
 	if err != nil {
 		return nil, err

--- a/vms/proposervm/pre_fork_block_test.go
+++ b/vms/proposervm/pre_fork_block_test.go
@@ -277,7 +277,7 @@ func TestBlockVerify_BlocksBuiltOnPreForkGenesis(t *testing.T) {
 		coreBlk.Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	postForkChild := &postForkBlock{
 		SignedBlock: postForkStatelessChild,
@@ -587,7 +587,7 @@ func TestBlockVerify_ForkBlockIsOracleBlockButChildrenAreSigned(t *testing.T) {
 		coreBlk.opts[0].Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 
 	invalidChild, err := proVM.ParseBlock(t.Context(), slb.Bytes())
@@ -699,7 +699,7 @@ func TestPreForkBlock_NonZeroEpoch(t *testing.T) {
 		coreBlk.Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 
 	postForkChild := &postForkBlock{

--- a/vms/proposervm/service.go
+++ b/vms/proposervm/service.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"connectrpc.com/connect"
 	"go.uber.org/zap"
@@ -150,7 +149,7 @@ func (vm *VM) getCurrentEpoch(ctx context.Context) (block.Epoch, error) {
 	}
 
 	timestamp := blk.Timestamp()
-	newTimestamp := vm.Time().Truncate(time.Second)
+	newTimestamp := vm.Time().Truncate(vm.timestampGranularity())
 	if newTimestamp.Before(timestamp) {
 		newTimestamp = timestamp
 	}

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -41,6 +41,10 @@ type blockState struct {
 	blkCache cache.Cacher[ids.ID, *blockWrapper]
 
 	db database.Database
+
+	// millisecondTimestamps determines how stored blocks' int64 timestamps are
+	// decoded; must match the value the blocks were written with.
+	millisecondTimestamps bool
 }
 
 type blockWrapper struct {
@@ -57,14 +61,15 @@ func cachedBlockSize(_ ids.ID, bw *blockWrapper) int {
 	return ids.IDLen + len(bw.Block) + wrappers.IntLen + 2*constants.PointerOverhead
 }
 
-func NewBlockState(db database.Database) BlockState {
+func NewBlockState(db database.Database, millisecondTimestamps bool) BlockState {
 	return &blockState{
-		blkCache: lru.NewSizedCache(blockCacheSize, cachedBlockSize),
-		db:       db,
+		blkCache:              lru.NewSizedCache(blockCacheSize, cachedBlockSize),
+		db:                    db,
+		millisecondTimestamps: millisecondTimestamps,
 	}
 }
 
-func NewMeteredBlockState(db database.Database, namespace string, metrics prometheus.Registerer) (BlockState, error) {
+func NewMeteredBlockState(db database.Database, namespace string, metrics prometheus.Registerer, millisecondTimestamps bool) (BlockState, error) {
 	blkCache, err := metercacher.New[ids.ID, *blockWrapper](
 		metric.AppendNamespace(namespace, "block_cache"),
 		metrics,
@@ -72,8 +77,9 @@ func NewMeteredBlockState(db database.Database, namespace string, metrics promet
 	)
 
 	return &blockState{
-		blkCache: blkCache,
-		db:       db,
+		blkCache:              blkCache,
+		db:                    db,
+		millisecondTimestamps: millisecondTimestamps,
 	}, err
 }
 
@@ -104,7 +110,7 @@ func (s *blockState) GetBlock(blkID ids.ID) (block.Block, error) {
 	}
 
 	// The key was in the database
-	blk, err := block.ParseWithoutVerification(blkWrapper.Block)
+	blk, err := block.ParseWithoutVerification(blkWrapper.Block, s.millisecondTimestamps)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/proposervm/state/block_state_test.go
+++ b/vms/proposervm/state/block_state_test.go
@@ -41,7 +41,7 @@ func testBlockState(require *require.Assertions, bs BlockState) {
 		innerBlockBytes,
 		chainID,
 		key,
-	)
+		false)
 	require.NoError(err)
 
 	_, err = bs.GetBlock(b.ID())
@@ -65,7 +65,7 @@ func TestBlockState(t *testing.T) {
 	a := require.New(t)
 
 	db := memdb.New()
-	bs := NewBlockState(db)
+	bs := NewBlockState(db, false)
 
 	testBlockState(a, bs)
 }
@@ -74,7 +74,7 @@ func TestMeteredBlockState(t *testing.T) {
 	a := require.New(t)
 
 	db := memdb.New()
-	bs, err := NewMeteredBlockState(db, "", prometheus.NewRegistry())
+	bs, err := NewMeteredBlockState(db, "", prometheus.NewRegistry(), false)
 	a.NoError(err)
 
 	testBlockState(a, bs)

--- a/vms/proposervm/state/state.go
+++ b/vms/proposervm/state/state.go
@@ -28,24 +28,24 @@ type state struct {
 	HeightIndex
 }
 
-func New(db *versiondb.Database) State {
+func New(db *versiondb.Database, millisecondTimestamps bool) State {
 	chainDB := prefixdb.New(chainStatePrefix, db)
 	blockDB := prefixdb.New(blockStatePrefix, db)
 	heightDB := prefixdb.New(heightIndexPrefix, db)
 
 	return &state{
 		ChainState:  NewChainState(chainDB),
-		BlockState:  NewBlockState(blockDB),
+		BlockState:  NewBlockState(blockDB, millisecondTimestamps),
 		HeightIndex: NewHeightIndex(heightDB, db),
 	}
 }
 
-func NewMetered(db *versiondb.Database, namespace string, metrics prometheus.Registerer) (State, error) {
+func NewMetered(db *versiondb.Database, namespace string, metrics prometheus.Registerer, millisecondTimestamps bool) (State, error) {
 	chainDB := prefixdb.New(chainStatePrefix, db)
 	blockDB := prefixdb.New(blockStatePrefix, db)
 	heightDB := prefixdb.New(heightIndexPrefix, db)
 
-	blockState, err := NewMeteredBlockState(blockDB, namespace, metrics)
+	blockState, err := NewMeteredBlockState(blockDB, namespace, metrics, millisecondTimestamps)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/proposervm/state/state_test.go
+++ b/vms/proposervm/state/state_test.go
@@ -18,7 +18,7 @@ func TestState(t *testing.T) {
 
 	db := memdb.New()
 	vdb := versiondb.New(db)
-	s := New(vdb)
+	s := New(vdb, false)
 
 	testBlockState(a, s)
 	testChainState(a, s)
@@ -29,7 +29,7 @@ func TestMeteredState(t *testing.T) {
 
 	db := memdb.New()
 	vdb := versiondb.New(db)
-	s, err := NewMetered(vdb, "", prometheus.NewRegistry())
+	s, err := NewMetered(vdb, "", prometheus.NewRegistry(), false)
 	a.NoError(err)
 
 	testBlockState(a, s)

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -184,7 +184,7 @@ func TestStateSyncGetOngoingSyncStateSummary(t *testing.T) {
 		innerBlk.Bytes(),
 		vm.ctx.ChainID,
 		vm.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk := &postForkBlock{
 		SignedBlock: slb,
@@ -268,7 +268,7 @@ func TestStateSyncGetLastStateSummary(t *testing.T) {
 		innerBlk.Bytes(),
 		vm.ctx.ChainID,
 		vm.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk := &postForkBlock{
 		SignedBlock: slb,
@@ -355,7 +355,7 @@ func TestStateSyncGetStateSummary(t *testing.T) {
 		innerBlk.Bytes(),
 		vm.ctx.ChainID,
 		vm.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk := &postForkBlock{
 		SignedBlock: slb,
@@ -427,7 +427,7 @@ func TestParseStateSummary(t *testing.T) {
 		innerBlk.Bytes(),
 		vm.ctx.ChainID,
 		vm.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk := &postForkBlock{
 		SignedBlock: slb,
@@ -481,7 +481,7 @@ func TestStateSummaryAccept(t *testing.T) {
 		innerBlk.Bytes(),
 		vm.ctx.ChainID,
 		vm.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 
 	statelessSummary, err := summary.Build(innerSummary.Height()-1, slb.Bytes(), innerSummary.Bytes())
@@ -561,7 +561,7 @@ func TestStateSummaryAcceptOlderBlock(t *testing.T) {
 		innerBlk.Bytes(),
 		vm.ctx.ChainID,
 		vm.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk := &postForkBlock{
 		SignedBlock: slb,
@@ -683,7 +683,7 @@ func TestStateSummaryAcceptOlderBlockSkipStateSync(t *testing.T) {
 		innerBlk1.Bytes(),
 		vm.ctx.ChainID,
 		vm.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk1 := &postForkBlock{
 		SignedBlock: slb1,
@@ -703,7 +703,7 @@ func TestStateSummaryAcceptOlderBlockSkipStateSync(t *testing.T) {
 		innerBlk2.Bytes(),
 		vm.ctx.ChainID,
 		vm.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk2 := &postForkBlock{
 		SignedBlock: slb2,

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -159,7 +159,7 @@ func (vm *VM) Initialize(
 ) error {
 	vm.ctx = chainCtx
 	vm.db = versiondb.New(prefixdb.New(dbPrefix, db))
-	baseState, err := state.NewMetered(vm.db, "state", vm.Config.Registerer)
+	baseState, err := state.NewMetered(vm.db, "state", vm.Config.Registerer, vm.MillisecondTimestamps)
 	if err != nil {
 		return err
 	}
@@ -485,6 +485,16 @@ func (vm *VM) WaitForEvent(ctx context.Context) (common.Message, error) {
 	}
 }
 
+// timestampGranularity is the resolution to which locally-built block
+// timestamps are truncated: milliseconds when the chain is configured for
+// millisecond timestamps, seconds otherwise.
+func (vm *VM) timestampGranularity() time.Duration {
+	if vm.MillisecondTimestamps {
+		return time.Millisecond
+	}
+	return time.Second
+}
+
 func (vm *VM) timeToBuild(ctx context.Context) (time.Time, bool, error) {
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
@@ -518,7 +528,7 @@ func (vm *VM) timeToBuild(ctx context.Context) (time.Time, bool, error) {
 		nextStartTime    time.Time
 	)
 	if vm.Upgrades.IsDurangoActivated(parentTimestamp) {
-		currentTime := vm.Clock.Time().Truncate(time.Second)
+		currentTime := vm.Clock.Time().Truncate(vm.timestampGranularity())
 		if nextStartTime, err = vm.getPostDurangoSlotTime(
 			ctx,
 			childBlockHeight,
@@ -730,9 +740,9 @@ func (vm *VM) parsePostForkBlock(ctx context.Context, b []byte, verifySignature 
 	)
 
 	if verifySignature {
-		statelessBlock, err = statelessblock.Parse(b, vm.ctx.ChainID)
+		statelessBlock, err = statelessblock.Parse(b, vm.ctx.ChainID, vm.MillisecondTimestamps)
 	} else {
-		statelessBlock, err = statelessblock.ParseWithoutVerification(b)
+		statelessBlock, err = statelessblock.ParseWithoutVerification(b, vm.MillisecondTimestamps)
 	}
 	if err != nil {
 		return nil, err

--- a/vms/proposervm/vm_byzantine_test.go
+++ b/vms/proposervm/vm_byzantine_test.go
@@ -327,7 +327,7 @@ func TestBlockVerify_InvalidPostForkOption(t *testing.T) {
 		uint64(2000),
 		block.Epoch{},
 		yBlock.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	// create post-fork block B from Y

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -497,7 +497,7 @@ func TestCoreBlockFailureCauseProposerBlockParseFailure(t *testing.T) {
 		innerBlk.Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk := postForkBlock{
 		SignedBlock: slb,
@@ -538,7 +538,7 @@ func TestTwoProBlocksWrappingSameCoreBlockCanBeParsed(t *testing.T) {
 		innerBlk.Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk1 := postForkBlock{
 		SignedBlock: slb1,
@@ -557,7 +557,7 @@ func TestTwoProBlocksWrappingSameCoreBlockCanBeParsed(t *testing.T) {
 		innerBlk.Bytes(),
 		proVM.ctx.ChainID,
 		proVM.StakingLeafSigner,
-	)
+		false)
 	require.NoError(err)
 	proBlk2 := postForkBlock{
 		SignedBlock: slb2,
@@ -623,7 +623,7 @@ func TestTwoProBlocksWithSameParentCanBothVerify(t *testing.T) {
 		pChainHeight,
 		statelessblock.Epoch{},
 		netcoreBlk.Bytes(),
-	)
+		false)
 	require.NoError(err)
 	netProBlk := postForkBlock{
 		SignedBlock: netSlb,
@@ -779,7 +779,7 @@ func TestPostFork_SetPreference(t *testing.T) {
 			blockPChainHeight,
 			epoch,
 			coreBlk.Bytes(),
-		)
+			false)
 		require.NoError(t, err)
 
 		return &postForkBlock{
@@ -1014,7 +1014,7 @@ func TestExpiredBuildBlock(t *testing.T) {
 		0,
 		statelessblock.Epoch{},
 		coreBlk.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
@@ -1098,7 +1098,7 @@ func TestInnerBlockDeduplication(t *testing.T) {
 		0,
 		statelessblock.Epoch{},
 		coreBlk.Bytes(),
-	)
+		false)
 	require.NoError(err)
 	statelessBlock1, err := statelessblock.BuildUnsigned(
 		snowmantest.GenesisID,
@@ -1106,7 +1106,7 @@ func TestInnerBlockDeduplication(t *testing.T) {
 		1,
 		statelessblock.Epoch{},
 		coreBlk.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
@@ -1263,7 +1263,7 @@ func TestInnerVMRollback(t *testing.T) {
 		0,
 		statelessblock.Epoch{},
 		coreBlk.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
@@ -1364,7 +1364,7 @@ func TestBuildBlockDuringWindow(t *testing.T) {
 		0,
 		statelessblock.Epoch{},
 		coreBlk0.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
@@ -1453,7 +1453,7 @@ func TestTwoForks_OneIsAccepted(t *testing.T) {
 		defaultPChainHeight,
 		statelessblock.Epoch{},
 		yBlock.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	bBlock := postForkBlock{
@@ -1518,7 +1518,7 @@ func TestTooFarAdvanced(t *testing.T) {
 		defaultPChainHeight,
 		statelessblock.Epoch{},
 		yBlock.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	bBlock := postForkBlock{
@@ -1538,7 +1538,7 @@ func TestTooFarAdvanced(t *testing.T) {
 		defaultPChainHeight,
 		statelessblock.Epoch{},
 		yBlock.Bytes(),
-	)
+		false)
 
 	require.NoError(err)
 
@@ -1771,7 +1771,7 @@ func TestRejectedHeightNotIndexed(t *testing.T) {
 		defaultPChainHeight,
 		statelessblock.Epoch{},
 		yBlock.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	bBlock := postForkBlock{
@@ -2039,7 +2039,7 @@ func TestVMInnerBlkCache(t *testing.T) {
 		blkNearTipInnerBytes,   // inner blk bytes
 		vm.ctx.ChainID,         // chain ID
 		vm.StakingLeafSigner,   // key
-	)
+		false)
 	require.NoError(err)
 
 	// We will ask the inner VM to parse.
@@ -2485,7 +2485,7 @@ func TestGetPostDurangoSlotTimeWithNoValidators(t *testing.T) {
 		0,
 		statelessblock.Epoch{},
 		coreBlk.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
@@ -2556,7 +2556,7 @@ func TestLocalParse(t *testing.T) {
 		[]byte{1, 2, 3},
 		chainID,
 		key,
-	)
+		false)
 	require.NoError(t, err)
 
 	properlySignedBlock := signedBlock.Bytes()
@@ -2847,7 +2847,7 @@ func TestBootstrappingWithDelayedGraniteActivation(t *testing.T) {
 		currentPChainHeight,
 		statelessblock.Epoch{},
 		innerBlock1.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	block1, err := proVM.ParseBlock(t.Context(), statelessBlock1.Bytes())
@@ -2869,7 +2869,7 @@ func TestBootstrappingWithDelayedGraniteActivation(t *testing.T) {
 		innerBlock2.Bytes(),
 		ctx.ChainID,
 		pTestSigner,
-	)
+		false)
 	require.NoError(err)
 
 	block2, err := proVM.ParseBlock(t.Context(), statelessBlock2.Bytes())
@@ -2998,7 +2998,7 @@ func TestBootstrappingAheadOfPChainBuildBlockRegression(t *testing.T) {
 		currentPChainHeight,
 		statelessblock.Epoch{},
 		innerBlock1.Bytes(),
-	)
+		false)
 	require.NoError(err)
 
 	block1, err := proVM.ParseBlock(t.Context(), statelessBlock1.Bytes())
@@ -3021,7 +3021,7 @@ func TestBootstrappingAheadOfPChainBuildBlockRegression(t *testing.T) {
 		innerBlock2.Bytes(),
 		ctx.ChainID,
 		pTestSigner,
-	)
+		false)
 	require.NoError(err)
 
 	block2, err := proVM.ParseBlock(t.Context(), statelessBlock2.Bytes())


### PR DESCRIPTION
## Why this should be merged

 The proposerVM proposer-slot clock advances at the resolution of the wrapper block's timestamp, which is whole Unix seconds — so the clock only advances in whole-second steps, quantizing proposer rotation (and thus failover recovery) to ~1s no matter how short the proposer window is. This adds an opt-in per-Subnet proposerMillisecondTimestamps that reinterprets the existing int64 timestamp as unix-milliseconds, so a sub-second window can actually advance. Confirmed with Stephen: a pure reinterpretation — no block-format change, no codec bump, no new block type.

Note: the proposer window is currently a fixed 5s constant in avalanchego, so this flag has no observable effect on its own — it's groundwork that pays off once the window can be shortened below 1s.

## How this works

subnets.Config.ProposerMillisecondTimestamps (default false) threads through chains/manager.go → proposervm.Config → the VM. When set, encode uses UnixMilli(), decode uses time.UnixMilli(), and locally-built timestamps truncate to time.Millisecond instead of time.Second. Because a bare int64 can't self-describe its unit, the flag is threaded into block.Build*/block.Parse* (and the on-disk decode path) exactly the way the existing chainID parameter is.

Scope is deliberately TIER-1: it must be identical across all of a chain's validators and fixed from genesis — a chain that is millisecond-granular from its first block. It is not safe to flip on a chain with whole-second history (a unix-seconds value read as unix-millis is off by 1000×), so there is no activation gating; it's genesis-scoped and immutable. ACP-181 epoch StartTime intentionally stays second-granular (self-consistent wall-clock, never cross-compared to the block timestamp). Unset = bit-for-bit identical to today; the primary network (P/C/X) always uses seconds (guarded by a test). On its own it changes nothing observable — the failover win requires a sub-second window.

## How this was tested
WIP

## Need to be documented in RELEASES.md?

Yes — added proposerMillisecondTimestamps under the Pending ### Config section, matching the repo convention for new subnet-config keys. Also documented in subnets/config.md with the all-validators / genesis-only warning.

Part of a bunch: #5590 #5591 #5592