### PR TITLE
fix(blockdb): address review feedback and harden recovery

### DIFF
--- a/x/blockdb/BUILD.bazel
+++ b/x/blockdb/BUILD.bazel
@@ -41,11 +41,9 @@ go_test(
         "//cache/lru",
         "//database",
         "//database/heightindexdb/dbtest",
-        "//utils",
         "//utils/compression",
         "//utils/logging",
         "//utils/math",
-        "@com_github_datadog_zstd//:zstd",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/x/blockdb/config.go
+++ b/x/blockdb/config.go
@@ -8,7 +8,7 @@ import "errors"
 // DefaultMaxDataFileSize is the default maximum size of the data block file in bytes (500GB).
 const DefaultMaxDataFileSize = 500 * 1024 * 1024 * 1024
 
-// DefaultMaxDataFiles is the default maximum number of data files descriptors cached.
+// DefaultMaxDataFiles is the default maximum number of data file descriptors cached.
 const DefaultMaxDataFiles = 10
 
 // DefaultBlockCacheSize is the default size of the block cache.
@@ -28,7 +28,9 @@ type DatabaseConfig struct {
 	// MaxDataFileSize sets the maximum size of the data block file in bytes.
 	MaxDataFileSize uint64
 
-	// MaxDataFiles is the maximum number of data files descriptors cached.
+	// MaxDataFiles is the maximum number of data file descriptors cached.
+	// Most callers should use DefaultMaxDataFiles and only increase it if
+	// concurrent access to distinct data files causes descriptor churn.
 	MaxDataFiles int
 
 	// BlockCacheSize is the size of the block cache (default: 256).

--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -185,13 +185,13 @@ type Database struct {
 
 	// fileOpenMu prevents race conditions when multiple threads try to open the same data file
 	fileOpenMu sync.Mutex
+	// checkpointMu keeps a checkpoint from observing an incomplete Put.
+	checkpointMu sync.RWMutex
 
 	// maxBlockHeight tracks the highest block height written
 	maxBlockHeight atomic.Uint64
-	// nextDataWriteOffset tracks the next position to write new data in the data file.
-	nextDataWriteOffset atomic.Uint64
-	// headerWriteOccupied prevents concurrent writes to the index header
-	headerWriteOccupied atomic.Bool
+	// nextDataReservationOffset tracks the next position available for a data write.
+	nextDataReservationOffset atomic.Uint64
 }
 
 // New creates a block database.
@@ -219,9 +219,7 @@ func New(config DatabaseConfig, log logging.Logger) (_ database.HeightIndex, err
 		config: config,
 		log:    databaseLog,
 		fileCache: lru.NewCacheWithOnEvict(config.MaxDataFiles, func(_ int, f *os.File) {
-			if f != nil {
-				f.Close()
-			}
+			f.Close()
 		}),
 		compressor: compressor,
 	}
@@ -254,12 +252,6 @@ func New(config DatabaseConfig, log logging.Logger) (_ database.HeightIndex, err
 		return nil, err
 	}
 
-	if err := db.initializeDataFiles(); err != nil {
-		db.log.Error("Failed to initialize database: failed to initialize data files", zap.Error(err))
-		db.closeFiles()
-		return nil, err
-	}
-
 	if err := db.recover(); err != nil {
 		db.log.Error("Failed to initialize database: recovery failed", zap.Error(err))
 		db.closeFiles()
@@ -268,7 +260,7 @@ func New(config DatabaseConfig, log logging.Logger) (_ database.HeightIndex, err
 
 	maxHeight := db.maxBlockHeight.Load()
 	db.log.Info("BlockDB initialized successfully",
-		zap.Uint64("nextWriteOffset", db.nextDataWriteOffset.Load()),
+		zap.Uint64("nextDataReservationOffset", db.nextDataReservationOffset.Load()),
 		zap.Uint64("maxBlockHeight", maxHeight),
 	)
 
@@ -350,7 +342,15 @@ func (db *Database) Put(height BlockHeight, block BlockData) error {
 		)
 		return fmt.Errorf("calculating total block size would overflow for block at height %d: %w", height, err)
 	}
-	writeDataOffset, err := db.allocateBlockSpace(sizeWithDataHeader)
+	db.checkpointMu.RLock()
+	checkpointLocked := true
+	defer func() {
+		if checkpointLocked {
+			db.checkpointMu.RUnlock()
+		}
+	}()
+
+	reservation, err := db.allocateBlockSpace(sizeWithDataHeader)
 	if err != nil {
 		db.log.Error("Failed to write block: failed to allocate block space",
 			zap.Uint64("height", height),
@@ -359,6 +359,7 @@ func (db *Database) Put(height BlockHeight, block BlockData) error {
 		)
 		return err
 	}
+	writeDataOffset := reservation.writeOffset
 
 	bh := blockEntryHeader{
 		Height:   height,
@@ -367,6 +368,8 @@ func (db *Database) Put(height BlockHeight, block BlockData) error {
 		Version:  BlockEntryVersion,
 	}
 	if err := db.writeBlockAt(writeDataOffset, bh, blockToWrite); err != nil {
+		// Reclaim the range only if no later Put has reserved past it.
+		db.nextDataReservationOffset.CompareAndSwap(reservation.endOffset, reservation.previousOffset)
 		db.log.Error("Failed to write block: error writing block data",
 			zap.Uint64("height", height),
 			zap.Uint64("dataOffset", writeDataOffset),
@@ -385,12 +388,20 @@ func (db *Database) Put(height BlockHeight, block BlockData) error {
 		return err
 	}
 
-	if err := db.updateBlockMaxHeight(height); err != nil {
-		db.log.Error("Failed to write block: error updating max block height",
-			zap.Uint64("height", height),
-			zap.Error(err),
-		)
-		return err
+	db.updateBlockMaxHeight(height)
+	// The index entry is complete, so a checkpoint may proceed.
+	db.checkpointMu.RUnlock()
+	checkpointLocked = false
+
+	if height%db.config.CheckpointInterval == 0 {
+		if err := db.persistIndexHeader(); err != nil {
+			err = fmt.Errorf("block %d was written, but checkpointing failed: %w", height, err)
+			db.log.Error("Failed to checkpoint written block",
+				zap.Uint64("height", height),
+				zap.Error(err),
+			)
+			return err
+		}
 	}
 
 	db.log.Debug("Block written successfully",
@@ -461,52 +472,40 @@ func (db *Database) Get(height BlockHeight) (BlockData, error) {
 		return nil, err
 	}
 
-	totalReadSize, err := safemath.Add(uint64(sizeOfBlockEntryHeader), uint64(indexEntry.Size))
+	dataEnd, err := db.dataFileEndForOffset(indexEntry.Offset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compute total read size: %w", err)
-	}
-	buf := make([]byte, int(totalReadSize))
-
-	// loop to retry fetching the data file if it got closed between get and read.
-	// If not closed, we read the block header and data.
-	for {
-		dataFile, localOffset, fileIndex, err := db.getDataFileAndOffset(indexEntry.Offset)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get data file and offset: %w", err)
+		if errors.Is(err, ErrCorrupted) {
+			return nil, db.blockUnavailableError(height, indexEntry, err)
 		}
-		if _, err := dataFile.ReadAt(buf, int64(localOffset)); err != nil {
-			if errors.Is(err, os.ErrClosed) {
-				db.fileCache.Evict(fileIndex)
-				continue
-			}
-			db.log.Error("Failed to read block: failed to read block data from file",
-				zap.Uint64("height", height),
-				zap.Uint64("localOffset", localOffset),
-				zap.Uint32("blockSize", indexEntry.Size),
-				zap.Error(err),
-			)
-			return nil, fmt.Errorf("failed to read block header and data: %w", err)
-		}
-		break
+		return nil, err
 	}
-
-	var bh blockEntryHeader
-	if err := bh.UnmarshalBinary(buf[:int(sizeOfBlockEntryHeader)]); err != nil {
-		return nil, fmt.Errorf("failed to deserialize block header: %w", err)
-	}
-	compressedData := buf[int(sizeOfBlockEntryHeader):]
-	decompressed, err := db.compressor.Decompress(compressedData)
+	bh, block, err := db.readBlockAtOffset(indexEntry.Offset, dataEnd, &indexEntry.Size)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decompress block data: %w", err)
+		if errors.Is(err, ErrCorrupted) {
+			return nil, db.blockUnavailableError(height, indexEntry, err)
+		}
+		return nil, err
+	}
+	if bh.Height != height {
+		return nil, db.blockUnavailableError(height, indexEntry, fmt.Errorf(
+			"%w: requested block height %d does not match stored height %d",
+			ErrCorrupted,
+			height,
+			bh.Height,
+		))
 	}
 
-	// Verify checksum on uncompressed data
-	calculatedChecksum := calculateChecksum(decompressed)
-	if calculatedChecksum != bh.Checksum {
-		return nil, fmt.Errorf("checksum mismatch: calculated %d, stored %d", calculatedChecksum, bh.Checksum)
-	}
+	return block, nil
+}
 
-	return decompressed, nil
+func (db *Database) blockUnavailableError(height BlockHeight, entry indexEntry, err error) error {
+	db.log.Error("Indexed block data is unavailable",
+		zap.Uint64("height", height),
+		zap.Uint64("dataOffset", entry.Offset),
+		zap.Uint32("indexedSize", entry.Size),
+		zap.Error(err),
+	)
+	return fmt.Errorf("block at height %d is unavailable: %w", height, err)
 }
 
 // Has checks if a block exists at the given height.
@@ -542,9 +541,9 @@ func (db *Database) getDataFileIndexForHeight(height BlockHeight) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	_, _, idx, err := db.getDataFileAndOffset(entry.Offset)
+	idx, _, err := db.dataFileIndexAndOffset(entry.Offset)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get data file index for height %d: %w", height, err)
+		return 0, fmt.Errorf("%w: calculating data file index for height %d: %w", ErrCorrupted, height, err)
 	}
 	return idx, nil
 }
@@ -580,11 +579,11 @@ func (db *Database) Sync(start, end uint64) error {
 	}
 
 	for idx := firstIdx; idx <= lastIdx; idx++ {
-		f, err := db.getOrOpenDataFile(idx)
+		f, err := db.getDataFile(idx, os.O_RDWR)
 		if err != nil {
 			return fmt.Errorf("failed to open data file %d: %w", idx, err)
 		}
-		if err := f.Sync(); err != nil {
+		if err := db.retryDataFileOperation(idx, f, (*os.File).Sync); err != nil {
 			return fmt.Errorf("failed to sync data file %d: %w", idx, err)
 		}
 	}
@@ -594,17 +593,17 @@ func (db *Database) Sync(start, end uint64) error {
 
 func (db *Database) indexEntryOffset(height BlockHeight) (uint64, error) {
 	if height < db.header.MinHeight {
-		return 0, fmt.Errorf("%w: failed to get index entry offset for block at height %d, minimum height is %d", ErrInvalidBlockHeight, height, db.header.MinHeight)
+		return 0, fmt.Errorf("%w: block height %d is below minimum height %d", ErrInvalidBlockHeight, height, db.header.MinHeight)
 	}
 
 	relativeHeight := height - db.header.MinHeight
 	offsetFromHeaderStart, err := safemath.Mul(relativeHeight, sizeOfIndexEntry)
 	if err != nil {
-		return 0, fmt.Errorf("%w: block height %d is too large", ErrInvalidBlockHeight, height)
+		return 0, fmt.Errorf("%w: block height %d is too large to calculate its index file offset", ErrInvalidBlockHeight, height)
 	}
 	finalOffset, err := safemath.Add(sizeOfIndexFileHeader, offsetFromHeaderStart)
 	if err != nil {
-		return 0, fmt.Errorf("%w: block height %d is too large", ErrInvalidBlockHeight, height)
+		return 0, fmt.Errorf("%w: block height %d is too large to calculate its index file offset", ErrInvalidBlockHeight, height)
 	}
 
 	return finalOffset, nil
@@ -626,7 +625,7 @@ func (db *Database) readIndexEntry(height BlockHeight) (indexEntry, error) {
 		// Return database.ErrNotFound if trying to read past the end of the index file
 		// for a block that has not been indexed yet.
 		if errors.Is(err, io.EOF) {
-			return entry, fmt.Errorf("%w: EOF reading index entry at offset %d for height %d", database.ErrNotFound, offset, height)
+			return entry, fmt.Errorf("%w: block at height %d is not indexed", database.ErrNotFound, height)
 		}
 		return entry, fmt.Errorf("failed to read index entry at offset %d for height %d: %w", offset, height, err)
 	}
@@ -635,7 +634,7 @@ func (db *Database) readIndexEntry(height BlockHeight) (indexEntry, error) {
 	}
 
 	if entry.IsEmpty() {
-		return entry, fmt.Errorf("%w: empty index entry for height %d", database.ErrNotFound, height)
+		return entry, fmt.Errorf("%w: block at height %d is not indexed", database.ErrNotFound, height)
 	}
 
 	return entry, nil
@@ -659,37 +658,94 @@ func (db *Database) writeIndexEntryAt(indexFileOffset, dataFileBlockOffset uint6
 }
 
 func (db *Database) persistIndexHeader() error {
-	if db.headerWriteOccupied.CompareAndSwap(false, true) {
-		defer db.headerWriteOccupied.Store(false)
-		return db.persistIndexHeaderInternal()
-	}
-	db.log.Info("Skipping persistIndexHeader due to concurrent header write")
-	return nil
-}
+	db.checkpointMu.Lock()
+	defer db.checkpointMu.Unlock()
 
-func (db *Database) persistIndexHeaderInternal() error {
+	// Persist the physical extent, not the reservation frontier, because a failed
+	// WriteAt may have created only part of its reserved record.
+	files, maxIdx, err := db.listDataFiles()
+	if err != nil {
+		return fmt.Errorf("failed to list data files before checkpointing: %w", err)
+	}
+	dataEnd, err := db.calculatePhysicalDataEnd(files, maxIdx)
+	if err != nil {
+		return err
+	}
+	checkpoint := max(dataEnd, db.header.NextWriteOffset)
+
 	// The index file must be fsync'd before the header is written to prevent
 	// a state where the header is persisted but the index entries it refers to
 	// are not. This could lead to data inconsistency on recovery.
 	if db.config.SyncToDisk {
 		if err := db.indexFile.Sync(); err != nil {
-			return fmt.Errorf("failed to sync index file before writing header state: %w", err)
+			return fmt.Errorf("failed to sync index entries before checkpointing: %w", err)
 		}
 	}
 
 	header := db.header
 
 	// Update the header with the current state of the database.
-	header.NextWriteOffset = db.nextDataWriteOffset.Load()
+	header.NextWriteOffset = checkpoint
 	header.MaxHeight = db.maxBlockHeight.Load()
 	headerBytes, err := header.MarshalBinary()
 	if err != nil {
-		return fmt.Errorf("failed to serialize header for writing state: %w", err)
+		return fmt.Errorf("failed to marshal checkpoint header: %w", err)
 	}
 	if _, err := db.indexFile.WriteAt(headerBytes, 0); err != nil {
-		return fmt.Errorf("failed to write header state to index file: %w", err)
+		return fmt.Errorf("failed to write checkpoint header: %w", err)
 	}
+	if db.config.SyncToDisk {
+		if err := db.indexFile.Sync(); err != nil {
+			return fmt.Errorf("failed to sync checkpoint header: %w", err)
+		}
+	}
+	db.header.NextWriteOffset = checkpoint
 	return nil
+}
+
+func (db *Database) calculatePhysicalDataEnd(files map[int]string, maxIdx int) (uint64, error) {
+	if maxIdx < 0 {
+		return 0, nil
+	}
+	path, ok := files[maxIdx]
+	if !ok {
+		return 0, fmt.Errorf("%w: data file at index %d is missing", ErrCorrupted, maxIdx)
+	}
+	return db.dataFileEnd(maxIdx, path)
+}
+
+func (db *Database) dataFileEnd(idx int, path string) (uint64, error) {
+	fileOffset, err := safemath.Mul(uint64(idx), db.header.MaxDataFileSize)
+	if err != nil {
+		return 0, fmt.Errorf("%w: calculating data file %d offset would overflow: %w", ErrCorrupted, idx, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get stats for data file %d: %w", idx, err)
+	}
+	fileEnd, err := safemath.Add(fileOffset, uint64(info.Size()))
+	if err != nil {
+		return 0, fmt.Errorf("%w: calculating data file %d end would overflow: %w", ErrCorrupted, idx, err)
+	}
+	return fileEnd, nil
+}
+
+func (db *Database) dataFileEndForOffset(offset uint64) (uint64, error) {
+	idx, _, err := db.dataFileIndexAndOffset(offset)
+	if err != nil {
+		return 0, fmt.Errorf("%w: calculating data file index for offset %d: %w", ErrCorrupted, offset, err)
+	}
+	fileEnd, err := db.dataFileEnd(idx, db.dataFilePath(idx))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, fmt.Errorf("%w: indexed data file %d does not exist", ErrCorrupted, idx)
+		}
+		return 0, err
+	}
+	if offset >= fileEnd {
+		return 0, fmt.Errorf("%w: index offset %d is outside data file %d", ErrCorrupted, offset, idx)
+	}
+	return fileEnd, nil
 }
 
 // recover detects and recovers unindexed blocks by scanning data files and updating the index.
@@ -698,67 +754,59 @@ func (db *Database) persistIndexHeaderInternal() error {
 // For each unindexed block found, it validates the block, then
 // writes the corresponding index entry and updates block height tracking.
 func (db *Database) recover() error {
-	dataFiles, maxIndex, err := db.listDataFiles()
+	checkpoint := db.header.NextWriteOffset
+	files, maxIdx, err := db.listDataFiles()
 	if err != nil {
 		return fmt.Errorf("failed to list data files for recovery: %w", err)
 	}
 
-	if len(dataFiles) == 0 {
+	if len(files) == 0 {
+		if checkpoint > 0 {
+			return fmt.Errorf(
+				"%w: index checkpoint is %d bytes, but no data files exist",
+				ErrCorrupted,
+				checkpoint,
+			)
+		}
 		return nil
 	}
 
-	if db.header.MaxDataFileSize == math.MaxUint64 && len(dataFiles) > 1 {
-		return fmt.Errorf("%w: only one data file expected when MaxDataFileSize is max uint64, got %d files with max index %d", ErrCorrupted, len(dataFiles), maxIndex)
+	if db.header.MaxDataFileSize == math.MaxUint64 && len(files) > 1 {
+		return fmt.Errorf("%w: only one data file expected when MaxDataFileSize is max uint64, got %d files with max index %d", ErrCorrupted, len(files), maxIdx)
 	}
 
-	// ensure no data files are missing
-	// If any data files are missing, we would need to recalculate the max height.
-	// This can be supported in the future but for now to keep things simple,
-	// we will just error if the data files are not as expected.
-	for i := 0; i <= maxIndex; i++ {
-		if _, exists := dataFiles[i]; !exists {
+	// File presence and extent are cheap structural checks. Recovery does not
+	// rescan record contents before the persisted checkpoint.
+	for i := 0; i <= maxIdx; i++ {
+		if _, ok := files[i]; !ok {
 			return fmt.Errorf("%w: data file at index %d is missing", ErrCorrupted, i)
 		}
 	}
 
-	// Calculate the expected next write offset based on the data on disk.
-	var calculatedNextDataWriteOffset uint64
-	fileSizeContribution, err := safemath.Mul(uint64(maxIndex), db.header.MaxDataFileSize)
+	dataEnd, err := db.calculatePhysicalDataEnd(files, maxIdx)
 	if err != nil {
-		return fmt.Errorf("calculating file size contribution would overflow: %w", err)
-	}
-	calculatedNextDataWriteOffset = fileSizeContribution
-
-	lastFileInfo, err := os.Stat(dataFiles[maxIndex])
-	if err != nil {
-		return fmt.Errorf("failed to get stats for last data file %s: %w", dataFiles[maxIndex], err)
-	}
-	calculatedNextDataWriteOffset, err = safemath.Add(calculatedNextDataWriteOffset, uint64(lastFileInfo.Size()))
-	if err != nil {
-		return fmt.Errorf("adding last file size would overflow: %w", err)
+		return err
 	}
 
-	nextDataWriteOffset := db.nextDataWriteOffset.Load()
 	switch {
-	case calculatedNextDataWriteOffset == nextDataWriteOffset:
+	case dataEnd == checkpoint:
 		db.log.Debug("Recovery: data files match index header, no recovery needed.")
 		return nil
 
-	case calculatedNextDataWriteOffset < nextDataWriteOffset:
-		// this happens when the index claims to have more data than is actually on disk
-		return fmt.Errorf("%w: index header claims to have more data than is actually on disk "+
-			"(calculated: %d bytes, index header: %d bytes)",
-			ErrCorrupted, calculatedNextDataWriteOffset, nextDataWriteOffset)
+	case dataEnd < checkpoint:
+		return fmt.Errorf("%w: index checkpoint is ahead of physical data "+
+			"(physical data end: %d bytes, checkpoint: %d bytes)",
+			ErrCorrupted, dataEnd, checkpoint)
 	default:
 		// The data on disk is ahead of the index. We need to recover unindexed blocks.
-		if err := db.recoverUnindexedBlocks(nextDataWriteOffset, calculatedNextDataWriteOffset); err != nil {
+		if err := db.recoverUnindexedBlocks(checkpoint, dataEnd); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// recoverUnindexedBlocks scans data files from the given offset and recovers blocks that were written but not indexed.
+// recoverUnindexedBlocks scans data written after the persisted checkpoint and rebuilds missing index entries.
 func (db *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error {
 	db.log.Info("Recovery: data files are ahead of index; recovering unindexed blocks.",
 		zap.Uint64("startOffset", startOffset),
@@ -766,27 +814,49 @@ func (db *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error 
 	)
 
 	var (
-		// Start scan from where the index left off.
+		// Start at the persisted checkpoint, where the index was last synchronized.
 		currentScanOffset   = startOffset
 		numRecoveredHeights int
-		maxRecoveredHeight  BlockHeight
+		currentFileIndex    = -1
+		currentFileEnd      uint64
+		badOffset           uint64
+		badErr              error
 	)
 	for currentScanOffset < endOffset {
-		bh, err := db.recoverBlockAtOffset(currentScanOffset, endOffset)
+		idx, _, err := db.dataFileIndexAndOffset(currentScanOffset)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				// Reached end of this file, try to read the next file
-				currentFileIndex := int(currentScanOffset / db.header.MaxDataFileSize)
-				nextFileIndex, err := safemath.Add(uint64(currentFileIndex), 1)
-				if err != nil {
-					return fmt.Errorf("recovery: overflow in file index calculation: %w", err)
-				}
-				if currentScanOffset, err = safemath.Mul(nextFileIndex, db.header.MaxDataFileSize); err != nil {
-					return fmt.Errorf("recovery: overflow in scan offset calculation: %w", err)
-				}
-				continue
+			return fmt.Errorf("recovery: %w: calculating data file index for offset %d: %w", ErrCorrupted, currentScanOffset, err)
+		}
+		if idx != currentFileIndex {
+			currentFileIndex = idx
+			fileEnd, err := db.dataFileEnd(currentFileIndex, db.dataFilePath(currentFileIndex))
+			if err != nil {
+				return fmt.Errorf("recovery: %w", err)
 			}
-			return err
+			currentFileEnd = fileEnd
+		}
+		if currentScanOffset >= currentFileEnd {
+			// A block that crosses a file boundary leaves this file's remaining range unused.
+			nextIdx, err := safemath.Add(uint64(currentFileIndex), 1)
+			if err != nil {
+				return fmt.Errorf("recovery: overflow in file index calculation: %w", err)
+			}
+			if currentScanOffset, err = safemath.Mul(nextIdx, db.header.MaxDataFileSize); err != nil {
+				return fmt.Errorf("recovery: overflow in scan offset calculation: %w", err)
+			}
+			continue
+		}
+
+		bh, err := db.recoverBlockAtOffset(currentScanOffset, currentFileEnd)
+		if err != nil {
+			if !errors.Is(err, ErrCorrupted) {
+				return err
+			}
+			badOffset = currentScanOffset
+			badErr = err
+			// The checkpoint header can lag a later index entry, so preserve this suffix.
+			currentScanOffset = endOffset
+			break
 		}
 		db.log.Debug("Recovery: Successfully validated and indexed block",
 			zap.Uint64("height", bh.Height),
@@ -794,107 +864,138 @@ func (db *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error 
 			zap.Uint64("dataOffset", currentScanOffset),
 		)
 		numRecoveredHeights++
-		maxRecoveredHeight = max(maxRecoveredHeight, bh.Height)
-		blockTotalSize, err := safemath.Add(uint64(sizeOfBlockEntryHeader), uint64(bh.Size))
+		db.updateBlockMaxHeight(bh.Height)
+		blockSize, err := safemath.Add(uint64(sizeOfBlockEntryHeader), uint64(bh.Size))
 		if err != nil {
 			return fmt.Errorf("recovery: overflow in block size calculation: %w", err)
 		}
-		currentScanOffset, err = safemath.Add(currentScanOffset, blockTotalSize)
+		currentScanOffset, err = safemath.Add(currentScanOffset, blockSize)
 		if err != nil {
 			return fmt.Errorf("recovery: overflow in scan offset calculation: %w", err)
 		}
 	}
-	db.nextDataWriteOffset.Store(currentScanOffset)
-
-	// Update the max block height if max recovered height is greater than
-	// the current max height.
-	if numRecoveredHeights > 0 {
-		currentMaxHeight := db.maxBlockHeight.Load()
-		if maxRecoveredHeight > currentMaxHeight || currentMaxHeight == unsetHeight {
-			db.maxBlockHeight.Store(maxRecoveredHeight)
-		}
-	}
+	// Append after recovered data and any malformed suffix left as an orphan.
+	db.nextDataReservationOffset.Store(currentScanOffset)
 
 	if err := db.persistIndexHeader(); err != nil {
 		return fmt.Errorf("recovery: failed to save index header after recovery scan: %w", err)
+	}
+	if badErr != nil {
+		db.log.Warn("Recovery stopped at malformed data; remaining suffix left orphaned",
+			zap.Uint64("dataOffset", badOffset),
+			zap.Uint64("dataEnd", endOffset),
+			zap.Error(badErr),
+		)
 	}
 
 	maxHeight := db.maxBlockHeight.Load()
 	db.log.Info("Recovery: Scan finished",
 		zap.Int("recoveredBlocks", numRecoveredHeights),
-		zap.Uint64("finalNextWriteOffset", db.nextDataWriteOffset.Load()),
+		zap.Uint64("finalNextDataReservationOffset", db.nextDataReservationOffset.Load()),
 		zap.Uint64("maxBlockHeight", maxHeight),
 	)
 	return nil
 }
 
-func (db *Database) recoverBlockAtOffset(offset, totalDataSize uint64) (blockEntryHeader, error) {
+func (db *Database) recoverBlockAtOffset(offset, dataEnd uint64) (blockEntryHeader, error) {
+	bh, _, err := db.readBlockAtOffset(offset, dataEnd, nil)
+	if err != nil {
+		return bh, err
+	}
+	indexOffset, err := db.indexEntryOffset(bh.Height)
+	if err != nil {
+		return bh, fmt.Errorf("%w: cannot get index offset for recovered block %d: %w", ErrCorrupted, bh.Height, err)
+	}
+	if err := db.writeIndexEntryAt(indexOffset, offset, bh.Size); err != nil {
+		return bh, fmt.Errorf("failed to write index entry for recovered block %d: %w", bh.Height, err)
+	}
+	return bh, nil
+}
+
+func (db *Database) readBlockAtOffset(offset, dataEnd uint64, indexedSize *uint32) (blockEntryHeader, BlockData, error) {
 	var bh blockEntryHeader
-	if totalDataSize-offset < uint64(sizeOfBlockEntryHeader) {
-		return bh, fmt.Errorf("%w: not enough data for block header at offset %d", ErrCorrupted, offset)
+	if dataEnd-offset < uint64(sizeOfBlockEntryHeader) {
+		return bh, nil, fmt.Errorf("%w: not enough data for block header at offset %d", ErrCorrupted, offset)
 	}
 
-	dataFile, localOffset, _, err := db.getDataFileAndOffset(offset)
+	idx, localOffset, err := db.dataFileIndexAndOffset(offset)
 	if err != nil {
-		return bh, fmt.Errorf("recovery: failed to get data file for offset %d: %w", offset, err)
+		return bh, nil, fmt.Errorf("%w: calculating data file index for offset %d: %w", ErrCorrupted, offset, err)
+	}
+	f, err := db.getDataFile(idx, os.O_RDWR)
+	if err != nil {
+		return bh, nil, blockReadError("header", offset, err)
 	}
 	bhBuf := make([]byte, sizeOfBlockEntryHeader)
-	if _, err := dataFile.ReadAt(bhBuf, int64(localOffset)); err != nil {
-		return bh, fmt.Errorf("%w: error reading block header at offset %d: %w", ErrCorrupted, offset, err)
+	if err := db.readDataFileAt(idx, f, bhBuf, int64(localOffset)); err != nil {
+		return bh, nil, blockReadError("header", offset, err)
 	}
 	if err := bh.UnmarshalBinary(bhBuf); err != nil {
-		return bh, fmt.Errorf("%w: error deserializing block header at offset %d: %w", ErrCorrupted, offset, err)
+		return bh, nil, fmt.Errorf("%w: error deserializing block header at offset %d: %w", ErrCorrupted, offset, err)
 	}
 	if bh.Size == 0 {
-		return bh, fmt.Errorf("%w: invalid block size in header at offset %d: %d", ErrCorrupted, offset, bh.Size)
+		return bh, nil, fmt.Errorf("%w: invalid block size in header at offset %d: %d", ErrCorrupted, offset, bh.Size)
+	}
+	// Validate the indexed size before allocating based on the stored header.
+	if indexedSize != nil && bh.Size != *indexedSize {
+		return bh, nil, fmt.Errorf("%w: indexed block size %d does not match stored size %d", ErrCorrupted, *indexedSize, bh.Size)
 	}
 	if bh.Version > BlockEntryVersion {
-		return bh, fmt.Errorf("%w: invalid block entry version at offset %d, version %d is greater than the current version %d", ErrCorrupted, offset, bh.Version, BlockEntryVersion)
+		return bh, nil, fmt.Errorf("%w: invalid block entry version at offset %d, version %d is greater than the current version %d", ErrCorrupted, offset, bh.Version, BlockEntryVersion)
 	}
 	if bh.Height < db.header.MinHeight || bh.Height == unsetHeight {
-		return bh, fmt.Errorf(
+		return bh, nil, fmt.Errorf(
 			"%w: invalid block height in header at offset %d: found %d, expected >= %d",
 			ErrCorrupted, offset, bh.Height, db.header.MinHeight,
 		)
 	}
-	expectedBlockEndOffset, err := safemath.Add(offset, uint64(sizeOfBlockEntryHeader))
+	blockEnd, err := safemath.Add(offset, uint64(sizeOfBlockEntryHeader))
 	if err != nil {
-		return bh, fmt.Errorf("calculating block end offset would overflow at offset %d: %w", offset, err)
+		return bh, nil, fmt.Errorf("%w: calculating block end offset would overflow at offset %d: %w", ErrCorrupted, offset, err)
 	}
-	expectedBlockEndOffset, err = safemath.Add(expectedBlockEndOffset, uint64(bh.Size))
+	blockEnd, err = safemath.Add(blockEnd, uint64(bh.Size))
 	if err != nil {
-		return bh, fmt.Errorf("calculating block end offset would overflow at offset %d: %w", offset, err)
+		return bh, nil, fmt.Errorf("%w: calculating block end offset would overflow at offset %d: %w", ErrCorrupted, offset, err)
 	}
-	if expectedBlockEndOffset > totalDataSize {
-		return bh, fmt.Errorf("%w: block data out of bounds at offset %d", ErrCorrupted, offset)
+	if blockEnd > dataEnd {
+		return bh, nil, fmt.Errorf("%w: block data out of bounds at offset %d", ErrCorrupted, offset)
 	}
-	blockData := make([]byte, bh.Size)
-	blockDataOffset, err := safemath.Add(localOffset, uint64(sizeOfBlockEntryHeader))
+	compressed := make([]byte, bh.Size)
+	dataOffset, err := safemath.Add(localOffset, uint64(sizeOfBlockEntryHeader))
 	if err != nil {
-		return bh, fmt.Errorf("calculating block data offset would overflow at offset %d: %w", offset, err)
+		return bh, nil, fmt.Errorf("%w: calculating block data offset would overflow at offset %d: %w", ErrCorrupted, offset, err)
 	}
-	if _, err := dataFile.ReadAt(blockData, int64(blockDataOffset)); err != nil {
-		return bh, fmt.Errorf("%w: failed to read block data at offset %d: %w", ErrCorrupted, offset, err)
+	if err := db.readDataFileAt(idx, f, compressed, int64(dataOffset)); err != nil {
+		return bh, nil, blockReadError("data", offset, err)
 	}
-	// Decompress block data and verify checksum
-	decompressed, err := db.compressor.Decompress(blockData)
+	block, err := db.compressor.Decompress(compressed)
 	if err != nil {
-		return bh, fmt.Errorf("%w: failed to decompress block at offset %d: %w", ErrCorrupted, offset, err)
+		return bh, nil, fmt.Errorf("%w: failed to decompress block at offset %d: %w", ErrCorrupted, offset, err)
 	}
-	calculatedChecksum := calculateChecksum(decompressed)
-	if calculatedChecksum != bh.Checksum {
-		return bh, fmt.Errorf("%w: checksum mismatch for block at offset %d", ErrCorrupted, offset)
+	checksum := calculateChecksum(block)
+	if checksum != bh.Checksum {
+		return bh, nil, fmt.Errorf("%w: checksum mismatch for block at offset %d", ErrCorrupted, offset)
 	}
 
-	// Write index entry for this block
-	indexFileOffset, idxErr := db.indexEntryOffset(bh.Height)
-	if idxErr != nil {
-		return bh, fmt.Errorf("cannot get index offset for recovered block %d: %w", bh.Height, idxErr)
+	return bh, block, nil
+}
+
+func (db *Database) readDataFileAt(idx int, f *os.File, buf []byte, offset int64) error {
+	return db.retryDataFileOperation(idx, f, func(f *os.File) error {
+		_, err := f.ReadAt(buf, offset)
+		return err
+	})
+}
+
+func blockReadError(part string, offset uint64, err error) error {
+	switch {
+	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+		return fmt.Errorf("%w: incomplete block %s at offset %d: %w", ErrCorrupted, part, offset, err)
+	case errors.Is(err, os.ErrNotExist):
+		return fmt.Errorf("%w: data file for offset %d does not exist: %w", ErrCorrupted, offset, err)
+	default:
+		return fmt.Errorf("failed to read block %s at offset %d: %w", part, offset, err)
 	}
-	if err := db.writeIndexEntryAt(indexFileOffset, offset, bh.Size); err != nil {
-		return bh, fmt.Errorf("failed to update index for recovered block %d: %w", bh.Height, err)
-	}
-	return bh, nil
 }
 
 func (db *Database) listDataFiles() (map[int]string, int, error) {
@@ -932,17 +1033,11 @@ func (db *Database) openAndInitializeIndex() error {
 	if err != nil {
 		return fmt.Errorf("failed to open index file %s: %w", indexPath, err)
 	}
-	return db.loadOrInitializeHeader()
-}
-
-func (db *Database) initializeDataFiles() error {
-	// Pre-load the data file for the next write offset.
-	nextOffset := db.nextDataWriteOffset.Load()
-	if nextOffset > 0 {
-		_, _, _, err := db.getDataFileAndOffset(nextOffset)
-		if err != nil {
-			return fmt.Errorf("failed to pre-load data file for offset %d: %w", nextOffset, err)
+	if err := db.loadOrInitializeHeader(); err != nil {
+		if closeErr := db.indexFile.Close(); closeErr != nil {
+			return errors.Join(err, fmt.Errorf("failed to close index file after initialization failure: %w", closeErr))
 		}
+		return err
 	}
 	return nil
 }
@@ -990,31 +1085,24 @@ func (db *Database) loadOrInitializeHeader() error {
 	if db.header.Version != IndexFileVersion {
 		return fmt.Errorf("mismatched index file version: found %d, expected %d", db.header.Version, IndexFileVersion)
 	}
-	db.nextDataWriteOffset.Store(db.header.NextWriteOffset)
+	db.nextDataReservationOffset.Store(db.header.NextWriteOffset)
 	db.maxBlockHeight.Store(db.header.MaxHeight)
-	db.logConfigAndHeaderMismatches()
-
-	return nil
+	return db.validateConfigMatchesHeader()
 }
 
-func (db *Database) logConfigAndHeaderMismatches() {
-	// Some config values cannot be changed after index initialization.
-	// If they do not match the index header, log an info that
-	// the index header values will be used instead.
-	if db.config.MinimumHeight != db.header.MinHeight {
-		db.log.Info(
-			"MinimumHeight in config does not match the index header. The MinimumHeight in the index header will be used.",
-			zap.Uint64("configMinimumHeight", db.config.MinimumHeight),
-			zap.Uint64("headerMinimumHeight", db.header.MinHeight),
-		)
+func (db *Database) validateConfigMatchesHeader() error {
+	if db.config.MinimumHeight == db.header.MinHeight &&
+		db.config.MaxDataFileSize == db.header.MaxDataFileSize {
+		return nil
 	}
-	if db.config.MaxDataFileSize != db.header.MaxDataFileSize {
-		db.log.Info(
-			"MaxDataFileSize in config does not match the index header. The MaxDataFileSize in the index header will be used.",
-			zap.Uint64("configMaxDataFileSize", db.config.MaxDataFileSize),
-			zap.Uint64("headerMaxDataFileSize", db.header.MaxDataFileSize),
-		)
-	}
+	return fmt.Errorf(
+		"%w: configured MinimumHeight=%d and MaxDataFileSize=%d bytes, persisted MinimumHeight=%d and MaxDataFileSize=%d bytes",
+		errConfigMismatch,
+		db.config.MinimumHeight,
+		db.config.MaxDataFileSize,
+		db.header.MinHeight,
+		db.header.MaxDataFileSize,
+	)
 }
 
 func (db *Database) closeFiles() {
@@ -1031,9 +1119,18 @@ func (db *Database) dataFilePath(index int) string {
 	return filepath.Join(db.config.DataDir, fmt.Sprintf(dataFileNameFormat, index))
 }
 
-func (db *Database) getOrOpenDataFile(fileIndex int) (*os.File, error) {
-	if handle, ok := db.fileCache.Get(fileIndex); ok {
-		return handle, nil
+func (db *Database) dataFileIndexAndOffset(offset uint64) (int, uint64, error) {
+	maxFileSize := db.header.MaxDataFileSize
+	idx := offset / maxFileSize
+	if idx > math.MaxInt {
+		return 0, 0, fmt.Errorf("data file index %d exceeds maximum %d: %w", idx, math.MaxInt, safemath.ErrOverflow)
+	}
+	return int(idx), offset % maxFileSize, nil
+}
+
+func (db *Database) getDataFile(idx, flags int) (*os.File, error) {
+	if f, ok := db.fileCache.Get(idx); ok {
+		return f, nil
 	}
 
 	// Prevent race conditions when multiple threads try to open the same file
@@ -1041,28 +1138,49 @@ func (db *Database) getOrOpenDataFile(fileIndex int) (*os.File, error) {
 	defer db.fileOpenMu.Unlock()
 
 	// Double-check the cache after acquiring the lock
-	if handle, ok := db.fileCache.Get(fileIndex); ok {
-		return handle, nil
+	if f, ok := db.fileCache.Get(idx); ok {
+		return f, nil
 	}
 
-	filePath := db.dataFilePath(fileIndex)
-	handle, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, defaultFilePermissions)
+	path := db.dataFilePath(idx)
+	f, err := os.OpenFile(path, flags, defaultFilePermissions)
 	if err != nil {
 		db.log.Error("Failed to open data file",
-			zap.Int("fileIndex", fileIndex),
-			zap.String("filePath", filePath),
+			zap.Int("fileIndex", idx),
+			zap.String("filePath", path),
 			zap.Error(err),
 		)
-		return nil, fmt.Errorf("failed to open data file %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to open data file %s: %w", path, err)
 	}
-	db.fileCache.Put(fileIndex, handle)
+	db.fileCache.Put(idx, f)
 
 	db.log.Debug("Opened data file",
-		zap.Int("fileIndex", fileIndex),
-		zap.String("filePath", filePath),
+		zap.Int("fileIndex", idx),
+		zap.String("filePath", path),
 	)
 
-	return handle, nil
+	return f, nil
+}
+
+func (db *Database) retryDataFileOperation(idx int, f *os.File, op func(*os.File) error) error {
+	for {
+		err := op(f)
+		if !errors.Is(err, os.ErrClosed) {
+			return err
+		}
+
+		db.fileOpenMu.Lock()
+		cached, ok := db.fileCache.Get(idx)
+		if ok && cached == f {
+			db.fileCache.Evict(idx)
+		}
+		db.fileOpenMu.Unlock()
+
+		f, err = db.getDataFile(idx, os.O_RDWR)
+		if err != nil {
+			return err
+		}
+	}
 }
 
 func calculateChecksum(data []byte) uint64 {
@@ -1070,98 +1188,80 @@ func calculateChecksum(data []byte) uint64 {
 }
 
 func (db *Database) writeBlockAt(offset uint64, bh blockEntryHeader, block BlockData) error {
-	headerBytes, err := bh.MarshalBinary()
+	header, err := bh.MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("failed to serialize block header: %w", err)
 	}
 
 	// Allocate combined buffer for header and block data and write it to the data file
-	combinedBufSize, err := safemath.Add(uint64(sizeOfBlockEntryHeader), uint64(len(block)))
+	bufSize, err := safemath.Add(uint64(sizeOfBlockEntryHeader), uint64(len(block)))
 	if err != nil {
 		return fmt.Errorf("calculating combined buffer size would overflow for block %d: %w", bh.Height, err)
 	}
-	combinedBuf := make([]byte, combinedBufSize)
-	copy(combinedBuf, headerBytes)
-	copy(combinedBuf[sizeOfBlockEntryHeader:], block)
+	buf := make([]byte, bufSize)
+	copy(buf, header)
+	copy(buf[sizeOfBlockEntryHeader:], block)
 
-	// loop to retry fetching the data file if it got closed between get and write.
-	// If not closed, we write the block and return.
-	for {
-		dataFile, localOffset, fileIndex, err := db.getDataFileAndOffset(offset)
-		if err != nil {
-			return fmt.Errorf("failed to get data file for writing block %d: %w", bh.Height, err)
+	idx, localOffset, err := db.dataFileIndexAndOffset(offset)
+	if err != nil {
+		return fmt.Errorf("failed to get data file index for writing block %d: %w", bh.Height, err)
+	}
+	f, err := db.getDataFile(idx, os.O_RDWR|os.O_CREATE)
+	if err != nil {
+		return fmt.Errorf("failed to get data file for writing block %d: %w", bh.Height, err)
+	}
+	if err := db.retryDataFileOperation(idx, f, func(f *os.File) error {
+		if _, err := f.WriteAt(buf, int64(localOffset)); err != nil {
+			return fmt.Errorf("failed to write block data: %w", err)
 		}
-
-		if _, err := dataFile.WriteAt(combinedBuf, int64(localOffset)); err != nil {
-			if errors.Is(err, os.ErrClosed) {
-				// ensure the file is evicted, otherwise we'll retry forever
-				db.fileCache.Evict(fileIndex)
-				continue
-			}
-			return fmt.Errorf("failed to write block to data file at offset %d: %w", offset, err)
-		}
-
 		if db.config.SyncToDisk {
-			if err := dataFile.Sync(); err != nil {
-				if errors.Is(err, os.ErrClosed) {
-					db.fileCache.Evict(fileIndex)
-					continue
-				}
-				return fmt.Errorf("failed to sync data file after writing block %d: %w", bh.Height, err)
+			if err := f.Sync(); err != nil {
+				return fmt.Errorf("failed to sync data file: %w", err)
 			}
 		}
 		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to write block to data file at offset %d: %w", offset, err)
 	}
-}
-
-func (db *Database) updateBlockMaxHeight(writtenBlockHeight BlockHeight) error {
-	for {
-		maxHeight := db.maxBlockHeight.Load()
-		if writtenBlockHeight <= maxHeight && maxHeight != unsetHeight {
-			break
-		}
-		if db.maxBlockHeight.CompareAndSwap(maxHeight, writtenBlockHeight) {
-			break
-		}
-		// If CAS failed, retry with the new max height
-	}
-
-	// Check if we need to persist header on checkpoint interval
-	if writtenBlockHeight%db.config.CheckpointInterval == 0 {
-		if err := db.persistIndexHeader(); err != nil {
-			return fmt.Errorf("block %d written, but checkpoint failed: %w", writtenBlockHeight, err)
-		}
-	}
-
 	return nil
 }
 
-// allocateBlockSpace reserves space for a block and returns the data file offset where it should be written.
-//
-// This function atomically reserves space by updating the nextWriteOffset and handles
-// file splitting by advancing the nextWriteOffset when a data file would be exceeded.
-//
-// Parameters:
-//   - totalSize: The total size in bytes needed for the block
-//
-// Returns:
-//   - writeDataOffset: The data file offset where the block should be written
-//   - err: Error if allocation fails (e.g., block too large, overflow, etc.)
-func (db *Database) allocateBlockSpace(totalSize uint32) (writeDataOffset uint64, err error) {
+func (db *Database) updateBlockMaxHeight(height BlockHeight) {
+	for {
+		maxHeight := db.maxBlockHeight.Load()
+		if height <= maxHeight && maxHeight != unsetHeight {
+			return
+		}
+		if db.maxBlockHeight.CompareAndSwap(maxHeight, height) {
+			return
+		}
+		// If CAS failed, retry with the new max height
+	}
+}
+
+type dataReservation struct {
+	writeOffset    uint64
+	endOffset      uint64
+	previousOffset uint64
+}
+
+// allocateBlockSpace atomically reserves space for a block, skipping to the
+// next data file when the block would cross a file boundary.
+func (db *Database) allocateBlockSpace(totalSize uint32) (dataReservation, error) {
 	maxDataFileSize := db.header.MaxDataFileSize
 
 	// Check if a single block would exceed the max data file size
 	if uint64(totalSize) > maxDataFileSize {
-		return 0, fmt.Errorf("%w: block of size %d exceeds max data file size of %d", ErrBlockTooLarge, totalSize, maxDataFileSize)
+		return dataReservation{}, fmt.Errorf("%w: block of size %d exceeds max data file size of %d", ErrBlockTooLarge, totalSize, maxDataFileSize)
 	}
 
 	for {
-		currentOffset := db.nextDataWriteOffset.Load()
+		currentOffset := db.nextDataReservationOffset.Load()
 
 		// Calculate where this block would end if written at current offset
 		blockEndOffset, err := safemath.Add(currentOffset, uint64(totalSize))
 		if err != nil {
-			return 0, fmt.Errorf(
+			return dataReservation{}, fmt.Errorf(
 				"adding block of size %d to offset %d would overflow uint64 data file pointer: %w",
 				totalSize, currentOffset, err,
 			)
@@ -1174,32 +1274,41 @@ func (db *Database) allocateBlockSpace(totalSize uint32) (writeDataOffset uint64
 
 		// If we have a max file size, check if we need to start a new file
 		if maxDataFileSize > 0 {
-			currentFileIndex := int(currentOffset / maxDataFileSize)
-			offsetWithinCurrentFile := currentOffset % maxDataFileSize
+			idx, localOffset, err := db.dataFileIndexAndOffset(currentOffset)
+			if err != nil {
+				return dataReservation{}, fmt.Errorf("calculating data file index for offset %d: %w", currentOffset, err)
+			}
 
 			// Check if this block would span across file boundaries
-			blockEndWithinFile, err := safemath.Add(offsetWithinCurrentFile, uint64(totalSize))
+			localEnd, err := safemath.Add(localOffset, uint64(totalSize))
 			if err != nil {
-				return 0, fmt.Errorf(
+				return dataReservation{}, fmt.Errorf(
 					"calculating block end within file would overflow: %w",
 					err,
 				)
 			}
-			if blockEndWithinFile > maxDataFileSize {
+			if localEnd > maxDataFileSize {
 				// Advance the current write offset to the start of the next file since
 				// it would exceed the current file size.
-				nextFileStartOffset, err := safemath.Mul(uint64(currentFileIndex+1), maxDataFileSize)
+				nextIdx, err := safemath.Add(uint64(idx), 1)
 				if err != nil {
-					return 0, fmt.Errorf(
+					return dataReservation{}, fmt.Errorf("calculating next data file index would overflow: %w", err)
+				}
+				if nextIdx > math.MaxInt {
+					return dataReservation{}, fmt.Errorf("calculating next data file index would overflow: %w", safemath.ErrOverflow)
+				}
+				nextFileOffset, err := safemath.Mul(nextIdx, maxDataFileSize)
+				if err != nil {
+					return dataReservation{}, fmt.Errorf(
 						"calculating next file offset would overflow: %w",
 						err,
 					)
 				}
-				actualWriteOffset = nextFileStartOffset
+				actualWriteOffset = nextFileOffset
 
 				// Recalculate the end offset for the block space to set the next write offset
 				if actualBlockEndOffset, err = safemath.Add(actualWriteOffset, uint64(totalSize)); err != nil {
-					return 0, fmt.Errorf(
+					return dataReservation{}, fmt.Errorf(
 						"adding block of size %d to new file offset %d would overflow: %w",
 						totalSize, actualWriteOffset, err,
 					)
@@ -1207,16 +1316,12 @@ func (db *Database) allocateBlockSpace(totalSize uint32) (writeDataOffset uint64
 			}
 		}
 
-		if db.nextDataWriteOffset.CompareAndSwap(currentOffset, actualBlockEndOffset) {
-			return actualWriteOffset, nil
+		if db.nextDataReservationOffset.CompareAndSwap(currentOffset, actualBlockEndOffset) {
+			return dataReservation{
+				writeOffset:    actualWriteOffset,
+				endOffset:      actualBlockEndOffset,
+				previousOffset: currentOffset,
+			}, nil
 		}
 	}
-}
-
-func (db *Database) getDataFileAndOffset(globalOffset uint64) (*os.File, uint64, int, error) {
-	maxFileSize := db.header.MaxDataFileSize
-	fileIndex := int(globalOffset / maxFileSize)
-	localOffset := globalOffset % maxFileSize
-	handle, err := db.getOrOpenDataFile(fileIndex)
-	return handle, localOffset, fileIndex, err
 }

--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -671,7 +671,12 @@ func (db *Database) persistIndexHeader() error {
 	if err != nil {
 		return err
 	}
-	checkpoint := max(dataEnd, db.header.NextWriteOffset)
+	// Do not checkpoint an index state that references missing data.
+	if dataEnd < db.header.NextWriteOffset {
+		return fmt.Errorf("%w: index checkpoint is ahead of physical data "+
+			"(physical data end: %d bytes, checkpoint: %d bytes)",
+			ErrCorrupted, dataEnd, db.header.NextWriteOffset)
+	}
 
 	// The index file must be fsync'd before the header is written to prevent
 	// a state where the header is persisted but the index entries it refers to
@@ -685,7 +690,7 @@ func (db *Database) persistIndexHeader() error {
 	header := db.header
 
 	// Update the header with the current state of the database.
-	header.NextWriteOffset = checkpoint
+	header.NextWriteOffset = dataEnd
 	header.MaxHeight = db.maxBlockHeight.Load()
 	headerBytes, err := header.MarshalBinary()
 	if err != nil {
@@ -699,7 +704,7 @@ func (db *Database) persistIndexHeader() error {
 			return fmt.Errorf("failed to sync checkpoint header: %w", err)
 		}
 	}
-	db.header.NextWriteOffset = checkpoint
+	db.header.NextWriteOffset = dataEnd
 	return nil
 }
 
@@ -876,6 +881,50 @@ func (db *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error 
 	}
 	// Append after recovered data and any malformed suffix left as an orphan.
 	db.nextDataReservationOffset.Store(currentScanOffset)
+	if badErr != nil {
+		// Valid entries past malformed data need a max-height update or Get
+		// short-circuits before reading them.
+		info, err := db.indexFile.Stat()
+		if err != nil {
+			return fmt.Errorf("recovery: failed to get index file stats: %w", err)
+		}
+		indexSize := uint64(info.Size())
+		if indexSize > sizeOfIndexFileHeader {
+			entryCount := (indexSize - sizeOfIndexFileHeader) / sizeOfIndexEntry
+			for entryCount > 0 {
+				entryCount--
+				height, err := safemath.Add(db.header.MinHeight, entryCount)
+				if err != nil {
+					return fmt.Errorf("recovery: %w: calculating max indexed height: %w", ErrCorrupted, err)
+				}
+				entry, err := db.readIndexEntry(height)
+				if errors.Is(err, database.ErrNotFound) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("recovery: failed to read index entry at height %d: %w", height, err)
+				}
+				dataEnd, err := db.dataFileEndForOffset(entry.Offset)
+				if errors.Is(err, ErrCorrupted) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("recovery: failed to get data end for indexed block %d: %w", height, err)
+				}
+				bh, _, err := db.readBlockAtOffset(entry.Offset, dataEnd, &entry.Size)
+				if errors.Is(err, ErrCorrupted) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("recovery: failed to validate indexed block %d: %w", height, err)
+				}
+				if bh.Height == height {
+					db.updateBlockMaxHeight(height)
+					break
+				}
+			}
+		}
+	}
 
 	if err := db.persistIndexHeader(); err != nil {
 		return fmt.Errorf("recovery: failed to save index header after recovery scan: %w", err)

--- a/x/blockdb/database_test.go
+++ b/x/blockdb/database_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,8 @@ import (
 	"github.com/ava-labs/avalanchego/database/heightindexdb/dbtest"
 	"github.com/ava-labs/avalanchego/utils/compression"
 	"github.com/ava-labs/avalanchego/utils/logging"
+
+	safemath "github.com/ava-labs/avalanchego/utils/math"
 )
 
 func TestInterface(t *testing.T) {
@@ -70,6 +73,38 @@ func TestSyncPersistence(t *testing.T) {
 	}
 }
 
+func TestOpenRejectsCheckpointPastPhysicalData(t *testing.T) {
+	db := newDatabase(t, DefaultConfig().WithCheckpointInterval(1))
+	require.NoError(t, db.Put(0, []byte("first block")))
+	info, err := os.Stat(db.dataFilePath(0))
+	require.NoError(t, err)
+	firstEnd := info.Size()
+	require.NoError(t, db.Put(1, []byte("second block")))
+
+	// Simulate external data loss after the second checkpoint was persisted.
+	require.NoError(t, os.Truncate(db.dataFilePath(0), firstEnd))
+	require.NoError(t, db.Close())
+
+	_, err = New(db.config, logging.NoLog{})
+	require.ErrorIs(t, err, ErrCorrupted)
+}
+
+func TestSyncRetriesClosedCachedFile(t *testing.T) {
+	db := newDatabase(t, DefaultConfig())
+	block := []byte("block")
+	require.NoError(t, db.Put(0, block))
+
+	f, ok := db.fileCache.Get(0)
+	require.True(t, ok)
+	// Force Sync to reopen the cached data file after its handle is closed.
+	require.NoError(t, f.Close())
+
+	require.NoError(t, db.Sync(0, 0))
+	got, err := db.Get(0)
+	require.NoError(t, err)
+	require.Equal(t, block, got)
+}
+
 func TestNew_Params(t *testing.T) {
 	tempDir := t.TempDir()
 	tests := []struct {
@@ -80,11 +115,11 @@ func TestNew_Params(t *testing.T) {
 	}{
 		{
 			name:   "default config",
-			config: DefaultConfig().WithDir(tempDir),
+			config: DefaultConfig().WithDir(filepath.Join(tempDir, "default")),
 		},
 		{
 			name: "custom config",
-			config: DefaultConfig().WithDir(tempDir).
+			config: DefaultConfig().WithDir(filepath.Join(tempDir, "custom")).
 				WithMinimumHeight(100).
 				WithMaxDataFileSize(1024 * 1024). // 1MB
 				WithMaxDataFiles(50).
@@ -233,47 +268,75 @@ func TestIndexEntrySizePowerOfTwo(t *testing.T) {
 		"sizeOfIndexEntry (%d) is not a power of 2", sizeOfIndexEntry)
 }
 
-func TestNew_IndexFileConfigPrecedence(t *testing.T) {
-	// set up db
-	tempDir := t.TempDir()
-	initialConfig := DefaultConfig().WithDir(tempDir).WithMinimumHeight(100).WithMaxDataFileSize(1024 * 1024)
-	db, err := New(initialConfig, logging.NoLog{})
-	require.NoError(t, err)
-	require.NotNil(t, db)
+func TestNewIndexFileConfigMismatch(t *testing.T) {
+	const (
+		persistedMinimumHeight   = 100
+		persistedMaxDataFileSize = 1024 * 1024
+	)
+	tests := []struct {
+		name            string
+		minimumHeight   uint64
+		maxDataFileSize uint64
+	}{
+		{
+			name:            "minimum_height",
+			minimumHeight:   200,
+			maxDataFileSize: persistedMaxDataFileSize,
+		},
+		{
+			name:            "max_data_file_size",
+			minimumHeight:   persistedMinimumHeight,
+			maxDataFileSize: 512 * 1024,
+		},
+	}
 
-	// Write a block at height 100 and close db
-	testBlock := []byte("test block data")
-	require.NoError(t, db.Put(100, testBlock))
-	readBlock, err := db.Get(100)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			initConfig := DefaultConfig().
+				WithDir(tmpDir).
+				WithMinimumHeight(persistedMinimumHeight).
+				WithMaxDataFileSize(persistedMaxDataFileSize)
+			db, err := New(initConfig, logging.NoLog{})
+			require.NoError(t, err)
+			require.NoError(t, db.Close())
+
+			config := DefaultConfig().
+				WithDir(tmpDir).
+				WithMinimumHeight(tt.minimumHeight).
+				WithMaxDataFileSize(tt.maxDataFileSize)
+			_, err = New(config, logging.NoLog{})
+			require.ErrorIs(t, err, errConfigMismatch)
+		})
+	}
+}
+
+func TestMinimumHeightIndexOffset(t *testing.T) {
+	const minimumHeight = uint64(100)
+	dir := t.TempDir()
+	db, err := New(
+		DefaultConfig().WithDir(dir).WithMinimumHeight(minimumHeight),
+		logging.NoLog{},
+	)
 	require.NoError(t, err)
-	require.Equal(t, testBlock, readBlock)
+	require.NoError(t, db.Put(minimumHeight+1, []byte("block")))
 	require.NoError(t, db.Close())
 
-	// Reopen with different config that has minimum height of 200 and smaller max data file size
-	differentConfig := DefaultConfig().WithDir(tempDir).WithMinimumHeight(200).WithMaxDataFileSize(512 * 1024)
-	db2, err := New(differentConfig, logging.NoLog{})
+	info, err := os.Stat(filepath.Join(dir, indexFileName))
 	require.NoError(t, err)
-	require.NotNil(t, db2)
-	defer db2.Close()
+	require.Equal(t, int64(sizeOfIndexFileHeader+2*sizeOfIndexEntry), info.Size())
+}
 
-	// The database should still accept blocks between 100 and 200
-	testBlock2 := []byte("test block data 2")
-	require.NoError(t, db2.Put(150, testBlock2))
-	readBlock2, err := db2.Get(150)
+func TestGetRejectsUnrepresentableDataFileIndex(t *testing.T) {
+	db := newDatabase(t, DefaultConfig().WithMaxDataFileSize(1))
+	indexOffset, err := db.indexEntryOffset(0)
 	require.NoError(t, err)
-	require.Equal(t, testBlock2, readBlock2)
+	require.NoError(t, db.writeIndexEntryAt(indexOffset, uint64(math.MaxInt)+1, 1))
+	db.maxBlockHeight.Store(0)
 
-	// Verify that writing below initial minimum height fails
-	err = db2.Put(50, []byte("invalid block"))
-	require.ErrorIs(t, err, ErrInvalidBlockHeight)
-
-	// Write a large block that would exceed the new config's 512KB limit
-	// but should succeed because we use the original 1MB limit from index file
-	largeBlock := make([]byte, 768*1024) // 768KB block
-	require.NoError(t, db2.Put(200, largeBlock))
-	readLargeBlock, err := db2.Get(200)
-	require.NoError(t, err)
-	require.Equal(t, largeBlock, readLargeBlock)
+	_, err = db.Get(0)
+	require.ErrorIs(t, err, ErrCorrupted)
+	require.ErrorIs(t, err, safemath.ErrOverflow)
 }
 
 func TestFileCache_Eviction(t *testing.T) {

--- a/x/blockdb/database_test.go
+++ b/x/blockdb/database_test.go
@@ -80,13 +80,24 @@ func TestOpenRejectsCheckpointPastPhysicalData(t *testing.T) {
 	require.NoError(t, err)
 	firstEnd := info.Size()
 	require.NoError(t, db.Put(1, []byte("second block")))
-
-	// Simulate external data loss after the second checkpoint was persisted.
-	require.NoError(t, os.Truncate(db.dataFilePath(0), firstEnd))
 	require.NoError(t, db.Close())
+
+	// Simulate external data loss after a clean shutdown.
+	require.NoError(t, os.Truncate(db.dataFilePath(0), firstEnd))
 
 	_, err = New(db.config, logging.NoLog{})
 	require.ErrorIs(t, err, ErrCorrupted)
+}
+
+func TestCloseRejectsCheckpointPastPhysicalData(t *testing.T) {
+	db := newDatabase(t, DefaultConfig().WithCheckpointInterval(1))
+	require.NoError(t, db.Put(0, []byte("first block")))
+	info, err := os.Stat(db.dataFilePath(0))
+	require.NoError(t, err)
+	require.NoError(t, db.Put(1, []byte("second block")))
+
+	require.NoError(t, os.Truncate(db.dataFilePath(0), info.Size()))
+	require.ErrorIs(t, db.Close(), ErrCorrupted)
 }
 
 func TestSyncRetriesClosedCachedFile(t *testing.T) {

--- a/x/blockdb/errors.go
+++ b/x/blockdb/errors.go
@@ -7,8 +7,9 @@ import "errors"
 
 var (
 	ErrInvalidBlockHeight = errors.New("blockdb: invalid block height")
-	ErrCorrupted          = errors.New("blockdb: unrecoverable corruption detected")
+	ErrCorrupted          = errors.New("blockdb: corrupted data")
 	ErrBlockTooLarge      = errors.New("blockdb: block size too large")
 
-	errDatabaseInUse = errors.New("database directory is locked by another process")
+	errConfigMismatch = errors.New("blockdb: configuration mismatch")
+	errDatabaseInUse  = errors.New("database directory is locked by another process")
 )

--- a/x/blockdb/readblock_test.go
+++ b/x/blockdb/readblock_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"math"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils/compression"
 )
 
 func TestReadOperations(t *testing.T) {
@@ -216,6 +218,99 @@ func TestReadOperations_Concurrency(t *testing.T) {
 
 	require.Zero(t, errorCount.Load(), "concurrent read operations had errors")
 	require.Zero(t, blockErrors.Load(), "block data mismatches detected")
+}
+
+func TestGetCorruptedRecord(t *testing.T) {
+	block := []byte("block")
+	blockSize := uint32(len(block))
+	checksum := calculateChecksum(block)
+	tests := []struct {
+		name        string
+		header      blockEntryHeader
+		indexedSize uint32
+	}{
+		{
+			name: "height_mismatch",
+			header: blockEntryHeader{
+				Height:   1,
+				Size:     blockSize,
+				Checksum: checksum,
+				Version:  BlockEntryVersion,
+			},
+			indexedSize: blockSize,
+		},
+		{
+			name: "indexed_size_mismatch",
+			header: blockEntryHeader{
+				Size:     blockSize,
+				Checksum: checksum,
+				Version:  BlockEntryVersion,
+			},
+			indexedSize: math.MaxUint32,
+		},
+		{
+			name: "zero_stored_size",
+			header: blockEntryHeader{
+				Checksum: checksum,
+				Version:  BlockEntryVersion,
+			},
+			indexedSize: blockSize,
+		},
+		{
+			name: "unsupported_version",
+			header: blockEntryHeader{
+				Size:     blockSize,
+				Checksum: checksum,
+				Version:  BlockEntryVersion + 1,
+			},
+			indexedSize: blockSize,
+		},
+		{
+			name: "checksum_mismatch",
+			header: blockEntryHeader{
+				Size:     blockSize,
+				Checksum: checksum + 1,
+				Version:  BlockEntryVersion,
+			},
+			indexedSize: blockSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := newDatabase(t, DefaultConfig())
+			db.compressor = compression.NewNoCompressor()
+			require.NoError(t, db.Put(0, block))
+
+			entry, err := db.readIndexEntry(0)
+			require.NoError(t, err)
+			require.NoError(t, writeBlockHeader(db, int64(entry.Offset), tt.header))
+			indexOffset, err := db.indexEntryOffset(0)
+			require.NoError(t, err)
+			require.NoError(t, db.writeIndexEntryAt(indexOffset, entry.Offset, tt.indexedSize))
+
+			_, err = db.Get(0)
+			require.ErrorIs(t, err, ErrCorrupted)
+			require.NotErrorIs(t, err, database.ErrNotFound)
+			require.NoError(t, db.Close())
+		})
+	}
+}
+
+func TestGetMissingDataFileDoesNotCreate(t *testing.T) {
+	db := newDatabase(t, DefaultConfig())
+	require.NoError(t, db.Put(0, randomBlock(t)))
+
+	dataFilePath := db.dataFilePath(0)
+	// Force Get to reopen the missing file instead of reusing the cached handle.
+	db.fileCache.Flush()
+	require.NoError(t, os.Remove(dataFilePath))
+
+	_, err := db.Get(0)
+	require.ErrorIs(t, err, ErrCorrupted)
+	_, err = os.Stat(dataFilePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.NoError(t, db.Close())
 }
 
 func TestHasBlock(t *testing.T) {

--- a/x/blockdb/readblock_test.go
+++ b/x/blockdb/readblock_test.go
@@ -302,14 +302,16 @@ func TestGetMissingDataFileDoesNotCreate(t *testing.T) {
 	require.NoError(t, db.Put(0, randomBlock(t)))
 
 	dataFilePath := db.dataFilePath(0)
+	missingDataFilePath := dataFilePath + ".missing"
 	// Force Get to reopen the missing file instead of reusing the cached handle.
 	db.fileCache.Flush()
-	require.NoError(t, os.Remove(dataFilePath))
+	require.NoError(t, os.Rename(dataFilePath, missingDataFilePath))
 
 	_, err := db.Get(0)
 	require.ErrorIs(t, err, ErrCorrupted)
 	_, err = os.Stat(dataFilePath)
 	require.ErrorIs(t, err, os.ErrNotExist)
+	require.NoError(t, os.Rename(missingDataFilePath, dataFilePath))
 	require.NoError(t, db.Close())
 }
 

--- a/x/blockdb/recovery_test.go
+++ b/x/blockdb/recovery_test.go
@@ -6,562 +6,243 @@ package blockdb
 import (
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/DataDog/zstd"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/utils"
-	"github.com/ava-labs/avalanchego/utils/compression"
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
-func getCompressedBlockSize(block []byte) (uint32, error) {
-	// Use the same compressor configuration as the database
-	compressor, err := compression.NewZstdCompressorWithLevel(math.MaxUint32, zstd.BestSpeed)
-	if err != nil {
-		return 0, fmt.Errorf("failed to create compressor: %w", err)
+func TestRecoveryRebuildsMissingIndex(t *testing.T) {
+	block := []byte("block")
+	db := newDatabase(t, DefaultConfig())
+	for height := range uint64(3) {
+		require.NoError(t, db.Put(height, block))
 	}
+	require.NoError(t, db.Close())
+	require.NoError(t, os.Remove(db.indexFile.Name()))
 
-	compressed, err := compressor.Compress(block)
-	if err != nil {
-		return 0, fmt.Errorf("failed to compress block: %w", err)
+	db = newDatabase(t, db.config)
+	for height := range uint64(3) {
+		got, err := db.Get(height)
+		require.NoError(t, err)
+		require.Equal(t, block, got)
 	}
-
-	return uint32(len(compressed)), nil
+	require.NoError(t, db.Close())
 }
 
-func TestRecovery_Success(t *testing.T) {
-	// Create database with 10KB file size and 4KB blocks
-	// This means each file will have 2 blocks (4KB + 26 bytes header = ~4KB per block)
-	config := DefaultConfig().WithMaxDataFileSize(10 * 1024) // 10KB per file
+func TestRecoveryRebuildsTruncatedIndex(t *testing.T) {
+	block := []byte("block")
+	db := newDatabase(t, DefaultConfig())
+	for height := range uint64(3) {
+		require.NoError(t, db.Put(height, block))
+	}
+	firstEntry, err := db.readIndexEntry(0)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
 
+	checkpointOffset := firstEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(firstEntry.Size)
+	// Simulate a checkpoint and index that include only the first block.
+	require.NoError(t, writeIndexFileHeader(db, 0, checkpointOffset))
+	require.NoError(t, os.Truncate(db.indexFile.Name(), int64(sizeOfIndexFileHeader+sizeOfIndexEntry)))
+
+	db = newDatabase(t, db.config)
+	for height := range uint64(3) {
+		got, err := db.Get(height)
+		require.NoError(t, err)
+		require.Equal(t, block, got)
+	}
+	require.NoError(t, db.Close())
+}
+
+func TestRecoveryRebuildsTruncatedIndexAcrossDataFiles(t *testing.T) {
+	config := DefaultConfig().WithMaxDataFileSize(1024)
+	db := newDatabase(t, config)
+	// Fixed pseudo-random blocks force the second record into data file 1.
+	rng := rand.NewChaCha8([32]byte{})
+	blocks := make([][]byte, 2)
+	for height := range blocks {
+		blocks[height] = make([]byte, 512)
+		_, err := rng.Read(blocks[height])
+		require.NoError(t, err)
+		require.NoError(t, db.Put(uint64(height), blocks[height]))
+	}
+	firstEntry, err := db.readIndexEntry(0)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	require.FileExists(t, db.dataFilePath(1))
+
+	checkpointOffset := firstEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(firstEntry.Size)
+	require.NoError(t, writeIndexFileHeader(db, 0, checkpointOffset))
+	require.NoError(t, os.Truncate(db.indexFile.Name(), int64(sizeOfIndexFileHeader+sizeOfIndexEntry)))
+
+	db = newDatabase(t, db.config)
+	for height, block := range blocks {
+		got, err := db.Get(uint64(height))
+		require.NoError(t, err)
+		require.Equal(t, block, got)
+	}
+	require.NoError(t, db.Close())
+}
+
+func TestRecoveryStructuralCorruption(t *testing.T) {
 	tests := []struct {
-		name         string
-		corruptIndex func(indexPath string, blocks map[uint64][]byte) error
+		name            string
+		maxDataFileSize uint64
+		nextWriteOffset uint64
+		dataFileSizes   map[int]int
 	}{
 		{
-			name: "recovery from missing index file; blocks will be recovered",
-			corruptIndex: func(indexPath string, _ map[uint64][]byte) error {
-				return os.Remove(indexPath)
+			name:            "checkpoint_past_physical_data",
+			maxDataFileSize: 1024,
+			nextWriteOffset: 2,
+			dataFileSizes:   map[int]int{0: 1},
+		},
+		{
+			name:            "checkpoint_references_missing_data",
+			maxDataFileSize: 1024,
+			nextWriteOffset: 1,
+		},
+		{
+			name:            "missing_intermediate_data_file",
+			maxDataFileSize: 1024,
+			dataFileSizes: map[int]int{
+				0: 1024,
+				2: 1,
 			},
 		},
 		{
-			name: "recovery from truncated index file that only indexed the first block",
-			corruptIndex: func(indexPath string, blocks map[uint64][]byte) error {
-				// Remove the existing index file
-				if err := os.Remove(indexPath); err != nil {
-					return err
-				}
-
-				// Create a new index file with only the first block indexed
-				// This simulates an unclean shutdown where the index file is behind
-				indexFile, err := os.OpenFile(indexPath, os.O_RDWR|os.O_CREATE, defaultFilePermissions)
-				if err != nil {
-					return err
-				}
-				defer indexFile.Close()
-
-				// Create a header that only knows about the first block
-				// Block 0: compressed data + header
-				firstBlockCompressedSize, err := getCompressedBlockSize(blocks[0])
-				if err != nil {
-					return err
-				}
-				firstBlockOffset := uint64(sizeOfBlockEntryHeader) + uint64(firstBlockCompressedSize)
-
-				header := indexFileHeader{
-					Version:         IndexFileVersion,
-					MaxDataFileSize: 4 * 10 * 1024, // 10KB per file
-					MinHeight:       0,
-					MaxHeight:       0,
-					NextWriteOffset: firstBlockOffset,
-				}
-
-				// Write the header
-				headerBytes, err := header.MarshalBinary()
-				if err != nil {
-					return err
-				}
-				if _, err := indexFile.WriteAt(headerBytes, 0); err != nil {
-					return err
-				}
-
-				// Write index entry for only the first block
-				indexEntry := indexEntry{
-					Offset: 0,
-					Size:   firstBlockCompressedSize,
-				}
-				entryBytes, err := indexEntry.MarshalBinary()
-				if err != nil {
-					return err
-				}
-				indexEntryOffset := sizeOfIndexFileHeader
-				if _, err := indexFile.WriteAt(entryBytes, int64(indexEntryOffset)); err != nil {
-					return err
-				}
-
-				return nil
-			},
-		},
-		{
-			name: "recovery from index file that is behind by one block",
-			corruptIndex: func(indexPath string, blocks map[uint64][]byte) error {
-				// Read the current index file to get the header
-				indexFile, err := os.OpenFile(indexPath, os.O_RDWR, 0)
-				if err != nil {
-					return err
-				}
-				defer indexFile.Close()
-
-				// Read the current header
-				headerBuf := make([]byte, sizeOfIndexFileHeader)
-				_, err = indexFile.ReadAt(headerBuf, 0)
-				if err != nil {
-					return err
-				}
-
-				// Parse the header
-				var header indexFileHeader
-				err = header.UnmarshalBinary(headerBuf)
-				if err != nil {
-					return err
-				}
-
-				// Corrupt the header by setting the NextWriteOffset to be one block behind
-				lastBlockCompressedSize, err := getCompressedBlockSize(blocks[8])
-				if err != nil {
-					return err
-				}
-				blockSize := uint64(sizeOfBlockEntryHeader) + uint64(lastBlockCompressedSize)
-				header.NextWriteOffset -= blockSize
-				header.MaxHeight = 8
-
-				// Write the corrupted header back
-				corruptedHeaderBytes, err := header.MarshalBinary()
-				if err != nil {
-					return err
-				}
-				_, err = indexFile.WriteAt(corruptedHeaderBytes, 0)
-				return err
-			},
-		},
-		{
-			name: "recovery from inconsistent index header (offset lagging behind heights)",
-			corruptIndex: func(indexPath string, blocks map[uint64][]byte) error {
-				// Read the current index file to get the header
-				indexFile, err := os.OpenFile(indexPath, os.O_RDWR, 0)
-				if err != nil {
-					return err
-				}
-				defer indexFile.Close()
-
-				// Read the current header
-				headerBuf := make([]byte, sizeOfIndexFileHeader)
-				_, err = indexFile.ReadAt(headerBuf, 0)
-				if err != nil {
-					return err
-				}
-
-				// Parse the header
-				var header indexFileHeader
-				err = header.UnmarshalBinary(headerBuf)
-				if err != nil {
-					return err
-				}
-
-				// Calculate the offset after the 5th block using actual compressed sizes
-				// We need to sum up the sizes of blocks 0, 1, 2, 3, 4 (5 blocks total)
-				// Each block size = header + compressed data
-				blocksToCompress := [][]byte{blocks[0], blocks[1], blocks[2], blocks[3], blocks[4]}
-				totalCompressedSize := uint32(0)
-				for _, block := range blocksToCompress {
-					compressedSize, err := getCompressedBlockSize(block)
-					if err != nil {
-						return err
-					}
-					totalCompressedSize += compressedSize
-				}
-				totalSize := uint64(len(blocksToCompress))*uint64(sizeOfBlockEntryHeader) + uint64(totalCompressedSize)
-				header.NextWriteOffset = totalSize
-
-				// Write the corrupted header back
-				corruptedHeaderBytes, err := header.MarshalBinary()
-				if err != nil {
-					return err
-				}
-				_, err = indexFile.WriteAt(corruptedHeaderBytes, 0)
-				return err
+			name:            "multiple_data_files_in_single_file_mode",
+			maxDataFileSize: math.MaxUint64,
+			dataFileSizes: map[int]int{
+				0: 1,
+				1: 1,
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			store := newDatabase(t, config)
-
-			blockHeights := []uint64{0, 1, 3, 6, 2, 8, 4}
-			blocks := make(map[uint64][]byte)
-
-			for _, height := range blockHeights {
-				// Create 4KB blocks
-				block := fixedSizeBlock(t, 4*1024, height)
-
-				require.NoError(t, store.Put(height, block))
-				blocks[height] = block
+			dir := t.TempDir()
+			header := indexFileHeader{
+				Version:         IndexFileVersion,
+				MaxDataFileSize: tt.maxDataFileSize,
+				MaxHeight:       unsetHeight,
+				NextWriteOffset: tt.nextWriteOffset,
 			}
-			checkDatabaseState(t, store, 8)
-			require.NoError(t, store.Close())
-
-			// Corrupt the index file according to the test case
-			indexPath := store.indexFile.Name()
-			require.NoError(t, tt.corruptIndex(indexPath, blocks))
-
-			// Reopen the database and test recovery
-			dir := store.config.DataDir
-			recoveredDB := newDatabase(t, config.WithIndexDir(dir).WithDataDir(dir))
-
-			// Verify blocks are readable
-			for _, height := range blockHeights {
-				readBlock, err := recoveredDB.Get(height)
-				require.NoError(t, err)
-				require.Equal(t, blocks[height], readBlock, "block %d should be the same", height)
+			headerBytes, err := header.MarshalBinary()
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(
+				filepath.Join(dir, indexFileName),
+				headerBytes,
+				defaultFilePermissions,
+			))
+			for index, size := range tt.dataFileSizes {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, fmt.Sprintf(dataFileNameFormat, index)),
+					make([]byte, size),
+					defaultFilePermissions,
+				))
 			}
-			checkDatabaseState(t, recoveredDB, 8)
+
+			config := DefaultConfig().
+				WithDir(dir).
+				WithMaxDataFileSize(tt.maxDataFileSize)
+			_, err = New(config, logging.NoLog{})
+			require.ErrorIs(t, err, ErrCorrupted)
 		})
 	}
 }
 
-func TestRecovery_CorruptionDetection(t *testing.T) {
-	tests := []struct {
-		name               string
-		blockHeights       []uint64
-		minHeight          uint64
-		maxDataFileSize    *uint64
-		disableCompression bool
-		blockSize          int // Optional: if set, creates fixed-size blocks instead of random
-		setupCorruption    func(store *Database, blocks [][]byte) error
-		wantErr            error
-		wantErrText        string
-	}{
-		{
-			name:         "index header claims larger offset than actual data",
-			blockHeights: []uint64{0, 1, 2, 3, 4},
-			setupCorruption: func(store *Database, _ [][]byte) error {
-				indexPath := store.indexFile.Name()
-				indexFile, err := os.OpenFile(indexPath, os.O_RDWR, 0)
-				if err != nil {
-					return err
-				}
-				defer indexFile.Close()
+func TestRecoveryLeavesPartialRecordSuffix(t *testing.T) {
+	firstBlock := []byte("first block")
+	secondBlock := []byte("second block")
+	db := newDatabase(t, DefaultConfig())
+	require.NoError(t, db.Put(0, firstBlock))
+	require.NoError(t, db.Put(1, secondBlock))
 
-				// Read the current header
-				headerBuf := make([]byte, sizeOfIndexFileHeader)
-				_, err = indexFile.ReadAt(headerBuf, 0)
-				if err != nil {
-					return err
-				}
+	firstEntry, err := db.readIndexEntry(0)
+	require.NoError(t, err)
+	secondEntry, err := db.readIndexEntry(1)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
 
-				// Parse and corrupt the header by setting NextWriteOffset to be much larger than actual data
-				var header indexFileHeader
-				err = header.UnmarshalBinary(headerBuf)
-				if err != nil {
-					return err
-				}
-				header.NextWriteOffset = 1000000
+	checkpointOffset := firstEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(firstEntry.Size)
+	// Treat the first block as checkpointed and truncate the later record mid-write.
+	require.NoError(t, writeIndexFileHeader(db, 0, checkpointOffset))
+	partialBlockEnd := secondEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(secondEntry.Size)/2
+	require.NoError(t, os.Truncate(db.dataFilePath(0), int64(partialBlockEnd)))
 
-				// Write the corrupted header back
-				corruptedHeaderBytes, err := header.MarshalBinary()
-				if err != nil {
-					return err
-				}
-				_, err = indexFile.WriteAt(corruptedHeaderBytes, 0)
-				return err
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "index header claims to have more data than is actually on disk",
-		},
-		{
-			name:         "corrupted block header in data file",
-			blockHeights: []uint64{0, 1, 3},
-			setupCorruption: func(store *Database, blocks [][]byte) error {
-				compressedSize, err := getCompressedBlockSize(blocks[0])
-				if err != nil {
-					return err
-				}
-				if err := resetIndexToBlock(store, uint64(compressedSize), 0); err != nil {
-					return err
-				}
-				// Corrupt second block header with invalid data
-				secondBlockOffset := int64(sizeOfBlockEntryHeader) + int64(compressedSize)
-				corruptedHeader := make([]byte, sizeOfBlockEntryHeader)
-				for i := range corruptedHeader {
-					corruptedHeader[i] = 0xFF // Invalid header data
-				}
-				dataFilePath := store.dataFilePath(0)
-				dataFile, err := os.OpenFile(dataFilePath, os.O_RDWR, 0)
-				if err != nil {
-					return err
-				}
-				defer dataFile.Close()
-				_, err = dataFile.WriteAt(corruptedHeader, secondBlockOffset)
-				return err
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "invalid block entry version at offset",
-		},
-		{
-			name:         "block with invalid block size in header that reads more than total data file size",
-			blockHeights: []uint64{0, 1},
-			setupCorruption: func(store *Database, blocks [][]byte) error {
-				compressedSize0, err := getCompressedBlockSize(blocks[0])
-				if err != nil {
-					return err
-				}
-				if err := resetIndexToBlock(store, uint64(compressedSize0), 0); err != nil {
-					return err
-				}
-				secondBlockOffset := int64(sizeOfBlockEntryHeader) + int64(compressedSize0)
-				compressedSize1, err := getCompressedBlockSize(blocks[1])
-				if err != nil {
-					return err
-				}
-				bh := blockEntryHeader{
-					Height:   1,
-					Checksum: calculateChecksum(blocks[1]),
-					Size:     compressedSize1 + 1, // make block larger than actual compressed size
-					Version:  BlockEntryVersion,
-				}
-				return writeBlockHeader(store, secondBlockOffset, bh)
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "block data out of bounds at offset ",
-		},
-		{
-			name:         "block with checksum mismatch",
-			blockHeights: []uint64{0, 1},
-			setupCorruption: func(store *Database, blocks [][]byte) error {
-				compressedSize0, err := getCompressedBlockSize(blocks[0])
-				if err != nil {
-					return err
-				}
-				if err := resetIndexToBlock(store, uint64(compressedSize0), 0); err != nil {
-					return err
-				}
-				secondBlockOffset := int64(sizeOfBlockEntryHeader) + int64(compressedSize0)
-				compressedSize1, err := getCompressedBlockSize(blocks[1])
-				if err != nil {
-					return err
-				}
-				bh := blockEntryHeader{
-					Height:   1,
-					Checksum: 0xDEADBEEF, // Wrong checksum
-					Size:     compressedSize1,
-					Version:  BlockEntryVersion,
-				}
-				return writeBlockHeader(store, secondBlockOffset, bh)
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "checksum mismatch for block",
-		},
-		{
-			name:         "partial block at end of file",
-			blockHeights: []uint64{0},
-			setupCorruption: func(store *Database, blocks [][]byte) error {
-				dataFilePath := store.dataFilePath(0)
-				dataFile, err := os.OpenFile(dataFilePath, os.O_RDWR, 0)
-				if err != nil {
-					return err
-				}
-				defer dataFile.Close()
+	db = newDatabase(t, db.config)
+	got, err := db.Get(0)
+	require.NoError(t, err)
+	require.Equal(t, firstBlock, got)
+	_, err = db.Get(1)
+	require.ErrorIs(t, err, database.ErrNotFound)
 
-				// Truncate data file to have only partial block data
-				compressedSize, err := getCompressedBlockSize(blocks[0])
-				if err != nil {
-					return err
-				}
-				truncateSize := int64(sizeOfBlockEntryHeader) + int64(compressedSize)/2
-				return dataFile.Truncate(truncateSize)
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "index header claims to have more data than is actually on disk",
-		},
-		{
-			name:         "block with invalid height",
-			blockHeights: []uint64{10, 11},
-			minHeight:    10,
-			setupCorruption: func(store *Database, blocks [][]byte) error {
-				compressedSize0, err := getCompressedBlockSize(blocks[0])
-				if err != nil {
-					return err
-				}
-				if err := resetIndexToBlock(store, uint64(compressedSize0), 10); err != nil {
-					return err
-				}
-				secondBlockOffset := int64(sizeOfBlockEntryHeader) + int64(compressedSize0)
-				compressedSize1, err := getCompressedBlockSize(blocks[1])
-				if err != nil {
-					return err
-				}
-				bh := blockEntryHeader{
-					Height:   5, // Invalid height because its below the minimum height of 10
-					Checksum: calculateChecksum(blocks[1]),
-					Size:     compressedSize1,
-					Version:  BlockEntryVersion,
-				}
-				return writeBlockHeader(store, secondBlockOffset, bh)
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "invalid block height in header",
-		},
-		{
-			name:               "missing data file at index 1",
-			blockHeights:       []uint64{0, 1, 2, 3, 4, 5},
-			disableCompression: true,
-			maxDataFileSize:    utils.PointerTo[uint64](1024), // 1KB per file to force multiple files
-			blockSize:          512,                           // 512 bytes per block
-			setupCorruption: func(store *Database, _ [][]byte) error {
-				// Delete the second data file (index 1)
-				dataFilePath := store.dataFilePath(1)
-				return os.Remove(dataFilePath)
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "data file at index 1 is missing",
-		},
-		{
-			name:            "unexpected multiple data files when MaxDataFileSize is max uint64",
-			blockHeights:    []uint64{0, 1, 2},
-			maxDataFileSize: utils.PointerTo[uint64](math.MaxUint64), // Single file mode
-			blockSize:       512,                                     // 512 bytes per block
-			setupCorruption: func(store *Database, _ [][]byte) error {
-				// Manually create a second data file to simulate corruption
-				secondDataFilePath := store.dataFilePath(1)
-				secondDataFile, err := os.Create(secondDataFilePath)
-				if err != nil {
-					return err
-				}
-				defer secondDataFile.Close()
-
-				// Write some dummy data to the second file
-				dummyData := []byte("dummy data file")
-				_, err = secondDataFile.Write(dummyData)
-				return err
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "only one data file expected when MaxDataFileSize is max uint64, got 2 files with max index 1",
-		},
-		{
-			name:         "block with invalid block entry version",
-			blockHeights: []uint64{0, 1},
-			setupCorruption: func(store *Database, blocks [][]byte) error {
-				compressedSize0, err := getCompressedBlockSize(blocks[0])
-				if err != nil {
-					return err
-				}
-				if err := resetIndexToBlock(store, uint64(compressedSize0), 0); err != nil {
-					return err
-				}
-				// Corrupt second block header version
-				secondBlockOffset := int64(sizeOfBlockEntryHeader) + int64(compressedSize0)
-				compressedSize1, err := getCompressedBlockSize(blocks[1])
-				if err != nil {
-					return err
-				}
-				bh := blockEntryHeader{
-					Height:   1,
-					Checksum: calculateChecksum(blocks[1]),
-					Size:     compressedSize1,
-					Version:  BlockEntryVersion + 1, // Invalid version
-				}
-				return writeBlockHeader(store, secondBlockOffset, bh)
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "invalid block entry version at offset",
-		},
-		{
-			name:         "second block with invalid version among 4 blocks",
-			blockHeights: []uint64{0, 3, 2, 4},
-			setupCorruption: func(store *Database, blocks [][]byte) error {
-				compressedSize0, err := getCompressedBlockSize(blocks[0])
-				if err != nil {
-					return err
-				}
-				if err := resetIndexToBlock(store, uint64(compressedSize0), 0); err != nil {
-					return err
-				}
-				// Corrupt second block header with invalid version
-				secondBlockOffset := int64(sizeOfBlockEntryHeader) + int64(compressedSize0)
-				compressedSize1, err := getCompressedBlockSize(blocks[1])
-				if err != nil {
-					return err
-				}
-				bh := blockEntryHeader{
-					Height:   1,
-					Checksum: calculateChecksum(blocks[1]),
-					Size:     compressedSize1,
-					Version:  BlockEntryVersion + 10, // version cannot be greater than current
-				}
-				return writeBlockHeader(store, secondBlockOffset, bh)
-			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "invalid block entry version at offset",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config := DefaultConfig()
-			if tt.minHeight > 0 {
-				config = config.WithMinimumHeight(tt.minHeight)
-			}
-			if tt.maxDataFileSize != nil {
-				config = config.WithMaxDataFileSize(*tt.maxDataFileSize)
-			}
-
-			store := newDatabase(t, config)
-			if tt.disableCompression {
-				store.compressor = compression.NewNoCompressor()
-			}
-
-			// Setup blocks
-			blocks := make([][]byte, len(tt.blockHeights))
-			for i, height := range tt.blockHeights {
-				if tt.blockSize > 0 {
-					blocks[i] = fixedSizeBlock(t, tt.blockSize, height)
-				} else {
-					blocks[i] = randomBlock(t)
-				}
-				require.NoError(t, store.Put(height, blocks[i]))
-			}
-			require.NoError(t, store.Close())
-
-			// Apply corruption logic
-			require.NoError(t, tt.setupCorruption(store, blocks))
-
-			// Try to reopen the database - it should detect corruption
-			_, err := New(config.WithIndexDir(store.config.IndexDir).WithDataDir(store.config.DataDir), store.log)
-			require.ErrorIs(t, err, tt.wantErr)
-			require.Contains(t, err.Error(), tt.wantErrText, "error message should contain expected text")
-		})
-	}
+	replacement := []byte("replacement block")
+	require.NoError(t, db.Put(1, replacement))
+	got, err = db.Get(1)
+	require.NoError(t, err)
+	require.Equal(t, replacement, got)
+	require.NoError(t, db.Close())
 }
 
-// Helper function to reset index file header to only a single block
-func resetIndexToBlock(store *Database, blockSize uint64, minHeight uint64) error {
-	indexPath := store.indexFile.Name()
+func TestRecoveryLeavesIndexedDataAfterChecksumMismatch(t *testing.T) {
+	checkpointBlock := []byte("checkpoint block")
+	malformedBlock := []byte("malformed block")
+	indexedBlock := []byte("indexed block")
+	db := newDatabase(t, DefaultConfig())
+	require.NoError(t, db.Put(10, checkpointBlock))
+	require.NoError(t, db.Put(3, malformedBlock))
+	require.NoError(t, db.Put(5, indexedBlock))
+	malformedEntry, err := db.readIndexEntry(3)
+	require.NoError(t, err)
+	checkpointEntry, err := db.readIndexEntry(10)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	checkpointOffset := checkpointEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(checkpointEntry.Size)
+	// The later index entry remains usable even though recovery stops at height 3.
+	require.NoError(t, writeIndexFileHeader(db, 10, checkpointOffset))
+	require.NoError(t, writeBlockHeader(db, int64(malformedEntry.Offset), blockEntryHeader{
+		Height:   3,
+		Size:     malformedEntry.Size,
+		Checksum: calculateChecksum(malformedBlock) + 1,
+		Version:  BlockEntryVersion,
+	}))
+
+	db = newDatabase(t, db.config)
+	got, err := db.Get(5)
+	require.NoError(t, err)
+	require.Equal(t, indexedBlock, got)
+	_, err = db.Get(3)
+	require.ErrorIs(t, err, ErrCorrupted)
+
+	replacement := randomBlock(t)
+	// A later Put must append after the preserved suffix without overwriting height 5.
+	require.NoError(t, db.Put(6, replacement))
+	got, err = db.Get(5)
+	require.NoError(t, err)
+	require.Equal(t, indexedBlock, got)
+	require.NoError(t, db.Close())
+}
+
+func writeIndexFileHeader(db *Database, maxHeight, nextWriteOffset uint64) error {
+	indexPath := db.indexFile.Name()
 	indexFile, err := os.OpenFile(indexPath, os.O_RDWR, 0)
 	if err != nil {
 		return err
 	}
 	defer indexFile.Close()
 
-	header := indexFileHeader{
-		Version:         IndexFileVersion,
-		MaxDataFileSize: DefaultMaxDataFileSize,
-		MinHeight:       minHeight,
-		MaxHeight:       minHeight,
-		NextWriteOffset: uint64(sizeOfBlockEntryHeader) + blockSize,
-	}
+	header := db.header
+	header.MaxHeight = maxHeight
+	header.NextWriteOffset = nextWriteOffset
 
 	headerBytes, err := header.MarshalBinary()
 	if err != nil {
@@ -571,11 +252,10 @@ func resetIndexToBlock(store *Database, blockSize uint64, minHeight uint64) erro
 	return err
 }
 
-// Helper function to write a block header at a specific offset
-func writeBlockHeader(store *Database, offset int64, bh blockEntryHeader) error {
-	fileIndex := int(offset / int64(store.header.MaxDataFileSize))
-	localOffset := offset % int64(store.header.MaxDataFileSize)
-	dataFilePath := store.dataFilePath(fileIndex)
+func writeBlockHeader(db *Database, offset int64, bh blockEntryHeader) error {
+	fileIndex := int(offset / int64(db.header.MaxDataFileSize))
+	localOffset := offset % int64(db.header.MaxDataFileSize)
+	dataFilePath := db.dataFilePath(fileIndex)
 	dataFile, err := os.OpenFile(dataFilePath, os.O_RDWR, 0)
 	if err != nil {
 		return err

--- a/x/blockdb/recovery_test.go
+++ b/x/blockdb/recovery_test.go
@@ -178,6 +178,7 @@ func TestRecoveryLeavesPartialRecordSuffix(t *testing.T) {
 	require.NoError(t, os.Truncate(db.dataFilePath(0), int64(partialBlockEnd)))
 
 	db = newDatabase(t, db.config)
+	checkDatabaseState(t, db, 0)
 	got, err := db.Get(0)
 	require.NoError(t, err)
 	require.Equal(t, firstBlock, got)
@@ -197,18 +198,19 @@ func TestRecoveryLeavesIndexedDataAfterChecksumMismatch(t *testing.T) {
 	malformedBlock := []byte("malformed block")
 	indexedBlock := []byte("indexed block")
 	db := newDatabase(t, DefaultConfig())
-	require.NoError(t, db.Put(10, checkpointBlock))
+	require.NoError(t, db.Put(2, checkpointBlock))
 	require.NoError(t, db.Put(3, malformedBlock))
 	require.NoError(t, db.Put(5, indexedBlock))
 	malformedEntry, err := db.readIndexEntry(3)
 	require.NoError(t, err)
-	checkpointEntry, err := db.readIndexEntry(10)
+	checkpointEntry, err := db.readIndexEntry(2)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
 	checkpointOffset := checkpointEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(checkpointEntry.Size)
-	// The later index entry remains usable even though recovery stops at height 3.
-	require.NoError(t, writeIndexFileHeader(db, 10, checkpointOffset))
+	// Keep the checkpoint max below height 5 to exercise max-height recovery.
+	require.NoError(t, writeIndexFileHeader(db, 2, checkpointOffset))
+	require.NoError(t, os.Truncate(db.indexFile.Name(), int64(sizeOfIndexFileHeader+7*sizeOfIndexEntry)))
 	require.NoError(t, writeBlockHeader(db, int64(malformedEntry.Offset), blockEntryHeader{
 		Height:   3,
 		Size:     malformedEntry.Size,
@@ -217,11 +219,19 @@ func TestRecoveryLeavesIndexedDataAfterChecksumMismatch(t *testing.T) {
 	}))
 
 	db = newDatabase(t, db.config)
+	checkDatabaseState(t, db, 5)
 	got, err := db.Get(5)
 	require.NoError(t, err)
 	require.Equal(t, indexedBlock, got)
 	_, err = db.Get(3)
 	require.ErrorIs(t, err, ErrCorrupted)
+	require.NoError(t, db.Close())
+
+	db = newDatabase(t, db.config)
+	checkDatabaseState(t, db, 5)
+	got, err = db.Get(5)
+	require.NoError(t, err)
+	require.Equal(t, indexedBlock, got)
 
 	replacement := randomBlock(t)
 	// A later Put must append after the preserved suffix without overwriting height 5.

--- a/x/blockdb/writeblock_test.go
+++ b/x/blockdb/writeblock_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -214,6 +215,105 @@ func TestWriteBlock_Concurrency(t *testing.T) {
 	checkDatabaseState(t, store, 19)
 }
 
+func TestPutContinuesAfterIndexWriteFailure(t *testing.T) {
+	db := newDatabase(t, DefaultConfig().WithDir(t.TempDir()))
+	indexPath := db.indexFile.Name()
+	// Fail after the data write, when Put attempts to write the index entry.
+	require.NoError(t, db.indexFile.Close())
+
+	err := db.Put(1, []byte("failed index write"))
+	require.ErrorIs(t, err, os.ErrClosed)
+
+	indexFile, err := os.OpenFile(indexPath, os.O_RDWR, defaultFilePermissions)
+	require.NoError(t, err)
+	db.indexFile = indexFile
+	require.NoError(t, db.Put(2, []byte("successful later write")))
+	require.NoError(t, db.Close())
+
+	db = newDatabase(t, db.config)
+	_, err = db.Get(1)
+	require.ErrorIs(t, err, database.ErrNotFound)
+	got, err := db.Get(2)
+	require.NoError(t, err)
+	require.Equal(t, []byte("successful later write"), got)
+	require.NoError(t, db.Close())
+}
+
+func TestFailedPutDoesNotAdvanceCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, "data")
+	config := DefaultConfig().
+		WithIndexDir(filepath.Join(dir, "index")).
+		WithDataDir(dataDir)
+	db := newDatabase(t, config)
+	blocks := [][]byte{
+		[]byte("first block"),
+		[]byte("second block"),
+	}
+	for height, block := range blocks {
+		require.NoError(t, db.Put(uint64(height), block))
+	}
+	// Make the next Put reserve an offset, then fail reopening the unavailable data file.
+	db.fileCache.Flush()
+
+	movedDataDir := filepath.Join(dir, "moved-data")
+	require.NoError(t, os.Rename(dataDir, movedDataDir))
+	err := db.Put(uint64(len(blocks)), []byte("failed data write"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.NoError(t, os.Rename(movedDataDir, dataDir))
+	require.NoError(t, db.Close())
+
+	db = newDatabase(t, config)
+	for height, block := range blocks {
+		got, err := db.Get(uint64(height))
+		require.NoError(t, err)
+		require.Equal(t, block, got)
+	}
+	_, err = db.Get(uint64(len(blocks)))
+	require.ErrorIs(t, err, database.ErrNotFound)
+	require.NoError(t, db.Close())
+}
+
+func TestPutContinuesAfterDataWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, "data")
+	config := DefaultConfig().
+		WithIndexDir(filepath.Join(dir, "index")).
+		WithDataDir(dataDir).
+		WithMaxDataFileSize(100)
+	db := newDatabase(t, config)
+	db.compressor = compression.NewNoCompressor()
+	require.NoError(t, db.Put(0, make([]byte, 40)))
+	wantLaterOffset := db.nextDataReservationOffset.Load()
+
+	// Force the failed Put to reserve in the next data file, then fail opening it.
+	db.fileCache.Flush()
+	movedDataDir := filepath.Join(dir, "moved-data")
+	require.NoError(t, os.Rename(dataDir, movedDataDir))
+	err := db.Put(1, make([]byte, 20))
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.NoError(t, os.Rename(movedDataDir, dataDir))
+
+	laterBlock := []byte("later")
+	require.NoError(t, db.Put(2, laterBlock))
+	laterEntry, err := db.readIndexEntry(2)
+	require.NoError(t, err)
+	require.Equal(t, wantLaterOffset, laterEntry.Offset)
+	got, err := db.Get(2)
+	require.NoError(t, err)
+	require.Equal(t, laterBlock, got)
+	require.NoError(t, db.Close())
+
+	db = newDatabase(t, config)
+	db.compressor = compression.NewNoCompressor()
+	_, err = db.Get(1)
+	require.ErrorIs(t, err, database.ErrNotFound)
+	got, err = db.Get(2)
+	require.NoError(t, err)
+	require.Equal(t, laterBlock, got)
+	require.NoError(t, db.Close())
+}
+
 func TestWriteBlock_Errors(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -263,7 +363,7 @@ func TestWriteBlock_Errors(t *testing.T) {
 			config:             DefaultConfig(),
 			setup: func(db *Database) {
 				// Set the next write offset to near max to trigger overflow
-				db.nextDataWriteOffset.Store(math.MaxUint64 - 50)
+				db.nextDataReservationOffset.Store(math.MaxUint64 - 50)
 			},
 			wantErr: safemath.ErrOverflow,
 		},
@@ -273,13 +373,13 @@ func TestWriteBlock_Errors(t *testing.T) {
 			block:  make([]byte, 100),
 			setup: func(db *Database) {
 				// Change file permissions to read-only
-				file, err := db.getOrOpenDataFile(0)
+				file, err := db.getDataFile(0, os.O_RDWR|os.O_CREATE)
 				require.NoError(t, err)
 				filePath := file.Name()
 				file.Close()
 				require.NoError(t, os.Chmod(filePath, 0o444))
 			},
-			wantErrMsg: "failed to get data file for writing block",
+			wantErrMsg: "failed to write block to data file at offset",
 		},
 		{
 			name:   "writeIndexEntryAt - index file write failure",


### PR DESCRIPTION
## Why this should be merged

This PR addresses the correctness, recovery, and documentation feedback tracked in [#5879](https://github.com/ava-labs/avalanchego/issues/5879):

- Reject persisted `MinimumHeight` and `MaxDataFileSize` configuration mismatches.
- Add coverage for minimum-height index offsets and return `ErrCorrupted` when an indexed record contains the wrong height.
- Close the index file when header initialization fails.
- Retry data-file operations when cache eviction closes a cached handle.
- Document `MaxDataFiles` concurrency guidance and simplify cache eviction.
- Prevent checkpoints from advancing past incomplete `Put` operations.

The recovery improvements made for #5879 also address two problems raised in [#5791](https://github.com/ava-labs/avalanchego/issues/5791):

- A failed data write could advance the reservation offset without producing a valid record, causing later writes to skip the unused range. The reservation is now rolled back when no later `Put` depends on it.
- A crash or partial write could leave malformed, unindexed data after the checkpoint. Recovery previously treated this trailing data as fatal and refused to reopen the database.

Fixes #5879.

## How this works

- `Put` reserves space through `nextDataReservationOffset` and prevents checkpointing until its data and index writes finish.
- A checkpoint waits for active `Put` operations, then stores the physical end of the data files as `NextWriteOffset`. A reservation alone can no longer advance the checkpoint. When `SyncToDisk` is enabled, index entries are synced before the checkpoint header.
- If a data write fails, its reservation is rolled back when it is still the newest reservation. The offset is not rolled back if another `Put` has already reserved space after it.
- On startup, recovery scans from `NextWriteOffset` to the physical end of the data and rebuilds index entries for complete records. If it encounters malformed trailing data, that suffix remains unindexed and future writes start after the physical data extent.

## How this was tested

Unit tests.

## Need to be documented in RELEASES.md?

No.
