### PR TITLE
[bazel] Log CI disk state around invocations

### DIFF
--- a/scripts/run_bazel_ci_command.sh
+++ b/scripts/run_bazel_ci_command.sh
@@ -81,4 +81,85 @@ if [[ -n "${BAZEL_CI_ENFORCE_DEPENDENCY_LIST-}" ]]; then
   assert_target_patterns_are_listed "${target_patterns}"
 fi
 
-exec bazelisk "${subcommand}" "$@"
+log_path_mount_state() {
+  local path="$1"
+
+  [[ -n "$path" && -e "$path" ]] || return 0
+
+  echo "--- path: $path ---"
+  findmnt -T "$path" || true
+  df -h "$path" || true
+  df -i "$path" || true
+  du -sh "$path" 2>/dev/null || true
+}
+
+log_disk_state() {
+  local phase="$1"
+  local output_base=""
+  local output_user_root=""
+  local execution_root=""
+
+  echo "=== bazel ci disk state (${phase}) ==="
+  df -h /
+  df -i / || true
+  df -h "$HOME" || true
+  df -h /mnt || true
+
+  echo "=== bazel ci paths (${phase}) ==="
+  bazelisk info output_base output_user_root execution_root bazel-bin bazel-testlogs 2>/dev/null || true
+
+  output_base="$(bazelisk info output_base 2>/dev/null || true)"
+  output_user_root="$(bazelisk info output_user_root 2>/dev/null || true)"
+  execution_root="$(bazelisk info execution_root 2>/dev/null || true)"
+
+  for path in \
+    "$output_base" \
+    "$output_user_root" \
+    "$execution_root" \
+    "$HOME/.cache/bazel-repository-cache" \
+    "$HOME/.cache/bazel-go-repository-modcache" \
+    "$HOME/.cache/bazelisk" \
+    "$HOME/.cache/bazel"; do
+    log_path_mount_state "$path"
+  done
+}
+
+log_largest_entries() {
+  local label="$1"
+  local path="$2"
+
+  [[ -n "$path" && -d "$path" ]] || return 0
+
+  echo "=== largest entries for ${label}: ${path} ==="
+  du -xh -d 2 "$path" 2>/dev/null | sort -h | tail -50 || true
+}
+
+log_failure_details() {
+  local output_base=""
+  local output_user_root=""
+
+  output_base="$(bazelisk info output_base 2>/dev/null || true)"
+  output_user_root="$(bazelisk info output_user_root 2>/dev/null || true)"
+
+  log_largest_entries "output_base" "$output_base"
+  log_largest_entries "output_user_root" "$output_user_root"
+  log_largest_entries "bazel cache" "$HOME/.cache/bazel"
+  log_largest_entries "home cache" "$HOME/.cache"
+  log_largest_entries "workspace root" "$REPO_ROOT"
+  log_largest_entries "runner work root" "/home/runner/work"
+  log_largest_entries "tmp" "/tmp"
+}
+
+on_exit() {
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    log_disk_state "failure"
+    log_failure_details
+  fi
+}
+
+log_disk_state "before"
+trap on_exit EXIT
+bazelisk "${subcommand}" "$@"
+trap - EXIT
+log_disk_state "after"


### PR DESCRIPTION
## Why this should be merged

Recent Bazel CI failures have included occasional ENOSPC errors, but current runner snapshots suggest Bazel often starts with substantial free space. Before re-introducing invasive mitigations like runner pruning, add logging to show where Bazel state lives, what filesystem backs it, and how much space is available there.

This updates the Bazel CI command wrapper to log:
- filesystem and inode usage before and after Bazel commands
- Bazel output and cache paths and the mounts backing them
- per-path size summaries for Bazel output and cache directories

On failure, it also logs the largest entries under the main Bazel output, cache, workspace, runner work, and temporary-directory roots to make future ENOSPC flakes easier to diagnose.

## How this was tested

- [ ] TODO Link to instances of new log output
