### PR TITLE
[ci] Skip re-execution benchmarks on PRs without secret access

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -88,7 +88,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego' }}
+    # This job needs repository secrets, which external users do not have.
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -89,7 +89,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego' }}
+    # This job needs repository secrets, which external users do not have.
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) }}
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Why this should be merged

Both C-Chain re-execution jobs fail on every Dependabot PR (e.g. #5861). Dependabot runs are served by the separate Dependabot secret store with a read-only token, so `secrets.AWS_S3_READ_ONLY_ROLE` resolves to empty and `Configure AWS Credentials` fails with `Could not load credentials from any providers` before the benchmark starts.

I verified re-running yourself does not help: [re-runs use the privileges of `github.actor`](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context), which stays `dependabot[bot]`.

## How this works

Extends the guard to also require an `author_association` that implies write access, which no bot author has.

## How this was tested

`actionlint` passes and I confirmed via the API that `author_association` is `CONTRIBUTOR` for the Dependabot PRs above and `MEMBER` for human-authored PRs on non-fork branches (just in my terminal)

## Need to be documented in RELEASES.md?

No.