### PR TITLE
fix(sae): Executor deadlock with duplicate verifications

### DIFF
--- a/vms/saevm/sae/consensus.go
+++ b/vms/saevm/sae/consensus.go
@@ -57,6 +57,9 @@ func (vm *VM) AcceptBlock(ctx context.Context, b *blocks.Block) error {
 	// blocks may have grabbed references to the instance in
 	// [VM.consensusCritical], we must ensure that we accept that instance, not
 	// the one passed in.
+	//
+	// TODO(StephenButtolph): Look into simplifying the VM API to avoid footguns
+	// around multiple instances of the same block.
 	b, ok := vm.consensusCritical.Load(b.Hash())
 	if !ok {
 		return errUnverifiedBlock

--- a/vms/saevm/sae/consensus.go
+++ b/vms/saevm/sae/consensus.go
@@ -5,6 +5,7 @@ package sae
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ava-labs/libevm/core"
@@ -38,6 +39,8 @@ func (vm *VM) GetPreference() *blocks.Block {
 	return vm.preference.Load()
 }
 
+var errUnverifiedBlock = errors.New("block not verified")
+
 // AcceptBlock marks the block as [accepted], resulting in:
 //   - All blocks settled by this block having their [blocks.Block.MarkSettled]
 //     method called; and
@@ -48,6 +51,16 @@ func (vm *VM) AcceptBlock(ctx context.Context, b *blocks.Block) error {
 	// Recall the terminology and ordering from the invariants document:
 	// - (D)isk then (M)emory then (I)nternal then e(X)ternal.
 	// - B accepted after all of B.Settles() settled
+
+	// If b was verified multiple times, we may be asked to accept a different
+	// instance of b than the one stored in [VM.consensusCritical]. Since other
+	// blocks may have grabbed references to the instance in
+	// [VM.consensusCritical], we must ensure that we accept that instance, not
+	// the one passed in.
+	b, ok := vm.consensusCritical.Load(b.Hash())
+	if !ok {
+		return errUnverifiedBlock
+	}
 
 	settles := b.Settles()
 	{

--- a/vms/saevm/sae/sae.go
+++ b/vms/saevm/sae/sae.go
@@ -63,23 +63,28 @@ func newSyncMap[K comparable, V any](onStore func(V), onDelete func(V)) *syncMap
 
 func (m *syncMap[K, V]) Load(k K) (V, bool) {
 	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	v, ok := m.m[k]
-	m.mu.RUnlock()
 	return v, ok
 }
 
 func (m *syncMap[K, V]) Store(k K, v V) {
-	m.onStore(v)
 	m.mu.Lock()
-	m.m[k] = v
-	m.mu.Unlock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.m[k]; !ok {
+		m.onStore(v)
+		m.m[k] = v
+	}
 }
 
 func (m *syncMap[K, V]) Delete(k K) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if v, ok := m.m[k]; ok {
 		m.onDelete(v)
+		delete(m.m, k)
 	}
-	delete(m.m, k)
-	m.mu.Unlock()
 }

--- a/vms/saevm/sae/sae.go
+++ b/vms/saevm/sae/sae.go
@@ -42,10 +42,10 @@ type syncMap[K comparable, V any] struct {
 	onDelete func(V)
 }
 
-// newSyncMap creates a concurrent-safe map, which automatically performs
-// `onStore` and `onDelete` if [syncMap.Store] and [syncMap.Delete] are called,
-// respectively. If either function is nil, or the key to be deleted doesn't
-// exist, no operation will be performed.
+// newSyncMap creates a concurrent-safe map. onStore is called when
+// [syncMap.Store] adds a new key, and onDelete is called when [syncMap.Delete]
+// removes an existing key. Storing an existing key and deleting a missing key
+// are no-ops. A nil onStore or onDelete is treated as a no-op.
 func newSyncMap[K comparable, V any](onStore func(V), onDelete func(V)) *syncMap[K, V] {
 	if onStore == nil {
 		onStore = func(V) {}

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1219,7 +1219,7 @@ func TestDuplicateVerify(t *testing.T) {
 			// The consensus engine may call
 			// [block.WithVerifyContext.VerifyWithContext] on multiple instances
 			// of the same block, in either order. [VM.consensusCritical] isn't
-			// overridden, so the last instance verified is the one kept in the
+			// overridden, so the first instance verified is the one kept in the
 			// map.
 			blks := []snowman.Block{
 				originalIndex:  original,

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1187,24 +1187,19 @@ func TestSettledGasTime(t *testing.T) {
 }
 
 // TestDuplicateVerify verifies that having two in-memory instances of the same
-// block doesn't corrupt the VM, regardless of the order in which the consensus
-// engine verifies them.
+// block doesn't corrupt the VM, regardless of which is accepted.
 func TestDuplicateVerify(t *testing.T) {
-	const (
-		originalIndex = iota
-		duplicateIndex
-	)
 	tests := []struct {
 		name        string
-		verifyOrder []int
+		acceptIndex int
 	}{
 		{
-			name:        "original_then_duplicate",
-			verifyOrder: []int{originalIndex, duplicateIndex},
+			name:        "accept_first",
+			acceptIndex: 0,
 		},
 		{
-			name:        "duplicate_then_original",
-			verifyOrder: []int{duplicateIndex, originalIndex},
+			name:        "accept_second",
+			acceptIndex: 1,
 		},
 	}
 
@@ -1212,40 +1207,37 @@ func TestDuplicateVerify(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx, sut := newSUT(t, 0)
 
-			original := sut.buildAndParseBlock(t, sut.lastAcceptedBlock(t))
-			duplicate, err := sut.ParseBlock(ctx, original.Bytes())
+			first := sut.buildAndParseBlock(t, sut.lastAcceptedBlock(t))
+			second, err := sut.ParseBlock(ctx, first.Bytes())
 			require.NoError(t, err, "%T.ParseBlock(BuildBlock().Bytes())", sut.ChainVM)
+			blks := []snowman.Block{first, second}
 
-			// The consensus engine may call
-			// [block.WithVerifyContext.VerifyWithContext] on multiple instances
-			// of the same block, in either order. [VM.consensusCritical] isn't
-			// overridden, so the first instance verified is the one kept in the
-			// map.
-			blks := []snowman.Block{
-				originalIndex:  original,
-				duplicateIndex: duplicate,
-			}
-			for _, i := range test.verifyOrder {
-				b := blks[i].(block.WithVerifyContext)
+			// Consensus may call [block.WithVerifyContext.VerifyWithContext] on
+			// multiple instances of the same block. [VM.consensusCritical]
+			// isn't overridden, so the first instance verified is the one kept
+			// in the map.
+			for _, blk := range blks {
+				b := blk.(block.WithVerifyContext)
 				require.NoErrorf(t,
 					b.VerifyWithContext(ctx, &block.Context{}),
 					"%T.VerifyWithContext()",
-					b,
+					blk,
 				)
 			}
 
-			require.NoErrorf(t, sut.SetPreference(ctx, original.ID()), "%T.SetPreference([duplicated block's ID])", sut.ChainVM)
+			parent := blks[test.acceptIndex]
+			require.NoErrorf(t, sut.SetPreference(ctx, parent.ID()), "%T.SetPreference([duplicated block's ID])", sut.ChainVM)
 			child, err := sut.BuildBlock(ctx)
 			require.NoErrorf(t, err, "%T.BuildBlock() with duplicated block as preference", sut.ChainVM)
 			// Loads the parent from [VM.consensusCritical].
 			require.NoErrorf(t, child.Verify(ctx), "%T.Verify() child of duplicated block", child)
 
-			// Accepting original and child adds them to the execution queue.
-			require.NoError(t, original.Accept(ctx), "original.Accept()")
+			// Accepting parent and child adds them to the execution queue.
+			require.NoError(t, parent.Accept(ctx), "parent.Accept()")
 			require.NoError(t, child.Accept(ctx), "child.Accept()")
 
 			// Inside the executor, execution results are read from
-			// [blocks.Blocks.ParentBlock]. When the ancestry differs from the
+			// [blocks.Block.ParentBlock]. When the ancestry differs from the
 			// accepted instance, a naive implementation would block child's
 			// execution forever.
 			childRaw := unwrap(t, child)

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1185,3 +1185,43 @@ func TestSettledGasTime(t *testing.T) {
 		}
 	}
 }
+
+// TestDuplicateVerify verifies that having two in-memory instances of the same
+// block doesn't corrupt the VM.
+func TestDuplicateVerify(t *testing.T) {
+	ctx, sut := newSUT(t, 0)
+
+	blk := sut.buildAndParseBlock(t, sut.lastAcceptedBlock(t))
+	duplicate, err := sut.ParseBlock(ctx, blk.Bytes())
+	require.NoError(t, err, "ParseBlock(BuildBlock().Bytes())")
+
+	// The consensus engine may call [block.WithVerifyContext.VerifyWithContext]
+	// on multiple instances of the same block.
+	//
+	// This causes [VM.consensusCritical] to be overridden, replacing blk with
+	// duplicate.
+	for _, b := range []snowman.Block{blk, duplicate} {
+		withContext := b.(block.WithVerifyContext)
+		require.NoErrorf(t,
+			withContext.VerifyWithContext(ctx, &block.Context{
+				PChainHeight: 1,
+			}),
+			"%T.VerifyWithContext()",
+			withContext,
+		)
+	}
+
+	// When creating child, [VM.VerifyBlock] loads duplicate from
+	// [VM.consensusCritical] and sets it as the parent of the child.
+	child := sut.createAndVerifyBlock(t, unwrap(t, blk))
+
+	// Accepting blk and child adds them to the execution queue.
+	require.NoErrorf(t, blk.Accept(ctx), "%T.Accept()", blk)
+	require.NoErrorf(t, child.Accept(ctx), "%T.Accept()", child)
+
+	// Inside the executor, execution results are read from the parent of child,
+	// which is duplicate. However, duplicate was never added to the executor,
+	// blk was. So child blocks execution forever.
+	childRaw := unwrap(t, child)
+	require.NoErrorf(t, childRaw.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", childRaw)
+}

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1230,7 +1230,7 @@ func TestDuplicateVerify(t *testing.T) {
 				withContext := b.(block.WithVerifyContext)
 				require.NoErrorf(t,
 					withContext.VerifyWithContext(ctx, &block.Context{
-						PChainHeight: 1,
+						PChainHeight: uint64(i), //#nosec G115 -- Known non-negative
 					}),
 					"%T.VerifyWithContext()",
 					withContext,

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1226,21 +1226,19 @@ func TestDuplicateVerify(t *testing.T) {
 				duplicateIndex: duplicate,
 			}
 			for _, i := range test.verifyOrder {
-				b := blks[i]
-				withContext := b.(block.WithVerifyContext)
+				b := blks[i].(block.WithVerifyContext)
 				require.NoErrorf(t,
-					withContext.VerifyWithContext(ctx, &block.Context{
-						PChainHeight: uint64(i), //#nosec G115 -- Known non-negative
-					}),
+					b.VerifyWithContext(ctx, &block.Context{}),
 					"%T.VerifyWithContext()",
-					withContext,
+					b,
 				)
 			}
 
-			// When creating child, [VM.VerifyBlock] loads the kept instance
-			// from [VM.consensusCritical] and sets it as the parent of the
-			// child.
-			child := sut.createAndVerifyBlock(t, unwrap(t, original))
+			require.NoErrorf(t, sut.SetPreference(ctx, original.ID()), "%T.SetPreference([duplicated block's ID])", sut.ChainVM)
+			child, err := sut.BuildBlock(ctx)
+			require.NoErrorf(t, err, "%T.BuildBlock() with duplicated block as preference", sut.ChainVM)
+			// Loads the parent from [VM.consensusCritical].
+			require.NoErrorf(t, child.Verify(ctx), "%T.Verify() child of duplicated block", child)
 
 			// Accepting original and child adds them to the execution queue.
 			require.NoError(t, original.Accept(ctx), "original.Accept()")

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1202,7 +1202,6 @@ func TestDuplicateVerify(t *testing.T) {
 			acceptIndex: 1,
 		},
 	}
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx, sut := newSUT(t, 0)

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1246,10 +1246,10 @@ func TestDuplicateVerify(t *testing.T) {
 			require.NoError(t, original.Accept(ctx), "original.Accept()")
 			require.NoError(t, child.Accept(ctx), "child.Accept()")
 
-			// Inside the executor, execution results are read from the parent
-			// of child. When the kept instance differs from the accepted
-			// instance, a naive implementation would block child's execution
-			// forever.
+			// Inside the executor, execution results are read from
+			// [blocks.Blocks.ParentBlock]. When the ancestry differs from the
+			// accepted instance, a naive implementation would block child's
+			// execution forever.
 			childRaw := unwrap(t, child)
 			require.NoErrorf(t, childRaw.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", childRaw)
 		})

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1191,8 +1191,8 @@ func TestSettledGasTime(t *testing.T) {
 // engine verifies them.
 func TestDuplicateVerify(t *testing.T) {
 	const (
-		original  = 0
-		duplicate = 1
+		originalIndex = iota
+		duplicateIndex
 	)
 	tests := []struct {
 		name        string
@@ -1200,11 +1200,11 @@ func TestDuplicateVerify(t *testing.T) {
 	}{
 		{
 			name:        "original_then_duplicate",
-			verifyOrder: []int{0, 1},
+			verifyOrder: []int{originalIndex, duplicateIndex},
 		},
 		{
 			name:        "duplicate_then_original",
-			verifyOrder: []int{1, 0},
+			verifyOrder: []int{duplicateIndex, originalIndex},
 		},
 	}
 
@@ -1221,7 +1221,10 @@ func TestDuplicateVerify(t *testing.T) {
 			// of the same block, in either order. [VM.consensusCritical] isn't
 			// overridden, so the last instance verified is the one kept in the
 			// map.
-			blks := []snowman.Block{original, duplicate}
+			blks := []snowman.Block{
+				originalIndex:  original,
+				duplicateIndex: duplicate,
+			}
 			for _, i := range test.verifyOrder {
 				b := blks[i]
 				withContext := b.(block.WithVerifyContext)

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -1187,41 +1187,68 @@ func TestSettledGasTime(t *testing.T) {
 }
 
 // TestDuplicateVerify verifies that having two in-memory instances of the same
-// block doesn't corrupt the VM.
+// block doesn't corrupt the VM, regardless of the order in which the consensus
+// engine verifies them.
 func TestDuplicateVerify(t *testing.T) {
-	ctx, sut := newSUT(t, 0)
-
-	blk := sut.buildAndParseBlock(t, sut.lastAcceptedBlock(t))
-	duplicate, err := sut.ParseBlock(ctx, blk.Bytes())
-	require.NoError(t, err, "ParseBlock(BuildBlock().Bytes())")
-
-	// The consensus engine may call [block.WithVerifyContext.VerifyWithContext]
-	// on multiple instances of the same block.
-	//
-	// This causes [VM.consensusCritical] to be overridden, replacing blk with
-	// duplicate.
-	for _, b := range []snowman.Block{blk, duplicate} {
-		withContext := b.(block.WithVerifyContext)
-		require.NoErrorf(t,
-			withContext.VerifyWithContext(ctx, &block.Context{
-				PChainHeight: 1,
-			}),
-			"%T.VerifyWithContext()",
-			withContext,
-		)
+	const (
+		original  = 0
+		duplicate = 1
+	)
+	tests := []struct {
+		name        string
+		verifyOrder []int
+	}{
+		{
+			name:        "original_then_duplicate",
+			verifyOrder: []int{0, 1},
+		},
+		{
+			name:        "duplicate_then_original",
+			verifyOrder: []int{1, 0},
+		},
 	}
 
-	// When creating child, [VM.VerifyBlock] loads duplicate from
-	// [VM.consensusCritical] and sets it as the parent of the child.
-	child := sut.createAndVerifyBlock(t, unwrap(t, blk))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, sut := newSUT(t, 0)
 
-	// Accepting blk and child adds them to the execution queue.
-	require.NoErrorf(t, blk.Accept(ctx), "%T.Accept()", blk)
-	require.NoErrorf(t, child.Accept(ctx), "%T.Accept()", child)
+			original := sut.buildAndParseBlock(t, sut.lastAcceptedBlock(t))
+			duplicate, err := sut.ParseBlock(ctx, original.Bytes())
+			require.NoError(t, err, "%T.ParseBlock(BuildBlock().Bytes())", sut.ChainVM)
 
-	// Inside the executor, execution results are read from the parent of child,
-	// which is duplicate. However, duplicate was never added to the executor,
-	// blk was. So child blocks execution forever.
-	childRaw := unwrap(t, child)
-	require.NoErrorf(t, childRaw.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", childRaw)
+			// The consensus engine may call
+			// [block.WithVerifyContext.VerifyWithContext] on multiple instances
+			// of the same block, in either order. [VM.consensusCritical] isn't
+			// overridden, so the last instance verified is the one kept in the
+			// map.
+			blks := []snowman.Block{original, duplicate}
+			for _, i := range test.verifyOrder {
+				b := blks[i]
+				withContext := b.(block.WithVerifyContext)
+				require.NoErrorf(t,
+					withContext.VerifyWithContext(ctx, &block.Context{
+						PChainHeight: 1,
+					}),
+					"%T.VerifyWithContext()",
+					withContext,
+				)
+			}
+
+			// When creating child, [VM.VerifyBlock] loads the kept instance
+			// from [VM.consensusCritical] and sets it as the parent of the
+			// child.
+			child := sut.createAndVerifyBlock(t, unwrap(t, original))
+
+			// Accepting original and child adds them to the execution queue.
+			require.NoError(t, original.Accept(ctx), "original.Accept()")
+			require.NoError(t, child.Accept(ctx), "child.Accept()")
+
+			// Inside the executor, execution results are read from the parent
+			// of child. When the kept instance differs from the accepted
+			// instance, a naive implementation would block child's execution
+			// forever.
+			childRaw := unwrap(t, child)
+			require.NoErrorf(t, childRaw.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", childRaw)
+		})
+	}
 }


### PR DESCRIPTION
## Why this should be merged

The proposerVM may verify the same block with different `block.Context`s.

If this were to happen, then a child block may hold a reference to a version of the block that wasn't passed to the executor.

This would cause the executor to deadlock waiting for an incorrect version of the parent to be executed.

## How this works

1. The `consensusCritical` map is updated so that values are NOT overridden when a duplicate insertion is requested (duplicate block verification)
2. On `BlockAccept`, the _first_ value produced to the `consensusCritical` map is passed into the executor, rather than the block actually provided to the function.

`Parent` references held are only ever populated from the `consensusCritical` map, so this guarantees that those references point to the concrete instance which will be managed by the executor. For the `LastSettled` pointer, this value is set by iterating through parents of parents. Because all parent references are populated from the `consensusCritical` map, this means that the `LastSettled` pointer is also sourced from the `consensusCritical` map.

Additionally, SAE's VM API was designed to primarily be consumed by the consensus engine through the adaptor. Because the stateful block methods are not reachable by the consensus engine, any footguns around having multiple references to the same block on the consensus side aren't actually reachable.

## How this was tested

- [X] Added regression test

## Need to be documented in RELEASES.md?

No