### PR TITLE
Silence noisy SAE log

### DIFF
--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -368,7 +368,7 @@ func lastToSettle(
 		return nil, err
 	}
 	if !ok {
-		log.Warn("Execution lagging when determining last block to settle")
+		log.Debug("Execution lagging when determining last block to settle")
 		return nil, errExecutionLagging
 	}
 	return lastSettled, nil


### PR DESCRIPTION
## Why this should be merged

This log was added to signal when the gas target is set too high (causing the gas clock to advance slower, eventually warning if the gas clock is advancing slower than the wall clock).

However, this log can also flake if:
1. Consensus takes longer than expected to confirm a block (which doesn't happen much, but if looking at the p99 consensus latency, this will fire)
2. The block builder attempts to skew the block timestamp

Since adding this log, we have also added metrics. Rather than using this log to determine if execution is falling behind, I think we should use a combination of:
- `execute_block_duration_seconds`
- `executed_gas_charged_total`

There are are ton of other metrics we could use to alert on variations of this - such as `gas_time_wall_time_gap_seconds`.

## How this works

Warn -> Debug

## How this was tested

N/A

## Need to be documented in RELEASES.md?

No