### PR TITLE
Remove ACP-176 state space from header.Extra in Helicon

### DIFF
--- a/graft/coreth/plugin/evm/customheader/extra.go
+++ b/graft/coreth/plugin/evm/customheader/extra.go
@@ -170,14 +170,7 @@ func VerifyExtra(rules extras.AvalancheRules, extra []byte) error {
 // PredicateBytesFromExtra returns the predicate result bytes from the header's
 // extra data. If the extra data is not long enough, an empty slice is returned.
 func PredicateBytesFromExtra(rules extras.AvalancheRules, extra []byte) []byte {
-	offset := ap3.WindowSize
-	if rules.IsFortuna {
-		offset = acp176.StateSize
-	}
-	if rules.IsHelicon {
-		offset = 0
-	}
-
+	offset := predicateBytesOffset(rules)
 	// Prior to Durango, the VM enforces the extra data is smaller than or equal
 	// to `offset`.
 	// After Durango, the VM pre-verifies the extra data past `offset` is valid.
@@ -191,14 +184,7 @@ func PredicateBytesFromExtra(rules extras.AvalancheRules, extra []byte) []byte {
 // data. If the extra data is not long enough (i.e., an incomplete header.Extra
 // as built in the miner), it is padded with zeros.
 func SetPredicateBytesInExtra(rules extras.AvalancheRules, extra []byte, predicateBytes []byte) []byte {
-	offset := ap3.WindowSize
-	if rules.IsFortuna {
-		offset = acp176.StateSize
-	}
-	if rules.IsHelicon {
-		offset = 0
-	}
-
+	offset := predicateBytesOffset(rules)
 	if len(extra) < offset {
 		// pad extra with zeros
 		extra = append(extra, make([]byte, offset-len(extra))...)
@@ -208,4 +194,15 @@ func SetPredicateBytesInExtra(rules extras.AvalancheRules, extra []byte, predica
 	}
 	extra = append(extra, predicateBytes...)
 	return extra
+}
+
+func predicateBytesOffset(rules extras.AvalancheRules) int {
+	switch {
+	case rules.IsHelicon:
+		return 0
+	case rules.IsFortuna:
+		return acp176.StateSize
+	default:
+		return ap3.WindowSize
+	}
 }

--- a/graft/coreth/plugin/evm/customheader/extra.go
+++ b/graft/coreth/plugin/evm/customheader/extra.go
@@ -117,6 +117,8 @@ func VerifyExtraPrefix(
 func VerifyExtra(rules extras.AvalancheRules, extra []byte) error {
 	extraLen := len(extra)
 	switch {
+	case rules.IsHelicon:
+		return nil
 	case rules.IsFortuna:
 		if extraLen < acp176.StateSize {
 			return fmt.Errorf(
@@ -172,6 +174,9 @@ func PredicateBytesFromExtra(rules extras.AvalancheRules, extra []byte) []byte {
 	if rules.IsFortuna {
 		offset = acp176.StateSize
 	}
+	if rules.IsHelicon {
+		offset = 0
+	}
 
 	// Prior to Durango, the VM enforces the extra data is smaller than or equal
 	// to `offset`.
@@ -189,6 +194,9 @@ func SetPredicateBytesInExtra(rules extras.AvalancheRules, extra []byte, predica
 	offset := ap3.WindowSize
 	if rules.IsFortuna {
 		offset = acp176.StateSize
+	}
+	if rules.IsHelicon {
+		offset = 0
 	}
 
 	if len(extra) < offset {

--- a/graft/coreth/plugin/evm/customheader/extra_test.go
+++ b/graft/coreth/plugin/evm/customheader/extra_test.go
@@ -785,7 +785,7 @@ func TestSetPredicateBytesInExtra(t *testing.T) {
 			},
 		},
 		{
-			name: "extra_too_long_helicon",
+			name: "extra_truncated_helicon",
 			rules: extras.AvalancheRules{
 				IsHelicon: true,
 			},
@@ -794,7 +794,7 @@ func TestSetPredicateBytesInExtra(t *testing.T) {
 			want:      []byte{2},
 		},
 		{
-			name: "extra_too_short_helicon",
+			name: "extra_overwritten_helicon",
 			rules: extras.AvalancheRules{
 				IsHelicon: true,
 			},

--- a/graft/coreth/plugin/evm/customheader/extra_test.go
+++ b/graft/coreth/plugin/evm/customheader/extra_test.go
@@ -608,6 +608,22 @@ func TestVerifyExtra(t *testing.T) {
 			extra:    make([]byte, acp176.StateSize-1),
 			expected: errInvalidExtraLength,
 		},
+		{
+			name: "helicon_empty_valid",
+			rules: extras.AvalancheRules{
+				IsHelicon: true,
+			},
+			extra:    nil,
+			expected: nil,
+		},
+		{
+			name: "helicon_non_empty_valid",
+			rules: extras.AvalancheRules{
+				IsHelicon: true,
+			},
+			extra:    make([]byte, 1),
+			expected: nil,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -678,6 +694,22 @@ func TestPredicateBytesFromExtra(t *testing.T) {
 			extra: []byte{
 				acp176.StateSize: 5,
 			},
+			expected: []byte{5},
+		},
+		{
+			name: "helicon_empty_predicate",
+			rules: extras.AvalancheRules{
+				IsHelicon: true,
+			},
+			extra:    nil,
+			expected: nil,
+		},
+		{
+			name: "helicon_non_empty_predicate",
+			rules: extras.AvalancheRules{
+				IsHelicon: true,
+			},
+			extra:    []byte{5},
 			expected: []byte{5},
 		},
 	}
@@ -751,6 +783,24 @@ func TestSetPredicateBytesInExtra(t *testing.T) {
 			want: []byte{
 				acp176.StateSize: 2,
 			},
+		},
+		{
+			name: "extra_too_long_helicon",
+			rules: extras.AvalancheRules{
+				IsHelicon: true,
+			},
+			extra:     []byte{1, 1},
+			predicate: []byte{2},
+			want:      []byte{2},
+		},
+		{
+			name: "extra_too_short_helicon",
+			rules: extras.AvalancheRules{
+				IsHelicon: true,
+			},
+			extra:     []byte{1},
+			predicate: []byte{2, 2},
+			want:      []byte{2, 2},
 		},
 	}
 	for _, test := range tests {

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -488,9 +488,9 @@ func (b *builder) BuildBlock(
 	if err != nil {
 		return nil, fmt.Errorf("serializing warp validity: %w", err)
 	}
-
-	// TODO(StephenButtolph): Remove padding for the ACP-176 fee state. The fee
-	// state is encoded in other fields.
+	// TODO(StephenButtolph): Delete [customheader.SetPredicateBytesInExtra]
+	// entirely during the coreth removal. warpValidityBytes could just be set
+	// directly.
 	header.Extra = customheader.SetPredicateBytesInExtra(
 		rulesExtra.AvalancheRules,
 		header.Extra,


### PR DESCRIPTION
## Why this should be merged

Currently, the cchain VM includes the 24-byte ACP-176 state in the `header.Extra` field as all zero bytes. This PR reclaims those bytes.

## How this works

- `VerifyExtra` is called by coreth during block parsing, so it must be updated to allow this new format.
- `PredicateBytesFromExtra` is called by the libevm hook to extract the predicate results for block execution, so this is the critical change which will need to be maintained even after the removal of coreth.
- `SetPredicateBytesInExtra` technically doesn't need to be used right now, but it felt weird for it not to be symmetric with `PredicateBytesFromExtra`, so I opted to update that instead of removing the call to it from the cchain VM code altogether (for now).

## How this was tested

- [x] Added unit tests for all modified coreth functions
- [x] The existing cchain VM integration test ensures that predicates are read from the block header post-helicon correctly 

## Need to be documented in RELEASES.md?

No.