### PR TITLE
fix(compression): reject negative zstd max sizes

### DIFF
--- a/utils/compression/compressor_test.go
+++ b/utils/compression/compressor_test.go
@@ -135,19 +135,36 @@ func TestSizeLimiting(t *testing.T) {
 	}
 }
 
-// Attempts to create a compressor with math.MaxInt64
-// which leads to undefined decompress behavior due to integer overflow
-// in limit reader creation.
 func TestNewCompressorWithInvalidLimit(t *testing.T) {
 	for compressionType, compressorFunc := range newCompressorFuncs {
 		if compressionType == TypeNone {
 			continue
 		}
 		t.Run(compressionType.String(), func(t *testing.T) {
-			_, err := compressorFunc(math.MaxInt64)
-			require.ErrorIs(t, err, ErrInvalidMaxSizeCompressor)
+			for _, maxSize := range []int64{
+				math.MinInt64,
+				-1,
+				math.MaxInt64,
+			} {
+				_, err := compressorFunc(maxSize)
+				require.ErrorIs(t, err, ErrInvalidMaxSizeCompressor)
+			}
 		})
 	}
+}
+
+func TestZstdCompressorWithZeroLimit(t *testing.T) {
+	require := require.New(t)
+
+	compressor, err := NewZstdCompressor(0)
+	require.NoError(err)
+
+	compressed, err := compressor.Compress(nil)
+	require.NoError(err)
+
+	decompressed, err := compressor.Decompress(compressed)
+	require.NoError(err)
+	require.Empty(decompressed)
 }
 
 func TestNewZstdCompressorWithLevel(t *testing.T) {

--- a/utils/compression/zstd_compressor.go
+++ b/utils/compression/zstd_compressor.go
@@ -26,7 +26,7 @@ func NewZstdCompressor(maxSize int64) (Compressor, error) {
 }
 
 func NewZstdCompressorWithLevel(maxSize int64, level int) (Compressor, error) {
-	if maxSize == math.MaxInt64 {
+	if maxSize < 0 || maxSize == math.MaxInt64 {
 		// "Decompress" creates "io.LimitReader" with max size + 1:
 		// if the max size + 1 overflows, "io.LimitReader" reads nothing
 		// returning 0 byte for the decompress call


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanchego/issues/5768

## Why this should be merged

The zstd compressor constructors currently accept negative `maxSize` values.

Because message lengths cannot be negative, a compressor created with a negative maximum size cannot successfully compress or decompress any input. The constructor therefore returns a valid-looking but unusable object.


## How this works

This change makes `NewZstdCompressorWithLevel` return `ErrInvalidMaxSizeCompressor` when `maxSize` is negative.

`maxSize == 0` remains valid, preserving the existing behavior for compressors that only allow messages with a decompressed size of zero.

## How this was tested

Added tests confirming that:

- `-1` is rejected.
- `math.MinInt64` is rejected.
- `math.MaxInt64` remains rejected.
- A zero maximum size remains valid and can round-trip an empty message.

Ran:

```text
go test ./utils/compression
```



## Need to be documented in RELEASES.md?

No. This is an input-validation bug fix with no user-facing configuration changes.