### PR TITLE
refactor(saevm): adopt libevm tracer hooks for before-block and blockhash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100
 	github.com/ava-labs/avalanchego/graft/coreth v1.14.2
 	github.com/ava-labs/avalanchego/graft/subnet-evm v1.14.2
-	github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670
+	github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100
 	github.com/ava-labs/avalanchego/graft/coreth v1.14.2
 	github.com/ava-labs/avalanchego/graft/subnet-evm v1.14.2
-	github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f
+	github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670 h1:q5+5mZAnes07b3FTPQ60TBjtNAPSFguyh9/bW75dOVw=
-github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990 h1:RgJq5Q3Lv4eVVxifNTovADYnWcbZtU0sy6qR8dcmO40=
+github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad h1:P5IRndHUinfIZ73jdxl3M6jdcnKkQOLYvhGvE3VDiSU=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad/go.mod h1:DADqV3zJ+ij8GqliStJ+aj9l/cPtb5ZUhNy5KxlDEsQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f h1:GJn0TkFP2Hw4UjbRm3invDlRodEqiCEQEOfD75k63Yo=
-github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670 h1:q5+5mZAnes07b3FTPQ60TBjtNAPSFguyh9/bW75dOVw=
+github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad h1:P5IRndHUinfIZ73jdxl3M6jdcnKkQOLYvhGvE3VDiSU=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad/go.mod h1:DADqV3zJ+ij8GqliStJ+aj9l/cPtb5ZUhNy5KxlDEsQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.work.sum
+++ b/go.work.sum
@@ -338,10 +338,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.3.0/go.mod h1:71C76bo47zlDX9gWnn3p/0QZQXkTQ/GNqUNI6fchvjs=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca h1:VEjyvhWTn6FR/tr3wzHnAgAMpVIAu4P5kDQKycbWGWQ=
-github.com/ava-labs/libevm v1.13.15-0.20260716180230-f887fa4393ca/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1 h1:Y9UdRQj28/t+GNzVSlP6nvoNLtzNRo3fNXLUc/NscVM=
 github.com/ava-labs/simplex v0.0.0-20260320130759-afe09323fdd1/go.mod h1:GVzumIo3zR23/qGRN2AdnVkIPHcKMq/D89EGWZfMGQ0=
 github.com/aws/aws-sdk-go-v2 v1.21.2 h1:+LXZ0sgo8quN9UOKXXzAWRT3FWd4NxeXWOZom9pE7GA=
@@ -948,6 +944,7 @@ golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
 golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
+golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1040,6 +1037,7 @@ golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY
 golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
+golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 gonum.org/v1/gonum v0.11.0/go.mod h1:fSG4YDCxxUZQJ7rKsQrj0gMOg00Il0Z96/qMA4bVQhA=

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670
+	github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f
+	github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/graft/coreth/go.sum
+++ b/graft/coreth/go.sum
@@ -30,8 +30,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670 h1:q5+5mZAnes07b3FTPQ60TBjtNAPSFguyh9/bW75dOVw=
-github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990 h1:RgJq5Q3Lv4eVVxifNTovADYnWcbZtU0sy6qR8dcmO40=
+github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/coreth/go.sum
+++ b/graft/coreth/go.sum
@@ -30,8 +30,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f h1:GJn0TkFP2Hw4UjbRm3invDlRodEqiCEQEOfD75k63Yo=
-github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670 h1:q5+5mZAnes07b3FTPQ60TBjtNAPSFguyh9/bW75dOVw=
+github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/coreth/params/BUILD.bazel
+++ b/graft/coreth/params/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//graft/coreth/precompile/contract",
         "//graft/coreth/precompile/modules",
         "//graft/coreth/precompile/precompileconfig",
+        "//graft/evm/constants",
         "//graft/evm/precompileconfig",
         "//snow",
         "//upgrade",
@@ -36,6 +37,7 @@ go_library(
         "@com_github_ava_labs_libevm//libevm",
         "@com_github_ava_labs_libevm//libevm/legacy",
         "@com_github_ava_labs_libevm//params",
+        "@com_github_holiman_uint256//:uint256",
     ],
 )
 

--- a/graft/coreth/params/hooks_libevm.go
+++ b/graft/coreth/params/hooks_libevm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/libevm/legacy"
+	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/avalanchego/graft/coreth/nativeasset"
 	"github.com/ava-labs/avalanchego/graft/coreth/params/extras"
@@ -25,6 +26,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/evm/predicate"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 
+	"github.com/ava-labs/avalanchego/graft/evm/constants"
 	evmprecompileconfig "github.com/ava-labs/avalanchego/graft/evm/precompileconfig"
 	ethparams "github.com/ava-labs/libevm/params"
 )
@@ -61,6 +63,20 @@ func (r RulesExtra) MinimumGasConsumption(limit uint64) uint64 {
 		return hook.MinimumGasConsumption(limit)
 	}
 	return (ethparams.NOOPHooks{}).MinimumGasConsumption(limit)
+}
+
+// AfterExecutingTransaction credits the base fee to [constants.BlackholeAddr].
+// The C-Chain has historically credited the full fee (base + priority) to the
+// blackhole address, but libevm's state transition only credits the priority
+// fee to the coinbase (the blackhole address) and discards the base fee.
+func (r RulesExtra) AfterExecutingTransaction(sdb libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
+	if !r.IsHelicon {
+		return
+	}
+	burned := new(uint256.Int).SetUint64(gasUsed)
+	bf := uint256.MustFromBig(baseFee)
+	burned.Mul(burned, bf)
+	sdb.AddBalance(constants.BlackholeAddr, burned)
 }
 
 // AccessListGas computes the intrinsic gas for an access list.

--- a/graft/coreth/params/hooks_libevm.go
+++ b/graft/coreth/params/hooks_libevm.go
@@ -21,12 +21,12 @@ import (
 	"github.com/ava-labs/avalanchego/graft/coreth/precompile/contract"
 	"github.com/ava-labs/avalanchego/graft/coreth/precompile/modules"
 	"github.com/ava-labs/avalanchego/graft/coreth/precompile/precompileconfig"
+	"github.com/ava-labs/avalanchego/graft/evm/constants"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/evm/predicate"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 
-	"github.com/ava-labs/avalanchego/graft/evm/constants"
 	evmprecompileconfig "github.com/ava-labs/avalanchego/graft/evm/precompileconfig"
 	ethparams "github.com/ava-labs/libevm/params"
 )

--- a/graft/coreth/params/hooks_libevm.go
+++ b/graft/coreth/params/hooks_libevm.go
@@ -69,8 +69,8 @@ func (r RulesExtra) MinimumGasConsumption(limit uint64) uint64 {
 // The C-Chain has historically credited the full fee (base + priority) to the
 // blackhole address, but libevm's state transition only credits the priority
 // fee to the coinbase (the blackhole address) and discards the base fee.
-func (r RulesExtra) AfterExecutingTransaction(sdb libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
-	if !r.IsHelicon {
+func (RulesExtra) AfterExecutingTransaction(sdb libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
+	if baseFee == nil {
 		return
 	}
 	burned := new(uint256.Int).SetUint64(gasUsed)

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f
+	github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/gorilla/rpc v1.2.0

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670
+	github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/gorilla/rpc v1.2.0

--- a/graft/evm/go.sum
+++ b/graft/evm/go.sum
@@ -21,8 +21,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670 h1:q5+5mZAnes07b3FTPQ60TBjtNAPSFguyh9/bW75dOVw=
-github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990 h1:RgJq5Q3Lv4eVVxifNTovADYnWcbZtU0sy6qR8dcmO40=
+github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/evm/go.sum
+++ b/graft/evm/go.sum
@@ -21,8 +21,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f h1:GJn0TkFP2Hw4UjbRm3invDlRodEqiCEQEOfD75k63Yo=
-github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670 h1:q5+5mZAnes07b3FTPQ60TBjtNAPSFguyh9/bW75dOVw=
+github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f
+	github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/gorilla/rpc v1.2.0

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670
+	github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/gorilla/rpc v1.2.0

--- a/graft/subnet-evm/go.sum
+++ b/graft/subnet-evm/go.sum
@@ -30,8 +30,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f h1:GJn0TkFP2Hw4UjbRm3invDlRodEqiCEQEOfD75k63Yo=
-github.com/ava-labs/libevm v1.13.15-0.20260716184100-9792aac7c76f/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670 h1:q5+5mZAnes07b3FTPQ60TBjtNAPSFguyh9/bW75dOVw=
+github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/subnet-evm/go.sum
+++ b/graft/subnet-evm/go.sum
@@ -30,8 +30,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670 h1:q5+5mZAnes07b3FTPQ60TBjtNAPSFguyh9/bW75dOVw=
-github.com/ava-labs/libevm v1.13.15-0.20260717161813-7deda5968670/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990 h1:RgJq5Q3Lv4eVVxifNTovADYnWcbZtU0sy6qR8dcmO40=
+github.com/ava-labs/libevm v1.13.15-0.20260717170447-41e284b20990/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/subnet-evm/params/hooks_libevm.go
+++ b/graft/subnet-evm/params/hooks_libevm.go
@@ -71,6 +71,11 @@ func (RulesExtra) MinimumGasConsumption(x uint64) uint64 {
 	return (ethparams.NOOPHooks{}).MinimumGasConsumption(x)
 }
 
+// AfterExecutingTransaction is a no-op.
+func (RulesExtra) AfterExecutingTransaction(sdb libevm.StateDB, bf *big.Int, gasUsed uint64) {
+	(ethparams.NOOPHooks{}).AfterExecutingTransaction(sdb, bf, gasUsed)
+}
+
 // AccessListGas computes the intrinsic gas for an access list.
 // When predicaters exist, it calculates gas per-tuple, delegating to predicate
 // contracts for addresses that have them. Otherwise, it returns override=false

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/trie"
-	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/graft/coreth/core/extstate"
@@ -253,17 +252,6 @@ func (h *hooks) BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB,
 	if isFirstDurangoBlock := corethparams.GetRulesExtra(rules).IsDurango && !config.IsDurango(parent.Time); isFirstDurangoBlock {
 		activatePrecompile(statedb, corethwarp.ContractAddress)
 	}
-	return nil
-}
-
-// AfterExecutingTransaction credits the base fee to [constants.BlackholeAddr].
-// The C-Chain has historically credited the full fee (base + priority) to the
-// blackhole address, but libevm's state transition only credits the priority
-// fee to the coinbase (the blackhole address) and discards the base fee.
-func (*hooks) AfterExecutingTransaction(db *state.StateDB, baseFee uint256.Int, r *types.Receipt) error {
-	burned := new(uint256.Int).SetUint64(r.GasUsed)
-	burned.Mul(burned, &baseFee)
-	db.AddBalance(constants.BlackholeAddr, burned)
 	return nil
 }
 

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -82,10 +82,6 @@ type Points interface {
 	// rules are those of the block and parent is the header of the block's
 	// parent.
 	BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, block *types.Block) error
-	// AfterExecutingTransaction is called immediately after executing each
-	// transaction, with the executing block's base fee and the resulting
-	// receipt. Note the caller finalises any state changes made by the hook.
-	AfterExecutingTransaction(db *state.StateDB, baseFee uint256.Int, r *types.Receipt) error
 	// AfterExecutingBlock is called immediately after executing the block.
 	AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
 }

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -246,11 +246,6 @@ func (*Stub) BeforeExecutingBlock(params.Rules, *state.StateDB, *types.Header, *
 	return nil
 }
 
-// AfterExecutingTransaction is a no-op that always returns nil.
-func (*Stub) AfterExecutingTransaction(*state.StateDB, uint256.Int, *types.Receipt) error {
-	return nil
-}
-
 // AfterExecutingBlock is a no-op that always returns nil.
 func (*Stub) AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error {
 	return nil

--- a/vms/saevm/sae/rpc/BUILD.bazel
+++ b/vms/saevm/sae/rpc/BUILD.bazel
@@ -59,7 +59,6 @@ go_library(
         "@com_github_ava_labs_libevm//libevm/ethapi",
         "@com_github_ava_labs_libevm//params",
         "@com_github_ava_labs_libevm//rpc",
-        "@com_github_holiman_uint256//:uint256",
     ],
 )
 

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/ava-labs/libevm/common"
@@ -18,7 +17,6 @@ import (
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/eth/tracers"
 	"github.com/ava-labs/libevm/rpc"
-	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
@@ -84,6 +82,11 @@ func (b *backend) StateAndHeaderByNumber(ctx context.Context, num rpc.BlockNumbe
 // StateAndHeaderByNumberOrHash fakes the returned [types.Header] to contain
 // post-execution results, mimicking a synchronous block. The [state.StateDB] is
 // opened at the post-execution root, as carried by the faked header.
+//
+// TODO(JonathanOppenheimer): eth_call and eth_callDetailed don't see the next
+// block's before-block state changes (e.g. durango warp activation).
+// I think this is impossible to fix as the next block's rules and time are
+// unknown.
 func (b *backend) StateAndHeaderByNumberOrHash(ctx context.Context, numOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
 	if n, ok := numOrHash.Number(); ok && n == rpc.PendingBlockNumber {
 		return nil, nil, errors.New("state not available for pending block")
@@ -106,8 +109,10 @@ func (b *backend) StateAndHeaderByNumberOrHash(ctx context.Context, numOrHash rp
 	return sdb, hdr, nil
 }
 
-// StateAtBlock returns the state database after executing the given block. The
-// reexec, base, readOnly, and preferDisk parameters are ignored because SAE
+// StateAtBlock returns the state database after executing the given block,
+// with the canonical child block's before-block state changes already applied.
+//
+// The reexec, base, readOnly, and preferDisk parameters are ignored because SAE
 // does not implement geth's re-execution-from-archive strategy.
 //
 // Like geth, SAE only stores historical state roots, not full historical state.
@@ -129,7 +134,26 @@ func (b *backend) StateAtBlock(ctx context.Context, block *types.Block, reexec u
 	if err != nil {
 		return nil, nil, err
 	}
+
+	if err := b.applyChildBeforeBlock(sdb, bl.Header(), num+1); err != nil {
+		return nil, nil, err
+	}
 	return sdb, noopRelease, nil
+}
+
+// applyChildBeforeBlock applies the canonical child block's pre-transaction
+// state changes to sdb, the parent's post-execution state. It is a no-op if no
+// block exists at height child.
+func (b *backend) applyChildBeforeBlock(sdb *state.StateDB, parent *types.Header, child rpc.BlockNumber) error {
+	bl, err := b.restoreBlock(rpc.BlockNumberOrHashWithNumber(child))
+	if errors.Is(err, blocks.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("restoring child block %d: %w", child, err)
+	}
+	_, err = saexec.BeforeExecutingBlock(b.Hooks(), b.ChainConfig(), sdb, parent, bl.EthBlock())
+	return err
 }
 
 // StateAtTransaction returns the execution environment of a particular
@@ -184,38 +208,24 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	return msg, result.BlockCtx, result.StateDB, noopRelease, nil
 }
 
-var _ tracers.ExtraExecutor = (*tracerBackend)(nil)
+var _ tracers.BlockHashOverrider = (*tracerBackend)(nil)
 
-// tracerBackend provides optional hooks for the tracers API to perform state
-// changes provided by the hooks.
+// tracerBackend adapts [backend] for the tracers API, faking headers to carry
+// post-execution results and reporting canonical hashes for the faked blocks.
 type tracerBackend struct {
 	*backend
 }
 
-// BeforeExecutingBlock mirrors the pre-transaction state changes performed by
-// [saexec.Execute].
-func (b *tracerBackend) BeforeExecutingBlock(sdb *state.StateDB, parent, header *types.Header) error {
-	rules := b.ChainConfig().Rules(header.Number, true /*isMerge*/, header.Time)
-	// The block's transactions are unavailable here so an empty block carries
-	// the header to the hook.
-	if err := b.Hooks().BeforeExecutingBlock(rules, sdb, parent, types.NewBlockWithHeader(header)); err != nil {
-		return fmt.Errorf("before-block hook: %v", err)
+// BlockHash returns the block's canonical hash, which differs from
+// block.Hash() because the blocks served by this backend carry faked headers.
+func (b *tracerBackend) BlockHash(block *types.Block) common.Hash {
+	num := rpc.BlockNumber(block.NumberU64()) // #nosec G115 -- won't overflow for a while.
+	bl, err := b.restoreBlock(rpc.BlockNumberOrHashWithNumber(num))
+	if err != nil {
+		// Unreachable: the tracers API only receives blocks this backend restored.
+		return block.Hash()
 	}
-	// Finalise any state changes made by the hook, mirroring the finalisation
-	// performed by [core.ApplyTransaction].
-	sdb.Finalise(rules.IsEIP158)
-	core.SetBeaconBlockRoot(sdb, header)
-	return nil
-}
-
-// AfterExecutingTransaction mirrors the post-transaction state changes performed by
-// [saexec.Execute].
-func (b *tracerBackend) AfterExecutingTransaction(sdb *state.StateDB, bf *big.Int, gasUsed uint64) error {
-	bf256, _ := uint256.FromBig(bf)
-	r := &types.Receipt{
-		GasUsed: gasUsed,
-	}
-	return b.Hooks().AfterExecutingTransaction(sdb, *bf256, r)
+	return bl.EthBlock().Hash()
 }
 
 // BlockByHash is the same as [backend.BlockByHash] but returns a faked header
@@ -242,11 +252,8 @@ func (b *tracerBackend) getBlockModified(ctx context.Context, nOrHash rpc.BlockN
 // results (state root and base fee), mimicking a synchronous block.
 //
 // The API implementations expect this to be synchronous, sourcing the state
-// root and the base fee from fields. At the time of writing, the returned
-// header's hash is never used so it's safe to modify it.
-//
-// TODO(arr4n) the above assumption is brittle under geth/libevm updates;
-// devise an approach to ensure that it is confirmed on each.
+// root and the base fee from fields. The faked header's hash is wrong; the
+// tracers API reports canonical hashes via [tracerBackend.BlockHash].
 func executedHeader(bl *blocks.Block) *types.Header {
 	hdr := bl.Header()
 	hdr.Root = bl.PostExecutionStateRoot()

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -152,8 +152,9 @@ func (b *backend) applyChildBeforeBlock(sdb *state.StateDB, parent *types.Header
 	if err != nil {
 		return fmt.Errorf("restoring child block %d: %w", child, err)
 	}
-	_, err = saexec.BeforeExecutingBlock(b.Hooks(), b.ChainConfig(), sdb, parent, bl.EthBlock())
-	return err
+	ethB := bl.EthBlock()
+	rules := b.ChainConfig().Rules(ethB.Number(), true /*isMerge*/, ethB.Time())
+	return saexec.BeforeExecutingBlock(b.Hooks(), rules, sdb, parent, ethB)
 }
 
 // StateAtTransaction returns the execution environment of a particular

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -153,6 +153,22 @@ type (
 	}
 )
 
+// BeforeExecutingBlock applies the state changes required before executing
+// b's transactions, specifically the before-block hook and the EIP-4788 beacon
+// root, mirroring [core.StateProcessor.Process].
+func BeforeExecutingBlock(hooks hook.Points, config *params.ChainConfig, stateDB *state.StateDB, parent *types.Header, b *types.Block) (params.Rules, error) {
+	rules := config.Rules(b.Number(), true /*isMerge*/, b.Time())
+	if err := hooks.BeforeExecutingBlock(rules, stateDB, parent, b); err != nil {
+		return params.Rules{}, fmt.Errorf("before-block hook: %v", err)
+	}
+	// Finalise any state changes made by the hook, mirroring the finalisation
+	// performed by [core.ApplyTransaction].
+	stateDB.Finalise(rules.IsEIP158)
+
+	core.SetBeaconBlockRoot(stateDB, b.Header())
+	return rules, nil
+}
+
 // Execute executes the transactions in the [blocks.Block], beginning from the
 // post-execution state of the [blocks.Block.ParentBlock]. `maxNumTxs` limits
 // the number of transactions to process, allowing partial execution for
@@ -186,21 +202,14 @@ func Execute(
 		return nil, err
 	}
 
-	rules := config.Rules(b.Number(), true /*isMerge*/, b.BuildTime())
-	if err := hooks.BeforeExecutingBlock(rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
-		return nil, fmt.Errorf("before-block hook: %v", err)
+	rules, err := BeforeExecutingBlock(hooks, config, stateDB, parent.Header(), b.EthBlock())
+	if err != nil {
+		return nil, err
 	}
-	// Finalise any state changes made by the hook, mirroring the finalisation
-	// performed by [core.ApplyTransaction].
-	stateDB.Finalise(rules.IsEIP158)
 
 	baseFee := gasClock.BaseFee()
 	b.CheckBaseFeeBound(baseFee)
 	header.BaseFee = baseFee.ToBig()
-
-	// EIP-4788: before processing any transactions, store the parent beacon
-	// block root, mirroring [core.StateProcessor.Process].
-	core.SetBeaconBlockRoot(stateDB, header)
 
 	signer := b.Signer(config)
 	gasPool := core.GasPool(math.MaxUint64) // required by geth but irrelevant so max it out

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -254,9 +254,6 @@ func Execute(
 		}
 		receipts[ti] = receipt
 
-		if err := hooks.AfterExecutingTransaction(stateDB, *baseFee, receipt); err != nil {
-			return nil, fmt.Errorf("after-transaction hook [%d](%#x): %w", ti, tx.Hash(), err)
-		}
 		// Finalise any state changes made by the hook, mirroring the finalisation
 		// performed by [core.ApplyTransaction].
 		stateDB.Finalise(rules.IsEIP158)

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -156,17 +156,16 @@ type (
 // BeforeExecutingBlock applies the state changes required before executing
 // b's transactions, specifically the before-block hook and the EIP-4788 beacon
 // root, mirroring [core.StateProcessor.Process].
-func BeforeExecutingBlock(hooks hook.Points, config *params.ChainConfig, stateDB *state.StateDB, parent *types.Header, b *types.Block) (params.Rules, error) {
-	rules := config.Rules(b.Number(), true /*isMerge*/, b.Time())
+func BeforeExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
 	if err := hooks.BeforeExecutingBlock(rules, stateDB, parent, b); err != nil {
-		return params.Rules{}, fmt.Errorf("before-block hook: %v", err)
+		return fmt.Errorf("before-block hook: %v", err)
 	}
 	// Finalise any state changes made by the hook, mirroring the finalisation
 	// performed by [core.ApplyTransaction].
 	stateDB.Finalise(rules.IsEIP158)
 
 	core.SetBeaconBlockRoot(stateDB, b.Header())
-	return rules, nil
+	return nil
 }
 
 // Execute executes the transactions in the [blocks.Block], beginning from the
@@ -202,8 +201,8 @@ func Execute(
 		return nil, err
 	}
 
-	rules, err := BeforeExecutingBlock(hooks, config, stateDB, parent.Header(), b.EthBlock())
-	if err != nil {
+	rules := config.Rules(header.Number, true /*isMerge*/, header.Time)
+	if err := BeforeExecutingBlock(hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Why this should be merged

This shouldn't be merged into the base branch until ava-labs/libevm#294 and ava-labs/libevm#295 get merged. The first commit here is a cherry-pick of #5682, which should ALSO merge first, then rebase this PR's target onto master, and then merge this in. 

This PR replaces the tracer-specific `ExtraExecutor` hooks with the two mechanisms from the two libevm PRs. 

## How this works

Bump libevm to ava-labs/libevm#295's head (contains #294), delete `ExtraExecutor`, apply before-block changes in `StateAtBlock` via the extracted `saexec.BeforeExecutingBlock`, and implement `tracers.BlockHashOverrider`.

## How this was tested

Existing UT, mostly `TestPreSAEChainRPCs`. 

## Need to be documented in RELEASES.md?

No.