### PR TITLE
Honor standard OpenTelemetry environment variables

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//snow/consensus/simplex",
         "//snow/consensus/snowball",
         "//subnets",
+        "//trace",
         "//utils",
         "//utils/constants",
         "@com_github_spf13_pflag//:pflag",

--- a/config/config.go
+++ b/config/config.go
@@ -1297,8 +1297,18 @@ func getDiskTargeterConfig(v *viper.Viper) (tracker.TargeterConfig, error) {
 }
 
 func getTraceConfig(v *viper.Viper) (trace.Config, error) {
-	exporterTypeStr := v.GetString(TracingExporterTypeKey)
-	exporterType, err := trace.ExporterTypeFromString(exporterTypeStr)
+	var (
+		exporterType trace.ExporterType
+		err          error
+	)
+	if v.IsSet(TracingExporterTypeKey) {
+		exporterType, err = trace.ExporterTypeFromString(v.GetString(TracingExporterTypeKey))
+	} else {
+		// The standard OTel variables (OTEL_TRACES_EXPORTER and
+		// OTEL_EXPORTER_OTLP_[TRACES_]PROTOCOL) are a fallback when the flag
+		// isn't explicitly set, still leaving tracing disabled by default.
+		exporterType, err = trace.ExporterTypeFromEnv()
+	}
 	if err != nil {
 		return trace.Config{}, err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/simplex"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowball"
 	"github.com/ava-labs/avalanchego/subnets"
+	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 )
@@ -1319,6 +1320,51 @@ func TestResolveConsensusMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, resolveConsensusMode(&tt.input))
+		})
+	}
+}
+
+func TestGetTraceConfigOTelEnvFallback(t *testing.T) {
+	tests := []struct {
+		name         string
+		env          map[string]string
+		explicitFlag string
+		want         trace.ExporterType
+	}{
+		{
+			name: "disabled_by_default",
+			want: trace.Disabled,
+		},
+		{
+			name: "env_enables_when_flag_unset",
+			env: map[string]string{
+				"OTEL_TRACES_EXPORTER":        "otlp",
+				"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+			},
+			want: trace.GRPC,
+		},
+		{
+			name:         "explicit_flag_overrides_env",
+			env:          map[string]string{"OTEL_TRACES_EXPORTER": "otlp"},
+			explicitFlag: "disabled",
+			want:         trace.Disabled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			v := setupViperFlags()
+			if tt.explicitFlag != "" {
+				v.Set(TracingExporterTypeKey, tt.explicitFlag)
+			}
+
+			got, err := getTraceConfig(v)
+			require.NoError(t, err, "getTraceConfig()")
+			require.Equal(t, tt.want, got.ExporterConfig.Type, "getTraceConfig() exporter type")
 		})
 	}
 }

--- a/config/flags.go
+++ b/config/flags.go
@@ -382,10 +382,10 @@ func addNodeFlags(fs *pflag.FlagSet) {
 	fs.Float64(DiskMaxNonVdrNodeUsageKey, 1000*units.GiB, "Maximum number of disk reads/writes per second that a non-validator can utilize. Must be >= 0")
 
 	// Opentelemetry tracing
-	fs.String(TracingExporterTypeKey, trace.Disabled.String(), fmt.Sprintf("Type of exporter to use for tracing. Options are [%s, %s, %s]", trace.Disabled, trace.GRPC, trace.HTTP))
+	fs.String(TracingExporterTypeKey, trace.Disabled.String(), fmt.Sprintf("Type of exporter to use for tracing. Options are [%s, %s, %s]. If not explicitly set, the OTEL_TRACES_EXPORTER and OTEL_EXPORTER_OTLP_PROTOCOL environment variables are used instead", trace.Disabled, trace.GRPC, trace.HTTP))
 	fs.String(TracingEndpointKey, "", "The endpoint to send trace data to. If unspecified, the default endpoint will be used; depending on the exporter type")
 	fs.Bool(TracingInsecureKey, true, "If true, don't use TLS when sending trace data")
-	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample")
+	fs.Float64(TracingSampleRateKey, 0.1, "The fraction of traces to sample. If >= 1, always sample. If <= 0, never sample. Ignored if the OTEL_TRACES_SAMPLER environment variable is set")
 	fs.StringToString(TracingHeadersKey, map[string]string{}, "The headers to provide the trace indexer")
 
 	fs.String(ProcessContextFileKey, defaultProcessContextPath, "The path to write process context to (including PID, API URI, and staking address).")

--- a/trace/BUILD.bazel
+++ b/trace/BUILD.bazel
@@ -26,7 +26,14 @@ go_library(
 
 go_test(
     name = "trace_test",
-    srcs = ["exporter_type_test.go"],
+    srcs = [
+        "exporter_type_test.go",
+        "tracer_test.go",
+    ],
     embed = [":trace"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//semconv/v1.4.0:v1_4_0",
+    ],
 )

--- a/trace/README.md
+++ b/trace/README.md
@@ -26,3 +26,26 @@ The default export endpoint is `localhost:4317`, which matches the Jaeger contai
 ## 3. View traces
 
 Open <http://localhost:16686>, select the `avalanchego` service, and click Find Traces.
+
+## OpenTelemetry environment variables
+
+Tracing is enabled with the `--tracing-exporter-type` flag (or its
+`AVAGO_TRACING_EXPORTER_TYPE` form). When the flag isn't explicitly set, the
+standard `OTEL_TRACES_EXPORTER` variable is honored instead: `otlp` enables
+tracing (with the transport from `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` or
+`OTEL_EXPORTER_OTLP_PROTOCOL`, defaulting to `http/protobuf`) and `none`
+disables it. If neither the flag nor `OTEL_TRACES_EXPORTER` is set, tracing
+stays disabled.
+
+Once enabled, the standard
+[OTel SDK](https://opentelemetry.io/docs/languages/sdk-configuration/) and
+[OTLP exporter](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/)
+environment variables are honored, e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`,
+`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`,
+`OTEL_TRACES_SAMPLER` and `OTEL_BSP_*`.
+
+Where a `--tracing-*` flag configures the same thing, the flag takes
+precedence, with two exceptions: `OTEL_SERVICE_NAME`/`OTEL_RESOURCE_ATTRIBUTES`
+override the default resource, and `OTEL_TRACES_SAMPLER` (with
+`OTEL_TRACES_SAMPLER_ARG`) takes precedence over `--tracing-sample-rate`, since
+setting either is an explicit opt-in.

--- a/trace/exporter.go
+++ b/trace/exporter.go
@@ -29,13 +29,20 @@ type ExporterConfig struct {
 	Insecure bool `json:"insecure"`
 }
 
+// newExporter only applies client options for the [ExporterConfig] fields
+// that are actually set. The OTLP clients read the standard OTel environment
+// variables (OTEL_EXPORTER_OTLP_ENDPOINT, _HEADERS, _TIMEOUT, etc.) but
+// explicit options override them, so an unconditional option would mask its
+// environment variable. The request timeout is always left to the client
+// default (10s, the same as the previously pinned value) so that
+// OTEL_EXPORTER_OTLP_TIMEOUT is honored.
 func newExporter(config ExporterConfig) (sdktrace.SpanExporter, error) {
 	var client otlptrace.Client
 	switch config.Type {
 	case GRPC:
-		opts := []otlptracegrpc.Option{
-			otlptracegrpc.WithHeaders(config.Headers),
-			otlptracegrpc.WithTimeout(tracerExportTimeout),
+		var opts []otlptracegrpc.Option
+		if len(config.Headers) > 0 {
+			opts = append(opts, otlptracegrpc.WithHeaders(config.Headers))
 		}
 		if config.Endpoint != "" {
 			opts = append(opts, otlptracegrpc.WithEndpoint(config.Endpoint))
@@ -45,9 +52,9 @@ func newExporter(config ExporterConfig) (sdktrace.SpanExporter, error) {
 		}
 		client = otlptracegrpc.NewClient(opts...)
 	case HTTP:
-		opts := []otlptracehttp.Option{
-			otlptracehttp.WithHeaders(config.Headers),
-			otlptracehttp.WithTimeout(tracerExportTimeout),
+		var opts []otlptracehttp.Option
+		if len(config.Headers) > 0 {
+			opts = append(opts, otlptracehttp.WithHeaders(config.Headers))
 		}
 		if config.Endpoint != "" {
 			opts = append(opts, otlptracehttp.WithEndpoint(config.Endpoint))

--- a/trace/exporter_type.go
+++ b/trace/exporter_type.go
@@ -6,6 +6,7 @@ package trace
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -15,18 +16,66 @@ const (
 	HTTP
 )
 
-var (
-	errUnknownExporterType = errors.New("unknown exporter type")
-	errMissingQuotes       = errors.New("first and last characters should be quotes")
+const (
+	disabledStr = "disabled"
+	grpcStr     = "grpc"
+	httpStr     = "http"
 )
+
+// Standard OTel autoconfiguration variables, from
+// https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/.
+const (
+	tracesExporterKey     = "OTEL_TRACES_EXPORTER"
+	otlpProtocolKey       = "OTEL_EXPORTER_OTLP_PROTOCOL"
+	otlpTracesProtocolKey = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+)
+
+var (
+	errUnknownExporterType       = errors.New("unknown exporter type")
+	errMissingQuotes             = errors.New("first and last characters should be quotes")
+	errUnsupportedTracesExporter = errors.New(`unsupported ` + tracesExporterKey + ` (only "otlp" and "none" are supported)`)
+	errUnsupportedOTLPProtocol   = errors.New(`unsupported OTLP protocol (only "grpc" and "http/protobuf" are supported)`)
+)
+
+// ExporterTypeFromEnv returns the [ExporterType] configured by the standard
+// OTel [tracesExporterKey] variable, resolving the OTLP transport from
+// [otlpTracesProtocolKey] or [otlpProtocolKey]. It returns [Disabled] when
+// [tracesExporterKey] is unset, keeping tracing opt-in.
+func ExporterTypeFromEnv() (ExporterType, error) {
+	exporter, ok := os.LookupEnv(tracesExporterKey)
+	if !ok {
+		return Disabled, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(exporter)) {
+	case "none":
+		return Disabled, nil
+	case "otlp":
+	default:
+		return 0, fmt.Errorf("%w: %q", errUnsupportedTracesExporter, exporter)
+	}
+
+	protocol := os.Getenv(otlpTracesProtocolKey)
+	if protocol == "" {
+		protocol = os.Getenv(otlpProtocolKey)
+	}
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case grpcStr:
+		return GRPC, nil
+	case "", "http/protobuf":
+		// http/protobuf is the default protocol recommended by the OTel spec.
+		return HTTP, nil
+	default:
+		return 0, fmt.Errorf("%w: %q", errUnsupportedOTLPProtocol, protocol)
+	}
+}
 
 func ExporterTypeFromString(exporterTypeStr string) (ExporterType, error) {
 	switch strings.ToLower(exporterTypeStr) {
-	case "disabled":
+	case disabledStr:
 		return Disabled, nil
-	case "grpc":
+	case grpcStr:
 		return GRPC, nil
-	case "http":
+	case httpStr:
 		return HTTP, nil
 	default:
 		return 0, fmt.Errorf("%w: %q", errUnknownExporterType, exporterTypeStr)
@@ -73,11 +122,11 @@ func (t ExporterType) String() string {
 func (t ExporterType) toString() (string, bool) {
 	switch t {
 	case Disabled:
-		return "disabled", true
+		return disabledStr, true
 	case GRPC:
-		return "grpc", true
+		return grpcStr, true
 	case HTTP:
-		return "http", true
+		return httpStr, true
 	default:
 		return "unknown", false
 	}

--- a/trace/exporter_type_test.go
+++ b/trace/exporter_type_test.go
@@ -9,6 +9,87 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExporterTypeFromEnv(t *testing.T) {
+	tests := []struct {
+		name          string
+		env           map[string]string
+		expected      ExporterType
+		expectedError error
+	}{
+		{
+			name:     "unset_disables_tracing",
+			expected: Disabled,
+		},
+		{
+			name:     "none",
+			env:      map[string]string{"OTEL_TRACES_EXPORTER": "none"},
+			expected: Disabled,
+		},
+		{
+			name:     "case_insensitive",
+			env:      map[string]string{"OTEL_TRACES_EXPORTER": "NONE"},
+			expected: Disabled,
+		},
+		{
+			name: "otlp_defaults_to_http_protobuf",
+			env:  map[string]string{"OTEL_TRACES_EXPORTER": "otlp"},
+			// http/protobuf is the protocol the OTel spec recommends as the
+			// default.
+			expected: HTTP,
+		},
+		{
+			name: "otlp_grpc",
+			env: map[string]string{
+				"OTEL_TRACES_EXPORTER":        "otlp",
+				"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+			},
+			expected: GRPC,
+		},
+		{
+			name: "otlp_http_protobuf",
+			env: map[string]string{
+				"OTEL_TRACES_EXPORTER":        "otlp",
+				"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+			},
+			expected: HTTP,
+		},
+		{
+			name: "traces_protocol_overrides_general_protocol",
+			env: map[string]string{
+				"OTEL_TRACES_EXPORTER":               "otlp",
+				"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/protobuf",
+				"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "grpc",
+			},
+			expected: GRPC,
+		},
+		{
+			name: "unsupported_protocol",
+			env: map[string]string{
+				"OTEL_TRACES_EXPORTER":        "otlp",
+				"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+			},
+			expectedError: errUnsupportedOTLPProtocol,
+		},
+		{
+			name:          "unsupported_exporter",
+			env:           map[string]string{"OTEL_TRACES_EXPORTER": "zipkin"},
+			expectedError: errUnsupportedTracesExporter,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			actual, err := ExporterTypeFromEnv()
+			require.ErrorIs(t, err, tt.expectedError, "ExporterTypeFromEnv()")
+			require.Equal(t, tt.expected, actual, "ExporterTypeFromEnv()")
+		})
+	}
+}
+
 func TestMarshal(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/trace/tracer.go
+++ b/trace/tracer.go
@@ -6,6 +6,7 @@ package trace
 import (
 	"context"
 	"io"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -52,6 +53,30 @@ func (t *tracer) Close() error {
 	return t.tp.Shutdown(ctx)
 }
 
+// newResource describes this process for exported spans. The env detector
+// runs after the defaults, so the standard OTEL_SERVICE_NAME and
+// OTEL_RESOURCE_ATTRIBUTES variables take precedence over them.
+func newResource(appName, version string) (*resource.Resource, error) {
+	return resource.New(context.Background(),
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(
+			attribute.String("version", version),
+			semconv.ServiceNameKey.String(appName),
+		),
+		resource.WithFromEnv(),
+	)
+}
+
+// batcherOptions pins [tracerExportTimeout] as the batcher's export timeout
+// unless the standard OTEL_BSP_EXPORT_TIMEOUT variable is set, which an
+// explicit option would otherwise override.
+func batcherOptions() []sdktrace.BatchSpanProcessorOption {
+	if _, ok := os.LookupEnv("OTEL_BSP_EXPORT_TIMEOUT"); ok {
+		return nil
+	}
+	return []sdktrace.BatchSpanProcessorOption{sdktrace.WithExportTimeout(tracerExportTimeout)}
+}
+
 func New(config Config) (Tracer, error) {
 	if config.ExporterConfig.Type == Disabled {
 		return Noop, nil
@@ -62,13 +87,20 @@ func New(config Config) (Tracer, error) {
 		return nil, err
 	}
 
+	res, err := newResource(config.AppName, config.Version)
+	if err != nil {
+		return nil, err
+	}
+
 	tracerProviderOpts := []sdktrace.TracerProviderOption{
-		sdktrace.WithBatcher(exporter, sdktrace.WithExportTimeout(tracerExportTimeout)),
-		sdktrace.WithResource(resource.NewWithAttributes(semconv.SchemaURL,
-			attribute.String("version", config.Version),
-			semconv.ServiceNameKey.String(config.AppName),
-		)),
-		sdktrace.WithSampler(sdktrace.TraceIDRatioBased(config.TraceSampleRate)),
+		sdktrace.WithBatcher(exporter, batcherOptions()...),
+		sdktrace.WithResource(res),
+	}
+	// An explicit sampler would override the SDK's handling of the standard
+	// OTEL_TRACES_SAMPLER (and _ARG) variables, so only configure one from
+	// TraceSampleRate when sampling isn't configured via the environment.
+	if _, ok := os.LookupEnv("OTEL_TRACES_SAMPLER"); !ok {
+		tracerProviderOpts = append(tracerProviderOpts, sdktrace.WithSampler(sdktrace.TraceIDRatioBased(config.TraceSampleRate)))
 	}
 
 	tracerProvider := sdktrace.NewTracerProvider(tracerProviderOpts...)

--- a/trace/tracer_test.go
+++ b/trace/tracer_test.go
@@ -1,0 +1,149 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package trace
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+)
+
+// TestExporterHonorsOTelEnv checks that, when the equivalent avalanchego flags
+// are unset, the OTLP exporter's endpoint and headers can be configured with
+// the standard OTel environment variables.
+func TestExporterHonorsOTelEnv(t *testing.T) {
+	type export struct {
+		path       string
+		testHeader string
+	}
+	received := make(chan export, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case received <- export{path: r.URL.Path, testHeader: r.Header.Get("x-test")}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	// The http:// scheme also marks the endpoint insecure, exercising env
+	// handling with the tracing-insecure flag left false.
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", server.URL)
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "x-test=abc")
+
+	tracer, err := New(Config{
+		ExporterConfig: ExporterConfig{
+			Type: HTTP,
+			// Endpoint and Headers deliberately unset.
+		},
+		TraceSampleRate: 1,
+		AppName:         "avalanchego-test",
+	})
+	require.NoError(t, err, "New()")
+
+	_, span := tracer.Start(t.Context(), "test")
+	span.End()
+	// Close shuts down the tracer provider, flushing the ended span to the
+	// test server.
+	require.NoError(t, tracer.Close(), "Close()")
+
+	select {
+	case got := <-received:
+		require.Equal(t, "/v1/traces", got.path, "OTEL_EXPORTER_OTLP_ENDPOINT must determine the export URL")
+		require.Equal(t, "abc", got.testHeader, "OTEL_EXPORTER_OTLP_HEADERS must be sent with exports")
+	default:
+		t.Fatal("no export received by the endpoint in OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+}
+
+// newTestTracer returns a [Tracer] exporting over HTTP to an in-process
+// server that accepts and discards everything.
+func newTestTracer(t *testing.T, sampleRate float64) Tracer {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	tracer, err := New(Config{
+		ExporterConfig: ExporterConfig{
+			Type:     HTTP,
+			Endpoint: strings.TrimPrefix(server.URL, "http://"),
+			Insecure: true,
+		},
+		TraceSampleRate: sampleRate,
+		AppName:         "avalanchego-test",
+	})
+	require.NoError(t, err, "New()")
+	t.Cleanup(func() {
+		require.NoError(t, tracer.Close(), "Close()")
+	})
+	return tracer
+}
+
+func TestBatcherOptionsHonorOTelEnv(t *testing.T) {
+	require.Len(t, batcherOptions(), 1, "the default export timeout must be pinned when OTEL_BSP_EXPORT_TIMEOUT is unset")
+
+	t.Setenv("OTEL_BSP_EXPORT_TIMEOUT", "30000")
+	require.Empty(t, batcherOptions(), "OTEL_BSP_EXPORT_TIMEOUT must take precedence over the default export timeout")
+}
+
+func TestSamplerFromConfig(t *testing.T) {
+	tracer := newTestTracer(t, 1)
+
+	_, span := tracer.Start(t.Context(), "test")
+	defer span.End()
+	require.True(t, span.SpanContext().IsSampled(), "TraceSampleRate=1 must sample every span")
+}
+
+func TestSamplerEnvOverride(t *testing.T) {
+	t.Setenv("OTEL_TRACES_SAMPLER", "always_off")
+	tracer := newTestTracer(t, 1)
+
+	_, span := tracer.Start(t.Context(), "test")
+	defer span.End()
+	require.False(t, span.SpanContext().IsSampled(), "OTEL_TRACES_SAMPLER=always_off must take precedence over TraceSampleRate")
+}
+
+func TestNewResourceDefaults(t *testing.T) {
+	res, err := newResource("avalanchego-test", "v1.2.3")
+	require.NoError(t, err, "newResource()")
+
+	attrs := attribute.NewSet(res.Attributes()...)
+	name, ok := attrs.Value(semconv.ServiceNameKey)
+	require.True(t, ok, "resource must have a service.name attribute")
+	require.Equal(t, "avalanchego-test", name.AsString(), "service.name defaults to the app name")
+
+	version, ok := attrs.Value("version")
+	require.True(t, ok, "resource must have a version attribute")
+	require.Equal(t, "v1.2.3", version.AsString(), "version attribute")
+}
+
+func TestNewResourceHonorsOTelEnv(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "custom-name")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=prod")
+
+	res, err := newResource("avalanchego-test", "v1.2.3")
+	require.NoError(t, err, "newResource()")
+
+	attrs := attribute.NewSet(res.Attributes()...)
+	name, ok := attrs.Value(semconv.ServiceNameKey)
+	require.True(t, ok, "resource must have a service.name attribute")
+	require.Equal(t, "custom-name", name.AsString(), "OTEL_SERVICE_NAME overrides the default service.name")
+
+	env, ok := attrs.Value("deployment.environment")
+	require.True(t, ok, "OTEL_RESOURCE_ATTRIBUTES must be merged into the resource")
+	require.Equal(t, "prod", env.AsString(), "deployment.environment from OTEL_RESOURCE_ATTRIBUTES")
+
+	version, ok := attrs.Value("version")
+	require.True(t, ok, "default attributes must survive env merging")
+	require.Equal(t, "v1.2.3", version.AsString(), "version attribute")
+}


### PR DESCRIPTION
## Why this should be merged

OpenTelemetry supports a lot of standard environment variables that can be used to configure the tracer provided by the Go OpenTelemetry SDK. These environment variables are standard across languages so it makes it easy for operators to configure them without having to learn the quirks of another software service's configuration.

This PR adds support for supporting all of them and integrating it into existing trace flags / configuration in AvalancheGo.

## How this works

## How this was tested

## Need to be documented in RELEASES.md?

Yes, to let users know that these new environment variables are available.