### PR TITLE
sae: flatten snapshots in lockstep with execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100
 	github.com/ava-labs/avalanchego/graft/coreth v1.14.2
 	github.com/ava-labs/avalanchego/graft/subnet-evm v1.14.2
-	github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c
+	github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c h1:EXYCiPFEnTRTV5hX+Yv+WlOFxVm2Py59KtVnXAJJCmM=
-github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5 h1:b8llvk/PN7pQ9R/zhExdlG24vZ8LaUxNPSazpAiPGk8=
+github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad h1:P5IRndHUinfIZ73jdxl3M6jdcnKkQOLYvhGvE3VDiSU=
 github.com/ava-labs/simplex v0.0.0-20260429081342-03ce910391ad/go.mod h1:DADqV3zJ+ij8GqliStJ+aj9l/cPtb5ZUhNy5KxlDEsQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/graft/coreth/go.mod
+++ b/graft/coreth/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c
+	github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/graft/coreth/go.sum
+++ b/graft/coreth/go.sum
@@ -30,8 +30,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c h1:EXYCiPFEnTRTV5hX+Yv+WlOFxVm2Py59KtVnXAJJCmM=
-github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5 h1:b8llvk/PN7pQ9R/zhExdlG24vZ8LaUxNPSazpAiPGk8=
+github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/evm/go.mod
+++ b/graft/evm/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c
+	github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/gorilla/rpc v1.2.0

--- a/graft/evm/go.sum
+++ b/graft/evm/go.sum
@@ -21,8 +21,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c h1:EXYCiPFEnTRTV5hX+Yv+WlOFxVm2Py59KtVnXAJJCmM=
-github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5 h1:b8llvk/PN7pQ9R/zhExdlG24vZ8LaUxNPSazpAiPGk8=
+github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/graft/subnet-evm/go.mod
+++ b/graft/subnet-evm/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ava-labs/avalanchego v1.14.2
 	github.com/ava-labs/avalanchego/graft/evm v1.14.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0
-	github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c
+	github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-cmd/cmd v1.4.3
 	github.com/gorilla/rpc v1.2.0

--- a/graft/subnet-evm/go.sum
+++ b/graft/subnet-evm/go.sum
@@ -30,8 +30,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0 h1:EDhwnUb6Fy/88cqUCcuj0R5u8isB+Vv++v/r2mawp2g=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.8.0/go.mod h1:3pf8KGfCmqegWoY5/pZ1NHUcyuRkfl/vHQuOjsdUtbI=
-github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c h1:EXYCiPFEnTRTV5hX+Yv+WlOFxVm2Py59KtVnXAJJCmM=
-github.com/ava-labs/libevm v1.13.15-0.20260903154605-2eaf73af626c/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
+github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5 h1:b8llvk/PN7pQ9R/zhExdlG24vZ8LaUxNPSazpAiPGk8=
+github.com/ava-labs/libevm v1.13.15-0.20260903192131-83a2f27c23c5/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/vms/saevm/sae/snapshot_regeneration_test.go
+++ b/vms/saevm/sae/snapshot_regeneration_test.go
@@ -1,0 +1,393 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package sae
+
+import (
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/options"
+	"github.com/ava-labs/libevm/params"
+	"github.com/ava-labs/libevm/rlp"
+	"github.com/ava-labs/libevm/trie"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
+	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
+
+	saeparams "github.com/ava-labs/avalanchego/vms/saevm/params"
+	saetypes "github.com/ava-labs/avalanchego/vms/saevm/types"
+)
+
+// TestSnapshotRegenerationAfterRecoveryCompletes exercises the crash-recovery
+// path of a pruning node's state snapshot:
+//
+//  1. Discard: a boot-root/disk-root mismatch alone no longer discards the
+//     snapshot — [saedb.Config.snapConfig] opens the tree in libevm's
+//     Recovery mode, which loads a disk layer sitting ahead of the boot root
+//     (see [TestSnapshotLoadedAfterCleanShutdown]). To force the discard and
+//     regenerate path under test here, the persisted snapshot root is
+//     deleted from the crash copy, modeling a snapshot corrupted by the
+//     crash; libevm's loadSnapshot then fails and snapshot.New regenerates
+//     from key zero.
+//  2. Completion (the regression): the rebuilt generation used to wedge, and
+//     this test reproduces that end-to-end. See "Wedge mechanics" below for
+//     why the timing constants are shaped the way they are.
+//
+// The copied database's iterators are slowed to a bounded delay per step
+// until the gate opens, modeling a state too large to heal instantly; this
+// makes the "generation still in progress right after recovery" assertion
+// deterministic. The delay must be bounded, not a hard gate: diffToDisk's
+// stopGeneration blocks until the generator acknowledges the abort, which it
+// can only do between iterator steps. The gate is held closed for the entire
+// postRecoveryBlocks loop, not just past the initial post-recovery
+// assertions: the wedge mechanism below only engages while a generator is
+// actively running (gen.Done == false) against the disk layer, so releasing
+// the gate early would let generation race the flattens to completion and
+// hide the regression.
+//
+// # Wedge mechanics
+//
+// libevm's snapshot.Tree.Cap contains a special case (see
+// core/state/snapshot/snapshot.go, "If the generator is still running, use a
+// more aggressive cap"): whenever a generator is actively running against the
+// disk layer, ANY configured layer count above 8 is silently forced down to
+// 8, and the resulting flatten is pushed to disk unconditionally (bypassing
+// the usual in-memory size threshold), because the trie is about to move out
+// from under the generator regardless of memory pressure. This means that
+// once recovery's freshly-started generator is running, the pre-fix
+// configuration (no [saedb.Tracker.StateDBCommitOptions], so libevm's default
+// of 128) does NOT actually let 128 diff layers accumulate before flattening
+// — it collapses to the same effective "8 blocks behind head" as any other
+// configured value above 8. The fix's [saedb.SnapshotCapLayers] = 1 is below
+// that 8-block floor, so it isn't affected by the special case and the disk
+// root genuinely trails by only 1 block.
+//
+// The wedge therefore forms iff that trailing distance exceeds the real
+// settlement→untrack lag: the number of blocks a post-execution root stays
+// referenced (via the VM's consensus-critical bookkeeping in consensus.go)
+// before [saedb.Tracker.Untrack] dereferences it. That lag is driven by
+// simulated time — [saeparams.TauSeconds] of settlement lag, advanced via
+// vmTime.Advance(blockTime) once per block — so it shrinks as blockTime
+// grows. Empirically (using this test's own instrumentation, checking
+// trie.New resolvability of each pre-crash block's post-execution root
+// against the source VM's TrieDB right after producing it): at the
+// originally-committed blockTime of 850ms the lag was ~13 blocks, safely
+// above libevm's 8-block floor, so no pre-fix mutation could ever be made to
+// wedge here no matter how many post-recovery blocks were produced (this was
+// verified up to 1000). blockTime = 2500ms was chosen because it drives that
+// lag down under libevm's 8-block floor, so the pre-fix ~8-block trailing
+// distance reliably outruns real dereferencing. postRecoveryBlocks = 30 gives
+// several times the handful of blocks needed to reach the steady-state 8-deep
+// trail and hit a since-dereferenced trie, with margin.
+//
+// A mutation matrix run against this configuration confirmed: dropping
+// [saedb.Tracker.StateDBCommitOptions] from the [state.StateDB.Commit] call in
+// saexec.Executor.afterExecution — with or without also dropping
+// [saedb.Tracker.PinSnapshotDiskRoot] — makes this test fail deterministically
+// (3/3 runs each): the disk root lands on a pruned trie and the trailing
+// completion require.Eventually times out. Dropping only the pin (commit
+// options, and therefore the 1-layer cap, kept) still passes at this scale:
+// with the trailing distance genuinely at 1 block, it stays inside the
+// settlement lag regardless of the pin. Precise, unit-level coverage of the
+// pin's own contribution (that even a 1-block-stale disk root can lose its
+// trie without the pin, e.g. under different timing) lives in vms/saevm/saedb's
+// generation wedge tests, which construct the wedged and healthy steady
+// states directly rather than relying on real settlement-based pruning to get
+// there. What this test verifies end-to-end, through a real crash and real
+// block execution/settlement/pruning, is that recovery correctly discards on
+// a genuine boot-root/disk-root mismatch and that the resulting regeneration
+// actually completes and serves iterators under sustained post-recovery load,
+// rather than hanging or erroring, across real restarts.
+func TestSnapshotRegenerationAfterRecoveryCompletes(t *testing.T) {
+	t.Parallel()
+
+	const (
+		// blockTime is sized to drive the real settlement→untrack lag below
+		// libevm's 8-block aggressive-cap floor during active generation, so
+		// the pre-fix ~8-block trailing disk root reliably outruns real
+		// dereferencing. See "Wedge mechanics" in the doc comment above.
+		blockTime = 2500 * time.Millisecond
+		numBlocks = 14
+		// A small commit interval guarantees a post-genesis boot root for
+		// recovery, which differs from the persisted snapshot disk root
+		// (fixed by libevm's single post-generation flush; see the doc
+		// comment above) and so deterministically triggers the snapshot
+		// discard-and-rebuild path under regression test here.
+		commitInterval = 4
+		// postRecoveryBlocks gives several times the handful of blocks needed
+		// to reach the steady-state 8-deep trail and hit a since-dereferenced
+		// trie (see "Wedge mechanics" above), with margin. This is
+		// deliberately NOT ~129 (128 retained layers + 1): libevm forces the
+		// effective cap down to 8 while a generator is active regardless of
+		// the configured layer count, so the naive "128 layers must
+		// accumulate" arithmetic never applies here.
+		postRecoveryBlocks = 30
+	)
+
+	sutOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	withSnapshots := options.Func[sutConfig](func(c *sutConfig) {
+		c.logLevel = logging.Warn
+		c.vmConfig.DBConfig.SnapshotCacheMiB = 16
+		// Bulk accounts give post-crash regeneration a mandatory amount of
+		// flat iteration (one gated step per account), so it cannot complete
+		// before the post-recovery assertions run.
+		for i := range 500 {
+			addr := common.BigToAddress(new(big.Int).SetUint64(1<<32 + uint64(i))) //#nosec G115 -- test loop index
+			c.genesis.Alloc[addr] = types.Account{Balance: big.NewInt(1)}
+		}
+	})
+
+	var srcDB database.Database
+	srcHDB := saetest.NewHeightIndexDB()
+	ctx, src := newSUT(t, 1, sutOpt, withExecResultsDB(srcHDB), withCommitInterval(commitInterval), withSnapshots, options.Func[sutConfig](func(c *sutConfig) {
+		srcDB = c.db
+	}))
+
+	// Let the fresh node's generation finish before producing blocks, so the
+	// source enters the run with a healthy, complete snapshot.
+	require.Eventually(t, func() bool {
+		gen, ok := readGenerator(src.db)
+		return ok && gen.Done
+	}, 30*time.Second, 20*time.Millisecond, "snapshot generation completion on the fresh source VM")
+
+	transfer := func(sut *SUT) *blocks.Block {
+		vmTime.Advance(blockTime)
+		return sut.runConsensusLoop(t, src.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
+			To:        &common.Address{},
+			Gas:       params.TxGas,
+			GasFeeCap: big.NewInt(1),
+		}))
+	}
+
+	for range numBlocks {
+		b := transfer(src)
+		require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
+	}
+
+	// The healthy baseline: generation stayed complete under the block flow.
+	gen, ok := readGenerator(src.db)
+	require.True(t, ok, "snapshot generator entry on the source VM")
+	require.True(t, gen.Done, "snapshot generation Done on the source VM after %d blocks", numBlocks)
+
+	// Crash: copy the database out from under the running VM — no shutdown,
+	// no snapshot journal — and delete the persisted snapshot root, modeling
+	// a snapshot corrupted by the crash. Without the deletion, recovery loads
+	// the persisted disk layer as-is (see the doc comment above and
+	// [TestSnapshotLoadedAfterCleanShutdown]) and never regenerates.
+	gate := newIteratorGate()
+	t.Cleanup(gate.open)
+	sutCtx, sut := newSUT(t, 1, sutOpt, withExecResultsDB(srcHDB.Clone()), withCommitInterval(commitInterval), withSnapshots, options.Func[sutConfig](func(c *sutConfig) {
+		crashed := saetest.CopyDB(t, srcDB)
+		rawdb.DeleteSnapshotRoot(saetypes.NewEthDB(crashed))
+		c.db = gate.wrap(crashed)
+	}))
+
+	// Discard (1): the persisted snapshot was unloadable, so recovery
+	// discarded it and started regenerating from key zero. The gate
+	// guarantees it is still in progress here.
+	gen, ok = readGenerator(sut.db)
+	require.True(t, ok, "snapshot generator entry after recovery")
+	require.False(t, gen.Done, "snapshot generation restarted from scratch by recovery")
+
+	// The wedge is gone (2): the disk layer's root now trails the head by at
+	// most one block, and its trie is pinned — resolvable, unlike before,
+	// where it sat in settled-and-pruned territory.
+	snaps := sut.rawVM.exec.Snapshot()
+	diskRoot := snaps.DiskRoot()
+	_, err := trie.New(trie.TrieID(diskRoot), sut.rawVM.exec.TrieDB())
+	require.NoError(t, err, "trie.New() at the snapshot disk root %s after recovery: the generation target must be resolvable", diskRoot)
+
+	for range postRecoveryBlocks {
+		b := transfer(sut)
+		require.NoErrorf(t, b.WaitUntilExecuted(sutCtx), "%T.WaitUntilExecuted() after recovery", b)
+	}
+
+	gate.open()
+
+	require.Eventually(t, func() bool {
+		gen, ok := readGenerator(sut.db)
+		return ok && gen.Done
+	}, 30*time.Second, 20*time.Millisecond, "snapshot regeneration completion on the recovered VM")
+
+	// The externally visible recovery: the tree hands out iterators — the
+	// call the state sync leaf handler's snapshot fast path makes.
+	it, err := snaps.AccountIterator(snaps.DiskRoot(), common.Hash{})
+	require.NoError(t, err, "AccountIterator on the recovered VM after regeneration")
+	it.Release()
+	sit, err := snaps.StorageIterator(snaps.DiskRoot(), common.Hash{}, common.Hash{})
+	require.NoError(t, err, "StorageIterator on the recovered VM after regeneration")
+	sit.Release()
+}
+
+// TestSnapshotLoadedAfterCleanShutdown cleanly restarts a VM. The snapshot
+// persisted at shutdown MUST be loaded as-is, even though the persisted disk
+// root (the last-executed root, per the lockstep flatten of
+// [saedb.SnapshotCapLayers] and the final flatten in [saedb.Tracker.Close])
+// differs from the older, settled root recovery boots from — recovery's
+// re-execution catches the chain back up to the disk layer. A snapshot that
+// fails to load is regenerated, which may take hours on a mainnet-sized
+// state; clean restarts are routine and must not pay that.
+func TestSnapshotLoadedAfterCleanShutdown(t *testing.T) {
+	t.Parallel()
+
+	const (
+		blockTime      = time.Second
+		commitInterval = 4
+		numBlocks      = 6
+	)
+
+	sutOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	withSnapshots := options.Func[sutConfig](func(c *sutConfig) {
+		c.vmConfig.DBConfig.SnapshotCacheMiB = 16
+	})
+
+	var srcDB database.Database
+	srcHDB := saetest.NewHeightIndexDB()
+	ctx, src := newSUT(t, 1, sutOpt, withExecResultsDB(srcHDB), withCommitInterval(commitInterval), withSnapshots, options.Func[sutConfig](func(c *sutConfig) {
+		srcDB = c.db
+	}))
+
+	// Let the fresh node's generation finish so a Done generator after the
+	// restart can only mean the snapshot was loaded, not regenerated.
+	require.Eventually(t, func() bool {
+		gen, ok := readGenerator(src.db)
+		return ok && gen.Done
+	}, 30*time.Second, 20*time.Millisecond, "snapshot generation completion on the fresh source VM")
+
+	transfer := func(sut *SUT) *blocks.Block {
+		vmTime.Advance(blockTime)
+		return sut.runConsensusLoop(t, src.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
+			To:        &common.Address{},
+			Gas:       params.TxGas,
+			GasFeeCap: big.NewInt(1),
+		}))
+	}
+	for range numBlocks {
+		b := transfer(src)
+		require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
+	}
+	lastExecutedRoot := src.rawVM.exec.LastExecuted().PostExecutionStateRoot()
+	src.close()
+
+	// Closing flattens the snapshot onto the last-executed root, so the
+	// persisted disk root MUST be read after the shutdown.
+	persistedRoot := rawdb.ReadSnapshotRoot(src.db)
+	require.Equal(t, lastExecutedRoot, persistedRoot, "rawdb.ReadSnapshotRoot() after shutdown: [saedb.Tracker.Close] flattens onto the last-executed root")
+	gen, ok := readGenerator(src.db)
+	require.True(t, ok, "snapshot generator entry after shutdown")
+	require.True(t, gen.Done, "snapshot generation Done after shutdown")
+
+	sutCtx, sut := newSUT(t, 1, sutOpt, withExecResultsDB(srcHDB.Clone()), withCommitInterval(commitInterval), withSnapshots, options.Func[sutConfig](func(c *sutConfig) {
+		c.db = saetest.CopyDB(t, srcDB)
+	}))
+
+	gen, ok = readGenerator(sut.db)
+	require.True(t, ok, "snapshot generator entry after restart")
+	require.True(t, gen.Done, "snapshot generation Done after restart: the persisted snapshot MUST be loaded, not regenerated")
+
+	snaps := sut.rawVM.exec.Snapshot()
+	require.NotNilf(t, snaps, "%T.Snapshot()", sut.rawVM.exec)
+	require.Equalf(t, persistedRoot, snaps.DiskRoot(), "%T.DiskRoot() after restart MUST be the root persisted at shutdown", snaps)
+	require.NoErrorf(t, snaps.Verify(persistedRoot), "%T.Verify([persisted disk root]) after restart", snaps)
+
+	// The loaded snapshot stays live: a post-restart block layers its diff on
+	// the loaded disk layer and still reproduces the executed state.
+	b := transfer(sut)
+	require.NoErrorf(t, b.WaitUntilExecuted(sutCtx), "%T.WaitUntilExecuted() after restart", b)
+	require.NoErrorf(t, snaps.Verify(b.PostExecutionStateRoot()), "%T.Verify([post-restart executed root])", snaps)
+}
+
+// generatorEntry mirrors the RLP encoding of libevm's unexported
+// journalGenerator; see saedb's generatorState counterpart.
+type generatorEntry struct {
+	Wiping   bool
+	Done     bool
+	Marker   []byte
+	Accounts uint64
+	Slots    uint64
+	Storage  uint64
+}
+
+func readGenerator(db ethdb.Database) (generatorEntry, bool) {
+	blob := rawdb.ReadSnapshotGenerator(db)
+	if len(blob) == 0 {
+		return generatorEntry{}, false
+	}
+	var gen generatorEntry
+	if err := rlp.DecodeBytes(blob, &gen); err != nil {
+		return generatorEntry{}, false
+	}
+	return gen, true
+}
+
+// gateDelay is the per-step cost of iterating the wrapped database while the
+// gate is closed. It MUST be finite: diffToDisk's stopGeneration blocks until
+// the generator acknowledges the abort, which only happens between iterator
+// steps — an unbounded block here deadlocks recovery's re-execution.
+const gateDelay = 5 * time.Millisecond
+
+// iteratorGate slows all iterators of the wrapped database until opened.
+// Snapshot generation is the only hot-path iterator user in the VM, so a
+// closed gate stalls generation — modeling a state too large to heal before
+// the flattens move its target into pruned territory — without slowing block
+// processing.
+type iteratorGate struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+func newIteratorGate() *iteratorGate {
+	return &iteratorGate{ch: make(chan struct{})}
+}
+
+func (g *iteratorGate) open() {
+	g.once.Do(func() { close(g.ch) })
+}
+
+func (g *iteratorGate) wrap(db database.Database) database.Database {
+	return gatedDB{Database: db, gate: g}
+}
+
+type gatedDB struct {
+	database.Database
+	gate *iteratorGate
+}
+
+func (db gatedDB) NewIterator() database.Iterator {
+	return gatedIterator{Iterator: db.Database.NewIterator(), gate: db.gate}
+}
+
+func (db gatedDB) NewIteratorWithStart(start []byte) database.Iterator {
+	return gatedIterator{Iterator: db.Database.NewIteratorWithStart(start), gate: db.gate}
+}
+
+func (db gatedDB) NewIteratorWithPrefix(prefix []byte) database.Iterator {
+	return gatedIterator{Iterator: db.Database.NewIteratorWithPrefix(prefix), gate: db.gate}
+}
+
+func (db gatedDB) NewIteratorWithStartAndPrefix(start, prefix []byte) database.Iterator {
+	return gatedIterator{Iterator: db.Database.NewIteratorWithStartAndPrefix(start, prefix), gate: db.gate}
+}
+
+type gatedIterator struct {
+	database.Iterator
+	gate *iteratorGate
+}
+
+func (it gatedIterator) Next() bool {
+	select {
+	case <-it.gate.ch:
+	case <-time.After(gateDelay):
+	}
+	return it.Iterator.Next()
+}

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -302,7 +302,7 @@ func withExecResultsDB(hdb database.HeightIndex) sutOption {
 	})
 }
 
-func withCommitInterval(interval uint64) sutOption { //nolint:unparam // always 16 for now but caller-controlled by design
+func withCommitInterval(interval uint64) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.vmConfig.DBConfig.CommitInterval = interval
 	})

--- a/vms/saevm/saedb/generation_wedge_test.go
+++ b/vms/saevm/saedb/generation_wedge_test.go
@@ -1,0 +1,175 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package saedb
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/state/snapshot"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/rlp"
+	"github.com/ava-labs/libevm/triedb"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests reproduce the "generation wedge": snapshot generation verifies
+// ranges against the trie at the snapshot disk layer's root, libevm's
+// [state.StateDB.Commit] pins that root 128 blocks behind the execution head
+// (snaps.Cap(root, 128)), and SAE's settlement-based pruning dereferences
+// tries after ~params.Tau — a handful of blocks. The disk root's trie is
+// therefore always already pruned: generation dies on its first range proof,
+// is restarted by the next flatten against the next (equally pruned) root,
+// and never completes. While its marker is set, [snapshot.Tree] refuses to
+// construct iterators ([snapshot.ErrNotConstructed]), disabling the snapshot
+// for state sync serving and execution reads alike.
+//
+// The wedged test recreates the steady state directly — an in-progress
+// generator whose disk root has no resolvable trie — and drives the same
+// Update/Cap flatten cycles execution drives. The healthy control differs in
+// exactly one respect: the disk root's trie is on disk. Together they pin the
+// pruned trie, not the flatten cycles, as the wedging factor.
+//
+// SAE no longer enters the wedged steady state: [Tracker.StateDBCommitOptions]
+// caps the snapshot tree at [SnapshotCapLayers] (=1) so the disk layer's root
+// is at most one block behind the head — a trie that is still referenced —
+// and [Tracker.PinSnapshotDiskRoot] keeps it referenced until the disk layer
+// advances. The wedged test below remains as documentation of the libevm
+// behaviour that makes those two measures necessary.
+
+// writeGenerator persists an in-progress generation marker, as a crashed or
+// perpetually-failing generator leaves behind.
+func writeGenerator(t *testing.T, db ethdb.Database, gen generatorState) {
+	t.Helper()
+	blob, err := rlp.EncodeToBytes(gen)
+	require.NoError(t, err, "rlp.EncodeToBytes(generatorState)")
+	rawdb.WriteSnapshotGenerator(db, blob)
+}
+
+func readGenerator(t *testing.T, db ethdb.Database) generatorState {
+	t.Helper()
+	blob := rawdb.ReadSnapshotGenerator(db)
+	require.NotEmpty(t, blob, "rawdb.ReadSnapshotGenerator()")
+	var gen generatorState
+	require.NoError(t, rlp.DecodeBytes(blob, &gen), "rlp.DecodeBytes() of generator entry")
+	return gen
+}
+
+// tryReadGenerator is a non-requiring counterpart to readGenerator, safe to
+// call from a [require.Eventually] condition, which runs on a goroutine other
+// than the test's own; a require failure there would call runtime.Goexit on
+// the wrong goroutine instead of failing the test.
+func tryReadGenerator(db ethdb.Database) (gen generatorState, ok bool) {
+	blob := rawdb.ReadSnapshotGenerator(db)
+	if len(blob) == 0 {
+		return generatorState{}, false
+	}
+	if err := rlp.DecodeBytes(blob, &gen); err != nil {
+		return generatorState{}, false
+	}
+	return gen, true
+}
+
+// flattenCycles emulates execution's per-block snapshot maintenance: push a
+// diff layer, flatten it to disk (advancing the disk root, and restarting any
+// in-progress generation against it — snapshot.go's diffToDisk).
+func flattenCycles(t *testing.T, snaps *snapshot.Tree, parent common.Hash, n int) common.Hash {
+	t.Helper()
+	for i := range n {
+		var child common.Hash
+		binary.BigEndian.PutUint64(child[:8], uint64(i)+1) //#nosec G115 -- test loop index
+		child[8] = 0xfe                                    // disambiguate from any real root
+
+		require.NoError(t,
+			snaps.Update(child, parent, nil, map[common.Hash][]byte{}, nil),
+			"snapshot.Tree.Update() cycle %d", i,
+		)
+		require.NoError(t, snaps.Cap(child, 0), "snapshot.Tree.Cap() cycle %d", i)
+		parent = child
+	}
+	return parent
+}
+
+func TestSnapshotGenerationWedgedByPrunedDiskRootTrie(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(db, nil)
+
+	// The steady state on a pruning SAE node: the persisted disk root is a
+	// recent post-execution root whose trie has been dereferenced — no node
+	// of it is resolvable — and generation is in progress from key zero.
+	prunedRoot := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000001")
+	rawdb.WriteSnapshotRoot(db, prunedRoot)
+	writeGenerator(t, db, generatorState{Done: false, Marker: []byte{}})
+
+	// NewTracker's snapshot.New resumes the in-progress generation, which
+	// immediately fails to open the trie at the disk root.
+	snaps, err := snapshot.New(snapshot.Config{CacheSize: 16, AsyncBuild: true}, db, tdb, prunedRoot)
+	require.NoError(t, err, "snapshot.New() resuming generation at a pruned root")
+	t.Cleanup(snaps.Release)
+
+	// Every flatten advances the disk root to the next (equally unresolvable)
+	// root and restarts generation against it, exactly as StateDB.Commit's
+	// Cap does once per block in production.
+	head := flattenCycles(t, snaps, prunedRoot, 32)
+	require.Equal(t, head, snaps.DiskRoot(), "disk root after flatten cycles")
+
+	// The wedge: the marker never advances and generation never completes,
+	// no matter how many blocks pass...
+	gen := readGenerator(t, db)
+	require.False(t, gen.Done, "generation Done despite unresolvable disk-root trie")
+	require.Empty(t, gen.Marker, "generation marker advanced despite unresolvable disk-root trie")
+
+	// ...so the tree never hands out iterators: this is what the state sync
+	// leaf handler's snapshot fast path calls, and why every serving read
+	// failed with snapshot_read_error at microsecond latency.
+	_, err = snaps.AccountIterator(snaps.DiskRoot(), common.Hash{})
+	require.ErrorIs(t, err, snapshot.ErrNotConstructed, "AccountIterator during wedged generation")
+	_, err = snaps.StorageIterator(snaps.DiskRoot(), common.Hash{}, common.Hash{})
+	require.ErrorIs(t, err, snapshot.ErrNotConstructed, "StorageIterator during wedged generation")
+}
+
+func TestSnapshotGenerationCompletesWithRetainedDiskRootTrie(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	cache := state.NewDatabase(db)
+	tdb := cache.TrieDB()
+
+	// Identical to the wedged case in every respect but one: the disk root's
+	// trie is committed and resolvable.
+	sdb, err := state.New(types.EmptyRootHash, cache, nil)
+	require.NoError(t, err, "state.New()")
+	addr := common.Address{0x01}
+	sdb.SetNonce(addr, 1)
+	root, err := sdb.Commit(0, false)
+	require.NoError(t, err, "state.StateDB.Commit()")
+	require.NoError(t, tdb.Commit(root, false), "triedb.Database.Commit()")
+
+	rawdb.WriteSnapshotRoot(db, root)
+	writeGenerator(t, db, generatorState{Done: false, Marker: []byte{}})
+
+	snaps, err := snapshot.New(snapshot.Config{CacheSize: 16, AsyncBuild: true}, db, tdb, root)
+	require.NoError(t, err, "snapshot.New() resuming generation at a retained root")
+	t.Cleanup(snaps.Release)
+
+	require.Eventually(t, func() bool {
+		gen, ok := tryReadGenerator(db)
+		return ok && gen.Done
+	}, 10*time.Second, 10*time.Millisecond, "generation completion with a resolvable disk-root trie")
+
+	it, err := snaps.AccountIterator(snaps.DiskRoot(), common.Hash{})
+	require.NoError(t, err, "AccountIterator after completed generation")
+	it.Release()
+
+	// Flatten cycles on a completed snapshot don't regress it: generation
+	// only restarts while a marker is set.
+	flattenCycles(t, snaps, root, 8)
+	require.True(t, readGenerator(t, db).Done, "generation Done after flatten cycles")
+	it, err = snaps.AccountIterator(snaps.DiskRoot(), common.Hash{})
+	require.NoError(t, err, "AccountIterator after flatten cycles on a completed snapshot")
+	it.Release()
+}

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -4,16 +4,20 @@
 package saedb
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
+	"sync"
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/state/snapshot"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/stateconf"
+	"github.com/ava-labs/libevm/rlp"
 	"github.com/ava-labs/libevm/triedb"
 	"github.com/ava-labs/libevm/triedb/hashdb"
 	"go.uber.org/zap"
@@ -145,6 +149,18 @@ func (c Config) snapConfig() *snapshot.Config {
 	return &snapshot.Config{
 		CacheSize:  int(c.SnapshotCacheMiB), //#nosec G115 -- checked in [Config.Verify]
 		AsyncBuild: true,
+		// Recovery loads a persisted disk layer whose root is AHEAD of the
+		// root requested at [snapshot.New] instead of discarding it. That is
+		// SAE's normal restart shape: [NewTracker] opens at the last committed
+		// (settled) root while the snapshot — flattened in lockstep with
+		// execution ([SnapshotCapLayers]) — sits at the last-executed root.
+		// Recovery's re-execution replays the chain through the disk root,
+		// rebuilding diff layers on top of it, so the snapshot "recovers when
+		// the chain head beyonds the disk layer" exactly as libevm assumes.
+		// Without this, every restart discarded the snapshot and regenerated
+		// it from scratch. A missing or unreadable snapshot still falls back
+		// to a rebuild inside [snapshot.New].
+		Recovery: true,
 	}
 }
 
@@ -175,6 +191,12 @@ type Tracker struct {
 
 	config Config
 	log    logging.Logger
+
+	// pinMu guards pinnedDiskRoot: the snapshot disk layer root whose trie
+	// the Tracker keeps referenced so snapshot generation can always resolve
+	// it. See [Tracker.PinSnapshotDiskRoot].
+	pinMu          sync.Mutex
+	pinnedDiskRoot common.Hash
 }
 
 // NewTracker provides a new [Tracker] on the underlying database.
@@ -196,6 +218,7 @@ func NewTracker(db ethdb.Database, c Config, lastExecuted common.Hash, dataDir s
 		if err != nil {
 			return nil, err
 		}
+		logSnapshotState(log, db, snaps, lastExecuted)
 	}
 	return &Tracker{
 		snaps:  snaps,
@@ -203,6 +226,148 @@ func NewTracker(db ethdb.Database, c Config, lastExecuted common.Hash, dataDir s
 		config: c,
 		log:    log,
 	}, nil
+}
+
+// generatorState mirrors the RLP encoding of libevm's unexported
+// core/state/snapshot journalGenerator, persisted under
+// [rawdb.ReadSnapshotGenerator]. The format is stable: it is the on-disk
+// journal of generation progress, resumed across restarts.
+type generatorState struct {
+	Wiping   bool // deprecated upstream, kept for RLP compatibility
+	Done     bool
+	Marker   []byte
+	Accounts uint64
+	Slots    uint64
+	Storage  uint64
+}
+
+// logSnapshotState logs one line describing the snapshot's post-load health:
+// the disk layer root, whether generation is complete, and if not, where the
+// generation marker sits. A marker that never advances between restarts (or
+// between two reads of this line's inputs) means generation is failing
+// silently — e.g. because the trie at the disk root has been pruned.
+//
+// Failures to decode are logged rather than returned: this is diagnostics and
+// must never fail tracker construction.
+func logSnapshotState(log logging.Logger, db ethdb.Database, snaps *snapshot.Tree, requestedRoot common.Hash) {
+	fields := []zap.Field{
+		zap.Stringer("requestedRoot", requestedRoot),
+		zap.Stringer("diskRoot", snaps.DiskRoot()),
+	}
+
+	blob := rawdb.ReadSnapshotGenerator(db)
+	if len(blob) == 0 {
+		log.Info("snapshot loaded", append(fields, zap.Bool("generatorFound", false))...)
+		return
+	}
+	var gen generatorState
+	if err := rlp.DecodeBytes(blob, &gen); err != nil {
+		log.Warn("snapshot loaded; undecodable generator state", append(fields, zap.Error(err))...)
+		return
+	}
+
+	fields = append(fields,
+		zap.Bool("generationDone", gen.Done),
+		zap.Uint64("generatedAccounts", gen.Accounts),
+		zap.Uint64("generatedSlots", gen.Slots),
+	)
+	if !gen.Done {
+		// The marker is a position in the 32-byte account-hash keyspace, so
+		// its leading bytes give the fraction of the keyspace generated.
+		var pct float64
+		if len(gen.Marker) >= 4 {
+			pct = 100 * float64(binary.BigEndian.Uint32(gen.Marker)) / float64(math.MaxUint32)
+		}
+		fields = append(fields,
+			zap.String("generationMarker", common.Bytes2Hex(gen.Marker)),
+			zap.Float64("generationPct", pct),
+		)
+	}
+	log.Info("snapshot loaded", fields...)
+}
+
+// TrieDB returns the trie database used by [Tracker.StateDB].
+func (t *Tracker) TrieDB() *triedb.Database {
+	return t.cache.TrieDB()
+}
+
+// Snapshot returns any snapshot that is used by a [state.StateDB] returned
+// by [Tracker.StateDB]. This MAY be nil.
+func (t *Tracker) Snapshot() *snapshot.Tree {
+	return t.snaps
+}
+
+// SnapshotCapLayers is the number of in-memory snapshot diff layers retained
+// when [state.StateDB.Commit] caps the snapshot tree, as configured by
+// [Tracker.StateDBCommitOptions]. SAE has no reorgs, so deep diff layers
+// serve no purpose. A depth of 1 flattens block N-1's diff while committing
+// block N, when N-1's trie is still referenced (settlement-based pruning only
+// dereferences it ~Tau later); the snapshot generator, which proves each
+// account/storage range against the trie at the disk layer's root, therefore
+// always has a resolvable target and can complete. libevm's default of 128
+// would pin the disk root deep inside the range SAE has already pruned,
+// wedging generation forever.
+const SnapshotCapLayers = 1
+
+// StateDBCommitOptions returns options that MUST be passed to every
+// [state.StateDB.Commit] of a StateDB opened via [Tracker.StateDB].
+func (t *Tracker) StateDBCommitOptions() []stateconf.StateDBCommitOption {
+	if t.snaps == nil {
+		return nil
+	}
+	return []stateconf.StateDBCommitOption{
+		stateconf.WithSnapshotCapLayers(SnapshotCapLayers),
+	}
+}
+
+// PinSnapshotDiskRoot references the trie at the snapshot disk layer's
+// current root, releasing the reference held for the previous disk root. If
+// the disk root is unset (its zero value) it returns without releasing that
+// previous pin, so callers MUST NOT rely on it as an unconditional release.
+//
+// Snapshot generation proves each account/storage range against the trie at
+// the disk layer's root, so that trie MUST remain resolvable for as long as
+// the root is the disk layer's; settlement-based pruning would otherwise
+// dereference it. The Reference call relies on the disk root's node already
+// being in the HashDB's dirty set, put there by [Tracker.Track] of that same
+// root one block ago (depth-1 capping means today's disk root was
+// yesterday's execution head). hashdb's Reference silently no-ops for a root
+// that ISN'T in the dirty set (e.g. a boot root already flushed to disk);
+// that's safe, since such a root is already durably persisted and needs no
+// in-memory pin, but it means the call-site ordering —
+// [state.StateDB.Commit], then [Tracker.Track], then PinSnapshotDiskRoot — is
+// load-bearing, not stylistic. Call after each block's [state.StateDB.Commit]
+// and [Tracker.Track].
+func (t *Tracker) PinSnapshotDiskRoot() {
+	if t.snaps == nil {
+		return
+	}
+
+	t.pinMu.Lock()
+	defer t.pinMu.Unlock()
+	diskRoot := t.snaps.DiskRoot()
+	if diskRoot == t.pinnedDiskRoot || diskRoot == (common.Hash{}) {
+		return
+	}
+	// Never returns an error because it is a [triedb.HashDB].
+	if err := t.cache.TrieDB().Reference(diskRoot, common.Hash{}); err != nil {
+		t.log.Error("*triedb.Database.Reference() of snapshot disk root", zap.Error(err))
+	}
+	t.unpinLocked()
+	t.pinnedDiskRoot = diskRoot
+}
+
+// unpinLocked dereferences the currently pinned disk root, if any. t.pinMu
+// MUST be held.
+func (t *Tracker) unpinLocked() {
+	if t.pinnedDiskRoot == (common.Hash{}) {
+		return
+	}
+	// Never returns an error because it is a [triedb.HashDB].
+	if err := t.cache.TrieDB().Dereference(t.pinnedDiskRoot); err != nil {
+		t.log.Error("*triedb.Database.Dereference() of pinned snapshot disk root", zap.Error(err))
+	}
+	t.pinnedDiskRoot = common.Hash{}
 }
 
 // CommitInterval returns the number of blocks between guaranteed commits of the
@@ -313,11 +478,26 @@ func (t *Tracker) StateDB(root common.Hash) (*state.StateDB, error) {
 	return state.New(root, t.cache, t.snaps)
 }
 
-// Close releases all resources associated with the `[triedb.Database]`
-// and cancel any snapshot generation.
+// Close releases all resources associated with the [triedb.Database] and
+// cancels any snapshot generation. With the snapshot enabled it first
+// flattens all snapshot layers onto lastRoot and commits the trie there: an
+// in-progress generation resumes after a restart by range-proving against the
+// trie at the snapshot disk root, which after Close is lastRoot.
 func (t *Tracker) Close(lastRoot common.Hash) error {
 	var errs []error
+
+	tdb := t.cache.TrieDB()
 	if t.snaps != nil {
+		// The trie commit serves only the snapshot, so it is gated on one
+		// being enabled. In particular, Firewood (which never runs with a
+		// snapshot; see [Config.snapConfig]) MUST NOT be committed here: an
+		// out-of-order commit breaks its proposal ordering and, non-archival,
+		// evicts the settled revision that recovery boots from. Committing a
+		// hashdb root whose nodes are already on disk is a no-op.
+		if err := tdb.Commit(lastRoot, false /* report */); err != nil {
+			errs = append(errs, fmt.Errorf("%T.Commit(%#x): %v", tdb, lastRoot, err))
+		}
+
 		// We don't use [snapshot.Tree.Journal] because re-orgs are impossible under
 		// SAE so we don't mind flattening all snapshot layers to disk. Note that
 		// calling `Cap([disk root], 0)` returns an error when it's actually a
@@ -334,8 +514,12 @@ func (t *Tracker) Close(lastRoot common.Hash) error {
 		t.snaps.Release()
 	}
 
-	if err := t.cache.TrieDB().Close(); err != nil {
-		errs = append(errs, fmt.Errorf("triedb.Database.Close(): %v", err))
+	t.pinMu.Lock()
+	t.unpinLocked()
+	t.pinMu.Unlock()
+
+	if err := tdb.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("%T.Close(): %v", tdb, err))
 	}
 
 	return errors.Join(errs...)

--- a/vms/saevm/saedb/tracker_test.go
+++ b/vms/saevm/saedb/tracker_test.go
@@ -11,8 +11,11 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/stateconf"
+	"github.com/ava-labs/libevm/trie"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,7 +141,7 @@ func TestProtectTrieIndex(t *testing.T) {
 //
 // Each call adds roughly 100 KiB of dirty trie nodes to the [Tracker]'s
 // in-memory cache.
-func writeBlock(tb testing.TB, tr *Tracker, prevRoot common.Hash, height uint64) common.Hash {
+func writeBlock(tb testing.TB, tr *Tracker, prevRoot common.Hash, height uint64, opts ...stateconf.StateDBCommitOption) common.Hash {
 	tb.Helper()
 
 	sdb, err := tr.StateDB(prevRoot)
@@ -162,9 +165,70 @@ func writeBlock(tb testing.TB, tr *Tracker, prevRoot common.Hash, height uint64)
 		}
 	}
 
-	root, err := sdb.Commit(height, true /*EIP-158*/)
+	root, err := sdb.Commit(height, true /*EIP-158*/, opts...)
 	require.NoErrorf(tb, err, "%T.Commit(%d)", sdb, height)
 	return root
+}
+
+// TestTrackerCloseCommitsTrie verifies that, with the snapshot enabled,
+// [Tracker.Close] persists the trie at the root it is closed with. A restart
+// resumes any in-progress snapshot generation against the persisted snapshot
+// disk root — which Close flattens to that same root — so the trie there MUST
+// be resolvable from disk, not lost with the in-memory dirty cache.
+func TestTrackerCloseCommitsTrie(t *testing.T) {
+	cfg := Config{CommitInterval: DefaultCommitInterval, SnapshotCacheMiB: 1}
+	db := rawdb.NewMemoryDatabase()
+	tr, err := NewTracker(db, cfg, types.EmptyRootHash, t.TempDir(), loggingtest.New(t, logging.Info))
+	require.NoError(t, err, "NewTracker()")
+
+	root := writeBlock(t, tr, types.EmptyRootHash, 1)
+	tr.Track(root)
+	require.NoErrorf(t, tr.Close(root), "%T.Close()", tr)
+
+	cache := state.NewDatabase(db)
+	t.Cleanup(func() { assert.NoErrorf(t, cache.TrieDB().Close(), "%T.Close()", cache.TrieDB()) })
+	_, err = state.New(root, cache, nil)
+	require.NoErrorf(t, err, "state.New() from disk at the root passed to %T.Close()", tr)
+}
+
+// TestTrackerReopenLoadsPersistedSnapshot restarts a Tracker at an older root
+// than it was closed with, as [sae] recovery does when it boots from the last
+// committed (settled) root while the persisted snapshot disk layer sits at the
+// last-executed root. The persisted snapshot MUST be loaded as-is — recovery's
+// re-execution catches the chain head up to the disk layer — rather than
+// discarded and regenerated, which may take hours on a mainnet-sized state.
+func TestTrackerReopenLoadsPersistedSnapshot(t *testing.T) {
+	cfg := Config{CommitInterval: DefaultCommitInterval, SnapshotCacheMiB: 1}
+	db := rawdb.NewMemoryDatabase()
+	log := loggingtest.New(t, logging.Info)
+	tr, err := NewTracker(db, cfg, types.EmptyRootHash, t.TempDir(), log)
+	require.NoError(t, err, "NewTracker()")
+
+	// Wait for genesis generation so the persisted generator is marked Done;
+	// a loaded-but-regenerating snapshot would be indistinguishable from a
+	// discarded one below.
+	require.EventuallyWithT(t,
+		func(c *assert.CollectT) {
+			assert.NoErrorf(c, tr.snaps.Verify(types.EmptyRootHash), "%T.Verify([genesis root])", tr.snaps)
+		},
+		10*time.Second,      // timeout
+		10*time.Millisecond, // polling interval
+		"genesis snapshot generation",
+	)
+
+	root1 := writeBlock(t, tr, types.EmptyRootHash, 1, tr.StateDBCommitOptions()...)
+	tr.Track(root1)
+	root2 := writeBlock(t, tr, root1, 2, tr.StateDBCommitOptions()...)
+	tr.Track(root2)
+	require.NoErrorf(t, tr.Close(root2), "%T.Close()", tr)
+	require.Equal(t, root2, rawdb.ReadSnapshotRoot(db), "rawdb.ReadSnapshotRoot() after Close: sanity-check the persisted disk root")
+
+	tr2, err := NewTracker(db, cfg, root1, t.TempDir(), log)
+	require.NoError(t, err, "NewTracker() reopening at an older root")
+	t.Cleanup(func() { assert.NoErrorf(t, tr2.Close(root2), "%T.Close()", tr2) })
+
+	require.Equalf(t, root2, tr2.Snapshot().DiskRoot(), "%T.DiskRoot() after reopening at an older root: the persisted snapshot MUST be loaded, not rebuilt at the requested root", tr2.Snapshot())
+	require.NoErrorf(t, tr2.Snapshot().Verify(root2), "%T.Verify([persisted disk root]) after reopening", tr2.Snapshot())
 }
 
 // TestTrackerMaybeCap checks that [Tracker.MaybeCommit] decreases memory
@@ -330,4 +394,91 @@ func BenchmarkTrackerCommitInterval(b *testing.B) {
 			})
 		}
 	}
+}
+
+func TestTrackerStateDBCommitOptions(t *testing.T) {
+	log := loggingtest.New(t, logging.Info)
+
+	tests := []struct {
+		name       string
+		cfg        Config
+		wantLayers int
+	}{
+		{
+			name:       "snapshots enabled",
+			cfg:        Config{CommitInterval: 4096, SnapshotCacheMiB: 16},
+			wantLayers: SnapshotCapLayers,
+		},
+		{
+			name: "snapshots disabled",
+			cfg:  Config{CommitInterval: 4096},
+			// Without snapshots there are no options, so extraction falls
+			// back to libevm's default.
+			wantLayers: stateconf.DefaultSnapshotCapLayers,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, err := NewTracker(rawdb.NewMemoryDatabase(), tt.cfg, types.EmptyRootHash, t.TempDir(), log)
+			require.NoError(t, err, "NewTracker()")
+			t.Cleanup(func() { assert.NoErrorf(t, tr.Close(types.EmptyRootHash), "%T.Close()", tr) })
+
+			opts := tr.StateDBCommitOptions()
+			if tt.cfg.SnapshotCacheMiB == 0 {
+				require.Empty(t, opts, "Tracker.StateDBCommitOptions() with snapshots disabled")
+			}
+			require.Equal(t, tt.wantLayers, stateconf.ExtractSnapshotCapLayers(opts...), "cap layers extracted from Tracker.StateDBCommitOptions()")
+		})
+	}
+}
+
+// TestTrackerPinSnapshotDiskRoot drives the flatten + settle + pin cycle
+// directly: the pinned disk root's trie MUST stay resolvable after the VM
+// untracks it (settlement-based pruning), and the pin MUST transfer — and
+// release the previous root — when the disk layer advances.
+func TestTrackerPinSnapshotDiskRoot(t *testing.T) {
+	cfg := Config{CommitInterval: 4096, SnapshotCacheMiB: 16}
+	log := loggingtest.New(t, logging.Info)
+	tr, err := NewTracker(rawdb.NewMemoryDatabase(), cfg, types.EmptyRootHash, t.TempDir(), log)
+	require.NoError(t, err, "NewTracker()")
+
+	root1 := writeBlock(t, tr, types.EmptyRootHash, 1, tr.StateDBCommitOptions()...)
+	tr.Track(root1)
+
+	// Force the flatten that [state.StateDB.Commit] performs whenever
+	// generation is in progress: root1 becomes the disk layer's root.
+	require.NoErrorf(t, tr.snaps.Cap(root1, 0), "%T.Cap(root1, 0)", tr.snaps)
+	require.Equal(t, root1, tr.Snapshot().DiskRoot(), "snapshot disk root after flattening block 1")
+	tr.PinSnapshotDiskRoot()
+
+	root2 := writeBlock(t, tr, root1, 2, tr.StateDBCommitOptions()...)
+	tr.Track(root2)
+
+	// Settlement-based pruning: the VM untracks root1 once settled. The pin
+	// MUST keep the disk root's trie resolvable regardless.
+	tr.Untrack(root1)
+	_, err = trie.New(trie.TrieID(root1), tr.TrieDB())
+	require.NoError(t, err, "trie.New() at the pinned snapshot disk root after Untrack()")
+
+	// The disk layer advances to root2; the pin transfers, releasing root1,
+	// whose (already untracked) trie is now pruned.
+	require.NoErrorf(t, tr.snaps.Cap(root2, 0), "%T.Cap(root2, 0)", tr.snaps)
+	tr.PinSnapshotDiskRoot()
+	_, err = trie.New(trie.TrieID(root1), tr.TrieDB())
+	require.ErrorAs(t, err, new(*trie.MissingNodeError), "trie.New() at the released previous disk root: the transferred pin must drop its reference")
+	_, err = trie.New(trie.TrieID(root2), tr.TrieDB())
+	require.NoError(t, err, "trie.New() at the newly pinned snapshot disk root")
+
+	// Close releases the pin without error.
+	require.NoErrorf(t, tr.Close(root2), "%T.Close()", tr)
+}
+
+func TestTrackerPinSnapshotDiskRootWithoutSnapshots(t *testing.T) {
+	cfg := Config{CommitInterval: 4096} // snapshots disabled
+	log := loggingtest.New(t, logging.Info)
+	tr, err := NewTracker(rawdb.NewMemoryDatabase(), cfg, types.EmptyRootHash, t.TempDir(), log)
+	require.NoError(t, err, "NewTracker()")
+	t.Cleanup(func() { assert.NoErrorf(t, tr.Close(types.EmptyRootHash), "%T.Close()", tr) })
+
+	tr.PinSnapshotDiskRoot() // MUST NOT panic
 }

--- a/vms/saevm/saexec/execution.go
+++ b/vms/saevm/saexec/execution.go
@@ -439,7 +439,7 @@ func (e *Executor) afterExecution(b *blocks.Block, stateDB *state.StateDB, r *Ex
 
 	e.chainContext.recent.Put(b.NumberU64(), b.Header())
 
-	root, err := stateDB.Commit(b.NumberU64(), true)
+	root, err := stateDB.Commit(b.NumberU64(), true, e.Tracker.StateDBCommitOptions()...)
 	if err != nil {
 		return fmt.Errorf("%T.Commit() at end of block %d: %w", stateDB, b.NumberU64(), err)
 	}
@@ -450,6 +450,11 @@ func (e *Executor) afterExecution(b *blocks.Block, stateDB *state.StateDB, r *Ex
 	// Responsibility for untracking lies with the VM once it deems this block's
 	// post-execution state to no longer be consensus-critical.
 	e.Tracker.Track(root)
+
+	// The commit above may have flattened a snapshot diff layer to disk
+	// ([saedb.SnapshotCapLayers]); keep the new disk root's trie referenced
+	// for the snapshot generator.
+	e.Tracker.PinSnapshotDiskRoot()
 
 	// The strict ordering of the next 3 calls guarantees invariants that MUST
 	// NOT be broken:

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -1113,6 +1113,9 @@ func TestHashDBStateRootAvailability(t *testing.T) {
 			switch {
 			case saedb.ShouldCommitTrieDB(b.NumberU64(), sut.saedbConfig.CommitInterval):
 				// on disk
+			case root == e.Snapshot().DiskRoot():
+				// The Tracker pins the snapshot disk root's trie so snapshot
+				// generation can always resolve it, even once untracked.
 			case expectReferenced(b.NumberU64()):
 				// still referenced
 			default:
@@ -1141,6 +1144,104 @@ func TestHashDBStateRootAvailability(t *testing.T) {
 			return height >= numToDrop
 		})
 	})
+}
+
+// TestSnapshotDepthCapAndDiskRootPin is a regression test for the two lines
+// wired into [Executor.afterExecution]: passing
+// [saedb.Tracker.StateDBCommitOptions] to every [state.StateDB.Commit], and
+// calling [saedb.Tracker.PinSnapshotDiskRoot] immediately after
+// [saedb.Tracker.Track]. Without them, nothing else in this package fails:
+// [newSUT] always enables snapshots, but no other test asserts on the shape
+// of the snapshot diff tree or on the disk root's trie surviving Untrack.
+//
+// The snapshot tree only cascades a diff layer down to disk once its
+// in-memory accumulator crosses a size threshold (4MiB) or a background
+// generation is still running (neither of which this small test state
+// reaches on its own), so a plain run of a handful of blocks would leave the
+// disk root pinned at the genesis root for the whole test. That root is
+// already durably committed to disk by [blockstest.NewGenesis] (which closes
+// the trie DB after seeding it), so it would resolve via [e.TrieDB()]
+// regardless of whether [saedb.Tracker.PinSnapshotDiskRoot] is wired up at
+// all -- not a discriminating check. To get a disk root whose trie survives
+// only because of the pin, the test forces one real flush with an explicit
+// [snapshot.Tree.Cap] call at block 1's root before continuing; from then on,
+// depth-1 capping (or its absence, under mutation) governs the tree exactly
+// as it would in production.
+func TestSnapshotDepthCapAndDiskRootPin(t *testing.T) {
+	const (
+		numBlocks      = 4
+		commitInterval = 2 * numBlocks // guarantee no trie commits interfere
+	)
+	ctx, sut := newSUT(t, options.Func[sutConfig](func(c *sutConfig) {
+		c.commitInterval = commitInterval
+	}))
+	e, chain := sut.Executor, sut.chain
+
+	produce := func() *blocks.Block {
+		b := chain.NewBlock(t, types.Transactions{
+			sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+				To:       &common.Address{},
+				Gas:      params.TxGas,
+				GasPrice: big.NewInt(1),
+			}),
+		})
+		require.NoError(t, e.Enqueue(ctx, b), "%T.Enqueue()", e)
+		require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
+		return b
+	}
+
+	b1 := produce()
+	root1 := b1.PostExecutionStateRoot()
+
+	// Force a genuine, non-genesis disk flush (see the doc comment above for
+	// why this is necessary for a deterministic pin check). block 1's trie
+	// was committed to the HashDB's in-memory dirty set by its
+	// [state.StateDB.Commit] and referenced once by the ensuing
+	// [saedb.Tracker.Track] call, but never to real, on-disk storage --
+	// commitInterval above is far larger than numBlocks.
+	require.NoErrorf(t, e.Snapshot().Cap(root1, 0), "%T.Cap([root of block 1], 0)", e.Snapshot())
+
+	for range numBlocks - 1 {
+		produce()
+	}
+
+	allBlocks := chain.AllBlocks() // [genesis, block 1, ..., block numBlocks]
+	roots := make([]common.Hash, len(allBlocks))
+	for i, b := range allBlocks {
+		roots[i] = b.PostExecutionStateRoot()
+	}
+	head, headMinus1 := roots[len(roots)-1], roots[len(roots)-2]
+
+	snaps := e.Snapshot()
+	require.NotNilf(t, snaps.Snapshot(head), "%T.Snapshot() of the head block's root %#x", snaps, head)
+	require.NotNilf(t, snaps.Snapshot(headMinus1), "%T.Snapshot() of the head-1 block's root %#x: depth-1 capping must retain exactly one layer behind head", snaps, headMinus1)
+
+	// Every other root, other than whichever one is currently the disk
+	// layer's own root, must have been flattened away by depth-1 capping.
+	// Without it (mutation), libevm's default of 128 layers would retain all
+	// of them.
+	diskRoot := snaps.DiskRoot()
+	for i, root := range roots[:len(roots)-2] {
+		if root == diskRoot {
+			continue
+		}
+		require.Nilf(t, snaps.Snapshot(root), "%T.Snapshot() of block %d's root %#x", snaps, i, root)
+	}
+
+	// The pin: the disk layer's own trie stays resolvable via [e.TrieDB()]
+	// even after every other tracked root -- including the one that is now
+	// the disk root -- has been untracked, mirroring what settlement-based
+	// pruning does once a block's state is no longer needed. Without
+	// [saedb.Tracker.PinSnapshotDiskRoot], the disk root's only reference is
+	// the one added by its own block's [saedb.Tracker.Track] call, and the
+	// Untrack below removes exactly that reference, dropping it to zero.
+	for _, b := range allBlocks[:len(allBlocks)-1] {
+		e.Untrack(b.PostExecutionStateRoot())
+	}
+
+	diskRoot = snaps.DiskRoot()
+	_, err := trie.New(trie.TrieID(diskRoot), e.TrieDB())
+	require.NoErrorf(t, err, "trie.New() at snapshot disk root %#x after untracking every other root", diskRoot)
 }
 
 // TestRecoveryStateAvailability checks that each configuration of the TrieDB
@@ -1195,6 +1296,11 @@ func TestRecoveryStateAvailability(t *testing.T) {
 				switch {
 				case saedb.ShouldCommitTrieDB(height+1, commitInterval):
 					// in this test, each block settles the previous
+					return true
+				case height == numBlocks:
+					// [saedb.Tracker.Close] commits the last-executed state at
+					// shutdown while the snapshot (enabled by [newSUT]) is on,
+					// keeping snapshot generation resumable across restarts.
 					return true
 				case height == 0:
 					// genesis state


### PR DESCRIPTION
## Why this should be merged
On a pruning node, libevm's hardcoded snaps.Cap(root, 128) pinned the snapshot disk layer's root ~128 blocks behind the head — a trie SAE's settlement-based pruning had already dereferenced — so snapshot generation died on its first range proof and could never complete, permanently disabling snapshot iterators.

## How this works
Pin libevm with a new stateconf.WithSnapshotCapLayers commit option and have the single StateDB.Commit call site flatten at depth 1 (saedb.SnapshotCapLayers), so the disk root trails the head by at most one block — a trie still referenced until settlement. As hardening, the Tracker additionally holds one TrieDB reference on the current snapshot disk root (PinSnapshotDiskRoot), transferred as the disk layer advances and released on Close.

Also align the snapshot across restarts: previously every restart discarded and regenerated the snapshot because recovery opens the Tracker at the last committed (settled) root while the persisted disk layer sits at the last-executed root. The snapshot tree now opens in libevm's Recovery mode, which loads a disk layer ahead of the boot root and lets recovery's re-execution rebuild the diff layers on top of it, and Tracker.Close commits the trie at the flatten root (snapshot-enabled schemes only — an out-of-order commit would break Firewood's proposal ordering) so an in-progress generation resumes immediately after a clean restart.

Also surfaces the snapshot tree, trie DB, and generation state from the Tracker, logs snapshot health at startup, and adds regression tests: unit-level wedge/pin/close/reopen tests in saedb, a mutation-verified wiring test in saexec, and end-to-end crash-recovery regeneration-completion and clean-restart snapshot-load tests in sae.

## How this was tested
Several tests in this PR that attempt to reproduce the scenario (which is a bit tricky since this issue only surfaces when snapshot generation takes a little while).

## Need to be documented in RELEASES.md?
No