### PR TITLE
Move ExtDataGasUsed from syntactic to semantic verification

### DIFF
--- a/graft/coreth/plugin/evm/atomic/vm/block_extension.go
+++ b/graft/coreth/plugin/evm/atomic/vm/block_extension.go
@@ -134,8 +134,21 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 		return ErrEmptyBlock
 	}
 
+	return nil
+}
+
+// SemanticVerify checks the semantic validity of the block. This is called by the wrapper
+// block manager's SemanticVerify method.
+func (be *blockExtension) SemanticVerify() error {
+	vm := be.blockExtender.vm
+	ethBlock := be.block.GetEthBlock()
+	rules := vm.rules(ethBlock.Number(), ethBlock.Time())
+
 	// If we are in ApricotPhase4, ensure that ExtDataGasUsed is populated correctly.
 	if rules.IsApricotPhase4 {
+		headerExtra := customtypes.GetHeaderExtra(ethBlock.Header())
+		atomicTxs := be.atomicTxs
+
 		// After the F upgrade, the extDataGasUsed field is validated by
 		// [header.VerifyGasUsed].
 		if !rules.IsFortuna && rules.IsApricotPhase5 {
@@ -163,13 +176,6 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 		}
 	}
 
-	return nil
-}
-
-// SemanticVerify checks the semantic validity of the block. This is called by the wrapper
-// block manager's SemanticVerify method.
-func (be *blockExtension) SemanticVerify() error {
-	vm := be.blockExtender.vm
 	if vm.bootstrapped.Get() {
 		// Verify that the UTXOs named in import txs are present in shared
 		// memory.


### PR DESCRIPTION
## Why this should be merged

During the Coreth SAE transition, Coreth must be able to parse SAE blocks. Because Coreth performs `Syntactic` verification during parsing, this means that Coreth's `Syntactic` verification must pass for SAE blocks. We don't want to change the verification rules for Coreth blocks though.

## How this works

The only rule that SAE breaks is the ExtDataGasUsed field. In SAE - the atomic txs are included in just the normal gas values. So the ExtDataGasUsed is hardcoded to 0 in SAE.

To avoid breaking coreth's verification, the syntactic verification is moved to semantic verification.

## How this was tested

TBH - I don't see coreth having tested this verification at all... But moving it from syntactic to semantic verification doesn't feel worthwhile for me to actually write tests for this behavior.

## Need to be documented in RELEASES.md?

No