### PR TITLE
fix(subnet-evm/params): use semantic equality for state upgrade compat check

### DIFF
--- a/graft/subnet-evm/params/extras/state_upgrade.go
+++ b/graft/subnet-evm/params/extras/state_upgrade.go
@@ -45,9 +45,7 @@ type StateUpgradeAccount struct {
 // Equal reports whether s and other describe the same state modifications.
 // It must treat a config as equal to its own JSON round-trip, since the copy
 // persisted by WriteChainConfig is compared against a fresh parse of the
-// upgrade bytes on every startup: nil and empty code/storage are equivalent
-// (matching their len/range handling in stateupgrade.Configure), and balance
-// changes are compared by value regardless of hex or decimal representation.
+// upgrade bytes on every startup.
 func (s *StateUpgrade) Equal(other *StateUpgrade) bool {
 	if s == nil || other == nil {
 		return s == other

--- a/graft/subnet-evm/params/extras/state_upgrade.go
+++ b/graft/subnet-evm/params/extras/state_upgrade.go
@@ -4,13 +4,17 @@
 package extras
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
+	"maps"
+	"math/big"
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/common/math"
+
+	"github.com/ava-labs/avalanchego/graft/evm/utils"
 
 	ethparams "github.com/ava-labs/libevm/params"
 )
@@ -38,8 +42,31 @@ type StateUpgradeAccount struct {
 	BalanceChange *math.HexOrDecimal256       `json:"balanceChange,omitempty"`
 }
 
+// Equal reports whether s and other describe the same state modifications.
+// It must treat a config as equal to its own JSON round-trip, since the copy
+// persisted by WriteChainConfig is compared against a fresh parse of the
+// upgrade bytes on every startup: nil and empty code/storage are equivalent
+// (matching their len/range handling in stateupgrade.Configure), and balance
+// changes are compared by value regardless of hex or decimal representation.
 func (s *StateUpgrade) Equal(other *StateUpgrade) bool {
-	return reflect.DeepEqual(s, other)
+	if s == nil || other == nil {
+		return s == other
+	}
+	return utils.Uint64PtrEqual(s.BlockTimestamp, other.BlockTimestamp) &&
+		maps.EqualFunc(s.StateUpgradeAccounts, other.StateUpgradeAccounts, StateUpgradeAccount.equal)
+}
+
+func (s StateUpgradeAccount) equal(other StateUpgradeAccount) bool {
+	return bytes.Equal(s.Code, other.Code) &&
+		maps.Equal(s.Storage, other.Storage) &&
+		balanceChangeEqual(s.BalanceChange, other.BalanceChange)
+}
+
+func balanceChangeEqual(a, b *math.HexOrDecimal256) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return (*big.Int)(a).Cmp((*big.Int)(b)) == 0
 }
 
 // verifyStateUpgrades checks [c.StateUpgrades] is well formed:

--- a/graft/subnet-evm/params/extras/state_upgrade.go
+++ b/graft/subnet-evm/params/extras/state_upgrade.go
@@ -59,14 +59,7 @@ func (s *StateUpgrade) Equal(other *StateUpgrade) bool {
 func (s StateUpgradeAccount) equal(other StateUpgradeAccount) bool {
 	return bytes.Equal(s.Code, other.Code) &&
 		maps.Equal(s.Storage, other.Storage) &&
-		balanceChangeEqual(s.BalanceChange, other.BalanceChange)
-}
-
-func balanceChangeEqual(a, b *math.HexOrDecimal256) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return (*big.Int)(a).Cmp((*big.Int)(b)) == 0
+		utils.BigEqual((*big.Int)(s.BalanceChange), (*big.Int)(other.BalanceChange))
 }
 
 // verifyStateUpgrades checks [c.StateUpgrades] is well formed:

--- a/graft/subnet-evm/params/extras/state_upgrade_test.go
+++ b/graft/subnet-evm/params/extras/state_upgrade_test.go
@@ -152,6 +152,99 @@ func TestCheckCompatibleStateUpgrades(t *testing.T) {
 	}
 }
 
+func TestStateUpgradeEqual(t *testing.T) {
+	tests := []struct {
+		name    string
+		upgrade string
+		// other is compared against upgrade; if empty, the JSON round-trip
+		// of upgrade is used, mirroring how the config persisted by
+		// WriteChainConfig is compared against a fresh parse of the
+		// upgrade bytes at startup.
+		other string
+		want  bool
+	}{
+		{
+			name:    "round-trip full entry",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234","storage":{"0x0000000000000000000000000000000000000000000000000000000000000001":"0x0000000000000000000000000000000000000000000000000000000000000002"},"balanceChange":"100"}}}`,
+			want:    true,
+		},
+		{
+			name:    "round-trip empty storage dropped by omitempty",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234","storage":{}}}}`,
+			want:    true,
+		},
+		{
+			name:    "round-trip empty code dropped by omitempty",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x","balanceChange":"0x1"}}}`,
+			want:    true,
+		},
+		{
+			name:    "round-trip decimal zero balance change re-marshaled as hex",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"balanceChange":"0"}}}`,
+			want:    true,
+		},
+		{
+			name:    "hex and decimal balance change compare by value",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"balanceChange":"100"}}}`,
+			other:   `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"balanceChange":"0x64"}}}`,
+			want:    true,
+		},
+		{
+			name:    "different timestamp",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234"}}}`,
+			other:   `{"blockTimestamp":2,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234"}}}`,
+			want:    false,
+		},
+		{
+			name:    "different code",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234"}}}`,
+			other:   `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x125678"}}}`,
+			want:    false,
+		},
+		{
+			name:    "different storage value",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"storage":{"0x0000000000000000000000000000000000000000000000000000000000000001":"0x0000000000000000000000000000000000000000000000000000000000000002"}}}}`,
+			other:   `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"storage":{"0x0000000000000000000000000000000000000000000000000000000000000001":"0x0000000000000000000000000000000000000000000000000000000000000003"}}}}`,
+			want:    false,
+		},
+		{
+			name:    "different balance change",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"balanceChange":"1"}}}`,
+			other:   `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"balanceChange":"2"}}}`,
+			want:    false,
+		},
+		{
+			name:    "removed balance change",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234","balanceChange":"0"}}}`,
+			other:   `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234"}}}`,
+			want:    false,
+		},
+		{
+			name:    "extra account",
+			upgrade: `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234"}}}`,
+			other:   `{"blockTimestamp":1,"accounts":{"0x0100000000000000000000000000000000000000":{"code":"0x1234"},"0x0200000000000000000000000000000000000000":{"code":"0xff"}}}`,
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			var a StateUpgrade
+			require.NoError(json.Unmarshal([]byte(tt.upgrade), &a))
+			var b StateUpgrade
+			if tt.other == "" {
+				roundTripped, err := json.Marshal(a)
+				require.NoError(err)
+				require.NoError(json.Unmarshal(roundTripped, &b))
+			} else {
+				require.NoError(json.Unmarshal([]byte(tt.other), &b))
+			}
+			require.Equal(tt.want, a.Equal(&b))
+			require.Equal(tt.want, b.Equal(&a))
+		})
+	}
+}
+
 func TestUnmarshalStateUpgradeJSON(t *testing.T) {
 	jsonBytes := []byte(
 		`{

--- a/graft/subnet-evm/params/extras/state_upgrade_test.go
+++ b/graft/subnet-evm/params/extras/state_upgrade_test.go
@@ -156,12 +156,8 @@ func TestStateUpgradeEqual(t *testing.T) {
 	tests := []struct {
 		name    string
 		upgrade string
-		// other is compared against upgrade; if empty, the JSON round-trip
-		// of upgrade is used, mirroring how the config persisted by
-		// WriteChainConfig is compared against a fresh parse of the
-		// upgrade bytes at startup.
-		other string
-		want  bool
+		other   string // if empty, round-trips upgrade
+		want    bool
 	}{
 		{
 			name:    "round-trip full entry",
@@ -232,13 +228,13 @@ func TestStateUpgradeEqual(t *testing.T) {
 			var a StateUpgrade
 			require.NoError(json.Unmarshal([]byte(tt.upgrade), &a))
 			var b StateUpgrade
-			if tt.other == "" {
-				roundTripped, err := json.Marshal(a)
+			other := []byte(tt.other)
+			if len(other) == 0 {
+				var err error
+				other, err = json.Marshal(a)
 				require.NoError(err)
-				require.NoError(json.Unmarshal(roundTripped, &b))
-			} else {
-				require.NoError(json.Unmarshal([]byte(tt.other), &b))
 			}
+			require.NoError(json.Unmarshal(other, &b))
 			require.Equal(tt.want, a.Equal(&b))
 			require.Equal(tt.want, b.Equal(&a))
 		})


### PR DESCRIPTION
## What

Replaces `reflect.DeepEqual` in `StateUpgrade.Equal` with field-wise comparison: `bytes.Equal` for code, `maps.Equal` for storage, and value comparison (`big.Int.Cmp`) for balance changes, following the `precompileconfig` Equal convention.

## Why

`checkStateUpgradesCompatible` compares a fresh parse of the upgrade bytes against the copy persisted by `WriteChainConfig`, which is a JSON round-trip of the same parse. `DeepEqual` rejects three semantically no-op inputs (`"storage": {}` and `"code": "0x"` become nil through omitempty; `"balanceChange": "0"` re-marshals as `"0x0"` with different big.Int internals), so a node fails to restart after the upgrade activates, with an error naming two equal timestamps. The equivalences in the new Equal match the apply semantics in `stateupgrade.Configure` (code gated on `len != 0`, storage ranged, balance change on `!= nil`).

Fixes #5764.

## Verification

- New `TestStateUpgradeEqual`: round-trip property for the three failing inputs plus equality/inequality table (the round-trip cases fail on the old implementation)
- Existing `params/extras` tests pass, including `TestCheckCompatibleStateUpgrades` (genuinely modified activated upgrades are still rejected)
- Standalone repro against the released module: https://github.com/owenwahlgren/subnet-evm-stateupgrade-repro

## Open questions

- A present-zero `balanceChange` still compares different from an absent one. That matches what the round-trip preserves and the `!= nil` gate in `Configure`, so it cannot produce a restart false positive; flagging in case reviewers prefer to conflate them.
