### PR TITLE
refactor(platformvm): reuse avax nil transaction error

### DIFF
--- a/vms/platformvm/txs/add_auto_renewed_validator_tx.go
+++ b/vms/platformvm/txs/add_auto_renewed_validator_tx.go
@@ -142,7 +142,7 @@ func (tx *AddAutoRenewedValidatorTx) InitCtx(ctx *snow.Context) {
 func (tx *AddAutoRenewedValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case len(tx.StakeOuts) == 0:

--- a/vms/platformvm/txs/add_auto_renewed_validator_tx_test.go
+++ b/vms/platformvm/txs/add_auto_renewed_validator_tx_test.go
@@ -38,7 +38,7 @@ func TestAddAutoRenewedValidatorTxSyntacticVerify(t *testing.T) {
 			mutate: func(*AddAutoRenewedValidatorTx) *AddAutoRenewedValidatorTx {
 				return nil
 			},
-			want: ErrNilTx,
+			want: avax.ErrNilTx,
 		},
 		{
 			name: "already_verified",

--- a/vms/platformvm/txs/add_delegator_test.go
+++ b/vms/platformvm/txs/add_delegator_test.go
@@ -38,7 +38,7 @@ func TestAddDelegatorTxSyntacticVerify(t *testing.T) {
 
 	// Case : unsigned tx is nil
 	err = addDelegatorTx.SyntacticVerify(ctx)
-	require.ErrorIs(err, ErrNilTx)
+	require.ErrorIs(err, avax.ErrNilTx)
 
 	validatorWeight := uint64(2022)
 	inputs := []*avax.TransferableInput{{

--- a/vms/platformvm/txs/add_delegator_tx.go
+++ b/vms/platformvm/txs/add_delegator_tx.go
@@ -82,7 +82,7 @@ func (tx *AddDelegatorTx) RewardsOwner() fx.Owner {
 func (tx *AddDelegatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	}

--- a/vms/platformvm/txs/add_permissionless_delegator_tx.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx.go
@@ -86,7 +86,7 @@ func (tx *AddPermissionlessDelegatorTx) RewardsOwner() fx.Owner {
 func (tx *AddPermissionlessDelegatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case len(tx.StakeOuts) == 0: // Ensure there is provided stake

--- a/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_delegator_tx_test.go
@@ -1538,7 +1538,7 @@ func TestAddPermissionlessDelegatorTxSyntacticVerify(t *testing.T) {
 			txFunc: func(*gomock.Controller) *AddPermissionlessDelegatorTx {
 				return nil
 			},
-			err: ErrNilTx,
+			err: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/add_permissionless_validator_tx.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx.go
@@ -121,7 +121,7 @@ func (tx *AddPermissionlessValidatorTx) Shares() uint32 {
 func (tx *AddPermissionlessValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case tx.Validator.NodeID == ids.EmptyNodeID:

--- a/vms/platformvm/txs/add_permissionless_validator_tx_test.go
+++ b/vms/platformvm/txs/add_permissionless_validator_tx_test.go
@@ -1414,7 +1414,7 @@ func TestAddPermissionlessValidatorTxSyntacticVerify(t *testing.T) {
 			txFunc: func(*gomock.Controller) *AddPermissionlessValidatorTx {
 				return nil
 			},
-			err: ErrNilTx,
+			err: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/add_subnet_validator_test.go
+++ b/vms/platformvm/txs/add_subnet_validator_test.go
@@ -37,7 +37,7 @@ func TestAddSubnetValidatorTxSyntacticVerify(t *testing.T) {
 
 	// Case : unsigned tx is nil
 	err = addSubnetValidatorTx.SyntacticVerify(ctx)
-	require.ErrorIs(err, ErrNilTx)
+	require.ErrorIs(err, avax.ErrNilTx)
 
 	validatorWeight := uint64(2022)
 	subnetID := ids.ID{'s', 'u', 'b', 'n', 'e', 't', 'I', 'D'}

--- a/vms/platformvm/txs/add_subnet_validator_tx.go
+++ b/vms/platformvm/txs/add_subnet_validator_tx.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 )
 
@@ -50,7 +51,7 @@ func (*AddSubnetValidatorTx) CurrentPriority() Priority {
 func (tx *AddSubnetValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case tx.Subnet == constants.PrimaryNetworkID:

--- a/vms/platformvm/txs/add_validator_test.go
+++ b/vms/platformvm/txs/add_validator_test.go
@@ -37,7 +37,7 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 
 	// Case : unsigned tx is nil
 	err = addValidatorTx.SyntacticVerify(ctx)
-	require.ErrorIs(err, ErrNilTx)
+	require.ErrorIs(err, avax.ErrNilTx)
 
 	validatorWeight := uint64(2022)
 	rewardAddress := preFundedKeys[0].Address()

--- a/vms/platformvm/txs/add_validator_tx.go
+++ b/vms/platformvm/txs/add_validator_tx.go
@@ -93,7 +93,7 @@ func (tx *AddValidatorTx) Shares() uint32 {
 func (tx *AddValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case tx.DelegationShares > reward.PercentDenominator: // Ensure delegators shares are in the allowed amount

--- a/vms/platformvm/txs/base_tx.go
+++ b/vms/platformvm/txs/base_tx.go
@@ -18,8 +18,6 @@ import (
 var (
 	_ UnsignedTx = (*BaseTx)(nil)
 
-	ErrNilTx = errors.New("tx is nil")
-
 	errOutputsNotSorted      = errors.New("outputs not sorted")
 	errInputsNotSortedUnique = errors.New("inputs not sorted and unique")
 )
@@ -72,7 +70,7 @@ func (tx *BaseTx) InitCtx(ctx *snow.Context) {
 func (tx *BaseTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	}

--- a/vms/platformvm/txs/convert_subnet_to_l1_tx.go
+++ b/vms/platformvm/txs/convert_subnet_to_l1_tx.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
@@ -49,7 +50,7 @@ type ConvertSubnetToL1Tx struct {
 func (tx *ConvertSubnetToL1Tx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified:
 		// already passed syntactic verification
 		return nil

--- a/vms/platformvm/txs/convert_subnet_to_l1_tx_test.go
+++ b/vms/platformvm/txs/convert_subnet_to_l1_tx_test.go
@@ -587,7 +587,7 @@ func TestConvertSubnetToL1TxSyntacticVerify(t *testing.T) {
 		{
 			name:        "nil tx",
 			tx:          nil,
-			expectedErr: ErrNilTx,
+			expectedErr: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/create_chain_test.go
+++ b/vms/platformvm/txs/create_chain_test.go
@@ -42,7 +42,7 @@ func TestUnsignedCreateChainTxVerify(t *testing.T) {
 			setup: func(*CreateChainTx) *CreateChainTx {
 				return nil
 			},
-			expectedErr: ErrNilTx,
+			expectedErr: avax.ErrNilTx,
 		},
 		{
 			description: "vm ID is empty",

--- a/vms/platformvm/txs/create_chain_tx.go
+++ b/vms/platformvm/txs/create_chain_tx.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 )
 
@@ -53,7 +54,7 @@ type CreateChainTx struct {
 func (tx *CreateChainTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case tx.SubnetID == constants.PrimaryNetworkID:

--- a/vms/platformvm/txs/create_subnet_tx.go
+++ b/vms/platformvm/txs/create_subnet_tx.go
@@ -5,6 +5,7 @@ package txs
 
 import (
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 )
 
@@ -30,7 +31,7 @@ func (tx *CreateSubnetTx) InitCtx(ctx *snow.Context) {
 func (tx *CreateSubnetTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	}

--- a/vms/platformvm/txs/disable_l1_validator_tx.go
+++ b/vms/platformvm/txs/disable_l1_validator_tx.go
@@ -6,6 +6,7 @@ package txs
 import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 )
 
@@ -23,7 +24,7 @@ type DisableL1ValidatorTx struct {
 func (tx *DisableL1ValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified:
 		// already passed syntactic verification
 		return nil

--- a/vms/platformvm/txs/disable_l1_validator_tx_test.go
+++ b/vms/platformvm/txs/disable_l1_validator_tx_test.go
@@ -336,7 +336,7 @@ func TestDisableL1ValidatorTxSyntacticVerify(t *testing.T) {
 		{
 			name:        "nil tx",
 			tx:          nil,
-			expectedErr: ErrNilTx,
+			expectedErr: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/executor/proposal_tx_executor.go
+++ b/vms/platformvm/txs/executor/proposal_tx_executor.go
@@ -310,7 +310,7 @@ func (e *proposalTxExecutor) AddDelegatorTx(tx *txs.AddDelegatorTx) error {
 func (e *proposalTxExecutor) AdvanceTimeTx(tx *txs.AdvanceTimeTx) error {
 	switch {
 	case tx == nil:
-		return txs.ErrNilTx
+		return avax.ErrNilTx
 	case len(e.tx.Creds) != 0:
 		return errWrongNumberOfCredentials
 	}
@@ -344,7 +344,7 @@ func (e *proposalTxExecutor) AdvanceTimeTx(tx *txs.AdvanceTimeTx) error {
 func (e *proposalTxExecutor) RewardValidatorTx(tx *txs.RewardValidatorTx) error {
 	switch {
 	case tx == nil:
-		return txs.ErrNilTx
+		return avax.ErrNilTx
 	case tx.TxID == ids.Empty:
 		return ErrInvalidID
 	case len(e.tx.Creds) != 0:

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -2172,7 +2172,7 @@ func TestStandardExecutorTransformSubnetTx(t *testing.T) {
 				}
 				return env.unsignedTx, e
 			},
-			err: txs.ErrNilTx,
+			err: avax.ErrNilTx,
 		},
 		{
 			name: "max stake duration too large",

--- a/vms/platformvm/txs/export_tx.go
+++ b/vms/platformvm/txs/export_tx.go
@@ -47,7 +47,7 @@ func (tx *ExportTx) InitCtx(ctx *snow.Context) {
 func (tx *ExportTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case len(tx.ExportedOutputs) == 0:

--- a/vms/platformvm/txs/import_tx.go
+++ b/vms/platformvm/txs/import_tx.go
@@ -62,7 +62,7 @@ func (tx *ImportTx) InputIDs() set.Set[ids.ID] {
 func (tx *ImportTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case len(tx.ImportedInputs) == 0:

--- a/vms/platformvm/txs/increase_l1_validator_balance_tx.go
+++ b/vms/platformvm/txs/increase_l1_validator_balance_tx.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 )
 
 var (
@@ -28,7 +29,7 @@ type IncreaseL1ValidatorBalanceTx struct {
 func (tx *IncreaseL1ValidatorBalanceTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified:
 		// already passed syntactic verification
 		return nil

--- a/vms/platformvm/txs/increase_l1_validator_balance_tx_test.go
+++ b/vms/platformvm/txs/increase_l1_validator_balance_tx_test.go
@@ -329,7 +329,7 @@ func TestIncreaseL1ValidatorBalanceTxSyntacticVerify(t *testing.T) {
 		{
 			name:        "nil tx",
 			tx:          nil,
-			expectedErr: ErrNilTx,
+			expectedErr: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/register_l1_validator_tx.go
+++ b/vms/platformvm/txs/register_l1_validator_tx.go
@@ -6,6 +6,7 @@ package txs
 import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/types"
 )
 
@@ -26,7 +27,7 @@ type RegisterL1ValidatorTx struct {
 func (tx *RegisterL1ValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified:
 		// already passed syntactic verification
 		return nil

--- a/vms/platformvm/txs/register_l1_validator_tx_test.go
+++ b/vms/platformvm/txs/register_l1_validator_tx_test.go
@@ -340,7 +340,7 @@ func TestRegisterL1ValidatorTxSyntacticVerify(t *testing.T) {
 		{
 			name:        "nil tx",
 			tx:          nil,
-			expectedErr: ErrNilTx,
+			expectedErr: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/remove_subnet_validator_tx.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 )
 
@@ -32,7 +33,7 @@ type RemoveSubnetValidatorTx struct {
 func (tx *RemoveSubnetValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified:
 		// already passed syntactic verification
 		return nil

--- a/vms/platformvm/txs/remove_subnet_validator_tx_test.go
+++ b/vms/platformvm/txs/remove_subnet_validator_tx_test.go
@@ -559,7 +559,7 @@ func TestRemoveSubnetValidatorTxSyntacticVerify(t *testing.T) {
 			txFunc: func(*gomock.Controller) *RemoveSubnetValidatorTx {
 				return nil
 			},
-			expectedErr: ErrNilTx,
+			expectedErr: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/reward_auto_renewed_validator_tx.go
+++ b/vms/platformvm/txs/reward_auto_renewed_validator_tx.go
@@ -64,7 +64,7 @@ func (*RewardAutoRenewedValidatorTx) Outputs() []*avax.TransferableOutput {
 func (tx *RewardAutoRenewedValidatorTx) SyntacticVerify(*snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.TxID == ids.Empty:
 		return errMissingTxID
 	case tx.Timestamp == 0:

--- a/vms/platformvm/txs/reward_auto_renewed_validator_tx_test.go
+++ b/vms/platformvm/txs/reward_auto_renewed_validator_tx_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 )
 
 func TestRewardAutoRenewedValidatorTxSyntacticVerify(t *testing.T) {
@@ -20,7 +21,7 @@ func TestRewardAutoRenewedValidatorTxSyntacticVerify(t *testing.T) {
 		{
 			name: "nil",
 			tx:   nil,
-			want: ErrNilTx,
+			want: avax.ErrNilTx,
 		},
 		{
 			name: "missing_timestamp",

--- a/vms/platformvm/txs/set_auto_renewed_validator_config_tx.go
+++ b/vms/platformvm/txs/set_auto_renewed_validator_config_tx.go
@@ -6,6 +6,7 @@ package txs
 import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
@@ -37,7 +38,7 @@ type SetAutoRenewedValidatorConfigTx struct {
 func (tx *SetAutoRenewedValidatorConfigTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified:
 		// already passed syntactic verification
 		return nil

--- a/vms/platformvm/txs/set_auto_renewed_validator_config_tx_test.go
+++ b/vms/platformvm/txs/set_auto_renewed_validator_config_tx_test.go
@@ -31,7 +31,7 @@ func TestSetAutoRenewedValidatorConfigTxSyntacticVerify(t *testing.T) {
 			mutate: func(*SetAutoRenewedValidatorConfigTx) *SetAutoRenewedValidatorConfigTx {
 				return nil
 			},
-			want: ErrNilTx,
+			want: avax.ErrNilTx,
 		},
 		{
 			name: "already_verified",

--- a/vms/platformvm/txs/set_l1_validator_weight_tx.go
+++ b/vms/platformvm/txs/set_l1_validator_weight_tx.go
@@ -5,6 +5,7 @@ package txs
 
 import (
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/types"
 )
 
@@ -21,7 +22,7 @@ type SetL1ValidatorWeightTx struct {
 func (tx *SetL1ValidatorWeightTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified:
 		// already passed syntactic verification
 		return nil

--- a/vms/platformvm/txs/set_l1_validator_weight_tx_test.go
+++ b/vms/platformvm/txs/set_l1_validator_weight_tx_test.go
@@ -311,7 +311,7 @@ func TestSetL1ValidatorWeightTxSyntacticVerify(t *testing.T) {
 		{
 			name:        "nil tx",
 			tx:          nil,
-			expectedErr: ErrNilTx,
+			expectedErr: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/transfer_subnet_ownership_tx.go
+++ b/vms/platformvm/txs/transfer_subnet_ownership_tx.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 )
@@ -41,7 +42,7 @@ func (tx *TransferSubnetOwnershipTx) InitCtx(ctx *snow.Context) {
 func (tx *TransferSubnetOwnershipTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified:
 		// already passed syntactic verification
 		return nil

--- a/vms/platformvm/txs/transfer_subnet_ownership_tx_test.go
+++ b/vms/platformvm/txs/transfer_subnet_ownership_tx_test.go
@@ -586,7 +586,7 @@ func TestTransferSubnetOwnershipTxSyntacticVerify(t *testing.T) {
 			txFunc: func(*gomock.Controller) *TransferSubnetOwnershipTx {
 				return nil
 			},
-			expectedErr: ErrNilTx,
+			expectedErr: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",

--- a/vms/platformvm/txs/transform_subnet_tx.go
+++ b/vms/platformvm/txs/transform_subnet_tx.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
@@ -115,7 +116,7 @@ type TransformSubnetTx struct {
 func (tx *TransformSubnetTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {
 	case tx == nil:
-		return ErrNilTx
+		return avax.ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
 	case tx.Subnet == constants.PrimaryNetworkID:

--- a/vms/platformvm/txs/transform_subnet_tx_test.go
+++ b/vms/platformvm/txs/transform_subnet_tx_test.go
@@ -669,7 +669,7 @@ func TestTransformSubnetTxSyntacticVerify(t *testing.T) {
 			txFunc: func(*gomock.Controller) *TransformSubnetTx {
 				return nil
 			},
-			err: ErrNilTx,
+			err: avax.ErrNilTx,
 		},
 		{
 			name: "already verified",


### PR DESCRIPTION
## Why this should be merged
Removes the duplicate PlatformVM nil-transaction error and consistently reuses the shared avax.ErrNilTx error.

## How this works
Replace `platformvm.ErrNilTx` with `avax.ErrNilTx`.

## How this was tested
Existing UTs.

## Need to be documented in RELEASES.md?
No.