### PR TITLE
Refactor staker struct constructors

### DIFF
--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -235,7 +235,7 @@ func TestBuildBlockShouldRewardAutoRenewedValidator(t *testing.T) {
 	// Add the tx and staker directly to state
 	env.state.AddTx(addTx, status.Committed)
 
-	staker, err := state.NewStaker(txID, validatorTx, startTime, endTime, validatorTx.Weight(), 0)
+	staker, err := state.NewCurrentStaker(txID, validatorTx, startTime, endTime, validatorTx.Weight(), 0)
 	require.NoError(err)
 
 	require.NoError(env.state.PutCurrentValidator(staker))

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -568,6 +568,8 @@ func TestBanffProposalBlockUpdateStakers(t *testing.T) {
 					addStaker0.ID(),
 					addValTx,
 					addValTx.StartTime(),
+					addValTx.EndTime(),
+					addValTx.Weight(),
 					0,
 				)
 				require.NoError(err)
@@ -671,6 +673,8 @@ func TestBanffProposalBlockRemoveSubnetValidator(t *testing.T) {
 		tx.ID(),
 		addSubnetValTx,
 		addSubnetValTx.StartTime(),
+		addSubnetValTx.EndTime(),
+		addSubnetValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -739,6 +743,8 @@ func TestBanffProposalBlockRemoveSubnetValidator(t *testing.T) {
 		addStaker0.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -861,6 +867,8 @@ func TestBanffProposalBlockTrackedSubnet(t *testing.T) {
 				addStaker0.ID(),
 				addValTx,
 				addValTx.StartTime(),
+				addValTx.EndTime(),
+				addValTx.Weight(),
 				0,
 			)
 			require.NoError(err)
@@ -953,6 +961,8 @@ func TestBanffProposalBlockDelegatorStakerWeight(t *testing.T) {
 		addStaker0.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -1042,6 +1052,8 @@ func TestBanffProposalBlockDelegatorStakerWeight(t *testing.T) {
 		addStaker0.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -1138,6 +1150,8 @@ func TestBanffProposalBlockDelegatorStakers(t *testing.T) {
 		addStaker0.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -1227,6 +1241,8 @@ func TestBanffProposalBlockDelegatorStakers(t *testing.T) {
 		addStaker0.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -607,6 +607,8 @@ func TestBanffStandardBlockRemoveSubnetValidator(t *testing.T) {
 		tx.ID(),
 		addSubnetValTx,
 		addSubnetValTx.StartTime(),
+		addSubnetValTx.EndTime(),
+		addSubnetValTx.Weight(),
 		0,
 	)
 	require.NoError(err)

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -546,6 +546,8 @@ func TestGetStake(t *testing.T) {
 		tx.ID(),
 		addDelTx,
 		genesistest.DefaultValidatorStartTime,
+		addDelTx.EndTime(),
+		addDelTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -700,6 +702,8 @@ func TestGetCurrentValidators(t *testing.T) {
 		delTx.ID(),
 		addDelTx,
 		genesistest.DefaultValidatorStartTime,
+		addDelTx.EndTime(),
+		addDelTx.Weight(),
 		0,
 	)
 	require.NoError(err)

--- a/vms/platformvm/state/staker.go
+++ b/vms/platformvm/state/staker.go
@@ -94,42 +94,9 @@ func (s *Staker) Less(than *Staker) bool {
 	return bytes.Compare(s.TxID[:], than.TxID[:]) == -1
 }
 
-// NewCurrentStaker returns a current Staker built from a [txs.BoundedStaker]
-// transaction, deriving its EndTime and Weight.
+// NewCurrentStaker returns a current-priority Staker built from [txs.Staker] with
+// the provided start time, end time, weight, and potential reward.
 func NewCurrentStaker(
-	txID ids.ID,
-	staker txs.BoundedStaker,
-	startTime time.Time,
-	potentialReward uint64,
-) (*Staker, error) {
-	return NewStaker(txID, staker, startTime, staker.EndTime(), staker.Weight(), potentialReward)
-}
-
-// NewPendingStaker returns a pending Staker built from a [txs.ScheduledStaker]
-// transaction.
-func NewPendingStaker(txID ids.ID, staker txs.ScheduledStaker) (*Staker, error) {
-	publicKey, _, err := staker.PublicKey()
-	if err != nil {
-		return nil, err
-	}
-	startTime := staker.StartTime()
-	return &Staker{
-		TxID:      txID,
-		NodeID:    staker.NodeID(),
-		PublicKey: publicKey,
-		SubnetID:  staker.SubnetID(),
-		Weight:    staker.Weight(),
-		StartTime: startTime,
-		EndTime:   staker.EndTime(),
-		NextTime:  startTime,
-		Priority:  staker.PendingPriority(),
-	}, nil
-}
-
-// NewStaker returns a raw Staker built from explicitly provided startTime,
-// endTime, weight, and potentialReward, rather than deriving them from
-// [txs.Staker]. It is mostly used to build auto-renewed validators.
-func NewStaker(
 	txID ids.ID,
 	staker txs.Staker,
 	startTime time.Time,
@@ -152,5 +119,26 @@ func NewStaker(
 		PotentialReward: potentialReward,
 		NextTime:        endTime,
 		Priority:        staker.CurrentPriority(),
+	}, nil
+}
+
+// NewPendingStaker returns a pending Staker built from a [txs.ScheduledStaker]
+// transaction.
+func NewPendingStaker(txID ids.ID, staker txs.ScheduledStaker) (*Staker, error) {
+	publicKey, _, err := staker.PublicKey()
+	if err != nil {
+		return nil, err
+	}
+	startTime := staker.StartTime()
+	return &Staker{
+		TxID:      txID,
+		NodeID:    staker.NodeID(),
+		PublicKey: publicKey,
+		SubnetID:  staker.SubnetID(),
+		Weight:    staker.Weight(),
+		StartTime: startTime,
+		EndTime:   staker.EndTime(),
+		NextTime:  startTime,
+		Priority:  staker.PendingPriority(),
 	}, nil
 }

--- a/vms/platformvm/state/staker_test.go
+++ b/vms/platformvm/state/staker_test.go
@@ -141,7 +141,7 @@ func TestNewCurrentStaker(t *testing.T) {
 	startTime := stakerTx.StartTime().Add(2 * time.Hour)
 	potentialReward := uint64(12345)
 
-	staker, err := NewCurrentStaker(txID, stakerTx, startTime, potentialReward)
+	staker, err := NewCurrentStaker(txID, stakerTx, startTime, stakerTx.EndTime(), stakerTx.Weight(), potentialReward)
 	require.NoError(err)
 	publicKey, isNil, err := stakerTx.PublicKey()
 	require.NoError(err)
@@ -164,7 +164,7 @@ func TestNewCurrentStaker(t *testing.T) {
 	signer.EXPECT().Verify().Return(errCustom)
 	stakerTx.Signer = signer
 
-	_, err = NewCurrentStaker(txID, stakerTx, startTime, potentialReward)
+	_, err = NewCurrentStaker(txID, stakerTx, startTime, stakerTx.EndTime(), stakerTx.Weight(), potentialReward)
 	require.ErrorIs(err, errCustom)
 }
 

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1743,7 +1743,7 @@ func (s *State) syncGenesis(genesisBlk block.Block, genesis *genesis.Genesis) er
 			return err
 		}
 
-		staker, err := NewCurrentStaker(vdrTx.ID(), validatorTx, startTime, potentialReward)
+		staker, err := NewCurrentStaker(vdrTx.ID(), validatorTx, startTime, validatorTx.EndTime(), validatorTx.Weight(), potentialReward)
 		if err != nil {
 			return err
 		}
@@ -1948,7 +1948,7 @@ func (s *State) loadCurrentValidators() error {
 				return fmt.Errorf("adding accrued delegatee rewards: %w", err)
 			}
 
-			staker, err = NewStaker(
+			staker, err = NewCurrentStaker(
 				txID,
 				stakerTx,
 				time.Unix(int64(metadata.StakerStartTime), 0),
@@ -1964,6 +1964,8 @@ func (s *State) loadCurrentValidators() error {
 				txID,
 				stakerTx,
 				time.Unix(int64(metadata.StakerStartTime), 0),
+				stakerTx.EndTime(),
+				stakerTx.Weight(),
 				metadata.PotentialReward,
 			)
 			if err != nil {
@@ -2018,6 +2020,8 @@ func (s *State) loadCurrentValidators() error {
 			txID,
 			stakerTx,
 			time.Unix(int64(metadata.StakerStartTime), 0),
+			stakerTx.EndTime(),
+			stakerTx.Weight(),
 			metadata.PotentialReward,
 		)
 		if err != nil {
@@ -2073,6 +2077,8 @@ func (s *State) loadCurrentValidators() error {
 				txID,
 				stakerTx,
 				time.Unix(int64(metadata.StakerStartTime), 0),
+				stakerTx.EndTime(),
+				stakerTx.Weight(),
 				metadata.PotentialReward,
 			)
 			if err != nil {

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -217,6 +217,8 @@ func TestState_writeStakers(t *testing.T) {
 		addPrimaryNetworkValidator.ID(),
 		unsignedAddPrimaryNetworkValidator,
 		primaryValidatorStartTime,
+		unsignedAddPrimaryNetworkValidator.EndTime(),
+		unsignedAddPrimaryNetworkValidator.Weight(),
 		primaryValidatorReward,
 	)
 	require.NoError(t, err)
@@ -235,6 +237,8 @@ func TestState_writeStakers(t *testing.T) {
 		addPrimaryNetworkDelegator.ID(),
 		unsignedAddPrimaryNetworkDelegator,
 		primaryDelegatorStartTime,
+		unsignedAddPrimaryNetworkDelegator.EndTime(),
+		unsignedAddPrimaryNetworkDelegator.Weight(),
 		primaryDelegatorReward,
 	)
 	require.NoError(t, err)
@@ -247,6 +251,8 @@ func TestState_writeStakers(t *testing.T) {
 		addSubnetValidator.ID(),
 		unsignedAddSubnetValidator,
 		subnetValidatorStartTime,
+		unsignedAddSubnetValidator.EndTime(),
+		unsignedAddSubnetValidator.Weight(),
 		subnetValidatorReward,
 	)
 	require.NoError(t, err)
@@ -752,7 +758,7 @@ func createStakerAndTx(
 	tx := &txs.Tx{Unsigned: unsignedTx}
 	require.NoError(t, tx.Initialize(txs.Codec))
 
-	staker, err := NewCurrentStaker(tx.ID(), unsignedTx, startTime, potentialReward)
+	staker, err := NewCurrentStaker(tx.ID(), unsignedTx, startTime, unsignedTx.EndTime(), unsignedTx.Weight(), potentialReward)
 	require.NoError(t, err)
 
 	return staker, tx
@@ -3041,7 +3047,7 @@ func TestDiffMultipleBlocksRollback(t *testing.T) {
 	})
 	tx1 := &txs.Tx{Unsigned: unsignedTx1}
 	require.NoError(tx1.Initialize(txs.Codec))
-	staker1, err := NewCurrentStaker(tx1.ID(), unsignedTx1, startTime, 0)
+	staker1, err := NewCurrentStaker(tx1.ID(), unsignedTx1, startTime, unsignedTx1.EndTime(), unsignedTx1.Weight(), 0)
 	require.NoError(err)
 	pk1 := staker1.PublicKey
 	require.NotNil(pk1)
@@ -3053,7 +3059,7 @@ func TestDiffMultipleBlocksRollback(t *testing.T) {
 	})
 	tx2 := &txs.Tx{Unsigned: unsignedTx2}
 	require.NoError(tx2.Initialize(txs.Codec))
-	staker2, err := NewCurrentStaker(tx2.ID(), unsignedTx2, startTime, 0)
+	staker2, err := NewCurrentStaker(tx2.ID(), unsignedTx2, startTime, unsignedTx2.EndTime(), unsignedTx2.Weight(), 0)
 	require.NoError(err)
 	pk2 := staker2.PublicKey
 	require.NotNil(pk2)
@@ -3065,7 +3071,7 @@ func TestDiffMultipleBlocksRollback(t *testing.T) {
 	})
 	tx3 := &txs.Tx{Unsigned: unsignedTx3}
 	require.NoError(tx3.Initialize(txs.Codec))
-	staker3, err := NewCurrentStaker(tx3.ID(), unsignedTx3, startTime, 0)
+	staker3, err := NewCurrentStaker(tx3.ID(), unsignedTx3, startTime, unsignedTx3.EndTime(), unsignedTx3.Weight(), 0)
 	require.NoError(err)
 
 	// Block 0: Add staker1 (weight=10, PK1).
@@ -3147,7 +3153,7 @@ func TestSubnetValidatorPublicKeyDiffOnPrimaryAndSubnetReplacement(t *testing.T)
 	})
 	primaryTx1 := &txs.Tx{Unsigned: primaryUnsigned1}
 	require.NoError(primaryTx1.Initialize(txs.Codec))
-	primaryStaker1, err := NewCurrentStaker(primaryTx1.ID(), primaryUnsigned1, startTime, 0)
+	primaryStaker1, err := NewCurrentStaker(primaryTx1.ID(), primaryUnsigned1, startTime, primaryUnsigned1.EndTime(), primaryUnsigned1.Weight(), 0)
 	require.NoError(err)
 	pk1 := primaryStaker1.PublicKey
 	require.NotNil(pk1)
@@ -3160,7 +3166,7 @@ func TestSubnetValidatorPublicKeyDiffOnPrimaryAndSubnetReplacement(t *testing.T)
 	})
 	subnetTx1 := &txs.Tx{Unsigned: subnetUnsigned1}
 	require.NoError(subnetTx1.Initialize(txs.Codec))
-	subnetStaker1, err := NewCurrentStaker(subnetTx1.ID(), subnetUnsigned1, startTime, 0)
+	subnetStaker1, err := NewCurrentStaker(subnetTx1.ID(), subnetUnsigned1, startTime, subnetUnsigned1.EndTime(), subnetUnsigned1.Weight(), 0)
 	require.NoError(err)
 	require.Nil(subnetStaker1.PublicKey, "subnet validators must not carry their own BLS key")
 
@@ -3172,7 +3178,7 @@ func TestSubnetValidatorPublicKeyDiffOnPrimaryAndSubnetReplacement(t *testing.T)
 	})
 	primaryTx2 := &txs.Tx{Unsigned: primaryUnsigned2}
 	require.NoError(primaryTx2.Initialize(txs.Codec))
-	primaryStaker2, err := NewCurrentStaker(primaryTx2.ID(), primaryUnsigned2, startTime, 0)
+	primaryStaker2, err := NewCurrentStaker(primaryTx2.ID(), primaryUnsigned2, startTime, primaryUnsigned2.EndTime(), primaryUnsigned2.Weight(), 0)
 	require.NoError(err)
 	pk2 := primaryStaker2.PublicKey
 	require.NotNil(pk2)
@@ -3189,7 +3195,7 @@ func TestSubnetValidatorPublicKeyDiffOnPrimaryAndSubnetReplacement(t *testing.T)
 	})
 	subnetTx2 := &txs.Tx{Unsigned: subnetUnsigned2}
 	require.NoError(subnetTx2.Initialize(txs.Codec))
-	subnetStaker2, err := NewCurrentStaker(subnetTx2.ID(), subnetUnsigned2, startTime, 0)
+	subnetStaker2, err := NewCurrentStaker(subnetTx2.ID(), subnetUnsigned2, startTime, subnetUnsigned2.EndTime(), subnetUnsigned2.Weight(), 0)
 	require.NoError(err)
 
 	// Block 0: Add primary validator 1 + subnet validator 1.
@@ -3268,7 +3274,7 @@ func TestSubnetValidatorReplacementWithUnchangedPrimaryKey(t *testing.T) {
 	})
 	primaryTx := &txs.Tx{Unsigned: primaryUnsigned}
 	require.NoError(primaryTx.Initialize(txs.Codec))
-	primaryStaker, err := NewCurrentStaker(primaryTx.ID(), primaryUnsigned, startTime, 0)
+	primaryStaker, err := NewCurrentStaker(primaryTx.ID(), primaryUnsigned, startTime, primaryUnsigned.EndTime(), primaryUnsigned.Weight(), 0)
 	require.NoError(err)
 	pk1 := primaryStaker.PublicKey
 	require.NotNil(pk1)
@@ -3281,7 +3287,7 @@ func TestSubnetValidatorReplacementWithUnchangedPrimaryKey(t *testing.T) {
 	})
 	subnetTx1 := &txs.Tx{Unsigned: subnetUnsigned1}
 	require.NoError(subnetTx1.Initialize(txs.Codec))
-	subnetStaker1, err := NewCurrentStaker(subnetTx1.ID(), subnetUnsigned1, startTime, 0)
+	subnetStaker1, err := NewCurrentStaker(subnetTx1.ID(), subnetUnsigned1, startTime, subnetUnsigned1.EndTime(), subnetUnsigned1.Weight(), 0)
 	require.NoError(err)
 
 	// Create subnet validator 2 (replacement).
@@ -3292,7 +3298,7 @@ func TestSubnetValidatorReplacementWithUnchangedPrimaryKey(t *testing.T) {
 	})
 	subnetTx2 := &txs.Tx{Unsigned: subnetUnsigned2}
 	require.NoError(subnetTx2.Initialize(txs.Codec))
-	subnetStaker2, err := NewCurrentStaker(subnetTx2.ID(), subnetUnsigned2, startTime, 0)
+	subnetStaker2, err := NewCurrentStaker(subnetTx2.ID(), subnetUnsigned2, startTime, subnetUnsigned2.EndTime(), subnetUnsigned2.Weight(), 0)
 	require.NoError(err)
 
 	// Block 0: Add primary validator + subnet validator 1.
@@ -4425,7 +4431,7 @@ func TestAutoRenewedValidatorRestakeStateReload(t *testing.T) {
 	autoRenewedTx := &txs.Tx{Unsigned: autoRenewedUnsigned}
 	require.NoError(autoRenewedTx.Initialize(txs.Codec))
 
-	autoRenewedStaker, err := NewStaker(
+	autoRenewedStaker, err := NewCurrentStaker(
 		autoRenewedTx.ID(),
 		autoRenewedUnsigned,
 		startTime,
@@ -4452,7 +4458,7 @@ func TestAutoRenewedValidatorRestakeStateReload(t *testing.T) {
 	require.NoError(err)
 	require.NoError(d.DeleteCurrentValidator(autoRenewedStaker))
 
-	renewedStaker, err := NewStaker(
+	renewedStaker, err := NewCurrentStaker(
 		autoRenewedTx.ID(),
 		autoRenewedUnsigned,
 		wantStartTime,

--- a/vms/platformvm/txs/executor/advance_time_test.go
+++ b/vms/platformvm/txs/executor/advance_time_test.go
@@ -506,6 +506,8 @@ func TestAdvanceTimeTxRemoveSubnetValidator(t *testing.T) {
 		tx.ID(),
 		addSubnetValTx,
 		addSubnetValTx.StartTime(),
+		addSubnetValTx.EndTime(),
+		addSubnetValTx.Weight(),
 		0,
 	)
 	require.NoError(err)

--- a/vms/platformvm/txs/executor/proposal_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor_test.go
@@ -61,6 +61,8 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 			tx.ID(),
 			addValTx,
 			addValTx.StartTime(),
+			addValTx.EndTime(),
+			addValTx.Weight(),
 			0,
 		)
 		require.NoError(err)
@@ -97,6 +99,8 @@ func TestProposalTxExecuteAddDelegator(t *testing.T) {
 			tx.ID(),
 			addValTx,
 			addValTx.StartTime(),
+			addValTx.EndTime(),
+			addValTx.Weight(),
 			0,
 		)
 		require.NoError(err)
@@ -426,6 +430,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		addDSTx.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -610,6 +616,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 		subnetTx.ID(),
 		addSubnetValTx,
 		addSubnetValTx.StartTime(),
+		addSubnetValTx.EndTime(),
+		addSubnetValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -764,6 +772,8 @@ func TestProposalTxExecuteAddSubnetValidator(t *testing.T) {
 			subnetTx.ID(),
 			addSubnetValTx,
 			addSubnetValTx.StartTime(),
+			addSubnetValTx.EndTime(),
+			addSubnetValTx.Weight(),
 			0,
 		)
 		require.NoError(err)
@@ -891,6 +901,8 @@ func TestProposalTxExecuteAddValidator(t *testing.T) {
 			tx.ID(),
 			addValTx,
 			addValTx.StartTime(),
+			addValTx.EndTime(),
+			addValTx.Weight(),
 			0,
 		)
 		require.NoError(err)

--- a/vms/platformvm/txs/executor/reward_validator_test.go
+++ b/vms/platformvm/txs/executor/reward_validator_test.go
@@ -190,7 +190,7 @@ func addAutoRenewedValidator(t testing.TB, env *environment, tx *txs.Tx, cfg aut
 		AutoCompoundRewardShares: cfg.autoCompoundRewardShares,
 	}
 	if cfg.restake {
-		stakingInfo.NextPeriod = env.config.MinValidatorStake
+		stakingInfo.NextPeriod = uint64(env.config.MinStakeDuration / time.Second)
 	}
 
 	nodeID := (tx.Unsigned.(*txs.AddAutoRenewedValidatorTx)).NodeID()
@@ -569,6 +569,8 @@ func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 		vdrTx.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -578,6 +580,8 @@ func TestRewardDelegatorTxExecuteOnCommitPreDelegateeDeferral(t *testing.T) {
 		delTx.ID(),
 		addDelTx,
 		addDelTx.StartTime(),
+		addDelTx.EndTime(),
+		addDelTx.Weight(),
 		1000000,
 	)
 	require.NoError(err)
@@ -699,7 +703,9 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	vdrStaker, err := state.NewCurrentStaker(
 		vdrTx.ID(),
 		addValTx,
-		time.Unix(int64(vdrStartTime), 0),
+		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		vdrRewardAmt,
 	)
 	require.NoError(err)
@@ -709,7 +715,9 @@ func TestRewardDelegatorTxExecuteOnCommitPostDelegateeDeferral(t *testing.T) {
 	delStaker, err := state.NewCurrentStaker(
 		delTx.ID(),
 		addDelTx,
-		time.Unix(int64(delStartTime), 0),
+		addDelTx.StartTime(),
+		addDelTx.EndTime(),
+		addDelTx.Weight(),
 		delRewardAmt,
 	)
 	require.NoError(err)
@@ -925,6 +933,8 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 		vdrTx.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		vdrRewardAmt,
 	)
 	require.NoError(err)
@@ -934,7 +944,9 @@ func TestRewardDelegatorTxAndValidatorTxExecuteOnCommitPostDelegateeDeferral(t *
 	delStaker, err := state.NewCurrentStaker(
 		delTx.ID(),
 		addDelTx,
-		time.Unix(int64(delStartTime), 0),
+		addDelTx.StartTime(),
+		addDelTx.EndTime(),
+		addDelTx.Weight(),
 		delRewardAmt,
 	)
 	require.NoError(err)
@@ -1095,6 +1107,8 @@ func TestRewardDelegatorTxExecuteOnAbort(t *testing.T) {
 		vdrTx.ID(),
 		addValTx,
 		addValTx.StartTime(),
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -1104,6 +1118,8 @@ func TestRewardDelegatorTxExecuteOnAbort(t *testing.T) {
 		delTx.ID(),
 		addDelTx,
 		addDelTx.StartTime(),
+		addDelTx.EndTime(),
+		addDelTx.Weight(),
 		1000000,
 	)
 	require.NoError(err)

--- a/vms/platformvm/txs/executor/standard_tx_executor.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor.go
@@ -1410,7 +1410,7 @@ func (e *standardTxExecutor) AddAutoRenewedValidatorTx(tx *txs.AddAutoRenewedVal
 
 	endTime := stakeStartTime.Add(duration)
 
-	staker, err := state.NewStaker(
+	staker, err := state.NewCurrentStaker(
 		e.tx.ID(),
 		tx,
 		stakeStartTime,
@@ -1533,7 +1533,14 @@ func (e *standardTxExecutor) putStaker(stakerTx txs.BoundedStaker) error {
 			e.state.SetCurrentSupply(subnetID, currentSupply+potentialReward)
 		}
 
-		staker, err = state.NewCurrentStaker(txID, stakerTx, stakeStartTime, potentialReward)
+		staker, err = state.NewCurrentStaker(
+			txID,
+			stakerTx,
+			stakeStartTime,
+			stakerTx.EndTime(),
+			stakerTx.Weight(),
+			potentialReward,
+		)
 	}
 	if err != nil {
 		return err

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -156,6 +156,8 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 			tx.ID(),
 			addValTx,
 			newValidatorStartTime,
+			addValTx.EndTime(),
+			addValTx.Weight(),
 			0,
 		)
 		require.NoError(err)
@@ -191,6 +193,8 @@ func TestStandardTxExecutorAddDelegator(t *testing.T) {
 			tx.ID(),
 			addValTx,
 			newValidatorStartTime,
+			addValTx.EndTime(),
+			addValTx.Weight(),
 			0,
 		)
 		require.NoError(err)
@@ -507,6 +511,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		addDSTx.ID(),
 		addValTx,
 		dsStartTime,
+		addValTx.EndTime(),
+		addValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -676,6 +682,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 		subnetTx.ID(),
 		addSubnetValTx,
 		genesistest.DefaultValidatorStartTime,
+		addSubnetValTx.EndTime(),
+		addSubnetValTx.Weight(),
 		0,
 	)
 	require.NoError(err)
@@ -861,6 +869,8 @@ func TestApricotStandardTxExecutorAddSubnetValidator(t *testing.T) {
 			subnetTx.ID(),
 			addSubnetValTx,
 			genesistest.DefaultValidatorStartTime,
+			addSubnetValTx.EndTime(),
+			addSubnetValTx.Weight(),
 			0,
 		)
 		require.NoError(err)
@@ -993,6 +1003,8 @@ func TestBanffStandardTxExecutorAddValidator(t *testing.T) {
 			tx.ID(),
 			addValTx,
 			startTime,
+			addValTx.EndTime(),
+			addValTx.Weight(),
 			0,
 		)
 		require.NoError(err)
@@ -4850,7 +4862,7 @@ func TestStandardExecutorSetAutoRenewedValidatorConfigTxErrors(t *testing.T) {
 
 	startTime := time.Unix(int64(genesistest.DefaultValidatorStartTimeUnix+1), 0)
 	duration := time.Duration(validatorTx.Period) * time.Second
-	staker, err := state.NewStaker(
+	staker, err := state.NewCurrentStaker(
 		addAutoRenewedValidatorTx.ID(),
 		validatorTx,
 		startTime,


### PR DESCRIPTION
## Why this should be merged
This simplifies staker construction by removing the multiple `Staker` constructors and using `NewCurrentStaker` for all current stakers, including auto-renewed validators.

## How this works
`NewCurrentStaker` now accepts a `txs.Staker` and explicit start time, end time, weight, and potential reward values.

Regular bounded stakers pass their transaction-derived end time and weight. Auto-renewed validators pass the values calculated for their current staking period (initial weight + accrued rewards).

## How this was tested
Existing tests.

## Need to be documented in RELEASES.md?
No.