### PR TITLE
fix(cache/lru): evict stale entry before re-Put in SizedCache

### DIFF
--- a/cache/lru/sized_cache.go
+++ b/cache/lru/sized_cache.go
@@ -91,9 +91,7 @@ func (c *SizedCache[K, V]) put(key K, value V) {
 		return
 	}
 
-	if oldElement, ok := c.elements.Get(key); ok {
-		c.currentSize -= oldElement.size
-	}
+	c.evict(key)
 
 	// Remove elements until the size of elements in the cache <= [c.maxSize].
 	for c.currentSize > c.maxSize-newEntrySize {

--- a/cache/lru/sized_cache_test.go
+++ b/cache/lru/sized_cache_test.go
@@ -50,6 +50,27 @@ func TestSizedCacheWrongKeyEvictionRegression(t *testing.T) {
 	require.True(ok)
 }
 
+// Overwriting the oldest key with a larger value must not subtract the old
+// size twice.
+func TestSizedCacheOverwriteOldestRegression(t *testing.T) {
+	require := require.New(t)
+
+	cache := NewSizedCache(
+		100,
+		func(_ string, v int) int {
+			return v
+		},
+	)
+
+	cache.Put("a", 60)
+	cache.Put("b", 40)
+	cache.Put("a", 61)
+
+	_, ok := cache.Get("b")
+	require.False(ok, "Get(b)")
+	require.Equal(0.61, cache.PortionFilled(), "PortionFilled()")
+}
+
 func TestSizedLRUSizeAlteringRegression(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
## Why this should be merged

@StephenButtolph had me look at some of the security alert scans. `SizedCache.put` subtracts an existing key's size from `currentSize` but leaves the old entry in the hashmap. If the eviction loop then reaches that stale entry, it subtracts the size a second time, so the cache permanently undercounts its real size and can exceed `maxSize`. 

## How this works

`put` now calls `evict(key)`, which removes the old entry and its size together. The eviction loop can no longer find the stale entry, so `currentSize` always equals the sum of cached element sizes.

## How this was tested

Added `TestSizedCacheOverwriteOldestRegression`, which is basically the test Claude provided in the security report. 

## Need to be documented in RELEASES.md?

No. 