### PR TITLE
[ci] Reduce e2e job runtime by running tests in parallel

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,4 +1,5 @@
 self-hosted-runner:
   labels:
     - avalanche-avalanchego-runner # Github Action Runner Controller
-    - blacksmith-4vcpu-ubuntu-2404 # Blacksmith runner
+    - blacksmith-4vcpu-ubuntu-2404 # Beefier x86 runner
+    - ubuntu-24.04-arm-4-core      # Beefier arm64 runner

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - avalanche-avalanchego-runner # Github Action Runner Controller
+    - blacksmith-4vcpu-ubuntu-2404 # Blacksmith runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,9 @@ jobs:
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   e2e_schedule_latest:
-    runs-on: ubuntu-24.04
+    # The default free runners lack the resources for parallel execution, so a beefier
+    # runner is required.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
       - name: Run e2e tests
@@ -133,7 +135,9 @@ jobs:
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   e2e_post_latest:
-    runs-on: ubuntu-24.04
+    # The default free runners lack the resources for parallel execution, so a beefier
+    # runner is required.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
       - name: Run e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        # The default free runners lack the resources for parallel execution, so
+        # beefier runners are required.
+        os: [blacksmith-4vcpu-ubuntu-2404, ubuntu-24.04-arm-4-core]
     steps:
       - uses: actions/checkout@v5
       - name: Run e2e tests

--- a/.github/workflows/subnet-evm-ci.yml
+++ b/.github/workflows/subnet-evm-ci.yml
@@ -133,7 +133,9 @@ jobs:
 
   test_build_antithesis_images:
     name: Build Antithesis images
-    runs-on: ubuntu-24.04
+    # Use a faster runner pending migration to bazel. The default free runners result
+    # in 20+ minute runtime, slowing down every PR and merge queue CI run.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-go-for-project

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -512,18 +512,14 @@ tasks:
       - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh {{.CLI_ARGS}}'
 
   test-e2e-ci-post-latest:
-    desc: Runs e2e tests [serially with race detection enabled] and posts latest activation immediately
-    env:
-      E2E_SERIAL: 1
+    desc: Runs e2e tests in parallel with race detection enabled and posts latest activation immediately
     cmds:
       - task: build-race
       - task: build-xsvm
       - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=0'
 
   test-e2e-ci-schedule-latest:
-    desc: Runs e2e tests [serially with race detection enabled] and schedules latest activation after 4 minutes
-    env:
-      E2E_SERIAL: 1
+    desc: Runs e2e tests in parallel with race detection enabled and schedules latest activation after 4 minutes
     cmds:
       - task: build-race
       - task: build-xsvm

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -503,9 +503,7 @@ tasks:
       - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh {{.CLI_ARGS}}'
 
   test-e2e-ci:
-    desc: Runs e2e tests [serially with race detection enabled]
-    env:
-      E2E_SERIAL: 1
+    desc: Runs e2e tests in parallel with race detection enabled
     cmds:
       - task: build-race
       - task: build-xsvm

--- a/tests/e2e/p/auto_renewed_reward_eligibility.go
+++ b/tests/e2e/p/auto_renewed_reward_eligibility.go
@@ -17,7 +17,9 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
-var _ = e2e.DescribePChain("[Auto-Renewed Validators] [Reward Eligibility]", func() {
+// This test asserts global P-Chain supply values so it cannot run concurrently with
+// other supply-changing tests.
+var _ = e2e.DescribePChain("[Auto-Renewed Validators] [Reward Eligibility]", ginkgo.Serial, func() {
 	tc := e2e.NewTestContext()
 
 	ginkgo.It("should reward eligible stakers and not reward ineligible ones", func() {

--- a/tests/e2e/p/auto_renewed_staking_rewards.go
+++ b/tests/e2e/p/auto_renewed_staking_rewards.go
@@ -18,7 +18,9 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
-var _ = e2e.DescribePChain("[Auto-Renewed Validators] [Staking Rewards]", func() {
+// This test asserts global P-Chain supply values so it cannot run concurrently with
+// other supply-changing tests.
+var _ = e2e.DescribePChain("[Auto-Renewed Validators] [Staking Rewards]", ginkgo.Serial, func() {
 	tc := e2e.NewTestContext()
 
 	ginkgo.It("should add an auto-renewed validator and complete a staking cycle", func() {

--- a/tests/fixture/tmpnet/node_config.go
+++ b/tests/fixture/tmpnet/node_config.go
@@ -54,7 +54,11 @@ func (n *Node) writeConfig() error {
 	if err != nil {
 		return stacktrace.Errorf("failed to marshal node config: %w", err)
 	}
-	if err := os.WriteFile(n.getConfigPath(), bytes, perms.ReadWrite); err != nil {
+	// Write configuration atomically to ensure tests running in parallel can create
+	// new ephemeral nodes without breaking tests trying to read network
+	// configuration. Non-atomic writes otherwise risk having a read of network
+	// configuration fail due to partially written node configuration.
+	if err := perms.WriteFile(n.getConfigPath(), bytes, perms.ReadWrite); err != nil {
 		return stacktrace.Errorf("failed to write node config: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Why this should be merged

E2E jobs have been running tests serially for compatibility with resource-constrained free GitHub Actions runners, but their serial runtime can be > 20 minutes. Pending further CI cleanup, the jobs with the longest runtime (*_latest) are configured to run on beefier runners that support parallel execution so that the jobs take less wall clock time.

Edit: Updated to also run subnet-evm's antithesis job on beefier runners.

## Before

<img width="797" height="69" alt="image" src="https://github.com/user-attachments/assets/dd77d8a2-2763-4c77-9ff7-30c3a4d2e964" />
<img width="802" height="36" alt="image" src="https://github.com/user-attachments/assets/802519d8-96ac-40e3-af87-d26199b13c23" />

## After

<img width="799" height="68" alt="image" src="https://github.com/user-attachments/assets/1c9c0a2c-b4b5-4675-ab41-f96a59e11cd7" />

<img width="786" height="38" alt="image" src="https://github.com/user-attachments/assets/b74eaeaa-2e0c-492f-aaa5-2ad6ae302a77" />
