### PR TITLE
[ci] Gate re-execution benchmarks on secret availability

### DIFF
--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Check AWS Role Availability
         id: check-aws-role
-        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE_BUT_WRONG_HAHAHA != '' }}" >> "$GITHUB_OUTPUT"
+        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE != '' }}" >> "$GITHUB_OUTPUT"
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Check AWS Role Availability
         id: check-aws-role
-        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE != '' }}" >> "$GITHUB_OUTPUT"
+        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE_BUT_WRONG_HAHAHA != '' }}" >> "$GITHUB_OUTPUT"
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}

--- a/.github/workflows/c-chain-reexecution-benchmark-container.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-container.yml
@@ -48,8 +48,12 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
+      has-aws-role: ${{ steps.check-aws-role.outputs.available }}
     steps:
       - uses: actions/checkout@v5
+      - name: Check AWS Role Availability
+        id: check-aws-role
+        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE != '' }}" >> "$GITHUB_OUTPUT"
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}
@@ -88,8 +92,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
-    # This job needs repository secrets, which external users do not have.
-    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) }}
+    # Fork PRs and Dependabot PRs are served by secret stores without this role, so
+    # authenticating to S3 would fail before the benchmark starts.
+    if: ${{ needs.define-matrix.outputs.has-aws-role == 'true' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Check AWS Role Availability
         id: check-aws-role
-        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE_BUT_WRONG_HAHAHA != '' }}" >> "$GITHUB_OUTPUT"
+        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE != '' }}" >> "$GITHUB_OUTPUT"
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Check AWS Role Availability
         id: check-aws-role
-        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE != '' }}" >> "$GITHUB_OUTPUT"
+        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE_BUT_WRONG_HAHAHA != '' }}" >> "$GITHUB_OUTPUT"
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}

--- a/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
+++ b/.github/workflows/c-chain-reexecution-benchmark-gh-native.yml
@@ -48,8 +48,12 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
+      has-aws-role: ${{ steps.check-aws-role.outputs.available }}
     steps:
       - uses: actions/checkout@v5
+      - name: Check AWS Role Availability
+        id: check-aws-role
+        run: echo "available=${{ secrets.AWS_S3_READ_ONLY_ROLE != '' }}" >> "$GITHUB_OUTPUT"
       - name: Define Matrix
         id: define-matrix
         shell: bash -x {0}
@@ -89,8 +93,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
-    # This job needs repository secrets, which external users do not have.
-    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == 'ava-labs/avalanchego' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) }}
+    # Fork PRs and Dependabot PRs are served by secret stores without this role, so
+    # authenticating to S3 would fail before the benchmark starts.
+    if: ${{ needs.define-matrix.outputs.has-aws-role == 'true' }}
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Why this should be merged

My bad guys -- #5870 skipped the re-execution benchmarks on Dependabot PRs by requiring an `author_association` of `OWNER`/`MEMBER`/`COLLABORATOR` which makes sense BUT that guard skips *every* PR, not just bot ones.

`author_association` in a webhook payload reflects only publicly visible association, and `ava-labs` membership is almost always private for all but @rkuris -- no idea why this is the case. 

```console
$ gh api orgs/ava-labs/public_members --jq ".[].login"
rkuris
```

Anyway that means the invocation reports `CONTRIBUTOR` for human members, which gets skipped, so all PRs get skipped. I should have tested without my `gh api` for the prior PR. 

## How this works

We just gate on whether whether `AWS_S3_READ_ONLY_ROLE` resolves, instead of trying to guess. I think this is a much better solution, and we don't need the prior checks either anymore. The only cost is that `define-matrix` now runs on fork PRs, whcih I think is fine. 

## How this was tested

We can verify this works by running the PR with the secret not available by mutating the conditional (e.g. changing the name of the secret so that it shows up missing) and with the secret available properly: 

**Secret available:** 
<img width="828" height="630" alt="Screenshot 2026-08-25 at 3 26 54 PM" src="https://github.com/user-attachments/assets/1cb388de-c4d8-4f65-9241-d77cfd84a11c" />
**Secret unavailable**: 

<img width="886" height="688" alt="Screenshot 2026-08-25 at 3 29 56 PM" src="https://github.com/user-attachments/assets/2532bd9e-67af-4278-9b8f-0025182958cd" />

## Need to be documented in RELEASES.md?

No.