### PR TITLE
fix(core): Potential crash loop at SAE upgrade

### DIFF
--- a/graft/coreth/core/blockchain.go
+++ b/graft/coreth/core/blockchain.go
@@ -761,6 +761,21 @@ func (bc *BlockChain) loadLastState(lastAcceptedHash common.Hash) error {
 		return fmt.Errorf("could not load last accepted block")
 	}
 
+	// SAE requires these values to be set to the last accepted hash on
+	// transition. Nodes that do not accept any blocks after upgrading before
+	// transition wouldn't otherwise correctly set these values.
+	{
+		lastAcceptedHash := bc.lastAccepted.Hash()
+		if finalized := rawdb.ReadFinalizedBlockHash(bc.db); finalized != lastAcceptedHash {
+			log.Info("Repairing finalized block hash", "from", finalized, "to", lastAcceptedHash)
+			rawdb.WriteFinalizedBlockHash(bc.db, lastAcceptedHash)
+		}
+		if headFast := rawdb.ReadHeadFastBlockHash(bc.db); headFast != lastAcceptedHash {
+			log.Info("Repairing head fast block hash", "from", headFast, "to", lastAcceptedHash)
+			rawdb.WriteHeadFastBlockHash(bc.db, lastAcceptedHash)
+		}
+	}
+
 	// This ensures that the head block is updated to the last accepted block on startup
 	if err := bc.setPreference(bc.lastAccepted); err != nil {
 		return fmt.Errorf("failed to set preference to last accepted block while loading last state: %w", err)

--- a/graft/coreth/core/blockchain_test.go
+++ b/graft/coreth/core/blockchain_test.go
@@ -46,6 +46,8 @@ import (
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/eth/tracers/logger"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/stretchr/testify/require"
+
 	ethparams "github.com/ava-labs/libevm/params"
 )
 
@@ -1388,4 +1390,52 @@ func TestEIP3651(t *testing.T) {
 	if actual.Cmp(expected) != 0 {
 		t.Fatalf("sender balance incorrect: expected %d, got %d", expected, actual)
 	}
+}
+
+func TestLegacyMarkersRepairedOnStartup(t *testing.T) {
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	db := rawdb.NewMemoryDatabase()
+	gspec := &Genesis{
+		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Alloc:  types.GenesisAlloc{addr: {Balance: big.NewInt(1000000)}},
+	}
+
+	blockchain, err := createBlockChain(db, pruningConfig, gspec, common.Hash{})
+	require.NoError(t, err, "createBlockChain()")
+
+	_, chain, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, 3, 10, func(int, *BlockGen) {})
+	require.NoError(t, err, "GenerateChainWithGenesis()")
+
+	_, err = blockchain.InsertChain(chain)
+	require.NoErrorf(t, err, "%T.InsertChain()", blockchain)
+	lastAccepted := chain[1]
+	for _, b := range chain[:2] {
+		require.NoErrorf(t, blockchain.Accept(b), "%T.Accept()", blockchain)
+	}
+	blockchain.DrainAcceptorQueue()
+	genesisHash := blockchain.genesisBlock.Hash()
+	lastAcceptedHash := lastAccepted.Hash()
+	lastVerifiedHash := chain[len(chain)-1].Hash()
+	blockchain.Stop()
+
+	require.Equal(t, lastAcceptedHash, rawdb.ReadFinalizedBlockHash(db), "finalized block hash after normal shutdown")
+	require.Equal(t, lastVerifiedHash, rawdb.ReadHeadFastBlockHash(db), "head fast block hash after normal shutdown")
+
+	// Emulate legacy markers
+	legacyFinalizedBlockKey := []byte("LastFinalized") // mirrors the unexported [rawdb] schema key
+	require.NoErrorf(t, db.Delete(legacyFinalizedBlockKey), "%T.Delete(%q)", db, legacyFinalizedBlockKey)
+	require.Equal(t, common.Hash{}, rawdb.ReadFinalizedBlockHash(db), "finalized block hash after simulating a legacy database")
+	rawdb.WriteHeadFastBlockHash(db, genesisHash)
+
+	restarted, err := createBlockChain(db, pruningConfig, gspec, lastAcceptedHash)
+	require.NoError(t, err, "createBlockChain() on restart")
+	defer restarted.Stop()
+
+	require.Equal(t, lastAcceptedHash, rawdb.ReadFinalizedBlockHash(db), "repaired finalized block hash")
+	require.Equal(t, lastAcceptedHash, rawdb.ReadHeadFastBlockHash(db), "repaired head fast block hash")
+
+	// The repair must use the last accepted block, whose state [BlockChain.Stop]
+	// commits, because the block settled from must have its state on disk.
+	require.True(t, restarted.HasState(lastAccepted.Root()), "state of repaired marker block is on disk")
 }

--- a/graft/subnet-evm/core/blockchain.go
+++ b/graft/subnet-evm/core/blockchain.go
@@ -778,6 +778,21 @@ func (bc *BlockChain) loadLastState(lastAcceptedHash common.Hash) error {
 		return fmt.Errorf("could not load last accepted block")
 	}
 
+	// SAE requires these values to be set to the last accepted hash on
+	// transition. Nodes that do not accept any blocks after upgrading before
+	// transition wouldn't otherwise correctly set these values.
+	{
+		lastAcceptedHash := bc.lastAccepted.Hash()
+		if finalized := rawdb.ReadFinalizedBlockHash(bc.db); finalized != lastAcceptedHash {
+			log.Info("Repairing finalized block hash", "from", finalized, "to", lastAcceptedHash)
+			rawdb.WriteFinalizedBlockHash(bc.db, lastAcceptedHash)
+		}
+		if headFast := rawdb.ReadHeadFastBlockHash(bc.db); headFast != lastAcceptedHash {
+			log.Info("Repairing head fast block hash", "from", headFast, "to", lastAcceptedHash)
+			rawdb.WriteHeadFastBlockHash(bc.db, lastAcceptedHash)
+		}
+	}
+
 	// This ensures that the head block is updated to the last accepted block on startup
 	if err := bc.setPreference(bc.lastAccepted); err != nil {
 		return fmt.Errorf("failed to set preference to last accepted block while loading last state: %w", err)
@@ -860,7 +875,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := bc.db.NewBatch()
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadBlockHash(batch, block.Hash())
+	rawdb.WriteHeadFastBlockHash(batch, block.Hash())
 	rawdb.WriteHeadBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 

--- a/graft/subnet-evm/core/blockchain_test.go
+++ b/graft/subnet-evm/core/blockchain_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/eth/tracers/logger"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/graft/evm/core/state/pruner"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/consensus/dummy"
@@ -1342,4 +1343,52 @@ func TestEIP3651(t *testing.T) {
 	if actual.Cmp(expected) != 0 {
 		t.Fatalf("sender balance incorrect: expected %d, got %d", expected, actual)
 	}
+}
+
+func TestLegacyMarkersRepairedOnStartup(t *testing.T) {
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	db := rawdb.NewMemoryDatabase()
+	gspec := &Genesis{
+		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Alloc:  types.GenesisAlloc{addr: {Balance: big.NewInt(1000000)}},
+	}
+
+	blockchain, err := createBlockChain(db, pruningConfig, gspec, common.Hash{})
+	require.NoError(t, err, "createBlockChain()")
+
+	_, chain, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, 3, 10, func(int, *BlockGen) {})
+	require.NoError(t, err, "GenerateChainWithGenesis()")
+
+	_, err = blockchain.InsertChain(chain)
+	require.NoErrorf(t, err, "%T.InsertChain()", blockchain)
+	lastAccepted := chain[1]
+	for _, b := range chain[:2] {
+		require.NoErrorf(t, blockchain.Accept(b), "%T.Accept()", blockchain)
+	}
+	blockchain.DrainAcceptorQueue()
+	genesisHash := blockchain.genesisBlock.Hash()
+	lastAcceptedHash := lastAccepted.Hash()
+	lastVerifiedHash := chain[len(chain)-1].Hash()
+	blockchain.Stop()
+
+	require.Equal(t, lastAcceptedHash, rawdb.ReadFinalizedBlockHash(db), "finalized block hash after normal shutdown")
+	require.Equal(t, lastVerifiedHash, rawdb.ReadHeadFastBlockHash(db), "head fast block hash after normal shutdown")
+
+	// Emulate legacy markers
+	legacyFinalizedBlockKey := []byte("LastFinalized") // mirrors the unexported [rawdb] schema key
+	require.NoErrorf(t, db.Delete(legacyFinalizedBlockKey), "%T.Delete(%q)", db, legacyFinalizedBlockKey)
+	require.Equal(t, common.Hash{}, rawdb.ReadFinalizedBlockHash(db), "finalized block hash after simulating a legacy database")
+	rawdb.WriteHeadFastBlockHash(db, genesisHash)
+
+	restarted, err := createBlockChain(db, pruningConfig, gspec, lastAcceptedHash)
+	require.NoError(t, err, "createBlockChain() on restart")
+	defer restarted.Stop()
+
+	require.Equal(t, lastAcceptedHash, rawdb.ReadFinalizedBlockHash(db), "repaired finalized block hash")
+	require.Equal(t, lastAcceptedHash, rawdb.ReadHeadFastBlockHash(db), "repaired head fast block hash")
+
+	// The repair must use the last accepted block, whose state [BlockChain.Stop]
+	// commits, because the block settled from must have its state on disk.
+	require.True(t, restarted.HasState(lastAccepted.Root()), "state of repaired marker block is on disk")
 }


### PR DESCRIPTION
## Why this should be merged

At Helicon Fuji activation, all nodes that had not yet upgraded were disconnected from the network, as expected. They should have been able to upgrade to the newer version, rejoin the network, and continue. However, they entered a crash loop since both the finalized block hash didn't exist and the head fast block hash was outdated.

An alternative to #5747 that can be used before the nodes hit the crash loop.

## How this works

On startup of transition VM, if the node has not yet transitioned, it will start up a single time in coreth/subnet-evm. We can use this time to repair the database. This didn't work for the already broken nodes since the transitioned marker had been placed.

## How this was tested

UT that starts up the block-chain after clobbering the pointers in a historical-accurate way.

## Need to be documented in RELEASES.md?

No