### PR TITLE
feat(cchain): enforce ACP-226 min block delay

### DIFF
--- a/vms/saevm/cchain/BUILD.bazel
+++ b/vms/saevm/cchain/BUILD.bazel
@@ -157,6 +157,7 @@ go_test(
         "//vms/components/avax",
         "//vms/components/gas",
         "//vms/evm/acp176",
+        "//vms/evm/acp226",
         "//vms/evm/predicate",
         "//vms/platformvm/warp",
         "//vms/platformvm/warp/payload",

--- a/vms/saevm/cchain/config.go
+++ b/vms/saevm/cchain/config.go
@@ -33,7 +33,9 @@ type config struct {
 	// GasTarget is the target gas per second this node votes for when building
 	// blocks under ACP-176. nil means follow the parent block.
 	GasTarget *gas.Gas `json:"gas-target,omitempty"`
-	// MinDelayTarget *uint64    `json:"min-delay-target,omitempty"`
+	// MinDelayTarget is the ACP-226 minimum block delay (ms) this node votes
+	// for; nil follows the parent.
+	MinDelayTarget *uint64 `json:"min-delay-target,omitempty"`
 
 	// State & trie
 	Pruning        bool   `json:"pruning-enabled"` // If enabled, trie roots are only persisted every commit-interval blocks.
@@ -145,6 +147,7 @@ func (c config) WarpMessages() ([]*warp.UnsignedMessage, error) {
 type desiredParams struct {
 	targetExponent *dynamic.TargetExponent
 	priceExponent  *dynamic.PriceExponent
+	delayExponent  *dynamic.DelayExponent
 }
 
 // desired returns c's user-facing targets as internal exponent votes.
@@ -157,6 +160,10 @@ func (c config) desired() desiredParams {
 	if c.PriceTarget != nil {
 		e := dynamic.DesiredPriceExponent(*c.PriceTarget)
 		d.priceExponent = &e
+	}
+	if c.MinDelayTarget != nil {
+		e := dynamic.DesiredDelayExponent(*c.MinDelayTarget)
+		d.delayExponent = &e
 	}
 	return d
 }

--- a/vms/saevm/cchain/config_test.go
+++ b/vms/saevm/cchain/config_test.go
@@ -110,6 +110,11 @@ func TestParseConfig(t *testing.T) {
 			wantErr: testerr.Is(rpc.ErrBatchRequestLimitTooLarge),
 		},
 		{
+			name: "min_delay_target",
+			json: `{"min-delay-target":2000}`,
+			want: with(func(c *config) { c.MinDelayTarget = utils.PointerTo[uint64](2000) }),
+		},
+		{
 			name: "warp_off_chain_messages",
 			json: `{"warp-off-chain-messages":["0x1234"]}`,
 			want: with(func(c *config) {
@@ -121,6 +126,7 @@ func TestParseConfig(t *testing.T) {
 			json: `{
 				"min-price-target":500,
 				"gas-target":1500,
+				"min-delay-target":3000,
 				"pruning-enabled":false,
 				"commit-interval":256,
 				"local-txs-enabled":true,
@@ -133,6 +139,7 @@ func TestParseConfig(t *testing.T) {
 			want: config{
 				PriceTarget:          utils.PointerTo(gas.Price(500)),
 				GasTarget:            utils.PointerTo(gas.Gas(1500)),
+				MinDelayTarget:       utils.PointerTo[uint64](3000),
 				Pruning:              false,
 				CommitInterval:       256,
 				LocalTxsEnabled:      true,

--- a/vms/saevm/cchain/dynamic/delay.go
+++ b/vms/saevm/cchain/dynamic/delay.go
@@ -3,13 +3,28 @@
 
 package dynamic
 
-import "github.com/ava-labs/avalanchego/vms/components/gas"
+import (
+	"time"
+
+	"github.com/ava-labs/avalanchego/vms/components/gas"
+)
 
 // DelayExponent encodes the minimum block delay.
 //
 // Implements ACP-226, specified here:
 // https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/226-dynamic-minimum-block-times/README.md
 type DelayExponent uint64
+
+// InitialDelayExponent is the ACP-226 initial delay exponent. It is the
+// smallest exponent whose [DelayExponent.Delay] decodes to the 2000ms initial
+// minimum block delay, obtained by inverting the
+// Delay = minimum·e^(exponent/conversionRate) formula (minimum = 1ms,
+// conversionRate = 2²⁰) for a 2000ms target and rounding up so the floored
+// decode reaches 2000ms exactly:
+//
+//	InitialDelayExponent = ⌊conversionRate·ln(2000/minimum)⌋ + 1
+//	                     = ⌊2²⁰·ln(2000)⌋ + 1
+const InitialDelayExponent DelayExponent = 7_970_124
 
 // Delay returns the minimum block delay in milliseconds.
 //
@@ -24,6 +39,12 @@ func (d DelayExponent) Delay() uint64 {
 		gas.Gas(d),
 		conversionRate,
 	))
+}
+
+// DelayDuration returns the minimum block delay ([DelayExponent.Delay], which
+// is denominated in milliseconds) as a [time.Duration].
+func (d DelayExponent) DelayDuration() time.Duration {
+	return time.Duration(d.Delay()) * time.Millisecond //#nosec G115 -- Delay() returns ms values that fit in int64 for centuries
 }
 
 // Toward returns a new value where d is moved to be as close as possible to

--- a/vms/saevm/cchain/dynamic/delay_test.go
+++ b/vms/saevm/cchain/dynamic/delay_test.go
@@ -6,6 +6,9 @@ package dynamic
 import (
 	"math"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/utils"
 )
@@ -59,4 +62,24 @@ func FuzzDelayExponentToward(f *testing.F) {
 
 func FuzzDesiredDelayExponent(f *testing.F) {
 	fuzzSearch(f, delayReaderCases, DesiredDelayExponent, DelayExponent.Delay)
+}
+
+func TestInitialDelayExponent(t *testing.T) {
+	require.Equal(t, uint64(2000), InitialDelayExponent.Delay(), "InitialDelayExponent.Delay()")
+}
+
+func TestDelayDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		exponent DelayExponent
+		want     time.Duration
+	}{
+		{name: "minimum_floor", exponent: 0, want: time.Millisecond}, // Delay() == 1ms
+		{name: "initial", exponent: InitialDelayExponent, want: 2 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.exponent.DelayDuration(), "DelayExponent.DelayDuration()")
+		})
+	}
 }

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -204,13 +204,12 @@ func (*hooks) SettledBy(h *types.Header) hook.Settled {
 	}
 }
 
-// BlockTime returns the canonical wall-clock time of the block with header h.
+// BlockTime returns the canonical wall-clock time of a block.
 //
-// It anchors the seconds component to h.Time so that the documented invariant
-// BlockTime(h).Unix() == h.Time holds, taking only the sub-second component
-// from TimeMilliseconds. This guards against malformed headers where
-// TimeMilliseconds disagrees with Time (e.g. from a malicious peer), which
-// would otherwise yield an unexpected block time.
+// The whole-second value is authoritative and the millisecond field only
+// refines it below the second, so the two can never disagree on which second a
+// block belongs to. This keeps a block's time stable even when a peer sends a
+// header whose millisecond field is inconsistent with its seconds.
 func (*hooks) BlockTime(h *types.Header) time.Time {
 	return blockTime(h)
 }

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -116,6 +116,7 @@ func (h *hooks) BlockRebuilderFrom(b *types.Block) (hook.BlockBuilder[*hookTx], 
 		desiredParams{
 			targetExponent: customtypes.GetHeaderExtra(b.Header()).TargetExponent,
 			priceExponent:  customtypes.GetHeaderExtra(b.Header()).MinPriceExponent,
+			delayExponent:  (*dynamic.DelayExponent)(customtypes.GetHeaderExtra(b.Header()).MinDelayExcess),
 		},
 	}, nil
 }
@@ -140,6 +141,15 @@ func priceExponent(h *types.Header) dynamic.PriceExponent {
 		return *pe
 	}
 	return dynamic.InitialPriceExponent
+}
+
+// delayExponent returns h's ACP-226 minimum block delay exponent, defaulting to
+// [dynamic.InitialDelayExponent] when the header does not carry one.
+func delayExponent(h *types.Header) dynamic.DelayExponent {
+	if de := customtypes.GetHeaderExtra(h).MinDelayExcess; de != nil {
+		return dynamic.DelayExponent(*de)
+	}
+	return dynamic.InitialDelayExponent
 }
 
 func targetExponent(config *extras.ChainConfig, h *types.Header) (dynamic.TargetExponent, error) {
@@ -194,12 +204,18 @@ func (*hooks) SettledBy(h *types.Header) hook.Settled {
 	}
 }
 
+// BlockTime returns the canonical wall-clock time of the block with header h.
+//
+// It anchors the seconds component to h.Time so that the documented invariant
+// BlockTime(h).Unix() == h.Time holds, taking only the sub-second component
+// from TimeMilliseconds. This guards against malformed headers where
+// TimeMilliseconds disagrees with Time (e.g. from a malicious peer), which
+// would otherwise yield an unexpected block time.
 func (*hooks) BlockTime(h *types.Header) time.Time {
-	// Anchor the seconds component to h.Time so that the documented invariant
-	// BlockTime(h).Unix() == h.Time holds, taking only the sub-second component
-	// from TimeMilliseconds. This guards against malformed headers where
-	// TimeMilliseconds disagrees with Time (e.g. from a malicious peer), which
-	// would otherwise yield an unexpected block time.
+	return blockTime(h)
+}
+
+func blockTime(h *types.Header) time.Time {
 	ms := customtypes.HeaderTimeMilliseconds(h)
 	subSecondNanos := int64(ms%1000) * int64(time.Millisecond) //#nosec G115 -- ms%1000 < 1000
 	return time.Unix(int64(h.Time), subSecondNanos)            //#nosec G115 -- Won't overflow for a few millennia
@@ -271,7 +287,10 @@ type builder struct {
 	desired      desiredParams
 }
 
-var errHeliconUnactivated = errors.New("helicon is not activated")
+var (
+	errHeliconUnactivated = errors.New("helicon is not activated")
+	errBelowMinBlockDelay = errors.New("block time below the ACP-226 minimum block delay")
+)
 
 // See [hook.BlockBuilder.BuildHeader] for which fields MUST or MAY be set in
 // the returned header.
@@ -281,15 +300,25 @@ func (b *builder) BuildHeader(parent *types.Header) (*types.Header, error) {
 		return nil, errHeliconUnactivated
 	}
 
-	// TODO(StephenButtolph): Enforce the minimum block time here.
+	de := delayExponent(parent)
+	parentTime := blockTime(parent)
+	if minTime := parentTime.Add(de.DelayDuration()); now.Before(minTime) {
+		return nil, fmt.Errorf("%w: block time %s is before the minimum %s (parent %s + %s)",
+			errBelowMinBlockDelay, now, minTime, parentTime, de.DelayDuration())
+	}
+
 	nowMS := uint64(now.UnixMilli()) //#nosec G115 -- Known non-negative
+
 	config := corethparams.GetExtra(b.chainConfig)
 	te, err := targetExponent(config, parent)
 	if err != nil {
 		return nil, fmt.Errorf("getting target exponent: %w", err)
 	}
+	// Move each dynamic parameter toward this node's vote (nil = no move).
+	de = de.Toward(b.desired.delayExponent)
 	te = te.Toward(b.desired.targetExponent)
 	pe := priceExponent(parent).Toward(b.desired.priceExponent)
+	minDelayExcess := acp226.DelayExcess(de)
 	return customtypes.WithHeaderExtra(
 		&types.Header{
 			ParentHash:       parent.Hash(),
@@ -309,8 +338,7 @@ func (b *builder) BuildHeader(parent *types.Header) (*types.Header, error) {
 			// BlockGasCost has been set to 0 since the Granite upgrade.
 			BlockGasCost:     big.NewInt(0),
 			TimeMilliseconds: &nowMS,
-			// TODO(StephenButtolph): Encode the min-delay excess.
-			MinDelayExcess:   new(acp226.DelayExcess),
+			MinDelayExcess:   &minDelayExcess,
 			TargetExponent:   &te,
 			MinPriceExponent: &pe,
 		},

--- a/vms/saevm/cchain/hooks_test.go
+++ b/vms/saevm/cchain/hooks_test.go
@@ -20,11 +20,39 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/evm/acp176"
+	"github.com/ava-labs/avalanchego/vms/evm/acp226"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/cchaintest"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/dynamic"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx/txtest"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 )
+
+func TestDelayExponent(t *testing.T) {
+	tests := []struct {
+		name   string
+		header *types.Header
+		want   dynamic.DelayExponent
+	}{
+		{
+			name: "header_carries_excess",
+			header: customtypes.WithHeaderExtra(
+				&types.Header{},
+				&customtypes.HeaderExtra{MinDelayExcess: utils.PointerTo[acp226.DelayExcess](42)},
+			),
+			want: dynamic.DelayExponent(42),
+		},
+		{
+			name:   "no_field_defaults_to_initial",
+			header: &types.Header{},
+			want:   dynamic.InitialDelayExponent,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, delayExponent(tt.header), "delayExponent()")
+		})
+	}
+}
 
 // When TimeMilliseconds is unset, BlockTime falls back to Header.Time's seconds.
 // The VM always sets TimeMilliseconds, so this legacy decode path is only

--- a/vms/saevm/cchain/hooks_test.go
+++ b/vms/saevm/cchain/hooks_test.go
@@ -63,31 +63,29 @@ func TestBlockTime(t *testing.T) {
 		// When TimeMilliseconds is unset, BlockTime falls back to Time's
 		// seconds. The VM always sets it, so this decode path is only reachable
 		// by exercising the hook directly.
-		header        *types.Header
-		wantUnix      int64
-		wantUnixMilli int64
+		header    *types.Header
+		wantMilli int64
 	}{
 		{
-			name:          "unset_falls_back_to_seconds",
-			header:        &types.Header{Time: 1_700_000_000},
-			wantUnix:      1_700_000_000,
-			wantUnixMilli: 1_700_000_000_000,
+			name:      "unset_falls_back_to_seconds",
+			header:    &types.Header{Time: 1_700_000_000},
+			wantMilli: 1_700_000_000_000,
 		},
 		{
 			// TimeMilliseconds encodes 105.500s while Time says 100s (e.g. from
 			// a malicious peer). Only the 500ms sub-second remainder is honored.
-			name:          "milliseconds_disagreeing_on_second_ignored",
-			header:        customtypes.WithHeaderExtra(&types.Header{Time: 100}, &customtypes.HeaderExtra{TimeMilliseconds: utils.PointerTo[uint64](105_500)}),
-			wantUnix:      100,
-			wantUnixMilli: 100_500,
+			name:      "milliseconds_disagreeing_on_second_ignored",
+			header:    customtypes.WithHeaderExtra(&types.Header{Time: 100}, &customtypes.HeaderExtra{TimeMilliseconds: utils.PointerTo[uint64](105_500)}),
+			wantMilli: 100_500,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := hooks.BlockTime(tt.header)
-			// Documented invariant: BlockTime(h).Unix() == h.Time.
-			require.Equal(t, tt.wantUnix, got.Unix(), "hooks.BlockTime().Unix()")
-			require.Equal(t, tt.wantUnixMilli, got.UnixMilli(), "hooks.BlockTime().UnixMilli()")
+			require.Equal(t, tt.wantMilli, got.UnixMilli(), "hooks.BlockTime().UnixMilli()")
+			// Documented invariant: BlockTime(h).Unix() == h.Time, i.e. the
+			// second is just the millisecond value floored.
+			require.Equal(t, tt.wantMilli/1000, got.Unix(), "hooks.BlockTime().Unix()")
 		})
 	}
 }

--- a/vms/saevm/cchain/hooks_test.go
+++ b/vms/saevm/cchain/hooks_test.go
@@ -70,6 +70,42 @@ func TestBlockTime(t *testing.T) {
 	require.Equal(t, unixMilli, got.UnixMilli(), "hooks.BlockTime(unset TimeMilliseconds).UnixMilli()")
 	// Documented invariant: BlockTime(h).Unix() == h.Time.
 	require.Equal(t, int64(unix), got.Unix(), "hooks.BlockTime(unset TimeMilliseconds).Unix()")
+func TestBlockTime(t *testing.T) {
+	_, sut := newSUT(t)
+	hooks := sut.hooks()
+
+	tests := []struct {
+		name string
+		// When TimeMilliseconds is unset, BlockTime falls back to Time's
+		// seconds. The VM always sets it, so this decode path is only reachable
+		// by exercising the hook directly.
+		header        *types.Header
+		wantUnix      int64
+		wantUnixMilli int64
+	}{
+		{
+			name:          "unset_falls_back_to_seconds",
+			header:        &types.Header{Time: 1_700_000_000},
+			wantUnix:      1_700_000_000,
+			wantUnixMilli: 1_700_000_000_000,
+		},
+		{
+			// TimeMilliseconds encodes 105.500s while Time says 100s (e.g. from
+			// a malicious peer). Only the 500ms sub-second remainder is honored.
+			name:          "milliseconds_disagreeing_on_second_ignored",
+			header:        customtypes.WithHeaderExtra(&types.Header{Time: 100}, &customtypes.HeaderExtra{TimeMilliseconds: utils.PointerTo[uint64](105_500)}),
+			wantUnix:      100,
+			wantUnixMilli: 100_500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hooks.BlockTime(tt.header)
+			// Documented invariant: BlockTime(h).Unix() == h.Time.
+			require.Equal(t, tt.wantUnix, got.Unix(), "hooks.BlockTime().Unix()")
+			require.Equal(t, tt.wantUnixMilli, got.UnixMilli(), "hooks.BlockTime().UnixMilli()")
+		})
+	}
 }
 
 func TestAncestorInputIDs(t *testing.T) {

--- a/vms/saevm/cchain/hooks_test.go
+++ b/vms/saevm/cchain/hooks_test.go
@@ -54,22 +54,6 @@ func TestDelayExponent(t *testing.T) {
 	}
 }
 
-// When TimeMilliseconds is unset, BlockTime falls back to Header.Time's seconds.
-// The VM always sets TimeMilliseconds, so this legacy decode path is only
-// reachable by exercising the hook directly.
-func TestBlockTime(t *testing.T) {
-	_, sut := newSUT(t)
-	hooks := sut.hooks()
-
-	const (
-		unix            = 1_700_000_000
-		unixMilli int64 = unix * 1000
-	)
-	header := &types.Header{Time: unix}
-	got := hooks.BlockTime(header)
-	require.Equal(t, unixMilli, got.UnixMilli(), "hooks.BlockTime(unset TimeMilliseconds).UnixMilli()")
-	// Documented invariant: BlockTime(h).Unix() == h.Time.
-	require.Equal(t, int64(unix), got.Unix(), "hooks.BlockTime(unset TimeMilliseconds).Unix()")
 func TestBlockTime(t *testing.T) {
 	_, sut := newSUT(t)
 	hooks := sut.hooks()

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -341,16 +341,10 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 		}
 	}
 
-	// Race the SAE VM's event source against the cross-chain txpool; whichever
-	// signals first wins.
-	//
-	// raceCtx exists to unblock the loser: it is canceled by the winner's
-	// deferred cancel as soon as either goroutine produces a result, so the
-	// other's still-pending WaitForEvent/AwaitTxs call returns promptly rather
-	// than lingering until the caller's ctx is canceled. results is buffered for
-	// both sends so the loser can always deliver its (discarded) result and
-	// exit, i.e. neither goroutine leaks.
-	raceCtx, cancel := context.WithCancel(ctx)
+    // Race the SAE event source against the cross-chain txpool. The winner's
+    // deferred cancel unblocks the loser, whose pending call returns and delivers
+    // its discarded result to the buffered channel, so neither goroutine leaks.
+    raceCtx, cancel := context.WithCancel(ctx)
 	type result struct {
 		msg snowcommon.Message
 		err error

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -310,17 +310,45 @@ func (vm *VM) CreateHandlers(ctx context.Context) (map[string]http.Handler, erro
 	return m, nil
 }
 
-// WaitForEvent waits for a transaction to be in the txpool or for the SAE VM to
-// produce an event.
+// earliestBuildTime returns the earliest wall-clock time at which a child of b
+// may be built: b's timestamp plus b's ACP-226 minimum block delay.
+func earliestBuildTime(b *blocks.Block) time.Time {
+	h := b.Header()
+	return blockTime(h).Add(delayExponent(h).DelayDuration())
+}
+
+// WaitForEvent waits until the ACP-226 minimum block delay since the preferred
+// block has elapsed, then waits for a transaction to be in the txpool or for
+// the SAE VM to produce an event.
 func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 	// TODO(StephenButtolph): Do not busy loop with [snowcommon.PendingTxs]. The
 	// txpools are cleared after block execution, so we may still have
 	// transactions in the txpool while blocks containing those transactions are
 	// processing.
 
-	// TODO(StephenButtolph): Wait until the minimum block delay has passed.
+	// Pace block building on the ACP-226 minimum block delay before consulting
+	// the event sources so that the mempools are queried when we are actually
+	// willing to build.
+	if preferred := vm.VM.GetPreference(); preferred != nil {
+		if now, minTime := vm.now(), earliestBuildTime(preferred); now.Before(minTime) {
+			select {
+			case <-ctx.Done():
+				return 0, context.Cause(ctx)
+			case <-time.After(minTime.Sub(now)):
+			}
+		}
+	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	// Race the SAE VM's event source against the cross-chain txpool; whichever
+	// signals first wins.
+	//
+	// raceCtx exists to unblock the loser: it is canceled by the winner's
+	// deferred cancel as soon as either goroutine produces a result, so the
+	// other's still-pending WaitForEvent/AwaitTxs call returns promptly rather
+	// than lingering until the caller's ctx is canceled. results is buffered for
+	// both sends so the loser can always deliver its (discarded) result and
+	// exit, i.e. neither goroutine leaks.
+	raceCtx, cancel := context.WithCancel(ctx)
 	type result struct {
 		msg snowcommon.Message
 		err error
@@ -328,12 +356,12 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 	results := make(chan result, 2)
 	go func() {
 		defer cancel()
-		msg, err := vm.VM.WaitForEvent(ctx)
+		msg, err := vm.VM.WaitForEvent(raceCtx)
 		results <- result{msg, err}
 	}()
 	go func() {
 		defer cancel()
-		err := vm.txpool.AwaitTxs(ctx)
+		err := vm.txpool.AwaitTxs(raceCtx)
 		results <- result{snowcommon.PendingTxs, err}
 	}()
 

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -330,11 +330,13 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 	// the event sources so that the mempools are queried when we are actually
 	// willing to build.
 	if preferred := vm.VM.GetPreference(); preferred != nil {
-		if now, minTime := vm.now(), earliestBuildTime(preferred); now.Before(minTime) {
+		minTime := earliestBuildTime(preferred)
+		timeToWait := minTime.Sub(vm.now())
+		if timeToWait > 0 {
 			select {
 			case <-ctx.Done():
 				return 0, context.Cause(ctx)
-			case <-time.After(minTime.Sub(now)):
+			case <-time.After(timeToWait):
 			}
 		}
 	}

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -329,22 +329,19 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 	// Pace block building on the ACP-226 minimum block delay before consulting
 	// the event sources so that the mempools are queried when we are actually
 	// willing to build.
-	if preferred := vm.VM.GetPreference(); preferred != nil {
-		minTime := earliestBuildTime(preferred)
-		timeToWait := minTime.Sub(vm.now())
-		if timeToWait > 0 {
-			select {
-			case <-ctx.Done():
-				return 0, context.Cause(ctx)
-			case <-time.After(timeToWait):
-			}
+	minTime := earliestBuildTime(vm.VM.GetPreference())
+	if timeToWait := minTime.Sub(vm.now()); timeToWait > 0 {
+		select {
+		case <-ctx.Done():
+			return 0, context.Cause(ctx)
+		case <-time.After(timeToWait):
 		}
 	}
 
-    // Race the SAE event source against the cross-chain txpool. The winner's
-    // deferred cancel unblocks the loser, whose pending call returns and delivers
-    // its discarded result to the buffered channel, so neither goroutine leaks.
-    raceCtx, cancel := context.WithCancel(ctx)
+	// Race the SAE event source against the cross-chain txpool. The winner's
+	// deferred cancel unblocks the loser, whose pending call returns and delivers
+	// its discarded result to the buffered channel, so neither goroutine leaks.
+	raceCtx, cancel := context.WithCancel(ctx)
 	type result struct {
 		msg snowcommon.Message
 		err error

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -311,7 +311,7 @@ func (vm *VM) CreateHandlers(ctx context.Context) (map[string]http.Handler, erro
 }
 
 // earliestBuildTime returns the earliest wall-clock time at which a child of b
-// may be built: b's timestamp plus b's ACP-226 minimum block delay.
+// may be built.
 func earliestBuildTime(b *blocks.Block) time.Time {
 	h := b.Header()
 	return blockTime(h).Add(delayExponent(h).DelayDuration())

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -1572,9 +1572,7 @@ func TestWaitForEventMinDelayPacing(t *testing.T) {
 				// Build an in-process SUT with no real RPC transport: real
 				// sockets never reach a durable block under synctest, so the
 				// txpool is primed directly via the gossip set rather than
-				// through the absent Client. The SUT is a fully-initialized VM in
-				// [snow.NormalOp] whose only block is genesis (also its current
-				// preference), with exactly one pending transaction.
+				// through the absent Client.
 				//
 				// Do not build/execute blocks: these tests are only
 				// synctest-teardown-safe because they run no blocks (a block can

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -126,6 +126,14 @@ func withState(state snow.State) sutOption {
 
 // withoutRPCTransport skips the SUT's real HTTP/WebSocket transport. Required
 // under testing/synctest, where real sockets never reach a durable block.
+//
+// The resulting SUT has no RPC surface: [SUT.Client] and [SUT.ethclient] are
+// left nil, so tests using this option must drive the VM directly (e.g. via
+// the txpool and consensus methods) rather than through RPC.
+//
+// TODO: investigate in-process client implementations (e.g. served over
+// net.Pipe or an in-memory listener) that stay durably blocked under
+// synctest, so RPC-driven tests can run in a bubble too.
 func withoutRPCTransport() sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.skipRPCTransport = true

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/ava-labs/libevm/common"
@@ -107,6 +108,8 @@ type (
 		db         database.Database
 		state      snow.State
 		upgrades   upgrade.Config
+
+		skipRPCTransport bool
 	}
 	sutOption = options.Option[sutConfig]
 )
@@ -118,6 +121,14 @@ type (
 func withState(state snow.State) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.state = state
+	})
+}
+
+// withoutRPCTransport skips the SUT's real HTTP/WebSocket transport. Required
+// under testing/synctest, where real sockets never reach a durable block.
+func withoutRPCTransport() sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		c.skipRPCTransport = true
 	})
 }
 
@@ -179,6 +190,10 @@ func withHeliconTime(t time.Time) sutOption {
 	})
 }
 
+// testStartTime pins the SUT clock at the genesis block's ACP-226 minimum
+// delay deadline, i.e. the earliest time a child of genesis may be built.
+var testStartTime = upgrade.InitiallyActiveTime.Add(dynamic.InitialDelayExponent.DelayDuration())
+
 // withVMTime fixes the SUT's clock at startTime and returns a handle that lets
 // the test move the clock forward (e.g. past Tau to settle a block).
 func withVMTime(startTime time.Time) (sutOption, *saetest.Clock) {
@@ -199,6 +214,12 @@ func withPriceTarget(p gas.Price) sutOption {
 func withGasTarget(g gas.Gas) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.vmConfig.GasTarget = &g
+	})
+}
+
+func withMinDelayTarget(ms uint64) sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		c.vmConfig.MinDelayTarget = &ms
 	})
 }
 
@@ -293,30 +314,33 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 	// need to treat our node as a special case.
 	require.NoErrorf(tb, vm.Connected(ctx, snowCtx.NodeID, version.Current), "%T.Connected(%s)", vm, snowCtx.NodeID)
 
-	handlers, err := vm.CreateHandlers(ctx)
-	require.NoErrorf(tb, err, "%T.CreateHandlers()", vm)
-
-	mux := http.NewServeMux()
-	for path, h := range handlers {
-		mux.Handle(cchainHTTPPrefix+path, h)
-	}
-	server := httptest.NewServer(mux)
-	tb.Cleanup(server.Close)
-
-	const wsHTTPPath = cchainHTTPPrefix + "/ws"
-	wsURI := "ws://" + server.Listener.Addr().String() + wsHTTPPath
-	ethRPCClient, err := ethrpc.Dial(wsURI)
-	require.NoErrorf(tb, err, "rpc.Dial(%s)", wsURI)
-	tb.Cleanup(ethRPCClient.Close)
-
 	sut := &SUT{
 		VM:        vm,
-		Client:    NewClient(server.URL),
 		db:        db,
 		memory:    memory,
 		sender:    appSender,
-		ethclient: ethclient.NewClient(ethRPCClient),
 		p2pclient: saetest.NewCapturingPeer(tb, validatorIDs),
+	}
+
+	if !cfg.skipRPCTransport {
+		handlers, err := vm.CreateHandlers(ctx)
+		require.NoErrorf(tb, err, "%T.CreateHandlers()", vm)
+
+		mux := http.NewServeMux()
+		for path, h := range handlers {
+			mux.Handle(cchainHTTPPrefix+path, h)
+		}
+		server := httptest.NewServer(mux)
+		tb.Cleanup(server.Close)
+
+		const wsHTTPPath = cchainHTTPPrefix + "/ws"
+		wsURI := "ws://" + server.Listener.Addr().String() + wsHTTPPath
+		ethRPCClient, err := ethrpc.Dial(wsURI)
+		require.NoErrorf(tb, err, "rpc.Dial(%s)", wsURI)
+		tb.Cleanup(ethRPCClient.Close)
+
+		sut.Client = NewClient(server.URL)
+		sut.ethclient = ethclient.NewClient(ethRPCClient)
 	}
 	appSender.Start(tb, sut)
 	saetest.ConnectTo[saetest.Peer](tb, sut, sut.p2pclient)
@@ -586,21 +610,29 @@ func (s *SUT) buildVerify(ctx context.Context, tb testing.TB, preferenceID ids.I
 	return blk
 }
 
-// verifyTampered re-seals valid with a mutated header extra and returns the
-// VerifyBlock error, exercising rebuild-and-compare against the tampered field.
-func (s *SUT) verifyTampered(ctx context.Context, tb testing.TB, valid *blocks.Block, tamper func(*customtypes.HeaderExtra)) error {
+// verifyTampered re-seals valid with a mutated header and returns the
+// VerifyBlock error, exercising rebuild-and-compare against the tampered
+// field(s). tamper receives the full header so callers can mutate both
+// [types.Header] fields (e.g. Time) and the header extra.
+func (s *SUT) verifyTampered(ctx context.Context, tb testing.TB, valid *blocks.Block, tamper func(*types.Header)) error {
 	tb.Helper()
 
 	hdr := valid.Header()
-	extra := customtypes.GetHeaderExtra(hdr)
-	tamper(extra)
-	customtypes.SetHeaderExtra(hdr, extra)
+	tamper(hdr)
 
 	buf, err := rlp.EncodeToBytes(valid.EthBlock().WithSeal(hdr))
 	require.NoErrorf(tb, err, "rlp.EncodeToBytes(tampered block)")
 	parsed, err := s.ParseBlock(ctx, buf)
 	require.NoErrorf(tb, err, "%T.ParseBlock(tampered block)", s.VM)
 	return s.VerifyBlock(ctx, nil, parsed)
+}
+
+// tamperExtra adapts a header-extra mutator into the [types.Header] mutator that
+// [SUT.verifyTampered] expects.
+func tamperExtra(mut func(*customtypes.HeaderExtra)) func(*types.Header) {
+	return func(hdr *types.Header) {
+		mut(customtypes.GetHeaderExtra(hdr))
+	}
 }
 
 // acceptAndExecute accepts blk and blocks until it has been executed.
@@ -1181,9 +1213,9 @@ func TestVerifyBlockRejectsTamperedHeader(t *testing.T) {
 			require.NoErrorf(t, sut.IssueTx(ctx, stx), "%T.IssueTx()", sut.Client)
 			valid := sut.buildVerify(ctx, t, sut.lastAccepted(ctx, t))
 
-			err := sut.verifyTampered(ctx, t, valid, func(e *customtypes.HeaderExtra) {
+			err := sut.verifyTampered(ctx, t, valid, tamperExtra(func(e *customtypes.HeaderExtra) {
 				tt.tamper(t, e)
-			})
+			}))
 			require.ErrorContainsf(t, err, "hash mismatch", "%T.VerifyBlock(malformed block)", sut.VM)
 		})
 	}
@@ -1197,7 +1229,7 @@ func TestVerifyDuringBootstrappingChecksSettledMarker(t *testing.T) {
 	key := txtest.NewKey(t)
 	alloc := withMaxAllocFor(key.EthAddress())
 
-	timeOpt, clock := withVMTime(upgrade.InitiallyActiveTime)
+	timeOpt, clock := withVMTime(testStartTime)
 	db := memdb.New()
 	ctx, node := newSUT(t, alloc, timeOpt, withDB(db))
 	w := newWallet(key, node.ctx, node.Client)
@@ -1379,6 +1411,60 @@ func TestDynamicTargetExponent(t *testing.T) {
 	}
 }
 
+// TestDynamicMinDelayExcess verifies each built block's MinDelayExcess steps
+// toward the node's ACP-226 vote by at most the per-block cap, and holds at the
+// initial value with no vote.
+func TestDynamicMinDelayExcess(t *testing.T) {
+	const maxDiff = 200
+	tests := []struct {
+		name    string
+		desired *uint64
+		want    []dynamic.DelayExponent
+	}{
+		{
+			name: "unset",
+			want: []dynamic.DelayExponent{dynamic.InitialDelayExponent},
+		},
+		{
+			name:    "votes_up_capped",
+			desired: utils.PointerTo[uint64](4000), // above the ~2000ms initial
+			want: []dynamic.DelayExponent{
+				dynamic.InitialDelayExponent + maxDiff,
+				dynamic.InitialDelayExponent + 2*maxDiff,
+			},
+		},
+		{
+			name:    "votes_down_capped",
+			desired: utils.PointerTo[uint64](1000),
+			want: []dynamic.DelayExponent{
+				dynamic.InitialDelayExponent - maxDiff,
+				dynamic.InitialDelayExponent - 2*maxDiff,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			key := txtest.NewKey(t)
+			timeOpt, clock := withVMTime(testStartTime)
+			opts := []sutOption{withMaxAllocFor(key.EthAddress()), timeOpt}
+			if test.desired != nil {
+				opts = append(opts, withMinDelayTarget(*test.desired))
+			}
+			ctx, sut := newSUT(t, opts...)
+			w := newWallet(key, sut.ctx, sut.Client)
+
+			for _, wantExponent := range test.want {
+				blk := sut.issueAndExecute(ctx, t, w.newMinimalTx(t))
+				he := customtypes.GetHeaderExtra(blk.Header())
+				require.NotNilf(t, he.MinDelayExcess, "block %d %T.MinDelayExcess", blk.Height(), he)
+				got := dynamic.DelayExponent(*he.MinDelayExcess)
+				assert.Equalf(t, wantExponent, got, "block %d %T.MinDelayExcess", blk.Height(), he)
+				clock.Advance(got.DelayDuration())
+			}
+		})
+	}
+}
+
 // TestGasRefundsDisabled asserts that EVM gas refunds are disabled.
 func TestGasRefundsDisabled(t *testing.T) {
 	w := saetest.NewUNSAFEWallet(t, 1, types.LatestSigner(saetest.ChainConfig()))
@@ -1420,6 +1506,107 @@ func TestGasRefundsDisabled(t *testing.T) {
 
 	const gasIfRefunded = wantGasUsed - ethparams.SstoreClearsScheduleRefundEIP3529
 	assert.Equalf(t, wantGasUsed, receipt.GasUsed, "gas charged (would be %d if refunds were enabled)", gasIfRefunded)
+}
+
+func TestVerifyRejectsBlockTimeBelowMinDelay(t *testing.T) {
+	key := txtest.NewKey(t)
+	timeOpt, clock := withVMTime(testStartTime)
+	ctx, sut := newSUT(t, withMaxAllocFor(key.EthAddress()), timeOpt)
+	w := newWallet(key, sut.ctx, sut.Client)
+
+	parent := sut.issueAndExecute(ctx, t, w.newMinimalTx(t))
+	clock.Set(earliestBuildTime(parent))
+	require.NoErrorf(t, sut.IssueTx(ctx, w.newMinimalTx(t)), "%T.IssueTx()", sut.Client)
+	child := sut.buildVerify(ctx, t, sut.lastAccepted(ctx, t))
+
+	earlyMS := uint64(earliestBuildTime(parent).UnixMilli()) - 1 //#nosec G115 -- Known non-negative
+	err := sut.verifyTampered(ctx, t, child, func(hdr *types.Header) {
+		hdr.Time = earlyMS / 1000
+		tamperExtra(func(e *customtypes.HeaderExtra) {
+			e.TimeMilliseconds = &earlyMS
+		})(hdr)
+	})
+	require.ErrorIsf(t, err, errBelowMinBlockDelay, "%T.VerifyBlock() (block below the ACP-226 minimum delay)", sut.VM)
+}
+
+// TestWaitForEventMinDelayPacing exercises WaitForEvent's ACP-226 min-delay
+// pacing under synctest: the call stays blocked on the pacing timer until it is
+// released, either by the timer firing (returning PendingTxs) or by the context
+// being canceled (returning the cancellation cause). synctest lets us assert
+// "still blocked" without a real-time grace window.
+func TestWaitForEventMinDelayPacing(t *testing.T) {
+	type result struct {
+		msg snowcommon.Message
+		err error
+	}
+	tests := []struct {
+		name string
+		// cancelDuringDelay releases WaitForEvent by canceling its context while
+		// it is parked on the pacing timer. When false, synctest advances the
+		// fake clock to fire the timer instead.
+		cancelDuringDelay bool
+		wantMsg           snowcommon.Message
+		wantErr           error
+	}{
+		{
+			name:    "timer_fires",
+			wantMsg: snowcommon.PendingTxs,
+		},
+		{
+			name:              "context_canceled",
+			cancelDuringDelay: true,
+			wantErr:           context.Canceled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				// Build an in-process SUT with no real RPC transport: real
+				// sockets never reach a durable block under synctest, so the
+				// txpool is primed directly via the gossip set rather than
+				// through the absent Client. The SUT is a fully-initialized VM in
+				// [snow.NormalOp] whose only block is genesis (also its current
+				// preference), with exactly one pending transaction.
+				//
+				// Do not build/execute blocks: these tests are only
+				// synctest-teardown-safe because they run no blocks (a block can
+				// reactivate a goleak-suppressed libevm shutdown race that
+				// deadlocks the bubble).
+				key := txtest.NewKey(t)
+				timeOpt, _ := withVMTime(upgrade.InitiallyActiveTime)
+				ctx, sut := newSUT(t, withMaxAllocFor(key.EthAddress()), timeOpt, withoutRPCTransport())
+				w := newWallet(key, sut.ctx, nil)
+
+				gossipTx := toGossipTx(w.newMinimalTx(t))
+				require.NoErrorf(t, sut.gossipSet.Add(gossipTx), "%T.Add()", sut.gossipSet)
+
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+
+				done := make(chan result, 1)
+				go func() {
+					msg, err := sut.WaitForEvent(ctx)
+					done <- result{msg, err}
+				}()
+
+				// Blocked on the pacing timer until we release it.
+				synctest.Wait()
+				require.Emptyf(t, done, "%T.WaitForEvent() should be blocked on the min delay", sut.VM)
+
+				if test.cancelDuringDelay {
+					cancel()
+				}
+
+				got := <-done
+				if test.wantErr != nil {
+					require.ErrorIsf(t, got.err, test.wantErr, "%T.WaitForEvent()", sut.VM)
+				} else {
+					require.NoErrorf(t, got.err, "%T.WaitForEvent()", sut.VM)
+				}
+				require.Equalf(t, test.wantMsg, got.msg, "%T.WaitForEvent() event", sut.VM)
+			})
+		})
+	}
 }
 
 // TestEmptyBlocksDisallowed asserts that empty blocks are not allowed.

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -1598,11 +1598,7 @@ func TestWaitForEventMinDelayPacing(t *testing.T) {
 				}
 
 				got := <-done
-				if test.wantErr != nil {
-					require.ErrorIsf(t, got.err, test.wantErr, "%T.WaitForEvent()", sut.VM)
-				} else {
-					require.NoErrorf(t, got.err, "%T.WaitForEvent()", sut.VM)
-				}
+				require.ErrorIsf(t, got.err, test.wantErr, "%T.WaitForEvent()", sut.VM)
 				require.Equalf(t, test.wantMsg, got.msg, "%T.WaitForEvent() event", sut.VM)
 			})
 		})

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -1538,10 +1538,7 @@ func TestVerifyRejectsBlockTimeBelowMinDelay(t *testing.T) {
 }
 
 // TestWaitForEventMinDelayPacing exercises WaitForEvent's ACP-226 min-delay
-// pacing under synctest: the call stays blocked on the pacing timer until it is
-// released, either by the timer firing (returning PendingTxs) or by the context
-// being canceled (returning the cancellation cause). synctest lets us assert
-// "still blocked" without a real-time grace window.
+// pacing.
 func TestWaitForEventMinDelayPacing(t *testing.T) {
 	type result struct {
 		msg snowcommon.Message

--- a/vms/saevm/sae/consensus.go
+++ b/vms/saevm/sae/consensus.go
@@ -33,9 +33,7 @@ func (vm *VM) SetPreference(ctx context.Context, id ids.ID, _ *block.Context) er
 }
 
 // GetPreference returns the block the VM would currently build on top of, as
-// set by [VM.SetPreference]. It never returns nil: [NewVM] initializes the
-// preference to the last executed block, and SetPreference only overwrites it
-// with a block it successfully retrieved.
+// set by [NewVM] and [VM.SetPreference]. It never returns nil.
 func (vm *VM) GetPreference() *blocks.Block {
 	return vm.preference.Load()
 }

--- a/vms/saevm/sae/consensus.go
+++ b/vms/saevm/sae/consensus.go
@@ -33,7 +33,9 @@ func (vm *VM) SetPreference(ctx context.Context, id ids.ID, _ *block.Context) er
 }
 
 // GetPreference returns the block the VM would currently build on top of, as
-// set by [VM.SetPreference]. It returns nil before the first SetPreference.
+// set by [VM.SetPreference]. It never returns nil: [NewVM] initializes the
+// preference to the last executed block, and SetPreference only overwrites it
+// with a block it successfully retrieved.
 func (vm *VM) GetPreference() *blocks.Block {
 	return vm.preference.Load()
 }

--- a/vms/saevm/sae/consensus.go
+++ b/vms/saevm/sae/consensus.go
@@ -32,6 +32,12 @@ func (vm *VM) SetPreference(ctx context.Context, id ids.ID, _ *block.Context) er
 	return nil
 }
 
+// GetPreference returns the block the VM would currently build on top of, as
+// set by [VM.SetPreference]. It returns nil before the first SetPreference.
+func (vm *VM) GetPreference() *blocks.Block {
+	return vm.preference.Load()
+}
+
 // AcceptBlock marks the block as [accepted], resulting in:
 //   - All blocks settled by this block having their [blocks.Block.MarkSettled]
 //     method called; and


### PR DESCRIPTION
## Why this should be merged

Implements [ACP-226 (dynamic minimum block times)](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/226-dynamic-minimum-block-times) for SAE, closing #5455. Blocks must now be spaced at least a parent-dictated minimum delay apart, and the delay is a dynamic parameter each node votes on — mirroring how ACP-176 (gas target) and ACP-283 (min price) are already handled.

## How this works

**Config vote.** A new C-Chain config field `min-delay-target` (milliseconds, `*uint64`; `nil` = follow the parent) is wired through `config.desired()` into `desiredParams.delayExponent` via `dynamic.DesiredDelayExponent`.

**Dynamic parameter (`dynamic/delay.go`).** `DelayExponent` encodes the minimum block delay as `minimum·e^(exponent/conversionRate)` (minimum = 1ms, conversionRate = 2²⁰), matching the ACP-226 spec:
- `Delay()` decodes to milliseconds; `DelayDuration()` returns it as a `time.Duration`.
- `Toward()` moves the exponent toward the node's vote, capped at 200 per block.
- `InitialDelayExponent` is the genesis seed decoding to exactly 2000ms.

**Enforcement (`hooks.go`).** `builder.BuildHeader` reads the parent's delay exponent (`delayExponent`, defaulting to `InitialDelayExponent` when the header carries none), and rejects any block whose timestamp is earlier than `parentTime + delay` with `errBelowMinBlockDelay`. It then moves the exponent toward this node's vote and records the result in the header's `MinDelayExcess`. Because `VM.VerifyBlock` re-runs `BuildHeader` via `BlockRebuilderFrom` (with `now()` pinned to the block's own timestamp), the identical check rejects too-early blocks received from peers.

**Build pacing (`vm.go`).** `VM.WaitForEvent` now, after the txpool/SAE-event race resolves, holds the build-ready signal back until the preferred block's minimum delay has elapsed, so the engine never builds faster than ACP-226 permits.

## How this was tested

New unit tests (all under `vms/saevm/cchain`).

## Need to be documented in RELEASES.md?

No
