### PR TITLE
feat(proposervm): dedup inner block bytes when the inner VM retains accepted blocks

### DIFF
--- a/graft/coreth/plugin/evm/atomic/vm/vm.go
+++ b/graft/coreth/plugin/evm/atomic/vm/vm.go
@@ -58,6 +58,7 @@ var (
 	_ block.ChainVM                      = (*VM)(nil)
 	_ block.BuildBlockWithContextChainVM = (*VM)(nil)
 	_ block.StateSyncableVM              = (*VM)(nil)
+	_ block.RetainsAcceptedBlocksVM      = (*VM)(nil)
 
 	errAtomicGasExceedsLimit = errors.New("atomic gas used exceeds atomic gas limit")
 )
@@ -107,6 +108,13 @@ type VM struct {
 
 func WrapVM(vm extension.InnerVM) *VM {
 	return &VM{InnerVM: vm}
+}
+
+// RetainsAcceptedBlocks declares that this VM durably retains the bytes of
+// every accepted block, retrievable via GetBlock, forever: accepted block
+// bodies are never pruned from the chain database.
+func (*VM) RetainsAcceptedBlocks() bool {
+	return true
 }
 
 // Initialize implements the snowman.ChainVM interface

--- a/graft/subnet-evm/plugin/evm/vm.go
+++ b/graft/subnet-evm/plugin/evm/vm.go
@@ -97,6 +97,7 @@ var (
 	_ block.ChainVM                      = (*VM)(nil)
 	_ block.BuildBlockWithContextChainVM = (*VM)(nil)
 	_ block.StateSyncableVM              = (*VM)(nil)
+	_ block.RetainsAcceptedBlocksVM      = (*VM)(nil)
 	_ client.EthBlockParser              = (*VM)(nil)
 )
 
@@ -1088,6 +1089,13 @@ func (vm *VM) GetAcceptedBlock(ctx context.Context, blkID ids.ID) (snowman.Block
 		return nil, database.ErrNotFound
 	}
 	return blk, nil
+}
+
+// RetainsAcceptedBlocks declares that this VM durably retains the bytes of
+// every accepted block, retrievable via GetBlock, forever: accepted block
+// bodies are never pruned from the chain database.
+func (*VM) RetainsAcceptedBlocks() bool {
+	return true
 }
 
 // SetPreference sets what the current tail of the chain is

--- a/proto/pb/vm/vm.pb.go
+++ b/proto/pb/vm/vm.pb.go
@@ -579,8 +579,11 @@ type InitializeResponse struct {
 	Height               uint64                 `protobuf:"varint,3,opt,name=height,proto3" json:"height,omitempty"`
 	Bytes                []byte                 `protobuf:"bytes,4,opt,name=bytes,proto3" json:"bytes,omitempty"`
 	Timestamp            *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// retains_accepted_blocks is true if the VM durably retains the bytes of
+	// every accepted block, retrievable via GetBlock, forever.
+	RetainsAcceptedBlocks bool `protobuf:"varint,6,opt,name=retains_accepted_blocks,json=retainsAcceptedBlocks,proto3" json:"retains_accepted_blocks,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *InitializeResponse) Reset() {
@@ -646,6 +649,13 @@ func (x *InitializeResponse) GetTimestamp() *timestamppb.Timestamp {
 		return x.Timestamp
 	}
 	return nil
+}
+
+func (x *InitializeResponse) GetRetainsAcceptedBlocks() bool {
+	if x != nil {
+		return x.RetainsAcceptedBlocks
+	}
+	return false
 }
 
 type SetStateRequest struct {
@@ -2915,13 +2925,14 @@ const file_vm_vm_proto_rawDesc = "" +
 	"\ffortuna_time\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampR\vfortunaTime\x12=\n" +
 	"\fgranite_time\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\vgraniteTime\x12O\n" +
 	"\x16granite_epoch_duration\x18\x11 \x01(\v2\x19.google.protobuf.DurationR\x14graniteEpochDuration\x12=\n" +
-	"\fhelicon_time\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\vheliconTime\"\xdd\x01\n" +
+	"\fhelicon_time\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\vheliconTime\"\x95\x02\n" +
 	"\x12InitializeResponse\x12(\n" +
 	"\x10last_accepted_id\x18\x01 \x01(\fR\x0elastAcceptedId\x125\n" +
 	"\x17last_accepted_parent_id\x18\x02 \x01(\fR\x14lastAcceptedParentId\x12\x16\n" +
 	"\x06height\x18\x03 \x01(\x04R\x06height\x12\x14\n" +
 	"\x05bytes\x18\x04 \x01(\fR\x05bytes\x128\n" +
-	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"2\n" +
+	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x126\n" +
+	"\x17retains_accepted_blocks\x18\x06 \x01(\bR\x15retainsAcceptedBlocks\"2\n" +
 	"\x0fSetStateRequest\x12\x1f\n" +
 	"\x05state\x18\x01 \x01(\x0e2\t.vm.StateR\x05state\"\xdb\x01\n" +
 	"\x10SetStateResponse\x12(\n" +

--- a/proto/vm/vm.proto
+++ b/proto/vm/vm.proto
@@ -147,6 +147,9 @@ message InitializeResponse {
   uint64 height = 3;
   bytes bytes = 4;
   google.protobuf.Timestamp timestamp = 5;
+  // retains_accepted_blocks is true if the VM durably retains the bytes of
+  // every accepted block, retrievable via GetBlock, forever.
+  bool retains_accepted_blocks = 6;
 }
 
 message SetStateRequest {

--- a/snow/engine/snowman/block/vm.go
+++ b/snow/engine/snowman/block/vm.go
@@ -91,3 +91,13 @@ type ParseFunc func(context.Context, []byte) (snowman.Block, error)
 func (f ParseFunc) ParseBlock(ctx context.Context, blockBytes []byte) (snowman.Block, error) {
 	return f(ctx, blockBytes)
 }
+
+// RetainsAcceptedBlocksVM defines the interface a ChainVM can optionally
+// implement to declare that it durably retains the bytes of every accepted
+// block, retrievable via GetBlock, forever.
+//
+// Wrappers of a VM (e.g. the proposervm) may rely on this to avoid persisting
+// a second copy of accepted blocks' bytes.
+type RetainsAcceptedBlocksVM interface {
+	RetainsAcceptedBlocks() bool
+}

--- a/vms/proposervm/block/dedup.go
+++ b/vms/proposervm/block/dedup.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package block
+
+import "errors"
+
+var errUnknownBlockType = errors.New("unknown block type")
+
+// setInnerBytes replaces the inner (wrapped) block bytes carried by [b].
+func setInnerBytes(b Block, innerBytes []byte) error {
+	switch blk := b.(type) {
+	case *statelessBlock:
+		blk.StatelessBlock.Block = innerBytes
+	case *statelessGraniteBlock:
+		blk.StatelessGraniteBlock.StatelessBlock.Block = innerBytes
+	case *option:
+		blk.InnerBytes = innerBytes
+	default:
+		return errUnknownBlockType
+	}
+	return nil
+}
+
+// StripInnerBytes returns the serialized form of the proposervm block encoded by
+// [fullBytes] with its inner (wrapped) block bytes removed. The inner bytes can
+// be re-injected with [RestoreInnerBytes] to recover [fullBytes] exactly.
+//
+// This lets a caller that can recover the inner block bytes from another source
+// (e.g. the inner VM) avoid persisting them a second time.
+func StripInnerBytes(fullBytes []byte) ([]byte, error) {
+	var b Block
+	version, err := Codec.Unmarshal(fullBytes, &b)
+	if err != nil {
+		return nil, err
+	}
+	if err := setInnerBytes(b, nil); err != nil {
+		return nil, err
+	}
+	return Codec.Marshal(version, &b)
+}
+
+// RestoreInnerBytes is the inverse of [StripInnerBytes]: it re-injects
+// [innerBytes] into the stripped block encoded by [strippedBytes] and returns
+// the recovered full serialized block. When [innerBytes] are the exact bytes
+// that were stripped, the result is byte-identical to the original block, so its
+// ID and signature are preserved.
+func RestoreInnerBytes(strippedBytes []byte, innerBytes []byte) ([]byte, error) {
+	var b Block
+	version, err := Codec.Unmarshal(strippedBytes, &b)
+	if err != nil {
+		return nil, err
+	}
+	if err := setInnerBytes(b, innerBytes); err != nil {
+		return nil, err
+	}
+	return Codec.Marshal(version, &b)
+}

--- a/vms/proposervm/block/dedup_test.go
+++ b/vms/proposervm/block/dedup_test.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package block
+
+import (
+	"crypto"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/staking"
+)
+
+// requireStripRestore checks that stripping then restoring the inner bytes of
+// [b] reproduces the original bytes (and therefore the original ID) exactly, and
+// that the stripped form is actually smaller.
+func requireStripRestore(require *require.Assertions, b Block, innerBytes []byte) {
+	full := b.Bytes()
+
+	stripped, err := StripInnerBytes(full)
+	require.NoError(err)
+	require.Less(len(stripped), len(full))
+
+	restored, err := RestoreInnerBytes(stripped, innerBytes)
+	require.NoError(err)
+	require.Equal(full, restored)
+
+	parsed, err := ParseWithoutVerification(restored)
+	require.NoError(err)
+	require.Equal(b.ID(), parsed.ID())
+	require.Equal(innerBytes, parsed.Block())
+}
+
+func TestStripRestoreSignedBlock(t *testing.T) {
+	require := require.New(t)
+
+	tlsCert, err := staking.NewTLSCert()
+	require.NoError(err)
+	cert, err := staking.ParseCertificate(tlsCert.Leaf.Raw)
+	require.NoError(err)
+	key := tlsCert.PrivateKey.(crypto.Signer)
+
+	innerBytes := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	b, err := Build(
+		ids.ID{1},
+		time.Unix(123, 0),
+		uint64(2),
+		Epoch{},
+		cert,
+		innerBytes,
+		ids.ID{4},
+		key,
+	)
+	require.NoError(err)
+
+	requireStripRestore(require, b, innerBytes)
+}
+
+func TestStripRestoreGraniteBlock(t *testing.T) {
+	require := require.New(t)
+
+	tlsCert, err := staking.NewTLSCert()
+	require.NoError(err)
+	cert, err := staking.ParseCertificate(tlsCert.Leaf.Raw)
+	require.NoError(err)
+	key := tlsCert.PrivateKey.(crypto.Signer)
+
+	innerBytes := []byte{8, 7, 6, 5, 4, 3, 2, 1}
+	b, err := Build(
+		ids.ID{1},
+		time.Unix(123, 0),
+		uint64(2),
+		Epoch{PChainHeight: 5, Number: 6, StartTime: 7},
+		cert,
+		innerBytes,
+		ids.ID{4},
+		key,
+	)
+	require.NoError(err)
+
+	requireStripRestore(require, b, innerBytes)
+}
+
+func TestStripRestoreUnsignedBlock(t *testing.T) {
+	require := require.New(t)
+
+	innerBytes := []byte{9, 9, 9, 9}
+	b, err := BuildUnsigned(ids.ID{1}, time.Unix(123, 0), uint64(2), Epoch{}, innerBytes)
+	require.NoError(err)
+
+	requireStripRestore(require, b, innerBytes)
+}
+
+func TestStripRestoreOption(t *testing.T) {
+	require := require.New(t)
+
+	innerBytes := []byte{2, 4, 6, 8}
+	b, err := BuildOption(ids.ID{1}, innerBytes)
+	require.NoError(err)
+
+	requireStripRestore(require, b, innerBytes)
+}

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -29,9 +29,12 @@ import (
 const blockCacheSize = 64 * units.MiB
 
 var (
-	errBlockWrongVersion     = errors.New("wrong version")
-	errShortBlockRecord      = errors.New("block record too short to contain a codec version")
-	errInnerBlockUnavailable = errors.New("inner block unavailable for deduplicated block")
+	errBlockWrongVersion = errors.New("wrong version")
+	errShortBlockRecord  = errors.New("block record too short to contain a codec version")
+	// ErrInnerBlockUnavailable is returned when a deduplicated block record
+	// cannot be reconstructed because the inner VM does not have its inner
+	// block.
+	ErrInnerBlockUnavailable = errors.New("inner block unavailable for deduplicated block")
 	errRestoredBlockMismatch = errors.New("restored block bytes do not match original")
 
 	_ BlockState = (*blockState)(nil)
@@ -204,7 +207,7 @@ func (s *blockState) parseStored(blkID ids.ID, storedBytes []byte) (*blockWrappe
 
 func (s *blockState) parseDedupBlock(blkID ids.ID, storedBytes []byte) (*blockWrapper, error) {
 	if s.getInnerBytes == nil {
-		return nil, errInnerBlockUnavailable
+		return nil, ErrInnerBlockUnavailable
 	}
 
 	wrapper := dedupBlockWrapper{}
@@ -218,7 +221,7 @@ func (s *blockState) parseDedupBlock(blkID ids.ID, storedBytes []byte) (*blockWr
 
 	innerBytes, err := s.getInnerBytes(wrapper.InnerID)
 	if err != nil {
-		return nil, fmt.Errorf("%w: inner block %s: %w", errInnerBlockUnavailable, wrapper.InnerID, err)
+		return nil, fmt.Errorf("%w: inner block %s: %w", ErrInnerBlockUnavailable, wrapper.InnerID, err)
 	}
 
 	fullBytes, err := block.RestoreInnerBytes(wrapper.StrippedBlock, innerBytes)
@@ -236,7 +239,7 @@ func (s *blockState) parseDedupBlock(blkID ids.ID, storedBytes []byte) (*blockWr
 	// inner bytes and the block originally stored, rather than serving a block
 	// that doesn't match its ID.
 	if blk.ID() != blkID {
-		return nil, fmt.Errorf("%w: reconstructed block %s does not match key %s", errInnerBlockUnavailable, blk.ID(), blkID)
+		return nil, fmt.Errorf("%w: reconstructed block %s does not match key %s", ErrInnerBlockUnavailable, blk.ID(), blkID)
 	}
 
 	return &blockWrapper{

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -4,7 +4,10 @@
 package state
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -24,14 +27,18 @@ import (
 const blockCacheSize = 64 * units.MiB
 
 var (
-	errBlockWrongVersion = errors.New("wrong version")
+	errBlockWrongVersion     = errors.New("wrong version")
+	errShortBlockRecord      = errors.New("block record too short to contain a codec version")
+	errInnerBlockUnavailable = errors.New("inner block unavailable for deduplicated block")
 
 	_ BlockState = (*blockState)(nil)
 )
 
 type BlockState interface {
 	GetBlock(blkID ids.ID) (block.Block, error)
-	PutBlock(blk block.Block) error
+	// PutBlock persists [blk]. [innerID] is the ID of [blk]'s inner block and is
+	// only used when inner-block deduplication is enabled.
+	PutBlock(blk block.Block, innerID ids.ID) error
 	DeleteBlock(blkID ids.ID) error
 }
 
@@ -41,13 +48,37 @@ type blockState struct {
 	blkCache cache.Cacher[ids.ID, *blockWrapper]
 
 	db database.Database
+
+	// getInnerBytes, when non-nil, enables inner-block deduplication: accepted
+	// blocks are stored without their inner bytes, which are reconstructed on
+	// read by looking them up by inner block ID. nil disables deduplication and
+	// preserves the legacy full-block storage format.
+	getInnerBytes func(innerID ids.ID) ([]byte, error)
+
+	// numDedupStored counts blocks written in the deduplicated (inner-bytes
+	// stripped) format; numDedupFallback counts blocks for which stripping did
+	// not round-trip and were written in the legacy full format instead. Both
+	// are nil when deduplication is disabled or the state is unmetered.
+	numDedupStored   prometheus.Counter
+	numDedupFallback prometheus.Counter
 }
 
+// blockWrapper is the legacy (CodecVersion) record: the full block bytes plus
+// status. It is also reused as the in-memory cache entry for both formats.
 type blockWrapper struct {
 	Block  []byte         `serialize:"true"`
 	Status choices.Status `serialize:"true"`
 
 	block block.Block
+}
+
+// dedupBlockWrapper is the deduplicated (CodecVersionDedup) record: the block
+// bytes with the inner bytes stripped, the inner block ID needed to recover
+// them, and status.
+type dedupBlockWrapper struct {
+	StrippedBlock []byte         `serialize:"true"`
+	InnerID       ids.ID         `serialize:"true"`
+	Status        choices.Status `serialize:"true"`
 }
 
 func cachedBlockSize(_ ids.ID, bw *blockWrapper) int {
@@ -57,24 +88,52 @@ func cachedBlockSize(_ ids.ID, bw *blockWrapper) int {
 	return ids.IDLen + len(bw.Block) + wrappers.IntLen + 2*constants.PointerOverhead
 }
 
-func NewBlockState(db database.Database) BlockState {
+func NewBlockState(db database.Database, getInnerBytes func(ids.ID) ([]byte, error)) BlockState {
 	return &blockState{
-		blkCache: lru.NewSizedCache(blockCacheSize, cachedBlockSize),
-		db:       db,
+		blkCache:      lru.NewSizedCache(blockCacheSize, cachedBlockSize),
+		db:            db,
+		getInnerBytes: getInnerBytes,
 	}
 }
 
-func NewMeteredBlockState(db database.Database, namespace string, metrics prometheus.Registerer) (BlockState, error) {
+func NewMeteredBlockState(db database.Database, namespace string, metrics prometheus.Registerer, getInnerBytes func(ids.ID) ([]byte, error)) (BlockState, error) {
 	blkCache, err := metercacher.New[ids.ID, *blockWrapper](
 		metric.AppendNamespace(namespace, "block_cache"),
 		metrics,
 		lru.NewSizedCache(blockCacheSize, cachedBlockSize),
 	)
+	if err != nil {
+		return nil, err
+	}
 
-	return &blockState{
-		blkCache: blkCache,
-		db:       db,
-	}, err
+	s := &blockState{
+		blkCache:      blkCache,
+		db:            db,
+		getInnerBytes: getInnerBytes,
+	}
+
+	// Only register dedup counters when deduplication is enabled, so the legacy
+	// path is byte-for-byte and metric-for-metric unchanged.
+	if getInnerBytes != nil {
+		s.numDedupStored = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "dedup_blocks_stored",
+			Help:      "Number of accepted blocks stored with inner bytes deduplicated",
+		})
+		s.numDedupFallback = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "dedup_blocks_fallback",
+			Help:      "Number of accepted blocks stored full because stripping did not round-trip",
+		})
+		if err := errors.Join(
+			metrics.Register(s.numDedupStored),
+			metrics.Register(s.numDedupFallback),
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return s, nil
 }
 
 func (s *blockState) GetBlock(blkID ids.ID) (block.Block, error) {
@@ -94,8 +153,28 @@ func (s *blockState) GetBlock(blkID ids.ID) (block.Block, error) {
 		return nil, err
 	}
 
+	wrapper, err := s.parseStored(blkID, blkWrapperBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	s.blkCache.Put(blkID, wrapper)
+	return wrapper.block, nil
+}
+
+// parseStored decodes a stored record (legacy full or deduplicated) into a
+// cacheable [blockWrapper] holding the fully reconstructed block.
+func (s *blockState) parseStored(blkID ids.ID, storedBytes []byte) (*blockWrapper, error) {
+	if len(storedBytes) < wrappers.ShortLen {
+		return nil, errShortBlockRecord
+	}
+	version := binary.BigEndian.Uint16(storedBytes)
+	if version == CodecVersionDedup {
+		return s.parseDedupBlock(blkID, storedBytes)
+	}
+
 	blkWrapper := blockWrapper{}
-	parsedVersion, err := Codec.Unmarshal(blkWrapperBytes, &blkWrapper)
+	parsedVersion, err := Codec.Unmarshal(storedBytes, &blkWrapper)
 	if err != nil {
 		return nil, err
 	}
@@ -103,32 +182,121 @@ func (s *blockState) GetBlock(blkID ids.ID) (block.Block, error) {
 		return nil, errBlockWrongVersion
 	}
 
-	// The key was in the database
 	blk, err := block.ParseWithoutVerification(blkWrapper.Block)
 	if err != nil {
 		return nil, err
 	}
 	blkWrapper.block = blk
-
-	s.blkCache.Put(blkID, &blkWrapper)
-	return blk, nil
+	return &blkWrapper, nil
 }
 
-func (s *blockState) PutBlock(blk block.Block) error {
+func (s *blockState) parseDedupBlock(blkID ids.ID, storedBytes []byte) (*blockWrapper, error) {
+	if s.getInnerBytes == nil {
+		return nil, errInnerBlockUnavailable
+	}
+
+	wrapper := dedupBlockWrapper{}
+	parsedVersion, err := Codec.Unmarshal(storedBytes, &wrapper)
+	if err != nil {
+		return nil, err
+	}
+	if parsedVersion != CodecVersionDedup {
+		return nil, errBlockWrongVersion
+	}
+
+	innerBytes, err := s.getInnerBytes(wrapper.InnerID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: inner block %s: %w", errInnerBlockUnavailable, wrapper.InnerID, err)
+	}
+
+	fullBytes, err := block.RestoreInnerBytes(wrapper.StrippedBlock, innerBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	blk, err := block.ParseWithoutVerification(fullBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Safety net: the reconstructed block ID must match the key it was stored
+	// under. This catches any divergence between the stripped bytes / fetched
+	// inner bytes and the block originally stored, rather than serving a block
+	// that doesn't match its ID.
+	if blk.ID() != blkID {
+		return nil, fmt.Errorf("%w: reconstructed block %s does not match key %s", errInnerBlockUnavailable, blk.ID(), blkID)
+	}
+
+	return &blockWrapper{
+		Block:  wrapper.StrippedBlock,
+		Status: wrapper.Status,
+		block:  blk,
+	}, nil
+}
+
+func (s *blockState) PutBlock(blk block.Block, innerID ids.ID) error {
+	blkID := blk.ID()
+
+	if s.getInnerBytes != nil {
+		if storedBytes, cached, ok := tryStripBlock(blk, innerID); ok {
+			s.blkCache.Put(blkID, cached)
+			if s.numDedupStored != nil {
+				s.numDedupStored.Inc()
+			}
+			return s.db.Put(blkID[:], storedBytes)
+		}
+		// Could not safely strip the inner bytes (round-trip mismatch); fall
+		// through to full storage. Correctness is never traded for the saving.
+		if s.numDedupFallback != nil {
+			s.numDedupFallback.Inc()
+		}
+	}
+
 	blkWrapper := blockWrapper{
 		Block:  blk.Bytes(),
 		Status: choices.Accepted,
 		block:  blk,
 	}
-
-	bytes, err := Codec.Marshal(CodecVersion, &blkWrapper)
+	bytesValue, err := Codec.Marshal(CodecVersion, &blkWrapper)
 	if err != nil {
 		return err
 	}
 
-	blkID := blk.ID()
 	s.blkCache.Put(blkID, &blkWrapper)
-	return s.db.Put(blkID[:], bytes)
+	return s.db.Put(blkID[:], bytesValue)
+}
+
+// tryStripBlock attempts to build a deduplicated record for [blk]. It returns
+// ok=false if stripping the inner bytes does not round-trip back to the exact
+// original block bytes, in which case the caller must store the full block.
+func tryStripBlock(blk block.Block, innerID ids.ID) ([]byte, *blockWrapper, bool) {
+	fullBytes := blk.Bytes()
+	strippedBytes, err := block.StripInnerBytes(fullBytes)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	restored, err := block.RestoreInnerBytes(strippedBytes, blk.Block())
+	if err != nil || !bytes.Equal(restored, fullBytes) {
+		return nil, nil, false
+	}
+
+	wrapper := dedupBlockWrapper{
+		StrippedBlock: strippedBytes,
+		InnerID:       innerID,
+		Status:        choices.Accepted,
+	}
+	storedBytes, err := Codec.Marshal(CodecVersionDedup, &wrapper)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	cached := &blockWrapper{
+		Block:  strippedBytes,
+		Status: choices.Accepted,
+		block:  blk,
+	}
+	return storedBytes, cached, true
 }
 
 func (s *blockState) DeleteBlock(blkID ids.ID) error {

--- a/vms/proposervm/state/block_state.go
+++ b/vms/proposervm/state/block_state.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/cache/lru"
@@ -18,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/metric"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
@@ -30,6 +32,7 @@ var (
 	errBlockWrongVersion     = errors.New("wrong version")
 	errShortBlockRecord      = errors.New("block record too short to contain a codec version")
 	errInnerBlockUnavailable = errors.New("inner block unavailable for deduplicated block")
+	errRestoredBlockMismatch = errors.New("restored block bytes do not match original")
 
 	_ BlockState = (*blockState)(nil)
 )
@@ -54,6 +57,13 @@ type blockState struct {
 	// read by looking them up by inner block ID. nil disables deduplication and
 	// preserves the legacy full-block storage format.
 	getInnerBytes func(innerID ids.ID) ([]byte, error)
+
+	// log, when non-nil, reports every dedup fallback at error level. A
+	// fallback has no legitimate data-dependent cause (the write-time
+	// round-trip is pure in-memory container mechanics), so it can only be a
+	// strip/restore code bug for some container shape and must not go
+	// unnoticed.
+	log logging.Logger
 
 	// numDedupStored counts blocks written in the deduplicated (inner-bytes
 	// stripped) format; numDedupFallback counts blocks for which stripping did
@@ -88,15 +98,16 @@ func cachedBlockSize(_ ids.ID, bw *blockWrapper) int {
 	return ids.IDLen + len(bw.Block) + wrappers.IntLen + 2*constants.PointerOverhead
 }
 
-func NewBlockState(db database.Database, getInnerBytes func(ids.ID) ([]byte, error)) BlockState {
+func NewBlockState(db database.Database, getInnerBytes func(ids.ID) ([]byte, error), log logging.Logger) BlockState {
 	return &blockState{
 		blkCache:      lru.NewSizedCache(blockCacheSize, cachedBlockSize),
 		db:            db,
 		getInnerBytes: getInnerBytes,
+		log:           log,
 	}
 }
 
-func NewMeteredBlockState(db database.Database, namespace string, metrics prometheus.Registerer, getInnerBytes func(ids.ID) ([]byte, error)) (BlockState, error) {
+func NewMeteredBlockState(db database.Database, namespace string, metrics prometheus.Registerer, getInnerBytes func(ids.ID) ([]byte, error), log logging.Logger) (BlockState, error) {
 	blkCache, err := metercacher.New[ids.ID, *blockWrapper](
 		metric.AppendNamespace(namespace, "block_cache"),
 		metrics,
@@ -110,6 +121,7 @@ func NewMeteredBlockState(db database.Database, namespace string, metrics promet
 		blkCache:      blkCache,
 		db:            db,
 		getInnerBytes: getInnerBytes,
+		log:           log,
 	}
 
 	// Only register dedup counters when deduplication is enabled, so the legacy
@@ -238,15 +250,24 @@ func (s *blockState) PutBlock(blk block.Block, innerID ids.ID) error {
 	blkID := blk.ID()
 
 	if s.getInnerBytes != nil {
-		if storedBytes, cached, ok := tryStripBlock(blk, innerID); ok {
+		storedBytes, cached, err := tryStripBlock(blk, innerID)
+		if err == nil {
 			s.blkCache.Put(blkID, cached)
 			if s.numDedupStored != nil {
 				s.numDedupStored.Inc()
 			}
 			return s.db.Put(blkID[:], storedBytes)
 		}
-		// Could not safely strip the inner bytes (round-trip mismatch); fall
-		// through to full storage. Correctness is never traded for the saving.
+		// Could not safely strip the inner bytes; fall through to full storage
+		// so correctness is never traded for the saving. This has no legitimate
+		// data-dependent cause and can only be a strip/restore code bug for
+		// some container shape, so it must not go unnoticed.
+		if s.log != nil {
+			s.log.Error("failed to deduplicate accepted block; stored full block",
+				zap.Stringer("blkID", blkID),
+				zap.Error(err),
+			)
+		}
 		if s.numDedupFallback != nil {
 			s.numDedupFallback.Inc()
 		}
@@ -267,18 +288,22 @@ func (s *blockState) PutBlock(blk block.Block, innerID ids.ID) error {
 }
 
 // tryStripBlock attempts to build a deduplicated record for [blk]. It returns
-// ok=false if stripping the inner bytes does not round-trip back to the exact
-// original block bytes, in which case the caller must store the full block.
-func tryStripBlock(blk block.Block, innerID ids.ID) ([]byte, *blockWrapper, bool) {
+// an error describing the cause if stripping the inner bytes does not
+// round-trip back to the exact original block bytes, in which case the caller
+// must store the full block.
+func tryStripBlock(blk block.Block, innerID ids.ID) ([]byte, *blockWrapper, error) {
 	fullBytes := blk.Bytes()
 	strippedBytes, err := block.StripInnerBytes(fullBytes)
 	if err != nil {
-		return nil, nil, false
+		return nil, nil, fmt.Errorf("stripping inner bytes: %w", err)
 	}
 
 	restored, err := block.RestoreInnerBytes(strippedBytes, blk.Block())
-	if err != nil || !bytes.Equal(restored, fullBytes) {
-		return nil, nil, false
+	if err != nil {
+		return nil, nil, fmt.Errorf("restoring inner bytes: %w", err)
+	}
+	if !bytes.Equal(restored, fullBytes) {
+		return nil, nil, errRestoredBlockMismatch
 	}
 
 	wrapper := dedupBlockWrapper{
@@ -288,7 +313,7 @@ func tryStripBlock(blk block.Block, innerID ids.ID) ([]byte, *blockWrapper, bool
 	}
 	storedBytes, err := Codec.Marshal(CodecVersionDedup, &wrapper)
 	if err != nil {
-		return nil, nil, false
+		return nil, nil, fmt.Errorf("marshalling deduplicated record: %w", err)
 	}
 
 	cached := &blockWrapper{
@@ -296,7 +321,7 @@ func tryStripBlock(blk block.Block, innerID ids.ID) ([]byte, *blockWrapper, bool
 		Status: choices.Accepted,
 		block:  blk,
 	}
-	return storedBytes, cached, true
+	return storedBytes, cached, nil
 }
 
 func (s *blockState) DeleteBlock(blkID ids.ID) error {

--- a/vms/proposervm/state/block_state_test.go
+++ b/vms/proposervm/state/block_state_test.go
@@ -5,16 +5,19 @@ package state
 
 import (
 	"crypto"
+	"encoding/binary"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/staking"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/proposervm/block"
 )
 
@@ -65,7 +68,7 @@ func TestBlockState(t *testing.T) {
 	a := require.New(t)
 
 	db := memdb.New()
-	bs := NewBlockState(db, nil)
+	bs := NewBlockState(db, nil, nil)
 
 	testBlockState(a, bs)
 }
@@ -74,7 +77,7 @@ func TestMeteredBlockState(t *testing.T) {
 	a := require.New(t)
 
 	db := memdb.New()
-	bs, err := NewMeteredBlockState(db, "", prometheus.NewRegistry(), nil)
+	bs, err := NewMeteredBlockState(db, "", prometheus.NewRegistry(), nil, nil)
 	a.NoError(err)
 
 	testBlockState(a, bs)
@@ -101,7 +104,8 @@ func TestBlockStateDedup(t *testing.T) {
 	}
 
 	db := memdb.New()
-	bs := NewBlockState(db, getInnerBytes)
+	bs, err := NewMeteredBlockState(db, "", prometheus.NewRegistry(), getInnerBytes, logging.NoLog{})
+	require.NoError(err)
 
 	tlsCert, err := staking.NewTLSCert()
 	require.NoError(err)
@@ -123,6 +127,12 @@ func TestBlockStateDedup(t *testing.T) {
 
 	require.NoError(bs.PutBlock(b, innerID))
 
+	// The write must have been deduplicated; a fallback here means stripping
+	// stopped round-tripping for this block shape, which is a bug.
+	state := bs.(*blockState)
+	require.Equal(float64(1), testutil.ToFloat64(state.numDedupStored))
+	require.Zero(testutil.ToFloat64(state.numDedupFallback))
+
 	// On-disk record must not contain the full block bytes (inner bytes stripped).
 	blkID := b.ID()
 	stored, err := db.Get(blkID[:])
@@ -139,4 +149,70 @@ func TestBlockStateDedup(t *testing.T) {
 	fetched, err = bs.GetBlock(b.ID())
 	require.NoError(err)
 	require.Equal(b.Bytes(), fetched.Bytes())
+}
+
+// corruptedBlock wraps a real block but reports bytes that cannot round-trip
+// through strip/restore, forcing the dedup write path into its fallback. The
+// alias avoids the embedded field name colliding with the Block() method.
+type wrappedBlock = block.Block
+
+type corruptedBlock struct {
+	wrappedBlock
+}
+
+func (b corruptedBlock) Bytes() []byte {
+	return append(b.wrappedBlock.Bytes(), 0)
+}
+
+// TestBlockStateDedupFallback exercises the write-time fallback: a block whose
+// bytes do not round-trip must be stored in the legacy full format and counted,
+// never dropped or stored deduplicated.
+func TestBlockStateDedupFallback(t *testing.T) {
+	require := require.New(t)
+
+	getInnerBytes := func(ids.ID) ([]byte, error) {
+		require.FailNow("getInnerBytes must not be called on the write path")
+		return nil, nil
+	}
+
+	db := memdb.New()
+	bs, err := NewMeteredBlockState(db, "", prometheus.NewRegistry(), getInnerBytes, logging.NoLog{})
+	require.NoError(err)
+
+	tlsCert, err := staking.NewTLSCert()
+	require.NoError(err)
+	cert, err := staking.ParseCertificate(tlsCert.Leaf.Raw)
+	require.NoError(err)
+	key := tlsCert.PrivateKey.(crypto.Signer)
+
+	b, err := block.Build(
+		ids.ID{1},
+		time.Unix(123, 0),
+		uint64(2),
+		block.Epoch{},
+		cert,
+		[]byte{3},
+		ids.ID{4},
+		key,
+	)
+	require.NoError(err)
+	corrupted := corruptedBlock{wrappedBlock: b}
+
+	require.NoError(bs.PutBlock(corrupted, ids.ID{9}))
+
+	state := bs.(*blockState)
+	require.Zero(testutil.ToFloat64(state.numDedupStored))
+	require.Equal(float64(1), testutil.ToFloat64(state.numDedupFallback))
+
+	// The fallback record must be the legacy full format holding the block's
+	// reported bytes.
+	blkID := corrupted.ID()
+	stored, err := db.Get(blkID[:])
+	require.NoError(err)
+	require.Equal(uint16(CodecVersion), binary.BigEndian.Uint16(stored))
+
+	blkWrapper := blockWrapper{}
+	_, err = Codec.Unmarshal(stored, &blkWrapper)
+	require.NoError(err)
+	require.Equal(corrupted.Bytes(), blkWrapper.Block)
 }

--- a/vms/proposervm/state/block_state_test.go
+++ b/vms/proposervm/state/block_state_test.go
@@ -50,7 +50,7 @@ func testBlockState(require *require.Assertions, bs BlockState) {
 	_, err = bs.GetBlock(b.ID())
 	require.Equal(database.ErrNotFound, err)
 
-	require.NoError(bs.PutBlock(b))
+	require.NoError(bs.PutBlock(b, ids.Empty))
 
 	fetchedBlock, err := bs.GetBlock(b.ID())
 	require.NoError(err)
@@ -65,7 +65,7 @@ func TestBlockState(t *testing.T) {
 	a := require.New(t)
 
 	db := memdb.New()
-	bs := NewBlockState(db)
+	bs := NewBlockState(db, nil)
 
 	testBlockState(a, bs)
 }
@@ -74,8 +74,69 @@ func TestMeteredBlockState(t *testing.T) {
 	a := require.New(t)
 
 	db := memdb.New()
-	bs, err := NewMeteredBlockState(db, "", prometheus.NewRegistry())
+	bs, err := NewMeteredBlockState(db, "", prometheus.NewRegistry(), nil)
 	a.NoError(err)
 
 	testBlockState(a, bs)
+}
+
+// TestBlockStateDedup exercises the deduplicated storage path: blocks are stored
+// without their inner bytes and reconstructed on read by looking the inner bytes
+// up by inner block ID.
+func TestBlockStateDedup(t *testing.T) {
+	require := require.New(t)
+
+	innerID := ids.ID{9}
+	// Real inner EVM blocks are KB-sized; dedup only nets a win when the stripped
+	// inner bytes exceed the 32-byte inner-ID + codec overhead we add in their place.
+	innerBlockBytes := make([]byte, 1024)
+	for i := range innerBlockBytes {
+		innerBlockBytes[i] = byte(i)
+	}
+
+	// getInnerBytes simulates the inner VM returning the inner block's bytes.
+	getInnerBytes := func(id ids.ID) ([]byte, error) {
+		require.Equal(innerID, id)
+		return innerBlockBytes, nil
+	}
+
+	db := memdb.New()
+	bs := NewBlockState(db, getInnerBytes)
+
+	tlsCert, err := staking.NewTLSCert()
+	require.NoError(err)
+	cert, err := staking.ParseCertificate(tlsCert.Leaf.Raw)
+	require.NoError(err)
+	key := tlsCert.PrivateKey.(crypto.Signer)
+
+	b, err := block.Build(
+		ids.ID{1},
+		time.Unix(123, 0),
+		uint64(2),
+		block.Epoch{},
+		cert,
+		innerBlockBytes,
+		ids.ID{4},
+		key,
+	)
+	require.NoError(err)
+
+	require.NoError(bs.PutBlock(b, innerID))
+
+	// On-disk record must not contain the full block bytes (inner bytes stripped).
+	blkID := b.ID()
+	stored, err := db.Get(blkID[:])
+	require.NoError(err)
+	require.Less(len(stored), len(b.Bytes()))
+
+	// Reconstructed block must be byte-identical to the original (uncached and
+	// cached paths).
+	fetched, err := bs.GetBlock(b.ID())
+	require.NoError(err)
+	require.Equal(b.Bytes(), fetched.Bytes())
+	require.Equal(b.ID(), fetched.ID())
+
+	fetched, err = bs.GetBlock(b.ID())
+	require.NoError(err)
+	require.Equal(b.Bytes(), fetched.Bytes())
 }

--- a/vms/proposervm/state/codec.go
+++ b/vms/proposervm/state/codec.go
@@ -4,13 +4,21 @@
 package state
 
 import (
+	"errors"
 	"math"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 )
 
-const CodecVersion = 0
+const (
+	// CodecVersion is the version used for full block records, which embed the
+	// inner block bytes.
+	CodecVersion = 0
+	// CodecVersionDedup is the version used for deduplicated block records,
+	// which store the block without its inner bytes plus the inner block ID.
+	CodecVersionDedup = 1
+)
 
 var Codec codec.Manager
 
@@ -18,7 +26,10 @@ func init() {
 	lc := linearcodec.NewDefault()
 	Codec = codec.NewManager(math.MaxInt32)
 
-	err := Codec.RegisterCodec(CodecVersion, lc)
+	err := errors.Join(
+		Codec.RegisterCodec(CodecVersion, lc),
+		Codec.RegisterCodec(CodecVersionDedup, lc),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/vms/proposervm/state/state.go
+++ b/vms/proposervm/state/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
 var (
@@ -29,24 +30,24 @@ type state struct {
 	HeightIndex
 }
 
-func New(db *versiondb.Database, getInnerBytes func(ids.ID) ([]byte, error)) State {
+func New(db *versiondb.Database, getInnerBytes func(ids.ID) ([]byte, error), log logging.Logger) State {
 	chainDB := prefixdb.New(chainStatePrefix, db)
 	blockDB := prefixdb.New(blockStatePrefix, db)
 	heightDB := prefixdb.New(heightIndexPrefix, db)
 
 	return &state{
 		ChainState:  NewChainState(chainDB),
-		BlockState:  NewBlockState(blockDB, getInnerBytes),
+		BlockState:  NewBlockState(blockDB, getInnerBytes, log),
 		HeightIndex: NewHeightIndex(heightDB, db),
 	}
 }
 
-func NewMetered(db *versiondb.Database, namespace string, metrics prometheus.Registerer, getInnerBytes func(ids.ID) ([]byte, error)) (State, error) {
+func NewMetered(db *versiondb.Database, namespace string, metrics prometheus.Registerer, getInnerBytes func(ids.ID) ([]byte, error), log logging.Logger) (State, error) {
 	chainDB := prefixdb.New(chainStatePrefix, db)
 	blockDB := prefixdb.New(blockStatePrefix, db)
 	heightDB := prefixdb.New(heightIndexPrefix, db)
 
-	blockState, err := NewMeteredBlockState(blockDB, namespace, metrics, getInnerBytes)
+	blockState, err := NewMeteredBlockState(blockDB, namespace, metrics, getInnerBytes, log)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/proposervm/state/state.go
+++ b/vms/proposervm/state/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/ids"
 )
 
 var (
@@ -28,24 +29,24 @@ type state struct {
 	HeightIndex
 }
 
-func New(db *versiondb.Database) State {
+func New(db *versiondb.Database, getInnerBytes func(ids.ID) ([]byte, error)) State {
 	chainDB := prefixdb.New(chainStatePrefix, db)
 	blockDB := prefixdb.New(blockStatePrefix, db)
 	heightDB := prefixdb.New(heightIndexPrefix, db)
 
 	return &state{
 		ChainState:  NewChainState(chainDB),
-		BlockState:  NewBlockState(blockDB),
+		BlockState:  NewBlockState(blockDB, getInnerBytes),
 		HeightIndex: NewHeightIndex(heightDB, db),
 	}
 }
 
-func NewMetered(db *versiondb.Database, namespace string, metrics prometheus.Registerer) (State, error) {
+func NewMetered(db *versiondb.Database, namespace string, metrics prometheus.Registerer, getInnerBytes func(ids.ID) ([]byte, error)) (State, error) {
 	chainDB := prefixdb.New(chainStatePrefix, db)
 	blockDB := prefixdb.New(blockStatePrefix, db)
 	heightDB := prefixdb.New(heightIndexPrefix, db)
 
-	blockState, err := NewMeteredBlockState(blockDB, namespace, metrics)
+	blockState, err := NewMeteredBlockState(blockDB, namespace, metrics, getInnerBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/proposervm/state/state_test.go
+++ b/vms/proposervm/state/state_test.go
@@ -18,7 +18,7 @@ func TestState(t *testing.T) {
 
 	db := memdb.New()
 	vdb := versiondb.New(db)
-	s := New(vdb, nil)
+	s := New(vdb, nil, nil)
 
 	testBlockState(a, s)
 	testChainState(a, s)
@@ -29,7 +29,7 @@ func TestMeteredState(t *testing.T) {
 
 	db := memdb.New()
 	vdb := versiondb.New(db)
-	s, err := NewMetered(vdb, "", prometheus.NewRegistry(), nil)
+	s, err := NewMetered(vdb, "", prometheus.NewRegistry(), nil, nil)
 	a.NoError(err)
 
 	testBlockState(a, s)

--- a/vms/proposervm/state/state_test.go
+++ b/vms/proposervm/state/state_test.go
@@ -18,7 +18,7 @@ func TestState(t *testing.T) {
 
 	db := memdb.New()
 	vdb := versiondb.New(db)
-	s := New(vdb)
+	s := New(vdb, nil)
 
 	testBlockState(a, s)
 	testChainState(a, s)
@@ -29,7 +29,7 @@ func TestMeteredState(t *testing.T) {
 
 	db := memdb.New()
 	vdb := versiondb.New(db)
-	s, err := NewMetered(vdb, "", prometheus.NewRegistry())
+	s, err := NewMetered(vdb, "", prometheus.NewRegistry(), nil)
 	a.NoError(err)
 
 	testBlockState(a, s)

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -647,25 +647,38 @@ func (vm *VM) repairAcceptedChainByHeight(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get last accepted: %w", err)
 	}
-	proLastAccepted, err := vm.getPostForkBlock(ctx, proLastAcceptedID)
-	if err != nil {
-		return fmt.Errorf("failed to get last accepted block: %w", err)
-	}
-
-	proLastAcceptedHeight := proLastAccepted.Height()
 	innerLastAcceptedHeight := innerLastAccepted.Height()
-	if proLastAcceptedHeight < innerLastAcceptedHeight {
-		return fmt.Errorf("proposervm height index (%d) should never be lower than the inner height index (%d)", proLastAcceptedHeight, innerLastAcceptedHeight)
-	}
-	if proLastAcceptedHeight == innerLastAcceptedHeight {
-		// There is nothing to repair - as the heights match
-		return nil
-	}
+	proLastAccepted, err := vm.getPostForkBlock(ctx, proLastAcceptedID)
+	switch {
+	case errors.Is(err, state.ErrInnerBlockUnavailable):
+		// The last accepted block is a deduplicated record whose inner block
+		// the inner VM doesn't have. This happens when the node shut down
+		// uncleanly between the proposervm accepting the block and the inner
+		// VM durably accepting it, which leaves the proposervm's last
+		// accepted above the inner VM's. Roll back to the inner VM's height
+		// without reading the unreconstructable block.
+		vm.ctx.Log.Warn("repairing accepted chain with unreconstructable last accepted block",
+			zap.Stringer("blkID", proLastAcceptedID),
+			zap.Uint64("innerHeight", innerLastAcceptedHeight),
+			zap.Error(err),
+		)
+	case err != nil:
+		return fmt.Errorf("failed to get last accepted block: %w", err)
+	default:
+		proLastAcceptedHeight := proLastAccepted.Height()
+		if proLastAcceptedHeight < innerLastAcceptedHeight {
+			return fmt.Errorf("proposervm height index (%d) should never be lower than the inner height index (%d)", proLastAcceptedHeight, innerLastAcceptedHeight)
+		}
+		if proLastAcceptedHeight == innerLastAcceptedHeight {
+			// There is nothing to repair - as the heights match
+			return nil
+		}
 
-	vm.ctx.Log.Info("repairing accepted chain by height",
-		zap.Uint64("outerHeight", proLastAcceptedHeight),
-		zap.Uint64("innerHeight", innerLastAcceptedHeight),
-	)
+		vm.ctx.Log.Info("repairing accepted chain by height",
+			zap.Uint64("outerHeight", proLastAcceptedHeight),
+			zap.Uint64("innerHeight", innerLastAcceptedHeight),
+		)
+	}
 
 	// The inner vm must be behind the proposer vm, so we must roll the
 	// proposervm back.

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -200,7 +200,7 @@ func (vm *VM) Initialize(
 			return innerBlk.Bytes(), nil
 		}
 	}
-	baseState, err := state.NewMetered(vm.db, "state", vm.Config.Registerer, getInnerBytes)
+	baseState, err := state.NewMetered(vm.db, "state", vm.Config.Registerer, getInnerBytes, chainCtx.Log)
 	if err != nil {
 		return err
 	}

--- a/vms/proposervm/vm.go
+++ b/vms/proposervm/vm.go
@@ -156,11 +156,6 @@ func (vm *VM) Initialize(
 ) error {
 	vm.ctx = chainCtx
 	vm.db = versiondb.New(prefixdb.New(dbPrefix, db))
-	baseState, err := state.NewMetered(vm.db, "state", vm.Config.Registerer)
-	if err != nil {
-		return err
-	}
-	vm.State = baseState
 	vm.Windower = proposer.New(chainCtx.ValidatorState, chainCtx.SubnetID, chainCtx.ChainID, vm.ctx.Log)
 	vm.Tree = tree.New()
 	innerBlkCache, err := metercacher.New(
@@ -188,6 +183,28 @@ func (vm *VM) Initialize(
 	if err != nil {
 		return err
 	}
+
+	// The inner VM's capabilities are only known once it has initialized. When
+	// it durably retains every accepted block's bytes (retrievable via
+	// GetBlock), store accepted blocks without their inner bytes and
+	// reconstruct them on read, instead of persisting a second copy of every
+	// inner block.
+	var getInnerBytes func(ids.ID) ([]byte, error)
+	if r, ok := vm.ChainVM.(block.RetainsAcceptedBlocksVM); ok && r.RetainsAcceptedBlocks() {
+		chainCtx.Log.Info("inner VM retains accepted blocks; storing blocks without inner bytes")
+		getInnerBytes = func(innerID ids.ID) ([]byte, error) {
+			innerBlk, err := vm.ChainVM.GetBlock(context.Background(), innerID)
+			if err != nil {
+				return nil, err
+			}
+			return innerBlk.Bytes(), nil
+		}
+	}
+	baseState, err := state.NewMetered(vm.db, "state", vm.Config.Registerer, getInnerBytes)
+	if err != nil {
+		return err
+	}
+	vm.State = baseState
 
 	if err := vm.repairAcceptedChainByHeight(ctx); err != nil {
 		return fmt.Errorf("failed to repair accepted chain by height: %w", err)
@@ -830,7 +847,7 @@ func (vm *VM) acceptPostForkBlock(blk PostForkBlock) error {
 	if err := vm.State.SetLastAccepted(blkID); err != nil {
 		return err
 	}
-	if err := vm.State.PutBlock(blk.getStatelessBlk()); err != nil {
+	if err := vm.State.PutBlock(blk.getStatelessBlk(), blk.getInnerBlk().ID()); err != nil {
 		return err
 	}
 	if err := vm.updateHeightIndex(height, blkID); err != nil {

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -1340,6 +1340,220 @@ func TestInnerVMRollback(t *testing.T) {
 	require.Equal(snowmantest.GenesisID, lastAcceptedID)
 }
 
+// retainsAcceptedBlocksVM wraps a test inner VM to declare the
+// RetainsAcceptedBlocks capability, enabling inner-block deduplication.
+type retainsAcceptedBlocksVM struct {
+	*blocktest.VM
+}
+
+func (*retainsAcceptedBlocksVM) RetainsAcceptedBlocks() bool {
+	return true
+}
+
+// TestInnerVMRollbackWithDedup is the crash-window regression test for
+// inner-block deduplication: the proposervm accepts and durably commits a
+// deduplicated block, but the node dies before the inner VM durably accepts
+// the inner block, so on restart the inner bytes needed to reconstruct the
+// last accepted record are gone. The repair path must roll back to the inner
+// VM's height instead of failing chain creation.
+func TestInnerVMRollbackWithDedup(t *testing.T) {
+	require := require.New(t)
+
+	valState := &validatorstest.State{
+		T: t,
+		GetCurrentHeightF: func(context.Context) (uint64, error) {
+			return defaultPChainHeight, nil
+		},
+		GetValidatorSetF: func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+			nodeID := ids.BuildTestNodeID([]byte{1})
+			return map[ids.NodeID]*validators.GetValidatorOutput{
+				nodeID: {
+					NodeID: nodeID,
+					Weight: 100,
+				},
+			}, nil
+		},
+	}
+
+	coreVM := &retainsAcceptedBlocksVM{
+		VM: &blocktest.VM{
+			VM: enginetest.VM{
+				T: t,
+				InitializeF: func(
+					context.Context,
+					*snow.Context,
+					database.Database,
+					[]byte,
+					[]byte,
+					[]byte,
+					[]*common.Fx,
+					common.AppSender,
+				) error {
+					return nil
+				},
+			},
+			ParseBlockF: func(_ context.Context, b []byte) (snowman.Block, error) {
+				switch {
+				case bytes.Equal(b, snowmantest.GenesisBytes):
+					return snowmantest.Genesis, nil
+				default:
+					return nil, errUnknownBlock
+				}
+			},
+			GetBlockF: func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
+				switch blkID {
+				case snowmantest.GenesisID:
+					return snowmantest.Genesis, nil
+				default:
+					return nil, errUnknownBlock
+				}
+			},
+			LastAcceptedF: snowmantest.MakeLastAcceptedBlockF(
+				[]*snowmantest.Block{snowmantest.Genesis},
+			),
+		},
+	}
+
+	ctx := snowtest.Context(t, snowtest.CChainID)
+	ctx.NodeID = ids.NodeIDFromCert(pTestCert)
+	ctx.ValidatorState = valState
+
+	db := memdb.New()
+	registry := prometheus.NewRegistry()
+
+	proVM := New(
+		coreVM,
+		Config{
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Time{}),
+			MinBlkDelay:         DefaultMinBlockDelay,
+			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
+			StakingLeafSigner:   pTestSigner,
+			StakingCertLeaf:     pTestCert,
+			Registerer:          registry,
+		},
+	)
+
+	require.NoError(proVM.Initialize(
+		t.Context(),
+		ctx,
+		db,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	))
+
+	require.NoError(proVM.SetState(t.Context(), snow.NormalOp))
+	require.NoError(proVM.SetPreference(t.Context(), snowmantest.GenesisID))
+
+	coreBlk := snowmantest.BuildChild(snowmantest.Genesis)
+	statelessBlock, err := statelessblock.BuildUnsigned(
+		snowmantest.GenesisID,
+		coreBlk.Timestamp(),
+		0,
+		statelessblock.Epoch{},
+		coreBlk.Bytes(),
+	)
+	require.NoError(err)
+
+	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
+		switch blkID {
+		case snowmantest.GenesisID:
+			return snowmantest.Genesis, nil
+		case coreBlk.ID():
+			return coreBlk, nil
+		default:
+			return nil, errUnknownBlock
+		}
+	}
+	coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
+		switch {
+		case bytes.Equal(b, snowmantest.GenesisBytes):
+			return snowmantest.Genesis, nil
+		case bytes.Equal(b, coreBlk.Bytes()):
+			return coreBlk, nil
+		default:
+			return nil, errUnknownBlock
+		}
+	}
+
+	proVM.Clock.Set(statelessBlock.Timestamp())
+
+	parsedBlock, err := proVM.ParseBlock(t.Context(), statelessBlock.Bytes())
+	require.NoError(err)
+
+	require.NoError(parsedBlock.Verify(t.Context()))
+	require.NoError(proVM.SetPreference(t.Context(), parsedBlock.ID()))
+	require.NoError(parsedBlock.Accept(t.Context()))
+
+	// The accepted block must have been stored deduplicated, otherwise this
+	// test exercises nothing beyond TestInnerVMRollback.
+	metricFamilies, err := registry.Gather()
+	require.NoError(err)
+	var dedupStored float64
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "state_dedup_blocks_stored" {
+			for _, m := range mf.GetMetric() {
+				dedupStored += m.GetCounter().GetValue()
+			}
+		}
+	}
+	require.Equal(float64(1), dedupStored)
+
+	// Restart the node as if it was killed between the proposervm accepting
+	// the block and the inner VM durably accepting the inner block: the inner
+	// VM is back at genesis and no longer has the inner block at all.
+	require.NoError(proVM.Shutdown(t.Context()))
+	coreBlk.Status = snowtest.Undecided
+	coreVM.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
+		switch blkID {
+		case snowmantest.GenesisID:
+			return snowmantest.Genesis, nil
+		default:
+			return nil, errUnknownBlock
+		}
+	}
+	coreVM.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
+		switch {
+		case bytes.Equal(b, snowmantest.GenesisBytes):
+			return snowmantest.Genesis, nil
+		default:
+			return nil, errUnknownBlock
+		}
+	}
+
+	proVM = New(
+		coreVM,
+		Config{
+			Upgrades:            upgradetest.GetConfigWithUpgradeTime(upgradetest.ApricotPhase4, time.Time{}),
+			MinBlkDelay:         DefaultMinBlockDelay,
+			NumHistoricalBlocks: DefaultNumHistoricalBlocks,
+			StakingLeafSigner:   pTestSigner,
+			StakingCertLeaf:     pTestCert,
+			Registerer:          prometheus.NewRegistry(),
+		},
+	)
+
+	require.NoError(proVM.Initialize(
+		t.Context(),
+		ctx,
+		db,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	))
+	defer func() {
+		require.NoError(proVM.Shutdown(t.Context()))
+	}()
+
+	lastAcceptedID, err := proVM.LastAccepted(t.Context())
+	require.NoError(err)
+	require.Equal(snowmantest.GenesisID, lastAcceptedID)
+}
+
 func TestBuildBlockDuringWindow(t *testing.T) {
 	require := require.New(t)
 

--- a/vms/rpcchainvm/vm_client.go
+++ b/vms/rpcchainvm/vm_client.go
@@ -72,6 +72,7 @@ var (
 	_ block.BuildBlockWithContextChainVM = (*VMClient)(nil)
 	_ block.BatchedChainVM               = (*VMClient)(nil)
 	_ block.StateSyncableVM              = (*VMClient)(nil)
+	_ block.RetainsAcceptedBlocksVM      = (*VMClient)(nil)
 	_ prometheus.Gatherer                = (*VMClient)(nil)
 
 	_ snowman.Block           = (*blockClient)(nil)
@@ -100,6 +101,11 @@ type VMClient struct {
 	conns        []*grpc.ClientConn
 
 	grpcServerMetrics *grpc_prometheus.ServerMetrics
+
+	// retainsAcceptedBlocks reports whether the served VM durably retains the
+	// bytes of every accepted block, retrievable via GetBlock, forever. Set
+	// from the VM's InitializeResponse.
+	retainsAcceptedBlocks bool
 }
 
 // NewClient returns a VM connected to a remote VM
@@ -224,6 +230,8 @@ func (vm *VMClient) Initialize(
 	if err != nil {
 		return err
 	}
+
+	vm.retainsAcceptedBlocks = resp.RetainsAcceptedBlocks
 
 	// We don't need to check whether this is a block.WithVerifyContext because
 	// we'll never Verify this block.
@@ -374,6 +382,12 @@ func (vm *VMClient) Shutdown(ctx context.Context) error {
 
 	vm.processTracker.UntrackProcess(vm.pid)
 	return errs.Err
+}
+
+// RetainsAcceptedBlocks reports the capability declared by the served VM in
+// its InitializeResponse. It is only valid after Initialize has returned.
+func (vm *VMClient) RetainsAcceptedBlocks() bool {
+	return vm.retainsAcceptedBlocks
 }
 
 func (vm *VMClient) CreateHandlers(ctx context.Context) (map[string]http.Handler, error) {

--- a/vms/rpcchainvm/vm_server.go
+++ b/vms/rpcchainvm/vm_server.go
@@ -273,12 +273,17 @@ func (vm *VMServer) Initialize(ctx context.Context, req *vmpb.InitializeRequest)
 		return nil, err
 	}
 	parentID := blk.Parent()
+	retainsAcceptedBlocks := false
+	if r, ok := vm.vm.(block.RetainsAcceptedBlocksVM); ok {
+		retainsAcceptedBlocks = r.RetainsAcceptedBlocks()
+	}
 	return &vmpb.InitializeResponse{
-		LastAcceptedId:       lastAccepted[:],
-		LastAcceptedParentId: parentID[:],
-		Height:               blk.Height(),
-		Bytes:                blk.Bytes(),
-		Timestamp:            grpcutils.TimestampFromTime(blk.Timestamp()),
+		LastAcceptedId:        lastAccepted[:],
+		LastAcceptedParentId:  parentID[:],
+		Height:                blk.Height(),
+		Bytes:                 blk.Bytes(),
+		Timestamp:             grpcutils.TimestampFromTime(blk.Timestamp()),
+		RetainsAcceptedBlocks: retainsAcceptedBlocks,
 	}, nil
 }
 

--- a/vms/tracedvm/block_vm.go
+++ b/vms/tracedvm/block_vm.go
@@ -25,6 +25,7 @@ var (
 	_ block.SetPreferenceWithContextChainVM = (*blockVM)(nil)
 	_ block.BatchedChainVM                  = (*blockVM)(nil)
 	_ block.StateSyncableVM                 = (*blockVM)(nil)
+	_ block.RetainsAcceptedBlocksVM         = (*blockVM)(nil)
 )
 
 type blockVM struct {
@@ -124,6 +125,13 @@ func (vm *blockVM) Initialize(
 		fxs,
 		appSender,
 	)
+}
+
+// RetainsAcceptedBlocks forwards the wrapped VM's capability so it remains
+// visible through the tracing wrapper.
+func (vm *blockVM) RetainsAcceptedBlocks() bool {
+	r, ok := vm.ChainVM.(block.RetainsAcceptedBlocksVM)
+	return ok && r.RetainsAcceptedBlocks()
 }
 
 func (vm *blockVM) BuildBlock(ctx context.Context) (snowman.Block, error) {


### PR DESCRIPTION
## Why this should be merged

The proposervm persists each accepted block's full container, including the inner block bytes that the inner VM already persists in its own database, so every subnet block is stored twice. Measured on a 751k-block mainnet L1 (FIFA): the duplicate inner bytes are 1.36 GiB, 19.7% of that subnet's total storage (proposervm store 1.755 GiB, of which 1.385 GiB is inner bytes). This removes the second copy with no configuration.

## How this works

Inner VMs declare a capability in their `InitializeResponse`: a new additive proto3 field `retains_accepted_blocks = 6` meaning the VM durably retains every accepted block's bytes, retrievable via `GetBlock`, forever. No `RPCChainVMProtocol` bump is required (additive field, defaults false). The capability surfaces through a small optional interface (`block.RetainsAcceptedBlocksVM`), is set by `rpcchainvm.VMServer` from the served VM, exposed by `VMClient`, and forwarded through `tracedvm`. subnet-evm and coreth (the C-chain) implement it returning true: in both VMs accepted bodies are never deleted (state pruning, offline pruning included, only touches the state trie; only rejected blocks are removed). On the C-chain the method is declared by the atomic VM wrapper, since that is the VM the proposervm wraps and it embeds the inner VM as an interface, so a declaration on the inner `evm.VM` alone would not surface; coreth runs in-process, so the Go interface rather than the proto field is what engages there.

The proposervm checks the capability after the inner VM initializes and, when set, stores accepted blocks in a new state codec version (v1): the block bytes with the inner bytes stripped, plus the inner block ID. Reads reconstruct the exact original container by fetching the inner block from the inner VM. Both codec versions are always readable, so databases with mixed records (normal after an upgrade) work; existing v0 records are not rewritten.

Safety, in depth:
- Write time: every stripped block is restored and byte-compared against the original before being written; any mismatch falls back to the legacy full v0 record. Because this check is pure in-memory container mechanics, a mismatch has no legitimate data-dependent cause and can only be a strip/restore code bug for some container shape, so the fallback is loud: an error-level log with the block ID and the cause, plus the `dedup_blocks_fallback` metric (alongside `dedup_blocks_stored`). Hard-failing the write instead was rejected: a shape-dependent bug would halt every upgraded node on the same block, and a storage feature must not be able to halt consensus.
- Read time: the reconstructed block's ID is asserted to match the store key, so a wrong inner block can never be served.
- VMs without the capability (P-chain, X-chain) keep the v0 path byte-for-byte unchanged.

## How this was tested

- Unit tests: strip/restore round-trips for all four stateless block types (signed, Granite, unsigned, option), dedup storage path, plus the existing state suites against the new constructor signatures. Tests that exercise the dedup write path assert `dedup_blocks_fallback` stays 0, and a dedicated test drives the fallback branch (a block whose bytes cannot round-trip) asserting the counter fires and the record is stored in the legacy full format.
- End-to-end on a mainnet L1 (TixChain, 2834 blocks), synced from genesis with no subnet config and no chain config: the capability engages on its own (`inner VM retains accepted blocks; storing blocks without inner bytes`), `dedup_blocks_stored` 2834, `dedup_blocks_fallback` 0, all records codec v1, clean restart, historical RPC reads fine.
- Size: proposervm block store 7.14 MiB (master baseline node, same chain, same tip) vs 1.51 MiB deduplicated, 79% smaller, consistent with the FIFA measurement above.
- Bulk serving (the GetAncestors bootstrap-serve path adds an inner `GetBlock` hop per block): a p2p test peer walked the full 2835-block chain against both nodes. Master-built node: 0.11 s cold, 0.05 s warm. Dedup node: 1.15 s cold (about 0.4 ms per block for the inner hop, until the proposervm block cache warms), 0.05 s warm. Both nodes served byte-identical containers (7,187,477 bytes total).
- C-chain: unit tests (`graft/coreth/plugin/evm/atomic/vm`, `vms/proposervm`). The proposervm side is chain-agnostic, the same write/read path exercised end to end above; the C-chain declaration itself is a constant method guarded by a compile-time interface assertion, and the write-time round-trip fallback applies there like everywhere else.
- Downgrade: pointing a master-built binary at the deduplicated data dir fails chain creation with, verbatim: `error while creating new snowman vm failed to repair accepted chain by height: failed to get last accepted block: unknown codec version`. The node stays up, nothing is written, and re-upgrading works. avalanchego currently has no database version stamp at startup (the `v1.4.5` in the db path is only a folder name), so making future downgrades fail with a friendlier message would be new node-level machinery; left as future work.

## Need to be documented in RELEASES.md?

Yes: modifies the proposervm database format for chains whose VM declares `retains_accepted_blocks` (subnet-evm and the C-chain); downgrade to earlier versions is not supported after running this code.
