### PR TITLE
fix(ci): checkout before local install-nix in firewood-chaos-test

### DIFF
--- a/.github/workflows/firewood-chaos-test.yml
+++ b/.github/workflows/firewood-chaos-test.yml
@@ -87,6 +87,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/install-nix
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -94,7 +95,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_S3_READ_ONLY_ROLE }}
           aws-region: 'us-east-2'
           role-duration-seconds: '43200'
-      - uses: actions/checkout@v5
       - name: Run chaos test with Firewood
         shell: nix develop --impure --command bash -x {0}
         run: ./scripts/run_task.sh test-cchain-reexecution -- "${{ matrix.test || '' }}"


### PR DESCRIPTION
## Why this should be merged

The `firewood-chaos-test` job recently started failing:

 - https://github.com/ava-labs/avalanchego/actions/runs/28285608359/attempts/1
 - https://github.com/ava-labs/avalanchego/actions/runs/28318719738/attempts/1

In all failed runs, we get this error message: 

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/avalanchego/avalanchego/.github/actions/install-nix'. Did you forget to run actions/checkout before running your local action?
```

After some investigation, it seems that #5588 swapped the remote `cachix/install-nix-action` for the local action `./.github/actions/install-nix`, but left `actions/checkout` as the third step. A local action's files only exist on disk after checkout, so the runner can't resolve `action.yml` and the job fails immediately. The previous remote action needed no checkout, which is why the ordering worked before.

## How this works

Move `actions/checkout@v5` to be the first step of the `firewood-chaos-test` job, before the local `./.github/actions/install-nix` action.

## How this was tested

Manually ran chaos test on this branch here: https://github.com/ava-labs/avalanchego/actions/runs/28324226950/job/83911397207

## Need to be documented in RELEASES.md?

No