### PR TITLE
Fix flaky node uptime test

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -347,6 +347,7 @@ func TestNodeUptimeACP267Requirement(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := defaultConfig
+			config.PingFrequency = time.Hour
 			config.UptimeCalculator = uptime.TestCalculator{StartTime: tt.startTime}
 			config.UpgradeConfig.HeliconTime = heliconTime
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -347,6 +347,9 @@ func TestNodeUptimeACP267Requirement(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := defaultConfig
+			// Set the ping frequency to one hour so the explicit ping below should be the only
+			// ping sent during the test. Multiple in-flight pings can make a pong appear unexpected
+			// and disconnect the peer.
 			config.PingFrequency = time.Hour
 			config.UptimeCalculator = uptime.TestCalculator{StartTime: tt.startTime}
 			config.UpgradeConfig.HeliconTime = heliconTime
@@ -373,8 +376,7 @@ func TestNodeUptimeACP267Requirement(t *testing.T) {
 
 			peerUptime := uint32(tt.peerUptime * 100)
 
-			// Send the uptime explicitly to avoid overlapping periodic pings.
-			// Multiple in-flight pings can make a pong appear unexpected and disconnect the peer.
+			// Send the uptime explicitly instead of relying on a periodic ping.
 			ping, err := sender.peerConfig.MessageCreator.Ping(peerUptime)
 			require.NoError(t, err)
 			require.True(t, peers[0].Send(t.Context(), ping))

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -347,14 +347,10 @@ func TestNodeUptimeACP267Requirement(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := defaultConfig
-			config.PingFrequency = 10 * time.Millisecond
-			config.UptimeCalculator = uptime.TestCalculator{
-				StartTime: tt.startTime,
-				Percent:   tt.peerUptime,
-			}
+			config.UptimeCalculator = uptime.TestCalculator{StartTime: tt.startTime}
 			config.UpgradeConfig.HeliconTime = heliconTime
 
-			_, networks, eg := newFullyConnectedTestNetworkWithConfig(
+			nodeIDs, networks, eg := newFullyConnectedTestNetworkWithConfig(
 				t,
 				[]router.InboundHandler{nil, nil},
 				config,
@@ -366,9 +362,25 @@ func TestNodeUptimeACP267Requirement(t *testing.T) {
 				require.NoError(t, eg.Wait())
 			})
 
+			sender := networks[1]
+			peers := sender.getPeers(
+				set.Of(nodeIDs[0]),
+				constants.PrimaryNetworkID,
+				subnets.NoOpAllower,
+			)
+			require.Len(t, peers, 1)
+
+			peerUptime := uint32(tt.peerUptime * 100)
+
+			// Send the uptime explicitly to avoid overlapping periodic pings.
+			// Multiple in-flight pings can make a pong appear unexpected and disconnect the peer.
+			ping, err := sender.peerConfig.MessageCreator.Ping(peerUptime)
+			require.NoError(t, err)
+			require.True(t, peers[0].Send(t.Context(), ping))
+
 			require.Eventually(t, func() bool {
 				peers := networks[0].PeerInfo(nil)
-				return len(peers) == 1 && uint32(peers[0].ObservedUptime) == uint32(tt.peerUptime*100)
+				return len(peers) == 1 && uint32(peers[0].ObservedUptime) == peerUptime
 			}, 10*time.Second, 10*time.Millisecond)
 
 			uptime, err := networks[0].NodeUptime()


### PR DESCRIPTION
## Why this should be merged

`TestNodeUptimeACP267Requirement` sent pings every 10 ms. Under CI load, multiple pings could be in flight. An earlier pong could clear the latest ping state, causing the next pong to appear unexpected and disconnect the peer.

## How this works

Send one ping with the desired uptime explicitly and wait until the receiving network records it. This removes the reliance on high-frequency periodic pings.

## How this was tested

Unit test

## Need to be documented in RELEASES.md?

No.