### PR TITLE
[e2e] Add coverage of C-Chain bootstrap during P-Chain activity

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -131,3 +131,25 @@ jobs:
           loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
           loki_username: ${{ secrets.LOKI_USERNAME || '' }}
           loki_password: ${{ secrets.LOKI_PASSWORD || '' }}
+
+  e2e-bootstrap:
+    needs: setup
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run isolated C-Chain bootstrap test with Bazel-built binary
+        uses: ./.github/actions/run-monitored-tmpnet-cmd
+        with:
+          run: ./scripts/run_task.sh bazel-test-e2e-bootstrap
+          setup_bazel: 'true'
+          artifact_prefix: e2e-bootstrap-bazel-${{ inputs.platform_name }}
+          filter_by_owner: avalanchego-e2e-bootstrap
+          prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
+          prometheus_push_url: ${{ secrets.PROMETHEUS_PUSH_URL || '' }}
+          prometheus_username: ${{ secrets.PROMETHEUS_USERNAME || '' }}
+          prometheus_password: ${{ secrets.PROMETHEUS_PASSWORD || '' }}
+          loki_url: ${{ secrets.LOKI_URL || '' }}
+          loki_push_url: ${{ secrets.LOKI_PUSH_URL || '' }}
+          loki_username: ${{ secrets.LOKI_USERNAME || '' }}
+          loki_password: ${{ secrets.LOKI_PASSWORD || '' }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -88,6 +88,21 @@ tasks:
       - cmd: |
           {{.NIX_RUN}} bash -c 'AVALANCHEGO_PATH=$(bazelisk cquery --output=files //main:avalanchego 2>/dev/null) bash -x ./scripts/tests.e2e.existing.sh'
 
+  bazel-test-e2e-bootstrap:
+    desc: Run the isolated C-Chain bootstrap test with a Bazel-built binary
+    env:
+      E2E_SERIAL: 1
+      E2E_TARGET: ./tests/bootstrap/interchain
+    cmds:
+      - task: bazel-build
+      - cmd: |
+          {{.NIX_RUN}} bash -c '
+            AVALANCHEGO_PATH=$(bazelisk cquery --output=files //main:avalanchego 2>/dev/null)
+            export AVALANCHEGO_PATH
+            bash -x ./scripts/tests.e2e.sh --ginkgo.focus-file=tests/bootstrap/interchain/bootstrap.go --activate-latest-after=-1ns --check-metrics-collected=false --check-logs-collected=false --start-metrics-collector=false --start-logs-collector=false
+            bash -x ./scripts/tests.e2e.sh --ginkgo.focus-file=tests/bootstrap/interchain/bootstrap.go --activate-latest-after=0 --check-metrics-collected=false --check-logs-collected=false --start-metrics-collector=false --start-logs-collector=false
+          '
+
   bazel-test-e2e-ci:
     desc: Run the E2E network-reuse smoke test with a Bazel-built binary [serially with race detection]
     env:

--- a/scripts/test_tests_unit.sh
+++ b/scripts/test_tests_unit.sh
@@ -35,6 +35,7 @@ case "\${1-}" in
           github.com/ava-labs/avalanchego/mocks \
           github.com/ava-labs/avalanchego/proto/pb \
           github.com/ava-labs/avalanchego/tests/antithesis \
+          github.com/ava-labs/avalanchego/tests/bootstrap/interchain \
           github.com/ava-labs/avalanchego/tests/e2e
         ;;
       "${repo_root}/graft/coreth")

--- a/scripts/tests.unit.sh
+++ b/scripts/tests.unit.sh
@@ -49,7 +49,7 @@ while IFS= read -r package; do
       ;;
     "${coreth_prefix}"|"${coreth_prefix}/"*|"${subnet_evm_prefix}"|"${subnet_evm_prefix}/"*)
       ;;
-    */mocks*|*proto*|*/tests/e2e*|*/tests/load/c*|*/tests/upgrade*|*/tests/fixture/bootstrapmonitor/e2e*|*/tests/reexecute*)
+    */mocks*|*proto*|*/tests/bootstrap*|*/tests/e2e*|*/tests/load/c*|*/tests/upgrade*|*/tests/fixture/bootstrapmonitor/e2e*|*/tests/reexecute*)
       continue
       ;;
   esac

--- a/tests/bootstrap/interchain/BUILD.bazel
+++ b/tests/bootstrap/interchain/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "go_test")
+
+go_library(
+    name = "interchain",
+    srcs = ["bootstrap.go"],
+    importpath = "github.com/ava-labs/avalanchego/tests/bootstrap/interchain",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//genesis",
+        "//ids",
+        "//tests/fixture/e2e",
+        "//tests/fixture/tmpnet",
+        "//utils/constants",
+        "//vms/platformvm/txs",
+        "//vms/secp256k1fx",
+        "@com_github_ava_labs_libevm//core/types",
+        "@com_github_onsi_ginkgo_v2//:ginkgo",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
+go_test(
+    name = "interchain_test",
+    srcs = ["bootstrap_test.go"],
+    tags = ["manual"],  # keep
+    deps = [
+        ":interchain",
+        "//tests/fixture/e2e",
+        "//tests/fixture/tmpnet",
+        "@com_github_onsi_ginkgo_v2//:ginkgo",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_zap//:zap",
+    ],
+)

--- a/tests/bootstrap/interchain/bootstrap.go
+++ b/tests/bootstrap/interchain/bootstrap.go
@@ -1,0 +1,187 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package interchain
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/genesis"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+var _ = e2e.DescribeCChain("[Interchain Bootstrap]", func() {
+	var (
+		tc      = e2e.NewTestContext()
+		require = require.New(tc)
+	)
+
+	ginkgo.It("bootstraps while the P-Chain and C-Chain are advancing", func() {
+		var (
+			env       = e2e.GetEnv(tc)
+			network   = env.GetNetwork()
+			nodeURI   = env.GetRandomNodeURI()
+			ctx       = tc.DefaultContext()
+			ethClient = e2e.NewEthClient(tc, nodeURI)
+		)
+
+		tc.By("initializing clients for both chains")
+		var (
+			keychain      = env.NewKeychain()
+			pWallet       = e2e.NewWallet(tc, keychain, nodeURI).P()
+			avaxAssetID   = pWallet.Builder().Context().AVAXAssetID
+			rewardAddress = e2e.NewPrivateKey(tc).Address()
+			cRecipient    = e2e.NewPrivateKey(tc).EthAddress()
+			senderKey     = env.PreFundedKey
+			senderAddress = senderKey.EthAddress()
+		)
+		chainID, err := ethClient.ChainID(ctx)
+		require.NoError(err)
+
+		// issuePChainBatch issues and confirms permissionless delegator
+		// transactions to advance the P-Chain by the requested number of blocks.
+		issuePChainBatch := func(count int) {
+			endTime := time.Now().Add(6 * time.Minute)
+			for range count {
+				_, err := pWallet.IssueAddPermissionlessDelegatorTx(
+					&txs.SubnetValidator{
+						Validator: txs.Validator{
+							NodeID: nodeURI.NodeID,
+							End:    uint64(endTime.Unix()),
+							Wght:   genesis.LocalParams.StakingConfig.MinDelegatorStake,
+						},
+						Subnet: constants.PrimaryNetworkID,
+					},
+					avaxAssetID,
+					&secp256k1fx.OutputOwners{
+						Threshold: 1,
+						Addrs:     []ids.ShortID{rewardAddress},
+					},
+					tc.WithDefaultContext(),
+				)
+				require.NoError(err)
+			}
+		}
+
+		// Create the same validator-set updates that preceded the failure in CI.
+		// Do not create a C-Chain block yet. The first post-genesis C-Chain block
+		// must refer to a P-Chain height that the new node has not reached.
+		const initialDelegatorCount = 15
+		tc.By("adding an initial batch of P-Chain delegators", func() {
+			issuePChainBatch(initialDelegatorCount)
+		})
+		tc.By("starting a node with both chains behind the network")
+		bootstrapNode := tmpnet.NewEphemeralNode(tmpnet.FlagsMap{})
+		// StartNode returns when the process has started, not when its chains are
+		// healthy.
+		require.NoError(network.StartNode(ctx, bootstrapNode))
+		tc.DeferCleanup(func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), e2e.DefaultTimeout)
+			defer cancel()
+			require.NoError(bootstrapNode.Stop(stopCtx))
+		})
+
+		// Wait until the new node's P-Chain has reached its selected bootstrap
+		// frontier and is waiting for the C-Chain to finish syncing. Advancing the
+		// established network before this point could allow the new node to select
+		// the newer P-Chain height as its frontier and avoid the failure.
+		const waitingForRemainingChains = "waiting for the remaining chains in this subnet to finish syncing"
+		pChainLogPath := filepath.Join(bootstrapNode.DataDir, "logs", "P.log")
+		tc.By("waiting for the new P-Chain to reach its bootstrap frontier", func() {
+			tc.Eventually(
+				func() bool {
+					pChainLog, err := os.ReadFile(pChainLogPath)
+					return err == nil && strings.Contains(string(pChainLog), waitingForRemainingChains)
+				},
+				e2e.DefaultTimeout,
+				e2e.DefaultPollingInterval,
+				"new P-Chain did not reach its bootstrap frontier before timeout",
+			)
+		})
+
+		// Advance the established network's P-Chain after the new node selected
+		// its bootstrap frontier. The subsequent C-Chain proposer block records
+		// this newer P-Chain height and is the first C-Chain block the new node
+		// must verify.
+		tc.By("advancing the P-Chain while the new node waits for the C-Chain", func() {
+			issuePChainBatch(1)
+		})
+		tc.By("confirming a C-Chain transaction at the advanced P-Chain height", func() {
+			nonce, err := ethClient.AcceptedNonceAt(ctx, senderAddress)
+			require.NoError(err)
+			tx := types.NewTransaction(
+				nonce,
+				cRecipient,
+				big.NewInt(1),
+				e2e.DefaultGasLimit,
+				e2e.SuggestGasPrice(tc, ethClient),
+				nil,
+			)
+			signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), senderKey.ToECDSA())
+			require.NoError(err)
+			receipt := e2e.SendEthTransaction(tc, ethClient, signedTx)
+			require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+		})
+
+		// Health is the behavior under test. Because C-Chain is critical, its
+		// shutdown also stops the node and causes this check to fail immediately.
+		// Otherwise, allow the standard e2e deadline for bootstrap on slow hosts.
+		tc.By("waiting for the new node to become healthy")
+		healthErr := bootstrapNode.WaitForHealthy(ctx)
+		if healthErr == nil {
+			return
+		}
+
+		// Keep the health failure as the assertion result. Reading C.log only
+		// adds the known bootstrap failure to the Ginkgo output for diagnosis.
+		const heightMismatch = "block P-chain height larger than current P-chain height"
+		cChainLogPath := filepath.Join(bootstrapNode.DataDir, "logs", "C.log")
+		cChainLog, logErr := os.ReadFile(cChainLogPath)
+		if logErr != nil {
+			require.NoError(
+				healthErr,
+				"C-Chain log: %s (failed to read log: %v)",
+				cChainLogPath,
+				logErr,
+			)
+			return
+		}
+
+		var fatalLine string
+		lines := strings.Split(string(cChainLog), "\n")
+		for i := len(lines) - 1; i >= 0; i-- {
+			if strings.Contains(lines[i], "FATAL <C Chain>") && strings.Contains(lines[i], heightMismatch) {
+				fatalLine = lines[i]
+				break
+			}
+		}
+		if fatalLine == "" {
+			require.NoError(
+				healthErr,
+				"C-Chain log does not contain the expected height mismatch: %s",
+				cChainLogPath,
+			)
+			return
+		}
+		require.NoError(
+			healthErr,
+			"C-Chain bootstrap failure: %s\nC-Chain log: %s",
+			fatalLine,
+			cChainLogPath,
+		)
+	})
+})

--- a/tests/bootstrap/interchain/bootstrap_test.go
+++ b/tests/bootstrap/interchain/bootstrap_test.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package interchain_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	_ "github.com/ava-labs/avalanchego/tests/bootstrap/interchain"
+
+	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+)
+
+func TestE2E(t *testing.T) {
+	ginkgo.RunSpecs(t, "bootstrap e2e test suite")
+}
+
+var flagVars *e2e.FlagVars
+
+func init() {
+	flagVars = e2e.RegisterFlags(e2e.WithDefaultOwner("avalanchego-e2e-bootstrap"))
+}
+
+var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
+	tc := e2e.NewEventHandlerTestContext()
+
+	nodeCount, err := flagVars.NodeCount()
+	require.NoError(tc, err)
+	nodes := tmpnet.NewNodesOrPanic(nodeCount)
+
+	upgrades := tmpnet.UpgradeConfig(flagVars.ActivateLatestAfter())
+	tc.Log().Info("setting upgrades", zap.Reflect("upgrades", upgrades))
+
+	defaultFlags, err := tmpnet.UpgradeFlags(upgrades)
+	require.NoError(tc, err)
+	defaultFlags.SetDefaults(tmpnet.DefaultE2EFlags())
+
+	return e2e.NewTestEnvironment(
+		tc,
+		flagVars,
+		&tmpnet.Network{
+			Owner:        flagVars.NetworkOwner(),
+			DefaultFlags: defaultFlags,
+			Nodes:        nodes,
+		},
+	).Marshal()
+}, func(envBytes []byte) {
+	e2e.InitSharedTestEnvironment(e2e.NewTestContext(), envBytes)
+})

--- a/tests/fixture/tmpnet/BUILD.bazel
+++ b/tests/fixture/tmpnet/BUILD.bazel
@@ -96,6 +96,7 @@ go_test(
     srcs = [
         "kube_runtime_test.go",
         "network_test.go",
+        "node_test.go",
     ],
     embed = [":tmpnet"],
     deps = [

--- a/tests/fixture/tmpnet/node.go
+++ b/tests/fixture/tmpnet/node.go
@@ -428,6 +428,11 @@ func (n *Node) WaitForHealthy(ctx context.Context) error {
 	for {
 		healthy, err := n.IsHealthy(ctx)
 		switch {
+		case errors.Is(err, errNotRunning):
+			// WaitForHealthy is called after the runtime has started the node.
+			// Recovering from a stopped node requires an explicit lifecycle
+			// operation, so retrying the health check cannot succeed.
+			return stacktrace.Errorf("node %q stopped before becoming healthy: %w", n.NodeID, err)
 		case errors.Is(err, ErrUnrecoverableNodeHealthCheck):
 			return stacktrace.Errorf("node %q saw unrecoverable health check: %w", n.NodeID, err)
 		case err != nil:

--- a/tests/fixture/tmpnet/node_test.go
+++ b/tests/fixture/tmpnet/node_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package tmpnet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+type healthErrorRuntime struct {
+	NodeRuntime
+	err error
+}
+
+func (r *healthErrorRuntime) IsHealthy(context.Context) (bool, error) {
+	return false, r.err
+}
+
+func TestWaitForHealthyReturnsWhenNodeStopped(t *testing.T) {
+	node := &Node{
+		runtime: &healthErrorRuntime{err: errNotRunning},
+		network: &Network{log: logging.NoLog{}},
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	err := node.WaitForHealthy(ctx)
+	require.ErrorIs(t, err, errNotRunning)
+}


### PR DESCRIPTION
## Why this should be merged

A node should be able to complete bootstrap while the P-Chain and C-Chain continue advancing. Add a test that advances the P-Chain, creates a C-Chain block, and requires the node to become healthy. Run the test against a pre-Helicon network and a post-Helicon network.