### PR TITLE
fix(ci): stop deleting the Go toolchain when reclaiming disk space

### DIFF
--- a/.github/actions/ensure-disk-space/action.yml
+++ b/.github/actions/ensure-disk-space/action.yml
@@ -48,7 +48,7 @@ runs:
         # Do not set tool-cache to true. It deletes /opt/hostedtoolcache, which
         # holds the Go toolchain from the runner image or from setup-go. Jobs
         # that start task with `go tool` then fail with exit 127.
-        tool-cache: true  # TEMP: we should expect exit 127.
+        tool-cache: false
         docker-images: true
 
     - name: Re-check runner disk space

--- a/.github/actions/ensure-disk-space/action.yml
+++ b/.github/actions/ensure-disk-space/action.yml
@@ -48,7 +48,7 @@ runs:
         # Do not set tool-cache to true. It deletes /opt/hostedtoolcache, which
         # holds the Go toolchain from the runner image or from setup-go. Jobs
         # that start task with `go tool` then fail with exit 127.
-        tool-cache: false
+        tool-cache: true  # TEMP: we should expect exit 127.
         docker-images: true
 
     - name: Re-check runner disk space

--- a/.github/actions/ensure-disk-space/action.yml
+++ b/.github/actions/ensure-disk-space/action.yml
@@ -45,7 +45,10 @@ runs:
       if: ${{ runner.os == 'Linux' && steps.initial-check.outputs.below_threshold == 'true' }}
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
-        tool-cache: true
+        # Do not set tool-cache to true. It deletes /opt/hostedtoolcache, which
+        # holds the Go toolchain from the runner image or from setup-go. Jobs
+        # that start task with `go tool` then fail with exit 127.
+        tool-cache: false
         docker-images: true
 
     - name: Re-check runner disk space

--- a/.github/actions/run-docker-with-disk-space/action.yml
+++ b/.github/actions/run-docker-with-disk-space/action.yml
@@ -20,6 +20,8 @@ runs:
     - uses: ./.github/actions/ensure-disk-space
       with:
         diagnostic-groups: docker
+        # TEMP: force the deletion.
+        force-free-gb: '1'
 
     - name: Set up QEMU (required for cross-platform builds)
       if: ${{ inputs.setup-qemu == 'true' }}

--- a/.github/actions/run-docker-with-disk-space/action.yml
+++ b/.github/actions/run-docker-with-disk-space/action.yml
@@ -20,8 +20,6 @@ runs:
     - uses: ./.github/actions/ensure-disk-space
       with:
         diagnostic-groups: docker
-        # TEMP: force the deletion.
-        force-free-gb: '1'
 
     - name: Set up QEMU (required for cross-platform builds)
       if: ${{ inputs.setup-qemu == 'true' }}


### PR DESCRIPTION
## Why this should be merged

`ensure-disk-space` deletes the Go toolchain that CI jobs need. When a runner starts below the 20GB threshold, the reclaim step runs `free-disk-space` with `tool-cache: true`, removing `/opt/hostedtoolcache`. `scripts/run_task.sh` starts Task with `go tool`, so it then finds no `go` and exits 127.

This broke the `v1.15.0-fuji-rc.7` publish Docker Image job recently. 

## How this works

Sets `tool-cache: false`. In the failing run it contributed 5.4GiB of 32GiB, so we still will recover a lot of space. 

## How this was tested

I confirmed from the failing job log that the reclaim deletes the tool cache and `run_task.sh` exits 127 immediately after,

The reclaim only runs below the 20GB threshold, so normal CI does not ALWAYS deterministically hit it. To test this I edited the action `force-free-gb: '1'` in `run-docker-with-disk-space`, and then reverted the commit. You can verify this here: 

With `tool-cache: true` (062cee3d), all four affected jobs failed as the
`v1.15.0-fuji-rc.7` publish job did: 

| Job                                 | Workflow   | setup-go? | Link                                                                             |
| ----------------------------------- | ---------- | --------- | -------------------------------------------------------------------------------- |
| Build Antithesis avalanchego images | Tests      | Yes       | https://github.com/ava-labs/avalanchego/actions/runs/33226837622/job/99032181632 |
| Build Antithesis images             | Subnet-EVM | Yes       | https://github.com/ava-labs/avalanchego/actions/runs/33226837604/job/99032112108 |
| Image build                         | Subnet-EVM | No        | https://github.com/ava-labs/avalanchego/actions/runs/33226837604/job/99032111996 |
| Image build                         | Tests      | No        | https://github.com/ava-labs/avalanchego/actions/runs/33226837622/job/99032181716 |

With `tool-cache: false` (e7e5058), the reclaim still ran (`below threshold`, 19GiB recovered, no `Tool cache` line) and [all four jobs still passed!](https://github.com/ava-labs/avalanchego/actions/runs/33227053771).

## Need to be documented in RELEASES.md?

No