### PR TITLE
Increase SAE execution log level

### DIFF
--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -172,7 +172,7 @@ func Execute(
 	receiptStore ReceiptStore,
 	log logging.Logger,
 ) (*ExecutionResults, error) {
-	log.Debug("Executing block")
+	log.Trace("Executing block")
 
 	parent := b.ParentBlock()
 	header := b.Header()
@@ -274,7 +274,7 @@ func Execute(
 		return nil, fmt.Errorf("after-block gas time update: %w", err)
 	}
 
-	log.Debug(
+	log.Trace(
 		"Block execution complete",
 		zap.Uint64("gas_consumed", uint64(blockGasConsumed)),
 		zap.Time("gas_time", gasClock.AsTime()),


### PR DESCRIPTION
## Why this should be merged

The log levels are as follows (most verbose to least verbose):

- `VERBO`
- `DEBUG`
- `TRACE`
- `INFO`
- `WARN`
- `ERROR`
- `FATAL`
- `OFF`

p2p messages are logged at `DEBUG`.

consensus events (block acceptance, block rejection) are logged at `TRACE`.

Block execution is more similar to block acceptance, then p2p messages.

## How this works

`Debug` -> `Trace`

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No