### PR TITLE
Add retries for antithesis image push

### DIFF
--- a/scripts/lib_build_antithesis_images.sh
+++ b/scripts/lib_build_antithesis_images.sh
@@ -8,6 +8,25 @@ set -euo pipefail
 #
 # Since this file only defines functions, it is intended to be sourced rather than executed.
 
+# Retry a command to tolerate transient failures (e.g. a registry returning
+# 502 during an image push). Buildx caches completed layers so a retried build
+# only repeats the step that failed.
+function retry_command {
+  local max_attempts=3
+  local delay=5
+  local attempt=1
+  while ! "$@"; do
+    if ((attempt >= max_attempts)); then
+      echo "Command failed after ${max_attempts} attempts: $*" >&2
+      return 1
+    fi
+    echo "Attempt ${attempt} of ${max_attempts} failed, retrying in ${delay}s: $*" >&2
+    sleep "${delay}"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
 # Build the image that enables compiling golang binaries for the node and workload image
 # builds. The builder image is intended to enable building instrumented binaries if built
 # on amd64 and non-instrumented binaries if built on arm64.
@@ -62,12 +81,14 @@ function build_antithesis_images {
   fi
 
   # Define default build command
-  local docker_cmd="docker buildx build\
- --build-arg GO_VERSION=${go_version}\
- --build-arg BUILDER_IMAGE_TAG=${image_tag}\
- --build-arg BUILDER_WORKDIR=${builder_workdir}"
+  local docker_cmd=(
+    docker buildx build
+    --build-arg "GO_VERSION=${go_version}"
+    --build-arg "BUILDER_IMAGE_TAG=${image_tag}"
+    --build-arg "BUILDER_WORKDIR=${builder_workdir}"
+  )
   if [[ -n "${avalanchego_commit}" ]]; then
-    docker_cmd="${docker_cmd} --build-arg AVALANCHEGO_COMMIT=${avalanchego_commit}"
+    docker_cmd+=(--build-arg "AVALANCHEGO_COMMIT=${avalanchego_commit}")
   fi
 
   # By default the node image is intended to be local-only.
@@ -76,17 +97,17 @@ function build_antithesis_images {
   if [[ -n "${image_prefix}" && -z "${node_only}" ]]; then
     # Push images with an image prefix since the prefix defines a registry location, and only if building
     # all images. When building just the node image the image is only intended to be used locally.
-    docker_cmd="${docker_cmd} --push"
+    docker_cmd+=(--push)
 
     # When the node image is pushed as part of the build, references to the image must be qualified.
     AVALANCHEGO_NODE_IMAGE="${image_prefix}/${AVALANCHEGO_NODE_IMAGE}"
   fi
 
   # Ensure the correct node image name is configured
-  docker_cmd="${docker_cmd} --build-arg AVALANCHEGO_NODE_IMAGE=${AVALANCHEGO_NODE_IMAGE}"
+  docker_cmd+=(--build-arg "AVALANCHEGO_NODE_IMAGE=${AVALANCHEGO_NODE_IMAGE}")
 
   # Build node image first to allow the workload image to use it.
-  ${docker_cmd} -t "${node_image_name}" -f "${node_dockerfile}" "${target_path}"
+  retry_command "${docker_cmd[@]}" -t "${node_image_name}" -f "${node_dockerfile}" "${target_path}"
 
   if [[ -n "${node_only}" ]]; then
     # Skip building the config and workload images. Supports building the avalanchego node image as the
@@ -95,10 +116,10 @@ function build_antithesis_images {
   fi
 
   # Build the config image
-  ${docker_cmd} -t "${config_image_name}" -f "${base_dockerfile}.config" "${target_path}"
+  retry_command "${docker_cmd[@]}" -t "${config_image_name}" -f "${base_dockerfile}.config" "${target_path}"
 
   # Build the workload image
-  ${docker_cmd} -t "${workload_image_name}" -f "${base_dockerfile}.workload" "${target_path}"
+  retry_command "${docker_cmd[@]}" -t "${workload_image_name}" -f "${base_dockerfile}.workload" "${target_path}"
 }
 
 # Generate the docker compose configuration for the antithesis config image.


### PR DESCRIPTION
## Why this should be merged

Antithesis builds have been failing due to outages at the third party docker repo we push to. We push three docker images and sometimes one of the succeeds while a subsequent fails - which points at transient failures. We can improve robustness by adding a few retries - the expectation is that these failures only last a few seconds and the retry will succeed.

## How this works

We wrap each of the docker push steps with a retry bash function.

## How this was tested

Ran the [antithesis build](https://github.com/ava-labs/avalanchego/actions/runs/33512426737) on this branch.

## Need to be documented in RELEASES.md?
No