### PR TITLE
test(cchain): Unblock WaitForEvent on slow tests

### DIFF
--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -219,14 +219,6 @@ func withVMTime(startTime time.Time) (sutOption, *saetest.Clock) {
 	return opt, c
 }
 
-// nowFunc returns c.Now, falling back to [time.Now] if c is nil.
-func nowFunc(c *saetest.Clock) func() time.Time {
-	if c == nil {
-		return time.Now
-	}
-	return c.Now
-}
-
 // withPriceTarget sets [config.PriceTarget] on the SUT.
 func withPriceTarget(p gas.Price) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
@@ -269,6 +261,7 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 			nodeID:     ids.GenerateTestNodeID(),
 			networkID:  constants.UnitTestID,
 			validators: warptest.NewValidators(tb, 0),
+			clock:      saetest.NewClock(testStartTime, time.Millisecond),
 			vmConfig:   defaultConfig(),
 			db:         memdb.New(),
 			state:      snow.NormalOp,
@@ -277,7 +270,7 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 		vm = &VM{
 			pullGossipPeriod: 100 * time.Millisecond,
 			pushGossipPeriod: 100 * time.Millisecond,
-			now:              nowFunc(cfg.clock),
+			now:              cfg.clock.Now,
 		}
 		db = cfg.db
 	)
@@ -921,8 +914,7 @@ func TestBuildBlockOnProcessing(t *testing.T) {
 	for i, sk := range keys {
 		addrs[i] = sk.EthAddress()
 	}
-	timeOpt, _ := withVMTime(testStartTime)
-	ctx, sut := newSUT(t, withMaxAllocFor(addrs...), timeOpt)
+	ctx, sut := newSUT(t, withMaxAllocFor(addrs...))
 
 	var (
 		preference = sut.lastAccepted(ctx, t)
@@ -1417,10 +1409,8 @@ func TestDynamicPriceExponent(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			key := txtest.NewKey(t)
-			timeOpt, _ := withVMTime(testStartTime)
 			opts := []sutOption{
 				withMaxAllocFor(key.EthAddress()),
-				timeOpt,
 			}
 			if test.desired != nil {
 				opts = append(opts, withPriceTarget(*test.desired))
@@ -1472,10 +1462,8 @@ func TestDynamicTargetExponent(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			key := txtest.NewKey(t)
-			timeOpt, _ := withVMTime(testStartTime)
 			opts := []sutOption{
 				withMaxAllocFor(key.EthAddress()),
-				timeOpt,
 			}
 			if test.desired != nil {
 				opts = append(opts, withGasTarget(*test.desired))
@@ -1535,7 +1523,7 @@ func TestDynamicMinDelayExcess(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			key := txtest.NewKey(t)
-			timeOpt, _ := withVMTime(testStartTime)
+			timeOpt, clock := withVMTime(testStartTime)
 			opts := []sutOption{withMaxAllocFor(key.EthAddress()), timeOpt}
 			if test.desired != nil {
 				opts = append(opts, withMinDelayTarget(*test.desired))
@@ -1549,6 +1537,7 @@ func TestDynamicMinDelayExcess(t *testing.T) {
 				require.NotNilf(t, he.MinDelayExcess, "block %d %T.MinDelayExcess", blk.Height(), he)
 				got := dynamic.DelayExponent(*he.MinDelayExcess)
 				assert.Equalf(t, wantExponent, got, "block %d %T.MinDelayExcess", blk.Height(), he)
+				clock.Advance(got.DelayDuration())
 			}
 		})
 	}
@@ -1599,11 +1588,12 @@ func TestGasRefundsDisabled(t *testing.T) {
 
 func TestVerifyRejectsBlockTimeBelowMinDelay(t *testing.T) {
 	key := txtest.NewKey(t)
-	timeOpt, _ := withVMTime(testStartTime)
+	timeOpt, clock := withVMTime(testStartTime)
 	ctx, sut := newSUT(t, withMaxAllocFor(key.EthAddress()), timeOpt)
 	w := newWallet(key, sut.ctx, sut.Client)
 
 	parent := sut.issueAndExecute(ctx, t, w.newMinimalTx(t))
+	clock.Set(earliestBuildTime(parent))
 	require.NoErrorf(t, sut.IssueTx(ctx, w.newMinimalTx(t)), "%T.IssueTx()", sut.Client)
 	child := sut.buildVerify(ctx, t, sut.lastAccepted(ctx, t))
 
@@ -1812,15 +1802,20 @@ func TestPreHeliconBlocksDisallowed(t *testing.T) {
 // block marks the warp precompile's account as non-empty when the genesis
 // predates Durango.
 func TestWarpPrecompileActivation(t *testing.T) {
+	const upgradeThreshold = 5 * time.Second
 	key := txtest.NewKey(t)
+	timeOpt, vmTime := withVMTime(upgrade.InitiallyActiveTime)
 	ctx, sut := newSUT(t,
 		withMaxAllocFor(key.EthAddress()),
-		withUpgradeTime(upgradetest.Durango, upgrade.InitiallyActiveTime.Add(5*time.Second)),
+		withUpgradeTime(upgradetest.Durango, upgrade.InitiallyActiveTime.Add(upgradeThreshold)),
+		timeOpt,
 	)
 
 	genesisState, err := sut.LastExecutedState()
 	require.NoErrorf(t, err, "%T.LastExecutedState()", sut.VM)
 	require.Empty(t, genesisState.GetCode(corethwarp.ContractAddress), "warp precompile code in pre-Durango genesis state")
+
+	vmTime.Advance(upgradeThreshold) // activate Durango in next block
 
 	stx := newWallet(key, sut.ctx, sut.Client).newMinimalTx(t)
 	sut.issueAndExecute(ctx, t, stx)

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -95,6 +95,7 @@ type SUT struct {
 	sender    *saetest.Sender
 	ethclient *ethclient.Client
 	p2pclient *saetest.CapturingPeer
+	clock     *saetest.Clock // MAY be nil
 }
 
 func (s *SUT) NodeID() ids.NodeID      { return s.ctx.NodeID }
@@ -106,7 +107,7 @@ type (
 		nodeID     ids.NodeID
 		networkID  uint32
 		validators *warptest.Validators
-		now        func() time.Time
+		clock      *saetest.Clock
 		vmConfig   config
 		db         database.Database
 		state      snow.State
@@ -207,22 +208,23 @@ func withUpgradeTime(fork upgradetest.Fork, t time.Time) sutOption {
 var testStartTime = upgrade.InitiallyActiveTime.Add(dynamic.InitialDelayExponent.DelayDuration())
 
 // withVMTime fixes the SUT's clock at startTime and returns a handle that lets
-// the test move the clock forward (e.g. past Tau to settle a block).
+// the test move the clock forward (e.g. past Tau to settle a block). It also
+// makes [SUT.waitForPendingTxs] automatically advance the clock past the
+// ACP-226 min-delay pacing timer; see [SUT.unblockWaitForEvent].
 func withVMTime(startTime time.Time) (sutOption, *saetest.Clock) {
 	c := saetest.NewClock(startTime, time.Millisecond)
 	opt := options.Func[sutConfig](func(cfg *sutConfig) {
-		cfg.now = c.Now
+		cfg.clock = c
 	})
 	return opt, c
 }
 
-// unblockWaitForEvent advances clock to the earliest time a child of parent
-// may be built, so the next [VM.WaitForEvent] returns without parking on the
-// ACP-226 min-delay pacing timer. It never moves the clock backwards.
-func unblockWaitForEvent(clock *saetest.Clock, parent *blocks.Block) {
-	if t := earliestBuildTime(parent); clock.Now().Before(t) {
-		clock.Set(t)
+// nowFunc returns c.Now, falling back to [time.Now] if c is nil.
+func nowFunc(c *saetest.Clock) func() time.Time {
+	if c == nil {
+		return time.Now
 	}
+	return c.Now
 }
 
 // withPriceTarget sets [config.PriceTarget] on the SUT.
@@ -267,7 +269,6 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 			nodeID:     ids.GenerateTestNodeID(),
 			networkID:  constants.UnitTestID,
 			validators: warptest.NewValidators(tb, 0),
-			now:        time.Now,
 			vmConfig:   defaultConfig(),
 			db:         memdb.New(),
 			state:      snow.NormalOp,
@@ -276,7 +277,7 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 		vm = &VM{
 			pullGossipPeriod: 100 * time.Millisecond,
 			pushGossipPeriod: 100 * time.Millisecond,
-			now:              cfg.now,
+			now:              nowFunc(cfg.clock),
 		}
 		db = cfg.db
 	)
@@ -341,6 +342,7 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 		memory:    memory,
 		sender:    appSender,
 		p2pclient: saetest.NewCapturingPeer(tb, validatorIDs),
+		clock:     cfg.clock,
 	}
 
 	if !cfg.skipRPCTransport {
@@ -589,9 +591,21 @@ func (s *SUT) lastAccepted(ctx context.Context, tb testing.TB) ids.ID {
 	return id
 }
 
+// unblockWaitForEvent advances the [withVMTime] clock to ensure that
+// [VM.WaitForEvent] will not throttle for ACP-226 delays.
+func (s *SUT) unblockWaitForEvent() {
+	if s.clock == nil {
+		return
+	}
+	if t := earliestBuildTime(s.VM.VM.GetPreference()); s.clock.Now().Before(t) {
+		s.clock.Set(t)
+	}
+}
+
 func (s *SUT) waitForPendingTxs(ctx context.Context, tb testing.TB) {
 	tb.Helper()
 
+	s.unblockWaitForEvent()
 	e, err := s.WaitForEvent(ctx)
 	require.NoErrorf(tb, err, "%T.WaitForEvent()", s.VM)
 	assert.Equalf(tb, snowcommon.PendingTxs, e, "%T.WaitForEvent() event", s.VM)
@@ -907,7 +921,7 @@ func TestBuildBlockOnProcessing(t *testing.T) {
 	for i, sk := range keys {
 		addrs[i] = sk.EthAddress()
 	}
-	timeOpt, clock := withVMTime(testStartTime)
+	timeOpt, _ := withVMTime(testStartTime)
 	ctx, sut := newSUT(t, withMaxAllocFor(addrs...), timeOpt)
 
 	var (
@@ -926,7 +940,6 @@ func TestBuildBlockOnProcessing(t *testing.T) {
 		}
 		blocks[i] = block
 		preference = block.ID()
-		unblockWaitForEvent(clock, block)
 	}
 	for i, block := range blocks {
 		require.NoErrorf(t, sut.AcceptBlock(ctx, block), "%T.AcceptBlock(%d)", sut.VM, i)
@@ -1404,7 +1417,7 @@ func TestDynamicPriceExponent(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			key := txtest.NewKey(t)
-			timeOpt, clock := withVMTime(testStartTime)
+			timeOpt, _ := withVMTime(testStartTime)
 			opts := []sutOption{
 				withMaxAllocFor(key.EthAddress()),
 				timeOpt,
@@ -1426,8 +1439,6 @@ func TestDynamicPriceExponent(t *testing.T) {
 				wantBaseFee := new(big.Int).SetUint64(uint64(wantExponent.Price()))
 				require.NotNilf(t, header.BaseFee, "block %d %T.BaseFee", header.Number, header)
 				require.Zerof(t, wantBaseFee.Cmp(header.BaseFee), "block %d %T.BaseFee", header.Number, header)
-
-				unblockWaitForEvent(clock, blk)
 			}
 		})
 	}
@@ -1461,7 +1472,7 @@ func TestDynamicTargetExponent(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			key := txtest.NewKey(t)
-			timeOpt, clock := withVMTime(testStartTime)
+			timeOpt, _ := withVMTime(testStartTime)
 			opts := []sutOption{
 				withMaxAllocFor(key.EthAddress()),
 				timeOpt,
@@ -1485,7 +1496,6 @@ func TestDynamicTargetExponent(t *testing.T) {
 				assert.Equalf(t, wantGasLimit, header.GasLimit, "block %d %T.GasLimit", header.Number, header)
 
 				parentExponent = wantExponent
-				unblockWaitForEvent(clock, blk)
 			}
 		})
 	}
@@ -1525,7 +1535,7 @@ func TestDynamicMinDelayExcess(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			key := txtest.NewKey(t)
-			timeOpt, clock := withVMTime(testStartTime)
+			timeOpt, _ := withVMTime(testStartTime)
 			opts := []sutOption{withMaxAllocFor(key.EthAddress()), timeOpt}
 			if test.desired != nil {
 				opts = append(opts, withMinDelayTarget(*test.desired))
@@ -1539,7 +1549,6 @@ func TestDynamicMinDelayExcess(t *testing.T) {
 				require.NotNilf(t, he.MinDelayExcess, "block %d %T.MinDelayExcess", blk.Height(), he)
 				got := dynamic.DelayExponent(*he.MinDelayExcess)
 				assert.Equalf(t, wantExponent, got, "block %d %T.MinDelayExcess", blk.Height(), he)
-				unblockWaitForEvent(clock, blk)
 			}
 		})
 	}
@@ -1590,12 +1599,11 @@ func TestGasRefundsDisabled(t *testing.T) {
 
 func TestVerifyRejectsBlockTimeBelowMinDelay(t *testing.T) {
 	key := txtest.NewKey(t)
-	timeOpt, clock := withVMTime(testStartTime)
+	timeOpt, _ := withVMTime(testStartTime)
 	ctx, sut := newSUT(t, withMaxAllocFor(key.EthAddress()), timeOpt)
 	w := newWallet(key, sut.ctx, sut.Client)
 
 	parent := sut.issueAndExecute(ctx, t, w.newMinimalTx(t))
-	unblockWaitForEvent(clock, parent)
 	require.NoErrorf(t, sut.IssueTx(ctx, w.newMinimalTx(t)), "%T.IssueTx()", sut.Client)
 	child := sut.buildVerify(ctx, t, sut.lastAccepted(ctx, t))
 

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -216,6 +216,15 @@ func withVMTime(startTime time.Time) (sutOption, *saetest.Clock) {
 	return opt, c
 }
 
+// unblockWaitForEvent advances clock to the earliest time a child of parent
+// may be built, so the next [VM.WaitForEvent] returns without parking on the
+// ACP-226 min-delay pacing timer. It never moves the clock backwards.
+func unblockWaitForEvent(clock *saetest.Clock, parent *blocks.Block) {
+	if t := earliestBuildTime(parent); clock.Now().Before(t) {
+		clock.Set(t)
+	}
+}
+
 // withPriceTarget sets [config.PriceTarget] on the SUT.
 func withPriceTarget(p gas.Price) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
@@ -898,7 +907,8 @@ func TestBuildBlockOnProcessing(t *testing.T) {
 	for i, sk := range keys {
 		addrs[i] = sk.EthAddress()
 	}
-	ctx, sut := newSUT(t, withMaxAllocFor(addrs...))
+	timeOpt, clock := withVMTime(testStartTime)
+	ctx, sut := newSUT(t, withMaxAllocFor(addrs...), timeOpt)
 
 	var (
 		preference = sut.lastAccepted(ctx, t)
@@ -916,6 +926,7 @@ func TestBuildBlockOnProcessing(t *testing.T) {
 		}
 		blocks[i] = block
 		preference = block.ID()
+		unblockWaitForEvent(clock, block)
 	}
 	for i, block := range blocks {
 		require.NoErrorf(t, sut.AcceptBlock(ctx, block), "%T.AcceptBlock(%d)", sut.VM, i)
@@ -1393,8 +1404,10 @@ func TestDynamicPriceExponent(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			key := txtest.NewKey(t)
+			timeOpt, clock := withVMTime(testStartTime)
 			opts := []sutOption{
 				withMaxAllocFor(key.EthAddress()),
+				timeOpt,
 			}
 			if test.desired != nil {
 				opts = append(opts, withPriceTarget(*test.desired))
@@ -1413,6 +1426,8 @@ func TestDynamicPriceExponent(t *testing.T) {
 				wantBaseFee := new(big.Int).SetUint64(uint64(wantExponent.Price()))
 				require.NotNilf(t, header.BaseFee, "block %d %T.BaseFee", header.Number, header)
 				require.Zerof(t, wantBaseFee.Cmp(header.BaseFee), "block %d %T.BaseFee", header.Number, header)
+
+				unblockWaitForEvent(clock, blk)
 			}
 		})
 	}
@@ -1446,8 +1461,10 @@ func TestDynamicTargetExponent(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			key := txtest.NewKey(t)
+			timeOpt, clock := withVMTime(testStartTime)
 			opts := []sutOption{
 				withMaxAllocFor(key.EthAddress()),
+				timeOpt,
 			}
 			if test.desired != nil {
 				opts = append(opts, withGasTarget(*test.desired))
@@ -1468,6 +1485,7 @@ func TestDynamicTargetExponent(t *testing.T) {
 				assert.Equalf(t, wantGasLimit, header.GasLimit, "block %d %T.GasLimit", header.Number, header)
 
 				parentExponent = wantExponent
+				unblockWaitForEvent(clock, blk)
 			}
 		})
 	}
@@ -1521,7 +1539,7 @@ func TestDynamicMinDelayExcess(t *testing.T) {
 				require.NotNilf(t, he.MinDelayExcess, "block %d %T.MinDelayExcess", blk.Height(), he)
 				got := dynamic.DelayExponent(*he.MinDelayExcess)
 				assert.Equalf(t, wantExponent, got, "block %d %T.MinDelayExcess", blk.Height(), he)
-				clock.Advance(got.DelayDuration())
+				unblockWaitForEvent(clock, blk)
 			}
 		})
 	}
@@ -1577,7 +1595,7 @@ func TestVerifyRejectsBlockTimeBelowMinDelay(t *testing.T) {
 	w := newWallet(key, sut.ctx, sut.Client)
 
 	parent := sut.issueAndExecute(ctx, t, w.newMinimalTx(t))
-	clock.Set(earliestBuildTime(parent))
+	unblockWaitForEvent(clock, parent)
 	require.NoErrorf(t, sut.IssueTx(ctx, w.newMinimalTx(t)), "%T.IssueTx()", sut.Client)
 	child := sut.buildVerify(ctx, t, sut.lastAccepted(ctx, t))
 

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -95,7 +95,7 @@ type SUT struct {
 	sender    *saetest.Sender
 	ethclient *ethclient.Client
 	p2pclient *saetest.CapturingPeer
-	clock     *saetest.Clock // MAY be nil
+	clock     *saetest.Clock
 }
 
 func (s *SUT) NodeID() ids.NodeID      { return s.ctx.NodeID }
@@ -587,9 +587,6 @@ func (s *SUT) lastAccepted(ctx context.Context, tb testing.TB) ids.ID {
 // unblockWaitForEvent advances the [withVMTime] clock to ensure that
 // [VM.WaitForEvent] will not throttle for ACP-226 delays.
 func (s *SUT) unblockWaitForEvent() {
-	if s.clock == nil {
-		return
-	}
 	if t := earliestBuildTime(s.VM.VM.GetPreference()); s.clock.Now().Before(t) {
 		s.clock.Set(t)
 	}

--- a/vms/saevm/cchain/warp_test.go
+++ b/vms/saevm/cchain/warp_test.go
@@ -202,10 +202,12 @@ func TestReceiveWarpMessage(t *testing.T) {
 		vdrs       = warptest.NewValidators(t, 2)
 		warpLogger = common.Address{'l', 'o', 'g', 'g', 'e', 'r'}
 	)
+	timeOpt, clock := withVMTime(testStartTime)
 	ctx, sut := newSUT(t,
 		withMaxAllocFor(wallet.Addresses()...),
 		withAccount(warpLogger, types.Account{Code: forwardAndLogCode(t, corethwarp.ContractAddress)}),
 		withValidators(vdrs),
+		timeOpt,
 	)
 
 	getMessage, err := corethwarp.PackGetVerifiedWarpMessage(0)
@@ -344,6 +346,7 @@ func TestReceiveWarpMessage(t *testing.T) {
 
 			sut.waitForPendingEthTxs(ctx, t, tx)
 			built := sut.runConsensusLoop(ctx, t, withBlockContext(&block.Context{}))
+			unblockWaitForEvent(clock, built)
 			receipts := built.Receipts()
 			require.Lenf(t, receipts, 1, "%T.Receipts()", built)
 			receipt := receipts[0]

--- a/vms/saevm/cchain/warp_test.go
+++ b/vms/saevm/cchain/warp_test.go
@@ -202,7 +202,7 @@ func TestReceiveWarpMessage(t *testing.T) {
 		vdrs       = warptest.NewValidators(t, 2)
 		warpLogger = common.Address{'l', 'o', 'g', 'g', 'e', 'r'}
 	)
-	timeOpt, clock := withVMTime(testStartTime)
+	timeOpt, _ := withVMTime(testStartTime)
 	ctx, sut := newSUT(t,
 		withMaxAllocFor(wallet.Addresses()...),
 		withAccount(warpLogger, types.Account{Code: forwardAndLogCode(t, corethwarp.ContractAddress)}),
@@ -346,7 +346,6 @@ func TestReceiveWarpMessage(t *testing.T) {
 
 			sut.waitForPendingEthTxs(ctx, t, tx)
 			built := sut.runConsensusLoop(ctx, t, withBlockContext(&block.Context{}))
-			unblockWaitForEvent(clock, built)
 			receipts := built.Receipts()
 			require.Lenf(t, receipts, 1, "%T.Receipts()", built)
 			receipt := receipts[0]

--- a/vms/saevm/cchain/warp_test.go
+++ b/vms/saevm/cchain/warp_test.go
@@ -202,12 +202,10 @@ func TestReceiveWarpMessage(t *testing.T) {
 		vdrs       = warptest.NewValidators(t, 2)
 		warpLogger = common.Address{'l', 'o', 'g', 'g', 'e', 'r'}
 	)
-	timeOpt, _ := withVMTime(testStartTime)
 	ctx, sut := newSUT(t,
 		withMaxAllocFor(wallet.Addresses()...),
 		withAccount(warpLogger, types.Account{Code: forwardAndLogCode(t, corethwarp.ContractAddress)}),
 		withValidators(vdrs),
-		timeOpt,
 	)
 
 	getMessage, err := corethwarp.PackGetVerifiedWarpMessage(0)


### PR DESCRIPTION
## Why this should be merged

The C-Chain tests took 20s locally before these changes. Now, it's only 2s.

## How this works

I added a helper on the worst offenders to mock the clock. I'm not sure that this is the best way to fix this problem since it's not that maintainable, so open to options.

## How this was tested

Locally (check the time)

## Need to be documented in RELEASES.md?

No
