### PR TITLE
fix(sae): Allow nodes without finalized hash to startup

### DIFF
--- a/vms/saevm/sae/always.go
+++ b/vms/saevm/sae/always.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/libevm/core"
-	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/triedb"
@@ -23,7 +22,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/network"
 
 	snowcommon "github.com/ava-labs/avalanchego/snow/engine/common"
-	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 var _ adaptor.ChainVM[*blocks.Block] = (*SinceGenesis[hook.Transaction])(nil)
@@ -84,15 +82,9 @@ func setupGenesis(db ethdb.Database, tdbConfig *triedb.Config, genesisBytes []by
 	if err := json.Unmarshal(genesisBytes, genesis); err != nil {
 		return nil, fmt.Errorf("json.Unmarshal(%T): %v", genesis, err)
 	}
-	config, hash, err := core.SetupGenesisBlock(db, tdb, genesis)
+	config, _, err := core.SetupGenesisBlock(db, tdb, genesis)
 	if err != nil {
 		return nil, fmt.Errorf("core.SetupGenesisBlock(...): %v", err)
-	}
-
-	// [NewVM] assumes that the genesis block is "finalized", which does not
-	// happen in [core.SetupGenesisBlock]. This MUST only happen once.
-	if rawdb.ReadFinalizedBlockHash(db) == (ethcommon.Hash{}) {
-		rawdb.WriteFinalizedBlockHash(db, hash)
 	}
 
 	return config, nil

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -55,7 +55,9 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 
 	lastSettledHash := rawdb.ReadFinalizedBlockHash(rec.db)
 	if lastSettledHash == (common.Hash{}) {
-		return nil, errors.New("no finalized block recorded")
+		// This is guaranteed to be written by the executor, but the synchronous VM may not have.
+		// Fall-back to head block
+		lastSettledHash = rawdb.ReadHeadBlockHash(rec.db)
 	}
 	lastSettledHeight := rawdb.ReadHeaderNumber(rec.db, lastSettledHash)
 	if lastSettledHeight == nil {

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 	"sync/atomic"
 
 	"github.com/ava-labs/libevm/common"
@@ -98,19 +99,16 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 
 func (rec *recovery) canonicalAfter(parent *blocks.Block) iter.Seq2[*blocks.Block, error] {
 	return func(yield func(*blocks.Block, error) bool) {
-		lastAcceptedHash := rawdb.ReadHeadFastBlockHash(rec.db)
-		if lastAcceptedHash == (common.Hash{}) {
-			// SAE writes this hash on [VM.AcceptBlock], so the set of accepted,
-			// asynchronous blocks MUST be empty.
-			return
-		}
+		// Old nodes may have written a head fast block hash at genesis, so non-empty is
+		// not sufficient to correct missing the activation.
+		nums, _ := rawdb.ReadAllCanonicalHashes(rec.db, parent.NumberU64()+1, math.MaxUint64, math.MaxInt)
 
-		for curr := parent; curr.Hash() != lastAcceptedHash; {
-			b, err := rec.newCanonicalBlock(curr.Height()+1, curr)
+		for _, num := range nums {
+			b, err := rec.newCanonicalBlock(num, parent)
 			if !yield(b, err) || err != nil {
 				return
 			}
-			curr = b
+			parent = b
 		}
 	}
 }

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -634,7 +634,9 @@ func (s *SUT) assertBlockHashInvariants(ctx context.Context, t *testing.T) {
 		// The RPC implementation doesn't use the database to resolve the block
 		// labels above, so we still need to check them.
 		assert.Equal(t, b.Hash(), rawdb.ReadHeadBlockHash(s.db), "rawdb.ReadHeadBlockHash() MUST reflect last-executed block")
-		assert.Equal(t, b.LastSettled().Hash(), rawdb.ReadFinalizedBlockHash(s.db), "rawdb.ReadFinalizedBlockHash() MUST reflect last-settled block")
+		if s.rawVM.last.settled.Load().NumberU64() > 0 {
+			assert.Equal(t, b.LastSettled().Hash(), rawdb.ReadFinalizedBlockHash(s.db), "rawdb.ReadFinalizedBlockHash() MUST reflect last-settled block")
+		}
 	})
 }
 


### PR DESCRIPTION
## Why this should be merged

Any nodes that updated after the helicon activation will see that they are in a crash loop due to a missing cursor.

## How this works

If the cursor is not found, use the head block. An alternative would be to correct this in `graft/coreth/core/blockchain.go`, by ensuring that `customrawdb.ReadAcceptorTip == rawdb.ReadFinalizedBlockHash`. However, this cannot correct the already fataling nodes, since they already wrote their transitioned cursor. Additionally, older C-Chain nodes may have written the `HeadFastBlockHash` cursor, which was unexpected

## How this was tested

I removed the requirement for the `always.go` to write the cursor, so it is now tested in the basic test flow.

## Need to be documented in RELEASES.md?

Maybe?
