### PR TITLE
Remove `test` build tag from fuzz and test scripts

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -399,8 +399,6 @@ bazel build //...
 By default, `bazel test` matches `scripts/build_test.sh` behavior,
 with a few exceptions:
 
-- The script passes `-tags test` to `go test`; currently there are no
-  `//go:build test` files in this repo, so it has no effect.
 - The script excludes several directories via `go list | grep -v ...`;
   Bazel instead relies on `tags = ["manual"]` to keep non-unit tests
   out of `bazel test //...`.

--- a/graft/evm/scripts/lint.sh
+++ b/graft/evm/scripts/lint.sh
@@ -157,8 +157,7 @@ function test_import_testing_only_in_tests {
   # Files in /tests/ are already excluded by the `find ... ! -path`
   INTENDED_FOR_TESTING="${IN_TEST_PKG}"
 
-  # -3 suppresses files that have test logic and have the "test" build tag
-  # -2 suppresses files that are tagged despite not having detectable test logic
+  # Report files with test-only dependencies outside a test package.
   UNTAGGED=$(comm -23 <(echo "${HAVE_TEST_LOGIC}" | sort -u) <(echo "${INTENDED_FOR_TESTING}" | sort -u))
   if [ -z "${UNTAGGED}" ]; then
     return 0

--- a/scripts/build_fuzz.sh
+++ b/scripts/build_fuzz.sh
@@ -48,7 +48,7 @@ do
         # cd into parentDir so packages in sub-modules (e.g. ./graft/coreth)
         # resolve against their own go.mod rather than the main module.
         # If any of the fuzz tests fail, return exit code 1
-        if ! ( cd "$parentDir" && go test -tags test -timeout="${timeout}s" . -run="$func" -fuzz="$func" -fuzztime="${fuzzTime}"s ); then
+        if ! ( cd "$parentDir" && go test -timeout="${timeout}s" . -run="$func" -fuzz="$func" -fuzztime="${fuzzTime}"s ); then
             failed=true
         fi
     done < <(grep -oP 'func \K(Fuzz\w*)' "$file")

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -30,4 +30,4 @@ fi
 TEST_TARGETS="$(eval "go list ./... ${EXCLUDED_TARGETS}")"
 
 # shellcheck disable=SC2086
-go test -tags test ${shuffle:-} ${race:-} -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}
+go test ${shuffle:-} ${race:-} -timeout="${TIMEOUT:-120s}" -coverprofile="coverage.out" -covermode="atomic" ${TEST_TARGETS}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -128,8 +128,7 @@ function test_import_testing_only_in_tests {
   # Files in /tests/ are already excluded by the `find ... ! -path`
   INTENDED_FOR_TESTING="${IN_TEST_PKG}"
 
-  # -3 suppresses files that have test logic and have the "test" build tag
-  # -2 suppresses files that are tagged despite not having detectable test logic
+  # Report files with test-only dependencies outside a test package.
   UNTAGGED=$( comm -23 <( echo "${HAVE_TEST_LOGIC}" | sort -u ) <( echo "${INTENDED_FOR_TESTING}" | sort -u ) );
   if [ -z "${UNTAGGED}" ];
   then


### PR DESCRIPTION
There are no instances of the `test` build tag anywhere in the repo.