### PR TITLE
refactor(sae): separate canonical post-execution hooks

### DIFF
--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -256,8 +256,6 @@ func (h *hooks) BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB,
 }
 
 func (h *hooks) AfterExecutingBlock(statedb *state.StateDB, b *types.Block, receipts types.Receipts) error {
-	h.metrics.setMinBlockDelay(delayExponent(b.Header()).DelayDuration())
-
 	txs, err := tx.ParseSlice(customtypes.BlockExtData(b))
 	if err != nil {
 		return fmt.Errorf("parsing txs: %w", err)
@@ -268,6 +266,16 @@ func (h *hooks) AfterExecutingBlock(statedb *state.StateDB, b *types.Block, rece
 		if err := t.TransferNonAVAX(h.ctx.AVAXAssetID, extstatedb); err != nil {
 			return fmt.Errorf("transferring non-AVAX assets of tx %s (%d): %w", t.ID(), i, err)
 		}
+	}
+	return nil
+}
+
+func (h *hooks) AfterExecutingCanonicalBlock(b *types.Block, receipts types.Receipts) error {
+	h.metrics.setMinBlockDelay(delayExponent(b.Header()).DelayDuration())
+
+	txs, err := tx.ParseSlice(customtypes.BlockExtData(b))
+	if err != nil {
+		return fmt.Errorf("parsing txs: %w", err)
 	}
 
 	if err := h.state.Apply(b.NumberU64(), txs); err != nil {

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -255,8 +255,7 @@ func (h *hooks) BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB,
 	return nil
 }
 
-//nolint:revive // TODO(JonathanOppenheimer): remove this nolint once https://github.com/ava-labs/avalanchego/pull/5774 is merged.
-func (h *hooks) AfterExecutingBlock(statedb *state.StateDB, b *types.Block, receipts types.Receipts) error {
+func (h *hooks) AfterExecutingBlock(statedb *state.StateDB, b *types.Block, _ types.Receipts) error {
 	txs, err := tx.ParseSlice(customtypes.BlockExtData(b))
 	if err != nil {
 		return fmt.Errorf("parsing txs: %w", err)

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -255,6 +255,7 @@ func (h *hooks) BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB,
 	return nil
 }
 
+//nolint:revive // TODO(JonathanOppenheimer): remove this nolint once https://github.com/ava-labs/avalanchego/pull/5774 is merged.
 func (h *hooks) AfterExecutingBlock(statedb *state.StateDB, b *types.Block, receipts types.Receipts) error {
 	txs, err := tx.ParseSlice(customtypes.BlockExtData(b))
 	if err != nil {

--- a/vms/saevm/cchain/hooks.go
+++ b/vms/saevm/cchain/hooks.go
@@ -247,7 +247,7 @@ func (*hooks) CanExecuteTransaction(common.Address, *common.Address, libevm.Stat
 	return nil
 }
 
-func (h *hooks) BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, _ *types.Block) error {
+func (h *hooks) StartExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, _ *types.Block) error {
 	config := corethparams.GetExtra(h.chainConfig)
 	if isFirstDurangoBlock := corethparams.GetRulesExtra(rules).IsDurango && !config.IsDurango(parent.Time); isFirstDurangoBlock {
 		activatePrecompile(statedb, corethwarp.ContractAddress)
@@ -255,7 +255,7 @@ func (h *hooks) BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB,
 	return nil
 }
 
-func (h *hooks) AfterExecutingBlock(statedb *state.StateDB, b *types.Block, _ types.Receipts) error {
+func (h *hooks) FinishExecutingBlock(statedb *state.StateDB, b *types.Block, _ types.Receipts) error {
 	txs, err := tx.ParseSlice(customtypes.BlockExtData(b))
 	if err != nil {
 		return fmt.Errorf("parsing txs: %w", err)
@@ -270,7 +270,7 @@ func (h *hooks) AfterExecutingBlock(statedb *state.StateDB, b *types.Block, _ ty
 	return nil
 }
 
-func (h *hooks) AfterExecutingCanonicalBlock(b *types.Block, receipts types.Receipts) error {
+func (h *hooks) AfterExecutingBlock(b *types.Block, receipts types.Receipts) error {
 	h.metrics.setMinBlockDelay(delayExponent(b.Header()).DelayDuration())
 
 	txs, err := tx.ParseSlice(customtypes.BlockExtData(b))

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -88,7 +88,7 @@ type Points interface {
 	// MUST NOT apply any state changes outside of the [state.StateDB].
 	AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
 	// AfterExecutingCanonicalBlock runs only after canonical block execution. It
-	// can update data outside the state database.
+	// can update data outside the [state.StateDB].
 	AfterExecutingCanonicalBlock(*types.Block, types.Receipts) error
 }
 

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -79,16 +79,18 @@ type Points interface {
 	// CanExecuteTransaction mirrors [params.RulesAllowlistHooks.CanExecuteTransaction]
 	// so that consumers can use a single concrete type for both SAE and libevm hooks.
 	CanExecuteTransaction(common.Address, *common.Address, libevm.StateReader) error
-	// StartExecutingBlock is called immediately prior to executing the block;
-	// rules are those of the block and parent is the header of the block's
-	// parent.
+	// StartExecutingBlock applies state changes before the block's transactions
+	// run. `rules` are those of the block and `parent` is the parent header. It
+	// runs during canonical and historical execution. It MUST NOT change data
+	// outside of the [state.StateDB].
 	StartExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, block *types.Block) error
-	// FinishExecutingBlock applies final block changes to the provided state
-	// database. It runs during canonical and historical block execution. It
-	// MUST NOT apply any state changes outside of the [state.StateDB].
+	// FinishExecutingBlock applies state changes after the block's transactions
+	// and end-of-block operations. It runs during canonical and historical
+	// execution. It MUST NOT change data outside of the [state.StateDB].
 	FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
-	// AfterExecutingBlock runs only after canonical block execution. It
-	// can update data outside the [state.StateDB].
+	// AfterExecutingBlock runs only during canonical execution, before the VM
+	// commits the post-execution state. It MAY change data outside of the
+	// [state.StateDB].
 	AfterExecutingBlock(*types.Block, types.Receipts) error
 }
 

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -79,17 +79,17 @@ type Points interface {
 	// CanExecuteTransaction mirrors [params.RulesAllowlistHooks.CanExecuteTransaction]
 	// so that consumers can use a single concrete type for both SAE and libevm hooks.
 	CanExecuteTransaction(common.Address, *common.Address, libevm.StateReader) error
-	// BeforeExecutingBlock is called immediately prior to executing the block;
+	// StartExecutingBlock is called immediately prior to executing the block;
 	// rules are those of the block and parent is the header of the block's
 	// parent.
-	BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, block *types.Block) error
-	// AfterExecutingBlock applies final block changes to the provided state
+	StartExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, block *types.Block) error
+	// FinishExecutingBlock applies final block changes to the provided state
 	// database. It runs during canonical and historical block execution. It
 	// MUST NOT apply any state changes outside of the [state.StateDB].
-	AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
-	// AfterExecutingCanonicalBlock runs only after canonical block execution. It
+	FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
+	// AfterExecutingBlock runs only after canonical block execution. It
 	// can update data outside the [state.StateDB].
-	AfterExecutingCanonicalBlock(*types.Block, types.Receipts) error
+	AfterExecutingBlock(*types.Block, types.Receipts) error
 }
 
 // BlockBuilder constructs a block given its components.

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -83,8 +83,12 @@ type Points interface {
 	// rules are those of the block and parent is the header of the block's
 	// parent.
 	BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, block *types.Block) error
-	// AfterExecutingBlock is called immediately after executing the block.
+	// AfterExecutingBlock applies final block changes to the provided state
+	// database. It runs during canonical and historical block execution.
 	AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
+	// AfterExecutingCanonicalBlock runs only after canonical block execution. It
+	// can update data outside the state database.
+	AfterExecutingCanonicalBlock(*types.Block, types.Receipts) error
 }
 
 // BlockBuilder constructs a block given its components.

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -89,8 +89,7 @@ type Points interface {
 	// execution. It MUST NOT change data outside of the [state.StateDB].
 	FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
 	// AfterExecutingBlock runs only during canonical execution, before the VM
-	// commits the post-execution state. It MAY change data outside of the
-	// [state.StateDB].
+	// commits the post-execution state.
 	AfterExecutingBlock(*types.Block, types.Receipts) error
 }
 

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -84,7 +84,8 @@ type Points interface {
 	// parent.
 	BeforeExecutingBlock(rules params.Rules, statedb *state.StateDB, parent *types.Header, block *types.Block) error
 	// AfterExecutingBlock applies final block changes to the provided state
-	// database. It runs during canonical and historical block execution.
+	// database. It runs during canonical and historical block execution. It
+	// MUST NOT apply any state changes outside of the [state.StateDB].
 	AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
 	// AfterExecutingCanonicalBlock runs only after canonical block execution. It
 	// can update data outside the state database.

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -242,7 +242,7 @@ func (s *Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr
 	return nil
 }
 
-// StartExecutingBlock proxies to [Stub.BeforeExecutingBlockFn] if non-nil,
+// StartExecutingBlock proxies to [Stub.StartExecutingBlockFn] if non-nil,
 // otherwise it is a no-op.
 func (s *Stub) StartExecutingBlock(rules params.Rules, sdb *state.StateDB, parent *types.Header, b *types.Block) error {
 	if fn := s.StartExecutingBlockFn; fn != nil {

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -242,22 +242,22 @@ func (s *Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr
 	return nil
 }
 
-// BeforeExecutingBlock proxies to [Stub.BeforeExecutingBlockFn] if non-nil,
+// StartExecutingBlock proxies to [Stub.BeforeExecutingBlockFn] if non-nil,
 // otherwise it is a no-op.
-func (s *Stub) BeforeExecutingBlock(rules params.Rules, sdb *state.StateDB, parent *types.Header, b *types.Block) error {
+func (s *Stub) StartExecutingBlock(rules params.Rules, sdb *state.StateDB, parent *types.Header, b *types.Block) error {
 	if fn := s.BeforeExecutingBlockFn; fn != nil {
 		return fn(rules, sdb, parent, b)
 	}
 	return nil
 }
 
-// AfterExecutingBlock is a no-op that always returns nil.
-func (*Stub) AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error {
+// FinishExecutingBlock is a no-op that always returns nil.
+func (*Stub) FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error {
 	return nil
 }
 
-// AfterExecutingCanonicalBlock is a no-op that always returns nil.
-func (*Stub) AfterExecutingCanonicalBlock(*types.Block, types.Receipts) error {
+// AfterExecutingBlock is a no-op that always returns nil.
+func (*Stub) AfterExecutingBlock(*types.Block, types.Receipts) error {
 	return nil
 }
 

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -37,7 +37,7 @@ type Stub struct {
 	Ops                     []Op
 	ExecutionResultsDBFn    func(string) (saetypes.ExecutionResults, error)
 	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
-	BeforeExecutingBlockFn  func(params.Rules, *state.StateDB, *types.Header, *types.Block) error
+	StartExecutingBlockFn   func(params.Rules, *state.StateDB, *types.Header, *types.Block) error
 	GasPriceConfig          gastime.GasPriceConfig
 }
 
@@ -245,7 +245,7 @@ func (s *Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr
 // StartExecutingBlock proxies to [Stub.BeforeExecutingBlockFn] if non-nil,
 // otherwise it is a no-op.
 func (s *Stub) StartExecutingBlock(rules params.Rules, sdb *state.StateDB, parent *types.Header, b *types.Block) error {
-	if fn := s.BeforeExecutingBlockFn; fn != nil {
+	if fn := s.StartExecutingBlockFn; fn != nil {
 		return fn(rules, sdb, parent, b)
 	}
 	return nil

--- a/vms/saevm/hook/hookstest/stub.go
+++ b/vms/saevm/hook/hookstest/stub.go
@@ -256,6 +256,11 @@ func (*Stub) AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) e
 	return nil
 }
 
+// AfterExecutingCanonicalBlock is a no-op that always returns nil.
+func (*Stub) AfterExecutingCanonicalBlock(*types.Block, types.Receipts) error {
+	return nil
+}
+
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE
 
 //nolint:revive // struct-tag: canoto allows unexported fields

--- a/vms/saevm/sae/rpc/README.md
+++ b/vms/saevm/sae/rpc/README.md
@@ -25,10 +25,10 @@ beneath. The table below lists every method that differs.
 | Method | Behavior | Implementation |
 | --- | --- | --- |
 | `StateAtBlock` | The post-execution state of the provided block. | `backend` |
-| | The provided block's post-execution state with the **canonical child's** before-block changes applied, allowing transaction tracing on the child to include these operations. | `tracerBackend` |
+| | The provided block's post-execution state with the **canonical child's** `StartExecutingBlock` changes applied, allowing transaction tracing on the child to include these operations. | `tracerBackend` |
 | | The post-execution state of the provided block, with none of the child's changes, because `debug_traceCall` is expected to run immediately after that block. | `traceCallBackend` |
-| | The provided block's post-execution state with the **caller-supplied block** before-block changes. | `suppliedHashBackend` |
-| `StateAtTransaction` | Applies the provided block's before-block changes, then replays its transactions up to the target index, reaching the state just before it. | `backend` |
+| | The provided block's post-execution state with the **caller-supplied block's** `StartExecutingBlock` changes. | `suppliedHashBackend` |
+| `StateAtTransaction` | Applies the provided block's `StartExecutingBlock` changes, then replays its transactions up to the target index, reaching the state just before it. | `backend` |
 | | The same replay, but of the **stored block**, needed because the faked header would otherwise reach the hooks. | `tracerBackend` |
 | `BlockByHash`, `BlockByNumber` | The stored block: worst-case base fee, no post-execution state root. | `backend` |
 | | The stored block with a faked header carrying the executed base fee and post-execution state root. | `tracerBackend` |

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -45,8 +45,8 @@ type noEndOfBlockOps struct {
 // EndOfBlockOps always returns nil.
 func (noEndOfBlockOps) EndOfBlockOps(*types.Block) ([]hook.Op, error) { return nil, nil }
 
-// AfterExecutingBlock always returns nil.
-func (noEndOfBlockOps) AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error {
+// FinishExecutingBlock always returns nil.
+func (noEndOfBlockOps) FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error {
 	return nil
 }
 

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -32,7 +32,7 @@ import (
 var noopRelease tracers.StateReleaseFunc = func() {}
 
 // noEndOfBlockOps wraps [hook.Points] to suppress
-// [hook.Points.EndOfBlockOps] and [hook.Points.AfterExecutingBlock], used by
+// [hook.Points.EndOfBlockOps] and [hook.Points.FinishExecutingBlock], used by
 // the tracer to skip end-of-block operations during partial replay.
 //
 // TODO(StephenButtolph): Properly abstract execution to not rely on method
@@ -284,9 +284,9 @@ type tracerBackend struct {
 }
 
 // StateAtBlock returns the state served by [backend.StateAtBlock] with the
-// canonical child block's before-block state changes already applied, because
-// the block-tracing endpoints request the state that the child's transactions
-// ran on.
+// canonical child block's start-executing-block state changes already applied,
+// because the block-tracing endpoints request the state that the child's
+// transactions ran on.
 //
 //nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (b *tracerBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, tracers.StateReleaseFunc, error) {
@@ -404,9 +404,9 @@ func (b *suppliedHashBackend) BlockHash(block *types.Block) common.Hash {
 }
 
 // StateAtBlock returns the parent's post-execution state with the supplied
-// block's before-block changes applied. The hooks see the block as supplied,
-// not as re-sealed, so tracing a canonical block by RLP matches tracing it by
-// number.
+// block's start-executing-block changes applied. The hooks see the block as
+// supplied, not as re-sealed, so tracing a canonical block by RLP matches
+// tracing it by number.
 //
 //nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (b *suppliedHashBackend) StateAtBlock(ctx context.Context, parent *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, tracers.StateReleaseFunc, error) {
@@ -414,8 +414,8 @@ func (b *suppliedHashBackend) StateAtBlock(ctx context.Context, parent *types.Bl
 }
 
 // traceCallBackend is [tracerBackend] except that StateAtBlock excludes the
-// child block's before-block changes. debug_traceCall is expected to behave as
-// if it is executing immediately after the requested block.
+// child block's start-executing-block changes. debug_traceCall is expected to
+// behave as if it is executing immediately after the requested block.
 type traceCallBackend struct {
 	*tracerBackend
 }

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -311,14 +311,14 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 		return nil, nil, err
 	}
 	rules := b.ChainConfig().Rules(child.Number(), true /*isMerge*/, child.Time())
-	// All parameters passed to [saexec.BeforeExecutingBlock] MUST exactly match
+	// All parameters passed to [saexec.StartExecutingBlock] MUST exactly match
 	// those that [saexec.Execute] pass, so that the hooks see the same state.
 	// Parent will have a faked header, so we pass the restored parent block.
 	//
 	// TODO(JonathanOppenheimer): once libevm's tracer APIs apply the EIP-4788
 	// beacon root (already fixed upstream in geth), it will be applied twice,
 	// so we should drop it here.
-	if err := saexec.BeforeExecutingBlock(b.Hooks(), rules, sdb, parentBlock.Header(), child); err != nil {
+	if err := saexec.StartExecutingBlock(b.Hooks(), rules, sdb, parentBlock.Header(), child); err != nil {
 		return nil, nil, err
 	}
 	return sdb, noopRelease, nil

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -675,7 +675,7 @@ func TestDebugIntermediateRoots(t *testing.T) {
 	require.Len(t, roots, numTxs, "one root per transaction")
 	assert.NotEqual(t, roots[0], roots[1], "each transfer changes state (nonce and balances)")
 	// This holds only because nothing modifies state after the last tx:
-	// hookstest.Stub.AfterExecutingBlock is a no-op and there are no
+	// hookstest.Stub.FinishExecutingBlock is a no-op and there are no
 	// end-of-block ops. Hooks that mutate post-transaction state (e.g.
 	// the C-Chain's) would break this!!
 	assert.Equal(t, block.PostExecutionStateRoot(), roots[numTxs-1], "last root is the block's post-execution root")

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -188,7 +188,7 @@ func withBeforeExecutingBlockPrecompile(precompile common.Address) sutOption {
 
 	return options.Func[sutConfig](func(c *sutConfig) {
 		precompileOpt.Configure(c)
-		c.hooks.BeforeExecutingBlockFn = func(_ params.Rules, sdb *state.StateDB, parent *types.Header, b *types.Block) error {
+		c.hooks.StartExecutingBlockFn = func(_ params.Rules, sdb *state.StateDB, parent *types.Header, b *types.Block) error {
 			sdb.SetState(precompile, parentHashSlot, parent.Hash())
 			sdb.SetState(precompile, blockHashSlot, b.Hash())
 			// A non-empty account stops EIP-158 deleting the slots above, as

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -140,17 +140,17 @@ func logTopOfStackAfter(tb testing.TB, code []byte) ([]byte, uint64, cmp.Options
 	}
 }
 
-// beforeExecutingBlockResult describes the before-block hook's inputs. The
+// startExecutingBlockResult describes the before-block hook's inputs. The
 // hashes commit to every field of the parent header and block it receives, so a
 // faked or re-sealed one changes them. Balance counts the calls, which the
 // hashes can't, as a hook applied twice records the same ones.
-type beforeExecutingBlockResult struct {
+type startExecutingBlockResult struct {
 	ParentHash common.Hash
 	BlockHash  common.Hash
 	Balance    *uint256.Int
 }
 
-func (r beforeExecutingBlockResult) Bytes() []byte {
+func (r startExecutingBlockResult) Bytes() []byte {
 	balance := r.Balance.Bytes32()
 	return slices.Concat(
 		r.ParentHash[:],
@@ -159,17 +159,17 @@ func (r beforeExecutingBlockResult) Bytes() []byte {
 	)
 }
 
-// Hex is the encoding of [beforeExecutingBlockResult.Bytes] that a caller sees
+// Hex is the encoding of [startExecutingBlockResult.Bytes] that a caller sees
 // in [logger.ExecutionResult.ReturnValue].
-func (r beforeExecutingBlockResult) Hex() string {
+func (r startExecutingBlockResult) Hex() string {
 	return common.Bytes2Hex(r.Bytes())
 }
 
-// withBeforeExecutingBlockPrecompile records each before-block hook call in the
-// precompile's own account, and registers a precompile returning the recorded
-// [beforeExecutingBlockResult]. No debug_trace* endpoint exposes the hook, so
-// returning its inputs as data is what makes them assertable.
-func withBeforeExecutingBlockPrecompile(precompile common.Address) sutOption {
+// withStartExecutingBlockPrecompile records each start-executing-block hook call
+// in the precompile's own account, and registers a precompile returning the
+// recorded [startExecutingBlockResult]. No debug_trace* endpoint exposes the hook,
+// so returning its inputs as data is what makes them assertable.
+func withStartExecutingBlockPrecompile(precompile common.Address) sutOption {
 	var (
 		parentHashSlot = common.Hash{0}
 		blockHashSlot  = common.Hash{1}
@@ -177,7 +177,7 @@ func withBeforeExecutingBlockPrecompile(precompile common.Address) sutOption {
 	precompileOpt := withPrecompile(precompile, vm.NewStatefulPrecompile(
 		func(env vm.PrecompileEnvironment, _ []byte) ([]byte, error) {
 			sdb := env.ReadOnlyState()
-			result := beforeExecutingBlockResult{
+			result := startExecutingBlockResult{
 				ParentHash: sdb.GetState(precompile, parentHashSlot),
 				BlockHash:  sdb.GetState(precompile, blockHashSlot),
 				Balance:    sdb.GetBalance(precompile),
@@ -211,7 +211,7 @@ func TestDebugTrace(t *testing.T) {
 		timeOpt,
 		// Using an increased base fee allows the fee to change during the test.
 		withGenesisBaseFee(params.GWei),
-		withBeforeExecutingBlockPrecompile(precompile),
+		withStartExecutingBlockPrecompile(precompile),
 	)
 	var (
 		sender = sut.wallet.Addresses()[0]
@@ -279,8 +279,8 @@ func TestDebugTrace(t *testing.T) {
 
 	// precompileResult is what the precompile should return during the provided
 	// block's execution.
-	precompileResult := func(block *types.Block) beforeExecutingBlockResult {
-		return beforeExecutingBlockResult{
+	precompileResult := func(block *types.Block) startExecutingBlockResult {
+		return startExecutingBlockResult{
 			ParentHash: block.ParentHash(),
 			BlockHash:  block.Hash(),
 			Balance:    uint256.NewInt(block.NumberU64()),

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -140,9 +140,9 @@ func logTopOfStackAfter(tb testing.TB, code []byte) ([]byte, uint64, cmp.Options
 	}
 }
 
-// startExecutingBlockResult describes the before-block hook's inputs. The
-// hashes commit to every field of the parent header and block it receives, so a
-// faked or re-sealed one changes them. Balance counts the calls, which the
+// startExecutingBlockResult describes the start-executing-block hook's inputs.
+// The hashes commit to every field of the parent header and block it receives,
+// so a faked or re-sealed one changes them. Balance counts the calls, which the
 // hashes can't, as a hook applied twice records the same ones.
 type startExecutingBlockResult struct {
 	ParentHash common.Hash
@@ -165,10 +165,10 @@ func (r startExecutingBlockResult) Hex() string {
 	return common.Bytes2Hex(r.Bytes())
 }
 
-// withStartExecutingBlockPrecompile records each start-executing-block hook call
-// in the precompile's own account, and registers a precompile returning the
-// recorded [startExecutingBlockResult]. No debug_trace* endpoint exposes the hook,
-// so returning its inputs as data is what makes them assertable.
+// withStartExecutingBlockPrecompile records each start-executing-block hook
+// call in the precompile's own account, and registers a precompile returning
+// the recorded [startExecutingBlockResult]. No debug_trace* endpoint exposes
+// the hook, so returning its inputs as data is what makes them assertable.
 func withStartExecutingBlockPrecompile(precompile common.Address) sutOption {
 	var (
 		parentHashSlot = common.Hash{0}
@@ -245,8 +245,8 @@ func TestDebugTrace(t *testing.T) {
 	// MUST be fast-forwarded to the traced block's time to reach its base fee.
 	clock.Advance(time.Second)
 
-	// The traced block reports what its before-block hook saw at index 0 and
-	// logs the base fee it replayed with at index 1.
+	// The traced block reports what its start-executing-block hook saw at index
+	// 0 and logs the base fee it replayed with at index 1.
 	precompileTx := callPrecompile()
 	logBaseFeeCode, logBaseFeePC, cmpBaseFeeLOG1 := logTopOfStackAfter(t, saetest.Ops(vm.BASEFEE))
 	baseFeeTx := sut.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
@@ -373,8 +373,9 @@ func TestDebugTrace(t *testing.T) {
 					},
 				},
 				{
-					// debug_traceCall applies no before-block changes, so a result
-					// carrying the canonical child's would mean they leaked in.
+					// debug_traceCall applies no start-executing-block changes, so
+					// a result carrying the canonical child's would mean they
+					// leaked in.
 					name:   "call_on_parent",
 					method: "debug_traceCall",
 					args:   []any{callPrecompileArgs, rpc.BlockNumber(parent.NumberU64())}, // #nosec G115 -- block heights are small

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -127,6 +127,9 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	if err != nil {
 		return err
 	}
+	if err := e.hooks.AfterExecutingCanonicalBlock(b.EthBlock(), result.Receipts); err != nil {
+		return fmt.Errorf("after canonical block hook: %v", err)
+	}
 	return e.afterExecution(b, result)
 }
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -157,7 +157,7 @@ type (
 // b's transactions, specifically the before-block hook and the EIP-4788 beacon
 // root, mirroring [core.StateProcessor.Process].
 func BeforeExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
-	if err := hooks.BeforeExecutingBlock(rules, stateDB, parent, b); err != nil {
+	if err := hooks.StartExecutingBlock(rules, stateDB, parent, b); err != nil {
 		return fmt.Errorf("before-block hook: %v", err)
 	}
 
@@ -289,7 +289,7 @@ func Execute(
 		}
 	}
 
-	if err := hooks.AfterExecutingBlock(stateDB, b.EthBlock(), receipts); err != nil {
+	if err := hooks.FinishExecutingBlock(stateDB, b.EthBlock(), receipts); err != nil {
 		return nil, fmt.Errorf("after-block hook: %v", err)
 	}
 
@@ -320,7 +320,7 @@ func Execute(
 }
 
 func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
-	if err := e.hooks.AfterExecutingCanonicalBlock(b.EthBlock(), r.Receipts); err != nil {
+	if err := e.hooks.AfterExecutingBlock(b.EthBlock(), r.Receipts); err != nil {
 		return fmt.Errorf("after canonical block hook: %v", err)
 	}
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -153,12 +153,12 @@ type (
 	}
 )
 
-// StartExecutingBlock applies the state changes required before executing
-// b's transactions, specifically the before-block hook and the EIP-4788 beacon
-// root, mirroring [core.StateProcessor.Process].
+// StartExecutingBlock applies the state changes required before executing b's
+// transactions, specifically the start-executing-block hook and the EIP-4788
+// beacon root, mirroring [core.StateProcessor.Process].
 func StartExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
 	if err := hooks.StartExecutingBlock(rules, stateDB, parent, b); err != nil {
-		return fmt.Errorf("before-block hook: %v", err)
+		return fmt.Errorf("start-executing-block hook: %v", err)
 	}
 
 	core.SetBeaconBlockRoot(stateDB, b.Header())
@@ -177,6 +177,10 @@ func StartExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.S
 //
 // The gas clock and base fee come from the parent's post-execution clock,
 // except pre-SAE blocks, which use their own header's fee.
+//
+// Execute only runs the deterministic hooks, so it is also safe to use for
+// historical execution. Canonical-only side effects belong in
+// [hook.Points.AfterExecutingBlock], which only the [Executor] calls.
 //
 // Although Execute does not call [blocks.Block.MarkExecuted] it does mutate
 // consensus-critical internal values (e.g. interim execution time). A "live"
@@ -290,7 +294,7 @@ func Execute(
 	}
 
 	if err := hooks.FinishExecutingBlock(stateDB, b.EthBlock(), receipts); err != nil {
-		return nil, fmt.Errorf("after-block hook: %v", err)
+		return nil, fmt.Errorf("finish-executing-block hook: %v", err)
 	}
 
 	endTime := time.Now()
@@ -321,7 +325,7 @@ func Execute(
 
 func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
 	if err := e.hooks.AfterExecutingBlock(b.EthBlock(), r.Receipts); err != nil {
-		return fmt.Errorf("after canonical block hook: %v", err)
+		return fmt.Errorf("after-executing-block hook: %v", err)
 	}
 
 	e.chainContext.recent.Put(b.NumberU64(), b.Header())

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -127,9 +127,6 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	if err != nil {
 		return err
 	}
-	if err := e.hooks.AfterExecutingCanonicalBlock(b.EthBlock(), result.Receipts); err != nil {
-		return fmt.Errorf("after canonical block hook: %v", err)
-	}
 	return e.afterExecution(b, result)
 }
 
@@ -323,6 +320,10 @@ func Execute(
 }
 
 func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
+	if err := e.hooks.AfterExecutingCanonicalBlock(b.EthBlock(), r.Receipts); err != nil {
+		return fmt.Errorf("after canonical block hook: %v", err)
+	}
+
 	e.chainContext.recent.Put(b.NumberU64(), b.Header())
 
 	root, err := r.StateDB.Commit(b.NumberU64(), true)

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -153,10 +153,10 @@ type (
 	}
 )
 
-// BeforeExecutingBlock applies the state changes required before executing
+// StartExecutingBlock applies the state changes required before executing
 // b's transactions, specifically the before-block hook and the EIP-4788 beacon
 // root, mirroring [core.StateProcessor.Process].
-func BeforeExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
+func StartExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
 	if err := hooks.StartExecutingBlock(rules, stateDB, parent, b); err != nil {
 		return fmt.Errorf("before-block hook: %v", err)
 	}
@@ -207,7 +207,7 @@ func Execute(
 	}
 
 	rules := config.Rules(header.Number, true /*isMerge*/, header.Time)
-	if err := BeforeExecutingBlock(hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
+	if err := StartExecutingBlock(hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Why this should be merged

`AfterExecutingBlock` mixes StateDB changes with canonical-chain side effects.

Historical block execution must reproduce StateDB changes without modifying canonical auxiliary state. Separating these responsibilities establishes the boundary needed for a follow-up executor abstraction for historical execution and transaction tracing, which is needed just in general, but more imminently for the firewood re-execution PR. 

## How this works

`BeforeExecutingBlock` -> `StartExecutingBlock`
`AfterExecutingBlock` -> `FinishExecutingBlock`

Add new `AfterExecutingBlock` which doesn't take in the statedb and so won't be called to re-constitute the statedb.

## How this was tested

All the existing UTs. 

## Need to be documented in RELEASES.md?

No