### PR TITLE
fix(tmpnet): observe context deadline in WaitForHealthy on health errors

### DIFF
--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -435,7 +435,6 @@ func (n *Node) WaitForHealthy(ctx context.Context) error {
 				zap.Stringer("nodeID", n.NodeID),
 				zap.Error(err),
 			)
-			continue
 		case healthy:
 			return nil
 		}


### PR DESCRIPTION
## Why this should be merged

WaitForHealthy retried immediately on any health check error via `continue`, skipping the select that observes the context deadline and the ticker. Once a node process exited, every poll returned an error and the loop spun forever, hanging e2e runs (observed as 45+ minutes of silence in e2e-schedule-latest) instead of failing at the 2 minute deadline.

Fall through to the select so the deadline is honored and retries are rate-limited by the ticker.

## How this works

## How this was tested
CI

## Need to be documented in RELEASES.md?
No