### PR TITLE
[ci] Disable load_kube_kind pending bazel-ification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
       - test_build_antithesis_xsvm_images
       - e2e_bootstrap_monitor
       - load
-      - load_kube_kind
+      # Re-enable once images are built by Bazel and can be cached; otherwise, this job is too expensive for what it evaluates.
+      # - load_kube_kind
       - robustness
     runs-on: ubuntu-24.04
     steps:
@@ -352,24 +353,25 @@ jobs:
           loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
-  load_kube_kind:
-    name: Run load test on kind cluster
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/run-monitored-tmpnet-cmd
-        with:
-          run: ./scripts/run_task.sh test-load-kube-kind-ci
-          runtime: kube
-          artifact_prefix: load-kube
-          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
-          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
-          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
-          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
-          loki_url: ${{ secrets.LOKI_URL || '' }}
-          loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
-          loki_username: ${{ secrets.LOKI_USERNAME || '' }}
-          loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
+  # Re-enable once images are built by Bazel and can be cached; otherwise, this job is too expensive for what it evaluates.
+  # load_kube_kind:
+  #   name: Run load test on kind cluster
+  #   runs-on: ubuntu-24.04
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #     - uses: ./.github/actions/run-monitored-tmpnet-cmd
+  #       with:
+  #         run: ./scripts/run_task.sh test-load-kube-kind-ci
+  #         runtime: kube
+  #         artifact_prefix: load-kube
+  #         prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
+  #         prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+  #         prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+  #         prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+  #         loki_url: ${{ secrets.LOKI_URL || '' }}
+  #         loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
+  #         loki_username: ${{ secrets.LOKI_USERNAME || '' }}
+  #         loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
   robustness:
     runs-on: ubuntu-24.04
     defaults:


### PR DESCRIPTION
## Why this should be merged

The load_kube_kind job validates execution of the nascent load test machinery on a local kind cluster. The job is one of the longest in terms of runtime on PRs without providing much value for that runtime - it's only really validating the correct behavior of scripts/tests.load.kube.kind.sh. The load test is validated by the process-based job variant and tmpnet's kube support is validated by the e2e-kube job.

Pending bazelification of the job so that caching will be possible, disable the job to avoid extending CI runtime unnecessarily.
