### PR TITLE
refactor(sae): configure block execution with options

### DIFF
--- a/vms/saevm/blocks/block.go
+++ b/vms/saevm/blocks/block.go
@@ -54,7 +54,7 @@ type Block struct {
 	// Allows this block to be ruled out as able to be settled at a particular
 	// time (i.e. if this field is >= said time). The pointer MAY be nil if
 	// execution is yet to commence. For more details, see
-	// [Block.SetInterimExecutionTime for setting and [LastToSettleAt] for
+	// [Block.SwapInterimExecutionTime] for setting and [LastToSettleAt] for
 	// usage.
 	interimExecutionTime atomic.Pointer[proxytime.Time[gas.Gas]]
 

--- a/vms/saevm/blocks/execution.go
+++ b/vms/saevm/blocks/execution.go
@@ -31,11 +31,13 @@ import (
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
 )
 
-// SetInterimExecutionTime is expected to be called during execution of b's
+// SwapInterimExecutionTime is expected to be called during execution of b's
 // transactions, with the highest-known gas time. This MAY be at any resolution
 // but MUST be monotonic.
-func (b *Block) SetInterimExecutionTime(t *proxytime.Time[gas.Gas]) {
-	b.interimExecutionTime.Store(t.Clone())
+//
+// The returned old value is typically only useful for testing.
+func (b *Block) SwapInterimExecutionTime(t *proxytime.Time[gas.Gas]) *proxytime.Time[gas.Gas] {
+	return b.interimExecutionTime.Swap(t.Clone())
 }
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE

--- a/vms/saevm/blocks/settlement_test.go
+++ b/vms/saevm/blocks/settlement_test.go
@@ -350,7 +350,7 @@ func TestLastToSettleAt(t *testing.T) {
 		blocks[24].markExecutedForTests(t, db, xdb, tm)
 
 		partiallyExecutedAt := proxytime.New[gas.Gas](27, 1, 100)
-		blocks[25].SetInterimExecutionTime(partiallyExecutedAt)
+		blocks[25].SwapInterimExecutionTime(partiallyExecutedAt)
 
 		tests = append(tests, testCase{
 			settleAt: 26,

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -51,9 +51,20 @@ type PointsG[T Transaction] interface {
 	BlockRebuilderFrom(block *types.Block) (BlockBuilder[T], error)
 }
 
+// A SettlementPoint reports the settlement information encoded by a header.
+type SettlementPoint interface {
+	// SettledBy returns the extra information for the settled block of the
+	// provided header. It MUST match the value passed to
+	// [BlockBuilder.BuildBlock] and MUST be the zero value for synchronously
+	// executed (pre-SAE) headers.
+	SettledBy(*types.Header) Settled
+}
+
 // Points define user-injected hook points which do not depend on generic
 // types.
 type Points interface {
+	SettlementPoint
+
 	// ExecutionResultsDB opens and returns a height-indexed database, which
 	// will be closed by the VM when no longer needed. It MAY use the provided
 	// directory for persistence and MUST NOT write data outside of it.
@@ -66,11 +77,6 @@ type Points interface {
 	// ([time.Time.Unix] == [types.Header.Time]) and MAY include a sub-second
 	// component.
 	BlockTime(h *types.Header) time.Time
-	// SettledBy returns the extra information for the settled block of the
-	// provided header. It MUST match the value passed to
-	// [BlockBuilder.BuildBlock] and MUST be the zero value for synchronously
-	// executed (pre-SAE) headers.
-	SettledBy(*types.Header) Settled
 	// VerifyBlockSyntax checks chain-specific syntactic invariants of a parsed
 	// block, beyond the universal invariants enforced by [blocks.Parse]. It
 	// MUST be stateless.
@@ -231,7 +237,7 @@ type Settled struct {
 
 // Synchronous reports whether the header is that of a synchronously executed
 // (pre-SAE) block.
-func Synchronous(h Points, hdr *types.Header) bool {
+func Synchronous(h SettlementPoint, hdr *types.Header) bool {
 	return h.SettledBy(hdr) == (Settled{})
 }
 

--- a/vms/saevm/hook/hook.go
+++ b/vms/saevm/hook/hook.go
@@ -51,20 +51,9 @@ type PointsG[T Transaction] interface {
 	BlockRebuilderFrom(block *types.Block) (BlockBuilder[T], error)
 }
 
-// A SettlementPoint reports the settlement information encoded by a header.
-type SettlementPoint interface {
-	// SettledBy returns the extra information for the settled block of the
-	// provided header. It MUST match the value passed to
-	// [BlockBuilder.BuildBlock] and MUST be the zero value for synchronously
-	// executed (pre-SAE) headers.
-	SettledBy(*types.Header) Settled
-}
-
 // Points define user-injected hook points which do not depend on generic
 // types.
 type Points interface {
-	SettlementPoint
-
 	// ExecutionResultsDB opens and returns a height-indexed database, which
 	// will be closed by the VM when no longer needed. It MAY use the provided
 	// directory for persistence and MUST NOT write data outside of it.
@@ -77,6 +66,11 @@ type Points interface {
 	// ([time.Time.Unix] == [types.Header.Time]) and MAY include a sub-second
 	// component.
 	BlockTime(h *types.Header) time.Time
+	// SettledBy returns the extra information for the settled block of the
+	// provided header. It MUST match the value passed to
+	// [BlockBuilder.BuildBlock] and MUST be the zero value for synchronously
+	// executed (pre-SAE) headers.
+	SettledBy(*types.Header) Settled
 	// VerifyBlockSyntax checks chain-specific syntactic invariants of a parsed
 	// block, beyond the universal invariants enforced by [blocks.Parse]. It
 	// MUST be stateless.
@@ -237,7 +231,7 @@ type Settled struct {
 
 // Synchronous reports whether the header is that of a synchronously executed
 // (pre-SAE) block.
-func Synchronous(h SettlementPoint, hdr *types.Header) bool {
+func Synchronous(h Points, hdr *types.Header) bool {
 	return h.SettledBy(hdr) == (Settled{})
 }
 

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -170,7 +170,7 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 		b.ChainContext(),
 		b.Logger(),
 		saexec.WithMaxNumTxs(txIndex),
-		saexec.WithEndOfBlockOps(false),
+		saexec.SkipEndOfBlockOps(),
 	)
 	if err != nil {
 		return nil, bCtx, nil, nil, err
@@ -308,7 +308,7 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 		b.ChainContext(),
 		b.Logger(),
 		saexec.WithMaxNumTxs(0),
-		saexec.WithEndOfBlockOps(false),
+		saexec.SkipEndOfBlockOps(),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -169,7 +169,7 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 		b.ChainConfig(),
 		b.ChainContext(),
 		b.Logger(),
-		saexec.WithMaxNumTxs(txIndex),
+		saexec.WithMaxNumTxs(uint(txIndex)),
 		saexec.SkipEndOfBlockOps(),
 	)
 	if err != nil {

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -180,7 +180,7 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	if err != nil {
 		return nil, bCtx, nil, nil, err
 	}
-	return msg, result.BlockCtx, result.StateDB, noopRelease, nil
+	return msg, result.BlockCtx, stateDB, noopRelease, nil
 }
 
 // tracerAPI serves the debug tracer APIs, routing each endpoint to a
@@ -300,7 +300,7 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 	// TODO(JonathanOppenheimer): once libevm's tracer APIs apply the EIP-4788
 	// beacon root (already fixed upstream in geth), it will be applied twice,
 	// so we should drop it here.
-	result, err := saexec.Execute(
+	_, err = saexec.Execute(
 		block,
 		sdb,
 		b.Hooks(),
@@ -313,7 +313,7 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 	if err != nil {
 		return nil, nil, err
 	}
-	return result.StateDB, noopRelease, nil
+	return sdb, noopRelease, nil
 }
 
 // StateAtTransaction returns the state served by [backend.StateAtTransaction]

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -31,25 +31,6 @@ import (
 
 var noopRelease tracers.StateReleaseFunc = func() {}
 
-// noEndOfBlockOps wraps [hook.Points] to suppress
-// [hook.Points.EndOfBlockOps] and [hook.Points.FinishExecutingBlock], used by
-// the tracer to skip end-of-block operations during partial replay.
-//
-// TODO(StephenButtolph): Properly abstract execution to not rely on method
-// suppression. It is fragile and could result in accidentially modifying the
-// block state or even disk state during tracing.
-type noEndOfBlockOps struct {
-	hook.Points
-}
-
-// EndOfBlockOps always returns nil.
-func (noEndOfBlockOps) EndOfBlockOps(*types.Block) ([]hook.Op, error) { return nil, nil }
-
-// FinishExecutingBlock always returns nil.
-func (noEndOfBlockOps) FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error {
-	return nil
-}
-
 func (b *backend) RPCEVMTimeout() time.Duration {
 	return b.config.EVMTimeout
 }
@@ -152,11 +133,8 @@ func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB,
 // StateAtTransaction returns the execution environment of a particular
 // transaction within a block. It replays all preceding transactions to produce
 // the state just before the target transaction, then returns the message and
-// block context needed for tracing.
-//
-// Replay calls [saexec.Execute] - the same pipeline used by
-// [saexec.Executor] - with [noEndOfBlockOps] to suppress end-of-block
-// operations and [saexec.NullReceiptStore] to skip receipt broadcasting.
+// block context needed for tracing. Replay does not apply end-of-block
+// operations, record block progress, or publish receipts.
 //
 //nolint:revive // General-purpose types lose the meaning of args if unused ones are removed
 func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
@@ -177,18 +155,22 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	if err != nil {
 		return nil, bCtx, nil, nil, fmt.Errorf("constructing SAE block: %v", err)
 	}
+	stateDB, err := b.StateDB(parent.PostExecutionStateRoot())
+	if err != nil {
+		return nil, bCtx, nil, nil, err
+	}
 
 	// Replay transactions 0..txIndex-1 to produce the state just before the
 	// target transaction.
 	result, err := saexec.Execute(
 		block,
-		b,
-		txIndex,
-		noEndOfBlockOps{b.Hooks()},
+		stateDB,
+		b.Hooks(),
 		b.ChainConfig(),
 		b.ChainContext(),
-		&saexec.NullReceiptStore{},
 		b.Logger(),
+		saexec.WithMaxNumTxs(txIndex),
+		saexec.WithEndOfBlockOps(false),
 	)
 	if err != nil {
 		return nil, bCtx, nil, nil, err
@@ -310,18 +292,28 @@ func (b *tracerBackend) stateAtBlockWithChild(ctx context.Context, n uint64, chi
 	if err != nil {
 		return nil, nil, err
 	}
-	rules := b.ChainConfig().Rules(child.Number(), true /*isMerge*/, child.Time())
-	// All parameters passed to [saexec.StartExecutingBlock] MUST exactly match
-	// those that [saexec.Execute] pass, so that the hooks see the same state.
-	// Parent will have a faked header, so we pass the restored parent block.
-	//
+	block, err := b.NewBlock(child, parentBlock, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("constructing SAE block: %v", err)
+	}
+
 	// TODO(JonathanOppenheimer): once libevm's tracer APIs apply the EIP-4788
 	// beacon root (already fixed upstream in geth), it will be applied twice,
 	// so we should drop it here.
-	if err := saexec.StartExecutingBlock(b.Hooks(), rules, sdb, parentBlock.Header(), child); err != nil {
+	result, err := saexec.Execute(
+		block,
+		sdb,
+		b.Hooks(),
+		b.ChainConfig(),
+		b.ChainContext(),
+		b.Logger(),
+		saexec.WithMaxNumTxs(0),
+		saexec.WithEndOfBlockOps(false),
+	)
+	if err != nil {
 		return nil, nil, err
 	}
-	return sdb, noopRelease, nil
+	return result.StateDB, noopRelease, nil
 }
 
 // StateAtTransaction returns the state served by [backend.StateAtTransaction]

--- a/vms/saevm/saexec/BUILD.bazel
+++ b/vms/saevm/saexec/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":saexec"],
     deps = [
+        "//utils",
         "//utils/logging",
         "//utils/logging/loggingtest",
         "//vms/components/gas",

--- a/vms/saevm/saexec/BUILD.bazel
+++ b/vms/saevm/saexec/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "@com_github_ava_labs_libevm//ethdb",
         "@com_github_ava_labs_libevm//event",
         "@com_github_ava_labs_libevm//libevm/eventual",
+        "@com_github_ava_labs_libevm//libevm/options",
         "@com_github_ava_labs_libevm//params",
         "@com_github_holiman_uint256//:uint256",
         "@com_github_prometheus_client_golang//prometheus",

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -228,20 +228,20 @@ func (c *executionConfig) verify(numTxs uint) error {
 	return nil
 }
 
-// stateBeforeTransactions applies the state changes required before executing
-// b's transactions, specifically the start-executing-block hook and the
-// EIP-4788 beacon root, mirroring [core.StateProcessor.Process].
+// stateBeforeTransactions applies the EIP-4788 beacon root and finalizes the
+// state before calling the start-executing-block hook, mirroring
+// [core.StateProcessor.Process].
 func stateBeforeTransactions(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
+	core.SetBeaconBlockRoot(stateDB, b.Header())
+
+	// SetBeaconBlockRoot only finalizes when it applies the root. Finalize
+	// unconditionally before exposing the state to the hook. This mirrors the
+	// finalization performed by [core.ApplyTransaction].
+	stateDB.Finalise(rules.IsEIP158)
+
 	if err := hooks.StartExecutingBlock(rules, stateDB, parent, b); err != nil {
 		return fmt.Errorf("start-executing-block hook: %v", err)
 	}
-
-	core.SetBeaconBlockRoot(stateDB, b.Header())
-
-	// SetBeaconRoot only finalizes when it applies the root, so we want to
-	// finalize last. This mirrors the finalization performed by
-	// [core.ApplyTransaction].
-	stateDB.Finalise(rules.IsEIP158)
 	return nil
 }
 
@@ -364,6 +364,9 @@ func Execute(
 	}
 
 	if config.skipEndOfBlockOps {
+		// TODO(JonathanOppenheimer): skipping the FinishExecutingBlock hook
+		// leaks goroutines from an in-flight parallel.Processor, which requires
+		// a FinishBlock call.
 		return res, nil
 	}
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -33,7 +33,7 @@ var (
 	errTransactionCountOutOfRange    = errors.New("transaction count out of range")
 	errPartialEndOfBlockExecution    = errors.New("end-of-block operations require all transactions")
 	errCanonicalWithoutEndOfBlockOps = errors.New("canonical execution requires end-of-block operations")
-	errCanonicalWithoutReceiptStore  = errors.New("canonical execution requires a receipt store")
+	errNilReceiptStore               = errors.New("receipt store is nil")
 )
 
 // queuedBlock pairs a queued block with the time it was enqueued so that
@@ -152,7 +152,7 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 		e.chainContext,
 		log,
 		withCanonical(true),
-		withReceiptStore(e.receipts),
+		WithReceiptStore(e.receipts),
 	)
 	if err != nil {
 		return err
@@ -212,7 +212,8 @@ func withCanonical(canonical bool) Option {
 	})
 }
 
-func withReceiptStore(receiptStore ReceiptStore) Option {
+// WithReceiptStore configures where Execute publishes transaction receipts.
+func WithReceiptStore(receiptStore ReceiptStore) Option {
 	return options.Func[executionConfig](func(c *executionConfig) {
 		c.receiptStore = receiptStore
 	})
@@ -228,8 +229,8 @@ func (c *executionConfig) verify(numTxs int) error {
 	if c.canonical && !c.endOfBlockOps {
 		return errCanonicalWithoutEndOfBlockOps
 	}
-	if c.canonical && c.receiptStore == nil {
-		return errCanonicalWithoutReceiptStore
+	if c.receiptStore == nil {
+		return errNilReceiptStore
 	}
 	return nil
 }
@@ -263,7 +264,7 @@ func stateBeforeTransactions(hooks executionHooks, rules params.Rules, stateDB *
 // [hook.Points.AfterExecutingBlock], which only the [Executor] calls.
 //
 // Execute does not call [blocks.Block.MarkExecuted]. Only canonical execution
-// records block progress and publishes receipts.
+// records block progress. Receipt publication is configured independently.
 func Execute(
 	b *blocks.Block,
 	stateDB *state.StateDB,
@@ -277,6 +278,7 @@ func Execute(
 	execConfig := options.ApplyTo(&executionConfig{
 		maxNumTxs:     len(txs),
 		endOfBlockOps: true,
+		receiptStore:  &NullReceiptStore{},
 	}, opts...)
 	if err := execConfig.verify(len(txs)); err != nil {
 		return nil, err
@@ -332,6 +334,10 @@ func Execute(
 		}
 
 		perTxClock.Tick(gas.Gas(receipt.GasUsed))
+		// Interim execution time reports live canonical progress. Historical
+		// execution can run only part of the same in-memory block and overwrite
+		// that progress with an earlier time. This violates monotonicity and can
+		// change the settlement decision made by LastToSettleAt.
 		if execConfig.canonical {
 			b.SetInterimExecutionTime(perTxClock)
 			// TODO(arr4n) investigate calling the same method on pending blocks in
@@ -353,10 +359,8 @@ func Execute(
 		tip := tx.EffectiveGasTipValue(header.BaseFee)
 		receipt.EffectiveGasPrice = tip.Add(header.BaseFee, tip)
 
-		if execConfig.canonical {
-			if r, ok := execConfig.receiptStore.Load(tx.Hash()); ok {
-				r.Put(&Receipt{receipt, signer, tx})
-			}
+		if r, ok := execConfig.receiptStore.Load(tx.Hash()); ok {
+			r.Put(&Receipt{receipt, signer, tx})
 		}
 		receipts[ti] = receipt
 	}
@@ -444,4 +448,14 @@ func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
 	}
 	e.sendPostExecutionEvents(b, r) // (3)
 	return nil
+}
+
+// NullReceiptStore discards transaction receipts.
+type NullReceiptStore struct{}
+
+var _ ReceiptStore = (*NullReceiptStore)(nil)
+
+// Load always returns the zero value and false.
+func (*NullReceiptStore) Load(common.Hash) (eventual.Value[*Receipt], bool) {
+	return eventual.Value[*Receipt]{}, false
 }

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -140,7 +140,7 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 		e.chainConfig,
 		e.chainContext,
 		log,
-		withCanonical(true),
+		withCanonical(),
 		WithReceiptStore(e.receipts),
 	)
 	if err != nil {
@@ -196,9 +196,12 @@ func SkipEndOfBlockOps() Option {
 	})
 }
 
-func withCanonical(canonical bool) Option {
+// withCanonical marks execution as canonical. It is unexported because
+// canonical execution mutates the block's shared progress and is exclusive to
+// Executor.
+func withCanonical() Option {
 	return options.Func[executionConfig](func(c *executionConfig) {
-		c.canonical = canonical
+		c.canonical = true
 	})
 }
 
@@ -373,7 +376,7 @@ func Execute(
 	}
 	for i, o := range ops {
 		b.CheckOpBurnerBalanceBounds(stateDB, numTxs+i, o)
-		blockGasConsumed += o.Gas
+		r.GasConsumed += o.Gas
 		perTxClock.Tick(o.Gas)
 		if execConfig.canonical {
 			b.SetInterimExecutionTime(perTxClock)
@@ -390,18 +393,17 @@ func Execute(
 
 	endTime := time.Now()
 	target, gasCfg := hooks.GasConfigAfter(b.Header())
-	if err := gasClock.AfterBlock(blockGasConsumed, target, gasCfg); err != nil {
+	if err := gasClock.AfterBlock(r.GasConsumed, target, gasCfg); err != nil {
 		return nil, fmt.Errorf("after-block gas time update: %w", err)
 	}
 
 	log.Trace(
 		"Block execution complete",
-		zap.Uint64("gas_consumed", uint64(blockGasConsumed)),
+		zap.Uint64("gas_consumed", uint64(r.GasConsumed)),
 		zap.Time("gas_time", gasClock.AsTime()),
 		zap.Time("wall_time", endTime),
 	)
 
-	r.GasConsumed = blockGasConsumed
 	r.FinishBy.Gas = gasClock
 	r.FinishBy.Wall = endTime
 	return r, nil

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm/eventual"
+	"github.com/ava-labs/libevm/libevm/options"
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 	"go.uber.org/zap"
@@ -25,10 +26,15 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook"
-	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 )
 
-var errExecutorClosed = errors.New("saexec.Executor closed")
+var (
+	errExecutorClosed                = errors.New("saexec.Executor closed")
+	errTransactionCountOutOfRange    = errors.New("transaction count out of range")
+	errPartialEndOfBlockExecution    = errors.New("end-of-block operations require all transactions")
+	errCanonicalWithoutEndOfBlockOps = errors.New("canonical execution requires end-of-block operations")
+	errCanonicalWithoutReceiptStore  = errors.New("canonical execution requires a receipt store")
+)
 
 // queuedBlock pairs a queued block with the time it was enqueued so that
 // [Executor.processQueue] can record how long it spent in the queue, from
@@ -111,6 +117,17 @@ func (e *Executor) processQueue() {
 
 var errFatal = errors.New("fatal execution error")
 
+// executionHooks contains the hooks used while executing a block. It excludes
+// canonical-only hooks.
+type executionHooks interface {
+	GasConfigAfter(*types.Header) (gas.Gas, gastime.GasPriceConfig)
+	BlockTime(*types.Header) time.Time
+	SettledBy(*types.Header) hook.Settled
+	EndOfBlockOps(*types.Block) ([]hook.Op, error)
+	StartExecutingBlock(params.Rules, *state.StateDB, *types.Header, *types.Block) error
+	FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
+}
+
 func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	// If the VM were to encounter an error after enqueuing the block, we would
 	// receive the same block twice for execution should consensus retry
@@ -123,7 +140,20 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	defer func() {
 		e.metrics.observeExecuteDuration(time.Since(start))
 	}()
-	result, err := Execute(b, e, math.MaxInt, e.hooks, e.chainConfig, e.chainContext, e.receipts, log)
+	stateDB, err := e.StateDB(b.ParentBlock().PostExecutionStateRoot())
+	if err != nil {
+		return err
+	}
+	result, err := Execute(
+		b,
+		stateDB,
+		e.hooks,
+		e.chainConfig,
+		e.chainContext,
+		log,
+		withCanonical(true),
+		withReceiptStore(e.receipts),
+	)
 	if err != nil {
 		return err
 	}
@@ -132,10 +162,15 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 
 type (
 	// ReceiptStore receives per-transaction receipts during block execution.
-	// Only the [Executor] needs to provide a real implementation to [Execute]
-	// and all other callers MUST use [NullReceiptStore].
 	ReceiptStore interface {
 		Load(common.Hash) (eventual.Value[*Receipt], bool)
+	}
+
+	executionConfig struct {
+		maxNumTxs     int
+		endOfBlockOps bool
+		canonical     bool
+		receiptStore  ReceiptStore
 	}
 
 	// ExecutionResults holds the outputs of [Execute].
@@ -153,10 +188,56 @@ type (
 	}
 )
 
-// StartExecutingBlock applies the state changes required before executing b's
-// transactions, specifically the start-executing-block hook and the EIP-4788
-// beacon root, mirroring [core.StateProcessor.Process].
-func StartExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
+// Option configures [Execute].
+type Option = options.Option[executionConfig]
+
+// WithMaxNumTxs limits execution to the first maxNumTxs transactions.
+func WithMaxNumTxs(maxNumTxs int) Option {
+	return options.Func[executionConfig](func(c *executionConfig) {
+		c.maxNumTxs = maxNumTxs
+	})
+}
+
+// WithEndOfBlockOps configures whether execution applies the block's
+// end-of-block operations and finish-executing-block hook.
+func WithEndOfBlockOps(enabled bool) Option {
+	return options.Func[executionConfig](func(c *executionConfig) {
+		c.endOfBlockOps = enabled
+	})
+}
+
+func withCanonical(canonical bool) Option {
+	return options.Func[executionConfig](func(c *executionConfig) {
+		c.canonical = canonical
+	})
+}
+
+func withReceiptStore(receiptStore ReceiptStore) Option {
+	return options.Func[executionConfig](func(c *executionConfig) {
+		c.receiptStore = receiptStore
+	})
+}
+
+func (c *executionConfig) verify(numTxs int) error {
+	if c.maxNumTxs < 0 || c.maxNumTxs > numTxs {
+		return fmt.Errorf("%w: %d not in [0, %d]", errTransactionCountOutOfRange, c.maxNumTxs, numTxs)
+	}
+	if c.endOfBlockOps && c.maxNumTxs != numTxs {
+		return fmt.Errorf("%w: executing %d of %d transactions", errPartialEndOfBlockExecution, c.maxNumTxs, numTxs)
+	}
+	if c.canonical && !c.endOfBlockOps {
+		return errCanonicalWithoutEndOfBlockOps
+	}
+	if c.canonical && c.receiptStore == nil {
+		return errCanonicalWithoutReceiptStore
+	}
+	return nil
+}
+
+// stateBeforeTransactions applies the state changes required before executing
+// b's transactions, specifically the start-executing-block hook and the
+// EIP-4788 beacon root, mirroring [core.StateProcessor.Process].
+func stateBeforeTransactions(hooks executionHooks, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
 	if err := hooks.StartExecutingBlock(rules, stateDB, parent, b); err != nil {
 		return fmt.Errorf("start-executing-block hook: %v", err)
 	}
@@ -170,10 +251,9 @@ func StartExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.S
 	return nil
 }
 
-// Execute executes the transactions in the [blocks.Block], beginning from the
-// post-execution state of the [blocks.Block.ParentBlock]. `maxNumTxs` limits
-// the number of transactions to process, allowing partial execution for
-// intra-block inspection.
+// Execute applies b's deterministic state changes to stateDB. By default, it
+// executes every transaction and all end-of-block operations. Options can stop
+// execution after a transaction prefix for intra-block inspection.
 //
 // The gas clock and base fee come from the parent's post-execution clock,
 // except pre-SAE blocks, which use their own header's fee.
@@ -182,20 +262,26 @@ func StartExecutingBlock(hooks hook.Points, rules params.Rules, stateDB *state.S
 // historical execution. Canonical-only side effects belong in
 // [hook.Points.AfterExecutingBlock], which only the [Executor] calls.
 //
-// Although Execute does not call [blocks.Block.MarkExecuted] it does mutate
-// consensus-critical internal values (e.g. interim execution time). A "live"
-// accepted block (as against one recovered from the database) MUST NOT be
-// passed directly to [Execute], only to [Executor.Enqueue].
+// Execute does not call [blocks.Block.MarkExecuted]. Only canonical execution
+// records block progress and publishes receipts.
 func Execute(
 	b *blocks.Block,
-	sdbo saedb.StateDBOpener,
-	maxNumTxs int,
-	hooks hook.Points,
+	stateDB *state.StateDB,
+	hooks executionHooks,
 	config *params.ChainConfig,
 	chainCtx core.ChainContext,
-	receiptStore ReceiptStore,
 	log logging.Logger,
+	opts ...Option,
 ) (*ExecutionResults, error) {
+	txs := b.Transactions()
+	execConfig := options.ApplyTo(&executionConfig{
+		maxNumTxs:     len(txs),
+		endOfBlockOps: true,
+	}, opts...)
+	if err := execConfig.verify(len(txs)); err != nil {
+		return nil, err
+	}
+
 	log.Trace("Executing block")
 
 	parent := b.ParentBlock()
@@ -205,18 +291,13 @@ func Execute(
 	gasClock.BeforeBlock(hooks.BlockTime(header))
 	perTxClock := gasClock.Time.Clone()
 
-	stateDB, err := sdbo.StateDB(parent.PostExecutionStateRoot())
-	if err != nil {
-		return nil, err
-	}
-
 	rules := config.Rules(header.Number, true /*isMerge*/, header.Time)
-	if err := StartExecutingBlock(hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
+	if err := stateBeforeTransactions(hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
 		return nil, err
 	}
 
 	baseFee := gasClock.BaseFee()
-	if hook.Synchronous(hooks, header) {
+	if hooks.SettledBy(header) == (hook.Settled{}) {
 		baseFee = b.WorstCaseBaseFee()
 	} else {
 		b.CheckBaseFeeBound(baseFee)
@@ -227,8 +308,7 @@ func Execute(
 	gasPool := core.GasPool(math.MaxUint64) // required by geth but irrelevant so max it out
 	var blockGasConsumed gas.Gas
 
-	txs := b.Transactions()
-	txs = txs[:min(len(txs), maxNumTxs)]
+	txs = txs[:execConfig.maxNumTxs]
 	receipts := make(types.Receipts, len(txs))
 
 	for ti, tx := range txs {
@@ -252,10 +332,12 @@ func Execute(
 		}
 
 		perTxClock.Tick(gas.Gas(receipt.GasUsed))
-		b.SetInterimExecutionTime(perTxClock)
-		// TODO(arr4n) investigate calling the same method on pending blocks in
-		// the queue. It's only worth it if [blocks.LastToSettleAt] regularly
-		// returns false, meaning that execution is blocking consensus.
+		if execConfig.canonical {
+			b.SetInterimExecutionTime(perTxClock)
+			// TODO(arr4n) investigate calling the same method on pending blocks in
+			// the queue. It's only worth it if [blocks.LastToSettleAt] regularly
+			// returns false, meaning that execution is blocking consensus.
+		}
 
 		// The [types.Header] that we pass to [core.ApplyTransaction] is
 		// modified to reduce gas price from the worst-case value agreed by
@@ -271,10 +353,24 @@ func Execute(
 		tip := tx.EffectiveGasTipValue(header.BaseFee)
 		receipt.EffectiveGasPrice = tip.Add(header.BaseFee, tip)
 
-		if r, ok := receiptStore.Load(tx.Hash()); ok {
-			r.Put(&Receipt{receipt, signer, tx})
+		if execConfig.canonical {
+			if r, ok := execConfig.receiptStore.Load(tx.Hash()); ok {
+				r.Put(&Receipt{receipt, signer, tx})
+			}
 		}
 		receipts[ti] = receipt
+	}
+
+	r := &ExecutionResults{
+		BaseFee:     baseFee,
+		StateDB:     stateDB,
+		Signer:      signer,
+		BlockCtx:    core.NewEVMBlockContext(header, chainCtx, &header.Coinbase),
+		Receipts:    receipts,
+		GasConsumed: blockGasConsumed,
+	}
+	if !execConfig.endOfBlockOps {
+		return r, nil
 	}
 
 	numTxs := len(b.Transactions())
@@ -286,7 +382,9 @@ func Execute(
 		b.CheckOpBurnerBalanceBounds(stateDB, numTxs+i, o)
 		blockGasConsumed += o.Gas
 		perTxClock.Tick(o.Gas)
-		b.SetInterimExecutionTime(perTxClock)
+		if execConfig.canonical {
+			b.SetInterimExecutionTime(perTxClock)
+		}
 
 		if err := o.ApplyTo(stateDB); err != nil {
 			return nil, fmt.Errorf("%w: applying end-of-block operation [%d](%v): %v", errFatal, i, o.ID, err)
@@ -310,14 +408,7 @@ func Execute(
 		zap.Time("wall_time", endTime),
 	)
 
-	r := &ExecutionResults{
-		BaseFee:     baseFee,
-		StateDB:     stateDB,
-		Signer:      signer,
-		BlockCtx:    core.NewEVMBlockContext(header, chainCtx, &header.Coinbase),
-		Receipts:    receipts,
-		GasConsumed: blockGasConsumed,
-	}
+	r.GasConsumed = blockGasConsumed
 	r.FinishBy.Gas = gasClock
 	r.FinishBy.Wall = endTime
 	return r, nil
@@ -353,15 +444,4 @@ func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
 	}
 	e.sendPostExecutionEvents(b, r) // (3)
 	return nil
-}
-
-// NullReceiptStore is a no-op [ReceiptStore] for use when receipt broadcasting
-// is not needed (e.g. state tracing).
-type NullReceiptStore struct{}
-
-var _ ReceiptStore = (*NullReceiptStore)(nil)
-
-// Load always returns the zero value and false.
-func (*NullReceiptStore) Load(common.Hash) (eventual.Value[*Receipt], bool) {
-	return eventual.Value[*Receipt]{}, false
 }

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -196,10 +196,10 @@ func SkipEndOfBlockOps() Option {
 	})
 }
 
-// withCanonical marks execution as canonical. It is unexported because
+// asCanonical marks execution as canonical. It is unexported because
 // canonical execution mutates the block's shared progress and is exclusive to
 // Executor.
-func withCanonical() Option {
+func asCanonical() Option {
 	return options.Func[executionConfig](func(c *executionConfig) {
 		c.canonical = true
 	})

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -31,7 +31,7 @@ import (
 var (
 	errExecutorClosed                = errors.New("saexec.Executor closed")
 	errTransactionCountOutOfRange    = errors.New("transaction count out of range")
-	errPartialEndOfBlockExecution    = errors.New("end-of-block operations require all transactions")
+	errPartialEndOfBlockExecution    = errors.New("end-of-block operations require all transactions to have been executed")
 	errCanonicalWithoutEndOfBlockOps = errors.New("canonical execution requires end-of-block operations")
 	errNilReceiptStore               = errors.New("receipt store is nil")
 )

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -146,7 +146,7 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	if err != nil {
 		return err
 	}
-	return e.afterExecution(b, result)
+	return e.afterExecution(b, stateDB, result)
 }
 
 type (
@@ -165,7 +165,6 @@ type (
 	// ExecutionResults holds the outputs of [Execute].
 	ExecutionResults struct {
 		BaseFee     *uint256.Int
-		StateDB     *state.StateDB
 		Signer      types.Signer
 		BlockCtx    vm.BlockContext
 		Receipts    types.Receipts
@@ -189,7 +188,8 @@ func WithMaxNumTxs(maxNumTxs int) Option {
 }
 
 // SkipEndOfBlockOps prevents execution of the block's end-of-block operations
-// and finish-executing-block hook.
+// and finish-executing-block hook. [ExecutionResults.FinishBy] is not populated
+// because execution does not complete the block.
 func SkipEndOfBlockOps() Option {
 	return options.Func[executionConfig](func(c *executionConfig) {
 		c.skipEndOfBlockOps = true
@@ -359,7 +359,6 @@ func Execute(
 
 	r := &ExecutionResults{
 		BaseFee:     baseFee,
-		StateDB:     stateDB,
 		Signer:      signer,
 		BlockCtx:    core.NewEVMBlockContext(header, chainCtx, &header.Coinbase),
 		Receipts:    receipts,
@@ -409,16 +408,16 @@ func Execute(
 	return r, nil
 }
 
-func (e *Executor) afterExecution(b *blocks.Block, r *ExecutionResults) error {
+func (e *Executor) afterExecution(b *blocks.Block, stateDB *state.StateDB, r *ExecutionResults) error {
 	if err := e.hooks.AfterExecutingBlock(b.EthBlock(), r.Receipts); err != nil {
 		return fmt.Errorf("after-executing-block hook: %v", err)
 	}
 
 	e.chainContext.recent.Put(b.NumberU64(), b.Header())
 
-	root, err := r.StateDB.Commit(b.NumberU64(), true)
+	root, err := stateDB.Commit(b.NumberU64(), true)
 	if err != nil {
-		return fmt.Errorf("%T.Commit() at end of block %d: %w", r.StateDB, b.NumberU64(), err)
+		return fmt.Errorf("%T.Commit() at end of block %d: %w", stateDB, b.NumberU64(), err)
 	}
 	if err := e.Tracker.MaybeCommit(b.SettledStateRoot(), root, b.NumberU64()); err != nil {
 		return err

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -297,7 +297,7 @@ func Execute(
 	}
 
 	baseFee := gasClock.BaseFee()
-	if hooks.SettledBy(header) == (hook.Settled{}) {
+	if hook.Synchronous(hooks, header) {
 		baseFee = b.WorstCaseBaseFee()
 	} else {
 		b.CheckBaseFeeBound(baseFee)

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -156,7 +156,7 @@ type (
 	}
 
 	executionConfig struct {
-		maxNumTxs         int
+		maxNumTxs         uint
 		skipEndOfBlockOps bool
 		canonical         bool
 		receiptStore      ReceiptStore
@@ -181,7 +181,7 @@ type Option = options.Option[executionConfig]
 
 // WithMaxNumTxs limits execution to maxNumTxs transactions from the start of
 // the block. A value of 0 executes no transactions.
-func WithMaxNumTxs(maxNumTxs int) Option {
+func WithMaxNumTxs(maxNumTxs uint) Option {
 	return options.Func[executionConfig](func(c *executionConfig) {
 		c.maxNumTxs = maxNumTxs
 	})
@@ -212,8 +212,8 @@ func WithReceiptStore(receiptStore ReceiptStore) Option {
 	})
 }
 
-func (c *executionConfig) verify(numTxs int) error {
-	if c.maxNumTxs < 0 || c.maxNumTxs > numTxs {
+func (c *executionConfig) verify(numTxs uint) error {
+	if c.maxNumTxs > numTxs {
 		return fmt.Errorf("%w: %d not in [0, %d]", errTransactionCountOutOfRange, c.maxNumTxs, numTxs)
 	}
 	if !c.skipEndOfBlockOps && c.maxNumTxs != numTxs {
@@ -257,22 +257,24 @@ func stateBeforeTransactions(hooks hook.Points, rules params.Rules, stateDB *sta
 // [hook.Points.AfterExecutingBlock], which only the [Executor] calls.
 //
 // Execute does not call [blocks.Block.MarkExecuted]. Only canonical execution
-// records block progress. Receipt publication is configured independently.
+// records block progress. Receipts are always returned in [ExecutionResults]
+// but are only published to a [ReceiptStore] when configured with
+// [WithReceiptStore].
 func Execute(
 	b *blocks.Block,
 	stateDB *state.StateDB,
 	hooks hook.Points,
-	config *params.ChainConfig,
+	chainConfig *params.ChainConfig,
 	chainCtx core.ChainContext,
 	log logging.Logger,
 	opts ...Option,
 ) (*ExecutionResults, error) {
 	txs := b.Transactions()
-	execConfig := options.ApplyTo(&executionConfig{
-		maxNumTxs:    len(txs),
+	config := options.ApplyTo(&executionConfig{
+		maxNumTxs:    uint(len(txs)),
 		receiptStore: &NullReceiptStore{},
 	}, opts...)
-	if err := execConfig.verify(len(txs)); err != nil {
+	if err := config.verify(uint(len(txs))); err != nil {
 		return nil, err
 	}
 
@@ -285,7 +287,7 @@ func Execute(
 	gasClock.BeforeBlock(hooks.BlockTime(header))
 	perTxClock := gasClock.Time.Clone()
 
-	rules := config.Rules(header.Number, true /*isMerge*/, header.Time)
+	rules := chainConfig.Rules(header.Number, true /*isMerge*/, header.Time)
 	if err := stateBeforeTransactions(hooks, rules, stateDB, parent.Header(), b.EthBlock()); err != nil {
 		return nil, err
 	}
@@ -298,12 +300,16 @@ func Execute(
 	}
 	header.BaseFee = baseFee.ToBig()
 
-	signer := b.Signer(config)
+	signer := b.Signer(chainConfig)
 	gasPool := core.GasPool(math.MaxUint64) // required by geth but irrelevant so max it out
-	var blockGasConsumed gas.Gas
 
-	txs = txs[:execConfig.maxNumTxs]
-	receipts := make(types.Receipts, len(txs))
+	txs = txs[:config.maxNumTxs]
+	res := &ExecutionResults{
+		BaseFee:  baseFee,
+		Signer:   signer,
+		BlockCtx: core.NewEVMBlockContext(header, chainCtx, &header.Coinbase),
+		Receipts: make(types.Receipts, len(txs)),
+	}
 
 	for ti, tx := range txs {
 		stateDB.SetTxContext(tx.Hash(), ti)
@@ -311,14 +317,14 @@ func Execute(
 
 		// Executes the transaction and calls [state.StateDB.Finalise].
 		receipt, err := core.ApplyTransaction(
-			config,
+			chainConfig,
 			chainCtx,
 			&header.Coinbase,
 			&gasPool,
 			stateDB,
 			header,
 			tx,
-			(*uint64)(&blockGasConsumed),
+			(*uint64)(&res.GasConsumed),
 			vm.Config{},
 		)
 		if err != nil {
@@ -330,7 +336,7 @@ func Execute(
 		// execution can run only part of the same in-memory block and overwrite
 		// that progress with an earlier time. This violates monotonicity and can
 		// change the settlement decision made by LastToSettleAt.
-		if execConfig.canonical {
+		if config.canonical {
 			b.SetInterimExecutionTime(perTxClock)
 			// TODO(arr4n) investigate calling the same method on pending blocks in
 			// the queue. It's only worth it if [blocks.LastToSettleAt] regularly
@@ -351,21 +357,14 @@ func Execute(
 		tip := tx.EffectiveGasTipValue(header.BaseFee)
 		receipt.EffectiveGasPrice = tip.Add(header.BaseFee, tip)
 
-		if r, ok := execConfig.receiptStore.Load(tx.Hash()); ok {
+		if r, ok := config.receiptStore.Load(tx.Hash()); ok {
 			r.Put(&Receipt{receipt, signer, tx})
 		}
-		receipts[ti] = receipt
+		res.Receipts[ti] = receipt
 	}
 
-	r := &ExecutionResults{
-		BaseFee:     baseFee,
-		Signer:      signer,
-		BlockCtx:    core.NewEVMBlockContext(header, chainCtx, &header.Coinbase),
-		Receipts:    receipts,
-		GasConsumed: blockGasConsumed,
-	}
-	if execConfig.skipEndOfBlockOps {
-		return r, nil
+	if config.skipEndOfBlockOps {
+		return res, nil
 	}
 
 	numTxs := len(b.Transactions())
@@ -375,9 +374,9 @@ func Execute(
 	}
 	for i, o := range ops {
 		b.CheckOpBurnerBalanceBounds(stateDB, numTxs+i, o)
-		r.GasConsumed += o.Gas
+		res.GasConsumed += o.Gas
 		perTxClock.Tick(o.Gas)
-		if execConfig.canonical {
+		if config.canonical {
 			b.SetInterimExecutionTime(perTxClock)
 		}
 
@@ -386,26 +385,26 @@ func Execute(
 		}
 	}
 
-	if err := hooks.FinishExecutingBlock(stateDB, b.EthBlock(), receipts); err != nil {
+	if err := hooks.FinishExecutingBlock(stateDB, b.EthBlock(), res.Receipts); err != nil {
 		return nil, fmt.Errorf("finish-executing-block hook: %v", err)
 	}
 
 	endTime := time.Now()
 	target, gasCfg := hooks.GasConfigAfter(b.Header())
-	if err := gasClock.AfterBlock(r.GasConsumed, target, gasCfg); err != nil {
+	if err := gasClock.AfterBlock(res.GasConsumed, target, gasCfg); err != nil {
 		return nil, fmt.Errorf("after-block gas time update: %w", err)
 	}
 
 	log.Trace(
 		"Block execution complete",
-		zap.Uint64("gas_consumed", uint64(r.GasConsumed)),
+		zap.Uint64("gas_consumed", uint64(res.GasConsumed)),
 		zap.Time("gas_time", gasClock.AsTime()),
 		zap.Time("wall_time", endTime),
 	)
 
-	r.FinishBy.Gas = gasClock
-	r.FinishBy.Wall = endTime
-	return r, nil
+	res.FinishBy.Gas = gasClock
+	res.FinishBy.Wall = endTime
+	return res, nil
 }
 
 func (e *Executor) afterExecution(b *blocks.Block, stateDB *state.StateDB, r *ExecutionResults) error {

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -140,7 +140,7 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 		e.chainConfig,
 		e.chainContext,
 		log,
-		withCanonical(),
+		asCanonical(),
 		WithReceiptStore(e.receipts),
 	)
 	if err != nil {
@@ -337,7 +337,7 @@ func Execute(
 		// that progress with an earlier time. This violates monotonicity and can
 		// change the settlement decision made by LastToSettleAt.
 		if config.canonical {
-			b.SetInterimExecutionTime(perTxClock)
+			b.SwapInterimExecutionTime(perTxClock)
 			// TODO(arr4n) investigate calling the same method on pending blocks in
 			// the queue. It's only worth it if [blocks.LastToSettleAt] regularly
 			// returns false, meaning that execution is blocking consensus.
@@ -380,7 +380,7 @@ func Execute(
 		res.GasConsumed += o.Gas
 		perTxClock.Tick(o.Gas)
 		if config.canonical {
-			b.SetInterimExecutionTime(perTxClock)
+			b.SwapInterimExecutionTime(perTxClock)
 		}
 
 		if err := o.ApplyTo(stateDB); err != nil {

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -117,17 +117,6 @@ func (e *Executor) processQueue() {
 
 var errFatal = errors.New("fatal execution error")
 
-// executionHooks contains the hooks used while executing a block. It excludes
-// canonical-only hooks.
-type executionHooks interface {
-	GasConfigAfter(*types.Header) (gas.Gas, gastime.GasPriceConfig)
-	BlockTime(*types.Header) time.Time
-	SettledBy(*types.Header) hook.Settled
-	EndOfBlockOps(*types.Block) ([]hook.Op, error)
-	StartExecutingBlock(params.Rules, *state.StateDB, *types.Header, *types.Block) error
-	FinishExecutingBlock(*state.StateDB, *types.Block, types.Receipts) error
-}
-
 func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 	// If the VM were to encounter an error after enqueuing the block, we would
 	// receive the same block twice for execution should consensus retry
@@ -167,10 +156,10 @@ type (
 	}
 
 	executionConfig struct {
-		maxNumTxs     int
-		endOfBlockOps bool
-		canonical     bool
-		receiptStore  ReceiptStore
+		maxNumTxs         int
+		skipEndOfBlockOps bool
+		canonical         bool
+		receiptStore      ReceiptStore
 	}
 
 	// ExecutionResults holds the outputs of [Execute].
@@ -191,18 +180,19 @@ type (
 // Option configures [Execute].
 type Option = options.Option[executionConfig]
 
-// WithMaxNumTxs limits execution to the first maxNumTxs transactions.
+// WithMaxNumTxs limits execution to maxNumTxs transactions from the start of
+// the block. A value of 0 executes no transactions.
 func WithMaxNumTxs(maxNumTxs int) Option {
 	return options.Func[executionConfig](func(c *executionConfig) {
 		c.maxNumTxs = maxNumTxs
 	})
 }
 
-// WithEndOfBlockOps configures whether execution applies the block's
-// end-of-block operations and finish-executing-block hook.
-func WithEndOfBlockOps(enabled bool) Option {
+// SkipEndOfBlockOps prevents execution of the block's end-of-block operations
+// and finish-executing-block hook.
+func SkipEndOfBlockOps() Option {
 	return options.Func[executionConfig](func(c *executionConfig) {
-		c.endOfBlockOps = enabled
+		c.skipEndOfBlockOps = true
 	})
 }
 
@@ -223,10 +213,10 @@ func (c *executionConfig) verify(numTxs int) error {
 	if c.maxNumTxs < 0 || c.maxNumTxs > numTxs {
 		return fmt.Errorf("%w: %d not in [0, %d]", errTransactionCountOutOfRange, c.maxNumTxs, numTxs)
 	}
-	if c.endOfBlockOps && c.maxNumTxs != numTxs {
+	if !c.skipEndOfBlockOps && c.maxNumTxs != numTxs {
 		return fmt.Errorf("%w: executing %d of %d transactions", errPartialEndOfBlockExecution, c.maxNumTxs, numTxs)
 	}
-	if c.canonical && !c.endOfBlockOps {
+	if c.canonical && c.skipEndOfBlockOps {
 		return errCanonicalWithoutEndOfBlockOps
 	}
 	if c.receiptStore == nil {
@@ -238,7 +228,7 @@ func (c *executionConfig) verify(numTxs int) error {
 // stateBeforeTransactions applies the state changes required before executing
 // b's transactions, specifically the start-executing-block hook and the
 // EIP-4788 beacon root, mirroring [core.StateProcessor.Process].
-func stateBeforeTransactions(hooks executionHooks, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
+func stateBeforeTransactions(hooks hook.Points, rules params.Rules, stateDB *state.StateDB, parent *types.Header, b *types.Block) error {
 	if err := hooks.StartExecutingBlock(rules, stateDB, parent, b); err != nil {
 		return fmt.Errorf("start-executing-block hook: %v", err)
 	}
@@ -268,7 +258,7 @@ func stateBeforeTransactions(hooks executionHooks, rules params.Rules, stateDB *
 func Execute(
 	b *blocks.Block,
 	stateDB *state.StateDB,
-	hooks executionHooks,
+	hooks hook.Points,
 	config *params.ChainConfig,
 	chainCtx core.ChainContext,
 	log logging.Logger,
@@ -276,9 +266,8 @@ func Execute(
 ) (*ExecutionResults, error) {
 	txs := b.Transactions()
 	execConfig := options.ApplyTo(&executionConfig{
-		maxNumTxs:     len(txs),
-		endOfBlockOps: true,
-		receiptStore:  &NullReceiptStore{},
+		maxNumTxs:    len(txs),
+		receiptStore: &NullReceiptStore{},
 	}, opts...)
 	if err := execConfig.verify(len(txs)); err != nil {
 		return nil, err
@@ -373,7 +362,7 @@ func Execute(
 		Receipts:    receipts,
 		GasConsumed: blockGasConsumed,
 	}
-	if !execConfig.endOfBlockOps {
+	if execConfig.skipEndOfBlockOps {
 		return r, nil
 	}
 

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -176,7 +176,7 @@ type (
 	}
 )
 
-// Option configures [Execute].
+// An Option configures [Execute].
 type Option = options.Option[executionConfig]
 
 // WithMaxNumTxs limits execution to maxNumTxs transactions from the start of

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -13,6 +13,7 @@ import (
 	"math/rand/v2"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/arr4n/shed/testerr"
 	"github.com/ava-labs/libevm/common"
@@ -36,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
@@ -532,56 +534,72 @@ func TestExecuteRejectsInvalidOptions(t *testing.T) {
 // TestExecuteRecordsOnlyCanonicalProgress verifies that non-canonical execution
 // does not overwrite an in-memory block's canonical progress.
 func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
+	makeTxs := func(t *testing.T, w *saetest.Wallet) types.Transactions {
+		t.Helper()
+		return types.Transactions{w.SetNonceAndSign(t, 0, &types.LegacyTx{
+			To:       &common.Address{},
+			Gas:      params.TxGas,
+			GasPrice: big.NewInt(1),
+		})}
+	}
+
 	tests := []struct {
-		name   string
-		withTx bool
-		ops    []saehookstest.Op
-		opts   []Option
-		want   bool
+		name            string
+		txs             func(*testing.T, *saetest.Wallet) types.Transactions
+		ops             []saehookstest.Op
+		opts            []Option
+		wantInterimTick *gas.Gas // nil implies nil interim execution time, not no tick
 	}{
 		{
-			name:   "non-canonical transaction and end-of-block operation",
-			withTx: true,
-			ops:    []saehookstest.Op{{Gas: 1}},
+			name:            "non-canonical with transaction and end-of-block operation",
+			txs:             makeTxs,
+			ops:             []saehookstest.Op{{Gas: 1}},
+			wantInterimTick: nil, // not canonical
 		},
 		{
-			name:   "canonical transaction",
-			withTx: true,
-			opts:   []Option{asCanonical()},
-			want:   true,
+			name:            "canonical with transaction only",
+			txs:             makeTxs,
+			ops:             nil,
+			opts:            []Option{asCanonical()},
+			wantInterimTick: utils.PointerTo(gas.Gas(params.TxGas)),
 		},
 		{
-			name: "canonical end-of-block operation",
-			ops:  []saehookstest.Op{{Gas: 1}},
-			opts: []Option{asCanonical()},
-			want: true,
+			name:            "canonical with end-of-block operation only",
+			txs:             nil,
+			ops:             []saehookstest.Op{{Gas: 1}},
+			opts:            []Option{asCanonical()},
+			wantInterimTick: utils.PointerTo[gas.Gas](1),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, sut := newSUT(t)
+
 			var txs types.Transactions
-			if tt.withTx {
-				txs = types.Transactions{sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-					To:       &common.Address{},
-					Gas:      params.TxGas,
-					GasPrice: big.NewInt(1),
-				})}
+			if tt.txs != nil {
+				txs = tt.txs(t, sut.wallet)
 			}
-			b := sut.chain.NewBlock(
-				t,
-				txs,
-				blockstest.WithEthBlockOptions(blockstest.WithOps(tt.ops)),
-			)
+			withOps := blockstest.WithEthBlockOptions(blockstest.WithOps(tt.ops))
+			b := sut.chain.NewBlock(t, txs, withOps)
+
 			stateDB, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
 			require.NoError(t, err, "Executor.StateDB(parent root)")
 
 			_, err = Execute(b, stateDB, sut.hooks, sut.chainConfig, sut.chainContext, sut.logger, tt.opts...)
 			require.NoError(t, err, "Execute()")
 
-			interimExecutionTime := proxytime.New[gas.Gas](math.MaxUint64, 0, 1)
-			got := b.SwapInterimExecutionTime(interimExecutionTime) != nil
-			require.Equal(t, tt.want, got, "Block.SwapInterimExecutionTime()")
+			got := b.SwapInterimExecutionTime(proxytime.Of[gas.Gas](time.Time{}))
+			if tick := tt.wantInterimTick; tick == nil {
+				require.Nilf(t, got, "%T.SwapInterimExecutionTime(...)", b)
+			} else {
+				want := b.ParentBlock().ExecutedByGasTime()
+				want.BeforeBlock(b.PreciseTime())
+				want.Tick(*tick)
+
+				if diff := cmp.Diff(want.Time, got, proxytime.CmpOpt[gas.Gas]()); diff != "" {
+					t.Errorf("%T.SwapInterimExecutionTime(...); diff (-want +got):\n%s", b, diff)
+				}
+			}
 		})
 	}
 }

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -524,7 +524,7 @@ func TestExecuteRejectsInvalidOptions(t *testing.T) {
 			require.NoError(t, err, "Executor.StateDB(parent root)")
 
 			_, err = Execute(b, stateDB, sut.hooks, sut.chainConfig, sut.chainContext, sut.logger, tt.opts...)
-			require.ErrorIs(t, err, tt.wantErr, "Execute() with %s options", tt.name)
+			require.ErrorIsf(t, err, tt.wantErr, "Execute() with %s options", tt.name)
 		})
 	}
 }

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -565,7 +565,7 @@ func TestExecute(t *testing.T) {
 	}{
 		{
 			name:         "transaction prefix",
-			opts:         []Option{WithMaxNumTxs(1), WithEndOfBlockOps(false)},
+			opts:         []Option{WithMaxNumTxs(1), SkipEndOfBlockOps()},
 			wantReceipts: 1,
 			wantBalances: []*uint256.Int{uint256.NewInt(1), uint256.NewInt(0), uint256.NewInt(0)},
 		},
@@ -589,6 +589,59 @@ func TestExecute(t *testing.T) {
 			require.Len(t, result.Receipts, tt.wantReceipts, "ExecutionResults.Receipts")
 			require.Equal(t, tt.wantBalances, gotBalances, "recipient balances")
 			require.Equal(t, tt.wantFinished, result.FinishBy.Gas != nil, "ExecutionResults.FinishBy.Gas")
+		})
+	}
+}
+
+func TestExecuteRejectsInvalidOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []Option
+		wantErr testerr.Want
+	}{
+		{
+			name:    "negative transaction count",
+			opts:    []Option{WithMaxNumTxs(-1)},
+			wantErr: testerr.Is(errTransactionCountOutOfRange),
+		},
+		{
+			name:    "excessive transaction count",
+			opts:    []Option{WithMaxNumTxs(3)},
+			wantErr: testerr.Is(errTransactionCountOutOfRange),
+		},
+		{
+			name:    "partial end-of-block execution",
+			opts:    []Option{WithMaxNumTxs(1)},
+			wantErr: testerr.Is(errPartialEndOfBlockExecution),
+		},
+		{
+			name:    "canonical without end-of-block operations",
+			opts:    []Option{withCanonical(true), SkipEndOfBlockOps()},
+			wantErr: testerr.Is(errCanonicalWithoutEndOfBlockOps),
+		},
+		{
+			name:    "nil receipt store",
+			opts:    []Option{WithReceiptStore(nil)},
+			wantErr: testerr.Is(errNilReceiptStore),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newExecuteFixture(t)
+			stateDB, err := f.sut.StateDB(f.block.ParentBlock().PostExecutionStateRoot())
+			require.NoError(t, err, "Executor.StateDB(parent root)")
+			_, err = Execute(
+				f.block,
+				stateDB,
+				f.sut.hooks,
+				f.sut.chainConfig,
+				f.sut.chainContext,
+				f.sut.logger,
+				tt.opts...,
+			)
+			if diff := testerr.Diff(err, tt.wantErr); diff != "" {
+				t.Errorf("Execute() %s", diff)
+			}
 		})
 	}
 }

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -487,138 +487,156 @@ func TestEndOfBlockOps(t *testing.T) {
 	})
 }
 
-type executeFixture struct {
-	sut                 *SUT
-	block               *blocks.Block
-	firstRecipient      common.Address
-	secondRecipient     common.Address
-	endOfBlockRecipient common.Address
-}
-
-func newExecuteFixture(t *testing.T) *executeFixture {
-	t.Helper()
-
+func TestExecuteTransactionPrefix(t *testing.T) {
 	_, sut := newSUT(t)
-	f := &executeFixture{
-		sut:                 sut,
-		firstRecipient:      common.Address{'f', 'i', 'r', 's', 't'},
-		secondRecipient:     common.Address{'s', 'e', 'c', 'o', 'n', 'd'},
-		endOfBlockRecipient: common.Address{'e', 'n', 'd'},
-	}
-	f.block = sut.chain.NewBlock(t, types.Transactions{
+	firstRecipient := common.Address{'f', 'i', 'r', 's', 't'}
+	secondRecipient := common.Address{'s', 'e', 'c', 'o', 'n', 'd'}
+	endOfBlockRecipient := common.Address{'e', 'n', 'd'}
+	b := sut.chain.NewBlock(t, types.Transactions{
 		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-			To:       &f.firstRecipient,
+			To:       &firstRecipient,
 			Value:    big.NewInt(1),
 			Gas:      params.TxGas,
 			GasPrice: big.NewInt(1),
 		}),
 		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-			To:       &f.secondRecipient,
+			To:       &secondRecipient,
 			Value:    big.NewInt(2),
 			Gas:      params.TxGas,
 			GasPrice: big.NewInt(1),
 		}),
 	}, blockstest.WithEthBlockOptions(blockstest.WithOps([]saehookstest.Op{{
+		Gas: 1,
 		Mint: []saehookstest.AccountCredit{{
-			Address: f.endOfBlockRecipient,
+			Address: endOfBlockRecipient,
 			Amount:  *uint256.NewInt(100),
 		}},
 	}})))
-	return f
-}
-
-func (f *executeFixture) execute(t *testing.T, opts ...Option) (*ExecutionResults, error) {
-	t.Helper()
-
-	stateDB, err := f.sut.StateDB(f.block.ParentBlock().PostExecutionStateRoot())
+	stateDB, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
 	require.NoError(t, err, "Executor.StateDB(parent root)")
-	return Execute(
-		f.block,
-		stateDB,
-		f.sut.hooks,
-		f.sut.chainConfig,
-		f.sut.chainContext,
-		f.sut.logger,
-		opts...,
-	)
-}
 
-func TestExecuteTransactionPrefix(t *testing.T) {
-	f := newExecuteFixture(t)
-	result, err := f.execute(t, WithMaxNumTxs(1), SkipEndOfBlockOps())
+	result, err := Execute(
+		b,
+		stateDB,
+		sut.hooks,
+		sut.chainConfig,
+		sut.chainContext,
+		sut.logger,
+		WithMaxNumTxs(1),
+		SkipEndOfBlockOps(),
+	)
 	require.NoError(t, err, "Execute()")
 	gotBalances := []*uint256.Int{
-		result.StateDB.GetBalance(f.firstRecipient),
-		result.StateDB.GetBalance(f.secondRecipient),
-		result.StateDB.GetBalance(f.endOfBlockRecipient),
+		result.StateDB.GetBalance(firstRecipient),
+		result.StateDB.GetBalance(secondRecipient),
+		result.StateDB.GetBalance(endOfBlockRecipient),
 	}
 
 	require.Len(t, result.Receipts, 1, "ExecutionResults.Receipts")
 	require.Equal(t, []*uint256.Int{uint256.NewInt(1), uint256.NewInt(0), uint256.NewInt(0)}, gotBalances, "recipient balances")
+	require.Equal(t, gas.Gas(params.TxGas), result.GasConsumed, "ExecutionResults.GasConsumed")
 	require.Nil(t, result.FinishBy.Gas, "ExecutionResults.FinishBy.Gas")
 }
 
 func TestExecuteRejectsInvalidOptions(t *testing.T) {
-	f := newExecuteFixture(t)
+	_, sut := newSUT(t)
+	b := sut.chain.NewBlock(t, types.Transactions{
+		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{}),
+	})
 	tests := []struct {
 		name    string
 		opts    []Option
-		wantErr testerr.Want
+		wantErr error
 	}{
 		{
 			name:    "negative transaction count",
 			opts:    []Option{WithMaxNumTxs(-1)},
-			wantErr: testerr.Is(errTransactionCountOutOfRange),
+			wantErr: errTransactionCountOutOfRange,
 		},
 		{
 			name:    "excessive transaction count",
-			opts:    []Option{WithMaxNumTxs(3)},
-			wantErr: testerr.Is(errTransactionCountOutOfRange),
+			opts:    []Option{WithMaxNumTxs(2)},
+			wantErr: errTransactionCountOutOfRange,
 		},
 		{
 			name:    "partial end-of-block execution",
-			opts:    []Option{WithMaxNumTxs(1)},
-			wantErr: testerr.Is(errPartialEndOfBlockExecution),
+			opts:    []Option{WithMaxNumTxs(0)},
+			wantErr: errPartialEndOfBlockExecution,
 		},
 		{
 			name:    "canonical without end-of-block operations",
-			opts:    []Option{withCanonical(true), SkipEndOfBlockOps()},
-			wantErr: testerr.Is(errCanonicalWithoutEndOfBlockOps),
+			opts:    []Option{withCanonical(), SkipEndOfBlockOps()},
+			wantErr: errCanonicalWithoutEndOfBlockOps,
 		},
 		{
 			name:    "nil receipt store",
 			opts:    []Option{WithReceiptStore(nil)},
-			wantErr: testerr.Is(errNilReceiptStore),
+			wantErr: errNilReceiptStore,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := f.execute(t, tt.opts...)
-			if diff := testerr.Diff(err, tt.wantErr); diff != "" {
-				t.Errorf("Execute() %s", diff)
-			}
+			stateDB, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
+			require.NoError(t, err, "Executor.StateDB(parent root)")
+
+			_, err = Execute(b, stateDB, sut.hooks, sut.chainConfig, sut.chainContext, sut.logger, tt.opts...)
+			require.ErrorIs(t, err, tt.wantErr, "Execute() with %s options", tt.name)
 		})
 	}
 }
 
 func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 	tests := []struct {
-		name string
-		opts []Option
-		want bool
+		name   string
+		withTx bool
+		ops    []saehookstest.Op
+		opts   []Option
+		want   bool
 	}{
-		{name: "non-canonical"},
-		{name: "canonical", opts: []Option{withCanonical(true)}, want: true},
+		{
+			name:   "non-canonical transaction and end-of-block operation",
+			withTx: true,
+			ops:    []saehookstest.Op{{Gas: 1}},
+		},
+		{
+			name:   "canonical transaction",
+			withTx: true,
+			opts:   []Option{withCanonical()},
+			want:   true,
+		},
+		{
+			name: "canonical end-of-block operation",
+			ops:  []saehookstest.Op{{Gas: 1}},
+			opts: []Option{withCanonical()},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := newExecuteFixture(t)
-			_, err := f.execute(t, tt.opts...)
+			_, sut := newSUT(t)
+			var txs types.Transactions
+			if tt.withTx {
+				recipient := common.Address{}
+				txs = types.Transactions{sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+					To:       &recipient,
+					Gas:      params.TxGas,
+					GasPrice: big.NewInt(1),
+				})}
+			}
+			b := sut.chain.NewBlock(
+				t,
+				txs,
+				blockstest.WithEthBlockOptions(blockstest.WithOps(tt.ops)),
+			)
+			stateDB, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
+			require.NoError(t, err, "Executor.StateDB(parent root)")
+
+			_, err = Execute(b, stateDB, sut.hooks, sut.chainConfig, sut.chainContext, sut.logger, tt.opts...)
 			require.NoError(t, err, "Execute()")
 
-			gasClock := f.block.ParentBlock().ExecutedByGasTime()
-			gasClock.BeforeBlock(f.sut.hooks.BlockTime(f.block.Header()))
-			_, got, err := blocks.LastToSettleAt(f.sut.hooks, gasClock.AsTime(), f.block)
+			gasClock := b.ParentBlock().ExecutedByGasTime()
+			gasClock.BeforeBlock(sut.hooks.BlockTime(b.Header()))
+			_, got, err := blocks.LastToSettleAt(sut.hooks, gasClock.AsTime(), b)
 			require.NoError(t, err, "blocks.LastToSettleAt()")
 			require.Equal(t, tt.want, got, "Execute() reports canonical progress")
 		})

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -531,7 +531,7 @@ func TestExecuteRejectsInvalidOptions(t *testing.T) {
 
 // TestExecuteRecordsOnlyCanonicalProgress verifies that non-canonical execution
 // does not overwrite an in-memory block's canonical progress and change the
-// settlement decision made by LastToSettleAt.
+// settlement decision made by  [blocks.LastToSettleAt].
 func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -509,7 +509,7 @@ func TestExecuteRejectsInvalidOptions(t *testing.T) {
 		},
 		{
 			name:    "canonical without end-of-block operations",
-			opts:    []Option{withCanonical(), SkipEndOfBlockOps()},
+			opts:    []Option{asCanonical(), SkipEndOfBlockOps()},
 			wantErr: errCanonicalWithoutEndOfBlockOps,
 		},
 		{
@@ -530,8 +530,7 @@ func TestExecuteRejectsInvalidOptions(t *testing.T) {
 }
 
 // TestExecuteRecordsOnlyCanonicalProgress verifies that non-canonical execution
-// does not overwrite an in-memory block's canonical progress and change the
-// settlement decision made by  [blocks.LastToSettleAt].
+// does not overwrite an in-memory block's canonical progress.
 func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -548,13 +547,13 @@ func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 		{
 			name:   "canonical transaction",
 			withTx: true,
-			opts:   []Option{withCanonical()},
+			opts:   []Option{asCanonical()},
 			want:   true,
 		},
 		{
 			name: "canonical end-of-block operation",
 			ops:  []saehookstest.Op{{Gas: 1}},
-			opts: []Option{withCanonical()},
+			opts: []Option{asCanonical()},
 			want: true,
 		},
 	}
@@ -580,11 +579,9 @@ func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 			_, err = Execute(b, stateDB, sut.hooks, sut.chainConfig, sut.chainContext, sut.logger, tt.opts...)
 			require.NoError(t, err, "Execute()")
 
-			gasClock := b.ParentBlock().ExecutedByGasTime()
-			gasClock.BeforeBlock(sut.hooks.BlockTime(b.Header()))
-			_, got, err := blocks.LastToSettleAt(gasClock.AsTime(), b)
-			require.NoError(t, err, "blocks.LastToSettleAt()")
-			require.Equal(t, tt.want, got, "Execute() reports canonical progress")
+			interimExecutionTime := proxytime.New[gas.Gas](math.MaxUint64, 0, 1)
+			got := b.SwapInterimExecutionTime(interimExecutionTime) != nil
+			require.Equal(t, tt.want, got, "Block.SwapInterimExecutionTime()")
 		})
 	}
 }

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -527,12 +527,12 @@ func newExecuteFixture(t *testing.T) *executeFixture {
 	return f
 }
 
-func (f *executeFixture) execute(t *testing.T, opts ...Option) *ExecutionResults {
+func (f *executeFixture) execute(t *testing.T, opts ...Option) (*ExecutionResults, error) {
 	t.Helper()
 
 	stateDB, err := f.sut.StateDB(f.block.ParentBlock().PostExecutionStateRoot())
 	require.NoError(t, err, "Executor.StateDB(parent root)")
-	result, err := Execute(
+	return Execute(
 		f.block,
 		stateDB,
 		f.sut.hooks,
@@ -541,59 +541,25 @@ func (f *executeFixture) execute(t *testing.T, opts ...Option) *ExecutionResults
 		f.sut.logger,
 		opts...,
 	)
+}
+
+func TestExecuteTransactionPrefix(t *testing.T) {
+	f := newExecuteFixture(t)
+	result, err := f.execute(t, WithMaxNumTxs(1), SkipEndOfBlockOps())
 	require.NoError(t, err, "Execute()")
-	return result
-}
-
-func (f *executeFixture) reportsProgress(t *testing.T) bool {
-	t.Helper()
-
-	gasClock := f.block.ParentBlock().ExecutedByGasTime()
-	gasClock.BeforeBlock(f.sut.hooks.BlockTime(f.block.Header()))
-	_, ok, err := blocks.LastToSettleAt(f.sut.hooks, gasClock.AsTime(), f.block)
-	require.NoError(t, err, "blocks.LastToSettleAt()")
-	return ok
-}
-
-func TestExecute(t *testing.T) {
-	tests := []struct {
-		name         string
-		opts         []Option
-		wantReceipts int
-		wantBalances []*uint256.Int
-		wantFinished bool
-	}{
-		{
-			name:         "transaction prefix",
-			opts:         []Option{WithMaxNumTxs(1), SkipEndOfBlockOps()},
-			wantReceipts: 1,
-			wantBalances: []*uint256.Int{uint256.NewInt(1), uint256.NewInt(0), uint256.NewInt(0)},
-		},
-		{
-			name:         "full block",
-			wantReceipts: 2,
-			wantBalances: []*uint256.Int{uint256.NewInt(1), uint256.NewInt(2), uint256.NewInt(100)},
-			wantFinished: true,
-		},
+	gotBalances := []*uint256.Int{
+		result.StateDB.GetBalance(f.firstRecipient),
+		result.StateDB.GetBalance(f.secondRecipient),
+		result.StateDB.GetBalance(f.endOfBlockRecipient),
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := newExecuteFixture(t)
-			result := f.execute(t, tt.opts...)
-			gotBalances := []*uint256.Int{
-				result.StateDB.GetBalance(f.firstRecipient),
-				result.StateDB.GetBalance(f.secondRecipient),
-				result.StateDB.GetBalance(f.endOfBlockRecipient),
-			}
 
-			require.Len(t, result.Receipts, tt.wantReceipts, "ExecutionResults.Receipts")
-			require.Equal(t, tt.wantBalances, gotBalances, "recipient balances")
-			require.Equal(t, tt.wantFinished, result.FinishBy.Gas != nil, "ExecutionResults.FinishBy.Gas")
-		})
-	}
+	require.Len(t, result.Receipts, 1, "ExecutionResults.Receipts")
+	require.Equal(t, []*uint256.Int{uint256.NewInt(1), uint256.NewInt(0), uint256.NewInt(0)}, gotBalances, "recipient balances")
+	require.Nil(t, result.FinishBy.Gas, "ExecutionResults.FinishBy.Gas")
 }
 
 func TestExecuteRejectsInvalidOptions(t *testing.T) {
+	f := newExecuteFixture(t)
 	tests := []struct {
 		name    string
 		opts    []Option
@@ -627,37 +593,12 @@ func TestExecuteRejectsInvalidOptions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := newExecuteFixture(t)
-			stateDB, err := f.sut.StateDB(f.block.ParentBlock().PostExecutionStateRoot())
-			require.NoError(t, err, "Executor.StateDB(parent root)")
-			_, err = Execute(
-				f.block,
-				stateDB,
-				f.sut.hooks,
-				f.sut.chainConfig,
-				f.sut.chainContext,
-				f.sut.logger,
-				tt.opts...,
-			)
+			_, err := f.execute(t, tt.opts...)
 			if diff := testerr.Diff(err, tt.wantErr); diff != "" {
 				t.Errorf("Execute() %s", diff)
 			}
 		})
 	}
-}
-
-func TestExecutePublishesReceiptsWhenConfigured(t *testing.T) {
-	f := newExecuteFixture(t)
-	f.sut.createReceiptBuffers(f.block)
-	result := f.execute(t, WithReceiptStore(f.sut.receipts))
-
-	tx := f.block.Transactions()[0]
-	value, ok := f.sut.receipts.Load(tx.Hash())
-	require.True(t, ok, "receipt store contains transaction")
-	got, ready := value.TryPeek()
-	require.True(t, ready, "receipt store contains executed receipt")
-	require.Same(t, result.Receipts[0], got.Receipt, "Receipt.Receipt")
-	require.Same(t, tx, got.Tx, "Receipt.Tx")
 }
 
 func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
@@ -672,17 +613,16 @@ func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newExecuteFixture(t)
-			f.execute(t, tt.opts...)
-			require.Equal(t, tt.want, f.reportsProgress(t), "Execute() reports canonical progress")
+			_, err := f.execute(t, tt.opts...)
+			require.NoError(t, err, "Execute()")
+
+			gasClock := f.block.ParentBlock().ExecutedByGasTime()
+			gasClock.BeforeBlock(f.sut.hooks.BlockTime(f.block.Header()))
+			_, got, err := blocks.LastToSettleAt(f.sut.hooks, gasClock.AsTime(), f.block)
+			require.NoError(t, err, "blocks.LastToSettleAt()")
+			require.Equal(t, tt.want, got, "Execute() reports canonical progress")
 		})
 	}
-}
-
-func TestExecuteDoesNotMarkBlockExecuted(t *testing.T) {
-	f := newExecuteFixture(t)
-	f.execute(t, withCanonical(true))
-	require.False(t, f.block.Executed(), "Execute() marked block executed")
-	require.Same(t, f.block.ParentBlock(), f.sut.LastExecuted(), "Executor.LastExecuted()")
 }
 
 func TestGasAccounting(t *testing.T) {

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -487,52 +487,6 @@ func TestEndOfBlockOps(t *testing.T) {
 	})
 }
 
-// TestExecuteTransactionPrefix verifies that executing a transaction prefix
-// does not execute later transactions or end-of-block operations.
-func TestExecuteTransactionPrefix(t *testing.T) {
-	_, sut := newSUT(t)
-	recipient := common.Address{'r', 'e', 'c', 'i', 'p', 'i', 'e', 'n', 't'}
-	b := sut.chain.NewBlock(t, types.Transactions{
-		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-			To:       &recipient,
-			Value:    big.NewInt(1),
-			Gas:      params.TxGas,
-			GasPrice: big.NewInt(1),
-		}),
-		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-			To:       &recipient,
-			Value:    big.NewInt(2),
-			Gas:      params.TxGas,
-			GasPrice: big.NewInt(1),
-		}),
-	}, blockstest.WithEthBlockOptions(blockstest.WithOps([]saehookstest.Op{{
-		Gas: 1,
-		Mint: []saehookstest.AccountCredit{{
-			Address: recipient,
-			Amount:  *uint256.NewInt(100),
-		}},
-	}})))
-	stateDB, err := sut.StateDB(b.ParentBlock().PostExecutionStateRoot())
-	require.NoError(t, err, "Executor.StateDB(parent root)")
-
-	result, err := Execute(
-		b,
-		stateDB,
-		sut.hooks,
-		sut.chainConfig,
-		sut.chainContext,
-		sut.logger,
-		WithMaxNumTxs(1),
-		SkipEndOfBlockOps(),
-	)
-	require.NoError(t, err, "Execute()")
-
-	require.Len(t, result.Receipts, 1, "ExecutionResults.Receipts")
-	require.Equal(t, uint256.NewInt(1), stateDB.GetBalance(recipient), "recipient balance")
-	require.Equal(t, gas.Gas(params.TxGas), result.GasConsumed, "ExecutionResults.GasConsumed")
-	require.Nil(t, result.FinishBy.Gas, "ExecutionResults.FinishBy.Gas")
-}
-
 func TestExecuteRejectsInvalidOptions(t *testing.T) {
 	_, sut := newSUT(t)
 	b := sut.chain.NewBlock(t, types.Transactions{
@@ -543,11 +497,6 @@ func TestExecuteRejectsInvalidOptions(t *testing.T) {
 		opts    []Option
 		wantErr error
 	}{
-		{
-			name:    "negative transaction count",
-			opts:    []Option{WithMaxNumTxs(-1)},
-			wantErr: errTransactionCountOutOfRange,
-		},
 		{
 			name:    "excessive transaction count",
 			opts:    []Option{WithMaxNumTxs(2)},

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -487,20 +487,20 @@ func TestEndOfBlockOps(t *testing.T) {
 	})
 }
 
+// TestExecuteTransactionPrefix verifies that executing a transaction prefix
+// does not execute later transactions or end-of-block operations.
 func TestExecuteTransactionPrefix(t *testing.T) {
 	_, sut := newSUT(t)
-	firstRecipient := common.Address{'f', 'i', 'r', 's', 't'}
-	secondRecipient := common.Address{'s', 'e', 'c', 'o', 'n', 'd'}
-	endOfBlockRecipient := common.Address{'e', 'n', 'd'}
+	recipient := common.Address{'r', 'e', 'c', 'i', 'p', 'i', 'e', 'n', 't'}
 	b := sut.chain.NewBlock(t, types.Transactions{
 		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-			To:       &firstRecipient,
+			To:       &recipient,
 			Value:    big.NewInt(1),
 			Gas:      params.TxGas,
 			GasPrice: big.NewInt(1),
 		}),
 		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-			To:       &secondRecipient,
+			To:       &recipient,
 			Value:    big.NewInt(2),
 			Gas:      params.TxGas,
 			GasPrice: big.NewInt(1),
@@ -508,7 +508,7 @@ func TestExecuteTransactionPrefix(t *testing.T) {
 	}, blockstest.WithEthBlockOptions(blockstest.WithOps([]saehookstest.Op{{
 		Gas: 1,
 		Mint: []saehookstest.AccountCredit{{
-			Address: endOfBlockRecipient,
+			Address: recipient,
 			Amount:  *uint256.NewInt(100),
 		}},
 	}})))
@@ -526,14 +526,9 @@ func TestExecuteTransactionPrefix(t *testing.T) {
 		SkipEndOfBlockOps(),
 	)
 	require.NoError(t, err, "Execute()")
-	gotBalances := []*uint256.Int{
-		result.StateDB.GetBalance(firstRecipient),
-		result.StateDB.GetBalance(secondRecipient),
-		result.StateDB.GetBalance(endOfBlockRecipient),
-	}
 
 	require.Len(t, result.Receipts, 1, "ExecutionResults.Receipts")
-	require.Equal(t, []*uint256.Int{uint256.NewInt(1), uint256.NewInt(0), uint256.NewInt(0)}, gotBalances, "recipient balances")
+	require.Equal(t, uint256.NewInt(1), stateDB.GetBalance(recipient), "recipient balance")
 	require.Equal(t, gas.Gas(params.TxGas), result.GasConsumed, "ExecutionResults.GasConsumed")
 	require.Nil(t, result.FinishBy.Gas, "ExecutionResults.FinishBy.Gas")
 }
@@ -585,6 +580,9 @@ func TestExecuteRejectsInvalidOptions(t *testing.T) {
 	}
 }
 
+// TestExecuteRecordsOnlyCanonicalProgress verifies that non-canonical execution
+// does not overwrite an in-memory block's canonical progress and change the
+// settlement decision made by LastToSettleAt.
 func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -616,9 +614,8 @@ func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 			_, sut := newSUT(t)
 			var txs types.Transactions
 			if tt.withTx {
-				recipient := common.Address{}
 				txs = types.Transactions{sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-					To:       &recipient,
+					To:       &common.Address{},
 					Gas:      params.TxGas,
 					GasPrice: big.NewInt(1),
 				})}

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -636,7 +636,7 @@ func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
 
 			gasClock := b.ParentBlock().ExecutedByGasTime()
 			gasClock.BeforeBlock(sut.hooks.BlockTime(b.Header()))
-			_, got, err := blocks.LastToSettleAt(sut.hooks, gasClock.AsTime(), b)
+			_, got, err := blocks.LastToSettleAt(gasClock.AsTime(), b)
 			require.NoError(t, err, "blocks.LastToSettleAt()")
 			require.Equal(t, tt.want, got, "Execute() reports canonical progress")
 		})

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -487,6 +487,151 @@ func TestEndOfBlockOps(t *testing.T) {
 	})
 }
 
+type executeFixture struct {
+	sut                 *SUT
+	block               *blocks.Block
+	firstRecipient      common.Address
+	secondRecipient     common.Address
+	endOfBlockRecipient common.Address
+}
+
+func newExecuteFixture(t *testing.T) *executeFixture {
+	t.Helper()
+
+	_, sut := newSUT(t)
+	f := &executeFixture{
+		sut:                 sut,
+		firstRecipient:      common.Address{'f', 'i', 'r', 's', 't'},
+		secondRecipient:     common.Address{'s', 'e', 'c', 'o', 'n', 'd'},
+		endOfBlockRecipient: common.Address{'e', 'n', 'd'},
+	}
+	f.block = sut.chain.NewBlock(t, types.Transactions{
+		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+			To:       &f.firstRecipient,
+			Value:    big.NewInt(1),
+			Gas:      params.TxGas,
+			GasPrice: big.NewInt(1),
+		}),
+		sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+			To:       &f.secondRecipient,
+			Value:    big.NewInt(2),
+			Gas:      params.TxGas,
+			GasPrice: big.NewInt(1),
+		}),
+	}, blockstest.WithEthBlockOptions(blockstest.WithOps([]saehookstest.Op{{
+		Mint: []saehookstest.AccountCredit{{
+			Address: f.endOfBlockRecipient,
+			Amount:  *uint256.NewInt(100),
+		}},
+	}})))
+	return f
+}
+
+func (f *executeFixture) execute(t *testing.T, opts ...Option) *ExecutionResults {
+	t.Helper()
+
+	stateDB, err := f.sut.StateDB(f.block.ParentBlock().PostExecutionStateRoot())
+	require.NoError(t, err, "Executor.StateDB(parent root)")
+	result, err := Execute(
+		f.block,
+		stateDB,
+		f.sut.hooks,
+		f.sut.chainConfig,
+		f.sut.chainContext,
+		f.sut.logger,
+		opts...,
+	)
+	require.NoError(t, err, "Execute()")
+	return result
+}
+
+func (f *executeFixture) reportsProgress(t *testing.T) bool {
+	t.Helper()
+
+	gasClock := f.block.ParentBlock().ExecutedByGasTime()
+	gasClock.BeforeBlock(f.sut.hooks.BlockTime(f.block.Header()))
+	_, ok, err := blocks.LastToSettleAt(f.sut.hooks, gasClock.AsTime(), f.block)
+	require.NoError(t, err, "blocks.LastToSettleAt()")
+	return ok
+}
+
+func TestExecute(t *testing.T) {
+	tests := []struct {
+		name         string
+		opts         []Option
+		wantReceipts int
+		wantBalances []*uint256.Int
+		wantFinished bool
+	}{
+		{
+			name:         "transaction prefix",
+			opts:         []Option{WithMaxNumTxs(1), WithEndOfBlockOps(false)},
+			wantReceipts: 1,
+			wantBalances: []*uint256.Int{uint256.NewInt(1), uint256.NewInt(0), uint256.NewInt(0)},
+		},
+		{
+			name:         "full block",
+			wantReceipts: 2,
+			wantBalances: []*uint256.Int{uint256.NewInt(1), uint256.NewInt(2), uint256.NewInt(100)},
+			wantFinished: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newExecuteFixture(t)
+			result := f.execute(t, tt.opts...)
+			gotBalances := []*uint256.Int{
+				result.StateDB.GetBalance(f.firstRecipient),
+				result.StateDB.GetBalance(f.secondRecipient),
+				result.StateDB.GetBalance(f.endOfBlockRecipient),
+			}
+
+			require.Len(t, result.Receipts, tt.wantReceipts, "ExecutionResults.Receipts")
+			require.Equal(t, tt.wantBalances, gotBalances, "recipient balances")
+			require.Equal(t, tt.wantFinished, result.FinishBy.Gas != nil, "ExecutionResults.FinishBy.Gas")
+		})
+	}
+}
+
+func TestExecutePublishesReceiptsWhenConfigured(t *testing.T) {
+	f := newExecuteFixture(t)
+	f.sut.createReceiptBuffers(f.block)
+	result := f.execute(t, WithReceiptStore(f.sut.receipts))
+
+	tx := f.block.Transactions()[0]
+	value, ok := f.sut.receipts.Load(tx.Hash())
+	require.True(t, ok, "receipt store contains transaction")
+	got, ready := value.TryPeek()
+	require.True(t, ready, "receipt store contains executed receipt")
+	require.Same(t, result.Receipts[0], got.Receipt, "Receipt.Receipt")
+	require.Same(t, tx, got.Tx, "Receipt.Tx")
+}
+
+func TestExecuteRecordsOnlyCanonicalProgress(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []Option
+		want bool
+	}{
+		{name: "non-canonical"},
+		{name: "canonical", opts: []Option{withCanonical(true)}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newExecuteFixture(t)
+			f.execute(t, tt.opts...)
+			require.Equal(t, tt.want, f.reportsProgress(t), "Execute() reports canonical progress")
+		})
+	}
+}
+
+func TestExecuteDoesNotMarkBlockExecuted(t *testing.T) {
+	f := newExecuteFixture(t)
+	f.execute(t, withCanonical(true))
+	require.False(t, f.block.Executed(), "Execute() marked block executed")
+	require.Same(t, f.block.ParentBlock(), f.sut.LastExecuted(), "Executor.LastExecuted()")
+}
+
 func TestGasAccounting(t *testing.T) {
 	const gasPerTx = gas.Gas(params.TxGas)
 	hooks := saehookstest.NewStub(5 * gasPerTx)


### PR DESCRIPTION
## Why this should be merged

Firewood does not retain state at every block. Reconstructing historical state therefore requires replaying canonical blocks into an isolated `StateDB` without publishing receipts, persisting state, or advancing canonical execution.

This PR creates that execution boundary and unblocks Firewood state reconstruction in #5787. It supersedes the approach in #5802, which introduced separate `BlockProcessor` execution paths and duplicated transaction and end-of-block processing.

Using one configurable execution path, also further seperates the execution and RPC layer, which, during the implementation of the RPCs, became blurry. Wins! 

## How this works

- Adds `saexec.Execute`, which executes against a caller-provided `StateDB`.
- Supports transaction-prefix execution, optional end-of-block operations, and receipt collection.
- Keeps canonical-only progress and lifecycle changes within `Executor`.
- Routes RPC replay through the same execution implementation.

Full non-canonical block execution is the default, allowing Firewood to replay blocks directly into a reconstructed state view.

## How this was tested

Added coverage for execution options, invalid option combinations, transaction-prefix execution, and canonical-only progress reporting.

## Need to be documented in RELEASES.md?

No