### PR TITLE
test(saevm/sae): expect debug_trace* to honor JS tracer configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100
 	github.com/ava-labs/avalanchego/graft/coreth v1.14.2
 	github.com/ava-labs/avalanchego/graft/subnet-evm v1.14.2
-	github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff
+	github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff h1:OEBrr1VL5yLS7NPNWmV+tUb8HduRGflAGnWVehDDMO0=
-github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad h1:P5IRndHUinfIZ73jdxl3M6jdcnKkQOLYvhGvE3VDiSU=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad/go.mod h1:DADqV3zJ+ij8GqliStJ+aj9l/cPtb5ZUhNy5KxlDEsQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.work.sum
+++ b/go.work.sum
@@ -338,6 +338,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.3.0/go.mod h1:71C76bo47zlDX9gWnn3p/0QZQXkTQ/GNqUNI6fchvjs=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1 h1:Y9UdRQj28/t+GNzVSlP6nvoNLtzNRo3fNXLUc/NscVM=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1/go.mod h1:GVzumIo3zR23/qGRN2AdnVkIPHcKMq/D89EGWZfMGQ0=
 github.com/aws/aws-sdk-go-v2 v1.21.2 h1:+LXZ0sgo8quN9UOKXXzAWRT3FWd4NxeXWOZom9pE7GA=

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff
+	github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/graft/coreth/go.sum
+++ b/graft/coreth/go.sum
@@ -30,8 +30,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff h1:OEBrr1VL5yLS7NPNWmV+tUb8HduRGflAGnWVehDDMO0=
-github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff
+	github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/gorilla/rpc v1.2.0

--- a/graft/evm/go.sum
+++ b/graft/evm/go.sum
@@ -21,8 +21,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff h1:OEBrr1VL5yLS7NPNWmV+tUb8HduRGflAGnWVehDDMO0=
-github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff
+	github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/gorilla/rpc v1.2.0

--- a/graft/subnet-evm/go.sum
+++ b/graft/subnet-evm/go.sum
@@ -30,8 +30,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff h1:OEBrr1VL5yLS7NPNWmV+tUb8HduRGflAGnWVehDDMO0=
-github.com/ava-labs/libevm v1.13.15-0.20260629092640-7d62036142ff/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
+github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/vms/saevm/sae/BUILD.bazel
+++ b/vms/saevm/sae/BUILD.bazel
@@ -128,6 +128,7 @@ go_test(
         "@com_github_ava_labs_libevm//crypto",
         "@com_github_ava_labs_libevm//eth/filters",
         "@com_github_ava_labs_libevm//eth/tracers/logger",
+        "@com_github_ava_labs_libevm//eth/tracers/native",
         "@com_github_ava_labs_libevm//ethclient",
         "@com_github_ava_labs_libevm//ethclient/gethclient",
         "@com_github_ava_labs_libevm//ethdb",

--- a/vms/saevm/sae/BUILD.bazel
+++ b/vms/saevm/sae/BUILD.bazel
@@ -127,7 +127,6 @@ go_test(
         "@com_github_ava_labs_libevm//core/vm",
         "@com_github_ava_labs_libevm//crypto",
         "@com_github_ava_labs_libevm//eth/filters",
-        "@com_github_ava_labs_libevm//eth/tracers/js",
         "@com_github_ava_labs_libevm//eth/tracers/logger",
         "@com_github_ava_labs_libevm//ethclient",
         "@com_github_ava_labs_libevm//ethclient/gethclient",

--- a/vms/saevm/sae/BUILD.bazel
+++ b/vms/saevm/sae/BUILD.bazel
@@ -127,6 +127,7 @@ go_test(
         "@com_github_ava_labs_libevm//core/vm",
         "@com_github_ava_labs_libevm//crypto",
         "@com_github_ava_labs_libevm//eth/filters",
+        "@com_github_ava_labs_libevm//eth/tracers/js",
         "@com_github_ava_labs_libevm//eth/tracers/logger",
         "@com_github_ava_labs_libevm//ethclient",
         "@com_github_ava_labs_libevm//ethclient/gethclient",

--- a/vms/saevm/sae/BUILD.bazel
+++ b/vms/saevm/sae/BUILD.bazel
@@ -219,6 +219,7 @@ go_test(
         "@com_github_ava_labs_libevm//crypto",
         "@com_github_ava_labs_libevm//eth/filters",
         "@com_github_ava_labs_libevm//eth/tracers/logger",
+        "@com_github_ava_labs_libevm//eth/tracers/native",
         "@com_github_ava_labs_libevm//ethclient",
         "@com_github_ava_labs_libevm//ethclient/gethclient",
         "@com_github_ava_labs_libevm//ethdb",

--- a/vms/saevm/sae/rpc/BUILD.bazel
+++ b/vms/saevm/sae/rpc/BUILD.bazel
@@ -51,6 +51,8 @@ go_library(
         "@com_github_ava_labs_libevm//eth",
         "@com_github_ava_labs_libevm//eth/filters",
         "@com_github_ava_labs_libevm//eth/tracers",
+        "@com_github_ava_labs_libevm//eth/tracers/js",
+        "@com_github_ava_labs_libevm//eth/tracers/native",
         "@com_github_ava_labs_libevm//ethdb",
         "@com_github_ava_labs_libevm//event",
         "@com_github_ava_labs_libevm//libevm/debug",

--- a/vms/saevm/sae/rpc/server.go
+++ b/vms/saevm/sae/rpc/server.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ava-labs/libevm/libevm/debug"
 	"github.com/ava-labs/libevm/libevm/ethapi"
 	"github.com/ava-labs/libevm/rpc"
+
+	// Force-load tracer engines to trigger registration of the JS and native
+	// (e.g. "callTracer") tracers available to debug_trace* APIs.
+	_ "github.com/ava-labs/libevm/eth/tracers/js"
+	_ "github.com/ava-labs/libevm/eth/tracers/native"
 )
 
 // Taken as the default from geth / libevm's `node.DefaultConfig`.

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -27,9 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	// Register JS tracers for [TestDebugTrace].
-	_ "github.com/ava-labs/libevm/eth/tracers/js"
-
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -147,6 +147,19 @@ func TestDebugTrace(t *testing.T) {
 	}
 	wantDeploy, wantDeposit := want[:1], want[1:]
 
+	// callFrame is the JSON encoding of the native callTracer's output.
+	// TODO(JonathanOppenheimer): export from libevm?
+	type callFrame struct {
+		From    common.Address  `json:"from"`
+		Gas     hexutil.Uint64  `json:"gas"`
+		GasUsed hexutil.Uint64  `json:"gasUsed"`
+		To      *common.Address `json:"to"`
+		Input   hexutil.Bytes   `json:"input"`
+		Value   *hexutil.Big    `json:"value"`
+		Type    string          `json:"type"`
+		Error   string          `json:"error"`
+	}
+
 	tests := []rpcTest{
 		{
 			method:       "debug_traceBlockByNumber",
@@ -184,23 +197,25 @@ func TestDebugTrace(t *testing.T) {
 			wantErr: testerr.Contains("not found"),
 		},
 		{
-			method: "debug_traceBlockByNumber",
-			args: []any{
-				hexutil.Uint64(depositBlock.NumberU64()),
-				map[string]any{
-					"tracer": `{
-						step: function() {
-							for (;;) {}
-						},
-						fault: function() {},
-						result: function() {
-							return {};
-						}
-					}`,
-					"timeout": "10ms",
-				},
-			},
+			method: "debug_traceTransaction",
+			args: []any{depositTx.Hash(), map[string]any{
+				"tracer":  `{fault: function() {}, result: function() { for (;;) {} }}`,
+				"timeout": "10ms",
+			}},
 			wantErr: testerr.Contains("execution timeout"),
+		},
+		{
+			method: "debug_traceTransaction",
+			args:   []any{depositTx.Hash(), map[string]any{"tracer": "callTracer"}},
+			want: callFrame{
+				From:    sut.wallet.Addresses()[0],
+				Gas:     hexutil.Uint64(depositTx.Gas()),
+				GasUsed: hexutil.Uint64(depositBlock.Receipts()[0].GasUsed),
+				To:      &escrowAddr,
+				Input:   escrow.CallDataToDeposit(recipient),
+				Value:   (*hexutil.Big)(big.NewInt(escrowDepositVal)),
+				Type:    "CALL",
+			},
 		},
 	}
 

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/eth/tracers/logger"
+	"github.com/ava-labs/libevm/eth/tracers/native"
 	"github.com/ava-labs/libevm/ethclient/gethclient"
 	"github.com/ava-labs/libevm/ethdb/memorydb"
 	"github.com/ava-labs/libevm/params"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
 
 	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
@@ -147,19 +149,6 @@ func TestDebugTrace(t *testing.T) {
 	}
 	wantDeploy, wantDeposit := want[:1], want[1:]
 
-	// callFrame is the JSON encoding of the native callTracer's output.
-	// TODO(JonathanOppenheimer): export from libevm?
-	type callFrame struct {
-		From    common.Address  `json:"from"`
-		Gas     hexutil.Uint64  `json:"gas"`
-		GasUsed hexutil.Uint64  `json:"gasUsed"`
-		To      *common.Address `json:"to"`
-		Input   hexutil.Bytes   `json:"input"`
-		Value   *hexutil.Big    `json:"value"`
-		Type    string          `json:"type"`
-		Error   string          `json:"error"`
-	}
-
 	tests := []rpcTest{
 		{
 			method:       "debug_traceBlockByNumber",
@@ -212,15 +201,16 @@ func TestDebugTrace(t *testing.T) {
 		{
 			method: "debug_traceTransaction",
 			args:   []any{depositTx.Hash(), map[string]any{"tracer": "callTracer"}},
-			want: callFrame{
+			// Type is unasserted as [native.CallFrame.UnmarshalJSON] drops it.
+			want: native.CallFrame{
 				From:    sut.wallet.Addresses()[0],
-				Gas:     hexutil.Uint64(depositTx.Gas()),
-				GasUsed: hexutil.Uint64(depositBlock.Receipts()[0].GasUsed),
+				Gas:     depositTx.Gas(),
+				GasUsed: depositBlock.Receipts()[0].GasUsed,
 				To:      &escrowAddr,
 				Input:   escrow.CallDataToDeposit(recipient),
-				Value:   (*hexutil.Big)(big.NewInt(escrowDepositVal)),
-				Type:    "CALL",
+				Value:   big.NewInt(escrowDepositVal),
 			},
+			extraCmpOpts: cmp.Options{cmputils.BigInts()},
 		},
 	}
 

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -201,7 +201,6 @@ func TestDebugTrace(t *testing.T) {
 		{
 			method: "debug_traceTransaction",
 			args:   []any{depositTx.Hash(), map[string]any{"tracer": "callTracer"}},
-			// Type is unasserted as [native.CallFrame.UnmarshalJSON] drops it.
 			want: native.CallFrame{
 				From:    sut.wallet.Addresses()[0],
 				Gas:     depositTx.Gas(),

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -199,7 +199,12 @@ func TestDebugTrace(t *testing.T) {
 		{
 			method: "debug_traceTransaction",
 			args: []any{depositTx.Hash(), map[string]any{
-				"tracer":  `{fault: function() {}, result: function() { for (;;) {} }}`,
+				"tracer": `{
+					fault: function() {},
+					result: function() {
+						for (;;) {}
+					}
+				}`,
 				"timeout": "10ms",
 			}},
 			wantErr: testerr.Contains("execution timeout"),

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	// Register JS tracers for [TestDebugTrace].
+	_ "github.com/ava-labs/libevm/eth/tracers/js"
+
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
@@ -182,6 +185,25 @@ func TestDebugTrace(t *testing.T) {
 			method:  "debug_traceTransaction",
 			args:    []any{common.Hash{}},
 			wantErr: testerr.Contains("not found"),
+		},
+		{
+			method: "debug_traceBlockByNumber",
+			args: []any{
+				hexutil.Uint64(depositBlock.NumberU64()),
+				map[string]any{
+					"tracer": `{
+						step: function() {
+							for (;;) {}
+						},
+						fault: function() {},
+						result: function() {
+							return {};
+						}
+					}`,
+					"timeout": "10ms",
+				},
+			},
+			wantErr: testerr.Contains("execution timeout"),
 		},
 	}
 


### PR DESCRIPTION
## Why this should be merged

`debug_traceBlockByNumber` silently ignores user-supplied tracer configs: an infinite-loop JS tracer with a 10ms timeout returns success instead of an execution-timeout error. This PR adds a regression test to enforce this behavior. 

## How this works

Registers libevm's JS tracers as the C-Chain plugin does in production) and adds a `TestDebugTrace` case asserting the tracer's timeout is enforced.

## How this was tested

TestDebugTrace. 

## Need to be documented in RELEASES.md?

No.
```