### PR TITLE
Remove unnecessary header copies

### DIFF
--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -106,7 +106,9 @@ func (h *hooks) BlockRebuilderFrom(b *types.Block) (hook.BlockBuilder[*hookTx], 
 		txs[i] = ht
 	}
 
-	now := h.BlockTime(b.Header())
+	header := b.Header()
+	headerExtra := customtypes.GetHeaderExtra(header)
+	now := h.BlockTime(header)
 	return &builder{
 		h.ctx,
 		h.chainConfig,
@@ -115,9 +117,9 @@ func (h *hooks) BlockRebuilderFrom(b *types.Block) (hook.BlockBuilder[*hookTx], 
 		},
 		slices.Values(txs),
 		desiredParams{
-			targetExponent: customtypes.GetHeaderExtra(b.Header()).TargetExponent,
-			priceExponent:  customtypes.GetHeaderExtra(b.Header()).MinPriceExponent,
-			delayExponent:  (*dynamic.DelayExponent)(customtypes.GetHeaderExtra(b.Header()).MinDelayExcess),
+			targetExponent: headerExtra.TargetExponent,
+			priceExponent:  headerExtra.MinPriceExponent,
+			delayExponent:  (*dynamic.DelayExponent)(headerExtra.MinDelayExcess),
 		},
 	}, nil
 }


### PR DESCRIPTION
## Why this should be merged

`Block.Header()` copies the entire header. In all the other places in the hook, we correctly only call it once per-function on a block. In this place, we call it 4 times repeatedly.

In addition to being more performant, I think it makes the code cleaner as well.

## How this works

Trivial refactor.

## How this was tested

- [x] 👀

## Need to be documented in RELEASES.md?

No.