### PR TITLE
Add e2e test with scheduled upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - Unit
       - Fuzz
       - e2e
+      - e2e_schedule_latest
       - e2e_post_latest
       - e2e_kube
       - e2e_existing_network
@@ -113,6 +114,24 @@ jobs:
           loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
+  e2e_schedule_latest:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run e2e tests
+        uses: ./.github/actions/run-monitored-tmpnet-cmd
+        with:
+          run: ./scripts/run_task.sh test-e2e-ci -- --activate-latest-after=4m
+          artifact_prefix: e2e-schedule-latest
+          filter_by_owner: avalanchego-e2e
+          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          loki_url: ${{ secrets.LOKI_URL || '' }}
+          loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
+          loki_username: ${{ secrets.LOKI_USERNAME || '' }}
+          loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   e2e_post_latest:
     runs-on: ubuntu-24.04
     steps:
@@ -120,7 +139,7 @@ jobs:
       - name: Run e2e tests
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
-          run: ./scripts/run_task.sh test-e2e-ci -- --activate-latest
+          run: ./scripts/run_task.sh test-e2e-ci -- --activate-latest-after=0
           artifact_prefix: e2e-post-latest
           filter_by_owner: avalanchego-e2e
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}

--- a/tests/e2e/BUILD.bazel
+++ b/tests/e2e/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "//tests/e2e/x/transfer",
         "//tests/fixture/e2e",
         "//tests/fixture/tmpnet",
+        "//upgrade",
         "//upgrade/upgradetest",
         "@com_github_onsi_ginkgo_v2//:ginkgo",
         "@com_github_stretchr_testify//require",

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ava-labs/avalanchego/tests/e2e/vms"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 )
 
@@ -40,6 +41,29 @@ func init() {
 	flagVars = e2e.RegisterFlags(e2e.WithDefaultOwner("avalanchego-e2e"))
 }
 
+// upgradeConfig builds the e2e upgrade config based on when the latest upgrade
+// should activate:
+//   - activateLatestAfter < 0: leave the latest upgrade unscheduled
+//   - activateLatestAfter == 0: activate the latest upgrade from genesis
+//   - activateLatestAfter > 0: schedule the latest upgrade that duration after
+//     network start
+func upgradeConfig(activateLatestAfter time.Duration) upgrade.Config {
+	var upgrades upgrade.Config
+	switch {
+	case activateLatestAfter < 0:
+		upgrades = upgradetest.GetConfig(upgradetest.Latest - 1)
+	case activateLatestAfter == 0:
+		upgrades = upgradetest.GetConfig(upgradetest.Latest)
+	default:
+		// Schedule only the latest fork after start: set every fork to the
+		// scheduled time, then reset all prior forks to be active from genesis.
+		upgrades = upgradetest.GetConfigWithUpgradeTime(upgradetest.Latest, time.Now().Add(activateLatestAfter))
+		upgradetest.SetTimesTo(&upgrades, upgradetest.Latest-1, upgrade.InitiallyActiveTime)
+	}
+	upgrades.GraniteEpochDuration = 4 * time.Second
+	return upgrades
+}
+
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// Run only once in the first ginkgo process
 
@@ -50,12 +74,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	nodes := tmpnet.NewNodesOrPanic(nodeCount)
 	subnets := vms.XSVMSubnetsOrPanic(nodes...)
 
-	upgradeToActivate := upgradetest.Latest
-	if !flagVars.ActivateLatest() {
-		upgradeToActivate--
-	}
-	upgrades := upgradetest.GetConfig(upgradeToActivate)
-	upgrades.GraniteEpochDuration = 4 * time.Second
+	upgrades := upgradeConfig(flagVars.ActivateLatestAfter())
 	tc.Log().Info("setting upgrades",
 		zap.Reflect("upgrades", upgrades),
 	)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -41,24 +41,24 @@ func init() {
 	flagVars = e2e.RegisterFlags(e2e.WithDefaultOwner("avalanchego-e2e"))
 }
 
-// upgradeConfig builds the e2e upgrade config based on when the latest upgrade
-// should activate:
-//   - activateLatestAfter < 0: leave the latest upgrade unscheduled
-//   - activateLatestAfter == 0: activate the latest upgrade from genesis
-//   - activateLatestAfter > 0: schedule the latest upgrade that duration after
-//     network start
+// upgradeConfig configures the latest upgrade:
+//   - activateLatestAfter < 0: leave latest unscheduled
+//   - activateLatestAfter == 0: activate latest from genesis
+//   - activateLatestAfter > 0: schedule latest that duration after starting
 func upgradeConfig(activateLatestAfter time.Duration) upgrade.Config {
+	const previous = upgradetest.Latest - 1
 	var upgrades upgrade.Config
 	switch {
 	case activateLatestAfter < 0:
-		upgrades = upgradetest.GetConfig(upgradetest.Latest - 1)
+		upgrades = upgradetest.GetConfig(previous)
 	case activateLatestAfter == 0:
 		upgrades = upgradetest.GetConfig(upgradetest.Latest)
 	default:
-		// Schedule only the latest fork after start: set every fork to the
-		// scheduled time, then reset all prior forks to be active from genesis.
-		upgrades = upgradetest.GetConfigWithUpgradeTime(upgradetest.Latest, time.Now().Add(activateLatestAfter))
-		upgradetest.SetTimesTo(&upgrades, upgradetest.Latest-1, upgrade.InitiallyActiveTime)
+		upgrades = upgradetest.GetConfigWithUpgradeTime(
+			upgradetest.Latest,
+			time.Now().Add(activateLatestAfter),
+		)
+		upgradetest.SetTimesTo(&upgrades, previous, upgrade.InitiallyActiveTime)
 	}
 	upgrades.GraniteEpochDuration = 4 * time.Second
 	return upgrades

--- a/tests/fixture/e2e/flags.go
+++ b/tests/fixture/e2e/flags.go
@@ -40,7 +40,7 @@ type FlagVars struct {
 	stopNetwork    bool
 	restartNetwork bool
 
-	activateLatest bool
+	activateLatestAfter time.Duration
 }
 
 func (v *FlagVars) NetworkCmd() (NetworkCmd, error) {
@@ -120,8 +120,8 @@ func (v *FlagVars) NetworkShutdownDelay() time.Duration {
 	return 0
 }
 
-func (v *FlagVars) ActivateLatest() bool {
-	return v.activateLatest
+func (v *FlagVars) ActivateLatestAfter() time.Duration {
+	return v.activateLatestAfter
 }
 
 type DefaultOption func(*DefaultOptions)
@@ -214,11 +214,11 @@ func RegisterFlags(ops ...DefaultOption) *FlagVars {
 		"[optional] stop an existing network started with --reuse-network and exit without executing any tests.",
 	)
 
-	flag.BoolVar(
-		&vars.activateLatest,
-		"activate-latest",
-		false,
-		"[optional] activate all upgrades up to and including the latest upgrade",
+	flag.DurationVar(
+		&vars.activateLatestAfter,
+		"activate-latest-after",
+		-1,
+		"[optional] controls activation of the latest upgrade: <0 leaves it unscheduled, 0 activates it from genesis, >0 schedules it that duration after network start",
 	)
 
 	return &vars


### PR DESCRIPTION
## Why this should be merged

Currently, the e2e tests only run with two different upgrade settings:
1. Latest unscheduled
2. Latest initially activated

This adds a third setting:
- Latest scheduled some duration in the future

## How this works

Changes the `--activate-latest` flag to `--activate-latest-after`. The default behavior is left unchanged. `--activate-latest` can be replicated with `--activate-latest-after=0`.

## How this was tested

CI

## Need to be documented in RELEASES.md?

No