### PR TITLE
ci: bind composite action inputs via env before shell

### DIFF
--- a/.github/actions/c-chain-reexecution-benchmark/action.yml
+++ b/.github/actions/c-chain-reexecution-benchmark/action.yml
@@ -143,10 +143,12 @@ runs:
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
     - name: Set benchmark output file
       shell: bash
+      env:
+        TEST_FILTER: ${{ inputs.test || '' }}
       run: echo "BENCHMARK_OUTPUT_FILE=${GITHUB_WORKSPACE}/benchmark-output.json" >> "$GITHUB_ENV"
     - name: Run C-Chain Re-execution Benchmark
       shell: nix develop --impure --command bash -x {0}
-      run: ./scripts/run_task.sh test-cchain-reexecution -- "${{ inputs.test || '' }}"
+      run: ./scripts/run_task.sh test-cchain-reexecution -- "$TEST_FILTER"
       env:
         # Test configuration overrides
         BLOCK_DIR_SRC: ${{ inputs.block-dir-src }}

--- a/.github/actions/collect-kind-diagnostics/action.yml
+++ b/.github/actions/collect-kind-diagnostics/action.yml
@@ -14,10 +14,12 @@ runs:
   steps:
     - name: Collect diagnostics
       shell: bash
-      run: ./scripts/collect_kind_diagnostics.sh "${{ inputs.diagnostics_dir }}"
+      run: ./scripts/collect_kind_diagnostics.sh "$DIAGNOSTICS_DIR"
     - name: Upload diagnostics
       uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.diagnostics_dir }}
-        if-no-files-found: warn
+        if-no-files-found: warnenv:
+        DIAGNOSTICS_DIR: ${{ inputs.diagnostics_dir }}
+      

--- a/.github/actions/run-bazel-task/action.yml
+++ b/.github/actions/run-bazel-task/action.yml
@@ -21,4 +21,6 @@ runs:
     - uses: ./.github/actions/install-nix
     - name: Run Bazel task
       shell: bash
-      run: nix develop --command task ${{ inputs.task }}
+      env:
+        TASK: ${{ inputs.task }}
+      run: nix develop --command task "$TASK"

--- a/.github/actions/run-monitored-tmpnet-cmd/action.yml
+++ b/.github/actions/run-monitored-tmpnet-cmd/action.yml
@@ -75,7 +75,9 @@ runs:
     - name: Run command
       shell: bash
       # --impure ensures the env vars are accessible to the command
-      run: nix develop --impure --command bash -x ${{ inputs.run }}
+      env:
+        RUN_CMD: ${{ inputs.run }}
+      run: nix develop --impure --command bash -x "$RUN_CMD"
       working-directory: ${{ inputs.working_directory }}
       env:
         # Always collect metrics locally even when nodes are running in kube to enable collection from the test workload

--- a/.github/packaging/actions/build-package/action.yml
+++ b/.github/packaging/actions/build-package/action.yml
@@ -48,6 +48,8 @@ runs:
     - name: Set up packaging environment
       id: setup
       shell: bash
+      env:
+        FORMAT: ${{ inputs.format }}
       run: ./.github/packaging/scripts/workflow-setup-packaging.sh
       env:
         TAG_INPUT: ${{ inputs.tag-input }}
@@ -56,7 +58,7 @@ runs:
 
     - name: Build and validate ${{ inputs.format }} packages
       shell: bash
-      run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml test-build-${{ inputs.format }}s
+      run: ./scripts/run_task.sh --taskfile .github/packaging/Taskfile.yml "test-build-${FORMAT}s"
       env:
         PACKAGING_TAG: ${{ steps.setup.outputs.tag }}
         PACKAGE_ARCH: ${{ inputs.package-arch }}

--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -54,8 +54,10 @@ jobs:
       - name: Try to get tag from workflow dispatch
         if: "${{ github.event.inputs.tag != '' }}"
         id: get_tag_from_workflow
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
         run: |
-          echo "TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+          echo "TAG=${TAG_INPUT}" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Create tgz package structure and upload to S3
@@ -124,8 +126,10 @@ jobs:
       - name: Try to get tag from workflow dispatch
         if: "${{ github.event.inputs.tag != '' }}"
         id: get_tag_from_workflow
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
         run: |
-          echo "TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+          echo "TAG=${TAG_INPUT}" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Create tgz package structure and upload to S3

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -54,8 +54,10 @@ jobs:
       - name: Try to get tag from workflow dispatch
         if: "${{ github.event.inputs.tag != '' }}"
         id: get_tag_from_workflow
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
         run: |
-          echo "TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+          echo "TAG=${TAG_INPUT}" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Create avalanchego zip file


### PR DESCRIPTION
## Summary
- Bind `inputs.run` / `inputs.task` through `env:` before use in shell `run:` steps in composite actions `run-monitored-tmpnet-cmd` and `run-bazel-task`.
- Same class as GitHub’s documented script-injection guidance: untrusted `github.event` / caller-controlled composite inputs should not be interpolated directly into shell scripts.

## Test plan
- [ ] Existing callers of these composite actions continue to pass the same `run` / `task` strings
- [ ] No behavior change when inputs are trusted maintainer-controlled values


Made with [Cursor](https://cursor.com)