### PR TITLE
Expose the node tracer on snow.Context

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -508,6 +508,7 @@ func (m *manager) buildChain(chainParams ChainParameters, sb subnets.Subnet) (*c
 			AVAXAssetID: m.AVAXAssetID,
 
 			Log:          chainLog,
+			Tracer:       m.Tracer,
 			SharedMemory: m.AtomicMemory.NewSharedMemory(chainParams.ID),
 			BCLookup:     m,
 			Metrics:      metrics.NewPrefixGatherer(),

--- a/snow/BUILD.bazel
+++ b/snow/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//ids",
         "//proto/pb/p2p",
         "//snow/validators",
+        "//trace",
         "//upgrade",
         "//utils",
         "//utils/crypto/bls",

--- a/snow/context.go
+++ b/snow/context.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
@@ -43,6 +44,9 @@ type Context struct {
 	AVAXAssetID ids.ID
 
 	Log logging.Logger
+	// Tracer records spans for chain operations. VMs SHOULD use it to trace
+	// their internals. It is [trace.Noop] when tracing is disabled.
+	Tracer trace.Tracer
 	// Deprecated: This lock should not be used unless absolutely necessary.
 	// This lock will be removed in a future release once it is replaced with
 	// more granular locks.

--- a/snow/snowtest/BUILD.bazel
+++ b/snow/snowtest/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "go_test")
 
 go_library(
     name = "snowtest",
@@ -17,12 +18,24 @@ go_library(
         "//snow",
         "//snow/validators",
         "//snow/validators/validatorstest",
+        "//trace",
         "//upgrade/upgradetest",
         "//utils/constants",
         "//utils/crypto/bls/signer/localsigner",
         "//utils/logging",
         "//vms/platformvm/warp",
         "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
+go_test(
+    name = "snowtest_test",
+    srcs = ["context_test.go"],
+    embed = [":snowtest"],
+    deps = [
+        "//ids",
+        "//trace",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/snow/snowtest/context.go
+++ b/snow/snowtest/context.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
+	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
@@ -104,6 +105,7 @@ func Context(tb testing.TB, chainID ids.ID) *snow.Context {
 		AVAXAssetID: AVAXAssetID,
 
 		Log:          logging.NoLog{},
+		Tracer:       trace.Noop,
 		SharedMemory: sharedMemory,
 		BCLookup:     aliaser,
 		Metrics:      metrics.NewPrefixGatherer(),

--- a/snow/snowtest/context_test.go
+++ b/snow/snowtest/context_test.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package snowtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/trace"
+)
+
+func TestContextTracerDefaultsToNoop(t *testing.T) {
+	ctx := Context(t, ids.GenerateTestID())
+	require.Equal(t, trace.Noop, ctx.Tracer, "snowtest.Context() must populate Tracer so VMs can use it without nil checks")
+}


### PR DESCRIPTION
## Why this should be merged
I'm working on setting up tracing in SAE and exposing the tracer in the `snow.Context` will enable SAE to emit traces in the various places that it needs to.

## How this works
Adds a new `Tracer` field to the context and wires in the tracer from the chain manager.

## How this was tested
I have a PR on top that uses this that is completely inside of SAEVM. See https://github.com/ava-labs/avalanchego/pull/5903.

## Need to be documented in RELEASES.md?
No