### PR TITLE
fix(sae): Prevent statedb concurrent access in Txpool

### DIFF
--- a/vms/saevm/cchain/api_test.go
+++ b/vms/saevm/cchain/api_test.go
@@ -100,6 +100,8 @@ func TestIssueTxRejectsInvalidTransaction(t *testing.T) {
 //
 // This is a regression test ensuring that the txpool does not concurrently
 // access a statedb instance.
+//
+// This test is best run with the race detector enabled.
 func TestIssueTxConcurrent(t *testing.T) {
 	const numConcurrentTxs = 2
 

--- a/vms/saevm/cchain/api_test.go
+++ b/vms/saevm/cchain/api_test.go
@@ -103,6 +103,7 @@ func TestIssueTxRejectsInvalidTransaction(t *testing.T) {
 func TestIssueTxConcurrent(t *testing.T) {
 	const numConcurrentTxs = 2
 
+	// Each tx uses a different key so that they don't conflict.
 	keys := make([]*secp256k1.PrivateKey, numConcurrentTxs)
 	addrs := make([]common.Address, numConcurrentTxs)
 	for i := range keys {

--- a/vms/saevm/cchain/api_test.go
+++ b/vms/saevm/cchain/api_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"maps"
 	"reflect"
+	"sync"
 	"testing"
 
+	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/libevm/options"
 	"github.com/google/go-cmp/cmp"
@@ -19,9 +21,12 @@ import (
 	"github.com/ava-labs/avalanchego/graft/coreth/plugin/evm/customtypes"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/choices"
+	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/tx/txtest"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 )
@@ -88,6 +93,55 @@ func TestIssueTxRejectsInvalidTransaction(t *testing.T) {
 
 	err := sut.IssueTx(ctx, stx)
 	require.ErrorContainsf(t, err, errIssuingTx.Error(), "%T.IssueTx()", sut.Client)
+}
+
+// TestIssueTxConcurrent issues multiple [tx.Export] transactions through
+// [Client.IssueTx] simultaneously.
+//
+// This is a regression test ensuring that the txpool does not concurrently
+// access a statedb instance.
+func TestIssueTxConcurrent(t *testing.T) {
+	const numConcurrentTxs = 2
+
+	keys := make([]*secp256k1.PrivateKey, numConcurrentTxs)
+	addrs := make([]common.Address, numConcurrentTxs)
+	for i := range keys {
+		keys[i] = txtest.NewKey(t)
+		addrs[i] = keys[i].EthAddress()
+	}
+	ctx, sut := newSUT(t, withMaxAllocFor(addrs...))
+
+	txs := make([]*tx.Tx, numConcurrentTxs)
+	for i, sk := range keys {
+		const (
+			txFee          = 1
+			exportedAmount = 1
+		)
+		// Export transactions are validated against the statedb, so they must
+		// be used rather than Import transactions here.
+		txs[i], _ = newWallet(sk, sut.ctx, sut.Client).newExportTx(
+			t,
+			snowtest.XChainID,
+			txFee,
+			txtest.NewTransferOutput(exportedAmount, sk.Address()),
+		)
+	}
+
+	var (
+		done sync.WaitGroup
+		errs = make([]error, numConcurrentTxs)
+	)
+	for i, stx := range txs {
+		done.Go(func() {
+			errs[i] = sut.IssueTx(ctx, stx)
+		})
+	}
+	done.Wait()
+
+	for i, stx := range txs {
+		require.NoErrorf(t, errs[i], "%T.IssueTx(txs[%d])", sut.Client, i)
+		require.Truef(t, sut.txpool.Has(stx.ID()), "%T.Has(txs[%d])", sut.txpool, i)
+	}
 }
 
 // TestGetTxNotFound asserts that [Client.GetTx] surfaces an error when the

--- a/vms/saevm/cchain/txpool/txpool.go
+++ b/vms/saevm/cchain/txpool/txpool.go
@@ -54,10 +54,11 @@ type Txpool struct {
 	maxSize int
 	wg      sync.WaitGroup
 
-	// stateLock is ordered before [Pending.lock]. Acquiring stateLock with
-	// [Pending.lock] held will deadlock.
-	stateLock sync.RWMutex
-	state     libevm.StateReader
+	// executionLock is ordered before [Pending.lock] and [Txpool.stateLock].
+	// Acquiring executionLock with either other lock held will deadlock.
+	executionLock sync.RWMutex
+	stateLock     sync.Mutex
+	state         libevm.StateReader
 }
 
 // New constructs a [Txpool] that wraps the provided [Pending].
@@ -139,14 +140,14 @@ func (p *Txpool) updateState(
 				continue
 			}
 
-			p.stateLock.Lock()
+			p.executionLock.Lock()
 			p.lock.Lock()
 
 			p.removeConflicts(inputs)
 			p.state = newState
 
 			p.lock.Unlock()
-			p.stateLock.Unlock()
+			p.executionLock.Unlock()
 
 			log.Debug("updated to new state")
 		case err := <-sub.Err():
@@ -195,13 +196,13 @@ func (p *Txpool) Add(tx *tx.Tx) error {
 	//
 	// Verifying against an older state risks admitting a tx that would never
 	// be evicted.
-	p.stateLock.RLock()
-	defer p.stateLock.RUnlock()
+	p.executionLock.RLock()
+	defer p.executionLock.RUnlock()
 
 	if err := tx.VerifyCredentials(p.snowCtx.SharedMemory); err != nil {
 		return fmt.Errorf("%w: %w", errVerifyCredentials, err)
 	}
-	if err := verifyOp(p.state, t.op); err != nil {
+	if err := p.verifyOp(t.op); err != nil {
 		return fmt.Errorf("%w: %w", errVerifyState, err)
 	}
 
@@ -238,6 +239,15 @@ func (p *Txpool) Add(tx *tx.Tx) error {
 func (p *Txpool) Close() {
 	p.sub.Unsubscribe()
 	p.wg.Wait()
+}
+
+func (p *Txpool) verifyOp(op hook.Op) error {
+	// [libevm.StateReader] is not thread-safe, we must lock it even for
+	// read-only operations.
+	p.stateLock.Lock()
+	defer p.stateLock.Unlock()
+
+	return verifyOp(p.state, op)
 }
 
 // inputUTXOs returns the union of all UTXO IDs consumed by transactions in b,


### PR DESCRIPTION
## Why this should be merged

Fixes crash bug in the atomic txpool.

## How this works

statedb instances are not safe for concurrent reads. Currently, only a read lock is held when accessing the statedb. Which means that multiple Export txs could race when being submitted either over gossip or over RPC.

## How this was tested

Regression test.

## Need to be documented in RELEASES.md?

No.