### PR TITLE
fix(bazel): pin macOS CC to the host clang and exclude .claude from Gazelle

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,4 @@
+.claude
 .direnv
 .bazel/patches/build_files
 bazel-avalanchego

--- a/.bazelrc
+++ b/.bazelrc
@@ -47,6 +47,10 @@ test:norace --@io_bazel_rules_go//go/config:race=false
 build --action_env=CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"
 build --action_env=CGO_ENABLED=1
 
+# macos: Bazel reads CC from the client environment, which in the nix dev shell is 
+# nix's clang wrapper, whose sysroot comes from the NIX_CFLAGS_COMPILE that Bazel 
+# strips from action environments, failing the cgo stdlib build on a missing resolv.h.
+build:macos --repo_env=CC=/usr/bin/clang
 # macOS: Use the default CommandLineTools location (also used by GitHub Actions
 # runners for CI). Hosts with a different active Apple toolchain can either rely on
 # direnv to create `.bazelrc.local` with appropriate values or run `task

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@ exports_files(["BUILD.bazel"])
 
 # gazelle:prefix github.com/ava-labs/avalanchego
 # gazelle:exclude tools
+# gazelle:exclude .claude
 # gazelle:exclude .direnv
 # gazelle:exclude .bazel/patches/build_files
 # gazelle:proto disable_global

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -713,10 +713,24 @@ directory and macOS SDK and writes those values to `.bazelrc.local`.
 The script can also be run directly and is invoked automatically by
 direnv.
 
+Both entrypoints run inside the nix dev shell, whose `DEVELOPER_DIR`
+and `SDKROOT` would make `xcode-select` and `xcrun` report nix's SDK.
+The script clears them and calls those binaries by absolute path, so a
+hand-exported `DEVELOPER_DIR` is ignored — use `sudo xcode-select -s`.
+
 When invoked by direnv, generation is best-effort: failures are shown
 as warnings during shell entry but do not prevent entering the repo.
 When run directly, the script exits non-zero on discovery failures so
 manual setup problems remain actionable.
+
+### The macOS C compiler
+
+`.bazelrc` pins `--repo_env=CC=/usr/bin/clang`. Bazel resolves the
+compiler from `CC` in the client environment, which in the nix dev
+shell is nix's clang wrapper; that wrapper takes its sysroot from
+`NIX_CFLAGS_COMPILE`, which Bazel strips from action environments,
+failing the cgo stdlib build on a missing `resolv.h`. `DEVELOPER_DIR`
+and `SDKROOT` do not help — they select an SDK, not a compiler.
 
 ## Adding a New Go Module
 
@@ -765,6 +779,28 @@ secp256k1), verify that:
 1. Patches in `.bazel/patches/` are applied correctly in `MODULE.bazel`
 2. The `gazelle_override` with `build_file_generation = "off"` is set
    for packages with custom BUILD files
+
+#### Missing SDK headers on macOS (`resolv.h`)
+
+```
+GoStdlib external/rules_go+/stdlib_/pkg failed: (Exit 1)
+.../net/internal/cgotest/resstate.go:10:10: fatal error: resolv.h: No such file or directory
+```
+
+means Bazel picked a compiler with no usable sysroot — see
+[The macOS C compiler](#the-macos-c-compiler). Check which one:
+
+```bash
+grep -r 'exec ' "$(./scripts/nix_run.sh bazelisk info output_base)"/external/*local_config_cc/cc_wrapper.sh
+```
+
+If that names a `/nix/store/...` binary rather than `/usr/bin/clang`,
+something is overriding `CC`. `local_config_cc` is cached in the output
+base, so force a re-resolve after fixing it:
+
+```bash
+./scripts/nix_run.sh bazelisk sync --configure
+```
 
 ### gnark-crypto assembly errors
 

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -780,28 +780,6 @@ secp256k1), verify that:
 2. The `gazelle_override` with `build_file_generation = "off"` is set
    for packages with custom BUILD files
 
-#### Missing SDK headers on macOS (`resolv.h`)
-
-```
-GoStdlib external/rules_go+/stdlib_/pkg failed: (Exit 1)
-.../net/internal/cgotest/resstate.go:10:10: fatal error: resolv.h: No such file or directory
-```
-
-means Bazel picked a compiler with no usable sysroot — see
-[The macOS C compiler](#the-macos-c-compiler). Check which one:
-
-```bash
-grep -r 'exec ' "$(./scripts/nix_run.sh bazelisk info output_base)"/external/*local_config_cc/cc_wrapper.sh
-```
-
-If that names a `/nix/store/...` binary rather than `/usr/bin/clang`,
-something is overriding `CC`. `local_config_cc` is cached in the output
-base, so force a re-resolve after fixing it:
-
-```bash
-./scripts/nix_run.sh bazelisk sync --configure
-```
-
 ### gnark-crypto assembly errors
 
 If you see errors like:

--- a/scripts/generate_bazelrc_local.sh
+++ b/scripts/generate_bazelrc_local.sh
@@ -18,14 +18,20 @@ OUT_PATH="${REPO_ROOT}/.bazelrc.local"
 ERR_FILE="$(mktemp)"
 trap 'rm -f "$ERR_FILE"' EXIT
 
-if ! DEVELOPER_DIR="$(xcode-select -p 2>"$ERR_FILE")"; then
+# Both callers run this inside the nix dev shell, whose DEVELOPER_DIR and SDKROOT
+# would make xcode-select and xcrun report nix's SDK instead of the host's.
+host_toolchain() {
+  env -u DEVELOPER_DIR -u SDKROOT "$@"
+}
+
+if ! DEVELOPER_DIR="$(host_toolchain /usr/bin/xcode-select -p 2>"$ERR_FILE")"; then
   echo "error: failed to determine the active Apple developer directory via xcode-select -p" >&2
   cat "$ERR_FILE" >&2
   echo "hint: install Apple CommandLineTools with 'xcode-select --install' or select an existing Xcode with 'sudo xcode-select -s /Applications/Xcode.app/Contents/Developer'" >&2
   exit 1
 fi
 
-if ! SDKROOT="$(xcrun --sdk macosx --show-sdk-path 2>"$ERR_FILE")"; then
+if ! SDKROOT="$(host_toolchain /usr/bin/xcrun --sdk macosx --show-sdk-path 2>"$ERR_FILE")"; then
   echo "error: failed to determine the macOS SDK path via xcrun --sdk macosx --show-sdk-path" >&2
   cat "$ERR_FILE" >&2
   echo "hint: install Apple CommandLineTools with 'xcode-select --install' or ensure the selected Xcode/CommandLineTools installation provides the macOS SDK" >&2


### PR DESCRIPTION
## Why this should be merged

On my macOS bare machine, `task bazel-generate-metadata` and any cgo-touching Bazel build fail with `fatal error: resolv.h: No such file or directory`. This has been broken for awhile, but has annoyed me when trying to work outside my VM. I am fairly confident that this affects anyone using the repo's own nix + direnv flow on MacOS, which is probably just me -- I don't know who else adopted @maru-ava's `direnv` tooling. 

In this PR seperately, (admittedly not as tightly scoped as it perhaps should be), Gazelle indexes the git worktrees Claude Code creates under `.claude/worktrees/`. Each is a full copy of the tree, so every internal import becomes
ambiguous and Gazelle drops the dep from the generated files if you run the command with worktrees going. 

## How this works

@claude: 

> Bazel resolves the C compiler from `CC` in the *client* environment, which inside the nix dev shell is nix's clang wrapper. That wrapper takes its sysroot from `NIX_CFLAGS_COMPILE`, which Bazel strips from action environments, leaving no usable sysroot. `DEVELOPER_DIR`/`SDKROOT` do not help — they select an SDK, not a compiler.
> 
> - `.bazelrc`: pin `--repo_env=CC=/usr/bin/clang` for macOS.
> - `scripts/generate_bazelrc_local.sh`: both callers run it inside the dev shell, so
>   `xcode-select`/`xcrun` reported nix's SDK. It now clears those variables and queries
>   the host toolchain.
> - `.bazelignore` + root `BUILD.bazel`: exclude `.claude` from Gazelle.
> - `docs/bazel.md`: document the compiler pin and the `resolv.h` failure mode.

## How this was tested

Watch! 

https://github.com/user-attachments/assets/c4e1defd-b820-4605-9089-676a9f3b25aa



## Need to be documented in RELEASES.md?

No