### PR TITLE
Refactor stateful block header verification

### DIFF
--- a/graft/subnet-evm/consensus/BUILD.bazel
+++ b/graft/subnet-evm/consensus/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "graft_go_test")
 
 package(default_visibility = [
     "//graft/subnet-evm:__subpackages__",
@@ -17,6 +18,17 @@ go_library(
         "//graft/subnet-evm/params",
         "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/state",
+        "@com_github_ava_labs_libevm//core/types",
+    ],
+)
+
+graft_go_test(
+    name = "consensus_test",
+    srcs = ["consensus_test.go"],
+    embed = [":consensus"],
+    deps = [
+        "//graft/subnet-evm/params",
+        "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/types",
     ],
 )

--- a/graft/subnet-evm/consensus/consensus.go
+++ b/graft/subnet-evm/consensus/consensus.go
@@ -55,6 +55,15 @@ type ChainHeaderReader interface {
 
 	// GetHeaderByHash retrieves a block header from the database by its hash.
 	GetHeaderByHash(hash common.Hash) *types.Header
+}
+
+// ChainReader defines the methods needed to access blocks and state-backed
+// configuration during full block verification.
+type ChainReader interface {
+	ChainHeaderReader
+
+	// GetBlock retrieves a block from the database by hash and number.
+	GetBlock(hash common.Hash, number uint64) *types.Block
 
 	// GetFeeConfigAt retrieves the fee config and last changed block number at block header.
 	GetFeeConfigAt(parent *types.Header) (commontype.FeeConfig, *big.Int, error)
@@ -62,15 +71,6 @@ type ChainHeaderReader interface {
 	// GetCoinbaseAt retrieves the configured coinbase address at [parent].
 	// If fee recipients are allowed, returns true in the second return value and a predefined address in the first value.
 	GetCoinbaseAt(parent *types.Header) (common.Address, bool, error)
-}
-
-// ChainReader defines a small collection of methods needed to access the local
-// blockchain during header and/or uncle verification.
-type ChainReader interface {
-	ChainHeaderReader
-
-	// GetBlock retrieves a block from the database by hash and number.
-	GetBlock(hash common.Hash, number uint64) *types.Block
 }
 
 // Engine is an algorithm agnostic consensus engine.
@@ -88,6 +88,10 @@ type Engine interface {
 	// header).
 	VerifyHeader(chain ChainHeaderReader, header *types.Header) error
 
+	// VerifyBlock checks state-dependent header fields that require the full
+	// block verification context.
+	VerifyBlock(chain ChainReader, block *types.Block) error
+
 	// VerifyUncles verifies that the given block's uncles conform to the consensus
 	// rules of a given engine.
 	VerifyUncles(chain ChainReader, block *types.Block) error
@@ -101,14 +105,14 @@ type Engine interface {
 	//
 	// Note: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).
-	Finalize(chain ChainHeaderReader, block *types.Block, parent *types.Header, state *state.StateDB, receipts []*types.Receipt) error
+	Finalize(chain ChainReader, block *types.Block, parent *types.Header, state *state.StateDB, receipts []*types.Receipt) error
 
 	// FinalizeAndAssemble runs any post-transaction state modifications (e.g. block
 	// rewards) and assembles the final block.
 	//
 	// Note: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).
-	FinalizeAndAssemble(chain ChainHeaderReader, header *types.Header, parent *types.Header, state *state.StateDB, txs []*types.Transaction,
+	FinalizeAndAssemble(chain ChainReader, header *types.Header, parent *types.Header, state *state.StateDB, txs []*types.Transaction,
 		uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error)
 
 	// CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty

--- a/graft/subnet-evm/consensus/consensus_test.go
+++ b/graft/subnet-evm/consensus/consensus_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package consensus
+
+import (
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
+
+	"github.com/ava-labs/avalanchego/graft/subnet-evm/params"
+)
+
+type headerOnlyReader struct{}
+
+func (*headerOnlyReader) Config() *params.ChainConfig {
+	return nil
+}
+
+func (*headerOnlyReader) CurrentHeader() *types.Header {
+	return nil
+}
+
+func (*headerOnlyReader) GetHeader(common.Hash, uint64) *types.Header {
+	return nil
+}
+
+func (*headerOnlyReader) GetHeaderByNumber(uint64) *types.Header {
+	return nil
+}
+
+func (*headerOnlyReader) GetHeaderByHash(common.Hash) *types.Header {
+	return nil
+}
+
+func TestChainHeaderReaderDoesNotRequireState(t *testing.T) {
+	if _, ok := any(&headerOnlyReader{}).(ChainHeaderReader); !ok {
+		t.Fatal("expected header-only implementation to satisfy ChainHeaderReader")
+	}
+}

--- a/graft/subnet-evm/consensus/dummy/consensus.go
+++ b/graft/subnet-evm/consensus/dummy/consensus.go
@@ -107,7 +107,7 @@ func NewFullFaker() *DummyEngine {
 }
 
 // verifyCoinbase checks that the coinbase is valid for the given [header] and [parent].
-func (eng *DummyEngine) verifyCoinbase(header *types.Header, parent *types.Header, chain consensus.ChainHeaderReader) error {
+func (eng *DummyEngine) verifyCoinbase(header *types.Header, parent *types.Header, chain consensus.ChainReader) error {
 	if eng.consensusMode.ModeSkipCoinbase {
 		return nil
 	}
@@ -129,7 +129,7 @@ func (eng *DummyEngine) verifyCoinbase(header *types.Header, parent *types.Heade
 	return nil
 }
 
-func verifyHeaderGasFields(config *extras.ChainConfig, header *types.Header, parent *types.Header, chain consensus.ChainHeaderReader) error {
+func verifyHeaderGasFields(config *extras.ChainConfig, header *types.Header, parent *types.Header, chain consensus.ChainReader) error {
 	// We verify the current block by checking the parent fee config
 	// this is because the current block cannot set the fee config for itself
 	// Fee config might depend on the state when precompile is activated
@@ -186,15 +186,6 @@ func (eng *DummyEngine) verifyHeader(chain consensus.ChainHeaderReader, header *
 		return err
 	}
 
-	// Ensure gas-related header fields are correct
-	if err := verifyHeaderGasFields(config, header, parent, chain); err != nil {
-		return err
-	}
-	// Ensure that coinbase is valid
-	if err := eng.verifyCoinbase(header, parent, chain); err != nil {
-		return err
-	}
-
 	// Verify that the block number is parent's +1
 	if diff := new(big.Int).Sub(header.Number, parent.Number); diff.Cmp(big.NewInt(1)) != 0 {
 		return consensus.ErrInvalidNumber
@@ -224,6 +215,24 @@ func (eng *DummyEngine) VerifyHeader(chain consensus.ChainHeaderReader, header *
 	return eng.verifyHeader(chain, header, parent, false)
 }
 
+func (eng *DummyEngine) VerifyBlock(chain consensus.ChainReader, block *types.Block) error {
+	if eng.consensusMode.ModeSkipHeader {
+		return nil
+	}
+
+	header := block.Header()
+	parent := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
+	if parent == nil {
+		return consensus.ErrUnknownAncestor
+	}
+
+	config := params.GetExtra(chain.Config())
+	if err := verifyHeaderGasFields(config, header, parent, chain); err != nil {
+		return err
+	}
+	return eng.verifyCoinbase(header, parent, chain)
+}
+
 func (*DummyEngine) VerifyUncles(_ consensus.ChainReader, block *types.Block) error {
 	if len(block.Uncles()) > 0 {
 		return errUnclesUnsupported
@@ -236,7 +245,7 @@ func (*DummyEngine) Prepare(_ consensus.ChainHeaderReader, header *types.Header)
 	return nil
 }
 
-func (eng *DummyEngine) Finalize(chain consensus.ChainHeaderReader, block *types.Block, parent *types.Header, _ *state.StateDB, receipts []*types.Receipt) error {
+func (eng *DummyEngine) Finalize(chain consensus.ChainReader, block *types.Block, parent *types.Header, _ *state.StateDB, receipts []*types.Receipt) error {
 	config := params.GetExtra(chain.Config())
 	timestamp := block.Time()
 	// we use the parent to determine the fee config
@@ -274,7 +283,7 @@ func (eng *DummyEngine) Finalize(chain consensus.ChainHeaderReader, block *types
 	return nil
 }
 
-func (eng *DummyEngine) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, parent *types.Header, state *state.StateDB, txs []*types.Transaction,
+func (eng *DummyEngine) FinalizeAndAssemble(chain consensus.ChainReader, header *types.Header, parent *types.Header, state *state.StateDB, txs []*types.Transaction,
 	uncles []*types.Header, receipts []*types.Receipt,
 ) (*types.Block, error) {
 	// we use the parent to determine the fee config

--- a/graft/subnet-evm/core/block_validator.go
+++ b/graft/subnet-evm/core/block_validator.go
@@ -71,6 +71,9 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	// Header validity is known at this point. Here we verify that uncle and transactions
 	// given in the block body match the header.
 	header := block.Header()
+	if err := v.engine.VerifyBlock(v.bc, block); err != nil {
+		return err
+	}
 	if err := v.engine.VerifyUncles(v.bc, block); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This change separates header-only consensus verification from checks that require parent state.

`ChainHeaderReader` currently exposes `GetFeeConfigAt` and `GetCoinbaseAt`. Both methods may load the state trie at the parent root, so any implementation used for header verification must also provide state access. That coupling prevents a truly header-only reader and mixes two different validation phases.

## Proposed solution

1. Remove `GetFeeConfigAt` and `GetCoinbaseAt` from `ChainHeaderReader`.
2. Move both methods to `ChainReader`, which represents the full block verification context.
3. Add `Engine.VerifyBlock` for state-dependent header checks that need the complete block and parent state.
4. Keep `Engine.VerifyHeader` limited to checks that can be performed with headers alone.
5. Invoke `VerifyBlock` from `BlockValidator.ValidateBody` before transaction execution.
6. Update finalization methods to accept `ChainReader` because they already read state-backed configuration.
7. Preserve full header-skip behavior in the dummy engine.

The dummy engine now performs extra-data structure and block-number checks during `VerifyHeader`. Fee configuration, gas limit, base fee, block gas cost, extra prefix, and configured coinbase checks run during `VerifyBlock`.

## Validation behavior

State-dependent fields are still rejected before transactions execute. The change moves those checks out of the header-only interface without weakening block validation or delaying rejection until state transition finalization.

## Test coverage

- Added a regression test proving that an implementation with header access only satisfies `ChainHeaderReader`.
- Ran the full Subnet-EVM consensus and core test suites.
- Compiled every package under `graft/subnet-evm`.
- Passed the Bazel Gazelle metadata test.
- Passed the Bazel consensus test target.

Fixes #4726
