### PR TITLE
refactor(blocks): Remove last settled from ancestry

### DIFF
--- a/vms/saevm/blocks/BUILD.bazel
+++ b/vms/saevm/blocks/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "@com_github_ava_labs_libevm//core/types",
         "@com_github_ava_labs_libevm//ethdb",
         "@com_github_ava_labs_libevm//params",
+        "@com_github_ava_labs_libevm//rlp",
         "@com_github_google_go_cmp//cmp",
         "@com_github_holiman_uint256//:uint256",
         "@com_github_stretchr_testify//assert",

--- a/vms/saevm/blocks/block.go
+++ b/vms/saevm/blocks/block.go
@@ -45,7 +45,8 @@ type Block struct {
 	// an early warning system in case of near-miss incorrect predictions.
 	bounds *WorstCaseBounds
 	// Non-nil i.f.f. [Block.MarkExecuted] has returned without error.
-	execution atomic.Pointer[executionResults]
+	execution   atomic.Pointer[executionResults]
+	synchronous bool // set at construction
 
 	// Allows this block to be ruled out as able to be settled at a particular
 	// time (i.e. if this field is >= said time). The pointer MAY be nil if
@@ -77,10 +78,11 @@ func InMemoryBlockCount() int64 {
 // only be done when parsing an encoded Block.
 func New(eth *types.Block, parent *Block, hooks hook.Points, log logging.Logger) (*Block, error) {
 	b := &Block{
-		b:        eth,
-		executed: make(chan struct{}),
-		settled:  make(chan struct{}),
-		hooks:    hooks,
+		b:           eth,
+		executed:    make(chan struct{}),
+		settled:     make(chan struct{}),
+		hooks:       hooks,
+		synchronous: hook.Synchronous(hooks, eth.Header()),
 	}
 
 	inMemoryBlockCount.Add(1)

--- a/vms/saevm/blocks/block.go
+++ b/vms/saevm/blocks/block.go
@@ -31,21 +31,16 @@ import (
 // execution and settlement. It MUST be constructed with [New].
 type Block struct {
 	b *types.Block
-	// Invariant: ancestry is non-nil and contains non-nil pointers i.f.f. the
-	// block hasn't itself been settled. A synchronous block (e.g. SAE genesis
-	// or the last pre-SAE block) is always considered settled. See [New] for
-	// caveats during construction.
+	// Invariant: parent is non-nil only if the block hasn't itself been
+	// settled. A synchronous block (e.g. SAE genesis or the last pre-SAE block)
+	// is always considered settled. See [New] for caveats during construction.
 	//
 	// Rationale: the ancestral pointers form a linked list that would prevent
 	// garbage collection if not severed. Once a block is settled there is no
 	// need to inspect its history so we sacrifice the ancestors to the GC
 	// Overlord as a sign of our unwavering fealty. See [InMemoryBlockCount] for
 	// observability.
-	ancestry atomic.Pointer[ancestry]
-	// Only the genesis block or the last pre-SAE block is synchronous. These
-	// are self-settling by definition so their `ancestry` MUST be nil.
-	// TODO(JonathanOppenheimer): remove this in favor of the settled hook.
-	synchronous bool
+	parent atomic.Pointer[Block]
 	// Determined during block building and SHOULD be set before execution as
 	// an early warning system in case of near-miss incorrect predictions.
 	bounds *WorstCaseBounds
@@ -60,9 +55,10 @@ type Block struct {
 	interimExecutionTime atomic.Pointer[proxytime.Time[gas.Gas]]
 
 	executed chan struct{} // closed after `execution` is set
-	settled  chan struct{} // closed after `ancestry` is cleared
+	settled  chan struct{} // closed after `parent` is cleared
 
-	log logging.Logger
+	hooks hook.Points
+	log   logging.Logger
 }
 
 var inMemoryBlockCount atomic.Int64
@@ -75,16 +71,16 @@ func InMemoryBlockCount() int64 {
 
 // New constructs a new Block.
 //
-// While both the `parent` and `lastSettled` arguments MAY be nil, this will
-// result in an invalid Block as it breaks important invariants. In such
-// situations, [Block.CopyAncestorsFrom] MUST then be called before further use
-// of the Block. In practice, this SHOULD only be done when parsing an encoded
-// Block.
-func New(eth *types.Block, parent, lastSettled *Block, log logging.Logger) (*Block, error) {
+// While the `parent` argument MAY be nil, this will result in an invalid Block
+// as it breaks important invariants. In such situations, [Block.CopyParentFrom]
+// MUST then be called before further use of the Block. In practice, this SHOULD
+// only be done when parsing an encoded Block.
+func New(eth *types.Block, parent *Block, hooks hook.Points, log logging.Logger) (*Block, error) {
 	b := &Block{
 		b:        eth,
 		executed: make(chan struct{}),
 		settled:  make(chan struct{}),
+		hooks:    hooks,
 	}
 
 	inMemoryBlockCount.Add(1)
@@ -92,7 +88,7 @@ func New(eth *types.Block, parent, lastSettled *Block, log logging.Logger) (*Blo
 		inMemoryBlockCount.Add(-1)
 	}, struct{}{})
 
-	if err := b.SetAncestors(parent, lastSettled); err != nil {
+	if err := b.SetParent(parent); err != nil {
 		return nil, err
 	}
 	b.log = log.With(
@@ -106,11 +102,11 @@ func New(eth *types.Block, parent, lastSettled *Block, log logging.Logger) (*Blo
 // settled state before returning it. By definition of being settled, the
 // returned block also includes post-execution artefacts.
 func RestoreSettledBlock(eth *types.Block, hooks hook.Points, log logging.Logger, db ethdb.Database, xdb saetypes.ExecutionResults, config *params.ChainConfig) (*Block, error) {
-	b, err := New(eth, nil, nil, log)
+	b, err := New(eth, nil, hooks, log)
 	if err != nil {
 		return nil, err
 	}
-	if err := b.RestoreExecutionArtefacts(hooks, db, xdb, config); err != nil {
+	if err := b.RestoreExecutionArtefacts(db, xdb, config); err != nil {
 		return nil, fmt.Errorf("restoring to executed state: %w", err)
 	}
 	if err := b.markSettled(nil); err != nil {
@@ -128,8 +124,8 @@ var (
 	errHashMismatch               = errors.New("block hash mismatch")
 )
 
-// SetAncestors sets the block's ancestry while enforcing invariants.
-func (b *Block) SetAncestors(parent, lastSettled *Block) error {
+// SetParent sets the block's parent while enforcing invariants.
+func (b *Block) SetParent(parent *Block) error {
 	if parent != nil {
 		if got, want := parent.Hash(), b.ParentHash(); got != want {
 			return fmt.Errorf("%w: constructing Block with parent hash %v; expecting %v", errParentHashMismatch, got, want)
@@ -138,26 +134,22 @@ func (b *Block) SetAncestors(parent, lastSettled *Block) error {
 			return fmt.Errorf("%w: constructing Block with parent height %v and own height %v", errBlockHeightNotIncrementing, parent.Number(), b.Number())
 		}
 	}
-	b.ancestry.Store(&ancestry{
-		parent:      parent,
-		lastSettled: lastSettled,
-	})
+	b.parent.Store(parent)
 	return nil
 }
 
-// CopyAncestorsFrom populates the [Block.ParentBlock] and [Block.LastSettled]
-// values, typically only required during database recovery or block
-// verification. The source block MUST have the same hash as b.
+// CopyParentFrom populates the [Block.ParentBlock] value, typically only
+// required during database recovery or block verification. The source block
+// MUST have the same hash as b.
 //
 // Although the individual ancestral blocks are shallow copied, calling
 // [Block.MarkSettled] on either the source or destination will NOT clear the
 // pointers of the other.
-func (b *Block) CopyAncestorsFrom(c *Block) error {
+func (b *Block) CopyParentFrom(c *Block) error {
 	if from, to := c.Hash(), b.Hash(); from != to {
 		return fmt.Errorf("%w: copying internals from block %#x to %#x", errHashMismatch, from, to)
 	}
-	a := c.ancestry.Load()
-	return b.SetAncestors(a.parent, a.lastSettled)
+	return b.SetParent(c.parent.Load())
 }
 
 // Signer returns the transaction signer for the block.

--- a/vms/saevm/blocks/block_test.go
+++ b/vms/saevm/blocks/block_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/google/go-cmp/cmp"
@@ -15,34 +16,95 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 )
 
-func newEthBlock(num, time uint64, parent *types.Block) *types.Block {
-	hdr := &types.Header{
-		Number:  new(big.Int).SetUint64(num),
-		BaseFee: big.NewInt(1),
-		Time:    time,
-	}
-	if parent != nil {
-		hdr.ParentHash = parent.Hash()
-	}
-	return types.NewBlockWithHeader(hdr)
+type blockBuilder struct {
+	hooks    *hookstest.Stub
+	hookTime *time.Time
 }
 
-func newBlock(tb testing.TB, eth *types.Block, parent, lastSettled *Block) *Block {
+func newBlockBuilder() *blockBuilder {
+	hookTime := new(time.Time)
+	return &blockBuilder{
+		hooks: hookstest.NewStub(1e9, hookstest.WithNow(func() time.Time {
+			return *hookTime
+		})),
+		hookTime: hookTime,
+	}
+}
+
+// new creates a [Block] using [New].
+func (bb *blockBuilder) new(tb testing.TB, ethB *types.Block, parent *Block) (*Block, error) {
 	tb.Helper()
-	b, err := New(eth, parent, lastSettled, loggingtest.New(tb, logging.Warn))
-	require.NoError(tb, err, "New()")
+	return New(ethB, parent, bb.hooks, loggingtest.New(tb, logging.Warn))
+}
+
+// mustNew is like [blockBuilder.new] but fails the test on error.
+func (bb *blockBuilder) mustNew(tb testing.TB, ethB *types.Block, parent *Block) *Block {
+	tb.Helper()
+
+	b, err := bb.new(tb, ethB, parent)
+	require.NoErrorf(tb, err, "%T.New() for block %d", bb.hooks, ethB.NumberU64())
 	return b
 }
 
-func newChain(tb testing.TB, startHeight, total uint64, lastSettledAtHeight map[uint64]uint64) []*Block {
+// settledBy returns the [hook.Settled] to encode in a block with the given
+// last-settled block. A nil argument returns the zero value, which denotes a
+// synchronous block; see [hook.Synchronous].
+func settledBy(lastSettled *Block) hook.Settled {
+	if lastSettled == nil {
+		return hook.Settled{}
+	}
+	return hook.Settled{
+		Height: lastSettled.Height(),
+		// Guaranteed non-zero so that a block settling the genesis (height 0)
+		// isn't mistaken for a synchronous block.
+		GasNumerator: 1,
+	}
+}
+
+func (bb *blockBuilder) newFromHooks(tb testing.TB, num, sec uint64, parent *Block, lastSettled *Block) *Block {
+	tb.Helper()
+
+	*bb.hookTime = time.Unix(int64(sec), 0)
+	var ethHdr *types.Header
+	if parent != nil {
+		var err error
+		ethHdr, err = bb.hooks.BuildHeader(parent.Header())
+		require.NoErrorf(tb, err, "%T.BuildHeader() for block %d", bb.hooks, num)
+	} else {
+		// A root block (e.g. genesis) has no parent from which to build, so
+		// its height and time are set directly.
+		ethHdr = &types.Header{
+			Number:  new(big.Int).SetUint64(num),
+			Time:    sec,
+			BaseFee: big.NewInt(1),
+		}
+	}
+	ethB, err := bb.hooks.BuildBlock(
+		ethHdr,
+		nil, nil, nil, nil,
+		settledBy(lastSettled),
+	)
+	require.NoErrorf(tb, err, "%T.BuildBlock() for block %d", bb.hooks, num)
+
+	return bb.mustNew(tb, ethB, parent)
+}
+
+// newChain returns a chain of blocks with heights in [startHeight,
+// startHeight+total) and build times equal to their heights. The
+// lastSettledAtHeight map determines each block's last-settled block; a
+// self-settling entry (only valid for the genesis) results in a synchronous
+// block that is marked as settled.
+func (bb *blockBuilder) newChain(tb testing.TB, startHeight, total uint64, lastSettledAtHeight map[uint64]uint64) []*Block {
 	tb.Helper()
 
 	var (
-		ethParent *types.Block
 		parent    *Block
 		blocks    []*Block
+		blackhole atomic.Pointer[Block]
 	)
 	byNum := make(map[uint64]*Block)
 
@@ -63,35 +125,32 @@ func newChain(tb testing.TB, startHeight, total uint64, lastSettledAtHeight map[
 			}
 		}
 
-		b := newBlock(tb, newEthBlock(n, n /*time*/, ethParent), parent, settle)
+		b := bb.newFromHooks(tb, n, n /*time*/, parent, settle)
 		byNum[n] = b
 		blocks = append(blocks, b)
 		if synchronous {
-			var lastSettledPtr atomic.Pointer[Block]
-			require.NoErrorf(tb, b.MarkSettled(&lastSettledPtr), "MarkSettled()")
-			b.synchronous = true // avoid requiring hooks and DB to mark as synchronous
+			require.NoErrorf(tb, b.MarkSettled(&blackhole), "MarkSettled()")
 		}
-
-		parent = byNum[n]
-		ethParent = parent.EthBlock()
+		parent = b
 	}
 
 	return blocks
 }
 
 func TestSetAncestors(t *testing.T) {
-	parent := newBlock(t, newEthBlock(5, 5, nil), nil, nil)
-	lastSettled := newBlock(t, newEthBlock(3, 0, nil), nil, nil)
-	child := newEthBlock(6, 6, parent.EthBlock())
+	bb := newBlockBuilder()
+	parent := bb.newFromHooks(t, 5, 5, nil, nil)
+	lastSettled := bb.newFromHooks(t, 3, 0, nil, nil)
+	source := bb.newFromHooks(t, 6, 6, parent, lastSettled)
+	child := source.EthBlock()
 
 	t.Run("incorrect_parent", func(t *testing.T) {
 		// Note that the arguments to [New] are inverted.
-		_, err := New(child, lastSettled, parent, loggingtest.New(t, logging.Warn))
+		_, err := bb.new(t, child, lastSettled)
 		require.ErrorIs(t, err, errParentHashMismatch, "New() with inverted parent and last-settled blocks")
 	})
 
-	source := newBlock(t, child, parent, lastSettled)
-	dest := newBlock(t, child, nil, nil)
+	dest := bb.mustNew(t, child, nil)
 
 	t.Run("destination_before_copy", func(t *testing.T) {
 		assert.Nilf(t, dest.ParentBlock(), "%T.ParentBlock()", dest)
@@ -101,20 +160,23 @@ func TestSetAncestors(t *testing.T) {
 		t.FailNow()
 	}
 
-	require.NoError(t, dest.CopyAncestorsFrom(source), "CopyAncestorsFrom()")
+	require.NoError(t, dest.CopyParentFrom(source), "CopyAncestorsFrom()")
 	if diff := cmp.Diff(source, dest, CmpOpt()); diff != "" {
 		t.Errorf("After %T.CopyAncestorsFrom(); diff (-want +got):\n%s", dest, diff)
 	}
 
 	t.Run("incompatible_destination_block", func(t *testing.T) {
-		ethB := newEthBlock(source.Height(), source.BuildTime()+1 /*hash mismatch*/, parent.EthBlock())
-		dest := newBlock(t, ethB, nil, nil)
-		require.ErrorIs(t, dest.CopyAncestorsFrom(source), errHashMismatch)
+		dest := bb.newFromHooks(t, source.Height(), source.BuildTime()+1 /*hash mismatch*/, parent, lastSettled)
+		require.ErrorIs(t, dest.CopyParentFrom(source), errHashMismatch)
 	})
 
 	t.Run("not_incrementing_height", func(t *testing.T) {
-		ethB := newEthBlock(parent.Height() /*not incrementing*/, parent.BuildTime(), parent.EthBlock())
-		_, err := New(ethB, parent, nil, nil)
+		ethHdr, err := bb.hooks.BuildHeader(parent.Header())
+		require.NoErrorf(t, err, "%T.BuildHeader()", bb.hooks)
+		ethHdr.Number = parent.Number() // not incrementing
+		ethB, err := bb.hooks.BuildBlock(ethHdr, nil, nil, nil, nil, hook.Settled{})
+		require.NoErrorf(t, err, "%T.BuildBlock()", bb.hooks)
+		_, err = bb.new(t, ethB, parent)
 		require.ErrorIs(t, err, errBlockHeightNotIncrementing)
 	})
 }

--- a/vms/saevm/blocks/block_test.go
+++ b/vms/saevm/blocks/block_test.go
@@ -68,7 +68,7 @@ func settledBy(lastSettled *Block) hook.Settled {
 func (bb *blockBuilder) newFromHooks(tb testing.TB, num, sec uint64, parent *Block, lastSettled *Block) *Block {
 	tb.Helper()
 
-	*bb.hookTime = time.Unix(int64(sec), 0)
+	*bb.hookTime = time.Unix(int64(sec), 0) //#nosec G115 -- block time is probably not that high.
 	var ethHdr *types.Header
 	if parent != nil {
 		var err error

--- a/vms/saevm/blocks/blockstest/blocks.go
+++ b/vms/saevm/blocks/blockstest/blocks.go
@@ -99,7 +99,7 @@ func WithOps(ops []hookstest.Op) EthBlockOption {
 type BlockOption = options.Option[blockProperties]
 
 // NewBlock constructs an SAE block, wrapping the raw Ethereum block.
-func NewBlock(tb testing.TB, eth *types.Block, parent, lastSettled *blocks.Block, opts ...BlockOption) *blocks.Block {
+func NewBlock(tb testing.TB, eth *types.Block, parent *blocks.Block, opts ...BlockOption) *blocks.Block {
 	tb.Helper()
 
 	props := options.ApplyTo(&blockProperties{}, opts...)
@@ -107,7 +107,7 @@ func NewBlock(tb testing.TB, eth *types.Block, parent, lastSettled *blocks.Block
 		props.logger = loggingtest.New(tb, logging.Warn)
 	}
 
-	b, err := blocks.New(eth, parent, lastSettled, props.logger)
+	b, err := blocks.New(eth, parent, nil, props.logger)
 	require.NoError(tb, err, "blocks.New()")
 	return b
 }

--- a/vms/saevm/blocks/blockstest/blocks.go
+++ b/vms/saevm/blocks/blockstest/blocks.go
@@ -107,7 +107,7 @@ func NewBlock(tb testing.TB, eth *types.Block, parent *blocks.Block, opts ...Blo
 		props.logger = loggingtest.New(tb, logging.Warn)
 	}
 
-	b, err := blocks.New(eth, parent, nil, props.logger)
+	b, err := blocks.New(eth, parent, hookstest.NewStub(0), props.logger)
 	require.NoError(tb, err, "blocks.New()")
 	return b
 }

--- a/vms/saevm/blocks/blockstest/blocks_test.go
+++ b/vms/saevm/blocks/blockstest/blocks_test.go
@@ -60,7 +60,7 @@ func TestIntegration(t *testing.T) {
 	sdb, err := state.New(bc.Genesis().Root(), state.NewDatabase(db), nil)
 	require.NoError(t, err, "state.New(%T.Genesis().Root())", bc)
 
-	build := NewChainBuilder(NewBlock(t, bc.Genesis(), nil, nil))
+	build := NewChainBuilder(NewBlock(t, bc.Genesis(), nil))
 	dest := common.Address{'d', 'e', 's', 't'}
 	for i := range numBlocks {
 		// Genesis is block 0
@@ -126,7 +126,7 @@ func TestNewGenesis(t *testing.T) {
 	gen := NewGenesis(t, db, config, alloc)
 
 	assert.True(t, gen.Executed(), "genesis.Executed()")
-	require.NoError(t, gen.WaitUntilSettled(t.Context()), "genesis.WaitUntilSettled()")
+	assert.True(t, gen.Settled(), "genesis.Settled()")
 	assert.Equal(t, gen.Hash(), gen.LastSettled().Hash(), "genesis.LastSettled().Hash() is self")
 
 	t.Run("alloc", func(t *testing.T) {

--- a/vms/saevm/blocks/blockstest/chain.go
+++ b/vms/saevm/blocks/blockstest/chain.go
@@ -80,7 +80,7 @@ func (cb *ChainBuilder) NewBlock(tb testing.TB, txs []*types.Transaction, opts .
 
 	last := cb.Last()
 	eth := NewEthBlock(tb, last.EthBlock(), txs, allOpts.eth...)
-	b := NewBlock(tb, eth, last, nil, allOpts.sae...)
+	b := NewBlock(tb, eth, last, allOpts.sae...)
 
 	cb.chain = append(cb.chain, b)
 	cb.blocksByHash.Store(b.Hash(), b)

--- a/vms/saevm/blocks/cmpopt.go
+++ b/vms/saevm/blocks/cmpopt.go
@@ -18,10 +18,11 @@ import (
 // tests.
 func CmpOpt() cmp.Option {
 	return cmp.Options{
-		cmp.AllowUnexported(Block{}, ancestry{}),
+		cmp.AllowUnexported(Block{}),
 		cmpopts.IgnoreFields(
 			Block{},
 			"bounds",
+			"hooks",
 			"interimExecutionTime",
 		),
 		cmputils.IfIn[Block](cmputils.NilSlicesAreEmpty[types.Transactions]()),
@@ -34,7 +35,7 @@ func CmpOpt() cmp.Option {
 		)),
 		cmputils.Blocks(),
 		cmputils.Headers(),
-		cmputils.LoadAtomicPointers[ancestry](),
+		cmputils.LoadAtomicPointers[Block](),
 		cmputils.LoadAtomicPointers[executionResults](),
 		cmp.Comparer((*executionResults).equalForTests),
 	}

--- a/vms/saevm/blocks/execution.go
+++ b/vms/saevm/blocks/execution.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
-	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 
 	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
@@ -259,15 +258,14 @@ func (b *Block) PostExecutionStateRoot() common.Hash {
 // SHOULD consider using [RestoreSettledBlock] instead, if possible.
 //
 // Any error returned corrupts the block's in-memory state.
-func (b *Block) RestoreExecutionArtefacts(hooks hook.Points, db ethdb.Database, xdb saetypes.ExecutionResults, chainConfig *params.ChainConfig) error {
+func (b *Block) RestoreExecutionArtefacts(db ethdb.Database, xdb saetypes.ExecutionResults, chainConfig *params.ChainConfig) error {
 	e, err := loadExecutionResults(xdb, b.NumberU64())
 	if errors.Is(err, database.ErrNotFound) {
 		// TODO(JonathanOppenheimer): missing results result in us assuming
 		// "synchronous" here, so once state sync exist and the database can be
 		// pruned, this would result in async blocks being restored incorrectly.
 		// We can ask [hook.Synchronous] instead?
-		e, err = b.synchronousExecutionResults(hooks)
-		b.synchronous = true
+		e, err = b.synchronousExecutionResults()
 	}
 	if err != nil {
 		return err
@@ -292,10 +290,10 @@ func (b *Block) RestoreExecutionArtefacts(hooks hook.Points, db ethdb.Database, 
 // synchronous block. Unlike asynchronously executed blocks, synchronous blocks
 // do not persist their execution results in the [saetypes.ExecutionResults]
 // database, thus they are extracted from the header.
-func (b *Block) synchronousExecutionResults(hooks hook.Points) (*executionResults, error) {
+func (b *Block) synchronousExecutionResults() (*executionResults, error) {
 	// Target, excess, and config _after_ are a requirement of
 	// [Block.MarkExecuted], as provided by [Block.synchronousGasTime].
-	execTime, err := b.synchronousGasTime(hooks)
+	execTime, err := b.synchronousGasTime()
 	if err != nil {
 		return nil, err
 	}
@@ -315,11 +313,11 @@ func (b *Block) synchronousExecutionResults(hooks hook.Points) (*executionResult
 // synchronousGasTime derives the gas time of a synchronous block, which has no
 // predecessor clock to advance. Inverting the base fee only approximates the
 // excess.
-func (b *Block) synchronousGasTime(hooks hook.Points) (*gastime.Time, error) {
+func (b *Block) synchronousGasTime() (*gastime.Time, error) {
 	hdr := b.Header()
-	target, cfg := hooks.GasConfigAfter(hdr)
+	target, cfg := b.hooks.GasConfigAfter(hdr)
 	return gastime.New(
-		hooks.BlockTime(hdr),
+		b.hooks.BlockTime(hdr),
 		target,
 		gas.Price(b.headerBaseFee()),
 		cfg,

--- a/vms/saevm/blocks/execution_test.go
+++ b/vms/saevm/blocks/execution_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
-	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 
 	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
@@ -50,23 +49,26 @@ func TestMarkExecuted(t *testing.T) {
 		})
 	}
 
-	ethB := types.NewBlock(
-		&types.Header{
-			Number: big.NewInt(1),
-			Time:   42,
-		},
-		txs,
-		nil, nil, // uncles, receipts
-		saetest.TrieHasher(),
-	)
+	bb := newBlockBuilder()
 	db := rawdb.NewMemoryDatabase()
-	rawdb.WriteBlock(db, ethB)
 	xdb := saetest.NewExecutionResultsDB()
 
-	settles := newBlock(t, newEthBlock(0, 0, nil), nil, nil)
+	settles := bb.newFromHooks(t, 0, 0, nil, nil)
 	tm := mustNewGasTime(t, time.Unix(0, 0), 1, 0, gastime.DefaultGasPriceConfig())
 	settles.markExecutedForTests(t, db, xdb, tm)
-	b := newBlock(t, ethB, nil, settles)
+
+	ethB, err := bb.hooks.BuildBlock(
+		&types.Header{
+			ParentHash: settles.Hash(),
+			Number:     big.NewInt(1),
+			Time:       42,
+		},
+		nil, txs, nil, nil,
+		settledBy(settles),
+	)
+	require.NoErrorf(t, err, "%T.BuildBlock()", bb.hooks)
+	rawdb.WriteBlock(db, ethB)
+	b := bb.mustNew(t, ethB, settles)
 
 	t.Run("before_MarkExecuted", func(t *testing.T) {
 		require.False(t, b.Executed(), "Executed()")
@@ -102,10 +104,8 @@ func TestMarkExecuted(t *testing.T) {
 	lastExecuted := new(atomic.Pointer[Block])
 	require.NoError(t, b.MarkExecuted(db, xdb, gasTime, wallTime, baseFee.ToBig(), receipts, stateRoot, lastExecuted), "MarkExecuted()")
 
-	fromDB := newBlock(t, b.EthBlock(), b.ParentBlock(), b.LastSettled())
-	// This block is NOT synchronous, so no hooks are needed.
-	// NOTE: this pattern is only acceptable in tests.
-	require.NoErrorf(t, fromDB.RestoreExecutionArtefacts(nil, db, xdb, saetest.ChainConfig()), "%T.RestoreExecutionArtefacts()", fromDB)
+	fromDB := bb.mustNew(t, b.EthBlock(), b.ParentBlock())
+	require.NoErrorf(t, fromDB.RestoreExecutionArtefacts(db, xdb, saetest.ChainConfig()), "%T.RestoreExecutionArtefacts()", fromDB)
 	tests := []struct {
 		name           string
 		isLastExecuted bool
@@ -183,11 +183,11 @@ func TestRestoreExecutionArtefactsSynchronous(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
 	rawdb.WriteBlock(db, ethB)
 
-	// An empty execution-results DB is what signals the block is synchronous.
+	// An empty [types.Header.Extra] encodes the zero-value [hook.Settled],
+	// which is what marks the block as synchronous.
+	b := newBlockBuilder().mustNew(t, ethB, nil)
 	xdb := saetest.NewExecutionResultsDB()
-	hooks := hookstest.NewStub(1e6)
-	b := newBlock(t, ethB, nil, nil)
-	require.NoErrorf(t, b.RestoreExecutionArtefacts(hooks, db, xdb, saetest.ChainConfig()), "%T.RestoreExecutionArtefacts()", b)
+	require.NoErrorf(t, b.RestoreExecutionArtefacts(db, xdb, saetest.ChainConfig()), "%T.RestoreExecutionArtefacts()", b)
 
 	assert.Truef(t, b.Executed(), "%T.Executed()", b)
 	assert.Truef(t, b.Synchronous(), "%T.Synchronous()", b)

--- a/vms/saevm/blocks/invariants.go
+++ b/vms/saevm/blocks/invariants.go
@@ -194,7 +194,7 @@ func (b *Block) CheckInvariants(expect LifeCycleStage) error {
 		}
 	}
 
-	switch a := b.ancestry.Load(); a {
+	switch a := b.parent.Load(); a {
 	case nil: // settled
 		if expect < Settled {
 			return b.brokenInvariantErr("unexpectedly settled")
@@ -202,9 +202,6 @@ func (b *Block) CheckInvariants(expect LifeCycleStage) error {
 	default: // not settled
 		if expect >= Settled {
 			return b.brokenInvariantErr("expected to be settled")
-		}
-		if b.SettledStateRoot() != b.LastSettled().PostExecutionStateRoot() {
-			return b.brokenInvariantErr("state root does not match last-settled post execution")
 		}
 	}
 

--- a/vms/saevm/blocks/parse_test.go
+++ b/vms/saevm/blocks/parse_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/params"
+	"github.com/ava-labs/libevm/rlp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -149,19 +150,16 @@ func TestParseEthBlock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			log := loggingtest.New(t, logging.Debug)
-
 			hdr := tt.mutate(&types.Header{
 				Number:    big.NewInt(1),
 				UncleHash: types.EmptyUncleHash,
 				TxHash:    types.EmptyTxsHash,
 			})
 			ethB := types.NewBlockWithHeader(hdr).WithBody(tt.body).WithWithdrawals(tt.withdrawals)
+			bytes, err := rlp.EncodeToBytes(ethB)
+			require.NoError(t, err, "rlp.EncodeToBytes()")
 
-			hooks := hookstest.NewStub(0)
-			b, err := New(ethB, nil, hooks, log)
-			require.NoError(t, err, "New()")
-			_, err = ParseEth(b.Bytes(), hooks)
+			_, err = ParseEth(bytes, hookstest.NewStub(0))
 			assert.ErrorIs(t, err, tt.wantErr, "Parse(#%v @ time %v)", hdr.Number, hdr.Time)
 		})
 	}

--- a/vms/saevm/blocks/parse_test.go
+++ b/vms/saevm/blocks/parse_test.go
@@ -174,7 +174,7 @@ func TestParseVerifyBlockSyntax(t *testing.T) {
 		UncleHash: types.EmptyUncleHash,
 		TxHash:    types.EmptyTxsHash,
 	})
-	b, err := New(ethB, nil, nil, log)
+	b, err := New(ethB, nil, hookstest.NewStub(0), log)
 	require.NoError(t, err, "New()")
 	bytes := b.Bytes()
 

--- a/vms/saevm/blocks/parse_test.go
+++ b/vms/saevm/blocks/parse_test.go
@@ -158,9 +158,10 @@ func TestParseEthBlock(t *testing.T) {
 			})
 			ethB := types.NewBlockWithHeader(hdr).WithBody(tt.body).WithWithdrawals(tt.withdrawals)
 
-			b, err := New(ethB, nil, nil, log)
+			hooks := hookstest.NewStub(0)
+			b, err := New(ethB, nil, hooks, log)
 			require.NoError(t, err, "New()")
-			_, err = ParseEth(b.Bytes(), hookstest.NewStub(0))
+			_, err = ParseEth(b.Bytes(), hooks)
 			assert.ErrorIs(t, err, tt.wantErr, "Parse(#%v @ time %v)", hdr.Number, hdr.Time)
 		})
 	}

--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
-	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
@@ -60,7 +59,7 @@ func (b *Block) Settled() bool {
 // Synchronous reports whether the block was marked as synchronous during
 // [RestoreSettledBlock] or [Block.RestoreExecutionArtefacts].
 func (b *Block) Synchronous() bool {
-	return hook.Synchronous(b.hooks, b.Header())
+	return b.synchronous
 }
 
 const (

--- a/vms/saevm/blocks/settlement.go
+++ b/vms/saevm/blocks/settlement.go
@@ -4,7 +4,6 @@
 package blocks
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -18,14 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 )
 
-type ancestry struct {
-	parent, lastSettled *Block
-}
-
-var (
-	errBlockResettled       = errors.New("block re-settled")
-	errBlockAncestryChanged = errors.New("block ancestry changed during settlement")
-)
+var errBlockResettled = errors.New("block re-settled")
 
 // MarkSettled marks the block as having been settled. This function MUST NOT be
 // called more than once. The atomic pointer to the last-settled block is
@@ -41,17 +33,11 @@ func (b *Block) MarkSettled(lastSettled *atomic.Pointer[Block]) error {
 }
 
 func (b *Block) markSettled(lastSettled *atomic.Pointer[Block]) error {
-	a := b.ancestry.Load()
-	if a == nil {
+	if b.Settled() {
 		b.log.Error(errBlockResettled.Error())
 		return fmt.Errorf("%w: block height %d", errBlockResettled, b.Height())
 	}
-	if !b.ancestry.CompareAndSwap(a, nil) { // almost certainly means concurrent calls to this method
-		b.log.Fatal("Block ancestry changed during settlement")
-		// We have to return something to keen the compiler happy, even though we
-		// expect the Fatal to be, well, fatal.
-		return errBlockAncestryChanged
-	}
+	b.parent.Store(nil)
 
 	if lastSettled != nil {
 		lastSettled.Store(b)
@@ -60,63 +46,65 @@ func (b *Block) markSettled(lastSettled *atomic.Pointer[Block]) error {
 	return nil
 }
 
-// WaitUntilSettled blocks until either [Block.MarkSettled] is called or the
-// [context.Context] is cancelled.
-func (b *Block) WaitUntilSettled(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-b.settled:
-		return nil
-	}
-}
-
 // Settled reports whether [Block.MarkSettled] has been called without resulting
 // in an error, or the block was constructed by [RestoreSettledBlock].
 func (b *Block) Settled() bool {
-	return b.ancestry.Load() == nil
+	select {
+	case <-b.settled:
+		return true
+	default:
+		return false
+	}
 }
 
 // Synchronous reports whether the block was marked as synchronous during
 // [RestoreSettledBlock] or [Block.RestoreExecutionArtefacts].
 func (b *Block) Synchronous() bool {
-	return b.synchronous
-}
-
-func (b *Block) ancestor(ifSettledErrMsg string, get func(*ancestry) *Block) *Block {
-	a := b.ancestry.Load()
-	if a == nil {
-		b.log.Error(ifSettledErrMsg)
-		return nil
-	}
-	return get(a)
+	return hook.Synchronous(b.hooks, b.Header())
 }
 
 const (
 	getParentOfSettledErrMsg  = "Get parent of settled block"
-	getSettledOfSettledErrMsg = "Get last-settled of settled block"
+	getSettledOfSettledErrMsg = getParentOfSettledErrMsg + " while finding last-settled"
 )
 
 // ParentBlock returns the block's parent unless [Block.MarkSettled] has been
 // called, in which case it returns nil and logs an error.
 func (b *Block) ParentBlock() *Block {
-	return b.ancestor(getParentOfSettledErrMsg, func(a *ancestry) *Block {
-		return a.parent
-	})
+	p := b.parent.Load()
+	if p == nil && b.Settled() {
+		b.log.Error(getParentOfSettledErrMsg)
+	}
+	return p
 }
 
-// LastSettled returns the last-settled block at the time of b's acceptance,
-// unless [Block.MarkSettled] has been called, in which case it returns nil and
-// logs an error. Note that this value might not be distinct between contiguous
-// blocks. If the block is synchronous, LastSettled always returns b itself,
-// without logging.
+// LastSettled returns the last-settled block at the time of b's acceptance.
+// If [Block.MarkSettled] has been called on any block in the chain between b
+// and the last-settled block, LastSettled returns nil and logs an error.
+//
+// Note that this value might not be distinct between contiguous blocks. If the
+// block is synchronous, LastSettled always returns b itself, without logging.
 func (b *Block) LastSettled() *Block {
-	if b.synchronous {
+	if b.Synchronous() {
 		return b
 	}
-	return b.ancestor(getSettledOfSettledErrMsg, func(a *ancestry) *Block {
-		return a.lastSettled
-	})
+
+	parent := b.parent.Load()
+	if parent == nil {
+		if b.Settled() {
+			b.log.Error(getSettledOfSettledErrMsg)
+		}
+		return nil
+	}
+
+	settledHeight := b.hooks.SettledBy(b.Header()).Height
+	for parent.Height() > settledHeight {
+		parent = parent.ParentBlock() // a settled intermediate logs for itself
+		if parent == nil {
+			return nil
+		}
+	}
+	return parent
 }
 
 // Settles returns the executed blocks that b settles if it is accepted by
@@ -129,10 +117,13 @@ func (b *Block) LastSettled() *Block {
 // b or its parent. If the block is synchronous, Settles always returns a
 // single-element slice of `b` itself.
 func (b *Block) Settles() []*Block {
-	if b.synchronous {
+	if b.Synchronous() {
 		return []*Block{b}
 	}
-	return Range(b.ParentBlock().LastSettled(), b.LastSettled())
+	return Range(
+		b.hooks.SettledBy(b.ParentBlock().Header()).Height,
+		b.LastSettled(),
+	)
 }
 
 // Range returns the blocks in the continuous, half-open interval (start, end]
@@ -143,8 +134,7 @@ func (b *Block) Settles() []*Block {
 // chain from `end`.
 //
 // If the two arguments are the same block, Range returns an empty slice.
-func Range(start, end *Block) []*Block {
-	startHeight := start.Height()
+func Range(startHeight uint64, end *Block) []*Block {
 	endHeight := end.Height()
 	if endHeight <= startHeight {
 		return nil
@@ -176,7 +166,7 @@ var errIncompleteBlockHistory = errors.New("incomplete block history when determ
 //
 // See the Example for [Block.WhenChildSettles] for one usage of the returned
 // block.
-func LastToSettleAt(hooks hook.Points, settleAt time.Time, parent *Block) (b *Block, ok bool, _ error) {
+func LastToSettleAt(settleAt time.Time, parent *Block) (b *Block, ok bool, _ error) {
 	defer func() {
 		// Avoids having to perform this check at every return.
 		if !ok {
@@ -184,6 +174,7 @@ func LastToSettleAt(hooks hook.Points, settleAt time.Time, parent *Block) (b *Bl
 		}
 	}()
 
+	hooks := parent.hooks // presumably all blocks have the same hooks
 	settleAtGasTime := proxytime.Of[gas.Gas](settleAt)
 
 	// A block can be the last to settle at some time i.f.f. two criteria are

--- a/vms/saevm/blocks/settlement_test.go
+++ b/vms/saevm/blocks/settlement_test.go
@@ -4,7 +4,6 @@
 package blocks
 
 import (
-	"context"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -20,8 +19,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
 	"github.com/ava-labs/avalanchego/vms/saevm/gastime"
-	"github.com/ava-labs/avalanchego/vms/saevm/hook"
-	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/params"
 	"github.com/ava-labs/avalanchego/vms/saevm/proxytime"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
@@ -30,7 +27,7 @@ import (
 //nolint:testableexamples // Output is meaningless
 func ExampleRange() {
 	parent := blockBuildingPreference()
-	settle, ok, err := LastToSettleAt(vmHooks(), time.Now().Add(-params.Tau), parent)
+	settle, ok, err := LastToSettleAt(time.Now().Add(-params.Tau), parent)
 	if err != nil {
 		// Due to a malformed input to block verification.
 		return // err
@@ -41,21 +38,24 @@ func ExampleRange() {
 
 	// Returns the (possibly empty) slice of blocks that would be settled by the
 	// block being built.
-	_ = Range(parent.LastSettled(), settle)
+	_ = Range(parent.LastSettled().Height(), settle)
 	// Returns the (possibly empty) slice of blocks that would be left unsettled
 	// by the block being built.
-	_ = Range(settle, parent)
+	_ = Range(settle.Height(), parent)
 }
 
-// blockBuildingPreference and vmHooks exist only to allow examples to build.
+// blockBuildingPreference exists only to allow examples to build.
 func blockBuildingPreference() *Block { return nil }
-func vmHooks() hook.Points            { return nil }
 
 func TestSettlementInvariants(t *testing.T) {
-	parent := newBlock(t, newEthBlock(5, 5, nil), nil, nil)
-	lastSettled := newBlock(t, newEthBlock(3, 3, nil), nil, nil)
+	bb := newBlockBuilder()
+	lastSettled := bb.newFromHooks(t, 3, 3, nil, nil)
+	// [Block.LastSettled] traverses parent links down to the settled height, so
+	// the chain between b and lastSettled must be connected.
+	b4 := bb.newFromHooks(t, 4, 4, lastSettled, lastSettled)
+	parent := bb.newFromHooks(t, 5, 5, b4, lastSettled)
 
-	b := newBlock(t, newEthBlock(6, 10, parent.EthBlock()), parent, lastSettled)
+	b := bb.newFromHooks(t, 6, 10, parent, lastSettled)
 
 	db := rawdb.NewMemoryDatabase()
 	xdb := saetest.NewExecutionResultsDB()
@@ -66,9 +66,6 @@ func TestSettlementInvariants(t *testing.T) {
 
 	t.Run("before_MarkSettled", func(t *testing.T) {
 		require.False(t, b.Settled(), "Settled()")
-		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-		defer cancel()
-		require.ErrorIs(t, b.WaitUntilSettled(ctx), context.DeadlineExceeded, "WaitUntilSettled()")
 
 		if diff := cmp.Diff(parent, b.ParentBlock(), CmpOpt()); diff != "" {
 			t.Errorf("ParentBlock() diff (-constructor arg +got):\n%s", diff)
@@ -88,8 +85,7 @@ func TestSettlementInvariants(t *testing.T) {
 	t.Run("after_MarkSettled", func(t *testing.T) {
 		assert.Equal(t, b, lastSettledPtr.Load(), "Atomic pointer to last-settled block")
 		require.True(t, b.Settled(), "Settled()")
-		assert.NoError(t, b.WaitUntilSettled(t.Context()), "WaitUntilSettled()")
-		assert.NoError(t, b.CheckInvariants(Settled), "CheckInvariants(Settled)")
+		require.NoError(t, b.CheckInvariants(Settled), "CheckInvariants(Settled)")
 
 		rec := loggingtest.NewRecorder(logging.Warn)
 		b.log = rec
@@ -153,7 +149,7 @@ func TestSettles(t *testing.T) {
 		8: nil,
 		9: {4, 5, 6, 7},
 	}
-	blocks := newChain(t, 0, 10, lastSettledAtHeight)
+	blocks := newBlockBuilder().newChain(t, 0, 10, lastSettledAtHeight)
 
 	numsToBlocks := func(nums ...uint64) []*Block {
 		bs := make([]*Block, len(nums))
@@ -180,26 +176,26 @@ func TestSettles(t *testing.T) {
 	for _, b := range blocks[1:] {
 		tests = append(tests, testCase{
 			name: "Range([identical blocks])",
-			got:  Range(b.LastSettled(), b.LastSettled()),
+			got:  Range(b.LastSettled().Height(), b.LastSettled()),
 			want: nil,
 		})
 	}
 
 	tests = append(tests, []testCase{
 		{
-			got:  Range(blocks[7].LastSettled(), blocks[3]),
+			got:  Range(blocks[7].LastSettled().Height(), blocks[3]),
 			want: nil,
 		},
 		{
-			got:  Range(blocks[7].LastSettled(), blocks[4]),
+			got:  Range(blocks[7].LastSettled().Height(), blocks[4]),
 			want: numsToBlocks(4),
 		},
 		{
-			got:  Range(blocks[7].LastSettled(), blocks[5]),
+			got:  Range(blocks[7].LastSettled().Height(), blocks[5]),
 			want: numsToBlocks(4, 5),
 		},
 		{
-			got:  Range(blocks[7].LastSettled(), blocks[6]),
+			got:  Range(blocks[7].LastSettled().Height(), blocks[6]),
 			want: numsToBlocks(4, 5, 6),
 		},
 	}...)
@@ -220,7 +216,7 @@ func TestSettles(t *testing.T) {
 func TestLastToSettleAt(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
 	xdb := saetest.NewExecutionResultsDB()
-	blocks := newChain(t, 0, 30, nil)
+	blocks := newBlockBuilder().newChain(t, 0, 30, nil)
 	t.Run("helper_invariants", func(t *testing.T) {
 		for i, b := range blocks {
 			require.Equal(t, uint64(i), b.Height()) //#nosec G115 -- Slice index won't overflow
@@ -366,7 +362,7 @@ func TestLastToSettleAt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			settleAt := time.Unix(int64(tt.settleAt), 0) //#nosec G115 -- Hard-coded, non-overflowing values
-			got, gotOK, err := LastToSettleAt(hookstest.NewStub(0), settleAt, tt.parent)
+			got, gotOK, err := LastToSettleAt(settleAt, tt.parent)
 			if err != nil || gotOK != tt.wantOK {
 				t.Fatalf("LastToSettleAt(%d, [parent height %d]) got (_, %t, %v); want (_, %t, nil)", tt.settleAt, tt.parent.Height(), gotOK, err, tt.wantOK)
 			}

--- a/vms/saevm/sae/accept_block_test.go
+++ b/vms/saevm/sae/accept_block_test.go
@@ -67,7 +67,6 @@ func TestAcceptBlock(t *testing.T) {
 				wantInMemory.Add(
 					bb.Height(),
 					bb.ParentBlock().Height(),
-					bb.LastSettled().Height(),
 				)
 			}
 		}

--- a/vms/saevm/sae/block_builder.go
+++ b/vms/saevm/sae/block_builder.go
@@ -33,7 +33,7 @@ type blockBuilder interface {
 	// new constructs a [blocks.Block] with the provided arguments. It is
 	// allowed for parent and lastSettled to be nil as an indication that the
 	// block hasn't yet been verified.
-	new(eth *types.Block, parent, lastSettled *blocks.Block) (*blocks.Block, error)
+	new(eth *types.Block, parent *blocks.Block) (*blocks.Block, error)
 	// build a new block on top of the provided parent. The block context MAY be
 	// nil.
 	build(ctx context.Context, bCtx *block.Context, parent *blocks.Block) (*blocks.Block, error)
@@ -53,8 +53,8 @@ type blockBuilderG[T hook.Transaction] struct {
 	source  saetypes.BlockSource
 }
 
-func (b *blockBuilderG[_]) new(eth *types.Block, parent, lastSettled *blocks.Block) (*blocks.Block, error) {
-	return blocks.New(eth, parent, lastSettled, b.log)
+func (b *blockBuilderG[_]) new(eth *types.Block, parent *blocks.Block) (*blocks.Block, error) {
+	return blocks.New(eth, parent, b.hooks, b.log)
 }
 
 func (b *blockBuilderG[_]) build(
@@ -184,7 +184,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		return nil, err
 	}
 
-	unsettled := blocks.Range(lastSettled, parent)
+	unsettled := blocks.Range(lastSettled.Height(), parent)
 	for _, block := range unsettled {
 		blockLog := log.With(
 			zap.Uint64("block_height", block.Height()),
@@ -339,7 +339,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 	}
 
 	var receipts types.Receipts
-	settling := blocks.Range(parent.LastSettled(), lastSettled)
+	settling := blocks.Range(parent.LastSettled().Height(), lastSettled)
 	for _, b := range settling {
 		receipts = append(receipts, b.Receipts()...)
 	}
@@ -365,7 +365,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 		return nil, err
 	}
 
-	block, err := b.new(ethB, parent, lastSettled)
+	block, err := b.new(ethB, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ func lastToSettle(
 	}
 
 	// Underflow of Add(-tau) is prevented by the above check.
-	lastSettled, ok, err := blocks.LastToSettleAt(hooks, bTime.Add(-saeparams.Tau), parent)
+	lastSettled, ok, err := blocks.LastToSettleAt(bTime.Add(-saeparams.Tau), parent)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/saevm/sae/blocks.go
+++ b/vms/saevm/sae/blocks.go
@@ -35,7 +35,7 @@ func (vm *VM) ParseBlock(ctx context.Context, buf []byte) (*blocks.Block, error)
 		return nil, err
 	}
 
-	return vm.blockBuilder.new(b, nil, nil)
+	return vm.blockBuilder.new(b, nil)
 }
 
 // BuildBlock builds a new block, using the last block passed to
@@ -89,7 +89,7 @@ func (vm *VM) VerifyBlock(ctx context.Context, bCtx *block.Context, b *blocks.Bl
 		)
 		return fmt.Errorf("%w; rebuilt as %#x when verifying %#x", errHashMismatch, reH, verH)
 	}
-	if err := b.CopyAncestorsFrom(rebuilt); err != nil {
+	if err := b.CopyParentFrom(rebuilt); err != nil {
 		return err
 	}
 	b.SetWorstCaseBounds(rebuilt.WorstCaseBounds())
@@ -122,7 +122,7 @@ func (vm *VM) verifyWhenBootstrapping(b, parent *blocks.Block) error {
 	if got, want := lastSettled.NumberU64(), vm.hooks.SettledBy(header).Height; got != want {
 		return fmt.Errorf("%w: got %d ; want %d", errSettledHeightMismatch, got, want)
 	}
-	if err := b.SetAncestors(parent, lastSettled); err != nil {
+	if err := b.SetParent(parent); err != nil {
 		return err
 	}
 

--- a/vms/saevm/sae/recovery.go
+++ b/vms/saevm/sae/recovery.go
@@ -45,7 +45,7 @@ func (rec *recovery) newCanonicalBlock(num uint64, parent *blocks.Block) (*block
 	if err != nil {
 		return nil, err
 	}
-	return blocks.New(ethB, parent, nil, rec.snowCtx.Log)
+	return blocks.New(ethB, parent, rec.hooks, rec.snowCtx.Log)
 }
 
 // lastCommittedBlock returns the highest settled block whose post-execution
@@ -285,7 +285,10 @@ func (rec *recovery) populateConsensusCriticalBlocks(exec *saexec.Executor, bMap
 				if err != nil {
 					return err
 				}
-				if err := parent.RestoreExecutionArtefacts(rec.hooks, rec.db, rec.xdb, rec.chainConfig); err != nil {
+				if err := parent.RestoreExecutionArtefacts(rec.db, rec.xdb, rec.chainConfig); err != nil {
+					return err
+				}
+				if err := b.SetParent(parent); err != nil {
 					return err
 				}
 				chain = append(chain, parent)
@@ -308,14 +311,6 @@ func (rec *recovery) populateConsensusCriticalBlocks(exec *saexec.Executor, bMap
 		bMap.Store(b.Hash(), b)
 	}
 
-	for i, b := range chain[:len(chain)-1] {
-		if err := extend(b); err != nil {
-			return err
-		}
-		if err := b.SetAncestors(chain[i+1], lastOf(chain)); err != nil {
-			return err
-		}
-	}
 	for _, b := range bMap.m {
 		stage := blocks.Executed
 		if b.Hash() == lastSettled.Hash() {

--- a/vms/saevm/sae/rpc.go
+++ b/vms/saevm/sae/rpc.go
@@ -53,8 +53,8 @@ func (c chain) ResolvePendingToLastExecuted() bool {
 	return c.VM.config.RPCConfig.ResolvePendingToLastExecuted
 }
 
-func (c chain) NewBlock(eth *types.Block, parent, lastSettled *blocks.Block) (*blocks.Block, error) {
-	return c.blockBuilder.new(eth, parent, lastSettled)
+func (c chain) NewBlock(eth *types.Block, parent *blocks.Block) (*blocks.Block, error) {
+	return c.blockBuilder.new(eth, parent)
 }
 
 func (c chain) SubscribeAcceptedBlocks(ch chan<- *blocks.Block) event.Subscription {

--- a/vms/saevm/sae/rpc/rpc.go
+++ b/vms/saevm/sae/rpc/rpc.go
@@ -50,7 +50,7 @@ type Chain interface {
 	// Execution results and replay
 	saedb.StateDBOpener
 	RecentReceipt(context.Context, common.Hash) (*saexec.Receipt, bool, error)
-	NewBlock(eth *types.Block, parent, lastSettled *blocks.Block) (*blocks.Block, error)
+	NewBlock(eth *types.Block, parent *blocks.Block) (*blocks.Block, error)
 
 	// Subscriptions
 	SubscribeAcceptedBlocks(chan<- *blocks.Block) event.Subscription

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -173,7 +173,7 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 	if err != nil {
 		return nil, bCtx, nil, nil, fmt.Errorf("restoring parent block: %w", err)
 	}
-	block, err := b.NewBlock(ethB, parent, nil)
+	block, err := b.NewBlock(ethB, parent)
 	if err != nil {
 		return nil, bCtx, nil, nil, fmt.Errorf("constructing SAE block: %v", err)
 	}

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -496,7 +496,7 @@ func TestVerifyBlockSizeLimit(t *testing.T) {
 		nil, // receipts
 		saetest.TrieHasher(),
 	)
-	b := blockstest.NewBlock(t, ethB, nil, nil)
+	b := blockstest.NewBlock(t, ethB, nil)
 	require.ErrorIs(t, sut.rawVM.VerifyBlock(ctx, nil, b), errBlockTooLarge, "VerifyBlock()")
 }
 
@@ -956,7 +956,7 @@ func TestSemanticBlockChecks(t *testing.T) {
 				tt.receipts,
 				saetest.TrieHasher(),
 			)
-			b := blockstest.NewBlock(t, ethB, nil, nil)
+			b := blockstest.NewBlock(t, ethB, nil)
 			require.ErrorIs(t, sut.rawVM.VerifyBlock(ctx, nil, b), tt.wantErr, "VerifyBlock()")
 		})
 	}

--- a/vms/saevm/statesync/handler.go
+++ b/vms/saevm/statesync/handler.go
@@ -119,7 +119,7 @@ func (h *SummaryHandler) ParseBlock(_ context.Context, blkBytes []byte) (*blocks
 	if err != nil {
 		return nil, err
 	}
-	return blocks.New(ethB, nil, nil, h.log)
+	return blocks.New(ethB, nil, h.hooks, h.log)
 }
 
 // GetBlock returns the block with the given ID. If the block is not found, it
@@ -137,7 +137,7 @@ func (h *SummaryHandler) GetBlock(_ context.Context, id ids.ID) (*blocks.Block, 
 		return nil, err
 	}
 
-	return blocks.New(ethB, nil, nil, h.log)
+	return blocks.New(ethB, nil, h.hooks, h.log)
 }
 
 // LastAccepted returns the ID of the last accepted block. If no blocks have


### PR DESCRIPTION
## Why this should be merged

A bug was uncovered with state sync in #5822, where a block is unable to restore the execution results of a settled block, since only the last settled will have them. Of course, this is the only block that actually needs them. This PR attempts to address the root of the problem, which is requiring a settled pointer.

## How this works

Removes settled pointer, and instead relies on tracing through parents.

## How this was tested

Existing UT

## Need to be documented in RELEASES.md?

No
