### PR TITLE
ci: auto-add team-authored issues and PRs to project boards

### DIFF
--- a/.github/workflows/add-to-team-boards.yml
+++ b/.github/workflows/add-to-team-boards.yml
@@ -1,0 +1,53 @@
+name: Add team items to project boards
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  route_team_items:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Determine author team membership
+        id: membership
+        env:
+          GH_TOKEN: ${{ secrets.TEAM_BOARDS_GH_PAT }}
+          AUTHOR: ${{ github.event.sender.login }}
+        run: |
+          is_active_member() {
+            [ "$(gh api "orgs/ava-labs/teams/$1/memberships/$AUTHOR" --jq .state 2>/dev/null)" = "active" ]
+          }
+          {
+            echo "avalanchego=$(is_active_member platform-avalanchego && echo true || echo false)"
+            echo "evm=$(is_active_member platform-evm && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add to avalanchego board
+        if: steps.membership.outputs.avalanchego == 'true'
+        uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/orgs/ava-labs/projects/23
+          github-token: ${{ secrets.TEAM_BOARDS_GH_PAT }}
+
+      - name: Add evm label
+        if: steps.membership.outputs.evm == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/$NUMBER/labels" -f "labels[]=evm"
+
+      - name: Add to EVM Team Board
+        if: steps.membership.outputs.evm == 'true'
+        uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/orgs/ava-labs/projects/36
+          github-token: ${{ secrets.TEAM_BOARDS_GH_PAT }}


### PR DESCRIPTION
## Why this should be merged

Board cleanup following the EVM retro. The current board automation has two issues that pollute both boards:

- Every issue/PR  is auto-added to the AvalancheGo board and has to be manually removed (which in practice hasn't been happening).
- The EVM board only picks up items that someone remembers to manually label `evm`.

The AvalancheGo board already filters out `evm`-labeled items to keep a clear view of its own work, so we can keep using this label as the filter, we just need to do it automatically. 

## How this works

A new workflow runs whenever an issue or PR is opened and checks the author's org team membership via the GitHub API (no hardcoded username lists to maintain, in case team membership changes):

- `platform-avalanchego` member -> item added to the [avalanchego board](https://github.com/orgs/ava-labs/projects/23)
- `platform-evm` member -> item labeled `evm` and added to the [EVM Team Board](https://github.com/orgs/ava-labs/projects/36)

Note that we do need a new `TEAM_BOARDS_GH_PAT` secret (`read:org` + `project` scopes) for this. The  avalanchego project's built-in "auto-add" workflow has already been removed. 

## How this was tested

The team-membership API calls were verified manually. The `issues`/`pull_request_target` triggers only ever run the workflow definition from the default branch, so I'm not sure how we could test fully without merging it.

```bash
$ gh api orgs/ava-labs/teams/platform-evm/memberships/JonathanOppenheimer --jq .state
active
$ gh api orgs/ava-labs/teams/platform-avalanchego/memberships/JonathanOppenheimer --jq .state
gh: Not Found (HTTP 404)        # -> treated as not a member
$ gh api orgs/ava-labs/teams/platform-avalanchego/memberships/octocat --jq .state
gh: Not Found (HTTP 404)        # outside contributor -> no automation
```

## Need to be documented in RELEASES.md?

No. 