### PR TITLE
refactor(sae): centralize block execution in executor

### DIFF
--- a/vms/saevm/cchain/BUILD.bazel
+++ b/vms/saevm/cchain/BUILD.bazel
@@ -180,7 +180,6 @@ go_test(
         "//vms/saevm/params",
         "//vms/saevm/sae/rpc",
         "//vms/saevm/saetest",
-        "//vms/saevm/saexec",
         "//vms/saevm/txgossip/txgossiptest",
         "//vms/secp256k1fx",
         "@com_github_arr4n_shed//testerr",

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -30,9 +30,6 @@ import (
 	"go.uber.org/goleak"
 	"google.golang.org/protobuf/proto"
 
-	// Imported for [saexec.Execute] comment resolution.
-	_ "github.com/ava-labs/avalanchego/vms/saevm/saexec"
-
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
@@ -1017,10 +1014,7 @@ func TestDebugTraceDoesNotApplyAtomicState(t *testing.T) {
 	}
 
 	rpc := sut.GethRPCBackends()
-	// To rebuild the state at a particular tx, the [saexec.Execute] method is
-	// called with all preceding transactions. In turn, this calls post-block
-	// hooks of which atomic-state application would be one, but must be
-	// excluded when tracing.
+	// Prefix execution MUST NOT apply canonical atomic state changes.
 	_, _, _, release, err := rpc.StateAtTransaction(ctx, blk.EthBlock(), 0, 0)
 	require.NoErrorf(t, err, "%T.StateAtTransaction(...)", rpc)
 	defer release()

--- a/vms/saevm/sae/rpc/rpc.go
+++ b/vms/saevm/sae/rpc/rpc.go
@@ -52,8 +52,8 @@ type Chain interface {
 	saedb.StateDBOpener
 	RecentReceipt(context.Context, common.Hash) (*saexec.Receipt, bool, error)
 	NewBlock(eth *types.Block, parent, lastSettled *blocks.Block) (*blocks.Block, error)
-	StateBeforeTransactions(*blocks.Block) (*state.StateDB, error)
-	ExecuteBlockUntil(*blocks.Block, int) (*saexec.BlockExecutionState, error)
+	StateBeforeTransactions(*blocks.Block, *state.StateDB) error
+	ExecuteBlockUntil(*blocks.Block, *state.StateDB, int) (*saexec.BlockExecutionState, error)
 
 	// Subscriptions
 	SubscribeAcceptedBlocks(chan<- *blocks.Block) event.Subscription

--- a/vms/saevm/sae/rpc/rpc.go
+++ b/vms/saevm/sae/rpc/rpc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/libevm/accounts"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/eth/filters"
 	"github.com/ava-labs/libevm/event"
@@ -51,6 +52,8 @@ type Chain interface {
 	saedb.StateDBOpener
 	RecentReceipt(context.Context, common.Hash) (*saexec.Receipt, bool, error)
 	NewBlock(eth *types.Block, parent, lastSettled *blocks.Block) (*blocks.Block, error)
+	ExecuteBlock(*blocks.Block, *state.StateDB) (*saexec.ExecutionResults, error)
+	ExecuteTransactionPrefix(*blocks.Block, *state.StateDB, int) (*saexec.ExecutionResults, error)
 
 	// Subscriptions
 	SubscribeAcceptedBlocks(chan<- *blocks.Block) event.Subscription

--- a/vms/saevm/sae/rpc/rpc.go
+++ b/vms/saevm/sae/rpc/rpc.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/libevm/accounts"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
-	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/eth/filters"
 	"github.com/ava-labs/libevm/event"
@@ -52,8 +51,7 @@ type Chain interface {
 	saedb.StateDBOpener
 	RecentReceipt(context.Context, common.Hash) (*saexec.Receipt, bool, error)
 	NewBlock(eth *types.Block, parent, lastSettled *blocks.Block) (*blocks.Block, error)
-	StateBeforeTransactions(*blocks.Block, *state.StateDB) error
-	ExecuteBlockUntil(*blocks.Block, *state.StateDB, int) (*saexec.BlockExecutionState, error)
+	BlockProcessor() *saexec.BlockProcessor
 
 	// Subscriptions
 	SubscribeAcceptedBlocks(chan<- *blocks.Block) event.Subscription

--- a/vms/saevm/sae/rpc/rpc.go
+++ b/vms/saevm/sae/rpc/rpc.go
@@ -52,8 +52,8 @@ type Chain interface {
 	saedb.StateDBOpener
 	RecentReceipt(context.Context, common.Hash) (*saexec.Receipt, bool, error)
 	NewBlock(eth *types.Block, parent, lastSettled *blocks.Block) (*blocks.Block, error)
-	ExecuteBlock(*blocks.Block, *state.StateDB) (*saexec.ExecutionResults, error)
-	ExecuteTransactionPrefix(*blocks.Block, *state.StateDB, int) (*saexec.ExecutionResults, error)
+	StateBeforeTransactions(*blocks.Block) (*state.StateDB, error)
+	ExecuteBlockUntil(*blocks.Block, int) (*saexec.BlockExecutionState, error)
 
 	// Subscriptions
 	SubscribeAcceptedBlocks(chan<- *blocks.Block) event.Subscription

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -154,9 +154,13 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	if err != nil {
 		return nil, bCtx, nil, nil, fmt.Errorf("constructing SAE block: %v", err)
 	}
+	stateDB, err := b.StateDB(parent.PostExecutionStateRoot())
+	if err != nil {
+		return nil, bCtx, nil, nil, err
+	}
 	// Replay transactions 0..txIndex-1 to produce the state just before the
 	// target transaction.
-	result, err := b.ExecuteBlockUntil(block, txIndex)
+	result, err := b.ExecuteBlockUntil(block, stateDB, txIndex)
 	if err != nil {
 		return nil, bCtx, nil, nil, err
 	}
@@ -165,7 +169,7 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	if err != nil {
 		return nil, bCtx, nil, nil, err
 	}
-	return msg, result.BlockCtx, result.StateDB, noopRelease, nil
+	return msg, result.BlockCtx, stateDB, noopRelease, nil
 }
 
 // tracerAPI serves the debug tracer APIs, routing each endpoint to a
@@ -283,11 +287,14 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 	if err != nil {
 		return nil, nil, fmt.Errorf("constructing SAE block: %v", err)
 	}
+	sdb, err := b.StateDB(parentBlock.PostExecutionStateRoot())
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// TODO(JonathanOppenheimer): Once libevm's tracer APIs apply the EIP-4788
 	// beacon root, avoid applying it here while preserving the start-of-block hook.
-	sdb, err := b.StateBeforeTransactions(block)
-	if err != nil {
+	if err := b.StateBeforeTransactions(block, sdb); err != nil {
 		return nil, nil, err
 	}
 	return sdb, noopRelease, nil

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -160,7 +160,7 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	}
 	// Replay transactions 0..txIndex-1 to produce the state just before the
 	// target transaction.
-	result, err := b.ExecuteBlockUntil(block, stateDB, txIndex)
+	result, err := b.BlockProcessor().ExecuteBlockUntil(block, stateDB, txIndex)
 	if err != nil {
 		return nil, bCtx, nil, nil, err
 	}
@@ -294,7 +294,7 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 
 	// TODO(JonathanOppenheimer): Once libevm's tracer APIs apply the EIP-4788
 	// beacon root, avoid applying it here while preserving the start-of-block hook.
-	if err := b.StateBeforeTransactions(block, sdb); err != nil {
+	if err := b.BlockProcessor().StateBeforeTransactions(block, sdb); err != nil {
 		return nil, nil, err
 	}
 	return sdb, noopRelease, nil

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -26,29 +26,9 @@ import (
 
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
-	"github.com/ava-labs/avalanchego/vms/saevm/saexec"
 )
 
 var noopRelease tracers.StateReleaseFunc = func() {}
-
-// noEndOfBlockOps wraps [hook.Points] to suppress
-// [hook.Points.EndOfBlockOps] and [hook.Points.FinishExecutingBlock], used by
-// the tracer to skip end-of-block operations during partial replay.
-//
-// TODO(StephenButtolph): Properly abstract execution to not rely on method
-// suppression. It is fragile and could result in accidentially modifying the
-// block state or even disk state during tracing.
-type noEndOfBlockOps struct {
-	hook.Points
-}
-
-// EndOfBlockOps always returns nil.
-func (noEndOfBlockOps) EndOfBlockOps(*types.Block) ([]hook.Op, error) { return nil, nil }
-
-// FinishExecutingBlock always returns nil.
-func (noEndOfBlockOps) FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error {
-	return nil
-}
 
 func (b *backend) RPCEVMTimeout() time.Duration {
 	return b.config.EVMTimeout
@@ -154,10 +134,6 @@ func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB,
 // the state just before the target transaction, then returns the message and
 // block context needed for tracing.
 //
-// Replay calls [saexec.Execute] - the same pipeline used by
-// [saexec.Executor] - with [noEndOfBlockOps] to suppress end-of-block
-// operations and [saexec.NullReceiptStore] to skip receipt broadcasting.
-//
 //nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	var bCtx vm.BlockContext
@@ -177,19 +153,14 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	if err != nil {
 		return nil, bCtx, nil, nil, fmt.Errorf("constructing SAE block: %v", err)
 	}
+	stateDB, err := b.StateDB(parent.PostExecutionStateRoot())
+	if err != nil {
+		return nil, bCtx, nil, nil, err
+	}
 
 	// Replay transactions 0..txIndex-1 to produce the state just before the
 	// target transaction.
-	result, err := saexec.Execute(
-		block,
-		b,
-		txIndex,
-		noEndOfBlockOps{b.Hooks()},
-		b.ChainConfig(),
-		b.ChainContext(),
-		&saexec.NullReceiptStore{},
-		b.Logger(),
-	)
+	result, err := b.ExecuteTransactionPrefix(block, stateDB, txIndex)
 	if err != nil {
 		return nil, bCtx, nil, nil, err
 	}
@@ -310,18 +281,19 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 	if err != nil {
 		return nil, nil, err
 	}
-	rules := b.ChainConfig().Rules(child.Number(), true /*isMerge*/, child.Time())
-	// All parameters passed to [saexec.StartExecutingBlock] MUST exactly match
-	// those that [saexec.Execute] pass, so that the hooks see the same state.
-	// Parent will have a faked header, so we pass the restored parent block.
+	block, err := b.NewBlock(child, parentBlock, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("constructing SAE block: %v", err)
+	}
 	//
 	// TODO(JonathanOppenheimer): once libevm's tracer APIs apply the EIP-4788
 	// beacon root (already fixed upstream in geth), it will be applied twice,
 	// so we should drop it here.
-	if err := saexec.StartExecutingBlock(b.Hooks(), rules, sdb, parentBlock.Header(), child); err != nil {
+	result, err := b.ExecuteTransactionPrefix(block, sdb, 0)
+	if err != nil {
 		return nil, nil, err
 	}
-	return sdb, noopRelease, nil
+	return result.StateDB, noopRelease, nil
 }
 
 // StateAtTransaction returns the state served by [backend.StateAtTransaction]

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -285,10 +285,9 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 	if err != nil {
 		return nil, nil, fmt.Errorf("constructing SAE block: %v", err)
 	}
-	//
-	// TODO(JonathanOppenheimer): once libevm's tracer APIs apply the EIP-4788
-	// beacon root (already fixed upstream in geth), it will be applied twice,
-	// so we should drop it here.
+
+	// TODO(JonathanOppenheimer): Once libevm's tracer APIs apply the EIP-4788
+	// beacon root, avoid applying it here while preserving the start-of-block hook.
 	result, err := b.ExecuteTransactionPrefix(block, sdb, 0)
 	if err != nil {
 		return nil, nil, err

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -132,7 +132,8 @@ func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB,
 // StateAtTransaction returns the execution environment of a particular
 // transaction within a block. It replays all preceding transactions to produce
 // the state just before the target transaction, then returns the message and
-// block context needed for tracing.
+// block context needed for tracing. Replay does not record block progress or
+// mark the block as executed.
 //
 //nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
@@ -153,14 +154,9 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	if err != nil {
 		return nil, bCtx, nil, nil, fmt.Errorf("constructing SAE block: %v", err)
 	}
-	stateDB, err := b.StateDB(parent.PostExecutionStateRoot())
-	if err != nil {
-		return nil, bCtx, nil, nil, err
-	}
-
 	// Replay transactions 0..txIndex-1 to produce the state just before the
 	// target transaction.
-	result, err := b.ExecuteTransactionPrefix(block, stateDB, txIndex)
+	result, err := b.ExecuteBlockUntil(block, txIndex)
 	if err != nil {
 		return nil, bCtx, nil, nil, err
 	}
@@ -275,9 +271,11 @@ func (b *tracerBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 }
 
 // stateAtBlockWithChild returns the parent's post-execution state with the
-// child block's pre-transaction state changes applied.
+// child block's pre-transaction state changes applied. It does not record
+// block progress or mark the child as executed.
 func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, child *types.Block) (*state.StateDB, tracers.StateReleaseFunc, error) {
-	sdb, parentBlock, err := b.backend.stateAtBlock(ctx, n)
+	num := rpc.BlockNumber(n) // #nosec G115 -- won't overflow for a while.
+	parentBlock, err := b.restoreExecutedBlock(ctx, rpc.BlockNumberOrHashWithNumber(num))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -288,11 +286,11 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 
 	// TODO(JonathanOppenheimer): Once libevm's tracer APIs apply the EIP-4788
 	// beacon root, avoid applying it here while preserving the start-of-block hook.
-	result, err := b.ExecuteTransactionPrefix(block, sdb, 0)
+	sdb, err := b.StateBeforeTransactions(block)
 	if err != nil {
 		return nil, nil, err
 	}
-	return result.StateDB, noopRelease, nil
+	return sdb, noopRelease, nil
 }
 
 // StateAtTransaction returns the state served by [backend.StateAtTransaction]

--- a/vms/saevm/saexec/BUILD.bazel
+++ b/vms/saevm/saexec/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//vms/saevm/blocks",
         "//vms/saevm/gastime",
         "//vms/saevm/hook",
+        "//vms/saevm/proxytime",
         "//vms/saevm/saedb",
         "//vms/saevm/types",
         "@com_github_ava_labs_libevm//common",

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
+	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
@@ -111,6 +112,23 @@ func (e *Executor) processQueue() {
 
 var errFatal = errors.New("fatal execution error")
 
+// blockProcessorHooks contains the deterministic hooks required to process a
+// block. It intentionally excludes canonical-only hooks.
+type blockProcessorHooks interface {
+	BlockTime(*types.Header) time.Time
+	SettledBy(*types.Header) hook.Settled
+	StartExecutingBlock(params.Rules, *state.StateDB, *types.Header, *types.Block) error
+}
+
+// A BlockProcessor applies deterministic block state transitions. It has no
+// access to the canonical persistence and publication capabilities owned by
+// [Executor].
+type BlockProcessor struct {
+	hooks        blockProcessorHooks
+	chainConfig  *params.ChainConfig
+	chainContext core.ChainContext
+}
+
 func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	// If the VM were to encounter an error after enqueuing the block, we would
 	// receive the same block twice for execution should consensus retry
@@ -135,7 +153,7 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 }
 
 type (
-	// blockContext holds the values that [Executor.beforeTransactions]
+	// blockContext holds the values that [BlockProcessor.beforeTransactions]
 	// derives. The later phases of execution require all of them.
 	blockContext struct {
 		BlockExecutionState
@@ -145,6 +163,8 @@ type (
 		header      *types.Header
 		gasClock    *gastime.Time
 		interimTime *proxytime.Time[gas.Gas]
+		gasPool     core.GasPool
+		gasConsumed gas.Gas
 	}
 
 	// executionResults holds the outputs of executing an entire block.
@@ -174,23 +194,38 @@ type (
 // executeBlock applies every deterministic state change in b to stateDB, in
 // the three phases of block execution:
 //
-//  1. [Executor.beforeTransactions]
-//  2. [Executor.executeTransactions], for all of b's transactions
+//  1. [BlockProcessor.beforeTransactions]
+//  2. [BlockProcessor.executeTransaction], for all of b's transactions
 //  3. [Executor.endOfBlock]
 //
 // Canonical-only side effects belong in [Executor.afterExecution].
 func (e *Executor) executeBlock(b *blocks.Block, stateDB *state.StateDB, log logging.Logger) (*executionResults, error) {
 	log.Trace("Executing block")
 
-	bc, err := e.beforeTransactions(b, stateDB)
+	bc, err := e.blockProcessor.beforeTransactions(b, stateDB)
 	if err != nil {
 		return nil, err
 	}
-	receipts, gasConsumed, err := e.executeTransactions(b, stateDB, bc, len(b.Transactions()), true /*canonical*/)
-	if err != nil {
-		return nil, err
+	txs := b.Transactions()
+	receipts := make(types.Receipts, len(txs))
+	for ti, tx := range txs {
+		receipt, err := e.blockProcessor.executeTransaction(b, stateDB, bc, ti, tx)
+		if err != nil {
+			return nil, err
+		}
+
+		// Reporting progress allows settlement to proceed while the block is
+		// still executing.
+		b.SetInterimExecutionTime(bc.interimTime)
+		// TODO(arr4n) investigate calling the same method on pending blocks in
+		// the queue. It's only worth it if [blocks.LastToSettleAt] regularly
+		// returns false, meaning that execution is blocking consensus.
+		if r, ok := e.receipts.Load(tx.Hash()); ok {
+			r.Put(&Receipt{receipt, bc.Signer, tx})
+		}
+		receipts[ti] = receipt
 	}
-	return e.endOfBlock(b, stateDB, bc, receipts, gasConsumed, log)
+	return e.endOfBlock(b, stateDB, bc, receipts, log)
 }
 
 // beforeTransactions performs the steps that b requires before any of its
@@ -202,18 +237,18 @@ func (e *Executor) executeBlock(b *blocks.Block, stateDB *state.StateDB, log log
 //     reached.
 //
 // stateDB MUST represent b's parent's post-execution state.
-func (e *Executor) beforeTransactions(b *blocks.Block, stateDB *state.StateDB) (*blockContext, error) {
+func (p *BlockProcessor) beforeTransactions(b *blocks.Block, stateDB *state.StateDB) (*blockContext, error) {
 	header := b.Header()
 
 	gasClock := b.ParentBlock().ExecutedByGasTime()
-	gasClock.BeforeBlock(e.hooks.BlockTime(header))
+	gasClock.BeforeBlock(p.hooks.BlockTime(header))
 
-	if err := e.StateBeforeTransactions(b, stateDB); err != nil {
+	if err := p.StateBeforeTransactions(b, stateDB); err != nil {
 		return nil, err
 	}
 
 	baseFee := gasClock.BaseFee()
-	if hook.Synchronous(e.hooks, header) {
+	if p.hooks.SettledBy(header) == (hook.Settled{}) {
 		baseFee = b.WorstCaseBaseFee()
 	} else {
 		b.CheckBaseFeeBound(baseFee)
@@ -223,100 +258,72 @@ func (e *Executor) beforeTransactions(b *blocks.Block, stateDB *state.StateDB) (
 	return &blockContext{
 		BlockExecutionState: BlockExecutionState{
 			BaseFee:  baseFee,
-			Signer:   b.Signer(e.chainConfig),
-			BlockCtx: core.NewEVMBlockContext(header, e.chainContext, &header.Coinbase),
+			Signer:   b.Signer(p.chainConfig),
+			BlockCtx: core.NewEVMBlockContext(header, p.chainContext, &header.Coinbase),
 		},
 		header:      header,
 		gasClock:    gasClock,
 		interimTime: gasClock.Time.Clone(),
+		gasPool:     core.GasPool(math.MaxUint64),
 	}, nil
 }
 
-// executeTransactions executes b's first numTxs transactions against stateDB
-// and performs no end-of-block operation. [Executor.beforeTransactions] MUST
-// apply b's pre-transaction changes to stateDB first.
-//
-// Only canonical execution publishes receipts and records block progress.
-func (e *Executor) executeTransactions(
+// executeTransaction executes tx against stateDB and updates bc with the gas
+// it consumes. [BlockProcessor.beforeTransactions] MUST apply b's
+// pre-transaction changes to stateDB first.
+func (p *BlockProcessor) executeTransaction(
 	b *blocks.Block,
 	stateDB *state.StateDB,
 	bc *blockContext,
-	numTxs int,
-	canonical bool,
-) (types.Receipts, gas.Gas, error) {
+	ti int,
+	tx *types.Transaction,
+) (*types.Receipt, error) {
 	header := bc.header
-	gasPool := core.GasPool(math.MaxUint64) // required by geth but irrelevant so max it out
-	var gasConsumed gas.Gas
+	stateDB.SetTxContext(tx.Hash(), ti)
+	b.CheckSenderBalanceBound(stateDB, bc.Signer, tx)
 
-	txs := b.Transactions()[:numTxs]
-	receipts := make(types.Receipts, len(txs))
-
-	for ti, tx := range txs {
-		stateDB.SetTxContext(tx.Hash(), ti)
-		b.CheckSenderBalanceBound(stateDB, bc.Signer, tx)
-
-		// Executes the transaction and calls [state.StateDB.Finalise].
-		receipt, err := core.ApplyTransaction(
-			e.chainConfig,
-			e.chainContext,
-			&header.Coinbase,
-			&gasPool,
-			stateDB,
-			header,
-			tx,
-			(*uint64)(&gasConsumed),
-			vm.Config{},
-		)
-		if err != nil {
-			return nil, 0, fmt.Errorf("%w: transaction execution errored (not reverted) [%d](%#x): %v", errFatal, ti, tx.Hash(), err)
-		}
-
-		bc.interimTime.Tick(gas.Gas(receipt.GasUsed))
-		if canonical {
-			// Reporting progress allows settlement to proceed while the block
-			// is still executing.
-			b.SetInterimExecutionTime(bc.interimTime)
-			// TODO(arr4n) investigate calling the same method on pending blocks
-			// in the queue. It's only worth it if [blocks.LastToSettleAt]
-			// regularly returns false, meaning that execution is blocking
-			// consensus.
-		}
-
-		// The [types.Header] that we pass to [core.ApplyTransaction] is
-		// modified to reduce gas price from the worst-case value agreed by
-		// consensus. This changes the hash, which is what is copied to receipts
-		// and logs.
-		//
-		// [core.ApplyTransaction] also doesn't set [types.Receipt.EffectiveGasPrice].
-		// Fixing both here avoids needing to call [types.Receipt.DeriveFields].
-		receipt.BlockHash = b.Hash()
-		for _, l := range receipt.Logs {
-			l.BlockHash = b.Hash()
-		}
-		tip := tx.EffectiveGasTipValue(header.BaseFee)
-		receipt.EffectiveGasPrice = tip.Add(header.BaseFee, tip)
-
-		if canonical {
-			if r, ok := e.receipts.Load(tx.Hash()); ok {
-				r.Put(&Receipt{receipt, bc.Signer, tx})
-			}
-		}
-		receipts[ti] = receipt
+	// Executes the transaction and calls [state.StateDB.Finalise].
+	receipt, err := core.ApplyTransaction(
+		p.chainConfig,
+		p.chainContext,
+		&header.Coinbase,
+		&bc.gasPool,
+		stateDB,
+		header,
+		tx,
+		(*uint64)(&bc.gasConsumed),
+		vm.Config{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: transaction execution errored (not reverted) [%d](%#x): %v", errFatal, ti, tx.Hash(), err)
 	}
 
-	return receipts, gasConsumed, nil
+	bc.interimTime.Tick(gas.Gas(receipt.GasUsed))
+
+	// The [types.Header] that we pass to [core.ApplyTransaction] is modified to
+	// reduce gas price from the worst-case value agreed by consensus. This
+	// changes the hash, which is what is copied to receipts and logs.
+	//
+	// [core.ApplyTransaction] also doesn't set [types.Receipt.EffectiveGasPrice].
+	// Fixing both here avoids needing to call [types.Receipt.DeriveFields].
+	receipt.BlockHash = b.Hash()
+	for _, l := range receipt.Logs {
+		l.BlockHash = b.Hash()
+	}
+	tip := tx.EffectiveGasTipValue(header.BaseFee)
+	receipt.EffectiveGasPrice = tip.Add(header.BaseFee, tip)
+	return receipt, nil
 }
 
 // endOfBlock applies b's end-of-block operations to stateDB. It then stops
 // both of b's clocks and returns the results of executing b in full.
 //
-// receipts and gasConsumed MUST cover every one of b's transactions.
+// receipts MUST cover every one of b's transactions.
 func (e *Executor) endOfBlock(
 	b *blocks.Block,
 	stateDB *state.StateDB,
 	bc *blockContext,
 	receipts types.Receipts,
-	gasConsumed gas.Gas,
 	log logging.Logger,
 ) (*executionResults, error) {
 	ops, err := e.hooks.EndOfBlockOps(b.EthBlock())
@@ -325,6 +332,7 @@ func (e *Executor) endOfBlock(
 	}
 
 	numTxs := len(b.Transactions())
+	gasConsumed := bc.gasConsumed
 	for i, o := range ops {
 		b.CheckOpBurnerBalanceBounds(stateDB, numTxs+i, o)
 		gasConsumed += o.Gas
@@ -402,10 +410,10 @@ func (e *Executor) afterExecution(b *blocks.Block, stateDB *state.StateDB, r *ex
 //
 // It executes no transaction and no end-of-block operation, and it leaves b's
 // worst-case base fee in place.
-func (e *Executor) StateBeforeTransactions(b *blocks.Block, stateDB *state.StateDB) error {
+func (p *BlockProcessor) StateBeforeTransactions(b *blocks.Block, stateDB *state.StateDB) error {
 	header := b.Header()
-	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
-	if err := e.hooks.StartExecutingBlock(rules, stateDB, b.ParentBlock().Header(), b.EthBlock()); err != nil {
+	rules := p.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
+	if err := p.hooks.StartExecutingBlock(rules, stateDB, b.ParentBlock().Header(), b.EthBlock()); err != nil {
 		return fmt.Errorf("start-executing-block hook: %v", err)
 	}
 
@@ -426,16 +434,18 @@ func (e *Executor) StateBeforeTransactions(b *blocks.Block, stateDB *state.State
 // It records no block progress and does not mark b as executed.
 //
 // numTxs MUST be in the range [0, len(b.Transactions())].
-func (e *Executor) ExecuteBlockUntil(b *blocks.Block, stateDB *state.StateDB, numTxs int) (*BlockExecutionState, error) {
+func (p *BlockProcessor) ExecuteBlockUntil(b *blocks.Block, stateDB *state.StateDB, numTxs int) (*BlockExecutionState, error) {
 	if numTxs < 0 || numTxs > len(b.Transactions()) {
 		return nil, fmt.Errorf("%w: %d not in [0, %d]", errTransactionCountOutOfRange, numTxs, len(b.Transactions()))
 	}
-	bc, err := e.beforeTransactions(b, stateDB)
+	bc, err := p.beforeTransactions(b, stateDB)
 	if err != nil {
 		return nil, err
 	}
-	if _, _, err := e.executeTransactions(b, stateDB, bc, numTxs, false /*canonical*/); err != nil {
-		return nil, err
+	for ti, tx := range b.Transactions()[:numTxs] {
+		if _, err := p.executeTransaction(b, stateDB, bc, ti, tx); err != nil {
+			return nil, err
+		}
 	}
 	return &bc.BlockExecutionState, nil
 }

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
-	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
 
@@ -132,21 +131,35 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	if err != nil {
 		return err
 	}
-	return e.afterExecution(b, result)
+	return e.afterExecution(b, stateDB, result)
 }
 
 type (
-	// executionResults holds block execution outputs.
-	executionResults struct {
+	// blockContext holds the values that [Executor.beforeTransactions]
+	// derives. The later phases of execution require all of them.
+	blockContext struct {
 		BlockExecutionState
-		StateDB     *state.StateDB
+		// header carries the executed base fee in place of the worst-case fee
+		// that consensus agreed. Later phases MUST use this header, because
+		// [blocks.Block.Header] returns a new copy on every call.
+		header      *types.Header
+		gasClock    *gastime.Time
+		interimTime *proxytime.Time[gas.Gas]
+	}
+
+	// executionResults holds the outputs of executing an entire block.
+	executionResults struct {
+		BaseFee     *uint256.Int
 		Receipts    types.Receipts
 		GasConsumed gas.Gas
-		FinishBy    struct {
-			Gas  *gastime.Time
-			Wall time.Time
-		}
-		interimTime *proxytime.Time[gas.Gas]
+		FinishBy    finishTimes
+	}
+
+	// finishTimes records when a block finished executing, on both the gas
+	// clock and the wall clock.
+	finishTimes struct {
+		Gas  *gastime.Time
+		Wall time.Time
 	}
 
 	// BlockExecutionState holds the state and execution context at a point in
@@ -158,108 +171,42 @@ type (
 	}
 )
 
-// startExecutingBlock applies the state changes required before executing b's
-// transactions, specifically the start-executing-block hook and the EIP-4788
-// beacon root, mirroring [core.StateProcessor.Process].
-func startExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
-	if err := hooks.StartExecutingBlock(rules, stateDB, parent, b); err != nil {
-		return fmt.Errorf("start-executing-block hook: %v", err)
-	}
-
-	core.SetBeaconBlockRoot(stateDB, b.Header())
-
-	// SetBeaconRoot only finalizes when it applies the root, so we want to
-	// finalize last. This mirrors the finalization performed by
-	// [core.ApplyTransaction].
-	stateDB.Finalise(rules.IsEIP158)
-	return nil
-}
-
-// StateBeforeTransactions applies b's pre-transaction state changes to
-// stateDB, which MUST represent b's parent's post-execution state. It does not
-// execute transactions or subsequent block operations.
-func (e *Executor) StateBeforeTransactions(b *blocks.Block, stateDB *state.StateDB) error {
-	header := b.Header()
-	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
-	return startExecutingBlock(e.hooks, rules, stateDB, b.ParentBlock().Header(), b.EthBlock())
-}
-
-// ExecuteBlockUntil executes the first numTxs transactions in b. After those
-// transactions execute, it returns the pending state and execution context. It
-// skips the remaining transactions and all subsequent block operations. It
-// does not record block progress or mark the block as executed.
+// executeBlock applies every deterministic state change in b to stateDB, in
+// the three phases of block execution:
 //
-// numTxs MUST be in the range [0, len(b.Transactions())].
-func (e *Executor) ExecuteBlockUntil(b *blocks.Block, stateDB *state.StateDB, numTxs int) (*BlockExecutionState, error) {
-	if numTxs < 0 || numTxs > len(b.Transactions()) {
-		return nil, fmt.Errorf("%w: %d not in [0, %d]", errTransactionCountOutOfRange, numTxs, len(b.Transactions()))
-	}
-	r, err := e.executeTransactions(b, stateDB, numTxs, false /*canonical*/, e.log)
-	if err != nil {
-		return nil, err
-	}
-	return &r.BlockExecutionState, nil
-}
-
-// executeBlock executes all deterministic block state changes.
+//  1. [Executor.beforeTransactions]
+//  2. [Executor.executeTransactions], for all of b's transactions
+//  3. [Executor.endOfBlock]
+//
+// Canonical-only side effects belong in [Executor.afterExecution].
 func (e *Executor) executeBlock(b *blocks.Block, stateDB *state.StateDB, log logging.Logger) (*executionResults, error) {
-	numTxs := len(b.Transactions())
-	r, err := e.executeTransactions(b, stateDB, numTxs, true /*canonical*/, log)
-	if err != nil {
-		return nil, err
-	}
-
-	ops, err := e.hooks.EndOfBlockOps(b.EthBlock())
-	if err != nil {
-		return nil, fmt.Errorf("%w: %T.EndOfBlockOps(%#x): %v", errFatal, e.hooks, b.Hash(), err)
-	}
-	for i, o := range ops {
-		b.CheckOpBurnerBalanceBounds(r.StateDB, numTxs+i, o)
-		r.GasConsumed += o.Gas
-		r.interimTime.Tick(o.Gas)
-		b.SetInterimExecutionTime(r.interimTime)
-
-		if err := o.ApplyTo(r.StateDB); err != nil {
-			return nil, fmt.Errorf("%w: applying end-of-block operation [%d](%v): %v", errFatal, i, o.ID, err)
-		}
-	}
-
-	if err := e.hooks.FinishExecutingBlock(r.StateDB, b.EthBlock(), r.Receipts); err != nil {
-		return nil, fmt.Errorf("finish-executing-block hook: %v", err)
-	}
-
-	target, gasCfg := e.hooks.GasConfigAfter(b.Header())
-	if err := r.FinishBy.Gas.AfterBlock(r.GasConsumed, target, gasCfg); err != nil {
-		return nil, fmt.Errorf("after-block gas time update: %w", err)
-	}
-
-	r.FinishBy.Wall = time.Now()
-	log.Trace(
-		"Block execution complete",
-		zap.Uint64("gas_consumed", uint64(r.GasConsumed)),
-		zap.Time("gas_time", r.FinishBy.Gas.AsTime()),
-		zap.Time("wall_time", r.FinishBy.Wall),
-	)
-	return r, nil
-}
-
-// executeTransactions executes the first numTxs transactions in b against
-// stateDB. Only canonical execution publishes receipts and records progress.
-func (e *Executor) executeTransactions(
-	b *blocks.Block,
-	stateDB *state.StateDB,
-	numTxs int,
-	canonical bool,
-	log logging.Logger,
-) (*executionResults, error) {
 	log.Trace("Executing block")
 
-	parent := b.ParentBlock()
+	bc, err := e.beforeTransactions(b, stateDB)
+	if err != nil {
+		return nil, err
+	}
+	receipts, gasConsumed, err := e.executeTransactions(b, stateDB, bc, len(b.Transactions()), true /*canonical*/)
+	if err != nil {
+		return nil, err
+	}
+	return e.endOfBlock(b, stateDB, bc, receipts, gasConsumed, log)
+}
+
+// beforeTransactions performs the steps that b requires before any of its
+// transactions can execute:
+//
+//  1. It advances the parent's gas clock to the start of b.
+//  2. It applies b's pre-transaction state changes to stateDB.
+//  3. It replaces b's worst-case base fee with the fee that the gas clock
+//     reached.
+//
+// stateDB MUST represent b's parent's post-execution state.
+func (e *Executor) beforeTransactions(b *blocks.Block, stateDB *state.StateDB) (*blockContext, error) {
 	header := b.Header()
 
-	gasClock := parent.ExecutedByGasTime()
+	gasClock := b.ParentBlock().ExecutedByGasTime()
 	gasClock.BeforeBlock(e.hooks.BlockTime(header))
-	interimTime := gasClock.Time.Clone()
 
 	if err := e.StateBeforeTransactions(b, stateDB); err != nil {
 		return nil, err
@@ -273,16 +220,40 @@ func (e *Executor) executeTransactions(
 	}
 	header.BaseFee = baseFee.ToBig()
 
-	signer := b.Signer(e.chainConfig)
+	return &blockContext{
+		BlockExecutionState: BlockExecutionState{
+			BaseFee:  baseFee,
+			Signer:   b.Signer(e.chainConfig),
+			BlockCtx: core.NewEVMBlockContext(header, e.chainContext, &header.Coinbase),
+		},
+		header:      header,
+		gasClock:    gasClock,
+		interimTime: gasClock.Time.Clone(),
+	}, nil
+}
+
+// executeTransactions executes b's first numTxs transactions against stateDB
+// and performs no end-of-block operation. [Executor.beforeTransactions] MUST
+// apply b's pre-transaction changes to stateDB first.
+//
+// Only canonical execution publishes receipts and records block progress.
+func (e *Executor) executeTransactions(
+	b *blocks.Block,
+	stateDB *state.StateDB,
+	bc *blockContext,
+	numTxs int,
+	canonical bool,
+) (types.Receipts, gas.Gas, error) {
+	header := bc.header
 	gasPool := core.GasPool(math.MaxUint64) // required by geth but irrelevant so max it out
-	var blockGasConsumed gas.Gas
+	var gasConsumed gas.Gas
 
 	txs := b.Transactions()[:numTxs]
 	receipts := make(types.Receipts, len(txs))
 
 	for ti, tx := range txs {
 		stateDB.SetTxContext(tx.Hash(), ti)
-		b.CheckSenderBalanceBound(stateDB, signer, tx)
+		b.CheckSenderBalanceBound(stateDB, bc.Signer, tx)
 
 		// Executes the transaction and calls [state.StateDB.Finalise].
 		receipt, err := core.ApplyTransaction(
@@ -293,18 +264,18 @@ func (e *Executor) executeTransactions(
 			stateDB,
 			header,
 			tx,
-			(*uint64)(&blockGasConsumed),
+			(*uint64)(&gasConsumed),
 			vm.Config{},
 		)
 		if err != nil {
-			return nil, fmt.Errorf("%w: transaction execution errored (not reverted) [%d](%#x): %v", errFatal, ti, tx.Hash(), err)
+			return nil, 0, fmt.Errorf("%w: transaction execution errored (not reverted) [%d](%#x): %v", errFatal, ti, tx.Hash(), err)
 		}
 
-		interimTime.Tick(gas.Gas(receipt.GasUsed))
+		bc.interimTime.Tick(gas.Gas(receipt.GasUsed))
 		if canonical {
 			// Reporting progress allows settlement to proceed while the block
 			// is still executing.
-			b.SetInterimExecutionTime(interimTime)
+			b.SetInterimExecutionTime(bc.interimTime)
 			// TODO(arr4n) investigate calling the same method on pending blocks
 			// in the queue. It's only worth it if [blocks.LastToSettleAt]
 			// regularly returns false, meaning that execution is blocking
@@ -327,37 +298,81 @@ func (e *Executor) executeTransactions(
 
 		if canonical {
 			if r, ok := e.receipts.Load(tx.Hash()); ok {
-				r.Put(&Receipt{receipt, signer, tx})
+				r.Put(&Receipt{receipt, bc.Signer, tx})
 			}
 		}
 		receipts[ti] = receipt
 	}
 
-	r := &executionResults{
-		BlockExecutionState: BlockExecutionState{
-			BaseFee:  baseFee,
-			Signer:   signer,
-			BlockCtx: core.NewEVMBlockContext(header, e.chainContext, &header.Coinbase),
-		},
-		StateDB:     stateDB,
-		Receipts:    receipts,
-		GasConsumed: blockGasConsumed,
-		interimTime: interimTime,
+	return receipts, gasConsumed, nil
+}
+
+// endOfBlock applies b's end-of-block operations to stateDB. It then stops
+// both of b's clocks and returns the results of executing b in full.
+//
+// receipts and gasConsumed MUST cover every one of b's transactions.
+func (e *Executor) endOfBlock(
+	b *blocks.Block,
+	stateDB *state.StateDB,
+	bc *blockContext,
+	receipts types.Receipts,
+	gasConsumed gas.Gas,
+	log logging.Logger,
+) (*executionResults, error) {
+	ops, err := e.hooks.EndOfBlockOps(b.EthBlock())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %T.EndOfBlockOps(%#x): %v", errFatal, e.hooks, b.Hash(), err)
 	}
-	r.FinishBy.Gas = gasClock
+
+	numTxs := len(b.Transactions())
+	for i, o := range ops {
+		b.CheckOpBurnerBalanceBounds(stateDB, numTxs+i, o)
+		gasConsumed += o.Gas
+		bc.interimTime.Tick(o.Gas)
+		b.SetInterimExecutionTime(bc.interimTime)
+
+		if err := o.ApplyTo(stateDB); err != nil {
+			return nil, fmt.Errorf("%w: applying end-of-block operation [%d](%v): %v", errFatal, i, o.ID, err)
+		}
+	}
+
+	if err := e.hooks.FinishExecutingBlock(stateDB, b.EthBlock(), receipts); err != nil {
+		return nil, fmt.Errorf("finish-executing-block hook: %v", err)
+	}
+
+	target, gasCfg := e.hooks.GasConfigAfter(b.Header())
+	if err := bc.gasClock.AfterBlock(gasConsumed, target, gasCfg); err != nil {
+		return nil, fmt.Errorf("after-block gas time update: %w", err)
+	}
+
+	r := &executionResults{
+		BaseFee:     bc.BaseFee,
+		Receipts:    receipts,
+		GasConsumed: gasConsumed,
+		FinishBy: finishTimes{
+			Gas:  bc.gasClock,
+			Wall: time.Now(),
+		},
+	}
+	log.Trace(
+		"Block execution complete",
+		zap.Uint64("gas_consumed", uint64(r.GasConsumed)),
+		zap.Time("gas_time", r.FinishBy.Gas.AsTime()),
+		zap.Time("wall_time", r.FinishBy.Wall),
+	)
 	return r, nil
 }
 
-func (e *Executor) afterExecution(b *blocks.Block, r *executionResults) error {
+func (e *Executor) afterExecution(b *blocks.Block, stateDB *state.StateDB, r *executionResults) error {
 	if err := e.hooks.AfterExecutingBlock(b.EthBlock(), r.Receipts); err != nil {
 		return fmt.Errorf("after-executing-block hook: %v", err)
 	}
 
 	e.chainContext.recent.Put(b.NumberU64(), b.Header())
 
-	root, err := r.StateDB.Commit(b.NumberU64(), true)
+	root, err := stateDB.Commit(b.NumberU64(), true)
 	if err != nil {
-		return fmt.Errorf("%T.Commit() at end of block %d: %w", r.StateDB, b.NumberU64(), err)
+		return fmt.Errorf("%T.Commit() at end of block %d: %w", stateDB, b.NumberU64(), err)
 	}
 	if err := e.Tracker.MaybeCommit(b.SettledStateRoot(), root, b.NumberU64()); err != nil {
 		return err
@@ -378,4 +393,49 @@ func (e *Executor) afterExecution(b *blocks.Block, r *executionResults) error {
 	}
 	e.sendPostExecutionEvents(b, r) // (3)
 	return nil
+}
+
+// StateBeforeTransactions applies b's pre-transaction state changes to
+// stateDB: the start-executing-block hook, then the EIP-4788 beacon root.
+// This mirrors [core.StateProcessor.Process]. stateDB MUST represent b's
+// parent's post-execution state.
+//
+// It executes no transaction and no end-of-block operation, and it leaves b's
+// worst-case base fee in place.
+func (e *Executor) StateBeforeTransactions(b *blocks.Block, stateDB *state.StateDB) error {
+	header := b.Header()
+	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
+	if err := e.hooks.StartExecutingBlock(rules, stateDB, b.ParentBlock().Header(), b.EthBlock()); err != nil {
+		return fmt.Errorf("start-executing-block hook: %v", err)
+	}
+
+	core.SetBeaconBlockRoot(stateDB, header)
+
+	// SetBeaconRoot only finalizes when it applies the root, so we want to
+	// finalize last. This mirrors the finalization performed by
+	// [core.ApplyTransaction].
+	stateDB.Finalise(rules.IsEIP158)
+	return nil
+}
+
+// ExecuteBlockUntil applies b's pre-transaction state changes to stateDB and
+// then executes b's first numTxs transactions. It returns the context in
+// which the next transaction would execute.
+//
+// It skips b's remaining transactions and all of its end-of-block operations.
+// It records no block progress and does not mark b as executed.
+//
+// numTxs MUST be in the range [0, len(b.Transactions())].
+func (e *Executor) ExecuteBlockUntil(b *blocks.Block, stateDB *state.StateDB, numTxs int) (*BlockExecutionState, error) {
+	if numTxs < 0 || numTxs > len(b.Transactions()) {
+		return nil, fmt.Errorf("%w: %d not in [0, %d]", errTransactionCountOutOfRange, numTxs, len(b.Transactions()))
+	}
+	bc, err := e.beforeTransactions(b, stateDB)
+	if err != nil {
+		return nil, err
+	}
+	if _, _, err := e.executeTransactions(b, stateDB, bc, numTxs, false /*canonical*/); err != nil {
+		return nil, err
+	}
+	return &bc.BlockExecutionState, nil
 }

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -10,12 +10,10 @@ import (
 	"math"
 	"time"
 
-	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
-	"github.com/ava-labs/libevm/libevm/eventual"
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
@@ -25,9 +23,13 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
-var errExecutorClosed = errors.New("saexec.Executor closed")
+var (
+	errExecutorClosed             = errors.New("saexec.Executor closed")
+	errTransactionCountOutOfRange = errors.New("transaction count out of range")
+)
 
 // queuedBlock pairs a queued block with the time it was enqueued so that
 // [Executor.processQueue] can record how long it spent in the queue, from
@@ -122,11 +124,7 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	defer func() {
 		e.metrics.observeExecuteDuration(time.Since(start))
 	}()
-	stateDB, err := e.StateDB(b.ParentBlock().PostExecutionStateRoot())
-	if err != nil {
-		return err
-	}
-	result, err := e.executeBlock(b, stateDB, e.receipts, log, true)
+	result, err := e.executeBlock(b, log)
 	if err != nil {
 		return err
 	}
@@ -134,24 +132,25 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 }
 
 type (
-	// receiptStore receives per-transaction receipts during block execution.
-	// Only canonical execution provides a real implementation.
-	receiptStore interface {
-		Load(common.Hash) (eventual.Value[*Receipt], bool)
-	}
-
-	// ExecutionResults holds block execution outputs.
-	ExecutionResults struct {
-		BaseFee     *uint256.Int
-		StateDB     *state.StateDB
-		Signer      types.Signer
-		BlockCtx    vm.BlockContext
+	// executionResults holds block execution outputs.
+	executionResults struct {
+		BlockExecutionState
 		Receipts    types.Receipts
 		GasConsumed gas.Gas
 		FinishBy    struct {
 			Gas  *gastime.Time
 			Wall time.Time
 		}
+		interimTime *proxytime.Time[gas.Gas]
+	}
+
+	// BlockExecutionState holds the state and execution context at a point in
+	// block execution.
+	BlockExecutionState struct {
+		BaseFee  *uint256.Int
+		StateDB  *state.StateDB
+		Signer   types.Signer
+		BlockCtx vm.BlockContext
 	}
 )
 
@@ -172,56 +171,64 @@ func startExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.S
 	return nil
 }
 
-// ExecuteBlock executes all deterministic state changes in b against stateDB.
-// It does not commit stateDB or run canonical-only hooks.
-func (e *Executor) ExecuteBlock(b *blocks.Block, stateDB *state.StateDB) (*ExecutionResults, error) {
-	return e.executeBlock(b, stateDB, nullReceiptStore{}, e.log, false)
+// StateBeforeTransactions opens b's parent state and applies b's
+// pre-transaction state changes, including the start-executing-block hook. It
+// does not execute transactions, apply end-of-block operations, commit state,
+// or mark the block as executed.
+func (e *Executor) StateBeforeTransactions(b *blocks.Block) (*state.StateDB, error) {
+	stateDB, err := e.StateDB(b.ParentBlock().PostExecutionStateRoot())
+	if err != nil {
+		return nil, err
+	}
+	header := b.Header()
+	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
+	if err := startExecutingBlock(e.hooks, rules, stateDB, b.ParentBlock().Header(), b.EthBlock()); err != nil {
+		return nil, err
+	}
+	return stateDB, nil
 }
 
-// ExecuteTransactionPrefix executes the first numTxs transactions in b against
-// stateDB. It does not run end-of-block operations or finish-executing-block
-// hooks.
-func (e *Executor) ExecuteTransactionPrefix(b *blocks.Block, stateDB *state.StateDB, numTxs int) (*ExecutionResults, error) {
+// ExecuteBlockUntil executes the first numTxs transactions in b. After those
+// transactions execute, it returns the pending state and execution context. It
+// skips the remaining transactions and all subsequent block operations. It
+// does not record block progress or mark the block as executed.
+//
+// numTxs MUST be in the range [0, len(b.Transactions())].
+func (e *Executor) ExecuteBlockUntil(b *blocks.Block, numTxs int) (*BlockExecutionState, error) {
 	if numTxs < 0 || numTxs > len(b.Transactions()) {
-		return nil, fmt.Errorf("transaction count %d out of range [0, %d]", numTxs, len(b.Transactions()))
+		return nil, fmt.Errorf("%w: %d not in [0, %d]", errTransactionCountOutOfRange, numTxs, len(b.Transactions()))
 	}
-	return e.executeTransactions(b, stateDB, numTxs, nullReceiptStore{}, e.log, false)
+	r, err := e.executeTransactions(b, numTxs, false /*canonical*/, e.log)
+	if err != nil {
+		return nil, err
+	}
+	return &r.BlockExecutionState, nil
 }
 
 // executeBlock executes all deterministic block state changes.
-func (e *Executor) executeBlock(
-	b *blocks.Block,
-	stateDB *state.StateDB,
-	receiptStore receiptStore,
-	log logging.Logger,
-	recordProgress bool,
-) (*ExecutionResults, error) {
-	r, err := e.executeTransactions(b, stateDB, len(b.Transactions()), receiptStore, log, recordProgress)
+func (e *Executor) executeBlock(b *blocks.Block, log logging.Logger) (*executionResults, error) {
+	numTxs := len(b.Transactions())
+	r, err := e.executeTransactions(b, numTxs, true /*canonical*/, log)
 	if err != nil {
 		return nil, err
 	}
 
-	numTxs := len(b.Transactions())
-	interimExecutionTime := r.FinishBy.Gas.Time.Clone()
-	interimExecutionTime.Tick(r.GasConsumed)
 	ops, err := e.hooks.EndOfBlockOps(b.EthBlock())
 	if err != nil {
 		return nil, fmt.Errorf("%w: %T.EndOfBlockOps(%#x): %v", errFatal, e.hooks, b.Hash(), err)
 	}
 	for i, o := range ops {
-		b.CheckOpBurnerBalanceBounds(stateDB, numTxs+i, o)
+		b.CheckOpBurnerBalanceBounds(r.StateDB, numTxs+i, o)
 		r.GasConsumed += o.Gas
-		interimExecutionTime.Tick(o.Gas)
-		if recordProgress {
-			b.SetInterimExecutionTime(interimExecutionTime)
-		}
+		r.interimTime.Tick(o.Gas)
+		b.SetInterimExecutionTime(r.interimTime)
 
-		if err := o.ApplyTo(stateDB); err != nil {
+		if err := o.ApplyTo(r.StateDB); err != nil {
 			return nil, fmt.Errorf("%w: applying end-of-block operation [%d](%v): %v", errFatal, i, o.ID, err)
 		}
 	}
 
-	if err := e.hooks.FinishExecutingBlock(stateDB, b.EthBlock(), r.Receipts); err != nil {
+	if err := e.hooks.FinishExecutingBlock(r.StateDB, b.EthBlock(), r.Receipts); err != nil {
 		return nil, fmt.Errorf("finish-executing-block hook: %v", err)
 	}
 
@@ -240,18 +247,18 @@ func (e *Executor) executeBlock(
 	return r, nil
 }
 
-// executeTransactions executes the first numTxs transactions in b.
+// executeTransactions executes the first numTxs transactions in b, beginning
+// from the post-execution state of b's parent. Only canonical execution
+// publishes receipts and records block progress.
 //
 // The gas clock and base fee come from the parent's post-execution clock,
 // except pre-SAE blocks, which use their own header's fee.
 func (e *Executor) executeTransactions(
 	b *blocks.Block,
-	stateDB *state.StateDB,
 	numTxs int,
-	receiptStore receiptStore,
+	canonical bool,
 	log logging.Logger,
-	recordProgress bool,
-) (*ExecutionResults, error) {
+) (*executionResults, error) {
 	log.Trace("Executing block")
 
 	parent := b.ParentBlock()
@@ -259,7 +266,12 @@ func (e *Executor) executeTransactions(
 
 	gasClock := parent.ExecutedByGasTime()
 	gasClock.BeforeBlock(e.hooks.BlockTime(header))
-	perTxClock := gasClock.Time.Clone()
+	interimTime := gasClock.Time.Clone()
+
+	stateDB, err := e.StateDB(parent.PostExecutionStateRoot())
+	if err != nil {
+		return nil, err
+	}
 
 	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
 	if err := startExecutingBlock(e.hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
@@ -301,13 +313,16 @@ func (e *Executor) executeTransactions(
 			return nil, fmt.Errorf("%w: transaction execution errored (not reverted) [%d](%#x): %v", errFatal, ti, tx.Hash(), err)
 		}
 
-		perTxClock.Tick(gas.Gas(receipt.GasUsed))
-		if recordProgress {
-			b.SetInterimExecutionTime(perTxClock)
+		interimTime.Tick(gas.Gas(receipt.GasUsed))
+		if canonical {
+			// Reporting progress allows settlement to proceed while the block
+			// is still executing.
+			b.SetInterimExecutionTime(interimTime)
+			// TODO(arr4n) investigate calling the same method on pending blocks
+			// in the queue. It's only worth it if [blocks.LastToSettleAt]
+			// regularly returns false, meaning that execution is blocking
+			// consensus.
 		}
-		// TODO(arr4n) investigate calling the same method on pending blocks in
-		// the queue. It's only worth it if [blocks.LastToSettleAt] regularly
-		// returns false, meaning that execution is blocking consensus.
 
 		// The [types.Header] that we pass to [core.ApplyTransaction] is
 		// modified to reduce gas price from the worst-case value agreed by
@@ -323,25 +338,30 @@ func (e *Executor) executeTransactions(
 		tip := tx.EffectiveGasTipValue(header.BaseFee)
 		receipt.EffectiveGasPrice = tip.Add(header.BaseFee, tip)
 
-		if r, ok := receiptStore.Load(tx.Hash()); ok {
-			r.Put(&Receipt{receipt, signer, tx})
+		if canonical {
+			if r, ok := e.receipts.Load(tx.Hash()); ok {
+				r.Put(&Receipt{receipt, signer, tx})
+			}
 		}
 		receipts[ti] = receipt
 	}
 
-	r := &ExecutionResults{
-		BaseFee:     baseFee,
-		StateDB:     stateDB,
-		Signer:      signer,
-		BlockCtx:    core.NewEVMBlockContext(header, e.chainContext, &header.Coinbase),
+	r := &executionResults{
+		BlockExecutionState: BlockExecutionState{
+			BaseFee:  baseFee,
+			StateDB:  stateDB,
+			Signer:   signer,
+			BlockCtx: core.NewEVMBlockContext(header, e.chainContext, &header.Coinbase),
+		},
 		Receipts:    receipts,
 		GasConsumed: blockGasConsumed,
+		interimTime: interimTime,
 	}
 	r.FinishBy.Gas = gasClock
 	return r, nil
 }
 
-func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
+func (e *Executor) afterExecution(b *blocks.Block, r *executionResults) error {
 	if err := e.hooks.AfterExecutingBlock(b.EthBlock(), r.Receipts); err != nil {
 		return fmt.Errorf("after-executing-block hook: %v", err)
 	}
@@ -371,14 +391,4 @@ func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
 	}
 	e.sendPostExecutionEvents(b, r) // (3)
 	return nil
-}
-
-// nullReceiptStore discards receipt notifications.
-type nullReceiptStore struct{}
-
-var _ receiptStore = nullReceiptStore{}
-
-// Load always returns the zero value and false.
-func (nullReceiptStore) Load(common.Hash) (eventual.Value[*Receipt], bool) {
-	return eventual.Value[*Receipt]{}, false
 }

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -261,8 +261,7 @@ func (e *Executor) executeTransactions(
 	gasClock.BeforeBlock(e.hooks.BlockTime(header))
 	interimTime := gasClock.Time.Clone()
 
-	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
-	if err := startExecutingBlock(e.hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
+	if err := e.StateBeforeTransactions(b, stateDB); err != nil {
 		return nil, err
 	}
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
-	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 )
 
 var errExecutorClosed = errors.New("saexec.Executor closed")
@@ -123,7 +122,11 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	defer func() {
 		e.metrics.observeExecuteDuration(time.Since(start))
 	}()
-	result, err := Execute(b, e, math.MaxInt, e.hooks, e.chainConfig, e.chainContext, e.receipts, log)
+	stateDB, err := e.StateDB(b.ParentBlock().PostExecutionStateRoot())
+	if err != nil {
+		return err
+	}
+	result, err := e.executeBlock(b, stateDB, e.receipts, log, true)
 	if err != nil {
 		return err
 	}
@@ -131,14 +134,13 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 }
 
 type (
-	// ReceiptStore receives per-transaction receipts during block execution.
-	// Only the [Executor] needs to provide a real implementation to [Execute]
-	// and all other callers MUST use [NullReceiptStore].
-	ReceiptStore interface {
+	// receiptStore receives per-transaction receipts during block execution.
+	// Only canonical execution provides a real implementation.
+	receiptStore interface {
 		Load(common.Hash) (eventual.Value[*Receipt], bool)
 	}
 
-	// ExecutionResults holds the outputs of [Execute].
+	// ExecutionResults holds block execution outputs.
 	ExecutionResults struct {
 		BaseFee     *uint256.Int
 		StateDB     *state.StateDB
@@ -153,10 +155,10 @@ type (
 	}
 )
 
-// StartExecutingBlock applies the state changes required before executing b's
+// startExecutingBlock applies the state changes required before executing b's
 // transactions, specifically the start-executing-block hook and the EIP-4788
 // beacon root, mirroring [core.StateProcessor.Process].
-func StartExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
+func startExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
 	if err := hooks.StartExecutingBlock(rules, stateDB, parent, b); err != nil {
 		return fmt.Errorf("start-executing-block hook: %v", err)
 	}
@@ -170,31 +172,85 @@ func StartExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.S
 	return nil
 }
 
-// Execute executes the transactions in the [blocks.Block], beginning from the
-// post-execution state of the [blocks.Block.ParentBlock]. `maxNumTxs` limits
-// the number of transactions to process, allowing partial execution for
-// intra-block inspection.
+// ExecuteBlock executes all deterministic state changes in b against stateDB.
+// It does not commit stateDB or run canonical-only hooks.
+func (e *Executor) ExecuteBlock(b *blocks.Block, stateDB *state.StateDB) (*ExecutionResults, error) {
+	return e.executeBlock(b, stateDB, nullReceiptStore{}, e.log, false)
+}
+
+// ExecuteTransactionPrefix executes the first numTxs transactions in b against
+// stateDB. It does not run end-of-block operations or finish-executing-block
+// hooks.
+func (e *Executor) ExecuteTransactionPrefix(b *blocks.Block, stateDB *state.StateDB, numTxs int) (*ExecutionResults, error) {
+	if numTxs < 0 || numTxs > len(b.Transactions()) {
+		return nil, fmt.Errorf("transaction count %d out of range [0, %d]", numTxs, len(b.Transactions()))
+	}
+	return e.executeTransactions(b, stateDB, numTxs, nullReceiptStore{}, e.log, false)
+}
+
+// executeBlock executes all deterministic block state changes.
+func (e *Executor) executeBlock(
+	b *blocks.Block,
+	stateDB *state.StateDB,
+	receiptStore receiptStore,
+	log logging.Logger,
+	recordProgress bool,
+) (*ExecutionResults, error) {
+	r, err := e.executeTransactions(b, stateDB, len(b.Transactions()), receiptStore, log, recordProgress)
+	if err != nil {
+		return nil, err
+	}
+
+	numTxs := len(b.Transactions())
+	interimExecutionTime := r.FinishBy.Gas.Time.Clone()
+	interimExecutionTime.Tick(r.GasConsumed)
+	ops, err := e.hooks.EndOfBlockOps(b.EthBlock())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %T.EndOfBlockOps(%#x): %v", errFatal, e.hooks, b.Hash(), err)
+	}
+	for i, o := range ops {
+		b.CheckOpBurnerBalanceBounds(stateDB, numTxs+i, o)
+		r.GasConsumed += o.Gas
+		interimExecutionTime.Tick(o.Gas)
+		if recordProgress {
+			b.SetInterimExecutionTime(interimExecutionTime)
+		}
+
+		if err := o.ApplyTo(stateDB); err != nil {
+			return nil, fmt.Errorf("%w: applying end-of-block operation [%d](%v): %v", errFatal, i, o.ID, err)
+		}
+	}
+
+	if err := e.hooks.FinishExecutingBlock(stateDB, b.EthBlock(), r.Receipts); err != nil {
+		return nil, fmt.Errorf("finish-executing-block hook: %v", err)
+	}
+
+	target, gasCfg := e.hooks.GasConfigAfter(b.Header())
+	if err := r.FinishBy.Gas.AfterBlock(r.GasConsumed, target, gasCfg); err != nil {
+		return nil, fmt.Errorf("after-block gas time update: %w", err)
+	}
+
+	r.FinishBy.Wall = time.Now()
+	log.Trace(
+		"Block execution complete",
+		zap.Uint64("gas_consumed", uint64(r.GasConsumed)),
+		zap.Time("gas_time", r.FinishBy.Gas.AsTime()),
+		zap.Time("wall_time", r.FinishBy.Wall),
+	)
+	return r, nil
+}
+
+// executeTransactions executes the first numTxs transactions in b.
 //
 // The gas clock and base fee come from the parent's post-execution clock,
 // except pre-SAE blocks, which use their own header's fee.
-//
-// Execute only runs the deterministic hooks, so it is also safe to use for
-// historical execution. Canonical-only side effects belong in
-// [hook.Points.AfterExecutingBlock], which only the [Executor] calls.
-//
-// Although Execute does not call [blocks.Block.MarkExecuted] it does mutate
-// consensus-critical internal values (e.g. interim execution time). A "live"
-// accepted block (as against one recovered from the database) MUST NOT be
-// passed directly to [Execute], only to [Executor.Enqueue].
-func Execute(
+func (e *Executor) executeTransactions(
 	b *blocks.Block,
-	sdbo saedb.StateDBOpener,
-	maxNumTxs int,
-	hooks hook.Points,
-	config *params.ChainConfig,
-	chainCtx core.ChainContext,
-	receiptStore ReceiptStore,
+	stateDB *state.StateDB,
+	numTxs int,
+	receiptStore receiptStore,
 	log logging.Logger,
+	recordProgress bool,
 ) (*ExecutionResults, error) {
 	log.Trace("Executing block")
 
@@ -202,33 +258,27 @@ func Execute(
 	header := b.Header()
 
 	gasClock := parent.ExecutedByGasTime()
-	gasClock.BeforeBlock(hooks.BlockTime(header))
+	gasClock.BeforeBlock(e.hooks.BlockTime(header))
 	perTxClock := gasClock.Time.Clone()
 
-	stateDB, err := sdbo.StateDB(parent.PostExecutionStateRoot())
-	if err != nil {
-		return nil, err
-	}
-
-	rules := config.Rules(header.Number, true /*isMerge*/, header.Time)
-	if err := StartExecutingBlock(hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
+	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
+	if err := startExecutingBlock(e.hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
 		return nil, err
 	}
 
 	baseFee := gasClock.BaseFee()
-	if hook.Synchronous(hooks, header) {
+	if hook.Synchronous(e.hooks, header) {
 		baseFee = b.WorstCaseBaseFee()
 	} else {
 		b.CheckBaseFeeBound(baseFee)
 	}
 	header.BaseFee = baseFee.ToBig()
 
-	signer := b.Signer(config)
+	signer := b.Signer(e.chainConfig)
 	gasPool := core.GasPool(math.MaxUint64) // required by geth but irrelevant so max it out
 	var blockGasConsumed gas.Gas
 
-	txs := b.Transactions()
-	txs = txs[:min(len(txs), maxNumTxs)]
+	txs := b.Transactions()[:numTxs]
 	receipts := make(types.Receipts, len(txs))
 
 	for ti, tx := range txs {
@@ -237,8 +287,8 @@ func Execute(
 
 		// Executes the transaction and calls [state.StateDB.Finalise].
 		receipt, err := core.ApplyTransaction(
-			config,
-			chainCtx,
+			e.chainConfig,
+			e.chainContext,
 			&header.Coinbase,
 			&gasPool,
 			stateDB,
@@ -252,7 +302,9 @@ func Execute(
 		}
 
 		perTxClock.Tick(gas.Gas(receipt.GasUsed))
-		b.SetInterimExecutionTime(perTxClock)
+		if recordProgress {
+			b.SetInterimExecutionTime(perTxClock)
+		}
 		// TODO(arr4n) investigate calling the same method on pending blocks in
 		// the queue. It's only worth it if [blocks.LastToSettleAt] regularly
 		// returns false, meaning that execution is blocking consensus.
@@ -277,49 +329,15 @@ func Execute(
 		receipts[ti] = receipt
 	}
 
-	numTxs := len(b.Transactions())
-	ops, err := hooks.EndOfBlockOps(b.EthBlock())
-	if err != nil {
-		return nil, fmt.Errorf("%w: %T.EndOfBlockOps(%#x): %v", errFatal, hooks, b.Hash(), err)
-	}
-	for i, o := range ops {
-		b.CheckOpBurnerBalanceBounds(stateDB, numTxs+i, o)
-		blockGasConsumed += o.Gas
-		perTxClock.Tick(o.Gas)
-		b.SetInterimExecutionTime(perTxClock)
-
-		if err := o.ApplyTo(stateDB); err != nil {
-			return nil, fmt.Errorf("%w: applying end-of-block operation [%d](%v): %v", errFatal, i, o.ID, err)
-		}
-	}
-
-	if err := hooks.FinishExecutingBlock(stateDB, b.EthBlock(), receipts); err != nil {
-		return nil, fmt.Errorf("finish-executing-block hook: %v", err)
-	}
-
-	endTime := time.Now()
-	target, gasCfg := hooks.GasConfigAfter(b.Header())
-	if err := gasClock.AfterBlock(blockGasConsumed, target, gasCfg); err != nil {
-		return nil, fmt.Errorf("after-block gas time update: %w", err)
-	}
-
-	log.Trace(
-		"Block execution complete",
-		zap.Uint64("gas_consumed", uint64(blockGasConsumed)),
-		zap.Time("gas_time", gasClock.AsTime()),
-		zap.Time("wall_time", endTime),
-	)
-
 	r := &ExecutionResults{
 		BaseFee:     baseFee,
 		StateDB:     stateDB,
 		Signer:      signer,
-		BlockCtx:    core.NewEVMBlockContext(header, chainCtx, &header.Coinbase),
+		BlockCtx:    core.NewEVMBlockContext(header, e.chainContext, &header.Coinbase),
 		Receipts:    receipts,
 		GasConsumed: blockGasConsumed,
 	}
 	r.FinishBy.Gas = gasClock
-	r.FinishBy.Wall = endTime
 	return r, nil
 }
 
@@ -355,13 +373,12 @@ func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
 	return nil
 }
 
-// NullReceiptStore is a no-op [ReceiptStore] for use when receipt broadcasting
-// is not needed (e.g. state tracing).
-type NullReceiptStore struct{}
+// nullReceiptStore discards receipt notifications.
+type nullReceiptStore struct{}
 
-var _ ReceiptStore = (*NullReceiptStore)(nil)
+var _ receiptStore = nullReceiptStore{}
 
 // Load always returns the zero value and false.
-func (*NullReceiptStore) Load(common.Hash) (eventual.Value[*Receipt], bool) {
+func (nullReceiptStore) Load(common.Hash) (eventual.Value[*Receipt], bool) {
 	return eventual.Value[*Receipt]{}, false
 }

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -124,7 +124,11 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	defer func() {
 		e.metrics.observeExecuteDuration(time.Since(start))
 	}()
-	result, err := e.executeBlock(b, log)
+	stateDB, err := e.StateDB(b.ParentBlock().PostExecutionStateRoot())
+	if err != nil {
+		return err
+	}
+	result, err := e.executeBlock(b, stateDB, log)
 	if err != nil {
 		return err
 	}
@@ -135,6 +139,7 @@ type (
 	// executionResults holds block execution outputs.
 	executionResults struct {
 		BlockExecutionState
+		StateDB     *state.StateDB
 		Receipts    types.Receipts
 		GasConsumed gas.Gas
 		FinishBy    struct {
@@ -148,7 +153,6 @@ type (
 	// block execution.
 	BlockExecutionState struct {
 		BaseFee  *uint256.Int
-		StateDB  *state.StateDB
 		Signer   types.Signer
 		BlockCtx vm.BlockContext
 	}
@@ -171,21 +175,13 @@ func startExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.S
 	return nil
 }
 
-// StateBeforeTransactions opens b's parent state and applies b's
-// pre-transaction state changes, including the start-executing-block hook. It
-// does not execute transactions, apply end-of-block operations, commit state,
-// or mark the block as executed.
-func (e *Executor) StateBeforeTransactions(b *blocks.Block) (*state.StateDB, error) {
-	stateDB, err := e.StateDB(b.ParentBlock().PostExecutionStateRoot())
-	if err != nil {
-		return nil, err
-	}
+// StateBeforeTransactions applies b's pre-transaction state changes to
+// stateDB, which MUST represent b's parent's post-execution state. It does not
+// execute transactions or subsequent block operations.
+func (e *Executor) StateBeforeTransactions(b *blocks.Block, stateDB *state.StateDB) error {
 	header := b.Header()
 	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
-	if err := startExecutingBlock(e.hooks, rules, stateDB, b.ParentBlock().Header(), b.EthBlock()); err != nil {
-		return nil, err
-	}
-	return stateDB, nil
+	return startExecutingBlock(e.hooks, rules, stateDB, b.ParentBlock().Header(), b.EthBlock())
 }
 
 // ExecuteBlockUntil executes the first numTxs transactions in b. After those
@@ -194,11 +190,11 @@ func (e *Executor) StateBeforeTransactions(b *blocks.Block) (*state.StateDB, err
 // does not record block progress or mark the block as executed.
 //
 // numTxs MUST be in the range [0, len(b.Transactions())].
-func (e *Executor) ExecuteBlockUntil(b *blocks.Block, numTxs int) (*BlockExecutionState, error) {
+func (e *Executor) ExecuteBlockUntil(b *blocks.Block, stateDB *state.StateDB, numTxs int) (*BlockExecutionState, error) {
 	if numTxs < 0 || numTxs > len(b.Transactions()) {
 		return nil, fmt.Errorf("%w: %d not in [0, %d]", errTransactionCountOutOfRange, numTxs, len(b.Transactions()))
 	}
-	r, err := e.executeTransactions(b, numTxs, false /*canonical*/, e.log)
+	r, err := e.executeTransactions(b, stateDB, numTxs, false /*canonical*/, e.log)
 	if err != nil {
 		return nil, err
 	}
@@ -206,9 +202,9 @@ func (e *Executor) ExecuteBlockUntil(b *blocks.Block, numTxs int) (*BlockExecuti
 }
 
 // executeBlock executes all deterministic block state changes.
-func (e *Executor) executeBlock(b *blocks.Block, log logging.Logger) (*executionResults, error) {
+func (e *Executor) executeBlock(b *blocks.Block, stateDB *state.StateDB, log logging.Logger) (*executionResults, error) {
 	numTxs := len(b.Transactions())
-	r, err := e.executeTransactions(b, numTxs, true /*canonical*/, log)
+	r, err := e.executeTransactions(b, stateDB, numTxs, true /*canonical*/, log)
 	if err != nil {
 		return nil, err
 	}
@@ -247,14 +243,11 @@ func (e *Executor) executeBlock(b *blocks.Block, log logging.Logger) (*execution
 	return r, nil
 }
 
-// executeTransactions executes the first numTxs transactions in b, beginning
-// from the post-execution state of b's parent. Only canonical execution
-// publishes receipts and records block progress.
-//
-// The gas clock and base fee come from the parent's post-execution clock,
-// except pre-SAE blocks, which use their own header's fee.
+// executeTransactions executes the first numTxs transactions in b against
+// stateDB. Only canonical execution publishes receipts and records progress.
 func (e *Executor) executeTransactions(
 	b *blocks.Block,
+	stateDB *state.StateDB,
 	numTxs int,
 	canonical bool,
 	log logging.Logger,
@@ -267,11 +260,6 @@ func (e *Executor) executeTransactions(
 	gasClock := parent.ExecutedByGasTime()
 	gasClock.BeforeBlock(e.hooks.BlockTime(header))
 	interimTime := gasClock.Time.Clone()
-
-	stateDB, err := e.StateDB(parent.PostExecutionStateRoot())
-	if err != nil {
-		return nil, err
-	}
 
 	rules := e.chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
 	if err := startExecutingBlock(e.hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
@@ -349,10 +337,10 @@ func (e *Executor) executeTransactions(
 	r := &executionResults{
 		BlockExecutionState: BlockExecutionState{
 			BaseFee:  baseFee,
-			StateDB:  stateDB,
 			Signer:   signer,
 			BlockCtx: core.NewEVMBlockContext(header, e.chainContext, &header.Coinbase),
 		},
+		StateDB:     stateDB,
 		Receipts:    receipts,
 		GasConsumed: blockGasConsumed,
 		interimTime: interimTime,

--- a/vms/saevm/saexec/metrics.go
+++ b/vms/saevm/saexec/metrics.go
@@ -163,7 +163,7 @@ func (m *metrics) observeQueueDuration(d time.Duration) {
 
 // markExecuted records that the block has finished executing with the given
 // results.
-func (m *metrics) markExecuted(block *blocks.Block, results *ExecutionResults) {
+func (m *metrics) markExecuted(block *blocks.Block, results *executionResults) {
 	m.executionQueueBlocks.Dec()
 	// MUST use the same worst-case gas value as [metrics.markEnqueued].
 	worstCaseGas := float64(block.WorstCaseGasUsed())

--- a/vms/saevm/saexec/saexec.go
+++ b/vms/saevm/saexec/saexec.go
@@ -35,9 +35,10 @@ var _ saedb.StateDBOpener = (*Executor)(nil)
 // An Executor accepts and executes a [blocks.Block] FIFO queue.
 type Executor struct {
 	*saedb.Tracker
-	quit, done chan struct{}
-	log        logging.Logger
-	hooks      hook.Points
+	quit, done     chan struct{}
+	log            logging.Logger
+	hooks          hook.Points
+	blockProcessor BlockProcessor
 
 	queue        chan queuedBlock
 	lastExecuted atomic.Pointer[blocks.Block]
@@ -48,7 +49,6 @@ type Executor struct {
 	receipts    *syncMap[common.Hash, eventual.Value[*Receipt]]
 
 	chainContext *chainContext
-	chainConfig  *params.ChainConfig
 	db           ethdb.Database
 	xdb          saetypes.ExecutionResults
 	metrics      *metrics
@@ -76,26 +76,31 @@ func New(
 		return nil, fmt.Errorf("initializing saexec metrics: %w", err)
 	}
 
+	chainContext := &chainContext{
+		headerSrc,
+		lru.NewCache[uint64, *types.Header](256), // minimum history for BLOCKHASH op
+		logger,
+	}
 	e := &Executor{
 		Tracker: tracker,
 		quit:    make(chan struct{}), // closed by [Executor.Close]
 		done:    make(chan struct{}), // closed by [Executor.processQueue] after `quit` is closed
 		log:     logger,
 		hooks:   hooks,
+		blockProcessor: BlockProcessor{
+			hooks:        hooks,
+			chainConfig:  chainConfig,
+			chainContext: chainContext,
+		},
 		// On startup we enqueue every block since the last time the trie DB was
 		// committed, so the queue needs sufficient capacity to avoid
 		// [Executor.Enqueue] warning about it being too full.
-		queue: make(chan queuedBlock, 2*tracker.CommitInterval()),
-		chainContext: &chainContext{
-			headerSrc,
-			lru.NewCache[uint64, *types.Header](256), // minimum history for BLOCKHASH op
-			logger,
-		},
-		chainConfig: chainConfig,
-		db:          db,
-		xdb:         xdb,
-		metrics:     m,
-		receipts:    newSyncMap[common.Hash, eventual.Value[*Receipt]](),
+		queue:        make(chan queuedBlock, 2*tracker.CommitInterval()),
+		chainContext: chainContext,
+		db:           db,
+		xdb:          xdb,
+		metrics:      m,
+		receipts:     newSyncMap[common.Hash, eventual.Value[*Receipt]](),
 	}
 	e.lastExecuted.Store(lastExecuted)
 
@@ -116,13 +121,18 @@ func (e *Executor) Close() error {
 
 // ChainConfig returns the config originally passed to [New].
 func (e *Executor) ChainConfig() *params.ChainConfig {
-	return e.chainConfig
+	return e.blockProcessor.chainConfig
 }
 
 // ChainContext returns a context backed by the [blocks.Source] originally
 // passed to [New].
 func (e *Executor) ChainContext() core.ChainContext {
 	return e.chainContext
+}
+
+// BlockProcessor returns the deterministic block processor used by e.
+func (e *Executor) BlockProcessor() *BlockProcessor {
+	return &e.blockProcessor
 }
 
 // LastExecuted returns the last-executed block in a threadsafe manner.

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -547,14 +547,16 @@ func TestExecuteBlockUntil(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := sut.ExecuteBlockUntil(b, tt.numTxs)
+			stateDB, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
+			require.NoError(t, err, "Executor.StateDB(parent root)")
+			_, err = sut.ExecuteBlockUntil(b, stateDB, tt.numTxs)
 			if tt.wantErr {
 				require.ErrorIs(t, err, errTransactionCountOutOfRange, "Executor.ExecuteBlockUntil()")
 				return
 			}
 			require.NoError(t, err, "Executor.ExecuteBlockUntil()")
-			require.Equal(t, tt.wantFirst, result.StateDB.GetBalance(firstRecipient), "first recipient balance")
-			require.Equal(t, tt.wantSecond, result.StateDB.GetBalance(secondRecipient), "second recipient balance")
+			require.Equal(t, tt.wantFirst, stateDB.GetBalance(firstRecipient), "first recipient balance")
+			require.Equal(t, tt.wantSecond, stateDB.GetBalance(secondRecipient), "second recipient balance")
 
 			gasClock := b.ParentBlock().ExecutedByGasTime()
 			gasClock.BeforeBlock(sut.hooks.BlockTime(b.Header()))

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -486,30 +486,83 @@ func TestEndOfBlockOps(t *testing.T) {
 	})
 }
 
-func TestExecuteTransactionPrefixSkipsEndOfBlockOps(t *testing.T) {
+func TestExecuteBlockUntil(t *testing.T) {
 	_, sut := newSUT(t)
-	recipient := common.Address{'r', 'e', 'c', 'i', 'p', 'i', 'e', 'n', 't'}
+	firstRecipient := common.Address{'f', 'i', 'r', 's', 't'}
+	secondRecipient := common.Address{'s', 'e', 'c', 'o', 'n', 'd'}
 	b := sut.chain.NewBlock(t, types.Transactions{
 		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-			To:       &recipient,
+			To:       &firstRecipient,
 			Value:    big.NewInt(1),
+			Gas:      params.TxGas,
+			GasPrice: big.NewInt(1),
+		}),
+		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+			To:       &secondRecipient,
+			Value:    big.NewInt(2),
 			Gas:      params.TxGas,
 			GasPrice: big.NewInt(1),
 		}),
 	}, blockstest.WithEthBlockOptions(blockstest.WithOps([]saehookstest.Op{{
 		Mint: []saehookstest.AccountCredit{{
-			Address: recipient,
+			Address: firstRecipient,
 			Amount:  *uint256.NewInt(100),
 		}},
 	}})))
 
-	sdb, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
-	require.NoError(t, err, "Executor.StateDB()")
-	result, err := sut.ExecuteTransactionPrefix(b, sdb, len(b.Transactions()))
-	require.NoError(t, err, "Executor.ExecuteTransactionPrefix()")
+	tests := []struct {
+		name       string
+		numTxs     int
+		wantFirst  *uint256.Int
+		wantSecond *uint256.Int
+		wantErr    bool
+	}{
+		{
+			name:       "no transactions",
+			wantFirst:  new(uint256.Int),
+			wantSecond: new(uint256.Int),
+		},
+		{
+			name:       "one transaction",
+			numTxs:     1,
+			wantFirst:  uint256.NewInt(1),
+			wantSecond: new(uint256.Int),
+		},
+		{
+			name:       "all transactions",
+			numTxs:     len(b.Transactions()),
+			wantFirst:  uint256.NewInt(1),
+			wantSecond: uint256.NewInt(2),
+		},
+		{
+			name:    "negative transaction count",
+			numTxs:  -1,
+			wantErr: true,
+		},
+		{
+			name:    "transaction count exceeds block",
+			numTxs:  len(b.Transactions()) + 1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sut.ExecuteBlockUntil(b, tt.numTxs)
+			if tt.wantErr {
+				require.ErrorIs(t, err, errTransactionCountOutOfRange, "Executor.ExecuteBlockUntil()")
+				return
+			}
+			require.NoError(t, err, "Executor.ExecuteBlockUntil()")
+			require.Equal(t, tt.wantFirst, result.StateDB.GetBalance(firstRecipient), "first recipient balance")
+			require.Equal(t, tt.wantSecond, result.StateDB.GetBalance(secondRecipient), "second recipient balance")
 
-	want := uint256.NewInt(1)
-	require.Equal(t, want, result.StateDB.GetBalance(recipient), "recipient balance after transaction prefix")
+			gasClock := b.ParentBlock().ExecutedByGasTime()
+			gasClock.BeforeBlock(sut.hooks.BlockTime(b.Header()))
+			_, ok, err := blocks.LastToSettleAt(sut.hooks, gasClock.AsTime(), b)
+			require.NoError(t, err, "blocks.LastToSettleAt()")
+			require.False(t, ok, "prefix execution recorded canonical progress")
+		})
+	}
 }
 
 func TestGasAccounting(t *testing.T) {

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -486,6 +486,32 @@ func TestEndOfBlockOps(t *testing.T) {
 	})
 }
 
+func TestExecuteTransactionPrefixSkipsEndOfBlockOps(t *testing.T) {
+	_, sut := newSUT(t)
+	recipient := common.Address{'r', 'e', 'c', 'i', 'p', 'i', 'e', 'n', 't'}
+	b := sut.chain.NewBlock(t, types.Transactions{
+		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+			To:       &recipient,
+			Value:    big.NewInt(1),
+			Gas:      params.TxGas,
+			GasPrice: big.NewInt(1),
+		}),
+	}, blockstest.WithEthBlockOptions(blockstest.WithOps([]saehookstest.Op{{
+		Mint: []saehookstest.AccountCredit{{
+			Address: recipient,
+			Amount:  *uint256.NewInt(100),
+		}},
+	}})))
+
+	sdb, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
+	require.NoError(t, err, "Executor.StateDB()")
+	result, err := sut.ExecuteTransactionPrefix(b, sdb, len(b.Transactions()))
+	require.NoError(t, err, "Executor.ExecuteTransactionPrefix()")
+
+	want := uint256.NewInt(1)
+	require.Equal(t, want, result.StateDB.GetBalance(recipient), "recipient balance after transaction prefix")
+}
+
 func TestGasAccounting(t *testing.T) {
 	const gasPerTx = gas.Gas(params.TxGas)
 	hooks := saehookstest.NewStub(5 * gasPerTx)

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -71,6 +71,7 @@ type SUT struct {
 	saedbConfig  saedb.Config
 	chain        *blockstest.ChainBuilder
 	wallet       *saetest.Wallet
+	hooks        *saehookstest.Stub
 	logger       *loggingtest.Logger
 	db           ethdb.Database
 	chainDataDir string
@@ -149,6 +150,7 @@ func newSUT(tb testing.TB, opts ...sutOption) (context.Context, *SUT) {
 		saedbConfig:  saedbConfig,
 		chain:        chain,
 		wallet:       wallet,
+		hooks:        sutCfg.hooks,
 		logger:       logger,
 		db:           db,
 		chainDataDir: chainDataDir,
@@ -549,12 +551,12 @@ func TestExecuteBlockUntil(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			stateDB, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
 			require.NoError(t, err, "Executor.StateDB(parent root)")
-			_, err = sut.ExecuteBlockUntil(b, stateDB, tt.numTxs)
+			_, err = sut.BlockProcessor().ExecuteBlockUntil(b, stateDB, tt.numTxs)
 			if tt.wantErr {
-				require.ErrorIs(t, err, errTransactionCountOutOfRange, "Executor.ExecuteBlockUntil()")
+				require.ErrorIs(t, err, errTransactionCountOutOfRange, "BlockProcessor.ExecuteBlockUntil()")
 				return
 			}
-			require.NoError(t, err, "Executor.ExecuteBlockUntil()")
+			require.NoError(t, err, "BlockProcessor.ExecuteBlockUntil()")
 			require.Equal(t, tt.wantFirst, stateDB.GetBalance(firstRecipient), "first recipient balance")
 			require.Equal(t, tt.wantSecond, stateDB.GetBalance(secondRecipient), "second recipient balance")
 
@@ -1202,7 +1204,7 @@ func TestRecoveryStateAvailability(t *testing.T) {
 				log := loggingtest.New(t, logging.Debug)
 				tr, err := saedb.NewTracker(sut.db, sut.saedbConfig, chain.Last().PostExecutionStateRoot(), sut.chainDataDir, log)
 				require.NoError(t, err, "saedb.NewTracker()")
-				e, err := New(chain.Last(), src.AsHeaderSource(), sut.chainConfig, sut.db, sut.xdb, tr, defaultHooks(), log, prometheus.NewRegistry())
+				e, err := New(chain.Last(), src.AsHeaderSource(), sut.ChainConfig(), sut.db, sut.xdb, tr, defaultHooks(), log, prometheus.NewRegistry())
 				require.NoError(t, err, "New()")
 				t.Cleanup(func() {
 					require.NoErrorf(t, e.Close(), "%T.Close()", e)

--- a/vms/saevm/saexec/subscription.go
+++ b/vms/saevm/saexec/subscription.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 )
 
-func (e *Executor) sendPostExecutionEvents(block *blocks.Block, results *ExecutionResults) {
+func (e *Executor) sendPostExecutionEvents(block *blocks.Block, results *executionResults) {
 	e.metrics.markExecuted(block, results)
 
 	b := block.EthBlock()


### PR DESCRIPTION
## Why this should be merged

RPC tracing currently drives execution directly and suppresses lifecycle hooks through a wrapper. This is fragile because new hooks can unintentionally modify block or persistent state during tracing.

## How this works

- Adds executor APIs for full-block and transaction-prefix execution.
- Routes RPC replay through the executor.
- Removes RPC hook suppression and direct execution setup.
- Keeps canonical commits, hooks, and events exclusive to canonical execution.

This also establishes the execution boundary needed for future Firewood state reconstruction.

## How this was tested
 Added coverage that transaction-prefix execution skips end-of-block operations, and all existing UTs pass. 
