### PR TITLE
l1.go e2e test refactored

### DIFF
--- a/tests/e2e/p/l1.go
+++ b/tests/e2e/p/l1.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/example/xsvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
+	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
@@ -49,6 +50,7 @@ import (
 	platformapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
 	platformvmvalidators "github.com/ava-labs/avalanchego/vms/platformvm/validators"
 	warpmessage "github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
+	pwallet "github.com/ava-labs/avalanchego/wallet/chain/p/wallet"
 )
 
 const (
@@ -91,19 +93,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 		)
 
 		tc.By("creating the chain genesis")
-		genesisKey, err := secp256k1.NewPrivateKey()
-		require.NoError(err)
-
-		genesisBytes, err := genesis.Codec.Marshal(genesis.CodecVersion, &genesis.Genesis{
-			Timestamp: time.Now().Unix(),
-			Allocations: []genesis.Allocation{
-				{
-					Address: genesisKey.Address(),
-					Balance: math.MaxUint64,
-				},
-			},
-		})
-		require.NoError(err)
+		genesisBytes := newXSVMGenesisBytes(tc)
 
 		var subnetID ids.ID
 		tc.By("issuing a CreateSubnetTx", func() {
@@ -148,28 +138,6 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			chainID = chainTx.ID()
 		})
 
-		verifyValidatorSet := func(expectedValidators map[ids.NodeID]*snowvalidators.GetValidatorOutput) {
-			height, err := pClient.GetHeight(tc.DefaultContext())
-			require.NoError(err)
-
-			subnetValidators, err := pClient.GetValidatorsAt(tc.DefaultContext(), subnetID, platformapi.Height(height))
-			require.NoError(err)
-			require.Equal(expectedValidators, subnetValidators)
-
-			// Test GetAllValidatorsAt too, for coverage
-			flattenedExpectedValidators, err := snowvalidators.FlattenValidatorSet(expectedValidators) // for coverage
-			require.NoError(err)
-
-			// require.Equal will complain if one has a nil slice and the other
-			// has an empty slice. This avoids that issue.
-			if len(flattenedExpectedValidators.Validators) == 0 {
-				flattenedExpectedValidators.Validators = nil
-			}
-
-			allValidators, err := pClient.GetAllValidatorsAt(tc.DefaultContext(), platformapi.Height(height))
-			require.NoError(err)
-			require.Equal(flattenedExpectedValidators, allValidators[subnetID])
-		}
 		tc.By("verifying the Permissioned Subnet is configured as expected", func() {
 			tc.By("verifying the subnet reports as permissioned", func() {
 				subnet, err := pClient.GetSubnet(tc.DefaultContext(), subnetID)
@@ -187,7 +155,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			})
 
 			tc.By("verifying the validator set is empty", func() {
-				verifyValidatorSet(map[ids.NodeID]*snowvalidators.GetValidatorOutput{})
+				verifyValidatorSet(tc, pClient, subnetID, map[ids.NodeID]*snowvalidators.GetValidatorOutput{})
 			})
 		})
 
@@ -196,34 +164,11 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			config.TrackSubnetsKey: subnetID.String(),
 		}))
 
-		genesisNodePoP, err := subnetGenesisNode.GetProofOfPossession()
-		require.NoError(err)
-
-		genesisNodePK, err := bls.PublicKeyFromCompressedBytes(genesisNodePoP.PublicKey[:])
-		require.NoError(err)
+		genesisNodePoP, genesisNodePK := nodeProofOfPossession(tc, subnetGenesisNode)
 
 		tc.By("connecting to the genesis validator")
-		var (
-			networkID           = env.GetNetwork().GetNetworkID()
-			genesisPeerMessages = buffer.NewUnboundedBlockingDeque[*p2pmessage.InboundMessage](1)
-		)
-		stakingAddress, cancel, err := subnetGenesisNode.GetAccessibleStakingAddress(tc.DefaultContext())
-		require.NoError(err)
-		tc.DeferCleanup(cancel)
-		genesisPeer, err := peer.StartTestPeer(
-			tc.DefaultContext(),
-			stakingAddress,
-			networkID,
-			router.InboundHandlerFunc(func(_ context.Context, m *p2pmessage.InboundMessage) {
-				tc.Log().Info("received a message",
-					zap.Stringer("op", m.Op),
-					zap.Stringer("message", m.Message),
-					zap.Stringer("from", m.NodeID),
-				)
-				genesisPeerMessages.PushRight(m)
-			}),
-		)
-		require.NoError(err)
+		networkID := env.GetNetwork().GetNetworkID()
+		genesisPeer, genesisPeerMessages := startL1TestPeer(tc, subnetGenesisNode, networkID)
 
 		subnetGenesisNodeURI := subnetGenesisNode.GetAccessibleURI()
 
@@ -245,21 +190,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			)
 			require.NoError(err)
 
-			tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNodeURI, func() {
-				var (
-					client = platformvm.NewClient(subnetGenesisNodeURI)
-					txID   = tx.ID()
-				)
-				tc.Eventually(
-					func() bool {
-						_, err := client.GetTx(tc.DefaultContext(), txID)
-						return err == nil
-					},
-					tests.DefaultTimeout,
-					e2e.DefaultPollingInterval,
-					"transaction not accepted",
-				)
-			})
+			awaitTxAccepted(tc, subnetGenesisNodeURI, tx.ID())
 		})
 		genesisValidationID := subnetID.Append(0)
 
@@ -297,7 +228,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			})
 
 			tc.By("verifying the validator set was updated", func() {
-				verifyValidatorSet(map[ids.NodeID]*snowvalidators.GetValidatorOutput{
+				verifyValidatorSet(tc, pClient, subnetID, map[ids.NodeID]*snowvalidators.GetValidatorOutput{
 					subnetGenesisNode.NodeID: {
 						NodeID:    subnetGenesisNode.NodeID,
 						PublicKey: genesisNodePK,
@@ -332,108 +263,22 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			})
 
 			tc.By("fetching the subnet conversion attestation", func() {
-				unsignedSubnetToL1Conversion := must[*warp.UnsignedMessage](tc)(warp.NewUnsignedMessage(
-					networkID,
-					constants.PlatformChainID,
-					must[*payload.AddressedCall](tc)(payload.NewAddressedCall(
-						nil,
-						must[*warpmessage.SubnetToL1Conversion](tc)(warpmessage.NewSubnetToL1Conversion(
-							expectedConversionID,
-						)).Bytes(),
-					)).Bytes(),
-				))
-
-				tc.By("sending the request to sign the warp message", func() {
-					registerL1ValidatorRequest, err := wrapWarpSignatureRequest(
-						unsignedSubnetToL1Conversion,
-						subnetID[:],
-					)
-					require.NoError(err)
-
-					require.True(genesisPeer.Send(tc.DefaultContext(), registerL1ValidatorRequest))
-				})
-
-				tc.By("getting the signature response", func() {
-					signature, ok, err := findMessage(genesisPeerMessages, unwrapWarpSignature)
-					require.NoError(err)
-					require.True(ok)
-					require.True(bls.Verify(genesisNodePK, signature, unsignedSubnetToL1Conversion.Bytes()))
-				})
+				conversion, err := warpmessage.NewSubnetToL1Conversion(expectedConversionID)
+				require.NoError(err)
+				verifyPChainAttestation(tc, genesisPeer, genesisPeerMessages, networkID, genesisNodePK, conversion.Bytes(), subnetID[:])
 			})
 		})
 
-		advanceProposerVMPChainHeight := func() {
-			upgrades, err := infoClient.Upgrades(tc.DefaultContext())
-			require.NoError(err)
-
-			if !upgrades.IsGraniteActivated(time.Now()) {
-				// Wait to ensure the next block will reference the last
-				// accepted P-chain height.
-				time.Sleep(timeToAdvancePChainWindow)
-				return
-			}
-
-			epochBefore, err := proposerClient.GetCurrentEpoch(tc.DefaultContext())
-			require.NoError(err)
-
-			tc.By("waiting", func() {
-				timeToAdvanceEpoch := max(timeToAdvancePChainWindow, upgrades.GraniteEpochDuration)
-				time.Sleep(timeToAdvanceEpoch)
-			})
-
-			tc.By("issuing a dummy tx to advance the epoch", func() {
-				tx, err := pWallet.IssueBaseTx(
-					[]*avax.TransferableOutput{
-						{
-							Asset: avax.Asset{ID: pWallet.Builder().Context().AVAXAssetID},
-							Out: &secp256k1fx.TransferOutput{
-								Amt: 100 * units.MicroAvax,
-								OutputOwners: secp256k1fx.OutputOwners{
-									Threshold: 1,
-									Addrs: []ids.ShortID{
-										ids.GenerateTestShortID(),
-									},
-								},
-							},
-						},
-					},
-					tc.WithDefaultContext(),
-				)
-				require.NoError(err)
-
-				tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNodeURI, func() {
-					var (
-						client = platformvm.NewClient(subnetGenesisNodeURI)
-						txID   = tx.ID()
-					)
-					tc.Eventually(
-						func() bool {
-							_, err := client.GetTx(tc.DefaultContext(), txID)
-							return err == nil
-						},
-						tests.DefaultTimeout,
-						e2e.DefaultPollingInterval,
-						"transaction not accepted",
-					)
-				})
-			})
-
-			epochAfter, err := proposerClient.GetCurrentEpoch(tc.DefaultContext())
-			require.NoError(err)
-			require.Greater(epochAfter.PChainHeight, epochBefore.PChainHeight)
-		}
-		tc.By("advancing the proposervm P-chain height", advanceProposerVMPChainHeight)
+		tc.By("advancing the proposervm P-chain height", func() {
+			advanceProposerVMPChainHeight(tc, pWallet, infoClient, proposerClient, subnetGenesisNodeURI)
+		})
 
 		tc.By("creating the validator to register")
 		subnetRegisterNode := e2e.AddEphemeralNode(tc, env.GetNetwork(), tmpnet.NewEphemeralNode(tmpnet.FlagsMap{
 			config.TrackSubnetsKey: subnetID.String(),
 		}))
 
-		registerNodePoP, err := subnetRegisterNode.GetProofOfPossession()
-		require.NoError(err)
-
-		registerNodePK, err := bls.PublicKeyFromCompressedBytes(registerNodePoP.PublicKey[:])
-		require.NoError(err)
+		registerNodePoP, registerNodePK := nodeProofOfPossession(tc, subnetRegisterNode)
 
 		tc.By("ensuring the subnet nodes are healthy", func() {
 			e2e.WaitForHealthy(tc, subnetGenesisNode)
@@ -453,74 +298,23 @@ var _ = e2e.DescribePChain("[L1]", func() {
 		)
 		require.NoError(err)
 		registerValidationID := registerL1ValidatorMessage.ValidationID()
+		manager := &l1Manager{
+			pWallet:       pWallet,
+			genesisPeer:   genesisPeer,
+			peerMessages:  genesisPeerMessages,
+			networkID:     networkID,
+			chainID:       chainID,
+			address:       address,
+			acceptanceURI: subnetGenesisNodeURI,
+		}
 
 		tc.By("registering the validator", func() {
-			tc.By("creating the unsigned warp message")
-			unsignedRegisterL1Validator := must[*warp.UnsignedMessage](tc)(warp.NewUnsignedMessage(
-				networkID,
-				chainID,
-				must[*payload.AddressedCall](tc)(payload.NewAddressedCall(
-					address,
-					registerL1ValidatorMessage.Bytes(),
-				)).Bytes(),
-			))
-
-			tc.By("sending the request to sign the warp message", func() {
-				registerL1ValidatorRequest, err := wrapWarpSignatureRequest(
-					unsignedRegisterL1Validator,
-					nil,
-				)
-				require.NoError(err)
-
-				require.True(genesisPeer.Send(tc.DefaultContext(), registerL1ValidatorRequest))
-			})
-
-			tc.By("getting the signature response")
-			registerL1ValidatorSignature, ok, err := findMessage(genesisPeerMessages, unwrapWarpSignature)
-			require.NoError(err)
-			require.True(ok)
-
-			tc.By("creating the signed warp message to register the validator")
-			registerL1Validator, err := warp.NewMessage(
-				unsignedRegisterL1Validator,
-				&warp.BitSetSignature{
-					Signers: set.NewBits(0).Bytes(), // [signers] has weight from the genesis peer
-					Signature: ([bls.SignatureLen]byte)(
-						bls.SignatureToBytes(registerL1ValidatorSignature),
-					),
-				},
-			)
-			require.NoError(err)
-
-			tc.By("issuing a RegisterL1ValidatorTx", func() {
-				tx, err := pWallet.IssueRegisterL1ValidatorTx(
-					registerBalance,
-					registerNodePoP.ProofOfPossession,
-					registerL1Validator.Bytes(),
-				)
-				require.NoError(err)
-
-				tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNodeURI, func() {
-					var (
-						client = platformvm.NewClient(subnetGenesisNodeURI)
-						txID   = tx.ID()
-					)
-					tc.Eventually(
-						func() bool {
-							_, err := client.GetTx(tc.DefaultContext(), txID)
-							return err == nil
-						},
-						tests.DefaultTimeout,
-						e2e.DefaultPollingInterval,
-						"transaction not accepted",
-					)
-				})
-			})
+			manager.registerValidator(tc, registerL1ValidatorMessage, registerBalance, registerNodePoP.ProofOfPossession)
 		})
 
 		tc.By("verifying the validator was registered", func() {
 			tc.By("verifying the validator set was updated", func() {
-				verifyValidatorSet(map[ids.NodeID]*snowvalidators.GetValidatorOutput{
+				verifyValidatorSet(tc, pClient, subnetID, map[ids.NodeID]*snowvalidators.GetValidatorOutput{
 					subnetGenesisNode.NodeID: {
 						NodeID:    subnetGenesisNode.NodeID,
 						PublicKey: genesisNodePK,
@@ -558,103 +352,15 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			})
 
 			tc.By("fetching the validator registration attestation", func() {
-				unsignedL1ValidatorRegistration := must[*warp.UnsignedMessage](tc)(warp.NewUnsignedMessage(
-					networkID,
-					constants.PlatformChainID,
-					must[*payload.AddressedCall](tc)(payload.NewAddressedCall(
-						nil,
-						must[*warpmessage.L1ValidatorRegistration](tc)(warpmessage.NewL1ValidatorRegistration(
-							registerValidationID,
-							true, // registered
-						)).Bytes(),
-					)).Bytes(),
-				))
-
-				tc.By("sending the request to sign the warp message", func() {
-					l1ValidatorRegistrationRequest, err := wrapWarpSignatureRequest(
-						unsignedL1ValidatorRegistration,
-						nil,
-					)
-					require.NoError(err)
-
-					require.True(genesisPeer.Send(tc.DefaultContext(), l1ValidatorRegistrationRequest))
-				})
-
-				tc.By("getting the signature response", func() {
-					signature, ok, err := findMessage(genesisPeerMessages, unwrapWarpSignature)
-					require.NoError(err)
-					require.True(ok)
-					require.True(bls.Verify(genesisNodePK, signature, unsignedL1ValidatorRegistration.Bytes()))
-				})
+				registration, err := warpmessage.NewL1ValidatorRegistration(registerValidationID, true)
+				require.NoError(err)
+				verifyPChainAttestation(tc, genesisPeer, genesisPeerMessages, networkID, genesisNodePK, registration.Bytes(), nil)
 			})
 		})
 
 		var nextNonce uint64
 		setWeight := func(validationID ids.ID, weight uint64) {
-			tc.By("creating the unsigned L1ValidatorWeightMessage")
-			unsignedL1ValidatorWeight := must[*warp.UnsignedMessage](tc)(warp.NewUnsignedMessage(
-				networkID,
-				chainID,
-				must[*payload.AddressedCall](tc)(payload.NewAddressedCall(
-					address,
-					must[*warpmessage.L1ValidatorWeight](tc)(warpmessage.NewL1ValidatorWeight(
-						validationID,
-						nextNonce,
-						weight,
-					)).Bytes(),
-				)).Bytes(),
-			))
-
-			tc.By("sending the request to sign the warp message", func() {
-				setL1ValidatorWeightRequest, err := wrapWarpSignatureRequest(
-					unsignedL1ValidatorWeight,
-					nil,
-				)
-				require.NoError(err)
-
-				require.True(genesisPeer.Send(tc.DefaultContext(), setL1ValidatorWeightRequest))
-			})
-
-			tc.By("getting the signature response")
-			setL1ValidatorWeightSignature, ok, err := findMessage(genesisPeerMessages, unwrapWarpSignature)
-			require.NoError(err)
-			require.True(ok)
-
-			tc.By("creating the signed warp message to increase the weight of the validator")
-			setL1ValidatorWeight, err := warp.NewMessage(
-				unsignedL1ValidatorWeight,
-				&warp.BitSetSignature{
-					Signers: set.NewBits(0).Bytes(), // [signers] has weight from the genesis validator
-					Signature: ([bls.SignatureLen]byte)(
-						bls.SignatureToBytes(setL1ValidatorWeightSignature),
-					),
-				},
-			)
-			require.NoError(err)
-
-			tc.By("issuing a SetL1ValidatorWeightTx", func() {
-				tx, err := pWallet.IssueSetL1ValidatorWeightTx(
-					setL1ValidatorWeight.Bytes(),
-				)
-				require.NoError(err)
-
-				tc.By("ensuring the genesis peer has accepted the tx at "+subnetGenesisNodeURI, func() {
-					var (
-						client = platformvm.NewClient(subnetGenesisNodeURI)
-						txID   = tx.ID()
-					)
-					tc.Eventually(
-						func() bool {
-							_, err := client.GetTx(tc.DefaultContext(), txID)
-							return err == nil
-						},
-						tests.DefaultTimeout,
-						e2e.DefaultPollingInterval,
-						"transaction not accepted",
-					)
-				})
-			})
-
+			manager.setValidatorWeight(tc, validationID, nextNonce, weight)
 			nextNonce++
 		}
 
@@ -664,7 +370,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 
 		tc.By("verifying the validator weight was increased", func() {
 			tc.By("verifying the validator set was updated", func() {
-				verifyValidatorSet(map[ids.NodeID]*snowvalidators.GetValidatorOutput{
+				verifyValidatorSet(tc, pClient, subnetID, map[ids.NodeID]*snowvalidators.GetValidatorOutput{
 					subnetGenesisNode.NodeID: {
 						NodeID:    subnetGenesisNode.NodeID,
 						PublicKey: genesisNodePK,
@@ -702,35 +408,13 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			})
 
 			tc.By("fetching the validator weight change attestation", func() {
-				unsignedL1ValidatorWeight := must[*warp.UnsignedMessage](tc)(warp.NewUnsignedMessage(
-					networkID,
-					constants.PlatformChainID,
-					must[*payload.AddressedCall](tc)(payload.NewAddressedCall(
-						nil,
-						must[*warpmessage.L1ValidatorWeight](tc)(warpmessage.NewL1ValidatorWeight(
-							registerValidationID,
-							nextNonce-1, // Use the prior nonce
-							updatedWeight,
-						)).Bytes(),
-					)).Bytes(),
-				))
-
-				tc.By("sending the request to sign the warp message", func() {
-					l1ValidatorRegistrationRequest, err := wrapWarpSignatureRequest(
-						unsignedL1ValidatorWeight,
-						nil,
-					)
-					require.NoError(err)
-
-					require.True(genesisPeer.Send(tc.DefaultContext(), l1ValidatorRegistrationRequest))
-				})
-
-				tc.By("getting the signature response", func() {
-					signature, ok, err := findMessage(genesisPeerMessages, unwrapWarpSignature)
-					require.NoError(err)
-					require.True(ok)
-					require.True(bls.Verify(genesisNodePK, signature, unsignedL1ValidatorWeight.Bytes()))
-				})
+				weightMessage, err := warpmessage.NewL1ValidatorWeight(
+					registerValidationID,
+					nextNonce-1,
+					updatedWeight,
+				)
+				require.NoError(err)
+				verifyPChainAttestation(tc, genesisPeer, genesisPeerMessages, networkID, genesisNodePK, weightMessage.Bytes(), nil)
 			})
 		})
 
@@ -743,7 +427,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 		})
 
 		tc.By("verifying the validator was activated", func() {
-			verifyValidatorSet(map[ids.NodeID]*snowvalidators.GetValidatorOutput{
+			verifyValidatorSet(tc, pClient, subnetID, map[ids.NodeID]*snowvalidators.GetValidatorOutput{
 				subnetGenesisNode.NodeID: {
 					NodeID:    subnetGenesisNode.NodeID,
 					PublicKey: genesisNodePK,
@@ -765,7 +449,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 		})
 
 		tc.By("verifying the validator was deactivated", func() {
-			verifyValidatorSet(map[ids.NodeID]*snowvalidators.GetValidatorOutput{
+			verifyValidatorSet(tc, pClient, subnetID, map[ids.NodeID]*snowvalidators.GetValidatorOutput{
 				subnetGenesisNode.NodeID: {
 					NodeID:    subnetGenesisNode.NodeID,
 					PublicKey: genesisNodePK,
@@ -778,7 +462,9 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			})
 		})
 
-		tc.By("advancing the proposervm P-chain height", advanceProposerVMPChainHeight)
+		tc.By("advancing the proposervm P-chain height", func() {
+			advanceProposerVMPChainHeight(tc, pWallet, infoClient, proposerClient, subnetGenesisNodeURI)
+		})
 
 		tc.By("removing the registered validator", func() {
 			setWeight(registerValidationID, 0)
@@ -786,7 +472,7 @@ var _ = e2e.DescribePChain("[L1]", func() {
 
 		tc.By("verifying the validator was removed", func() {
 			tc.By("verifying the validator set was updated", func() {
-				verifyValidatorSet(map[ids.NodeID]*snowvalidators.GetValidatorOutput{
+				verifyValidatorSet(tc, pClient, subnetID, map[ids.NodeID]*snowvalidators.GetValidatorOutput{
 					subnetGenesisNode.NodeID: {
 						NodeID:    subnetGenesisNode.NodeID,
 						PublicKey: genesisNodePK,
@@ -796,18 +482,8 @@ var _ = e2e.DescribePChain("[L1]", func() {
 			})
 
 			tc.By("fetching the validator removal attestation", func() {
-				unsignedL1ValidatorRegistration := must[*warp.UnsignedMessage](tc)(warp.NewUnsignedMessage(
-					networkID,
-					constants.PlatformChainID,
-					must[*payload.AddressedCall](tc)(payload.NewAddressedCall(
-						nil,
-						must[*warpmessage.L1ValidatorRegistration](tc)(warpmessage.NewL1ValidatorRegistration(
-							registerValidationID,
-							false, // removed
-						)).Bytes(),
-					)).Bytes(),
-				))
-
+				registration, err := warpmessage.NewL1ValidatorRegistration(registerValidationID, false)
+				require.NoError(err)
 				justification := platformvmpb.L1ValidatorRegistrationJustification{
 					Preimage: &platformvmpb.L1ValidatorRegistrationJustification_RegisterL1ValidatorMessage{
 						RegisterL1ValidatorMessage: registerL1ValidatorMessage.Bytes(),
@@ -816,32 +492,334 @@ var _ = e2e.DescribePChain("[L1]", func() {
 				justificationBytes, err := proto.Marshal(&justification)
 				require.NoError(err)
 
-				tc.By("sending the request to sign the warp message", func() {
-					l1ValidatorRegistrationRequest, err := wrapWarpSignatureRequest(
-						unsignedL1ValidatorRegistration,
-						justificationBytes,
-					)
-					require.NoError(err)
-
-					require.True(genesisPeer.Send(tc.DefaultContext(), l1ValidatorRegistrationRequest))
-				})
-
-				tc.By("getting the signature response", func() {
-					signature, ok, err := findMessage(genesisPeerMessages, unwrapWarpSignature)
-					require.NoError(err)
-					require.True(ok)
-					require.True(bls.Verify(genesisNodePK, signature, unsignedL1ValidatorRegistration.Bytes()))
-				})
+				verifyPChainAttestation(tc, genesisPeer, genesisPeerMessages, networkID, genesisNodePK, registration.Bytes(), justificationBytes)
 			})
 		})
 
-		genesisPeerMessages.Close()
-		genesisPeer.StartClose()
-		require.NoError(genesisPeer.AwaitClosed(tc.DefaultContext()))
+		closeTestPeer(tc, genesisPeer, genesisPeerMessages)
 
 		_ = e2e.CheckBootstrapIsPossible(tc, env.GetNetwork())
 	})
 })
+
+///// Helpers ///////
+
+// newXSVMGenesisBytes returns the Bytes of an XSVM genesis that allocates
+// the supply to a new key
+func newXSVMGenesisBytes(tc tests.TestContext) []byte {
+	require := require.New(tc)
+
+	genesisKey, err := secp256k1.NewPrivateKey()
+	require.NoError(err)
+
+	genesisBytes, err := genesis.Codec.Marshal(genesis.CodecVersion, &genesis.Genesis{
+		Timestamp: time.Now().Unix(),
+		Allocations: []genesis.Allocation{
+			{
+				Address: genesisKey.Address(),
+				Balance: math.MaxUint64,
+			},
+		},
+	})
+	require.NoError(err)
+	return genesisBytes
+}
+
+// nodeProofOfPossession returns the BLS proof of possession and public key of the provided node
+func nodeProofOfPossession(tc tests.TestContext, node *tmpnet.Node) (*signer.ProofOfPossession, *bls.PublicKey) {
+	require := require.New(tc)
+	pop, err := node.GetProofOfPossession()
+	require.NoError(err)
+
+	pk, err := bls.PublicKeyFromCompressedBytes(pop.PublicKey[:])
+	require.NoError(err)
+
+	return pop, pk
+}
+
+// awaitTxAccepted polls the P-Chain API at uri until the transaction has been accepted
+func awaitTxAccepted(tc tests.TestContext, uri string, txID ids.ID) {
+	tc.By("ensuring the genesis peer has accepted the tx at "+uri, func() {
+		client := platformvm.NewClient(uri)
+		tc.Eventually(
+			func() bool {
+				_, err := client.GetTx(tc.DefaultContext(), txID)
+				return err == nil
+			},
+			tests.DefaultTimeout,
+			e2e.DefaultPollingInterval,
+			"transaction not accepted",
+		)
+	})
+}
+
+// newAddressedCallMessage returns an unsigned warp message from [sourceChainID] whose payload is an AddressedCall from sourceAddress containing payloadBytes
+func newAddressedCallMessage(
+	tc tests.TestContext,
+	networkID uint32,
+	sourceChainID ids.ID,
+	sourceAddress []byte,
+	payloadBytes []byte,
+) *warp.UnsignedMessage {
+	require := require.New(tc)
+	addressedCall, err := payload.NewAddressedCall(sourceAddress, payloadBytes)
+	require.NoError(err)
+
+	msg, err := warp.NewUnsignedMessage(networkID, sourceChainID, addressedCall.Bytes())
+	require.NoError(err)
+
+	return msg
+}
+
+// startL1TestPeer connects a test peer to [node] and returns it with a deque that collects every inbound message
+func startL1TestPeer(
+	tc tests.TestContext,
+	node *tmpnet.Node,
+	networkID uint32,
+) (*peer.Peer, buffer.BlockingDeque[*p2pmessage.InboundMessage]) {
+	require := require.New(tc)
+	messages := buffer.NewUnboundedBlockingDeque[*p2pmessage.InboundMessage](1)
+
+	stakingAddress, cancel, err := node.GetAccessibleStakingAddress(tc.DefaultContext())
+	require.NoError(err)
+	tc.DeferCleanup(cancel)
+	p, err := peer.StartTestPeer(
+		tc.DefaultContext(),
+		stakingAddress,
+		networkID,
+		router.InboundHandlerFunc(func(_ context.Context, m *p2pmessage.InboundMessage) {
+			tc.Log().Info("received a message",
+				zap.Stringer("op", m.Op),
+				zap.Stringer("message", m.Message),
+				zap.Stringer("from", m.NodeID),
+			)
+			messages.PushRight(m)
+		}),
+	)
+	require.NoError(err)
+	return p, messages
+}
+
+// closes [p] and its message deque
+func closeTestPeer(
+	tc tests.TestContext,
+	p *peer.Peer,
+	messages buffer.BlockingDeque[*p2pmessage.InboundMessage],
+) {
+	require := require.New(tc)
+
+	messages.Close()
+	p.StartClose()
+	require.NoError(p.AwaitClosed(tc.DefaultContext()))
+}
+
+// requestWarpSignature requests that [p] signs [msg], optionally providing s justification, and returns the resulting BLS signature.
+func requestWarpSignature(
+	tc tests.TestContext,
+	p *peer.Peer,
+	messages buffer.BlockingDeque[*p2pmessage.InboundMessage],
+	msg *warp.UnsignedMessage,
+	justification []byte,
+) *bls.Signature {
+	require := require.New(tc)
+
+	tc.By("sending the request to sign the warp message", func() {
+		request, err := wrapWarpSignatureRequest(msg, justification)
+		require.NoError(err)
+		require.True(p.Send(tc.DefaultContext(), request))
+	})
+
+	var signature *bls.Signature
+	tc.By("getting the signature response", func() {
+		sig, ok, err := findMessage(messages, unwrapWarpSignature)
+		require.NoError(err)
+		require.True(ok)
+		signature = sig
+	})
+	return signature
+}
+
+// verifyPChainAttestation verifies that the P-Chain attests to [payload] by requesting a signature over it from [p] and verifying the signature against [signerPK]
+func verifyPChainAttestation(
+	tc tests.TestContext,
+	p *peer.Peer,
+	messages buffer.BlockingDeque[*p2pmessage.InboundMessage],
+	networkID uint32,
+	signerPK *bls.PublicKey,
+	payloadBytes []byte,
+	justification []byte,
+) {
+	require := require.New(tc)
+
+	unsignedMessage := newAddressedCallMessage(tc, networkID, constants.PlatformChainID, nil, payloadBytes)
+	signature := requestWarpSignature(tc, p, messages, unsignedMessage, justification)
+	require.True(bls.Verify(signerPK, signature, unsignedMessage.Bytes()))
+}
+
+// verifyValidatorSet checks that the subnet validator set at the current heigt matches [expectedValidators]
+func verifyValidatorSet(
+	tc tests.TestContext,
+	pClient *platformvm.Client,
+	subnetID ids.ID,
+	expectedValidators map[ids.NodeID]*snowvalidators.GetValidatorOutput,
+) {
+	require := require.New(tc)
+
+	height, err := pClient.GetHeight(tc.DefaultContext())
+	require.NoError(err)
+
+	subnetValidators, err := pClient.GetValidatorsAt(tc.DefaultContext(), subnetID, platformapi.Height(height))
+	require.NoError(err)
+	require.Equal(expectedValidators, subnetValidators)
+
+	flattenedExpectedValidators, err := snowvalidators.FlattenValidatorSet(expectedValidators)
+	require.NoError(err)
+
+	if len(flattenedExpectedValidators.Validators) == 0 {
+		flattenedExpectedValidators.Validators = nil
+	}
+
+	allValidators, err := pClient.GetAllValidatorsAt(tc.DefaultContext(), platformapi.Height(height))
+	require.NoError(err)
+	require.Equal(flattenedExpectedValidators, allValidators[subnetID])
+
+}
+
+// advanceProposerVMPChainHeight ensures that the proposervm's referenced P-Chain height advances past the current height and advancing the epoch by issuing a dummy transaction.
+func advanceProposerVMPChainHeight(
+	tc tests.TestContext,
+	pWallet pwallet.Wallet,
+	infoClient *info.Client,
+	proposerClient *proposervm.JSONRPCClient,
+	acceptanceURI string,
+) {
+	require := require.New(tc)
+
+	upgrades, err := infoClient.Upgrades(tc.DefaultContext())
+	require.NoError(err)
+
+	if !upgrades.IsGraniteActivated(time.Now()) {
+		time.Sleep(timeToAdvancePChainWindow)
+		return
+	}
+	epochBefore, err := proposerClient.GetCurrentEpoch(tc.DefaultContext())
+	require.NoError(err)
+
+	tc.By("waiting", func() {
+		timeToAdvanceEpoch := max(timeToAdvancePChainWindow, upgrades.GraniteEpochDuration)
+		time.Sleep(timeToAdvanceEpoch)
+	})
+
+	tc.By("Issuing a dummy tx to advance the epoch", func() {
+		tx, err := pWallet.IssueBaseTx(
+			[]*avax.TransferableOutput{
+				{
+					Asset: avax.Asset{ID: pWallet.Builder().Context().AVAXAssetID},
+					Out: &secp256k1fx.TransferOutput{
+						Amt: 100 * units.MicroAvax,
+						OutputOwners: secp256k1fx.OutputOwners{
+							Threshold: 1,
+							Addrs: []ids.ShortID{
+								ids.GenerateTestShortID(),
+							},
+						},
+					},
+				},
+			},
+			tc.WithDefaultContext(),
+		)
+		require.NoError(err)
+		awaitTxAccepted(tc, acceptanceURI, tx.ID())
+	})
+	epochAfter, err := proposerClient.GetCurrentEpoch(tc.DefaultContext())
+	require.NoError(err)
+	require.Greater(epochAfter.PChainHeight, epochBefore.PChainHeight)
+}
+
+// l1Manager issues manager-originated validator changes for an L1.
+type l1Manager struct {
+	pWallet      pwallet.Wallet
+	genesisPeer  *peer.Peer
+	peerMessages buffer.BlockingDeque[*p2pmessage.InboundMessage]
+	networkID    uint32
+	chainID      ids.ID
+	address      []byte
+	// acceptanceURI is the API URI polled to confirm issued txs are accpeted.
+	acceptanceURI string
+}
+
+// registerValidator signs [message] as the manager and issues the RegisterL1ValidatorTx, funding the validator with [balance] and proving ownership of its BLS key with [pop]
+func (m *l1Manager) registerValidator(
+	tc tests.TestContext,
+	message *warpmessage.RegisterL1Validator,
+	balance uint64,
+	pop [bls.SignatureLen]byte,
+) {
+
+	require := require.New(tc)
+	tc.By("creating the unsigned warp message")
+	unsigned := newAddressedCallMessage(tc, m.networkID, m.chainID, m.address, message.Bytes())
+
+	signature := requestWarpSignature(tc, m.genesisPeer, m.peerMessages, unsigned, nil)
+
+	tc.By("creating the signed warp message to register the validator")
+	signed, err := warp.NewMessage(
+		unsigned,
+		&warp.BitSetSignature{
+			Signers: set.NewBits(0).Bytes(), // [signers] has weight from the genesis peer
+			Signature: ([bls.SignatureLen]byte)(
+				bls.SignatureToBytes(signature),
+			),
+		},
+	)
+	require.NoError(err)
+
+	tc.By("issuing a RegisterL1ValidatorTx", func() {
+		tx, err := m.pWallet.IssueRegisterL1ValidatorTx(
+			balance,
+			pop,
+			signed.Bytes(),
+		)
+		require.NoError(err)
+		awaitTxAccepted(tc, m.acceptanceURI, tx.ID())
+	})
+}
+
+func (m *l1Manager) setValidatorWeight(
+	tc tests.TestContext,
+	validationID ids.ID,
+	nonce uint64,
+	weight uint64,
+) {
+	require := require.New(tc)
+
+	tc.By("creating the unsigned L1ValidatorWeightMessage")
+	weightMessage, err := warpmessage.NewL1ValidatorWeight(validationID, nonce, weight)
+	require.NoError(err)
+
+	unsigned := newAddressedCallMessage(tc, m.networkID, m.chainID, m.address, weightMessage.Bytes())
+
+	signature := requestWarpSignature(tc, m.genesisPeer, m.peerMessages, unsigned, nil)
+
+	tc.By("creating the signed warp message to set the weight of the validator")
+	signed, err := warp.NewMessage(
+		unsigned,
+		&warp.BitSetSignature{
+			Signers: set.NewBits(0).Bytes(), // [signers] has weight from the genesis peer
+			Signature: ([bls.SignatureLen]byte)(
+				bls.SignatureToBytes(signature),
+			),
+		},
+	)
+	require.NoError(err)
+
+	tc.By("issuing a SetL1ValidatorWeightTx", func() {
+		tx, err := m.pWallet.IssueSetL1ValidatorWeightTx(signed.Bytes())
+		require.NoError(err)
+		awaitTxAccepted(tc, m.acceptanceURI, tx.ID())
+	})
+
+}
 
 func wrapWarpSignatureRequest(
 	msg *warp.UnsignedMessage,
@@ -926,11 +904,4 @@ func unwrapWarpSignature(msg *p2pmessage.InboundMessage) (*bls.Signature, bool, 
 
 	warpSignature, err := bls.SignatureFromBytes(response.Signature)
 	return warpSignature, true, err
-}
-
-func must[T any](t require.TestingT) func(T, error) T {
-	return func(val T, err error) T {
-		require.NoError(t, err)
-		return val
-	}
 }

--- a/tests/e2e/p/l1.go
+++ b/tests/e2e/p/l1.go
@@ -553,7 +553,9 @@ func awaitTxAccepted(tc tests.TestContext, uri string, txID ids.ID) {
 	})
 }
 
-// newAddressedCallMessage returns an unsigned warp message from [sourceChainID] whose payload is an AddressedCall from sourceAddress containing payloadBytes
+// newAddressedCallMessage returns an unsigned warp message from [sourceChainID] whose payload
+//
+//	is an AddressedCall from sourceAddress containing payloadBytes
 func newAddressedCallMessage(
 	tc tests.TestContext,
 	networkID uint32,
@@ -571,7 +573,8 @@ func newAddressedCallMessage(
 	return msg
 }
 
-// startL1TestPeer connects a test peer to [node] and returns it with a deque that collects every inbound message
+// startL1TestPeer connects a test peer to [node] and returns it with a deque that
+// collects every inbound message
 func startL1TestPeer(
 	tc tests.TestContext,
 	node *tmpnet.Node,
@@ -600,7 +603,7 @@ func startL1TestPeer(
 	return p, messages
 }
 
-// closes [p] and its message deque
+// closeTestPeer closes [p] and its message deque
 func closeTestPeer(
 	tc tests.TestContext,
 	p *peer.Peer,
@@ -613,7 +616,8 @@ func closeTestPeer(
 	require.NoError(p.AwaitClosed(tc.DefaultContext()))
 }
 
-// requestWarpSignature requests that [p] signs [msg], optionally providing s justification, and returns the resulting BLS signature.
+// requestWarpSignature requests that [p] signs [msg], optionally providing a justification,
+// and returns the resulting BLS signature.
 func requestWarpSignature(
 	tc tests.TestContext,
 	p *peer.Peer,
@@ -639,7 +643,8 @@ func requestWarpSignature(
 	return signature
 }
 
-// verifyPChainAttestation verifies that the P-Chain attests to [payload] by requesting a signature over it from [p] and verifying the signature against [signerPK]
+// verifyPChainAttestation verifies that the P-Chain attests to [payload] by requesting
+// a signature over it from [p] and verifying the signature against [signerPK]
 func verifyPChainAttestation(
 	tc tests.TestContext,
 	p *peer.Peer,
@@ -656,7 +661,8 @@ func verifyPChainAttestation(
 	require.True(bls.Verify(signerPK, signature, unsignedMessage.Bytes()))
 }
 
-// verifyValidatorSet checks that the subnet validator set at the current heigt matches [expectedValidators]
+// verifyValidatorSet checks that the subnet validator set at the current height
+// matches [expectedValidators]
 func verifyValidatorSet(
 	tc tests.TestContext,
 	pClient *platformvm.Client,
@@ -747,7 +753,8 @@ type l1Manager struct {
 	acceptanceURI string
 }
 
-// registerValidator signs [message] as the manager and issues the RegisterL1ValidatorTx, funding the validator with [balance] and proving ownership of its BLS key with [pop]
+// registerValidator signs [message] as the manager and issues the RegisterL1ValidatorTx,
+// funding the validator with [balance] and proving ownership of its BLS key with [pop]
 func (m *l1Manager) registerValidator(
 	tc tests.TestContext,
 	message *warpmessage.RegisterL1Validator,

--- a/tests/e2e/p/l1.go
+++ b/tests/e2e/p/l1.go
@@ -682,7 +682,6 @@ func verifyValidatorSet(
 	allValidators, err := pClient.GetAllValidatorsAt(tc.DefaultContext(), platformapi.Height(height))
 	require.NoError(err)
 	require.Equal(flattenedExpectedValidators, allValidators[subnetID])
-
 }
 
 // advanceProposerVMPChainHeight ensures that the proposervm's referenced P-Chain height advances past the current height and advancing the epoch by issuing a dummy transaction.
@@ -744,7 +743,7 @@ type l1Manager struct {
 	networkID    uint32
 	chainID      ids.ID
 	address      []byte
-	// acceptanceURI is the API URI polled to confirm issued txs are accpeted.
+	// acceptanceURI is the API URI polled to confirm issued txs are accepted.
 	acceptanceURI string
 }
 
@@ -755,7 +754,6 @@ func (m *l1Manager) registerValidator(
 	balance uint64,
 	pop [bls.SignatureLen]byte,
 ) {
-
 	require := require.New(tc)
 	tc.By("creating the unsigned warp message")
 	unsigned := newAddressedCallMessage(tc, m.networkID, m.chainID, m.address, message.Bytes())
@@ -818,7 +816,6 @@ func (m *l1Manager) setValidatorWeight(
 		require.NoError(err)
 		awaitTxAccepted(tc, m.acceptanceURI, tx.ID())
 	})
-
 }
 
 func wrapWarpSignatureRequest(


### PR DESCRIPTION
## Why this should be merged
Cleaner and more extendible e2e test for l1.go. it will make review for the e2e tests for createL1Tx much simpler. 

## How this works
extracted code that we will need for future tests into helper methods to avoid copying and pasting code.

## How this was tested
Ran the test and it passes as usual.

## Need to be documented in RELEASES.md?
No