### PR TITLE
test(sae): Only 1 tx per acct in a block

### DIFF
--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -207,7 +207,7 @@ func TestDebugTrace(t *testing.T) {
 	// A controlled clock keeps the executed base fees reproducible.
 	timeOpt, clock := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 	precompile := common.Address{'p', 'r', 'e', 'c', 'o', 'm', 'p'}
-	ctx, sut := newSUT(t, 1,
+	ctx, sut := newSUT(t, 2,
 		timeOpt,
 		// Using an increased base fee allows the fee to change during the test.
 		withGenesisBaseFee(params.GWei),
@@ -249,7 +249,7 @@ func TestDebugTrace(t *testing.T) {
 	// 0 and logs the base fee it replayed with at index 1.
 	precompileTx := callPrecompile()
 	logBaseFeeCode, logBaseFeePC, cmpBaseFeeLOG1 := logTopOfStackAfter(t, saetest.Ops(vm.BASEFEE))
-	baseFeeTx := sut.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
+	baseFeeTx := sut.wallet.SetNonceAndSign(t, 1, &types.DynamicFeeTx{
 		GasFeeCap: gasPrice,
 		Gas:       1e6,
 		Data:      logBaseFeeCode,


### PR DESCRIPTION
## Why this should be merged

The test times out sometimes. This is because of a well-known flake in go-ethereum's mempool.

## How this works

Just avoid making a block with two txs from the same account.

## How this was tested

Test seems to pass - no harm no foul

## Need to be documented in RELEASES.md?

No
