### PR TITLE
fix(statesync): Disallow synchronous summaries

### DIFF
--- a/vms/saevm/cchain/statesync/BUILD.bazel
+++ b/vms/saevm/cchain/statesync/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
     embed = [":statesync"],
     deps = [
         "//chains/atomic",
+        "//database",
         "//database/memdb",
         "//database/prefixdb",
         "//snow/engine/enginetest",

--- a/vms/saevm/cchain/statesync/handler_test.go
+++ b/vms/saevm/cchain/statesync/handler_test.go
@@ -226,18 +226,6 @@ func TestGetLastStateSummary(t *testing.T) {
 	require.Equal(t, sut.wantRoot(t, lastCommitted), got.settledRoot, "GetLastStateSummary().settledRoot")
 }
 
-// TestOnlyGenesis asserts that a chain containing only the genesis block has
-// no servable summaries: the genesis block is synchronous.
-func TestOnlyGenesis(t *testing.T) {
-	handler := newSUT(t)
-
-	_, err := handler.GetLastStateSummary(t.Context())
-	require.ErrorIs(t, err, database.ErrNotFound, "GetLastStateSummary()")
-
-	_, err = handler.GetStateSummary(t.Context(), 0)
-	require.ErrorIs(t, err, database.ErrNotFound, "GetStateSummary(0)")
-}
-
 func TestWaitForEvent(t *testing.T) {
 	handler := newSUT(t)
 	ctx, cancel := context.WithCancel(t.Context())

--- a/vms/saevm/cchain/statesync/handler_test.go
+++ b/vms/saevm/cchain/statesync/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
@@ -195,7 +196,7 @@ func TestGetStateSummary(t *testing.T) {
 
 	// Only committed heights can be served. Each settles a distinct, earlier
 	// height, so an incorrect height selection would embed a different root.
-	for _, blockHeight := range []uint64{0, commitInterval, 2 * commitInterval} {
+	for _, blockHeight := range []uint64{commitInterval, 2 * commitInterval} {
 		t.Run(fmt.Sprintf("height_%d", blockHeight), func(t *testing.T) {
 			got, err := sut.GetStateSummary(t.Context(), blockHeight)
 			require.NoErrorf(t, err, "GetStateSummary(%d)", blockHeight)
@@ -203,6 +204,13 @@ func TestGetStateSummary(t *testing.T) {
 			require.Equalf(t, sut.wantRoot(t, blockHeight), got.settledRoot, "GetStateSummary(%d).settledRoot", blockHeight)
 		})
 	}
+
+	// The genesis block is synchronous, so its summary must not be served
+	// even though height 0 is a committed height.
+	t.Run("height_0", func(t *testing.T) {
+		_, err := sut.GetStateSummary(t.Context(), 0)
+		require.ErrorIs(t, err, database.ErrNotFound, "GetStateSummary(0)")
+	})
 }
 
 func TestGetLastStateSummary(t *testing.T) {
@@ -218,18 +226,16 @@ func TestGetLastStateSummary(t *testing.T) {
 	require.Equal(t, sut.wantRoot(t, lastCommitted), got.settledRoot, "GetLastStateSummary().settledRoot")
 }
 
+// TestOnlyGenesis asserts that a chain containing only the genesis block has
+// no servable summaries: the genesis block is synchronous.
 func TestOnlyGenesis(t *testing.T) {
 	handler := newSUT(t)
 
-	got, err := handler.GetLastStateSummary(t.Context())
-	require.NoError(t, err, "GetLastStateSummary()")
-	require.Equal(t, uint64(0), got.Height(), "GetLastStateSummary().Height()")
-	require.Equal(t, types.EmptyRootHash, got.settledRoot, "GetLastStateSummary().settledRoot")
+	_, err := handler.GetLastStateSummary(t.Context())
+	require.ErrorIs(t, err, database.ErrNotFound, "GetLastStateSummary()")
 
-	got, err = handler.GetStateSummary(t.Context(), 0)
-	require.NoError(t, err, "GetStateSummary(0)")
-	require.Equal(t, uint64(0), got.Height(), "GetStateSummary(0).Height()")
-	require.Equal(t, types.EmptyRootHash, got.settledRoot, "GetStateSummary(0).settledRoot")
+	_, err = handler.GetStateSummary(t.Context(), 0)
+	require.ErrorIs(t, err, database.ErrNotFound, "GetStateSummary(0)")
 }
 
 func TestWaitForEvent(t *testing.T) {

--- a/vms/saevm/statesync/handler.go
+++ b/vms/saevm/statesync/handler.go
@@ -74,7 +74,7 @@ func parser(hooks hook.Points) syncblocks.Parser {
 
 // GetLastStateSummary returns the summary of the last accepted block at
 // multiple of [syncCommitInterval] height.
-func (h *Handler) GetLastStateSummary(ctx context.Context) (*Summary, error) {
+func (h *Handler) GetLastStateSummary(context.Context) (*Summary, error) {
 	hash, err := h.lastAcceptedHash()
 	if err != nil {
 		return nil, err
@@ -89,24 +89,40 @@ func (h *Handler) GetLastStateSummary(ctx context.Context) (*Summary, error) {
 	}
 
 	height := saedb.LastCommittedTrieDBHeight(*lastHeight, h.cfg.DBConfig.CommitInterval)
-	return h.GetStateSummary(ctx, height)
+	return h.getSummaryAtHeight(height)
 }
 
 // GetStateSummary returns the summary of the block at the given height, if it
 // is available to be served. Otherwise, [database.ErrNotFound] is returned.
-//
-// TODO(alarso16): don't serve summaries for synchronous blocks.
 func (h *Handler) GetStateSummary(ctx context.Context, height uint64) (*Summary, error) {
 	if !saedb.ShouldCommitTrieDB(height, h.cfg.DBConfig.CommitInterval) {
 		// can't serve committed state at this height
 		return nil, database.ErrNotFound
 	}
+	return h.getSummaryAtHeight(height)
+}
 
-	id, err := h.GetBlockIDAtHeight(ctx, height)
+func (h *Handler) getSummaryAtHeight(height uint64) (*Summary, error) {
+	hash, err := h.getHashAtHeight(height)
 	if err != nil {
 		return nil, err
 	}
-	return NewSummary(common.Hash(id), height), nil
+
+	hdr := rawdb.ReadHeader(h.db, hash, height)
+	if hdr == nil {
+		h.snowCtx.Log.Warn("rawdb.ReadHeader in getSummaryAtHeight",
+			zap.Stringer("hash", hash),
+			zap.Uint64("height", height),
+		)
+		return nil, database.ErrNotFound
+	}
+
+	// State sync will not work with synchronous blocks.
+	if hook.Synchronous(h.hooks, hdr) {
+		return nil, database.ErrNotFound
+	}
+
+	return NewSummary(hash, height), nil
 }
 
 // ParseBlock parses the given bytes into a [blocks.Block] via [blocks.ParseEth]
@@ -151,11 +167,16 @@ func (h *Handler) LastAccepted(context.Context) (ids.ID, error) {
 // GetBlockIDAtHeight returns the ID of the block at the given height. If no
 // block exists at that height, it returns [database.ErrNotFound].
 func (h *Handler) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, error) {
+	hash, err := h.getHashAtHeight(height)
+	return ids.ID(hash), err
+}
+
+func (h *Handler) getHashAtHeight(height uint64) (common.Hash, error) {
 	hash := rawdb.ReadCanonicalHash(h.db, height)
 	if hash == (common.Hash{}) {
-		return ids.Empty, database.ErrNotFound
+		return common.Hash{}, database.ErrNotFound
 	}
-	return ids.ID(hash), nil
+	return hash, nil
 }
 
 // lastAcceptedHash returns the hash of the last accepted block, and whether

--- a/vms/saevm/statesync/handler.go
+++ b/vms/saevm/statesync/handler.go
@@ -94,7 +94,7 @@ func (h *Handler) GetLastStateSummary(context.Context) (*Summary, error) {
 
 // GetStateSummary returns the summary of the block at the given height, if it
 // is available to be served. Otherwise, [database.ErrNotFound] is returned.
-func (h *Handler) GetStateSummary(ctx context.Context, height uint64) (*Summary, error) {
+func (h *Handler) GetStateSummary(_ context.Context, height uint64) (*Summary, error) {
 	if !saedb.ShouldCommitTrieDB(height, h.cfg.DBConfig.CommitInterval) {
 		// can't serve committed state at this height
 		return nil, database.ErrNotFound

--- a/vms/saevm/statesync/handler_test.go
+++ b/vms/saevm/statesync/handler_test.go
@@ -56,50 +56,127 @@ func TestBlock(t *testing.T) {
 	})
 }
 
-func TestStateSummary(t *testing.T) {
+// TestGetStateSummary asserts that a summary is served only for an
+// asynchronous block at a committed height.
+func TestGetStateSummary(t *testing.T) {
 	t.Parallel()
 
-	const numBlocks = defaultCommitInterval + 1
-	vm := newVM(t)
-	vm.acceptBlocks(t, numBlocks)
-	h := vm.Handler
-	lastCommitted := vm.blockAtHeight(t, defaultCommitInterval).EthBlock() // last block at a commit boundary
+	const (
+		lastCommitted = defaultCommitInterval
+		numBlocks     = defaultCommitInterval + 1
+	)
 
-	t.Run("GetLastStateSummary", func(t *testing.T) {
-		summary, err := h.GetLastStateSummary(t.Context())
-		require.NoError(t, err)
-		checkSummaryMatchesBlock(t, summary, lastCommitted)
-	})
+	tests := []struct {
+		name            string
+		numBlocks       uint64
+		lastSynchronous uint64
+		height          uint64
+		wantErr         error
+	}{
+		{
+			name:      "committed_height",
+			numBlocks: numBlocks,
+			height:    lastCommitted,
+		},
+		{
+			name:      "uncommitted_height",
+			numBlocks: numBlocks,
+			height:    numBlocks,
+			wantErr:   database.ErrNotFound,
+		},
+		{
+			name:      "unknown_committed_height",
+			numBlocks: numBlocks,
+			height:    2 * defaultCommitInterval,
+			wantErr:   database.ErrNotFound,
+		},
+		{
+			name:      "genesis",
+			numBlocks: numBlocks,
+			height:    0,
+			wantErr:   database.ErrNotFound,
+		},
+		{
+			name:            "synchronous_committed_height",
+			numBlocks:       numBlocks,
+			lastSynchronous: lastCommitted,
+			height:          lastCommitted,
+			wantErr:         database.ErrNotFound,
+		},
+	}
 
-	t.Run("GetStateSummary_at_committed_height", func(t *testing.T) {
-		summary, err := h.GetStateSummary(t.Context(), lastCommitted.NumberU64())
-		require.NoError(t, err)
-		checkSummaryMatchesBlock(t, summary, lastCommitted)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("GetStateSummary_at_uncommitted_height", func(t *testing.T) {
-		_, err := h.GetStateSummary(t.Context(), numBlocks)
-		require.Equal(t, database.ErrNotFound, err)
-	})
+			vm := newVM(t, withLastSynchronous(tt.lastSynchronous))
+			vm.acceptBlocks(t, tt.numBlocks)
+
+			summary, err := vm.Handler.GetStateSummary(t.Context(), tt.height)
+			require.ErrorIs(t, err, tt.wantErr)
+			if tt.wantErr != nil {
+				return
+			}
+			checkSummaryMatchesBlock(t, summary, vm.blockAtHeight(t, tt.height).EthBlock())
+		})
+	}
 }
 
-func TestGenesisStateSummary(t *testing.T) {
+// TestGetLastStateSummary asserts that the last summary is served only if the
+// block at the last committed height is asynchronous.
+func TestGetLastStateSummary(t *testing.T) {
 	t.Parallel()
 
-	sut := newSUT(t)
-	genesis := sut.genesis.ToBlock()
+	const (
+		lastCommitted = defaultCommitInterval
+		numBlocks     = defaultCommitInterval + 1
+	)
 
-	t.Run("GetLastStateSummary", func(t *testing.T) {
-		summary, err := sut.GetLastStateSummary(t.Context())
-		require.NoError(t, err)
-		checkSummaryMatchesBlock(t, summary, genesis)
-	})
+	tests := []struct {
+		name            string
+		numBlocks       uint64
+		lastSynchronous uint64
+		wantHeight      uint64
+		wantErr         error
+	}{
+		{
+			name:       "last_committed",
+			numBlocks:  numBlocks,
+			wantHeight: lastCommitted,
+		},
+		{
+			name:    "only_genesis",
+			wantErr: database.ErrNotFound,
+		},
+		{
+			name:            "last_committed_synchronous",
+			numBlocks:       numBlocks,
+			lastSynchronous: lastCommitted,
+			wantErr:         database.ErrNotFound,
+		},
+		{
+			name:            "last_committed_above_synchronous_threshold",
+			numBlocks:       numBlocks,
+			lastSynchronous: lastCommitted - 1,
+			wantHeight:      lastCommitted,
+		},
+	}
 
-	t.Run("GetStateSummary", func(t *testing.T) {
-		summary, err := sut.GetStateSummary(t.Context(), genesis.NumberU64())
-		require.NoError(t, err)
-		checkSummaryMatchesBlock(t, summary, genesis)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			vm := newVM(t, withLastSynchronous(tt.lastSynchronous))
+			vm.acceptBlocks(t, tt.numBlocks)
+
+			summary, err := vm.Handler.GetLastStateSummary(t.Context())
+			require.ErrorIs(t, err, tt.wantErr)
+			if tt.wantErr != nil {
+				return
+			}
+			checkSummaryMatchesBlock(t, summary, vm.blockAtHeight(t, tt.wantHeight).EthBlock())
+		})
+	}
 }
 
 func checkSummaryMatchesBlock(t *testing.T, summary *Summary, block *types.Block) {

--- a/vms/saevm/statesync/sut_test.go
+++ b/vms/saevm/statesync/sut_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/logging/loggingtest"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/hook"
 	"github.com/ava-labs/avalanchego/vms/saevm/hook/hookstest"
 	"github.com/ava-labs/avalanchego/vms/saevm/network"
 	"github.com/ava-labs/avalanchego/vms/saevm/sae"
@@ -64,10 +65,11 @@ type (
 	}
 
 	sutConfig struct {
-		syncConfig Config
-		avaDB      database.Database
-		xdb        saetypes.ExecutionResults
-		startTime  time.Time
+		syncConfig      Config
+		avaDB           database.Database
+		xdb             saetypes.ExecutionResults
+		startTime       time.Time
+		lastSynchronous uint64
 	}
 	sutOption = options.Option[sutConfig]
 )
@@ -99,6 +101,27 @@ func withTime(t time.Time) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.startTime = t
 	})
+}
+
+// withLastSynchronous makes the [SummaryHandler]'s hooks report every block at
+// or below height as synchronous, deferring to the real [hookstest.Stub]
+// implementation above it.
+func withLastSynchronous(height uint64) sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		c.lastSynchronous = height
+	})
+}
+
+type settledOverride struct {
+	*hookstest.Stub
+	height uint64
+}
+
+func (s settledOverride) SettledBy(header *types.Header) hook.Settled {
+	if header.Number.Uint64() <= s.height {
+		return hook.Settled{}
+	}
+	return s.Stub.SettledBy(header)
 }
 
 const (
@@ -176,7 +199,7 @@ func newSUT(t *testing.T, opts ...sutOption) *sut {
 		ethDB,
 		snowCtx,
 		net,
-		hooks,
+		settledOverride{Stub: hooks, height: cfg.lastSynchronous},
 	)
 	require.NoError(t, err, "New()")
 
@@ -203,7 +226,7 @@ func (s *sut) Sender() *saetest.Sender { return s.sender }
 func (s *sut) syncer() *Syncer {
 	return NewSyncer(
 		s.cfg.syncConfig,
-		s.hooks,
+		settledOverride{Stub: s.hooks, height: s.cfg.lastSynchronous},
 		s.snowCtx,
 		s.Network,
 		s.db,

--- a/vms/saevm/statesync/sut_test.go
+++ b/vms/saevm/statesync/sut_test.go
@@ -103,9 +103,9 @@ func withTime(t time.Time) sutOption {
 	})
 }
 
-// withLastSynchronous makes the [SummaryHandler]'s hooks report every block at
-// or below height as synchronous, deferring to the real [hookstest.Stub]
-// implementation above it.
+// withLastSynchronous makes the [Handler]'s hooks report every block at or
+// below height as synchronous, deferring to the real [hookstest.Stub]
+// implementation above it. This does NOT affect the [vmSUT].
 func withLastSynchronous(height uint64) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.lastSynchronous = height

--- a/vms/saevm/statesync/syncer.go
+++ b/vms/saevm/statesync/syncer.go
@@ -120,7 +120,7 @@ func (s *Syncer) Sync(ctx context.Context, summary *Summary) error {
 
 	if hook.Synchronous(s.hooks, hdr) {
 		// This requires malicious summary providers, but would corrupt database.
-		return errSynchronousBlock
+		return fmt.Errorf("%w: %s at height %d", errSynchronousBlock, summary.AcceptedHash, summary.AcceptedHeight)
 	}
 
 	codeSyncer, err := code.NewSyncer(

--- a/vms/saevm/statesync/syncer.go
+++ b/vms/saevm/statesync/syncer.go
@@ -84,6 +84,8 @@ func (s *Syncer) ShouldAcceptSummary(summary *Summary) bool {
 	return height == nil || *height == 0
 }
 
+var errSynchronousBlock = errors.New("cannot state sync to synchronous block")
+
 // Sync fetches all state associated with [Summary] and applies it to disk.
 // Any error returned MUST be treated as fatal. After this method returns
 // without error, one MUST call [Syncer.WriteSynced] to finalize the state
@@ -114,6 +116,11 @@ func (s *Syncer) Sync(ctx context.Context, summary *Summary) error {
 	hdr := rawdb.ReadHeader(s.db, summary.AcceptedHash, summary.AcceptedHeight)
 	if hdr == nil {
 		return fmt.Errorf("couldn't find header %s at height %d", summary.AcceptedHash, summary.AcceptedHeight)
+	}
+
+	if hook.Synchronous(s.hooks, hdr) {
+		// This requires malicious summary providers, but would corrupt database.
+		return errSynchronousBlock
 	}
 
 	codeSyncer, err := code.NewSyncer(

--- a/vms/saevm/statesync/syncer_test.go
+++ b/vms/saevm/statesync/syncer_test.go
@@ -369,3 +369,21 @@ func TestSyncAfterAbandonedSync(t *testing.T) {
 	saetest.ConnectTo[saetest.Peer](t, client, sourceVM)
 	require.NoErrorf(t, client.syncTo(ctx, t, summary), "%T.syncTo(%v)", client, summary)
 }
+
+func TestSyncToSynchronousBlock(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sourceVM := newVM(t)
+	sourceVM.acceptBlocks(t, defaultCommitInterval)
+
+	summary, err := sourceVM.GetLastStateSummary(ctx)
+	require.NoErrorf(t, err, "%T.GetLastStateSummary()", sourceVM.Handler)
+
+	client := newSUT(t, withLastSynchronous(summary.AcceptedHeight))
+	saetest.ConnectTo[saetest.Peer](t, client, sourceVM)
+
+	syncer := client.syncer()
+	err = syncer.Sync(ctx, summary)
+	require.ErrorIsf(t, err, errSynchronousBlock, "%T.Sync(%v)", syncer, summary)
+}


### PR DESCRIPTION
## Why this should be merged

There's tons of security and correctness bugs that could come from a synchronous state summary. One should take care not to serve one.

## How this works

Checks the hooks to see if the requested summary would refer to a synchronous block, and avoids sending in that case. This will still break state sync for a couple hours after transition.

## How this was tested

New UT

## Need to be documented in RELEASES.md?

No