### PR TITLE
[docs] Make task maintenance expectations explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Run e2e tests
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
-          run: ./scripts/run_task.sh test-e2e-ci -- --activate-latest-after=4m
+          run: ./scripts/run_task.sh test-e2e-ci-schedule-latest
           artifact_prefix: e2e-schedule-latest
           filter_by_owner: avalanchego-e2e
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
@@ -139,7 +139,7 @@ jobs:
       - name: Run e2e tests
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
-          run: ./scripts/run_task.sh test-e2e-ci -- --activate-latest-after=0
+          run: ./scripts/run_task.sh test-e2e-ci-post-latest
           artifact_prefix: e2e-post-latest
           filter_by_owner: avalanchego-e2e
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
@@ -319,7 +319,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
-          run: ./scripts/run_task.sh test-load -- --load-timeout=30s
+          run: ./scripts/run_task.sh test-load-ci
           artifact_prefix: load
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
           prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
@@ -336,7 +336,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
-          run: ./scripts/run_task.sh test-load-kube-kind -- --load-timeout=30s
+          run: ./scripts/run_task.sh test-load-kube-kind-ci
           runtime: kube
           artifact_prefix: load-kube
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}

--- a/.github/workflows/firewood-load-test.yml
+++ b/.github/workflows/firewood-load-test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
-          run: ./scripts/run_task.sh test-load -- --load-timeout=30m --firewood
+          run: ./scripts/run_task.sh test-load-firewood-ci
           artifact_prefix: load
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
           prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}

--- a/.github/workflows/self-hosted-load-tests.yaml
+++ b/.github/workflows/self-hosted-load-tests.yaml
@@ -7,7 +7,6 @@ on:
       avalanchego_image:
         description: 'AvalancheGo image to test'
         required: false
-        default: 'avaplatform/avalanchego:latest'
         type: string
       exclusive_scheduling:
         description: 'Enable exclusive scheduling'
@@ -42,9 +41,9 @@ jobs:
         with:
           run: >-
             ./scripts/run_task.sh test-load-kube --
-            --kube-image ${{ inputs.avalanchego_image }}
+            ${{ inputs.avalanchego_image && format('--kube-image {0}', inputs.avalanchego_image) || '' }}
             ${{ inputs.exclusive_scheduling == 'true' && '--kube-use-exclusive-scheduling' || '' }}
-            ${{ inputs.duration && format('--duration {0}', inputs.duration) || '' }}
+            ${{ inputs.duration && format('--load-timeout {0}', inputs.duration) || '' }}
           artifact_prefix: self-hosted-load-test${{ inputs.exclusive_scheduling == 'true' && '-exclusive' || '' }}
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
           prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}

--- a/.github/workflows/self-hosted-load-tests.yaml
+++ b/.github/workflows/self-hosted-load-tests.yaml
@@ -39,6 +39,10 @@ jobs:
       - name: Run load test
         uses: ./.github/actions/run-monitored-tmpnet-cmd
         with:
+          # This task invocation is an exception to the usual "named task without
+          # extra flags" rule because it is only triggerable by workflow_dispatch.
+          # The task still works with its defaults, and the forwarded flags can also
+          # be used when running test-load-kube locally.
           run: >-
             ./scripts/run_task.sh test-load-kube --
             ${{ inputs.avalanchego_image && format('--kube-image {0}', inputs.avalanchego_image) || '' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,10 @@ export DIRENV_LOG_FORMAT=
 ## Running tasks
 
 This repo uses the [Task](https://taskfile.dev/) task runner to simplify usage and discoverability
-of development tasks. To list available tasks:
+of development tasks. For the repo's task model and maintainer guidance, see
+[docs/tasks.md](./docs/tasks.md).
+
+To list available tasks:
 
 ```bash
 task

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,10 +2,7 @@
 # To run on a system without task installed, `./scripts/run_task.sh` will
 # prefer a task binary in the PATH and otherwise run task with `go tool`.
 # If in the nix dev shell, repo tasks use the pinned toolchain.
-
-# - Tasks should be simple entrypoints to functionality exposed by scripts or code.
-# - Avoid the temptation to use task vars to define an API surface. Prefer configuring the
-#   underlying script or code via CLI args and/or env vars.
+# General guidance for maintaining tasks is documented in docs/tasks.md.
 
 version: '3'
 
@@ -473,6 +470,24 @@ tasks:
       - task: build-xsvm
       - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh {{.CLI_ARGS}}'
 
+  test-e2e-ci-schedule-latest:
+    desc: Runs e2e tests [serially with race detection enabled] and schedules latest activation after 4 minutes
+    env:
+      E2E_SERIAL: 1
+    cmds:
+      - task: build-race
+      - task: build-xsvm
+      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=4m'
+
+  test-e2e-ci-post-latest:
+    desc: Runs e2e tests [serially with race detection enabled] and posts latest activation immediately
+    env:
+      E2E_SERIAL: 1
+    cmds:
+      - task: build-race
+      - task: build-xsvm
+      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=0'
+
   test-e2e-existing-ci:
     desc: Runs e2e tests with an existing network [serially with race detection enabled]
     env:
@@ -519,6 +534,20 @@ tasks:
       - task: build
       - cmd: '{{.NIX_RUN}} go run ./tests/load/main --avalanchego-path=./build/avalanchego {{.CLI_ARGS}}'
 
+  test-load-ci:
+    desc: Runs load tests with the standard CI timeout
+    cmds:
+      - task: generate-load-contract-bindings
+      - task: build
+      - cmd: '{{.NIX_RUN}} go run ./tests/load/main --avalanchego-path=./build/avalanchego --load-timeout=30s'
+
+  test-load-firewood-ci:
+    desc: Runs firewood load tests with the scheduled CI timeout
+    cmds:
+      - task: generate-load-contract-bindings
+      - task: build
+      - cmd: '{{.NIX_RUN}} go run ./tests/load/main --avalanchego-path=./build/avalanchego --load-timeout=30m --firewood'
+
   test-load-exclusive:
     desc: Runs load tests against kube with exclusive scheduling
     cmds:
@@ -535,6 +564,12 @@ tasks:
     cmds:
       - task: generate-load-contract-bindings
       - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.load.kube.kind.sh {{.CLI_ARGS}}'
+
+  test-load-kube-kind-ci:
+    desc: Runs load tests against a kind cluster with the standard CI timeout
+    cmds:
+      - task: generate-load-contract-bindings
+      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.load.kube.kind.sh --load-timeout=30s'
 
   test-robustness:
     desc: Deploys kind with chaos mesh. Intended to eventually run a robustness (fault-injection) test suite.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -470,15 +470,6 @@ tasks:
       - task: build-xsvm
       - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh {{.CLI_ARGS}}'
 
-  test-e2e-ci-schedule-latest:
-    desc: Runs e2e tests [serially with race detection enabled] and schedules latest activation after 4 minutes
-    env:
-      E2E_SERIAL: 1
-    cmds:
-      - task: build-race
-      - task: build-xsvm
-      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=4m'
-
   test-e2e-ci-post-latest:
     desc: Runs e2e tests [serially with race detection enabled] and posts latest activation immediately
     env:
@@ -487,6 +478,15 @@ tasks:
       - task: build-race
       - task: build-xsvm
       - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=0'
+
+  test-e2e-ci-schedule-latest:
+    desc: Runs e2e tests [serially with race detection enabled] and schedules latest activation after 4 minutes
+    env:
+      E2E_SERIAL: 1
+    cmds:
+      - task: build-race
+      - task: build-xsvm
+      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=4m'
 
   test-e2e-existing-ci:
     desc: Runs e2e tests with an existing network [serially with race detection enabled]

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ that span multiple areas of the tree.
 - [Documentation guidelines](./documentation-guidelines.md) - how to decide
   what belongs in repository documentation, where it should live, and how it
   should be maintained
+- [Tasks](./tasks.md) - why this repo uses Task and how tasks should be written
 - [Bazel](./bazel.md) - Bazel-related repository guidance
 - [External consumption](./external_consumption.md) - guidance for externally
   consumed repository outputs

--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -336,6 +336,11 @@ Use the earlier framework for the detailed questions each section may want to
 answer. This is a recommendation, not a rigid template. The important thing is
 to make it easy for a reader to find the right level of detail.
 
+Include a table of contents in every dedicated document. Even when a document is
+still fairly short, a TOC makes the structure visible up front, helps readers
+jump to the part they need, and makes it easier to notice when the document's
+shape has drifted.
+
 A trailing **References** section pointing to the relevant code, tests, and
 related docs is often useful. It makes the links between the document and the
 code explicit, supports the discoverability conventions above, and helps

--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -328,7 +328,9 @@ looking for.
 
 Start simple. A single document is often enough.
 
-A good document is complete, but usability matters just as much. Write so a future reader can skim the document and quickly find what they need. In practice, that usually means:
+A good document is complete, but usability matters just as much. Write so a future
+reader can skim the document and quickly find what they need. In practice, that
+usually means:
 
 - front-load the principles or mental model
 - use headings that clearly describe what a section is doing

--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -78,7 +78,7 @@ after the current task or PR is finished.
 
 ## A four-layer framework
 
-A useful default is to think about repository documentation in four layers:
+One way to think about repository documentation is in four layers:
 
 1. **Why does this exist?**
    - what problem does it solve
@@ -116,13 +116,12 @@ layer 3 occasionally, and layer 4 rarely. It is also the layer where LLMs can be
 the most helpful because an LLM working with you already has much of the context
 needed to write it.
 
-Layer 4 should not be interpreted narrowly as only "validation steps" or
-"current invariants." It also includes enough preserved decision context that a
-future maintainer can understand why a different change may be wrong, or why it
-might only become appropriate under changed assumptions. Repository
-documentation should usually preserve enough context around meaningful
-alternatives that a future reader can understand why the current choice was
-made.
+Layer 4 is not just about validation steps or current invariants. It also
+includes enough decision context that a future maintainer can understand why a
+different change may be wrong, or why it might only become appropriate under
+changed assumptions. Repository documentation should preserve enough context
+around alternatives that a future reader can understand why the current choice
+was made.
 
 ### What this looks like in practice
 
@@ -187,6 +186,11 @@ This guide deliberately does not prescribe:
   produce it. The criteria for what belongs apply regardless of who writes it.
   The details of drafting, checking for drift, and using session history can
   evolve over time.
+
+This guide can help preserve the right information and catch common problems,
+but it cannot replace judgment. A document can be correct and still be clumsy,
+repetitive, or hard to use. Clarity, proportion, and restraint have to be
+learned through practice and review.
 
 ## When to add or expand documentation
 
@@ -257,7 +261,7 @@ Do not use repository documentation as:
 
 Some explored paths are worth preserving, but only after they are translated
 into a stable explanation such as a trade-off, rejected alternative, or
-important discovered constraint.
+constraint that still matters.
 
 When deciding whether to keep rationale from an explored path, ask whether a
 future maintainer would understand the trade-off, rejected alternative, or
@@ -288,7 +292,7 @@ include:
   repository
 
 The exact filename matters less than making the document easy to find and
-interpret.
+understand.
 
 ## Discoverability
 
@@ -324,8 +328,19 @@ looking for.
 
 Start simple. A single document is often enough.
 
-One useful default is to structure a document around the [four-layer
-framework](#a-four-layer-framework) above, often with sections such as:
+A good document is not just complete; it is usable. Write so a future reader
+can skim the document and find what they need, not just so the right facts
+appear somewhere in the text. In practice, that usually means:
+
+- front-load the principles or mental model
+- use headings that clearly describe what a section is doing
+- prefer plain language over jargon when the simpler wording is accurate
+- state the default guidance clearly, then explain exceptions briefly
+- use examples when a rule would otherwise stay abstract
+- remove repetition that restates a point without sharpening it
+
+A useful default is to structure a document around the [four-layer framework](#a-four-layer-framework)
+above, often with sections such as:
 
 1. **Overview**
 2. **Usage**
@@ -397,3 +412,15 @@ maintainers will still need. The updated document does not need every detail
 from the original, but it should preserve the reasoning that still matters for
 future changes, including important constraints, relevant alternatives, and why
 those alternatives were not chosen.
+
+When revising a document that has grown by accretion, check whether the result
+is still easy to use. Questions like these may help:
+
+- Is the opening section really an overview, or is it principles, usage, or
+  maintainer guidance?
+- Are the main rules explained by a small number of reasons a reader can
+  remember?
+- Are the important exceptions concrete enough, or do they need examples?
+- Is any section repeating itself instead of helping the reader decide or act?
+- Have useful points from review discussion been folded back into the durable
+  document rather than left only in PR comments?

--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -328,9 +328,7 @@ looking for.
 
 Start simple. A single document is often enough.
 
-A good document is not just complete; it is usable. Write so a future reader
-can skim the document and find what they need, not just so the right facts
-appear somewhere in the text. In practice, that usually means:
+A good document is complete, but usability matters just as much. Write so a future reader can skim the document and quickly find what they need. In practice, that usually means:
 
 - front-load the principles or mental model
 - use headings that clearly describe what a section is doing

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,218 @@
+# Tasks
+
+This document explains why avalanchego uses [Task](https://taskfile.dev) and
+how tasks should be maintained in this repo.
+
+For basic usage, including how to list and run tasks, see the [Running
+tasks](../CONTRIBUTING.md#running-tasks) section of
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Table of contents
+
+- [Overview](#overview)
+- [Why this repo uses Task](#why-this-repo-uses-task)
+  - [Why not Make?](#why-not-make)
+  - [Why Task instead of just?](#why-task-instead-of-just)
+- [How tasks should work in this repo](#how-tasks-should-work-in-this-repo)
+  - [Tasks used directly by CI should use stable named entrypoints](#tasks-used-directly-by-ci-should-use-stable-named-entrypoints)
+  - [Exception: CI execution environment details](#exception-ci-execution-environment-details)
+  - [Example: good pattern](#example-good-pattern)
+  - [Example: pattern to avoid](#example-pattern-to-avoid)
+- [When to add or change a task](#when-to-add-or-change-a-task)
+
+## Overview
+
+This repo uses Task so contributors can list useful commands and run them
+consistently.
+
+Two goals matter here:
+
+- **Discoverability**: Invoking `task` without arguments lists available commands
+- **Reproducibility**: when CI runs a task, a contributor can run the same task
+  locally and expect broadly similar behavior. This is intended to maximize the
+  chances of reproducing CI failures locally.
+
+Not every task in this repo is used directly by CI. Some tasks are simple wrappers
+around tools that naturally take arguments or other user input. The stronger rules
+below apply mainly to tasks used directly by CI or used as stable entrypoints that
+contributors are expected to rerun locally to reproduce CI behavior.
+
+## Why this repo uses Task
+
+Task is a command runner: a tool for defining named commands that can be
+listed and run in a consistent way.
+
+This repo wanted a command runner, not a build system. The main need was a simple way
+to expose common commands for builds, tests, linting, generation, and similar work,
+while keeping those commands easy to find and easy to rerun.
+
+### Why not Make?
+
+Make brings build dependency features and rules for deciding what needs to be
+rebuilt. Those can be useful for some projects, but they were not the point
+here. This repo mainly wanted stable, discoverable command names.
+
+### Why Task instead of just?
+
+[just](https://just.systems) could also serve as a command runner here. Task was
+chosen because it fit this repo's toolchain and needs at the time:
+
+- it was a mature enough tool for the job
+- it fit naturally with the repo's existing Go-based tooling
+- its structured YAML format was considered acceptable for repo maintenance
+
+This does not mean Task needs to be a permanent fixture of the repo. What matters is
+the task model, not the specific tool. The repo needs a command runner that makes
+common commands easy to find and run, especially commands that CI and developers both
+need to run.
+
+## How tasks should work in this repo
+
+Tasks should be simple named commands. In most cases, the task name should be what
+people and CI use, while scripts and code hold the real behavior.
+
+This is a general preference across the repo, and a stronger expectation for tasks
+used directly by CI or reused as stable reproduction entrypoints.
+
+That means tasks should usually:
+
+- stay simple
+- call scripts, tools, or other tasks that hold the real logic
+- avoid turning into their own separate place to configure behavior
+
+Composing a few commands or other tasks inside `Taskfile.yml` is fine when that
+keeps the supported entrypoint clear. The main thing to avoid is hiding the real
+configuration or behavior only in workflow callsites or Task-specific wiring that a
+local user would have to rediscover.
+
+Keeping non-trivial logic out of tasks makes it easier to apply the right linting and
+validation to scripts or code. That is much harder to do when behavior only exists
+inside a task definition.
+
+### Tasks used directly by CI should use stable named entrypoints
+
+A **CI entrypoint task** is a task CI uses as the named way to run a
+repo-managed operation.
+
+A CI entrypoint task should usually be invoked through a stable named
+entrypoint.
+
+In GitHub Actions workflows in this repo, that normally means invoking the task via
+`./scripts/run_task.sh` which ensures that task will run in a variety of different
+environments that may not have it directly installed.
+
+In normal use, the caller should not need to know special:
+
+- flags
+- environment variables
+- Taskfile variables
+- other task-specific configuration
+
+Tasks used directly by CI should usually not require positional arguments or other
+caller-supplied input. If CI needs different behavior, that should usually be
+expressed as a different named task rather than by parameterizing a single task at the
+workflow callsite.
+
+A task does not need to reject all input in every context. The potential problem is in
+defining behavior via CI-only settings that a local user would have to manually apply
+locally.
+
+This repo does have some intentional exceptions. A small number of tasks are used as
+stable launchers for a family of related runs where the varying input is part of the
+user-facing interface rather than hidden CI-only behavior. For example, CI may select
+a fuzz shard, a particular re-execution scenario, or load-test flags that a developer
+can also pass locally to reproduce the same run.
+
+As a practical guardrail, workflow task invocations should not pass extra option flags
+after `--`. In this repo, `scripts/actionlint.sh` checks for that exact pattern in
+workflow `run:` steps because it is usually a sign that CI is changing task behavior
+where it is called instead of invoking a stable named task. This is only a narrow
+guardrail, not a full semantic check of all workflow task usage.
+
+The goal is that a contributor should usually be able to reproduce the results of a CI
+command locally by running the same named task without additional configuration. Only
+in exceptional cases should it be necessary to locally configure a task run by CI.
+
+### Exception: CI execution environment details
+
+CI sometimes needs extra settings because of the CI environment itself. That is
+acceptable when those settings support how the task runs in CI, rather than changing
+the fundamental behavior of the task.
+
+For example, CI may need launcher or environment settings because of CI setup
+requirements. But the same task should still be runnable locally without those CI-only
+settings.
+
+### Example: good pattern
+
+If a workflow runs:
+
+```bash
+./scripts/run_task.sh bazel-test-main
+```
+
+then a contributor should usually be able to run the same task locally:
+
+```bash
+task bazel-test-main
+```
+
+The task may call wrappers, scripts, or tools underneath, but the caller should not
+need to know those details just to rerun the command.
+
+### Example: pattern to avoid
+
+Avoid designs where CI is effectively defining the real command through extra
+configuration that a local user has to rediscover, for example by putting the
+important behavior in workflow-only task vars, flags, or environment settings.
+
+For example, avoid the following style of job definition:
+
+```yaml
+- run: ./scripts/run_task.sh test-e2e
+  env:
+    E2E_FILTER: xsvm
+    E2E_RUNTIME: kube
+```
+
+Reproduction of a CI failure for this job would require duplicating the environment
+configured by the job rather than just invoking the task.
+
+The problem here is not that environment variables exist at all. The problem is that
+these variables change what the task does, rather than only adapting it to run inside
+CI. A developer should not need those settings just to run the same task locally.
+
+By contrast, workflows may pass arguments that are already part of the task's intended
+public interface when that interface is also available to local users.  That kind of
+parameterization should stay explicit and reproducible rather than being hidden in
+CI-only environment configuration.
+
+## When to add or change a task
+
+Add or keep a task when it gives the repo a stable, discoverable command that people
+or CI are expected to run.
+
+A task is often a good fit when:
+
+- contributors will run it regularly
+- CI and local use should share the same named command
+- the task makes a supported command easier to find with `task`
+
+A task is often **not** the right fit when:
+
+- the command is a one-off maintenance step
+- the real interface needs a lot of user-supplied configuration
+- the script or tool should remain the primary interface
+- the task would mostly duplicate implementation detail rather than provide a useful
+  stable command name
+
+Direct script execution is acceptable when the script is the real interface and
+the repo does not need a separate stable, discoverable task name for CI or
+contributors. Add a task when the repo wants that named entrypoint; do not add
+one when it would only hide or duplicate the real interface.
+
+When changing an existing task, preserve the main reasons tasks exist here:
+
+- people should be able to find supported commands easily
+- tasks used directly by CI should stay easy to rerun locally
+- the real behavior should stay in scripts or code, not in task-only settings

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,172 +1,181 @@
 # Tasks
 
 This document explains why avalanchego uses [Task](https://taskfile.dev) and
-how tasks should be maintained in this repo.
+how to maintain tasks in this repo.
 
-For basic usage, including how to list and run tasks, see the [Running
-tasks](../CONTRIBUTING.md#running-tasks) section of
+For basic usage, including how to list and run tasks, see [Running
+tasks](../CONTRIBUTING.md#running-tasks) in
 [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ## Table of contents
 
-- [Overview](#overview)
+- [Principles](#principles)
 - [Why this repo uses Task](#why-this-repo-uses-task)
-  - [Why not Make?](#why-not-make)
-  - [Why Task instead of just?](#why-task-instead-of-just)
+  - [The double dash delimiter](#the-double-dash-delimiter)
+  - [Why not Make or just?](#why-not-make-or-just)
 - [How tasks should work in this repo](#how-tasks-should-work-in-this-repo)
-  - [Tasks used directly by CI should use stable named entrypoints](#tasks-used-directly-by-ci-should-use-stable-named-entrypoints)
-  - [Exception: CI execution environment details](#exception-ci-execution-environment-details)
-  - [Example: good pattern](#example-good-pattern)
-  - [Example: pattern to avoid](#example-pattern-to-avoid)
+  - [Keep tasks simple](#keep-tasks-simple)
+  - [CI should run named tasks](#ci-should-run-named-tasks)
+  - [Some CI-only setup still belongs in workflows](#some-ci-only-setup-still-belongs-in-workflows)
+- [Examples](#examples)
+  - [Good: CI runs a named task](#good-ci-runs-a-named-task)
+  - [Good: the workflow passes a normal task argument](#good-the-workflow-passes-a-normal-task-argument)
+  - [Avoid: the workflow changes what the task does](#avoid-the-workflow-changes-what-the-task-does)
 - [When to add or change a task](#when-to-add-or-change-a-task)
 
-## Overview
+## Principles
 
-This repo uses Task so contributors can list useful commands and run them
-consistently.
-
-Two goals matter here:
-
-- **Discoverability**: Invoking `task` without arguments lists available commands
-- **Reproducibility**: when CI runs a task, a contributor can run the same task
-  locally and expect broadly similar behavior. This is intended to maximize the
-  chances of reproducing CI failures locally.
-
-Not every task in this repo is used directly by CI. Some tasks are simple wrappers
-around tools that naturally take arguments or other user input. The stronger rules
-below apply mainly to tasks used directly by CI or used as stable entrypoints that
-contributors are expected to rerun locally to reproduce CI behavior.
+- Defining common repo operations with Task makes them **easy to find**.
+  - `task` without arguments lists supported commands.
+- Requiring that CI runs named tasks makes **CI easier to reproduce locally**.
+  - A contributor can usually rerun the same task locally.
+  - Local execution may still depend on supporting tools such as nix or bazel.
 
 ## Why this repo uses Task
 
-Task is a command runner: a tool for defining named commands that can be
-listed and run in a consistent way.
+Task is a tool for naming and running commands. This repo wanted that kind of tool,
+not a build system.
 
-This repo wanted a command runner, not a build system. The main need was a simple way
-to expose common commands for builds, tests, linting, generation, and similar work,
-while keeping those commands easy to find and easy to rerun.
+What matters is less the specific tool than what it enables. The repo needs a way to
+define stable, discoverable command names for builds, tests, linting, code generation,
+and similar work. Task was a reasonable fit for that need.
 
-### Why not Make?
+### The double dash delimiter
 
-Make brings build dependency features and rules for deciding what needs to be
-rebuilt. Those can be useful for some projects, but they were not the point
-here. This repo mainly wanted stable, discoverable command names.
+Task has one quirk worth noting: task arguments come after `--` (for example,
+`task task-name -- arg1 arg2`). Without that delimiter, Task treats additional
+words as more task names rather than arguments.
 
-### Why Task instead of just?
+This repo generally prefers tasks that can be run without extra arguments, so
+that tradeoff was considered acceptable.
 
-[just](https://just.systems) could also serve as a command runner here. Task was
-chosen because it fit this repo's toolchain and needs at the time:
+### Why not Make or just?
 
-- it was a mature enough tool for the job
-- it fit naturally with the repo's existing Go-based tooling
-- its structured YAML format was considered acceptable for repo maintenance
+Make is most useful when a repo needs build rules and dependency tracking, but this
+repo already has solutions for those concerns. This repo just needs a way to define
+and discover commands on top of existing tooling. Make is more tool than is needed for
+that job, and its configuration format can be harder for casual users to understand.
 
-This does not mean Task needs to be a permanent fixture of the repo. What matters is
-the task model, not the specific tool. The repo needs a command runner that makes
-common commands easy to find and run, especially commands that CI and developers both
-need to run.
+[just](https://just.systems) is a reasonable alternative to Task. Its syntax is more
+like Make or shell scripting, which some people may prefer to Task's YAML style. Task
+was chosen over just because the existing dependency on Go tooling made adoption
+simpler and the repo's use of GitHub Actions also meant that YAML was already a
+familiar format.
 
 ## How tasks should work in this repo
 
-Tasks should be simple named commands. In most cases, the task name should be what
-people and CI use, while scripts and code hold the real behavior.
+These guidelines describe the repo's default approach to tasks, not rules that
+forbid every exception. When a different design is warranted, it should still
+be easy to explain in terms of making commands easy to find and easy to rerun
+locally.
 
-This is a general preference across the repo, and a stronger expectation for tasks
-used directly by CI or reused as stable reproduction entrypoints.
+### Keep tasks simple
 
-That means tasks should usually:
+In most cases, the task name should be the thing people run, while scripts and code do
+the real work.
+
+Task names should be clear enough that someone scanning `task` output can identify the
+command they want. For common repo operations, the task name should ideally also be a
+standard, memorable entrypoint that people can reuse in discussion, review, CI, and
+local reproduction. Names do not need to carry every detail because the `desc` field of
+a task can provide additional context, but they should avoid unusual wording that makes
+a task's purpose harder to recognize.
+
+In practice, tasks should usually:
 
 - stay simple
-- call scripts, tools, or other tasks that hold the real logic
-- avoid turning into their own separate place to configure behavior
+- call scripts, tools, or other tasks
+- avoid requiring extra workflow-only configuration
 
-Composing a few commands or other tasks inside `Taskfile.yml` is fine when that
-keeps the supported entrypoint clear. The main thing to avoid is hiding the real
-configuration or behavior only in workflow callsites or Task-specific wiring that a
-local user would have to rediscover.
+Most non-trivial shell logic should usually live under [`scripts/`](../scripts/). The
+main exception is code under [`.github/`](../.github/) when it is specific to GitHub
+Actions or packaging.
 
-Keeping non-trivial logic out of tasks makes it easier to apply the right linting and
-validation to scripts or code. That is much harder to do when behavior only exists
-inside a task definition.
+This makes the real behavior easier to check, test, reuse, and review.
 
-### Tasks used directly by CI should use stable named entrypoints
+### CI should run named tasks
 
-A **CI entrypoint task** is a task CI uses as the named way to run a
-repo-managed operation.
+When CI runs a repo operation, it should usually do so by running a named task. CI
+behavior existing only in GitHub Actions YAML is harder to discover, run, and
+maintain.
 
-A CI entrypoint task should usually be invoked through a stable named
-entrypoint.
+In this repo, that usually means calling `./scripts/run_task.sh` from a workflow. That
+helps keep the task runnable even when `task` is not already installed.
 
-In GitHub Actions workflows in this repo, that normally means invoking the task via
-`./scripts/run_task.sh` which ensures that task will run in a variety of different
-environments that may not have it directly installed.
-
-In normal use, the caller should not need to know special:
+For tasks that CI runs directly, the caller should usually not need special:
 
 - flags
 - environment variables
 - Taskfile variables
-- other task-specific configuration
+- other task-only configuration
 
-Tasks used directly by CI should usually not require positional arguments or other
-caller-supplied input. If CI needs different behavior, that should usually be
-expressed as a different named task rather than by parameterizing a single task at the
-workflow callsite.
-
-A task does not need to reject all input in every context. The potential problem is in
-defining behavior via CI-only settings that a local user would have to manually apply
+If CI needs different behavior, prefer a different named task instead of having the
+workflow reconfigure a shared task. Avoid workflow-only configuration that forces
+contributors to reconstruct the CI invocation manually when reproducing a failure
 locally.
 
-This repo does have some intentional exceptions. A small number of tasks are used as
-stable launchers for a family of related runs where the varying input is part of the
-user-facing interface rather than hidden CI-only behavior. For example, CI may select
-a fuzz shard, a particular re-execution scenario, or load-test flags that a developer
-can also pass locally to reproduce the same run.
+An exception is tasks that already support many different configurations. When a
+separate task for each configuration would be too cumbersome, CI may pass arguments to
+choose one, as long as contributors can use the same form locally. See [Good: the
+workflow passes a normal task argument](#good-the-workflow-passes-a-normal-task-argument).
 
-As a practical guardrail, workflow task invocations should not pass extra option flags
-after `--`. In this repo, `scripts/actionlint.sh` checks for that exact pattern in
-workflow `run:` steps because it is usually a sign that CI is changing task behavior
-where it is called instead of invoking a stable named task. This is only a narrow
-guardrail, not a full semantic check of all workflow task usage.
+As a practical, best-effort check, workflow task invocations should usually not pass
+extra option flags after `--`. In this repo, `scripts/actionlint.sh` checks for that
+pattern in workflow `run:` steps. The check is best-effort: it only catches a common
+mistake rather than every possible form.
 
-The goal is that a contributor should usually be able to reproduce the results of a CI
-command locally by running the same named task without additional configuration. Only
-in exceptional cases should it be necessary to locally configure a task run by CI.
+### Some CI-only setup still belongs in workflows
 
-### Exception: CI execution environment details
+CI sometimes needs extra CI-specific setup. That is usually fine when the setup is
+about the environment rather than about changing what repo operation is being run.
 
-CI sometimes needs extra settings because of the CI environment itself. That is
-acceptable when those settings support how the task runs in CI, rather than changing
-the fundamental behavior of the task.
+For example, workflows may still need runner choice, container setup, artifact
+uploads, or secrets. That is normal CI setup, not task definition.
 
-For example, CI may need launcher or environment settings because of CI setup
-requirements. But the same task should still be runnable locally without those CI-only
-settings.
+## Examples
 
-### Example: good pattern
+### Good: CI runs a named task
 
-If a workflow runs:
+In [`.github/workflows/ci.yml`](../.github/workflows/ci.yml), the process-based
+load test runs:
 
 ```bash
-./scripts/run_task.sh bazel-test-main
+./scripts/run_task.sh test-load-ci
 ```
 
-then a contributor should usually be able to run the same task locally:
+A contributor can run the same thing locally with:
 
 ```bash
-task bazel-test-main
+task test-load-ci
 ```
 
-The task may call wrappers, scripts, or tools underneath, but the caller should not
-need to know those details just to rerun the command.
+The task may call other tasks, scripts, or tools underneath, but the workflow
+is not hiding extra behavior.
 
-### Example: pattern to avoid
+### Good: the workflow passes a normal task argument
 
-Avoid designs where CI is effectively defining the real command through extra
-configuration that a local user has to rediscover, for example by putting the
-important behavior in workflow-only task vars, flags, or environment settings.
+In [`.github/workflows/fuzz.yml`](../.github/workflows/fuzz.yml), CI runs:
 
-For example, avoid the following style of job definition:
+```bash
+./scripts/run_task.sh test-fuzz-long -- ./vms/platformvm
+```
+
+That is fine because the path is part of the task's normal interface, and a
+contributor can run the same form locally:
+
+```bash
+task test-fuzz-long -- ./vms/platformvm
+```
+
+The workflow is choosing from an existing task interface rather than inventing
+hidden CI-only behavior.
+
+### Avoid: the workflow changes what the task does
+
+Prefer to avoid designs where the workflow defines the real command through
+workflow-only environment variables or task configuration.
+
+For example:
 
 ```yaml
 - run: ./scripts/run_task.sh test-e2e
@@ -175,17 +184,8 @@ For example, avoid the following style of job definition:
     E2E_RUNTIME: kube
 ```
 
-Reproduction of a CI failure for this job would require duplicating the environment
-configured by the job rather than just invoking the task.
-
-The problem here is not that environment variables exist at all. The problem is that
-these variables change what the task does, rather than only adapting it to run inside
-CI. A developer should not need those settings just to run the same task locally.
-
-By contrast, workflows may pass arguments that are already part of the task's intended
-public interface when that interface is also available to local users.  That kind of
-parameterization should stay explicit and reproducible rather than being hidden in
-CI-only environment configuration.
+That forces a contributor to reconstruct workflow state instead of rerunning a clear
+named task. In a case like this, prefer a dedicated task such as `test-e2e-kube-ci`.
 
 ## When to add or change a task
 
@@ -195,24 +195,21 @@ or CI are expected to run.
 A task is often a good fit when:
 
 - contributors will run it regularly
-- CI and local use should share the same named command
+- CI and local use should share the same command name
 - the task makes a supported command easier to find with `task`
 
 A task is often **not** the right fit when:
 
 - the command is a one-off maintenance step
-- the real interface needs a lot of user-supplied configuration
-- the script or tool should remain the primary interface
-- the task would mostly duplicate implementation detail rather than provide a useful
-  stable command name
+- the real command needs a lot of user-supplied configuration
+- the script or tool should remain the main thing people run
+- the task would mostly duplicate lower-level details instead of adding a useful
+  command name
 
-Direct script execution is acceptable when the script is the real interface and
-the repo does not need a separate stable, discoverable task name for CI or
-contributors. Add a task when the repo wants that named entrypoint; do not add
-one when it would only hide or duplicate the real interface.
+Direct script execution is fine when the script itself is the main thing people should
+run, or when the command is too one-off to benefit from a stable task name. Add a task
+only when a given capability would benefit from being discoverable and reproducible.
 
-When changing an existing task, preserve the main reasons tasks exist here:
-
-- people should be able to find supported commands easily
-- tasks used directly by CI should stay easy to rerun locally
-- the real behavior should stay in scripts or code, not in task-only settings
+When changing an existing task, check whether the change still leaves the task easy to
+find in `task` output, easy to rerun locally if CI uses it, and free of behavior that
+is only defined in workflow YAML.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -40,15 +40,6 @@ What matters is less the specific tool than what it enables. The repo needs a wa
 define stable, discoverable command names for builds, tests, linting, code generation,
 and similar work. Task was a reasonable fit for that need.
 
-### The double dash delimiter
-
-Task has one quirk worth noting: task arguments come after `--` (for example,
-`task task-name -- arg1 arg2`). Without that delimiter, Task treats additional
-words as more task names rather than arguments.
-
-This repo generally prefers tasks that can be run without extra arguments, so
-that tradeoff was considered acceptable.
-
 ### Why not Make or just?
 
 Make is most useful when a repo needs build rules and dependency tracking, but this
@@ -61,6 +52,15 @@ like Make or shell scripting, which some people may prefer to Task's YAML style.
 was chosen over just because the existing dependency on Go tooling made adoption
 simpler and the repo's use of GitHub Actions also meant that YAML was already a
 familiar format.
+
+### The double dash delimiter
+
+Task has one quirk worth noting: task arguments come after `--` (for example,
+`task task-name -- arg1 arg2`). Without that delimiter, Task treats additional
+words as more task names rather than arguments.
+
+This repo generally prefers tasks that can be run without extra arguments, so
+that tradeoff was considered acceptable.
 
 ## How tasks should work in this repo
 

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -27,6 +27,27 @@ if [[ -n "${SCRIPT_USAGE}" ]]; then
   exit 1
 fi
 
+echo "Checking for workflow task invocations configured with passthrough flags..."
+# CI should invoke stable named tasks rather than redefining task behavior at
+# the workflow callsite. As a practical guardrail, reject task invocations that
+# pass extra option flags after `--`.
+TASK_CONFIGURATION=
+for file in "${AVALANCHE_PATH}"/.github/workflows/*.{yml,yaml}; do
+  [[ -f "$file" ]] || continue
+
+  MATCHES=$(grep -H -n -P '^\s*run:\s*(?:(?:\./)?scripts/run_task\.sh|task)\s+[^#\n]*\s--\s+--' "$file" || true)
+  if [[ -n "${MATCHES}" ]]; then
+    echo "${MATCHES}"
+    TASK_CONFIGURATION=1
+  fi
+done
+
+if [[ -n "${TASK_CONFIGURATION}" ]]; then
+  echo "Error: workflow task invocations must not pass option flags after '--'."
+  echo "Define a stable named task instead of configuring task behavior at the CI callsite."
+  exit 1
+fi
+
 echo "Checking for floating GitHub runner labels..."
 # Floating runner labels (e.g. ubuntu-latest, macos-latest) can change out
 # from under the default branch and break CI without any corresponding change

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -29,8 +29,11 @@ fi
 
 echo "Checking for workflow task invocations configured with passthrough flags..."
 # CI should invoke stable named tasks rather than redefining task behavior at
-# the workflow callsite. As a practical guardrail, reject task invocations that
-# pass extra option flags after `--`.
+# the workflow callsite. As a practical, best-effort guardrail, reject task
+# invocations that pass extra option flags after `--`.
+#
+# This check is intentionally narrow. It is meant to catch a common failure
+# mode, not to exhaustively model every possible workflow command form.
 TASK_CONFIGURATION=
 for file in "${AVALANCHE_PATH}"/.github/workflows/*.{yml,yaml}; do
   [[ -f "$file" ]] || continue


### PR DESCRIPTION
## Why this should be merged

Document the repo's task model so future task and CI workflow changes can be reviewed against explicit expectations instead of inferred convention.

In keeping with the now-documented expectations for task usage in CI, a lint check is added that rejects workflow task invocations passing passthrough option flags after --. This is intended to prevent CI from needing to configure a task in a way that requires local invocation to manually duplicate that configuration. Existing workflow invocations that violated the new lint check are updated accordingly.

## How this was tested

CI