### PR TITLE
fix(cchain): throttle WaitForEvent to avoid PendingTxs busy loop

### DIFF
--- a/vms/saevm/cchain/BUILD.bazel
+++ b/vms/saevm/cchain/BUILD.bazel
@@ -166,6 +166,7 @@ go_test(
         "//vms/saevm/cchain/dynamic",
         "//vms/saevm/cchain/tx",
         "//vms/saevm/cchain/tx/txtest",
+        "//vms/saevm/cchain/txpool",
         "//vms/saevm/cchain/warp",
         "//vms/saevm/cchain/warp/warptest",
         "//vms/saevm/cmputils",

--- a/vms/saevm/cchain/BUILD.bazel
+++ b/vms/saevm/cchain/BUILD.bazel
@@ -167,7 +167,6 @@ go_test(
         "//vms/saevm/cchain/dynamic",
         "//vms/saevm/cchain/tx",
         "//vms/saevm/cchain/tx/txtest",
-        "//vms/saevm/cchain/txpool",
         "//vms/saevm/cchain/warp",
         "//vms/saevm/cchain/warp/warptest",
         "//vms/saevm/cmputils",

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -330,26 +330,26 @@ const minWaitForEventDelay = 100 * time.Millisecond
 // block has elapsed, then waits for a transaction to be in the txpool or for
 // the SAE VM to produce an event.
 func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
+	defer func() {
+		vm.lastWaitForEvent.Set(vm.now())
+	}()
+
 	// Throttle to avoid busy looping: the txpools only clear after block
 	// execution, so pending txs can re-signal while their block is processing.
 	//
 	// TODO(JonathanOppenheimer): The txpool should track preference / reorgs so
 	// we don't need this throttle.
-	{
-		defer func() {
-			vm.lastWaitForEvent.Set(vm.now())
-		}()
+	throttleUntil := vm.lastWaitForEvent.Get().Add(minWaitForEventDelay)
 
-		throttleUntil := vm.lastWaitForEvent.Get().Add(minWaitForEventDelay)
-		if err := vm.waitUntil(ctx, throttleUntil); err != nil {
-			return 0, err
-		}
+	// Pace block building on the ACP-226 minimum block delay so that the event
+	// sources are consulted when we are actually willing to build.
+	buildTime := earliestBuildTime(vm.VM.GetPreference())
+
+	until := throttleUntil
+	if buildTime.After(until) {
+		until = buildTime
 	}
-
-	// Pace block building on the ACP-226 minimum block delay before consulting
-	// the event sources so that the mempools are queried when we are actually
-	// willing to build.
-	if err := vm.waitUntil(ctx, earliestBuildTime(vm.VM.GetPreference())); err != nil {
+	if err := vm.waitUntil(ctx, until); err != nil {
 		return 0, err
 	}
 

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -330,10 +330,6 @@ const minWaitForEventDelay = 100 * time.Millisecond
 // block has elapsed, then waits for a transaction to be in the txpool or for
 // the SAE VM to produce an event.
 func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
-	defer func() {
-		vm.lastWaitForEvent.Set(vm.now())
-	}()
-
 	// Throttle to avoid busy looping: the txpools only clear after block
 	// execution, so pending txs can re-signal while their block is processing.
 	//
@@ -374,6 +370,9 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 	}()
 
 	r := <-results
+	if r.err == nil {
+		vm.lastWaitForEvent.Set(vm.now())
+	}
 	return r.msg, r.err
 }
 

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -320,6 +320,12 @@ func earliestBuildTime(b *blocks.Block) time.Time {
 	return blockTime(h).Add(delayExponent(h).DelayDuration())
 }
 
+// minWaitForEventDelay is the minimum spacing between consecutive
+// [VM.WaitForEvent] returns. 100ms isn't special here, it was selected as a
+// reasonable frequency for the engine to poll on whether to build a block or
+// not.
+const minWaitForEventDelay = 100 * time.Millisecond
+
 // WaitForEvent waits until the ACP-226 minimum block delay since the preferred
 // block has elapsed, then waits for a transaction to be in the txpool or for
 // the SAE VM to produce an event.
@@ -331,31 +337,20 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 	// we don't need this throttle.
 	{
 		defer func() {
-			vm.lastWaitForEvent.Set(time.Now())
+			vm.lastWaitForEvent.Set(vm.now())
 		}()
 
-		// 100ms isn't special here, it was selected as a reasonable frequency
-		// for the engine to poll on whether to build a block or not.
-		const minimumDelay = 100 * time.Millisecond
-		sinceLastCall := time.Since(vm.lastWaitForEvent.Get())
-		timeToWait := minimumDelay - sinceLastCall
-		select {
-		case <-ctx.Done():
-			return 0, ctx.Err()
-		case <-time.After(timeToWait):
+		throttleUntil := vm.lastWaitForEvent.Get().Add(minWaitForEventDelay)
+		if err := vm.waitUntil(ctx, throttleUntil); err != nil {
+			return 0, err
 		}
 	}
 
 	// Pace block building on the ACP-226 minimum block delay before consulting
 	// the event sources so that the mempools are queried when we are actually
 	// willing to build.
-	minTime := earliestBuildTime(vm.VM.GetPreference())
-	if timeToWait := minTime.Sub(vm.now()); timeToWait > 0 {
-		select {
-		case <-ctx.Done():
-			return 0, context.Cause(ctx)
-		case <-time.After(timeToWait):
-		}
+	if err := vm.waitUntil(ctx, earliestBuildTime(vm.VM.GetPreference())); err != nil {
+		return 0, err
 	}
 
 	// Race the SAE event source against the cross-chain txpool. The winner's
@@ -380,6 +375,21 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 
 	r := <-results
 	return r.msg, r.err
+}
+
+// waitUntil blocks until [VM.now] reaches t, returning early with the
+// cancellation cause if ctx is canceled first.
+func (vm *VM) waitUntil(ctx context.Context, t time.Time) error {
+	timeToWait := t.Sub(vm.now())
+	if timeToWait <= 0 {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-time.After(timeToWait):
+		return nil
+	}
 }
 
 // Shutdown releases every resource allocated by [VM.Initialize] in reverse

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -334,6 +334,8 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 			vm.lastWaitForEvent.Set(time.Now())
 		}()
 
+		// 100ms isn't special here, it was selected as a reasonable frequency
+		// for the engine to poll on whether to build a block or not.
 		const minimumDelay = 100 * time.Millisecond
 		sinceLastCall := time.Since(vm.lastWaitForEvent.Get())
 		timeToWait := minimumDelay - sinceLastCall

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/bloom"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/vms/evm/database"
@@ -65,6 +66,8 @@ type VM struct {
 	// depends on another resource, it MUST be added AFTER the resource it
 	// depends on.
 	onClose []func(context.Context) error
+
+	lastWaitForEvent utils.Atomic[time.Time]
 }
 
 var ethDBPrefix = []byte("ethdb")
@@ -321,10 +324,22 @@ func earliestBuildTime(b *blocks.Block) time.Time {
 // block has elapsed, then waits for a transaction to be in the txpool or for
 // the SAE VM to produce an event.
 func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
-	// TODO(StephenButtolph): Do not busy loop with [snowcommon.PendingTxs]. The
-	// txpools are cleared after block execution, so we may still have
-	// transactions in the txpool while blocks containing those transactions are
-	// processing.
+	// Throttle to avoid busy looping: the txpools only clear after block
+	// execution, so pending txs can re-signal while their block is processing.
+	{
+		defer func() {
+			vm.lastWaitForEvent.Set(time.Now())
+		}()
+
+		const minimumDelay = 100 * time.Millisecond
+		sinceLastCall := time.Since(vm.lastWaitForEvent.Get())
+		timeToWait := minimumDelay - sinceLastCall
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(timeToWait):
+		}
+	}
 
 	// Pace block building on the ACP-226 minimum block delay before consulting
 	// the event sources so that the mempools are queried when we are actually

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -326,6 +326,9 @@ func earliestBuildTime(b *blocks.Block) time.Time {
 func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 	// Throttle to avoid busy looping: the txpools only clear after block
 	// execution, so pending txs can re-signal while their block is processing.
+	//
+	// TODO(JonathanOppenheimer): The txpool should track preference / reorgs so
+	// we don't need this throttle.
 	{
 		defer func() {
 			vm.lastWaitForEvent.Set(time.Now())

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -1584,7 +1584,7 @@ func TestVerifyRejectsBlockTimeBelowMinDelay(t *testing.T) {
 	require.ErrorIsf(t, err, errBelowMinBlockDelay, "%T.VerifyBlock() (block below the ACP-226 minimum delay)", sut.VM)
 }
 
-// waitForEventResult carries a [VM.WaitForEvent] return out of a goroutine.
+// waitForEventResult carries a [VM.WaitForEvent] output.
 type waitForEventResult struct {
 	msg snowcommon.Message
 	err error

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -1682,17 +1682,20 @@ func TestWaitForEventThrottle(t *testing.T) {
 		require.NoErrorf(t, err, "%T.WaitForEvent() first call", sut.VM)
 		require.Equalf(t, snowcommon.PendingTxs, msg, "%T.WaitForEvent() first call event", sut.VM)
 
+                start := time.Now()
 		done := make(chan waitForEventResult, 1)
 		go func() {
 			msg, err := sut.WaitForEvent(ctx)
 			done <- waitForEventResult{msg, err}
 		}()
-
+		
 		// Blocked on the throttle timer until synctest fires it.
 		synctest.Wait()
 		require.Emptyf(t, done, "%T.WaitForEvent() second call should be blocked on the throttle", sut.VM)
 
 		got := <-done
+		require.Equalf(t, minWaitForEventDelay, time.Since(start), "%T.WaitForEvent() second call throttle delay", sut.VM
+)
 		require.NoErrorf(t, got.err, "%T.WaitForEvent() second call", sut.VM)
 		require.Equalf(t, snowcommon.PendingTxs, got.msg, "%T.WaitForEvent() second call event", sut.VM)
 	})

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -59,7 +59,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/dynamic"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx/txtest"
-	"github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/warp"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/warp/warptest"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
@@ -1670,32 +1669,30 @@ func TestWaitForEventThrottle(t *testing.T) {
 		w := newWallet(key, sut.ctx, nil)
 
 		gossipTx := toGossipTx(w.newMinimalTx(t))
-		if err := sut.gossipSet.Add(gossipTx); err != nil {
-			require.ErrorIsf(t, err, txpool.ErrAlreadyKnown, "%T.gossipSet.Add()", sut.VM)
-		}
-		sut.pushGossiper.Add(gossipTx)
+		require.NoErrorf(t, sut.gossipSet.Add(gossipTx), "%T.Add()", sut.gossipSet)
 
 		// Skip the min-delay pacing so only the throttle can block.
 		clock.Advance(2 * dynamic.InitialDelayExponent.DelayDuration())
 
+		// The throttle clock starts when a call returns, so this first
+		// (immediate) call is what forces the second one to wait.
 		msg, err := sut.WaitForEvent(ctx)
 		require.NoErrorf(t, err, "%T.WaitForEvent() first call", sut.VM)
 		require.Equalf(t, snowcommon.PendingTxs, msg, "%T.WaitForEvent() first call event", sut.VM)
 
-                start := time.Now()
+		start := time.Now()
 		done := make(chan waitForEventResult, 1)
 		go func() {
 			msg, err := sut.WaitForEvent(ctx)
 			done <- waitForEventResult{msg, err}
 		}()
-		
+
 		// Blocked on the throttle timer until synctest fires it.
 		synctest.Wait()
 		require.Emptyf(t, done, "%T.WaitForEvent() second call should be blocked on the throttle", sut.VM)
 
 		got := <-done
-		require.Equalf(t, minWaitForEventDelay, time.Since(start), "%T.WaitForEvent() second call throttle delay", sut.VM
-)
+		require.Equalf(t, minWaitForEventDelay, time.Since(start), "%T.WaitForEvent() second call throttle delay", sut.VM)
 		require.NoErrorf(t, got.err, "%T.WaitForEvent() second call", sut.VM)
 		require.Equalf(t, snowcommon.PendingTxs, got.msg, "%T.WaitForEvent() second call event", sut.VM)
 	})

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/dynamic"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx/txtest"
+	"github.com/ava-labs/avalanchego/vms/saevm/cchain/txpool"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/warp"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/warp/warptest"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -1537,13 +1537,15 @@ func TestVerifyRejectsBlockTimeBelowMinDelay(t *testing.T) {
 	require.ErrorIsf(t, err, errBelowMinBlockDelay, "%T.VerifyBlock() (block below the ACP-226 minimum delay)", sut.VM)
 }
 
+// waitForEventResult carries a [VM.WaitForEvent] return out of a goroutine.
+type waitForEventResult struct {
+	msg snowcommon.Message
+	err error
+}
+
 // TestWaitForEventMinDelayPacing exercises WaitForEvent's ACP-226 min-delay
 // pacing.
 func TestWaitForEventMinDelayPacing(t *testing.T) {
-	type result struct {
-		msg snowcommon.Message
-		err error
-	}
 	tests := []struct {
 		name string
 		// cancelDuringDelay releases WaitForEvent by canceling its context while
@@ -1586,10 +1588,10 @@ func TestWaitForEventMinDelayPacing(t *testing.T) {
 				ctx, cancel := context.WithCancel(ctx)
 				defer cancel()
 
-				done := make(chan result, 1)
+				done := make(chan waitForEventResult, 1)
 				go func() {
 					msg, err := sut.WaitForEvent(ctx)
-					done <- result{msg, err}
+					done <- waitForEventResult{msg, err}
 				}()
 
 				// Blocked on the pacing timer until we release it.
@@ -1606,6 +1608,47 @@ func TestWaitForEventMinDelayPacing(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestWaitForEventThrottle asserts that consecutive [VM.WaitForEvent] calls
+// are throttled even when a pending tx is available and the preferred block's
+// ACP-226 minimum delay has elapsed.
+func TestWaitForEventThrottle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// See [TestWaitForEventMinDelayPacing] for why the SUT has no RPC
+		// transport and MUST NOT build blocks.
+		key := txtest.NewKey(t)
+		timeOpt, clock := withVMTime(upgrade.InitiallyActiveTime)
+		ctx, sut := newSUT(t, withMaxAllocFor(key.EthAddress()), timeOpt, withoutRPCTransport())
+		w := newWallet(key, sut.ctx, nil)
+
+		gossipTx := toGossipTx(w.newMinimalTx(t))
+		if err := sut.gossipSet.Add(gossipTx); err != nil {
+			require.ErrorIsf(t, err, txpool.ErrAlreadyKnown, "%T.gossipSet.Add()", sut.VM)
+		}
+		sut.pushGossiper.Add(gossipTx)
+
+		// Skip the min-delay pacing so only the throttle can block.
+		clock.Advance(2 * dynamic.InitialDelayExponent.DelayDuration())
+
+		msg, err := sut.WaitForEvent(ctx)
+		require.NoErrorf(t, err, "%T.WaitForEvent() first call", sut.VM)
+		require.Equalf(t, snowcommon.PendingTxs, msg, "%T.WaitForEvent() first call event", sut.VM)
+
+		done := make(chan waitForEventResult, 1)
+		go func() {
+			msg, err := sut.WaitForEvent(ctx)
+			done <- waitForEventResult{msg, err}
+		}()
+
+		// Blocked on the throttle timer until synctest fires it.
+		synctest.Wait()
+		require.Emptyf(t, done, "%T.WaitForEvent() second call should be blocked on the throttle", sut.VM)
+
+		got := <-done
+		require.NoErrorf(t, got.err, "%T.WaitForEvent() second call", sut.VM)
+		require.Equalf(t, snowcommon.PendingTxs, got.msg, "%T.WaitForEvent() second call event", sut.VM)
+	})
 }
 
 // TestEmptyBlocksDisallowed asserts that empty blocks are not allowed.


### PR DESCRIPTION
## Why this should be merged

Closes #5459. 

`WaitForEvent` busy-loops on `common.PendingTxs`: the txpools only clear after block execution, so a pending tx re-signals while its block is still processing. 

## How this works

Consecutive `WaitForEvent` returns are spaced by at least 100ms, copied directly from Stephen's `sae-devnet-5` POC.

## How this was tested

Added `TestWaitForEventThrottle`. 

## Update RELEASES.md? 

No 