### PR TITLE
fix(tags-push): Only push tags one-at-a-time

### DIFF
--- a/scripts/push_tags.sh
+++ b/scripts/push_tags.sh
@@ -44,4 +44,9 @@ for tag in "${TAGS[@]}"; do
 done
 
 echo "Pushing tags for $VERSION to $REMOTE:"
-git push "$REMOTE" "${TAGS[@]}"
+# GitHub does not create tag push/create events when more than three tags are
+# pushed at once, which prevents release workflows from running. Push the tags
+# individually so each push stays under that limit.
+for tag in "${TAGS[@]}"; do
+    git push "$REMOTE" "$tag"
+done


### PR DESCRIPTION
## Why this should be merged

When we do releases, we push 4 tags at once. This exceeds github's [3 tag limit](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#create):

> An event will not be created when you create more than three tags at once.

## How this works

Rather than pushing 4 tags in a single push, the script is updated to push each tag separately.

## How this was tested

I manually deleted the tags and used the new script to push `v1.15.0-fuji-rc.0` which worked correctly.

## Need to be documented in RELEASES.md?

No.