### PR TITLE
fix(vms/saevm/cchain): reject HTTP handler path mismatches

### DIFF
--- a/vms/saevm/cchain/genesis.go
+++ b/vms/saevm/cchain/genesis.go
@@ -185,8 +185,7 @@ func (g *genesis) setup(db ethdb.Database) error {
 		return fmt.Errorf("constructing genesis block: %w", err)
 	}
 
-	// We can't exit early here. Even if the genesis block is on disk, the
-	// genesis state might not be.
+	// No early exit: the stored chainConfig is checked for compatibility below.
 	hash := block.Hash()
 	if prev := rawdb.ReadCanonicalHash(db, genesisNumber); prev == (common.Hash{}) {
 		if err := writeGenesisBlock(db, block, g.Config); err != nil {

--- a/vms/saevm/cchain/http.go
+++ b/vms/saevm/cchain/http.go
@@ -5,6 +5,7 @@ package cchain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -45,8 +46,7 @@ func (vm *VM) setHandlers(ctx context.Context) error {
 
 	m[avaxHTTPExtensionPath] = handler
 
-	vm.handlers.setHandlers(m)
-	return nil
+	return vm.handlers.setHandlers(m)
 }
 
 // A handlerMap is a fixed set of HTTP routes whose implementations can be
@@ -69,14 +69,30 @@ func (m handlerMap) toInterface() map[string]http.Handler {
 	return iface
 }
 
-// setHandlers routes each lazy handler to its actual implementation. The
-// actual paths MUST exactly match the paths registered at construction.
-func (m handlerMap) setHandlers(actual map[string]http.Handler) {
-	for path, h := range actual {
-		if lazy, ok := m[path]; ok {
-			lazy.set(h)
+var (
+	errUnregisteredHandlerPath = errors.New("handler path not registered at construction")
+	errMissingHandlerPath      = errors.New("no handler provided for registered path")
+)
+
+// setHandlers routes each lazy handler to its implementation. Paths must match
+// those registered at construction exactly, else a route stays unserved. Both
+// directions are validated before any routing, so a mismatch changes nothing.
+func (m handlerMap) setHandlers(actual map[string]http.Handler) error {
+	for path := range actual {
+		if _, ok := m[path]; !ok {
+			return fmt.Errorf("%w: %q", errUnregisteredHandlerPath, path)
 		}
 	}
+	for path := range m {
+		if _, ok := actual[path]; !ok {
+			return fmt.Errorf("%w: %q", errMissingHandlerPath, path)
+		}
+	}
+
+	for path, h := range actual {
+		m[path].set(h)
+	}
+	return nil
 }
 
 var _ http.Handler = (*lazyHandler)(nil)

--- a/vms/saevm/cchain/http_test.go
+++ b/vms/saevm/cchain/http_test.go
@@ -51,7 +51,7 @@ func TestHandlerMap(t *testing.T) {
 		assert.Equalf(t, http.StatusNotFound, get(t, h).Code, "GET %q before setHandlers", path)
 	}
 
-	m.setHandlers(stubHandlers(paths...))
+	require.NoErrorf(t, m.setHandlers(stubHandlers(paths...)), "%T.setHandlers(matching paths)", m)
 
 	after := m.toInterface()
 	require.ElementsMatchf(t, paths, slices.Collect(maps.Keys(after)), "%T.toInterface() paths", m)
@@ -65,5 +65,38 @@ func TestHandlerMap(t *testing.T) {
 			assert.Equalf(t, http.StatusOK, rec.Code, "GET %q via %s", path, desc)
 			assert.Equalf(t, path, rec.Body.String(), "GET %q via %s routed to wrong handler", path, desc)
 		}
+	}
+}
+
+// Route-set drift must be an error, not a permanently unserved path.
+func TestHandlerMapPathMismatch(t *testing.T) {
+	paths := []string{"/foo", "/bar"}
+
+	tests := []struct {
+		name    string
+		actual  []string
+		wantErr error
+	}{
+		{
+			name:    "unregistered_path",
+			actual:  []string{"/foo", "/bar", "/surprise"},
+			wantErr: errUnregisteredHandlerPath,
+		},
+		{
+			name:    "missing_path",
+			actual:  []string{"/foo"},
+			wantErr: errMissingHandlerPath,
+		},
+		{
+			name:   "exact_match",
+			actual: paths,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := newHandlerMap(paths...).setHandlers(stubHandlers(tt.actual...))
+			require.ErrorIsf(t, err, tt.wantErr, "setHandlers(%v) with %v registered", tt.actual, paths)
+		})
 	}
 }

--- a/vms/saevm/cchain/state.go
+++ b/vms/saevm/cchain/state.go
@@ -81,7 +81,7 @@ func (vm *VM) WaitForEvent(ctx context.Context) (snowcommon.Message, error) {
 	case snow.Initializing:
 		// no event can occur while the VM is initializing.
 		<-ctx.Done()
-		return 0, ctx.Err()
+		return 0, context.Cause(ctx)
 	case snow.StateSyncing:
 		return vm.SummaryHandler.WaitForEvent(ctx)
 	}

--- a/vms/saevm/cchain/statesync/acceptor.go
+++ b/vms/saevm/cchain/statesync/acceptor.go
@@ -30,7 +30,7 @@ func (h *SummaryHandler) AcceptSummary(ctx context.Context, summary *summary) (b
 
 	go func() {
 		defer close(h.stateSyncDone)
-		// TODO(alarso16): implement state sync with a synchronus statesync.SummaryHandler API.
+		// TODO(alarso16): implement state sync with a synchronous statesync.SummaryHandler API.
 	}()
 	return mode, nil
 }

--- a/vms/saevm/cchain/vm.go
+++ b/vms/saevm/cchain/vm.go
@@ -284,10 +284,10 @@ func (vm *VM) onBootstrapping(ctx context.Context) error {
 	return nil
 }
 
-// Shutdown releases every resource allocated by [VM.Initialize] in reverse
-// order.
+// Shutdown releases every resource allocated by [VM.Initialize] and
+// [VM.onBootstrapping] in reverse order.
 //
-// It is idempotent and safe to call after a partially-failed [VM.Initialize].
+// It is idempotent and safe to call after either phase partially failed.
 func (vm *VM) Shutdown(ctx context.Context) error {
 	errs := make([]error, len(vm.onClose))
 	for i, f := range slices.Backward(vm.onClose) {


### PR DESCRIPTION
## Why this should be merged

## How this works

- `setHandlers` ignored unrecognized paths, so drift in sae's two copies of the path set would leave a route 404ing with tests green.
- `WaitForEvent` returned `ctx.Err()` instead of the cancellation cause.
- `Shutdown`'s doc and a genesis comment predate the two-phase startup.

## How this was tested

## Need to be documented in RELEASES.md?

no

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)