### PR TITLE
refactor(sae): simplify `NewVM()`

### DIFF
--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -112,24 +112,30 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 	}
 }
 
-// newExecutor returns an [sae.Executor] that is ready to execute any child of
-// the last-known accepted block, a map of all consesnsus-critical blocks, and
-// the last-settled block.
-func (rec *recovery) newExecutor(
+// recoverExecutor returns an [sae.Executor] that is ready to execute any child
+// of the last-known accepted block, and a map of all consesnsus-critical blocks.
+func recoverExecutor(
 	ctx context.Context,
+	db ethdb.Database,
+	xdb saetypes.ExecutionResults,
+	chainConfig *params.ChainConfig,
+	snowCtx *snow.Context,
+	hooks hook.Points,
+	cfg Config,
 	reg prometheus.Registerer,
 ) (
 	_ *saexec.Executor,
-	consensusCritical *syncMap[common.Hash, *blocks.Block],
-	lastSettled *blocks.Block,
+	_ *syncMap[common.Hash, *blocks.Block],
 	retErr error,
 ) {
 	var closers unwind.Closers
 	defer closers.CloseIfPointsToNonNil(&retErr)
 
+	rec := &recovery{db, xdb, chainConfig, snowCtx, hooks, cfg}
+
 	lastCommitted, err := rec.lastCommittedBlock()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("finding last committed state: %w", err)
+		return nil, nil, fmt.Errorf("finding last committed state: %w", err)
 	}
 	lastCommittedRoot := lastCommitted.PostExecutionStateRoot()
 
@@ -141,11 +147,11 @@ func (rec *recovery) newExecutor(
 		rec.snowCtx.Log,
 	)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("saedb.NewTracker(...): %w", err)
+		return nil, nil, fmt.Errorf("saedb.NewTracker(...): %w", err)
 	}
 	closers.Push(unwind.CloserFuncT(tracker.Close, lastCommittedRoot))
 
-	consensusCritical = newSyncMap[common.Hash, *blocks.Block](
+	consensusCritical := newSyncMap[common.Hash, *blocks.Block](
 		func(b *blocks.Block) {
 			tracker.Track(b.SettledStateRoot())
 			// The post-execution root is tracked by the [saexec.Executor]
@@ -172,18 +178,17 @@ func (rec *recovery) newExecutor(
 		reg,
 	)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("saexec.New(...): %v", err)
+		return nil, nil, fmt.Errorf("saexec.New(...): %v", err)
 	}
 	closers.Push(exec)
 
 	if err := rec.executeAllAccepted(ctx, exec); err != nil {
-		return nil, nil, nil, fmt.Errorf("executing all previously accepted blocks: %w", err)
+		return nil, nil, fmt.Errorf("executing all previously accepted blocks: %w", err)
 	}
-	lastSettled, err = rec.populateConsensusCriticalBlocks(exec, consensusCritical)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("finding consensus-critical blocks: %w", err)
+	if err := rec.populateConsensusCriticalBlocks(exec, consensusCritical); err != nil {
+		return nil, nil, fmt.Errorf("finding consensus-critical blocks: %w", err)
 	}
-	return exec, consensusCritical, lastSettled, nil
+	return exec, consensusCritical, nil
 }
 
 func (rec *recovery) canonicalAfter(parent *blocks.Block) iter.Seq2[*blocks.Block, error] {
@@ -251,10 +256,10 @@ func lastOf[E any](s []E) E {
 }
 
 // populateConsensusCriticalBlocks populates bMap with all blocks from the last
-// executed back to, and including, the block that it settled. Said settled
-// block is returned for convenience. bMap MUST be empty and MUST already have
-// its callbacks bound to the executor's state tracker; see [NewVM].
-func (rec *recovery) populateConsensusCriticalBlocks(exec *saexec.Executor, bMap *syncMap[common.Hash, *blocks.Block]) (lastSettled *blocks.Block, _ error) {
+// executed back to, and including, the block that it settled. bMap MUST be
+// empty and MUST already have its callbacks bound to the executor's state
+// tracker.
+func (rec *recovery) populateConsensusCriticalBlocks(exec *saexec.Executor, bMap *syncMap[common.Hash, *blocks.Block]) error {
 	chain := []*blocks.Block{exec.LastExecuted()} // reverse height order
 	blackhole := new(atomic.Pointer[blocks.Block])
 
@@ -296,19 +301,19 @@ func (rec *recovery) populateConsensusCriticalBlocks(exec *saexec.Executor, bMap
 	}
 
 	if err := extend(exec.LastExecuted()); err != nil {
-		return nil, err
+		return err
 	}
-	lastSettled = lastOf(chain)
+	lastSettled := lastOf(chain)
 	for _, b := range chain {
 		bMap.Store(b.Hash(), b)
 	}
 
 	for i, b := range chain[:len(chain)-1] {
 		if err := extend(b); err != nil {
-			return nil, err
+			return err
 		}
 		if err := b.SetAncestors(chain[i+1], lastOf(chain)); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	for _, b := range bMap.m {
@@ -317,8 +322,8 @@ func (rec *recovery) populateConsensusCriticalBlocks(exec *saexec.Executor, bMap
 			stage = blocks.Settled
 		}
 		if err := b.CheckInvariants(stage); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return lastSettled, nil
+	return nil
 }

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -112,17 +112,24 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 	}
 }
 
-// newExecution returns an executor that is ready to execute any child of
-// [recovery.lastCommitted] and an empty map to track consensus-critical blocks.
-// This map will guarantee that a block's settled and post-execution state is
-// available, if the block is executed, as long as it is in the map.
-func (rec *recovery) newExecution(reg prometheus.Registerer) (_ *saexec.Executor, _ *syncMap[common.Hash, *blocks.Block], retErr error) {
+// newExecutor returns an [sae.Executor] that is ready to execute any child of
+// the last-known accepted block, a map of all consesnsus-critical blocks, and
+// the last-settled block.
+func (rec *recovery) newExecutor(
+	ctx context.Context,
+	reg prometheus.Registerer,
+) (
+	_ *saexec.Executor,
+	consensusCritical *syncMap[common.Hash, *blocks.Block],
+	lastSettled *blocks.Block,
+	retErr error,
+) {
 	var closers unwind.Closers
 	defer closers.CloseIfPointsToNonNil(&retErr)
 
 	lastCommitted, err := rec.lastCommittedBlock()
 	if err != nil {
-		return nil, nil, fmt.Errorf("finding last committed state: %w", err)
+		return nil, nil, nil, fmt.Errorf("finding last committed state: %w", err)
 	}
 	lastCommittedRoot := lastCommitted.PostExecutionStateRoot()
 
@@ -134,11 +141,11 @@ func (rec *recovery) newExecution(reg prometheus.Registerer) (_ *saexec.Executor
 		rec.snowCtx.Log,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("saedb.NewTracker(...): %w", err)
+		return nil, nil, nil, fmt.Errorf("saedb.NewTracker(...): %w", err)
 	}
 	closers.Push(unwind.CloserFuncT(tracker.Close, lastCommittedRoot))
 
-	consensusCritical := newSyncMap[common.Hash, *blocks.Block](
+	consensusCritical = newSyncMap[common.Hash, *blocks.Block](
 		func(b *blocks.Block) {
 			tracker.Track(b.SettledStateRoot())
 			// The post-execution root is tracked by the [saexec.Executor]
@@ -152,6 +159,7 @@ func (rec *recovery) newExecution(reg prometheus.Registerer) (_ *saexec.Executor
 			}
 		},
 	)
+
 	exec, err := saexec.New(
 		lastCommitted,
 		headerSource(consensusCritical, rec.db),
@@ -164,9 +172,18 @@ func (rec *recovery) newExecution(reg prometheus.Registerer) (_ *saexec.Executor
 		reg,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("saexec.New(...): %v", err)
+		return nil, nil, nil, fmt.Errorf("saexec.New(...): %v", err)
 	}
-	return exec, consensusCritical, nil
+	closers.Push(exec)
+
+	if err := rec.executeAllAccepted(ctx, exec); err != nil {
+		return nil, nil, nil, fmt.Errorf("executing all previously accepted blocks: %w", err)
+	}
+	lastSettled, err = rec.populateConsensusCriticalBlocks(exec, consensusCritical)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("finding consensus-critical blocks: %w", err)
+	}
+	return exec, consensusCritical, lastSettled, nil
 }
 
 func (rec *recovery) canonicalAfter(parent *blocks.Block) iter.Seq2[*blocks.Block, error] {

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -113,7 +113,7 @@ func (rec *recovery) lastCommittedBlock() (_ *blocks.Block, retErr error) {
 }
 
 // recoverExecutor returns an [sae.Executor] that is ready to execute any child
-// of the last-known accepted block, and a map of all consesnsus-critical blocks.
+// of the last-known accepted block, and a map of all consensus-critical blocks.
 func recoverExecutor(
 	ctx context.Context,
 	db ethdb.Database,

--- a/vms/saevm/sae/vm.go
+++ b/vms/saevm/sae/vm.go
@@ -143,13 +143,11 @@ func NewVM[T hook.Transaction](
 	closers.Push(&xdb)
 
 	// ==========  Block State  ==========
-	rec := &recovery{db, xdb, chainConfig, snowCtx, hooks, cfg}
-	exec, consensusCritical, lastSettled, err := rec.newExecutor(ctx, reg)
+	exec, consensusCritical, err := recoverExecutor(ctx, db, xdb, chainConfig, snowCtx, hooks, cfg, reg)
 	if err != nil {
 		return nil, fmt.Errorf("creating new execution: %w", err)
 	}
 	closers.Push(exec)
-	metrics.markSettled(lastSettled.Height())
 
 	// ==========  Mempool & P2P Gossip  ==========
 	pool, mempoolClosers, err := newGossipMempool(cfg.MempoolConfig, snowCtx, network, exec, ethBlockSource(consensusCritical, db), reg)
@@ -182,10 +180,16 @@ func NewVM[T hook.Transaction](
 		closers: closers,
 	}
 
-	head := exec.LastExecuted()
-	vm.preference.Store(head)
-	vm.last.accepted.Store(head)
-	vm.last.settled.Store(lastSettled)
+	// ==========  Frontiers  ==========
+	{
+		e := exec.LastExecuted()
+		vm.preference.Store(e)
+		vm.last.accepted.Store(e)
+
+		s := e.LastSettled()
+		vm.last.settled.Store(s)
+		metrics.markSettled(s.Height())
+	}
 
 	// ==========  RPC Provider  ==========
 	{

--- a/vms/saevm/sae/vm.go
+++ b/vms/saevm/sae/vm.go
@@ -123,11 +123,17 @@ func NewVM[T hook.Transaction](
 		zap.Reflect("config", cfg),
 	)
 
+	// ==========  Metrics  ==========
 	reg, err := apimetrics.MakeAndRegister(snowCtx.Metrics, "sae")
 	if err != nil {
 		return nil, fmt.Errorf("registering sae metrics: %w", err)
 	}
+	metrics, err := newMetrics(reg)
+	if err != nil {
+		return nil, fmt.Errorf("registering sae metrics: %w", err)
+	}
 
+	// ==========  Execution Results DB  ==========
 	xdb, err := hooks.ExecutionResultsDB(
 		filepath.Join(snowCtx.ChainDataDir, "sae_execution_results"),
 	)
@@ -138,37 +144,20 @@ func NewVM[T hook.Transaction](
 
 	// ==========  Block State  ==========
 	rec := &recovery{db, xdb, chainConfig, snowCtx, hooks, cfg}
-	exec, consensusCritical, err := rec.newExecution(reg)
+	exec, consensusCritical, lastSettled, err := rec.newExecutor(ctx, reg)
 	if err != nil {
 		return nil, fmt.Errorf("creating new execution: %w", err)
 	}
 	closers.Push(exec)
-
-	if err := rec.executeAllAccepted(ctx, exec); err != nil {
-		return nil, fmt.Errorf("executing all previously accepted blocks: %w", err)
-	}
-
-	lastSettled, err := rec.populateConsensusCriticalBlocks(exec, consensusCritical)
-	if err != nil {
-		return nil, fmt.Errorf("finding consensus-critical blocks: %w", err)
-	}
+	metrics.markSettled(lastSettled.Height())
 
 	// ==========  Mempool & P2P Gossip  ==========
 	pool, mempoolClosers, err := newGossipMempool(cfg.MempoolConfig, snowCtx, network, exec, ethBlockSource(consensusCritical, db), reg)
 	if err != nil {
 		return nil, err
 	}
-	closers.Push(mempoolClosers...)
-
 	newTxs, newTxsCloser := signalNewTxsToEngine(pool)
-	closers.Push(newTxsCloser)
-
-	// ==========  Metrics  ==========
-	metrics, err := newMetrics(reg)
-	if err != nil {
-		return nil, fmt.Errorf("registering sae metrics: %w", err)
-	}
-	metrics.markSettled(lastSettled.Height())
+	closers.Push(append(mempoolClosers, newTxsCloser)...)
 
 	vm := &VM{
 		network:           network,


### PR DESCRIPTION
## Why this should be merged

Part 2/2 of `sae.NewVM()` simplification, after #5792.

## How this works

Normalises stages of `NewVM()` to all follow the same pattern:

1. Call constructor;
2. Return error if non-nil; and
3. Push constructed object to closer stack if necessary.

Primarily this meant moving more into `recovery.newExecutor()` so that it returns objects that are ready to use, instead of requiring that `NewVM()` takes care of further setup.

## How this was tested

Existing tests.

## Need to be documented in RELEASES.md?

No