### PR TITLE
fix(sync): Race on small storage tries

### DIFF
--- a/graft/evm/sync/evmstate/state_syncer.go
+++ b/graft/evm/sync/evmstate/state_syncer.go
@@ -216,10 +216,11 @@ func (t *stateSync) onMainTrieFinished() error {
 	}
 	t.stats.setTriesRemaining(numStorageTries)
 
-	// mark the main trie done
-	close(t.mainTrieDone)
-	_, err = t.removeTrieInProgress(t.root)
-	return err
+	if _, err := t.removeTrieInProgress(t.root); err != nil {
+		return err
+	}
+	close(t.mainTrieDone) // awakens storage trie producer
+	return nil
 }
 
 // onSyncComplete is called after the account trie and


### PR DESCRIPTION
## Why this should be merged

There's a race! It doesn't affect any production systems because the window is REALLY tight, but this is likely the bug that's plagued the coreth and subnet-evm test flakes for years.

## How this works

`mainTrieDone` is an internal indicator to unblock adding all the storage tries to the queue. After the storage tries are added, the `leaf.CallbackSyncer` will start fetching their state. When each trie is done syncing, it checks this value:
```go
if numInProgress == 0 {
	select {
	case <-t.storageTriesDone:
		// when the last storage trie finishes, close the segments channel
		close(t.segments)
	default:
	}
}
```
`numInProgress` MAY include the account trie, unless it's removed before. By removing the account trie from the pending list BEFORE we awaken the storage trie producer, the race is avoided.

## How this was tested

Adding a strategically placed `time.Sleep` locally will cause any test to fail. Writing a unit test is kind of impossible without grabbing some internal locks

## Need to be documented in RELEASES.md?

No.
