### PR TITLE
[e2e] Ensure consistency with SAE execution semantics

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -518,7 +518,7 @@ tasks:
     cmds:
       - task: build-race
       - task: build-xsvm
-      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=0'
+      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=0 {{.CLI_ARGS}}'
 
   test-e2e-ci-schedule-latest:
     desc: Runs e2e tests [serially with race detection enabled] and schedules latest activation after 4 minutes
@@ -527,7 +527,7 @@ tasks:
     cmds:
       - task: build-race
       - task: build-xsvm
-      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=4m'
+      - cmd: '{{.NIX_RUN}} bash -x ./scripts/tests.e2e.sh --activate-latest-after=4m {{.CLI_ARGS}}'
 
   test-e2e-existing-ci:
     desc: Runs e2e tests with an existing network [serially with race detection enabled]

--- a/tests/antithesis/avalanchego/main.go
+++ b/tests/antithesis/avalanchego/main.go
@@ -997,6 +997,10 @@ func (w *workload) confirmCChainTx(ctx context.Context, tx *types.Transaction) e
 			return fmt.Errorf("failed to get receipt for tx %s on %s: %w", txHash, uri, err)
 		}
 
+		if err := e2e.WaitForEthBlockExecution(ctx, client, receipt.BlockNumber); err != nil {
+			return fmt.Errorf("failed to wait for execution of tx %s on %s: %w", txHash, uri, err)
+		}
+
 		if receipt.Status != types.ReceiptStatusSuccessful {
 			// A failed receipt should be unreachable for this workload. These are
 			// funded EOA self-transfers with the accepted nonce, no calldata, and

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,6 +13,24 @@
 
 See [`tests.e2e.sh`](../../scripts/tests.e2e.sh) for an example.
 
+Prefer the task entrypoint, which builds the required binaries before invoking
+Ginkgo:
+
+```bash
+task test-e2e
+```
+
+Do not use `go test ./tests/e2e/...` to run this suite. The packages beneath
+`tests/e2e` register Ginkgo specs, but the suite executes only through the
+Ginkgo runner in `tests/e2e/e2e_test.go`.
+
+E2E specs are usually one per file. To run one spec through the task
+entrypoint, pass that file to Ginkgo:
+
+```bash
+task test-e2e -- --ginkgo.focus-file=c/interchain_workflow
+```
+
 ### Simplifying usage with direnv
 
 For repo-level `direnv` setup and behavior, see [CONTRIBUTING.md](../../CONTRIBUTING.md#direnv).
@@ -55,6 +73,26 @@ tests
 
 `x/transfer/virtuous.go` defines X-Chain transfer tests,
 labeled with `x`, which can be selected by `--label-filter=x`.
+
+### SAE C-Chain API ordering
+
+SAE can return an EVM transaction receipt when it marks a transaction
+executed, before the containing block is fully executed. The C-Chain `latest`
+state can therefore omit the transaction's nonce, balance changes, and other
+state changes. This ordering can occur even on a single node or when running a
+Ginkgo suite serially.
+
+The required synchronization depends on the assertion:
+
+- Use `SendEthTransactionAndWait` before a wallet snapshot or another read of
+  `latest`. It waits until the receipt block state is available.
+- `SendEthTransaction` waits only for a receipt. The code using it needs to
+  record a nonce from accepted state, then advances that nonce locally for
+  each transaction.
+- Use `WaitForEthBlockExecution` after a receipt obtained through another API.
+- When an assertion must read the state produced by one transaction, read
+  state at that transaction's inclusion height. This also waits for the
+  block's execution.
 
 ## Reusing temporary networks
 

--- a/tests/e2e/c/api.go
+++ b/tests/e2e/c/api.go
@@ -55,8 +55,8 @@ var _ = e2e.DescribeCChain("[ProposerVM API]", ginkgo.Label("proposervm"), func(
 				signedTx, err := types.SignTx(tx, signer, senderKey.ToECDSA())
 				require.NoError(err)
 
-				// Send the transaction and wait for receipt
-				receipt := e2e.SendEthTransaction(tc, ethClient, signedTx)
+				// Send the transaction and wait for its block state
+				receipt := e2e.SendEthTransactionAndWait(tc, ethClient, signedTx)
 				require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 			}
 		})

--- a/tests/e2e/c/interchain_workflow.go
+++ b/tests/e2e/c/interchain_workflow.go
@@ -64,15 +64,14 @@ var _ = e2e.DescribeCChain("[Interchain Workflow]", func() {
 			signedTx, err := types.SignTx(tx, signer, senderKey.ToECDSA())
 			require.NoError(err)
 
-			receipt := e2e.SendEthTransaction(tc, ethClient, signedTx)
+			receipt := e2e.SendEthTransactionAndWait(tc, ethClient, signedTx)
 			require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 
-			tc.By("waiting for the C-Chain recipient address to have received the sent funds")
-			tc.Eventually(func() bool {
+			tc.By("checking that the C-Chain recipient address received the sent funds", func() {
 				balance, err := ethClient.BalanceAt(tc.DefaultContext(), recipientEthAddress, nil)
 				require.NoError(err)
-				return balance.Cmp(big.NewInt(0)) > 0
-			}, e2e.DefaultTimeout, e2e.DefaultPollingInterval, "failed to see funds delivered before timeout")
+				require.Positive(balance.Cmp(big.NewInt(0)))
+			})
 		})
 
 		// Wallet must be initialized after sending funds on the

--- a/tests/e2e/c/proposervm_epoch.go
+++ b/tests/e2e/c/proposervm_epoch.go
@@ -102,6 +102,6 @@ func issueTransaction(
 	signedTx, err := types.SignTx(tx, signer, senderKey.ToECDSA())
 	require.NoError(tc, err)
 
-	receipt := e2e.SendEthTransaction(tc, ethClient, signedTx)
+	receipt := e2e.SendEthTransactionAndWait(tc, ethClient, signedTx)
 	require.Equal(tc, types.ReceiptStatusSuccessful, receipt.Status)
 }

--- a/tests/fixture/e2e/BUILD.bazel
+++ b/tests/fixture/e2e/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//wallet/subnet/primary",
         "//wallet/subnet/primary/common",
         "@com_github_ava_labs_libevm//:libevm",
+        "@com_github_ava_labs_libevm//common",
         "@com_github_ava_labs_libevm//core/types",
         "@com_github_onsi_ginkgo_v2//:ginkgo",
         "@com_github_spf13_cast//:cast",

--- a/tests/fixture/e2e/helpers.go
+++ b/tests/fixture/e2e/helpers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 
 	ethereum "github.com/ava-labs/libevm"
+	ethcommon "github.com/ava-labs/libevm/common"
 )
 
 const (
@@ -168,8 +169,7 @@ func WaitForHealthy(t require.TestingT, node *tmpnet.Node) {
 	require.NoError(t, node.WaitForHealthy(ctx))
 }
 
-// Sends an eth transaction and waits for the transaction receipt from the
-// execution of the transaction.
+// Sends an eth transaction and waits for its receipt.
 func SendEthTransaction(tc tests.TestContext, ethClient *ethclient.Client, signedTx *types.Transaction) *types.Receipt {
 	require := require.New(tc)
 
@@ -198,7 +198,37 @@ func SendEthTransaction(tc tests.TestContext, ethClient *ethclient.Client, signe
 		zap.Stringer("gasPrice", receipt.EffectiveGasPrice),
 		zap.Stringer("blockNumber", receipt.BlockNumber),
 	)
+
 	return receipt
+}
+
+// SendEthTransactionAndWait sends an eth transaction and waits for the state
+// of its receipt block to be fully executed.
+func SendEthTransactionAndWait(tc tests.TestContext, ethClient *ethclient.Client, signedTx *types.Transaction) *types.Receipt {
+	receipt := SendEthTransaction(tc, ethClient, signedTx)
+	require.NoError(tc, WaitForEthBlockExecution(
+		tc.DefaultContext(),
+		ethClient,
+		receipt.BlockNumber,
+	))
+	return receipt
+}
+
+// WaitForEthBlockExecution waits for the state of the block at [blockNumber]
+// to be fully executed.
+func WaitForEthBlockExecution(
+	ctx context.Context,
+	ethClient *ethclient.Client,
+	blockNumber *big.Int,
+) error {
+	if blockNumber == nil {
+		return errors.New("missing block number")
+	}
+
+	// SAE can return a receipt before the containing block is fully executed.
+	// A state read at the block's height waits for that execution.
+	_, err := ethClient.BalanceAt(ctx, ethcommon.Address{}, blockNumber)
+	return err
 }
 
 // Determines the suggested gas price for the configured client that will


### PR DESCRIPTION
**EDIT: This approach is not fit for purpose. This PR will remain in draft until a workable solution is found**

## Why this should be merged

PR #5566 removed API ordering assumptions from e2e tests, but didn't ensure that all tests were compatible with SAE's separation of transaction acceptance from execution (as per a [recent flake](https://github.com/ava-labs/avalanchego/actions/runs/32314949019/job/96265175013?pr=5843#step:3:2504)). This change attempts to ensure that all e2e tests are compatible with that separation.

As part of this change, e2e test documentation and tasks were updated for clarity.