### PR TITLE
feat(saevm): Disallow empty blocks

### DIFF
--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -363,6 +363,8 @@ func ancestorInputIDs(h *types.Header, settled common.Hash, source saetypes.Bloc
 	return s, nil
 }
 
+var errEmptyBlock = errors.New("empty block")
+
 func (b *builder) BuildBlock(
 	header *types.Header,
 	blockCtx *block.Context,
@@ -371,6 +373,10 @@ func (b *builder) BuildBlock(
 	avaxTxs []*hookTx,
 	settled hook.Settled,
 ) (*types.Block, error) {
+	if len(ethTxs) == 0 && len(avaxTxs) == 0 {
+		return nil, errEmptyBlock
+	}
+
 	txs := make([]*tx.Tx, len(avaxTxs))
 	for i, avaxTx := range avaxTxs {
 		txs[i] = avaxTx.tx

--- a/vms/saevm/cchain/hooks_test.go
+++ b/vms/saevm/cchain/hooks_test.go
@@ -110,14 +110,26 @@ func TestAncestorInputIDs(t *testing.T) {
 // Verifies that [hooks.SettledBy] decodes the marker that [builder.BuildBlock]
 // writes into the header, and returns the zero marker when the header carries none.
 func TestSettledBy(t *testing.T) {
-	_, sut := newSUT(t)
+	key := txtest.NewKey(t)
+	_, sut := newSUT(t, withMaxAllocFor(key.EthAddress()))
 	hooks := sut.hooks()
+
+	stx := newWallet(key, sut.ctx, sut.Client).newMinimalTx(t)
+	htx, err := newHookTx(stx, sut.ctx.AVAXAssetID)
+	require.NoError(t, err, "newHookTx()")
 
 	// built returns the header of a block built carrying the given settled marker.
 	built := func(t *testing.T, settled hook.Settled) *types.Header {
 		t.Helper()
 
-		block, err := hooks.BuildBlock(&types.Header{}, nil, nil, nil, nil, settled)
+		block, err := hooks.BuildBlock(
+			&types.Header{},
+			nil, // blockContext
+			nil, // ethTxs
+			nil, // receipts
+			[]*hookTx{htx},
+			settled,
+		)
 		require.NoError(t, err, "builder.BuildBlock()")
 		return block.Header()
 	}

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -566,6 +566,7 @@ func (s *SUT) verifyTampered(ctx context.Context, tb testing.TB, valid *blocks.B
 	hdr := valid.Header()
 	extra := customtypes.GetHeaderExtra(hdr)
 	tamper(extra)
+	customtypes.SetHeaderExtra(hdr, extra)
 
 	buf, err := rlp.EncodeToBytes(valid.EthBlock().WithSeal(hdr))
 	require.NoErrorf(tb, err, "rlp.EncodeToBytes(tampered block)")
@@ -1340,8 +1341,8 @@ func TestEmptyBlocksDisallowed(t *testing.T) {
 		require.NoErrorf(t, sut.IssueTx(ctx, stx), "%T.IssueTx()", sut.Client)
 		valid := sut.buildVerify(ctx, t, sut.lastAccepted(ctx, t))
 
-		// In addition to removing the the block's extData, we need to update
-		// the header's ExtDataHash to allow parsing.
+		// In addition to removing the block's extData, we need to update the
+		// header's ExtDataHash to allow parsing.
 		hdr := valid.Header()
 		customtypes.GetHeaderExtra(hdr).ExtDataHash = customtypes.EmptyExtDataHash
 

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -566,7 +566,6 @@ func (s *SUT) verifyTampered(ctx context.Context, tb testing.TB, valid *blocks.B
 	hdr := valid.Header()
 	extra := customtypes.GetHeaderExtra(hdr)
 	tamper(extra)
-	customtypes.SetHeaderExtra(hdr, extra)
 
 	buf, err := rlp.EncodeToBytes(valid.EthBlock().WithSeal(hdr))
 	require.NoErrorf(tb, err, "rlp.EncodeToBytes(tampered block)")
@@ -1325,4 +1324,36 @@ func TestGasRefundsDisabled(t *testing.T) {
 
 	const gasIfRefunded = wantGasUsed - ethparams.SstoreClearsScheduleRefundEIP3529
 	assert.Equalf(t, wantGasUsed, receipt.GasUsed, "gas charged (would be %d if refunds were enabled)", gasIfRefunded)
+}
+
+// TestEmptyBlocksDisallowed asserts that empty blocks are not allowed.
+func TestEmptyBlocksDisallowed(t *testing.T) {
+	key := txtest.NewKey(t)
+	ctx, sut := newSUT(t, withMaxAllocFor(key.EthAddress()))
+
+	t.Run("build", func(t *testing.T) {
+		_, err := sut.BuildBlock(ctx, nil)
+		require.ErrorIsf(t, err, errEmptyBlock, "%T.BuildBlock() should not produce empty blocks", sut)
+	})
+	t.Run("verify", func(t *testing.T) {
+		stx := newWallet(key, sut.ctx, sut.Client).newMinimalTx(t)
+		require.NoErrorf(t, sut.IssueTx(ctx, stx), "%T.IssueTx()", sut.Client)
+		valid := sut.buildVerify(ctx, t, sut.lastAccepted(ctx, t))
+
+		// In addition to removing the the block's extData, we need to update
+		// the header's ExtDataHash to allow parsing.
+		hdr := valid.Header()
+		customtypes.GetHeaderExtra(hdr).ExtDataHash = customtypes.EmptyExtDataHash
+
+		emptied := valid.EthBlock().WithSeal(hdr)
+		customtypes.SetBlockExtra(emptied, new(customtypes.BlockBodyExtra))
+
+		buf, err := rlp.EncodeToBytes(emptied)
+		require.NoErrorf(t, err, "rlp.EncodeToBytes(emptied block)")
+		parsed, err := sut.ParseBlock(ctx, buf)
+		require.NoErrorf(t, err, "%T.ParseBlock(emptied block)", sut.VM)
+
+		err = sut.VerifyBlock(ctx, nil, parsed)
+		require.ErrorIsf(t, err, errEmptyBlock, "%T.VerifyBlock() should not allow empty blocks", sut.VM)
+	})
 }


### PR DESCRIPTION
## Why this should be merged

The C-chain does not allow empty blocks. This maintains that invariant within SAE.

Additionally, this is required for transitionVM to be able to bootstrap because Coreth will not even Parse empty blocks. We could additionally disallow parsing of empty blocks in SAE - but it needlessly duplicates the verification logic.

## How this works

Disallows blocks that do not contain at least one eth/avax tx.

## How this was tested

- [x] BuildBlock should not produce empty blocks
- [x] VerifyBlock should not allow empty blocks.

## Need to be documented in RELEASES.md?

No.