### PR TITLE
project(sidecar): Add oracle sidecar binary with Solana verifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ awscpu
 
 # Test binary, build with `go test -c`
 *.test
+
+# Built sidecar binary (the /sidecar rule ignores the binary; !/sidecar/ re-includes the source dir)
+/sidecar
+!/sidecar/
 tmp/
 
 # Output of the go coverage tool, specifically when used with LiteIDE

--- a/graft/subnet-evm/plugin/evm/BUILD.bazel
+++ b/graft/subnet-evm/plugin/evm/BUILD.bazel
@@ -73,6 +73,8 @@ go_library(
         "//network/p2p",
         "//network/p2p/acp118",
         "//network/p2p/gossip",
+        "//network/p2p/oracle",
+        "//network/p2p/oracle/validator",
         "//snow",
         "//snow/consensus/snowman",
         "//snow/engine/common",

--- a/graft/subnet-evm/plugin/evm/config/config.go
+++ b/graft/subnet-evm/plugin/evm/config/config.go
@@ -21,6 +21,18 @@ type (
 	}
 )
 
+// OracleSidecarConfig holds operator-supplied settings for the oracle sidecar verifier.
+type OracleSidecarConfig struct {
+	// Endpoint is the gRPC address of the sidecar process, e.g. "127.0.0.1:9900".
+	// If empty, the oracle verifier is not registered.
+	Endpoint string `json:"endpoint"`
+	// AllowedSources is the explicit list of source types this validator will
+	// sign oracle attestations for, e.g. ["solana"]. Required when Endpoint is
+	// set. Each entry is validated against the compile-time registry in
+	// network/p2p/oracle at startup.
+	AllowedSources []string `json:"allowed-sources"`
+}
+
 // Config ...
 type Config struct {
 	// Airdrop
@@ -187,6 +199,9 @@ type Config struct {
 
 	// Database Scheme
 	StateScheme string `json:"state-scheme"`
+
+	// Oracle is the configuration for the oracle sidecar verifier.
+	Oracle OracleSidecarConfig `json:"oracle"`
 }
 
 // GetConfig returns a new config object with the default values set and the

--- a/graft/subnet-evm/plugin/evm/vm.go
+++ b/graft/subnet-evm/plugin/evm/vm.go
@@ -85,6 +85,8 @@ import (
 	handlerstats "github.com/ava-labs/avalanchego/graft/evm/sync/handlers/stats"
 	subnetevmlog "github.com/ava-labs/avalanchego/graft/subnet-evm/plugin/evm/log"
 	avalanchegossip "github.com/ava-labs/avalanchego/network/p2p/gossip"
+	oraclepkg "github.com/ava-labs/avalanchego/network/p2p/oracle"
+	p2poracle "github.com/ava-labs/avalanchego/network/p2p/oracle/validator"
 	commonEng "github.com/ava-labs/avalanchego/snow/engine/common"
 	avalancheUtils "github.com/ava-labs/avalanchego/utils"
 	avajson "github.com/ava-labs/avalanchego/utils/json"
@@ -497,9 +499,39 @@ func (vm *VM) Initialize(
 		return err
 	}
 
+	if vm.config.Oracle.Endpoint != "" {
+		if len(vm.config.Oracle.AllowedSources) == 0 {
+			return errors.New("oracle.endpoint is set but oracle.allowed-sources is empty; both are required to register the oracle handler")
+		}
+		allowed := make(map[string]struct{}, len(vm.config.Oracle.AllowedSources))
+		for _, sourceType := range vm.config.Oracle.AllowedSources {
+			if !oraclepkg.IsKnownSourceType(sourceType) {
+				return fmt.Errorf("oracle.allowed-sources contains unknown source type %q; register it in network/p2p/oracle first", sourceType)
+			}
+			allowed[sourceType] = struct{}{}
+		}
+		sidecar, err := p2poracle.NewGRPCSidecarClient(vm.config.Oracle.Endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to create oracle gRPC client: %w", err)
+		}
+		if err := vm.registerOracleHandler(p2poracle.NewOracleVerifier(sidecar, allowed)); err != nil {
+			return fmt.Errorf("failed to register oracle handler: %w", err)
+		}
+	}
+
 	vm.stateSyncDone = make(chan struct{})
 
 	return vm.initializeStateSync(lastAcceptedHeight)
+}
+
+func (vm *VM) registerOracleHandler(verifier acp118.Verifier) error {
+	cache := lru.NewCache[ids.ID, []byte](warpSignatureCacheSize)
+	meteredCache, err := metercacher.New("oracle_signature_cache", vm.sdkMetrics, cache)
+	if err != nil {
+		return fmt.Errorf("failed to create oracle signature cache: %w", err)
+	}
+	handler := acp118.NewCachedHandler(meteredCache, verifier, vm.ctx.WarpSigner)
+	return vm.P2PNetwork().AddHandler(p2poracle.SignatureRequestHandlerID, handler)
 }
 
 func parseGenesis(ctx *snow.Context, genesisBytes []byte, upgradeBytes []byte, airdropFile string) (*core.Genesis, error) {

--- a/proto/oracle/oracle.proto
+++ b/proto/oracle/oracle.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // gRPC service defining the oracle attestation contract between AvalancheGo

--- a/proto/pb/oracle/oracle.pb.go
+++ b/proto/pb/oracle/oracle.pb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // gRPC service defining the oracle attestation contract between AvalancheGo

--- a/proto/pb/oracle/oracle_grpc.pb.go
+++ b/proto/pb/oracle/oracle_grpc.pb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // gRPC service defining the oracle attestation contract between AvalancheGo

--- a/sidecar/BUILD.bazel
+++ b/sidecar/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//.bazel:defs.bzl", "go_test")
+
+go_library(
+    name = "sidecar_lib",
+    srcs = [
+        "main.go",
+        "server.go",
+    ],
+    importpath = "github.com/ava-labs/avalanchego/sidecar",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//network/p2p/oracle",
+        "//proto/pb/oracle",
+        "//sidecar/config",
+        "//sidecar/solanarpc",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_binary(
+    name = "sidecar",
+    embed = [":sidecar_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "sidecar_test",
+    srcs = ["server_test.go"],
+    embed = [":sidecar_lib"],
+    deps = [
+        "//network/p2p/oracle",
+        "//proto/pb/oracle",
+        "@com_github_ava_labs_libevm//common",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/sidecar/config/BUILD.bazel
+++ b/sidecar/config/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "go_test")
+
+go_library(
+    name = "config",
+    srcs = ["config.go"],
+    importpath = "github.com/ava-labs/avalanchego/sidecar/config",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    embed = [":config"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/sidecar/config/config.go
+++ b/sidecar/config/config.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// Package config defines the on-disk config file shared by the sidecar binary
+// and the AvalancheGo validator. The sidecar consumes verifier bodies; the
+// validator reads only the Verifiers map keys.
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+var (
+	ErrRead        = errors.New("failed to read sidecar config")
+	ErrParse       = errors.New("failed to parse sidecar config")
+	ErrNoVerifiers = errors.New("sidecar config has no verifiers")
+)
+
+type SidecarConfig struct {
+	BindAddr  string                     `json:"bind_addr"`
+	Verifiers map[string]json.RawMessage `json:"verifiers"`
+}
+
+func Load(path string) (*SidecarConfig, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w %s: %w", ErrRead, path, err)
+	}
+	var cfg SidecarConfig
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return nil, fmt.Errorf("%w %s: %w", ErrParse, path, err)
+	}
+	if len(cfg.Verifiers) == 0 {
+		return nil, ErrNoVerifiers
+	}
+	return &cfg, nil
+}
+
+// SourceTypes returns the Verifiers map keys. Contract with the validator:
+// reshaping Verifiers requires updating graft/subnet-evm/plugin/evm/vm.go's loader.
+func (c *SidecarConfig) SourceTypes() []string {
+	out := make([]string, 0, len(c.Verifiers))
+	for k := range c.Verifiers {
+		out = append(out, k)
+	}
+	return out
+}

--- a/sidecar/config/config_test.go
+++ b/sidecar/config/config_test.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		wantErr      error
+		wantTypes    []string
+		wantBindAddr string
+	}{
+		{
+			name: "happy path single verifier",
+			content: `{
+				"bind_addr": ":9900",
+				"verifiers": {
+					"solana": {"rpc_url": "https://api.devnet.solana.com"}
+				}
+			}`,
+			wantTypes:    []string{"solana"},
+			wantBindAddr: ":9900",
+		},
+		{
+			name: "multiple verifiers",
+			content: `{
+				"bind_addr": ":9900",
+				"verifiers": {
+					"solana":   {"rpc_url": "x"},
+					"polkadot": {"rpc_url": "y"}
+				}
+			}`,
+			wantTypes:    []string{"polkadot", "solana"},
+			wantBindAddr: ":9900",
+		},
+		{
+			name:    "malformed json",
+			content: `{ this is not json`,
+			wantErr: ErrParse,
+		},
+		{
+			name:    "empty verifiers map",
+			content: `{"bind_addr": ":9900", "verifiers": {}}`,
+			wantErr: ErrNoVerifiers,
+		},
+		{
+			name:    "missing verifiers field",
+			content: `{"bind_addr": ":9900"}`,
+			wantErr: ErrNoVerifiers,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTemp(t, tt.content)
+			cfg, err := Load(path)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBindAddr, cfg.BindAddr)
+			got := cfg.SourceTypes()
+			slices.Sort(got)
+			require.Equal(t, tt.wantTypes, got)
+		})
+	}
+}
+
+func TestLoadFileNotFound(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	require.ErrorIs(t, err, ErrRead)
+}

--- a/sidecar/config/sample-sidecar-config.json
+++ b/sidecar/config/sample-sidecar-config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Sample sidecar config. This same file is read by (a) the sidecar binary at startup to register verifiers, (b) each validator whose oracle.sidecar-config-path points at it to derive the allowed source-type set, and (c) optionally by icm-services/solana-observer via its sidecar_config_path field to derive which programs to watch. Top-level `verifiers` keys must be registered in network/p2p/oracle KnownSourceTypes.",
+
+  "bind_addr": ":9900",
+
+  "verifiers": {
+    "solana": {
+      "rpc_url": "https://api.devnet.solana.com",
+      "allowed_programs": [
+        "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+      ]
+    }
+  }
+}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
+	"google.golang.org/grpc"
+
+	"github.com/ava-labs/avalanchego/network/p2p/oracle"
+	"github.com/ava-labs/avalanchego/sidecar/config"
+	"github.com/ava-labs/avalanchego/sidecar/solanarpc"
+
+	pb "github.com/ava-labs/avalanchego/proto/pb/oracle"
+)
+
+// Add a case here when registering a new source type in
+// network/p2p/oracle/message.go (KnownSourceTypes).
+func buildVerifier(sourceType string, body json.RawMessage) (oracleVerifier, error) {
+	switch sourceType {
+	case oracle.SourceTypeSolana:
+		return solanarpc.NewSolanaVerifier(body, nil)
+	default:
+		return nil, fmt.Errorf("no verifier implementation for source type %q", sourceType)
+	}
+}
+
+func main() {
+	addr := flag.String("addr", "", "address to listen on (overrides bind_addr in config)")
+	configPath := flag.String("config-path", "", "path to sidecar config file (required)")
+	flag.Parse()
+
+	if *configPath == "" {
+		log.Fatal("--config-path is required")
+	}
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		log.Fatalf("failed to load sidecar config: %v", err)
+	}
+
+	verifiers := make(map[string]oracleVerifier, len(cfg.Verifiers))
+	for sourceType, body := range cfg.Verifiers {
+		if !oracle.IsKnownSourceType(sourceType) {
+			log.Fatalf("sidecar config declares unknown source type %q; register it in network/p2p/oracle first", sourceType)
+		}
+		v, err := buildVerifier(sourceType, body)
+		if err != nil {
+			log.Fatalf("failed to build %q verifier: %v", sourceType, err)
+		}
+		verifiers[sourceType] = v
+	}
+
+	bindAddr := cfg.BindAddr
+	if *addr != "" {
+		bindAddr = *addr
+	}
+	if bindAddr == "" {
+		log.Fatal("no bind address: set --addr or bind_addr in config")
+	}
+
+	lis, err := net.Listen("tcp", bindAddr)
+	if err != nil {
+		log.Fatalf("failed to listen on %s: %v", bindAddr, err)
+	}
+
+	grpcServer := grpc.NewServer()
+	pb.RegisterOracleSidecarServer(grpcServer, NewServer(verifiers))
+
+	log.Printf("starting oracle sidecar (gRPC) on %s with verifiers %v", bindAddr, keys(verifiers))
+	if err := grpcServer.Serve(lis); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}
+
+func keys(m map[string]oracleVerifier) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -24,7 +24,7 @@ import (
 func buildVerifier(sourceType string, body json.RawMessage) (oracleVerifier, error) {
 	switch sourceType {
 	case oracle.SourceTypeSolana:
-		return solanarpc.NewSolanaVerifier(body, nil)
+		return solanarpc.NewSolanaVerifier(body)
 	default:
 		return nil, fmt.Errorf("no verifier implementation for source type %q", sourceType)
 	}

--- a/sidecar/server.go
+++ b/sidecar/server.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ava-labs/avalanchego/network/p2p/oracle"
+
+	pb "github.com/ava-labs/avalanchego/proto/pb/oracle"
+)
+
+type oracleVerifier interface {
+	Verify(ctx context.Context, msg *oracle.OracleMessage, justification []byte) error
+}
+
+// Server routes each VerifyRequest to the verifier registered for
+// msg.SourceType. Unknown source types return InvalidArgument.
+type Server struct {
+	pb.UnimplementedOracleSidecarServer
+	verifiers map[string]oracleVerifier
+}
+
+func NewServer(verifiers map[string]oracleVerifier) *Server {
+	return &Server{verifiers: verifiers}
+}
+
+func (s *Server) Verify(ctx context.Context, req *pb.VerifyRequest) (*pb.VerifyResponse, error) {
+	msg, err := oracle.ParseOracleMessage(req.MessageBytes)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse OracleMessage: %v", err)
+	}
+
+	v, ok := s.verifiers[msg.SourceType]
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "no verifier registered for source type %q", msg.SourceType)
+	}
+
+	if err := v.Verify(ctx, msg, req.Justification); err != nil {
+		if errors.Is(err, oracle.ErrSourceUnavailable) {
+			return nil, status.Errorf(codes.Unavailable, "source chain unavailable: %v", err)
+		}
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	return &pb.VerifyResponse{}, nil
+}

--- a/sidecar/server_test.go
+++ b/sidecar/server_test.go
@@ -1,0 +1,116 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ava-labs/avalanchego/network/p2p/oracle"
+
+	pb "github.com/ava-labs/avalanchego/proto/pb/oracle"
+)
+
+// mockVerifier is a test double for oracleVerifier. It returns the configured
+// error, allowing server_test.go to stay independent of any chain implementation.
+type mockVerifier struct {
+	err error
+}
+
+func (m *mockVerifier) Verify(_ context.Context, _ *oracle.OracleMessage, _ []byte) error {
+	return m.err
+}
+
+// validMsgBytes returns ABI-encoded bytes for a well-formed OracleMessage,
+// suitable as pb.VerifyRequest.MessageBytes in tests that reach the verifier.
+func validMsgBytes(t *testing.T) []byte {
+	t.Helper()
+	msg, err := oracle.NewOracleMessage(oracle.SourceTypeSolana, "So11111111111111111111111111111111111111112", common.Address{1, 2, 3}, 100, 1, []byte("payload"))
+	require.NoError(t, err)
+	return msg.Bytes()
+}
+
+// unsupportedMsgBytes returns ABI-encoded bytes for a message with a source
+// type the test server has no verifier for.
+func unsupportedMsgBytes(t *testing.T) []byte {
+	t.Helper()
+	msg, err := oracle.NewOracleMessage("bitcoin", "addr", common.Address{}, 100, 1, []byte("payload"))
+	require.NoError(t, err)
+	return msg.Bytes()
+}
+
+func TestServer_Verify(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *pb.VerifyRequest
+		verifiers map[string]oracleVerifier
+		wantCode  codes.Code
+	}{
+		{
+			name:      "invalid message bytes returns InvalidArgument",
+			req:       &pb.VerifyRequest{MessageBytes: []byte("not-abi"), Justification: make([]byte, 64)},
+			verifiers: map[string]oracleVerifier{oracle.SourceTypeSolana: &mockVerifier{}},
+			wantCode:  codes.InvalidArgument,
+		},
+		{
+			// Verifier wraps oracle.ErrSourceUnavailable when the source chain RPC
+			// is unreachable; server maps this to codes.Unavailable.
+			name:      "source unavailable returns Unavailable",
+			req:       &pb.VerifyRequest{MessageBytes: validMsgBytes(t), Justification: make([]byte, 64)},
+			verifiers: map[string]oracleVerifier{oracle.SourceTypeSolana: &mockVerifier{err: fmt.Errorf("%w: rpc failed", oracle.ErrSourceUnavailable)}},
+			wantCode:  codes.Unavailable,
+		},
+		{
+			name:      "verifier rejection returns InvalidArgument",
+			req:       &pb.VerifyRequest{MessageBytes: validMsgBytes(t), Justification: make([]byte, 64)},
+			verifiers: map[string]oracleVerifier{oracle.SourceTypeSolana: &mockVerifier{err: errors.New("slot mismatch: got 99, want 100")}},
+			wantCode:  codes.InvalidArgument,
+		},
+		{
+			name:      "valid request returns OK",
+			req:       &pb.VerifyRequest{MessageBytes: validMsgBytes(t), Justification: make([]byte, 64)},
+			verifiers: map[string]oracleVerifier{oracle.SourceTypeSolana: &mockVerifier{}},
+			wantCode:  codes.OK,
+		},
+		{
+			// SourceType not registered → InvalidArgument, no verifier call.
+			name:      "unregistered source type returns InvalidArgument",
+			req:       &pb.VerifyRequest{MessageBytes: unsupportedMsgBytes(t), Justification: make([]byte, 64)},
+			verifiers: map[string]oracleVerifier{oracle.SourceTypeSolana: &mockVerifier{}},
+			wantCode:  codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := NewServer(tt.verifiers)
+			resp, err := srv.Verify(t.Context(), tt.req)
+			require.Equal(t, tt.wantCode, status.Code(err))
+			if tt.wantCode == codes.OK {
+				require.NotNil(t, resp)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServer_PayloadRoundtrip(t *testing.T) {
+	want, err := oracle.NewOracleMessage(oracle.SourceTypeSolana, "So11111111111111111111111111111111111111112", common.Address{}, 100, 1, []byte("payload"))
+	require.NoError(t, err)
+
+	srv := NewServer(map[string]oracleVerifier{oracle.SourceTypeSolana: &mockVerifier{}})
+	resp, err := srv.Verify(t.Context(), &pb.VerifyRequest{
+		MessageBytes:  want.Bytes(),
+		Justification: make([]byte, 64),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}

--- a/sidecar/solanarpc/BUILD.bazel
+++ b/sidecar/solanarpc/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "go_test")
+
+go_library(
+    name = "solanarpc",
+    srcs = [
+        "rpc.go",
+        "verifier.go",
+    ],
+    importpath = "github.com/ava-labs/avalanchego/sidecar/solanarpc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//network/p2p/oracle",
+        "@com_github_mr_tron_base58//:base58",
+    ],
+)
+
+go_test(
+    name = "solanarpc_test",
+    srcs = [
+        "integration_test.go",
+        "verifier_test.go",
+    ],
+    embed = [":solanarpc"],
+    deps = [
+        "//network/p2p/oracle",
+        "@com_github_ava_labs_libevm//common",
+        "@com_github_mr_tron_base58//:base58",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/sidecar/solanarpc/integration_test.go
+++ b/sidecar/solanarpc/integration_test.go
@@ -1,0 +1,403 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package solanarpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/network/p2p/oracle"
+)
+
+// newVerifier is a test helper that constructs a SolanaVerifier from a plain
+// RPC URL, marshaling it into the Config shape the verifier expects.
+func newVerifier(t *testing.T, rpcURL string) *SolanaVerifier {
+	t.Helper()
+	cfgBytes, err := json.Marshal(Config{RPCURL: rpcURL})
+	require.NoError(t, err)
+	v, err := NewSolanaVerifier(cfgBytes, nil)
+	require.NoError(t, err)
+	return v
+}
+
+// memoProgram is the Solana Memo Program v2 address. It exists on both mainnet
+// and devnet and almost always has recent transactions, making it a reliable
+// source of real on-chain data for integration testing.
+const memoProgram = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+
+// atokenProgram is the Associated Token Account Program. Almost every DeFi
+// wallet interaction creates ATAs, so it reliably produces CPI transactions
+// (it calls the Token Program and System Program via CPI).
+const atokenProgram = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJe8bXh"
+
+// fetchSignatures fetches up to limit recent transaction signatures for address
+// from rpcURL. Returns only the signature strings (errors from the RPC are fatal).
+func fetchSignatures(t *testing.T, rpcURL, address string, limit int) []string {
+	t.Helper()
+
+	reqBody, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "getSignaturesForAddress",
+		"params":  []any{address, map[string]any{"limit": limit}},
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, rpcURL, bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var result struct {
+		Result []struct {
+			Signature string `json:"signature"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+	}
+	require.NoError(t, json.Unmarshal(body, &result))
+	if result.Error != nil {
+		t.Fatalf("getSignaturesForAddress RPC error: %s", result.Error.Message)
+	}
+
+	sigs := make([]string, 0, len(result.Result))
+	for _, r := range result.Result {
+		sigs = append(sigs, r.Signature)
+	}
+	return sigs
+}
+
+// fetchRecentMemoTxSig fetches the most recent transaction signature that
+// involved the Memo Program from the given Solana RPC endpoint.
+func fetchRecentMemoTxSig(t *testing.T, rpcURL string) string {
+	t.Helper()
+	sigs := fetchSignatures(t, rpcURL, memoProgram, 1)
+	if len(sigs) == 0 {
+		t.Skip("no recent Memo Program transactions found at SOLANA_RPC_URL — try again later or use a busier endpoint")
+	}
+	return sigs[0]
+}
+
+// buildEffectiveKeys mirrors the key-space construction in verifier.go so that
+// test helpers and verifier.Verify stay consistent as the code evolves.
+func buildEffectiveKeys(tx *txResult) []string {
+	keys := make([]string, len(tx.Transaction.Message.AccountKeys))
+	copy(keys, tx.Transaction.Message.AccountKeys)
+	keys = append(keys, tx.Meta.LoadedAddresses.Writable...)
+	keys = append(keys, tx.Meta.LoadedAddresses.Readonly...)
+	return keys
+}
+
+// findTxWithInnerInstructions searches recent AToken Program transactions for
+// one that has at least one inner instruction group with usable data. Returns
+// the signature and parsed txResult. Skips the test if none found.
+func findTxWithInnerInstructions(t *testing.T, rpcURL string) (string, *txResult) {
+	t.Helper()
+	client := newSolanaClient(rpcURL, nil)
+	sigs := fetchSignatures(t, rpcURL, atokenProgram, 50)
+	if len(sigs) == 0 {
+		t.Skip("no recent AToken Program transactions — try again later or use a busier endpoint")
+	}
+	for _, sig := range sigs {
+		tx, err := client.getTransaction(t.Context(), sig)
+		if err != nil || tx == nil {
+			continue
+		}
+		if len(tx.Meta.InnerInstructions) == 0 {
+			continue
+		}
+		// Require at least one inner instruction with decodeable data.
+		keys := buildEffectiveKeys(tx)
+		for _, group := range tx.Meta.InnerInstructions {
+			for _, instr := range group.Instructions {
+				if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
+					continue
+				}
+				if _, decErr := base58.Decode(instr.Data); decErr == nil {
+					return sig, tx
+				}
+			}
+		}
+	}
+	t.Skip("no AToken Program transaction with inner-instruction data found in recent 50 signatures")
+	return "", nil
+}
+
+// findV0TxWithLoadedAddresses searches recent Memo Program transactions for one
+// that has non-empty meta.loadedAddresses. Returns the signature and txResult.
+// Skips the test if none found.
+func findV0TxWithLoadedAddresses(t *testing.T, rpcURL string) (string, *txResult) {
+	t.Helper()
+	client := newSolanaClient(rpcURL, nil)
+	sigs := fetchSignatures(t, rpcURL, memoProgram, 100)
+	if len(sigs) == 0 {
+		t.Skip("no recent Memo Program transactions — try again later or use a busier endpoint")
+	}
+	for _, sig := range sigs {
+		tx, err := client.getTransaction(t.Context(), sig)
+		if err != nil || tx == nil {
+			continue
+		}
+		if len(tx.Meta.LoadedAddresses.Writable)+len(tx.Meta.LoadedAddresses.Readonly) > 0 {
+			return sig, tx
+		}
+	}
+	t.Skip("no v0 Memo Program transaction with loadedAddresses found in recent 100 signatures — this is expected on quiet endpoints")
+	return "", nil
+}
+
+// findFirstCPIInstruction returns the program address and decoded payload of the
+// first inner instruction with decodeable data. ok is false if none found.
+func findFirstCPIInstruction(tx *txResult) (programAddr string, payload []byte, ok bool) {
+	keys := buildEffectiveKeys(tx)
+	for _, group := range tx.Meta.InnerInstructions {
+		for _, instr := range group.Instructions {
+			if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
+				continue
+			}
+			data, err := base58.Decode(instr.Data)
+			if err != nil {
+				continue
+			}
+			return keys[instr.ProgramIDIndex], data, true
+		}
+	}
+	return "", nil, false
+}
+
+// TestSolanaVerifierIntegration tests SolanaVerifier against a real Solana RPC
+// for the basic happy path (Memo Program, top-level instruction).
+//
+// Required environment variable:
+//
+//	SOLANA_RPC_URL — e.g. https://api.devnet.solana.com or https://api.mainnet-beta.solana.com
+//
+// The test auto-discovers a recent Memo Program transaction; no transaction
+// signature needs to be supplied manually.
+func TestSolanaVerifierIntegration(t *testing.T) {
+	rpcURL := os.Getenv("SOLANA_RPC_URL")
+	if rpcURL == "" {
+		t.Skip("SOLANA_RPC_URL not set")
+	}
+
+	txSig := fetchRecentMemoTxSig(t, rpcURL)
+	t.Logf("using transaction: %s", txSig)
+
+	// Fetch the full transaction to extract ground truth (slot, program, payload).
+	client := newSolanaClient(rpcURL, nil)
+	tx, err := client.getTransaction(t.Context(), txSig)
+	require.NoError(t, err)
+	require.NotNil(t, tx, "transaction not found — the signature returned by getSignaturesForAddress was not retrievable")
+
+	instrs := tx.Transaction.Message.Instructions
+	keys := tx.Transaction.Message.AccountKeys
+	require.NotEmpty(t, instrs)
+
+	// Find the Memo Program instruction and use its data as ground truth payload.
+	var instrData []byte
+	for _, instr := range instrs {
+		if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
+			continue
+		}
+		if keys[instr.ProgramIDIndex] != memoProgram {
+			continue
+		}
+		data, decodeErr := base58.Decode(instr.Data)
+		if decodeErr != nil {
+			continue
+		}
+		instrData = data
+		break
+	}
+	require.NotNil(t, instrData, "could not find Memo Program instruction in transaction")
+
+	slot := tx.Slot
+	justification, err := base58.Decode(txSig)
+	require.NoError(t, err)
+
+	verifier := newVerifier(t, rpcURL)
+
+	t.Run("valid transaction accepted", func(t *testing.T) {
+		msg, err := oracle.NewOracleMessage("solana", memoProgram, common.Address{}, slot, 1, instrData)
+		require.NoError(t, err)
+		require.NoError(t, verifier.Verify(t.Context(), msg, justification))
+	})
+
+	t.Run("slot off by one rejected", func(t *testing.T) {
+		msg, err := oracle.NewOracleMessage("solana", memoProgram, common.Address{}, slot+1, 1, instrData)
+		require.NoError(t, err)
+		verifyErr := verifier.Verify(t.Context(), msg, justification)
+		require.Errorf(t, verifyErr, "expected slot mismatch error")
+		require.Contains(t, verifyErr.Error(), "slot mismatch")
+	})
+
+	t.Run("payload tampered rejected", func(t *testing.T) {
+		tampered := make([]byte, max(len(instrData), 1))
+		copy(tampered, instrData)
+		tampered[len(tampered)-1] ^= 0xFF
+		msg, err := oracle.NewOracleMessage("solana", memoProgram, common.Address{}, slot, 1, tampered)
+		require.NoError(t, err)
+		verifyErr := verifier.Verify(t.Context(), msg, justification)
+		require.Errorf(t, verifyErr, "expected payload mismatch error")
+		require.Contains(t, verifyErr.Error(), "payload mismatch")
+	})
+
+	t.Run("wrong program rejected", func(t *testing.T) {
+		const systemProgram = "11111111111111111111111111111111"
+		msg, err := oracle.NewOracleMessage("solana", systemProgram, common.Address{}, slot, 1, instrData)
+		require.NoError(t, err)
+		verifyErr := verifier.Verify(t.Context(), msg, justification)
+		require.Errorf(t, verifyErr, "expected program-not-found error")
+		require.Contains(t, verifyErr.Error(), fmt.Sprintf("no instruction found for program %q", systemProgram))
+	})
+}
+
+// TestSolanaVerifierIntegration_CPI verifies that SolanaVerifier correctly finds
+// programs invoked via Cross-Program Invocation (CPI), which appear in
+// meta.innerInstructions rather than transaction.message.instructions.
+//
+// Uses the Associated Token Account Program, which reliably produces CPI calls
+// into the Token Program and System Program on every ATA creation.
+//
+// Requires SOLANA_RPC_URL. Skips automatically if no qualifying transaction is
+// found in the 50 most recent AToken Program transactions.
+func TestSolanaVerifierIntegration_CPI(t *testing.T) {
+	rpcURL := os.Getenv("SOLANA_RPC_URL")
+	if rpcURL == "" {
+		t.Skip("SOLANA_RPC_URL not set")
+	}
+
+	txSig, tx := findTxWithInnerInstructions(t, rpcURL)
+	t.Logf("using CPI transaction: %s", txSig)
+
+	programAddr, payload, ok := findFirstCPIInstruction(tx)
+	require.True(t, ok, "findTxWithInnerInstructions should have guaranteed at least one decodeable inner instruction")
+
+	slot := tx.Slot
+	justification, err := base58.Decode(txSig)
+	require.NoError(t, err)
+
+	verifier := newVerifier(t, rpcURL)
+
+	t.Run("CPI instruction accepted", func(t *testing.T) {
+		msg, err := oracle.NewOracleMessage("solana", programAddr, common.Address{}, slot, 1, payload)
+		require.NoError(t, err)
+		require.NoError(t, verifier.Verify(t.Context(), msg, justification))
+	})
+
+	t.Run("slot off by one rejected", func(t *testing.T) {
+		msg, err := oracle.NewOracleMessage("solana", programAddr, common.Address{}, slot+1, 1, payload)
+		require.NoError(t, err)
+		verifyErr := verifier.Verify(t.Context(), msg, justification)
+		require.Errorf(t, verifyErr, "expected slot mismatch error")
+		require.Contains(t, verifyErr.Error(), "slot mismatch")
+	})
+
+	t.Run("payload tampered rejected", func(t *testing.T) {
+		tampered := make([]byte, max(len(payload), 1))
+		copy(tampered, payload)
+		tampered[len(tampered)-1] ^= 0xFF
+		msg, err := oracle.NewOracleMessage("solana", programAddr, common.Address{}, slot, 1, tampered)
+		require.NoError(t, err)
+		verifyErr := verifier.Verify(t.Context(), msg, justification)
+		require.Errorf(t, verifyErr, "expected payload mismatch error")
+		require.Contains(t, verifyErr.Error(), "payload mismatch")
+	})
+}
+
+// TestSolanaVerifierIntegration_V0LoadedAddresses verifies that SolanaVerifier
+// correctly parses meta.loadedAddresses from v0 transactions and builds the
+// combined key space (static accountKeys + loadedAddresses).
+//
+// Two things are validated:
+//  1. The struct parsing works: we can read non-empty loadedAddresses from a
+//     real v0 transaction (proves rpc.go decodes the JSON correctly).
+//  2. Key space correctness: a loaded address that is NOT referenced as a
+//     programIdIndex in any instruction causes "no instruction found", not a
+//     panic or index-out-of-bounds — confirming the key slice is built right.
+//
+// Note: it is essentially impossible in practice for a program to be IN
+// loadedAddresses (lookup tables hold data accounts, not programs). The test
+// therefore only validates key-space construction, not a full CPI-via-lookup
+// happy path.
+//
+// Requires SOLANA_RPC_URL. Skips automatically if no qualifying v0 transaction
+// is found in the 100 most recent Memo Program transactions.
+func TestSolanaVerifierIntegration_V0LoadedAddresses(t *testing.T) {
+	rpcURL := os.Getenv("SOLANA_RPC_URL")
+	if rpcURL == "" {
+		t.Skip("SOLANA_RPC_URL not set")
+	}
+
+	txSig, tx := findV0TxWithLoadedAddresses(t, rpcURL)
+	t.Logf("using v0 transaction: %s", txSig)
+
+	loaded := append(append([]string(nil), tx.Meta.LoadedAddresses.Writable...), tx.Meta.LoadedAddresses.Readonly...)
+	require.NotEmpty(t, loaded, "findV0TxWithLoadedAddresses should have guaranteed non-empty loadedAddresses")
+
+	t.Logf("loadedAddresses: writable=%d readonly=%d",
+		len(tx.Meta.LoadedAddresses.Writable),
+		len(tx.Meta.LoadedAddresses.Readonly),
+	)
+
+	slot := tx.Slot
+	justification, err := base58.Decode(txSig)
+	require.NoError(t, err)
+
+	verifier := newVerifier(t, rpcURL)
+
+	t.Run("loaded address not invoked returns no-instruction-found", func(t *testing.T) {
+		// Use the first loaded address as the claimed program. It is not
+		// referenced by any programIdIndex, so Verify must return the
+		// "no instruction found" error — not panic or index error.
+		uninvokedAddr := loaded[0]
+		msg, err := oracle.NewOracleMessage("solana", uninvokedAddr, common.Address{}, slot, 1, []byte("anything"))
+		require.NoError(t, err)
+		verifyErr := verifier.Verify(t.Context(), msg, justification)
+		require.ErrorIs(t, verifyErr, ErrInstructionNotFound)
+		require.Contains(t, verifyErr.Error(), "no instruction found for program")
+	})
+
+	t.Run("top-level instruction on v0 transaction accepted", func(t *testing.T) {
+		// Find a top-level instruction that we can verify to confirm the verifier
+		// works end-to-end on this v0 transaction (not just for the error case).
+		keys := buildEffectiveKeys(tx)
+		var foundProgram string
+		var foundPayload []byte
+		for _, instr := range tx.Transaction.Message.Instructions {
+			if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
+				continue
+			}
+			data, decErr := base58.Decode(instr.Data)
+			if decErr != nil {
+				continue
+			}
+			foundProgram = keys[instr.ProgramIDIndex]
+			foundPayload = data
+			break
+		}
+		if foundProgram == "" {
+			t.Skip("no decodeable top-level instruction found in this v0 transaction")
+		}
+		msg, err := oracle.NewOracleMessage("solana", foundProgram, common.Address{}, slot, 1, foundPayload)
+		require.NoError(t, err)
+		require.NoError(t, verifier.Verify(t.Context(), msg, justification))
+	})
+}

--- a/sidecar/solanarpc/integration_test.go
+++ b/sidecar/solanarpc/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ava-labs/libevm/common"
@@ -25,23 +26,47 @@ func newVerifier(t *testing.T, rpcURL string) *SolanaVerifier {
 	t.Helper()
 	cfgBytes, err := json.Marshal(Config{RPCURL: rpcURL})
 	require.NoError(t, err)
-	v, err := NewSolanaVerifier(cfgBytes, nil)
+	v, err := NewSolanaVerifier(cfgBytes)
 	require.NoError(t, err)
 	return v
 }
 
-// memoProgram is the Solana Memo Program v2 address. It exists on both mainnet
-// and devnet and almost always has recent transactions, making it a reliable
-// source of real on-chain data for integration testing.
-const memoProgram = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+// The Solana Memo Program exists in two deployed versions, both live on mainnet
+// and devnet, and both are a reliable source of real on-chain data.
+//
+// Which one is useful depends on the network, so tests accept either. Sampling
+// 30 recent transactions per address on mainnet:
+//
+//	memo v1: invoked as a top-level instruction in 30/30
+//	memo v2: invoked as a top-level instruction in 2/30 — the other 28 merely
+//	         pull v2 into the key space via an address lookup table
+//
+// On devnet v2 is the one that shows up as a top-level instruction. Searching
+// both is what keeps these tests meaningful on mainnet and devnet alike.
+const (
+	memoV1Program = "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo"
+	memoV2Program = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+)
+
+var memoPrograms = []string{memoV1Program, memoV2Program}
 
 // atokenProgram is the Associated Token Account Program. Almost every DeFi
 // wallet interaction creates ATAs, so it reliably produces CPI transactions
 // (it calls the Token Program and System Program via CPI).
-const atokenProgram = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJe8bXh"
+const atokenProgram = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 
-// fetchSignatures fetches up to limit recent transaction signatures for address
-// from rpcURL. Returns only the signature strings (errors from the RPC are fatal).
+// fetchSignatures fetches up to limit recent transaction signatures that
+// *mention* address, via getSignaturesForAddress.
+//
+// Despite the method name, this has nothing to do with signing authority:
+// programs never sign transactions. The RPC indexes address mentions, so a
+// transaction is returned whenever address appears anywhere in its key space —
+// as an invoked program, as a passive account, or merely as an entry loaded
+// through an address lookup table and never invoked at all. Callers that need
+// the address to have actually been invoked must check the instructions
+// themselves.
+//
+// Returns only the signature strings (errors from the RPC are fatal).
 func fetchSignatures(t *testing.T, rpcURL, address string, limit int) []string {
 	t.Helper()
 
@@ -74,6 +99,11 @@ func fetchSignatures(t *testing.T, rpcURL, address string, limit int) []string {
 	}
 	require.NoError(t, json.Unmarshal(body, &result))
 	if result.Error != nil {
+		// Public endpoints throttle aggressively. That is a property of the
+		// endpoint, not a defect in the verifier, so skip rather than fail.
+		if strings.Contains(strings.ToLower(result.Error.Message), "rate limit") {
+			t.Skipf("SOLANA_RPC_URL is rate limiting (%s) — retry later or use a dedicated endpoint", result.Error.Message)
+		}
 		t.Fatalf("getSignaturesForAddress RPC error: %s", result.Error.Message)
 	}
 
@@ -84,15 +114,52 @@ func fetchSignatures(t *testing.T, rpcURL, address string, limit int) []string {
 	return sigs
 }
 
-// fetchRecentMemoTxSig fetches the most recent transaction signature that
-// involved the Memo Program from the given Solana RPC endpoint.
-func fetchRecentMemoTxSig(t *testing.T, rpcURL string) string {
+// findMemoTxWithTopLevelInstruction scans recent transactions mentioning either
+// Memo Program version and returns the first that actually invokes one as a
+// top-level instruction: the signature, the transaction, the invoked program
+// address, and that instruction's decoded data.
+//
+// Two filters matter here, and dropping either produces a test that fails for
+// reasons unrelated to the verifier:
+//
+//   - Invocation. getSignaturesForAddress returns mere mentions, and on mainnet
+//     memo v2 is usually only pulled in by a lookup table, never invoked. Taking
+//     the newest mention therefore finds no Memo instruction most of the time.
+//   - Success. Roughly half of recent memo transactions failed on-chain. A
+//     failed transaction still lists its instructions, but its effects were
+//     rolled back, so it is not a sound basis for asserting a verifier accepts
+//     a real event.
+func findMemoTxWithTopLevelInstruction(t *testing.T, rpcURL string) (string, *txResult, string, []byte) {
 	t.Helper()
-	sigs := fetchSignatures(t, rpcURL, memoProgram, 1)
-	if len(sigs) == 0 {
-		t.Skip("no recent Memo Program transactions found at SOLANA_RPC_URL — try again later or use a busier endpoint")
+	client := newSolanaClient(rpcURL)
+	for _, memoProgram := range memoPrograms {
+		sigs := fetchSignatures(t, rpcURL, memoProgram, 50)
+		for _, sig := range sigs {
+			tx, err := client.getTransaction(t.Context(), sig)
+			if err != nil || tx == nil {
+				continue
+			}
+			if tx.Meta.failed() {
+				continue
+			}
+			keys := buildEffectiveKeys(tx)
+			for _, instr := range tx.Transaction.Message.Instructions {
+				if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
+					continue
+				}
+				if keys[instr.ProgramIDIndex] != memoProgram {
+					continue
+				}
+				data, decErr := base58.Decode(instr.Data)
+				if decErr != nil {
+					continue
+				}
+				return sig, tx, memoProgram, data
+			}
+		}
 	}
-	return sigs[0]
+	t.Skip("no successful transaction invoking either Memo Program as a top-level instruction found in the 50 most recent mentions of each")
+	return "", nil, "", nil
 }
 
 // buildEffectiveKeys mirrors the key-space construction in verifier.go so that
@@ -106,11 +173,16 @@ func buildEffectiveKeys(tx *txResult) []string {
 }
 
 // findTxWithInnerInstructions searches recent AToken Program transactions for
-// one that has at least one inner instruction group with usable data. Returns
-// the signature and parsed txResult. Skips the test if none found.
+// one that has at least one inner instruction with decodeable data. Returns the
+// signature and parsed txResult. Skips the test if none found.
+//
+// The "has a usable inner instruction" predicate is exactly what
+// findFirstCPIInstruction answers, so this delegates rather than repeating the
+// group/instruction walk — keeping the search and the subsequent extraction in
+// TestSolanaVerifierIntegration_CPI guaranteed to agree.
 func findTxWithInnerInstructions(t *testing.T, rpcURL string) (string, *txResult) {
 	t.Helper()
-	client := newSolanaClient(rpcURL, nil)
+	client := newSolanaClient(rpcURL)
 	sigs := fetchSignatures(t, rpcURL, atokenProgram, 50)
 	if len(sigs) == 0 {
 		t.Skip("no recent AToken Program transactions — try again later or use a busier endpoint")
@@ -120,33 +192,27 @@ func findTxWithInnerInstructions(t *testing.T, rpcURL string) (string, *txResult
 		if err != nil || tx == nil {
 			continue
 		}
-		if len(tx.Meta.InnerInstructions) == 0 {
+		if tx.Meta.failed() {
 			continue
 		}
-		// Require at least one inner instruction with decodeable data.
-		keys := buildEffectiveKeys(tx)
-		for _, group := range tx.Meta.InnerInstructions {
-			for _, instr := range group.Instructions {
-				if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
-					continue
-				}
-				if _, decErr := base58.Decode(instr.Data); decErr == nil {
-					return sig, tx
-				}
-			}
+		if _, _, ok := findFirstCPIInstruction(tx); ok {
+			return sig, tx
 		}
 	}
 	t.Skip("no AToken Program transaction with inner-instruction data found in recent 50 signatures")
 	return "", nil
 }
 
-// findV0TxWithLoadedAddresses searches recent Memo Program transactions for one
-// that has non-empty meta.loadedAddresses. Returns the signature and txResult.
-// Skips the test if none found.
+// findV0TxWithLoadedAddresses searches recent Memo Program transactions for a
+// successful one that has non-empty meta.loadedAddresses. Returns the signature
+// and txResult. Skips the test if none found.
+//
+// Scans memo v2 specifically: on mainnet it is predominantly referenced *by*
+// lookup tables, which is exactly the shape this test needs.
 func findV0TxWithLoadedAddresses(t *testing.T, rpcURL string) (string, *txResult) {
 	t.Helper()
-	client := newSolanaClient(rpcURL, nil)
-	sigs := fetchSignatures(t, rpcURL, memoProgram, 100)
+	client := newSolanaClient(rpcURL)
+	sigs := fetchSignatures(t, rpcURL, memoV2Program, 100)
 	if len(sigs) == 0 {
 		t.Skip("no recent Memo Program transactions — try again later or use a busier endpoint")
 	}
@@ -155,12 +221,107 @@ func findV0TxWithLoadedAddresses(t *testing.T, rpcURL string) (string, *txResult
 		if err != nil || tx == nil {
 			continue
 		}
+		if tx.Meta.failed() {
+			continue
+		}
 		if len(tx.Meta.LoadedAddresses.Writable)+len(tx.Meta.LoadedAddresses.Readonly) > 0 {
 			return sig, tx
 		}
 	}
 	t.Skip("no v0 Memo Program transaction with loadedAddresses found in recent 100 signatures — this is expected on quiet endpoints")
 	return "", nil
+}
+
+// tamperedPayload returns a payload that differs from payload and that no
+// instruction invoking program carries anywhere in tx.
+//
+// Simply flipping a byte is not enough. Programs are frequently invoked several
+// times in one transaction with short payloads — a Token Program instruction
+// discriminator is often a single byte — so a flipped payload can collide with a
+// sibling invocation's real data. Verify would then correctly find that sibling
+// and succeed, and the assertion that tampering is rejected would fail for a
+// reason having nothing to do with tampering.
+func tamperedPayload(tx *txResult, program string, payload []byte) []byte {
+	keys := buildEffectiveKeys(tx)
+	existing := make(map[string]struct{})
+	collect := func(instrs []txInstruction) {
+		for _, instr := range instrs {
+			if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
+				continue
+			}
+			if keys[instr.ProgramIDIndex] != program {
+				continue
+			}
+			data, err := base58.Decode(instr.Data)
+			if err != nil {
+				continue
+			}
+			existing[string(data)] = struct{}{}
+		}
+	}
+	collect(tx.Transaction.Message.Instructions)
+	for _, group := range tx.Meta.InnerInstructions {
+		collect(group.Instructions)
+	}
+
+	tampered := make([]byte, max(len(payload), 1))
+	copy(tampered, payload)
+	tampered[len(tampered)-1] ^= 0xFF
+	for {
+		if _, ok := existing[string(tampered)]; !ok {
+			return tampered
+		}
+		tampered = append(tampered, 0xFF)
+	}
+}
+
+// absentProgramAddress returns a syntactically valid Solana address that does
+// not appear anywhere in tx's key space, so Verify is guaranteed to reach its
+// "no instruction found" path for it.
+func absentProgramAddress(tx *txResult) string {
+	present := make(map[string]struct{})
+	for _, k := range buildEffectiveKeys(tx) {
+		present[k] = struct{}{}
+	}
+	candidate := make([]byte, 32)
+	for i := range candidate {
+		candidate[i] = 0x01
+	}
+	for {
+		addr := base58.Encode(candidate)
+		if _, ok := present[addr]; !ok {
+			return addr
+		}
+		candidate[0]++
+	}
+}
+
+// findUninvokedLoadedAddress returns the first meta.loadedAddresses entry that
+// is not referenced as the program of any instruction, top-level or inner.
+// Returns "" if every loaded address is invoked.
+func findUninvokedLoadedAddress(tx *txResult) string {
+	keys := buildEffectiveKeys(tx)
+	invoked := make(map[string]struct{})
+	markInvoked := func(instrs []txInstruction) {
+		for _, instr := range instrs {
+			if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
+				continue
+			}
+			invoked[keys[instr.ProgramIDIndex]] = struct{}{}
+		}
+	}
+	markInvoked(tx.Transaction.Message.Instructions)
+	for _, group := range tx.Meta.InnerInstructions {
+		markInvoked(group.Instructions)
+	}
+
+	loaded := append(append([]string(nil), tx.Meta.LoadedAddresses.Writable...), tx.Meta.LoadedAddresses.Readonly...)
+	for _, addr := range loaded {
+		if _, ok := invoked[addr]; !ok {
+			return addr
+		}
+	}
+	return ""
 }
 
 // findFirstCPIInstruction returns the program address and decoded payload of the
@@ -197,36 +358,11 @@ func TestSolanaVerifierIntegration(t *testing.T) {
 		t.Skip("SOLANA_RPC_URL not set")
 	}
 
-	txSig := fetchRecentMemoTxSig(t, rpcURL)
+	// The helper guarantees the returned transaction invokes the Memo Program as
+	// a top-level instruction, and returns that instruction's data as the ground
+	// truth payload.
+	txSig, tx, memoProgram, instrData := findMemoTxWithTopLevelInstruction(t, rpcURL)
 	t.Logf("using transaction: %s", txSig)
-
-	// Fetch the full transaction to extract ground truth (slot, program, payload).
-	client := newSolanaClient(rpcURL, nil)
-	tx, err := client.getTransaction(t.Context(), txSig)
-	require.NoError(t, err)
-	require.NotNil(t, tx, "transaction not found — the signature returned by getSignaturesForAddress was not retrievable")
-
-	instrs := tx.Transaction.Message.Instructions
-	keys := tx.Transaction.Message.AccountKeys
-	require.NotEmpty(t, instrs)
-
-	// Find the Memo Program instruction and use its data as ground truth payload.
-	var instrData []byte
-	for _, instr := range instrs {
-		if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
-			continue
-		}
-		if keys[instr.ProgramIDIndex] != memoProgram {
-			continue
-		}
-		data, decodeErr := base58.Decode(instr.Data)
-		if decodeErr != nil {
-			continue
-		}
-		instrData = data
-		break
-	}
-	require.NotNil(t, instrData, "could not find Memo Program instruction in transaction")
 
 	slot := tx.Slot
 	justification, err := base58.Decode(txSig)
@@ -249,9 +385,7 @@ func TestSolanaVerifierIntegration(t *testing.T) {
 	})
 
 	t.Run("payload tampered rejected", func(t *testing.T) {
-		tampered := make([]byte, max(len(instrData), 1))
-		copy(tampered, instrData)
-		tampered[len(tampered)-1] ^= 0xFF
+		tampered := tamperedPayload(tx, memoProgram, instrData)
 		msg, err := oracle.NewOracleMessage("solana", memoProgram, common.Address{}, slot, 1, tampered)
 		require.NoError(t, err)
 		verifyErr := verifier.Verify(t.Context(), msg, justification)
@@ -260,12 +394,17 @@ func TestSolanaVerifierIntegration(t *testing.T) {
 	})
 
 	t.Run("wrong program rejected", func(t *testing.T) {
-		const systemProgram = "11111111111111111111111111111111"
-		msg, err := oracle.NewOracleMessage("solana", systemProgram, common.Address{}, slot, 1, instrData)
+		// Derive an address absent from this transaction rather than hardcoding
+		// one. A fixed "obviously unrelated" program does not work: mainnet memo
+		// transactions routinely invoke the System Program too, in which case
+		// Verify finds it and reports a payload mismatch, silently testing a
+		// different code path than the one intended here.
+		absentProgram := absentProgramAddress(tx)
+		msg, err := oracle.NewOracleMessage("solana", absentProgram, common.Address{}, slot, 1, instrData)
 		require.NoError(t, err)
 		verifyErr := verifier.Verify(t.Context(), msg, justification)
-		require.Errorf(t, verifyErr, "expected program-not-found error")
-		require.Contains(t, verifyErr.Error(), fmt.Sprintf("no instruction found for program %q", systemProgram))
+		require.ErrorIs(t, verifyErr, ErrInstructionNotFound)
+		require.Contains(t, verifyErr.Error(), fmt.Sprintf("no instruction found for program %q", absentProgram))
 	})
 }
 
@@ -311,9 +450,7 @@ func TestSolanaVerifierIntegration_CPI(t *testing.T) {
 	})
 
 	t.Run("payload tampered rejected", func(t *testing.T) {
-		tampered := make([]byte, max(len(payload), 1))
-		copy(tampered, payload)
-		tampered[len(tampered)-1] ^= 0xFF
+		tampered := tamperedPayload(tx, programAddr, payload)
 		msg, err := oracle.NewOracleMessage("solana", programAddr, common.Address{}, slot, 1, tampered)
 		require.NoError(t, err)
 		verifyErr := verifier.Verify(t.Context(), msg, justification)
@@ -333,10 +470,11 @@ func TestSolanaVerifierIntegration_CPI(t *testing.T) {
 //     programIdIndex in any instruction causes "no instruction found", not a
 //     panic or index-out-of-bounds — confirming the key slice is built right.
 //
-// Note: it is essentially impossible in practice for a program to be IN
-// loadedAddresses (lookup tables hold data accounts, not programs). The test
-// therefore only validates key-space construction, not a full CPI-via-lookup
-// happy path.
+// Note: programs certainly can appear in loadedAddresses — on mainnet the Memo
+// Program itself is frequently loaded through a lookup table (as a readonly
+// entry) without being invoked. What this test does not attempt is a full
+// happy path for a program that is both loaded via a lookup table and invoked;
+// it validates key-space construction only.
 //
 // Requires SOLANA_RPC_URL. Skips automatically if no qualifying v0 transaction
 // is found in the 100 most recent Memo Program transactions.
@@ -364,10 +502,15 @@ func TestSolanaVerifierIntegration_V0LoadedAddresses(t *testing.T) {
 	verifier := newVerifier(t, rpcURL)
 
 	t.Run("loaded address not invoked returns no-instruction-found", func(t *testing.T) {
-		// Use the first loaded address as the claimed program. It is not
-		// referenced by any programIdIndex, so Verify must return the
-		// "no instruction found" error — not panic or index error.
-		uninvokedAddr := loaded[0]
+		// Pick a loaded address that no instruction actually invokes, rather than
+		// assuming loaded[0] qualifies — lookup tables do carry programs, and an
+		// invoked one would make Verify succeed and fail this assertion for the
+		// wrong reason. Verify must return "no instruction found" for it, not
+		// panic or index out of range.
+		uninvokedAddr := findUninvokedLoadedAddress(tx)
+		if uninvokedAddr == "" {
+			t.Skip("every loaded address in this transaction is invoked by some instruction")
+		}
 		msg, err := oracle.NewOracleMessage("solana", uninvokedAddr, common.Address{}, slot, 1, []byte("anything"))
 		require.NoError(t, err)
 		verifyErr := verifier.Verify(t.Context(), msg, justification)

--- a/sidecar/solanarpc/rpc.go
+++ b/sidecar/solanarpc/rpc.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package solanarpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type rpcEnvelope struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type txResult struct {
+	Slot        uint64 `json:"slot"`
+	Transaction txData `json:"transaction"`
+	Meta        txMeta `json:"meta"`
+}
+
+type txMeta struct {
+	InnerInstructions []txInnerInstructionGroup `json:"innerInstructions"`
+	LoadedAddresses   txLoadedAddresses         `json:"loadedAddresses"`
+}
+
+type txInnerInstructionGroup struct {
+	Index        int             `json:"index"`
+	Instructions []txInstruction `json:"instructions"`
+}
+
+type txLoadedAddresses struct {
+	Writable []string `json:"writable"`
+	Readonly []string `json:"readonly"`
+}
+
+type txData struct {
+	Message txMessage `json:"message"`
+}
+
+type txMessage struct {
+	AccountKeys  []string        `json:"accountKeys"`
+	Instructions []txInstruction `json:"instructions"`
+}
+
+type txInstruction struct {
+	ProgramIDIndex int    `json:"programIdIndex"`
+	Data           string `json:"data"` // base58-encoded
+}
+
+// rpcClient is the interface SolanaVerifier uses to fetch Solana transactions.
+// The only production implementation is solanaClient; tests inject a stub.
+type rpcClient interface {
+	getTransaction(ctx context.Context, sig string) (*txResult, error)
+}
+
+type solanaClient struct {
+	rpcURL     string
+	httpClient *http.Client
+}
+
+func newSolanaClient(rpcURL string, httpClient *http.Client) *solanaClient {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &solanaClient{
+		rpcURL:     rpcURL,
+		httpClient: httpClient,
+	}
+}
+
+// getTransaction fetches a Solana transaction by its base58-encoded signature.
+// Returns (nil, nil) when the transaction is not found (result is JSON null).
+func (c *solanaClient) getTransaction(ctx context.Context, sig string) (*txResult, error) {
+	req := rpcEnvelope{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "getTransaction",
+		Params: []any{
+			sig,
+			map[string]any{
+				"encoding":                       "json",
+				"maxSupportedTransactionVersion": 0,
+			},
+		},
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal RPC request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.rpcURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build RPC HTTP request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("RPC request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read RPC response body: %w", err)
+	}
+
+	var rpcResp rpcResponse
+	if err := json.Unmarshal(respBytes, &rpcResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal RPC response: %w", err)
+	}
+
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("RPC error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+
+	// null result means transaction not found
+	if string(rpcResp.Result) == "null" {
+		return nil, nil
+	}
+
+	var tx txResult
+	if err := json.Unmarshal(rpcResp.Result, &tx); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal transaction result: %w", err)
+	}
+
+	return &tx, nil
+}

--- a/sidecar/solanarpc/rpc.go
+++ b/sidecar/solanarpc/rpc.go
@@ -38,6 +38,16 @@ type txResult struct {
 type txMeta struct {
 	InnerInstructions []txInnerInstructionGroup `json:"innerInstructions"`
 	LoadedAddresses   txLoadedAddresses         `json:"loadedAddresses"`
+	// Err is null for transactions that succeeded and a structured error object
+	// for those that failed. Failed transactions are still recorded on-chain
+	// with their full instruction list, but their effects were rolled back, so
+	// their instructions must not be treated as events that occurred.
+	Err json.RawMessage `json:"err"`
+}
+
+// failed reports whether the transaction executed successfully on-chain.
+func (m txMeta) failed() bool {
+	return len(m.Err) > 0 && string(m.Err) != "null"
 }
 
 type txInnerInstructionGroup struct {
@@ -75,13 +85,10 @@ type solanaClient struct {
 	httpClient *http.Client
 }
 
-func newSolanaClient(rpcURL string, httpClient *http.Client) *solanaClient {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
+func newSolanaClient(rpcURL string) *solanaClient {
 	return &solanaClient{
 		rpcURL:     rpcURL,
-		httpClient: httpClient,
+		httpClient: http.DefaultClient,
 	}
 }
 

--- a/sidecar/solanarpc/verifier.go
+++ b/sidecar/solanarpc/verifier.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package solanarpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/mr-tron/base58"
+
+	"github.com/ava-labs/avalanchego/network/p2p/oracle"
+)
+
+const defaultRPCURL = "https://api.mainnet-beta.solana.com"
+
+// Config is the verifier's own configuration, parsed from the sidecar's
+// --config-path file. The sidecar binary treats this as opaque bytes;
+// SolanaVerifier is the authority on what fields are valid.
+type Config struct {
+	// RPCURL is the Solana JSON-RPC endpoint.
+	// Defaults to https://api.mainnet-beta.solana.com if omitted.
+	RPCURL string `json:"rpc_url"`
+	// AllowedPrograms is an optional list of Solana program addresses this
+	// sidecar will attest to. Omit or leave empty to allow all programs.
+	AllowedPrograms []string `json:"allowed_programs"`
+}
+
+// SolanaVerifier verifies OracleMessages by querying the Solana RPC.
+type SolanaVerifier struct {
+	client          rpcClient
+	allowedPrograms map[string]struct{} // empty = allow all
+}
+
+// NewSolanaVerifier parses configBytes as a JSON Config and constructs a
+// SolanaVerifier. configBytes may be nil or empty, in which case defaults
+// apply (mainnet RPC, all programs allowed).
+func NewSolanaVerifier(configBytes []byte, httpClient *http.Client) (*SolanaVerifier, error) {
+	cfg := Config{RPCURL: defaultRPCURL}
+	if len(configBytes) > 0 {
+		if err := json.Unmarshal(configBytes, &cfg); err != nil {
+			return nil, fmt.Errorf("invalid solana verifier config: %w", err)
+		}
+	}
+	if cfg.RPCURL == "" {
+		return nil, errors.New("solana verifier config: rpc_url must not be empty")
+	}
+	allowed := make(map[string]struct{}, len(cfg.AllowedPrograms))
+	for _, p := range cfg.AllowedPrograms {
+		allowed[p] = struct{}{}
+	}
+	return &SolanaVerifier{
+		client:          newSolanaClient(cfg.RPCURL, httpClient),
+		allowedPrograms: allowed,
+	}, nil
+}
+
+// errProgramNotFound is returned by matchInstruction when no instruction in the
+// set invokes msg.SourceAddress. It signals the caller to keep searching (e.g.
+// in inner instructions). Any other non-nil return means the program was found
+// but verification failed — the caller must not continue searching.
+var errProgramNotFound = errors.New("program not found in instruction set")
+
+// ErrInstructionNotFound is returned by Verify when no instruction in the
+// transaction (including CPI inner instructions) invokes msg.SourceAddress.
+var ErrInstructionNotFound = errors.New("no instruction found for program")
+
+// matchInstruction scans instrs for one whose program matches msg.SourceAddress
+// and whose data matches msg.Payload. Returns nil on the first match,
+// errProgramNotFound if the program isn't present, or a descriptive error if
+// the program is present but the data doesn't verify.
+func matchInstruction(instrs []txInstruction, keys []string, msg *oracle.OracleMessage) error {
+	for _, instr := range instrs {
+		if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
+			continue
+		}
+		if keys[instr.ProgramIDIndex] != msg.SourceAddress {
+			continue
+		}
+		data, err := base58.Decode(instr.Data)
+		if err != nil {
+			return fmt.Errorf("failed to base58-decode instruction data: %w", err)
+		}
+		if !bytes.Equal(data, msg.Payload) {
+			return errors.New("payload mismatch: instruction data does not match OracleMessage.Payload")
+		}
+		return nil
+	}
+	return errProgramNotFound
+}
+
+// Verify checks that the given OracleMessage is backed by a real Solana
+// transaction. The justification must be a raw 64-byte Ed25519 transaction
+// signature.
+func (v *SolanaVerifier) Verify(ctx context.Context, msg *oracle.OracleMessage, justification []byte) error {
+	if len(v.allowedPrograms) > 0 {
+		if _, ok := v.allowedPrograms[msg.SourceAddress]; !ok {
+			return fmt.Errorf("source address %q is not in the allowed programs list", msg.SourceAddress)
+		}
+	}
+
+	// Encode the raw signature bytes as base58 to use as the RPC lookup key.
+	sig := base58.Encode(justification)
+
+	tx, err := v.client.getTransaction(ctx, sig)
+	if err != nil {
+		return fmt.Errorf("%w: getTransaction RPC call failed: %w", oracle.ErrSourceUnavailable, err)
+	}
+	if tx == nil {
+		return fmt.Errorf("transaction not found for signature %s", sig)
+	}
+
+	// 1. Verify the slot matches the claimed source block height.
+	if tx.Slot != msg.SourceBlockHeight {
+		return fmt.Errorf("slot mismatch: got %d, want %d", tx.Slot, msg.SourceBlockHeight)
+	}
+
+	// Build the effective account key space. For legacy transactions
+	// loadedAddresses is empty; for v0 transactions it contains accounts
+	// resolved from address lookup tables that programIdIndex may reference.
+	keys := tx.Transaction.Message.AccountKeys
+	keys = append(keys, tx.Meta.LoadedAddresses.Writable...)
+	keys = append(keys, tx.Meta.LoadedAddresses.Readonly...)
+
+	// 2. Find an instruction whose programId matches msg.SourceAddress.
+	// 3. For that instruction, verify the decoded data equals msg.Payload.
+	// Check top-level instructions first, then CPI inner instructions.
+	// Only continue to the next set if the program was not found; a
+	// definitive failure (e.g. payload mismatch) stops the search immediately.
+	if err := matchInstruction(tx.Transaction.Message.Instructions, keys, msg); !errors.Is(err, errProgramNotFound) {
+		return err
+	}
+	for _, group := range tx.Meta.InnerInstructions {
+		if err := matchInstruction(group.Instructions, keys, msg); !errors.Is(err, errProgramNotFound) {
+			return err
+		}
+	}
+
+	return fmt.Errorf("%w %q in transaction", ErrInstructionNotFound, msg.SourceAddress)
+}

--- a/sidecar/solanarpc/verifier.go
+++ b/sidecar/solanarpc/verifier.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/mr-tron/base58"
 
@@ -39,7 +38,7 @@ type SolanaVerifier struct {
 // NewSolanaVerifier parses configBytes as a JSON Config and constructs a
 // SolanaVerifier. configBytes may be nil or empty, in which case defaults
 // apply (mainnet RPC, all programs allowed).
-func NewSolanaVerifier(configBytes []byte, httpClient *http.Client) (*SolanaVerifier, error) {
+func NewSolanaVerifier(configBytes []byte) (*SolanaVerifier, error) {
 	cfg := Config{RPCURL: defaultRPCURL}
 	if len(configBytes) > 0 {
 		if err := json.Unmarshal(configBytes, &cfg); err != nil {
@@ -54,26 +53,42 @@ func NewSolanaVerifier(configBytes []byte, httpClient *http.Client) (*SolanaVeri
 		allowed[p] = struct{}{}
 	}
 	return &SolanaVerifier{
-		client:          newSolanaClient(cfg.RPCURL, httpClient),
+		client:          newSolanaClient(cfg.RPCURL),
 		allowedPrograms: allowed,
 	}, nil
 }
 
 // errProgramNotFound is returned by matchInstruction when no instruction in the
-// set invokes msg.SourceAddress. It signals the caller to keep searching (e.g.
-// in inner instructions). Any other non-nil return means the program was found
-// but verification failed — the caller must not continue searching.
+// set invokes msg.SourceAddress.
+//
+// No non-nil result from matchInstruction is decisive on its own: a program can
+// be invoked several times within one transaction, both at the top level and
+// through CPI, so the caller must examine every instruction set before
+// concluding that verification failed. Only a nil return ends the search.
 var errProgramNotFound = errors.New("program not found in instruction set")
+
+// errPayloadMismatch means msg.SourceAddress was invoked in this instruction
+// set, but no invocation of it carried data equal to msg.Payload.
+var errPayloadMismatch = errors.New("payload mismatch: instruction data does not match OracleMessage.Payload")
 
 // ErrInstructionNotFound is returned by Verify when no instruction in the
 // transaction (including CPI inner instructions) invokes msg.SourceAddress.
 var ErrInstructionNotFound = errors.New("no instruction found for program")
 
-// matchInstruction scans instrs for one whose program matches msg.SourceAddress
-// and whose data matches msg.Payload. Returns nil on the first match,
-// errProgramNotFound if the program isn't present, or a descriptive error if
-// the program is present but the data doesn't verify.
+// matchInstruction scans instrs for an instruction whose program matches
+// msg.SourceAddress and whose data matches msg.Payload. Returns nil on the
+// first full match, errProgramNotFound if the program is absent from the set,
+// or errPayloadMismatch if it was invoked but never with the claimed payload.
+//
+// Every invocation of the program is examined, not just the first. A program
+// invoked repeatedly in one transaction — a batch of memos, a multi-hop swap —
+// produces several instructions with the same programId and different data, and
+// each is an independently attestable event. Returning on the first programId
+// hit would make every invocation after the first unverifiable.
 func matchInstruction(instrs []txInstruction, keys []string, msg *oracle.OracleMessage) error {
+	// Least-specific result, upgraded as more is learned about why no match was
+	// found. Never downgraded, so the most informative reason survives.
+	result := errProgramNotFound
 	for _, instr := range instrs {
 		if instr.ProgramIDIndex < 0 || instr.ProgramIDIndex >= len(keys) {
 			continue
@@ -83,14 +98,22 @@ func matchInstruction(instrs []txInstruction, keys []string, msg *oracle.OracleM
 		}
 		data, err := base58.Decode(instr.Data)
 		if err != nil {
-			return fmt.Errorf("failed to base58-decode instruction data: %w", err)
+			// Malformed data from the RPC must not mask a valid invocation
+			// elsewhere in the set, so record it and keep scanning.
+			if errors.Is(result, errProgramNotFound) {
+				result = fmt.Errorf("failed to base58-decode instruction data: %w", err)
+			}
+			continue
 		}
 		if !bytes.Equal(data, msg.Payload) {
-			return errors.New("payload mismatch: instruction data does not match OracleMessage.Payload")
+			if errors.Is(result, errProgramNotFound) {
+				result = errPayloadMismatch
+			}
+			continue
 		}
 		return nil
 	}
-	return errProgramNotFound
+	return result
 }
 
 // Verify checks that the given OracleMessage is backed by a real Solana
@@ -114,7 +137,15 @@ func (v *SolanaVerifier) Verify(ctx context.Context, msg *oracle.OracleMessage, 
 		return fmt.Errorf("transaction not found for signature %s", sig)
 	}
 
-	// 1. Verify the slot matches the claimed source block height.
+	// 1. Reject transactions that failed on-chain. A failed transaction is still
+	// recorded with its full instruction list, but the runtime rolled its effects
+	// back, so nothing it describes actually happened. Attesting to one would
+	// have validators sign for an event that never took effect.
+	if tx.Meta.failed() {
+		return fmt.Errorf("transaction %s failed on-chain and cannot be attested: %s", sig, tx.Meta.Err)
+	}
+
+	// 2. Verify the slot matches the claimed source block height.
 	if tx.Slot != msg.SourceBlockHeight {
 		return fmt.Errorf("slot mismatch: got %d, want %d", tx.Slot, msg.SourceBlockHeight)
 	}
@@ -122,23 +153,38 @@ func (v *SolanaVerifier) Verify(ctx context.Context, msg *oracle.OracleMessage, 
 	// Build the effective account key space. For legacy transactions
 	// loadedAddresses is empty; for v0 transactions it contains accounts
 	// resolved from address lookup tables that programIdIndex may reference.
-	keys := tx.Transaction.Message.AccountKeys
+	// Copied rather than appended onto AccountKeys, whose backing array append
+	// would otherwise write into when its capacity exceeds its length.
+	keys := make([]string, 0, len(tx.Transaction.Message.AccountKeys)+len(tx.Meta.LoadedAddresses.Writable)+len(tx.Meta.LoadedAddresses.Readonly))
+	keys = append(keys, tx.Transaction.Message.AccountKeys...)
 	keys = append(keys, tx.Meta.LoadedAddresses.Writable...)
 	keys = append(keys, tx.Meta.LoadedAddresses.Readonly...)
 
-	// 2. Find an instruction whose programId matches msg.SourceAddress.
-	// 3. For that instruction, verify the decoded data equals msg.Payload.
-	// Check top-level instructions first, then CPI inner instructions.
-	// Only continue to the next set if the program was not found; a
-	// definitive failure (e.g. payload mismatch) stops the search immediately.
-	if err := matchInstruction(tx.Transaction.Message.Instructions, keys, msg); !errors.Is(err, errProgramNotFound) {
-		return err
+	// 3. Find an instruction that invokes msg.SourceAddress with data equal to
+	// msg.Payload, checking top-level instructions and then each CPI inner
+	// instruction group.
+	//
+	// Every set is searched before failing. The same program may be invoked in
+	// more than one set — top-level with one payload, via CPI with another — so
+	// a non-match in one set says nothing about the rest. Only a match ends the
+	// search early.
+	result := matchInstruction(tx.Transaction.Message.Instructions, keys, msg)
+	if result == nil {
+		return nil
 	}
 	for _, group := range tx.Meta.InnerInstructions {
-		if err := matchInstruction(group.Instructions, keys, msg); !errors.Is(err, errProgramNotFound) {
-			return err
+		err := matchInstruction(group.Instructions, keys, msg)
+		if err == nil {
+			return nil
+		}
+		// Upgrade to the more informative reason, never back to "not found".
+		if errors.Is(result, errProgramNotFound) {
+			result = err
 		}
 	}
 
-	return fmt.Errorf("%w %q in transaction", ErrInstructionNotFound, msg.SourceAddress)
+	if errors.Is(result, errProgramNotFound) {
+		return fmt.Errorf("%w %q in transaction", ErrInstructionNotFound, msg.SourceAddress)
+	}
+	return result
 }

--- a/sidecar/solanarpc/verifier_test.go
+++ b/sidecar/solanarpc/verifier_test.go
@@ -1,0 +1,165 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package solanarpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/network/p2p/oracle"
+)
+
+// stubRPC is a test double for rpcClient. Set Tx to return a transaction,
+// Err to simulate an RPC failure, or leave both nil for "not found".
+type stubRPC struct {
+	Tx  *txResult
+	Err error
+}
+
+func (s *stubRPC) getTransaction(_ context.Context, _ string) (*txResult, error) {
+	return s.Tx, s.Err
+}
+
+const (
+	testProgram = "So11111111111111111111111111111111111111112"
+	testSlotV   = uint64(100)
+)
+
+func makeMsg(t *testing.T, sourceAddr string, slot uint64, payload []byte) *oracle.OracleMessage { //nolint:unparam
+	t.Helper()
+	msg, err := oracle.NewOracleMessage("solana", sourceAddr, common.Address{1, 2, 3}, slot, 1, payload)
+	require.NoError(t, err)
+	return msg
+}
+
+func makeValidTx(programAddr string, slot uint64, payload []byte) *txResult {
+	return &txResult{
+		Slot: slot,
+		Transaction: txData{
+			Message: txMessage{
+				AccountKeys: []string{"payer111", programAddr},
+				Instructions: []txInstruction{
+					{
+						ProgramIDIndex: 1,
+						Data:           base58.Encode(payload),
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSolanaVerifier(t *testing.T) {
+	payload := []byte("payload")
+
+	tests := []struct {
+		name    string
+		rpc     *stubRPC
+		msg     func(*testing.T) *oracle.OracleMessage
+		wantErr string
+	}{
+		{
+			name: "valid transaction",
+			rpc:  &stubRPC{Tx: makeValidTx(testProgram, testSlotV, payload)},
+			msg:  func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+		},
+		{
+			name:    "rpc error",
+			rpc:     &stubRPC{Err: errors.New("connection refused")},
+			msg:     func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+			wantErr: "getTransaction RPC call failed",
+		},
+		{
+			name:    "transaction not found",
+			rpc:     &stubRPC{Tx: nil},
+			msg:     func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+			wantErr: "transaction not found",
+		},
+		{
+			name:    "slot mismatch",
+			rpc:     &stubRPC{Tx: makeValidTx(testProgram, testSlotV+999, payload)},
+			msg:     func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+			wantErr: "slot mismatch",
+		},
+		{
+			name:    "program not in account keys",
+			rpc:     &stubRPC{Tx: makeValidTx("SomeOtherProgram1111111111111111111111111111", testSlotV, payload)},
+			msg:     func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+			wantErr: "no instruction found for program",
+		},
+		{
+			name:    "payload mismatch",
+			rpc:     &stubRPC{Tx: makeValidTx(testProgram, testSlotV, []byte("WRONG"))},
+			msg:     func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+			wantErr: "payload mismatch",
+		},
+		{
+			// Program invoked via CPI: appears in meta.innerInstructions, not
+			// in transaction.message.instructions.
+			name: "program invoked via CPI",
+			rpc: &stubRPC{Tx: &txResult{
+				Slot: testSlotV,
+				Transaction: txData{
+					Message: txMessage{
+						AccountKeys:  []string{"payer111", "routerProgram"},
+						Instructions: []txInstruction{{ProgramIDIndex: 1, Data: base58.Encode([]byte("router-data"))}},
+					},
+				},
+				Meta: txMeta{
+					InnerInstructions: []txInnerInstructionGroup{
+						{
+							Index: 0,
+							Instructions: []txInstruction{
+								{ProgramIDIndex: 2, Data: base58.Encode(payload)},
+							},
+						},
+					},
+					LoadedAddresses: txLoadedAddresses{
+						Writable: []string{testProgram},
+					},
+				},
+			}},
+			msg: func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+		},
+		{
+			// Program address is in a v0 lookup table (meta.loadedAddresses),
+			// not in the static message.accountKeys.
+			name: "v0 program address from lookup table",
+			rpc: &stubRPC{Tx: &txResult{
+				Slot: testSlotV,
+				Transaction: txData{
+					Message: txMessage{
+						AccountKeys:  []string{"payer111"},
+						Instructions: []txInstruction{{ProgramIDIndex: 1, Data: base58.Encode(payload)}},
+					},
+				},
+				Meta: txMeta{
+					LoadedAddresses: txLoadedAddresses{
+						Writable: []string{testProgram},
+					},
+				},
+			}},
+			msg: func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &SolanaVerifier{client: tt.rpc}
+			justification := make([]byte, 64)
+			err := v.Verify(t.Context(), tt.msg(t), justification)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Errorf(t, err, "expected error containing %q", tt.wantErr)
+				require.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/sidecar/solanarpc/verifier_test.go
+++ b/sidecar/solanarpc/verifier_test.go
@@ -5,6 +5,7 @@ package solanarpc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -146,6 +147,78 @@ func TestSolanaVerifier(t *testing.T) {
 				},
 			}},
 			msg: func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+		},
+		{
+			// A failed transaction is recorded on-chain with its full instruction
+			// list, but the runtime rolled its effects back, so the event it
+			// describes never took effect and must not be attested.
+			name: "failed transaction rejected",
+			rpc: func() *stubRPC {
+				tx := makeValidTx(testProgram, testSlotV, payload)
+				tx.Meta.Err = json.RawMessage(`{"InstructionError":[0,{"Custom":1}]}`)
+				return &stubRPC{Tx: tx}
+			}(),
+			msg:     func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+			wantErr: "failed on-chain and cannot be attested",
+		},
+		{
+			// The same program invoked twice with different data: both events are
+			// real and independently attestable, so the second must verify rather
+			// than being shadowed by the first invocation's payload.
+			name: "second invocation of same program",
+			rpc: &stubRPC{Tx: &txResult{
+				Slot: testSlotV,
+				Transaction: txData{
+					Message: txMessage{
+						AccountKeys: []string{"payer111", testProgram},
+						Instructions: []txInstruction{
+							{ProgramIDIndex: 1, Data: base58.Encode([]byte("first-invocation"))},
+							{ProgramIDIndex: 1, Data: base58.Encode(payload)},
+						},
+					},
+				},
+			}},
+			msg: func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+		},
+		{
+			// Invoked top-level with one payload and via CPI with another. A
+			// non-match among the top-level instructions must not end the search
+			// before the inner instructions are examined.
+			name: "match in CPI after top-level payload mismatch",
+			rpc: &stubRPC{Tx: &txResult{
+				Slot: testSlotV,
+				Transaction: txData{
+					Message: txMessage{
+						AccountKeys:  []string{"payer111", testProgram},
+						Instructions: []txInstruction{{ProgramIDIndex: 1, Data: base58.Encode([]byte("top-level-data"))}},
+					},
+				},
+				Meta: txMeta{
+					InnerInstructions: []txInnerInstructionGroup{
+						{Index: 0, Instructions: []txInstruction{{ProgramIDIndex: 1, Data: base58.Encode(payload)}}},
+					},
+				},
+			}},
+			msg: func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+		},
+		{
+			// Invoked several times, never with the claimed payload: the reported
+			// reason should be the specific mismatch, not "no instruction found".
+			name: "invoked repeatedly but never with claimed payload",
+			rpc: &stubRPC{Tx: &txResult{
+				Slot: testSlotV,
+				Transaction: txData{
+					Message: txMessage{
+						AccountKeys: []string{"payer111", testProgram},
+						Instructions: []txInstruction{
+							{ProgramIDIndex: 1, Data: base58.Encode([]byte("aaa"))},
+							{ProgramIDIndex: 1, Data: base58.Encode([]byte("bbb"))},
+						},
+					},
+				},
+			}},
+			msg:     func(t *testing.T) *oracle.OracleMessage { return makeMsg(t, testProgram, testSlotV, payload) },
+			wantErr: "payload mismatch",
 		},
 	}
 


### PR DESCRIPTION
## NOTE:
This is a draft, not to be merged just yet. Opening for review as part of the oracle attestation intern project. This PR depends on PR #5636 and should be stacked on top of it.

## Why this should be merged
PR #5636 introduced the p2p handler and shared oracle types inside AvalancheGo. This PR delivers the other half of the system: the oracle sidecar binary that validators run alongside their node to verify external chain events before signing, and one implementation of a verifier, using Solana as an example.

Validators can consult a separate sidecar service to verify the claimed event actually occurred on the source chain. This PR gives validators that capability through the sidecar, and implements a facade pattern, under which any custom verifier can be implemented. Solana is implemented here, with the architecture designed to be extended to other chains by adding a verifier and a case in buildVerifier.

How this works
- `sidecar/ binary`: A standalone gRPC server (OracleSidecar service, defined in proto/oracle/oracle.proto) that validators run as a sidecar process. On startup it reads a config file mapping source types to verifier configurations, validates all declared source types against `oracle.KnownSourceTypes`, and refuses to start if any source type is unrecognized.
- `sidecar/server.go`: Routes each `VerifyRequest` to the verifier registered for `msg.SourceType`. Decodes the ABI-encoded `OracleMessage` from request bytes, dispatches to the appropriate verifier, and maps Go errors to gRPC status codes
- `sidecar/solanarpc/`: The Solana verifier. Given a `VerifyRequest`, it:
 1. Checks the program address against an optional allowlist.
 2. Treats the justification bytes as a raw 64-byte Ed25519 transaction signature, base58-encodes it, and calls getTransaction on the configured Solana JSON-RPC endpoint.
 3. Verifies the transaction's slot matches OracleMessage.SourceBlockHeight.
 4. Scans top-level instructions then CPI inner instructions for one whose programId matches OracleMessage.SourceAddress and whose decoded data matches OracleMessage.Payload.
 5. Handles v0 transactions by merging meta.loadedAddresses into the account key space before resolving programIdIndex.
- `sidecar/config/`: Shared config package (bind_addr + a verifiers map of source type in JSON). The sidecar owns the parsing per source type; the validator node reads only the keys.

How this was tested
- Unit tests: Cover invalid message bytes, unknown source type, allowlist rejection, slot mismatch, payload mismatch, RPC failure, not-found, and happy path. A stub `rpcClient` keeps these fast.
- Integration tests: Auto-discover recent live transactions from the devnet and submit them for verification. Also exercises v0 transactions with `loadedAddresses` to validate key-space construction. Sad paths are tested against devnet data.
- gRPC: `server_test.go` tests the full `Verify` RPC path through the `Server` struct using a `mockVerifier`, covering gRPC status code mapping end to end.

Need to be documented in RELEASES.md?

For now, no. Deferred.

All comments and feedback welcome. Would be especially valuable to hear from the AvalancheGo team