### PR TITLE
Simplex: Find last non-simplex block

### DIFF
--- a/simplex/storage.go
+++ b/simplex/storage.go
@@ -10,6 +10,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"sync/atomic"
 
 	"github.com/ava-labs/simplex"
@@ -265,6 +267,172 @@ func (s *Storage) retrieveBlacklist(seq uint64) (simplex.Blacklist, error) {
 		return simplex.Blacklist{}, fmt.Errorf("failed to parse blacklist: %w", err)
 	}
 	return blacklist, nil
+}
+
+// locateLastNonSimplexBlock returns the highest block that was accepted before Simplex was activated.
+// It returns the block, a boolean indicating if a non-simplex block was found, and an error if any occurred during the search.
+// The parameter numBlocksInChain is the number of blocks in the chain, not the number of blocks on disk.
+func locateLastNonSimplexBlock(
+	ctx context.Context,
+	genesisBlock snowman.Block,
+	proposerVM block.ChainVM,
+	db database.KeyValueReader,
+	log logging.Logger,
+	numBlocksInChain uint64,
+) (snowman.Block, bool, error) {
+	if numBlocksInChain == 0 {
+		// This is a sanity check, as the genesis block should always be present in storage.
+		return nil, false, errors.New("no blocks in storage")
+	}
+
+	if numBlocksInChain == 1 {
+		// If there's only one block in the chain, it must be the genesis block, which is a non-simplex block.
+		return genesisBlock, true, nil
+	}
+
+	// We first check if the last block is a non-simplex block. If it is, we can return it immediately.
+	lastBlock, isNonSimplexBlock, err := isLastBlockNonSimplexBlock(ctx, proposerVM, log, numBlocksInChain)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if isNonSimplexBlock {
+		return lastBlock, true, nil
+	}
+
+	// Else, the last block is a simplex block, so we need to find the lowest simplex block in the chain and then return the block before it,
+	// which is the last non-simplex block.
+
+	if numBlocksInChain > math.MaxInt {
+		// This cannot happen, but we check to avoid potential overflow issues with sort.Search.
+		return nil, false, errors.New("too many blocks in storage")
+	}
+
+	lowestSimplexBlockSeq, simplexBlockExists, err := findLowestSimplexBlockSeq(db, log, int(numBlocksInChain))
+	if err != nil {
+		return nil, false, err
+	}
+
+	if !simplexBlockExists {
+		// This is a sanity check, as we should have found at least one simplex block if the last block was a simplex block.
+		return nil, false, errors.New("no simplex blocks found in storage")
+	}
+
+	if err := validateLowestSimplexBlock(db, log, lowestSimplexBlockSeq); err != nil {
+		return nil, false, err
+	}
+
+	blockBeforeLowestSimplexSeq := lowestSimplexBlockSeq - 1
+
+	if blockBeforeLowestSimplexSeq == 0 {
+		// If the block before the lowest simplex block is the genesis block, we return it as the last non-simplex block.
+		return genesisBlock, true, nil
+	}
+
+	// Retrieve the last non-simplex block from the proposerVM and return it.
+	lastNonSimplexBlock, err := getBlock(ctx, proposerVM, uint64(blockBeforeLowestSimplexSeq))
+	if errors.Is(err, database.ErrNotFound) {
+		// The block before the lowest simplex block isn't in the proposerVM, so we only
+		// have simplex blocks, which can happen if we have bootstrapped with state sync.
+		return nil, false, nil
+	}
+	if err != nil {
+		log.Error("Failed to retrieve last non-simplex block", zap.Int("seq", blockBeforeLowestSimplexSeq), zap.Error(err))
+		return nil, false, fmt.Errorf("failed getting block %d: %w", blockBeforeLowestSimplexSeq, err)
+	}
+
+	return lastNonSimplexBlock, true, nil
+}
+
+// isLastBlockNonSimplexBlock returns the last block of the chain, and whether it was
+// accepted before Simplex was activated. Blocks accepted by Simplex are not retrievable
+// from the proposerVM, so a block that is missing from it is a Simplex block.
+// [numBlocksInChain] is assumed to be positive.
+func isLastBlockNonSimplexBlock(
+	ctx context.Context,
+	proposerVM block.ChainVM,
+	log logging.Logger,
+	numBlocksInChain uint64,
+) (snowman.Block, bool, error) {
+	lastBlockSeq := numBlocksInChain - 1
+
+	// If the last block is not found in the proposerVM, it is a Simplex block, so we return false.
+	lastBlock, err := getBlock(ctx, proposerVM, lastBlockSeq)
+	if errors.Is(err, database.ErrNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		log.Error("Failed to retrieve last block", zap.Uint64("lastBlockSeq", lastBlockSeq), zap.Error(err))
+		return nil, false, fmt.Errorf("failed getting block %d: %w", lastBlockSeq, err)
+	}
+
+	return lastBlock, true, nil
+}
+
+// findLowestSimplexBlockSeq binary searches for the lowest sequence number in
+// [0, searchUpperBound) that has a finalization, which is the first block that was
+// accepted by Simplex. If no such sequence exists, false is returned.
+func findLowestSimplexBlockSeq(db database.KeyValueReader, log logging.Logger, searchUpperBound int) (int, bool, error) {
+	var internalError error
+
+	// The below binary search searches for the lowest sequence number that has a finalization,
+	// which is the first block that was accepted by Simplex.
+	lowestSimplexBlockSeq := sort.Search(searchUpperBound, func(seq int) bool {
+		if internalError != nil {
+			return false
+		}
+		_, err := db.Get(finalizationKey(uint64(seq)))
+		// If the finalization is not found, this block is not a Simplex block, so we return false.
+		if errors.Is(err, database.ErrNotFound) {
+			return false
+		}
+		if err != nil {
+			internalError = err
+			log.Error("Failed to get finalization for block", zap.Int("seq", seq), zap.Error(err))
+			return false
+		}
+		// Else err == nil therefore the finalization exists in the storage, so it's a Simplex block.
+		return true
+	})
+
+	if internalError != nil {
+		return 0, false, internalError
+	}
+
+	// sort.Search returns the upper bound if the predicate is false for every sequence,
+	// which means there are no simplex blocks in the storage.
+	if lowestSimplexBlockSeq == searchUpperBound {
+		return 0, false, nil
+	}
+
+	return lowestSimplexBlockSeq, true, nil
+}
+
+// validateLowestSimplexBlock sanity checks the lowest sequence number that was accepted
+// by Simplex: it must not be the genesis block, and the block preceding it must not have
+// a finalization of its own, which contradicts it being the simplex block with the lowest sequence.
+func validateLowestSimplexBlock(db database.KeyValueReader, log logging.Logger, lowestSimplexBlockSeq int) error {
+	// Sanity check I - make sure lowest simplex block is not the genesis block,
+	// as the genesis block should never be a simplex block.
+	if lowestSimplexBlockSeq == 0 {
+		log.Error("Found simplex block at genesis block sequence number")
+		return errors.New("found simplex block at genesis block sequence number")
+	}
+
+	// Sanity check II - check that the block before the lowest simplex block doesn't have a finalization.
+	blockBeforeLowestSimplexSeq := lowestSimplexBlockSeq - 1
+
+	_, err := db.Get(finalizationKey(uint64(blockBeforeLowestSimplexSeq)))
+	if err == nil {
+		log.Error("Found finalization for block that should be a non-simplex block", zap.Int("seq", blockBeforeLowestSimplexSeq))
+		return fmt.Errorf("found finalization for block %d that should be a non-simplex block", blockBeforeLowestSimplexSeq)
+	}
+	if !errors.Is(err, database.ErrNotFound) {
+		log.Error("Failed to get finalization for block", zap.Int("seq", blockBeforeLowestSimplexSeq), zap.Error(err))
+		return fmt.Errorf("failed getting finalization for block %d: %w", blockBeforeLowestSimplexSeq, err)
+	}
+
+	return nil
 }
 
 func getBlock(ctx context.Context, vm block.ChainVM, height uint64) (snowman.Block, error) {

--- a/simplex/storage_test.go
+++ b/simplex/storage_test.go
@@ -4,6 +4,9 @@
 package simplex
 
 import (
+	"context"
+	"errors"
+	"math"
 	"testing"
 
 	"github.com/ava-labs/simplex"
@@ -11,10 +14,252 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman/snowmantest"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block/blocktest"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/avalanchego/utils/logging"
 )
+
+// putFinalizations marks each of [seqs] as a simplex block by storing a finalization for it in db.
+func putFinalizations(t *testing.T, db database.KeyValueWriter, seqs ...uint64) {
+	for _, seq := range seqs {
+		require.NoError(t, db.Put(finalizationKey(seq), []byte("finalization")))
+	}
+}
+
+func TestLocateLastNonSimplexBlock(t *testing.T) {
+	tests := []struct {
+		name string
+		// numBlocks is the number of blocks indexed in storage.
+		numBlocks uint64
+		// proposerVMMaxHeight is the highest height retrievable from the proposerVM.
+		proposerVMMaxHeight uint64
+		// finalizedSeqs are the sequences that have a finalization, i.e. the
+		// blocks that were accepted by simplex.
+		finalizedSeqs []uint64
+		// closeDB closes the database before the search, making every read fail.
+		closeDB bool
+		// expectedFound is whether a non-simplex block is expected to be located.
+		expectedFound  bool
+		expectedHeight uint64
+		expectedErr    error
+		expectedErrMsg string
+	}{
+		{
+			name:           "no blocks in storage",
+			numBlocks:      0,
+			expectedErrMsg: "no blocks in storage",
+		},
+		{
+			name:                "only genesis, simplex never activated",
+			numBlocks:           1,
+			proposerVMMaxHeight: 0,
+			expectedFound:       true,
+			expectedHeight:      0,
+		},
+		{
+			name:                "simplex never activated",
+			numBlocks:           5,
+			proposerVMMaxHeight: 4,
+			expectedFound:       true,
+			expectedHeight:      4,
+		},
+		{
+			name:                "simplex activated right after genesis",
+			numBlocks:           5,
+			proposerVMMaxHeight: 0,
+			finalizedSeqs:       []uint64{1, 2, 3, 4},
+			expectedFound:       true,
+			expectedHeight:      0,
+		},
+		{
+			name:                "simplex activated mid chain",
+			numBlocks:           8,
+			proposerVMMaxHeight: 3,
+			finalizedSeqs:       []uint64{4, 5, 6, 7},
+			expectedFound:       true,
+			expectedHeight:      3,
+		},
+		{
+			name:                "only the last block is a simplex block",
+			numBlocks:           5,
+			proposerVMMaxHeight: 3,
+			finalizedSeqs:       []uint64{4},
+			expectedFound:       true,
+			expectedHeight:      3,
+		},
+		{
+			// The last block isn't in the proposerVM, so it must be a simplex block,
+			// yet no finalization is stored for any sequence.
+			name:                "no simplex blocks found",
+			numBlocks:           5,
+			proposerVMMaxHeight: 0,
+			expectedErrMsg:      "no simplex blocks found in storage",
+		},
+		{
+			name:                "genesis is a simplex block",
+			numBlocks:           3,
+			proposerVMMaxHeight: 0,
+			finalizedSeqs:       []uint64{0, 1, 2},
+			expectedErrMsg:      "found simplex block at genesis block sequence number",
+		},
+		{
+			// A state synced node may not have the last non-simplex block, as its
+			// height index only covers genesis and a recent window. There is then no
+			// non-simplex block to locate, which is not an error.
+			name:                "last non-simplex block missing from the proposerVM",
+			numBlocks:           8,
+			proposerVMMaxHeight: 2,
+			finalizedSeqs:       []uint64{4, 5, 6, 7},
+			expectedFound:       false,
+		},
+		{
+			name:                "database read fails",
+			numBlocks:           5,
+			proposerVMMaxHeight: 0,
+			closeDB:             true,
+			expectedErr:         database.ErrClosed,
+		},
+		{
+			name:                "more blocks than can be searched",
+			numBlocks:           math.MaxUint64,
+			proposerVMMaxHeight: 0,
+			expectedErrMsg:      "too many blocks in storage",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := t.Context()
+			// The proposerVM holds a single chain rooted at the genesis block, up to
+			// and including proposerVMMaxHeight.
+			vm := newTestVM()
+			for _, blk := range snowmantest.BuildDescendants(snowmantest.Genesis, int(testCase.proposerVMMaxHeight)) {
+				vm.blocks[blk.ID()] = blk
+			}
+
+			db := memdb.New()
+			putFinalizations(t, db, testCase.finalizedSeqs...)
+			if testCase.closeDB {
+				require.NoError(t, db.Close())
+			}
+
+			blk, found, err := locateLastNonSimplexBlock(ctx, snowmantest.Genesis, vm, db, logging.NoLog{}, testCase.numBlocks)
+
+			if testCase.expectedErr != nil || testCase.expectedErrMsg != "" {
+				if testCase.expectedErr != nil {
+					require.ErrorIs(t, err, testCase.expectedErr)
+				}
+				if testCase.expectedErrMsg != "" {
+					require.ErrorContains(t, err, testCase.expectedErrMsg)
+				}
+				require.False(t, found)
+				require.Nil(t, blk)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedFound, found)
+			if !testCase.expectedFound {
+				require.Nil(t, blk)
+				return
+			}
+
+			require.Equal(t, testCase.expectedHeight, blk.Height())
+
+			// The returned block must be the one the proposerVM indexes at that height.
+			expectedID, err := vm.GetBlockIDAtHeight(ctx, testCase.expectedHeight)
+			require.NoError(t, err)
+			require.Equal(t, expectedID, blk.ID())
+		})
+	}
+}
+
+// TestLocateLastNonSimplexBlockUnexpectedVMError asserts that an error other than
+// database.ErrNotFound from the proposerVM is reported and is not interpreted as database.ErrNotFound.
+func TestLocateLastNonSimplexBlockUnexpectedVMError(t *testing.T) {
+	errUnexpected := errors.New("unexpected proposerVM failure")
+
+	tests := []struct {
+		name          string
+		finalizedSeqs []uint64
+		// failingHeight is the height the proposerVM fails to retrieve due to an unexpected error.
+		// Every other height reports database.ErrNotFound.
+		failingHeight uint64
+	}{
+		{
+			name:          "retrieving the last block fails",
+			failingHeight: 4,
+		},
+		{
+			// The last non-simplex block must not be the genesis block, as that is
+			// returned without consulting the proposerVM.
+			name:          "retrieving the last non-simplex block fails",
+			finalizedSeqs: []uint64{2, 3, 4},
+			failingHeight: 1,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			vm := &blocktest.VM{
+				GetBlockIDAtHeightF: func(_ context.Context, height uint64) (ids.ID, error) {
+					if height == testCase.failingHeight {
+						return ids.Empty, errUnexpected
+					}
+					return ids.Empty, database.ErrNotFound
+				},
+			}
+
+			db := memdb.New()
+			putFinalizations(t, db, testCase.finalizedSeqs...)
+
+			blk, found, err := locateLastNonSimplexBlock(t.Context(), snowmantest.Genesis, vm, db, logging.NoLog{}, 5)
+			require.ErrorIs(t, err, errUnexpected)
+			require.False(t, found)
+			require.Nil(t, blk)
+		})
+	}
+}
+
+func TestLocateLastNonSimplexBlockNoProposerVMBlocks(t *testing.T) {
+	// A proposerVM that holds no blocks at all.
+	vm := &blocktest.VM{
+		GetBlockIDAtHeightF: func(context.Context, uint64) (ids.ID, error) {
+			return ids.Empty, database.ErrNotFound
+		},
+	}
+
+	tests := []struct {
+		name          string
+		numBlocks     uint64
+		finalizedSeqs []uint64
+	}{
+		{
+			name:      "genesis is the only block in the chain",
+			numBlocks: 1,
+		},
+		{
+			name:          "simplex activated right after genesis",
+			numBlocks:     5,
+			finalizedSeqs: []uint64{1, 2, 3, 4},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			db := memdb.New()
+			putFinalizations(t, db, testCase.finalizedSeqs...)
+
+			blk, found, err := locateLastNonSimplexBlock(t.Context(), snowmantest.Genesis, vm, db, logging.NoLog{}, testCase.numBlocks)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, snowmantest.Genesis.ID(), blk.ID())
+		})
+	}
+}
 
 func TestStorageNew(t *testing.T) {
 	ctx := t.Context()


### PR DESCRIPTION
## Why this should be merged

Simplex can be activated for the first time either on top of a genesis block (new L1), or on top of a snowman block built by proposerVM (migration from snowman to Simplex).

(And in the future, via state-sync assisted boostrapping).

In any of the above cases, Simplex needs to identity the last block that is not a Simplex block, in order for Simplex to know:

1. What is the next sequence number / block height to build on (to continue from the next sequence where snowman left off)
2. Which previous block hash to point to
3. What is the P-chain height that the Simplex L1 starts with, which is encoded by the proposerVM and not by Simplex.

## How this works

This commit adds a function - locateLastNonSimplexBlock() which given the genesis block, the proposerVM, the DB simplex stores finalizations in, and the number of blocks in the L1 chain, returns the last non-simplex block, if applicable.

The function performs a binary search for the simplex block with the lowest sequence, and returns the block before it.

## How this was tested

unit tests are included. 

## Need to be documented in RELEASES.md?
