### PR TITLE
Snowman performance improvements

### DIFF
--- a/proto/p2p/p2p.proto
+++ b/proto/p2p/p2p.proto
@@ -342,7 +342,7 @@ message PushQuery {
   uint64 deadline = 3;
   // Container being gossiped
   bytes container = 4;
-  // Requesting peer's last accepted height
+  // Requesting peer's next preferred height (one above its current preference)
   uint64 requested_height = 6;
 }
 
@@ -359,7 +359,7 @@ message PullQuery {
   uint64 deadline = 3;
   // Container id being gossiped
   bytes container_id = 4;
-  // Requesting peer's last accepted height
+  // Requesting peer's next preferred height (one above its current preference)
   uint64 requested_height = 6;
 }
 

--- a/proto/pb/p2p/p2p.pb.go
+++ b/proto/pb/p2p/p2p.pb.go
@@ -1978,7 +1978,7 @@ type PushQuery struct {
 	Deadline uint64 `protobuf:"varint,3,opt,name=deadline,proto3" json:"deadline,omitempty"`
 	// Container being gossiped
 	Container []byte `protobuf:"bytes,4,opt,name=container,proto3" json:"container,omitempty"`
-	// Requesting peer's last accepted height
+	// Requesting peer's next preferred height (one above its current preference)
 	RequestedHeight uint64 `protobuf:"varint,6,opt,name=requested_height,json=requestedHeight,proto3" json:"requested_height,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
@@ -2062,7 +2062,7 @@ type PullQuery struct {
 	Deadline uint64 `protobuf:"varint,3,opt,name=deadline,proto3" json:"deadline,omitempty"`
 	// Container id being gossiped
 	ContainerId []byte `protobuf:"bytes,4,opt,name=container_id,json=containerId,proto3" json:"container_id,omitempty"`
-	// Requesting peer's last accepted height
+	// Requesting peer's next preferred height (one above its current preference)
 	RequestedHeight uint64 `protobuf:"varint,6,opt,name=requested_height,json=requestedHeight,proto3" json:"requested_height,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache

--- a/snow/consensus/snowman/consensus.go
+++ b/snow/consensus/snowman/consensus.go
@@ -49,9 +49,9 @@ type Consensus interface {
 	// Returns the ID and height of the last accepted decision.
 	LastAccepted() (ids.ID, uint64)
 
-	// Returns the ID of the tail of the strongly preferred sequence of
+	// Returns the ID, height of the tail of the strongly preferred sequence of
 	// decisions.
-	Preference() ids.ID
+	Preference() (ids.ID, uint64)
 
 	// Returns the ID of the strongly preferred decision with the provided
 	// height. Only the last accepted decision and processing decisions are

--- a/snow/consensus/snowman/consensus_test.go
+++ b/snow/consensus/snowman/consensus_test.go
@@ -22,6 +22,13 @@ import (
 	"github.com/ava-labs/avalanchego/utils/bag"
 )
 
+// preferenceID returns just the preferred block ID, for assertions that
+// don't care about the preferred height.
+func preferenceID(sm Consensus) ids.ID {
+	prefID, _ := sm.Preference()
+	return prefID
+}
+
 type testFunc func(*testing.T, Factory)
 
 var (
@@ -45,6 +52,7 @@ var (
 		RecordPollTransitiveVotingTest,
 		RecordPollDivergedVotingWithNoConflictingBitTest,
 		RecordPollChangePreferredChainTest,
+		RecordPollPreferenceHeightAfterSwitchTest,
 		LastAcceptedTest,
 		MetricsProcessingErrorTest,
 		MetricsAcceptedErrorTest,
@@ -101,7 +109,7 @@ func InitializeTest(t *testing.T, factory Factory) {
 		snowmantest.GenesisTimestamp,
 	))
 
-	require.Equal(snowmantest.GenesisID, sm.Preference())
+	require.Equal(snowmantest.GenesisID, preferenceID(sm))
 	require.Zero(sm.NumProcessing())
 }
 
@@ -174,7 +182,7 @@ func AddToTailTest(t *testing.T, factory Factory) {
 
 	// Adding to the previous preference will update the preference
 	require.NoError(sm.Add(block))
-	require.Equal(block.ID(), sm.Preference())
+	require.Equal(block.ID(), preferenceID(sm))
 	require.True(sm.IsPreferred(block.ID()))
 
 	pref, ok := sm.PreferenceAtHeight(block.Height())
@@ -213,12 +221,12 @@ func AddToNonTailTest(t *testing.T, factory Factory) {
 
 	// Adding to the previous preference will update the preference
 	require.NoError(sm.Add(firstBlock))
-	require.Equal(firstBlock.IDV, sm.Preference())
+	require.Equal(firstBlock.IDV, preferenceID(sm))
 
 	// Adding to something other than the previous preference won't update the
 	// preference
 	require.NoError(sm.Add(secondBlock))
-	require.Equal(firstBlock.IDV, sm.Preference())
+	require.Equal(firstBlock.IDV, preferenceID(sm))
 }
 
 // Make sure that adding a block that is detached from the rest of the tree
@@ -435,12 +443,12 @@ func RecordPollAcceptSingleBlockTest(t *testing.T, factory Factory) {
 
 	votes := bag.Of(block.ID())
 	require.NoError(sm.RecordPoll(t.Context(), votes))
-	require.Equal(block.ID(), sm.Preference())
+	require.Equal(block.ID(), preferenceID(sm))
 	require.Equal(1, sm.NumProcessing())
 	require.Equal(snowtest.Undecided, block.Status)
 
 	require.NoError(sm.RecordPoll(t.Context(), votes))
-	require.Equal(block.ID(), sm.Preference())
+	require.Equal(block.ID(), preferenceID(sm))
 	require.Zero(sm.NumProcessing())
 	require.Equal(snowtest.Accepted, block.Status)
 }
@@ -479,13 +487,13 @@ func RecordPollAcceptAndRejectTest(t *testing.T, factory Factory) {
 	votes := bag.Of(firstBlock.ID())
 
 	require.NoError(sm.RecordPoll(t.Context(), votes))
-	require.Equal(firstBlock.ID(), sm.Preference())
+	require.Equal(firstBlock.ID(), preferenceID(sm))
 	require.Equal(2, sm.NumProcessing())
 	require.Equal(snowtest.Undecided, firstBlock.Status)
 	require.Equal(snowtest.Undecided, secondBlock.Status)
 
 	require.NoError(sm.RecordPoll(t.Context(), votes))
-	require.Equal(firstBlock.ID(), sm.Preference())
+	require.Equal(firstBlock.ID(), preferenceID(sm))
 	require.Zero(sm.NumProcessing())
 	require.Equal(snowtest.Accepted, firstBlock.Status)
 	require.Equal(snowtest.Rejected, secondBlock.Status)
@@ -532,7 +540,7 @@ func RecordPollSplitVoteNoChangeTest(t *testing.T, factory Factory) {
 
 	// The first poll will accept shared bits
 	require.NoError(sm.RecordPoll(t.Context(), votes))
-	require.Equal(firstBlock.ID(), sm.Preference())
+	require.Equal(firstBlock.ID(), preferenceID(sm))
 	require.Equal(2, sm.NumProcessing())
 
 	metrics := gatherCounterGauge(t, registerer)
@@ -541,7 +549,7 @@ func RecordPollSplitVoteNoChangeTest(t *testing.T, factory Factory) {
 
 	// The second poll will do nothing
 	require.NoError(sm.RecordPoll(t.Context(), votes))
-	require.Equal(firstBlock.ID(), sm.Preference())
+	require.Equal(firstBlock.ID(), preferenceID(sm))
 	require.Equal(2, sm.NumProcessing())
 
 	metrics = gatherCounterGauge(t, registerer)
@@ -577,7 +585,7 @@ func RecordPollWhenFinalizedTest(t *testing.T, factory Factory) {
 	votes := bag.Of(snowmantest.GenesisID)
 	require.NoError(sm.RecordPoll(t.Context(), votes))
 	require.Zero(sm.NumProcessing())
-	require.Equal(snowmantest.GenesisID, sm.Preference())
+	require.Equal(snowmantest.GenesisID, preferenceID(sm))
 }
 
 func RecordPollRejectTransitivelyTest(t *testing.T, factory Factory) {
@@ -629,7 +637,7 @@ func RecordPollRejectTransitivelyTest(t *testing.T, factory Factory) {
 	// Tail = 0
 
 	require.Zero(sm.NumProcessing())
-	require.Equal(block0.ID(), sm.Preference())
+	require.Equal(block0.ID(), preferenceID(sm))
 	require.Equal(snowtest.Accepted, block0.Status)
 	require.Equal(snowtest.Rejected, block1.Status)
 	require.Equal(snowtest.Rejected, block2.Status)
@@ -680,25 +688,25 @@ func RecordPollTransitivelyResetConfidenceTest(t *testing.T, factory Factory) {
 	votesFor2 := bag.Of(block2.ID())
 	require.NoError(sm.RecordPoll(t.Context(), votesFor2))
 	require.Equal(4, sm.NumProcessing())
-	require.Equal(block2.ID(), sm.Preference())
+	require.Equal(block2.ID(), preferenceID(sm))
 
 	emptyVotes := bag.Bag[ids.ID]{}
 	require.NoError(sm.RecordPoll(t.Context(), emptyVotes))
 	require.Equal(4, sm.NumProcessing())
-	require.Equal(block2.ID(), sm.Preference())
+	require.Equal(block2.ID(), preferenceID(sm))
 
 	require.NoError(sm.RecordPoll(t.Context(), votesFor2))
 	require.Equal(4, sm.NumProcessing())
-	require.Equal(block2.ID(), sm.Preference())
+	require.Equal(block2.ID(), preferenceID(sm))
 
 	votesFor3 := bag.Of(block3.ID())
 	require.NoError(sm.RecordPoll(t.Context(), votesFor3))
 	require.Equal(2, sm.NumProcessing())
-	require.Equal(block3.ID(), sm.Preference())
+	require.Equal(block3.ID(), preferenceID(sm))
 
 	require.NoError(sm.RecordPoll(t.Context(), votesFor3))
 	require.Zero(sm.NumProcessing())
-	require.Equal(block3.ID(), sm.Preference())
+	require.Equal(block3.ID(), preferenceID(sm))
 	require.Equal(snowtest.Rejected, block0.Status)
 	require.Equal(snowtest.Accepted, block1.Status)
 	require.Equal(snowtest.Rejected, block2.Status)
@@ -742,7 +750,7 @@ func RecordPollInvalidVoteTest(t *testing.T, factory Factory) {
 	require.NoError(sm.RecordPoll(t.Context(), invalidVotes))
 	require.NoError(sm.RecordPoll(t.Context(), validVotes))
 	require.Equal(1, sm.NumProcessing())
-	require.Equal(block.ID(), sm.Preference())
+	require.Equal(block.ID(), preferenceID(sm))
 }
 
 func RecordPollTransitiveVotingTest(t *testing.T, factory Factory) {
@@ -804,7 +812,7 @@ func RecordPollTransitiveVotingTest(t *testing.T, factory Factory) {
 	// Tail = 2
 
 	require.Equal(4, sm.NumProcessing())
-	require.Equal(block2.ID(), sm.Preference())
+	require.Equal(block2.ID(), preferenceID(sm))
 	require.Equal(snowtest.Accepted, block0.Status)
 	require.Equal(snowtest.Undecided, block1.Status)
 	require.Equal(snowtest.Undecided, block2.Status)
@@ -819,7 +827,7 @@ func RecordPollTransitiveVotingTest(t *testing.T, factory Factory) {
 	// Tail = 2
 
 	require.Zero(sm.NumProcessing())
-	require.Equal(block2.ID(), sm.Preference())
+	require.Equal(block2.ID(), preferenceID(sm))
 	require.Equal(snowtest.Accepted, block0.Status)
 	require.Equal(snowtest.Accepted, block1.Status)
 	require.Equal(snowtest.Accepted, block2.Status)
@@ -897,7 +905,7 @@ func RecordPollDivergedVotingWithNoConflictingBitTest(t *testing.T, factory Fact
 	// rejected.
 	require.NoError(sm.Add(block3))
 
-	require.Equal(block0.ID(), sm.Preference())
+	require.Equal(block0.ID(), preferenceID(sm))
 	require.Equal(snowtest.Undecided, block0.Status, "should not be decided yet")
 	require.Equal(snowtest.Undecided, block1.Status, "should not be decided yet")
 	require.Equal(snowtest.Undecided, block2.Status, "should not be decided yet")
@@ -964,7 +972,9 @@ func RecordPollChangePreferredChainTest(t *testing.T, factory Factory) {
 	require.NoError(sm.Add(b1Block))
 	require.NoError(sm.Add(b2Block))
 
-	require.Equal(a2Block.ID(), sm.Preference())
+	prefID, prefHeight := sm.Preference()
+	require.Equal(a2Block.ID(), prefID)
+	require.Equal(a2Block.Height(), prefHeight)
 
 	require.True(sm.IsPreferred(a1Block.ID()))
 	require.True(sm.IsPreferred(a2Block.ID()))
@@ -982,7 +992,9 @@ func RecordPollChangePreferredChainTest(t *testing.T, factory Factory) {
 	b2Votes := bag.Of(b2Block.ID())
 	require.NoError(sm.RecordPoll(t.Context(), b2Votes))
 
-	require.Equal(b2Block.ID(), sm.Preference())
+	prefID, prefHeight = sm.Preference()
+	require.Equal(b2Block.ID(), prefID)
+	require.Equal(b2Block.Height(), prefHeight)
 	require.False(sm.IsPreferred(a1Block.ID()))
 	require.False(sm.IsPreferred(a2Block.ID()))
 	require.True(sm.IsPreferred(b1Block.ID()))
@@ -1000,7 +1012,7 @@ func RecordPollChangePreferredChainTest(t *testing.T, factory Factory) {
 	require.NoError(sm.RecordPoll(t.Context(), a1Votes))
 	require.NoError(sm.RecordPoll(t.Context(), a1Votes))
 
-	require.Equal(a2Block.ID(), sm.Preference())
+	require.Equal(a2Block.ID(), preferenceID(sm))
 	require.True(sm.IsPreferred(a1Block.ID()))
 	require.True(sm.IsPreferred(a2Block.ID()))
 	require.False(sm.IsPreferred(b1Block.ID()))
@@ -1013,6 +1025,67 @@ func RecordPollChangePreferredChainTest(t *testing.T, factory Factory) {
 	pref, ok = sm.PreferenceAtHeight(a2Block.Height())
 	require.True(ok)
 	require.Equal(a2Block.ID(), pref)
+}
+
+// RecordPollPreferenceHeightAfterSwitchTest checks that when a poll switches the
+// preference from one branch to a deeper branch, Preference() returns the new
+// preferred block along with its own height.
+func RecordPollPreferenceHeightAfterSwitchTest(t *testing.T, factory Factory) {
+	require := require.New(t)
+
+	sm := factory.New()
+
+	snowCtx := snowtest.Context(t, snowtest.CChainID)
+	ctx := snowtest.ConsensusContext(snowCtx)
+	params := snowball.Parameters{
+		K:                     1,
+		AlphaPreference:       1,
+		AlphaConfidence:       1,
+		Beta:                  10,
+		ConcurrentRepolls:     1,
+		OptimalProcessing:     1,
+		MaxOutstandingItems:   1,
+		MaxItemProcessingTime: 1,
+	}
+	require.NoError(sm.Initialize(
+		ctx,
+		params,
+		snowmantest.GenesisID,
+		snowmantest.GenesisHeight,
+		snowmantest.GenesisTimestamp,
+	))
+
+	// Two branches fork from genesis. The a-branch is preferred (added first), so
+	// its tip a1 is the initial preference. The b-branch is deeper.
+	//
+	//	height
+	//	  3            b3
+	//	               |
+	//	  2            b2
+	//	               |
+	//	  1     a1     b1
+	//	         \    /
+	//	  0      genesis
+	a1Block := snowmantest.BuildChild(snowmantest.Genesis)
+	b1Block := snowmantest.BuildChild(snowmantest.Genesis)
+	b2Block := snowmantest.BuildChild(b1Block)
+	b3Block := snowmantest.BuildChild(b2Block)
+
+	require.NoError(sm.Add(a1Block)) // we have extended the preference (genesis) so this should be the new preference
+	require.NoError(sm.Add(b1Block))
+	require.NoError(sm.Add(b2Block))
+	require.NoError(sm.Add(b3Block))
+
+	prefID, prefHeight := sm.Preference()
+	require.Equal(a1Block.ID(), prefID)
+	require.Equal(a1Block.Height(), prefHeight)
+
+	// A single vote for b1 flips the preference to the b-branch.
+	require.NoError(sm.RecordPoll(t.Context(), bag.Of(b1Block.ID())))
+
+	prefID, prefHeight = sm.Preference()
+	require.Equal(b3Block.ID(), prefID)
+	require.Equal(b3Block.Height(), prefHeight)
 }
 
 func LastAcceptedTest(t *testing.T, factory Factory) {

--- a/snow/consensus/snowman/network_test.go
+++ b/snow/consensus/snowman/network_test.go
@@ -105,7 +105,7 @@ func (n *Network) Round() error {
 	sampledColors := bag.Bag[ids.ID]{}
 	for _, index := range indices {
 		peer := n.nodes[int(index)]
-		sampledColors.Add(peer.Preference())
+		sampledColors.Add(preferenceID(peer))
 	}
 
 	if err := running.RecordPoll(context.Background(), sampledColors); err != nil {
@@ -126,9 +126,9 @@ func (n *Network) Agreement() bool {
 	if len(n.nodes) == 0 {
 		return true
 	}
-	pref := n.nodes[0].Preference()
+	pref := preferenceID(n.nodes[0])
 	for _, node := range n.nodes {
-		if pref != node.Preference() {
+		if pref != preferenceID(node) {
 			return false
 		}
 	}

--- a/snow/consensus/snowman/topological.go
+++ b/snow/consensus/snowman/topological.go
@@ -36,6 +36,15 @@ type TopologicalFactory struct {
 	factory snowball.Factory
 }
 
+// preferredBlock is used to track the preferred block for snowman.
+// It couples the blockID and height so that they will always be updated together.
+type preferredBlock struct {
+	// blockID is the ID of the preferred block at this height
+	blockID ids.ID
+	// height is the height of the preferred block
+	height uint64
+}
+
 func (tf TopologicalFactory) New() Consensus {
 	return &Topological{Factory: tf.factory}
 }
@@ -71,8 +80,9 @@ type Topological struct {
 	// that height.
 	preferredHeights map[uint64]ids.ID // height -> blockID
 
-	// preference is the preferred block with highest height
-	preference ids.ID
+	// preference is the preferred block with highest height,
+	// we hold them both so that they will always be updated together.
+	preference preferredBlock
 
 	// Used in [calculateInDegree] and.
 	// Should only be accessed in that method.
@@ -136,7 +146,11 @@ func (ts *Topological) Initialize(
 		lastAcceptedID: {t: ts},
 	}
 	ts.preferredHeights = make(map[uint64]ids.ID)
-	ts.preference = lastAcceptedID
+	ts.preference = preferredBlock{
+		blockID: lastAcceptedID,
+		height:  lastAcceptedHeight,
+	}
+
 	return nil
 }
 
@@ -176,8 +190,11 @@ func (ts *Topological) Add(blk Block) error {
 	}
 
 	// If we are extending the preference, this is the new preference
-	if ts.preference == parentID {
-		ts.preference = blkID
+	if ts.preference.blockID == parentID {
+		ts.preference = preferredBlock{
+			blockID: blkID,
+			height:  height,
+		}
 		ts.preferredIDs.Add(blkID)
 		ts.preferredHeights[height] = blkID
 	}
@@ -210,8 +227,8 @@ func (ts *Topological) LastAccepted() (ids.ID, uint64) {
 	return ts.lastAcceptedID, ts.lastAcceptedHeight
 }
 
-func (ts *Topological) Preference() ids.ID {
-	return ts.preference
+func (ts *Topological) Preference() (ids.ID, uint64) {
+	return ts.preference.blockID, ts.preference.height
 }
 
 func (ts *Topological) PreferenceAtHeight(height uint64) (ids.ID, bool) {
@@ -282,8 +299,23 @@ func (ts *Topological) RecordPoll(ctx context.Context, voteBag bag.Bag[ids.ID]) 
 	ts.preferredIDs.Clear()
 	clear(ts.preferredHeights)
 
-	ts.preference = preferred
-	startBlock := ts.blocks[ts.preference]
+	// The only entry in the blocks map with a nil blk is the last accepted block,
+	// set at initialization. All other blocks are stored in Add() with a non-nil blk.
+	// Therefore, if the preferred is not the last accepted block,
+	// it was added by Add() with a non-nil block.
+	startBlock := ts.blocks[preferred]
+
+	if preferred == ts.lastAcceptedID {
+		ts.preference = preferredBlock{
+			blockID: preferred,
+			height:  ts.lastAcceptedHeight,
+		}
+	} else {
+		ts.preference = preferredBlock{
+			blockID: preferred,
+			height:  startBlock.blk.Height(),
+		}
+	}
 
 	// Runtime = |live set| ; Space = Constant
 	// Traverse from the preferred ID to the last accepted ancestor.
@@ -301,13 +333,17 @@ func (ts *Topological) RecordPoll(ctx context.Context, voteBag bag.Bag[ids.ID]) 
 	// Traverse from the preferred ID to the preferred child until there are no
 	// children.
 	for block := startBlock; block.sb != nil; {
-		ts.preference = block.sb.Preference()
-		ts.preferredIDs.Add(ts.preference)
-		block = ts.blocks[ts.preference]
+		preferred = block.sb.Preference()
+		ts.preferredIDs.Add(preferred)
+		block = ts.blocks[preferred]
 		// Invariant: Because the prior block had an initialized snowball
 		// instance, it must have a processing child. This guarantees that
 		// block.blk is non-nil here.
-		ts.preferredHeights[block.blk.Height()] = ts.preference
+		ts.preference = preferredBlock{
+			blockID: preferred,
+			height:  block.blk.Height(),
+		}
+		ts.preferredHeights[block.blk.Height()] = preferred
 	}
 	return nil
 }
@@ -479,7 +515,7 @@ func (ts *Topological) vote(ctx context.Context, voteStack []votes) (ids.ID, err
 			)
 			ts.metrics.FailedPoll()
 		}
-		return ts.preference, nil
+		return ts.preference.blockID, nil
 	}
 
 	// keep track of the new preferred block

--- a/snow/engine/snowman/BUILD.bazel
+++ b/snow/engine/snowman/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//snow/engine/enginetest",
         "//snow/engine/snowman/ancestor",
         "//snow/engine/snowman/block/blocktest",
+        "//snow/engine/snowman/enginetest",
         "//snow/engine/snowman/getter",
         "//snow/snowtest",
         "//snow/validators",

--- a/snow/engine/snowman/engine.go
+++ b/snow/engine/snowman/engine.go
@@ -34,8 +34,11 @@ import (
 )
 
 const (
-	nonVerifiedCacheSize = 64 * units.MiB
-	errInsufficientStake = "insufficient connected stake"
+	// maxAllowedBlockHeightDistanceIngestion limits how far ahead (by height) a block may be
+	// from the last preferred height before the engine stops fetching missing ancestors for it.
+	maxAllowedBlockHeightDistanceIngestion = 100
+	nonVerifiedCacheSize                   = 64 * units.MiB
+	errInsufficientStake                   = "insufficient connected stake"
 )
 
 var _ common.Engine = (*Engine)(nil)
@@ -156,7 +159,6 @@ func New(config Config) (*Engine, error) {
 }
 
 func (e *Engine) Gossip(ctx context.Context) error {
-	lastAcceptedID, lastAcceptedHeight := e.Consensus.LastAccepted()
 	if numProcessing := e.Consensus.NumProcessing(); numProcessing != 0 {
 		e.Ctx.Log.Debug("skipping block gossip",
 			zap.String("reason", "blocks currently processing"),
@@ -184,24 +186,27 @@ func (e *Engine) Gossip(ctx context.Context) error {
 		return nil
 	}
 
-	nextHeightToAccept, err := math.Add(lastAcceptedHeight, 1)
+	pref, preferredHeight := e.Consensus.Preference()
+
+	nextHeightToPrefer, err := math.Add(preferredHeight, 1)
 	if err != nil {
 		e.Ctx.Log.Error("skipping block gossip",
 			zap.String("reason", "block height overflow"),
-			zap.Stringer("blkID", lastAcceptedID),
-			zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
+			zap.Stringer("preferred", pref),
+			zap.Uint64("preferredHeight", preferredHeight),
 			zap.Error(err),
 		)
 		return nil
 	}
 
 	e.requestID++
+
 	e.Sender.SendPullQuery(
 		ctx,
 		set.Of(vdrID),
 		e.requestID,
-		e.Consensus.Preference(),
-		nextHeightToAccept,
+		pref,
+		nextHeightToPrefer,
 	)
 	return nil
 }
@@ -371,42 +376,22 @@ func (e *Engine) Chits(ctx context.Context, nodeID ids.NodeID, requestID uint32,
 	)
 
 	issuedMetric := e.metrics.issued.WithLabelValues(pullGossipSource)
-	if err := e.issueFromByID(ctx, nodeID, preferredID, issuedMetric); err != nil {
+
+	if err := e.issueFromByID(ctx, nodeID, preferredIDAtHeight, issuedMetric); err != nil {
 		return err
 	}
 
-	var (
-		preferredIDAtHeightShouldBlock bool
-		// Invariant: The order of [responseOptions] must be [preferredID] then
-		// (optionally) [preferredIDAtHeight]. During vote application, the
-		// first vote that can be applied will be used. So, the votes should be
-		// populated in order of decreasing height.
-		responseOptions = []ids.ID{preferredID}
-	)
-	if preferredID != preferredIDAtHeight {
-		if err := e.issueFromByID(ctx, nodeID, preferredIDAtHeight, issuedMetric); err != nil {
-			return err
-		}
-		preferredIDAtHeightShouldBlock = e.canDependOn(preferredIDAtHeight)
-		responseOptions = append(responseOptions, preferredIDAtHeight)
-	}
-
-	// Will record chits once [preferredID] and [preferredIDAtHeight] have been
-	// issued into consensus
+	// Will record chits once [preferredIDAtHeight] has been issued into consensus
 	v := &voter{
 		e:               e,
 		nodeID:          nodeID,
 		requestID:       requestID,
-		responseOptions: responseOptions,
+		responseOptions: []ids.ID{preferredIDAtHeight},
 	}
 
-	// Wait until [preferredID] and [preferredIDAtHeight] have been issued to
-	// consensus before applying this chit.
+	// Wait until [preferredIDAtHeight] has been issued to consensus before applying this chit.
 	var deps []ids.ID
-	if e.canDependOn(preferredID) {
-		deps = append(deps, preferredID)
-	}
-	if preferredIDAtHeightShouldBlock {
+	if e.canDependOn(preferredIDAtHeight) {
 		deps = append(deps, preferredIDAtHeight)
 	}
 
@@ -601,7 +586,7 @@ func (e *Engine) sendChits(ctx context.Context, nodeID ids.NodeID, requestID uin
 	}
 
 	var (
-		preference         = e.Consensus.Preference()
+		preference, _      = e.Consensus.Preference()
 		preferenceAtHeight ids.ID
 	)
 	if requestedHeight < lastAcceptedHeight {
@@ -666,7 +651,7 @@ func (e *Engine) buildBlocks(ctx context.Context) error {
 		// The newly created block should be built on top of the preferred block.
 		// Otherwise, the new block doesn't have the best chance of being confirmed.
 		parentID := blk.Parent()
-		if pref := e.Consensus.Preference(); parentID != pref {
+		if pref, _ := e.Consensus.Preference(); parentID != pref {
 			e.Ctx.Log.Warn("built block with unexpected parent",
 				zap.Stringer("expectedParentID", pref),
 				zap.Stringer("parentID", parentID),
@@ -696,7 +681,7 @@ func (e *Engine) buildBlocks(ctx context.Context) error {
 func (e *Engine) repoll(ctx context.Context) {
 	// if we are issuing a repoll, we should gossip our current preferences to
 	// propagate the most likely branch as quickly as possible
-	prefID := e.Consensus.Preference()
+	prefID, _ := e.Consensus.Preference()
 
 	for i := e.polls.Len(); i < e.Params.ConcurrentRepolls; i++ {
 		e.sendQuery(ctx, prefID, nil, false)
@@ -740,11 +725,31 @@ func (e *Engine) issueFrom(
 
 		// If we don't have this ancestor, request it from [nodeID]
 		blkID = blk.Parent()
+		childHeight := blk.Height()
 		blk, err = e.getBlock(ctx, blkID)
 		if err != nil {
+			// We don't have the parent block locally, so we need to fetch it.
+			// However, before fetching it, we check to see if the parent block is too far ahead of our last preferred height.
+			// If it is, we will abandon the parent block instead of fetching it.
+			// This is to prevent us from fetching a large number of blocks recursively.
+			// Instead, we should prefer fetching them in-order bottom-up so we can verify them as we receive them,
+			// and not only once we have fetched the entire chain of blocks we're missing.
+			_, lastPreferredHeight := e.Consensus.Preference()
+			if maxHeightAllowedToFetch, err := math.Add(lastPreferredHeight, maxAllowedBlockHeightDistanceIngestion); err == nil && maxHeightAllowedToFetch < childHeight {
+				e.Ctx.Log.Debug("abandoning block because it is too far ahead of our last preferred height",
+					zap.Stringer("blkID", blkID),
+					zap.Uint64("childHeight", childHeight),
+					zap.Uint64("lastPreferredHeight", lastPreferredHeight),
+					zap.Uint64("maxHeightAllowedToFetch", maxHeightAllowedToFetch),
+				)
+				return e.blocked.Abandon(ctx, blkID)
+			}
+			// If we reached here, then we either overflowed when calculating maxHeightAllowedToFetch or childHeight ≤ maxHeightAllowedToFetch.
+			// If we overflow, then it is because lastPreferredHeight is very close to maxuint64,
+			// but still lastPreferredHeight < childHeight ≤ maxuint64, so we should still be fetching the block
 			// If the block is not locally available, request it from the peer.
 			e.sendRequest(ctx, nodeID, blkID, issuedMetric)
-			return nil //nolint:nilerr
+			return nil
 		}
 	}
 
@@ -892,13 +897,13 @@ func (e *Engine) sendQuery(
 		return
 	}
 
-	_, lastAcceptedHeight := e.Consensus.LastAccepted()
-	nextHeightToAccept, err := math.Add(lastAcceptedHeight, 1)
+	_, preferredHeight := e.Consensus.Preference()
+	nextHeightToPrefer, err := math.Add(preferredHeight, 1)
 	if err != nil {
 		e.Ctx.Log.Error("dropped query for block",
 			zap.String("reason", "block height overflow"),
 			zap.Stringer("blkID", blkID),
-			zap.Uint64("lastAcceptedHeight", lastAcceptedHeight),
+			zap.Uint64("preferredHeight", preferredHeight),
 			zap.Error(err),
 		)
 		return
@@ -917,9 +922,9 @@ func (e *Engine) sendQuery(
 
 	vdrSet := set.Of(vdrIDs...)
 	if push {
-		e.Sender.SendPushQuery(ctx, vdrSet, e.requestID, blkBytes, nextHeightToAccept)
+		e.Sender.SendPushQuery(ctx, vdrSet, e.requestID, blkBytes, nextHeightToPrefer)
 	} else {
-		e.Sender.SendPullQuery(ctx, vdrSet, e.requestID, blkID, nextHeightToAccept)
+		e.Sender.SendPullQuery(ctx, vdrSet, e.requestID, blkID, nextHeightToPrefer)
 	}
 }
 
@@ -999,7 +1004,8 @@ func (e *Engine) deliver(
 		}
 	}
 
-	if err := e.VM.SetPreference(ctx, e.Consensus.Preference()); err != nil {
+	pref, _ := e.Consensus.Preference()
+	if err := e.VM.SetPreference(ctx, pref); err != nil {
 		return err
 	}
 

--- a/snow/engine/snowman/engine_test.go
+++ b/snow/engine/snowman/engine_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"runtime/debug"
 	"slices"
 	"testing"
 	"time"
@@ -34,6 +36,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
+
+	snowmanenginetest "github.com/ava-labs/avalanchego/snow/engine/snowman/enginetest"
 )
 
 var (
@@ -230,7 +234,7 @@ func TestEngineQuery(t *testing.T) {
 			RequestID: requestID,
 		}
 		require.Equal(parent.ID(), blockID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(parent.Height()+1, requestedHeight) // next preferred height
 	}
 
 	vm.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
@@ -277,7 +281,7 @@ func TestEngineQuery(t *testing.T) {
 			RequestID: requestID,
 		}
 		require.Equal(child.ID(), blockID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(child.Height()+1, requestedHeight) // next preferred height
 	}
 
 	vm.ParseBlockF = func(_ context.Context, b []byte) (snowman.Block, error) {
@@ -373,7 +377,7 @@ func TestEngineMultipleQuery(t *testing.T) {
 		vdrSet := set.Of(vdr0, vdr1, vdr2)
 		require.Equal(vdrSet, inVdrs)
 		require.Equal(blk0.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk0.Height()+1, requestedHeight) // next preferred height
 	}
 
 	vm.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
@@ -444,7 +448,7 @@ func TestEngineMultipleQuery(t *testing.T) {
 		vdrSet := set.Of(vdr0, vdr1, vdr2)
 		require.Equal(vdrSet, inVdrs)
 		require.Equal(blk1.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk1.Height()+1, requestedHeight) // next preferred height
 	}
 	require.NoError(te.Put(t.Context(), vdr0, *getRequestID, blk1.Bytes()))
 
@@ -493,7 +497,8 @@ func TestEngineBlockedIssue(t *testing.T) {
 		te.metrics.issued.WithLabelValues(unknownSource),
 	))
 
-	require.Equal(blk1.ID(), te.Consensus.Preference())
+	pref, _ := te.Consensus.Preference()
+	require.Equal(blk1.ID(), pref)
 }
 
 func TestEngineRespondsToGetRequest(t *testing.T) {
@@ -568,7 +573,7 @@ func TestEnginePushQuery(t *testing.T) {
 		vdrSet := set.Of(vdr)
 		require.True(inVdrs.Equals(vdrSet))
 		require.Equal(blk.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk.Height()+1, requestedHeight) // next preferred height
 	}
 
 	require.NoError(te.PushQuery(t.Context(), vdr, 20, blk.Bytes(), 1))
@@ -698,7 +703,7 @@ func TestVoteCanceling(t *testing.T) {
 		vdrSet := set.Of(vdr0, vdr1, vdr2)
 		require.Equal(vdrSet, inVdrs)
 		require.Equal(blk.Bytes(), blkBytes)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk.Height()+1, requestedHeight) // next preferred height
 	}
 
 	require.NoError(te.issue(
@@ -1066,7 +1071,7 @@ func TestEngineBlockingChitResponse(t *testing.T) {
 			RequestID: requestID,
 		}
 		require.Equal(issuedBlk.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(issuedBlk.Height()+1, requestedHeight) // next preferred height
 	}
 
 	// Issuing [issuedBlk] will immediately adds [issuedBlk] to consensus, sets
@@ -1080,10 +1085,10 @@ func TestEngineBlockingChitResponse(t *testing.T) {
 
 	sender.SendPullQueryF = nil
 
-	// In response to the query for [issuedBlk], the peer is responding with,
-	// the currently pending issuance, [blockingBlk]. The direct conflict of
-	// [issuedBlk] is [missingBlk]. This registers a voter job dependent on
-	// [blockingBlk] and [missingBlk].
+	// In response to the query for [issuedBlk], the peer responds with tip
+	// preference [blockingBlk] and preference-at-requested-height [missingBlk].
+	// The engine only acts on the block at the requested height, so it registers
+	// a voter job dependent solely on [missingBlk], which is still being fetched.
 	require.NoError(te.Chits(
 		t.Context(),
 		queryRequest.NodeID,
@@ -1093,7 +1098,7 @@ func TestEngineBlockingChitResponse(t *testing.T) {
 		blockingBlk.ID(),
 		blockingBlk.Height(),
 	))
-	require.Equal(2, te.blocked.NumDependencies())
+	require.Equal(1, te.blocked.NumDependencies())
 
 	queryRequest = nil
 	sender.SendPullQueryF = func(_ context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, blkID ids.ID, requestedHeight uint64) {
@@ -1104,7 +1109,7 @@ func TestEngineBlockingChitResponse(t *testing.T) {
 			RequestID: requestID,
 		}
 		require.Equal(blockingBlk.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blockingBlk.Height()+1, requestedHeight) // next preferred height
 	}
 
 	vm.GetBlockF = func(_ context.Context, blkID ids.ID) (snowman.Block, error) {
@@ -1122,8 +1127,12 @@ func TestEngineBlockingChitResponse(t *testing.T) {
 		}
 	}
 
-	// Issuing [missingBlk] will add the block into consensus. However, it will
-	// not send a query for it as it is not the preferred block.
+	// Delivering [missingBlk] adds it to consensus and resolves the voter's only
+	// dependency, so the vote for [missingBlk] (the peer's preference at the
+	// requested height) is applied: [missingBlk] is accepted and its conflict
+	// [issuedBlk] is rejected. [blockingBlk] becomes the new preferred block and
+	// is queried, but is not accepted - the vote was only for [missingBlk], not
+	// the tip.
 	require.NoError(te.Put(
 		t.Context(),
 		getRequest.NodeID,
@@ -1131,8 +1140,8 @@ func TestEngineBlockingChitResponse(t *testing.T) {
 		missingBlk.Bytes(),
 	))
 	require.Equal(snowtest.Accepted, missingBlk.Status)
-	require.Equal(snowtest.Accepted, blockingBlk.Status)
 	require.Equal(snowtest.Rejected, issuedBlk.Status)
+	require.Equal(snowtest.Undecided, blockingBlk.Status)
 }
 
 func TestEngineRetryFetch(t *testing.T) {
@@ -1321,7 +1330,8 @@ func TestEngineInvalidBlockIgnoredFromUnexpectedPeer(t *testing.T) {
 
 	require.NoError(te.Put(t.Context(), vdr, *reqID, missingBlk.Bytes()))
 
-	require.Equal(pendingBlk.ID(), te.Consensus.Preference())
+	pref, _ := te.Consensus.Preference()
+	require.Equal(pendingBlk.ID(), pref)
 }
 
 func TestEnginePushQueryRequestIDConflict(t *testing.T) {
@@ -1397,7 +1407,8 @@ func TestEnginePushQueryRequestIDConflict(t *testing.T) {
 
 	require.NoError(te.Put(t.Context(), vdr, *reqID, missingBlk.Bytes()))
 
-	require.Equal(pendingBlk.ID(), te.Consensus.Preference())
+	pref, _ := te.Consensus.Preference()
+	require.Equal(pendingBlk.ID(), pref)
 }
 
 func TestEngineAggressivePolling(t *testing.T) {
@@ -1539,7 +1550,7 @@ func TestEngineDoubleChit(t *testing.T) {
 		vdrSet := set.Of(vdr0, vdr1)
 		require.Equal(vdrSet, inVdrs)
 		require.Equal(blk.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk.Height()+1, requestedHeight) // next preferred height
 	}
 	require.NoError(te.issue(
 		t.Context(),
@@ -1749,11 +1760,11 @@ func TestEngineNonPreferredAmplification(t *testing.T) {
 
 	sender.SendPushQueryF = func(_ context.Context, _ set.Set[ids.NodeID], _ uint32, blkBytes []byte, requestedHeight uint64) {
 		require.NotEqual(nonPreferredBlk.Bytes(), blkBytes)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(preferredBlk.Height()+1, requestedHeight) // next preferred height
 	}
 	sender.SendPullQueryF = func(_ context.Context, _ set.Set[ids.NodeID], _ uint32, blkID ids.ID, requestedHeight uint64) {
 		require.NotEqual(nonPreferredBlk.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(preferredBlk.Height()+1, requestedHeight) // next preferred height
 	}
 
 	require.NoError(te.Put(t.Context(), vdr, 0, preferredBlk.Bytes()))
@@ -1837,7 +1848,7 @@ func TestEngineBubbleVotesThroughInvalidBlock(t *testing.T) {
 		vdrSet := set.Of(vdr)
 		require.Equal(vdrSet, inVdrs)
 		require.Equal(blk1.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk1.Height()+1, requestedHeight) // next preferred height
 	}
 	// This engine now handles the response to the "Get" request. This should cause [blk1] to be issued
 	// which will result in attempting to issue [blk2]. However, [blk2] should fail verification and be dropped.
@@ -1872,7 +1883,7 @@ func TestEngineBubbleVotesThroughInvalidBlock(t *testing.T) {
 
 	// Now we are expecting a Chits message, and we receive it for [blk2]
 	// instead of [blk1]. This will cause the node to again request [blk2].
-	require.NoError(te.Chits(t.Context(), vdr, *queryRequestID, blk2.ID(), blk1.ID(), blk2.ID(), blk2.Height()))
+	require.NoError(te.Chits(t.Context(), vdr, *queryRequestID, blk2.ID(), blk2.ID(), blk2.ID(), blk2.Height()))
 
 	// The votes should be bubbled through [blk2] despite the fact that it is
 	// failing verification.
@@ -1905,14 +1916,14 @@ func TestEngineBubbleVotesThroughInvalidBlock(t *testing.T) {
 		*queryRequestID = requestID
 		require.Equal(expectedVdrSet, inVdrs)
 		require.Equal(blk2.ID(), blkID)
-		require.Equal(uint64(2), requestedHeight)
+		require.Equal(blk2.Height()+1, requestedHeight) // next preferred height
 	}
 	// Expect that the Engine will send a PullQuery after receiving this Gossip message for [blk2].
 	require.NoError(te.PushQuery(t.Context(), vdr, 0, blk2.Bytes(), 0))
 	require.True(*queried)
 
 	// After a single vote for [blk2], it should be marked as accepted.
-	require.NoError(te.Chits(t.Context(), vdr, *queryRequestID, blk2.ID(), blk1.ID(), blk2.ID(), blk2.Height()))
+	require.NoError(te.Chits(t.Context(), vdr, *queryRequestID, blk2.ID(), blk2.ID(), blk2.ID(), blk2.Height()))
 	require.Equal(snowtest.Accepted, blk2.Status)
 }
 
@@ -1995,7 +2006,7 @@ func TestEngineBubbleVotesThroughInvalidChain(t *testing.T) {
 		*queryRequestID = requestID
 		require.Equal(expectedVdrSet, inVdrs)
 		require.Equal(blk1.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk1.Height()+1, requestedHeight) // next preferred height
 	}
 
 	// Answer the request, this should result in [blk1] being issued as well.
@@ -2079,7 +2090,7 @@ func TestEngineBuildBlockWithCachedNonVerifiedParent(t *testing.T) {
 	sender.SendPullQueryF = func(_ context.Context, _ set.Set[ids.NodeID], requestID uint32, blkID ids.ID, requestedHeight uint64) {
 		*queryRequestGPID = requestID
 		require.Equal(grandParentBlk.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(grandParentBlk.Height()+1, requestedHeight) // next preferred height
 	}
 
 	// Give the engine the grandparent
@@ -2117,7 +2128,7 @@ func TestEngineBuildBlockWithCachedNonVerifiedParent(t *testing.T) {
 	sender.SendPullQueryF = func(_ context.Context, _ set.Set[ids.NodeID], requestID uint32, blkID ids.ID, requestedHeight uint64) {
 		*queryRequestAID = requestID
 		require.Equal(parentBlkA.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(parentBlkA.Height()+1, requestedHeight) // next preferred height
 	}
 	sender.CantSendPullQuery = false
 
@@ -2129,8 +2140,8 @@ func TestEngineBuildBlockWithCachedNonVerifiedParent(t *testing.T) {
 	require.NoError(te.Put(t.Context(), vdr, 0, parentBlkA.BytesV))
 
 	// Give 2 chits for [parentBlkA]/[parentBlkB]
-	require.NoError(te.Chits(t.Context(), vdr, *queryRequestAID, parentBlkB.IDV, grandParentBlk.IDV, parentBlkB.IDV, parentBlkB.Height()))
-	require.NoError(te.Chits(t.Context(), vdr, *queryRequestGPID, parentBlkB.IDV, grandParentBlk.IDV, parentBlkB.IDV, parentBlkB.Height()))
+	require.NoError(te.Chits(t.Context(), vdr, *queryRequestAID, parentBlkB.IDV, parentBlkB.IDV, parentBlkB.IDV, parentBlkB.Height()))
+	require.NoError(te.Chits(t.Context(), vdr, *queryRequestGPID, parentBlkB.IDV, parentBlkB.IDV, parentBlkB.IDV, parentBlkB.Height()))
 
 	// Assert that the blocks' statuses are correct.
 	// The evicted [parentBlkA] shouldn't be changed.
@@ -2206,7 +2217,7 @@ func TestEngineApplyAcceptedFrontierInQueryFailed(t *testing.T) {
 		*queryRequestID = requestID
 		require.Contains(inVdrs, vdr)
 		require.Equal(blk.Bytes(), blkBytes)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk.Height()+1, requestedHeight) // next preferred height
 	}
 
 	require.NoError(te.issue(
@@ -2235,7 +2246,7 @@ func TestEngineApplyAcceptedFrontierInQueryFailed(t *testing.T) {
 		*queryRequestID = requestID
 		require.Contains(inVdrs, vdr)
 		require.Equal(blk.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk.Height()+1, requestedHeight) // next preferred height
 	}
 
 	require.NoError(te.Chits(t.Context(), vdr, *queryRequestID, blk.ID(), blk.ID(), blk.ID(), blk.Height()))
@@ -2321,7 +2332,7 @@ func TestEngineRepollsMisconfiguredSubnet(t *testing.T) {
 		queryRequestID = requestID
 		require.Contains(inVdrs, vdr)
 		require.Equal(blk.ID(), blkID)
-		require.Equal(uint64(1), requestedHeight)
+		require.Equal(blk.Height()+1, requestedHeight) // next preferred height
 		queried = true
 	}
 
@@ -2712,45 +2723,250 @@ func TestEngineEarlyTerminateVoterRegression(t *testing.T) {
 		chain[:1],
 	)
 
-	// Vote for block 2 or block 1 in poll 0. This should trigger Get requests
-	// for both block 2 and block 1.
+	// Vote for block 2 in poll 0. Under the "vote only on the block at the
+	// requested height" semantics, the voter has a single dependency: block 2.
+	// Block 2 isn't available yet, so the engine requests it.
 	require.NoError(engine.Chits(
 		t.Context(),
 		nodeID,
 		pollRequestIDs[0],
 		chain[2].ID(),
-		chain[1].ID(),
+		chain[2].ID(),
 		snowmantest.GenesisID,
 		0,
 	))
 	require.Len(pollRequestIDs, 1)
-	require.Contains(getRequestIDs, chain[1].ID())
 	require.Contains(getRequestIDs, chain[2].ID())
 
-	// Mark the request for block 2 as failed. This should not cause the poll to
-	// be applied as there is still an outstanding request for block 1.
-	require.NoError(engine.GetFailed(
+	// Deliver block 2. It can't be issued into consensus yet because its parent
+	// (block 1) is still missing, so block 2 is only queued as pending and block
+	// 1 is requested. The voter is still blocked on block 2 being issued, so
+	// poll 0 must NOT be applied yet. This is the early-termination regression:
+	// a partially-assembled branch must not terminate the voter.
+	require.NoError(engine.Put(
 		t.Context(),
 		nodeID,
 		getRequestIDs[chain[2].ID()],
+		chain[2].Bytes(),
 	))
 	require.Len(pollRequestIDs, 1)
+	require.Contains(getRequestIDs, chain[1].ID())
+	// Block 2 is only pending issuance, so its status is still Undecided.
+	require.Equal(snowtest.Undecided, chain[2].Status)
 
-	// Issue block 1. This should cause the poll to be applied to both block 0
-	// and block 1.
+	// Deliver block 1. This lets block 1 and then block 2 be issued into
+	// consensus, which finally resolves the voter's dependency and applies the
+	// poll to the whole branch. Each newly issued block extends the preferred
+	// chain, so each one also fires a follow-up query (polls for block 1 and
+	// block 2).
 	require.NoError(engine.Put(
 		t.Context(),
 		nodeID,
 		getRequestIDs[chain[1].ID()],
 		chain[1].Bytes(),
 	))
-	// Because Put added a new preferred block to the chain, a new poll will be
-	// created.
-	require.Len(pollRequestIDs, 2)
+	require.Len(pollRequestIDs, 3)
 	require.Equal(snowtest.Accepted, chain[0].Status)
 	require.Equal(snowtest.Accepted, chain[1].Status)
-	// Block 2 still hasn't been issued, so it's status should remain Undecided.
-	require.Equal(snowtest.Undecided, chain[2].Status)
+	require.Equal(snowtest.Accepted, chain[2].Status)
+}
+
+// TestEngineForkNearAcceptFrontierAdvancesAcceptFrontier is a liveness regression
+// test that tests that a node can still agree on blocks if the votes need to go through
+// blocks that fail verification while their parents aren't accepted.
+// It runs the same scenario twice: once with small blocks, and once with every block
+// inflated past the unverifiedBlockCache size (proving convergence doesn't depend
+// on that cache).
+//
+// The concern is that the votes that a node collects on a losing fork may not bubble to the accept frontier,
+// preventing the node from advancing its accept frontier and causing liveness to fail.
+//
+//	         accept frontier
+//	              │
+//	Genesis ──────┤
+//	 (0)          ├── A0 ── A1 ── A2      forkA: fetched from the remote peer; becomes
+//	              │   (1)   (2)   (3)            the node's tall processing chain
+//	              │
+//	              └── B0 ── B1 ── B2      forkB: what the remote peer prefers;
+//	                  (1)   (2)   (3)            diverges from the accepted chain
+//	                                             at the accept frontier (Genesis)
+//
+// The node holds neither fork: it fetches both from the remote peer over the wire.
+// It first learns of forkA via a PullQuery for its tip and fetches the whole chain,
+// building a tall processing chain. Meanwhile the remote peer keeps voting forkB.
+//
+// To make the concern as sharp as possible, forkB is verify-gated on parent
+// acceptance: B1 cannot be verified until B0 is accepted, and B2 not until B1
+// is accepted. So even though the peer's vote points the node at the forkB tip
+// (B2), the node cannot verify B2 - it can only make progress by accepting
+// forkB from the bottom up. The node must therefore reject its tall forkA and
+// climb forkB one accepted block at a time. The test asserts it does exactly
+// that and fully converges (liveness holds).
+func TestEngineForkNearAcceptFrontierAdvancesAcceptFrontier(t *testing.T) {
+	const forkLen = 3
+	tests := []struct {
+		name      string
+		blockSize int
+	}{
+		{
+			name:      "normal blocks",
+			blockSize: 0,
+		},
+		{
+			// Every block is inflated, so it overflows the unverifiedBlockCache.
+			// This proves vote bubbling does not depend on the byte-bounded
+			// cache.
+			name:      "blocks larger than cache",
+			blockSize: nonVerifiedCacheSize * 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			blockSize := test.blockSize
+
+			forkA := snowmantest.BuildDescendants(snowmantest.Genesis, forkLen)
+			forkB := snowmantest.BuildDescendants(snowmantest.Genesis, forkLen)
+
+			// Inflate every block past blockSize, keeping each block's bytes unique (its
+			// first bytes are its ID). Must run before the VMs index the blocks by bytes.
+			if blockSize > 0 {
+				for _, blk := range append(slices.Clone(forkA), forkB...) {
+					big := make([]byte, blockSize)
+					id := blk.ID()
+					copy(big, id[:])
+					blk.BytesV = big
+				}
+			}
+
+			forkATip := forkA[forkLen-1]
+			forkBTip := forkB[forkLen-1]
+
+			nodeID := ids.GenerateTestNodeID()
+			peerID := ids.GenerateTestNodeID()
+			network := snowmanenginetest.NewNetwork(t)
+
+			// [connect] controls whether the engine treats [peer] as a connected validator.
+			// A node that hasn't connected its validator can still fetch blocks via Get
+			// but its own queries abort for insufficient connected
+			// stake - which we use to fetch forkA without triggering forkB convergence.
+			newEngine := func(self, peer ids.NodeID, vm *snowmanenginetest.VM, connect bool) *Engine {
+				cfg := DefaultConfig(t) // K=1, AlphaPreference=1, AlphaConfidence=1, Beta=1
+				require.NoError(cfg.Validators.AddStaker(cfg.Ctx.SubnetID, peer, nil, ids.Empty, 1))
+				if connect {
+					require.NoError(cfg.ConnectedValidators.Connected(t.Context(), peer, version.Current))
+				}
+				cfg.Validators.RegisterSetCallbackListener(cfg.Ctx.SubnetID, cfg.ConnectedValidators)
+				cfg.VM = vm
+
+				cfg.Sender = network.CreateSender(self)
+				snowGetHandler, err := getter.New(vm, cfg.Sender, cfg.Ctx.Log, time.Second, 2000, cfg.Ctx.Registerer)
+				require.NoError(err)
+				cfg.AllGetsServer = snowGetHandler
+
+				e, err := New(cfg)
+				require.NoError(err)
+				network.Register(self, e)
+				return e
+			}
+
+			// The peer holds both forks and serves either on request.
+			// It reports the forkB tip as its last accepted block and prefers
+			// it, but it also serves forkA blocks over the wire so the node can fetch
+			// them.
+			peerVM := snowmanenginetest.NewVM(t, append(slices.Clone(forkA), forkB...))
+			peerVM.LastAcceptedBlock = forkBTip
+
+			// The node holds neither fork locally: it must fetch every block above Genesis
+			// over the wire. It can parse either fork. forkB is verify-gated on parent
+			// acceptance, so the node can only verify a forkB block after its parent has
+			// been accepted; forkA is not gated.
+			forkBIDs := set.Set[ids.ID]{}
+			for _, blk := range forkB {
+				forkBIDs.Add(blk.ID())
+			}
+			nodeVM := snowmanenginetest.NewVM(t, append(slices.Clone(forkA), forkB...))
+			nodeVM.LastAcceptedBlock = snowmantest.Genesis
+			nodeVM.Has = func(*snowmantest.Block) bool {
+				return false
+			}
+			nodeVM.RequireAcceptedParentToVerify = func(blk *snowmantest.Block) bool {
+				return forkBIDs.Contains(blk.ID())
+			}
+
+			// node is the engine under test, and peer is the remote peer it fetches blocks from.
+			// The peer is connected, the node isn't connected so it can't issue queries, just fetch blocks.
+			peerEngine := newEngine(peerID, nodeID, peerVM, true)
+			nodeEngine := newEngine(nodeID, peerID, nodeVM, false)
+
+			require.NoError(peerEngine.Start(t.Context(), 0))
+			require.NoError(nodeEngine.Start(t.Context(), 0))
+
+			// Phase 1 - fetch forkA over the wire. The node learns of forkA through a
+			// regular PullQuery for its tip (which carries just the block ID). Since the
+			// node holds no forkA blocks, it fetches the whole chain from the peer via
+			// Get/Put. Its own queries abort (peer not connected yet), so it
+			// builds forkA without any forkB convergence interfering.
+			require.NoError(nodeEngine.PullQuery(t.Context(), peerID, 0, forkATip.ID(), 0))
+			require.NoError(network.DeliverMessages())
+			require.False(network.HasQueuedMessagesToDispatch())
+
+			// The node now holds all of forkA as a tall processing chain preferred over
+			// Genesis, with nothing accepted yet.
+			for i, blk := range forkA {
+				require.Truef(nodeEngine.Consensus.Processing(blk.ID()), "forkA block at height %d not processing", i+1)
+			}
+			preferenceID, preferenceHeight := nodeEngine.Consensus.Preference()
+			require.Equal(forkATip.ID(), preferenceID)
+			require.Equal(uint64(forkLen), preferenceHeight)
+			nodeLastAcceptedID, nodeLastAcceptedHeight := nodeEngine.Consensus.LastAccepted()
+			require.Equal(snowmantest.GenesisID, nodeLastAcceptedID)
+			require.Zero(nodeLastAcceptedHeight)
+
+			// The node knows nothing about forkB: with its validator unconnected it never
+			// queried the peer, so it never received forkB's IDs and never requested,
+			// cached, or issued any forkB block. Only the forkA blocks are processing.
+			require.Equal(forkLen, nodeEngine.Consensus.NumProcessing())
+			for i, blk := range forkB {
+				id := blk.ID()
+				require.Falsef(nodeEngine.Consensus.Processing(id), "forkB block at height %d unexpectedly processing", i+1)
+				_, pending := nodeEngine.pending[id]
+				require.Falsef(pending, "forkB block at height %d unexpectedly pending", i+1)
+				_, cached := nodeEngine.unverifiedBlockCache.Get(id)
+				require.Falsef(cached, "forkB block at height %d unexpectedly cached", i+1)
+				require.Falsef(nodeEngine.blkReqs.HasValue(id), "forkB block at height %d unexpectedly requested", i+1)
+			}
+
+			// Phase 2 - converge onto forkB. Connect the peer so the node can query it.
+			require.NoError(nodeEngine.ConnectedValidators.Connected(t.Context(), peerID, version.Current))
+
+			// Round 1: the node queries at preferredHeight+1, the peer answers with forkB,
+			// and the node fetches forkB. But the blocks of forkB can only be verified upon parent acceptance,
+			// so only B0 (whose parent Genesis is accepted) can be verified. The vote for
+			// the forkB tip has to bubble to B0 and in each round the previously accepted block unblocks the next one,
+			// so the node climbs forkB one block at a time.
+			for height := uint64(1); height <= uint64(forkLen); height++ {
+				require.NoError(nodeEngine.Gossip(t.Context()))
+				require.NoError(network.DeliverMessages())
+				require.False(network.HasQueuedMessagesToDispatch())
+
+				_, acceptedHeight := nodeEngine.Consensus.LastAccepted()
+				require.Equal(height, acceptedHeight)
+			}
+
+			// The accept frontier advanced from Genesis all the way onto forkB.
+			acceptedID, acceptedHeight := nodeEngine.Consensus.LastAccepted()
+			require.Equal(forkBTip.ID(), acceptedID)
+			require.Equal(uint64(forkLen), acceptedHeight)
+			require.Zero(nodeEngine.Consensus.NumProcessing())
+			for i, blk := range forkB {
+				require.Equalf(snowtest.Accepted, blk.Status, "forkB block at height %d not accepted", i+1)
+			}
+			for i, blk := range forkA {
+				require.Equalf(snowtest.Rejected, blk.Status, "forkA block at height %d not rejected", i+1)
+			}
+		})
+	}
 }
 
 // Voting for an unissued cached block that fails verification should not
@@ -3367,4 +3583,316 @@ type mockPChainProgressUpdater struct {
 
 func (m *mockPChainProgressUpdater) SetProgress(height uint64) {
 	m.setProgressF(height)
+}
+
+func TestEngineLaggingCatchUpLongGap(t *testing.T) {
+	// In this test we have two nodes - a lagging node and an up-to-date node. The
+	// lagging node is behind the up-to-date node by 200,000 blocks, and the
+	// up-to-date node only answers queries for the top and bottom ranges of blocks below:
+	//
+	//	height
+	//	200,000 ─┐  tip
+	//	         │  blocks that the up-to-date node will answer queries for
+	//	100,001 ─┘
+	//
+	//	100,000 ─┐  for these blocks, the request times out, which causes
+	//	 90,001 ─┘  a recursive abandonment of block scheduling from the bottom up,
+	//              resulting in a call stack 100,000 deep unless we short-circuit it.
+	//	 90,000 ─┐
+	//	         │  These blocks are answered by the up-to-date node,
+	//	      1 ─┘  resulting in the lagging node climbing from the bottom to 90,000.
+	//	      0    genesis, where the lagging node starts
+	//
+	// Both routes run at once. The lagging node climbs from genesis to
+	// 90,000 and accepts every block up to it, while the recursive retrieval of blocks from the
+	// tip accumulates a job per block and then collapses because the middle range of blocks are not retrievable.
+	// We stop the climb at 90,000 only to show that it reaches an arbitrary but high height.
+
+	const (
+		// blockGap is how far ahead the up-to-date engine is.
+		blockGap = 200_000
+		// heightAtWhichUpdatedNodeRefusesToAnswer is the height that above it the up-to-date engine will answer queries,
+		// but below it it will refuse answering, unless the height is below catchUpHeight,
+		// which is how far the lagging engine can climb.
+		heightAtWhichUpdatedNodeRefusesToAnswer = 100_000
+		// catchUpHeight is how many blocks the peer answers from the bottom, which is
+		// how far the lagging engine can climb.
+		catchUpHeight = 90_000
+		maxStack      = 8 << 20
+	)
+
+	require := require.New(t)
+	// We set the max stack limit to something smaller (8MB) so the test will not
+	// require a lot of resources to run.
+	prevMaxStack := debug.SetMaxStack(maxStack)
+	defer debug.SetMaxStack(prevMaxStack) // restore the previous limit once the test finishes
+
+	// Build a chain from genesis to [blockGap] blocks above it.
+	chain := make([]*snowmantest.Block, blockGap)
+	parent := snowmantest.Genesis
+	for i := range chain {
+		chain[i] = snowmantest.BuildChild(parent)
+		parent = chain[i]
+	}
+	tip := chain[len(chain)-1]
+
+	laggingNodeID := ids.GenerateTestNodeID()
+	upToDateNodeID := ids.GenerateTestNodeID()
+	network := snowmanenginetest.NewNetwork(t)
+
+	newEngine := func(self, peer ids.NodeID, vm *snowmanenginetest.VM) *Engine {
+		cfg := DefaultConfig(t)
+		require.NoError(cfg.Validators.AddStaker(cfg.Ctx.SubnetID, peer, nil, ids.Empty, 1))
+		require.NoError(cfg.ConnectedValidators.Connected(t.Context(), peer, version.Current))
+		cfg.Validators.RegisterSetCallbackListener(cfg.Ctx.SubnetID, cfg.ConnectedValidators)
+		cfg.VM = vm
+
+		cfg.Sender = network.CreateSender(self)
+		snowGetHandler, err := getter.New(vm, cfg.Sender, cfg.Ctx.Log, time.Second, 2000, cfg.Ctx.Registerer)
+		require.NoError(err)
+		cfg.AllGetsServer = snowGetHandler
+
+		e, err := New(cfg)
+		require.NoError(err)
+		network.Register(self, e)
+		return e
+	}
+
+	// To make sure the up-to-date node only answers queries for the top and bottom ranges of blocks,
+	// we just override its 'Has' method.
+	upToDateVM := snowmanenginetest.NewVM(t, chain)
+	upToDateVM.LastAcceptedBlock = tip
+
+	// The updated node only replies if the block is either above [heightAtWhichUpdatedNodeRefusesToAnswer]
+	// or below [catchUpHeight].
+	upToDateVM.Has = func(blk *snowmantest.Block) bool {
+		return blk.Height() >= heightAtWhichUpdatedNodeRefusesToAnswer || blk.Height() <= catchUpHeight
+	}
+
+	laggingVM := snowmanenginetest.NewVM(t, chain)
+	laggingVM.Has = func(blk *snowmantest.Block) bool {
+		return blk.Status == snowtest.Accepted
+	}
+
+	upToDateEngine := newEngine(upToDateNodeID, laggingNodeID, upToDateVM)
+	laggingEngine := newEngine(laggingNodeID, upToDateNodeID, laggingVM)
+
+	require.NoError(upToDateEngine.Start(t.Context(), 0))
+	require.NoError(laggingEngine.Start(t.Context(), 0))
+
+	// Trigger the lagging engine to start catching up by gossiping the tip of the chain.
+	// Gossip() makes a Pull Query to the up-to-date engine, which will respond with a Get request for the tip.
+	require.NoError(laggingEngine.Gossip(t.Context()))
+	require.NoError(network.DeliverMessages())
+	require.False(network.HasQueuedMessagesToDispatch())
+
+	// The lagging engine climbed from the bottom, one block at a time to our target height.
+	_, lastAcceptedHeight := laggingEngine.Consensus.LastAccepted()
+	require.Equal(uint64(catchUpHeight), lastAcceptedHeight)
+
+	// The lagging engine should have accepted all blocks up to catchUpHeight.
+	for i := range catchUpHeight {
+		require.Equal(snowtest.Accepted, chain[i].Status)
+	}
+}
+
+func TestEngineNetworkBuildsAndAcceptsBlocks(t *testing.T) {
+	require := require.New(t)
+
+	// A shared chain that the building engine hands out one block at a time as it
+	// is asked to build. Both nodes hold every block, so a peer can parse a block
+	// the moment it is queried about it.
+	const numBlocks = 100
+	chain := snowmantest.BuildDescendants(snowmantest.Genesis, numBlocks)
+
+	network := snowmanenginetest.NewNetwork(t)
+
+	nodeAID := ids.GenerateTestNodeID()
+	nodeBID := ids.GenerateTestNodeID()
+
+	vmA := snowmanenginetest.NewVM(t, chain)
+	vmB := snowmanenginetest.NewVM(t, chain)
+
+	// Whichever engine is asked to build returns the next block in the chain. An
+	// engine only builds on top of its preferred tip, so the chain order matches
+	// the order blocks are accepted. Only one engine builds per round, so a single
+	// shared cursor over the chain is enough.
+	var built int
+	buildNext := func(context.Context) (snowman.Block, error) {
+		blk := chain[built]
+		built++
+		return blk, nil
+	}
+	vmA.BuildBlockF = buildNext
+	vmB.BuildBlockF = buildNext
+
+	newEngine := func(self, peer ids.NodeID, vm *snowmanenginetest.VM) *Engine {
+		cfg := DefaultConfig(t)
+		require.NoError(cfg.Validators.AddStaker(cfg.Ctx.SubnetID, peer, nil, ids.Empty, 1))
+		require.NoError(cfg.ConnectedValidators.Connected(t.Context(), peer, version.Current))
+		cfg.Validators.RegisterSetCallbackListener(cfg.Ctx.SubnetID, cfg.ConnectedValidators)
+		cfg.VM = vm
+
+		cfg.Sender = network.CreateSender(self)
+		snowGetHandler, err := getter.New(vm, cfg.Sender, cfg.Ctx.Log, time.Second, 2000, cfg.Ctx.Registerer)
+		require.NoError(err)
+		cfg.AllGetsServer = snowGetHandler
+
+		e, err := New(cfg)
+		require.NoError(err)
+		network.Register(self, e)
+		return e
+	}
+
+	engineA := newEngine(nodeAID, nodeBID, vmA)
+	engineB := newEngine(nodeBID, nodeAID, vmB)
+
+	require.NoError(engineA.Start(t.Context(), 0))
+	require.NoError(engineB.Start(t.Context(), 0))
+
+	engines := []*Engine{engineA, engineB}
+	for i, blk := range chain {
+		builder := engines[i%len(engines)]
+		require.NoError(builder.Notify(t.Context(), common.PendingTxs)) // Trigger to build the next block in the chain.
+		require.NoError(network.DeliverMessages())
+		require.False(network.HasQueuedMessagesToDispatch())
+
+		// The block was accepted, and both engines agree on it as their tip.
+		require.Equal(snowtest.Accepted, blk.Status)
+		for _, e := range engines {
+			acceptedID, acceptedHeight := e.Consensus.LastAccepted()
+			require.Equal(blk.ID(), acceptedID)
+			require.Equal(uint64(i+1), acceptedHeight)
+		}
+	}
+}
+
+// TestEngineAbandonsBlocksTooFarAhead tests when the engine decides to fetch a missing parent block or abandon it.
+// If the parent block is above [maxAllowedBlockHeightDistanceIngestion] in height it should abandon the block and not fetch it.
+// If the parent block is at or below [maxAllowedBlockHeightDistanceIngestion] in height, it should fetch it.
+// The height arithmetic must also tolerate uint64 overflow: when last accepted is near the top of the uint64
+// range, adding the allowed distance overflows, and in that case we still fetch.
+func TestEngineAbandonsBlocksTooFarAhead(t *testing.T) {
+	tests := []struct {
+		name                string
+		laggingLastAccepted uint64 // the lagging node's last accepted height
+		childHeight         uint64 // the offered block, whose parent is missing
+		expectFetch         bool
+	}{
+		{
+			name:                "at the cutoff is fetched",
+			laggingLastAccepted: 0,
+			childHeight:         maxAllowedBlockHeightDistanceIngestion,
+			expectFetch:         true,
+		},
+		{
+			name:                "just past the cutoff is abandoned",
+			laggingLastAccepted: 0,
+			childHeight:         maxAllowedBlockHeightDistanceIngestion + 1,
+			expectFetch:         false,
+		},
+		{
+			name:                "overflow of the cutoff is fetched",
+			laggingLastAccepted: math.MaxUint64 - 100,
+			childHeight:         math.MaxUint64,
+			expectFetch:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			newBlock := func(height uint64, parentID ids.ID, status snowtest.Status) *snowmantest.Block {
+				id := ids.GenerateTestID()
+				return &snowmantest.Block{
+					Decidable:  snowtest.Decidable{IDV: id, Status: status},
+					ParentV:    parentID,
+					HeightV:    height,
+					TimestampV: snowmantest.GenesisTimestamp,
+					BytesV:     id[:],
+				}
+			}
+
+			// [chain] is every block that both fake VMs know about.
+			// We only need a few blocks, at arbitrary heights, not a continuous chain.
+			chain := []*snowmantest.Block{snowmantest.Genesis}
+
+			var laggingLastAccepted *snowmantest.Block
+			if test.laggingLastAccepted != 0 { // Used to test the uint64 overflow case.
+				laggingLastAccepted = newBlock(test.laggingLastAccepted, snowmantest.GenesisID, snowtest.Accepted)
+				chain = append(chain, laggingLastAccepted)
+			}
+
+			// [missingParent] is the block the lagging node is missing; [lastBlockOfUpdatedNode] is the
+			// block the peer prefers, built on top of [missingParent].
+			missingParent := newBlock(test.childHeight-1, snowmantest.GenesisID, snowtest.Undecided)
+			lastBlockOfUpdatedNode := newBlock(test.childHeight, missingParent.ID(), snowtest.Undecided)
+			chain = append(chain, missingParent, lastBlockOfUpdatedNode)
+
+			network := snowmanenginetest.NewNetwork(t)
+
+			laggingNodeID := ids.GenerateTestNodeID()
+			upToDateNodeID := ids.GenerateTestNodeID()
+
+			// The up-to-date node prefers [lastBlockOfUpdatedNode] and serves every block except
+			// [missingParent], recording whenever it is asked for [missingParent]. That request
+			// is the signal that the lagging node chose to fetch rather than
+			// abandon.
+			var parentRequested bool
+			upToDateVM := snowmanenginetest.NewVM(t, chain)
+			upToDateVM.LastAcceptedBlock = lastBlockOfUpdatedNode
+
+			// If Has() is called, it means the lagging node is asking for a block.
+			// If the block is [missingParent], we record that it was requested.
+			upToDateVM.Has = func(blk *snowmantest.Block) bool {
+				if blk.ID() == missingParent.ID() {
+					parentRequested = true
+					return false
+				}
+				return true
+			}
+
+			// The lagging node holds only blocks it has already accepted, so it
+			// must fetch anything above its last accepted block from the peer.
+			laggingVM := snowmanenginetest.NewVM(t, chain)
+			laggingVM.LastAcceptedBlock = laggingLastAccepted
+			laggingVM.Has = func(blk *snowmantest.Block) bool {
+				return blk.Status == snowtest.Accepted
+			}
+
+			newEngine := func(self, peer ids.NodeID, vm *snowmanenginetest.VM) *Engine {
+				cfg := DefaultConfig(t)
+				require.NoError(cfg.Validators.AddStaker(cfg.Ctx.SubnetID, peer, nil, ids.Empty, 1))
+				require.NoError(cfg.ConnectedValidators.Connected(t.Context(), peer, version.Current))
+				cfg.Validators.RegisterSetCallbackListener(cfg.Ctx.SubnetID, cfg.ConnectedValidators)
+				cfg.VM = vm
+
+				cfg.Sender = network.CreateSender(self)
+				snowGetHandler, err := getter.New(vm, cfg.Sender, cfg.Ctx.Log, time.Second, 2000, cfg.Ctx.Registerer)
+				require.NoError(err)
+				cfg.AllGetsServer = snowGetHandler
+
+				e, err := New(cfg)
+				require.NoError(err)
+				network.Register(self, e)
+				return e
+			}
+
+			upToDateEngine := newEngine(upToDateNodeID, laggingNodeID, upToDateVM)
+			laggingEngine := newEngine(laggingNodeID, upToDateNodeID, laggingVM)
+
+			require.NoError(upToDateEngine.Start(t.Context(), 0))
+			require.NoError(laggingEngine.Start(t.Context(), 0))
+
+			// The lagging node pull-queries the peer (triggered by gossip), learns about [lastBlockOfUpdatedNode], fetches
+			// it, and then either requests [missingParent] or abandons it depending on how
+			// far ahead [lastBlockOfUpdatedNode] is.
+			require.NoError(laggingEngine.Gossip(t.Context()))
+			require.NoError(network.DeliverMessages())
+			require.False(network.HasQueuedMessagesToDispatch())
+
+			require.Equal(test.expectFetch, parentRequested)
+		})
+	}
 }

--- a/snow/engine/snowman/enginetest/BUILD.bazel
+++ b/snow/engine/snowman/enginetest/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "enginetest",
+    srcs = [
+        "network.go",
+        "vm.go",
+    ],
+    importpath = "github.com/ava-labs/avalanchego/snow/engine/snowman/enginetest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//database",
+        "//ids",
+        "//snow/consensus/snowman",
+        "//snow/consensus/snowman/snowmantest",
+        "//snow/engine/common",
+        "//snow/engine/enginetest",
+        "//snow/engine/snowman/block/blocktest",
+        "//snow/snowtest",
+        "//utils/set",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/snow/engine/snowman/enginetest/network.go
+++ b/snow/engine/snowman/enginetest/network.go
@@ -1,0 +1,252 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package enginetest
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/utils/set"
+
+	commonenginetest "github.com/ava-labs/avalanchego/snow/engine/enginetest"
+)
+
+// defaultMaxMessages makes the deliver loop fail fast instead of looping indefinitely if a handler is misbehaving.
+const defaultMaxMessages = 50_000_000
+
+// Network is a fake network to connect engines in a test.
+// The network adds each message to a queue and the messages are dispatched via DeliverMessages.
+// The dispatching of messages is not done directly by invoking the remote node in order to avoid
+// a stack overflow when the remote node sends a message back to the Sender and vice versa.
+// Similarly, the network doesn't run each engine in a separate goroutine to avoid non-deterministic behavior in tests.
+//
+// To "connect" a node to the network, just register the engine to the network:
+//
+//	network.Register(nodeID, engine)
+type Network struct {
+	t        *testing.T
+	handlers map[ids.NodeID]common.Handler
+	queue    []func() error
+	// awaiting holds each request that no handler registered a response. It keeps them in the
+	// order that the senders sent them. The network then reports timeouts in the
+	// same order every time.
+	awaiting []pendingRequest
+}
+
+// NewNetwork returns an empty [Network].
+func NewNetwork(t *testing.T) *Network {
+	return &Network{
+		t:        t,
+		handlers: make(map[ids.NodeID]common.Handler),
+	}
+}
+
+// CreateSender returns a [common.Sender] that sends messages on behalf of [nodeID].
+func (n *Network) CreateSender(nodeID ids.NodeID) *Sender {
+	stub := commonenginetest.Sender{T: n.t}
+	stub.Default(true)
+	return &Sender{
+		Sender:  stub,
+		network: n,
+		self:    nodeID,
+	}
+}
+
+// Register sets the handler that receives the messages for nodeID. Call Register
+// before the network delivers a message to nodeID.
+// The [handler] is often the snowman engine of the node.
+func (n *Network) Register(nodeID ids.NodeID, handler common.Handler) {
+	require.NotContains(n.t, n.handlers, nodeID, "node %s already registered", nodeID)
+	n.handlers[nodeID] = handler
+}
+
+// DeliverMessages sends each message in the queue to its recipient. A handler
+// can enqueue more messages while DeliverMessages runs, and DeliverMessages also
+// sends those.
+//
+// When the queue is empty, DeliverMessages reports a failure for each request
+// that no handler registered a response. It then dispatches those failure messages.
+//
+// DeliverMessages returns when the queue is empty and no request waits for an
+// answer.
+func (n *Network) DeliverMessages() error {
+	delivered := 0
+	for {
+		for len(n.queue) > 0 {
+			next := n.queue[0]
+			n.queue = n.queue[1:]
+
+			delivered++
+			require.LessOrEqual(n.t, delivered, defaultMaxMessages,
+				"network delivered more than %d messages; handlers are likely looping", defaultMaxMessages)
+
+			if err := next(); err != nil {
+				return err
+			}
+		}
+
+		if len(n.awaiting) == 0 {
+			return nil
+		}
+
+		// The queue is empty. No handler will answer the requests that remain.
+		timedOut := n.awaiting
+		n.awaiting = nil
+		for _, req := range timedOut {
+			n.dispatchLackOfResponse(req)
+		}
+	}
+}
+
+// HasQueuedMessagesToDispatch reports if the network has a message in the queue,
+// or a request that waits for an answer.
+func (n *Network) HasQueuedMessagesToDispatch() bool {
+	return len(n.queue) > 0 || len(n.awaiting) > 0
+}
+
+// Outstanding reports the number of requests that wait for an answer.
+func (n *Network) Outstanding() int {
+	return len(n.awaiting)
+}
+
+func (n *Network) push(f func() error) {
+	n.queue = append(n.queue, f)
+}
+
+// locateHandler finds the recipient when the network delivers the message. The
+// order in which you register the nodes is therefore not important.
+func (n *Network) locateHandler(nodeID ids.NodeID) common.Handler {
+	handler, ok := n.handlers[nodeID]
+	require.True(n.t, ok, "message sent to node %s, which was never registered", nodeID)
+	return handler
+}
+
+// registerExpectingResponse records that requester waits for a response from responder. The kind
+// value gives the type of the request.
+func (n *Network) registerExpectingResponse(requester, responder ids.NodeID, requestID uint32, kind requestKind) {
+	n.awaiting = append(n.awaiting, pendingRequest{
+		requester: requester,
+		responder: responder,
+		requestID: requestID,
+		kind:      kind,
+	})
+}
+
+// registerResponse removes the request that matches a response. A responder sends its
+// response with the request ID that the requester made.
+func (n *Network) registerResponse(responder, requester ids.NodeID, requestID uint32, kind requestKind) {
+	n.awaiting = slices.DeleteFunc(n.awaiting, func(req pendingRequest) bool {
+		return req.requester == requester &&
+			req.responder == responder &&
+			req.requestID == requestID &&
+			req.kind == kind
+	})
+}
+
+// dispatchLackOfResponse reports a request that no handler registered a response for.
+func (n *Network) dispatchLackOfResponse(req pendingRequest) {
+	n.push(func() error {
+		handler := n.locateHandler(req.requester)
+		ctx := context.Background()
+		switch req.kind {
+		case fetchBlock:
+			return handler.GetFailed(ctx, req.responder, req.requestID)
+		case fetchAncestors:
+			return handler.GetAncestorsFailed(ctx, req.responder, req.requestID)
+		case queryPreference:
+			return handler.QueryFailed(ctx, req.responder, req.requestID)
+		default:
+			return fmt.Errorf("unhandled request kind %d", req.kind)
+		}
+	})
+}
+
+type requestKind int
+
+const (
+	fetchBlock requestKind = iota
+	fetchAncestors
+	queryPreference
+)
+
+type pendingRequest struct {
+	requester ids.NodeID
+	responder ids.NodeID
+	requestID uint32
+	kind      requestKind
+}
+
+// Sender sends the messages from one node into the network. The embedded
+// [commonenginetest.Sender] fails the test if a message kind has no route.
+type Sender struct {
+	commonenginetest.Sender
+	network *Network
+	self    ids.NodeID
+}
+
+func (s *Sender) SendGet(_ context.Context, nodeID ids.NodeID, requestID uint32, blkID ids.ID) {
+	s.network.registerExpectingResponse(s.self, nodeID, requestID, fetchBlock)
+	s.network.push(func() error {
+		return s.network.locateHandler(nodeID).Get(context.Background(), s.self, requestID, blkID)
+	})
+}
+
+func (s *Sender) SendPut(_ context.Context, nodeID ids.NodeID, requestID uint32, blk []byte) {
+	s.network.registerResponse(s.self, nodeID, requestID, fetchBlock)
+	s.network.push(func() error {
+		return s.network.locateHandler(nodeID).Put(context.Background(), s.self, requestID, blk)
+	})
+}
+
+func (s *Sender) SendGetAncestors(_ context.Context, nodeID ids.NodeID, requestID uint32, blkID ids.ID) {
+	s.network.registerExpectingResponse(s.self, nodeID, requestID, fetchAncestors)
+	s.network.push(func() error {
+		return s.network.locateHandler(nodeID).GetAncestors(context.Background(), s.self, requestID, blkID)
+	})
+}
+
+func (s *Sender) SendAncestors(_ context.Context, nodeID ids.NodeID, requestID uint32, blks [][]byte) {
+	s.network.registerResponse(s.self, nodeID, requestID, fetchAncestors)
+	s.network.push(func() error {
+		return s.network.locateHandler(nodeID).Ancestors(context.Background(), s.self, requestID, blks)
+	})
+}
+
+func (s *Sender) SendPullQuery(_ context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, blkID ids.ID, requestedHeight uint64) {
+	for _, nodeID := range sortedNodeIDs(nodeIDs) {
+		s.network.registerExpectingResponse(s.self, nodeID, requestID, queryPreference)
+		s.network.push(func() error {
+			return s.network.locateHandler(nodeID).PullQuery(context.Background(), s.self, requestID, blkID, requestedHeight)
+		})
+	}
+}
+
+func (s *Sender) SendPushQuery(_ context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, blk []byte, requestedHeight uint64) {
+	for _, nodeID := range sortedNodeIDs(nodeIDs) {
+		s.network.registerExpectingResponse(s.self, nodeID, requestID, queryPreference)
+		s.network.push(func() error {
+			return s.network.locateHandler(nodeID).PushQuery(context.Background(), s.self, requestID, blk, requestedHeight)
+		})
+	}
+}
+
+func (s *Sender) SendChits(_ context.Context, nodeID ids.NodeID, requestID uint32, preferredID, preferredIDAtHeight, acceptedID ids.ID, acceptedHeight uint64) {
+	s.network.registerResponse(s.self, nodeID, requestID, queryPreference)
+	s.network.push(func() error {
+		return s.network.locateHandler(nodeID).Chits(context.Background(), s.self, requestID, preferredID, preferredIDAtHeight, acceptedID, acceptedHeight)
+	})
+}
+
+// sortedNodeIDs sorts the node IDs.
+func sortedNodeIDs(nodeIDs set.Set[ids.NodeID]) []ids.NodeID {
+	sorted := nodeIDs.List()
+	slices.SortFunc(sorted, ids.NodeID.Compare)
+	return sorted
+}

--- a/snow/engine/snowman/enginetest/vm.go
+++ b/snow/engine/snowman/enginetest/vm.go
@@ -1,0 +1,157 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package enginetest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	"github.com/ava-labs/avalanchego/snow/consensus/snowman/snowmantest"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block/blocktest"
+	"github.com/ava-labs/avalanchego/snow/snowtest"
+)
+
+// ErrParentNotAccepted is returned by a block's Verify when the VM is
+// configured with [VM.VerifyRequiresAcceptedParent] and the block's parent has
+// not been accepted yet.
+var ErrParentNotAccepted = errors.New("parent not accepted")
+
+// VM is a fake [block.ChainVM].
+type VM struct {
+	blocktest.VM
+
+	// Has reports if this node holds a block.
+	// The node always holds its last accepted block.
+	// If nil we have all blocks in the chain.
+	Has func(*snowmantest.Block) bool
+
+	// RequireAcceptedParentToVerify, when non-nil, gates block verification:
+	// a block for which it returns true fails Verify with [ErrParentNotAccepted]
+	// until its parent has been accepted.
+	RequireAcceptedParentToVerify func(*snowmantest.Block) bool
+
+	// LastAcceptedBlock is the block that LastAccepted returns.
+	// If LastAcceptedBlock is nil, LastAccepted reports the highest accepted block in
+	// the chain.
+	LastAcceptedBlock *snowmantest.Block
+
+	byID            map[ids.ID]*snowmantest.Block
+	byBytes         map[string]*snowmantest.Block
+	byHeight        map[uint64]*snowmantest.Block
+	highestAccepted *snowmantest.Block
+}
+
+// NewVM returns a [VM] for the given chain. The heights must ascend and be contiguous.
+func NewVM(t *testing.T, chain []*snowmantest.Block) *VM {
+	vm := &VM{
+		byID:            make(map[ids.ID]*snowmantest.Block, len(chain)+1),
+		byBytes:         make(map[string]*snowmantest.Block, len(chain)+1),
+		byHeight:        make(map[uint64]*snowmantest.Block, len(chain)+1),
+		highestAccepted: snowmantest.Genesis,
+	}
+	for _, blk := range chain {
+		vm.byID[blk.ID()] = blk
+		vm.byBytes[string(blk.Bytes())] = blk
+		vm.byHeight[blk.Height()] = blk
+	}
+	// The genesis block is always available, even if the caller left it out of the
+	// chain.
+	vm.byID[snowmantest.GenesisID] = snowmantest.Genesis
+	vm.byBytes[string(snowmantest.Genesis.Bytes())] = snowmantest.Genesis
+	vm.byHeight[snowmantest.Genesis.Height()] = snowmantest.Genesis
+
+	vm.T = t
+	vm.Default(true)
+	vm.CantSetState = false
+	vm.CantSetPreference = false
+	return vm
+}
+
+// GetBlock returns a block if this node holds it.
+func (vm *VM) GetBlock(_ context.Context, blkID ids.ID) (snowman.Block, error) {
+	blk, ok := vm.byID[blkID]
+	if !ok {
+		return nil, database.ErrNotFound
+	}
+	if !vm.has(blk) {
+		return nil, database.ErrNotFound
+	}
+	return vm.wrap(blk), nil
+}
+
+// ParseBlock returns any block in the chain. It does this even if the node does
+// not hold the block, because a node can parse a block that it never received.
+func (vm *VM) ParseBlock(_ context.Context, blkBytes []byte) (snowman.Block, error) {
+	blk, ok := vm.byBytes[string(blkBytes)]
+	if !ok {
+		return nil, database.ErrNotFound
+	}
+	return vm.wrap(blk), nil
+}
+
+// wrap returns [blk] as-is, or, if the VM is configured to gate its
+// verification on parent acceptance, wrapped so that Verify enforces that.
+func (vm *VM) wrap(blk *snowmantest.Block) snowman.Block {
+	if vm.RequireAcceptedParentToVerify != nil && vm.RequireAcceptedParentToVerify(blk) {
+		return &acceptGatedBlock{Block: blk, vm: vm}
+	}
+	return blk
+}
+
+// acceptGatedBlock is a block whose Verify only succeeds once its parent has
+// been accepted, modeling a VM that verifies against accepted parent state.
+type acceptGatedBlock struct {
+	*snowmantest.Block
+	vm *VM
+}
+
+func (b *acceptGatedBlock) Verify(ctx context.Context) error {
+	if parent, ok := b.vm.byID[b.Parent()]; ok && parent.Status != snowtest.Accepted {
+		return ErrParentNotAccepted
+	}
+	return b.Block.Verify(ctx)
+}
+
+// LastAccepted reports [VM.LastAcceptedBlock]. If [VM.LastAcceptedBlock] is nil,
+// LastAccepted reports the highest accepted block in the chain.
+func (vm *VM) LastAccepted(context.Context) (ids.ID, error) {
+	return vm.lastAccepted().ID(), nil
+}
+
+// GetBlockIDAtHeight returns the ID of the block at the given height.
+func (vm *VM) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, error) {
+	blk, ok := vm.byHeight[height]
+	if !ok || !vm.has(blk) {
+		return ids.Empty, database.ErrNotFound
+	}
+	return blk.ID(), nil
+}
+
+func (vm *VM) lastAccepted() *snowmantest.Block {
+	if vm.LastAcceptedBlock != nil {
+		return vm.LastAcceptedBlock
+	}
+
+	// The engine accepts blocks in ascending height order. The search therefore
+	// starts at the highest accepted block that it found before, and does not read
+	// the chain again.
+	for {
+		next, ok := vm.byHeight[vm.highestAccepted.Height()+1]
+		if !ok || next.Status != snowtest.Accepted {
+			return vm.highestAccepted
+		}
+		vm.highestAccepted = next
+	}
+}
+
+func (vm *VM) has(blk *snowmantest.Block) bool {
+	if blk.ID() == vm.lastAccepted().ID() {
+		return true
+	}
+	return vm.Has == nil || vm.Has(blk)
+}

--- a/snow/engine/snowman/voter.go
+++ b/snow/engine/snowman/voter.go
@@ -59,7 +59,8 @@ func (v *voter) Execute(ctx context.Context, _ []ids.ID, _ []ids.ID) error {
 		}
 	}
 
-	if err := v.e.VM.SetPreference(ctx, v.e.Consensus.Preference()); err != nil {
+	pref, _ := v.e.Consensus.Preference()
+	if err := v.e.VM.SetPreference(ctx, pref); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Why this should be merged

This commit makes two changes to the snowman engine:
    
(1) Restricts fetching missing blocks from a remote node if the missing blocks are too far ahead by short-circuiting fetching a parent block if its child is too far in the future.
(2) Instead of sending a query about the next accepted height, snowman now sends a query about the next preferred height.

It also adds some testing utilities (test fakes for communication and VM) to improve expressiveness in testing the snowman engine.

### Background:
    
A snowman engine fetches new blocks by sending queries, discovering new block IDs and then fetching them:
    
(i) The engine sends a query and in the query it puts its next accepted height. The remote node that receives the query responds with its current preference and also the preference at that height (the engine's next accepted height). If the engine doesn't know the block that corresponds to the preferred block of the remote node at its next accepted height, it fetches it from the remote node. In this manner the engine discovers what is the next block it should fetch and this is how it can extend its chain by one block at a time.

(ii) If the engine receives a block but this block's parent is not known to the engine, it fetches the parent of the parent recursively until a parent block along the chain is know and verified by the engine. However, if the engine from some reason cannot verify or fetch a block along the chain of blocks it fetched, it recursively cancels the tasks responsible to verify the blocks fetched. In case of a very long chain of blocks, this recursion may result in a stack overflow.
    
## How this works

Change (1) simply restricts how far the chain of blocks we can fetch recursively (from the furthest block we do not know its parent to a block that we know its parent or have accepted it). The maximum allowed height difference is now set to `maxAllowedBlockHeightDistanceIngestion` which is set to `100` .
    
By doing so, we prevent a lagging snowman engine from attempting to recursively fetch (a node can't verify a block before verifying its parent, so it fetches the child and then the parent until it has a block it has verified or it decides it can't fetch the parent) a chain of blocks that is too long.

Without the fix in the commit, the test TestEngineLaggingCatchUpLongGap fails with stack overflow.
    
TestEngineLaggingCatchUpLongGap creates a block gap of 200,000 blocks between a lagging node and an up-to-date node.

The lagging node replicates 90,000 blocks starting from the latest block it has, without fetching the entire 200,000 block gap which the fix prevents. This proves that even with the added short-circuit, the node can still replicate blocks properly and isn't entirely dependent on the recursive mechanism. Worth to note that we only need a single activation of Gossip() for the lagging node, and we don't need Gossip() to be called many times, which proves our replication speed isn't dependent on the clock but only by the network. 

As mentioned, without change (1) in the commit, the test TestEngineLaggingCatchUpLongGap fails with stack overflow. However, without change (2), the test TestEngineLaggingCatchUpLongGap also fails because the only reason that a single activation of Gossip() is sufficient for the lagging node to catchup is change (2):
    
Previously to this change, the reason that a lagging snowman engine could catch up fast was that it was fetching blocks recursively from the tip of the remote node's chain down to its last accepted block (method (ii) above). In case of a large block height gap (above `maxAllowedBlockHeightDistanceIngestion`) this way is effectively disabled. Therefore, the only way remaining is (i) - fetching one block at a time after the previous block has been accepted. This is very slow, as it is driven solely by periodical invocations of Gossip().
    
This is why we're also doing change (2) - instead of querying the next accepted height, we query the next preferred height. This makes replication work as fast as method (ii) because once we add a new block to consensus and that block extends the preferred chain, that block becomes the new preference. So when a snowman engine replicates blocks, once it fetches a block it becomes its new preference. Once a block is added to consensus it also sends a new query precisely because that block is now the new preference. That new query queries the next block height, because the next preferred height has increased because the preference moved one block higher.

However, now when we query for the next preference we don't need to look and fetch both the preference and the preference at the next height of the remote node, and instead we can be more efficient as follows:

In the code before this PR, the engine looked at the returned preference and preference at height and used both block IDs in its snowman voting.
We needed both the preference and the preference at the next accepted height and we couldn't do without one of them:

a) We needed the preference for efficiency - this is how we discovered blocks far ahead and sped up voting by bubbling votes down from the preference of the remote node to our last accepted block.
b) We needed the preference at the next accepted height for making progress, because we might not be able to fetch or verify a far away block until we have accepted some blocks before it but then we had no way of accepting them without explicitly using them for consensus.

In this change, we combine both preferences into looking at a single one - the next preferred height (not the next accepted height as earlier) and we get the best of both worlds:
a) It's at the node's preferred tip + 1, so it can be a far away block if our preference is ahead of our latest accepted height, and we also advance the preference very fast as we add a new block that is a child of our previous preference
b) It still enables us to make progress, because we can bubble the votes from *our* preference down to our last accepted block



## How this was tested

- Added `RecordPollPreferenceHeightAfterSwitchTest` to make sure the height is updated when we switch from one branch to another in `RecordPoll()`.
- Added `TestEngineLaggingCatchUpLongGap` which reproduces a scenario where a node tries to fetch recursively from a remote node when the block height gap is too large and without fix (1) we will get a stack overflow, and without fix (2) we won't be able to catch-up with a single invocation of Gossip(). 
- Added `TestEngineNetworkBuildsAndAcceptsBlocks` which demonstrates the newly added fake network with two validators that extend the chain. 
- Added `TestEngineAbandonsBlocksTooFarAhead` which checks corner cases around fetching a block exactly `maxAllowedBlockHeightDistanceIngestion` away, further away, and a scenario where we're close to maxuint64 so an overflow occurs. 
- Added `TestEngineForkNearAcceptFrontierAdvancesAcceptFrontier`: checks that change (2) preserves liveness when a node that has built a tall processing chain on a
  losing fork whose competitor diverges right at the accept frontier and can only verify blocks if their parents are accepted. 

I also did some manual testing to ensure that snow replication works well after this change:

I first only made change (1) and disconnected the validator from the network with `iptables`, let the node be a large amount of blocks behind and then re-enabled the network connectivity.  

The node started catching up at a rate of 2 blocks per second which is not good enough:

<img width="643" height="253" alt="image" src="https://github.com/user-attachments/assets/42977a88-ea71-429b-9af3-c4b7de190d3b" />



Then after making change (2) I repeated the experiment (twice...) and the node replicated at a rate of 10-13 blocks per second. 

<img width="648" height="256" alt="image" src="https://github.com/user-attachments/assets/852c789c-1fcf-4549-8301-605e019e79bb" />

<img width="571" height="260" alt="image" src="https://github.com/user-attachments/assets/8af2f2eb-c042-4018-92e3-de6b6d00db89" />




## Need to be documented in RELEASES.md?

No