### PR TITLE
[docs] Clarify links in documentation guidelines

### DIFF
--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -356,10 +356,9 @@ still fairly short, a TOC makes the structure visible up front, helps readers
 jump to the part they need, and makes it easier to notice when the document's
 shape has drifted.
 
-A trailing **References** section pointing to the relevant code, tests, and
-related docs is often useful. It makes the links between the document and the
-code explicit, supports the discoverability conventions above, and helps
-reviewers see what parts of the repository the document covers.
+Use an inline link when its text and the surrounding text explain the linked
+material. If readers need more explanation, link to the relevant item in a
+trailing **References** section.
 
 A README near the code can do more than explain usage. It can also preserve
 non-obvious context a future maintainer would otherwise need to reconstruct


### PR DESCRIPTION
## Why this should be merged

Previously, the doc guidelines recommended a References section without explaining when to use an inline link or a References entry.

The guidelines now explain that distinction.