### PR TITLE
Replay PlatformVM diff and state writes in order

### DIFF
--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -54,8 +54,11 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 
 	// create a proposal transaction to be included into proposal block
 	utx := &txs.AddValidatorTx{
-		BaseTx:    txs.BaseTx{},
-		Validator: txs.Validator{End: uint64(chainTime.Unix())},
+		BaseTx: txs.BaseTx{},
+		Validator: txs.Validator{
+			End:  uint64(chainTime.Unix()),
+			Wght: 1,
+		},
 		StakeOuts: []*avax.TransferableOutput{
 			{
 				Asset: avax.Asset{
@@ -83,6 +86,7 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 		TxID:      addValTx.ID(),
 		NodeID:    utx.NodeID(),
 		SubnetID:  utx.SubnetID(),
+		Weight:    utx.Weight(),
 		StartTime: utx.StartTime(),
 		EndTime:   chainTime,
 		NextTime:  chainTime,
@@ -145,8 +149,11 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	// setup state to validate proposal block transaction
 	nextStakerTime := chainTime.Add(executor.SyncBound).Add(-1 * time.Second)
 	unsignedNextStakerTx := &txs.AddValidatorTx{
-		BaseTx:    txs.BaseTx{},
-		Validator: txs.Validator{End: uint64(nextStakerTime.Unix())},
+		BaseTx: txs.BaseTx{},
+		Validator: txs.Validator{
+			End:  uint64(nextStakerTime.Unix()),
+			Wght: 1,
+		},
 		StakeOuts: []*avax.TransferableOutput{
 			{
 				Asset: avax.Asset{
@@ -170,6 +177,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 		NodeID:    unsignedNextStakerTx.NodeID(),
 		SubnetID:  unsignedNextStakerTx.SubnetID(),
 		Priority:  txs.PrimaryNetworkValidatorCurrentPriority,
+		Weight:    unsignedNextStakerTx.Weight(),
 		StartTime: nextStakerTime,
 		EndTime:   nextStakerTime,
 		NextTime:  nextStakerTime,

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -1550,7 +1550,7 @@ func TestGetCurrentValidatorsForL1(t *testing.T) {
 					SubnetID:  subnetID,
 					NodeID:    ids.GenerateTestNodeID(),
 					PublicKey: otherPK,
-					Weight:    0,
+					Weight:    1,
 					StartTime: time.Unix(2, 0),
 				},
 			},

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -48,7 +48,6 @@ type Diff struct {
 	currentStakerDiffs  diffStakers
 	pendingStakerDiffs  diffStakers
 
-	addedSubnetIDs []ids.ID
 	// Subnet ID --> Owner of the subnet
 	subnetOwners map[ids.ID]fx.Owner
 	// Subnet ID --> Conversion of the subnet
@@ -56,14 +55,14 @@ type Diff struct {
 	// Subnet ID --> Tx that transforms the subnet
 	transformedSubnets map[ids.ID]*txs.Tx
 
-	addedChains map[ids.ID][]*txs.Tx
-
-	addedRewardUTXOs map[ids.ID][]*avax.UTXO
-
 	addedTxs map[ids.ID]*txAndStatus
 
 	// map of modified UTXOID -> *UTXO if the UTXO is nil, it has been removed
 	modifiedUTXOs map[ids.ID]*avax.UTXO
+
+	// applyOps records mutations in the order they were issued. [Diff.Apply]
+	// replays them against the base state.
+	applyOps []func(Chain) error
 }
 
 // NewDiff returns a new [Diff] whose parent is identified by parentID within
@@ -119,6 +118,10 @@ func (d *Diff) GetTimestamp() time.Time {
 
 func (d *Diff) SetTimestamp(timestamp time.Time) {
 	d.timestamp = timestamp
+	d.recordOp(func(c Chain) error {
+		c.SetTimestamp(timestamp)
+		return nil
+	})
 }
 
 func (d *Diff) GetFeeState() gas.State {
@@ -127,6 +130,10 @@ func (d *Diff) GetFeeState() gas.State {
 
 func (d *Diff) SetFeeState(feeState gas.State) {
 	d.feeState = feeState
+	d.recordOp(func(c Chain) error {
+		c.SetFeeState(feeState)
+		return nil
+	})
 }
 
 func (d *Diff) GetL1ValidatorExcess() gas.Gas {
@@ -135,6 +142,10 @@ func (d *Diff) GetL1ValidatorExcess() gas.Gas {
 
 func (d *Diff) SetL1ValidatorExcess(excess gas.Gas) {
 	d.l1ValidatorExcess = excess
+	d.recordOp(func(c Chain) error {
+		c.SetL1ValidatorExcess(excess)
+		return nil
+	})
 }
 
 func (d *Diff) GetAccruedFees() uint64 {
@@ -143,6 +154,10 @@ func (d *Diff) GetAccruedFees() uint64 {
 
 func (d *Diff) SetAccruedFees(accruedFees uint64) {
 	d.accruedFees = accruedFees
+	d.recordOp(func(c Chain) error {
+		c.SetAccruedFees(accruedFees)
+		return nil
+	})
 }
 
 func (d *Diff) GetCurrentSupply(subnetID ids.ID) (uint64, error) {
@@ -167,6 +182,10 @@ func (d *Diff) SetCurrentSupply(subnetID ids.ID, currentSupply uint64) {
 	} else {
 		d.currentSupply[subnetID] = currentSupply
 	}
+	d.recordOp(func(c Chain) error {
+		c.SetCurrentSupply(subnetID, currentSupply)
+		return nil
+	})
 }
 
 func (d *Diff) GetExpiryIterator() (iterator.Iterator[ExpiryEntry], error) {
@@ -198,10 +217,18 @@ func (d *Diff) HasExpiry(entry ExpiryEntry) (bool, error) {
 
 func (d *Diff) PutExpiry(entry ExpiryEntry) {
 	d.expiryDiff.PutExpiry(entry)
+	d.recordOp(func(c Chain) error {
+		c.PutExpiry(entry)
+		return nil
+	})
 }
 
 func (d *Diff) DeleteExpiry(entry ExpiryEntry) {
 	d.expiryDiff.DeleteExpiry(entry)
+	d.recordOp(func(c Chain) error {
+		c.DeleteExpiry(entry)
+		return nil
+	})
 }
 
 func (d *Diff) GetActiveL1ValidatorsIterator() (iterator.Iterator[L1Validator], error) {
@@ -265,7 +292,13 @@ func (d *Diff) HasL1Validator(subnetID ids.ID, nodeID ids.NodeID) (bool, error) 
 }
 
 func (d *Diff) PutL1Validator(l1Validator L1Validator) error {
-	return d.l1ValidatorsDiff.putL1Validator(d, l1Validator)
+	if err := d.l1ValidatorsDiff.putL1Validator(d, l1Validator); err != nil {
+		return err
+	}
+	d.recordOp(func(c Chain) error {
+		return c.PutL1Validator(l1Validator)
+	})
+	return nil
 }
 
 func (d *Diff) GetCurrentValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker, error) {
@@ -293,6 +326,9 @@ func (d *Diff) SetStakingInfo(subnetID ids.ID, nodeID ids.NodeID, stakingInfo St
 	}
 
 	d.setStakingInfo(subnetID, nodeID, stakingInfo)
+	d.recordOp(func(c Chain) error {
+		return c.SetStakingInfo(subnetID, nodeID, stakingInfo)
+	})
 	return nil
 }
 
@@ -338,6 +374,9 @@ func (d *Diff) PutCurrentValidator(staker *Staker) error {
 
 	d.setStakingInfo(staker.SubnetID, staker.NodeID, StakingInfo{})
 
+	d.recordOp(func(c Chain) error {
+		return c.PutCurrentValidator(staker)
+	})
 	return nil
 }
 
@@ -353,6 +392,9 @@ func (d *Diff) DeleteCurrentValidator(staker *Staker) error {
 	d.currentStakerDiffs.DeleteValidator(staker)
 	delete(d.modifiedStakingInfo[staker.SubnetID], staker.NodeID)
 
+	d.recordOp(func(c Chain) error {
+		return c.DeleteCurrentValidator(staker)
+	})
 	return nil
 }
 
@@ -376,6 +418,9 @@ func (d *Diff) PutCurrentDelegator(staker *Staker) error {
 	}
 
 	d.currentStakerDiffs.PutDelegator(staker)
+	d.recordOp(func(c Chain) error {
+		return c.PutCurrentDelegator(staker)
+	})
 	return nil
 }
 
@@ -385,6 +430,9 @@ func (d *Diff) DeleteCurrentDelegator(staker *Staker) error {
 	}
 
 	d.currentStakerDiffs.DeleteDelegator(staker)
+	d.recordOp(func(c Chain) error {
+		return c.DeleteCurrentDelegator(staker)
+	})
 	return nil
 }
 
@@ -422,11 +470,21 @@ func (d *Diff) GetPendingValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker,
 }
 
 func (d *Diff) PutPendingValidator(staker *Staker) error {
-	return d.pendingStakerDiffs.PutValidator(staker)
+	if err := d.pendingStakerDiffs.PutValidator(staker); err != nil {
+		return err
+	}
+	d.recordOp(func(c Chain) error {
+		return c.PutPendingValidator(staker)
+	})
+	return nil
 }
 
 func (d *Diff) DeletePendingValidator(staker *Staker) {
 	d.pendingStakerDiffs.DeleteValidator(staker)
+	d.recordOp(func(c Chain) error {
+		c.DeletePendingValidator(staker)
+		return nil
+	})
 }
 
 func (d *Diff) GetPendingDelegatorIterator(subnetID ids.ID, nodeID ids.NodeID) (iterator.Iterator[*Staker], error) {
@@ -445,10 +503,18 @@ func (d *Diff) GetPendingDelegatorIterator(subnetID ids.ID, nodeID ids.NodeID) (
 
 func (d *Diff) PutPendingDelegator(staker *Staker) {
 	d.pendingStakerDiffs.PutDelegator(staker)
+	d.recordOp(func(c Chain) error {
+		c.PutPendingDelegator(staker)
+		return nil
+	})
 }
 
 func (d *Diff) DeletePendingDelegator(staker *Staker) {
 	d.pendingStakerDiffs.DeleteDelegator(staker)
+	d.recordOp(func(c Chain) error {
+		c.DeletePendingDelegator(staker)
+		return nil
+	})
 }
 
 func (d *Diff) GetPendingStakerIterator() (iterator.Iterator[*Staker], error) {
@@ -466,7 +532,10 @@ func (d *Diff) GetPendingStakerIterator() (iterator.Iterator[*Staker], error) {
 }
 
 func (d *Diff) AddSubnet(subnetID ids.ID) {
-	d.addedSubnetIDs = append(d.addedSubnetIDs, subnetID)
+	d.recordOp(func(c Chain) error {
+		c.AddSubnet(subnetID)
+		return nil
+	})
 }
 
 func (d *Diff) GetSubnetOwner(subnetID ids.ID) (fx.Owner, error) {
@@ -485,6 +554,10 @@ func (d *Diff) GetSubnetOwner(subnetID ids.ID) (fx.Owner, error) {
 
 func (d *Diff) SetSubnetOwner(subnetID ids.ID, owner fx.Owner) {
 	d.subnetOwners[subnetID] = owner
+	d.recordOp(func(c Chain) error {
+		c.SetSubnetOwner(subnetID, owner)
+		return nil
+	})
 }
 
 func (d *Diff) GetSubnetToL1Conversion(subnetID ids.ID) (SubnetToL1Conversion, error) {
@@ -500,8 +573,12 @@ func (d *Diff) GetSubnetToL1Conversion(subnetID ids.ID) (SubnetToL1Conversion, e
 	return parentState.GetSubnetToL1Conversion(subnetID)
 }
 
-func (d *Diff) SetSubnetToL1Conversion(subnetID ids.ID, c SubnetToL1Conversion) {
-	d.subnetToL1Conversions[subnetID] = c
+func (d *Diff) SetSubnetToL1Conversion(subnetID ids.ID, conv SubnetToL1Conversion) {
+	d.subnetToL1Conversions[subnetID] = conv
+	d.recordOp(func(c Chain) error {
+		c.SetSubnetToL1Conversion(subnetID, conv)
+		return nil
+	})
 }
 
 func (d *Diff) GetSubnetTransformation(subnetID ids.ID) (*txs.Tx, error) {
@@ -527,17 +604,17 @@ func (d *Diff) AddSubnetTransformation(transformSubnetTxIntf *txs.Tx) {
 	} else {
 		d.transformedSubnets[transformSubnetTx.Subnet] = transformSubnetTxIntf
 	}
+	d.recordOp(func(c Chain) error {
+		c.AddSubnetTransformation(transformSubnetTxIntf)
+		return nil
+	})
 }
 
 func (d *Diff) AddChain(createChainTx *txs.Tx) {
-	tx := createChainTx.Unsigned.(*txs.CreateChainTx)
-	if d.addedChains == nil {
-		d.addedChains = map[ids.ID][]*txs.Tx{
-			tx.SubnetID: {createChainTx},
-		}
-	} else {
-		d.addedChains[tx.SubnetID] = append(d.addedChains[tx.SubnetID], createChainTx)
-	}
+	d.recordOp(func(c Chain) error {
+		c.AddChain(createChainTx)
+		return nil
+	})
 }
 
 func (d *Diff) GetTx(txID ids.ID) (*txs.Tx, status.Status, error) {
@@ -565,13 +642,17 @@ func (d *Diff) AddTx(tx *txs.Tx, status status.Status) {
 	} else {
 		d.addedTxs[txID] = txStatus
 	}
+	d.recordOp(func(c Chain) error {
+		c.AddTx(tx, status)
+		return nil
+	})
 }
 
 func (d *Diff) AddRewardUTXO(txID ids.ID, utxo *avax.UTXO) {
-	if d.addedRewardUTXOs == nil {
-		d.addedRewardUTXOs = make(map[ids.ID][]*avax.UTXO)
-	}
-	d.addedRewardUTXOs[txID] = append(d.addedRewardUTXOs[txID], utxo)
+	d.recordOp(func(c Chain) error {
+		c.AddRewardUTXO(txID, utxo)
+		return nil
+	})
 }
 
 func (d *Diff) GetUTXO(utxoID ids.ID) (*avax.UTXO, error) {
@@ -597,6 +678,10 @@ func (d *Diff) AddUTXO(utxo *avax.UTXO) {
 	} else {
 		d.modifiedUTXOs[utxo.InputID()] = utxo
 	}
+	d.recordOp(func(c Chain) error {
+		c.AddUTXO(utxo)
+		return nil
+	})
 }
 
 func (d *Diff) DeleteUTXO(utxoID ids.ID) {
@@ -607,147 +692,21 @@ func (d *Diff) DeleteUTXO(utxoID ids.ID) {
 	} else {
 		d.modifiedUTXOs[utxoID] = nil
 	}
+	d.recordOp(func(c Chain) error {
+		c.DeleteUTXO(utxoID)
+		return nil
+	})
+}
+
+func (d *Diff) recordOp(op func(Chain) error) {
+	d.applyOps = append(d.applyOps, op)
 }
 
 func (d *Diff) Apply(baseState Chain) error {
-	baseState.SetTimestamp(d.timestamp)
-	baseState.SetFeeState(d.feeState)
-	baseState.SetL1ValidatorExcess(d.l1ValidatorExcess)
-	baseState.SetAccruedFees(d.accruedFees)
-	for subnetID, supply := range d.currentSupply {
-		baseState.SetCurrentSupply(subnetID, supply)
-	}
-	for entry, isAdded := range d.expiryDiff.modified {
-		if isAdded {
-			baseState.PutExpiry(entry)
-		} else {
-			baseState.DeleteExpiry(entry)
-		}
-	}
-	// Ensure that all l1Validator deletions happen before any l1Validator
-	// additions. This ensures that a subnetID+nodeID pair that was deleted and
-	// then re-added in a single diff can't get reordered into the addition
-	// happening first; which would return an error.
-	for _, l1Validator := range d.l1ValidatorsDiff.modified {
-		if !l1Validator.isDeleted() {
-			continue
-		}
-		if err := baseState.PutL1Validator(l1Validator); err != nil {
+	for _, op := range d.applyOps {
+		if err := op(baseState); err != nil {
 			return err
 		}
 	}
-	for _, l1Validator := range d.l1ValidatorsDiff.modified {
-		if l1Validator.isDeleted() {
-			continue
-		}
-		if err := baseState.PutL1Validator(l1Validator); err != nil {
-			return err
-		}
-	}
-	for _, subnetValidatorDiffs := range d.currentStakerDiffs.validatorDiffs {
-		for _, validatorDiff := range subnetValidatorDiffs {
-			// Delegators must be removed before their respective validators
-			for _, delegator := range validatorDiff.deletedDelegators {
-				if err := baseState.DeleteCurrentDelegator(delegator); err != nil {
-					return fmt.Errorf("deleting current delegator: %w", err)
-				}
-			}
-
-			// We might have removed the validator and then added it in the same diff.
-			// We therefore first delete and then only after add it.
-			if validatorDiff.removed != nil {
-				if err := baseState.DeleteCurrentValidator(validatorDiff.removed); err != nil {
-					return fmt.Errorf("deleting current validator: %w", err)
-				}
-			}
-			if validatorDiff.added != nil {
-				if err := baseState.PutCurrentValidator(validatorDiff.added); err != nil {
-					return err
-				}
-			}
-
-			// Delegators must be added after validators are added
-			if err := addCurrentDelegators(baseState, validatorDiff); err != nil {
-				return err
-			}
-		}
-	}
-	for subnetID, nodes := range d.modifiedStakingInfo {
-		for nodeID, stakingInfo := range nodes {
-			if err := baseState.SetStakingInfo(subnetID, nodeID, stakingInfo); err != nil {
-				return fmt.Errorf("setting staking info: %w", err)
-			}
-		}
-	}
-	for _, subnetValidatorDiffs := range d.pendingStakerDiffs.validatorDiffs {
-		for _, validatorDiff := range subnetValidatorDiffs {
-			// We might have removed the validator and then added it in the same diff.
-			// We therefore first delete and then only after add it.
-			if validatorDiff.removed != nil {
-				baseState.DeletePendingValidator(validatorDiff.removed)
-			}
-			if validatorDiff.added != nil {
-				if err := baseState.PutPendingValidator(validatorDiff.added); err != nil {
-					return err
-				}
-			}
-
-			addedDelegatorIterator := iterator.FromTree(validatorDiff.addedDelegators)
-			for addedDelegatorIterator.Next() {
-				baseState.PutPendingDelegator(addedDelegatorIterator.Value())
-			}
-			addedDelegatorIterator.Release()
-
-			for _, delegator := range validatorDiff.deletedDelegators {
-				baseState.DeletePendingDelegator(delegator)
-			}
-		}
-	}
-	for _, subnetID := range d.addedSubnetIDs {
-		baseState.AddSubnet(subnetID)
-	}
-	for _, tx := range d.transformedSubnets {
-		baseState.AddSubnetTransformation(tx)
-	}
-	for _, chains := range d.addedChains {
-		for _, chain := range chains {
-			baseState.AddChain(chain)
-		}
-	}
-	for _, tx := range d.addedTxs {
-		baseState.AddTx(tx.tx, tx.status)
-	}
-	for txID, utxos := range d.addedRewardUTXOs {
-		for _, utxo := range utxos {
-			baseState.AddRewardUTXO(txID, utxo)
-		}
-	}
-	for utxoID, utxo := range d.modifiedUTXOs {
-		if utxo != nil {
-			baseState.AddUTXO(utxo)
-		} else {
-			baseState.DeleteUTXO(utxoID)
-		}
-	}
-	for subnetID, owner := range d.subnetOwners {
-		baseState.SetSubnetOwner(subnetID, owner)
-	}
-	for subnetID, c := range d.subnetToL1Conversions {
-		baseState.SetSubnetToL1Conversion(subnetID, c)
-	}
-	return nil
-}
-
-// addCurrentDelegators adds all delegators for validator to baseState
-func addCurrentDelegators(state Chain, validator *diffValidator) error {
-	addedDelegatorIterator := iterator.FromTree(validator.addedDelegators)
-	defer addedDelegatorIterator.Release()
-
-	for addedDelegatorIterator.Next() {
-		if err := state.PutCurrentDelegator(addedDelegatorIterator.Value()); err != nil {
-			return fmt.Errorf("putting current delegator: %w", err)
-		}
-	}
-
 	return nil
 }

--- a/vms/platformvm/state/diff_test.go
+++ b/vms/platformvm/state/diff_test.go
@@ -6,6 +6,7 @@ package state
 import (
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -44,6 +45,22 @@ func TestNewDiffOn(t *testing.T) {
 	d, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
 	require.NoError(err)
 
+	assertChainsEqual(t, state, d)
+}
+
+func TestDiffTimestamp(t *testing.T) {
+	state := newTestState(t, memdb.New())
+
+	d, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+	require.NoError(t, err)
+
+	initial := state.GetTimestamp()
+	want := initial.Add(time.Second)
+	d.SetTimestamp(want)
+	require.Equal(t, want, d.GetTimestamp())
+	require.Equal(t, initial, state.GetTimestamp())
+
+	require.NoError(t, d.Apply(state))
 	assertChainsEqual(t, state, d)
 }
 
@@ -153,6 +170,34 @@ func TestDiffExpiry(t *testing.T) {
 			},
 		},
 		{
+			name: "insert multiple",
+			ops: []op{
+				{
+					put:   true,
+					entry: ExpiryEntry{Timestamp: 2},
+				},
+				{
+					put:   true,
+					entry: ExpiryEntry{Timestamp: 1},
+				},
+			},
+		},
+		{
+			// Entries are ordered by timestamp then validationID, so entries
+			// sharing a timestamp must still come back in validationID order.
+			name: "insert sharing a timestamp",
+			ops: []op{
+				{
+					put:   true,
+					entry: ExpiryEntry{Timestamp: 1, ValidationID: ids.ID{2}},
+				},
+				{
+					put:   true,
+					entry: ExpiryEntry{Timestamp: 1, ValidationID: ids.ID{1}},
+				},
+			},
+		},
+		{
 			name: "remove",
 			initialExpiries: []ExpiryEntry{
 				{Timestamp: 1},
@@ -222,7 +267,8 @@ func TestDiffExpiry(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
-			state := newTestState(t, memdb.New())
+			db := memdb.New()
+			state := newTestState(t, db)
 			for _, expiry := range test.initialExpiries {
 				state.PutExpiry(expiry)
 			}
@@ -278,6 +324,9 @@ func TestDiffExpiry(t *testing.T) {
 			require.NoError(d.Apply(state))
 			verifyChain(state)
 			assertChainsEqual(t, d, state)
+			state.SetHeight(state.currentHeight + 1)
+			require.NoError(state.Commit())
+			verifyChain(newTestState(t, db))
 		})
 	}
 }
@@ -651,6 +700,12 @@ func TestDiffTx(t *testing.T) {
 		require.Equal(status.Committed, gotStatus)
 		require.Equal(parentTx, gotParentTx)
 	}
+
+	require.NoError(d.Apply(state))
+	gotTx, gotStatus, err := state.GetTx(tx.ID())
+	require.NoError(err)
+	require.Equal(status.Committed, gotStatus)
+	require.Equal(tx, gotTx)
 }
 
 func TestDiffRewardUTXO(t *testing.T) {
@@ -737,6 +792,13 @@ func TestDiffUTXO(t *testing.T) {
 		require.Equal(parentUTXO, gotParentUTXO)
 	}
 
+	require.NoError(d.Apply(state))
+	gotUTXO, err := state.GetUTXO(utxo.InputID())
+	require.NoError(err)
+	require.Equal(utxo, gotUTXO)
+
+	d, err = NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+	require.NoError(err)
 	{
 		// Delete the UTXO
 		d.DeleteUTXO(utxo.InputID())
@@ -745,6 +807,10 @@ func TestDiffUTXO(t *testing.T) {
 		_, err = d.GetUTXO(utxo.InputID())
 		require.ErrorIs(err, database.ErrNotFound)
 	}
+
+	require.NoError(d.Apply(state))
+	_, err = state.GetUTXO(utxo.InputID())
+	require.ErrorIs(err, database.ErrNotFound)
 }
 
 func assertChainsEqual(t *testing.T, expected, actual Chain) {
@@ -904,6 +970,28 @@ func TestDiffSubnetToL1Conversion(t *testing.T) {
 	actualConversion, err = state.GetSubnetToL1Conversion(subnetID)
 	require.NoError(err)
 	require.Equal(expectedConversion, actualConversion)
+}
+
+func TestDiffSubnetTransformation(t *testing.T) {
+	state := newTestState(t, memdb.New())
+	subnetID := ids.GenerateTestID()
+
+	d, err := NewDiffOn(state, StakerAdditionAfterDeletionAllowed)
+	require.NoError(t, err)
+
+	wantTx := &txs.Tx{Unsigned: &txs.TransformSubnetTx{Subnet: subnetID}}
+	d.AddSubnetTransformation(wantTx)
+
+	gotTx, err := d.GetSubnetTransformation(subnetID)
+	require.NoError(t, err)
+	require.Equal(t, wantTx, gotTx)
+	_, err = state.GetSubnetTransformation(subnetID)
+	require.ErrorIs(t, err, database.ErrNotFound)
+
+	require.NoError(t, d.Apply(state))
+	gotTx, err = state.GetSubnetTransformation(subnetID)
+	require.NoError(t, err)
+	require.Equal(t, wantTx, gotTx)
 }
 
 func TestDiffStacking(t *testing.T) {

--- a/vms/platformvm/state/stakers.go
+++ b/vms/platformvm/state/stakers.go
@@ -5,15 +5,12 @@ package state
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/google/btree"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/iterator"
-
-	safemath "github.com/ava-labs/avalanchego/utils/math"
 )
 
 var (
@@ -127,8 +124,6 @@ type baseStakers struct {
 	// subnetID --> nodeID --> current state for the validator of the subnet
 	validators map[ids.ID]map[ids.NodeID]*baseStaker
 	stakers    *btree.BTreeG[*Staker]
-	// subnetID --> nodeID --> diff for that validator since the last db write
-	validatorDiffs map[ids.ID]map[ids.NodeID]*diffValidator
 }
 
 type baseStaker struct {
@@ -138,9 +133,8 @@ type baseStaker struct {
 
 func newBaseStakers() *baseStakers {
 	return &baseStakers{
-		validators:     make(map[ids.ID]map[ids.NodeID]*baseStaker),
-		stakers:        btree.NewG(defaultTreeDegree, (*Staker).Less),
-		validatorDiffs: make(map[ids.ID]map[ids.NodeID]*diffValidator),
+		validators: make(map[ids.ID]map[ids.NodeID]*baseStaker),
+		stakers:    btree.NewG(defaultTreeDegree, (*Staker).Less),
 	}
 }
 
@@ -163,9 +157,6 @@ func (v *baseStakers) PutValidator(staker *Staker) {
 	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
 	validator.validator = staker
 
-	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	validatorDiff.added = staker
-
 	v.stakers.ReplaceOrInsert(staker)
 }
 
@@ -173,10 +164,6 @@ func (v *baseStakers) DeleteValidator(staker *Staker) {
 	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
 	validator.validator = nil
 	v.pruneValidator(staker.SubnetID, staker.NodeID)
-
-	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	validatorDiff.added = nil
-	validatorDiff.removed = staker
 
 	v.stakers.Delete(staker)
 }
@@ -200,12 +187,6 @@ func (v *baseStakers) PutDelegator(staker *Staker) {
 	}
 	validator.delegators.ReplaceOrInsert(staker)
 
-	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	if validatorDiff.addedDelegators == nil {
-		validatorDiff.addedDelegators = btree.NewG(defaultTreeDegree, (*Staker).Less)
-	}
-	validatorDiff.addedDelegators.ReplaceOrInsert(staker)
-
 	v.stakers.ReplaceOrInsert(staker)
 }
 
@@ -215,12 +196,6 @@ func (v *baseStakers) DeleteDelegator(staker *Staker) {
 		validator.delegators.Delete(staker)
 	}
 	v.pruneValidator(staker.SubnetID, staker.NodeID)
-
-	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	if validatorDiff.deletedDelegators == nil {
-		validatorDiff.deletedDelegators = make(map[ids.ID]*Staker)
-	}
-	validatorDiff.deletedDelegators[staker.TxID] = staker
 
 	v.stakers.Delete(staker)
 }
@@ -260,20 +235,6 @@ func (v *baseStakers) pruneValidator(subnetID ids.ID, nodeID ids.NodeID) {
 	}
 }
 
-func (v *baseStakers) getOrCreateValidatorDiff(subnetID ids.ID, nodeID ids.NodeID) *diffValidator {
-	subnetValidatorDiffs, ok := v.validatorDiffs[subnetID]
-	if !ok {
-		subnetValidatorDiffs = make(map[ids.NodeID]*diffValidator)
-		v.validatorDiffs[subnetID] = subnetValidatorDiffs
-	}
-	validatorDiff, ok := subnetValidatorDiffs[nodeID]
-	if !ok {
-		validatorDiff = &diffValidator{}
-		subnetValidatorDiffs[nodeID] = validatorDiff
-	}
-	return validatorDiff
-}
-
 type diffStakers struct {
 	// isAdditionAfterDeletionAllowed specifies whether a staker can be added after being deleted in the same diff.
 	// This is done to preserve the pre-Helicon invariant that a staker cannot be added after being deleted,
@@ -294,54 +255,6 @@ type diffValidator struct {
 	removed           *Staker
 	addedDelegators   *btree.BTreeG[*Staker]
 	deletedDelegators map[ids.ID]*Staker
-}
-
-// weightChanges returns the total weight added to and removed from this
-// validator by this diff. The added weight includes the added validator and all
-// added delegators. The removed weight includes the removed validator and all
-// deleted delegators.
-func (d *diffValidator) weightChanges() (addedWeight uint64, removedWeight uint64, err error) {
-	if d.added != nil {
-		addedWeight = d.added.Weight
-	}
-
-	addedDelegatorIterator := iterator.FromTree(d.addedDelegators)
-	defer addedDelegatorIterator.Release()
-
-	for addedDelegatorIterator.Next() {
-		addedWeight, err = safemath.Add(addedWeight, addedDelegatorIterator.Value().Weight)
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to calculate added weight: %w", err)
-		}
-	}
-
-	if d.removed != nil {
-		removedWeight = d.removed.Weight
-	}
-	for _, staker := range d.deletedDelegators {
-		removedWeight, err = safemath.Add(removedWeight, staker.Weight)
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to calculate removed weight: %w", err)
-		}
-	}
-
-	return addedWeight, removedWeight, nil
-}
-
-func (d *diffValidator) WeightDiff() (ValidatorWeightDiff, error) {
-	addedWeight, removedWeight, err := d.weightChanges()
-	if err != nil {
-		return ValidatorWeightDiff{}, err
-	}
-
-	var weightDiff ValidatorWeightDiff
-	if err := weightDiff.Add(addedWeight); err != nil {
-		return ValidatorWeightDiff{}, fmt.Errorf("failed to increase node weight diff: %w", err)
-	}
-	if err := weightDiff.Sub(removedWeight); err != nil {
-		return ValidatorWeightDiff{}, fmt.Errorf("failed to decrease node weight diff: %w", err)
-	}
-	return weightDiff, nil
 }
 
 // GetValidator attempts to fetch the validator with the given subnetID and

--- a/vms/platformvm/state/stakers_test.go
+++ b/vms/platformvm/state/stakers_test.go
@@ -293,35 +293,6 @@ func TestDiffStakersDeleteThenReAddSameValidator(t *testing.T) {
 	require.Equal([]*Staker{v1}, stakers, "validator should still come through from parent")
 }
 
-func TestDiffValidatorWeightDiffAfterDeleteAndAdd(t *testing.T) {
-	require := require.New(t)
-	staker := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
-	staker.Weight = 5
-
-	modifiedStaker := *staker
-	modifiedStaker.Weight = 10
-
-	diff := diffStakers{isAdditionAfterDeletionAllowed: StakerAdditionAfterDeletionAllowed}
-
-	// Delete the original validator (weight 5)
-	diff.DeleteValidator(staker)
-
-	// Add a replacement validator (weight 10) for the same node
-	require.NoError(diff.PutValidator(&modifiedStaker))
-
-	// Verify the validator was replaced
-	returnedStaker, status := diff.GetValidator(staker.SubnetID, staker.NodeID)
-	require.Equal(added, status)
-	require.Equal(uint64(10), returnedStaker.Weight)
-
-	// WeightDiff should reflect the net change: +10 - 5 = +5
-	validatorDiff := diff.getOrCreateDiff(staker.SubnetID, staker.NodeID)
-	weightDiff, err := validatorDiff.WeightDiff()
-	require.NoError(err)
-	require.False(weightDiff.Decrease)
-	require.Equal(uint64(5), weightDiff.Amount, "expected net weight change of +5 (new 10 minus old 5)")
-}
-
 func TestDiffStakersValidator(t *testing.T) {
 	require := require.New(t)
 	staker := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -362,6 +362,9 @@ type State struct {
 	// TODO: Remove indexedHeights once v1.11.3 has been released.
 	indexedHeights *heightRange
 	singletonDB    database.Database
+
+	// pendingWriteOps records the write for each staker mutation, in execution order.
+	pendingWriteOps []pendingWriteOp
 }
 
 // heightRange is used to track which heights are safe to use the native DB
@@ -743,6 +746,12 @@ func New(
 	return s, nil
 }
 
+type pendingWriteOp func(updateValidators bool, height uint64) error
+
+func (s *State) recordPendingWriteOp(op pendingWriteOp) {
+	s.pendingWriteOps = append(s.pendingWriteOps, op)
+}
+
 func (s *State) GetStakingInfo(subnetID ids.ID, vdrID ids.NodeID) (StakingInfo, error) {
 	if _, err := s.GetCurrentValidator(subnetID, vdrID); err != nil {
 		return StakingInfo{}, fmt.Errorf("getting current validator: %w", err)
@@ -914,7 +923,30 @@ func (s *State) HasL1Validator(subnetID ids.ID, nodeID ids.NodeID) (bool, error)
 }
 
 func (s *State) PutL1Validator(l1Validator L1Validator) error {
-	return s.l1ValidatorsDiff.putL1Validator(s, l1Validator)
+	existing, err := s.GetL1Validator(l1Validator.ValidationID)
+	var prior *L1Validator
+	if err == nil {
+		prior = &existing
+	} else if !errors.Is(err, database.ErrNotFound) {
+		return err
+	}
+
+	if err := s.l1ValidatorsDiff.putL1Validator(s, l1Validator); err != nil {
+		return err
+	}
+
+	// Capture the running total as of this mutation so the replay writes it in order.
+	weight := s.l1ValidatorsDiff.modifiedTotalWeight[l1Validator.SubnetID]
+	s.recordPendingWriteOp(func(updateValidators bool, height uint64) error {
+		return s.updateL1Validator(
+			prior,
+			l1Validator,
+			weight,
+			updateValidators,
+			height,
+		)
+	})
+	return nil
 }
 
 func (s *State) GetCurrentValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker, error) {
@@ -929,11 +961,15 @@ func (s *State) PutCurrentValidator(staker *Staker) error {
 	}
 
 	s.currentStakers.PutValidator(staker)
+	publicKey := s.currentStakers.validators[constants.PrimaryNetworkID][staker.NodeID].validator.PublicKey
 
 	// The validator's metadata isn't written to [validatorState] until
 	// [State.Commit] runs, so seed [modifiedStakingInfo] with the zero value so
 	// that reads through [State.GetStakingInfo] before [State.Commit] observe a default.
 	s.setStakingInfo(staker.SubnetID, staker.NodeID, StakingInfo{})
+	s.recordPendingWriteOp(func(updateValidators bool, height uint64) error {
+		return s.writeCurrentValidator(staker, publicKey, updateValidators, height)
+	})
 	return nil
 }
 
@@ -946,8 +982,12 @@ func (s *State) DeleteCurrentValidator(staker *Staker) error {
 		return err
 	}
 
+	publicKey := s.currentStakers.validators[constants.PrimaryNetworkID][staker.NodeID].validator.PublicKey
 	s.currentStakers.DeleteValidator(staker)
 	delete(s.modifiedStakingInfo[staker.SubnetID], staker.NodeID)
+	s.recordPendingWriteOp(func(updateValidators bool, height uint64) error {
+		return s.deleteCurrentValidator(staker, publicKey, updateValidators, height)
+	})
 
 	return nil
 }
@@ -979,6 +1019,9 @@ func (s *State) PutCurrentDelegator(staker *Staker) error {
 	}
 
 	s.currentStakers.PutDelegator(staker)
+	s.recordPendingWriteOp(func(updateValidators bool, height uint64) error {
+		return s.writeCurrentDelegator(staker, updateValidators, height)
+	})
 	return nil
 }
 
@@ -988,6 +1031,9 @@ func (s *State) DeleteCurrentDelegator(staker *Staker) error {
 	}
 
 	s.currentStakers.DeleteDelegator(staker)
+	s.recordPendingWriteOp(func(updateValidators bool, height uint64) error {
+		return s.deleteCurrentDelegator(staker, updateValidators, height)
+	})
 	return nil
 }
 
@@ -1001,11 +1047,23 @@ func (s *State) GetPendingValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker
 
 func (s *State) PutPendingValidator(staker *Staker) error {
 	s.pendingStakers.PutValidator(staker)
+	s.recordPendingWriteOp(func(_ bool, _ uint64) error {
+		if err := s.pendingValidatorListForSubnet(staker.SubnetID).Put(staker.TxID[:], nil); err != nil {
+			return fmt.Errorf("failed to add pending validator: %w", err)
+		}
+		return nil
+	})
 	return nil
 }
 
 func (s *State) DeletePendingValidator(staker *Staker) {
 	s.pendingStakers.DeleteValidator(staker)
+	s.recordPendingWriteOp(func(_ bool, _ uint64) error {
+		if err := s.pendingValidatorListForSubnet(staker.SubnetID).Delete(staker.TxID[:]); err != nil {
+			return fmt.Errorf("failed to delete pending validator: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *State) GetPendingDelegatorIterator(subnetID ids.ID, nodeID ids.NodeID) (iterator.Iterator[*Staker], error) {
@@ -1014,10 +1072,22 @@ func (s *State) GetPendingDelegatorIterator(subnetID ids.ID, nodeID ids.NodeID) 
 
 func (s *State) PutPendingDelegator(staker *Staker) {
 	s.pendingStakers.PutDelegator(staker)
+	s.recordPendingWriteOp(func(_ bool, _ uint64) error {
+		if err := s.pendingDelegatorListForSubnet(staker.SubnetID).Put(staker.TxID[:], nil); err != nil {
+			return fmt.Errorf("failed to write pending delegator to list: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *State) DeletePendingDelegator(staker *Staker) {
 	s.pendingStakers.DeleteDelegator(staker)
+	s.recordPendingWriteOp(func(_ bool, _ uint64) error {
+		if err := s.pendingDelegatorListForSubnet(staker.SubnetID).Delete(staker.TxID[:]); err != nil {
+			return fmt.Errorf("failed to delete pending delegator: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *State) GetPendingStakerIterator() (iterator.Iterator[*Staker], error) {
@@ -2270,26 +2340,45 @@ func (s *State) initValidatorSets() error {
 		}
 	}
 
-	s.metrics.SetLocalStake(s.validators.GetWeight(constants.PrimaryNetworkID, s.ctx.NodeID))
-	totalWeight, err := s.validators.TotalWeight(constants.PrimaryNetworkID)
-	if err != nil {
-		return fmt.Errorf("failed to get total weight of primary network validators: %w", err)
-	}
-	s.metrics.SetTotalStake(totalWeight)
-	return nil
+	return s.updateStakeMetrics()
 }
 
 func (s *State) write(updateValidators bool, height uint64) error {
 	codecVersion := s.resolveValidatorMetadataCodec()
 
+	if err := s.replayPendingWriteOps(updateValidators, height); err != nil {
+		return err
+	}
+	if updateValidators {
+		if err := s.updateStakeMetrics(); err != nil {
+			return err
+		}
+	}
+
+	// Applying staking info must run after replaying the write ops.
+	// SetStakingInfo requires AddValidatorMetadata to have already populated the
+	// metadata entry for any newly added validator in this batch.
+	for subnetID, nodes := range s.modifiedStakingInfo {
+		for nodeID, stakingInfo := range nodes {
+			if err := s.validatorState.SetStakingInfo(subnetID, nodeID, stakingInfo); err != nil {
+				return fmt.Errorf("setting staking info: %w", err)
+			}
+		}
+	}
+	if err := s.validatorState.WriteValidatorMetadata(
+		s.currentValidatorList,
+		s.currentSubnetValidatorList,
+		codecVersion,
+	); err != nil {
+		return err
+	}
+	s.pendingWriteOps = nil
+	s.l1ValidatorsDiff = newL1ValidatorsDiff()
+	maps.Clear(s.modifiedStakingInfo)
+
 	return errors.Join(
 		s.writeBlocks(),
 		s.writeExpiry(),
-		s.updateValidatorManager(updateValidators),
-		s.writeValidatorDiffs(height),
-		s.writeCurrentStakers(codecVersion),
-		s.writePendingStakers(),
-		s.writeL1Validators(),
 		s.writeTXs(),
 		s.writeRewardUTXOs(),
 		s.writeUTXOs(),
@@ -2556,175 +2645,68 @@ func (s *State) writeExpiry() error {
 	return nil
 }
 
-// publicKeyDiff holds the previous and current public keys before and after applying a validator diff, respectively.
-type publicKeyDiff struct {
-	// prev is the public key before the current diff was applied.
-	prev *bls.PublicKey
-	// new is the public key after the current diff was applied.
-	new *bls.PublicKey
+func (s *State) replayPendingWriteOps(updateValidators bool, height uint64) error {
+	for _, op := range s.pendingWriteOps {
+		if err := op(updateValidators, height); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// getPublicKeyDiff computes the BLS public key change for the given nodeID.
-// It returns the key both before (prev) and after (new) the diff is applied.
-//
-// Either key in the result may be nil: prev is nil when the validator did
-// not exist before this diff, and new is nil when the validator was
-// deleted (not replaced) in this diff.
-func getPublicKeyDiff(
-	nodeID ids.NodeID,
-	current map[ids.NodeID]*baseStaker,
-	diffs map[ids.NodeID]*diffValidator,
-) publicKeyDiff {
-	// If the validator was deleted, there is no post-diff validator and new
-	// stays nil.
-	var keys publicKeyDiff
-	if vdr, ok := current[nodeID]; ok && vdr.validator != nil {
-		keys.new = vdr.validator.PublicKey
-	}
-	// If the validator was removed or replaced, the prev key is on the removed
-	// entry.
-	// If the validator was unmodified, the prev key is equal to the new key.
-	// Otherwise, the validator was added and prev stays nil.
-	diff, changed := diffs[nodeID]
-	if removed := changed && diff.removed != nil; removed {
-		keys.prev = diff.removed.PublicKey
-	} else if added := changed && diff.added != nil; !added {
-		keys.prev = keys.new
-	}
-	return keys
-}
-
-// updateValidatorManager updates the validator manager with the pending
-// validator set changes.
-//
-// This function must be called prior to writeCurrentStakers and
-// writeL1Validators.
-//
-// TODO: L1s with no active weight should not be held in memory.
-func (s *State) updateValidatorManager(updateValidators bool) error {
-	if !updateValidators {
-		return nil
+func (s *State) updateL1ValidatorManager(
+	priorL1Validator *L1Validator,
+	l1Validator L1Validator,
+) error {
+	if priorL1Validator == nil {
+		if l1Validator.isDeleted() {
+			// Drop the write if we are deleting a validator that did not previously exist.
+			return nil
+		}
+		return addL1ValidatorToValidatorManager(s.validators, l1Validator)
 	}
 
-	for subnetID, validatorDiffs := range s.currentStakers.validatorDiffs {
-		// Record the change in weight and/or public key for each validator.
-		for nodeID, diff := range validatorDiffs {
-			addedWeight, removedWeight, err := diff.weightChanges()
-			if err != nil {
+	// Validator is being deleted
+	if l1Validator.isDeleted() {
+		return s.validators.RemoveWeight(
+			priorL1Validator.SubnetID,
+			priorL1Validator.effectiveNodeID(),
+			priorL1Validator.Weight,
+		)
+	}
+
+	// Modifying an existing validator
+	if priorL1Validator.IsActive() == l1Validator.IsActive() {
+		// This validator's active status isn't changing. This means
+		// the effectiveNodeIDs are equal.
+		nodeID := l1Validator.effectiveNodeID()
+		if priorL1Validator.Weight < l1Validator.Weight {
+			if err := s.validators.AddWeight(l1Validator.SubnetID, nodeID, l1Validator.Weight-priorL1Validator.Weight); err != nil {
 				return err
 			}
-			// If the validator was replaced, addedWeight and removedWeight
-			// reflect the new and old weights respectively so we use them.
-			// Otherwise, a single validator is being modified (or a delegator is added),
-			// so the net weight change below is used.
-			if replaced := diff.added != nil && diff.removed != nil; !replaced {
-				if addedWeight > removedWeight {
-					addedWeight -= removedWeight
-					removedWeight = 0
-				} else {
-					removedWeight -= addedWeight
-					addedWeight = 0
-				}
-			}
-
-			if removedWeight > 0 {
-				if err := s.validators.RemoveWeight(subnetID, nodeID, removedWeight); err != nil {
-					return fmt.Errorf("failed to reduce validator weight: %w", err)
-				}
-			}
-
-			// If the validator was deleted, we would have already removed its weight above.
-			if addedWeight == 0 {
-				continue
-			}
-
-			// We're just adding a delegator, so we only need to update the weight of the existing validator without
-			// adding a new staker to the validator manager.
-			if diff.added == nil {
-				if err := s.validators.AddWeight(subnetID, nodeID, addedWeight); err != nil {
-					return fmt.Errorf("failed to increase validator weight: %w", err)
-				}
-				continue
-			}
-
-			pkDiff := getPublicKeyDiff(
-				nodeID,
-				s.currentStakers.validators[constants.PrimaryNetworkID],
-				s.currentStakers.validatorDiffs[constants.PrimaryNetworkID],
-			)
-			err = s.validators.AddStaker(
-				subnetID,
-				nodeID,
-				pkDiff.new,
-				diff.added.TxID,
-				addedWeight,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to add validator: %w", err)
+		} else if priorL1Validator.Weight > l1Validator.Weight {
+			if err := s.validators.RemoveWeight(l1Validator.SubnetID, nodeID, priorL1Validator.Weight-l1Validator.Weight); err != nil {
+				return err
 			}
 		}
-	}
-
-	// Remove all deleted L1 validators. This must be done before adding new
-	// L1 validators to support the case where a validator is removed and then
-	// immediately re-added with a different validationID.
-	for validationID, l1Validator := range s.l1ValidatorsDiff.modified {
-		if !l1Validator.isDeleted() {
-			continue
-		}
-
-		priorL1Validator, err := s.getPersistedL1Validator(validationID)
-		if err == database.ErrNotFound {
-			// Deleting a non-existent validator is a noop. This can happen if
-			// the validator was added and then immediately removed.
-			continue
-		}
-		if err != nil {
+	} else {
+		// This validator's active status is changing.
+		if err := s.validators.RemoveWeight(
+			l1Validator.SubnetID,
+			priorL1Validator.effectiveNodeID(),
+			priorL1Validator.Weight,
+		); err != nil {
 			return err
 		}
-
-		if err := s.validators.RemoveWeight(priorL1Validator.SubnetID, priorL1Validator.effectiveNodeID(), priorL1Validator.Weight); err != nil {
+		if err := addL1ValidatorToValidatorManager(s.validators, l1Validator); err != nil {
 			return err
 		}
 	}
 
-	// Now that the removed L1 validators have been deleted, perform additions
-	// and modifications.
-	for validationID, l1Validator := range s.l1ValidatorsDiff.modified {
-		if l1Validator.isDeleted() {
-			continue
-		}
+	return nil
+}
 
-		priorL1Validator, err := s.getPersistedL1Validator(validationID)
-		switch err {
-		case nil:
-			// Modifying an existing validator
-			if priorL1Validator.IsActive() == l1Validator.IsActive() {
-				// This validator's active status isn't changing. This means
-				// the effectiveNodeIDs are equal.
-				nodeID := l1Validator.effectiveNodeID()
-				if priorL1Validator.Weight < l1Validator.Weight {
-					err = s.validators.AddWeight(l1Validator.SubnetID, nodeID, l1Validator.Weight-priorL1Validator.Weight)
-				} else if priorL1Validator.Weight > l1Validator.Weight {
-					err = s.validators.RemoveWeight(l1Validator.SubnetID, nodeID, priorL1Validator.Weight-l1Validator.Weight)
-				}
-			} else {
-				// This validator's active status is changing.
-				err = errors.Join(
-					s.validators.RemoveWeight(l1Validator.SubnetID, priorL1Validator.effectiveNodeID(), priorL1Validator.Weight),
-					addL1ValidatorToValidatorManager(s.validators, l1Validator),
-				)
-			}
-		case database.ErrNotFound:
-			// Adding a new validator
-			err = addL1ValidatorToValidatorManager(s.validators, l1Validator)
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	// Update the stake metrics
+func (s *State) updateStakeMetrics() error {
 	totalWeight, err := s.validators.TotalWeight(constants.PrimaryNetworkID)
 	if err != nil {
 		return fmt.Errorf("failed to get total weight of primary network: %w", err)
@@ -2741,389 +2723,422 @@ type validatorDiff struct {
 	newPublicKey  []byte
 }
 
-// calculateValidatorDiffs calculates the validator set diff contained by the
-// pending validator set changes.
-//
-// This function must be called prior to writeCurrentStakers.
-func (s *State) calculateValidatorDiffs() (map[subnetIDNodeID]*validatorDiff, error) {
-	changes := make(map[subnetIDNodeID]*validatorDiff)
-
-	// Calculate the changes to the pre-ACP-77 validator set
-	for subnetID, subnetDiffs := range s.currentStakers.validatorDiffs {
-		for nodeID, diff := range subnetDiffs {
-			weightDiff, err := diff.WeightDiff()
-			if err != nil {
-				return nil, err
-			}
-
-			pkDiff := getPublicKeyDiff(
-				nodeID,
-				s.currentStakers.validators[constants.PrimaryNetworkID],
-				s.currentStakers.validatorDiffs[constants.PrimaryNetworkID],
-			)
-
-			change := &validatorDiff{
-				weightDiff: weightDiff,
-			}
-			if pkDiff.prev != nil && (diff.removed != nil || diff.added == nil) {
-				change.prevPublicKey = bls.PublicKeyToUncompressedBytes(pkDiff.prev)
-			}
-			if pkDiff.new != nil && (diff.added != nil || diff.removed == nil) {
-				change.newPublicKey = bls.PublicKeyToUncompressedBytes(pkDiff.new)
-			}
-
-			subnetIDNodeID := subnetIDNodeID{
-				subnetID: subnetID,
-				nodeID:   nodeID,
-			}
-			changes[subnetIDNodeID] = change
-		}
+func publicKeyBytes(publicKey *bls.PublicKey) []byte {
+	if publicKey == nil {
+		return nil
 	}
-
-	// Calculate the changes to the ACP-77 validator set
-	for validationID, l1Validator := range s.l1ValidatorsDiff.modified {
-		priorL1Validator, err := s.getPersistedL1Validator(validationID)
-		if err == nil {
-			// Delete the prior validator
-			subnetIDNodeID := subnetIDNodeID{
-				subnetID: priorL1Validator.SubnetID,
-				nodeID:   priorL1Validator.effectiveNodeID(),
-			}
-			diff := getOrSetDefault(changes, subnetIDNodeID)
-			if err := diff.weightDiff.Sub(priorL1Validator.Weight); err != nil {
-				return nil, err
-			}
-			diff.prevPublicKey = priorL1Validator.effectivePublicKeyBytes()
-		}
-		if err != database.ErrNotFound && err != nil {
-			return nil, err
-		}
-
-		// If the validator is being removed, we shouldn't work to re-add it.
-		if l1Validator.isDeleted() {
-			continue
-		}
-
-		// Add the new validator
-		subnetIDNodeID := subnetIDNodeID{
-			subnetID: l1Validator.SubnetID,
-			nodeID:   l1Validator.effectiveNodeID(),
-		}
-		diff := getOrSetDefault(changes, subnetIDNodeID)
-		if err := diff.weightDiff.Add(l1Validator.Weight); err != nil {
-			return nil, err
-		}
-		diff.newPublicKey = l1Validator.effectivePublicKeyBytes()
-	}
-
-	return changes, nil
+	return bls.PublicKeyToUncompressedBytes(publicKey)
 }
 
-// writeValidatorDiffs writes the validator set diff contained by the pending
-// validator set changes to disk.
-//
-// This function must be called prior to writeCurrentStakers.
-func (s *State) writeValidatorDiffs(height uint64) error {
-	changes, err := s.calculateValidatorDiffs()
-	if err != nil {
-		return err
-	}
+// writeValidatorDiff writes a diff and merges pending changes on disk for the current height.
+func (s *State) writeValidatorDiff(
+	height uint64,
+	subnetIDNodeID subnetIDNodeID,
+	diff validatorDiff,
+) error {
+	diffKeyBySubnetID := marshalDiffKeyBySubnetID(subnetIDNodeID.subnetID, height, subnetIDNodeID.nodeID)
+	diffKeyByHeight := marshalDiffKeyByHeight(height, subnetIDNodeID.subnetID, subnetIDNodeID.nodeID)
 
-	// Write the changes to the database
-	for subnetIDNodeID, diff := range changes {
-		diffKeyBySubnetID := marshalDiffKeyBySubnetID(subnetIDNodeID.subnetID, height, subnetIDNodeID.nodeID)
-		diffKeyByHeight := marshalDiffKeyByHeight(height, subnetIDNodeID.subnetID, subnetIDNodeID.nodeID)
-		if diff.weightDiff.Amount != 0 {
-			weightDiff := marshalWeightDiff(&diff.weightDiff)
-			err := s.validatorWeightDiffsBySubnetIDDB.Put(
-				diffKeyBySubnetID,
-				weightDiff,
-			)
+	if diff.weightDiff.Amount != 0 {
+		weightDiffBytes, err := s.validatorWeightDiffsBySubnetIDDB.Get(diffKeyBySubnetID)
+		if err != nil && !errors.Is(err, database.ErrNotFound) {
+			return err
+		}
+
+		var weightDiff ValidatorWeightDiff
+		if err == nil {
+			persistedWeightDiff, err := unmarshalWeightDiff(weightDiffBytes)
 			if err != nil {
 				return err
 			}
-			err = s.validatorWeightDiffsByHeightDB.Put(
-				diffKeyByHeight,
-				weightDiff,
-			)
-			if err != nil {
+			weightDiff = *persistedWeightDiff
+		}
+
+		if diff.weightDiff.Decrease {
+			if err := weightDiff.Sub(diff.weightDiff.Amount); err != nil {
+				return err
+			}
+		} else {
+			if err := weightDiff.Add(diff.weightDiff.Amount); err != nil {
 				return err
 			}
 		}
-		if !bytes.Equal(diff.prevPublicKey, diff.newPublicKey) {
-			err := s.validatorPublicKeyDiffsBySubnetIDDB.Put(
-				diffKeyBySubnetID,
-				diff.prevPublicKey,
-			)
-			if err != nil {
+
+		if weightDiff.Amount == 0 {
+			// We need to clear the pending weight diff if it results in a no-op.
+			if err := s.validatorWeightDiffsBySubnetIDDB.Delete(diffKeyBySubnetID); err != nil {
 				return err
 			}
-			err = s.validatorPublicKeyDiffsByHeightDB.Put(
-				diffKeyByHeight,
-				diff.prevPublicKey,
-			)
-			if err != nil {
+			if err := s.validatorWeightDiffsByHeightDB.Delete(diffKeyByHeight); err != nil {
 				return err
 			}
+		} else {
+			weightDiffBytes = marshalWeightDiff(&weightDiff)
+			if err := s.validatorWeightDiffsBySubnetIDDB.Put(diffKeyBySubnetID, weightDiffBytes); err != nil {
+				return err
+			}
+			if err := s.validatorWeightDiffsByHeightDB.Put(diffKeyByHeight, weightDiffBytes); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Callers with no public key transition — delegator writes — must not
+	// touch the public key diffs; another operation at this height may have
+	// already staged one.
+	if !bytes.Equal(diff.prevPublicKey, diff.newPublicKey) {
+		prevPublicKey, err := s.validatorPublicKeyDiffsBySubnetIDDB.Get(diffKeyBySubnetID)
+		if errors.Is(err, database.ErrNotFound) {
+			// Key diffs are processed backwards, so we persist the inverse of the operation occurring.
+			prevPublicKey = diff.prevPublicKey
+		} else if err != nil {
+			return err
+		}
+
+		if bytes.Equal(prevPublicKey, diff.newPublicKey) {
+			// Delete the key diff if it would result in a no-op.
+			if err := s.validatorPublicKeyDiffsBySubnetIDDB.Delete(diffKeyBySubnetID); err != nil {
+				return err
+			}
+			return s.validatorPublicKeyDiffsByHeightDB.Delete(diffKeyByHeight)
+		}
+
+		err = s.validatorPublicKeyDiffsBySubnetIDDB.Put(
+			diffKeyBySubnetID,
+			prevPublicKey,
+		)
+		if err != nil {
+			return err
+		}
+		err = s.validatorPublicKeyDiffsByHeightDB.Put(
+			diffKeyByHeight,
+			prevPublicKey,
+		)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-// getOrSetDefault returns the value at k in m if it exists. If it doesn't
-// exist, it sets m[k] to a new value and returns that value.
-func getOrSetDefault[K comparable, V any](m map[K]*V, k K) *V {
-	if v, ok := m[k]; ok {
-		return v
-	}
-
-	v := new(V)
-	m[k] = v
-	return v
-}
-
-func (s *State) writeCurrentStakers(codecVersion uint16) error {
-	for subnetID, validatorDiffs := range s.currentStakers.validatorDiffs {
-		delegatorDB := s.currentSubnetDelegatorList
-		if subnetID == constants.PrimaryNetworkID {
-			delegatorDB = s.currentDelegatorList
-		}
-
-		for nodeID, validatorDiff := range validatorDiffs {
-			// removed and added are handled with separate ifs (not
-			// if-else) because during a validator replacement both are set.
-			if validatorDiff.removed != nil {
-				s.validatorState.DeleteValidatorMetadata(nodeID, subnetID)
-			}
-			if validatorDiff.added != nil {
-				staker := validatorDiff.added
-
-				startTime := uint64(staker.StartTime.Unix())
-				metadata := &validatorMetadata{
-					txID:        staker.TxID,
-					lastUpdated: staker.StartTime,
-
-					UpDuration:               0,
-					LastUpdated:              startTime,
-					StakerStartTime:          startTime,
-					StakerEndTime:            uint64(staker.EndTime.Unix()),
-					PotentialReward:          staker.PotentialReward,
-					PotentialDelegateeReward: 0,
-				}
-
-				s.validatorState.AddValidatorMetadata(nodeID, subnetID, metadata)
-			}
-
-			err := writeCurrentDelegatorDiff(
-				delegatorDB,
-				validatorDiff,
-				codecVersion,
-			)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	// Applying staking info must run after applying validator diffs. SetStakingInfo requires AddValidatorMetadata
-	// to have already populated the metadata entry for any newly added validator in this batch.
-	for subnetID, nodes := range s.modifiedStakingInfo {
-		for nodeID, stakingInfo := range nodes {
-			if err := s.validatorState.SetStakingInfo(subnetID, nodeID, stakingInfo); err != nil {
-				return fmt.Errorf("setting staking info: %w", err)
-			}
-		}
-	}
-
-	maps.Clear(s.modifiedStakingInfo)
-
-	if err := s.validatorState.WriteValidatorMetadata(
-		s.currentValidatorList,
-		s.currentSubnetValidatorList,
-		codecVersion,
+func (s *State) writeCurrentValidator(
+	staker *Staker,
+	publicKey *bls.PublicKey,
+	updateValidators bool,
+	height uint64,
+) error {
+	if err := s.writeValidatorDiff(
+		height,
+		subnetIDNodeID{
+			subnetID: staker.SubnetID,
+			nodeID:   staker.NodeID,
+		},
+		validatorDiff{
+			weightDiff:   ValidatorWeightDiff{Amount: staker.Weight},
+			newPublicKey: publicKeyBytes(publicKey),
+		},
 	); err != nil {
 		return err
 	}
 
-	maps.Clear(s.currentStakers.validatorDiffs)
+	if updateValidators {
+		if err := s.validators.AddStaker(staker.SubnetID, staker.NodeID, publicKey, staker.TxID, staker.Weight); err != nil {
+			return fmt.Errorf("failed to add validator: %w", err)
+		}
+	}
+
+	startTime := uint64(staker.StartTime.Unix())
+	metadata := &validatorMetadata{
+		txID:        staker.TxID,
+		lastUpdated: staker.StartTime,
+
+		UpDuration:               0,
+		LastUpdated:              startTime,
+		StakerStartTime:          startTime,
+		StakerEndTime:            uint64(staker.EndTime.Unix()),
+		PotentialReward:          staker.PotentialReward,
+		PotentialDelegateeReward: 0,
+	}
+	s.validatorState.AddValidatorMetadata(
+		staker.NodeID,
+		staker.SubnetID,
+		metadata,
+	)
 	return nil
 }
 
-func writeCurrentDelegatorDiff(
-	currentDelegatorList linkeddb.LinkedDB,
-	validatorDiff *diffValidator,
-	codecVersion uint16,
+func (s *State) deleteCurrentValidator(
+	staker *Staker,
+	publicKey *bls.PublicKey,
+	updateValidators bool,
+	height uint64,
 ) error {
-	addedDelegatorIterator := iterator.FromTree(validatorDiff.addedDelegators)
-	defer addedDelegatorIterator.Release()
+	if err := s.writeValidatorDiff(
+		height,
+		subnetIDNodeID{
+			subnetID: staker.SubnetID,
+			nodeID:   staker.NodeID,
+		},
+		validatorDiff{
+			weightDiff: ValidatorWeightDiff{
+				Decrease: true,
+				Amount:   staker.Weight,
+			},
+			prevPublicKey: publicKeyBytes(publicKey),
+			newPublicKey:  nil,
+		},
+	); err != nil {
+		return err
+	}
 
-	for addedDelegatorIterator.Next() {
-		staker := addedDelegatorIterator.Value()
-
-		metadata := &delegatorMetadata{
-			txID:            staker.TxID,
-			PotentialReward: staker.PotentialReward,
-			StakerStartTime: uint64(staker.StartTime.Unix()),
-		}
-		if err := writeDelegatorMetadata(currentDelegatorList, metadata, codecVersion); err != nil {
-			return fmt.Errorf("failed to write current delegator to list: %w", err)
+	if updateValidators {
+		if err := s.validators.RemoveWeight(staker.SubnetID, staker.NodeID, staker.Weight); err != nil {
+			return fmt.Errorf("failed to reduce validator weight: %w", err)
 		}
 	}
 
-	for _, staker := range validatorDiff.deletedDelegators {
-		if err := currentDelegatorList.Delete(staker.TxID[:]); err != nil {
-			return fmt.Errorf("failed to delete current staker: %w", err)
+	s.validatorState.DeleteValidatorMetadata(staker.NodeID, staker.SubnetID)
+	return nil
+}
+
+func (s *State) writeCurrentDelegator(staker *Staker, updateValidators bool, height uint64) error {
+	if err := s.writeValidatorDiff(
+		height,
+		subnetIDNodeID{
+			subnetID: staker.SubnetID,
+			nodeID:   staker.NodeID,
+		},
+		validatorDiff{
+			weightDiff: ValidatorWeightDiff{Amount: staker.Weight},
+		},
+	); err != nil {
+		return err
+	}
+
+	if updateValidators {
+		if err := s.validators.AddWeight(staker.SubnetID, staker.NodeID, staker.Weight); err != nil {
+			return fmt.Errorf("failed to increase validator weight: %w", err)
 		}
+	}
+
+	metadata := &delegatorMetadata{
+		txID:            staker.TxID,
+		PotentialReward: staker.PotentialReward,
+		StakerStartTime: uint64(staker.StartTime.Unix()),
+	}
+	if err := writeDelegatorMetadata(
+		s.currentDelegatorListForSubnet(staker.SubnetID),
+		metadata,
+		s.resolveValidatorMetadataCodec(),
+	); err != nil {
+		return fmt.Errorf("failed to write current delegator to list: %w", err)
 	}
 	return nil
 }
 
-func (s *State) writePendingStakers() error {
-	for subnetID, subnetValidatorDiffs := range s.pendingStakers.validatorDiffs {
-		delete(s.pendingStakers.validatorDiffs, subnetID)
+func (s *State) deleteCurrentDelegator(staker *Staker, updateValidators bool, height uint64) error {
+	if err := s.writeValidatorDiff(
+		height,
+		subnetIDNodeID{
+			subnetID: staker.SubnetID,
+			nodeID:   staker.NodeID,
+		},
+		validatorDiff{
+			weightDiff: ValidatorWeightDiff{
+				Decrease: true,
+				Amount:   staker.Weight,
+			},
+		},
+	); err != nil {
+		return err
+	}
 
-		validatorDB := s.pendingSubnetValidatorList
-		delegatorDB := s.pendingSubnetDelegatorList
-		if subnetID == constants.PrimaryNetworkID {
-			validatorDB = s.pendingValidatorList
-			delegatorDB = s.pendingDelegatorList
+	if updateValidators {
+		if err := s.validators.RemoveWeight(staker.SubnetID, staker.NodeID, staker.Weight); err != nil {
+			return fmt.Errorf("failed to reduce validator weight: %w", err)
 		}
+	}
 
-		for _, validatorDiff := range subnetValidatorDiffs {
-			err := writePendingDiff(
-				validatorDB,
-				delegatorDB,
-				validatorDiff,
-			)
-			if err != nil {
-				return err
-			}
-		}
+	if err := s.currentDelegatorListForSubnet(staker.SubnetID).Delete(staker.TxID[:]); err != nil {
+		return fmt.Errorf("failed to delete current staker: %w", err)
 	}
 	return nil
 }
 
-func writePendingDiff(
-	pendingValidatorList linkeddb.LinkedDB,
-	pendingDelegatorList linkeddb.LinkedDB,
-	validatorDiff *diffValidator,
+func (s *State) currentDelegatorListForSubnet(subnetID ids.ID) linkeddb.LinkedDB {
+	if subnetID == constants.PrimaryNetworkID {
+		return s.currentDelegatorList
+	}
+	return s.currentSubnetDelegatorList
+}
+
+func (s *State) pendingValidatorListForSubnet(subnetID ids.ID) linkeddb.LinkedDB {
+	if subnetID == constants.PrimaryNetworkID {
+		return s.pendingValidatorList
+	}
+	return s.pendingSubnetValidatorList
+}
+
+func (s *State) pendingDelegatorListForSubnet(subnetID ids.ID) linkeddb.LinkedDB {
+	if subnetID == constants.PrimaryNetworkID {
+		return s.pendingDelegatorList
+	}
+	return s.pendingSubnetDelegatorList
+}
+
+// writeL1ValidatorDiff models an update as removing the previous l1 validator and then adding the new l1 validator.
+func (s *State) writeL1ValidatorDiff(
+	prev *L1Validator,
+	next L1Validator,
+	height uint64,
 ) error {
-	// removed and added are handled with separate ifs (not if-else) because
-	// during a validator replacement both are set.
-	if validatorDiff.removed != nil {
-		err := pendingValidatorList.Delete(validatorDiff.removed.TxID[:])
-		if err != nil {
-			return fmt.Errorf("failed to delete pending validator: %w", err)
+	if prev != nil {
+		if err := s.writeValidatorDiff(
+			height,
+			subnetIDNodeID{
+				subnetID: prev.SubnetID,
+				nodeID:   prev.effectiveNodeID(),
+			},
+			validatorDiff{
+				weightDiff: ValidatorWeightDiff{
+					Decrease: true,
+					Amount:   prev.Weight,
+				},
+				prevPublicKey: prev.effectivePublicKeyBytes(),
+				newPublicKey:  nil,
+			},
+		); err != nil {
+			return err
 		}
 	}
-	if validatorDiff.added != nil {
-		err := pendingValidatorList.Put(validatorDiff.added.TxID[:], nil)
-		if err != nil {
-			return fmt.Errorf("failed to add pending validator: %w", err)
-		}
-	}
-
-	addedDelegatorIterator := iterator.FromTree(validatorDiff.addedDelegators)
-	defer addedDelegatorIterator.Release()
-	for addedDelegatorIterator.Next() {
-		staker := addedDelegatorIterator.Value()
-
-		if err := pendingDelegatorList.Put(staker.TxID[:], nil); err != nil {
-			return fmt.Errorf("failed to write pending delegator to list: %w", err)
-		}
-	}
-
-	for _, staker := range validatorDiff.deletedDelegators {
-		if err := pendingDelegatorList.Delete(staker.TxID[:]); err != nil {
-			return fmt.Errorf("failed to delete pending delegator: %w", err)
+	if !next.isDeleted() {
+		if err := s.writeValidatorDiff(
+			height,
+			subnetIDNodeID{
+				subnetID: next.SubnetID,
+				nodeID:   next.effectiveNodeID(),
+			},
+			validatorDiff{
+				weightDiff:   ValidatorWeightDiff{Amount: next.Weight},
+				newPublicKey: next.effectivePublicKeyBytes(),
+			},
+		); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func (s *State) writeL1Validators() error {
-	// Write modified weights
-	for subnetID, weight := range s.l1ValidatorsDiff.modifiedTotalWeight {
-		var err error
-		if weight == 0 {
-			err = s.weightsDB.Delete(subnetID[:])
-		} else {
-			err = database.PutUInt64(s.weightsDB, subnetID[:], weight)
-		}
-		if err != nil {
-			return err
-		}
-
-		s.weightsCache.Put(subnetID, weight)
+func (s *State) updateL1Validator(
+	prev *L1Validator,
+	next L1Validator,
+	totalWeight uint64,
+	updateValidators bool,
+	height uint64,
+) error {
+	if err := s.writeL1ValidatorDiff(prev, next, height); err != nil {
+		return err
 	}
 
-	// The L1 validator diff application is split into two loops to ensure that all
-	// deletions to the subnetIDNodeIDDB happen prior to any additions.
-	// Otherwise replacing an L1 validator by deleting it and then re-adding it with a
-	// different validationID could result in an inconsistent state.
-	for validationID, l1Validator := range s.l1ValidatorsDiff.modified {
-		// Delete the prior validator if it exists
-		var err error
-		if s.activeL1Validators.delete(validationID) {
-			err = deleteL1Validator(s.activeDB, emptyL1ValidatorCache, validationID)
-		} else {
-			err = deleteL1Validator(s.inactiveDB, s.inactiveCache, validationID)
-		}
-		if err != nil {
-			return err
-		}
-
-		if !l1Validator.isDeleted() {
-			continue
-		}
-
-		var (
-			subnetIDNodeID = subnetIDNodeID{
-				subnetID: l1Validator.SubnetID,
-				nodeID:   l1Validator.NodeID,
-			}
-			subnetIDNodeIDKey = subnetIDNodeID.Marshal()
-		)
-		if err := s.subnetIDNodeIDDB.Delete(subnetIDNodeIDKey); err != nil {
-			return err
-		}
-
-		s.subnetIDNodeIDCache.Put(subnetIDNodeID, false)
-	}
-
-	for validationID, l1Validator := range s.l1ValidatorsDiff.modified {
-		if l1Validator.isDeleted() {
-			continue
-		}
-
-		// Update the subnetIDNodeID mapping
-		var (
-			subnetIDNodeID = subnetIDNodeID{
-				subnetID: l1Validator.SubnetID,
-				nodeID:   l1Validator.NodeID,
-			}
-			subnetIDNodeIDKey = subnetIDNodeID.Marshal()
-		)
-		if err := s.subnetIDNodeIDDB.Put(subnetIDNodeIDKey, validationID[:]); err != nil {
-			return err
-		}
-
-		s.subnetIDNodeIDCache.Put(subnetIDNodeID, true)
-
-		// Add the new validator
-		var err error
-		if l1Validator.IsActive() {
-			s.activeL1Validators.put(l1Validator)
-			err = putL1Validator(s.activeDB, emptyL1ValidatorCache, l1Validator)
-		} else {
-			err = putL1Validator(s.inactiveDB, s.inactiveCache, l1Validator)
-		}
-		if err != nil {
+	if updateValidators {
+		if err := s.updateL1ValidatorManager(prev, next); err != nil {
 			return err
 		}
 	}
 
-	s.l1ValidatorsDiff = newL1ValidatorsDiff()
+	var prevWeight uint64
+	if prev != nil {
+		prevWeight = prev.Weight
+	}
+
+	if prevWeight != next.Weight {
+		if err := s.writeL1ValidatorWeight(next.SubnetID, totalWeight); err != nil {
+			return err
+		}
+	}
+
+	if prev != nil {
+		if err := s.deleteL1Validator(*prev); err != nil {
+			return err
+		}
+	}
+
+	if next.isDeleted() {
+		return nil
+	}
+	return s.putL1Validator(next.ValidationID, next)
+}
+
+func (s *State) writeL1ValidatorWeight(subnetID ids.ID, weight uint64) error {
+	var err error
+	if weight == 0 {
+		err = s.weightsDB.Delete(subnetID[:])
+	} else {
+		err = database.PutUInt64(s.weightsDB, subnetID[:], weight)
+	}
+	if err != nil {
+		return err
+	}
+
+	s.weightsCache.Put(subnetID, weight)
+	return nil
+}
+
+func (s *State) deleteL1Validator(l1Validator L1Validator) error {
+	// Delete the previous validator if it exists
+	validationID := l1Validator.ValidationID
+	var err error
+	if s.activeL1Validators.delete(validationID) {
+		err = deleteL1Validator(s.activeDB, emptyL1ValidatorCache, validationID)
+	} else {
+		err = deleteL1Validator(s.inactiveDB, s.inactiveCache, validationID)
+	}
+	if err != nil {
+		return err
+	}
+
+	var (
+		subnetIDNodeID = subnetIDNodeID{
+			subnetID: l1Validator.SubnetID,
+			nodeID:   l1Validator.NodeID,
+		}
+		subnetIDNodeIDKey = subnetIDNodeID.Marshal()
+	)
+	if err := s.subnetIDNodeIDDB.Delete(subnetIDNodeIDKey); err != nil {
+		return err
+	}
+	s.subnetIDNodeIDCache.Put(subnetIDNodeID, false)
+	return nil
+}
+
+func (s *State) putL1Validator(
+	validationID ids.ID,
+	l1Validator L1Validator,
+) error {
+	// Update the subnetIDNodeID mapping
+	var (
+		subnetIDNodeID = subnetIDNodeID{
+			subnetID: l1Validator.SubnetID,
+			nodeID:   l1Validator.NodeID,
+		}
+		subnetIDNodeIDKey = subnetIDNodeID.Marshal()
+	)
+	if err := s.subnetIDNodeIDDB.Put(subnetIDNodeIDKey, validationID[:]); err != nil {
+		return err
+	}
+	s.subnetIDNodeIDCache.Put(subnetIDNodeID, true)
+
+	// Add the new validator
+	var err error
+	if l1Validator.IsActive() {
+		s.activeL1Validators.put(l1Validator)
+		err = putL1Validator(s.activeDB, emptyL1ValidatorCache, l1Validator)
+	} else {
+		err = putL1Validator(s.inactiveDB, s.inactiveCache, l1Validator)
+	}
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/vms/platformvm/state/state_test.go
+++ b/vms/platformvm/state/state_test.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"bytes"
+	"fmt"
 	"maps"
 	"math"
 	"math/rand"
@@ -331,7 +332,12 @@ func TestState_writeStakers(t *testing.T) {
 			staker:                   primaryNetworkPendingValidatorStaker,
 			addStakerTx:              addPrimaryNetworkValidator,
 			expectedPendingValidator: primaryNetworkPendingValidatorStaker,
-			expectedValidatorDiffs:   map[subnetIDNodeID]*validatorDiff{},
+			expectedValidatorDiffs: map[subnetIDNodeID]*validatorDiff{
+				{
+					subnetID: constants.PrimaryNetworkID,
+					nodeID:   primaryNetworkPendingValidatorStaker.NodeID,
+				}: {},
+			},
 		},
 		"add pending primary network delegator": {
 			initialStakers:            []*Staker{primaryNetworkPendingValidatorStaker},
@@ -340,7 +346,12 @@ func TestState_writeStakers(t *testing.T) {
 			addStakerTx:               addPrimaryNetworkDelegator,
 			expectedPendingValidator:  primaryNetworkPendingValidatorStaker,
 			expectedPendingDelegators: []*Staker{primaryNetworkPendingDelegatorStaker},
-			expectedValidatorDiffs:    map[subnetIDNodeID]*validatorDiff{},
+			expectedValidatorDiffs: map[subnetIDNodeID]*validatorDiff{
+				{
+					subnetID: constants.PrimaryNetworkID,
+					nodeID:   primaryNetworkPendingDelegatorStaker.NodeID,
+				}: {},
+			},
 		},
 		"add current subnet validator": {
 			initialStakers:           []*Staker{primaryNetworkCurrentValidatorStaker},
@@ -416,10 +427,15 @@ func TestState_writeStakers(t *testing.T) {
 			},
 		},
 		"delete pending primary network validator": {
-			initialStakers:         []*Staker{primaryNetworkPendingValidatorStaker},
-			initialTxs:             []*txs.Tx{addPrimaryNetworkValidator},
-			staker:                 primaryNetworkPendingValidatorStaker,
-			expectedValidatorDiffs: map[subnetIDNodeID]*validatorDiff{},
+			initialStakers: []*Staker{primaryNetworkPendingValidatorStaker},
+			initialTxs:     []*txs.Tx{addPrimaryNetworkValidator},
+			staker:         primaryNetworkPendingValidatorStaker,
+			expectedValidatorDiffs: map[subnetIDNodeID]*validatorDiff{
+				{
+					subnetID: constants.PrimaryNetworkID,
+					nodeID:   primaryNetworkPendingValidatorStaker.NodeID,
+				}: {},
+			},
 		},
 		"delete pending primary network delegator": {
 			initialStakers: []*Staker{
@@ -432,7 +448,12 @@ func TestState_writeStakers(t *testing.T) {
 			},
 			staker:                   primaryNetworkPendingDelegatorStaker,
 			expectedPendingValidator: primaryNetworkPendingValidatorStaker,
-			expectedValidatorDiffs:   map[subnetIDNodeID]*validatorDiff{},
+			expectedValidatorDiffs: map[subnetIDNodeID]*validatorDiff{
+				{
+					subnetID: constants.PrimaryNetworkID,
+					nodeID:   primaryNetworkPendingDelegatorStaker.NodeID,
+				}: {},
+			},
 		},
 		"delete current subnet validator": {
 			initialStakers: []*Staker{primaryNetworkCurrentValidatorStaker, subnetCurrentValidatorStaker},
@@ -503,10 +524,6 @@ func TestState_writeStakers(t *testing.T) {
 			if test.addStakerTx != nil {
 				state.AddTx(test.addStakerTx, status.Committed)
 			}
-
-			validatorDiffs, err := state.calculateValidatorDiffs()
-			require.NoError(err)
-			require.Equal(test.expectedValidatorDiffs, validatorDiffs)
 
 			state.SetHeight(1)
 			require.NoError(state.Commit())
@@ -1108,8 +1125,8 @@ func TestState_ApplyValidatorDiffs(t *testing.T) {
 		{
 			// Remove primary network and subnet validators 2 & 3 & 4
 			removedValidators: []Staker{
-				primaryStakers[2], primaryStakers[3], primaryStakers[4],
 				subnetStakers[2], subnetStakers[3], subnetStakers[4],
+				primaryStakers[2], primaryStakers[3], primaryStakers[4],
 			},
 			expectedPrimaryValidatorSet: map[ids.NodeID]*validators.GetValidatorOutput{},
 			expectedSubnetValidatorSet:  map[ids.NodeID]*validators.GetValidatorOutput{},
@@ -1583,6 +1600,23 @@ func TestStateAccruedFeesCommitAndLoad(t *testing.T) {
 
 	s = newTestState(t, db)
 	require.Equal(expectedAccruedFees, s.GetAccruedFees())
+}
+
+func TestStateCommitDoesNotReapplyValidatorWeight(t *testing.T) {
+	s := newTestState(t, memdb.New())
+
+	delegator := newTestStaker(constants.PrimaryNetworkID, defaultValidatorNodeID)
+	delegator.Weight = 7
+
+	require.NoError(t, s.PutCurrentDelegator(delegator))
+	require.NoError(t, s.Commit())
+
+	wantWeight := genesistest.DefaultValidatorWeight + delegator.Weight
+	require.Equal(t, wantWeight, s.validators.GetWeight(constants.PrimaryNetworkID, defaultValidatorNodeID))
+
+	// A second Commit has no pending writes and must not re-apply the weight.
+	require.NoError(t, s.Commit())
+	require.Equal(t, wantWeight, s.validators.GetWeight(constants.PrimaryNetworkID, defaultValidatorNodeID))
 }
 
 func TestMarkAndIsInitialized(t *testing.T) {
@@ -2440,7 +2474,7 @@ func TestGetCurrentValidators(t *testing.T) {
 					SubnetID:  subnetID1,
 					NodeID:    ids.GenerateTestNodeID(),
 					PublicKey: otherPK,
-					Weight:    0,
+					Weight:    1,
 					StartTime: now.Add(2 * time.Second),
 				},
 			},
@@ -3347,117 +3381,6 @@ func TestSubnetValidatorReplacementWithUnchangedPrimaryKey(t *testing.T) {
 		"subnet validator's inherited public key must remain PK1 after rollback")
 }
 
-func TestGetPublicKeyDiffs(t *testing.T) {
-	nodeID := ids.GenerateTestNodeID()
-
-	sk1, err := localsigner.New()
-	require.NoError(t, err)
-	pk1 := sk1.PublicKey()
-
-	sk2, err := localsigner.New()
-	require.NoError(t, err)
-	pk2 := sk2.PublicKey()
-
-	tests := []struct {
-		name              string
-		primaryValidators map[ids.NodeID]*baseStaker
-		primaryDiffs      map[ids.NodeID]*diffValidator
-		expected          publicKeyDiff
-	}{
-		{
-			name:              "no primary validator and no diff",
-			primaryValidators: map[ids.NodeID]*baseStaker{},
-			primaryDiffs:      map[ids.NodeID]*diffValidator{},
-		},
-		{
-			name: "primary validator exists with no diff",
-			primaryValidators: map[ids.NodeID]*baseStaker{
-				nodeID: {validator: &Staker{PublicKey: pk1}},
-			},
-			primaryDiffs: map[ids.NodeID]*diffValidator{},
-			expected: publicKeyDiff{
-				prev: pk1,
-				new:  pk1,
-			},
-		},
-		{
-			name: "primary validator exists with diff but removed is nil",
-			primaryValidators: map[ids.NodeID]*baseStaker{
-				nodeID: {validator: &Staker{PublicKey: pk1}},
-			},
-			primaryDiffs: map[ids.NodeID]*diffValidator{
-				nodeID: {removed: nil},
-			},
-			expected: publicKeyDiff{
-				prev: pk1,
-				new:  pk1,
-			},
-		},
-		{
-			name: "primary validator replaced",
-			primaryValidators: map[ids.NodeID]*baseStaker{
-				nodeID: {validator: &Staker{PublicKey: pk2}},
-			},
-			primaryDiffs: map[ids.NodeID]*diffValidator{
-				nodeID: {
-					removed: &Staker{PublicKey: pk1},
-					added:   &Staker{PublicKey: pk2},
-				},
-			},
-			expected: publicKeyDiff{
-				prev: pk1,
-				new:  pk2,
-			},
-		},
-		{
-			name: "primary validator purely deleted",
-			primaryValidators: map[ids.NodeID]*baseStaker{
-				nodeID: {validator: nil},
-			},
-			primaryDiffs: map[ids.NodeID]*diffValidator{
-				nodeID: {removed: &Staker{PublicKey: pk1}},
-			},
-			expected: publicKeyDiff{
-				prev: pk1,
-				new:  nil,
-			},
-		},
-		{
-			name:              "primary validator purely deleted and not in base state",
-			primaryValidators: map[ids.NodeID]*baseStaker{},
-			primaryDiffs: map[ids.NodeID]*diffValidator{
-				nodeID: {removed: &Staker{PublicKey: pk1}},
-			},
-			expected: publicKeyDiff{
-				prev: pk1,
-				new:  nil,
-			},
-		},
-		{
-			name: "primary validator only added",
-			primaryValidators: map[ids.NodeID]*baseStaker{
-				nodeID: {validator: &Staker{PublicKey: pk1}},
-			},
-			primaryDiffs: map[ids.NodeID]*diffValidator{
-				nodeID: {added: &Staker{PublicKey: pk1}},
-			},
-			expected: publicKeyDiff{
-				prev: nil,
-				new:  pk1,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-
-			result := getPublicKeyDiff(nodeID, tt.primaryValidators, tt.primaryDiffs)
-			require.Equal(tt.expected, result)
-		})
-	}
-}
-
 func newBaseCurrentStakers(t *testing.T) CurrentStakers {
 	return newTestState(t, memdb.New())
 }
@@ -3535,7 +3458,7 @@ func testGetCurrentValidator(t *testing.T, newCSF func(t *testing.T) CurrentStak
 		},
 		{
 			name:     "validator_added_in_diff",
-			puts:     []*Staker{subnetValidator},
+			puts:     []*Staker{primaryValidator, subnetValidator},
 			subnetID: subnetID,
 			nodeID:   nodeID,
 			want:     subnetValidator,
@@ -3555,7 +3478,7 @@ func testGetCurrentValidator(t *testing.T, newCSF func(t *testing.T) CurrentStak
 		},
 		{
 			name:     "validator_added_in_diff_and_deleted",
-			puts:     []*Staker{subnetValidator},
+			puts:     []*Staker{primaryValidator, subnetValidator},
 			deletes:  []*Staker{subnetValidator},
 			subnetID: subnetID,
 			nodeID:   nodeID,
@@ -3590,7 +3513,7 @@ func testGetCurrentValidator(t *testing.T, newCSF func(t *testing.T) CurrentStak
 func testPutCurrentValidator(t *testing.T, newCSF func(t *testing.T) CurrentStakers) {
 	cs := newCSF(t)
 
-	v := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
+	v := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
 	require.NoError(t, cs.PutCurrentValidator(v))
 	require.ErrorIs(t, cs.PutCurrentValidator(v), errUnexpectedStaker)
 }
@@ -3764,7 +3687,7 @@ func testGetCurrentDelegatorIterator(t *testing.T, csF func(t *testing.T) Curren
 	defaultValidator, err := cs.GetCurrentValidator(constants.PrimaryNetworkID, defaultValidatorNodeID)
 	require.NoError(t, err)
 
-	validator := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
+	validator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
 	validator.TxID = ids.GenerateTestID()
 
 	// Delegators ordered by their next times are d2 -> d3 -> d1
@@ -3853,7 +3776,7 @@ func testGetCurrentDelegatorIterator(t *testing.T, csF func(t *testing.T) Curren
 }
 
 func testPutCurrentDelegator(t *testing.T, csF func(t *testing.T) CurrentStakers) {
-	validator := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
+	validator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
 	delegator := newTestStaker(validator.SubnetID, validator.NodeID)
 
 	tests := []struct {
@@ -3900,7 +3823,7 @@ func testPutCurrentDelegator(t *testing.T, csF func(t *testing.T) CurrentStakers
 }
 
 func testDeleteCurrentDelegator(t *testing.T, csF func(t *testing.T) CurrentStakers) {
-	validator := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
+	validator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
 	delegator := newTestStaker(validator.SubnetID, validator.NodeID)
 
 	tests := []struct {
@@ -3949,16 +3872,16 @@ func testGetCurrentStakerIterator(t *testing.T, csF func(t *testing.T) CurrentSt
 	)
 	require.NoError(t, err)
 
-	currentPrimaryValidator := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
+	currentPrimaryValidator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
 	currentPrimaryValidator.Priority = txs.PrimaryNetworkValidatorCurrentPriority
 
 	currentPrimaryDelegator := newTestStaker(currentPrimaryValidator.SubnetID, currentPrimaryValidator.NodeID)
 	currentPrimaryDelegator.Priority = txs.PrimaryNetworkDelegatorCurrentPriority
 
-	permissionedSubnetValidator := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
+	permissionedSubnetValidator := newTestStaker(ids.GenerateTestID(), currentPrimaryValidator.NodeID)
 	permissionedSubnetValidator.Priority = txs.SubnetPermissionedValidatorCurrentPriority
 
-	permissionlessSubnetValidator := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
+	permissionlessSubnetValidator := newTestStaker(ids.GenerateTestID(), currentPrimaryValidator.NodeID)
 	permissionlessSubnetValidator.Priority = txs.SubnetPermissionlessValidatorCurrentPriority
 
 	permissionlessSubnetDelegator := newTestStaker(permissionlessSubnetValidator.SubnetID, permissionlessSubnetValidator.NodeID)
@@ -4044,7 +3967,7 @@ func TestStateAndDiffIntegration_DeleteValidatorAndItsDelegator(t *testing.T) {
 	require.NoError(t, err)
 
 	// Insert a validator and its delegator
-	validator := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
+	validator := newTestStaker(constants.PrimaryNetworkID, ids.GenerateTestNodeID())
 	require.NoError(t, diff.PutCurrentValidator(validator))
 	delegator := newTestStaker(validator.SubnetID, validator.NodeID)
 	require.NoError(t, diff.PutCurrentDelegator(delegator))
@@ -4068,10 +3991,10 @@ func TestStateAndDiffIntegration_DeleteValidatorAndItsDelegator(t *testing.T) {
 	require.Empty(t, iterator.ToSlice(itr))
 }
 
-func TestStateAndDiffIntegration_StakingInfo(t *testing.T) {
+func TestStateAndDiffIntegration_Stakers(t *testing.T) {
 	type op func(t *testing.T, d *Diff)
 
-	put := func(s *Staker) op {
+	putValidator := func(s *Staker) op {
 		return func(t *testing.T, d *Diff) {
 			require.NoError(t, d.PutCurrentValidator(s))
 		}
@@ -4083,116 +4006,299 @@ func TestStateAndDiffIntegration_StakingInfo(t *testing.T) {
 		}
 	}
 
-	del := func(s *Staker) op {
+	delValidator := func(s *Staker) op {
 		return func(t *testing.T, d *Diff) {
 			require.NoError(t, d.DeleteCurrentValidator(s))
 		}
 	}
 
+	putCurrentDelegator := func(s *Staker) op {
+		return func(t *testing.T, d *Diff) {
+			require.NoError(t, d.PutCurrentDelegator(s))
+		}
+	}
+
+	delCurrentDelegator := func(s *Staker) op {
+		return func(t *testing.T, d *Diff) {
+			require.NoError(t, d.DeleteCurrentDelegator(s))
+		}
+	}
+
+	putPendingValidator := func(s *Staker) op {
+		return func(t *testing.T, d *Diff) {
+			require.NoError(t, d.PutPendingValidator(s))
+		}
+	}
+
+	delPendingValidator := func(s *Staker) op {
+		return func(_ *testing.T, d *Diff) {
+			d.DeletePendingValidator(s)
+		}
+	}
+
+	putPendingDelegator := func(s *Staker) op {
+		return func(_ *testing.T, d *Diff) {
+			d.PutPendingDelegator(s)
+		}
+	}
+
+	delPendingDelegator := func(s *Staker) op {
+		return func(_ *testing.T, d *Diff) {
+			d.DeletePendingDelegator(s)
+		}
+	}
+
 	type want struct {
-		staker *Staker
-		info   StakingInfo
-		err    error
+		validator  *Staker
+		delegators []*Staker
+		info       StakingInfo
+		err        error
 	}
-
+	type assertion struct {
+		target *Staker
+		want   want
+	}
 	type diff struct {
-		ops   []op
-		wants []want // checked against this diff before Apply
+		ops        []op
+		assertions []assertion
+	}
+	type test struct {
+		name  string
+		txs   []*txs.Tx
+		diffs []diff
+	}
+	verify := func(t *testing.T, c Chain, assertions []assertion, msg string) {
+		s, isState := c.(*State)
+		for _, a := range assertions {
+			target := a.target
+			want := a.want
+			pending := target.Priority.IsPending()
+			var (
+				gotValidator *Staker
+				err          error
+			)
+			if pending {
+				gotValidator, err = c.GetPendingValidator(target.SubnetID, target.NodeID)
+			} else {
+				gotValidator, err = c.GetCurrentValidator(target.SubnetID, target.NodeID)
+			}
+			require.ErrorIs(t, err, want.err, msg)
+			require.True(t, want.validator.Equals(gotValidator), msg)
+
+			var it iterator.Iterator[*Staker]
+			if pending {
+				it, err = c.GetPendingDelegatorIterator(target.SubnetID, target.NodeID)
+			} else {
+				it, err = c.GetCurrentDelegatorIterator(target.SubnetID, target.NodeID)
+			}
+			require.NoError(t, err, msg)
+			gotDelegators := iterator.ToSlice(it)
+			require.Len(t, gotDelegators, len(want.delegators), msg)
+			for i, wantDelegator := range want.delegators {
+				require.True(t, wantDelegator.Equals(gotDelegators[i]), msg)
+			}
+
+			if !pending {
+				gotStakingInfo, err := c.GetStakingInfo(target.SubnetID, target.NodeID)
+				require.ErrorIs(t, err, want.err, msg)
+				require.Equal(t, want.info, gotStakingInfo, msg)
+			}
+
+			// Only State owns the validator manager, which tracks current validators.
+			if isState && target.Priority.IsCurrentValidator() {
+				vdr, exists := s.validators.GetValidator(target.SubnetID, target.NodeID)
+				require.Equal(t, want.err == nil, exists, msg)
+				if exists {
+					wantWeight := want.validator.Weight
+					for _, delegator := range want.delegators {
+						wantWeight += delegator.Weight
+					}
+					require.Equal(t, want.validator.TxID, vdr.TxID, msg)
+					require.Equal(t, wantWeight, vdr.Weight, msg)
+				}
+			}
+		}
 	}
 
-	validator1 := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
-	validator1Replacement := *validator1
-	validator1Replacement.TxID = ids.GenerateTestID()
-	validator2 := newTestStaker(ids.GenerateTestID(), ids.GenerateTestNodeID())
-	stakingInfo := StakingInfo{DelegateeReward: 123}
+	nodeID := ids.GenerateTestNodeID()
+	start := genesistest.DefaultValidatorStartTime
+	end := genesistest.DefaultValidatorEndTime
+	val1, val1Tx := createStakerAndTx(
+		t,
+		constants.PrimaryNetworkID,
+		nodeID,
+		start,
+		end,
+		5,
+		0,
+	)
+	replacement, replacementTx := createStakerAndTx(
+		t,
+		constants.PrimaryNetworkID,
+		nodeID,
+		start,
+		end,
+		1,
+		0,
+	)
+	val2, val2Tx := createStakerAndTx(
+		t,
+		constants.PrimaryNetworkID,
+		ids.GenerateTestNodeID(),
+		start,
+		end,
+		1,
+		0,
+	)
+	unsigned := createPermissionlessDelegatorTx(constants.PrimaryNetworkID, txs.Validator{
+		NodeID: nodeID,
+		Start:  uint64(start.Unix()),
+		End:    uint64(end.Unix()),
+		Wght:   17,
+	})
+	delegatorTx := &txs.Tx{Unsigned: unsigned}
+	require.NoError(t, delegatorTx.Initialize(txs.Codec))
+	delegator, err := NewCurrentStaker(
+		delegatorTx.ID(),
+		unsigned,
+		start,
+		unsigned.EndTime(),
+		unsigned.Weight(),
+		0,
+	)
+	require.NoError(t, err)
 
-	tests := []struct {
-		name  string
-		diffs []diff
-	}{
+	valUnsigned := createPermissionlessValidatorTx(t, constants.PrimaryNetworkID, txs.Validator{
+		NodeID: nodeID,
+		Start:  uint64(start.Unix()),
+		End:    uint64(end.Unix()),
+		Wght:   1,
+	})
+	pendingValTx := &txs.Tx{Unsigned: valUnsigned}
+	require.NoError(t, pendingValTx.Initialize(txs.Codec))
+	pendingVal, err := NewPendingStaker(pendingValTx.ID(), valUnsigned)
+	require.NoError(t, err)
+	delUnsigned := createPermissionlessDelegatorTx(constants.PrimaryNetworkID, txs.Validator{
+		NodeID: nodeID,
+		Start:  uint64(start.Unix()),
+		End:    uint64(end.Unix()),
+		Wght:   1,
+	})
+	pendingDelTx := &txs.Tx{Unsigned: delUnsigned}
+	require.NoError(t, pendingDelTx.Initialize(txs.Codec))
+	pendingDel, err := NewPendingStaker(pendingDelTx.ID(), delUnsigned)
+	require.NoError(t, err)
+	info := StakingInfo{DelegateeReward: 123}
+	subnetID := ids.GenerateTestID()
+	subnetVal, subnetValTx := createStakerAndTx(
+		t,
+		subnetID,
+		nodeID,
+		start,
+		end,
+		5,
+		0,
+	)
+	subnetReplacement, subnetReplacementTx := createStakerAndTx(
+		t,
+		subnetID,
+		nodeID,
+		start,
+		end,
+		1,
+		0,
+	)
+
+	tests := []test{
 		{
 			name: "add_defaults_to_zero",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 			},
 		},
 		{
 			name: "add_then_set",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
-					ops:   []op{setStakingInfo(validator1, stakingInfo)},
-					wants: []want{{staker: validator1, info: stakingInfo}},
+					ops:        []op{setStakingInfo(val1, info)},
+					assertions: []assertion{{target: val1, want: want{validator: val1, info: info}}},
 				},
 			},
 		},
 		{
 			name: "add_with_set",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
 					ops: []op{
-						put(validator1),
-						setStakingInfo(validator1, stakingInfo),
+						putValidator(val1),
+						setStakingInfo(val1, info),
 					},
-					wants: []want{{staker: validator1, info: stakingInfo}},
+					assertions: []assertion{{target: val1, want: want{validator: val1, info: info}}},
 				},
 			},
 		},
 		{
 			name: "set_then_delete",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
-					ops:   []op{setStakingInfo(validator1, stakingInfo)},
-					wants: []want{{staker: validator1, info: stakingInfo}},
+					ops:        []op{setStakingInfo(val1, info)},
+					assertions: []assertion{{target: val1, want: want{validator: val1, info: info}}},
 				},
 				{
-					ops:   []op{del(validator1)},
-					wants: []want{{staker: validator1, err: database.ErrNotFound}},
+					ops:        []op{delValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{err: database.ErrNotFound}}},
 				},
 			},
 		},
 		{
 			name: "set_and_delete",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
 					ops: []op{
-						setStakingInfo(validator1, stakingInfo),
-						del(validator1),
+						setStakingInfo(val1, info),
+						delValidator(val1),
 					},
-					wants: []want{{staker: validator1, err: database.ErrNotFound}},
+					assertions: []assertion{{target: val1, want: want{err: database.ErrNotFound}}},
 				},
 			},
 		},
 		{
 			name: "delete_and_add_different",
+			txs:  []*txs.Tx{val1Tx, val2Tx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
 					ops: []op{
-						del(validator1),
-						put(validator2),
-						setStakingInfo(validator2, stakingInfo),
+						delValidator(val1),
+						putValidator(val2),
+						setStakingInfo(val2, info),
 					},
-					wants: []want{
-						{staker: validator1, err: database.ErrNotFound},
-						{staker: validator2, info: stakingInfo},
+					assertions: []assertion{
+						{target: val1, want: want{err: database.ErrNotFound}},
+						{target: val2, want: want{validator: val2, info: info}},
 					},
 				},
 			},
@@ -4201,18 +4307,19 @@ func TestStateAndDiffIntegration_StakingInfo(t *testing.T) {
 			// A replacement (delete + put with a different TxID) drops any
 			// prior SetStakingInfo from the same diff and defaults back to zero.
 			name: "replace_resets_staking_info_to_zero",
+			txs:  []*txs.Tx{val1Tx, replacementTx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
 					ops: []op{
-						setStakingInfo(validator1, stakingInfo),
-						del(validator1),
-						put(&validator1Replacement),
+						setStakingInfo(val1, info),
+						delValidator(val1),
+						putValidator(replacement),
 					},
-					wants: []want{{staker: &validator1Replacement}},
+					assertions: []assertion{{target: replacement, want: want{validator: replacement}}},
 				},
 			},
 		},
@@ -4220,97 +4327,374 @@ func TestStateAndDiffIntegration_StakingInfo(t *testing.T) {
 			// A no-op replacement (delete + put with the exact same staker)
 			// cancels out in the diff and leaves the prior validator untouched.
 			name: "replace_with_same_validator",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
-					ops:   []op{del(validator1), put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{delValidator(val1), putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 			},
 		},
 		{
 			name: "replace_with_same_validator_and_set",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
 					ops: []op{
-						del(validator1),
-						put(validator1),
-						setStakingInfo(validator1, stakingInfo),
+						delValidator(val1),
+						putValidator(val1),
+						setStakingInfo(val1, info),
 					},
-					wants: []want{{staker: validator1, info: stakingInfo}},
+					assertions: []assertion{{target: val1, want: want{validator: val1, info: info}}},
 				},
 			},
 		},
 		{
 			name: "replace_with_same_validator_after_set_in_same_diff",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
 					ops: []op{
-						setStakingInfo(validator1, stakingInfo),
-						del(validator1),
-						put(validator1),
+						setStakingInfo(val1, info),
+						delValidator(val1),
+						putValidator(val1),
 					},
-					wants: []want{{staker: validator1}},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 			},
 		},
 		{
 			name: "replace_with_same_validator_after_set_in_prior_diff",
+			txs:  []*txs.Tx{val1Tx},
 			diffs: []diff{
 				{
 					ops: []op{
-						put(validator1),
-						setStakingInfo(validator1, stakingInfo),
+						putValidator(val1),
+						setStakingInfo(val1, info),
 					},
-					wants: []want{{staker: validator1, info: stakingInfo}},
+					assertions: []assertion{{target: val1, want: want{validator: val1, info: info}}},
 				},
 				{
 					ops: []op{
-						del(validator1),
-						put(validator1),
+						delValidator(val1),
+						putValidator(val1),
 					},
-					wants: []want{{staker: validator1}},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 			},
 		},
 		{
 			name: "replace_with_updated_validator",
+			txs:  []*txs.Tx{val1Tx, replacementTx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
-					ops:   []op{del(validator1), put(&validator1Replacement)},
-					wants: []want{{staker: &validator1Replacement}},
+					ops:        []op{delValidator(val1), putValidator(replacement)},
+					assertions: []assertion{{target: replacement, want: want{validator: replacement}}},
 				},
 			},
 		},
 		{
 			name: "replace_with_updated_validator_and_set",
+			txs:  []*txs.Tx{val1Tx, replacementTx},
 			diffs: []diff{
 				{
-					ops:   []op{put(validator1)},
-					wants: []want{{staker: validator1}},
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
 				},
 				{
 					ops: []op{
-						del(validator1),
-						put(&validator1Replacement),
-						setStakingInfo(&validator1Replacement, stakingInfo),
+						delValidator(val1),
+						putValidator(replacement),
+						setStakingInfo(replacement, info),
 					},
-					wants: []want{{staker: &validator1Replacement, info: stakingInfo}},
+					assertions: []assertion{{target: replacement, want: want{validator: replacement, info: info}}},
+				},
+			},
+		},
+		{
+			name: "put_current_validator",
+			txs:  []*txs.Tx{val1Tx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+			},
+		},
+		{
+			name: "delete_current_validator",
+			txs:  []*txs.Tx{val1Tx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+				{
+					ops:        []op{delValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{err: database.ErrNotFound}}},
+				},
+			},
+		},
+		{
+			name: "put_current_delegator",
+			txs:  []*txs.Tx{val1Tx, delegatorTx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+				{
+					ops: []op{putCurrentDelegator(delegator)},
+					assertions: []assertion{{
+						target: val1,
+						want:   want{validator: val1, delegators: []*Staker{delegator}},
+					}},
+				},
+			},
+		},
+		{
+			name: "delete_current_delegator",
+			txs:  []*txs.Tx{val1Tx, delegatorTx},
+			diffs: []diff{
+				{
+					ops: []op{putValidator(val1), putCurrentDelegator(delegator)},
+					assertions: []assertion{{
+						target: val1,
+						want:   want{validator: val1, delegators: []*Staker{delegator}},
+					}},
+				},
+				{
+					ops:        []op{delCurrentDelegator(delegator)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+			},
+		},
+		{
+			name: "put_pending_validator",
+			txs:  []*txs.Tx{pendingValTx},
+			diffs: []diff{
+				{
+					ops:        []op{putPendingValidator(pendingVal)},
+					assertions: []assertion{{target: pendingVal, want: want{validator: pendingVal}}},
+				},
+			},
+		},
+		{
+			name: "delete_pending_validator",
+			txs:  []*txs.Tx{pendingValTx},
+			diffs: []diff{
+				{
+					ops:        []op{putPendingValidator(pendingVal)},
+					assertions: []assertion{{target: pendingVal, want: want{validator: pendingVal}}},
+				},
+				{
+					ops:        []op{delPendingValidator(pendingVal)},
+					assertions: []assertion{{target: pendingVal, want: want{err: database.ErrNotFound}}},
+				},
+			},
+		},
+		{
+			name: "put_pending_delegator",
+			txs:  []*txs.Tx{pendingValTx, pendingDelTx},
+			diffs: []diff{
+				{
+					ops:        []op{putPendingValidator(pendingVal)},
+					assertions: []assertion{{target: pendingVal, want: want{validator: pendingVal}}},
+				},
+				{
+					ops: []op{putPendingDelegator(pendingDel)},
+					assertions: []assertion{{
+						target: pendingVal,
+						want:   want{validator: pendingVal, delegators: []*Staker{pendingDel}},
+					}},
+				},
+			},
+		},
+		{
+			name: "delete_pending_delegator",
+			txs:  []*txs.Tx{pendingValTx, pendingDelTx},
+			diffs: []diff{
+				{
+					ops: []op{putPendingValidator(pendingVal), putPendingDelegator(pendingDel)},
+					assertions: []assertion{{
+						target: pendingVal,
+						want:   want{validator: pendingVal, delegators: []*Staker{pendingDel}},
+					}},
+				},
+				{
+					ops:        []op{delPendingDelegator(pendingDel)},
+					assertions: []assertion{{target: pendingVal, want: want{validator: pendingVal}}},
+				},
+			},
+		},
+		{
+			name: "put_then_delete_current_delegator",
+			txs:  []*txs.Tx{val1Tx, delegatorTx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+				{
+					ops: []op{
+						putCurrentDelegator(delegator),
+						delCurrentDelegator(delegator),
+					},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+			},
+		},
+		{
+			name: "put_then_delete_pending_validator",
+			txs:  []*txs.Tx{pendingValTx},
+			diffs: []diff{{
+				ops: []op{
+					putPendingValidator(pendingVal),
+					delPendingValidator(pendingVal),
+				},
+				assertions: []assertion{{target: pendingVal, want: want{err: database.ErrNotFound}}},
+			}},
+		},
+		{
+			name: "put_then_delete_pending_delegator",
+			txs:  []*txs.Tx{pendingValTx, pendingDelTx},
+			diffs: []diff{
+				{
+					ops:        []op{putPendingValidator(pendingVal)},
+					assertions: []assertion{{target: pendingVal, want: want{validator: pendingVal}}},
+				},
+				{
+					ops: []op{
+						putPendingDelegator(pendingDel),
+						delPendingDelegator(pendingDel),
+					},
+					assertions: []assertion{{target: pendingVal, want: want{validator: pendingVal}}},
+				},
+			},
+		},
+		{
+			name: "primary_validator_put_then_delete",
+			txs:  []*txs.Tx{replacementTx},
+			diffs: []diff{{
+				ops:        []op{putValidator(replacement), delValidator(replacement)},
+				assertions: []assertion{{target: replacement, want: want{err: database.ErrNotFound}}},
+			}},
+		},
+		{
+			name: "primary_validator_delete_then_readd_same_validator",
+			txs:  []*txs.Tx{val1Tx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+				{
+					ops:        []op{delValidator(val1), putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+			},
+		},
+		{
+			name: "primary_validator_delete_then_replace",
+			txs:  []*txs.Tx{val1Tx, replacementTx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+				{
+					ops:        []op{delValidator(val1), putValidator(replacement)},
+					assertions: []assertion{{target: replacement, want: want{validator: replacement}}},
+				},
+			},
+		},
+		{
+			name: "primary_validator_delete_put_delete",
+			txs:  []*txs.Tx{val1Tx, replacementTx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+				{
+					ops:        []op{delValidator(val1), putValidator(replacement), delValidator(replacement)},
+					assertions: []assertion{{target: replacement, want: want{err: database.ErrNotFound}}},
+				},
+			},
+		},
+		{
+			name: "subnet_validator_put_then_delete",
+			txs:  []*txs.Tx{val1Tx, subnetReplacementTx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1)},
+					assertions: []assertion{{target: val1, want: want{validator: val1}}},
+				},
+				{
+					ops:        []op{putValidator(subnetReplacement), delValidator(subnetReplacement)},
+					assertions: []assertion{{target: subnetReplacement, want: want{err: database.ErrNotFound}}},
+				},
+			},
+		},
+		{
+			name: "subnet_validator_delete_then_readd_same_validator",
+			txs:  []*txs.Tx{val1Tx, subnetValTx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1), putValidator(subnetVal)},
+					assertions: []assertion{{target: subnetVal, want: want{validator: subnetVal}}},
+				},
+				{
+					ops:        []op{delValidator(subnetVal), putValidator(subnetVal)},
+					assertions: []assertion{{target: subnetVal, want: want{validator: subnetVal}}},
+				},
+			},
+		},
+		{
+			name: "subnet_validator_delete_then_replace",
+			txs:  []*txs.Tx{val1Tx, subnetValTx, subnetReplacementTx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1), putValidator(subnetVal)},
+					assertions: []assertion{{target: subnetVal, want: want{validator: subnetVal}}},
+				},
+				{
+					ops:        []op{delValidator(subnetVal), putValidator(subnetReplacement)},
+					assertions: []assertion{{target: subnetReplacement, want: want{validator: subnetReplacement}}},
+				},
+			},
+		},
+		{
+			name: "subnet_validator_delete_put_delete",
+			txs:  []*txs.Tx{val1Tx, subnetValTx, subnetReplacementTx},
+			diffs: []diff{
+				{
+					ops:        []op{putValidator(val1), putValidator(subnetVal)},
+					assertions: []assertion{{target: subnetVal, want: want{validator: subnetVal}}},
+				},
+				{
+					ops: []op{
+						delValidator(subnetVal),
+						putValidator(subnetReplacement),
+						delValidator(subnetReplacement),
+					},
+					assertions: []assertion{{target: subnetReplacement, want: want{err: database.ErrNotFound}}},
 				},
 			},
 		},
@@ -4318,7 +4702,11 @@ func TestStateAndDiffIntegration_StakingInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state := newTestState(t, memdb.New())
+			db := memdb.New()
+			state := newTestState(t, db)
+			for _, tx := range tt.txs {
+				state.AddTx(tx, status.Committed)
+			}
 
 			for i, d := range tt.diffs {
 				diff, err := NewDiffOn(state, true)
@@ -4328,36 +4716,16 @@ func TestStateAndDiffIntegration_StakingInfo(t *testing.T) {
 					o(t, diff)
 				}
 
-				for _, w := range d.wants {
-					gotValidator, err := diff.GetCurrentValidator(w.staker.SubnetID, w.staker.NodeID)
-					require.ErrorIsf(t, err, w.err, "diff %d", i)
-					if w.err != nil {
-						require.Nilf(t, gotValidator, "diff %d", i)
-					} else {
-						require.Equalf(t, w.staker, gotValidator, "diff %d", i)
-					}
+				// Verify the Diff's effective reads before Apply mutates state.
+				verify(t, diff, d.assertions, fmt.Sprintf("diff %d", i))
 
-					gotStakingInfo, err := diff.GetStakingInfo(w.staker.SubnetID, w.staker.NodeID)
-					require.ErrorIsf(t, err, w.err, "diff %d", i)
-					require.Equalf(t, w.info, gotStakingInfo, "diff %d", i)
-				}
+				applyDiffAndCommit(t, state, diff)
+				msg := fmt.Sprintf("state after diff %d", i)
+				verify(t, state, d.assertions, msg)
 
-				require.NoErrorf(t, diff.Apply(state), "diff %d", i)
-				require.NoErrorf(t, state.Commit(), "diff %d", i)
-			}
-
-			for _, w := range tt.diffs[len(tt.diffs)-1].wants {
-				gotValidator, err := state.GetCurrentValidator(w.staker.SubnetID, w.staker.NodeID)
-				require.ErrorIs(t, err, w.err)
-				if w.err != nil {
-					require.Nil(t, gotValidator)
-				} else {
-					require.Equal(t, w.staker, gotValidator)
-				}
-
-				gotStakingInfo, err := state.GetStakingInfo(w.staker.SubnetID, w.staker.NodeID)
-				require.ErrorIs(t, err, w.err)
-				require.Equal(t, w.info, gotStakingInfo)
+				reloaded := newTestState(t, db)
+				verify(t, reloaded, d.assertions, "reloaded state")
+				state = reloaded
 			}
 		})
 	}
@@ -4496,4 +4864,198 @@ func TestAutoRenewedValidatorRestakeStateReload(t *testing.T) {
 	require.Equal(accruedDelRewards, gotStakingInfo.AccruedDelegateeRewards)
 	require.Equal(autoCompoundRewardShares, gotStakingInfo.AutoCompoundRewardShares)
 	require.Equal(period, gotStakingInfo.NextPeriod)
+}
+
+func TestStateAndDiffIntegration_L1Validators(t *testing.T) {
+	subnetID := ids.GenerateTestID()
+	nodeID := ids.GenerateTestNodeID()
+
+	type want struct {
+		val    *L1Validator
+		absent []ids.ID
+	}
+	type test struct {
+		name    string
+		initial []L1Validator
+		puts    []L1Validator
+		want    want
+	}
+	verify := func(t *testing.T, s *State, want want) {
+		hasValidator := want.val != nil
+		var wantWeight uint64
+		if hasValidator {
+			wantWeight = want.val.Weight
+			got, err := s.GetL1Validator(want.val.ValidationID)
+			require.NoError(t, err)
+			require.Equal(t, *want.val, got)
+		}
+		for _, validationID := range want.absent {
+			_, err := s.GetL1Validator(validationID)
+			require.ErrorIs(t, err, database.ErrNotFound)
+		}
+
+		// The L1 record and validator-manager entry are separate state. Check the
+		// manager's node mapping, aggregate weight, and active validation ID too.
+		has, err := s.HasL1Validator(subnetID, nodeID)
+		require.NoError(t, err)
+		require.Equal(t, hasValidator, has)
+		gotWeight, err := s.WeightOfL1Validators(subnetID)
+		require.NoError(t, err)
+		require.Equal(t, wantWeight, gotWeight)
+		for _, id := range []ids.NodeID{nodeID, ids.EmptyNodeID} {
+			var wantNodeWeight uint64
+			if hasValidator && id == want.val.effectiveNodeID() {
+				wantNodeWeight = want.val.Weight
+			}
+			gotNodeWeight := s.validators.GetWeight(subnetID, id)
+			require.Equal(t, wantNodeWeight, gotNodeWeight)
+		}
+		if hasValidator && want.val.IsActive() {
+			vdr, ok := s.validators.GetValidator(subnetID, nodeID)
+			require.True(t, ok)
+			require.Equal(t, want.val.ValidationID, vdr.TxID)
+		}
+	}
+
+	val1 := L1Validator{
+		ValidationID:          ids.GenerateTestID(),
+		SubnetID:              subnetID,
+		NodeID:                nodeID,
+		PublicKey:             []byte{},
+		RemainingBalanceOwner: []byte{},
+		DeactivationOwner:     []byte{},
+		Weight:                5,
+		EndAccumulatedFee:     1,
+	}
+	val1Inactive := val1
+	val1Inactive.EndAccumulatedFee = 0
+	val1Deleted := val1Inactive
+	val1Deleted.Weight = 0
+
+	val2 := val1
+	val2.ValidationID = ids.GenerateTestID()
+	val2.Weight = 10
+	val2Deleted := val2
+	val2Deleted.Weight = 0
+	val2Deleted.EndAccumulatedFee = 0
+
+	missingValidationID := ids.GenerateTestID()
+
+	tests := []test{
+		{
+			name: "remove_non_existent",
+			puts: []L1Validator{{
+				ValidationID: missingValidationID,
+				SubnetID:     subnetID,
+				NodeID:       nodeID,
+				Weight:       0, // Deleting a non-existent validator is a no-op
+			}},
+			want: want{
+				absent: []ids.ID{missingValidationID},
+			},
+		},
+		{
+			name: "put_then_delete_via_zero_weight",
+			puts: []L1Validator{val2, val2Deleted},
+			want: want{absent: []ids.ID{val2.ValidationID}},
+		},
+		{
+			name:    "deactivate_l1_validator",
+			initial: []L1Validator{val1},
+			puts:    []L1Validator{val1Inactive},
+			want:    want{val: &val1Inactive},
+		},
+		{
+			name:    "reactivate_l1_validator",
+			initial: []L1Validator{val1Inactive},
+			puts:    []L1Validator{val1},
+			want:    want{val: &val1},
+		},
+		{
+			name:    "delete_then_readd_different_validation_id_same_node_id",
+			initial: []L1Validator{val1},
+			puts:    []L1Validator{val1Deleted, val2},
+			want: want{
+				val:    &val2,
+				absent: []ids.ID{val1.ValidationID},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := memdb.New()
+			s := newTestState(t, db)
+			if len(tt.initial) > 0 {
+				d := newDiffOn(t, s)
+				for _, validator := range tt.initial {
+					require.NoError(t, d.PutL1Validator(validator))
+				}
+				applyDiffAndCommit(t, s, d)
+			}
+
+			d := newDiffOn(t, s)
+			for _, validator := range tt.puts {
+				require.NoError(t, d.PutL1Validator(validator))
+			}
+			applyDiffAndCommit(t, s, d)
+
+			requireBeforeAndAfterReload(t, db, s, func(s *State) {
+				verify(t, s, tt.want)
+			})
+		})
+	}
+}
+
+func TestNestedDiffApply(t *testing.T) {
+	subnetID := constants.PrimaryNetworkID
+	val1 := newTestStaker(subnetID, ids.GenerateTestNodeID())
+	val1.Priority = txs.PrimaryNetworkValidatorCurrentPriority
+	val2 := newTestStaker(subnetID, ids.GenerateTestNodeID())
+	val2.Priority = txs.PrimaryNetworkValidatorCurrentPriority
+
+	s := newTestState(t, memdb.New())
+	diff1, err := NewDiffOn(s, StakerAdditionAfterDeletionAllowed)
+	require.NoError(t, err)
+	require.NoError(t, diff1.PutCurrentValidator(val1))
+
+	diff2, err := NewDiffOn(diff1, StakerAdditionAfterDeletionAllowed)
+	require.NoError(t, err)
+	require.NoError(t, diff2.DeleteCurrentValidator(val1))
+	require.NoError(t, diff2.PutCurrentValidator(val2))
+	require.NoError(t, diff2.Apply(diff1))
+	applyDiffAndCommit(t, s, diff1)
+
+	_, err = s.GetCurrentValidator(subnetID, val1.NodeID)
+	require.ErrorIs(t, err, database.ErrNotFound)
+
+	got, err := s.GetCurrentValidator(subnetID, val2.NodeID)
+	require.NoError(t, err)
+	require.Equal(t, val2.TxID, got.TxID)
+}
+
+func newDiffOn(t *testing.T, s *State) *Diff {
+	t.Helper()
+
+	d, err := NewDiffOn(s, StakerAdditionAfterDeletionAllowed)
+	require.NoError(t, err)
+	return d
+}
+
+func applyDiffAndCommit(t *testing.T, s *State, d *Diff) {
+	t.Helper()
+
+	require.NoError(t, d.Apply(s))
+	height := s.currentHeight + 1
+	s.SetHeight(height)
+	require.NoError(t, s.Commit())
+}
+
+// requireBeforeAndAfterReload runs assert against s, then against a state freshly
+// loaded from db, proving the committed batch and the in-memory state agree.
+func requireBeforeAndAfterReload(t *testing.T, db database.Database, s *State, assert func(*State)) {
+	t.Helper()
+
+	assert(s)
+	assert(newTestState(t, db))
 }

--- a/vms/platformvm/txs/executor/staker_tx_verification_test.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_test.go
@@ -389,6 +389,12 @@ func TestVerifyAddPermissionlessValidatorTx(t *testing.T) {
 				s.SetTimestamp(now)
 				s.AddSubnetTransformation(&transformTx)
 				// State says validator exists
+				primaryNetworkVdr := &state.Staker{
+					EndTime:  mockable.MaxTime,
+					SubnetID: constants.PrimaryNetworkID,
+					NodeID:   verifiedTx.NodeID(),
+				}
+				require.NoError(t, s.PutCurrentValidator(primaryNetworkVdr))
 				staker := &state.Staker{
 					EndTime:  mockable.MaxTime,
 					SubnetID: subnetID,


### PR DESCRIPTION
## Why this should be merged

Move PlatformVM diff and state writes to an ordered replay model.

## How this works

- Record `Diff` mutations as ordered operations and replay them through `Apply`.
- Record `State` persistence mutations as ordered operations and replay them during commit.
- Simplify state-diff aggregation and pending-write bookkeeping.
- Add unit coverage for ordered diff application, state writes, commits, and reloads.

## How this was tested

Unit tests.

## Need to be documented in RELEASES.md?

None.