### PR TITLE
[ci] Remove duplicate C-Chain re-execution coverage on PRs

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.json
@@ -2,13 +2,8 @@
     "pull_request": {
         "include": [
             {
-                "runner": "ubuntu-24.04",
-                "test": "hashdb-101-250k",
-                "timeout-minutes": 30
-            },
-            {
                 "runner": "avalanche-avalanchego-runner-2ti",
-                "test": "hashdb-101-250k",
+                "test": "hashdb-archive-101-250k",
                 "timeout-minutes": 30
             }
         ]

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.json
@@ -2,18 +2,8 @@
     "pull_request": {
         "include": [
             {
-              "runner": "ubuntu-24.04",
-              "test": "hashdb-101-250k",
-              "timeout-minutes": 30
-            },
-            {
-                "runner": "blacksmith-4vcpu-ubuntu-2404",
+                "runner": "ubuntu-24.04",
                 "test": "hashdb-101-250k",
-                "timeout-minutes": 30
-            },
-            {
-                "runner": "blacksmith-4vcpu-ubuntu-2404",
-                "test": "hashdb-archive-101-250k",
                 "timeout-minutes": 30
             }
         ]


### PR DESCRIPTION
## Why this should be merged

Previously there were 5 PR jobs running C-Chain re-execution configurations on native or self-hosted runners but only 2 configurations. Switch to running one configuration native and one self-hosted to remove the duplication while retaining coverage both of each configuration and of each mode of execution (native and self-hosted).