### PR TITLE
Gossip resubmitted discarded transactions on the next regossip cycle

### DIFF
--- a/network/p2p/gossip/gossip.go
+++ b/network/p2p/gossip/gossip.go
@@ -584,9 +584,12 @@ func (p *PushGossiper[T]) Add(gossipables ...T) {
 			addedTime: nowUnixNano,
 		}
 		if _, ok := p.discarded.Get(gossipID); ok {
-			// Pretend that recently discarded transactions were just gossiped.
-			tracking.lastGossiped = now
-			p.toRegossip.PushRight(gossipable)
+			// Recently discarded transactions are sent with the regossip
+			// fanout rather than the push fanout, to avoid overgossiping
+			// transactions that are frequently dropped. The zero lastGossiped
+			// makes this the oldest entry, so it goes to the front of the
+			// queue and out on the next regossip cycle.
+			p.toRegossip.PushLeft(gossipable)
 		} else {
 			p.toGossip.PushRight(gossipable)
 		}

--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -478,11 +478,13 @@ func (h hasFunc) Has(id ids.ID) bool {
 func TestPushGossiper(t *testing.T) {
 	type cycle struct {
 		toAdd    []tx
+		evict    []tx
 		expected [][]tx
 	}
 	tests := []struct {
 		name           string
 		cycles         []cycle
+		discardedSize  int
 		shouldRegossip bool
 	}{
 		{
@@ -532,6 +534,35 @@ func TestPushGossiper(t *testing.T) {
 				},
 			},
 			shouldRegossip: true,
+		},
+		{
+			name: "resubmitted discarded transaction is regossiped promptly",
+			cycles: []cycle{
+				{
+					toAdd: []tx{
+						{0},
+					},
+					expected: [][]tx{
+						{{0}},
+					},
+				},
+				{
+					evict: []tx{
+						{0},
+					},
+					expected: [][]tx{},
+				},
+				{
+					toAdd: []tx{
+						{0},
+					},
+					expected: [][]tx{
+						{{0}},
+					},
+				},
+			},
+			discardedSize:  1,
+			shouldRegossip: false,
 		},
 		{
 			name: "verify that we don't gossip empty messages",
@@ -592,10 +623,11 @@ func TestPushGossiper(t *testing.T) {
 				regossipTime = time.Nanosecond
 			}
 
+			evicted := set.Set[ids.ID]{}
 			gossiper, err := NewPushGossiper[tx](
 				marshaller,
-				hasFunc(func(ids.ID) bool {
-					return true // Never remove the items from the set
+				hasFunc(func(id ids.ID) bool {
+					return !evicted.Contains(id)
 				}),
 				validators,
 				client,
@@ -606,13 +638,19 @@ func TestPushGossiper(t *testing.T) {
 				BranchingFactor{
 					Validators: 1,
 				},
-				0, // the discarded cache size doesn't matter for this test
+				tt.discardedSize,
 				units.MiB,
 				regossipTime,
 			)
 			require.NoError(err)
 
 			for _, cycle := range tt.cycles {
+				for _, gossipable := range cycle.evict {
+					evicted.Add(gossipable.GossipID())
+				}
+				for _, gossipable := range cycle.toAdd {
+					evicted.Remove(gossipable.GossipID())
+				}
 				gossiper.Add(cycle.toAdd...)
 				require.NoError(gossiper.Gossip(ctx))
 


### PR DESCRIPTION
## Why this should be merged

This revisits one decision from the #2772 push gossip redesign: `PushGossiper.Add` treats a transaction found in the `discarded` cache as having been gossiped at the time of issuance, so a resubmission waits a full regossip period (default 30s) before its first send, behind every fresher entry in the regossip queue.

That choice is safe when pull gossip covers the gap, which was the assumption in #2772 ("nodes will still perform pull gossip to fully spread the transaction"). It does not hold for non-validators: pull gossip samples validators only, so a weight-0 RPC node's mempool is never pulled from, and push is its only path to block inclusion. On such a node, a burst that evicts sent transactions from the mempool fills `discarded`, and afterwards every resubmission is accepted over RPC, held valid in the pool, and not announced for 30+ seconds, while health reports fine.

Reproduced on a 12-node subnet-evm network: after a 30s burst, a flooded weight-0 node went from 98/99 probe transactions mined within 5s to 0/10, did not recover in 9 minutes, and was cured by a restart (the cache is in-memory). Transactions from a fresh account through the same degraded node mined in under a second, confirming the suppression is keyed on the discarded hashes.

## How this works

A recently discarded transaction still takes the regossip queue, so it keeps the anti-amplification properties from #2772: the smaller regossip fanout, and at most one send per regossip period thereafter. It now enters at the front of the queue with a zero `lastGossiped` instead of being stamped as just-gossiped, so its first send happens on the next regossip cycle rather than a full period later. Front placement keeps the queue sorted by last-issuance time, since zero is the oldest.

The amplification cost of a resubmission is one send at regossip fanout, gated by mempool re-admission; the previous behavior allowed the same send, just a period later.

## How this was tested

New `TestPushGossiper` case `resubmitted discarded transaction is regossiped promptly`: gossip, evict from the set, resubmit, and expect the send on the next cycle. It does not complete without the fix. Existing `network/p2p` tests pass.

## Need to be documented in RELEASES.md?

No.
