### PR TITLE
[bazel] Ignore .agents

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,5 @@
+.agents
+.bazel/patches/build_files
 .claude
 .direnv
-.bazel/patches/build_files
 bazel-avalanchego


### PR DESCRIPTION
## Why this should be merged

Prevent Bazel from treating files in .agents as build packages or inputs.
