### PR TITLE
refactor(hook): Move blackhole op to libevm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100
 	github.com/ava-labs/avalanchego/graft/coreth v1.14.2
 	github.com/ava-labs/avalanchego/graft/subnet-evm v1.14.2
-	github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca
+	github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5 h1:1gyMFsVSsCdoBYUwaw5KJmax/2ANuXH200IlayVNAJM=
+github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad h1:P5IRndHUinfIZ73jdxl3M6jdcnKkQOLYvhGvE3VDiSU=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad/go.mod h1:DADqV3zJ+ij8GqliStJ+aj9l/cPtb5ZUhNy5KxlDEsQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.work.sum
+++ b/go.work.sum
@@ -338,8 +338,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.3.0/go.mod h1:71C76bo47zlDX9gWnn3p/0QZQXkTQ/GNqUNI6fchvjs=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1 h1:Y9UdRQj28/t+GNzVSlP6nvoNLtzNRo3fNXLUc/NscVM=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1/go.mod h1:GVzumIo3zR23/qGRN2AdnVkIPHcKMq/D89EGWZfMGQ0=
 github.com/aws/aws-sdk-go-v2 v1.21.2 h1:+LXZ0sgo8quN9UOKXXzAWRT3FWd4NxeXWOZom9pE7GA=
@@ -1009,6 +1007,7 @@ golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8 h1:LvzTn0GQhWuvKH/kVRS3R3bVAsdQWI7hvfLHGgh9+lU=
 golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJEkyFTI5/Ocsu2jXyDr6iSdgJiYE/uwE=

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca
+	github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/graft/coreth/go.sum
+++ b/graft/coreth/go.sum
@@ -30,8 +30,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5 h1:1gyMFsVSsCdoBYUwaw5KJmax/2ANuXH200IlayVNAJM=
+github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/coreth/params/BUILD.bazel
+++ b/graft/coreth/params/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//graft/coreth/precompile/contract",
         "//graft/coreth/precompile/modules",
         "//graft/coreth/precompile/precompileconfig",
+        "//graft/evm/constants",
         "//graft/evm/precompileconfig",
         "//snow",
         "//upgrade",
@@ -36,6 +37,7 @@ go_library(
         "@com_github_ava_labs_libevm//libevm",
         "@com_github_ava_labs_libevm//libevm/legacy",
         "@com_github_ava_labs_libevm//params",
+        "@com_github_holiman_uint256//:uint256",
     ],
 )
 

--- a/graft/coreth/params/hooks_libevm.go
+++ b/graft/coreth/params/hooks_libevm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/libevm/legacy"
+	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/avalanchego/graft/coreth/nativeasset"
 	"github.com/ava-labs/avalanchego/graft/coreth/params/extras"
@@ -20,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/graft/coreth/precompile/contract"
 	"github.com/ava-labs/avalanchego/graft/coreth/precompile/modules"
 	"github.com/ava-labs/avalanchego/graft/coreth/precompile/precompileconfig"
+	"github.com/ava-labs/avalanchego/graft/evm/constants"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/evm/predicate"
@@ -61,6 +63,20 @@ func (r RulesExtra) MinimumGasConsumption(limit uint64) uint64 {
 		return hook.MinimumGasConsumption(limit)
 	}
 	return (ethparams.NOOPHooks{}).MinimumGasConsumption(limit)
+}
+
+// AfterExecutingTransaction credits the base fee to [constants.BlackholeAddr].
+// The C-Chain has historically credited the full fee (base + priority) to the
+// blackhole address, but libevm's state transition only credits the priority
+// fee to the coinbase (the blackhole address) and discards the base fee.
+func (RulesExtra) AfterExecutingTransaction(sdb libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
+	if baseFee == nil {
+		return
+	}
+	burned := new(uint256.Int).SetUint64(gasUsed)
+	bf := uint256.MustFromBig(baseFee)
+	burned.Mul(burned, bf)
+	sdb.AddBalance(constants.BlackholeAddr, burned)
 }
 
 // AccessListGas computes the intrinsic gas for an access list.

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca
+	github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/gorilla/rpc v1.2.0

--- a/graft/evm/go.sum
+++ b/graft/evm/go.sum
@@ -21,8 +21,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5 h1:1gyMFsVSsCdoBYUwaw5KJmax/2ANuXH200IlayVNAJM=
+github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca
+	github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/gorilla/rpc v1.2.0

--- a/graft/subnet-evm/go.sum
+++ b/graft/subnet-evm/go.sum
@@ -30,8 +30,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5 h1:1gyMFsVSsCdoBYUwaw5KJmax/2ANuXH200IlayVNAJM=
+github.com/ava-labs/libevm v1.13.15-0.20260720163803-90e9e9d2a1f5/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/subnet-evm/params/hooks_libevm.go
+++ b/graft/subnet-evm/params/hooks_libevm.go
@@ -71,6 +71,11 @@ func (RulesExtra) MinimumGasConsumption(x uint64) uint64 {
 	return (ethparams.NOOPHooks{}).MinimumGasConsumption(x)
 }
 
+// AfterExecutingTransaction is a no-op.
+func (RulesExtra) AfterExecutingTransaction(sdb libevm.StateDB, bf *big.Int, gasUsed uint64) {
+	(ethparams.NOOPHooks{}).AfterExecutingTransaction(sdb, bf, gasUsed)
+}
+
 // AccessListGas computes the intrinsic gas for an access list.
 // When predicaters exist, it calculates gas per-tuple, delegating to predicate
 // contracts for addresses that have them. Otherwise, it returns override=false

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/trie"
-	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/graft/coreth/core/extstate"
@@ -253,17 +252,6 @@ func (h *hooks) BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB,
 	if isFirstDurangoBlock := corethparams.GetRulesExtra(rules).IsDurango && !config.IsDurango(parent.Time); isFirstDurangoBlock {
 		activatePrecompile(statedb, corethwarp.ContractAddress)
 	}
-	return nil
-}
-
-// AfterExecutingTransaction credits the base fee to [constants.BlackholeAddr].
-// The C-Chain has historically credited the full fee (base + priority) to the
-// blackhole address, but libevm's state transition only credits the priority
-// fee to the coinbase (the blackhole address) and discards the base fee.
-func (*hooks) AfterExecutingTransaction(db *state.StateDB, baseFee uint256.Int, r *types.Receipt) error {
-	burned := new(uint256.Int).SetUint64(r.GasUsed)
-	burned.Mul(burned, &baseFee)
-	db.AddBalance(constants.BlackholeAddr, burned)
 	return nil
 }
 

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -82,10 +82,6 @@ type Points interface {
 	// rules are those of the block and parent is the header of the block's
 	// parent.
 	BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, block *types.Block) error
-	// AfterExecutingTransaction is called immediately after executing each
-	// transaction, with the executing block's base fee and the resulting
-	// receipt. Note the caller finalises any state changes made by the hook.
-	AfterExecutingTransaction(db *state.StateDB, baseFee uint256.Int, r *types.Receipt) error
 	// AfterExecutingBlock is called immediately after executing the block.
 	AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
 }

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -246,11 +246,6 @@ func (*Stub) BeforeExecutingBlock(params.Rules, *state.StateDB, *types.Header, *
 	return nil
 }
 
-// AfterExecutingTransaction is a no-op that always returns nil.
-func (*Stub) AfterExecutingTransaction(*state.StateDB, uint256.Int, *types.Receipt) error {
-	return nil
-}
-
 // AfterExecutingBlock is a no-op that always returns nil.
 func (*Stub) AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error {
 	return nil

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -214,6 +214,7 @@ func Execute(
 		stateDB.SetTxContext(tx.Hash(), ti)
 		b.CheckSenderBalanceBound(stateDB, signer, tx)
 
+		// Executes the transaction and calls [state.StateDB.Finalise].
 		receipt, err := core.ApplyTransaction(
 			config,
 			chainCtx,
@@ -253,10 +254,6 @@ func Execute(
 			r.Put(&Receipt{receipt, signer, tx})
 		}
 		receipts[ti] = receipt
-
-		// Finalise any state changes made by the hook, mirroring the finalisation
-		// performed by [core.ApplyTransaction].
-		stateDB.Finalise(rules.IsEIP158)
 	}
 
 	numTxs := len(b.Transactions())

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -254,9 +254,6 @@ func Execute(
 		}
 		receipts[ti] = receipt
 
-		if err := hooks.AfterExecutingTransaction(stateDB, *baseFee, receipt); err != nil {
-			return nil, fmt.Errorf("after-transaction hook [%d](%#x): %w", ti, tx.Hash(), err)
-		}
 		// Finalise any state changes made by the hook, mirroring the finalisation
 		// performed by [core.ApplyTransaction].
 		stateDB.Finalise(rules.IsEIP158)


### PR DESCRIPTION
## Why this should be merged

Using libevm for this simplifies calls, when there's some calls to `core.ApplyXXX` that we don't control from this side (e.g. tracer APIs)

## How this works

Add new libevm registration

## How this was tested

Thanks Jonathan for doing the hard work in #5619.

## Need to be documented in RELEASES.md?

No.
