### PR TITLE
chore(saexec): remove dead playbook link from execution logs

### DIFF
--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -73,8 +73,6 @@ func (e *Executor) Enqueue(ctx context.Context, block *blocks.Block) error {
 	}
 }
 
-const emergencyPlaybookLink = "https://github.com/ava-labs/avalanchego/issues/5276"
-
 func (e *Executor) processQueue() {
 	defer close(e.done)
 
@@ -97,13 +95,11 @@ func (e *Executor) processQueue() {
 			case errors.Is(err, errFatal):
 				log.Fatal( //nolint:gocritic // False positive, will not terminate the process
 					"Block execution failed",
-					zap.String("playbook", emergencyPlaybookLink),
 					zap.Error(err),
 				)
 			case err != nil:
 				log.Error(
 					"Error of unknown severity in block execution",
-					zap.String("if_escalation_required", emergencyPlaybookLink),
 					zap.Error(err),
 				)
 			}


### PR DESCRIPTION
## Why this should be merged

The fatal and error logs in `saexec` link to #5276 as a "playbook" -- we never made a public runbook, but if we do, we can reviist this. 

## How this works
on the tin

## How this was tested
CI

## Need to be documented in RELEASES.md?
No
