### PR TITLE
fix(saevm/cchain): activate warp precompile at Durango

### DIFF
--- a/vms/saevm/cchain/genesis.go
+++ b/vms/saevm/cchain/genesis.go
@@ -329,17 +329,13 @@ func (g *genesis) root() (_ common.Hash, retErr error) {
 	return g.writeState(db, tdb)
 }
 
-// activateWarpPrecompile marks the warp precompile's account as non-empty by
-// setting the nonce and code so it is not pruned as an empty account during
-// state finalization (EIP-161) and so it appears as a contract to EVM code
+// activatePrecompile marks the precompile's account as non-empty by setting
+// the nonce and code so it is not pruned as an empty account during state
+// finalization (EIP-161) and so it appears as a contract to EVM code
 // introspection (e.g. EXTCODESIZE/EXTCODEHASH).
-func activateWarpPrecompile(statedb *state.StateDB) {
-	const (
-		precompileNonce = 1
-		precompileCode  = "\x01"
-	)
-	statedb.SetNonce(warp.ContractAddress, precompileNonce)
-	statedb.SetCode(warp.ContractAddress, []byte(precompileCode))
+func activatePrecompile(statedb *state.StateDB, addr common.Address) {
+	statedb.SetNonce(addr, 1)
+	statedb.SetCode(addr, []byte{0x01})
 }
 
 // writeState commits the genesis allocation to the state database and returns
@@ -367,7 +363,7 @@ func (g *genesis) writeState(db ethdb.Database, tdb *triedb.Database) (common.Ha
 	// state needs to reflect that or the precompile would never be marked as
 	// active.
 	if c := corethparams.GetExtra(g.Config); c.IsDurango(g.Timestamp) {
-		activateWarpPrecompile(statedb)
+		activatePrecompile(statedb, warp.ContractAddress)
 	}
 
 	const deleteEmptyObjects = true

--- a/vms/saevm/cchain/genesis.go
+++ b/vms/saevm/cchain/genesis.go
@@ -329,6 +329,19 @@ func (g *genesis) root() (_ common.Hash, retErr error) {
 	return g.writeState(db, tdb)
 }
 
+// activateWarpPrecompile marks the warp precompile's account as non-empty by
+// setting the nonce and code so it is not pruned as an empty account during
+// state finalization (EIP-161) and so it appears as a contract to EVM code
+// introspection (e.g. EXTCODESIZE/EXTCODEHASH).
+func activateWarpPrecompile(statedb *state.StateDB) {
+	const (
+		precompileNonce = 1
+		precompileCode  = "\x01"
+	)
+	statedb.SetNonce(warp.ContractAddress, precompileNonce)
+	statedb.SetCode(warp.ContractAddress, []byte(precompileCode))
+}
+
 // writeState commits the genesis allocation to the state database and returns
 // the state root.
 func (g *genesis) writeState(db ethdb.Database, tdb *triedb.Database) (common.Hash, error) {
@@ -353,18 +366,8 @@ func (g *genesis) writeState(db ethdb.Database, tdb *triedb.Database) (common.Ha
 	// the genesis timestamp is already after the Warp activation, then the
 	// state needs to reflect that or the precompile would never be marked as
 	// active.
-	//
-	// When a precompile is activated, its account is marked as non-empty by
-	// setting the nonce and code so it is not pruned as an empty account during
-	// state finalization (EIP-161) and so it appears as a contract to EVM code
-	// introspection (e.g. EXTCODESIZE/EXTCODEHASH).
-	const (
-		precompileNonce = 1
-		precompileCode  = "\x01"
-	)
 	if c := corethparams.GetExtra(g.Config); c.IsDurango(g.Timestamp) {
-		statedb.SetNonce(warp.ContractAddress, precompileNonce)
-		statedb.SetCode(warp.ContractAddress, []byte(precompileCode))
+		activateWarpPrecompile(statedb)
 	}
 
 	const deleteEmptyObjects = true

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ava-labs/avalanchego/x/blockdb"
 
 	corethparams "github.com/ava-labs/avalanchego/graft/coreth/params"
+	corethwarp "github.com/ava-labs/avalanchego/graft/coreth/precompile/contracts/warp"
 	cchainstate "github.com/ava-labs/avalanchego/vms/saevm/cchain/state"
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
@@ -246,8 +247,8 @@ func (*hooks) CanExecuteTransaction(common.Address, *common.Address, libevm.Stat
 
 func (h *hooks) BeforeExecutingBlock(statedb *state.StateDB, parent, header *types.Header) error {
 	config := corethparams.GetExtra(h.chainConfig)
-	if config.IsDurango(header.Time) && !config.IsDurango(parent.Time) {
-		activateWarpPrecompile(statedb)
+	if isFirstDurangoBlock := config.IsDurango(header.Time) && !config.IsDurango(parent.Time); isFirstDurangoBlock {
+		activatePrecompile(statedb, corethwarp.ContractAddress)
 	}
 	return nil
 }

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -245,9 +245,9 @@ func (*hooks) CanExecuteTransaction(common.Address, *common.Address, libevm.Stat
 	return nil
 }
 
-func (h *hooks) BeforeExecutingBlock(statedb *state.StateDB, parent, header *types.Header) error {
+func (h *hooks) BeforeExecutingBlock(statedb *state.StateDB, parent *types.Header, block *types.Block) error {
 	config := corethparams.GetExtra(h.chainConfig)
-	if isFirstDurangoBlock := config.IsDurango(header.Time) && !config.IsDurango(parent.Time); isFirstDurangoBlock {
+	if isFirstDurangoBlock := config.IsDurango(block.Time()) && !config.IsDurango(parent.Time); isFirstDurangoBlock {
 		activatePrecompile(statedb, corethwarp.ContractAddress)
 	}
 	return nil

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -245,9 +245,9 @@ func (*hooks) CanExecuteTransaction(common.Address, *common.Address, libevm.Stat
 	return nil
 }
 
-func (h *hooks) BeforeExecutingBlock(statedb *state.StateDB, parent *types.Header, block *types.Block) error {
+func (h *hooks) BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, _ *types.Block) error {
 	config := corethparams.GetExtra(h.chainConfig)
-	if isFirstDurangoBlock := config.IsDurango(block.Time()) && !config.IsDurango(parent.Time); isFirstDurangoBlock {
+	if isFirstDurangoBlock := corethparams.GetRulesExtra(rules).IsDurango && !config.IsDurango(parent.Time); isFirstDurangoBlock {
 		activatePrecompile(statedb, corethwarp.ContractAddress)
 	}
 	return nil

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -244,11 +244,11 @@ func (*hooks) CanExecuteTransaction(common.Address, *common.Address, libevm.Stat
 	return nil
 }
 
-func (*hooks) BeforeExecutingBlock(params.Rules, *state.StateDB, *types.Block) error {
-	// TODO(StephenButtolph): If the genesis was configured to be pre-Durango
-	// and this block is the first post-Durango block, we need to activate the
-	// Warp precompile. This case does not happen on Mainnet, Fuji, or the Local
-	// network, but could happen on a custom network.
+func (h *hooks) BeforeExecutingBlock(statedb *state.StateDB, parent, header *types.Header) error {
+	config := corethparams.GetExtra(h.chainConfig)
+	if config.IsDurango(header.Time) && !config.IsDurango(parent.Time) {
+		activateWarpPrecompile(statedb)
+	}
 	return nil
 }
 

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -192,21 +192,12 @@ func withNetworkID(id uint32) sutOption {
 	})
 }
 
-// withHeliconTime schedules the Helicon activation at t rather than at
-// genesis, leaving the rest of the upgrade schedule unchanged.
-func withHeliconTime(t time.Time) sutOption {
-	return options.Func[sutConfig](func(c *sutConfig) {
-		c.upgrades.HeliconTime = t
-	})
-}
-
-// withDurangoTime schedules the Durango activation at t rather than at
-// genesis. Later upgrades cannot precede Durango, so they are also scheduled
-// at t; the pre-Durango schedule is left initially active.
-func withDurangoTime(t time.Time) sutOption {
+// withUpgradeTime schedules fork and all later upgrades at t. Earlier
+// upgrades remain initially active.
+func withUpgradeTime(fork upgradetest.Fork, t time.Time) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		upgradetest.SetTimesTo(&c.upgrades, upgradetest.Latest, t)
-		upgradetest.SetTimesTo(&c.upgrades, upgradetest.Durango-1, upgrade.InitiallyActiveTime)
+		upgradetest.SetTimesTo(&c.upgrades, fork-1, upgrade.InitiallyActiveTime)
 	})
 }
 
@@ -1752,7 +1743,7 @@ func TestPreHeliconBlocksDisallowed(t *testing.T) {
 	timeOpt, clock := withVMTime(preHeliconTime)
 	ctx, sut := newSUT(t,
 		withMaxAllocFor(key.EthAddress()),
-		withHeliconTime(heliconTime),
+		withUpgradeTime(upgradetest.Helicon, heliconTime),
 		timeOpt,
 	)
 
@@ -1792,7 +1783,7 @@ func TestWarpPrecompileActivation(t *testing.T) {
 	key := txtest.NewKey(t)
 	ctx, sut := newSUT(t,
 		withMaxAllocFor(key.EthAddress()),
-		withDurangoTime(upgrade.InitiallyActiveTime.Add(5*time.Second)),
+		withUpgradeTime(upgradetest.Durango, upgrade.InitiallyActiveTime.Add(5*time.Second)),
 	)
 
 	genesisState, err := sut.LastExecutedState()

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -68,6 +68,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
 	cparams "github.com/ava-labs/avalanchego/graft/coreth/params"
+	corethwarp "github.com/ava-labs/avalanchego/graft/coreth/precompile/contracts/warp"
 	evmconstants "github.com/ava-labs/avalanchego/graft/evm/constants"
 	snowcommon "github.com/ava-labs/avalanchego/snow/engine/common"
 	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
@@ -196,6 +197,16 @@ func withNetworkID(id uint32) sutOption {
 func withHeliconTime(t time.Time) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.upgrades.HeliconTime = t
+	})
+}
+
+// withDurangoTime schedules the Durango activation at t rather than at
+// genesis. Later upgrades cannot precede Durango, so they are also scheduled
+// at t; the pre-Durango schedule is left initially active.
+func withDurangoTime(t time.Time) sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		upgradetest.SetTimesTo(&c.upgrades, upgradetest.Latest, t)
+		upgradetest.SetTimesTo(&c.upgrades, upgradetest.Durango-1, upgrade.InitiallyActiveTime)
 	})
 }
 
@@ -1728,4 +1739,27 @@ func TestPreHeliconBlocksDisallowed(t *testing.T) {
 		err = sut.VerifyBlock(ctx, nil, parsed)
 		require.ErrorIsf(t, err, errHeliconUnactivated, "%T.VerifyBlock() should not allow pre-Helicon blocks", sut.VM)
 	})
+}
+
+// TestWarpPrecompileActivation verifies that executing the first post-Durango
+// block marks the warp precompile's account as non-empty when the genesis
+// predates Durango.
+func TestWarpPrecompileActivation(t *testing.T) {
+	key := txtest.NewKey(t)
+	ctx, sut := newSUT(t,
+		withMaxAllocFor(key.EthAddress()),
+		withDurangoTime(upgrade.InitiallyActiveTime.Add(5*time.Second)),
+	)
+
+	genesisState, err := sut.LastExecutedState()
+	require.NoErrorf(t, err, "%T.LastExecutedState()", sut.VM)
+	require.Empty(t, genesisState.GetCode(corethwarp.ContractAddress), "warp precompile code in pre-Durango genesis state")
+
+	stx := newWallet(key, sut.ctx, sut.Client).newMinimalTx(t)
+	sut.issueAndExecute(ctx, t, stx)
+
+	state, err := sut.LastExecutedState()
+	require.NoErrorf(t, err, "%T.LastExecutedState()", sut.VM)
+	assert.Equalf(t, uint64(1), state.GetNonce(corethwarp.ContractAddress), "warp precompile nonce after first Durango block")
+	assert.Equalf(t, []byte{0x01}, state.GetCode(corethwarp.ContractAddress), "warp precompile code after first Durango block")
 }

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -78,9 +78,9 @@ type Points interface {
 	// CanExecuteTransaction mirrors [params.RulesAllowlistHooks.CanExecuteTransaction]
 	// so that consumers can use a single concrete type for both SAE and libevm hooks.
 	CanExecuteTransaction(common.Address, *common.Address, libevm.StateReader) error
-	// BeforeExecutingBlock is called immediately prior to executing the block
-	// with the given header; parent is the header of that block's parent.
-	BeforeExecutingBlock(statedb *state.StateDB, parent, header *types.Header) error
+	// BeforeExecutingBlock is called immediately prior to executing the block;
+	// parent is the header of the block's parent.
+	BeforeExecutingBlock(statedb *state.StateDB, parent *types.Header, block *types.Block) error
 	// AfterExecutingTransaction is called immediately after executing each
 	// transaction, with the executing block's base fee and the resulting
 	// receipt. Note the caller finalises any state changes made by the hook.

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -78,8 +78,9 @@ type Points interface {
 	// CanExecuteTransaction mirrors [params.RulesAllowlistHooks.CanExecuteTransaction]
 	// so that consumers can use a single concrete type for both SAE and libevm hooks.
 	CanExecuteTransaction(common.Address, *common.Address, libevm.StateReader) error
-	// BeforeExecutingBlock is called immediately prior to executing the block.
-	BeforeExecutingBlock(params.Rules, *state.StateDB, *types.Block) error
+	// BeforeExecutingBlock is called immediately prior to executing the block
+	// with the given header; parent is the header of that block's parent.
+	BeforeExecutingBlock(statedb *state.StateDB, parent, header *types.Header) error
 	// AfterExecutingTransaction is called immediately after executing each
 	// transaction, with the executing block's base fee and the resulting
 	// receipt. Note the caller finalises any state changes made by the hook.

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -79,8 +79,9 @@ type Points interface {
 	// so that consumers can use a single concrete type for both SAE and libevm hooks.
 	CanExecuteTransaction(common.Address, *common.Address, libevm.StateReader) error
 	// BeforeExecutingBlock is called immediately prior to executing the block;
-	// parent is the header of the block's parent.
-	BeforeExecutingBlock(statedb *state.StateDB, parent *types.Header, block *types.Block) error
+	// rules are those of the block and parent is the header of the block's
+	// parent.
+	BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, block *types.Block) error
 	// AfterExecutingTransaction is called immediately after executing each
 	// transaction, with the executing block's base fee and the resulting
 	// receipt. Note the caller finalises any state changes made by the hook.

--- a/vms/saevm/hook/hookstest/BUILD.bazel
+++ b/vms/saevm/hook/hookstest/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_ava_labs_libevm//core/types",
         "@com_github_ava_labs_libevm//libevm",
         "@com_github_ava_labs_libevm//libevm/options",
+        "@com_github_ava_labs_libevm//params",
         "@com_github_holiman_uint256//:uint256",
         "@com_github_stephenbuttolph_canoto//:canoto",
     ],

--- a/vms/saevm/hook/hookstest/BUILD.bazel
+++ b/vms/saevm/hook/hookstest/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "@com_github_ava_labs_libevm//core/types",
         "@com_github_ava_labs_libevm//libevm",
         "@com_github_ava_labs_libevm//libevm/options",
-        "@com_github_ava_labs_libevm//params",
         "@com_github_holiman_uint256//:uint256",
         "@com_github_stephenbuttolph_canoto//:canoto",
     ],

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/libevm/options"
+	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -241,7 +242,7 @@ func (s *Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr
 }
 
 // BeforeExecutingBlock is a no-op that always returns nil.
-func (*Stub) BeforeExecutingBlock(*state.StateDB, *types.Header, *types.Block) error {
+func (*Stub) BeforeExecutingBlock(params.Rules, *state.StateDB, *types.Header, *types.Block) error {
 	return nil
 }
 

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/libevm/options"
-	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -242,7 +241,7 @@ func (s *Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr
 }
 
 // BeforeExecutingBlock is a no-op that always returns nil.
-func (*Stub) BeforeExecutingBlock(params.Rules, *state.StateDB, *types.Block) error {
+func (*Stub) BeforeExecutingBlock(*state.StateDB, *types.Header, *types.Header) error {
 	return nil
 }
 

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -241,7 +241,7 @@ func (s *Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr
 }
 
 // BeforeExecutingBlock is a no-op that always returns nil.
-func (*Stub) BeforeExecutingBlock(*state.StateDB, *types.Header, *types.Header) error {
+func (*Stub) BeforeExecutingBlock(*state.StateDB, *types.Header, *types.Block) error {
 	return nil
 }
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -187,7 +187,7 @@ func Execute(
 	}
 
 	rules := config.Rules(b.Number(), true /*isMerge*/, b.BuildTime())
-	if err := hooks.BeforeExecutingBlock(stateDB, parent.Header(), b.EthBlock()); err != nil {
+	if err := hooks.BeforeExecutingBlock(rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
 		return nil, fmt.Errorf("before-block hook: %v", err)
 	}
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -187,7 +187,7 @@ func Execute(
 	}
 
 	rules := config.Rules(b.Number(), true /*isMerge*/, b.BuildTime())
-	if err := hooks.BeforeExecutingBlock(stateDB, parent.Header(), header); err != nil {
+	if err := hooks.BeforeExecutingBlock(stateDB, parent.Header(), b.EthBlock()); err != nil {
 		return nil, fmt.Errorf("before-block hook: %v", err)
 	}
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -187,7 +187,7 @@ func Execute(
 	}
 
 	rules := config.Rules(b.Number(), true /*isMerge*/, b.BuildTime())
-	if err := hooks.BeforeExecutingBlock(rules, stateDB, b.EthBlock()); err != nil {
+	if err := hooks.BeforeExecutingBlock(stateDB, parent.Header(), header); err != nil {
 		return nil, fmt.Errorf("before-block hook: %v", err)
 	}
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -190,6 +190,9 @@ func Execute(
 	if err := hooks.BeforeExecutingBlock(rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
 		return nil, fmt.Errorf("before-block hook: %v", err)
 	}
+	// Finalise any state changes made by the hook, mirroring the finalisation
+	// performed by [core.ApplyTransaction].
+	stateDB.Finalise(rules.IsEIP158)
 
 	baseFee := gasClock.BaseFee()
 	b.CheckBaseFeeBound(baseFee)
@@ -255,8 +258,8 @@ func Execute(
 			return nil, fmt.Errorf("after-transaction hook [%d](%#x): %w", ti, tx.Hash(), err)
 		}
 		// Finalise any state changes made by the hook as part of this
-		// transaction, mirroring the finalisation performed by
-		// [core.ApplyTransaction].
+		// transaction, mirroring the finalisation performed after
+		// [hook.Points.BeforeExecutingBlock].
 		stateDB.Finalise(rules.IsEIP158)
 	}
 


### PR DESCRIPTION
## Why this should be merged

This resolves the `TODO(StephenButtolph)` in the cchain hooks: coreth writes the warp precompile's activation state (nonce and code) before executing the first post-Durango block, but the SAE hooks only did so for post-Durango geneses. 

## How this works

`hook.Points.BeforeExecutingBlock` now receives the parent header, so the cchain hooks activate the precompile exactly once. 

## How this was tested

Added `TestWarpPrecompileActivation` 

## Need to be documented in RELEASES.md?

No.