### PR TITLE
Remove unused variable NetworkHRPToNetworkID

### DIFF
--- a/utils/constants/network_ids.go
+++ b/utils/constants/network_ids.go
@@ -78,15 +78,6 @@ var (
 		UnitTestID: UnitTestHRP,
 		LocalID:    LocalHRP,
 	}
-	NetworkHRPToNetworkID = map[string]uint32{
-		MainnetHRP:  MainnetID,
-		CascadeHRP:  CascadeID,
-		DenaliHRP:   DenaliID,
-		EverestHRP:  EverestID,
-		FujiHRP:     FujiID,
-		UnitTestHRP: UnitTestID,
-		LocalHRP:    LocalID,
-	}
 	ProductionNetworkIDs = set.Of(MainnetID, FujiID)
 
 	ValidNetworkPrefix = "network-"


### PR DESCRIPTION
## Why this should be merged

Just removes an unused global variable introduced in [this](https://github.com/ava-labs/avalanchego/commit/23d324b91aa38d1f32c59d40a81bbae18d8706bf#diff-9b7a79a64e32c4c6f0cd004c8b63da0d291558789662304255583c14668c35d5R72-R78) commit.

## How this works

Removes an unused variable

## How this was tested

CI

## Need to be documented in RELEASES.md?
