### PR TITLE
Log SAE configs during startup

### DIFF
--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/libevm/core/rawdb"
+	"go.uber.org/zap"
 
 	_ "embed"
 
@@ -98,6 +99,10 @@ func (vm *VM) Initialize(
 	if err != nil {
 		return fmt.Errorf("parsing user config: %w", err)
 	}
+	vm.ctx.Log.Info("initializing C-Chain",
+		zap.Reflect("config", userConfig),
+	)
+
 	warpMessages, err := userConfig.WarpMessages()
 	if err != nil {
 		return fmt.Errorf("parsing warp messages: %w", err)

--- a/vms/saevm/sae/vm.go
+++ b/vms/saevm/sae/vm.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/event"
 	"github.com/ava-labs/libevm/params"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
@@ -99,7 +100,8 @@ type Config struct {
 	DBConfig      saedb.Config
 	RPCConfig     rpc.Config
 
-	Now func() time.Time // defaults to [time.Now] if nil
+	// Now defaults to [time.Now] if nil
+	Now func() time.Time `json:"-"`
 }
 
 // NewVM returns a new [VM] that is ready for use immediately upon return.
@@ -120,6 +122,10 @@ func NewVM[T hook.Transaction](
 	if cfg.Now == nil {
 		cfg.Now = time.Now
 	}
+	snowCtx.Log.Info("creating VM",
+		zap.Reflect("config", cfg),
+	)
+
 	reg, err := apimetrics.MakeAndRegister(snowCtx.Metrics, "sae")
 	if err != nil {
 		return nil, fmt.Errorf("registering sae metrics: %w", err)


### PR DESCRIPTION
## Why this should be merged

It is currently very hard to observe what chain configs are provided to SAE VMs.

## How this works

The C-Chain config already support json marshaling, so all we need to do there is add the log.

For the SAE config, we need to explicitly ignore the function to allow for json marshaling.

## How this was tested

Running locally:
```
[07-28|19:44:57.144] INFO <C Chain> cchain/vm.go:102 initializing C-Chain {"config": {"min-price-target":1000000000,"gas-target":2000000,"min-delay-target":1,"pruning-enabled":false,"commit-interval":4096,"trie-clean-cache":512,"snapshot-cache":256,"allow-missing-tries":false,"state-scheme":"","local-txs-enabled":false,"tx-pool-account-slots":16,"tx-pool-global-slots":5120,"allow-unprotected-txs":false,"batch-request-limit":1000,"warp-off-chain-messages":null}}
[07-28|19:44:57.145] INFO <C Chain> sae/vm.go:125 creating VM {"config": {"MempoolConfig":{"Locals":null,"NoLocals":true,"Journal":"transactions.rlp","Rejournal":3600000000000,"PriceLimit":1,"PriceBump":10,"AccountSlots":16,"GlobalSlots":5120,"AccountQueue":64,"GlobalQueue":1024,"Lifetime":10800000000000},"DBConfig":{"Scheme":"","TrieCacheMiB":512,"SnapshotCacheMiB":256,"Archival":true,"CommitInterval":4096,"AllowMissingTries":false},"RPCConfig":{"EnableDBInspecting":false,"EnableProfiling":false,"DisableTracing":false,"BlocksPerBloomSection":0,"EVMTimeout":0,"GasCap":0,"BatchRequestLimit":1000,"TxFeeCap":0,"AllowUnprotectedTxs":false}}}
```

## Need to be documented in RELEASES.md?
