### PR TITLE
Improved test coverage for autorenewed flow and state

### DIFF
--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -837,6 +837,39 @@ func createAutoRenewedValidatorTx(
 	}
 }
 
+func createAutoRenewedStakerAndTx(
+	t testing.TB,
+	nodeID ids.NodeID,
+	startTime time.Time,
+	endTime time.Time,
+	weight uint64,
+	potentialReward uint64,
+	period uint64,
+	autoCompoundRewardShares uint32,
+) (*Staker, *txs.Tx) {
+	unsignedTx := createAutoRenewedValidatorTx(
+		t,
+		nodeID,
+		weight,
+		period,
+		autoCompoundRewardShares,
+	)
+	tx := &txs.Tx{Unsigned: unsignedTx}
+	require.NoError(t, tx.Initialize(txs.Codec))
+
+	staker, err := NewCurrentStaker(
+		tx.ID(),
+		unsignedTx,
+		startTime,
+		endTime,
+		weight,
+		potentialReward,
+	)
+	require.NoError(t, err)
+
+	return staker, tx
+}
+
 func TestValidatorWeightDiff(t *testing.T) {
 	type op struct {
 		op     func(*ValidatorWeightDiff, uint64) error
@@ -4103,6 +4136,11 @@ func TestStateAndDiffIntegration_StakingInfo(t *testing.T) {
 	validator1 := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
 	validator1Replacement := *validator1
 	validator1Replacement.TxID = ids.GenerateTestID()
+	validator1Replacement.StartTime = validator1.StartTime.Add(time.Hour)
+	validator1Replacement.EndTime = validator1.EndTime.Add(2 * time.Hour)
+	validator1Replacement.NextTime = validator1Replacement.EndTime
+	validator1Replacement.Weight++
+	validator1Replacement.PotentialReward++
 	validator2 := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
 	stakingInfo := StakingInfo{DelegateeReward: 123}
 
@@ -4298,6 +4336,26 @@ func TestStateAndDiffIntegration_StakingInfo(t *testing.T) {
 			},
 		},
 		{
+			name: "re-add_after_delete_in_prior_commit",
+			diffs: []diff{
+				{
+					ops: []op{
+						put(validator1),
+						setStakingInfo(validator1, stakingInfo),
+					},
+					wants: []want{{staker: validator1, info: stakingInfo}},
+				},
+				{
+					ops:   []op{del(validator1)},
+					wants: []want{{staker: validator1, err: database.ErrNotFound}},
+				},
+				{
+					ops:   []op{put(&validator1Replacement)},
+					wants: []want{{staker: &validator1Replacement}},
+				},
+			},
+		},
+		{
 			name: "replace_with_updated_validator_and_set",
 			diffs: []diff{
 				{
@@ -4427,24 +4485,21 @@ func TestAutoRenewedValidatorRestakeStateReload(t *testing.T) {
 	)
 
 	// Create and add the auto-renewed validator with initial times
-	autoRenewedUnsigned := createAutoRenewedValidatorTx(t, nodeID, weight, period, autoCompoundRewardShares)
-	autoRenewedTx := &txs.Tx{Unsigned: autoRenewedUnsigned}
-	require.NoError(autoRenewedTx.Initialize(txs.Codec))
-
-	autoRenewedStaker, err := NewCurrentStaker(
-		autoRenewedTx.ID(),
-		autoRenewedUnsigned,
+	staker, stakerTx := createAutoRenewedStakerAndTx(
+		t,
+		nodeID,
 		startTime,
 		endTime,
 		weight,
 		potentialReward,
+		period,
+		autoCompoundRewardShares,
 	)
-	require.NoError(err)
 
 	d, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
 	require.NoError(err)
-	d.AddTx(autoRenewedTx, status.Committed)
-	require.NoError(d.PutCurrentValidator(autoRenewedStaker))
+	d.AddTx(stakerTx, status.Committed)
+	require.NoError(d.PutCurrentValidator(staker))
 	require.NoError(d.Apply(state))
 	require.NoError(state.Commit())
 
@@ -4456,11 +4511,11 @@ func TestAutoRenewedValidatorRestakeStateReload(t *testing.T) {
 
 	d, err = NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
 	require.NoError(err)
-	require.NoError(d.DeleteCurrentValidator(autoRenewedStaker))
+	require.NoError(d.DeleteCurrentValidator(staker))
 
 	renewedStaker, err := NewCurrentStaker(
-		autoRenewedTx.ID(),
-		autoRenewedUnsigned,
+		stakerTx.ID(),
+		stakerTx.Unsigned.(*txs.AddAutoRenewedValidatorTx),
 		wantStartTime,
 		wantEndTime,
 		wantWeight,
@@ -4496,4 +4551,110 @@ func TestAutoRenewedValidatorRestakeStateReload(t *testing.T) {
 	require.Equal(accruedDelRewards, gotStakingInfo.AccruedDelegateeRewards)
 	require.Equal(autoCompoundRewardShares, gotStakingInfo.AutoCompoundRewardShares)
 	require.Equal(period, gotStakingInfo.NextPeriod)
+}
+
+func TestAutoRenewedValidatorReaddStateReload(t *testing.T) {
+	require := require.New(t)
+
+	db := memdb.New()
+	state := newTestState(t, db)
+
+	var (
+		nodeID    = ids.GenerateTestNodeID()
+		subnetID  = constants.PrimaryNetworkID
+		startTime = genesistest.DefaultValidatorStartTime
+	)
+
+	const (
+		weight             = uint64(3000)
+		potentialReward    = uint64(500)
+		period             = uint64(time.Hour / time.Second)
+		autoCompoundShares = uint32(.1 * reward.PercentDenominator)
+	)
+
+	oldStaker, oldStakerTx := createAutoRenewedStakerAndTx(
+		t,
+		nodeID,
+		startTime,
+		startTime.Add(time.Hour),
+		weight,
+		potentialReward,
+		period,
+		autoCompoundShares,
+	)
+
+	diff, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+	require.NoError(err)
+	diff.AddTx(oldStakerTx, status.Committed)
+	require.NoError(diff.PutCurrentValidator(oldStaker))
+	require.NoError(diff.SetStakingInfo(subnetID, nodeID, StakingInfo{
+		DelegateeReward:          11,
+		AccruedValidationRewards: 12,
+		AccruedDelegateeRewards:  13,
+		AutoCompoundRewardShares: .2 * reward.PercentDenominator,
+		NextPeriod:               period,
+	}))
+	require.NoError(diff.Apply(state))
+	require.NoError(state.Commit())
+
+	// Exit in one commit, then add a new validator transaction for the same
+	// node in a later commit. None of the old transaction's metadata may leak.
+	diff, err = NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+	require.NoError(err)
+	require.NoError(diff.DeleteCurrentValidator(oldStaker))
+	require.NoError(diff.Apply(state))
+	require.NoError(state.Commit())
+
+	const (
+		newWeight                   = uint64(4000)
+		newPotentialReward          = uint64(700)
+		newPeriod                   = uint64(2 * time.Hour / time.Second)
+		newAutoCompoundShares       = uint32(.3 * reward.PercentDenominator)
+		newStakingInfoShares        = uint32(.4 * reward.PercentDenominator)
+		newDelegateeReward          = uint64(21)
+		newAccruedValidationRewards = uint64(22)
+		newAccruedDelegateeRewards  = uint64(23)
+	)
+
+	newStartTime := oldStaker.EndTime.Add(time.Hour)
+	newEndTime := newStartTime.Add(2 * time.Hour)
+	newStaker, newTx := createAutoRenewedStakerAndTx(
+		t,
+		nodeID,
+		newStartTime,
+		newEndTime,
+		newWeight,
+		newPotentialReward,
+		newPeriod,
+		newAutoCompoundShares,
+	)
+
+	diff, err = NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+	require.NoError(err)
+	diff.AddTx(newTx, status.Committed)
+	require.NoError(diff.PutCurrentValidator(newStaker))
+	newStakingInfo := StakingInfo{
+		DelegateeReward:          newDelegateeReward,
+		AccruedValidationRewards: newAccruedValidationRewards,
+		AccruedDelegateeRewards:  newAccruedDelegateeRewards,
+		AutoCompoundRewardShares: newStakingInfoShares,
+		NextPeriod:               newPeriod,
+	}
+	require.NoError(diff.SetStakingInfo(subnetID, nodeID, newStakingInfo))
+	require.NoError(diff.Apply(state))
+	require.NoError(state.Commit())
+
+	reloadedState := newTestState(t, db)
+	gotStaker, err := reloadedState.GetCurrentValidator(subnetID, nodeID)
+	require.NoError(err)
+
+	// On reload, accrued rewards from the staking info are added to the
+	// staker's weight.
+	expectedStaker := *newStaker
+	expectedStaker.Weight += newStakingInfo.AccruedValidationRewards + newStakingInfo.AccruedDelegateeRewards
+	require.True(expectedStaker.Equals(gotStaker))
+
+	gotStakingInfo, err := reloadedState.GetStakingInfo(subnetID, nodeID)
+	require.NoError(err)
+	require.Equal(newStakingInfo, gotStakingInfo)
 }

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -1490,6 +1490,8 @@ func TestRewardAutoRenewedValidatorTx(t *testing.T) {
 			require.NoError(t, err)
 			currentSupply, err := env.state.GetCurrentSupply(uStakerTx.SubnetID())
 			require.NoError(t, err)
+			stakingInfo, err := env.state.GetStakingInfo(uStakerTx.SubnetID(), uStakerTx.NodeID())
+			require.NoError(t, err)
 
 			diff, err := state.NewDiffOn(env.state, state.StakerAdditionAfterDeletionAllowed)
 			require.NoError(t, err)
@@ -1512,8 +1514,10 @@ func TestRewardAutoRenewedValidatorTx(t *testing.T) {
 
 			want := tt.want(cfg, staker.PotentialReward)
 			if want.commitRestaked {
+				period := time.Duration(stakingInfo.NextPeriod) * time.Second
+
 				want.commitStartTime = staker.EndTime
-				want.commitEndTime = staker.EndTime.Add(env.config.MinStakeDuration)
+				want.commitEndTime = staker.EndTime.Add(period)
 
 				rewards, err := GetRewardsCalculator(
 					env.backend.Config.RewardConfig,
@@ -1523,8 +1527,8 @@ func TestRewardAutoRenewedValidatorTx(t *testing.T) {
 				)
 				require.NoError(t, err)
 				want.commitPotentialReward = rewards.Calculate(
-					staker.StartTime,
-					env.config.MinStakeDuration,
+					want.commitStartTime,
+					period,
 					want.commitWeight,
 					currentSupply,
 				)

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -215,6 +215,9 @@ type wantRewardAutoRenewedValidator struct {
 	// commit* fields below are ignored.
 	commitRestaked                 bool
 	commitWeight                   uint64
+	commitStartTime                time.Time
+	commitEndTime                  time.Time
+	commitPotentialReward          uint64
 	commitAccruedValidationRewards uint64
 	commitAccruedDelegateeRewards  uint64
 
@@ -250,7 +253,9 @@ func assertValidatorRemoved(t testing.TB, chain state.Chain, stakerTx *txs.Tx, r
 	uStakerTx := stakerTx.Unsigned.(*txs.AddAutoRenewedValidatorTx)
 
 	_, err := chain.GetCurrentValidator(uStakerTx.SubnetID(), uStakerTx.NodeID())
-	require.ErrorIs(t, err, database.ErrNotFound)
+	require.Equal(t, err, database.ErrNotFound)
+	_, err = chain.GetStakingInfo(uStakerTx.SubnetID(), uStakerTx.NodeID())
+	require.Equal(t, database.ErrNotFound, err)
 
 	assertStakeReturned(t, chain, stakerTx.ID(), uStakerTx)
 	assertRewards(t, chain, stakerTx, rewardTxID, rewards)
@@ -298,6 +303,10 @@ func assertRewardAutoRenewedValidator(
 		require.NoError(t, err)
 
 		require.Equal(t, want.commitWeight, validator.Weight)
+		require.Equal(t, want.commitStartTime, validator.StartTime)
+		require.Equal(t, want.commitEndTime, validator.EndTime)
+		require.Equal(t, want.commitPotentialReward, validator.PotentialReward)
+		require.Zero(t, stakingInfo.DelegateeReward)
 		require.Equal(t, want.commitAccruedValidationRewards, stakingInfo.AccruedValidationRewards)
 		require.Equal(t, want.commitAccruedDelegateeRewards, stakingInfo.AccruedDelegateeRewards)
 
@@ -1479,6 +1488,8 @@ func TestRewardAutoRenewedValidatorTx(t *testing.T) {
 			uStakerTx := stakerTx.Unsigned.(*txs.AddAutoRenewedValidatorTx)
 			staker, err := env.state.GetCurrentValidator(uStakerTx.SubnetID(), uStakerTx.NodeID())
 			require.NoError(t, err)
+			currentSupply, err := env.state.GetCurrentSupply(uStakerTx.SubnetID())
+			require.NoError(t, err)
 
 			diff, err := state.NewDiffOn(env.state, state.StakerAdditionAfterDeletionAllowed)
 			require.NoError(t, err)
@@ -1499,6 +1510,20 @@ func TestRewardAutoRenewedValidatorTx(t *testing.T) {
 				onAbortState,
 			))
 
+			want := tt.want(cfg, staker.PotentialReward)
+			if want.commitRestaked {
+				want.commitStartTime = staker.EndTime
+				want.commitEndTime = staker.EndTime.Add(env.config.MinStakeDuration)
+
+				rewards, err := GetRewardsCalculator(&env.backend, env.state, staker.SubnetID)
+				require.NoError(t, err)
+				want.commitPotentialReward = rewards.Calculate(
+					env.config.MinStakeDuration,
+					want.commitWeight,
+					currentSupply,
+				)
+			}
+
 			assertRewardAutoRenewedValidator(
 				t,
 				env.state,
@@ -1506,7 +1531,7 @@ func TestRewardAutoRenewedValidatorTx(t *testing.T) {
 				rewardTx,
 				onCommitState,
 				onAbortState,
-				tt.want(cfg, staker.PotentialReward),
+				want,
 			)
 		})
 	}

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -1515,9 +1515,15 @@ func TestRewardAutoRenewedValidatorTx(t *testing.T) {
 				want.commitStartTime = staker.EndTime
 				want.commitEndTime = staker.EndTime.Add(env.config.MinStakeDuration)
 
-				rewards, err := GetRewardsCalculator(&env.backend, env.state, staker.SubnetID)
+				rewards, err := GetRewardsCalculator(
+					env.backend.Config.RewardConfig,
+					env.backend.Config.UpgradeConfig,
+					env.state,
+					staker.SubnetID,
+				)
 				require.NoError(t, err)
 				want.commitPotentialReward = rewards.Calculate(
+					staker.StartTime,
 					env.config.MinStakeDuration,
 					want.commitWeight,
 					currentSupply,

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -4571,6 +4571,150 @@ func TestStandardExecutorAddAutoRenewedValidatorTx(t *testing.T) {
 	}
 }
 
+// TestStandardExecutorReaddAutoRenewedValidatorTx asserts that re-adding a
+// node that previously validated as an auto-renewed validator produces a
+// staker and staking info derived exclusively from the new tx, with nothing
+// inherited from the exited validator.
+func TestStandardExecutorReaddAutoRenewedValidatorTx(t *testing.T) {
+	env := newEnvironment(t, upgradetest.Latest)
+
+	nodeID := ids.GenerateTestNodeID()
+
+	oldPop := newProofOfPossession(t)
+
+	// Stage the old validator with non-zero accrued rewards so that any state
+	// leaking into the re-added validator is visible.
+	oldCfg := autoRenewedValidatorConfig{
+		weight:                   2 * env.config.MinValidatorStake,
+		delegateeReward:          2_000,
+		accruedValidationRewards: 3_000,
+		accruedDelegateeRewards:  4_000,
+		delegationRewardShares:   100_000,
+		autoCompoundRewardShares: 300_000,
+		restake:                  false, // graceful stop at cycle end
+	}
+
+	wallet := newWallet(t, env, walletConfig{})
+	oldTx, err := wallet.IssueAddAutoRenewedValidatorTx(
+		nodeID,
+		oldCfg.weight,
+		oldPop,
+		&secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{ids.GenerateTestShortID()}},
+		&secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{ids.GenerateTestShortID()}},
+		&secp256k1fx.OutputOwners{},
+		oldCfg.delegationRewardShares,
+		oldCfg.autoCompoundRewardShares,
+		env.config.MinStakeDuration,
+	)
+	require.NoError(t, err)
+	addAutoRenewedValidator(t, env, oldTx, oldCfg)
+
+	// Gracefully exit the validator at the end of its cycle.
+	oldStaker, err := env.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+
+	env.state.SetTimestamp(oldStaker.EndTime)
+	rewardTx := newRewardAutoRenewedValidatorTx(t, oldTx.ID(), oldStaker.EndTime)
+
+	onCommitState, err := state.NewDiffOn(env.state, state.StakerAdditionAfterDeletionAllowed)
+	require.NoError(t, err)
+	onAbortState, err := state.NewDiffOn(env.state, state.StakerAdditionAfterDeletionAllowed)
+	require.NoError(t, err)
+
+	require.NoError(t, ProposalTx(
+		&env.backend,
+		state.PickFeeCalculator(env.config, env.state),
+		rewardTx,
+		onCommitState,
+		onAbortState,
+	))
+	require.NoError(t, onCommitState.Apply(env.state))
+	require.NoError(t, env.state.Commit())
+
+	_, err = env.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(t, err, database.ErrNotFound)
+
+	// Re-add the same node with a different BLS key and different parameters
+	// so every field of the resulting staker is distinguishable from the old
+	// validator's.
+	newSk, err := localsigner.New()
+	require.NoError(t, err)
+
+	newPop, err := signer.NewProofOfPossession(newSk)
+	require.NoError(t, err)
+
+	const (
+		newDelegationShares   = 150_000
+		newAutoCompoundShares = 450_000
+	)
+	newWeight := 3 * env.config.MinValidatorStake
+	newPeriod := 2 * env.config.MinStakeDuration
+
+	wallet = newWallet(t, env, walletConfig{})
+	newTx, err := wallet.IssueAddAutoRenewedValidatorTx(
+		nodeID,
+		newWeight,
+		newPop,
+		&secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{ids.GenerateTestShortID()}},
+		&secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{ids.GenerateTestShortID()}},
+		&secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{ids.GenerateTestShortID()}},
+		newDelegationShares,
+		newAutoCompoundShares,
+		newPeriod,
+	)
+	require.NoError(t, err)
+
+	currentSupply, err := env.state.GetCurrentSupply(constants.PrimaryNetworkID)
+	require.NoError(t, err)
+
+	wantPotentialReward := env.backend.Rewards.Calculate(
+		newPeriod,
+		newWeight,
+		currentSupply,
+	)
+
+	diff, err := state.NewDiffOn(env.state, state.StakerAdditionAfterDeletionAllowed)
+	require.NoError(t, err)
+
+	_, _, _, err = StandardTx(
+		&env.backend,
+		state.PickFeeCalculator(env.config, env.state),
+		newTx,
+		diff,
+	)
+	require.NoError(t, err)
+	require.NoError(t, diff.Apply(env.state))
+
+	// The re-added validator is defined exclusively by the new tx.
+	chainTime := env.state.GetTimestamp()
+	validator, err := env.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, &state.Staker{
+		TxID:            newTx.TxID,
+		NodeID:          nodeID,
+		PublicKey:       newSk.PublicKey(),
+		SubnetID:        constants.PrimaryNetworkID,
+		Weight:          newWeight,
+		StartTime:       chainTime,
+		EndTime:         chainTime.Add(newPeriod),
+		PotentialReward: wantPotentialReward,
+		NextTime:        chainTime.Add(newPeriod),
+		Priority:        txs.PrimaryNetworkValidatorCurrentPriority,
+	}, validator)
+
+	// The staking info starts from a clean slate: none of the old validator's
+	// accrued rewards leak into the re-added one.
+	stakingInfo, err := env.state.GetStakingInfo(constants.PrimaryNetworkID, nodeID)
+	require.NoError(t, err)
+	require.Equal(t, state.StakingInfo{
+		DelegateeReward:          0,
+		AccruedValidationRewards: 0,
+		AccruedDelegateeRewards:  0,
+		AutoCompoundRewardShares: newAutoCompoundShares,
+		NextPeriod:               uint64(newPeriod / time.Second),
+	}, stakingInfo)
+}
+
 func TestStandardExecutorAddAutoRenewedValidatorTxErrors(t *testing.T) {
 	var (
 		env           = newEnvironment(t, upgradetest.Latest)

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -4667,11 +4667,13 @@ func TestStandardExecutorReaddAutoRenewedValidatorTx(t *testing.T) {
 	currentSupply, err := env.state.GetCurrentSupply(constants.PrimaryNetworkID)
 	require.NoError(t, err)
 
-	wantPotentialReward := env.backend.Rewards.Calculate(
-		newPeriod,
-		newWeight,
-		currentSupply,
+	rewards, err := GetRewardsCalculator(
+		env.config.RewardConfig,
+		env.config.UpgradeConfig,
+		env.state,
+		constants.PrimaryNetworkID,
 	)
+	require.NoError(t, err)
 
 	diff, err := state.NewDiffOn(env.state, state.StakerAdditionAfterDeletionAllowed)
 	require.NoError(t, err)
@@ -4689,6 +4691,13 @@ func TestStandardExecutorReaddAutoRenewedValidatorTx(t *testing.T) {
 	chainTime := env.state.GetTimestamp()
 	validator, err := env.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
 	require.NoError(t, err)
+
+	wantPotentialReward := rewards.Calculate(
+		validator.StartTime,
+		newPeriod,
+		newWeight,
+		currentSupply,
+	)
 	require.Equal(t, &state.Staker{
 		TxID:            newTx.TxID,
 		NodeID:          nodeID,

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -4633,6 +4633,8 @@ func TestStandardExecutorReaddAutoRenewedValidatorTx(t *testing.T) {
 
 	_, err = env.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
 	require.ErrorIs(t, err, database.ErrNotFound)
+	_, err = env.state.GetStakingInfo(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(t, err, database.ErrNotFound)
 
 	// Re-add the same node with a different BLS key and different parameters
 	// so every field of the resulting staker is distinguishable from the old


### PR DESCRIPTION
## Why this should be merged
Improves test coverage for auto-renewed validator lifecycle and state persistence.

## How this works

- Adds coverage for deleting and re-adding a validator across separate state commits.
- Verifies the re-added validator and its staking info persist correctly after a state reload.
- Adds an executor test confirming that a re-added validator is derived exclusively from the new transaction.
- Strengthens restake assertions to cover start time, end time, potential reward, weight, and staking info.
- Corrects the test setup for `NextPeriod` to use the minimum staking duration.

## How this was tested
Only test files changed.

## Need to be documented in RELEASES.md?
No.