### PR TITLE
[tmpnet] Stop waiting for health after node exit

### DIFF
--- a/tests/fixture/tmpnet/BUILD.bazel
+++ b/tests/fixture/tmpnet/BUILD.bazel
@@ -96,6 +96,7 @@ go_test(
     srcs = [
         "kube_runtime_test.go",
         "network_test.go",
+        "node_test.go",
     ],
     embed = [":tmpnet"],
     deps = [

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -428,6 +428,11 @@ func (n *Node) WaitForHealthy(ctx context.Context) error {
 	for {
 		healthy, err := n.IsHealthy(ctx)
 		switch {
+		case errors.Is(err, errNotRunning):
+			// WaitForHealthy is called after the runtime has started the node.
+			// Recovering from a stopped node requires an explicit lifecycle
+			// operation, so retrying the health check cannot succeed.
+			return stacktrace.Errorf("node %q stopped before becoming healthy: %w", n.NodeID, err)
 		case errors.Is(err, ErrUnrecoverableNodeHealthCheck):
 			return stacktrace.Errorf("node %q saw unrecoverable health check: %w", n.NodeID, err)
 		case err != nil:

--- a/tests/fixture/tmpnet/node_test.go
+++ b/tests/fixture/tmpnet/node_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package tmpnet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+type healthErrorRuntime struct {
+	NodeRuntime
+	err error
+}
+
+func (r *healthErrorRuntime) IsHealthy(context.Context) (bool, error) {
+	return false, r.err
+}
+
+func TestWaitForHealthyReturnsWhenNodeStopped(t *testing.T) {
+	node := &Node{
+		runtime: &healthErrorRuntime{err: errNotRunning},
+		network: &Network{log: logging.NoLog{}},
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	err := node.WaitForHealthy(ctx)
+	require.ErrorIs(t, err, errNotRunning)
+}


### PR DESCRIPTION
## Why this should be merged

`Node.WaitForHealthy` previously treated `errNotRunning` as recoverable and retried until its context expired. Both runtimes (process and kube) return `errNotRunning` only when recovery is not automatic. To avoid masking node exit as a health timeout, return `errNotRunning` immediately rather than treating it as recoverable.
